### PR TITLE
Title overlay policy: rule, phase 5 guidance, scripts

### DIFF
--- a/rules/title-overlay-rules.md
+++ b/rules/title-overlay-rules.md
@@ -1,0 +1,163 @@
+# Title Overlay Rules
+
+Steering rules for placing overlaid slide titles on illustrated slides.
+Covers the generation-time directive pattern, the zones in use, and the
+safety net that applies regardless of placement.
+
+## 1. Engineer Negative Space at Generation Time
+
+When a slide will have a title overlaid on an illustration, bake a
+`TITLE SAFE ZONE` directive into the image prompt **before** generation.
+Do not rely on post-hoc placement heuristics to find a safe zone — if
+the generator doesn't know about it, the subject will occupy the best
+area by default.
+
+Directive to append to every Image prompt:
+
+```
+TITLE SAFE ZONE -- CRITICAL COMPOSITION RULE: Reserve the {zone} of
+the 16:9 frame as clean uninterrupted negative space filled only with
+{surface}. No subjects, objects, text, props, or focal points may
+appear in this region. The scene's subjects must be composed entirely
+in the remaining portion of the frame. This negative space will carry
+an overlaid title.
+```
+
+Where `{zone}` is `upper third`, `middle third`, or `lower third`, and
+`{surface}` is a short style-specific description of what should fill
+the zone (a uniform area drawn from the style anchor — for example,
+"an unbroken area of the painted sky", "a clean stretch of the studio
+backdrop", "a flat region of the base texture used elsewhere in the
+frame"). Always phrase the surface in the style's own vocabulary so
+the generator reaches for materials it already knows how to render.
+
+## 2. Five Zones Cover Practical Compositions
+
+Three horizontal-band zones and two half-frame zones are supported:
+
+- **`upper_third`** — uniform backdrop above the subject (sky, ceiling,
+  wall, gradient, etc. depending on style). Use for landscapes,
+  portraits, hero shots, and most open compositions.
+- **`middle_third`** — reserved center band, with the subject framing
+  around it. Use for styles that produce TV sets, portrait frames,
+  vignettes, windows, or any composition where the focal subject
+  surrounds a clean central opening intended to hold the title.
+- **`lower_third`** — uniform region below the subject. Use when the
+  subject is centered and top-heavy (e.g. a poster, hero object, or
+  sign that naturally leaves surface below it).
+- **`left_half`** — left side of the frame reserved as clean surface,
+  subject composed on the right. Use for split-panel, side-by-side,
+  or "subject pushed to one side" compositions.
+- **`right_half`** — mirror of `left_half`: subject on the left, clean
+  surface on the right. Useful when the subject naturally faces or
+  moves leftward.
+
+Do **not** use `left_third` or `right_third` — a third of a 16:9 frame
+is too narrow a vertical column for readable horizontal title text.
+`left_half` / `right_half` give the title enough column width to wrap
+across a few lines.
+
+## 3. Pick the Zone Per Slide Based on Subject Geometry
+
+A global default fails. Assign the zone per slide based on where the
+subject naturally sits, in the vocabulary of the chosen style:
+
+| Composition | Zone |
+|-------------|------|
+| Open landscape or scene with a uniform backdrop above the subject | `upper_third` |
+| Portrait / hero object with clean space above | `upper_third` |
+| Overhead shot with a clean surface at the top of frame | `upper_third` |
+| Framed composition (TV, monitor, window, portrait frame, vignette) | `middle_third` |
+| Full-frame artifact (poster, sign, document) with surface below it | `lower_third` |
+| Silhouette or element rising from the bottom against open backdrop | `lower_third` |
+| Subject pushed right, facing right, or split-panel with clean left side | `left_half` |
+| Subject pushed left, facing left, or split-panel with clean right side | `right_half` |
+
+The concrete surface (sky, fabric, paper, parchment, gradient, etc.)
+is chosen from the deck's style anchor. The zone assignment is what
+this rule governs.
+
+Persist assignments in the design brief as a per-slide table so the
+brief stays the single source of truth.
+
+## 4. Brightness Is Not the Same as Cleanness
+
+A brightness-based band picker conflates *darkness* with *safe*. A
+bright uniform backdrop is a valid title region; a dark cluttered
+scene is not. If you need a programmatic signal, use *variance* (low
+variance = uniform) rather than mean luminance. Better: specify the
+zone in the brief and skip the picker entirely.
+
+## 5. Always Apply a Scrim Behind the Title
+
+Regardless of zone choice, add a semi-transparent rectangle **sized to
+the title zone** (not the whole slide) between the background picture
+and the text. Scope matters: a full-slide scrim flattens the whole
+illustration, while a zone-sized scrim lifts the title locally and
+leaves the rest of the scene at full brightness.
+
+Default: 45% black.
+
+```xml
+<p:sp>
+  <p:spPr>
+    <a:xfrm>.. zone box ..</a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+    <a:solidFill>
+      <a:srgbClr val="000000"><a:alpha val="45000"/></a:srgbClr>
+    </a:solidFill>
+    <a:ln><a:noFill/></a:ln>
+  </p:spPr>
+</p:sp>
+```
+
+OOXML child order inside `<p:spPr>` must be `xfrm → prstGeom → solidFill
+→ ln`. Keynote (and some strict OOXML readers) silently drop the fill
+when `<a:ln>` precedes `<a:solidFill>`, which is the exact failure mode
+that makes "scrim isn't rendering" bugs look like "scrim has no visible
+effect."
+
+### Tinted scrims for styled decks
+
+Pure black is the right default for neutral styles. Warm-toned decks
+(sepia, painted Western, golden hour) and cool-toned decks (cyanotype,
+night, deep space) read better with a scrim color sampled from the
+deck's own natural shadows — the title still sits on a darker field,
+but the darkening looks like "deeper shadow of the same style" rather
+than a black film dropped on top.
+
+Suggested sampler (`scripts/suggest-scrim-color.py`):
+
+1. Resize each illustration to ~200px longest edge.
+2. Take the darkest 5% of pixels across the whole deck by Rec. 709
+   luminance.
+3. Average their sRGB.
+4. Clamp the result to a target luminance (~0.10) so mid-shadow averages
+   don't produce a washed-out scrim.
+5. Bump alpha above 45% slightly when the sample is chromatic (a tinted
+   scrim loses some darkening power to the tint).
+
+Persist the chosen color and alpha in the deck's design brief once, not
+per slide.
+
+## 6. Callbacks and Bookends Break Under Independent Regen
+
+When two slides are meant to be the same scene with one detail
+changed (bookend pattern — first and last slide of a deck), independent
+Gemini calls produce two different scenes. Generate the base slide
+first, then **edit** the callback slide from the base output instead
+of regenerating. This is consistent with the edit-vs-regenerate rule
+in `illustration-rules.md`: the callback is a content *modification*
+of an existing image, not a fresh concept.
+
+## 7. Loop B Is the Recovery Pattern, Not the Primary Pipeline
+
+When the up-front SAFE ZONE directive fails on a slide (the generator
+put the subject in the declared safe zone anyway):
+
+1. Send the generated image + the original prompt + the title to a
+   vision LLM, asking for a diagnosis and a revised prompt.
+2. Regenerate with the revised prompt.
+
+This costs an extra round-trip per slide. Use it only for the 10–25%
+of slides that resist the initial directive, not as the default path.

--- a/skills/presentation-creator/references/phase5-slides.md
+++ b/skills/presentation-creator/references/phase5-slides.md
@@ -497,6 +497,53 @@ always add #3 (preservation list) manually — the script cannot know what to pr
 - When auditing fix logs, flag any use of PIL/Pillow, ImageMagick, or programmatic
   image manipulation for illustration work as a technique anti-pattern.
 
+**Title-overlay compatibility — engineer the safe zone at generation time:**
+
+When a slide will have an overlaid title, the illustration must leave a
+clean negative-space region for it. Relying on a post-hoc placement
+heuristic to find one fails: the subject occupies the "best" area by
+default, and a brightness-based picker conflates darkness with
+cleanness (a bright uniform backdrop is a valid title region).
+
+Instead, assign a `SAFE ZONE` per slide in the design brief and inject
+a directive into every Image prompt:
+
+```
+TITLE SAFE ZONE -- CRITICAL COMPOSITION RULE: Reserve the {zone} of
+the 16:9 frame as clean uninterrupted negative space filled only with
+{surface}. No subjects, objects, text, props, or focal points may
+appear in this region. The scene's subjects must be composed entirely
+in the remaining portion of the frame. This negative space will carry
+an overlaid title.
+```
+
+Five zones are supported:
+
+- `upper_third` — uniform backdrop above the subject (open scenes,
+  portraits, hero shots)
+- `middle_third` — reserved center band, subject framing around it
+  (TV / monitor / window / portrait-frame / vignette compositions)
+- `lower_third` — uniform region below the subject (full-frame
+  posters, signs, or top-heavy compositions)
+- `left_half` — clean left half of the frame, subject composed on the
+  right (split-panel or "subject pushed to one side" compositions)
+- `right_half` — mirror of `left_half`, subject on the left
+
+The `{surface}` is chosen from the deck's style anchor — describe
+what should fill the reserved region in the style's own vocabulary
+(sky, fabric, paper, parchment, gradient, painted backdrop, etc.).
+Left/right thirds are intentionally excluded — too narrow for
+horizontal title text. `left_half` / `right_half` give the title
+enough column width to wrap across a few lines.
+
+Apply a zone-sized 45% black scrim between the picture and the title
+text. Scope matters: a full-slide scrim flattens the whole
+illustration, while a zone-sized scrim lifts the title locally. For
+styled decks (warm sepia, cool night, etc.) sample the scrim color
+from the deck's natural shadow tone instead of pure black.
+
+See `rules/title-overlay-rules.md` for the full policy.
+
 ---
 
 ## File Locations

--- a/skills/presentation-creator/scripts/README-title-placement.md
+++ b/skills/presentation-creator/scripts/README-title-placement.md
@@ -1,0 +1,78 @@
+# Title Placement — Outline Schema + Scripts
+
+Implements the policy in
+[`rules/title-overlay-rules.md`](../../../rules/title-overlay-rules.md).
+
+## Outline schema addition
+
+Each slide block in `presentation-outline.md` gains one optional line:
+
+```markdown
+### Slide 3: The Question
+- Format: **FULL**
+- Image prompt: `[STYLE ANCHOR]. <scene description> ...`
+- Safe zone: upper_third (uniform backdrop drawn from the style anchor)
+- Text: **how many hours last week...**
+```
+
+Grammar: `- Safe zone: <zone> (<surface>)`
+
+- `<zone>` — one of `upper_third`, `middle_third`, `lower_third`,
+  `left_half`, `right_half`. Horizontal bands reserve a full-width
+  strip; half-frame zones reserve one side of the frame for the title
+  column and push the subject to the opposite side. `left_third` /
+  `right_third` are intentionally excluded — too narrow to hold
+  horizontal title text. `middle_third` is for styles whose subject
+  naturally frames a clean center opening (TV sets, monitors, windows,
+  portrait frames, vignettes).
+- `<surface>` — optional short phrase describing what fills the zone in
+  the deck's own visual vocabulary (e.g. "unbroken painted sky", "flat
+  studio backdrop", "parchment grain", "gradient wash"). If omitted, a
+  generic default is used, but results are noticeably better with an
+  explicit style-anchored surface.
+
+Slides without a `Safe zone:` line generate and apply exactly as today.
+
+## Scripts
+
+| Script | Role |
+|--------|------|
+| `generate-illustrations.py` (modified) | Parses `Safe zone:` and appends the SAFE ZONE directive to each prompt before calling Gemini. No new CLI flags. |
+| `apply-illustrations-to-deck.py` (new) | Swaps generated images into a .pptx, adds a zone-sized scrim rectangle behind the title, and positions title text. Reads the same outline for zone data. Accepts `--scrim-color` / `--scrim-alpha`. |
+| `suggest-scrim-color.py` (new) | Samples the darkest 5% of pixels across a deck's illustrations and prints a scrim color + alpha tuned to the deck's natural shadow tone. |
+
+## End-to-end workflow
+
+```bash
+# 1. Author presentation-outline.md with `Safe zone:` lines
+
+# 2. Generate illustrations — directive appended automatically
+python3 generate-illustrations.py presentation-outline.md all
+
+# 3. (Optional) Sample a scrim color tuned to the deck's style
+python3 suggest-scrim-color.py illustrations/
+# -> prints: scrim base #RRGGBB, recommended alpha NNNNN
+
+# 4. Apply to deck
+python3 apply-illustrations-to-deck.py \
+    deck.pptx illustrations/ presentation-outline.md \
+    --out deck-with-titles.pptx \
+    --scrim-color 100903 --scrim-alpha 47553   # omit for plain 45% black
+```
+
+## Notes
+
+- **Scrim always applied, zone-scoped.** A rectangle matching the
+  title zone sits between the picture and the text. Full-slide scrims
+  flatten the illustration; zone-sized ones lift the title locally.
+- **Scrim color sampled from the deck.** Default is 45% black. For
+  styled decks (warm sepia, cool night, etc.) `suggest-scrim-color.py`
+  samples the natural shadow tone — the scrim then reads as "deeper
+  shadow of the same style" instead of a black film.
+- **Idempotence.** `generate-illustrations.py` strips any existing
+  `TITLE SAFE ZONE` block before re-appending, so re-running after a
+  zone edit produces the right result.
+- **Recovery path.** If a specific slide's illustration ignores the
+  directive, use the Loop B pattern (vision-LLM diagnose → revised
+  prompt → regenerate). Documented in the rule file; not mechanized
+  as a default.

--- a/skills/presentation-creator/scripts/apply-illustrations-to-deck.py
+++ b/skills/presentation-creator/scripts/apply-illustrations-to-deck.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Apply generated illustrations to a deck with designed title placement.
+
+For each slide whose outline block has a `Safe zone:` field:
+  1. Replace the background picture with the matching illustration.
+  2. Add a full-slide 45% black scrim between the picture and the text
+     (if not already present).
+  3. Reposition title text boxes into the designed safe zone:
+     upper_third/middle_third/lower_third -> full-width band at the
+     matching Y; left_half/right_half -> narrower column on that side.
+
+The outline is the single source of truth for zone assignments — the
+same `Safe zone:` lines that `generate-illustrations.py` reads.
+See `rules/title-overlay-rules.md` for the policy behind this.
+
+Usage:
+    apply-illustrations-to-deck.py DECK ILLUSTRATIONS_DIR OUTLINE_MD \\
+        [--out OUT_DECK] [--image-ext jpg|png]
+"""
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+from lxml import etree
+from pptx import Presentation
+from pptx.oxml.ns import qn
+from pptx.util import Inches
+
+# 16:9 slide geometry (inches)
+SLIDE_W_IN = 13.333
+SLIDE_H_IN = 7.5
+
+# Layout per zone: top/left of the title column, and column width.
+# Horizontal bands use the full content width centered horizontally.
+# Half-frame zones use a narrower column on the chosen side, with the
+# title vertically centered.
+TEXT_W_FULL_IN = 10.0
+TEXT_W_HALF_IN = 5.5
+HALF_MARGIN_IN = 0.4
+_BAND_H_IN = 1.9    # horizontal-band title height (title + subtitle)
+_HALF_H_IN = 4.5    # half-frame title column height
+_HALF_TOP_IN = (SLIDE_H_IN - _HALF_H_IN) / 2
+
+ZONE_LAYOUT = {
+    "upper_third":  {"top_in": 0.4,         "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2,            "width_in": TEXT_W_FULL_IN, "height_in": _BAND_H_IN},
+    "middle_third": {"top_in": (SLIDE_H_IN - _BAND_H_IN) / 2, "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2, "width_in": TEXT_W_FULL_IN, "height_in": _BAND_H_IN},
+    "lower_third":  {"top_in": SLIDE_H_IN - _BAND_H_IN - 0.4, "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2, "width_in": TEXT_W_FULL_IN, "height_in": _BAND_H_IN},
+    "left_half":    {"top_in": _HALF_TOP_IN, "left_in": HALF_MARGIN_IN,                               "width_in": TEXT_W_HALF_IN, "height_in": _HALF_H_IN},
+    "right_half":   {"top_in": _HALF_TOP_IN, "left_in": SLIDE_W_IN - HALF_MARGIN_IN - TEXT_W_HALF_IN, "width_in": TEXT_W_HALF_IN, "height_in": _HALF_H_IN},
+}
+
+SUBTITLE_OFFSET_IN = 1.2
+
+# Default scrim: 45% black. Decks with a strong tonal style (warm sepia,
+# cool night, etc.) should pass a sampled color via --scrim-color.
+# See scripts/suggest-scrim-color.py and rules/title-overlay-rules.md §5.
+DEFAULT_SCRIM_HEX = "000000"
+DEFAULT_SCRIM_ALPHA = 45000
+
+# python-pptx shape_type integers
+SHAPE_TYPE_AUTO = 1
+SHAPE_TYPE_PICTURE = 13
+SHAPE_TYPE_TEXT_BOX = 17
+
+
+def parse_zones(outline_path: Path) -> dict:
+    """Read `Safe zone:` lines from the outline.
+
+    Returns {slide_num: zone_name} where zone_name is a key of ZONE_LAYOUT.
+    """
+    text = outline_path.read_text()
+    zones = {}
+    pattern = re.compile(
+        r"###\s+Slide\s+(\d+):.*?-\s*Safe zone:\s*"
+        r"(upper_third|middle_third|lower_third|left_half|right_half)",
+        re.DOTALL,
+    )
+    for m in pattern.finditer(text):
+        zones[int(m.group(1))] = m.group(2)
+    return zones
+
+
+def replace_picture_blob(picture_shape, new_image_path: Path) -> None:
+    rel_id = picture_shape._element.blip_rId
+    image_part = picture_shape.part.rels[rel_id].target_part
+    image_part._blob = new_image_path.read_bytes()
+
+
+def ensure_scrim(slide, zone: str, scrim_hex: str, scrim_alpha: int) -> int:
+    """Add a zone-sized semi-transparent rectangle between picture and text.
+
+    Zone-scoped (not full-slide) — a full-slide scrim flattens the whole
+    illustration; scoping to the title box keeps the rest at full brightness.
+    OOXML spPr child order must be xfrm -> prstGeom -> solidFill -> ln.
+    """
+    if any(s.shape_type == SHAPE_TYPE_AUTO for s in slide.shapes):
+        return 0
+    layout = ZONE_LAYOUT[zone]
+    shape = slide.shapes.add_shape(
+        SHAPE_TYPE_AUTO,
+        left=Inches(layout["left_in"]), top=Inches(layout["top_in"]),
+        width=Inches(layout["width_in"]), height=Inches(layout["height_in"]),
+    )
+    sp = shape._element
+    style = sp.find(qn("p:style"))
+    if style is not None:
+        sp.remove(style)
+
+    spPr = sp.find(qn("p:spPr"))
+    keep = {qn("a:xfrm"), qn("a:prstGeom"), qn("a:custGeom")}
+    for child in list(spPr):
+        if child.tag not in keep:
+            spPr.remove(child)
+    solid = etree.SubElement(spPr, qn("a:solidFill"))
+    clr = etree.SubElement(solid, qn("a:srgbClr"))
+    clr.set("val", scrim_hex.upper())
+    alpha = etree.SubElement(clr, qn("a:alpha"))
+    alpha.set("val", str(scrim_alpha))
+    ln = etree.SubElement(spPr, qn("a:ln"))
+    etree.SubElement(ln, qn("a:noFill"))
+
+    # Put the scrim just below the topmost text so it sits between picture and text.
+    slide.shapes._spTree.remove(sp)
+    slide.shapes._spTree.insert(3, sp)
+    return 1
+
+
+def reposition_title(slide, zone: str) -> int:
+    text_shapes = [
+        s for s in slide.shapes
+        if s.has_text_frame and s.shape_type == SHAPE_TYPE_TEXT_BOX
+    ]
+    text_shapes.sort(key=lambda s: s.top)
+    if not text_shapes:
+        return 0
+
+    layout = ZONE_LAYOUT[zone]
+    title_top = Inches(layout["top_in"])
+    text_left = Inches(layout["left_in"])
+    text_width = Inches(layout["width_in"])
+
+    for j, shape in enumerate(text_shapes):
+        shape.left = int(text_left)
+        shape.width = int(text_width)
+        shape.top = int(title_top + Inches(SUBTITLE_OFFSET_IN * j))
+    return len(text_shapes)
+
+
+def apply(
+    deck: Path, illust_dir: Path, zones: dict, out_deck: Path, ext: str,
+    scrim_hex: str, scrim_alpha: int,
+) -> list[dict]:
+    if out_deck.exists():
+        out_deck.unlink()
+    shutil.copy2(deck, out_deck)
+
+    prs = Presentation(str(out_deck))
+    results = []
+
+    for n, zone in sorted(zones.items()):
+        illust = illust_dir / f"slide-{n:02d}.{ext}"
+        if not illust.exists():
+            print(f"  [{n:02d}] SKIP: missing {illust.name}")
+            continue
+        if n > len(prs.slides):
+            print(f"  [{n:02d}] SKIP: out of deck range")
+            continue
+
+        slide = prs.slides[n - 1]
+        pictures = [s for s in slide.shapes if s.shape_type == SHAPE_TYPE_PICTURE]
+        if not pictures:
+            print(f"  [{n:02d}] SKIP: no picture shape")
+            continue
+        bg = max(pictures, key=lambda s: (s.width or 0) * (s.height or 0))
+
+        try:
+            replace_picture_blob(bg, illust)
+        except Exception as e:
+            print(f"  [{n:02d}] FAILED image swap: {e}")
+            continue
+
+        scrim_added = ensure_scrim(slide, zone, scrim_hex, scrim_alpha)
+        moved = reposition_title(slide, zone)
+        print(f"  [{n:02d}] zone={zone}  moved={moved} text  scrim+{scrim_added}")
+        results.append({
+            "slide": n, "zone": zone,
+            "text_moved": moved, "scrim_added": scrim_added,
+        })
+
+    prs.save(str(out_deck))
+    return results
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("deck", type=Path, help="Path to source .pptx")
+    ap.add_argument("illustrations", type=Path, help="Directory with slide-NN.<ext> files")
+    ap.add_argument("outline", type=Path, help="Path to presentation-outline.md")
+    ap.add_argument("--out", type=Path, default=None, help="Output deck (default: <stem>-with-titles.pptx)")
+    ap.add_argument("--image-ext", default="jpg", choices=["jpg", "jpeg", "png"])
+    ap.add_argument("--scrim-color", default=DEFAULT_SCRIM_HEX,
+                    help="Scrim color as 6-digit hex (default: %(default)s). "
+                         "Run suggest-scrim-color.py to sample one from the deck's illustrations.")
+    ap.add_argument("--scrim-alpha", type=int, default=DEFAULT_SCRIM_ALPHA,
+                    help="Scrim opacity in OOXML thousandths (0-100000, default: %(default)s = 45%%).")
+    args = ap.parse_args()
+
+    out_deck = args.out or args.deck.with_name(args.deck.stem + "-with-titles.pptx")
+    zones = parse_zones(args.outline)
+    if not zones:
+        print(f"No `Safe zone:` lines found in {args.outline.name}. Nothing to do.")
+        return
+
+    scrim_hex = args.scrim_color.lstrip("#").upper()
+    if len(scrim_hex) != 6 or any(c not in "0123456789ABCDEF" for c in scrim_hex):
+        raise SystemExit(f"--scrim-color must be a 6-digit hex, got {args.scrim_color!r}")
+    if not (0 <= args.scrim_alpha <= 100000):
+        raise SystemExit(f"--scrim-alpha must be 0..100000, got {args.scrim_alpha}")
+
+    results = apply(
+        args.deck, args.illustrations, zones, out_deck, args.image_ext,
+        scrim_hex, args.scrim_alpha,
+    )
+    print(f"\nSaved {out_deck}")
+    print(f"Updated {len(results)}/{len(zones)} slides")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/presentation-creator/scripts/apply-illustrations-to-deck.py
+++ b/skills/presentation-creator/scripts/apply-illustrations-to-deck.py
@@ -82,9 +82,18 @@ def parse_zones(outline_path: Path) -> dict:
 
 
 def replace_picture_blob(picture_shape, new_image_path: Path) -> None:
-    rel_id = picture_shape._element.blip_rId
-    image_part = picture_shape.part.rels[rel_id].target_part
-    image_part._blob = new_image_path.read_bytes()
+    """Swap the picture's embedded image to the one at new_image_path.
+
+    Uses rel re-pointing rather than mutating ``image_part._blob`` in
+    place. A template may seed every slide's picture from a single
+    placeholder file; python-pptx dedupes identical source paths into
+    one image part shared across slides. Mutating that shared blob
+    would clobber every other slide referencing it — last swap wins
+    and every slide ends up with the same final image.
+    """
+    slide_part = picture_shape.part
+    _, new_rId = slide_part.get_or_add_image_part(str(new_image_path))
+    picture_shape._element.blipFill.blip.set(qn("r:embed"), new_rId)
 
 
 def ensure_scrim(slide, zone: str, scrim_hex: str, scrim_alpha: int) -> int:

--- a/skills/presentation-creator/scripts/generate-illustrations.py
+++ b/skills/presentation-creator/scripts/generate-illustrations.py
@@ -50,6 +50,30 @@ RATE_LIMIT_DELAY = 5  # seconds between API requests
 
 IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"]
 
+# --- Title safe-zone policy (see rules/title-overlay-rules.md) ---
+
+VALID_SAFE_ZONES = {
+    "upper_third", "middle_third", "lower_third",
+    "left_half", "right_half",
+}
+
+DEFAULT_SAFE_ZONE_SURFACE = {
+    "upper_third": "a clean uniform region at the top of the frame, drawn from the style's established backdrop",
+    "middle_third": "a clean uninterrupted region at the center of the frame, framed by the subject on top and bottom",
+    "lower_third": "a clean uniform region at the bottom of the frame, drawn from the style's established backdrop",
+    "left_half": "a clean uniform region covering the left half of the frame, drawn from the style's established backdrop",
+    "right_half": "a clean uniform region covering the right half of the frame, drawn from the style's established backdrop",
+}
+
+SAFE_ZONE_DIRECTIVE_TEMPLATE = (
+    " TITLE SAFE ZONE -- CRITICAL COMPOSITION RULE: Reserve the "
+    "{zone_words} of the 16:9 frame as clean uninterrupted negative "
+    "space filled only with {surface}. No subjects, objects, text, "
+    "props, or focal points may appear in this region. The scene's "
+    "subjects must be composed entirely in the remaining portion of "
+    "the frame. This negative space will carry an overlaid title."
+)
+
 # Canonical MIME <-> extension mapping
 _MIME_EXT_MAP = {
     "image/jpeg": ".jpg",
@@ -119,6 +143,23 @@ def parse_outline(path):
         prompt_match = re.search(r"-\s*Image prompt:\s*`(.+?)`", block, re.DOTALL)
         prompt = prompt_match.group(1).strip() if prompt_match else None
 
+        # Extract optional Safe zone: <zone> (<surface>)
+        safe_zone = None
+        zone_match = re.search(
+            r"-\s*Safe zone:\s*(upper_third|middle_third|lower_third|left_half|right_half)"
+            r"(?:\s*\(([^)]+)\))?",
+            block,
+        )
+        if zone_match:
+            zone = zone_match.group(1)
+            surface = (zone_match.group(2) or "").strip() or None
+            safe_zone = {"zone": zone, "surface": surface}
+        elif re.search(r"-\s*Safe zone:", block):
+            print(
+                f"  WARNING: Slide {slide_num}: Safe zone field present but invalid; "
+                "expected one of upper_third, middle_third, lower_third, left_half, right_half"
+            )
+
         # Extract build specifications
         builds = None
         builds_match = re.search(r"-\s*Builds:\s*(\d+)\s+steps?", block)
@@ -150,6 +191,8 @@ def parse_outline(path):
                 "format": slide_format,
                 "prompt": prompt,
             }
+            if safe_zone:
+                slide_data["safe_zone"] = safe_zone
             if builds:
                 slide_data["builds"] = builds
             result["slides"].append(slide_data)
@@ -171,6 +214,27 @@ def resolve_prompt(prompt, slide_format, anchors):
         return prompt.replace("[STYLE ANCHOR].", "").replace("[STYLE ANCHOR]", "")
 
     return prompt.replace("[STYLE ANCHOR]", anchor)
+
+
+def apply_safe_zone_directive(prompt, safe_zone):
+    """Append the SAFE ZONE directive to a prompt when safe_zone is set.
+
+    See rules/title-overlay-rules.md for the policy. Idempotent: if the
+    prompt already contains a TITLE SAFE ZONE block, it is replaced.
+    """
+    if not safe_zone:
+        return prompt
+    zone = safe_zone["zone"]
+    if zone not in VALID_SAFE_ZONES:
+        return prompt
+    surface = safe_zone.get("surface") or DEFAULT_SAFE_ZONE_SURFACE[zone]
+    if "TITLE SAFE ZONE" in prompt:
+        prompt = prompt.split("TITLE SAFE ZONE", 1)[0].rstrip()
+    directive = SAFE_ZONE_DIRECTIVE_TEMPLATE.format(
+        zone_words=zone.replace("_", " "),
+        surface=surface,
+    )
+    return prompt + directive
 
 
 # --- Slide Number Selection ---
@@ -447,6 +511,7 @@ def run_generate(outline_path, slide_args, versioned=False):
     for i, num in enumerate(to_generate):
         slide = slides_by_num[num]
         prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
+        prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
 
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
@@ -490,6 +555,7 @@ def run_compare(outline_path, slide_num):
 
     slide = slides_by_num[slide_num]
     prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
+    prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
 
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)),

--- a/skills/presentation-creator/scripts/suggest-scrim-color.py
+++ b/skills/presentation-creator/scripts/suggest-scrim-color.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Suggest a deck-appropriate scrim color by sampling the illustrations.
+
+A pure-black scrim desaturates warm/cool decks uniformly. Sampling the
+natural shadow tone of the deck's own illustrations gives a scrim that
+reads as "deeper shadow in the same style" rather than a flat black film.
+
+Algorithm:
+  1. For each illustration, resize to 200px longest edge (speed).
+  2. Compute luminance per pixel (Rec. 709).
+  3. Take the darkest 5% of pixels across the whole deck.
+  4. Average their sRGB values.
+  5. Clamp the result: push luminance down to ~8-12% so the sample is
+     usable as a scrim (otherwise mid-shadow averages come out too light).
+
+Output: suggested hex color + a recommended alpha (OOXML thousandths).
+"""
+import argparse
+from pathlib import Path
+
+from PIL import Image
+import numpy as np
+
+REC709 = np.array([0.2126, 0.7152, 0.0722])
+
+
+def sample_dark_pixels(img_paths, percentile=5.0, resize_to=200):
+    buckets = []
+    for p in img_paths:
+        img = Image.open(p).convert("RGB")
+        img.thumbnail((resize_to, resize_to), Image.LANCZOS)
+        arr = np.asarray(img, dtype=np.float32) / 255.0  # (H, W, 3)
+        lum = arr @ REC709                                # (H, W)
+        flat_px = arr.reshape(-1, 3)
+        flat_lum = lum.reshape(-1)
+        cutoff = np.percentile(flat_lum, percentile)
+        mask = flat_lum <= cutoff
+        if mask.sum() == 0:
+            continue
+        buckets.append(flat_px[mask])
+    if not buckets:
+        raise SystemExit("No pixels sampled — check image directory.")
+    all_dark = np.concatenate(buckets, axis=0)
+    return all_dark.mean(axis=0)  # (3,) in 0..1
+
+
+def clamp_to_scrim(rgb01, target_lum=0.10):
+    """Darken the sample so it's usable as a scrim base color.
+
+    Preserves hue/chroma by scaling RGB uniformly to hit a target luminance.
+    """
+    lum = float(rgb01 @ REC709)
+    if lum <= 1e-4:
+        return rgb01
+    scale = min(1.0, target_lum / lum)
+    return rgb01 * scale
+
+
+def to_hex(rgb01):
+    rgb = np.clip(rgb01 * 255.0, 0, 255).astype(int)
+    return "{:02X}{:02X}{:02X}".format(*rgb)
+
+
+def recommend_alpha(sample_rgb01):
+    """Warmer, more saturated samples need a touch more opacity.
+
+    Black scrims need only 45% to read; tinted scrims lose some darkening
+    power to the tint, so bump alpha a little when chroma is nonzero.
+    """
+    chroma = float(np.max(sample_rgb01) - np.min(sample_rgb01))
+    base = 0.45
+    bump = min(0.10, chroma * 0.5)
+    alpha = base + bump
+    return int(round(alpha * 100000))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("illustrations_dir", type=Path)
+    ap.add_argument("--percentile", type=float, default=5.0,
+                    help="Sample the darkest N%% of pixels (default 5)")
+    ap.add_argument("--target-luminance", type=float, default=0.10,
+                    help="Clamp sample to this Rec. 709 luminance (default 0.10)")
+    ap.add_argument("--glob", default="slide-*.jpg")
+    args = ap.parse_args()
+
+    paths = sorted(args.illustrations_dir.glob(args.glob))
+    if not paths:
+        raise SystemExit(f"No files matching {args.glob} in {args.illustrations_dir}")
+
+    raw = sample_dark_pixels(paths, percentile=args.percentile)
+    scrim = clamp_to_scrim(raw, target_lum=args.target_luminance)
+    alpha = recommend_alpha(raw)
+
+    print(f"Sampled {len(paths)} illustrations, darkest {args.percentile:.0f}% of pixels")
+    print(f"  raw dark-pixel mean : #{to_hex(raw)} (lum={float(raw @ REC709):.3f})")
+    print(f"  scrim base color    : #{to_hex(scrim)} (lum={float(scrim @ REC709):.3f})")
+    print(f"  recommended alpha   : {alpha} / 100000 ({alpha/1000:.1f}% opaque)")
+    print()
+    print("OOXML:")
+    print(f'  <a:solidFill><a:srgbClr val="{to_hex(scrim)}">'
+          f'<a:alpha val="{alpha}"/></a:srgbClr></a:solidFill>')
+
+
+if __name__ == "__main__":
+    main()

--- a/tile.json
+++ b/tile.json
@@ -32,6 +32,9 @@
     "illustration-rules": {
       "rules": "rules/illustration-rules.md"
     },
+    "title-overlay-rules": {
+      "rules": "rules/title-overlay-rules.md"
+    },
     "thumbnail-generation-rules": {
       "rules": "rules/thumbnail-generation-rules.md"
     },


### PR DESCRIPTION
## Summary

Combined replacement for #4, #5, #6. Same changes, reviewed as one unit. Three stacked commits, one per logical layer:

1. `Add title-overlay-rules.md for engineered title-safe zones` — new rule doc + tile.json registration.
2. `Phase 5: add title-overlay compatibility subsection` — Phase 5 guidance pointing at the rule.
3. `Title placement: Safe zone directive + zone-scoped scrim + color sampler` — mechanizes the policy in the illustration pipeline and pptx assembly.

## Motivation

Placing overlaid titles on illustrated slides reliably needs four pieces that have to agree:

- The **illustration** must leave clean negative space for the title (not a post-hoc placement problem).
- The **outline** has to carry a per-slide zone decision so that placement is deterministic.
- The **generation pipeline** has to surface that decision to the model as a directive.
- The **pptx assembly step** has to position the title in the designed zone and add a scrim behind it.

A brightness-based band picker fails here: it conflates darkness with cleanness, and by the time the illustration exists, the subject already occupies the space the title needed. This PR moves the decision to generation time.

## What lands

### Rule: `rules/title-overlay-rules.md`

1. Engineer negative space at generation time via a `TITLE SAFE ZONE` directive appended to the image prompt.
2. Five supported zones — `upper_third`, `middle_third`, `lower_third`, `left_half`, `right_half`. Thirds-sized vertical columns are intentionally excluded (too narrow for horizontal title text).
3. A composition → zone table plus the rule that the concrete surface is drawn from the deck's style anchor in its own vocabulary.
4. Brightness is not cleanness.
5. Always apply a zone-sized scrim behind the title (not full-slide). Documents the OOXML child order gotcha (`xfrm → prstGeom → solidFill → ln`; Keynote drops the fill when `ln` precedes `solidFill`). Includes guidance on sampling a tinted scrim color from the deck's natural shadow tone for styled decks.
6. Callbacks and bookends: edit, don't regen, to preserve scene identity across paired slides.
7. Loop B (vision-LLM diagnose → revised prompt → regenerate) is the recovery path, not the primary pipeline.

Registers the rule in `tile.json`.

### Phase 5 addendum: `skills/presentation-creator/references/phase5-slides.md`

New subsection under the illustration guidance telling the user to:

- Assign a `SAFE ZONE` per slide in the design brief.
- Inject the `TITLE SAFE ZONE` directive into every Image prompt.
- Pick from five zones with a short description of when each fits.
- Apply a zone-sized scrim behind the title, optionally tinted.
- Point at `rules/title-overlay-rules.md` for the full policy.

### Scripts

- **`generate-illustrations.py`** (modified): parses an optional `Safe zone: <zone> (<surface>)` field per slide and appends the directive to the prompt after `resolve_prompt`, at both single-model and `--compare` callsites. Idempotent; backwards compatible (slides without the field generate as today).
- **`apply-illustrations-to-deck.py`** (new): swaps generated images into a .pptx, adds a zone-sized scrim rectangle between picture and text, and positions title text into the designed zone. Reads the same outline for zone data — single source of truth. OOXML child order fixed. `--scrim-color` / `--scrim-alpha` flags for deck-matched tinted scrims; defaults to 45% black.
- **`suggest-scrim-color.py`** (new): samples the darkest 5% of pixels across the deck's illustrations by Rec. 709 luminance, averages their sRGB, clamps to a target luminance, and bumps alpha for chromatic samples. Output: scrim hex + recommended alpha + ready-to-paste OOXML snippet. On a warm-sepia reference deck it suggests `#100903` at ~47.6% — the scrim then reads as "deeper shadow of the same style" rather than a foreign black band.
- **`README-title-placement.md`** (new): short usage doc covering the outline schema addition, the three scripts, and the end-to-end workflow.

## Outline schema addition

One new optional field per slide block:

```markdown
### Slide 3: The Question
- Format: **FULL**
- Image prompt: `[STYLE ANCHOR]. <scene description> ...`
- Safe zone: upper_third (uniform backdrop drawn from the style anchor)
- Text: **how many hours last week...**
```

## End-to-end workflow

```bash
# 1. Author the outline with `Safe zone:` lines per slide

# 2. Generate illustrations — directive appended automatically
python3 generate-illustrations.py presentation-outline.md all

# 3. (Optional) Sample a style-matched scrim color
python3 suggest-scrim-color.py illustrations/

# 4. Apply to deck
python3 apply-illustrations-to-deck.py \
    deck.pptx illustrations/ presentation-outline.md \
    --out deck-with-titles.pptx \
    --scrim-color 100903 --scrim-alpha 47553   # or omit for 45% black
```

## Replaces

Closes #4, #5, #6 (same changes, combined for review).

## Test plan

- [ ] `tile.json` validates as JSON; new rule registered correctly
- [ ] Rule doc reads cleanly against a representative illustrated deck
- [ ] Phase 5 addendum reads cleanly in context
- [ ] Existing outlines (no `Safe zone:` field) generate exactly as before
- [ ] Outlines with `Safe zone:` lines get the directive appended
- [ ] Invalid zone values surface as warnings, not crashes
- [ ] `apply-illustrations-to-deck.py` produces a deck whose scrim renders in Keynote (OOXML child order)
- [ ] `suggest-scrim-color.py` runs against a sample illustrations directory and prints a usable hex + alpha