### PR TITLE
Add Keynote compatibility rules for slide generation

### DIFF
--- a/rules/slide-generation-rules.md
+++ b/rules/slide-generation-rules.md
@@ -26,3 +26,52 @@ batch operation on the saved .pptx file.
 
 Remove all existing slides from the template BEFORE adding new content slides.
 The clean deck should retain only layout definitions, no demo/sample slides.
+
+## Keynote Compatibility
+
+Keynote uses a stricter OOXML parser than PowerPoint. The rules below
+prevent generated `.pptx` files from being rejected on import.
+
+### notesMasterIdLst patch
+
+The `inject-speaker-notes.py` script automatically adds the
+`<p:notesMasterIdLst>` element to `presentation.xml` when it is missing.
+No manual step is needed — just run the script as part of the normal
+speaker-notes injection pass.
+
+### Use rectangles for decorative lines — never connectors
+
+Connectors emit `<p:cxnSp>` elements that Keynote's parser may reject.
+Use a thin `RECTANGLE` shape instead of `add_connector(MSO_CONNECTOR.STRAIGHT, ...)`.
+
+```python
+# ✅ CORRECT: thin rectangle acts as a decorative line
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.util import Inches
+
+shapes.add_shape(
+    MSO_SHAPE.RECTANGLE,
+    left, top, width,
+    Inches(0.04),          # very small height = visual line
+)
+# then set solid fill + no border as needed
+
+# ❌ WRONG: connector shape — Keynote may refuse the file
+from pptx.enum.shapes import MSO_CONNECTOR
+
+shapes.add_connector(MSO_CONNECTOR.STRAIGHT, left, top, end_x, end_y)
+```
+
+### Never create shapes then remove them via raw XML
+
+Calling `element.getparent().remove(element)` after creating a shape
+through python-pptx causes the library's internal state to diverge from
+the serialized XML. Strict parsers (including Keynote) choke on the
+inconsistency. If a shape is not needed, simply do not create it.
+
+### Keep shape IDs contiguous per slide
+
+Each slide's `cNvPr id` values should form a contiguous sequence
+(1, 2, 3 ...). This happens automatically when shapes are added through
+normal python-pptx APIs. It breaks when shapes are inserted or deleted
+via raw XML manipulation — another reason to avoid it.

--- a/rules/slide-generation-rules.md
+++ b/rules/slide-generation-rules.md
@@ -35,9 +35,9 @@ prevent generated `.pptx` files from being rejected on import.
 ### notesMasterIdLst patch
 
 The `inject-speaker-notes.py` script automatically adds the
-`<p:notesMasterIdLst>` element to `presentation.xml` when it is missing.
-No manual step is needed — just run the script as part of the normal
-speaker-notes injection pass.
+`<p:notesMasterIdLst>` element to `ppt/presentation.xml` inside the
+`.pptx` when it is missing. No manual step is needed — just run the
+script as part of the normal speaker-notes injection pass.
 
 ### Use rectangles for decorative lines — never connectors
 
@@ -62,12 +62,19 @@ from pptx.enum.shapes import MSO_CONNECTOR
 shapes.add_connector(MSO_CONNECTOR.STRAIGHT, left, top, end_x, end_y)
 ```
 
-### Never create shapes then remove them via raw XML
+### Never create slide shapes with python-pptx then remove them via raw XML in the same flow
 
-Calling `element.getparent().remove(element)` after creating a shape
-through python-pptx causes the library's internal state to diverge from
-the serialized XML. Strict parsers (including Keynote) choke on the
-inconsistency. If a shape is not needed, simply do not create it.
+Do not create a slide shape through python-pptx and then delete that
+same shape with `element.getparent().remove(element)` during generation.
+That pattern causes python-pptx's internal state to diverge from the
+serialized XML, and strict parsers (including Keynote) reject the result.
+If a shape is not needed, do not create it in the first place.
+
+This rule applies to slide-shape authoring flows. It does not prohibit
+narrowly scoped XML cleanup utilities that remove pre-existing elements
+(e.g., `_pptx_repair.py` cleaning viewProps, or `generate-qr.py`
+replacing an existing QR image) — those operate on elements not managed
+by python-pptx's in-memory state.
 
 ### Keep shape IDs contiguous per slide
 


### PR DESCRIPTION
## Summary

The `notesMasterIdLst` fix for Keynote compatibility is already shipped in `inject-speaker-notes.py` (landed in v0.15.0). This PR documents the remaining python-pptx gotchas from the findings doc that can cause Keynote to reject generated `.pptx` files:

- **Use thin rectangles instead of connectors** for decorative lines — `<p:cxnSp>` elements from `add_connector()` trip Keynote's strict OOXML parser
- **Never create-then-remove shapes via raw XML** — `element.getparent().remove(element)` causes python-pptx internal state to diverge from serialized XML
- **Keep `cNvPr id` values contiguous per slide** — automatic with normal python-pptx usage, breaks with raw XML manipulation

No script changes — documentation only.

Closes #8

## Test plan

- [x] Verify the new section renders correctly in the rules doc
- [x] Confirm no scripts were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)