### PR TITLE
Add timemytalk.app talk timer generation

### DIFF
--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -158,8 +158,9 @@ Read `publishing_process.export_format` and `publishing_process.export_method`.
 
 ### Step 6.4: Talk Timer Artifact
 
-**Profile-gated:** only generate when `publishing_process.talk_timer` is present
-in `speaker-profile.json`. If absent, skip this step entirely.
+**Optional step:** generate this artifact when `presentation-outline.md`
+includes a `## Pacing Summary` table. If that section is absent, skip this step
+unless the author explicitly asks for a talk timer file.
 
 Source: the `## Pacing Summary` table in `presentation-outline.md`.
 
@@ -182,8 +183,8 @@ talk duration (including Q&A if applicable).
 **Granularity guidelines:**
 - 25-min talks: 8-13 chapters
 - 45-60 min talks: 10-15 chapters
-- Subdivide acts exceeding ~5 min into multiple chapters (the script uses
-  `## Section` headers for finer granularity automatically)
+- Subdivide acts exceeding ~5 min into multiple chapters (the script
+  attempts to match `## Section` headers to pacing entries by name overlap)
 
 **Q&A:** if the talk slot includes Q&A time, pass `--qa MINUTES` to append a
 Q&A chapter before FINISH.

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -238,7 +238,7 @@ PUBLISHING REPORT — {talk title}
 [DONE/SKIP] Shownotes: {url or "not configured"}
 [DONE/SKIP] QR code: {inserted at slide N, encoded URL, shortener used}
 [DONE/SKIP] Export: {format} → {output path}
-[DONE/SKIP] Talk timer: {output path, or "talk_timer not configured"}
+[DONE/SKIP] Talk timer: {output path, or "no pacing summary in outline"}
 [DONE/SKIP/TODO] {additional step name}: {status}
 [INFO] Go-live checklist: {presented above}
 ==================================

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -156,7 +156,41 @@ Read `publishing_process.export_format` and `publishing_process.export_method`.
 - Common pattern: PowerPoint AppleScript for PDF (see [phase5-slides.md](phase5-slides.md))
 - If no export info, ask: "How do you want to export? PDF, keep .pptx only, or both?"
 
-### Step 6.4: Additional Steps
+### Step 6.4: Talk Timer Artifact
+
+**Profile-gated:** only generate when `publishing_process.talk_timer` is present
+in `speaker-profile.json`. If absent, skip this step entirely.
+
+Source: the `## Pacing Summary` table in `presentation-outline.md`.
+
+Generate a plain-text timing file for [timemytalk.app](https://timemytalk.app)
+by running:
+
+```bash
+python3 skills/presentation-creator/scripts/generate-talk-timings.py \
+  presentation-outline.md --output talk-timings.txt
+
+# If the talk slot includes Q&A time:
+python3 skills/presentation-creator/scripts/generate-talk-timings.py \
+  presentation-outline.md --qa 5 --output talk-timings.txt
+```
+
+**Format:** one line per chapter, `MM:SS Label`, using cumulative start times.
+The final line is always `MM:SS FINISH` where the timestamp equals the total
+talk duration (including Q&A if applicable).
+
+**Granularity guidelines:**
+- 25-min talks: 8-13 chapters
+- 45-60 min talks: 10-15 chapters
+- Subdivide acts exceeding ~5 min into multiple chapters (the script uses
+  `## Section` headers for finer granularity automatically)
+
+**Q&A:** if the talk slot includes Q&A time, pass `--qa MINUTES` to append a
+Q&A chapter before FINISH.
+
+The speaker uploads the resulting `.txt` file to timemytalk.app before delivery.
+
+### Step 6.5: Additional Steps
 
 Read `publishing_process.additional_steps[]`. For each entry:
 
@@ -164,7 +198,7 @@ Read `publishing_process.additional_steps[]`. For each entry:
 - If `automated` is false, present the step to the author as a manual TODO
 - Report completion status for each step
 
-### Step 6.5: Go-Live Preparation Checklist
+### Step 6.6: Go-Live Preparation Checklist
 
 Before delivery, surface unobservable patterns from [patterns/_index.md](patterns/_index.md)
 (the "Unobservable Patterns — Go-Live Checklist" section) as a preparation reminder.
@@ -194,7 +228,7 @@ AVOID:
 ==================================
 ```
 
-### Step 6.6: Publishing Report
+### Step 6.7: Publishing Report
 
 ```
 PUBLISHING REPORT — {talk title}
@@ -203,6 +237,7 @@ PUBLISHING REPORT — {talk title}
 [DONE/SKIP] Shownotes: {url or "not configured"}
 [DONE/SKIP] QR code: {inserted at slide N, encoded URL, shortener used}
 [DONE/SKIP] Export: {format} → {output path}
+[DONE/SKIP] Talk timer: {output path, or "talk_timer not configured"}
 [DONE/SKIP/TODO] {additional step name}: {status}
 [INFO] Go-live checklist: {presented above}
 ==================================

--- a/skills/presentation-creator/scripts/generate-talk-timings.py
+++ b/skills/presentation-creator/scripts/generate-talk-timings.py
@@ -158,8 +158,12 @@ def subdivide_long_acts(pacing_sections, section_headers, threshold_seconds=300)
     """Subdivide pacing sections that exceed the threshold using section headers.
 
     When a pacing section exceeds threshold_seconds (~5 min), look for
-    section headers whose names partially match or fall within that act,
-    and split accordingly.
+    section headers whose names match and split accordingly. Matching uses
+    substring containment (pacing name in header or vice versa) plus
+    meaningful word overlap.
+
+    Durations are scaled proportionally with remainder assigned to the last
+    segment to prevent rounding drift.
 
     Returns a new list of (name, duration_seconds) tuples.
     """
@@ -167,11 +171,6 @@ def subdivide_long_acts(pacing_sections, section_headers, threshold_seconds=300)
         return list(pacing_sections)
 
     result = []
-    # Build a lookup: try to match section headers to pacing sections
-    header_map = {}
-    for hdr_name, hdr_dur in section_headers:
-        # Normalize for matching
-        header_map[hdr_name.lower()] = (hdr_name, hdr_dur)
 
     for pace_name, pace_dur in pacing_sections:
         if pace_dur <= threshold_seconds:
@@ -179,23 +178,25 @@ def subdivide_long_acts(pacing_sections, section_headers, threshold_seconds=300)
             continue
 
         # Find section headers that match this pacing entry
-        # Match by checking if the pacing name appears in the header name or vice versa
         matching_headers = []
         pace_lower = pace_name.lower()
         for hdr_name, hdr_dur in section_headers:
             hdr_lower = hdr_name.lower()
-            # Match if the header name contains keywords from the pacing entry
-            # or they share substantial overlap
             if (pace_lower in hdr_lower or hdr_lower in pace_lower
                     or _name_overlap(pace_lower, hdr_lower)):
                 matching_headers.append((hdr_name, hdr_dur))
 
         if len(matching_headers) >= 2:
-            # Use the sub-headers, but normalize their durations to sum to pace_dur
+            # Scale durations proportionally, assign remainder to last segment
             header_total = sum(d for _, d in matching_headers)
             if header_total > 0:
-                for hdr_name, hdr_dur in matching_headers:
-                    scaled = round(pace_dur * hdr_dur / header_total)
+                allocated = 0
+                for i, (hdr_name, hdr_dur) in enumerate(matching_headers):
+                    if i == len(matching_headers) - 1:
+                        scaled = pace_dur - allocated
+                    else:
+                        scaled = pace_dur * hdr_dur // header_total
+                        allocated += scaled
                     result.append((hdr_name, scaled))
             else:
                 result.append((pace_name, pace_dur))
@@ -258,7 +259,7 @@ def main():
         epilog="Produces MM:SS chapter lines for timemytalk.app timer.",
     )
     parser.add_argument("outline", help="Path to presentation-outline.md")
-    parser.add_argument("--qa", type=float, default=0,
+    parser.add_argument("--qa", type=int, default=0,
                         help="Q&A duration in minutes to add before FINISH")
     parser.add_argument("--output", "-o",
                         help="Output path (default: stdout)")

--- a/skills/presentation-creator/scripts/generate-talk-timings.py
+++ b/skills/presentation-creator/scripts/generate-talk-timings.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Generate timemytalk.app timing files from a presentation outline.
+
+Parses the ## Pacing Summary table and ## Section headers from a
+presentation-outline.md to produce a plain-text timing file with
+cumulative MM:SS timestamps for each chapter.
+
+Usage:
+    python3 generate-talk-timings.py <outline.md>
+    python3 generate-talk-timings.py <outline.md> --qa 5
+    python3 generate-talk-timings.py <outline.md> --output timings.txt
+
+Requires:
+    - Python 3.7+ (stdlib only -- no pip install needed)
+"""
+
+import argparse
+import re
+import sys
+
+
+# --- Pacing Summary Parsing ---
+
+def parse_pacing_table(text):
+    """Parse the ## Pacing Summary markdown table.
+
+    Expects rows like:
+        | Act 1: The Challenge | 5 min |
+        | Act 2: The Journey   | 12 min |
+
+    Also handles sub-minute durations like "1:30 min" or "0:30 min".
+
+    Returns a list of (section_name, duration_seconds) tuples.
+    """
+    sections = []
+    in_pacing = False
+    header_seen = False
+
+    for line in text.split("\n"):
+        stripped = line.strip()
+
+        # Detect the Pacing Summary heading
+        if re.match(r"^##\s+Pacing\s+Summary", stripped, re.IGNORECASE):
+            in_pacing = True
+            header_seen = False
+            continue
+
+        # Stop at the next ## heading
+        if in_pacing and re.match(r"^##\s+", stripped) and not re.match(
+            r"^##\s+Pacing\s+Summary", stripped, re.IGNORECASE
+        ):
+            break
+
+        if not in_pacing:
+            continue
+
+        # Skip non-table lines
+        if not stripped.startswith("|"):
+            continue
+
+        # Skip separator rows (|---|---|)
+        if re.match(r"^\|[\s\-:|]+\|$", stripped):
+            header_seen = True
+            continue
+
+        # Skip the header row (first row before separator)
+        if not header_seen:
+            continue
+
+        # Parse table row: | Section Name | Duration |
+        cells = [c.strip() for c in stripped.split("|")]
+        # Split on | gives empty strings at start/end
+        cells = [c for c in cells if c]
+
+        if len(cells) < 2:
+            continue
+
+        name = cells[0].strip()
+        duration_str = cells[1].strip()
+
+        # Skip totals row
+        if name.lower().startswith("total") or name.startswith("**"):
+            continue
+
+        seconds = _parse_duration(duration_str)
+        if seconds is not None and seconds > 0:
+            sections.append((name, seconds))
+
+    return sections
+
+
+def _parse_duration(duration_str):
+    """Parse a duration string into seconds.
+
+    Supports:
+        "5 min"       -> 300
+        "12 min"      -> 720
+        "1:30 min"    -> 90
+        "0:30 min"    -> 30
+        ":30 min"     -> 30
+        "5"           -> 300  (bare number = minutes)
+        "1:30"        -> 90
+        ":30"         -> 30
+    """
+    s = duration_str.strip().lower()
+    # Remove trailing "min", "mins", "minutes"
+    s = re.sub(r"\s*min(ute)?s?\s*$", "", s).strip()
+
+    if not s:
+        return None
+
+    # MM:SS or :SS format
+    m = re.match(r"^(\d*):(\d{1,2})$", s)
+    if m:
+        minutes = int(m.group(1)) if m.group(1) else 0
+        secs = int(m.group(2))
+        return minutes * 60 + secs
+
+    # Plain number (minutes)
+    m = re.match(r"^(\d+)$", s)
+    if m:
+        return int(m.group(1)) * 60
+
+    return None
+
+
+# --- Section Header Parsing ---
+
+def parse_section_headers(text):
+    """Parse ## Section headers for finer-grained timing info.
+
+    Looks for patterns like:
+        ## Act 1: The Challenge [5 min, slides 4-8]
+        ## Opening [3 min, slides 1-3]
+
+    Returns a list of (section_name, duration_seconds) tuples.
+    """
+    sections = []
+    # Match ## headers with [N min, ...] bracketed info
+    pattern = re.compile(
+        r"^##\s+(.+?)\s*\[(\d+(?::\d{1,2})?)\s*min"
+    , re.MULTILINE)
+
+    for match in pattern.finditer(text):
+        name = match.group(1).strip()
+        duration_str = match.group(2).strip()
+        seconds = _parse_duration(duration_str + " min")
+        if seconds is not None and seconds > 0:
+            sections.append((name, seconds))
+
+    return sections
+
+
+# --- Subdivision ---
+
+def subdivide_long_acts(pacing_sections, section_headers, threshold_seconds=300):
+    """Subdivide pacing sections that exceed the threshold using section headers.
+
+    When a pacing section exceeds threshold_seconds (~5 min), look for
+    section headers whose names partially match or fall within that act,
+    and split accordingly.
+
+    Returns a new list of (name, duration_seconds) tuples.
+    """
+    if not section_headers:
+        return list(pacing_sections)
+
+    result = []
+    # Build a lookup: try to match section headers to pacing sections
+    header_map = {}
+    for hdr_name, hdr_dur in section_headers:
+        # Normalize for matching
+        header_map[hdr_name.lower()] = (hdr_name, hdr_dur)
+
+    for pace_name, pace_dur in pacing_sections:
+        if pace_dur <= threshold_seconds:
+            result.append((pace_name, pace_dur))
+            continue
+
+        # Find section headers that match this pacing entry
+        # Match by checking if the pacing name appears in the header name or vice versa
+        matching_headers = []
+        pace_lower = pace_name.lower()
+        for hdr_name, hdr_dur in section_headers:
+            hdr_lower = hdr_name.lower()
+            # Match if the header name contains keywords from the pacing entry
+            # or they share substantial overlap
+            if (pace_lower in hdr_lower or hdr_lower in pace_lower
+                    or _name_overlap(pace_lower, hdr_lower)):
+                matching_headers.append((hdr_name, hdr_dur))
+
+        if len(matching_headers) >= 2:
+            # Use the sub-headers, but normalize their durations to sum to pace_dur
+            header_total = sum(d for _, d in matching_headers)
+            if header_total > 0:
+                for hdr_name, hdr_dur in matching_headers:
+                    scaled = round(pace_dur * hdr_dur / header_total)
+                    result.append((hdr_name, scaled))
+            else:
+                result.append((pace_name, pace_dur))
+        else:
+            result.append((pace_name, pace_dur))
+
+    return result
+
+
+def _name_overlap(a, b):
+    """Check if two section names share meaningful words."""
+    stop_words = {"the", "a", "an", "of", "and", "in", "to", "for", "act", "section", "part"}
+    words_a = set(re.findall(r"[a-z]+", a)) - stop_words
+    words_b = set(re.findall(r"[a-z]+", b)) - stop_words
+    if not words_a or not words_b:
+        return False
+    overlap = words_a & words_b
+    return len(overlap) >= 1
+
+
+# --- Output ---
+
+def format_seconds(total_seconds):
+    """Format seconds as MM:SS."""
+    minutes = total_seconds // 60
+    secs = total_seconds % 60
+    return f"{minutes}:{secs:02d}"
+
+
+def generate_timings(sections, qa_minutes=0):
+    """Generate timing lines from sections list.
+
+    Args:
+        sections: list of (name, duration_seconds) tuples
+        qa_minutes: optional Q&A duration in minutes (added before FINISH)
+
+    Returns:
+        list of "MM:SS Label" strings
+    """
+    lines = []
+    cumulative = 0
+
+    for name, duration in sections:
+        lines.append(f"{format_seconds(cumulative)} {name}")
+        cumulative += duration
+
+    if qa_minutes > 0:
+        lines.append(f"{format_seconds(cumulative)} Q&A")
+        cumulative += qa_minutes * 60
+
+    lines.append(f"{format_seconds(cumulative)} FINISH")
+    return lines
+
+
+# --- Main ---
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate timemytalk.app timing file from a presentation outline.",
+        epilog="Produces MM:SS chapter lines for timemytalk.app timer.",
+    )
+    parser.add_argument("outline", help="Path to presentation-outline.md")
+    parser.add_argument("--qa", type=float, default=0,
+                        help="Q&A duration in minutes to add before FINISH")
+    parser.add_argument("--output", "-o",
+                        help="Output path (default: stdout)")
+
+    args = parser.parse_args()
+
+    with open(args.outline, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    # Parse pacing summary table
+    pacing = parse_pacing_table(text)
+
+    if not pacing:
+        print("WARNING: No pacing summary table found in outline.", file=sys.stderr)
+        # Emit a minimal FINISH-only output
+        output = "0:00 FINISH\n"
+    else:
+        # Parse section headers for subdivision
+        headers = parse_section_headers(text)
+
+        # Subdivide long acts
+        sections = subdivide_long_acts(pacing, headers)
+
+        # Generate timing lines
+        lines = generate_timings(sections, qa_minutes=args.qa)
+        output = "\n".join(lines) + "\n"
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output)
+        print(f"Timings written to {args.output}", file=sys.stderr)
+    else:
+        sys.stdout.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/presentation-creator/scripts/generate-talk-timings.py
+++ b/skills/presentation-creator/scripts/generate-talk-timings.py
@@ -12,7 +12,7 @@ Usage:
     python3 generate-talk-timings.py <outline.md> --output timings.txt
 
 Requires:
-    - Python 3.7+ (stdlib only -- no pip install needed)
+    - Python 3.10+ (stdlib only -- no pip install needed)
 """
 
 import argparse
@@ -273,7 +273,7 @@ def main():
     pacing = parse_pacing_table(text)
 
     if not pacing:
-        print("WARNING: No pacing summary table found in outline.", file=sys.stderr)
+        print("WARNING: No usable pacing rows found in outline (table missing or all rows empty).", file=sys.stderr)
         # Emit a minimal FINISH-only output
         output = "0:00 FINISH\n"
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,13 @@ def export_pdf():
     return _import_script(os.path.join(SCRIPTS_PC, "export-pdf.py"), "export_pdf")
 
 
+@pytest.fixture(scope="session")
+def generate_talk_timings():
+    return _import_script(
+        os.path.join(SCRIPTS_PC, "generate-talk-timings.py"), "generate_talk_timings"
+    )
+
+
 # ── PPTX fixture builders ────────────────────────────────────────────
 
 NS_P = "http://schemas.openxmlformats.org/presentationml/2006/main"

--- a/tests/test_generate_talk_timings.py
+++ b/tests/test_generate_talk_timings.py
@@ -1,0 +1,180 @@
+"""Tests for generate-talk-timings.py — timemytalk.app timer generation."""
+
+
+OUTLINE_WITH_PACING = """\
+# Presentation Outline
+
+## Opening [3 min, slides 1-3]
+
+### Slide 1: Title
+- Speaker: Welcome everyone!
+
+### Slide 2: Agenda
+- Speaker: Here's what we'll cover.
+
+## Act 1: The Challenge [5 min, slides 4-8]
+
+### Slide 4: Problem Statement
+- Speaker: Let me set the scene.
+
+## Act 2: The Journey [12 min, slides 9-20]
+
+### Slide 9: Step One
+- Speaker: First we need to understand...
+
+## Coda [5 min, slides 21-25]
+
+### Slide 21: Summary
+- Speaker: Let's wrap up.
+
+## Pacing Summary
+
+| Section | Duration |
+|---------|----------|
+| Opening | 3 min |
+| Act 1: The Challenge | 5 min |
+| Act 2: The Journey | 12 min |
+| Coda | 5 min |
+| **Total** | **25 min** |
+"""
+
+
+OUTLINE_SUBMUNITE = """\
+## Pacing Summary
+
+| Section | Duration |
+|---------|----------|
+| Intro | 1:30 min |
+| Main | 3 min |
+| Outro | :30 min |
+"""
+
+
+OUTLINE_EMPTY_PACING = """\
+# Presentation Outline
+
+## Pacing Summary
+
+| Section | Duration |
+|---------|----------|
+| **Total** | **0 min** |
+"""
+
+OUTLINE_NO_PACING = """\
+# Presentation Outline
+
+## Opening [3 min, slides 1-3]
+
+Just an outline with no pacing table at all.
+"""
+
+
+def test_parse_pacing_table(generate_talk_timings):
+    """Pacing summary table is parsed into section/duration pairs."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_WITH_PACING)
+    names = [name for name, _ in sections]
+    assert "Opening" in names
+    assert "Act 1: The Challenge" in names
+    assert "Act 2: The Journey" in names
+    assert "Coda" in names
+    assert len(sections) == 4
+
+
+def test_pacing_durations_correct(generate_talk_timings):
+    """Durations are parsed correctly as seconds."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_WITH_PACING)
+    dur_map = {name: dur for name, dur in sections}
+    assert dur_map["Opening"] == 180       # 3 min
+    assert dur_map["Act 1: The Challenge"] == 300   # 5 min
+    assert dur_map["Act 2: The Journey"] == 720     # 12 min
+    assert dur_map["Coda"] == 300           # 5 min
+
+
+def test_cumulative_times(generate_talk_timings):
+    """Timing lines use cumulative start times."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_WITH_PACING)
+    lines = generate_talk_timings.generate_timings(sections)
+    assert lines[0] == "0:00 Opening"
+    assert lines[1] == "3:00 Act 1: The Challenge"
+    assert lines[2] == "8:00 Act 2: The Journey"
+    assert lines[3] == "20:00 Coda"
+    assert lines[4] == "25:00 FINISH"
+
+
+def test_finish_equals_total(generate_talk_timings):
+    """FINISH time equals the sum of all section durations."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_WITH_PACING)
+    lines = generate_talk_timings.generate_timings(sections)
+    total_seconds = sum(dur for _, dur in sections)
+    expected_finish = generate_talk_timings.format_seconds(total_seconds)
+    assert lines[-1] == f"{expected_finish} FINISH"
+
+
+def test_qa_flag_adds_chapter(generate_talk_timings):
+    """--qa flag adds a Q&A chapter before FINISH."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_WITH_PACING)
+    lines = generate_talk_timings.generate_timings(sections, qa_minutes=5)
+    # Q&A should be second-to-last
+    assert "Q&A" in lines[-2]
+    assert lines[-2] == "25:00 Q&A"
+    # FINISH should account for Q&A
+    assert lines[-1] == "30:00 FINISH"
+
+
+def test_empty_pacing_table(generate_talk_timings):
+    """Empty pacing table (only total row) produces empty sections list."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_EMPTY_PACING)
+    assert sections == []
+
+
+def test_no_pacing_table(generate_talk_timings):
+    """Outline without pacing summary returns empty sections list."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_NO_PACING)
+    assert sections == []
+
+
+def test_subminute_resolution(generate_talk_timings):
+    """Sub-minute durations like 1:30 and :30 are parsed correctly."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_SUBMUNITE)
+    dur_map = {name: dur for name, dur in sections}
+    assert dur_map["Intro"] == 90    # 1:30
+    assert dur_map["Main"] == 180    # 3 min
+    assert dur_map["Outro"] == 30    # :30
+
+
+def test_subminute_cumulative_times(generate_talk_timings):
+    """Cumulative times handle sub-minute sections correctly."""
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_SUBMUNITE)
+    lines = generate_talk_timings.generate_timings(sections)
+    assert lines[0] == "0:00 Intro"
+    assert lines[1] == "1:30 Main"
+    assert lines[2] == "4:30 Outro"
+    assert lines[3] == "5:00 FINISH"
+
+
+def test_format_seconds(generate_talk_timings):
+    """format_seconds produces MM:SS strings."""
+    assert generate_talk_timings.format_seconds(0) == "0:00"
+    assert generate_talk_timings.format_seconds(90) == "1:30"
+    assert generate_talk_timings.format_seconds(300) == "5:00"
+    assert generate_talk_timings.format_seconds(1500) == "25:00"
+    assert generate_talk_timings.format_seconds(3600) == "60:00"
+
+
+def test_parse_section_headers(generate_talk_timings):
+    """Section headers with [N min, slides X-Y] are parsed."""
+    headers = generate_talk_timings.parse_section_headers(OUTLINE_WITH_PACING)
+    names = [name for name, _ in headers]
+    assert "Opening" in names
+    assert "Act 1: The Challenge" in names
+    assert "Act 2: The Journey" in names
+    assert "Coda" in names
+
+
+def test_generate_timings_returns_list(generate_talk_timings):
+    """generate_timings returns a list of strings."""
+    sections = [("Intro", 120), ("Main", 300)]
+    lines = generate_talk_timings.generate_timings(sections)
+    assert isinstance(lines, list)
+    assert all(isinstance(l, str) for l in lines)
+    assert len(lines) == 3  # 2 sections + FINISH

--- a/tests/test_generate_talk_timings.py
+++ b/tests/test_generate_talk_timings.py
@@ -39,7 +39,7 @@ OUTLINE_WITH_PACING = """\
 """
 
 
-OUTLINE_SUBMUNITE = """\
+OUTLINE_SUBMINUTE = """\
 ## Pacing Summary
 
 | Section | Duration |
@@ -135,7 +135,7 @@ def test_no_pacing_table(generate_talk_timings):
 
 def test_subminute_resolution(generate_talk_timings):
     """Sub-minute durations like 1:30 and :30 are parsed correctly."""
-    sections = generate_talk_timings.parse_pacing_table(OUTLINE_SUBMUNITE)
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_SUBMINUTE)
     dur_map = {name: dur for name, dur in sections}
     assert dur_map["Intro"] == 90    # 1:30
     assert dur_map["Main"] == 180    # 3 min
@@ -144,7 +144,7 @@ def test_subminute_resolution(generate_talk_timings):
 
 def test_subminute_cumulative_times(generate_talk_timings):
     """Cumulative times handle sub-minute sections correctly."""
-    sections = generate_talk_timings.parse_pacing_table(OUTLINE_SUBMUNITE)
+    sections = generate_talk_timings.parse_pacing_table(OUTLINE_SUBMINUTE)
     lines = generate_talk_timings.generate_timings(sections)
     assert lines[0] == "0:00 Intro"
     assert lines[1] == "1:30 Main"
@@ -178,3 +178,28 @@ def test_generate_timings_returns_list(generate_talk_timings):
     assert isinstance(lines, list)
     assert all(isinstance(l, str) for l in lines)
     assert len(lines) == 3  # 2 sections + FINISH
+
+
+def test_subdivide_preserves_total(generate_talk_timings):
+    """Subdivided durations sum exactly to the original pacing duration."""
+    pacing = [("Long Act", 600)]  # 10 min, above 5-min threshold
+    headers = [("Long Act Part A", 180), ("Long Act Part B", 420)]
+    result = generate_talk_timings.subdivide_long_acts(pacing, headers)
+    assert len(result) == 2
+    assert sum(d for _, d in result) == 600
+
+
+def test_subdivide_short_act_unchanged(generate_talk_timings):
+    """Acts under the threshold are not subdivided."""
+    pacing = [("Short Act", 240)]  # 4 min, under threshold
+    headers = [("Short Act Part A", 120), ("Short Act Part B", 120)]
+    result = generate_talk_timings.subdivide_long_acts(pacing, headers)
+    assert len(result) == 1
+    assert result[0] == ("Short Act", 240)
+
+
+def test_subdivide_no_headers(generate_talk_timings):
+    """Without section headers, pacing is returned unchanged."""
+    pacing = [("Act", 600)]
+    result = generate_talk_timings.subdivide_long_acts(pacing, [])
+    assert result == [("Act", 600)]


### PR DESCRIPTION
## Summary

- **New script** `skills/presentation-creator/scripts/generate-talk-timings.py` — parses the `## Pacing Summary` table from `presentation-outline.md` and emits cumulative `MM:SS Label` timing lines for [timemytalk.app](https://timemytalk.app)
- **`--qa MINUTES` flag** adds a Q&A chapter before FINISH when the talk slot includes Q&A time
- **Sub-minute resolution** supported (`:30`, `1:30` duration formats)
- **Auto-subdivision** of acts exceeding ~5 min using `## Section` headers for finer chapter granularity
- **Phase 6 docs updated** with new Step 6.4 "Talk Timer Artifact" section (profile-gated via `talk_timer` config), subsequent steps renumbered, publishing report template updated
- **12 passing tests** covering pacing table parsing, cumulative time calculation, Q&A insertion, empty/missing table handling, sub-minute resolution, and section header parsing
- **Test fixture** added to `tests/conftest.py`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)