### PR TITLE
fix(presentation-creator): insert placeholders at declared positions

### DIFF
--- a/skills/presentation-creator/scripts/insert-placeholder-slides.py
+++ b/skills/presentation-creator/scripts/insert-placeholder-slides.py
@@ -16,8 +16,16 @@ The JSON file format (multiple slides):
         {"position": 16, "title": "Cost Curves",       "subtitle": "MIT SSRN paper visualization"}
     ]
 
-Positions are 1-indexed (final slide number after all insertions). Slides are inserted
-from highest position to lowest so earlier inserts don't shift later targets.
+Positions are 1-indexed (final slide number after all insertions) and must be distinct.
+Slides are inserted from lowest position to highest so every move target stays within
+the current deck bounds (Python's list.insert silently clamps out-of-range indices).
+
+The title is auto-prefixed with "[PLACEHOLDER] "; if the JSON title already starts
+with that prefix (any case), the script does not double-prefix.
+
+If the target template has no layout named "Blank", the script falls back to the last
+layout and warns. Use --blank-layout-name to override when the last layout carries
+decorative shapes that would appear behind the yellow placeholder.
 
 Requires:
     - python-pptx  (pip install python-pptx)
@@ -36,17 +44,35 @@ YELLOW = RGBColor(0xFF, 0xF2, 0x9E)
 TITLE_COLOR = RGBColor(0x20, 0x20, 0x20)
 SUBTITLE_COLOR = RGBColor(0x40, 0x40, 0x40)
 
+PLACEHOLDER_PREFIX = "[PLACEHOLDER] "
 
-def add_placeholder_slide(prs, title, subtitle=""):
-    """Append a yellow placeholder slide with title and optional subtitle."""
-    blank_layout = None
+
+def _format_title(title):
+    """Prepend '[PLACEHOLDER] ' unless the caller already included it."""
+    stripped = title.lstrip()
+    if stripped.lower().startswith(PLACEHOLDER_PREFIX.lower()):
+        return stripped
+    return PLACEHOLDER_PREFIX + title
+
+
+def _find_blank_layout(prs, preferred_name="Blank"):
+    """Return (layout, used_fallback) — warns once in the caller if fallback was used."""
     for layout in prs.slide_layouts:
-        if layout.name == "Blank":
-            blank_layout = layout
-            break
-    if blank_layout is None:
-        print("  WARNING: No 'Blank' layout found, using last layout", file=sys.stderr)
-        blank_layout = prs.slide_layouts[-1]
+        if layout.name == preferred_name:
+            return layout, False
+    return prs.slide_layouts[-1], True
+
+
+def add_placeholder_slide(prs, title, subtitle="", blank_layout_name="Blank"):
+    """Append a yellow placeholder slide with title and optional subtitle."""
+    blank_layout, used_fallback = _find_blank_layout(prs, blank_layout_name)
+    if used_fallback:
+        print(
+            f"  WARNING: No '{blank_layout_name}' layout found — using last layout "
+            f"'{blank_layout.name}'. Any decorative shapes on that layout will appear "
+            f"behind the placeholder. Pass --blank-layout-name to choose a different layout.",
+            file=sys.stderr,
+        )
 
     slide = prs.slides.add_slide(blank_layout)
     sw, sh = prs.slide_width, prs.slide_height
@@ -64,7 +90,7 @@ def add_placeholder_slide(prs, title, subtitle=""):
     p = tf.paragraphs[0]
     p.alignment = PP_ALIGN.CENTER
     run = p.add_run()
-    run.text = f"[PLACEHOLDER] {title}"
+    run.text = _format_title(title)
     run.font.size = Pt(44)
     run.font.bold = True
     run.font.color.rgb = TITLE_COLOR
@@ -104,6 +130,12 @@ def main():
     parser.add_argument("--title", nargs="*", help="Title(s) for --at mode")
     parser.add_argument("--subtitle", nargs="*", help="Subtitle(s) for --at mode")
     parser.add_argument("--output", "-o", help="Output path (default: overwrite input)")
+    parser.add_argument(
+        "--blank-layout-name",
+        default="Blank",
+        help="Slide layout name to use for placeholders (default: 'Blank'). "
+             "Override when the template's last layout carries decorative shapes.",
+    )
     args = parser.parse_args()
 
     if args.json_file:
@@ -133,24 +165,35 @@ def main():
     total_after = original_count + len(placeholders)
     print(f"Opened {args.deck}: {original_count} slides")
 
-    # Validate positions
+    # Validate positions: in range and distinct
+    seen = set()
     for ph in placeholders:
         pos = ph["position"]
         if pos < 1 or pos > total_after:
             print(f"ERROR: position {pos} out of range (1..{total_after})", file=sys.stderr)
             sys.exit(1)
+        if pos in seen:
+            print(
+                f"ERROR: duplicate position {pos} — 'final position after all insertions' "
+                f"must be unique per placeholder",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        seen.add(pos)
 
-    # Insert from highest position to lowest so earlier inserts don't shift later targets.
-    # Each placeholder is appended to the end, then immediately moved to its target position.
-    for ph in sorted(placeholders, key=lambda x: x["position"], reverse=True):
+    # Insert from lowest position to highest. Each iteration appends one placeholder,
+    # growing the deck by one, then moves it to position-1. With distinct positions
+    # sorted ascending, position[i] <= original_count + i + 1 is guaranteed, so the
+    # move target is always within bounds (avoiding Python's list.insert clamp).
+    for ph in sorted(placeholders, key=lambda x: x["position"]):
         title = ph["title"]
         subtitle = ph.get("subtitle", "")
         position = ph["position"]
 
-        add_placeholder_slide(prs, title, subtitle)
+        add_placeholder_slide(prs, title, subtitle, blank_layout_name=args.blank_layout_name)
         last_idx = len(prs.slides) - 1
         move_slide(prs, last_idx, position - 1)
-        print(f"  Inserted [PLACEHOLDER] {title} at position {position}")
+        print(f"  Inserted {_format_title(title)} at position {position}")
 
     output_path = args.output or args.deck
     prs.save(output_path)

--- a/skills/presentation-creator/scripts/insert-placeholder-slides.py
+++ b/skills/presentation-creator/scripts/insert-placeholder-slides.py
@@ -48,10 +48,15 @@ PLACEHOLDER_PREFIX = "[PLACEHOLDER] "
 
 
 def _format_title(title):
-    """Prepend '[PLACEHOLDER] ' unless the caller already included it."""
-    stripped = title.lstrip()
-    if stripped.lower().startswith(PLACEHOLDER_PREFIX.lower()):
-        return stripped
+    """Prepend '[PLACEHOLDER] ' unless the title already starts with it
+    (case-insensitive, tolerating leading whitespace).
+
+    Always returns the original `title` when the prefix is already present —
+    leading whitespace is preserved either way, so behavior is independent of
+    whether the caller pre-prefixed or not.
+    """
+    if title.lstrip().lower().startswith(PLACEHOLDER_PREFIX.lower()):
+        return title
     return PLACEHOLDER_PREFIX + title
 
 
@@ -63,16 +68,24 @@ def _find_blank_layout(prs, preferred_name="Blank"):
     return prs.slide_layouts[-1], True
 
 
-def add_placeholder_slide(prs, title, subtitle="", blank_layout_name="Blank"):
-    """Append a yellow placeholder slide with title and optional subtitle."""
-    blank_layout, used_fallback = _find_blank_layout(prs, blank_layout_name)
-    if used_fallback:
-        print(
-            f"  WARNING: No '{blank_layout_name}' layout found — using last layout "
-            f"'{blank_layout.name}'. Any decorative shapes on that layout will appear "
-            f"behind the placeholder. Pass --blank-layout-name to choose a different layout.",
-            file=sys.stderr,
-        )
+def add_placeholder_slide(prs, title, subtitle="", blank_layout_name="Blank",
+                          blank_layout=None):
+    """Append a yellow placeholder slide with title and optional subtitle.
+
+    `blank_layout` (optional) — pre-resolved slide layout. When provided,
+    skips the in-function lookup and the fallback warning. The CLI resolves
+    once before the insertion loop and threads the result through to avoid
+    spamming stderr on batch inserts.
+    """
+    if blank_layout is None:
+        blank_layout, used_fallback = _find_blank_layout(prs, blank_layout_name)
+        if used_fallback:
+            print(
+                f"  WARNING: No '{blank_layout_name}' layout found — using last layout "
+                f"'{blank_layout.name}'. Any decorative shapes on that layout will appear "
+                f"behind the placeholder. Pass --blank-layout-name to choose a different layout.",
+                file=sys.stderr,
+            )
 
     slide = prs.slides.add_slide(blank_layout)
     sw, sh = prs.slide_width, prs.slide_height
@@ -181,6 +194,17 @@ def main():
             sys.exit(1)
         seen.add(pos)
 
+    # Resolve the layout once and warn at most once if we fall back, instead
+    # of warning per-insertion (which spams stderr on batch inserts).
+    blank_layout, used_fallback = _find_blank_layout(prs, args.blank_layout_name)
+    if used_fallback:
+        print(
+            f"  WARNING: No '{args.blank_layout_name}' layout found — using last layout "
+            f"'{blank_layout.name}'. Any decorative shapes on that layout will appear "
+            f"behind the placeholder. Pass --blank-layout-name to choose a different layout.",
+            file=sys.stderr,
+        )
+
     # Insert from lowest position to highest. Each iteration appends one placeholder,
     # growing the deck by one, then moves it to position-1. With distinct positions
     # sorted ascending, position[i] <= original_count + i + 1 is guaranteed, so the
@@ -190,7 +214,7 @@ def main():
         subtitle = ph.get("subtitle", "")
         position = ph["position"]
 
-        add_placeholder_slide(prs, title, subtitle, blank_layout_name=args.blank_layout_name)
+        add_placeholder_slide(prs, title, subtitle, blank_layout=blank_layout)
         last_idx = len(prs.slides) - 1
         move_slide(prs, last_idx, position - 1)
         print(f"  Inserted {_format_title(title)} at position {position}")

--- a/tests/test_insert_placeholder.py
+++ b/tests/test_insert_placeholder.py
@@ -1,9 +1,20 @@
 """Tests for insert-placeholder-slides.py — placeholder slide insertion."""
 
+import json
+import os
+import subprocess
+import sys
+
 from pptx import Presentation
 from pptx.dml.color import RGBColor
 
-from conftest import make_deck
+from conftest import make_deck, SCRIPTS_PC
+
+SCRIPT = os.path.join(SCRIPTS_PC, "insert-placeholder-slides.py")
+
+
+def _slide_texts(slide):
+    return [s.text_frame.text for s in slide.shapes if s.has_text_frame]
 
 
 def test_yellow_background(insert_placeholder, tmp_path):
@@ -92,3 +103,97 @@ def test_output_flag(insert_placeholder, tmp_path):
     assert len(Presentation(original).slides) == 3
     # Output has the new slide
     assert len(Presentation(output).slides) == 4
+
+
+def test_title_not_double_prefixed(insert_placeholder):
+    """A title that already starts with '[PLACEHOLDER] ' must not be re-prefixed."""
+    prs = make_deck(1)
+    slide = insert_placeholder.add_placeholder_slide(prs, "[PLACEHOLDER] Foo")
+    texts = _slide_texts(slide)
+    assert any(t == "[PLACEHOLDER] Foo" for t in texts)
+    assert not any("[PLACEHOLDER] [PLACEHOLDER]" in t for t in texts)
+
+
+def test_format_title_helper(insert_placeholder):
+    """The title formatter prepends the prefix only when missing."""
+    f = insert_placeholder._format_title
+    assert f("Foo") == "[PLACEHOLDER] Foo"
+    assert f("[PLACEHOLDER] Foo") == "[PLACEHOLDER] Foo"
+    # Case-insensitive: already-prefixed in lowercase should not double-prefix.
+    assert f("[placeholder] foo") == "[placeholder] foo"
+
+
+def _run_cli(deck_path, json_path):
+    """Invoke the script as a subprocess so argparse and stderr behave realistically."""
+    return subprocess.run(
+        [sys.executable, SCRIPT, deck_path, json_path],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_positions_land_at_declared_finals(tmp_path):
+    """Regression for #18: high positions must land at their declared final positions,
+    not silently append because list.insert clamped an out-of-range index."""
+    prs = make_deck(8)
+    deck = str(tmp_path / "deck.pptx")
+    prs.save(deck)
+
+    # Original length 8, 4 placeholders at final positions 2, 6, 11, 12 (total_after=12).
+    # Pre-fix with high-to-low iteration, positions 11 and 12 landed at wrong indexes.
+    spec = [
+        {"position": 2,  "title": "A", "subtitle": ""},
+        {"position": 6,  "title": "B", "subtitle": ""},
+        {"position": 11, "title": "C", "subtitle": ""},
+        {"position": 12, "title": "D", "subtitle": ""},
+    ]
+    spec_path = str(tmp_path / "spec.json")
+    with open(spec_path, "w") as f:
+        json.dump(spec, f)
+
+    result = _run_cli(deck, spec_path)
+    assert result.returncode == 0, result.stderr
+
+    final = Presentation(deck)
+    assert len(final.slides) == 12
+
+    # Each placeholder's title should appear at its declared 1-indexed position.
+    for entry in spec:
+        idx = entry["position"] - 1
+        texts = _slide_texts(final.slides[idx])
+        assert any(f"[PLACEHOLDER] {entry['title']}" in t for t in texts), (
+            f"expected '{entry['title']}' at position {entry['position']}, "
+            f"got texts {texts}"
+        )
+
+
+def test_cli_rejects_duplicate_positions(tmp_path):
+    prs = make_deck(3)
+    deck = str(tmp_path / "deck.pptx")
+    prs.save(deck)
+
+    spec_path = str(tmp_path / "spec.json")
+    with open(spec_path, "w") as f:
+        json.dump([
+            {"position": 2, "title": "A", "subtitle": ""},
+            {"position": 2, "title": "B", "subtitle": ""},
+        ], f)
+
+    result = _run_cli(deck, spec_path)
+    assert result.returncode != 0
+    assert "duplicate position" in result.stderr
+
+
+def test_cli_rejects_out_of_range(tmp_path):
+    prs = make_deck(3)
+    deck = str(tmp_path / "deck.pptx")
+    prs.save(deck)
+
+    spec_path = str(tmp_path / "spec.json")
+    with open(spec_path, "w") as f:
+        # Original 3 + 1 placeholder = total_after 4; position 99 is out of range.
+        json.dump([{"position": 99, "title": "A", "subtitle": ""}], f)
+
+    result = _run_cli(deck, spec_path)
+    assert result.returncode != 0
+    assert "out of range" in result.stderr

--- a/tests/test_insert_placeholder.py
+++ b/tests/test_insert_placeholder.py
@@ -10,7 +10,7 @@ from pptx.dml.color import RGBColor
 
 from conftest import make_deck, SCRIPTS_PC
 
-SCRIPT = os.path.join(SCRIPTS_PC, "insert-placeholder-slides.py")
+SCRIPT = os.path.abspath(os.path.join(SCRIPTS_PC, "insert-placeholder-slides.py"))
 
 
 def _slide_texts(slide):
@@ -121,6 +121,17 @@ def test_format_title_helper(insert_placeholder):
     assert f("[PLACEHOLDER] Foo") == "[PLACEHOLDER] Foo"
     # Case-insensitive: already-prefixed in lowercase should not double-prefix.
     assert f("[placeholder] foo") == "[placeholder] foo"
+
+
+def test_format_title_preserves_leading_whitespace(insert_placeholder):
+    """Leading whitespace must be preserved consistently regardless of whether
+    the prefix is already present — earlier behavior stripped only on the
+    already-prefixed branch."""
+    f = insert_placeholder._format_title
+    # Already prefixed with leading whitespace — return as-is, don't strip.
+    assert f("  [PLACEHOLDER] Foo") == "  [PLACEHOLDER] Foo"
+    # Not prefixed with leading whitespace — prepend, don't strip the input.
+    assert f("  Foo") == "[PLACEHOLDER]   Foo"
 
 
 def _run_cli(deck_path, json_path):


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

`scripts/insert-placeholder-slides.py` silently dropped high-position placeholders at the end of the deck instead of landing them at the positions the JSON declared. Root cause: Python's `list.insert(idx, x)` clamps out-of-range indices to the end of the list, and the script's high-to-low iteration combined with "position = final-after-all-insertions" semantics meant the first few moves targeted indices the deck hadn't grown into yet.

Fixes #18.

## What changed

- **Switch iteration to low-to-high.** With distinct positions sorted ascending, the invariant `position[i] ≤ original_count + i + 1` holds at every step (proof in the script's docstring), so every `list.insert` target is in range.
- **Reject duplicate positions up front.** "Final position after all insertions" is ambiguous when two placeholders both claim the same final slot.
- **Don't double-prefix titles.** A JSON title that already starts with `[PLACEHOLDER]` (any case) is left as-is, instead of becoming `[PLACEHOLDER] [PLACEHOLDER] Foo`.
- **Add `--blank-layout-name`.** Override the layout fallback when the template's last layout carries decorative shapes (e.g., comic-template speech bubbles) that would otherwise appear behind the yellow placeholder.

## Tests

- New regression test `test_cli_positions_land_at_declared_finals` — replays the exact failure mode from #18 (positions exceeding `current_deck_length + 1` at insertion time) and asserts each placeholder lands at its declared position.
- New tests for the duplicate-position guard, out-of-range guard, double-prefix guard, and the `_format_title` helper.
- All 12 placeholder tests pass; full suite was 161/166 before this PR (+5 thumbnail aesthetic tests landing in PR 2).

## Test plan

- [ ] CI: tests workflow green
- [ ] CI: `PR Policy Review (OpenAI)` posts a verdict (cross-family from claude-author)
- [ ] CI: `PR Policy Review (Anthropic)` self-skips with the cross-family-bias message
- [ ] Spot-check the CLI on a real deck once merged: `insert-placeholder-slides.py deck.pptx positions.json` with positions including some near the end of the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)