### PR TITLE
docs(vault-skills): promote post-processing steps and renumber

### DIFF
--- a/evals/clarification-interactive-session/task.md
+++ b/evals/clarification-interactive-session/task.md
@@ -2,15 +2,7 @@
 
 ## Problem/Feature Description
 
-One talk ("Robocoders: Judgment Day") has been processed through vault-ingress. The automated analysis identified rhetoric patterns, humor beats, and blind spots. Now a clarification session is needed to:
-
-1. Clarify surprising patterns (the delayed self-introduction — was it intentional?)
-2. Conduct a humor post-mortem (grade each joke, capture spontaneous moments)
-3. Probe blind spots (demo engagement, theatrical opening, Q&A room dynamics)
-4. Capture speaker infrastructure config (first session — all config fields are empty)
-5. Store confirmed intents and mark the session complete
-
-This is the speaker's first clarification session (`clarification_sessions_completed: 0`), so infrastructure config capture (Step 4) is required.
+One talk ("Robocoders: Judgment Day") has been processed through vault-ingress. The automated analysis identified rhetoric patterns, humor beats, and blind spots that the transcript and slides alone cannot fully resolve. The vault is in its initial state — all infrastructure config fields are empty (`config.clarification_sessions_completed: 0`).
 
 ## Setup
 
@@ -23,36 +15,14 @@ curl -sLO https://github.com/jbaruch/speaker-toolkit/raw/main/eval-resources/sce
 
 ## Task
 
-Run a clarification session on the processed talk. The session must cover all six steps from the vault-clarification skill:
+The speaker has just delivered "Robocoders: Judgment Day". The vault has automated observations that need human input before they can be used downstream:
 
-### Step 1: Rhetoric Clarification
-- The analysis flagged `delayed_self_introduction` as surprising. Ask the speaker whether this is deliberate, accidental, or context-dependent.
-- Ask ONE question at a time, not a batch.
+- The `delayed_self_introduction` pattern was flagged as surprising — the analysis can't tell whether it was deliberate or accidental.
+- Four humor beats were detected, plus an 8-second transcript gap after slide 15 that may indicate an off-script moment.
+- The demo section (slides 14-16), theatrical opening (slides 1-2), and Q&A section (slides 30-31) have content the transcript can't capture: audience reactions, stage effects, room dynamics.
+- This is the speaker's first session — `config.clarification_sessions_completed: 0` and infrastructure config fields are empty.
 
-### Step 2: Blind Spot Probing
-- For the demo section (slides 14-16): ask about audience engagement during live coding
-- For the theatrical opening (slides 1-2): ask about any stage effects tied to "Judgment Day"
-- For the Q&A section (slides 30-31): ask about room dynamics when speaker moved from mic
-
-### Step 3: Humor Post-Mortem
-- Walk through each of the 4 identified humor beats and ask if they landed
-- Grade each with: `hit`, `nod`, `flat`, or `spontaneous_hit`
-- Specifically probe the transcript gap after slide 15 — was there an off-script moment?
-- Ask about spontaneous humor not captured in the transcript
-- For any spontaneous humor that landed well, recommend whether to promote it to a planned beat
-
-### Step 4: Infrastructure Config Capture
-Since `clarification_sessions_completed` is 0, ask for all empty config fields:
-- speaker_name, speaker_handle, speaker_website
-- shownotes_url_pattern, shownotes_slug_convention
-- template_pptx_path, presentation_file_convention
-- publishing_process details (export format, QR code settings, shortener)
-
-### Step 5: Structured Intent Capture
-- Store all confirmed intents in `confirmed_intents` array (at minimum, the delayed intro decision from Step 1)
-
-### Step 6: Mark Complete
-- Increment `clarification_sessions_completed` to 1
+Run the clarification needed to resolve those gaps and bring the vault to a state where downstream skills (vault-profile, presentation-creator) can rely on it.
 
 ## Output Specification
 

--- a/evals/clarification-interactive-session/task.md
+++ b/evals/clarification-interactive-session/task.md
@@ -10,7 +10,7 @@ One talk ("Robocoders: Judgment Day") has been processed through vault-ingress. 
 4. Capture speaker infrastructure config (first session — all config fields are empty)
 5. Store confirmed intents and mark the session complete
 
-This is the speaker's first clarification session (`clarification_sessions_completed: 0`), so infrastructure config capture (Step 5B) is required.
+This is the speaker's first clarification session (`clarification_sessions_completed: 0`), so infrastructure config capture (Step 4) is required.
 
 ## Setup
 
@@ -23,7 +23,7 @@ curl -sLO https://github.com/jbaruch/speaker-toolkit/raw/main/eval-resources/sce
 
 ## Task
 
-Run a clarification session on the processed talk. The session must cover all five steps from the vault-clarification skill:
+Run a clarification session on the processed talk. The session must cover all six steps from the vault-clarification skill:
 
 ### Step 1: Rhetoric Clarification
 - The analysis flagged `delayed_self_introduction` as surprising. Ask the speaker whether this is deliberate, accidental, or context-dependent.
@@ -48,9 +48,11 @@ Since `clarification_sessions_completed` is 0, ask for all empty config fields:
 - template_pptx_path, presentation_file_convention
 - publishing_process details (export format, QR code settings, shortener)
 
-### Step 5: Mark Complete
+### Step 5: Structured Intent Capture
+- Store all confirmed intents in `confirmed_intents` array (at minimum, the delayed intro decision from Step 1)
+
+### Step 6: Mark Complete
 - Increment `clarification_sessions_completed` to 1
-- Store all confirmed intents in `confirmed_intents` array
 
 ## Output Specification
 

--- a/evals/summary_infeasible.json
+++ b/evals/summary_infeasible.json
@@ -7,9 +7,9 @@
       "reasoning": "Requires downloading real YouTube transcripts (yt-dlp/youtube-transcript-api) and Google Drive PDFs (gdown) with real URLs. Network services may be unavailable, rate-limited, or return different content. Cannot guarantee reproducible results within 10-minute timeout."
     },
     {
-      "scenarios": "Interactive clarification session (Step 5)",
-      "skill": "rhetoric-knowledge-vault",
-      "reasoning": "Step 5 requires multi-turn interactive conversation via AskUserQuestion to resolve ambiguities, validate findings, and capture speaker intent. The eval is one-shot with no user interaction available."
+      "scenarios": "Interactive clarification session",
+      "skill": "vault-clarification",
+      "reasoning": "The clarification skill requires multi-turn interactive conversation via AskUserQuestion to resolve ambiguities, validate findings, and capture speaker intent. The eval is one-shot with no user interaction available."
     },
     {
       "scenarios": "Parallel batch processing with 5 subagents",

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -12,6 +12,8 @@ user_invocable: true
 
 # Vault Clarification — Interactive Session
 
+Process the steps below in order; each step's output informs the next, and the first-session infrastructure capture in Step 4 gates profile generation downstream. Do not skip ahead.
+
 Run after vault-ingress has processed talks. Purpose: resolve ambiguities, validate
 findings, capture intent, and fill in speaker infrastructure config.
 
@@ -28,10 +30,6 @@ Read `tracking-database.json` from there to get `vault_root`.
 | [references/schemas-config.md](references/schemas-config.md) | Config fields + confirmed intents schema |
 | [references/humor-post-mortem.md](references/humor-post-mortem.md) | Protocol for grading humor effectiveness |
 | [references/blind-spot-moments.md](references/blind-spot-moments.md) | Protocol for capturing audience/room data |
-
-Process the steps below in order. Do not skip ahead — each step's output informs
-the next, and the first-session infrastructure capture in Step 4 gates profile
-generation downstream.
 
 ## Step 1 — Rhetoric Clarification
 

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -29,9 +29,11 @@ Read `tracking-database.json` from there to get `vault_root`.
 | [references/humor-post-mortem.md](references/humor-post-mortem.md) | Protocol for grading humor effectiveness |
 | [references/blind-spot-moments.md](references/blind-spot-moments.md) | Protocol for capturing audience/room data |
 
-## Workflow
+Process the steps below in order. Do not skip ahead — each step's output informs
+the next, and the first-session infrastructure capture in Step 4 gates profile
+generation downstream.
 
-### Step 5A: Rhetoric Clarification
+## Step 1 — Rhetoric Clarification
 
 For each surprising, contradictory, or ambiguous observation, ask one topic at a time
 via `AskUserQuestion`: intentional vs accidental patterns, invisible context,
@@ -50,22 +52,32 @@ AskUserQuestion(
 )
 ```
 
-### Step 5A-bis: Blind Spot Moments
+Proceed immediately to Step 2.
+
+## Step 2 — Blind Spot Moments
 
 Follow [references/blind-spot-moments.md](references/blind-spot-moments.md) — ask about audience reactions,
 physical performance, and room context that transcripts cannot capture.
 
-### Step 5A-ter: Humor Post-Mortem
+Proceed immediately to Step 3.
+
+## Step 3 — Humor Post-Mortem
 
 Follow [references/humor-post-mortem.md](references/humor-post-mortem.md) — walk through detected humor beats,
 grade effectiveness, capture spontaneous material.
 
-### Step 5B: Speaker Infrastructure (first session only)
+Proceed immediately to Step 4.
+
+## Step 4 — Speaker Infrastructure (first session only)
 
 Ask for any empty config fields (`speaker_name` through `publishing_process.*`).
 See [references/schemas-config.md](references/schemas-config.md) for the full field list and questions to ask.
 
-### Step 5C: Structured Intent Capture
+If `config.clarification_sessions_completed` is already ≥ 1, skip this step — infrastructure was captured in the first session.
+
+Proceed immediately to Step 5.
+
+## Step 5 — Structured Intent Capture
 
 Store confirmed intents in the `confirmed_intents` array of the tracking DB.
 Example:
@@ -79,12 +91,16 @@ Example:
 ```
 See [references/schemas-config.md](references/schemas-config.md) for the full schema.
 
-### Step 5D: Mark Session Complete
+Proceed immediately to Step 6.
+
+## Step 6 — Mark Session Complete
 
 Increment `config.clarification_sessions_completed` in the tracking DB. This counter
 gates profile generation (vault-profile skill requires >= 1).
 
-### Important Notes
+Finish here.
+
+## Important Notes
 
 - One topic at a time — don't dump all questions at once.
 - Update the summary and DB after each answer, not in a batch at the end.

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -70,10 +70,10 @@ Proceed immediately to Step 4.
 
 ## Step 4 — Speaker Infrastructure (first session only)
 
-Ask for any empty config fields (`speaker_name` through `publishing_process.*`).
-See [references/schemas-config.md](references/schemas-config.md) for the full field list and questions to ask.
+If `config.clarification_sessions_completed` is already ≥ 1, skip this step — infrastructure was captured in the first session. Proceed immediately to Step 5.
 
-If `config.clarification_sessions_completed` is already ≥ 1, skip this step — infrastructure was captured in the first session.
+Otherwise, ask for any empty config fields (`speaker_name` through `publishing_process.*`).
+See [references/schemas-config.md](references/schemas-config.md) for the full field list and questions to ask.
 
 Proceed immediately to Step 5.
 

--- a/skills/vault-clarification/references/blind-spot-moments.md
+++ b/skills/vault-clarification/references/blind-spot-moments.md
@@ -1,4 +1,4 @@
-## 5A-bis. Blind Spot Moments
+# Blind Spot Moments
 
 The skill can only analyze transcripts (speech) and
 slides (visuals). It CANNOT observe audience reactions, physical performance, stage

--- a/skills/vault-clarification/references/humor-post-mortem.md
+++ b/skills/vault-clarification/references/humor-post-mortem.md
@@ -1,4 +1,4 @@
-## 5A-ter. Humor Post-Mortem
+# Humor Post-Mortem
 
 The skill can identify jokes from transcripts and
 slides but CANNOT hear laughter. For every talk processed in this run, compile the

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -14,6 +14,8 @@ user_invocable: true
 
 # Vault Ingress — Incremental Talk Parser
 
+Process the steps below in order; each step's output (tracking DB state, batch results, per-talk artifacts) feeds the next. Do not skip ahead.
+
 Build a rhetoric and style knowledge base by analyzing presentation talks. Each run
 processes **unprocessed** talks, extracts rhetoric/style observations, and updates the
 running summary. The vault lives at `~/.claude/rhetoric-knowledge-vault/` (may be a
@@ -49,10 +51,7 @@ The `slide_source` field tracks which path: `"pptx"`, `"pdf"`, `"both"`,
 `"video_extracted"`, or `"none"`. The `pptx_catalog` array fuzzy-matches `.pptx`
 files to shownotes entries.
 
-Process the steps below in order. Do not skip ahead — each step's output
-(tracking DB state, batch results, per-talk artifacts) feeds the next.
-
-## Step 1 — Load State & Sync Sources
+## Step 1 — Bootstrap Vault State
 
 **Vault discovery** — canonical path is always `~/.claude/rhetoric-knowledge-vault/`.
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -97,7 +97,7 @@ Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
 
 ## Step 3 — Process Talks via Parallel Subagents (Batches of 5)
 
-Per batch: launch 5 subagents in parallel, wait, run Step 4 (Collect Results), then next batch. When all batches have finished, proceed to Step 5.
+Per batch: launch 5 subagents in parallel, wait, run Step 4 (Apply Subagent Results), then next batch. When all batches have finished, proceed to Step 5.
 Each subagent receives the talk's DB entry and current `rhetoric-style-summary.md`.
 
 #### Per-Talk Subagent Instructions:
@@ -192,10 +192,12 @@ Minimal structure:
 }
 ```
 
-## Step 4 — Collect Results & Update
+## Step 4 — Apply Subagent Results
 
 Runs after each batch inside Step 3's loop (not as a separate post-loop
-phase).
+phase). One action: take the subagent JSON returns from the batch and
+fold them into the tracking DB, per-talk analysis files, and the running
+rhetoric summary in a single atomic update.
 
 1. **Update tracking DB** — set `status`, `processed_date`, all result fields.
    Persist `pattern_observations` IDs + score. Populate structured fields
@@ -243,7 +245,7 @@ Proceed immediately to Step 6.
 
 ## Step 6 — Regenerate Speaker Profile
 
-If `{vault_root}/speaker-profile.json` exists, invoke the **vault-profile** skill
+If `{vault_root}/speaker-profile.json` exists, invoke `Skill(skill: "vault-profile")`
 with the updated tracking database. Report the diff of changes (added fields,
 changed values) so the speaker can verify.
 
@@ -253,12 +255,15 @@ Proceed immediately to Step 7.
 
 ## Step 7 — Same-Week Clarification Trigger
 
-Scan newly-processed talks for delivery date. For any talk whose `date` is within
-the past 7 days, explicitly recommend running **vault-clarification** NOW —
-memory of the delivery is freshest right after the talk, and verbal beats that
-didn't appear in auto-captions (bilingual jokes rendered in a non-primary
-language, improvised asides, fly-bys that weren't in the deck) need speaker
-confirmation while they're still recoverable.
+If no talks were newly processed in this run, finish here without further action.
+
+Otherwise, scan the newly-processed talks for delivery date. For any talk whose
+`date` is within the past 7 days, explicitly recommend running
+`Skill(skill: "vault-clarification")` NOW — memory of the delivery is freshest
+right after the talk, and verbal beats that didn't appear in auto-captions
+(bilingual jokes rendered in a non-primary language, improvised asides, fly-bys
+that weren't in the deck) need speaker confirmation while they're still
+recoverable.
 
 Surface these as candidate clarification topics in the recommendation:
 - Each per-talk `areas_for_improvement` entry.
@@ -270,9 +275,6 @@ For older talks (30+ days), recommend the compressed clarification session
 instead of the full one — memory has decayed and detailed recall is unreliable.
 For talks in the 7–30 day window, recommend the full session but note that some
 verbatim details may be lost.
-
-If no newly-processed talks fall inside any window, finish here without further
-action.
 
 ## Error Handling
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -49,9 +49,10 @@ The `slide_source` field tracks which path: `"pptx"`, `"pdf"`, `"both"`,
 `"video_extracted"`, or `"none"`. The `pptx_catalog` array fuzzy-matches `.pptx`
 files to shownotes entries.
 
-## Workflow
+Process the steps below in order. Do not skip ahead — each step's output
+(tracking DB state, batch results, per-talk artifacts) feeds the next.
 
-### Step 1: Load State & Sync Sources
+## Step 1 — Load State & Sync Sources
 
 **Vault discovery** — canonical path is always `~/.claude/rhetoric-knowledge-vault/`.
 
@@ -86,7 +87,7 @@ lack `pattern_observations` are marked `"needs-reprocessing"`.
 Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
 "X processed, Y remaining. PPTX: A cataloged, B matched, C extracted."
 
-### Step 2: Select Talks to Process
+## Step 2 — Select Talks to Process
 
 - Select talks with status `pending` or `needs-reprocessing`.
 - Set `slide_source` per the hierarchy above. Mark `"skipped_no_sources"` only if
@@ -94,9 +95,9 @@ Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
   regardless of whether slides exist.
 - If `$ARGUMENTS` specifies a talk filename or title, process ONLY that one.
 
-### Step 3: Process Talks — Parallel Subagents, Batches of 5
+## Step 3 — Process Talks via Parallel Subagents (Batches of 5)
 
-Per batch: launch 5 subagents in parallel, wait, run Step 4, then next batch.
+Per batch: launch 5 subagents in parallel, wait, run Step 4 (Collect Results), then next batch. When all batches have finished, proceed to Step 5.
 Each subagent receives the talk's DB entry and current `rhetoric-style-summary.md`.
 
 #### Per-Talk Subagent Instructions:
@@ -191,7 +192,37 @@ Minimal structure:
 }
 ```
 
-### Step 3B: Extract Remaining PPTX Visual Data
+## Step 4 — Collect Results & Update
+
+Runs after each batch inside Step 3's loop (not as a separate post-loop
+phase).
+
+1. **Update tracking DB** — set `status`, `processed_date`, all result fields.
+   Persist `pattern_observations` IDs + score. Populate structured fields
+   (`co_presenter`, `delivery_language`, etc.) — do not leave structured data buried
+   in free-text prose. See [references/processing-rules.md](references/processing-rules.md) for field extraction rules.
+2. **Write per-talk analysis files** — write
+   `{vault_root}/analyses/{talk_filename}.md` for each processed talk: all 14
+   dimensions, structured data, verbatim examples, and a "Presentation Patterns
+   Scoring" section. Create `analyses/` directory if missing.
+3. **Update rhetoric-style-summary.md** — integrate `new_patterns` and
+   `summary_updates`. Sections 1–14 map to the 14 dimensions; Section 15 aggregates
+   improvement areas; Section 16 captures speaker-confirmed intent. **Recount status
+   from the DB every time** — never increment manually.
+   **Speaker-review gate:** before applying any `summary_updates` or `new_patterns`
+   from a subagent, present the proposed changes (section-by-section diff) and wait
+   for explicit speaker confirmation. Silent application erodes the speaker's sense
+   of ownership of their own style summary; pattern taxonomy additions in particular
+   can drift if applied unreviewed. Only bypass the gate if the speaker has pre-
+   authorized this batch ("just apply everything, don't ask").
+4. **Report:** talks processed, new patterns, current state, skipped talks.
+5. Flag **structural changes** prominently (new presentation mode, new workflow pattern).
+
+When Step 3's batch loop finishes, proceed to Step 5.
+
+## Step 5 — Extract Remaining PPTX Visual Data
+
+Runs once after all Step 3 batches have completed.
 
 Process PPTX files not yet extracted during Step 3: unmatched catalog entries, talks
 that used PDF as primary but have a PPTX available, or entries with
@@ -208,28 +239,42 @@ files matching `config.template_skip_patterns`. Some talks have multiple .pptx f
 After 3+ extractions, populate `slide-design-spec.md`; after 5+, analyze cross-talk
 patterns (colors, fonts, footers).
 
-### Step 4: Collect Results & Update
+Proceed immediately to Step 6.
 
-After each batch:
+## Step 6 — Regenerate Speaker Profile
 
-1. **Update tracking DB** — set `status`, `processed_date`, all result fields.
-   Persist `pattern_observations` IDs + score. Populate structured fields
-   (`co_presenter`, `delivery_language`, etc.) — do not leave structured data buried
-   in free-text prose. See [references/processing-rules.md](references/processing-rules.md) for field extraction rules.
-2. **Write per-talk analysis files** — write
-   `{vault_root}/analyses/{talk_filename}.md` for each processed talk: all 14
-   dimensions, structured data, verbatim examples, and a "Presentation Patterns
-   Scoring" section. Create `analyses/` directory if missing.
-3. **Update rhetoric-style-summary.md** — integrate `new_patterns` and
-   `summary_updates`. Sections 1–14 map to the 14 dimensions; Section 15 aggregates
-   improvement areas; Section 16 captures speaker-confirmed intent. **Recount status
-   from the DB every time** — never increment manually.
-4. **Report:** talks processed, new patterns, current state, skipped talks.
-5. **Auto-regenerate speaker profile** (vault-profile skill) if it already exists.
-   Report the diff.
-6. Flag **structural changes** prominently (new presentation mode, new workflow pattern).
+If `{vault_root}/speaker-profile.json` exists, invoke the **vault-profile** skill
+with the updated tracking database. Report the diff of changes (added fields,
+changed values) so the speaker can verify.
 
-### Error Handling
+If the profile doesn't exist, skip this step silently.
+
+Proceed immediately to Step 7.
+
+## Step 7 — Same-Week Clarification Trigger
+
+Scan newly-processed talks for delivery date. For any talk whose `date` is within
+the past 7 days, explicitly recommend running **vault-clarification** NOW —
+memory of the delivery is freshest right after the talk, and verbal beats that
+didn't appear in auto-captions (bilingual jokes rendered in a non-primary
+language, improvised asides, fly-bys that weren't in the deck) need speaker
+confirmation while they're still recoverable.
+
+Surface these as candidate clarification topics in the recommendation:
+- Each per-talk `areas_for_improvement` entry.
+- Any `pattern_observations` the subagent flagged as **unverifiable from
+  transcript alone** (low confidence, heavy reliance on visual cues, non-English
+  dialogue without captions).
+
+For older talks (30+ days), recommend the compressed clarification session
+instead of the full one — memory has decayed and detailed recall is unreliable.
+For talks in the 7–30 day window, recommend the full session but note that some
+verbatim details may be lost.
+
+If no newly-processed talks fall inside any window, finish here without further
+action.
+
+## Error Handling
 
 | Transcript | Slides (PPTX/PDF) | Video | Status | Action |
 |-----------|-------------------|-------|--------|--------|
@@ -240,14 +285,12 @@ After each batch:
 | FAIL | FAIL | OK | `processed_partial` | Extract slides from video, visual only |
 | FAIL | FAIL | FAIL | `skipped_download_failed` | Skip, move on |
 
-### Important Notes
+## Important Notes
 
 - Create `transcripts/`, `slides/`, `analyses/` dirs if missing.
 - Re-read tracking DB before writing (single source of truth).
 - Preserve all summary content — add/refine, never delete.
 - After 10+ talks, start providing adherence assessments.
-- After processing, if `speaker-profile.json` exists, suggest running the
-  **vault-profile** skill to regenerate it with updated data.
 - **Wide-angle room recordings** defeat perceptual hash dedup — when the camera
   captures the full stage (speaker moving + slides on screen behind), every frame
   looks different. Mitigate by: increasing `--threshold` to 14-16, manually specifying
@@ -261,6 +304,3 @@ After each batch:
 - **Non-speaker talks slip into playlists.** Verify speaker identity early — check
   video frames and transcript for self-identification. Flag `is_baruch_talk: false`
   and set status to `skipped` if the speaker doesn't match.
-- **Step 5 timing matters.** Run the full clarification session IMMEDIATELY for talks
-  delivered within the past week — memory is freshest right after delivery. For older
-  talks (2+ years), use the compressed version.

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -96,7 +96,7 @@ Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
 
 ## Step 3 — Process Talks via Parallel Subagents (Batches of 5)
 
-Per batch: launch 5 subagents in parallel, wait, run Step 4 (Apply Subagent Results), then next batch. When all batches have finished, proceed to Step 5.
+Per batch: launch 5 subagents in parallel, wait, run Step 4 (Persist Subagent Results), then run Step 5 (Update Rhetoric Summary), then move to the next batch. When all batches have finished, proceed to Step 6.
 Each subagent receives the talk's DB entry and current `rhetoric-style-summary.md`.
 
 #### Per-Talk Subagent Instructions:
@@ -191,37 +191,49 @@ Minimal structure:
 }
 ```
 
-## Step 4 — Apply Subagent Results
+## Step 4 — Persist Subagent Results
 
 Runs after each batch inside Step 3's loop (not as a separate post-loop
-phase). One action: take the subagent JSON returns from the batch and
-fold them into the tracking DB, per-talk analysis files, and the running
-rhetoric summary in a single atomic update.
+phase). Mechanical persistence of the batch's subagent JSON returns:
 
-1. **Update tracking DB** — set `status`, `processed_date`, all result fields.
-   Persist `pattern_observations` IDs + score. Populate structured fields
-   (`co_presenter`, `delivery_language`, etc.) — do not leave structured data buried
-   in free-text prose. See [references/processing-rules.md](references/processing-rules.md) for field extraction rules.
-2. **Write per-talk analysis files** — write
-   `{vault_root}/analyses/{talk_filename}.md` for each processed talk: all 14
-   dimensions, structured data, verbatim examples, and a "Presentation Patterns
-   Scoring" section. Create `analyses/` directory if missing.
-3. **Update rhetoric-style-summary.md** — integrate `new_patterns` and
-   `summary_updates`. Sections 1–14 map to the 14 dimensions; Section 15 aggregates
-   improvement areas; Section 16 captures speaker-confirmed intent. **Recount status
-   from the DB every time** — never increment manually.
-   **Speaker-review gate:** before applying any `summary_updates` or `new_patterns`
-   from a subagent, present the proposed changes (section-by-section diff) and wait
-   for explicit speaker confirmation. Silent application erodes the speaker's sense
-   of ownership of their own style summary; pattern taxonomy additions in particular
-   can drift if applied unreviewed. Only bypass the gate if the speaker has pre-
-   authorized this batch ("just apply everything, don't ask").
-4. **Report:** talks processed, new patterns, current state, skipped talks.
-5. Flag **structural changes** prominently (new presentation mode, new workflow pattern).
+- **Update tracking DB** — set `status`, `processed_date`, all result fields.
+  Persist `pattern_observations` IDs + score. Populate structured fields
+  (`co_presenter`, `delivery_language`, etc.) — do not leave structured data
+  buried in free-text prose. See
+  [references/processing-rules.md](references/processing-rules.md) for field
+  extraction rules.
+- **Write per-talk analysis files** — write
+  `{vault_root}/analyses/{talk_filename}.md` for each processed talk: all 14
+  dimensions, structured data, verbatim examples, and a "Presentation Patterns
+  Scoring" section. Create `analyses/` directory if missing.
 
-When Step 3's batch loop finishes, proceed to Step 5.
+Proceed immediately to Step 5.
 
-## Step 5 — Extract Remaining PPTX Visual Data
+## Step 5 — Update Rhetoric Summary
+
+Still per-batch (continues Step 3's loop). The summary update is a separate
+step from Step 4's persistence because it requires a speaker-review gate —
+unlike DB writes, edits to `rhetoric-style-summary.md` change the speaker's
+ground-truth narrative and must not be applied silently.
+
+1. **Speaker-review gate.** Present the subagent's proposed `summary_updates`
+   and `new_patterns` as a section-by-section diff and wait for explicit
+   speaker confirmation. Silent application erodes the speaker's sense of
+   ownership of their own style summary; pattern-taxonomy additions in
+   particular drift if applied unreviewed. Only bypass the gate if the
+   speaker pre-authorized this batch ("just apply everything, don't ask").
+2. **Apply approved changes.** Integrate confirmed `new_patterns` and
+   `summary_updates` into `rhetoric-style-summary.md`. Sections 1–14 map to
+   the 14 dimensions; Section 15 aggregates improvement areas; Section 16
+   captures speaker-confirmed intent. **Recount status from the DB every
+   time** — never increment manually.
+3. **Report.** Output: talks processed, new patterns, current state, skipped
+   talks. Flag structural changes prominently (new presentation mode, new
+   workflow pattern).
+
+When Step 3's batch loop finishes, proceed to Step 6.
+
+## Step 6 — Extract Remaining PPTX Visual Data
 
 Runs once after all Step 3 batches have completed.
 
@@ -240,9 +252,9 @@ files matching `config.template_skip_patterns`. Some talks have multiple .pptx f
 After 3+ extractions, populate `slide-design-spec.md`; after 5+, analyze cross-talk
 patterns (colors, fonts, footers).
 
-Proceed immediately to Step 6.
+Proceed immediately to Step 7.
 
-## Step 6 — Regenerate Speaker Profile
+## Step 7 — Regenerate Speaker Profile
 
 If `{vault_root}/speaker-profile.json` exists, invoke `Skill(skill: "vault-profile")`
 with the updated tracking database. Report the diff of changes (added fields,
@@ -250,9 +262,9 @@ changed values) so the speaker can verify.
 
 If the profile doesn't exist, skip this step silently.
 
-Proceed immediately to Step 7.
+Proceed immediately to Step 8.
 
-## Step 7 — Same-Week Clarification Trigger
+## Step 8 — Same-Week Clarification Trigger
 
 If no talks were newly processed in this run, finish here without further action.
 

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -33,7 +33,7 @@ Read `tracking-database.json` from there to get `vault_root`.
 
 - **10+ talks parsed** AND `config.clarification_sessions_completed >= 1`.
 - Also runs on explicit request (overrides prerequisites).
-- Auto-triggered by vault-ingress Step 4 if profile already exists.
+- Auto-triggered by vault-ingress Step 6 (Regenerate Speaker Profile) if profile already exists.
 
 ## Process
 

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -33,7 +33,7 @@ Read `tracking-database.json` from there to get `vault_root`.
 
 - **10+ talks parsed** AND `config.clarification_sessions_completed >= 1`.
 - Also runs on explicit request (overrides prerequisites).
-- Auto-triggered by vault-ingress Step 6 (Regenerate Speaker Profile) if profile already exists.
+- Auto-triggered by vault-ingress Step 7 (Regenerate Speaker Profile) if profile already exists.
 
 ## Process
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Two coordinated changes to the vault skills, bundled because they touch the same step-numbering surface:

### 1. Promote vault-ingress post-processing — Fixes #22

The "After processing, suggest running vault-profile" and "Step 5 timing matters" rules used to live as bullets inside `### Important Notes`, easily missed by agents that finished Step 4 (Collect Results) and declared success. Promotes them to explicit workflow steps:

- **Step 6 — Regenerate Speaker Profile.** If `speaker-profile.json` exists, invoke vault-profile and report the diff. Skip silently if the profile doesn't exist.
- **Step 7 — Same-Week Clarification Trigger.** Scan newly-processed talks for delivery date; for any within the past 7 days, recommend running vault-clarification NOW (memory is freshest). Surface `areas_for_improvement` and unverifiable pattern observations as candidate clarification topics. Compressed session for 30+ day talks.

Also adds a **speaker-review gate** to Step 4 (Collect Results): subagent-proposed `summary_updates` and `new_patterns` get presented as a section-by-section diff before being applied to `rhetoric-style-summary.md`. Silent application erodes ownership of the speaker's own style summary; pattern-taxonomy additions in particular drift if applied unreviewed.

### 2. Step renumbering per `jbaruch/coding-policy: skill-authoring`

- **vault-clarification:** `5A` / `5A-bis` / `5A-ter` / `5B` / `5C` / `5D` → `1` / `2` / `3` / `4` / `5` / `6`. Sub-letter naming was a holdover from when the skill was a sub-phase of a larger pipeline; the rule now mandates flat integer numbering with em-dash titles.
- **vault-ingress:** `Step 3B` (sub-step) is promoted to a top-level step. Plus a semantic swap: previously Step 4 (Extract Remaining PPTX, post-loop) appeared before Step 5 (Collect Results, per-batch inside Step 3's loop), which contradicted the per-batch flow. Reordered so the per-batch step (`Step 4 — Collect Results`) immediately follows Step 3, and the post-loop one-time step (`Step 5 — Extract Remaining PPTX`) follows.

Adds explicit "Proceed immediately to Step N" handoffs and one terminal "Finish here" per the `Step Continuity` section of skill-authoring.

### Cross-reference sync

| File | Change |
|---|---|
| `vault-clarification/references/blind-spot-moments.md` | header `## 5A-bis. Blind Spot Moments` → `# Blind Spot Moments` |
| `vault-clarification/references/humor-post-mortem.md` | header `## 5A-ter. Humor Post-Mortem` → `# Humor Post-Mortem` |
| `vault-profile/SKILL.md` | prerequisite cross-ref `vault-ingress Step 4` → `vault-ingress Step 6 (Regenerate Speaker Profile)` |
| `evals/clarification-interactive-session/task.md` | "(Step 5B)" → "(Step 4)"; "all five steps" → "all six steps"; bundled "Step 5: Mark Complete" split into Step 5 (Structured Intent Capture) + Step 6 (Mark Complete) |
| `evals/summary_infeasible.json` | drops the obsolete "(Step 5)" parenthetical from the clarification entry; corrects the entry's `skill` field from `rhetoric-knowledge-vault` (legacy) to `vault-clarification` (current) |

### Out of scope

The shownotes-config redesign (#16, #17, #20, #21) is a separate, larger change. Three places where the renumbering touched the same files as the config redesign are intentionally held back to land together with PR 4:

- `vault-ingress/SKILL.md` Config-bootstrapping section still references `talks_source_dir` (single legacy field) — restructured to `shownotes.source.*` in PR 4
- `vault-{clarification,profile}/references/schemas-config.md` schema tables still list `shownotes_url_pattern` / `shownotes_publishing` — restructured to `shownotes.{source,url,...}` in PR 4
- `vault-ingress/references/schemas-db.md` config example still has the flat shape — restructured in PR 4

The `Step 4` text references in those files are also held — landing the rename without the schema rewrite would create a transient state where the doc says "Step 4" but still shows legacy fields. Cleaner to ship both together.

## Test plan

- [ ] CI: tests workflow green
- [ ] CI: PR Policy Review (Anthropic) self-skips per cross-family rule
- [ ] CI: PR Policy Review (OpenAI) posts a substantive verdict against the skill-authoring rule (both vault skills should now satisfy: H1 title, sequential preamble, flat H2 step numbering, explicit handoffs, "Finish here" terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)