### PR TITLE
refactor(shownotes): unified config block + slug-convention check

### DIFF
--- a/rules/qr-generation-rules.md
+++ b/rules/qr-generation-rules.md
@@ -43,8 +43,12 @@ Slug format: `{YYYY-MM-DD}-{conference-slug}-{talk-short-name}`
 
 Example: `2026-04-16-devnexus-robocoders-judgment-day`
 
-Read the speaker's convention from `shownotes_slug_convention` in the profile.
-If not set, ask the speaker.
+Read the speaker's convention from
+`publishing_process.shownotes.slug_convention.template` in the profile. If
+not set (or if it disagrees with recent shownotes entries under
+`publishing_process.shownotes.source.path_or_url` /
+`shownotes.source.talks_subdir`), treat the observed live convention as
+authoritative and offer to update the profile via vault-clarification.
 
 ## 5. Missing Shortener Config = STOP
 

--- a/rules/resources-gathering-rules.md
+++ b/rules/resources-gathering-rules.md
@@ -79,20 +79,27 @@ The publishing destination for shownotes MUST be discoverable from the speaker
 profile — agents should never guess, search the web, or grep local files to
 find where shownotes are published.
 
-Read from `speaker-profile.json`:
-- **Base URL:** `publishing_process.shownotes_site` — the shownotes host
-  (e.g., `https://speaking.jbaru.ch`)
-- **Per-talk URL pattern:** `speaker.shownotes_url_pattern` — uses
-  `{shownotes_site}` and `{slug}` placeholders
-  (e.g., `{shownotes_site}/{slug}`)
+Read from `speaker-profile.json` → `publishing_process.shownotes`:
+- **Base URL:** `url.base` (e.g., `https://speaking.jbaru.ch`)
+- **Permalink template:** `url.template` (e.g., `/talks/{slug}/`,
+  `/{yyyy}-{mm}-{dd}-{slug}/`) — reflects the SSG's actual deployed URL
+  structure, not a flat `{slug}` substitution
 
 When checking talk metadata (video status, slide links, resource lists):
-1. Substitute `{shownotes_site}` and `{slug}` into
-   `speaker.shownotes_url_pattern` to construct the talk URL
-2. If `shownotes_url_pattern` is absent but `shownotes_site` is present,
-   use `{shownotes_site}/{slug}` as the default
-3. Fetch the page to read current state
-4. Do NOT search Google, conference sites, or local directories
+1. Compose the full URL: `url.base` + the result of substituting `{slug}`
+   and date variables (`{yyyy}`, `{mm}`, `{dd}`) into `url.template`
+2. Fetch the page to read current state
+3. Do NOT search Google, conference sites, or local directories
 
-If `shownotes_site` is absent from the profile, ask the speaker during
-vault-clarification (Step 5B infrastructure capture).
+Supported template variables:
+
+| Variable | Meaning |
+|---|---|
+| `{slug}` | Talk slug from Presentation Spec |
+| `{yyyy}` / `{yy}` | Year from talk `date` |
+| `{mm}` / `{dd}` | Month / day |
+| `{venue}` | Slugified venue name |
+
+If `publishing_process.shownotes` is absent or incomplete, ask the speaker
+during vault-clarification (Step 4 infrastructure capture) — the config
+object, not the individual legacy fields.

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -107,7 +107,7 @@ Must-avoid:        [list]
 Co-presenter:      [none | name + handle + role split]
 Profanity register:[from profile rhetoric_defaults]
 Duration target:   [from profile rhetoric_defaults.default_duration_minutes]
-Shownotes slug:    [generated per profile shownotes_slug_convention — see phase1-intent.md]
+Shownotes slug:    [generated per profile publishing_process.shownotes.slug_convention — see phase1-intent.md]
 ```
 
 Gate: Author confirms or edits the spec.
@@ -267,7 +267,7 @@ If `publishing_process` is missing or empty, ask the author interactively.
 Execute the steps from the profile:
 0. **Resources** — extract and curate resource list from outline (`extract-resources.py`)
 1. **Export** — run `export_method` / `export_script` (see [references/phase5-slides.md](references/phase5-slides.md))
-2. **Shownotes** — if `shownotes_publishing.enabled`, use curated resources from Step 6.0
+2. **Shownotes** — if `publishing_process.shownotes.enabled`, use curated resources from Step 6.0
 3. **QR Code** — if `qr_code.enabled`, generate and insert per profile
 4. **Additional steps** — execute each `additional_steps[]` entry
 5. **Go-live checklist** — surface unobservable patterns from [references/patterns/_index.md](references/patterns/_index.md)

--- a/skills/presentation-creator/references/phase1-intent.md
+++ b/skills/presentation-creator/references/phase1-intent.md
@@ -71,27 +71,58 @@ If the spec has a co-presenter:
 
 ### Shownotes Slug Generation
 
-The slug is NOT free-form — read `shownotes_slug_convention` from the speaker
-profile config. Apply the convention to this talk's details. Example convention:
+The slug is NOT free-form. Conventions drift over time (older analyses often
+encode retired naming patterns), so derive from CURRENT shownotes entries, not
+whatever examples happen to be loaded in context.
+
+**Step 1 — Observe the current convention.** List the most recent entries in
+the speaker's live shownotes directory (source location comes from the vault's
+shownotes config — see `vault_root/speaker-profile.json`). Examples:
 
 ```
-Convention: {YYYY-MM-DD}-{conference-slug}-{talk-short-name}
-Input:      2026-04-16, DevNexus, "Robocoders: Judgment Day"
-Result:     2026-04-16-devnexus-robocoders-judgment-day
+ls {shownotes_talks_dir} | sort -r | head -20
 ```
+
+Extract the actual pattern from the latest 5–10 entries. Note that the current
+convention may differ from older convention examples that appear in archived
+analyses. Trust the live directory, not the analyses.
+
+**Step 2 — Read the declared convention.** Check
+`publishing_process.shownotes.slug_convention.template` in the speaker
+profile. If it matches what you observed in Step 1, use it. If it disagrees
+with recent entries, the profile is stale — treat the observed convention as
+authoritative and offer to update the profile (via vault-clarification) at
+the end of the phase.
+
+**Step 3 — Derive the slug mechanically.** Apply the convention to this talk's
+metadata (date, venue, title). Example convention:
+
+```
+Convention: {venue-compact}{yy}-{short-talk-id}
+Input:      DevNexus 2026-04-16, "Robocoders: Judgment Day"
+Result:     devnexus26-robocoders
+```
+
+**Step 4 — Confirm once, not as a menu.** Present a SINGLE generated slug for
+confirmation, not 2–3 options. If the convention is genuinely ambiguous (e.g.,
+the last 10 entries show two different patterns), show 2–3 examples from the
+live directory and ask the speaker which pattern applies — don't freestyle.
+
+**Step 5 — Backfill if needed.** If
+`publishing_process.shownotes.slug_convention.template` was `null` or missing,
+hand off to vault-clarification at end-of-phase to persist the observed
+convention in the profile (and populate
+`slug_convention.examples` with the recent live slugs). Next run shouldn't
+need Step 1 again.
 
 Rules:
-- Derive the slug mechanically from the convention + talk metadata (date,
-  conference, title). NEVER invent or freestyle a slug.
 - Kebab-case, lowercase, no special characters.
-- Present the generated slug to the author for confirmation before finalizing
-  the spec. The author may want to abbreviate or adjust.
-- If `shownotes_slug_convention` is not set in the profile, ask the author
-  for their convention and save it (same as any missing config field).
-
-The confirmed slug goes into the Presentation Spec as `Shownotes slug:` and is
-persisted in `presentation-spec.md`. All downstream uses (Phase 6 shownotes URL,
-QR code `--talk-slug`, directory name) must use this exact slug.
+- NEVER invent a slug from convention-like patterns you saw in analyses —
+  those are snapshots of whatever was current when the analysis was written.
+- The confirmed slug goes into the Presentation Spec as `Shownotes slug:` and
+  is persisted in `presentation-spec.md`. All downstream uses (Phase 6
+  shownotes URL, QR code `--talk-slug`, directory name) must use this exact
+  slug.
 
 ### Spec Validation
 

--- a/skills/presentation-creator/references/phase3-content.md
+++ b/skills/presentation-creator/references/phase3-content.md
@@ -68,7 +68,7 @@ Talks without an illustration strategy omit this entire section.
 - Speaker: "[brief intro]"
 
 ### Slide 4: Shownotes URL
-- Visual: [from profile speaker.shownotes_url_pattern] with QR code
+- Visual: [shownotes URL composed from profile `publishing_process.shownotes.url.base` + `url.template` with the Presentation Spec slug] with QR code
 - Speaker: "Everything — slides, links, resources — [shownotes URL]"
 
 ### Slide 5: [First content beat]

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -52,19 +52,51 @@ omit the resource links section from shownotes.
 
 ### Step 6.1: Shownotes
 
-Read `publishing_process.shownotes_publishing`. If `enabled`:
+Read `publishing_process.shownotes`. If `enabled`:
 
-- Follow the `method` description (git push, CMS, manual)
-- If `shownotes_repo_path` and `shownotes_template` are provided, generate the page
-- Include: title, abstract, slide embed/download link, speaker bio
+- Generate the talk page at
+  `{shownotes.source.path_or_url}/{shownotes.source.talks_subdir}/{slug}.md`
+  (adapt the extension for Hugo/Astro content collections if the SSG uses a
+  different convention — check `shownotes.source.type` and existing entries).
+- Follow the `publishing_method` description (git push, CMS, manual) to make
+  it live.
+- If `shownotes.shownotes_template` is provided, use it as the frontmatter /
+  layout skeleton for the new page. Otherwise follow the convention observed
+  in existing entries under the talks subdir.
+- Include: title, abstract, slide embed/download link, speaker bio.
 - If `resources.json` exists and has `approved: true` items, include a
   "Resources" section with those links. Read from `resources.json` in the
   talk working directory (produced by Step 6.0) — do not re-scan the outline.
-- Construct the shownotes URL by substituting the **talk slug from the Presentation
-  Spec** (Phase 1) into `shownotes_url_pattern` from the speaker profile. The slug
-  was agreed with the author in Phase 1 — NEVER invent or rephrase it. Example:
-  pattern `speaking.example.com/{slug}` + spec slug `arc-of-ai` →
-  `speaking.example.com/arc-of-ai`
+
+**Construct the live shownotes URL** by composing `shownotes.url.base` + the
+result of substituting the Presentation Spec's slug (and other variables, if
+the template uses them) into `shownotes.url.template`. The slug was agreed
+with the author in Phase 1 — NEVER invent or rephrase it.
+
+Template variables supported:
+- `{slug}` — talk slug from Presentation Spec
+- `{yyyy}`, `{mm}`, `{dd}` — 4- and 2-digit date components from the talk
+  frontmatter `date` field
+- `{yy}` — 2-digit year
+- `{venue}` — slugified venue name
+
+Examples:
+
+| `shownotes.url.base` | `shownotes.url.template` | slug | Resulting URL |
+|---|---|---|---|
+| `https://speaking.example.com` | `/{slug}/` | `arc-of-ai` | `https://speaking.example.com/arc-of-ai/` |
+| `https://speaker.dev` | `/talks/{slug}/` | `arc-of-ai` | `https://speaker.dev/talks/arc-of-ai/` |
+| `https://example.com` | `/{yyyy}-{mm}-{dd}-{slug}/` | `jfokus-robocoders` | `https://example.com/2026-04-16-jfokus-robocoders/` |
+| `https://jbaru.ch` | `/talks/{slug}/` | `devnexus26-robocoders` | `https://jbaru.ch/talks/devnexus26-robocoders/` |
+
+If the SSG uses per-file `permalink:` frontmatter (common in Eleventy), read
+the permalink from the newly-generated page's frontmatter rather than
+synthesizing from `url.template`. In that case `shownotes.url.template` may
+be null.
+
+Before passing the URL downstream (QR code, bit.ly target, post-event video
+description), verify the URL is reachable — a 404 on the deployed site
+breaks printed QR codes with no recovery path.
 
 If not enabled, skip.
 

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -140,7 +140,33 @@ Common revision requests:
 - "Too busy" → switch to simpler style variant
 - "Wrong mood" → adjust expression guidance
 
-#### 7. Tracking Database Update
+#### 7. Copy Thumbnail to Shownotes Site
+
+If `publishing_process.shownotes.enabled` is true, the SSG template expects
+the thumbnail at a specific path relative to the shownotes site root —
+otherwise the live page falls back to a placeholder image with no warning.
+
+Resolve the destination using `publishing_process.shownotes`:
+
+```
+{shownotes.source.path_or_url}/{shownotes.thumbnail_path_template}
+```
+
+with `{slug}` substituted from the Presentation Spec. For Jekyll-based
+shownotes in this toolkit the default template is
+`assets/images/thumbnails/{slug}-thumbnail.png` — both the nested
+`thumbnails/` subdirectory AND the `-thumbnail` suffix are mandatory. Do not
+strip either when landing the file.
+
+Create the `thumbnails/` directory if it doesn't exist, then copy (don't move)
+the generated thumbnail — the local copy in `illustrations/thumbnail.png`
+stays with the talk's working directory for tracking.
+
+If the SSG template pointer (`shownotes.ssg_template_pointer`) is set, read
+that file after a site redesign to re-derive the path convention. Don't
+re-invent it from folklore.
+
+#### 8. Tracking Database Update
 
 Add to `thumbnails[]` in `tracking-database.json`:
 
@@ -151,6 +177,7 @@ Add to `thumbnails[]` in `tracking-database.json`:
   "source_slide_num": 15,
   "speaker_photo_used": "/path/to/headshot.jpg",
   "thumbnail_path": "illustrations/thumbnail.png",
+  "shownotes_thumbnail_path": "assets/images/thumbnails/judgment-day-thumbnail.png",
   "dimensions": "1280x720",
   "file_size_kb": 185,
   "created_at": "2026-04-20",
@@ -170,7 +197,9 @@ Update the existing shownotes page with the video recording link.
 
 Check that shownotes were published in Phase 6 Step 6.1. Look for:
 - The shownotes URL in `tracking-database.json` for this talk
-- Or construct from `speaker.shownotes_url_pattern` + talk slug
+- Or construct from `publishing_process.shownotes.url.base` +
+  `publishing_process.shownotes.url.template` (substitute `{slug}` and any
+  date variables) — see phase6-publishing.md for the full template semantics
 
 If shownotes don't exist, STOP and ask the speaker. Options:
 - Run Phase 6 Step 6.1 to create them now

--- a/skills/vault-clarification/references/schemas-config.md
+++ b/skills/vault-clarification/references/schemas-config.md
@@ -2,22 +2,26 @@
 
 ## Config Fields — Clarification Session Questions
 
-Fields below `template_skip_patterns` are asked during Step 5B (first session only)
-when empty. The question column shows what to ask the speaker.
+Fields below `template_skip_patterns` are asked during Step 4 (first session
+only) when empty. The question column shows what to ask the speaker.
 
 | Config field | Question |
 |-------------|----------|
 | `speaker_name` | "Name as it appears on slides?" |
 | `speaker_handle` | "Social handle for footers?" |
 | `speaker_website` | "Website for talk resources?" |
-| `shownotes_url_pattern` | "URL pattern for talk pages? (e.g., `speaking.example.com/{slug}`)" |
-| `shownotes_slug_convention` | "How do you construct talk slugs for shownotes URLs? Example: `{YYYY-MM-DD}-{conference-slug}-{talk-short-name}` → `2026-04-16-devnexus-robocoders-judgment-day`. What components and format?" |
+| `shownotes.source.type` | "Where do your shownotes live? Local Jekyll, Hugo, Eleventy, Astro, a remote URL, or no shownotes site?" |
+| `shownotes.source.path_or_url` | "Path (or base URL) to the shownotes site root?" |
+| `shownotes.source.talks_subdir` | "Subdirectory under the site root where talk entries live? (e.g., `_talks`, `content/talks`)" |
+| `shownotes.url.base` | "Base URL where the shownotes site is deployed?" |
+| `shownotes.url.template` | "Permalink template for a single talk? (e.g., `/talks/{slug}/`, `/{yyyy}-{mm}-{dd}-{slug}/`). Verify against your deployed URLs before confirming." |
+| `shownotes.thumbnail_path_template` | "Where in the site repo does the SSG template expect the talk thumbnail? (e.g., `assets/images/thumbnails/{slug}-thumbnail.png`)" |
+| `shownotes.slug_convention.template` | "Convention for talk slugs? (e.g., `{venue-compact}{yy}-{short-id}` → `devnexus26-robocoders`). What components and format?" |
+| `shownotes.ssg_template_pointer` | "Which SSG template file encodes the URL/thumbnail conventions (so they can be re-derived after a redesign)? e.g., `_layouts/default.html` for Jekyll." |
 | `template_pptx_path` | "PowerPoint template path?" |
 | `presentation_file_convention` | "File organization? (default: `{conference}/{year}/{talk-slug}/`)" |
 | `publishing_process.export_format` | "How do you export final decks — PDF, keep .pptx only, or both?" |
 | `publishing_process.export_method` | "How do you produce the PDF? (e.g., PowerPoint AppleScript, LibreOffice CLI, manual)" |
-| `publishing_process.shownotes_site` | "What's the base URL where your shownotes are published? (e.g., `https://speaking.example.com`)" |
-| `publishing_process.shownotes_publishing` | "Do you publish shownotes for your talks? If yes, how?" |
 | `publishing_process.qr_code` | "Do you put QR codes in your decks? If yes, what do they link to?" |
 | `publishing_process.qr_code.shortener` | "Do you use a URL shortener for QR links? Options: `bitly`, `rebrandly`, or `none`." |
 | `publishing_process.qr_code.bitly_domain` | _(Only if shortener=bitly)_ "Do you have a custom Bitly domain? (e.g., `jbaru.ch`, or leave blank for default `bit.ly`)" |
@@ -28,26 +32,10 @@ when empty. The question column shows what to ask the speaker.
 
 ## Full Config Schema
 
-```json
-{
-  "config": {
-    "vault_root": "~/.claude/rhetoric-knowledge-vault",
-    "vault_storage_path": "/actual/path/if/custom (null when using default location)",
-    "talks_source_dir": "/path/to/_talks",
-    "pptx_source_dir": "/path/to/Presentations",
-    "python_path": "/path/to/python3",
-    "template_skip_patterns": ["template"],
-    "speaker_name": "",
-    "speaker_handle": "",
-    "speaker_website": "",
-    "shownotes_url_pattern": "",
-    "shownotes_slug_convention": "",
-    "template_pptx_path": "",
-    "presentation_file_convention": "{pptx_source_dir}/{conference}/{year}/{talk-slug}/",
-    "clarification_sessions_completed": 0
-  }
-}
-```
+See the canonical schema and field reference in
+[../../vault-profile/references/schemas-config.md](../../vault-profile/references/schemas-config.md).
+That file also documents the migration path for vaults created before the
+unified `shownotes` block.
 
 ## Confirmed Intents Schema
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -61,11 +61,19 @@ files to shownotes entries.
    `tracking-database.json` with empty `config`, `talks`, `pptx_catalog`.
 
 **Config bootstrapping** — ask once per missing field and persist to the tracking
-database. Core fields: `talks_source_dir`, `pptx_source_dir`, `python_path`,
-`template_skip_patterns`. See [references/schemas-db.md](references/schemas-db.md) for the full schema.
+database. Core fields: `shownotes` (enabled, source.type, source.path_or_url,
+source.talks_subdir, url.base, url.template, thumbnail_path_template,
+slug_convention), `pptx_source_dir`, `python_path`, `template_skip_patterns`.
+See [references/schemas-db.md](references/schemas-db.md) for the full schema
+and [../vault-profile/references/schemas-config.md](../vault-profile/references/schemas-config.md)
+for field-by-field semantics and migration notes.
 
-**Scan for new talks:** Glob `*.md` in `talks_source_dir`; parse and add any file not
-yet in `talks[]` (title, conference, date, URLs, status `"pending"`). Extract
+**Scan for new talks:** Build the talks directory path as
+`{shownotes.source.path_or_url}/{shownotes.source.talks_subdir}`; glob `*.md`
+there; parse and add any file not yet in `talks[]` (title, conference, date,
+URLs, status `"pending"`). For `remote_url` or `none` source types, skip the
+scan — the vault ingests only the talks the speaker has already registered
+elsewhere. Extract
 `video_url`, `slides_url` from frontmatter/links. Parse IDs from URLs:
 - `youtube_id`: extract the `v=` parameter from YouTube URLs
   (e.g., `https://www.youtube.com/watch?v=aBcDeFg` → `youtube_id: "aBcDeFg"`)

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -10,10 +10,21 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
   "config": {
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
     "vault_storage_path": "/actual/path/if/custom (null when using default location)",
-    "talks_source_dir": "/path/to/_talks",
     "pptx_source_dir": "/path/to/Presentations",
     "python_path": "/path/to/python3",
     "template_skip_patterns": ["template"],
+    "shownotes": {
+      "enabled": true,
+      "source": {
+        "type": "local_jekyll|local_hugo|local_eleventy|local_astro|remote_url|none",
+        "path_or_url": "/path/to/shownotes-site-root (or https://... for remote_url)",
+        "talks_subdir": "_talks"
+      },
+      "url": {"base": "https://speaking.example.com", "template": "/{slug}/"},
+      "thumbnail_path_template": "assets/images/thumbnails/{slug}-thumbnail.png",
+      "slug_convention": {"template": "{venue-compact}{yy}-{short-id}", "examples": []},
+      "ssg_template_pointer": "{source.path_or_url}/_layouts/default.html"
+    },
     "clarification_sessions_completed": 0
   },
   "talks": [{

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -91,8 +91,16 @@ Read `tracking-database.json` from there to get `vault_root`.
        "mode_visual_profiles": [], "confirmed_visual_intents": []
      },
      "publishing_process": {
+       "shownotes": {
+         "enabled": true,
+         "source": {"type": "...", "path_or_url": "...", "talks_subdir": "..."},
+         "url": {"base": "...", "template": "..."},
+         "thumbnail_path_template": "...",
+         "slug_convention": {"template": "...", "examples": []},
+         "ssg_template_pointer": "..."
+       },
        "export_format": "pdf", "export_method": "...",
-       "shownotes_publishing": {}, "qr_code": {}, "additional_steps": []
+       "qr_code": {}, "additional_steps": []
      },
      "design_rules": {
        "background_color_strategy": "...", "footer": { "pattern": "...", "elements": [] },

--- a/skills/vault-profile/references/schemas-config.md
+++ b/skills/vault-profile/references/schemas-config.md
@@ -2,20 +2,26 @@
 
 ## Config Fields — Clarification Session Questions
 
-Fields below `template_skip_patterns` are asked during Step 5B (first session only)
-when empty. The question column shows what to ask the speaker.
+Fields below `template_skip_patterns` are asked during vault-clarification
+Step 4 (first session only) when empty. The question column shows what to
+ask the speaker.
 
 | Config field | Question |
 |-------------|----------|
 | `speaker_name` | "Name as it appears on slides?" |
 | `speaker_handle` | "Social handle for footers?" |
 | `speaker_website` | "Website for talk resources?" |
-| `shownotes_url_pattern` | "URL pattern for talk pages? (e.g., `speaking.example.com/{slug}`)" |
+| `shownotes.source.type` | "Where do your shownotes live? Local Jekyll, Hugo, Eleventy, Astro, a remote URL, or no shownotes site?" |
+| `shownotes.source.path_or_url` | "Path (or base URL) to the shownotes site root?" |
+| `shownotes.source.talks_subdir` | "Subdirectory under the site root where talk entries live? (e.g., `_talks`, `content/talks`)" |
+| `shownotes.url.base` | "Base URL where the shownotes site is deployed?" |
+| `shownotes.url.template` | "Permalink template for a single talk? (e.g., `/talks/{slug}/`, `/{yyyy}-{mm}-{dd}-{slug}/`)" |
+| `shownotes.thumbnail_path_template` | "Where in the site repo does the SSG template expect the talk thumbnail? (e.g., `assets/images/thumbnails/{slug}-thumbnail.png`)" |
+| `shownotes.slug_convention.template` | "Convention for talk slugs? (e.g., `{venue-compact}{yy}-{short-id}`)" |
 | `template_pptx_path` | "PowerPoint template path?" |
 | `presentation_file_convention` | "File organization? (default: `{conference}/{year}/{talk-slug}/`)" |
 | `publishing_process.export_format` | "How do you export final decks — PDF, keep .pptx only, or both?" |
 | `publishing_process.export_method` | "How do you produce the PDF? (e.g., PowerPoint AppleScript, LibreOffice CLI, manual)" |
-| `publishing_process.shownotes_publishing` | "Do you publish shownotes for your talks? If yes, how?" |
 | `publishing_process.qr_code` | "Do you put QR codes in your decks? If yes, what do they link to?" |
 | `publishing_process.additional_steps` | "Any other distribution steps after exporting?" |
 
@@ -26,20 +32,128 @@ when empty. The question column shows what to ask the speaker.
   "config": {
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
     "vault_storage_path": "/actual/path/if/custom (null when using default location)",
-    "talks_source_dir": "/path/to/_talks",
     "pptx_source_dir": "/path/to/Presentations",
     "python_path": "/path/to/python3",
     "template_skip_patterns": ["template"],
     "speaker_name": "",
     "speaker_handle": "",
     "speaker_website": "",
-    "shownotes_url_pattern": "",
+
+    "shownotes": {
+      "enabled": true,
+      "source": {
+        "type": "local_jekyll",
+        "path_or_url": "/path/to/shownotes-site-root",
+        "talks_subdir": "_talks"
+      },
+      "url": {
+        "base": "https://speaking.example.com",
+        "template": "/{slug}/"
+      },
+      "thumbnail_path_template": "assets/images/thumbnails/{slug}-thumbnail.png",
+      "slug_convention": {
+        "template": "{venue-compact}{yy}-{short-id}",
+        "examples": []
+      },
+      "ssg_template_pointer": "{source.path_or_url}/_layouts/default.html"
+    },
+
     "template_pptx_path": "",
     "presentation_file_convention": "{pptx_source_dir}/{conference}/{year}/{talk-slug}/",
     "clarification_sessions_completed": 0
   }
 }
 ```
+
+## Shownotes Config — Field Reference
+
+**`shownotes.enabled`** — false means no shownotes site; skip Step 6.1 entirely,
+the QR target must be a `custom_url` if enabled at all.
+
+**`shownotes.source.type`** — one of:
+
+| Type | Talks live at | Frontmatter |
+|---|---|---|
+| `local_jekyll` | `{path_or_url}/{talks_subdir}/*.md` | Jekyll YAML |
+| `local_hugo` | `{path_or_url}/{talks_subdir}/*.md` | TOML/YAML/JSON front matter |
+| `local_eleventy` | `{path_or_url}/{talks_subdir}/*.md` | YAML with `permalink:` per-file |
+| `local_astro` | `{path_or_url}/{talks_subdir}/*.md` (content collections) | YAML |
+| `remote_url` | read-only; browse `{path_or_url}` for live entries | n/a — scrape |
+| `none` | no shownotes | n/a |
+
+**`shownotes.source.path_or_url`** — local filesystem path when `type` starts
+with `local_`, HTTPS URL when `type` is `remote_url`, null otherwise.
+
+**`shownotes.source.talks_subdir`** — subdirectory under the site root where
+talk entries live. Common values: `_talks` (Jekyll collections),
+`content/talks` (Hugo), `src/content/talks` (Astro). null for `remote_url` /
+`none`.
+
+**`shownotes.url.base`** — deployed site base URL (no trailing slash).
+
+**`shownotes.url.template`** — path component appended to `url.base` to form
+the live URL. Template variables:
+
+| Variable | Meaning |
+|---|---|
+| `{slug}` | The talk slug from the Presentation Spec |
+| `{yyyy}` | 4-digit year from the talk's `date` frontmatter field |
+| `{mm}` | 2-digit month |
+| `{dd}` | 2-digit day |
+| `{venue}` | Slugified venue name |
+| `{yy}` | 2-digit year |
+
+Presets for common SSGs (starting points — verify against the actual deployed
+URLs before shipping):
+
+- Jekyll `_talks` collection (default permalink): `/talks/{slug}/`
+- Jekyll with date permalink: `/{yyyy}/{mm}/{dd}/{slug}/`
+- Hugo default content section: `/{talks_subdir}/{slug}/`
+- Eleventy (permalink is per-file): use the most common pattern from your
+  entries; if each file overrides it, set `url.template` to null and let the
+  slug-convention step read the literal URL from per-file `permalink:`
+- Flat speaker-site with slug convention: `/{slug}/`
+
+**`shownotes.thumbnail_path_template`** — filesystem path (relative to
+`source.path_or_url`) where the SSG template expects the talk thumbnail image.
+The exact convention is encoded in the SSG template file (e.g., Jekyll
+`_layouts/default.html` `og:image` tag) — see `ssg_template_pointer`. The
+default for Jekyll-based shownotes in this toolkit is:
+
+```
+assets/images/thumbnails/{slug}-thumbnail.png
+```
+
+Both the nested `thumbnails/` subdirectory AND the `-thumbnail` suffix are
+mandatory for this convention — flat paths fall back to
+`placeholder-thumbnail.svg` on the live site with no warning.
+
+**`shownotes.slug_convention.template`** — pattern used to generate new talk
+slugs. Template variables are derived from talk metadata (venue, date, title).
+See the phase1-intent.md reference for derivation rules.
+
+**`shownotes.slug_convention.examples`** — array of recent slugs that match
+the current convention; used by presentation-creator Phase 1 to validate
+against drift (older analyses often encode retired conventions).
+
+**`shownotes.ssg_template_pointer`** — path to the SSG template file that
+encodes the URL and thumbnail-path conventions. Stored so the convention can
+be re-derived after a site redesign without spelunking through the template tree.
+
+## Migration from Legacy Fields
+
+Vaults created before this schema had `config.talks_source_dir` and
+`config.shownotes_url_pattern` as flat fields. Vault-profile regeneration maps
+them as follows:
+
+| Legacy field | New location |
+|---|---|
+| `config.talks_source_dir` | `config.shownotes.source.path_or_url` + `talks_subdir` (split on the last path segment) |
+| `config.shownotes_url_pattern` (flat `{slug}`) | `config.shownotes.url.base` + `config.shownotes.url.template` (template defaults to `/{slug}/`) |
+
+If a vault presents only the legacy fields, readers should upgrade-on-read
+(build the shownotes block in memory) and vault-profile writes the new schema
+on next regeneration. Do not leave both shapes populated — one source of truth.
 
 ## Confirmed Intents Schema
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -31,7 +31,6 @@ creation at runtime.
     "name": "",
     "handle": "",
     "website": "",
-    "shownotes_url_pattern": "{website}/{slug}",
     "bio_short": "one-sentence bio used on slides",
     "bio_context": "career trajectory or credentials chain shown on bio slides"
   },
@@ -278,16 +277,29 @@ creation at runtime.
   ],
 
   "publishing_process": {
-    "shownotes_site": "https://speaking.example.com",
+    "shownotes": {
+      "enabled": true,
+      "source": {
+        "type": "local_jekyll|local_hugo|local_eleventy|local_astro|remote_url|none",
+        "path_or_url": "/path/to/shownotes-site-root (or https://... for remote_url)",
+        "talks_subdir": "_talks"
+      },
+      "url": {
+        "base": "https://speaking.example.com",
+        "template": "/{slug}/"
+      },
+      "thumbnail_path_template": "assets/images/thumbnails/{slug}-thumbnail.png",
+      "slug_convention": {
+        "template": "{venue-compact}{yy}-{short-id}",
+        "examples": ["jfokus26-monkey", "devnexus26-robocoders"]
+      },
+      "ssg_template_pointer": "{source.path_or_url}/_layouts/default.html",
+      "publishing_method": "description of how shownotes are published (git push, CMS, manual)",
+      "shownotes_template": "path to the SSG template file for new talk pages, or null"
+    },
     "export_format": "pdf|pptx_only|both",
     "export_method": "description of how to export (e.g., PowerPoint AppleScript, LibreOffice CLI, manual)",
     "export_script": "optional: literal script/command to run for export, or null",
-    "shownotes_publishing": {
-      "enabled": true,
-      "method": "description of how shownotes are published (e.g., git push to site repo, CMS, manual)",
-      "shownotes_repo_path": "path to shownotes repo, or null",
-      "shownotes_template": "path to shownotes template file, or null"
-    },
     "qr_code": {
       "enabled": true,
       "target": "shownotes_url|custom_url",


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Replaces three scattered, drift-prone config fields with one coherent `publishing_process.shownotes` config block, and adds a Phase 1 step that derives the talk slug from observed live-directory state instead of stale archived analyses.

Fixes #16, #17, #20, #21.

## Why bundled

The four issues are designed to compose against the same config object:
- **#16** — shownotes source must be configurable (local Jekyll, Hugo, Eleventy, Astro, remote URL, or none) instead of hardcoded `talks_source_dir`
- **#17** — `shownotes_url_pattern` flat `{slug}` substitution breaks for any SSG that isn't a flat speaker-site
- **#21** — thumbnail path convention for the SSG template needs to live alongside the URL template
- **#20** — slug-convention check needs to read the live source directory, which only works with #16 in place

Splitting these would force a backwards-compat shim between intermediate states (which the no-shims rule disallows) and ship inconsistent guidance across phases.

## The new config block

```yaml
publishing_process.shownotes:
  enabled: true
  source:
    type: local_jekyll | local_hugo | local_eleventy | local_astro | remote_url | none
    path_or_url: <fs path or https url>
    talks_subdir: <e.g., _talks, content/talks>
  url:
    base: <deployed site base, no trailing slash>
    template: <permalink template; supports {slug}, {yyyy}, {mm}, {dd}, {yy}, {venue}>
  thumbnail_path_template: <e.g., assets/images/thumbnails/{slug}-thumbnail.png>
  slug_convention:
    template: <e.g., {venue-compact}{yy}-{short-id}>
    examples: [<recent live slugs that match>]
  ssg_template_pointer: <path to SSG template file encoding URL/thumbnail conventions>
```

## Replaces

| Legacy field | New location |
|---|---|
| `speaker.shownotes_url_pattern` | `publishing_process.shownotes.url.{base, template}` |
| `publishing_process.shownotes_publishing` | `publishing_process.shownotes` (with explicit source + url + thumbnail) |
| `publishing_process.shownotes_site` | `publishing_process.shownotes.url.base` |
| `config.talks_source_dir` | `config.shownotes.source.{path_or_url, talks_subdir}` |
| `config.shownotes_slug_convention` | `config.shownotes.slug_convention.template` |

Migration table documented in `skills/vault-profile/references/schemas-config.md`. Readers should upgrade-on-read for legacy vaults; vault-profile writes the new schema on next regenerate.

## Issue-by-issue

**#16 (shownotes source location):** new `shownotes.source.{type, path_or_url, talks_subdir}` covers local-SSG repos (Jekyll/Hugo/Eleventy/Astro), remote-URL-only sites (read-only scrape), and "no shownotes site" (skip Phase 6 Step 6.1 entirely).

**#17 (URL pattern):** `shownotes.url.template` accepts variables `{slug}`, `{yyyy}`, `{mm}`, `{dd}`, `{yy}`, `{venue}` — covers flat speaker sites, Jekyll `_talks` collection (`/talks/{slug}/`), Jekyll date permalinks (`/{yyyy}/{mm}/{dd}/{slug}/`), Hugo content sections, Astro content collections, and per-file Eleventy `permalink:` (set to null and read each file's frontmatter). Phase 6 docs include a worked-example table.

**#20 (slug convention):** Phase 1 now lists the speaker's live shownotes directory (sourced from `shownotes.source`) to extract the actual current convention before proposing a slug. Compares against `shownotes.slug_convention.template`; if they disagree, treats observed as authoritative and queues a backfill via vault-clarification.

**#21 (thumbnail path):** new `shownotes.thumbnail_path_template` (default `assets/images/thumbnails/{slug}-thumbnail.png` for Jekyll setups). Phase 7 Step 7.1 now copies the generated thumbnail to that exact path so the SSG template's expected location is hit — previously Jekyll would fall back to `placeholder-thumbnail.svg` with no warning.

## Files changed (13)

- Schemas: `vault-profile/references/schemas-config.md` (canonical), `vault-profile/references/speaker-profile-schema.md`, `vault-clarification/references/schemas-config.md` (now references the canonical), `vault-ingress/references/schemas-db.md`
- Phase docs: `presentation-creator/SKILL.md`, `phase1-intent.md` (slug derivation), `phase3-content.md` (slide 4 visual ref), `phase6-publishing.md` (URL construction + worked-example table), `phase7-post-event.md` (thumbnail copy step + URL construction in Step 7.2)
- Skill workflows: `vault-ingress/SKILL.md` (Step 1 config bootstrap names the new shownotes block), `vault-profile/SKILL.md` (publishing_process schema example shows new block)
- Rules: `qr-generation-rules.md` (slug convention reads from new block), `resources-gathering-rules.md` (URL composition uses url.base + url.template)

## Test plan

- [ ] CI: tests workflow green (no Python changed; existing tests should pass through)
- [ ] CI: PR Policy Review (Anthropic) self-skips per cross-family rule
- [ ] CI: PR Policy Review (OpenAI) posts a substantive verdict — this is the largest doc surface yet, expect more findings to address
- [ ] Smoke: after merge, regenerate speaker-profile.json and verify the new `publishing_process.shownotes` block populates from existing vault state without manual editing

## Out of scope

- `tessl.json` is also modified locally (declares `jbaruch/coding-policy` as a dependency), but it's unrelated to this refactor — leaving for a separate metadata commit.
- Eval fixtures under `eval-resources/scenario-*/speaker-profile.json` still carry the legacy schema. They represent older vault states by design (per the user's testing-standards memory: fixed test data, not regenerated). Readers handle the migration; fixtures don't need touching.
- The `evals/instructions.json` auto-index will refresh on next `tessl scenario generate` run; not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)