### PR TITLE
fix(thumbnail-rules): scope Rule 4 to input; flip Rule 7 bias for branded speakers

### DIFF
--- a/rules/thumbnail-generation-rules.md
+++ b/rules/thumbnail-generation-rules.md
@@ -35,11 +35,33 @@ Avoid these slide types:
 - Bullet-heavy slides
 - Generic title slides
 
-## 4. Speaker Photo Required
+## 4. Speaker Photo Required (Input)
 
-Real photo only — never AI-generated. Thumbnails with faces get 35-50%
-higher click-through rates. The expression should convey engagement, not
-a neutral corporate headshot.
+The speaker photo file passed to the script — `--speaker-photo` /
+`publishing_process.thumbnail.speaker_photo_path` — must be a real
+photograph of the speaker. Never an AI-generated headshot, stock-photo
+substitute, or stylized portrait. The script uses it as the identity
+anchor; an AI-generated input compounds artifacts when the model uses
+it as a reference.
+
+This rule scopes the **input only**. The output rendering depends on
+`--aesthetic` (Rule 7):
+
+- `aesthetic photo` — output preserves photographic realism. The face
+  in the thumbnail looks like the speaker's face in the input.
+- `aesthetic comic_book` — output renders the speaker as a comic-book
+  caricature derived from the input photo. The output is illustrated,
+  not photographic; identifying features (hair, beard, glasses, hat)
+  are preserved so the speaker remains recognizable.
+
+Both aesthetics still require a real photo as input; the comic-book
+aesthetic transforms it into illustration, but the source must be a
+photograph. Real-photo inputs produce thumbnails with faces, and faces
+boost CTR 35-50% regardless of which aesthetic the output uses.
+
+Expression: convey engagement, not a neutral corporate headshot. The
+expression carries through whether the output is photographic or
+caricatured.
 
 Resolution order:
 1. `publishing_process.thumbnail.speaker_photo_path` from profile
@@ -89,14 +111,34 @@ Two aesthetics are supported via `--aesthetic`:
 
 | Value | Description | When to use |
 |---|---|---|
-| `photo` (default) | Photographic composite; speaker face left natural; slide as background | Conservative default; safe for any speaker |
-| `comic_book` | Full comic-book illustration; speaker rendered as caricature with halftone shading; scene re-illustrated to match | Speakers with documented "comic-book aesthetic" branding; talks where viral reach matters more than realism |
+| `photo` | Photographic composite; speaker face left natural; slide as background | Speakers without an established illustrated brand; talks where corporate / documentary tone is required |
+| `comic_book` | Full comic-book illustration; speaker rendered as caricature with halftone shading; scene re-illustrated to match | **Recommended** for speakers with a documented comic-book aesthetic in their vault notes (`visual_style_history.default_illustration_style` or `confirmed_visual_intents`); talks where viral reach matters more than realism |
 
-**Phase 7 Step 7.1 protocol:** offer the speaker BOTH aesthetics for the same
-title/slide combination if you're unsure which lands better. Generate two
-candidates, present side-by-side, let the speaker pick. Don't auto-decide —
-the comic-book treatment is high-variance: when it works it produces
-significantly higher CTR, when it misses it looks off-brand.
+**Choosing per speaker.** Read `visual_style_history` from the speaker
+profile:
+
+- If `default_illustration_style` includes "comic-book", "halftone",
+  "illustrated", or similar — **comic_book** is the right default for
+  this speaker. The JCON Europe 2026 "Never Trust a Monkey" win
+  validates the approach for at least one such speaker; expand the
+  evidence base by trying it on other talks where the speaker's
+  brand fits.
+- If the speaker has a different documented style (retro tech manual,
+  watercolor, etc.) — neither default is right; the script's two
+  aesthetics don't yet cover those, file an issue requesting the new
+  variant rather than forcing photo.
+- If the speaker has no documented illustration style — default to
+  **photo**.
+
+**Phase 7 Step 7.1 protocol:** when in doubt, offer the speaker BOTH
+aesthetics for the same title/slide combination. Generate two
+candidates, present side-by-side, let the speaker pick. The comic-book
+treatment is high-variance: when it works it produces significantly
+higher CTR than photo composites, when it misses it looks off-brand.
+The two-candidate approach lets the speaker resolve that variance with
+their own taste — but lead with the recommendation from
+`visual_style_history`, don't present them as equal options when the
+profile clearly favors one.
 
 **Comic-book prompt anchors** (used internally by the script — don't reproduce
 them in agent-rolled prompts):
@@ -108,12 +150,12 @@ them in agent-rolled prompts):
 - Title with "thick black outline and a thin contrasting inner outline
   (classic blockbuster comic-book treatment)"
 
-**Why this is opt-in, not default:** the comic-book template is currently
-reverse-engineered from a single high-performing thumbnail (JCON Europe 2026
-"Never Trust a Monkey"). It needs to prove it generalizes across multiple
-talks before becoming the default. Track outcomes — if the comic-book
-aesthetic consistently outperforms photo across 3+ talks, file an issue to
-flip the default.
+**Why `--aesthetic` defaults to `photo` in the CLI:** speakers without
+a documented illustrated brand are the safer fallback for the script's
+default flag. The agent's recommendation, however, follows the profile's
+`visual_style_history` — see "Choosing per speaker" above — and should
+override the CLI default whenever the profile signals a clear illustrated
+brand.
 
 ## 8. Model Selection and Retry Ladder
 

--- a/rules/thumbnail-generation-rules.md
+++ b/rules/thumbnail-generation-rules.md
@@ -47,9 +47,9 @@ it as a reference.
 This rule scopes the **input only**. The output rendering depends on
 `--aesthetic` (Rule 7):
 
-- `aesthetic photo` — output preserves photographic realism. The face
+- `--aesthetic photo` — output preserves photographic realism. The face
   in the thumbnail looks like the speaker's face in the input.
-- `aesthetic comic_book` — output renders the speaker as a comic-book
+- `--aesthetic comic_book` — output renders the speaker as a comic-book
   caricature derived from the input photo. The output is illustrated,
   not photographic; identifying features (hair, beard, glasses, hat)
   are preserved so the speaker remains recognizable.
@@ -112,33 +112,41 @@ Two aesthetics are supported via `--aesthetic`:
 | Value | Description | When to use |
 |---|---|---|
 | `photo` | Photographic composite; speaker face left natural; slide as background | Speakers without an established illustrated brand; talks where corporate / documentary tone is required |
-| `comic_book` | Full comic-book illustration; speaker rendered as caricature with halftone shading; scene re-illustrated to match | **Recommended** for speakers with a documented comic-book aesthetic in their vault notes (`visual_style_history.default_illustration_style` or `confirmed_visual_intents`); talks where viral reach matters more than realism |
+| `comic_book` | Full comic-book illustration; speaker rendered as caricature with halftone shading; scene re-illustrated to match | **Recommended** for speakers with a documented comic-book aesthetic in their vault notes; talks where viral reach matters more than realism |
 
-**Choosing per speaker.** Read `visual_style_history` from the speaker
-profile:
+**Choosing per speaker — precedence (highest first):**
 
-- If `default_illustration_style` includes "comic-book", "halftone",
-  "illustrated", or similar — **comic_book** is the right default for
-  this speaker. The JCON Europe 2026 "Never Trust a Monkey" win
-  validates the approach for at least one such speaker; expand the
-  evidence base by trying it on other talks where the speaker's
-  brand fits.
-- If the speaker has a different documented style (retro tech manual,
-  watercolor, etc.) — neither default is right; the script's two
-  aesthetics don't yet cover those, file an issue requesting the new
-  variant rather than forcing photo.
-- If the speaker has no documented illustration style — default to
-  **photo**.
+1. **`publishing_process.thumbnail.aesthetic_preference`** — explicit
+   speaker-set preference. If `"photo"` or `"comic_book"`, that's the
+   answer; honor it and stop.
+2. **`visual_style_history.default_illustration_style`** — observed
+   pattern across past talks (free-form string set by vault-profile).
+   Fuzzy-match the value against keyword sets:
+   - Matches comic-book family (`comic_book`, `comic-book`, `halftone`,
+     `illustrated`, `cartoon`, `caricature`) → recommend `comic_book`.
+   - Matches a different documented style (`retro_tech_manual`,
+     `watercolor`, etc.) → out-of-scope for current aesthetics; ask
+     before generating, and consider filing an issue requesting the new
+     variant instead of forcing photo.
+   - No match / null → fall through to step 3.
+3. **`visual_style_history.confirmed_visual_intents`** — speaker-
+   confirmed deliberate visual patterns. Same fuzzy-match logic as
+   step 2 against each entry's `pattern` and `rule` fields.
+4. **Default** — `photo`.
 
-**Phase 7 Step 7.1 protocol:** when in doubt, offer the speaker BOTH
-aesthetics for the same title/slide combination. Generate two
-candidates, present side-by-side, let the speaker pick. The comic-book
-treatment is high-variance: when it works it produces significantly
-higher CTR than photo composites, when it misses it looks off-brand.
-The two-candidate approach lets the speaker resolve that variance with
-their own taste — but lead with the recommendation from
-`visual_style_history`, don't present them as equal options when the
-profile clearly favors one.
+The JCON Europe 2026 "Never Trust a Monkey" win validates the comic-book
+approach for at least one speaker whose `default_illustration_style`
+matches the comic-book family; expand the evidence base by trying it
+on other talks where the speaker's brand fits.
+
+**Phase 7 Step 7.1 protocol:** lead with the recommendation from the
+precedence chain above. Offer a two-candidate side-by-side comparison
+when the speaker is genuinely undecided or wants to validate before
+committing — not as a default. The comic-book treatment is high-variance:
+when it works it produces significantly higher CTR than photo composites,
+when it misses it looks off-brand. Two-candidate is for resolving that
+variance with the speaker's own taste, not for ignoring a clear profile
+signal.
 
 **Comic-book prompt anchors** (used internally by the script — don't reproduce
 them in agent-rolled prompts):

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -76,27 +76,29 @@ thumbnail readability at small sizes.
 
 #### 5. Generate
 
-Read `visual_style_history.default_illustration_style` (and
-`confirmed_visual_intents`) from the speaker profile to decide the
-recommended aesthetic per `rules/thumbnail-generation-rules.md` Rule 7:
+Decide the recommended `--aesthetic` per the precedence chain in
+`rules/thumbnail-generation-rules.md` Rule 7. Walk these in order; the
+first match wins:
 
-- Profile signals comic-book / halftone / illustrated brand → **lead
-  with `--aesthetic comic_book`**. Generate it as the primary candidate;
-  optionally also generate `--aesthetic photo` as a comparison if the
-  speaker explicitly asks to see one.
-- Profile signals a different documented style → flag as out-of-scope
-  for the current two aesthetics; ask the speaker before generating.
-- Profile has no documented illustration style → **lead with
-  `--aesthetic photo`**.
+1. `publishing_process.thumbnail.aesthetic_preference` — explicit
+   speaker preference (`"photo"` or `"comic_book"`). Honor it and stop.
+2. `visual_style_history.default_illustration_style` — observed pattern
+   from past talks. Fuzzy-match: matches the comic-book family
+   (`comic_book` / `comic-book` / `halftone` / `illustrated` /
+   `cartoon` / `caricature`) → recommend `comic_book`. Matches a
+   different documented style (`retro_tech_manual`, `watercolor`, etc.)
+   → out-of-scope for current aesthetics; ask the speaker before
+   generating. Otherwise fall through.
+3. `visual_style_history.confirmed_visual_intents` — same fuzzy-match
+   against each entry's `pattern` and `rule` fields.
+4. Default → `photo`.
 
-Generate **two candidates** for side-by-side comparison whenever the
-speaker is undecided or wants to validate before committing to a
-direction. The comic-book treatment is high-variance: when it works it
+Lead with the recommended aesthetic as the primary candidate. Offer a
+two-candidate side-by-side comparison only when the speaker is
+genuinely undecided or wants to validate before committing — not as a
+default. The comic-book treatment is high-variance: when it works it
 produces significantly higher CTR than photo composites, when it misses
-it looks off-brand. The two-candidate approach lets the speaker resolve
-that variance with their own taste — but lead with the recommendation
-from the profile, don't present the two as equal options when the
-profile clearly favors one.
+it looks off-brand.
 
 ```bash
 # Option A: photographic composite (conservative)
@@ -126,14 +128,17 @@ python3 skills/presentation-creator/scripts/generate-thumbnail.py \
   --output thumbnail-comic.png
 ```
 
-For speakers without a documented comic-book aesthetic, generate `photo`
-only and skip the second candidate.
+For most runs only ONE candidate is needed — the one chosen by the
+precedence chain above. The two-candidate command set is only for
+genuine uncertainty.
 
-Apply speaker preferences from `publishing_process.thumbnail`:
-- `aesthetic_preference` → `--aesthetic` (default: `photo`)
+Apply other speaker preferences from `publishing_process.thumbnail`:
 - `style_preference` → `--style`
 - `title_position` → `--title-position`
 - `brand_colors` → `--brand-colors`
+
+(`aesthetic_preference` is consumed at the top of this step as the first
+entry in the precedence chain — don't re-apply it here.)
 
 The script:
 - Sends both images + prompt to Gemini as multimodal input

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -140,8 +140,9 @@ Apply other speaker preferences from `publishing_process.thumbnail`:
 (`aesthetic_preference` is consumed at the top of this step as the first
 entry in the precedence chain — don't re-apply it here.)
 
-The script:
-- Sends both images + prompt to Gemini as multimodal input
+The script (per invocation — runs once per `--aesthetic`):
+- Sends the slide image + speaker photo + prompt to Gemini as
+  multimodal input (two input images, one Gemini call)
 - Uses researched prompt strategy per the chosen aesthetic
 - Validates output: exactly 1280x720, <2MB, PNG preferred
 - Saves to the specified output path (default: `thumbnail.png` in illustrations dir)

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -76,13 +76,27 @@ thumbnail readability at small sizes.
 
 #### 5. Generate
 
-Generate **two candidates** when the speaker has a documented comic-book
-aesthetic in their vault notes — one `--aesthetic photo` (conservative
-photographic composite), one `--aesthetic comic_book` (caricatured
-illustration). Present side-by-side; let the speaker pick. The comic-book
-treatment is high-variance: when it works it produces significantly higher
-CTR than photo composites, when it misses it looks off-brand. See
-`rules/thumbnail-generation-rules.md` Rule 7 for context.
+Read `visual_style_history.default_illustration_style` (and
+`confirmed_visual_intents`) from the speaker profile to decide the
+recommended aesthetic per `rules/thumbnail-generation-rules.md` Rule 7:
+
+- Profile signals comic-book / halftone / illustrated brand → **lead
+  with `--aesthetic comic_book`**. Generate it as the primary candidate;
+  optionally also generate `--aesthetic photo` as a comparison if the
+  speaker explicitly asks to see one.
+- Profile signals a different documented style → flag as out-of-scope
+  for the current two aesthetics; ask the speaker before generating.
+- Profile has no documented illustration style → **lead with
+  `--aesthetic photo`**.
+
+Generate **two candidates** for side-by-side comparison whenever the
+speaker is undecided or wants to validate before committing to a
+direction. The comic-book treatment is high-variance: when it works it
+produces significantly higher CTR than photo composites, when it misses
+it looks off-brand. The two-candidate approach lets the speaker resolve
+that variance with their own taste — but lead with the recommendation
+from the profile, don't present the two as equal options when the
+profile clearly favors one.
 
 ```bash
 # Option A: photographic composite (conservative)


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Fixes a contradiction between Rule 4 ("Speaker Photo Required") and Rule 7 ("Aesthetic Choice — Photo vs Comic Book") in `rules/thumbnail-generation-rules.md` that PR #26 introduced but didn't fully resolve.

## The contradiction

After #26, Rule 6 was scoped to the photo aesthetic only, and Rule 7 added the `comic_book` option. Rule 4, however, still read:

> Real photo only — never AI-generated. Thumbnails with faces get 35-50% higher click-through rates.

A strict reader (especially an LLM agent following the rule top-down) takes Rule 4 as a **blanket prohibition on illustrated faces in the output**. Under that reading, the JCON Europe 2026 "Never Trust a Monkey" thumbnail — the win that motivated #26 in the first place — would never have been generated, because its face is a comic-book caricature, not a photograph.

That's the opposite of what #26 was supposed to enable.

## Two scoped fixes

### 1. Rule 4 — scope to input only

Rewrites Rule 4 to explicitly govern the **speaker photo file passed to the script**, not the output thumbnail:

- Input must always be a real photograph (regardless of aesthetic).
- Output rendering is determined by `--aesthetic` (Rule 7).
- The 35-50% CTR boost from faces still applies whether the output is photographic or caricatured.

### 2. Rule 7 — flip the bias for speakers with documented illustrated brand

Rule 7 previously said "default photo, opt-in comic_book, promote to default after 3+ wins." With the JCON win + the speaker's documented comic-book aesthetic in `visual_style_history`, the right per-speaker recommendation is already comic_book — not a coin-flip side-by-side candidate, but the lead.

Rule 7 now reads:

| Profile signal | Recommendation |
|---|---|
| `visual_style_history` includes comic-book / halftone / illustrated | Lead with `comic_book` |
| Profile has a different documented style (retro tech manual, watercolor, etc.) | Out-of-scope for current aesthetics; ask before generating |
| No documented illustration style | Lead with `photo` |

The CLI default stays `--aesthetic photo` (safer fallback for un-profiled callers); the agent's recommendation now follows the profile and overrides the default when warranted.

## Phase 7 Step 7.1 update

Phase 7 protocol updated to match: read `visual_style_history.default_illustration_style` and `confirmed_visual_intents` to decide the recommended aesthetic. Two-candidate side-by-side is for resolving genuine uncertainty, not for ignoring a clear profile signal.

## Why this is a docs-only fixup

No code changes. The script's `--aesthetic` flag and prompt branches all work the same. The only thing that changed is what the rule text says about WHEN to recommend each aesthetic. PR #26 already shipped the runtime support; this PR fixes the documented policy that surrounds it.

## Test plan

- [ ] CI: tests workflow green (no Python touched)
- [ ] CI: PR Policy Review (Anthropic) self-skips
- [ ] CI: PR Policy Review (OpenAI) verdict — should be clean (no policy rule says "thumbnails must be photographic")

🤖 Generated with [Claude Code](https://claude.com/claude-code)