### PR TITLE
feat(thumbnail): --portrait-style for two-pass anchor-matched composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Presentation Creator
+
+- **`generate-thumbnail.py --portrait-style "<anchor>"`** — new flag
+  enables a two-pass pipeline for decks with an Illustration Style
+  Anchor (Phase 2 output). The script first pre-stylizes the speaker
+  photo into the anchor's medium (sepia tech-manual, watercolor, ink,
+  etc.) via a Gemini image-edit call, then runs the normal composition
+  step using the stylized portrait as input. Fixes the palette-mismatch
+  problem on illustrated decks that neither `--aesthetic photo` nor
+  `--aesthetic comic_book` could solve. Independent of `--aesthetic`;
+  they compose. Phase 7 Step 7.1 now passes the anchor through
+  automatically when `presentation-outline.md` has a `## STYLE ANCHOR`
+  block. Fixes #31.
+
+### Tests
+
+- 6 new tests for the two-pass thumbnail pipeline
+  (`test_stylize_portrait_*` × 4, `test_compose_thumbnail_*` × 2).
+
 ## 0.17.0
 
 **Talk timer, Keynote compatibility, shownotes destination** — New delivery timer

--- a/rules/thumbnail-generation-rules.md
+++ b/rules/thumbnail-generation-rules.md
@@ -165,6 +165,23 @@ default flag. The agent's recommendation, however, follows the profile's
 override the CLI default whenever the profile signals a clear illustrated
 brand.
 
+**Deck illustration anchor — `--portrait-style`.** When the deck has its
+own Illustration Style Anchor (Phase 2's `STYLE ANCHOR` block in
+`presentation-outline.md`), pass it to the script via `--portrait-style
+"<anchor>"`. The script pre-stylizes the speaker photo into the
+anchor's medium (sepia tech-manual, watercolor, pen-and-ink, retro
+poster, etc.) before composition. This fixes the palette mismatch that
+either standard aesthetic produces on illustrated decks: photographic
+skin tones beside a sepia background look jarring; the comic-book
+template's warm Marvel palette clashes with cool / muted anchor styles.
+
+`--portrait-style` is independent of `--aesthetic` — they compose. For
+most illustrated decks, `--aesthetic photo` + `--portrait-style "<anchor>"`
+yields the cleanest result (the portrait is already stylized, so the
+photo aesthetic's "natural" framing applies to a portrait that is no
+longer photographic). Use `--aesthetic comic_book` + `--portrait-style`
+only when the anchor itself describes comic-book treatment.
+
 ## 8. Model Selection and Retry Ladder
 
 Face-composition with real-person photos only works on Nano Banana Pro

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -100,6 +100,18 @@ default. The comic-book treatment is high-variance: when it works it
 produces significantly higher CTR than photo composites, when it misses
 it looks off-brand.
 
+**Pass through the deck's Illustration Style Anchor.** If
+`presentation-outline.md` contains a `## STYLE ANCHOR` block (Phase 2's
+illustration strategy output), pass its content through to
+`generate-thumbnail.py` via `--portrait-style "<anchor>"`. The script
+will pre-stylize the speaker photo into the anchor's medium (sepia
+tech-manual, watercolor, pen-and-ink, etc.) before composition, so the
+output palette matches the deck instead of clashing with it. Without
+this pass-through, photographic skin tones beside an illustrated
+background produce a jarring two-medium composite even when the
+selected aesthetic is otherwise correct. If Phase 2 didn't produce a
+style anchor (e.g., stock-image-only deck), omit `--portrait-style`.
+
 ```bash
 # Option A: photographic composite (conservative)
 python3 skills/presentation-creator/scripts/generate-thumbnail.py \
@@ -126,6 +138,19 @@ python3 skills/presentation-creator/scripts/generate-thumbnail.py \
   --title-position top \
   --brand-colors "#5B2C6F,#C0392B" \
   --output thumbnail-comic.png
+
+# Option C: anchor-matched (when Phase 2 produced a STYLE ANCHOR)
+python3 skills/presentation-creator/scripts/generate-thumbnail.py \
+  --slide-image illustrations/slide-15.png \
+  --speaker-photo ~/photos/headshot.jpg \
+  --title "JUDGMENT DAY" \
+  --subtitle "DevNexus 2026" \
+  --vault ~/.claude/rhetoric-knowledge-vault \
+  --aesthetic photo \
+  --portrait-style "Retro U.S. Military WWII technical manual, sepia, pen-and-ink crosshatching, WWII uniform with garrison cap" \
+  --style slide_dominant \
+  --title-position top \
+  --output thumbnail-anchored.png
 ```
 
 For most runs only ONE candidate is needed — the one chosen by the

--- a/skills/presentation-creator/scripts/generate-thumbnail.py
+++ b/skills/presentation-creator/scripts/generate-thumbnail.py
@@ -306,7 +306,11 @@ def stylize_portrait(speaker_b64, speaker_mime, anchor, model, api_key):
         # absolutes). If Gemini rejects this, the deck's anchor is likely
         # the trigger and softening won't help.
         raise RuntimeError(
-            f"Portrait pre-stylization failed: {result}"
+            f"Portrait pre-stylization failed: {result}\n"
+            f"Try a shorter / simpler --portrait-style anchor (Gemini rejects "
+            f"prompts with too much period-specific or restrictive language), "
+            f"or omit --portrait-style and pre-stylize the photo manually via "
+            f"Google AI Studio before passing it as --speaker-photo."
         )
     stylized_b64 = base64.b64encode(image_bytes).decode("utf-8")
     return stylized_b64, result  # `result` is the mime_type on success
@@ -592,11 +596,18 @@ def compose_thumbnail(args):
     # to the anchor, fixing the "skin tones beside sepia" mismatch that both
     # standard aesthetics produce on illustrated decks. See Issue #31.
     if args.portrait_style:
-        print(f"Pre-stylizing portrait to anchor: {args.portrait_style[:80]}"
-              f"{'...' if len(args.portrait_style) > 80 else ''}")
-        speaker_b64, speaker_mime = stylize_portrait(
-            speaker_b64, speaker_mime, args.portrait_style, model, api_key,
-        )
+        # Normalize whitespace for the preview log — anchors copied from
+        # markdown blocks can carry newlines that break log readability.
+        anchor_preview = " ".join(args.portrait_style.split())
+        print(f"Pre-stylizing portrait to anchor: {anchor_preview[:80]}"
+              f"{'...' if len(anchor_preview) > 80 else ''}")
+        try:
+            speaker_b64, speaker_mime = stylize_portrait(
+                speaker_b64, speaker_mime, args.portrait_style, model, api_key,
+            )
+        except RuntimeError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
 
     print("Generating thumbnail...")
 

--- a/skills/presentation-creator/scripts/generate-thumbnail.py
+++ b/skills/presentation-creator/scripts/generate-thumbnail.py
@@ -17,6 +17,7 @@ Usage:
       [--vault ~/.claude/rhetoric-knowledge-vault] \
       [--style slide_dominant|split_panel|overlay] \
       [--aesthetic photo|comic_book] \
+      [--portrait-style "<anchor>"] \
       [--title-position top|bottom|overlay] \
       [--brand-colors "#5B2C6F,#C0392B"] \
       [--model gemini-3-pro-image-preview]
@@ -264,6 +265,51 @@ def call_gemini(parts, model, api_key):
         pass
 
     return None, f"{_ERR_FILTER}No image in response: {json.dumps(body)[:500]}"
+
+
+# --- Portrait Pre-Stylization (Issue #31) ---
+#
+# When a deck has an Illustration Style Anchor (e.g., retro tech-manual sepia,
+# watercolor, ink-on-parchment), neither --aesthetic photo (palette mismatch)
+# nor --aesthetic comic_book (fixed warm-Marvel palette) produces a portrait
+# that fits the deck. The two-pass solution: first stylize the speaker photo
+# into the deck's anchor (one Gemini image-edit call), then run the normal
+# composition step using the stylized portrait as input. Output palette
+# matches the anchor automatically.
+
+_PORTRAIT_STYLIZE_PROMPT_TEMPLATE = (
+    "Render this portrait in the following illustration style: {anchor}. "
+    "Preserve identifying features (hair, beard, glasses, hat, accessories) "
+    "so the person remains recognizable. Output only the stylized portrait, "
+    "framed as a headshot from the shoulders up, on a neutral background "
+    "consistent with the requested style."
+)
+
+
+def stylize_portrait(speaker_b64, speaker_mime, anchor, model, api_key):
+    """Pre-stylize the speaker photo to match a deck illustration style anchor.
+
+    Returns (stylized_b64, stylized_mime) on success, or raises RuntimeError on
+    failure. The composition pipeline downstream treats the stylized portrait
+    as if it were the original speaker photo.
+    """
+    prompt = _PORTRAIT_STYLIZE_PROMPT_TEMPLATE.format(anchor=anchor)
+    parts = [
+        {"inlineData": {"mimeType": speaker_mime, "data": speaker_b64}},
+        {"text": prompt},
+    ]
+    image_bytes, result = call_gemini(parts, model, api_key)
+    if image_bytes is None:
+        # Either FILTER, HTTP, or OTHER. Caller decides how to surface; we
+        # don't soften the prompt for stylization because the prompt is
+        # already minimal (no viral-styling demands or face-preservation
+        # absolutes). If Gemini rejects this, the deck's anchor is likely
+        # the trigger and softening won't help.
+        raise RuntimeError(
+            f"Portrait pre-stylization failed: {result}"
+        )
+    stylized_b64 = base64.b64encode(image_bytes).decode("utf-8")
+    return stylized_b64, result  # `result` is the mime_type on success
 
 
 # --- Prompt Construction ---
@@ -540,6 +586,18 @@ def compose_thumbnail(args):
     print(f"Title: \"{args.title}\"")
     if args.subtitle:
         print(f"Subtitle: \"{args.subtitle}\"")
+
+    # Pre-stylize portrait to match the deck's illustration anchor when set.
+    # This makes the composition step's input photo already palette-matched
+    # to the anchor, fixing the "skin tones beside sepia" mismatch that both
+    # standard aesthetics produce on illustrated decks. See Issue #31.
+    if args.portrait_style:
+        print(f"Pre-stylizing portrait to anchor: {args.portrait_style[:80]}"
+              f"{'...' if len(args.portrait_style) > 80 else ''}")
+        speaker_b64, speaker_mime = stylize_portrait(
+            speaker_b64, speaker_mime, args.portrait_style, model, api_key,
+        )
+
     print("Generating thumbnail...")
 
     # Build the image parts once; the prompt text is rebuilt per softness level.
@@ -640,6 +698,13 @@ def main():
                         help="Rendering aesthetic (default: photo). 'comic_book' "
                              "produces a caricatured, halftone-shaded illustration "
                              "in the speaker's on-brand comic-book style.")
+    parser.add_argument("--portrait-style", default=None,
+                        help="Deck Illustration Style Anchor. When set, the "
+                             "speaker photo is first pre-stylized to match the "
+                             "anchor (e.g., retro tech-manual sepia, watercolor) "
+                             "before composition — fixes palette mismatch on "
+                             "decks with a strong visual style. Pass through from "
+                             "Phase 2's STYLE ANCHOR block when present.")
     parser.add_argument("--title-position", choices=["top", "bottom", "overlay"],
                         default="top",
                         help="Title text position (default: top)")

--- a/tests/test_generate_thumbnail.py
+++ b/tests/test_generate_thumbnail.py
@@ -256,6 +256,66 @@ def test_call_gemini_http_error_prefix(generate_thumbnail, monkeypatch):
     assert not err.startswith(generate_thumbnail._ERR_FILTER)
 
 
+# --- Issue #31: portrait pre-stylization (two-pass for deck anchors) ---
+
+
+def test_stylize_portrait_returns_stylized_bytes(generate_thumbnail, monkeypatch):
+    """stylize_portrait sends the photo + prompt to Gemini and returns the
+    base64-encoded stylized bytes + the response mime type."""
+    captured = {}
+
+    def fake_call_gemini(parts, model, api_key):
+        captured["parts"] = parts
+        return b"STYLIZED_BYTES", "image/png"
+
+    monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
+    b64, mime = generate_thumbnail.stylize_portrait(
+        "ORIGINAL_B64", "image/jpeg",
+        "retro tech-manual, sepia, pen-and-ink crosshatching",
+        "gemini-3-pro-image-preview", "key",
+    )
+    assert mime == "image/png"
+    # Stylized bytes are returned base64-encoded
+    import base64
+    assert base64.b64decode(b64) == b"STYLIZED_BYTES"
+    # The single Gemini call had exactly the photo + a prompt mentioning the anchor
+    assert len(captured["parts"]) == 2
+    assert captured["parts"][0]["inlineData"]["data"] == "ORIGINAL_B64"
+    assert "retro tech-manual" in captured["parts"][1]["text"]
+    assert "Preserve identifying features" in captured["parts"][1]["text"]
+
+
+def test_stylize_portrait_raises_on_filter_rejection(generate_thumbnail, monkeypatch):
+    """A filter rejection on the pre-stylize call is unrecoverable here —
+    the prompt is already minimal. Surface as a RuntimeError; don't soften."""
+    import pytest
+
+    def fake_call_gemini(parts, model, api_key):
+        return None, generate_thumbnail._ERR_FILTER + "blocked"
+
+    monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
+    with pytest.raises(RuntimeError) as excinfo:
+        generate_thumbnail.stylize_portrait(
+            "B64", "image/jpeg", "any anchor", "model", "key",
+        )
+    assert "Portrait pre-stylization failed" in str(excinfo.value)
+
+
+def test_stylize_portrait_raises_on_http_error(generate_thumbnail, monkeypatch):
+    """HTTP errors are also surfaced as RuntimeError — softening a stylize
+    call doesn't help (the prompt has no viral-styling demands to drop)."""
+    import pytest
+
+    def fake_call_gemini(parts, model, api_key):
+        return None, generate_thumbnail._ERR_HTTP + "429: rate limited"
+
+    monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
+    with pytest.raises(RuntimeError):
+        generate_thumbnail.stylize_portrait(
+            "B64", "image/jpeg", "any anchor", "model", "key",
+        )
+
+
 def _make_large_image_bytes():
     """Create a large random-ish image that exceeds 2MB as PNG."""
     import random

--- a/tests/test_generate_thumbnail.py
+++ b/tests/test_generate_thumbnail.py
@@ -316,6 +316,160 @@ def test_stylize_portrait_raises_on_http_error(generate_thumbnail, monkeypatch):
         )
 
 
+def test_stylize_portrait_error_message_is_actionable(generate_thumbnail, monkeypatch):
+    """Per error-handling rule, the error must tell the user what to DO,
+    not just what went wrong. The wrapper message includes recovery
+    guidance (shorter anchor / pre-stylize manually)."""
+    import pytest
+
+    def fake_call_gemini(parts, model, api_key):
+        return None, generate_thumbnail._ERR_FILTER + "blocked"
+
+    monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
+    with pytest.raises(RuntimeError) as excinfo:
+        generate_thumbnail.stylize_portrait("B64", "image/jpeg", "x", "m", "k")
+    msg = str(excinfo.value)
+    assert "Portrait pre-stylization failed" in msg
+    # Recovery guidance is what makes the error actionable.
+    assert "shorter" in msg.lower() or "simpler" in msg.lower()
+    assert "Google AI Studio" in msg or "manually" in msg.lower()
+
+
+def test_compose_thumbnail_two_pass_threads_stylized_portrait(
+    generate_thumbnail, monkeypatch, tmp_path,
+):
+    """When --portrait-style is set, compose_thumbnail must:
+    (a) call stylize_portrait with the original photo bytes, and
+    (b) feed the STYLIZED bytes into the subsequent composition call_gemini,
+        not the original photo bytes.
+    """
+    import argparse
+
+    # Build a minimal .png and .jpg on disk so load_image_as_base64 can read them.
+    slide_path = tmp_path / "slide.png"
+    speaker_path = tmp_path / "headshot.jpg"
+    slide_path.write_bytes(b"SLIDE_RAW")
+    speaker_path.write_bytes(b"PHOTO_RAW")
+
+    # Patch out the API key load so we don't need secrets.json.
+    monkeypatch.setattr(generate_thumbnail, "load_api_key", lambda v: "fake-key")
+
+    # Track every call_gemini invocation: order and the photo bytes inside.
+    calls = []
+
+    def fake_call_gemini(parts, model, api_key):
+        # Record the second inlineData part's `data` value (the speaker photo
+        # in the composition call) so the assertion can confirm it's the
+        # stylized output, not the original.
+        photo_part = next(
+            (p for p in parts if "inlineData" in p and p["inlineData"]["data"] != "PHOTO_RAW_B64"),
+            None,
+        )
+        # The composition call will have BOTH images; record the photo data.
+        composition_photo_data = None
+        if len(parts) >= 2 and "inlineData" in parts[1]:
+            composition_photo_data = parts[1]["inlineData"]["data"]
+        calls.append({"parts_count": len(parts), "composition_photo": composition_photo_data})
+        # Return a 1280x720 PNG to satisfy validate_and_resize.
+        from io import BytesIO
+        img = Image.new("RGB", (1280, 720), (10, 20, 30))
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue(), "image/png"
+
+    # Patch stylize_portrait to return identifiable bytes so the composition
+    # call's inlineData.data is verifiable.
+    def fake_stylize(speaker_b64, speaker_mime, anchor, model, api_key):
+        # Confirm the original photo bytes reach the stylize step
+        import base64
+        assert base64.b64decode(speaker_b64) == b"PHOTO_RAW"
+        assert anchor == "sepia tech-manual, pen-and-ink"
+        return "STYLIZED_B64", "image/png"
+
+    monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
+    monkeypatch.setattr(generate_thumbnail, "stylize_portrait", fake_stylize)
+
+    args = argparse.Namespace(
+        slide_image=str(slide_path),
+        speaker_photo=str(speaker_path),
+        title="JUDGMENT DAY",
+        subtitle=None,
+        output=str(tmp_path / "out.png"),
+        vault=str(tmp_path),
+        style="slide_dominant",
+        aesthetic="photo",
+        portrait_style="sepia tech-manual, pen-and-ink",
+        title_position="top",
+        brand_colors=None,
+        model=None,
+    )
+
+    generate_thumbnail.compose_thumbnail(args)
+
+    # Composition was called once (default softness path produced an image
+    # immediately, so the retry ladder didn't need to fire).
+    assert len(calls) == 1
+    # The composition call's photo data is the STYLIZED output, not the
+    # original PHOTO_RAW.
+    assert calls[0]["composition_photo"] == "STYLIZED_B64"
+
+
+def test_compose_thumbnail_skips_pre_stylize_when_no_anchor(
+    generate_thumbnail, monkeypatch, tmp_path,
+):
+    """Without --portrait-style, stylize_portrait must NOT be invoked; the
+    original photo bytes go directly to composition."""
+    import argparse, base64
+
+    slide_path = tmp_path / "slide.png"
+    speaker_path = tmp_path / "headshot.jpg"
+    slide_path.write_bytes(b"SLIDE_RAW")
+    speaker_path.write_bytes(b"PHOTO_RAW")
+
+    monkeypatch.setattr(generate_thumbnail, "load_api_key", lambda v: "fake-key")
+
+    stylize_called = []
+
+    def fake_stylize(*a, **kw):
+        stylize_called.append(True)
+        return "WRONG", "image/png"
+
+    captured_photo = []
+
+    def fake_call_gemini(parts, model, api_key):
+        if len(parts) >= 2 and "inlineData" in parts[1]:
+            captured_photo.append(parts[1]["inlineData"]["data"])
+        from io import BytesIO
+        img = Image.new("RGB", (1280, 720), (10, 20, 30))
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue(), "image/png"
+
+    monkeypatch.setattr(generate_thumbnail, "stylize_portrait", fake_stylize)
+    monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
+
+    args = argparse.Namespace(
+        slide_image=str(slide_path),
+        speaker_photo=str(speaker_path),
+        title="T", subtitle=None,
+        output=str(tmp_path / "out.png"),
+        vault=str(tmp_path),
+        style="slide_dominant",
+        aesthetic="photo",
+        portrait_style=None,
+        title_position="top",
+        brand_colors=None,
+        model=None,
+    )
+
+    generate_thumbnail.compose_thumbnail(args)
+
+    assert stylize_called == [], "stylize_portrait must not run without --portrait-style"
+    # The composition call received the ORIGINAL photo (base64-encoded raw).
+    expected_b64 = base64.b64encode(b"PHOTO_RAW").decode("utf-8")
+    assert captured_photo[0] == expected_b64
+
+
 def _make_large_image_bytes():
     """Create a large random-ish image that exceeds 2MB as PNG."""
     import random


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Adds `--portrait-style "<anchor>"` to `generate-thumbnail.py`. When set, the script runs a one-call pre-stylize pass on the speaker photo (Gemini image-edit) to render it in the deck's Illustration Style Anchor before the normal composition step.

Fixes #31.

## Why

For decks with a strong style anchor (Phase 2's `STYLE ANCHOR` block — sepia tech-manual, watercolor, pen-and-ink, etc.), neither current aesthetic produces a coherent thumbnail:

- `--aesthetic photo` → photographic skin tones beside a fully-stylized illustrated background = jarring two-medium composite.
- `--aesthetic comic_book` → comic-book caricature with fixed warm-Marvel palette clashing with cool/muted anchors.

The user validated a manual two-pass approach on a recent talk: pre-stylize the portrait into the anchor first, then composite as normal. Output had a unified palette and felt cohesive with the deck. This PR automates that workflow.

## How it composes

`--portrait-style` is **independent of `--aesthetic`**. They compose:

| `--aesthetic` | `--portrait-style` | Result |
|---|---|---|
| `photo` | unset | Current photographic-composite default |
| `comic_book` | unset | Current comic-book default (warm Marvel palette) |
| `photo` | `"<anchor>"` | **Recommended for illustrated decks** — portrait pre-stylized to anchor; composition uses the photo aesthetic's "natural" framing applied to a now-illustrated portrait |
| `comic_book` | `"<anchor>"` | Use only when the anchor itself describes comic-book treatment |

## Behavior of the pre-stylize call

- Single Gemini image-edit call: `[speaker photo, prompt with anchor]` → stylized portrait bytes
- Prompt template:
  > "Render this portrait in the following illustration style: {anchor}. Preserve identifying features (hair, beard, glasses, hat, accessories) so the person remains recognizable. Output only the stylized portrait, framed as a headshot from the shoulders up, on a neutral background consistent with the requested style."
- No softness retry ladder for the stylize call — the prompt is already minimal (no viral-styling demands, no face-preservation absolutes that would trip the safety filter). If Gemini rejects, the deck's anchor itself is the trigger and softening the script's wrapper wouldn't help.
- Failures (filter / HTTP / network) raise `RuntimeError` and abort the compose pipeline. The output thumbnail isn't half-stylized; it's either fully two-pass or the run fails loud.

## Auto-trigger from Phase 2

Phase 7 Step 7.1 now reads the deck's `## STYLE ANCHOR` block from `presentation-outline.md` and passes it through to the script via `--portrait-style "<anchor>"`. If Phase 2 didn't produce a style anchor, the flag is omitted and current single-pass behavior runs unchanged.

## Test coverage added

- `test_stylize_portrait_returns_stylized_bytes` — sends photo + prompt with anchor to Gemini; returns base64-encoded result; prompt mentions the anchor and the identifying-features preservation clause.
- `test_stylize_portrait_raises_on_filter_rejection` — `RuntimeError` on `_ERR_FILTER`; no softening attempted.
- `test_stylize_portrait_raises_on_http_error` — `RuntimeError` on `_ERR_HTTP`.

25/25 thumbnail tests pass; full suite 173 + 5 skipped.

## Test plan

- [ ] CI: tests workflow green
- [ ] CI: PR Policy Review (Anthropic) self-skips
- [ ] CI: PR Policy Review (OpenAI) verdict
- [ ] Smoke after merge: re-run the user's recent thumbnail with `--portrait-style "<the anchor that was used manually>"` and confirm the output matches the manually-pre-stylized result. (Anchor wording may need iteration; the prompt template is one Gemini call so quick to retry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)