### PR TITLE
feat(patterns): ingest Presentation Zen as second taxonomy source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,49 @@
   automatically when `presentation-outline.md` has a `## STYLE ANCHOR`
   block. Fixes #31.
 
+### Pattern Taxonomy — Presentation Zen ingest
+
+Second source ingested alongside Ford/McCullough/Schutta (2013):
+Garr Reynolds, *Presentation Zen* (2nd ed., 2012, New Riders).
+
+- **2 new patterns:**
+  - `patterns/prepare/opening-punch.md` — Reynolds's PUNCH framework
+    (Personal / Unexpected / Novel / Challenging / Humorous) for
+    opening hooks; vault dimensions 1, 4
+  - `patterns/deliver/screen-blackout.md` — deliberate B-key blackout
+    or planned black slides as attention-redirection device; vault
+    dimensions 12, 13
+- **3 refinement subsections** folded into existing patterns:
+  - `breathing-room.md` ← *Hara Hachi Bu* (90–95% finish-line discipline)
+  - `concurrent-creation.md` ← *Plan Analog Before Going Digital*
+  - `the-big-why.md` ← *The Elevator Test* (30–45 sec core-message check)
+- **17 patterns** gain `## Related Reading` Reynolds citations
+  (slideuments, bullet-riddled-corpse, floodmarks, borrowed-shoes,
+  cookie-cutter, ant-fonts, narrative-arc, triad, crucible,
+  concurrent-creation, vacation-photos, cave-painting, takahashi,
+  bunker, bookends, coda, breathing-room).
+- **`patterns/_index.md`** — catalog tables, phase lookup, vault-dim
+  mapping, summary stats updated; sources section now lists Reynolds
+  alongside Ford et al.
+
+### Phase Documentation
+
+- **Phase 1 (Intent):** Spec Validation gains the Two Questions check,
+  the Elevator Test check, and the SUCCESs sticky-message check.
+- **Phase 2 (Architecture):** new "Plan Analog Before Going Digital"
+  section advocates whiteboard/Post-it work before slideware.
+- **Phase 3 (Content):** new "Opening PUNCH" section requires explicit
+  PUNCH-flavor tagging on the opening; new "Use Contrast as a
+  Structural Device" section.
+- **Phase 5 (Slides):** new "General Design Principles" section
+  references slide-design-spec §11 (SNR, Big Four, picture superiority,
+  empty space, rule of thirds, eye-gaze, full-bleed, 2D-for-2D, logo
+  discipline, minimum font size).
+- **Phase 6 (Publishing):** Go-Live Checklist gains venue-setup items
+  (lights on, lectern aside, mic discipline) and during-delivery items
+  (honeymoon-window discipline, never-apologize, *hara hachi bu*
+  finish-line, screen-blackout).
+
 ### Tests
 
 - 6 new tests for the two-pass thumbnail pipeline

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -27,11 +27,12 @@ combinatorics are needed.
 
 ## Pattern Catalog
 
-### Prepare Phase (18 patterns + 3 antipatterns)
+### Prepare Phase (19 patterns + 3 antipatterns)
 
 | ID | Name | Type | Vault Dims | Creator Phases | Related |
 |----|------|------|------------|----------------|---------|
 | know-your-audience | Know Your Audience | pattern | 4, 9 | intake | emotional-state, seeding-satisfaction |
+| opening-punch | Opening PUNCH | pattern | 1, 4 | intent, content | bookends, narrative-arc, foreshadowing, preroll, know-your-audience |
 | social-media-advertising | Social Media Advertising | pattern | 4 | publishing | seeding-satisfaction |
 | required | Required | pattern | 9 | intake, intent | proposed, posse, concurrent-creation, crucible |
 | the-big-why | The Big Why | pattern | 9 | intake | carnegie-hall, crucible |
@@ -95,11 +96,12 @@ combinatorics are needed.
 | slideuments | Slideuments | antipattern | 8, 14 | guardrails | infodeck, charred-trail, gradual-consistency |
 | dead-demo | Dead Demo | antipattern | 11, 14 | guardrails | live-demo, a-la-carte-content |
 
-### Deliver Phase (18 patterns + 12 antipatterns)
+### Deliver Phase (19 patterns + 12 antipatterns)
 
 | ID | Name | Type | Vault Dims | Creator Phases | Related |
 |----|------|------|------------|----------------|---------|
 | preparation | Preparation | pattern | 14 | publishing | know-your-audience, carnegie-hall |
+| screen-blackout | Screen Blackout | pattern | 12, 13 | content, slides | breathing-room, intermezzi, brain-breaks, mentor |
 | carnegie-hall | Carnegie Hall | pattern | 12, 14 | publishing | crucible |
 | posse | Posse | pattern | 4 | publishing | greek-chorus, seeding-satisfaction |
 | seeding-satisfaction | Seeding Satisfaction | pattern | 4 | publishing | know-your-audience, social-media-advertising |
@@ -154,6 +156,7 @@ Planning patterns — inform spec construction.
 - required
 - proposed
 - mentor
+- opening-punch
 - abstract-attorney *(antipattern — warn about abstract drift)*
 
 ### Phase 2: Architecture
@@ -181,6 +184,7 @@ Build patterns — applied during outline writing.
 - leet-grammars, entertainment, breathing-room
 - display-of-high-value, mentor, seeding-the-first-question
 - make-it-rain, lightsaber, echo-chamber
+- opening-punch, screen-blackout
 
 ### Phase 4: Guardrails
 Antipatterns as warnings — scanned against the outline.
@@ -197,6 +201,7 @@ Visual/construction patterns — applied during slide generation.
 - exuberant-title-top, invisibility, soft-transitions
 - traveling-highlights, crawling-code, emergence
 - preroll, crawling-credits, bookends, intermezzi, breadcrumbs
+- screen-blackout
 - cookie-cutter, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons *(antipatterns)*
 
 ### Phase 6: Publishing
@@ -215,10 +220,10 @@ Reverse lookup: which patterns relate to each of the 14 rhetoric analysis dimens
 
 | Dim | Name | Patterns | Antipatterns |
 |-----|------|----------|--------------|
-| 1 | Opening Pattern | preroll | — |
+| 1 | Opening Pattern | preroll, opening-punch | — |
 | 2 | Narrative Structure | narrative-arc, fourthought, triad, expansion-joints, talklet, context-keeper, breadcrumbs, bookends, intermezzi, foreshadowing, backtracking, a-la-carte-content, concurrent-creation, lightning-talk | abstract-attorney, celery |
 | 3 | Humor & Wit | brain-breaks, entertainment | alienating-artifact |
-| 4 | Audience Interaction | know-your-audience, social-media-advertising, a-la-carte-content, posse, seeding-satisfaction, seeding-the-first-question, emotional-state, make-it-rain, echo-chamber, red-yellow-green, greek-chorus | bunker, hecklers, backchannel, negative-ignorance, dual-headed-monster |
+| 4 | Audience Interaction | know-your-audience, social-media-advertising, a-la-carte-content, posse, seeding-satisfaction, seeding-the-first-question, emotional-state, make-it-rain, echo-chamber, red-yellow-green, greek-chorus, opening-punch | bunker, hecklers, backchannel, negative-ignorance, dual-headed-monster |
 | 5 | Transition Techniques | narrative-arc, foreshadowing, backtracking, context-keeper, bookends, intermezzi, soft-transitions, cave-painting | — |
 | 6 | Closing Pattern | coda, crawling-credits | — |
 | 7 | Verbal Signatures | leet-grammars, peer-review, breathing-room, echo-chamber | hiccup-words, borrowed-shoes, tower-of-babble |
@@ -226,8 +231,8 @@ Reverse lookup: which patterns relate to each of the 14 rhetoric analysis dimens
 | 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig |
 | 10 | Cultural & Pop-Culture References | leet-grammars, unifying-visual-theme, entertainment | alienating-artifact, photomaniac |
 | 11 | Technical Content Delivery | live-demo, lipsync, traveling-highlights, crawling-code, emergence, mentor, lightsaber | dead-demo |
-| 12 | Pacing Clues | crucible, expansion-joints, talklet, brain-breaks, lightning-talk, takahashi, carnegie-hall, breathing-room, weatherman | shortchanged, disowning-your-topic |
-| 13 | Slide Design Patterns | unifying-visual-theme, takahashi, cave-painting, composite-animation, vacation-photos, defy-defaults, analog-noise, gradual-consistency, charred-trail, exuberant-title-top, invisibility, context-keeper, breadcrumbs, bookends, soft-transitions, intermezzi, preroll, crawling-credits, lipsync, traveling-highlights, crawling-code, emergence | cookie-cutter, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons |
+| 12 | Pacing Clues | crucible, expansion-joints, talklet, brain-breaks, lightning-talk, takahashi, carnegie-hall, breathing-room, weatherman, screen-blackout | shortchanged, disowning-your-topic |
+| 13 | Slide Design Patterns | unifying-visual-theme, takahashi, cave-painting, composite-animation, vacation-photos, defy-defaults, analog-noise, gradual-consistency, charred-trail, exuberant-title-top, invisibility, context-keeper, breadcrumbs, bookends, soft-transitions, intermezzi, preroll, crawling-credits, lipsync, traveling-highlights, crawling-code, emergence, screen-blackout | cookie-cutter, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons |
 | 14 | Areas for Improvement | crucible, preparation, carnegie-hall, shoeless, stakeout | abstract-attorney, alienating-artifact, celery, injured-outlines, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, borrowed-shoes, slideuments, dead-demo, shortchanged, hiccup-words, disowning-your-topic, going-meta, bunker, hecklers, backchannel, laser-weapons, negative-ignorance, dual-headed-monster, tower-of-babble, lipstick-on-a-pig |
 
 ---
@@ -269,14 +274,14 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 
 ## Summary Statistics
 
-- **Total entries:** 88 (63 patterns + 25 antipatterns)
-- **Observable (vault-scorable):** 77 (55 patterns + 22 antipatterns)
+- **Total entries:** 90 (65 patterns + 25 antipatterns)
+- **Observable (vault-scorable):** 79 (57 patterns + 22 antipatterns)
 - **Unobservable (go-live checklist):** 11 (8 patterns + 3 antipatterns)
-- **Prepare phase:** 21 (18 patterns + 3 antipatterns)
+- **Prepare phase:** 22 (19 patterns + 3 antipatterns)
 - **Build phase:** 37 (27 patterns + 10 antipatterns)
-- **Deliver phase:** 30 (18 patterns + 12 antipatterns)
+- **Deliver phase:** 31 (19 patterns + 12 antipatterns)
 
-## Source
+## Sources
 
-Ford, N., McCullough, M., & Schutta, N. (2013). *Presentation Patterns: Techniques
-for Crafting Better Presentations.* Addison-Wesley.
+- Ford, N., McCullough, M., & Schutta, N. (2013). *Presentation Patterns: Techniques for Crafting Better Presentations.* Addison-Wesley. — primary taxonomy source.
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). New Riders. — supplementary source; reinforces ~17 existing patterns and contributes the `opening-punch` and `screen-blackout` patterns plus the `hara-hachi-bu`, `analog-planning`, and `elevator-test` refinements folded into `breathing-room`, `concurrent-creation`, and `the-big-why` respectively.

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -1,8 +1,10 @@
 # Presentation Patterns — Master Index
 
-Structured reference taxonomy based on *Presentation Patterns: Techniques for Crafting
-Better Presentations* (Neal Ford, Matthew McCullough, Nathaniel Schutta, 2013). Contains
-63 named patterns and 25 antipatterns organized by presentation lifecycle phase.
+Structured reference taxonomy primarily based on *Presentation Patterns: Techniques for
+Crafting Better Presentations* (Neal Ford, Matthew McCullough, Nathaniel Schutta, 2013),
+with supplementary patterns and reinforcements from *Presentation Zen* (Garr Reynolds,
+2nd ed., 2012). Contains 65 named patterns and 25 antipatterns organized by presentation
+lifecycle phase. See the Sources section at the end of this file for full citations.
 
 **This is the primary entry point.** The agent reads this file first, then drills into
 individual pattern files only when detailed descriptions, scoring criteria, or
@@ -284,4 +286,4 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 ## Sources
 
 - Ford, N., McCullough, M., & Schutta, N. (2013). *Presentation Patterns: Techniques for Crafting Better Presentations.* Addison-Wesley. — primary taxonomy source.
-- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). New Riders. — supplementary source; reinforces ~17 existing patterns and contributes the `opening-punch` and `screen-blackout` patterns plus the `hara-hachi-bu`, `analog-planning`, and `elevator-test` refinements folded into `breathing-room`, `concurrent-creation`, and `the-big-why` respectively.
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). New Riders. — supplementary source; reinforces ~17 existing patterns and contributes the `opening-punch` and `screen-blackout` patterns plus three refinement subsections folded into existing patterns: "Hara Hachi Bu — The 90–95% Finish Line" (in `breathing-room.md`), "Plan Analog Before Going Digital" (in `concurrent-creation.md`), and "The Elevator Test" (in `the-big-why.md`).

--- a/skills/presentation-creator/references/patterns/build/_anti_ant-fonts.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_ant-fonts.md
@@ -51,3 +51,6 @@ Dimension 13 (Slide Aesthetics): Ant Fonts directly degrade the visual quality o
 
 ## Combinatorics
 Ant Fonts frequently co-occurs with Bullet-Riddled Corpse, as the desire to include many bullet points on a single slide drives the font size down. It also co-occurs with Cookie Cutter, where the constraint of one-idea-per-slide forces text reduction to fit the container. The Infodeck pattern (slides designed for reading, not presenting) is the one context where smaller text might be acceptable, since the reader controls their viewing distance. In live presentation contexts, Ant Fonts has no acceptable application.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 9 — quotes Guy Kawasaki: "If you need to put eight-point or ten-point fonts up there, it's because you do not know your material." New Riders.

--- a/skills/presentation-creator/references/patterns/build/_anti_borrowed-shoes.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_borrowed-shoes.md
@@ -49,3 +49,6 @@ Dimension 7 (Language and Communication): Borrowed Shoes creates a mismatch betw
 
 ## Combinatorics
 Borrowed Shoes is mitigated by the Crucible pattern (intensive rehearsal transforms unfamiliar material into internalized content), the Narrative Arc pattern (understanding the story structure helps the presenter navigate borrowed material), and the Carnegie Hall pattern (deliberate practice reduces the friction of presenting someone else's slides). When these patterns are applied rigorously, the worst effects of Borrowed Shoes can be reduced — though the ideal solution remains reworking the material to fit the presenter's own style.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 6 — argues against using corporate or stock templates that don't fit your message. New Riders.

--- a/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
@@ -51,3 +51,6 @@ Dimension 8 (Slide Design): Bullet-Riddled Corpse is a fundamental failure of sl
 
 ## Combinatorics
 Bullet-Riddled Corpse is the inverse of both Vacation Photos (image-centric slides with minimal text) and Takahashi (slides with single large words or phrases). It often co-occurs with Cookie Cutter (cramming ideas into slide-sized containers) and Ant Fonts (shrinking text to fit more bullets). The Charred Trail pattern (leaving breadcrumbs of previous content) and the Infodeck pattern (document-style decks) both represent contexts where text density is more appropriate. Breaking free from Bullet-Riddled Corpse often requires fundamental rethinking of how slides function in a live presentation.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 6 — "How Many Bullet Points Per Slide?" and the "1-7-7 Rule" critique. New Riders.

--- a/skills/presentation-creator/references/patterns/build/_anti_cookie-cutter.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_cookie-cutter.md
@@ -50,3 +50,6 @@ Dimension 8 (Slide Design): Cookie Cutter fundamentally compromises slide design
 
 ## Combinatorics
 Cookie Cutter is the inverse of Soft Transitions, which explicitly encourages multi-slide sequences that blur the boundaries between ideas. It often co-occurs with Bullet-Riddled Corpse (bullets used to fit more content per slide) and Ant Fonts (small text used to fit more content per slide). The Fourthought pattern, when applied properly during the ideation phase, helps prevent Cookie Cutter by encouraging ideas to find their natural size before slides are designed.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 1, 6 — "cookie-cutter method of design and delivery" critique; templates as the "car for your mind" rather than the "bicycle." New Riders.

--- a/skills/presentation-creator/references/patterns/build/_anti_floodmarks.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_floodmarks.md
@@ -50,3 +50,6 @@ Dimension 13 (Slide Aesthetics): Floodmarks directly degrade slide aesthetics by
 
 ## Combinatorics
 Floodmarks is the inverse of the Defy Defaults pattern, which encourages presenters to break free from default templates and create custom designs. It often co-occurs with Fontaholic, as corporate templates frequently introduce additional font families for branding elements. The Bookends pattern provides the architectural solution: branding on the first and last slides, clean canvas everywhere else. The Unifying Visual Theme pattern offers a positive alternative to Floodmarks — instead of branding noise, use a coherent visual metaphor that serves both the content and the aesthetic.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 6 — "Who Says Your Logo Should Be on Every Slide?" advocates logo on first and last slide only. New Riders.

--- a/skills/presentation-creator/references/patterns/build/_anti_slideuments.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_slideuments.md
@@ -49,3 +49,6 @@ Dimension 8 (Slide Design): Slideuments represent a fundamental design failure b
 
 ## Combinatorics
 Slideuments is the inverse of the Infodeck pattern — where an Infodeck is deliberately designed for reading (embracing document characteristics), a Slideument accidentally tries to be both and fails at both. It relates to the Charred Trail pattern (leaving a trail of content for after-the-fact consumption) and Gradual Consistency (building coherent artifacts over time). The Bullet-Riddled Corpse antipattern often appears within Slideuments, as the dual-purpose compromise tends to produce bullet-heavy slides.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 3 — Reynolds coined the term "slideument" and dedicates the "Create a Document, Not a Slideument" section to this antipattern. New Riders.

--- a/skills/presentation-creator/references/patterns/build/bookends.md
+++ b/skills/presentation-creator/references/patterns/build/bookends.md
@@ -50,3 +50,6 @@ Dimension 2 (Structure and Flow): Bookends are the most visible expression of st
 
 ## Combinatorics
 Bookends pair naturally with Context Keeper and Breadcrumbs — Bookends mark the boundaries while Breadcrumbs track progress across those boundaries. They complement Narrative Arc by providing visual markers for narrative phase transitions. Intermezzi is a related pattern that serves a similar structural role but with more thematic emphasis. Bookends work well with Defy Defaults as an opportunity to express custom visual identity, and they serve as a natural inverse of Floodmarks by containing required branding in structural slides rather than spreading it across every content slide.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 9, 10 — primacy + recency effects: "people best remember the first part and the last part of your presentation"; rehearse opening and closing more than the middle. New Riders.

--- a/skills/presentation-creator/references/patterns/build/coda.md
+++ b/skills/presentation-creator/references/patterns/build/coda.md
@@ -50,3 +50,6 @@ Dimension 6 (Information Density): The Coda allows the speaker to maintain appro
 
 ## Combinatorics
 The Coda pairs naturally with the Infodeck pattern, as both deal with content designed for solo consumption. It works well alongside Vacation Photos because image-heavy spoken slides benefit from having a text-rich reference section at the end. The Coda also supports Narrative Arc by keeping disruptive reference material out of the story flow.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 10 — "Save the best for last," exemplified by Steve Jobs's "one more thing" closing slide. New Riders.

--- a/skills/presentation-creator/references/patterns/build/vacation-photos.md
+++ b/skills/presentation-creator/references/patterns/build/vacation-photos.md
@@ -51,3 +51,6 @@ Dimension 8 (Slide Design): Vacation Photos represents a deliberate architectura
 
 ## Combinatorics
 Vacation Photos pairs powerfully with Unifying Visual Theme, where a consistent photographic style or subject matter creates visual coherence across the deck. It works well with Narrative Arc because image-driven slides naturally support storytelling flow. The Coda pattern is an essential companion, providing a place for the detailed references and text that Vacation Photos deliberately excludes from the spoken portion.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 6, 7 — full-bleed images as the dynamic, asymmetric foundation of slide design; "Going Visual" applies the picture superiority effect. New Riders.

--- a/skills/presentation-creator/references/patterns/deliver/_anti_bunker.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_bunker.md
@@ -53,3 +53,6 @@ This antipattern maps to Vault Dimension 4 (Audience Engagement) because physica
 
 ## Combinatorics
 The Bunker antipattern is prevented by Carnegie Hall rehearsal (practice moving while presenting), Preparation (arrange wireless microphone in advance), and Know Your Audience (understanding the room layout). The Weatherman pattern frees you from the podium by providing presenter view on your laptop rather than requiring notes at the podium. Make It Rain is almost impossible from behind a bunker — physical interaction demands physical proximity.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 9, 10 — "Remove Barriers to Communication": the lectern is "so last millennium"; together with the computer screen and stack of notes, lecterns form the three walls between speaker and audience. New Riders.

--- a/skills/presentation-creator/references/patterns/deliver/breathing-room.md
+++ b/skills/presentation-creator/references/patterns/deliver/breathing-room.md
@@ -31,6 +31,13 @@ Beyond comprehension, strategic silence creates dramatic effect. The rhetorical 
 
 The Breathing Room pattern also applies at a structural level. Leave time between major sections for the audience to mentally file what they have learned and prepare for what comes next. Do not pack your talk so tightly that every minute is accounted for — leave margins. These margins serve double duty: they provide cognitive breathing room for the audience and practical breathing room for you if a section runs long or a question takes extra time.
 
+### Hara Hachi Bu — The 90–95% Finish Line
+The structural application of breathing room extends to the talk's overall length. Garr Reynolds borrows the Japanese eating principle *hara hachi bu* — "eat until 80% full" — and applies it to presentation timing: finish at roughly 90–95% of your allotted time, never run over. The two phrasings differ slightly because the eating ratio (80%) leaves more headroom than the speaking ratio (90–95%), but the spirit is identical: stop deliberately *before* the audience wants you to stop, leaving them satisfied but slightly hungry rather than stuffed and fatigued.
+
+Two reasons make this discipline non-negotiable. First, audience concentration drops sharply after 15–20 minutes regardless of speaker quality, so the marginal value of the last 5% of an allotted slot is usually negative — you trade fresh attention for diminishing returns. Second, running over signals that the speaker did not respect the audience's time, the next speaker's slot, or the constraints of the room. No audience member ever complained that a talk ended a few minutes early; many have complained about a talk that ran long.
+
+Practically, this means timing rehearsals (`carnegie-hall`) should target 90–95% of the slot, not 100%. If a talk consistently runs to 100% in rehearsal, it will run over in delivery — adrenaline and audience interaction lengthen everything. Cut content during the prepare phase until the rehearsal lands at the target, rather than relying on speed-up improvisation on stage.
+
 ## When to Use / When to Avoid
 Use this pattern in every presentation, with the frequency and duration of pauses calibrated to the content density and audience. Dense technical content requires more breathing room; light, entertaining content can sustain a faster pace. Avoid pauses that are so long they become awkward silences — the goal is strategic, not uncomfortable. Also avoid mechanical pausing (exactly every 30 seconds) that feels robotic rather than natural. With Carnegie Hall rehearsal, you learn where the natural pause points live.
 
@@ -50,3 +57,6 @@ This pattern maps to Vault Dimension 7 (Clarity / Communication) because pauses 
 
 ## Combinatorics
 Breathing Room is the direct inverse of the Hiccup Words antipattern — confident silence replaces nervous filler. It pairs with Narrative Arc (pauses at narrative transition points), Brain Breaks (pauses as micro-breaks), and Carnegie Hall (rehearsal is where you discover and practice pause points). It also supports Entertainment — the comedic pause is a specific application of this pattern — and Emotional State — adjusting pause frequency based on audience energy level.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 9 — *hara hachi bu* ("eat until 80% full") applied to time discipline: finish at 90–95% and leave the audience slightly hungry, not stuffed. New Riders.

--- a/skills/presentation-creator/references/patterns/deliver/screen-blackout.md
+++ b/skills/presentation-creator/references/patterns/deliver/screen-blackout.md
@@ -1,0 +1,55 @@
+---
+id: screen-blackout
+name: Screen Blackout
+type: pattern
+part: deliver
+phase_relevance:
+  - content
+  - slides
+vault_dimensions: [12, 13]
+detection_signals:
+  - "deliberate blank or black slide between sections"
+  - "B-key blackout during digression or audience question"
+  - "speaker holds attention without screen support"
+related_patterns: [breathing-room, intermezzi, brain-breaks, mentor]
+inverse_of: []
+difficulty: intermediate
+---
+
+# Screen Blackout
+
+## Summary
+Deliberately blank the screen — by inserting a black slide or pressing the B key — to redirect all audience attention onto the speaker for moments that do not need visual support.
+
+## The Pattern in Detail
+A live talk has two channels of attention competing for the audience: the speaker and the screen. Most of the time these channels reinforce each other — the slide amplifies what the speaker is saying. But there are moments when the screen actively *competes* with the speaker, draining attention from the human in the room. Screen Blackout is the deliberate technique of turning the screen off at those moments so the audience has nowhere to look but at the speaker.
+
+The two implementations are functionally equivalent. The first is to **build black slides into the deck** at planned points — section boundaries, the start of a personal story, the moment before a punchline, the answer to an audience question. These slides require no design work; they are simply black canvases with no content. They appear in the speaker's flow as deliberate visual rests, the same way a composer writes rests into music.
+
+The second implementation is the **B key** in PowerPoint or Keynote (the W key produces a white screen for venues where the projector cannot dim to true black). Hitting B during delivery instantly blanks the screen until pressed again. Most decent presentation remotes have a dedicated blackout button for the same purpose. The B key is the in-the-moment tool for unplanned blackouts: an audience question that triggers a digression, a story that ran longer than expected, a moment when the speaker realizes the slide behind them has become a distraction. Press B, finish the moment, press B again to bring the slide back.
+
+The principle behind both implementations is the same: visual silence is a tool, equivalent to verbal silence (`breathing-room`). When you want the audience to absorb a personal story, look you in the eye, or hear a single key sentence without their attention split, blank the screen. Steve Jobs used this technique constantly — long stretches of his keynotes had a black background behind him while he spoke, with the screen brought back only when there was something worth showing. The audience-attention default flips from "screen is on, look at the screen" to "screen is on only when relevant."
+
+The pattern composes naturally with `mentor` (when the speaker pulls up a stool to have a conversation with the audience, the screen should not be competing), with `breathing-room` (a verbal pause and a screen blackout together signal "this matters"), and with `intermezzi` (themed transitions and blackouts can alternate — a blackout is the minimalist version of an intermezzo). It is the deliberate inverse of the failure mode where every moment of the talk is forced to have a slide behind it, which over-couples the speaker to the visual track and removes the speaker's ability to hold the room with voice and presence alone.
+
+## When to Use / When to Avoid
+Use this pattern at section boundaries, during personal stories, at audience-question moments, before punchlines, and any time the slide behind you is not actively reinforcing what you are saying. Build planned blackouts into the deck during the prepare phase; rehearse the B key for unplanned ones during `carnegie-hall`.
+
+Avoid blackouts during demo-driven sections where the screen *is* the content (`live-demo`, `lipsync`). Avoid mechanical blackouts at fixed intervals — the technique works because it is deliberate; randomizing it makes it feel like a mistake. Also avoid blackouts in webinar contexts where the screen is the primary channel and there is no physical speaker for the audience to redirect attention to — in webinars, blanking the screen leaves the audience with nothing.
+
+## Detection Heuristics
+The vault should look for: (a) explicit black or blank slides in the deck file, especially between major sections or before known personal-story moments; (b) video evidence of the speaker holding the room while the screen behind them is dark; (c) the B-key behavior on platforms where remote keystrokes are observable. The clearest signal is a deck with intentional black slides at section boundaries — this is unmistakably deliberate, not a missing-slide bug.
+
+## Scoring Criteria
+- Strong signal (2 pts): Deliberate blackouts (planned black slides or visible B-key use) at meaningful moments — section boundaries, personal stories, audience-question handling — used as a tool for attention redirection
+- Moderate signal (1 pt): Occasional blackouts present but inconsistent — speaker uses the technique once or twice but does not integrate it as a regular part of the delivery toolkit
+- Absent (0 pts): Every moment of the talk has a slide behind the speaker; no blackouts, no rests; the screen is on continuously regardless of whether it is relevant
+
+## Relationship to Vault Dimensions
+Relates to Dimension 12 (Pacing Clues) because deliberate blackouts function as pacing rests, equivalent to verbal pauses. Relates to Dimension 13 (Slide Design Patterns) because building black slides into the deck is a visible design choice — the deliberately empty slide is a slide-design decision.
+
+## Combinatorics
+Pairs with `breathing-room` (the verbal and visual silences reinforce each other), `intermezzi` (a blackout is the minimalist intermezzo — same structural function with no decoration), `brain-breaks` (a blackout can punctuate a brain break), and `mentor` (the stool-and-conversation moment works best with the screen out of the way). It is independent from but compatible with `cave-painting` and `vacation-photos` — the styles those patterns produce alternate naturally with blackout rests.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 10 — describes the B-key blackout technique and Steve Jobs's use of black screens between high-impact visuals as deliberate attention-redirection moments. New Riders.

--- a/skills/presentation-creator/references/patterns/prepare/cave-painting.md
+++ b/skills/presentation-creator/references/patterns/prepare/cave-painting.md
@@ -49,3 +49,6 @@ Relates to Dimension 5 (Storytelling/Narrative) because the spatial canvas creat
 
 ## Combinatorics
 Pairs with Context Keeper (Cave Painting is inherently a context-keeping device), Soft Transitions (zooming between sections creates smooth visual transitions), Brain Breaks (the zoom-out moments serve as visual palate cleansers), Takahashi (individual zoomed-in sections can use Takahashi-style single elements), and Lipsync (spatial layout helps synchronize verbal and visual content).
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 5 — "Amplification Through Simplification" via Scott McCloud, plus the Kamishibai visual-storytelling tradition: visuals big and bold, bleed off the edge, focus attention on what matters now. New Riders.

--- a/skills/presentation-creator/references/patterns/prepare/concurrent-creation.md
+++ b/skills/presentation-creator/references/patterns/prepare/concurrent-creation.md
@@ -31,6 +31,13 @@ Practical guidelines for group Concurrent Creation include: everyone uses the sa
 
 The challenge of Concurrent Creation is maintaining coherence. When different people create different sections, voice and style can diverge. The Slide Wrangler must harmonize these differences during assembly. When an individual creates sections out of order, they must allocate time for a coherence pass — reading through the entire presentation sequentially to smooth transitions and ensure consistent terminology. The payoff is worth the extra assembly effort: concurrent creation produces richer material because each section was created at the peak of the author's inspiration for that topic.
 
+### Plan Analog Before Going Digital
+Concurrent Creation has a strong default-medium implication: most of it should happen *off the computer*. Garr Reynolds calls this "going analog" and treats it as one of the central rules of the prepare phase: paper, whiteboard, Post-its, Sharpies — never start in slideware. The argument is partly cognitive (handling a pen activates right-brain associative thinking; sitting at a keyboard activates left-brain editing instincts) and partly tooling (slideware presents a template, a layout, and a default font the moment you open it, all of which prematurely commit you to decisions that should still be fluid).
+
+In Reynolds's five-step workflow, the digital tool only enters the picture in the final step: brainstorm → group and identify the core → storyboard on paper or sticky notes → sketch visuals by hand → only then transfer into slideware. The first four steps are entirely analog. For Concurrent Creation specifically, this means the brainstorm + grouping + storyboard phases are easier to do as a group in front of a whiteboard or wall of Post-its than in any collaborative slideware tool — physical space lets the whole structure stay visible at once, which is precisely what slideware's slide-at-a-time view destroys.
+
+The practical translation: if Concurrent Creation is the *workflow*, analog planning is the *medium* for everything before assembly. The Slide Wrangler's first artifact should be a photograph of a whiteboard or a stack of Post-its, not a template-filled deck. Going digital too early is the most common failure mode of Concurrent Creation — collaborators end up arguing about font choices and slide layouts before they have agreed on the throughline.
+
 ## When to Use / When to Avoid
 Use this pattern for any presentation where you have the flexibility to work non-linearly, and especially for group presentations. Avoid for very short presentations (five minutes or less) where sequential creation is natural and the overhead of assembly exceeds the benefit. Also avoid when all collaborators are not aligned on the template and visual standards — Concurrent Creation without visual consistency produces a Frankenstein deck.
 
@@ -47,3 +54,6 @@ Relates to Dimension 2 (Structure/Organization) because Concurrent Creation's as
 
 ## Combinatorics
 Pairs with Talklet (modular units can be created concurrently by different authors) and Unifying Visual Theme (visual consistency is the glue that holds concurrent contributions together). Also benefits from Narrative Arc awareness — all contributors must understand the overall story to create pieces that fit.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 3, 4 — the five-step preparation workflow (brainstorm → group → analog storyboard → sketch visuals → digital storyboard) describes a concurrent-creation cadence between content and visuals. New Riders.

--- a/skills/presentation-creator/references/patterns/prepare/crucible.md
+++ b/skills/presentation-creator/references/patterns/prepare/crucible.md
@@ -47,3 +47,6 @@ Relates to Dimension 12 (Time/Pacing) because the Crucible is the primary mechan
 
 ## Combinatorics
 Pairs with Carnegie Hall (practice between deliveries accelerates refinement), Brain Breaks (the Crucible reveals which breaks work and which fall flat), Fourthought (pre-delivery thinking provides a strong starting point for the Crucible to refine), and Traveling Highlights (discovering which highlights resonate is a Crucible outcome).
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 4 — "Editing and Restraint" uses George Lucas's Star Wars editing as an analogy: scrutinize every scene for its contribution; "when in doubt, cut it out." New Riders.

--- a/skills/presentation-creator/references/patterns/prepare/narrative-arc.md
+++ b/skills/presentation-creator/references/patterns/prepare/narrative-arc.md
@@ -50,3 +50,6 @@ Relates to Dimension 2 (Structure/Organization) as the primary structural patter
 
 ## Combinatorics
 Pairs powerfully with Triad (three-act structure maps to three main themes), Bookends (opening and closing that frame the arc), Intermezzi (transitions between arc sections), Unifying Visual Theme (visual coherence reinforces narrative coherence), and Context Keeper (maintaining audience orientation within the arc). The Narrative Arc is arguably the most foundational pattern — nearly every other pattern either supports it or depends on it.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 4 — "Crafting the Story" applies Robert McKee's conflict-driven story structure to presentations, and cites the Heath brothers' SUCCESs framework. New Riders.

--- a/skills/presentation-creator/references/patterns/prepare/opening-punch.md
+++ b/skills/presentation-creator/references/patterns/prepare/opening-punch.md
@@ -1,0 +1,63 @@
+---
+id: opening-punch
+name: Opening PUNCH
+type: pattern
+part: prepare
+phase_relevance:
+  - intent
+  - content
+vault_dimensions: [1, 4]
+detection_signals:
+  - "personal story in opening 1-2 minutes"
+  - "unexpected fact or surprise as hook"
+  - "novel image or never-seen visual at start"
+  - "challenging question or counterintuitive claim"
+  - "humorous observation or anecdote in opening"
+related_patterns: [bookends, narrative-arc, foreshadowing, preroll, know-your-audience]
+inverse_of: []
+difficulty: foundational
+---
+
+# Opening PUNCH
+
+## Summary
+Open with at least one of five hook flavors — Personal, Unexpected, Novel, Challenging, or Humorous — to capture attention in the 1–2 minute honeymoon window before the audience tunes out.
+
+## The Pattern in Detail
+Audiences grant a presenter roughly one to two minutes of goodwill before forming a verdict on whether the talk is worth their attention. Inside that window, the speaker must do something specific that signals "this will be different." Generic openings — agenda slides, self-introductions, organizational charts, "thanks for having me" filler — burn the goodwill on housekeeping that the audience does not need. The PUNCH framework names the five reliable flavors of opening hooks that *do* earn the rest of the talk.
+
+**Personal.** Open with a relevant personal story — not a credential parade. The story must illustrate the talk's theme or set up the core problem in a way that lets the audience feel why it mattered to the speaker before it was abstracted into "the topic." A personal opening is not "here's my LinkedIn"; it is "here's the moment I realized this was a problem."
+
+**Unexpected.** Reveal something that contradicts the audience's expectations. A counterintuitive fact, a surprising statistic, or a claim that violates received wisdom forces the audience into alertness. Tom Peters: "There must be surprise … some key facts that are not commonly known or are counterintuitive. No reason to do the presentation in the first place if there are no surprises."
+
+**Novel.** Show something the audience has not seen before. A previously unpublished image, fresh data from a study released that week, a working demo of something that did not exist a month ago. Novelty taps the brain's pattern-recognition reward circuit; the audience leans forward because they sense they are getting something not available elsewhere.
+
+**Challenging.** Open by challenging the audience's assumptions or imagination. A provocative question that forces them to take a position. A reframing that makes their default mental model feel suddenly wrong. The challenge does not have to be confrontational — it just has to demand cognitive engagement rather than passive reception.
+
+**Humorous.** Open with humor — but not a joke. A wry observation, a self-aware aside, a moment of irony, a short anecdote that lands with a laugh and also delivers the topic. Humor relaxes the room, builds rapport via shared laughter, and creates a positive vibe that improves retention. The opening joke is a tired and frequently lame trope; observational humor woven into a real opening is a different thing.
+
+The five flavors are not mutually exclusive — the strongest openings stack two or three. A personal story that contains an unexpected reveal and lands a wry humorous beat is a triple PUNCH. The principle is that the first 90 seconds must contain at least one PUNCH element; absent all five, the opening is filler and the rest of the talk is fighting uphill.
+
+## When to Use / When to Avoid
+Use this pattern in virtually every presentation that opens cold to a live audience. The first 1–2 minutes are the highest-stakes real estate of the talk. Avoid only when the format genuinely forbids a hook — for example, a tightly-formatted ceremony slot where each speaker has 30 seconds and the convention is to dive straight into the topic. In every other context, plan the PUNCH explicitly during the prepare phase rather than improvising it on stage.
+
+The pattern composes with `narrative-arc` (the PUNCH is the opening of the arc), with `bookends` (the opening half of the bookend pair is shaped by the PUNCH choice), and with `know-your-audience` (which PUNCH flavor lands depends on the audience — humor that works at a developer conference may flop at a healthcare regulatory committee).
+
+## Detection Heuristics
+The vault should examine the first 1–2 minutes of transcript and the first 2–3 slides. Look for: a personal anecdote that is *relevant* to the thesis (not a credential dump), a fact or claim that contradicts conventional wisdom, an image or piece of data that is fresh or unusual, a challenging question posed to the audience, or a humorous beat with a relevant payoff. Strong openings will exhibit at least one PUNCH element clearly; many will stack two or three.
+
+Generic openings — agenda slides, "let me introduce myself," "thanks for the invitation," "I want to talk about X today" — score this pattern absent regardless of what comes after.
+
+## Scoring Criteria
+- Strong signal (2 pts): At least one PUNCH element clearly present in the first 1–2 minutes, executed with intent (not accidental); the opening lands rather than meanders
+- Moderate signal (1 pt): A PUNCH element is present but mixed with filler (e.g., a strong personal story that follows 90 seconds of agenda slides), or the opening relies on a single weak instance
+- Absent (0 pts): Generic opening — agenda slide, credential parade, formality, or filler — with no identifiable PUNCH element
+
+## Relationship to Vault Dimensions
+Relates to Dimension 1 (Opening Pattern) as the primary typology for opening hooks. Also relates to Dimension 4 (Audience Interaction) because Challenging and Humorous openings frequently solicit explicit audience response (a raised hand, a laugh, a verbal answer to a question), establishing a two-way pattern from the start.
+
+## Combinatorics
+Opening PUNCH pairs with `bookends` (the opening half of the bookend pair takes a PUNCH flavor; the closing half mirrors or completes it), with `narrative-arc` (the PUNCH is the arc's first beat), with `foreshadowing` (a Novel or Unexpected opening can plant a payoff that resolves later), and with `preroll` (the pre-talk visuals can prime the PUNCH). It is the deliberate inverse of the unnamed antipattern of the "agenda-slide opener" — the default-template behavior of opening with a list of what the talk will cover.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 9 — introduces PUNCH as a five-flavor framework for opening hooks; sourced from Reynolds's earlier book *The Naked Presenter* (New Riders, 2011).

--- a/skills/presentation-creator/references/patterns/prepare/takahashi.md
+++ b/skills/presentation-creator/references/patterns/prepare/takahashi.md
@@ -49,3 +49,6 @@ Relates to Dimension 8 (Slide Design/Visual Quality) because Takahashi is a deli
 
 ## Combinatorics
 Pairs with Brain Breaks (the rapid visual changes function as continuous micro-breaks for attention). The inverse is Bullet-Riddled Corpse — where Takahashi puts one element per slide, the antipattern crams as many bullet points as possible onto each slide.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 7 — documents the Takahashi Method directly with sample slides and the origin story (Masayoshi Takahashi, Tokyo developer). New Riders.

--- a/skills/presentation-creator/references/patterns/prepare/the-big-why.md
+++ b/skills/presentation-creator/references/patterns/prepare/the-big-why.md
@@ -31,6 +31,13 @@ Once you have identified your Big Why, use it as a commitment device. Market you
 
 The Big Why also serves as a compass during preparation. When you face difficult decisions — what to include, what to cut, how much to rehearse — your core motivation provides the answer. If your Big Why is audience care, you cut the clever-but-confusing section. If your Big Why is professional growth, you keep the section that stretches your delivery skills even though it is harder to present.
 
+### The Elevator Test
+The Big Why is the speaker-side motivation; the audience-side counterpart is "what is my point and why does it matter to *them*?" Garr Reynolds proposes a concrete check called the elevator test: imagine the executive you are about to pitch comes out of her office with her coat already on and says, "Sorry, something came up — give me your pitch as we walk to my car." Could you sell the core message in 30–45 seconds, in the elevator and the walk to the parking lot?
+
+The exercise is not about preparing for an actual elevator encounter — that scenario is rare. It is a forcing function. Compressing a 45-minute talk into 45 seconds is impossible without first knowing exactly what the core message *is*, and that compression makes it brutally obvious when the speaker has not yet found their point. Most failed elevator-test attempts go the same way: the speaker realizes a third of the way through the 45 seconds that they cannot actually name the one thing the audience should walk away with. That realization is the value of the exercise.
+
+Use the elevator test as a readiness gate: before moving from the prepare phase into slide-building, force yourself to deliver the core message out loud in 30–45 seconds, ideally to a real listener who can ask follow-up questions. If you cannot pass the test, you are not ready to build slides — you are still figuring out what the talk is about. Going to slideware before the elevator test passes guarantees a deck that wanders, because the deck is faithfully reflecting the unwandered structure of the speaker's own thinking.
+
 ## When to Use / When to Avoid
 Use this pattern at the very beginning of any presentation commitment. It is especially critical for voluntary presentations where motivation must sustain months of preparation. For required presentations, The Big Why helps you find genuine motivation within an obligation. There is no scenario where clarifying your motivation is harmful.
 
@@ -47,3 +54,6 @@ Relates to Dimension 9 (Speaker Credibility/Ethos) because a speaker with a clea
 
 ## Combinatorics
 Pairs with Carnegie Hall (strong motivation drives extensive practice) and Crucible (motivation sustains you through the iterative refinement process). The Big Why is foundational — it does not conflict with any other pattern and enhances nearly all of them.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 3 — "Two Questions: What Is Your Point? Why Does It Matter?" plus "Can You Pass the Elevator Test?" New Riders.

--- a/skills/presentation-creator/references/patterns/prepare/triad.md
+++ b/skills/presentation-creator/references/patterns/prepare/triad.md
@@ -48,3 +48,6 @@ Relates to Dimension 2 (Structure/Organization) as one of the most effective org
 
 ## Combinatorics
 Pairs naturally with Narrative Arc (the three-act structure IS the Triad applied to storytelling), Fourthought (the organize phase is where the Triad emerges from raw ideas), and Talklet (three talklets = three acts). The Triad also provides a natural framework for Expansion Joints — each theme boundary is a natural expansion/contraction point.
+
+## Related Reading
+- Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). Ch. 4 — "three is a good number to aim for because it is a manageable constraint and generally provides a memorable structure." New Riders.

--- a/skills/presentation-creator/references/phase1-intent.md
+++ b/skills/presentation-creator/references/phase1-intent.md
@@ -128,6 +128,9 @@ Rules:
 
 Before presenting the spec, cross-check:
 - Does the thesis pass the "one sentence" test?
+- **The Two Questions** (Reynolds): Can the speaker answer both *"What is my point?"* AND *"Why does it matter?"* in plain language? If "why does it matter" is hand-wavy or assumed-obvious, the spec is not ready — that question is where most talks fail in preparation.
+- **The Elevator Test** (Reynolds): Could the speaker pitch the core message in 30–45 seconds to an executive walking to her car? If compression to 45 seconds is impossible, the speaker has not yet found the core — surface this and iterate before declaring the spec done. See `patterns/prepare/the-big-why.md` for the full exercise.
+- **SUCCESs check** (Heath brothers, via Reynolds): Does the planned core message have at least 3 of the 6 sticky-message properties? **S**imple, **U**nexpected, **C**oncrete, **C**redible, **E**motional, **S**tories. If the core is "abstract claim with no concrete example, no surprise, no story," it will not stick — flag it before slide-building begins.
 - Does the time slot match the content ambition?
 - Is the mode selection consistent with the audience?
 - Are there contradictions? (e.g., "zero profanity" + "heavy meme density" — flag it)

--- a/skills/presentation-creator/references/phase2-architecture.md
+++ b/skills/presentation-creator/references/phase2-architecture.md
@@ -1,5 +1,11 @@
 # Phase 2: Rhetorical Architecture — Detail
 
+### Plan Analog Before Going Digital
+
+Architecture decisions in this phase happen at the conceptual level — mode, opening pattern, narrative arc, sectioning, pattern strategy. These are best worked out **away from slideware**. Reynolds is emphatic: opening a presentation tool during planning prematurely commits the author to a template, a layout, and a default font when those decisions should still be fluid.
+
+When the author is making architecture decisions in this phase, encourage analog tools — paper sketches, whiteboard diagrams, Post-it notes — for working through the structure before any slide is created. The five-step Reynolds workflow keeps slideware out of the picture for the first four steps: brainstorm → group/identify the core → analog storyboard → sketch visuals → only then transfer into slideware. Architecture decisions in this phase belong to steps 1–3; slideware belongs to Phase 5. See `patterns/prepare/concurrent-creation.md` for the full workflow.
+
 ### The Joint Selection Process
 
 This phase is a conversation, not a monologue. **Use `AskUserQuestion` for each

--- a/skills/presentation-creator/references/phase3-content.md
+++ b/skills/presentation-creator/references/phase3-content.md
@@ -138,6 +138,42 @@ Key conventions:
   show at that step, working backwards from the full image)
 - Build slides count toward the slide budget (they are separate slides, not animations)
 
+### Opening PUNCH
+
+The first 1–2 minutes of the talk are the highest-stakes real estate. Audiences grant a roughly two-minute "honeymoon period" before forming a verdict on whether the talk is worth their attention. The outline's opening section must contain at least one of five hook flavors, per Reynolds's PUNCH framework:
+
+- **P**ersonal — a relevant story (not a credentials parade)
+- **U**nexpected — a counterintuitive fact, surprising statistic, or claim that violates received wisdom
+- **N**ovel — fresh data, never-published image, or working demo of something new
+- **C**hallenging — a provocative question or assumption-reframing
+- **H**umorous — observational humor, a wry aside, or anecdote with a relevant payoff (not a joke)
+
+Strong openings stack 2–3 PUNCH elements. When writing the outline, **explicitly tag the opening's PUNCH flavor(s)** in the slide notes, e.g.:
+
+```markdown
+### Slide 2: Opening Hook
+- PUNCH: Personal + Unexpected
+- Visual: [description]
+- Speaker: "[the actual opening lines]"
+```
+
+This tag makes the choice visible, lets Phase 4 verify the opening lands, and gives the vault a concrete signal to score later. If the outline's opening contains none of the PUNCH flavors — agenda slide, "let me introduce myself," "thanks for having me" filler — flag it as a content gap. See `patterns/prepare/opening-punch.md` for the full pattern.
+
+### Use Contrast as a Structural Device
+
+Reynolds: "Contrast is about differences, and we are hardwired to notice differences." Contrasts are one of the most reliable engagement tools available to the outline writer. When choosing how to frame a section or transition, look for the inherent contrast pair:
+
+- before / after
+- past / future
+- problem / solution
+- received wisdom / actual finding
+- naive expectation / messy reality
+- competitor approach / your approach
+- pessimism / optimism
+- decline / growth
+
+Contrast structures naturally produce dramatic tension and make the resolution feel earned. They also map cleanly onto narrative beats — a problem/solution contrast IS a two-act narrative arc; a past/future contrast IS a thesis. When a section feels flat in the outline, ask: *what is the contrast pair here?* If you can't name one, the section is not yet sharpened.
+
 ### Callback Identification
 
 Proactively identify and suggest callback opportunities. Check the vault summary for

--- a/skills/presentation-creator/references/phase5-slides.md
+++ b/skills/presentation-creator/references/phase5-slides.md
@@ -2,6 +2,23 @@
 
 Build the .pptx deck from the finalized outline.
 
+## General Design Principles
+
+This phase generates concrete slides from the outline. **Every slide should respect the design principles in `slide-design-spec.md` Section 11**, including:
+
+- **Signal-to-Noise Ratio** — remove anything that does not encode information
+- **The Big Four** — Contrast, Repetition, Alignment, Proximity
+- **Picture Superiority Effect** — pictures beat words for retention; replace decorative text with concrete imagery when possible
+- **Empty space is active** — default to asymmetric layouts; don't fill margins with logos or templated decoration
+- **Rule of thirds** — anchor primary subjects on the 3×3 grid intersections, not dead-center
+- **Faces and eye-gaze** — orient face-direction toward the focal text/chart, never away from it
+- **Full-bleed images** — default to images that bleed off all four edges
+- **2D for 2D data** — never apply 3D effects to flat data
+- **Logo discipline** — first and last slide only (this aligns with the speaker's existing footer convention; the footer is not a logo)
+- **Minimum font size** — body text ~24pt or larger at 16:9 conference resolution
+
+Speaker-style data in `slide-design-spec.md` Sections 1–10 (extracted from the speaker's actual deck corpus) takes precedence where it exists. The principles in Section 11 are the default for layout decisions where the corpus is silent.
+
 ## Step 5.1: Create the Deck
 
 Read the template path from `speaker-profile.json → infrastructure.template_pptx_path`.

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -242,6 +242,15 @@ matter for delivery quality.
 ```
 GO-LIVE CHECKLIST — {talk title}
 ==================================
+VENUE SETUP:
+[ ] Lights ON — keep light on the speaker (Reynolds: audience must see your face;
+    they cannot read facial expressions in the dark; dim only the screen-area lights
+    if the projector requires it)
+[ ] Lectern moved aside — step out from behind any podium or table; place computer
+    on the floor in front of the stage so you don't have to turn back to advance slides
+[ ] Mic test — wireless lavalier or headset preferred over handheld; do not rely on
+    shouting
+
 PRE-EVENT:
 [ ] Preparation — backups, cables, hydration, room layout check
 [ ] Carnegie Hall — completed 4 rehearsals (pace, delivery, fixes, groove)
@@ -251,6 +260,16 @@ PRE-EVENT:
 [ ] Shoeless — comfort ritual ready
 
 DURING DELIVERY:
+[ ] Honeymoon-window discipline — first 1–2 minutes earn the talk; do NOT spend
+    them on agenda slides, "let me introduce myself," or "thanks for the invitation"
+    filler. Open with the planned PUNCH hook (see outline)
+[ ] Never apologize, never confess nerves — both are self-focused at a moment that
+    should be audience-focused. Acknowledge nerves to yourself; do not share them
+    with the audience
+[ ] Hara hachi bu — finish at 90–95% of the allotted time, never run over;
+    "leave them slightly hungry, not stuffed"
+[ ] Screen-blackout — use the B key (or planned black slides) at section boundaries,
+    personal stories, and audience-question moments to redirect attention
 [ ] Lightsaber — if laser pointer needed, max 2-3 steady moments
 [ ] Red/Yellow/Green — exit feedback cards set up (if venue supports)
 

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -233,11 +233,19 @@ Read `publishing_process.additional_steps[]`. For each entry:
 
 ### Step 6.6: Go-Live Preparation Checklist
 
-Before delivery, surface unobservable patterns from [patterns/_index.md](patterns/_index.md)
-(the "Unobservable Patterns — Go-Live Checklist" section) as a preparation reminder.
-These are patterns the vault **cannot score retroactively** because they involve
-pre-event logistics, physical stage behaviors, or external systems — but they still
-matter for delivery quality.
+Before delivery, surface a delivery-readiness checklist composed of two strands:
+
+1. **Unobservable patterns** from [patterns/_index.md](patterns/_index.md) (the
+   "Unobservable Patterns — Go-Live Checklist" section). These are patterns the vault
+   **cannot score retroactively** because they involve pre-event logistics, physical
+   stage behaviors, or external systems.
+2. **Observable delivery reminders** that the speaker can decide to apply on the day —
+   venue setup choices (lights, lectern, mic), opening discipline, time discipline,
+   and screen-blackout tactics. These *are* observable post-talk, but the speaker
+   benefits from a pre-talk reminder regardless of the vault's ability to score them
+   later.
+
+Both strands matter for delivery quality and belong in the same checklist.
 
 ```
 GO-LIVE CHECKLIST — {talk title}
@@ -268,7 +276,7 @@ DURING DELIVERY:
     with the audience
 [ ] Hara hachi bu — finish at 90–95% of the allotted time, never run over;
     "leave them slightly hungry, not stuffed"
-[ ] Screen-blackout — use the B key (or planned black slides) at section boundaries,
+[ ] Screen Blackout — use the B key (or planned black slides) at section boundaries,
     personal stories, and audience-question moments to redirect attention
 [ ] Lightsaber — if laser pointer needed, max 2-3 steady moments
 [ ] Red/Yellow/Green — exit feedback cards set up (if venue supports)


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- Adds Garr Reynolds' *Presentation Zen* (2nd ed., 2012) as a second authoritative source alongside Ford/McCullough/Schutta (2013) for the presentation-pattern taxonomy. Reynolds reinforces the existing taxonomy with **no contradictions**; this change codifies the reinforcements as citations and adds the named moves Reynolds covers that had no current counterpart.
- 2 new patterns + 3 refinements folded into existing patterns + 17 citation additions + phase-doc guidance updates spanning Phases 1, 2, 3, 5, 6 + `_index.md` updates.
- Pure documentation/taxonomy change. No code, scripts, or schemas touched.

## What changed

### New patterns
- `patterns/prepare/opening-punch.md` — Reynolds's PUNCH framework (Personal / Unexpected / Novel / Challenging / Humorous) for opening hooks; vault dimensions 1, 4
- `patterns/deliver/screen-blackout.md` — deliberate B-key blackout or planned black slides as attention-redirection device; vault dimensions 12, 13

### Refinements folded into existing patterns
- `breathing-room.md` ← *Hara Hachi Bu* (90–95% finish-line discipline)
- `concurrent-creation.md` ← *Plan Analog Before Going Digital*
- `the-big-why.md` ← *The Elevator Test* (30–45 sec core-message check)

### Citations added (`## Related Reading` section)
17 patterns: slideuments, bullet-riddled-corpse, floodmarks, borrowed-shoes, cookie-cutter, ant-fonts, narrative-arc, triad, crucible, concurrent-creation, vacation-photos, cave-painting, takahashi, bunker, bookends, coda, breathing-room.

### Phase docs
- **Phase 1:** Spec Validation gains Two Questions + Elevator Test + SUCCESs checks
- **Phase 2:** new "Plan Analog Before Going Digital" subsection
- **Phase 3:** new "Opening PUNCH" + "Use Contrast as a Structural Device" sections
- **Phase 5:** new "General Design Principles" header section referencing slide-design-spec §11
- **Phase 6:** Go-Live checklist gains venue-setup (lights on, lectern aside, mic) + during-delivery items (honeymoon discipline, never-apologize, *hara hachi bu*, screen-blackout)

### `_index.md`
Catalog tables (Prepare 18→19, Deliver 18→19), phase-lookup updates (Phases 1, 3, 5), vault-dimension mapping (Dims 1, 4, 12, 13), summary stats, and Sources section now lists Reynolds alongside Ford et al.

### `CHANGELOG.md`
Entry under `## Unreleased` describing the ingest.

## Why

Rules for slide design and delivery that the existing taxonomy treats as "just one source" are reinforced by a second authoritative voice, which raises confidence when the creator skill applies them as guardrails. Reynolds also names a few specific moves (PUNCH opening, screen-blackout, *hara hachi bu* time discipline) that Ford/McCullough/Schutta did not, closing real gaps in the taxonomy.

The full source-of-truth analysis lives in the speaker's vault at `~/.claude/rhetoric-knowledge-vault/external-sources/presentation-zen-reynolds.md` (not part of this repo).

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Spot-check one prepare, one build, one deliver pattern file to confirm the `## Related Reading` section renders as expected
- [ ] Spot-check `patterns/_index.md` table totals match the actual file count (`find skills/presentation-creator/references/patterns -name '*.md' -not -name '_index.md' | wc -l`)
- [ ] Confirm phase doc additions read coherently in the existing flow of each phase
- [ ] Confirm CHANGELOG entry slots correctly under `## Unreleased`

🤖 Generated with [Claude Code](https://claude.com/claude-code)