### PR TITLE
fix: condense vault-ingress + repair tile-lint after illustrations merge

### DIFF
--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -41,10 +41,10 @@ Do not restate them here — apply them.
 | `speaker-profile.json` → `visual_style_history` | Default style, departures, mode profiles, confirmed visual intents |
 | `speaker-profile.json` → `publishing_process.thumbnail` | Speaker photo path + aesthetic preference |
 | `illustrations/` (alongside outline) | Generated images, builds, model-comparison output |
-| [skills/illustrations/references/strategy.md](skills/illustrations/references/strategy.md) | Phase 2 D#11 detail — style proposal, format vocabulary, model choice, continuity devices |
-| [skills/illustrations/references/generation.md](skills/illustrations/references/generation.md) | Deck generation, edit/fix workflow, model comparison |
-| [skills/illustrations/references/builds.md](skills/illustrations/references/builds.md) | Backwards-chained build generation |
-| [skills/illustrations/references/thumbnails.md](skills/illustrations/references/thumbnails.md) | Phase 7 thumbnail composition + slide selection |
+| [skills/illustrations/references/strategy.md](references/strategy.md) | Phase 2 D#11 detail — style proposal, format vocabulary, model choice, continuity devices |
+| [skills/illustrations/references/generation.md](references/generation.md) | Deck generation, edit/fix workflow, model comparison |
+| [skills/illustrations/references/builds.md](references/builds.md) | Backwards-chained build generation |
+| [skills/illustrations/references/thumbnails.md](references/thumbnails.md) | Phase 7 thumbnail composition + slide selection |
 | `skills/illustrations/scripts/generate-illustrations.py` | Deck illustrations, edits, fixes, builds, model comparison |
 | `skills/illustrations/scripts/apply-illustrations-to-deck.py` | Insert illustrations + builds into a .pptx |
 | `skills/illustrations/scripts/generate-thumbnail.py` | YouTube thumbnail composition |
@@ -80,7 +80,7 @@ paragraph, then define format vocabulary (FULL / IMG+TXT / EXCEPTION + any
 talk-specific additions), model choice, and visual continuity devices.
 
 Full protocol with the option-presentation template, format vocabulary
-defaults, and continuity-device options: [skills/illustrations/references/strategy.md](skills/illustrations/references/strategy.md).
+defaults, and continuity-device options: [skills/illustrations/references/strategy.md](references/strategy.md).
 
 Write the approved STYLE ANCHOR block into the outline header. Proceed
 immediately to Step 3 if generation was also requested; otherwise finish here.
@@ -101,7 +101,7 @@ governs which to pick. Save iteration versions (`v2`, `v3`) instead of
 overwriting — see `illustration-rules` Iteration Hygiene.
 
 Operational detail (compare modes, prompt patterns, retry ladder):
-[skills/illustrations/references/generation.md](skills/illustrations/references/generation.md).
+[skills/illustrations/references/generation.md](references/generation.md).
 
 Proceed immediately to Step 4.
 
@@ -118,7 +118,7 @@ python3 skills/illustrations/scripts/generate-illustrations.py \
 
 Output: `illustrations/builds/slide-NN-build-MM.jpg`. Build-00 is the empty
 frame; build-N is the full image. Detail and the per-step contract:
-[skills/illustrations/references/builds.md](skills/illustrations/references/builds.md).
+[skills/illustrations/references/builds.md](references/builds.md).
 
 If no slides specify builds, proceed silently to Step 5.
 
@@ -161,6 +161,6 @@ portrait is pre-stylized to match the deck.
 
 Iteration is conversational — change one thing at a time (style variant,
 expression, colors, title text, slide). Detail:
-[skills/illustrations/references/thumbnails.md](skills/illustrations/references/thumbnails.md).
+[skills/illustrations/references/thumbnails.md](references/thumbnails.md).
 
 Finish here.

--- a/skills/illustrations/references/generation.md
+++ b/skills/illustrations/references/generation.md
@@ -84,8 +84,8 @@ positioning:
 The `Safe zone:` line in each FULL slide block tells the script to append a
 `TITLE SAFE ZONE` directive to the prompt before generation. Five zones are
 supported: `upper_third`, `middle_third`, `lower_third`, `left_half`,
-`right_half`. See [skills/illustrations/references/title-placement.md](skills/illustrations/references/title-placement.md)
-for the outline schema and [`rules/title-overlay-rules.md`](rules/title-overlay-rules.md)
+`right_half`. See [skills/illustrations/references/title-placement.md](title-placement.md)
+for the outline schema and [`rules/title-overlay-rules.md`](../../../rules/title-overlay-rules.md)
 for the full policy (auto-loaded).
 
 ## Apply to Deck
@@ -105,7 +105,7 @@ The script:
 3. Repositions title text boxes into the declared safe zone.
 4. For each slide with `Format: IMG+TXT`, applies the IMG+TXT layout
    (image ~60% on the left, title placeholder + body on the right).
-5. Inserts build sequences (see [skills/illustrations/references/builds.md](skills/illustrations/references/builds.md)) for any slide with a
+5. Inserts build sequences (see [skills/illustrations/references/builds.md](builds.md)) for any slide with a
    `- Builds:` block.
 
 If no scrim color is supplied, run `python3 skills/illustrations/scripts/suggest-scrim-color.py illustrations/`

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -95,7 +95,7 @@ Agree on the target model (affects prompt style and capabilities):
 - Model name and API (e.g., `gemini-3-pro-image-preview`, `dall-e-3`, `flux`).
 - Any model-specific prompt conventions to bake into the style anchor.
 - Use `generate-illustrations.py --compare N` to generate the same prompt
-  across multiple models for visual comparison — see [skills/illustrations/references/generation.md](skills/illustrations/references/generation.md).
+  across multiple models for visual comparison — see [skills/illustrations/references/generation.md](generation.md).
 
 ## Sub-step 4: Visual Continuity Devices
 

--- a/skills/illustrations/references/title-placement.md
+++ b/skills/illustrations/references/title-placement.md
@@ -1,7 +1,7 @@
 # Title Placement — Outline Schema + Scripts
 
 Implements the policy in
-[`rules/title-overlay-rules.md`](rules/title-overlay-rules.md).
+[`rules/title-overlay-rules.md`](../../../rules/title-overlay-rules.md).
 
 ## Outline schema addition
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -34,8 +34,10 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | `slides/{id}.pdf` | Slide PDFs (from Google Drive, PPTX export, or video extraction) |
 | [references/schemas-db.md](references/schemas-db.md) | DB + subagent schemas; extraction output schemas |
 | [references/rhetoric-dimensions.md](references/rhetoric-dimensions.md) | 14 analysis dimensions |
+| [references/subagent-instructions.md](references/subagent-instructions.md) | Step 3 per-talk procedure — transcript download, slide acquisition, fallback chains, return-JSON shape |
 | [references/video-slide-extraction.md](references/video-slide-extraction.md) | Video-to-slides pipeline — layout heuristics, tuning, limitations |
 | [references/processing-rules.md](references/processing-rules.md) | Language policy, pattern migration logic, structured field rules |
+| [references/known-issues.md](references/known-issues.md) | Edge cases — wide-angle recordings, Whisper hallucination, non-speaker talks |
 | `scripts/pptx-extraction.py` | Extract visual design data from .pptx files |
 | `scripts/video-slide-extraction.py` | Extract slides from video via ffmpeg + perceptual dedup |
 | `scripts/batch-download-videos.sh` | Parallel video download for batch processing |
@@ -104,100 +106,16 @@ Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
 
 ## Step 3 — Process Talks via Parallel Subagents (Batches of 5)
 
-Per batch: launch 5 subagents in parallel, wait, run Step 4 (Persist Subagent Results), then run Step 5 (Update Rhetoric Summary), then move to the next batch. When all batches have finished, proceed to Step 6.
-Each subagent receives the talk's DB entry and current `rhetoric-style-summary.md`.
+Per batch: launch 5 subagents in parallel, wait, run Step 4 (Persist Subagent
+Results), then run Step 5 (Update Rhetoric Summary), then move to the next
+batch. When all batches have finished, proceed to Step 6.
 
-#### Per-Talk Subagent Instructions:
-
-**A. Download transcript and acquire slides.**
-
-**Transcript download:**
-- **YouTube talks:** use yt-dlp with auto-subtitles across likely languages:
-  ```bash
-  yt-dlp --write-auto-sub --sub-lang "en,ru,he,fr,de,es,ja" --skip-download --sub-format vtt \
-    -o "{vault_root}/transcripts/{youtube_id}" "https://www.youtube.com/watch?v={youtube_id}"
-  ```
-  The VTT filename includes the language code (e.g., `{youtube_id}.ru.vtt`). Record
-  the detected language as `delivery_language`. After download, clean the VTT:
-  ```bash
-  python3 scripts/vtt-cleanup.py "{vault_root}/transcripts/{youtube_id}.{lang}.vtt"
-  ```
-  This strips timestamps, cue markers, and deduplicates lines. Output: `transcripts/{youtube_id}.txt`.
-- **Fallback 1 — youtube-transcript-api** (if yt-dlp has no auto-captions):
-  ```bash
-  "{python_path}" -c "
-  from youtube_transcript_api import YouTubeTranscriptApi
-  transcript = YouTubeTranscriptApi.get_transcript('{youtube_id}', languages=['en','ru','he','fr','de'])
-  for entry in transcript:
-      print(entry['text'])
-  " > "{vault_root}/transcripts/{youtube_id}.txt"
-  ```
-- **Fallback 2 — Whisper** (no captions at all, requires downloaded video/audio):
-  ```bash
-  ffmpeg -i "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
-    -vn -acodec libmp3lame "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp3"
-  ```
-  Then transcribe with MLX Whisper (`mlx_whisper.transcribe()`) or OpenAI Whisper.
-  Set `transcript_source: "whisper"`.
-- **Non-YouTube talks** (InfoQ, Vimeo, conference platforms): attempt audio download
-  via yt-dlp, then transcribe locally with Whisper. Falls back to `processed_partial`
-  if audio fails.
-
-**Slide acquisition** per `slide_source`:
-- `pptx`/`both`: run `scripts/pptx-extraction.py <path.pptx>`.
-- `pdf`: download via gdown:
-  ```bash
-  "{python_path}" -m gdown "https://drive.google.com/uc?id={google_drive_id}" \
-    -O "{vault_root}/slides/{google_drive_id}.pdf"
-  ```
-- `video_extracted`: download video at 720p then run `scripts/video-slide-extraction.py`:
-  ```bash
-  yt-dlp -f "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best[height<=720]" \
-    --merge-output-format mp4 \
-    -o "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
-    "https://www.youtube.com/watch?v={youtube_id}"
-  python3 scripts/video-slide-extraction.py \
-    "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
-    "{vault_root}/slides-rebuild/{youtube_id}" "{youtube_id}"
-  ```
-  Copy PDF to `slides/{youtube_id}.pdf`. Delete video after extraction.
-  For batch downloads, use `scripts/batch-download-videos.sh <vault_root> ID1 ID2 ...`.
-- `none`: transcript-only, `processed_partial`.
-- **Fallback:** if primary slides fail but `video_url` exists, fall back to video
-  extraction. A talk can still reach `"processed"` status this way.
-
-**Set `transcript_source`** on the talk entry: `youtube_auto` (yt-dlp captions),
-`whisper` (local transcription), or `manual`. This field is required — downstream
-tools use it to gauge transcript reliability.
-
-**B. Analyze for Rhetoric & Style (NOT content).** Apply all 14 dimensions from
-[references/rhetoric-dimensions.md](references/rhetoric-dimensions.md) (including dimension 14: Areas for Improvement).
-Follow language policy and verbatim-quote rules in [references/processing-rules.md](references/processing-rules.md).
-**Key rule:** all verbatim quotes must be English-first — `"English translation"
-(original text)`. Never quote non-English text without an English translation preceding it.
-
-**B2. Tag Presentation Patterns.** Scan observations against the pattern taxonomy
-at `skills/presentation-creator/references/patterns/_index.md`. Skip patterns
-marked `observable: false`. Record confidence (strong/moderate/weak) and evidence per
-pattern. Compute per-talk score: count(patterns) − count(antipatterns). Store in
-`pattern_observations`. See [references/processing-rules.md](references/processing-rules.md) for full tagging rules.
-
-**C. Return JSON** per the subagent return schema in [references/schemas-db.md](references/schemas-db.md).
-Minimal structure:
-```json
-{
-  "talk_id": "...",
-  "status": "processed",
-  "transcript_source": "youtube",
-  "slide_source": "pdf",
-  "pattern_observations": [
-    {"pattern_id": "...", "confidence": "strong", "evidence": "..."}
-  ],
-  "new_patterns": ["..."],
-  "summary_updates": [{"section": 1, "content": "..."}],
-  "structured_data": {"delivery_language": "en", "co_presenter": false}
-}
-```
+Each subagent receives the talk's DB entry and current
+`rhetoric-style-summary.md`, runs A → B → B2 → C, and returns a JSON payload.
+Full procedure — transcript download (YouTube auto-subs → youtube-transcript-api
+→ Whisper fallback chain), slide acquisition per `slide_source`, rhetoric/style
+analysis, pattern-taxonomy tagging, and the return-JSON shape — lives in
+[references/subagent-instructions.md](references/subagent-instructions.md).
 
 ## Step 4 — Persist Subagent Results
 
@@ -312,16 +230,8 @@ verbatim details may be lost.
 - Re-read tracking DB before writing (single source of truth).
 - Preserve all summary content — add/refine, never delete.
 - After 10+ talks, start providing adherence assessments.
-- **Wide-angle room recordings** defeat perceptual hash dedup — when the camera
-  captures the full stage (speaker moving + slides on screen behind), every frame
-  looks different. Mitigate by: increasing `--threshold` to 14-16, manually specifying
-  `slide_region` crop coordinates, or accepting the bloated PDF and having the analysis
-  subagent sample frames at intervals. Best results with fullscreen slide recordings
-  (Devoxx, JFokus); worst with meetup/DevOpsDays audience-camera recordings.
-- **Whisper hallucination on bad audio:** Whisper large-v3-turbo recovers ~60% of
-  speech on poor recordings but hallucinates through silent/noisy sections. Always set
-  `transcript_source: "whisper"`, cross-reference against visible slide text, and note
-  quality issues (e.g., `transcript_quality: "partial"`).
-- **Non-speaker talks slip into playlists.** Verify speaker identity early — check
-  video frames and transcript for self-identification. Flag `is_baruch_talk: false`
-  and set status to `skipped` if the speaker doesn't match.
+
+For input-quality edge cases that require non-default handling — wide-angle
+room recordings, Whisper hallucination on bad audio, non-speaker talks
+slipping into playlists — see
+[references/known-issues.md](references/known-issues.md).

--- a/skills/vault-ingress/references/known-issues.md
+++ b/skills/vault-ingress/references/known-issues.md
@@ -1,0 +1,52 @@
+# Known Issues — Vault Ingress
+
+Edge cases and recovery strategies that don't change the happy-path workflow
+but matter when the input data is degraded. Linked from `SKILL.md`'s
+Important Notes section as one-line summaries.
+
+## Wide-Angle Room Recordings Defeat Slide Dedup
+
+When the camera captures the full stage (speaker moving + slides on screen
+behind), every frame looks different — perceptual hash dedup ends up
+producing one "unique" slide per frame.
+
+**Mitigations:**
+
+- Increase `--threshold` to 14–16 (looser similarity tolerance).
+- Manually specify `slide_region` crop coordinates so the deduper hashes
+  only the slide area, not the whole frame.
+- Accept the bloated PDF and have the analysis subagent sample frames at
+  intervals.
+
+**Best results:** fullscreen slide recordings (Devoxx, JFokus).
+**Worst results:** meetup / DevOpsDays audience-camera recordings.
+
+## Whisper Hallucination on Bad Audio
+
+Whisper large-v3-turbo recovers ~60% of speech on poor recordings but
+hallucinates through silent / noisy sections — generating plausible-looking
+text that wasn't said.
+
+**Mitigations:**
+
+- Always set `transcript_source: "whisper"` so downstream tools know the
+  reliability tier.
+- Cross-reference suspect passages against visible slide text — if the
+  transcript claims content the slide doesn't support, flag it.
+- Set `transcript_quality: "partial"` on talks where whole sections are
+  unreliable.
+
+## Non-Speaker Talks Slip into Playlists
+
+Conference playlists sometimes mix talks from multiple speakers, and a vault
+that ingests "everything in the playlist" will silently absorb them.
+
+**Mitigations:**
+
+- Verify speaker identity early — check video frames and the transcript for
+  self-introduction.
+- Flag `is_baruch_talk: false` (or the equivalent for the configured speaker
+  identity) and set status to `skipped` if the speaker doesn't match.
+- Review the skip list manually before publishing the speaker profile —
+  silent skips are the easiest way to corrupt the rhetoric summary with
+  someone else's patterns.

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -1,0 +1,129 @@
+# Per-Talk Subagent Instructions — Detail
+
+The Step 3 procedure each parallel subagent runs. The orchestrator passes the
+talk's DB entry plus the current `rhetoric-style-summary.md`; the subagent
+returns the JSON shape in [schemas-db.md](schemas-db.md).
+
+## A. Acquire Transcript and Slides
+
+### Transcript download
+
+**YouTube talks** — `yt-dlp` with auto-subtitles across likely languages:
+
+```bash
+yt-dlp --write-auto-sub --sub-lang "en,ru,he,fr,de,es,ja" --skip-download \
+  --sub-format vtt \
+  -o "{vault_root}/transcripts/{youtube_id}" \
+  "https://www.youtube.com/watch?v={youtube_id}"
+```
+
+The VTT filename includes the language code (e.g., `{youtube_id}.ru.vtt`).
+Record the detected language as `delivery_language`. After download, clean the
+VTT:
+
+```bash
+python3 skills/vault-ingress/scripts/vtt-cleanup.py \
+  "{vault_root}/transcripts/{youtube_id}.{lang}.vtt"
+```
+
+This strips timestamps, cue markers, and deduplicates lines. Output:
+`transcripts/{youtube_id}.txt`.
+
+**Fallback 1 — `youtube-transcript-api`** (when yt-dlp has no auto-captions):
+
+```bash
+"{python_path}" -c "
+from youtube_transcript_api import YouTubeTranscriptApi
+transcript = YouTubeTranscriptApi.get_transcript('{youtube_id}', languages=['en','ru','he','fr','de'])
+for entry in transcript:
+    print(entry['text'])
+" > "{vault_root}/transcripts/{youtube_id}.txt"
+```
+
+**Fallback 2 — Whisper** (no captions at all; requires downloaded video/audio):
+
+```bash
+ffmpeg -i "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
+  -vn -acodec libmp3lame \
+  "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp3"
+```
+
+Then transcribe with MLX Whisper (`mlx_whisper.transcribe()`) or OpenAI
+Whisper. Set `transcript_source: "whisper"`.
+
+**Non-YouTube talks** (InfoQ, Vimeo, conference platforms): attempt audio
+download via yt-dlp, then transcribe locally with Whisper. Falls back to
+`processed_partial` if audio fails.
+
+### Slide acquisition (per `slide_source`)
+
+- **`pptx` / `both`** — run
+  `python3 skills/vault-ingress/scripts/pptx-extraction.py <path.pptx>`.
+- **`pdf`** — download via gdown:
+  ```bash
+  "{python_path}" -m gdown \
+    "https://drive.google.com/uc?id={google_drive_id}" \
+    -O "{vault_root}/slides/{google_drive_id}.pdf"
+  ```
+- **`video_extracted`** — download video at 720p, then extract slides:
+  ```bash
+  yt-dlp -f "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best[height<=720]" \
+    --merge-output-format mp4 \
+    -o "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
+    "https://www.youtube.com/watch?v={youtube_id}"
+  python3 skills/vault-ingress/scripts/video-slide-extraction.py \
+    "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
+    "{vault_root}/slides-rebuild/{youtube_id}" "{youtube_id}"
+  ```
+  Copy the resulting PDF to `slides/{youtube_id}.pdf`. Delete the video after
+  extraction. For batch downloads, use
+  `skills/vault-ingress/scripts/batch-download-videos.sh <vault_root> ID1 ID2 ...`.
+- **`none`** — transcript-only, status `processed_partial`.
+- **Fallback** — if primary slides fail but `video_url` exists, fall back to
+  video extraction. A talk can still reach `processed` status this way.
+
+### `transcript_source` is required
+
+Set `transcript_source` on the talk entry: `youtube_auto` (yt-dlp captions),
+`whisper` (local transcription), or `manual`. Downstream tools use it to gauge
+transcript reliability.
+
+## B. Analyze for Rhetoric & Style (NOT content)
+
+Apply all 14 dimensions from
+[rhetoric-dimensions.md](rhetoric-dimensions.md), including dimension 14
+(Areas for Improvement). Follow language policy and verbatim-quote rules in
+[processing-rules.md](processing-rules.md).
+
+**Quote rule:** verbatim quotes must be English-first —
+`"English translation" (original text)`. Never quote non-English text without
+an English translation preceding it.
+
+## B2. Tag Presentation Patterns
+
+Scan observations against the pattern taxonomy at
+`skills/presentation-creator/references/patterns/_index.md`. Skip patterns
+marked `observable: false`. Record confidence (strong/moderate/weak) and
+evidence per pattern. Compute per-talk score:
+`count(patterns) − count(antipatterns)`. Store in `pattern_observations`.
+See [processing-rules.md](processing-rules.md) for full tagging rules.
+
+## C. Return JSON
+
+Per the subagent return schema in [schemas-db.md](schemas-db.md). Minimal
+structure:
+
+```json
+{
+  "talk_id": "...",
+  "status": "processed",
+  "transcript_source": "youtube",
+  "slide_source": "pdf",
+  "pattern_observations": [
+    {"pattern_id": "...", "confidence": "strong", "evidence": "..."}
+  ],
+  "new_patterns": ["..."],
+  "summary_updates": [{"section": 1, "content": "..."}],
+  "structured_data": {"delivery_language": "en", "co_presenter": false}
+}
+```

--- a/tessl.json
+++ b/tessl.json
@@ -6,7 +6,7 @@
       "version": "0.1.0"
     },
     "jbaruch/coding-policy": {
-      "version": "0.2.5"
+      "version": "0.3.14"
     }
   }
 }


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

The publish-tile workflow on main failed after merging #37: `vault-ingress` skill review scored 84% (one point under the 85% threshold), so the version-bump-and-publish step never ran and the tile didn't land in the registry. Boy Scout fix — leave the publish gate cleaner than I found it.

Three logical changes, three commits:

1. **`chore(deps): bump jbaruch/coding-policy to 0.3.14`** — local rule cache was 0.2.5 while CI's reviewer pulls latest at runtime. That gap is why local `tessl skill review` passed at 99% while CI's reviewer kept finding new violations across rounds in #37. Aligning the cache.
2. **`fix(vault-ingress): condense SKILL.md per skill-authoring conciseness`** — acted on the reviewer's three explicit suggestions: move Step 3's per-talk subagent procedure into a new `references/subagent-instructions.md`, move Important Notes' edge-case bullets into a new `references/known-issues.md`, update the Key Files table. SKILL.md drops 328 → 237 lines. Score: 84% → 93%.
3. **`fix(illustrations): keep link display repo-relative, target file-relative`** — `tessl tile lint` broke on main because the previous PR converted both display text AND markdown link target to repo-relative form. Re-reading the bumped policy, the rule governs paths-in-prose for greppability, not markdown link target resolution. Display stays repo-relative; targets revert to file-relative so GitHub/lint resolve them.

## Test plan

- [ ] CI: `tests.yml` passes (190 + 5 skipped).
- [ ] CI: gh-aw OpenAI reviewer (cross-family vs author `claude-opus-4-7`) approves.
- [ ] Once merged, `Review & Publish Tile` on main passes the `tessl skill review --threshold 85` gate for all five skills (current local sweep: 93 / 99 / 90 / 93 / 99).
- [ ] After publish workflow reaches a terminal state, `tessl tile info jbaruch/speaker-toolkit` shows `Latest Version` advanced past the pre-publish baseline `0.17.15`. Registry-advanced is the authoritative signal per `jbaruch/coding-policy: ci-safety`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)