### PR TITLE
feat(illustrations) + chore(ci): model-freshness step, cross-vendor image gen, and gh-aw / tessl-version-floating CI enforcement

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -5,10 +5,15 @@
       "version": "v9",
       "sha": "373c709c69115d41ff229c7e5df9f8788daa9553"
     },
-    "github/gh-aw-actions/setup@v0.71.0": {
+    "actions/github-script@v9.0.0": {
+      "repo": "actions/github-script",
+      "version": "v9.0.0",
+      "sha": "3a2844b7e9c422d3c10d287c895573f7108da1b3"
+    },
+    "github/gh-aw-actions/setup@v0.71.5": {
       "repo": "github/gh-aw-actions/setup",
-      "version": "v0.71.0",
-      "sha": "49157453228f9641824955e35cbeccbca74ee0fd"
+      "version": "v0.71.5",
+      "sha": "b8068426813005612b960b5ab0b8bd2c27142323"
     },
     "tesslio/setup-tessl@v2": {
       "repo": "tesslio/setup-tessl",

--- a/.github/workflows/evals-scheduled.yml
+++ b/.github/workflows/evals-scheduled.yml
@@ -1,0 +1,24 @@
+name: Evals (scheduled)
+
+# `jbaruch/coding-policy: plugin-evals` requires evals to run on a
+# recurring cadence in addition to every publish. Weekly is sufficient
+# for a tile whose evals exercise live web search — daily would add
+# cost without proportionate signal. The same suite gates publish in
+# publish-tile.yml.
+
+on:
+  schedule:
+    # Sunday 06:00 UTC — quiet window, gives a fresh signal at the start
+    # of the work week without colliding with the publish workflow.
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/setup-tessl@v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+      - run: tessl eval run .

--- a/.github/workflows/evals-scheduled.yml
+++ b/.github/workflows/evals-scheduled.yml
@@ -17,8 +17,12 @@ jobs:
   evals:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tesslio/setup-tessl@v2
+      # Actions pinned to commit SHAs per
+      # `jbaruch/coding-policy: dependency-management` (pin versions
+      # or use a lock file). The trailing `# v…` comment is the
+      # documented version the SHA resolves to.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - run: tessl eval run .

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -19,6 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Enforce tessl-version-floating carve-out
+        # See rules/tessl-version-floating.md. The
+        # `jbaruch/coding-policy: dependency-management`
+        # runtime-managed-manifest carve-out preconditions a
+        # deploy-time check that fails the deployment if any
+        # specifier other than the permitted floating value
+        # appears. Run before any publish step.
+        run: ./scripts/check-tessl-pins.sh
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -35,6 +35,11 @@ jobs:
       - run: tessl skill review --threshold 85 skills/vault-profile
       - run: tessl skill review --threshold 85 skills/presentation-creator
       - run: tessl skill review --threshold 85 skills/illustrations
+      - name: Run eval suite before publish
+        # `jbaruch/coding-policy: plugin-evals` requires evals to run
+        # on every publish (and on a recurring cadence — see
+        # evals-scheduled.yml). Regressions block the release.
+        run: tessl eval run .
       - uses: tesslio/patch-version-publish@v1
         with:
           token: ${{ secrets.TESSL_TOKEN }}

--- a/.github/workflows/review-anthropic.lock.yml
+++ b/.github/workflows/review-anthropic.lock.yml
@@ -1,20 +1,20 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"14c82836b71b4bc506769da1419b0ca6a2ff9c2fc92ac0e215f12760983a4e29","compiler_version":"v0.71.0","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"49157453228f9641824955e35cbeccbca74ee0fd","version":"v0.71.0"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.30","digest":"sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f"},{"image":"ghcr.io/github/github-mcp-server:v1.0.0","digest":"sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
-#    ___                   _   _
-#   / _ \                 | | (_)
-#  | |_| | __ _  ___ _ __ | |_ _  ___
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"14c82836b71b4bc506769da1419b0ca6a2ff9c2fc92ac0e215f12760983a4e29","compiler_version":"v0.71.5","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+#    ___                   _   _      
+#   / _ \                 | | (_)     
+#  | |_| | __ _  ___ _ __ | |_ _  ___ 
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__
+#  | | | | (_| |  __/ | | | |_| | (__ 
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/
+#  _    _ |___/ 
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
 # \  /\  / (_) | | | | ( | | | | (_) \ V  V /\__ \
 #  \/  \/ \___/|_| |_|\_\|_| |_|\___/ \_/\_/ |___/
 #
-# This file was automatically generated by gh-aw (v0.71.0). DO NOT EDIT.
+# This file was automatically generated by gh-aw (v0.71.5). DO NOT EDIT.
 #
 # To update this file, edit the corresponding .md file and run:
 #   gh aw compile
@@ -30,16 +30,16 @@
 # paired families (e.g., `gpt-5.4 claude-opus-4-7`), or neither paired
 # family (e.g., `gemini-2.5`, `human`-only), both reviewers run as the
 # documented fallback. See `jbaruch/coding-policy: author-model-declaration`.
-#
+# 
 # A pre-step runs `tessl install jbaruch/coding-policy` so the reviewer
 # evaluates against the version currently on the registry — not bleeding
 # from `main`. Fork PRs are skipped by gh-aw's fork-guard. Posts up to 10
 # inline comments plus one consolidated review verdict.
-#
+# 
 # Required repository secrets:
 # - ANTHROPIC_API_KEY — Claude Code engine authentication
 # - TESSL_TOKEN       — tessl install authentication
-#
+# 
 # Project `.mcp.json` is neutralized at runtime: this workflow runs
 # Claude with `--strict-mcp-config` (set under `engine.args` below) so
 # the agent only loads the MCP servers gh-aw injects via its own
@@ -58,17 +58,18 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+#   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+#   - github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
 #   - tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
 #
 # Container images used:
-#   - ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a
-#   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb
-#   - ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474
-#   - ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f
-#   - ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95
+#   - ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504
+#   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280
+#   - ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51
+#   - ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c
+#   - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 name: "PR Policy Review (Anthropic)"
@@ -104,6 +105,7 @@ jobs:
       body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
+      engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
@@ -114,31 +116,35 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-anthropic.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "2.1.126"
       - name: Generate agentic run info
         id: generate_aw_info
         env:
           GH_AW_INFO_ENGINE_ID: "claude"
           GH_AW_INFO_ENGINE_NAME: "Claude Code"
           GH_AW_INFO_MODEL: "claude-opus-4-7"
-          GH_AW_INFO_VERSION: "2.1.112"
-          GH_AW_INFO_AGENT_VERSION: "2.1.112"
-          GH_AW_INFO_CLI_VERSION: "v0.71.0"
+          GH_AW_INFO_VERSION: "2.1.126"
+          GH_AW_INFO_AGENT_VERSION: "2.1.126"
+          GH_AW_INFO_CLI_VERSION: "v0.71.5"
           GH_AW_INFO_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
           GH_AW_INFO_ALLOWED_DOMAINS: '["defaults"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
-          GH_AW_INFO_AWF_VERSION: "v0.25.28"
+          GH_AW_INFO_AWF_VERSION: "v0.25.40"
           GH_AW_INFO_AWMG_VERSION: ""
           GH_AW_INFO_FIREWALL_TYPE: "squid"
           GH_AW_COMPILED_STRICT: "true"
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -162,17 +168,18 @@ jobs:
             .crush
             .gemini
             .opencode
+            .pi
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Save agent config folders for base branch restoration
         env:
-          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode"
-          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md opencode.jsonc"
+          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode .pi"
+          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
         # poutine:ignore untrusted_checkout_exec
         run: bash "${RUNNER_TEMP}/gh-aw/actions/save_base_github_folders.sh"
       - name: Check workflow lock file
         id: check-lock-file
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_WORKFLOW_FILE: "review-anthropic.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
@@ -183,9 +190,9 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_workflow_timestamp_api.cjs');
             await main();
       - name: Check compile-agentic version
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_COMPILED_VERSION: "v0.71.0"
+          GH_AW_COMPILED_VERSION: "v0.71.5"
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -194,7 +201,7 @@ jobs:
             await main();
       - name: Compute current body text
         id: sanitized
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
         with:
@@ -231,6 +238,9 @@ jobs:
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:10), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
+          GH_AW_PROMPT_82a9f37a6e20e4d0_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
+          cat << 'GH_AW_PROMPT_82a9f37a6e20e4d0_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -258,7 +268,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-
+          
           GH_AW_PROMPT_82a9f37a6e20e4d0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           cat << 'GH_AW_PROMPT_82a9f37a6e20e4d0_EOF'
@@ -267,9 +277,10 @@ jobs:
           GH_AW_PROMPT_82a9f37a6e20e4d0_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_ENGINE_ID: "claude"
           GH_AW_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
@@ -280,7 +291,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/interpolate_prompt.cjs');
             await main();
       - name: Substitute placeholders
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
@@ -292,14 +303,15 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
-
+            
             const substitutePlaceholders = require('${{ runner.temp }}/gh-aw/actions/substitute_placeholders.cjs');
-
+            
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -313,6 +325,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
@@ -331,6 +344,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: activation
+          include-hidden-files: true
           path: |
             /tmp/gh-aw/aw_info.json
             /tmp/gh-aw/aw-prompts/prompt.txt
@@ -363,11 +377,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-anthropic.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "2.1.126"
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -413,7 +431,7 @@ jobs:
         id: checkout-pr
         if: |
           github.event.pull_request || github.event.issue.pull_request
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
@@ -429,9 +447,9 @@ jobs:
           node-version: '24'
           package-manager-cache: false
       - name: Install AWF binary
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.28
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
-        run: npm install --ignore-scripts -g @anthropic-ai/claude-code@2.1.112
+        run: npm install -g @anthropic-ai/claude-code@2.1.126
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -442,9 +460,20 @@ jobs:
           script: |
             const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
             await determineAutomaticLockdown(github, context, core);
+      - name: Download activation artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: activation
+          path: /tmp/gh-aw
+      - name: Restore agent config folders from base branch
+        if: steps.checkout-pr.outcome == 'success'
+        env:
+          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode .pi"
+          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_base_github_folders.sh"
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474 ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
-      - name: Write Safe Outputs Config
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+      - name: Generate Safe Outputs Config
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
@@ -452,7 +481,7 @@ jobs:
           cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_340c19cf72f9afcb_EOF'
           {"create_pull_request_review_comment":{"max":10,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["REQUEST_CHANGES","COMMENT"],"footer":"if-body","max":1,"target":"triggering"}}
           GH_AW_SAFE_OUTPUTS_CONFIG_340c19cf72f9afcb_EOF
-      - name: Write Safe Outputs Tools
+      - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
@@ -594,7 +623,7 @@ jobs:
                 }
               }
             }
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -608,17 +637,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-
+          
           PORT=3001
-
+          
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-
+          
           echo "Safe Outputs MCP server will run on port ${PORT}"
-
+          
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -638,9 +667,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-
+          
           bash "${RUNNER_TEMP}/gh-aw/actions/start_safe_outputs_server.sh"
-
+          
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -653,10 +682,11 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p "${RUNNER_TEMP}/gh-aw/mcp-config"
-
+          
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="8080"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
+          export MCP_GATEWAY_HOST_DOMAIN="localhost"
           MCP_GATEWAY_API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${MCP_GATEWAY_API_KEY}"
           export MCP_GATEWAY_API_KEY
@@ -664,19 +694,19 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-
+          
           export GH_AW_ENGINE="claude"
           MCP_GATEWAY_UID=$(id -u 2>/dev/null || echo '0')
           MCP_GATEWAY_GID=$(id -g 2>/dev/null || echo '0')
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
-          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.30'
-
+          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
+          
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
           cat << GH_AW_MCP_CONFIG_9b2242709757b9ad_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
-                "container": "ghcr.io/github/github-mcp-server:v1.0.0",
+                "container": "ghcr.io/github/github-mcp-server:v1.0.3",
                 "env": {
                   "GITHUB_HOST": "$GITHUB_SERVER_URL",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_MCP_SERVER_TOKEN",
@@ -713,20 +743,27 @@ jobs:
             }
           }
           GH_AW_MCP_CONFIG_9b2242709757b9ad_EOF
-      - name: Download activation artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: activation
-          path: /tmp/gh-aw
-      - name: Restore agent config folders from base branch
-        if: steps.checkout-pr.outcome == 'success'
+      - name: Mount MCP servers as CLIs
+        id: mount-mcp-clis
+        continue-on-error: true
         env:
-          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode"
-          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md opencode.jsonc"
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_base_github_folders.sh"
-      - name: Clean git credentials
+          MCP_GATEWAY_API_KEY: ${{ steps.start-mcp-gateway.outputs.gateway-api-key }}
+          MCP_GATEWAY_DOMAIN: ${{ steps.start-mcp-gateway.outputs.gateway-domain }}
+          MCP_GATEWAY_PORT: ${{ steps.start-mcp-gateway.outputs.gateway-port }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/mount_mcp_as_cli.cjs');
+            await main();
+      - name: Clean credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
+      - name: Audit pre-agent workspace
+        id: pre_agent_audit
+        continue-on-error: true
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/audit_pre_agent_workspace.sh"
       - name: Execute Claude Code CLI
         id: agentic_execution
         # Allowed tools (sorted):
@@ -743,6 +780,7 @@ jobs:
         # - Bash(head)
         # - Bash(ls)
         # - Bash(pwd)
+        # - Bash(safeoutputs:*)
         # - Bash(sort)
         # - Bash(tail)
         # - Bash(uniq)
@@ -820,14 +858,16 @@ jobs:
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.40/awf-config.schema.json","network":{"allowDomains":["*.githubusercontent.com","anthropic.com","api.anthropic.com","api.github.com","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","cdn.playwright.dev","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","files.pythonhosted.org","ghcr.io","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.com","host.docker.internal","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","lfs.github.com","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","playwright.download.prss.microsoft.com","ppa.launchpad.net","pypi.org","raw.githubusercontent.com","registry.npmjs.org","s.symcb.com","s.symcd.com","security.ubuntu.com","sentry.io","statsig.anthropic.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com"]},"apiProxy":{"enabled":true,"models":{"auto":["large"],"deep-research":["copilot/deep-research*","google/deep-research*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*"],"gpt-4.1":["copilot/gpt-4.1*","openai/gpt-4.1*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash"],"opus":["copilot/*opus*","anthropic/*opus*"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"]}},"container":{"imageTag":"0.25.40,squid=sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51,agent=sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504,api-proxy=sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280,cli-proxy=sha256:3e7152911d4b4b7b97beef9d3d7d924ff7902227e86001ef3838fb728d5d514c"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --image-tag 0.25.28,squid=sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474,agent=sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a,api-proxy=sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb,cli-proxy=sha256:fdf310e4678ce58d248c466b89399e9680a3003038fd19322c388559016aaac7 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && claude --print --no-chrome --mcp-config "${{ runner.temp }}/gh-aw/mcp-config/mcp-servers.json" --allowed-tools '\''Bash(cat),Bash(date),Bash(echo),Bash(find),Bash(gh pr diff *),Bash(gh pr view *),Bash(git diff *),Bash(git log *),Bash(git show *),Bash(grep),Bash(head),Bash(ls),Bash(pwd),Bash(sort),Bash(tail),Bash(uniq),Bash(wc),Bash(yq),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_label,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__issue_read,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_label,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__pull_request_read,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users,mcp__safeoutputs'\'' --debug-file /tmp/gh-aw/agent-stdio.log --verbose --permission-mode acceptEdits --output-format stream-json --strict-mcp-config "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+          sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
+            -- /bin/bash -c 'export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/claude_harness.cjs claude --print --no-chrome --mcp-config "${{ runner.temp }}/gh-aw/mcp-config/mcp-servers.json" --allowed-tools '\''Bash(cat),Bash(date),Bash(echo),Bash(find),Bash(gh pr diff *),Bash(gh pr view *),Bash(git diff *),Bash(git log *),Bash(git show *),Bash(grep),Bash(head),Bash(ls),Bash(pwd),Bash(safeoutputs:*),Bash(sort),Bash(tail),Bash(uniq),Bash(wc),Bash(yq),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_label,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__issue_read,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_label,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__pull_request_read,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users,mcp__safeoutputs'\'' --debug-file /tmp/gh-aw/agent-stdio.log --verbose --permission-mode acceptEdits --output-format stream-json --strict-mcp-config --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_MODEL: claude-opus-4-7
           BASH_DEFAULT_TIMEOUT_MS: 60000
           BASH_MAX_TIMEOUT_MS: 60000
+          CLAUDE_CODE_DISABLE_FAST_MODE: 1
           DISABLE_BUG_COMMAND: 1
           DISABLE_ERROR_REPORTING: 1
           DISABLE_TELEMETRY: 1
@@ -835,7 +875,7 @@ jobs:
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_VERSION: v0.71.0
+          GH_AW_VERSION: v0.71.5
           GITHUB_AW: true
           GITHUB_STEP_SUMMARY: /tmp/gh-aw/agent-step-summary.md
           GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -869,7 +909,7 @@ jobs:
           bash "${RUNNER_TEMP}/gh-aw/actions/stop_mcp_gateway.sh" "$GATEWAY_PID"
       - name: Redact secrets in logs
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -896,7 +936,7 @@ jobs:
       - name: Ingest agent output
         id: collect_output
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
@@ -910,7 +950,7 @@ jobs:
             await main();
       - name: Parse agent logs for step summary
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: /tmp/gh-aw/agent-stdio.log
         with:
@@ -922,7 +962,7 @@ jobs:
       - name: Parse MCP Gateway logs for step summary
         if: always()
         id: parse-mcp-gateway
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -947,12 +987,22 @@ jobs:
       - name: Parse token usage for step summary
         if: always()
         continue-on-error: true
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_token_usage.cjs');
+            await main();
+      - name: Print AWF reflect summary
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/awf_reflect_summary.cjs');
             await main();
       - name: Write agent output placeholder if missing
         if: always()
@@ -971,14 +1021,17 @@ jobs:
             /tmp/gh-aw/mcp-logs/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
+            /tmp/gh-aw/pre-agent-audit.txt
             /tmp/gh-aw/agent/
             /tmp/gh-aw/github_rate_limits.jsonl
             /tmp/gh-aw/safeoutputs.jsonl
             /tmp/gh-aw/agent_output.json
             /tmp/gh-aw/aw-*.patch
             /tmp/gh-aw/aw-*.bundle
+            /tmp/gh-aw/awf-config.json
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/sandbox/firewall/audit/
+            /tmp/gh-aw/sandbox/firewall/awf-reflect.json
           if-no-files-found: ignore
 
   conclusion:
@@ -1005,11 +1058,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-anthropic.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "2.1.126"
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1026,7 +1083,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
       - name: Process no-op messages
         id: noop
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
@@ -1043,7 +1100,7 @@ jobs:
             await main();
       - name: Log detection run
         id: detection_runs
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
@@ -1059,7 +1116,7 @@ jobs:
             await main();
       - name: Record missing tool
         id: missing_tool
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
@@ -1073,7 +1130,7 @@ jobs:
             await main();
       - name: Record incomplete
         id: report_incomplete
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
@@ -1088,7 +1145,7 @@ jobs:
       - name: Handle agent failure
         id: handle_agent_failure
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
@@ -1099,10 +1156,13 @@ jobs:
           GH_AW_ENGINE_ID: "claude"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
+          GH_AW_ENGINE_API_HOSTS: "api.anthropic.com"
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
+          GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1128,11 +1188,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-anthropic.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "2.1.126"
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1158,7 +1222,7 @@ jobs:
           rm -rf /tmp/gh-aw/sandbox/firewall/logs
           rm -rf /tmp/gh-aw/sandbox/firewall/audit
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51
       - name: Check if detection needed
         id: detection_guard
         if: always()
@@ -1173,7 +1237,7 @@ jobs:
             echo "run_detection=false" >> "$GITHUB_OUTPUT"
             echo "Detection skipped: no agent outputs or patches to analyze"
           fi
-      - name: Clear MCP configuration for detection
+      - name: Clear MCP Config for detection
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
           rm -f "${RUNNER_TEMP}/gh-aw/mcp-config/mcp-servers.json"
@@ -1195,7 +1259,7 @@ jobs:
           ls -la /tmp/gh-aw/threat-detection/ 2>/dev/null || true
       - name: Setup threat detection
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "PR Policy Review (Anthropic)"
           WORKFLOW_DESCRIPTION: "Reviews every same-repo pull request against the latest published\n`jbaruch/coding-policy` rule set, using an Anthropic-family reviewer model.\nPairs with `review-openai.md`; each workflow self-gates to skip PRs\nauthored by its own family so the active reviewer is cross-family\nwhenever the declaration permits — when the declaration spans both\npaired families (e.g., `gpt-5.4 claude-opus-4-7`), or neither paired\nfamily (e.g., `gemini-2.5`, `human`-only), both reviewers run as the\ndocumented fallback. See `jbaruch/coding-policy: author-model-declaration`.\n\nA pre-step runs `tessl install jbaruch/coding-policy` so the reviewer\nevaluates against the version currently on the registry — not bleeding\nfrom `main`. Fork PRs are skipped by gh-aw's fork-guard. Posts up to 10\ninline comments plus one consolidated review verdict.\n\nRequired repository secrets:\n  - ANTHROPIC_API_KEY — Claude Code engine authentication\n  - TESSL_TOKEN       — tessl install authentication\n\nProject `.mcp.json` is neutralized at runtime: this workflow runs\nClaude with `--strict-mcp-config` (set under `engine.args` below) so\nthe agent only loads the MCP servers gh-aw injects via its own\n`--mcp-config`. Any stdio MCP server the consumer repo declares in\nits checked-in `.mcp.json` is ignored, which sidesteps the awf\nsandbox's missing-binary failure that would otherwise kill the job."
@@ -1217,11 +1281,12 @@ jobs:
           node-version: '24'
           package-manager-cache: false
       - name: Install AWF binary
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.28
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Install Claude Code CLI
-        run: npm install --ignore-scripts -g @anthropic-ai/claude-code@2.1.112
+        run: npm install -g @anthropic-ai/claude-code@2.1.126
       - name: Execute Claude Code CLI
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
+        continue-on-error: true
         id: detection_agentic_execution
         # Allowed tools (sorted):
         # - Bash
@@ -1240,20 +1305,22 @@ jobs:
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           (umask 177 && touch /tmp/gh-aw/threat-detection/detection.log)
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.40/awf-config.schema.json","network":{"allowDomains":["*.githubusercontent.com","anthropic.com","api.anthropic.com","api.github.com","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","cdn.playwright.dev","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","files.pythonhosted.org","ghcr.io","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.com","host.docker.internal","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","lfs.github.com","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","playwright.download.prss.microsoft.com","ppa.launchpad.net","pypi.org","raw.githubusercontent.com","registry.npmjs.org","s.symcb.com","s.symcd.com","security.ubuntu.com","sentry.io","statsig.anthropic.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com"]},"apiProxy":{"enabled":true},"container":{"imageTag":"0.25.40,squid=sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51,agent=sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504,api-proxy=sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280,cli-proxy=sha256:3e7152911d4b4b7b97beef9d3d7d924ff7902227e86001ef3838fb728d5d514c"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --allow-domains '*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --image-tag 0.25.28,squid=sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474,agent=sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a,api-proxy=sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb,cli-proxy=sha256:fdf310e4678ce58d248c466b89399e9680a3003038fd19322c388559016aaac7 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && claude --print --no-chrome --allowed-tools Bash,BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite --debug-file /tmp/gh-aw/threat-detection/detection.log --verbose --permission-mode bypassPermissions --output-format stream-json --strict-mcp-config "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/threat-detection/detection.log
+          sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
+            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/claude_harness.cjs claude --print --no-chrome --allowed-tools Bash,BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite --debug-file /tmp/gh-aw/threat-detection/detection.log --verbose --permission-mode bypassPermissions --output-format stream-json --strict-mcp-config --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/threat-detection/detection.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_MODEL: claude-opus-4-7
           BASH_DEFAULT_TIMEOUT_MS: 60000
           BASH_MAX_TIMEOUT_MS: 60000
+          CLAUDE_CODE_DISABLE_FAST_MODE: 1
           DISABLE_BUG_COMMAND: 1
           DISABLE_ERROR_REPORTING: 1
           DISABLE_TELEMETRY: 1
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_VERSION: v0.71.0
+          GH_AW_VERSION: v0.71.5
           GITHUB_AW: true
           GITHUB_STEP_SUMMARY: /tmp/gh-aw/agent-step-summary.md
           GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -1273,16 +1340,33 @@ jobs:
       - name: Parse and conclude threat detection
         id: detection_conclusion
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RUN_DETECTION: ${{ steps.detection_guard.outputs.run_detection }}
           GH_AW_DETECTION_CONTINUE_ON_ERROR: "true"
         with:
           script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
-            await main();
+            try {
+              const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+              setupGlobals(core, github, context, exec, io, getOctokit);
+              const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
+              await main();
+            } catch (loadErr) {
+              const continueOnError = process.env.GH_AW_DETECTION_CONTINUE_ON_ERROR !== 'false';
+              const msg = 'ERR_SYSTEM: \u274C Unexpected error loading threat detection module: ' + (loadErr && loadErr.message ? loadErr.message : String(loadErr));
+              core.error(msg);
+              core.setOutput('reason', 'parse_error');
+              if (continueOnError) {
+                core.warning('\u26A0\uFE0F ' + msg);
+                core.setOutput('conclusion', 'warning');
+                core.setOutput('success', 'false');
+              } else {
+                core.setOutput('conclusion', 'failure');
+                core.setOutput('success', 'false');
+                core.setFailed(msg);
+              }
+            }
 
   pre_activation:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
@@ -1294,13 +1378,17 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-anthropic.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "2.1.126"
       - name: Check team membership for workflow
         id: check_membership
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
         with:
@@ -1312,7 +1400,7 @@ jobs:
             await main();
       - name: Check skip-bots
         id: check_skip_bots
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SKIP_BOTS: "dependabot[bot],renovate[bot]"
           GH_AW_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
@@ -1353,11 +1441,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (Anthropic)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-anthropic.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "2.1.126"
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1383,7 +1475,7 @@ jobs:
           echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
       - name: Process Safe Outputs
         id: process_safe_outputs
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"

--- a/.github/workflows/review-anthropic.lock.yml
+++ b/.github/workflows/review-anthropic.lock.yml
@@ -1,13 +1,13 @@
 # gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"14c82836b71b4bc506769da1419b0ca6a2ff9c2fc92ac0e215f12760983a4e29","compiler_version":"v0.71.5","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
-#    ___                   _   _      
-#   / _ \                 | | (_)     
-#  | |_| | __ _  ___ _ __ | |_ _  ___ 
+#    ___                   _   _
+#   / _ \                 | | (_)
+#  | |_| | __ _  ___ _ __ | |_ _  ___
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__ 
+#  | | | | (_| |  __/ | | | |_| | (__
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/ 
+#  _    _ |___/
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
@@ -30,16 +30,16 @@
 # paired families (e.g., `gpt-5.4 claude-opus-4-7`), or neither paired
 # family (e.g., `gemini-2.5`, `human`-only), both reviewers run as the
 # documented fallback. See `jbaruch/coding-policy: author-model-declaration`.
-# 
+#
 # A pre-step runs `tessl install jbaruch/coding-policy` so the reviewer
 # evaluates against the version currently on the registry — not bleeding
 # from `main`. Fork PRs are skipped by gh-aw's fork-guard. Posts up to 10
 # inline comments plus one consolidated review verdict.
-# 
+#
 # Required repository secrets:
 # - ANTHROPIC_API_KEY — Claude Code engine authentication
 # - TESSL_TOKEN       — tessl install authentication
-# 
+#
 # Project `.mcp.json` is neutralized at runtime: this workflow runs
 # Claude with `--strict-mcp-config` (set under `engine.args` below) so
 # the agent only loads the MCP servers gh-aw injects via its own
@@ -268,7 +268,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-          
+
           GH_AW_PROMPT_82a9f37a6e20e4d0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           cat << 'GH_AW_PROMPT_82a9f37a6e20e4d0_EOF'
@@ -309,9 +309,9 @@ jobs:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
-            
+
             const substitutePlaceholders = require('${{ runner.temp }}/gh-aw/actions/substitute_placeholders.cjs');
-            
+
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -637,17 +637,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-          
+
           PORT=3001
-          
+
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-          
+
           echo "Safe Outputs MCP server will run on port ${PORT}"
-          
+
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -667,9 +667,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-          
+
           bash "${RUNNER_TEMP}/gh-aw/actions/start_safe_outputs_server.sh"
-          
+
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -682,7 +682,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p "${RUNNER_TEMP}/gh-aw/mcp-config"
-          
+
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="8080"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -694,13 +694,13 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-          
+
           export GH_AW_ENGINE="claude"
           MCP_GATEWAY_UID=$(id -u 2>/dev/null || echo '0')
           MCP_GATEWAY_GID=$(id -g 2>/dev/null || echo '0')
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
-          
+
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
           cat << GH_AW_MCP_CONFIG_9b2242709757b9ad_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {

--- a/.github/workflows/review-openai.lock.yml
+++ b/.github/workflows/review-openai.lock.yml
@@ -1,13 +1,13 @@
 # gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"52bdf3b66b7d27ad2740a035748e943b3be8e0ffe7aebb7210c1f715540370e8","compiler_version":"v0.71.5","strict":true,"agent_id":"codex","agent_model":"gpt-5.4"}
 # gh-aw-manifest: {"version":1,"secrets":["CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
-#    ___                   _   _      
-#   / _ \                 | | (_)     
-#  | |_| | __ _  ___ _ __ | |_ _  ___ 
+#    ___                   _   _
+#   / _ \                 | | (_)
+#  | |_| | __ _  ___ _ __ | |_ _  ___
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__ 
+#  | | | | (_| |  __/ | | | |_| | (__
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/ 
+#  _    _ |___/
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
@@ -30,12 +30,12 @@
 # paired families (e.g., `gpt-5.4 claude-opus-4-7`), or neither paired
 # family (e.g., `gemini-2.5`, `human`-only), both reviewers run as the
 # documented fallback. See `jbaruch/coding-policy: author-model-declaration`.
-# 
+#
 # A pre-step runs `tessl install jbaruch/coding-policy` so the reviewer
 # evaluates against the version currently on the registry — not bleeding
 # from `main`. Fork PRs are skipped by gh-aw's fork-guard. Posts up to 10
 # inline comments plus one consolidated review verdict.
-# 
+#
 # Required repository secrets:
 # - OPENAI_API_KEY — Codex engine authentication
 # - TESSL_TOKEN    — tessl install authentication
@@ -263,7 +263,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-          
+
           GH_AW_PROMPT_ca8d2939940acf0d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           cat << 'GH_AW_PROMPT_ca8d2939940acf0d_EOF'
@@ -304,9 +304,9 @@ jobs:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
-            
+
             const substitutePlaceholders = require('${{ runner.temp }}/gh-aw/actions/substitute_placeholders.cjs');
-            
+
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -632,17 +632,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-          
+
           PORT=3001
-          
+
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-          
+
           echo "Safe Outputs MCP server will run on port ${PORT}"
-          
+
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -662,9 +662,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-          
+
           bash "${RUNNER_TEMP}/gh-aw/actions/start_safe_outputs_server.sh"
-          
+
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -678,7 +678,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p "${RUNNER_TEMP}/gh-aw/mcp-config"
-          
+
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="8080"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -690,21 +690,21 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-          
+
           export GH_AW_ENGINE="codex"
           MCP_GATEWAY_UID=$(id -u 2>/dev/null || echo '0')
           MCP_GATEWAY_GID=$(id -g 2>/dev/null || echo '0')
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
-          
+
           cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
           [history]
           persistence = "none"
-          
+
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "GH_AW_ASSETS_ALLOWED_EXTS", "GH_AW_ASSETS_BRANCH", "GH_AW_ASSETS_MAX_SIZE_KB", "GH_AW_SAFE_OUTPUTS", "GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_REPOSITORY", "GITHUB_SERVER_URL", "HOME", "OPENAI_API_KEY", "PATH"]
-          
+
           [mcp_servers.github]
           user_agent = "pr-policy-review-openai"
           startup_timeout_sec = 120
@@ -712,20 +712,20 @@ jobs:
           container = "ghcr.io/github/github-mcp-server:v1.0.3"
           env = { "GITHUB_HOST" = "$GITHUB_SERVER_URL", "GITHUB_PERSONAL_ACCESS_TOKEN" = "$GH_AW_GITHUB_TOKEN", "GITHUB_READ_ONLY" = "1", "GITHUB_TOOLSETS" = "pull_requests" }
           env_vars = ["GITHUB_HOST", "GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_READ_ONLY", "GITHUB_TOOLSETS"]
-          
+
           [mcp_servers.safeoutputs]
           type = "http"
           url = "http://host.docker.internal:$GH_AW_SAFE_OUTPUTS_PORT"
-          
+
           [mcp_servers.safeoutputs.headers]
           Authorization = "$GH_AW_SAFE_OUTPUTS_API_KEY"
-          
+
           [mcp_servers.safeoutputs."guard-policies"]
-          
+
           [mcp_servers.safeoutputs."guard-policies".write-sink]
           accept = ["*"]
           GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
-          
+
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
           cat << GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
@@ -769,7 +769,7 @@ jobs:
             }
           }
           GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
-          
+
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
           cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_39e89459ba2392c9_EOF
@@ -1253,7 +1253,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p "${RUNNER_TEMP}/gh-aw/mcp-config"
-          
+
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="8080"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -1265,22 +1265,22 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-          
+
           export GH_AW_ENGINE="codex"
           MCP_GATEWAY_UID=$(id -u 2>/dev/null || echo '0')
           MCP_GATEWAY_GID=$(id -g 2>/dev/null || echo '0')
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
-          
+
           cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_0a2cc29898e430dd_EOF
           [history]
           persistence = "none"
-          
+
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "HOME", "OPENAI_API_KEY", "PATH"]
           GH_AW_MCP_CONFIG_0a2cc29898e430dd_EOF
-          
+
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
           cat << GH_AW_MCP_CONFIG_cab44f36b263bf8a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
@@ -1295,7 +1295,7 @@ jobs:
             }
           }
           GH_AW_MCP_CONFIG_cab44f36b263bf8a_EOF
-          
+
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
           cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_6c65a0e96d8d2304_EOF

--- a/.github/workflows/review-openai.lock.yml
+++ b/.github/workflows/review-openai.lock.yml
@@ -1,20 +1,20 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"52bdf3b66b7d27ad2740a035748e943b3be8e0ffe7aebb7210c1f715540370e8","compiler_version":"v0.71.0","strict":true,"agent_id":"codex","agent_model":"gpt-5.4"}
-# gh-aw-manifest: {"version":1,"secrets":["CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"49157453228f9641824955e35cbeccbca74ee0fd","version":"v0.71.0"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.30","digest":"sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f"},{"image":"ghcr.io/github/github-mcp-server:v1.0.0","digest":"sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
-#    ___                   _   _
-#   / _ \                 | | (_)
-#  | |_| | __ _  ___ _ __ | |_ _  ___
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"52bdf3b66b7d27ad2740a035748e943b3be8e0ffe7aebb7210c1f715540370e8","compiler_version":"v0.71.5","strict":true,"agent_id":"codex","agent_model":"gpt-5.4"}
+# gh-aw-manifest: {"version":1,"secrets":["CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+#    ___                   _   _      
+#   / _ \                 | | (_)     
+#  | |_| | __ _  ___ _ __ | |_ _  ___ 
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__
+#  | | | | (_| |  __/ | | | |_| | (__ 
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/
+#  _    _ |___/ 
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
 # \  /\  / (_) | | | | ( | | | | (_) \ V  V /\__ \
 #  \/  \/ \___/|_| |_|\_\|_| |_|\___/ \_/\_/ |___/
 #
-# This file was automatically generated by gh-aw (v0.71.0). DO NOT EDIT.
+# This file was automatically generated by gh-aw (v0.71.5). DO NOT EDIT.
 #
 # To update this file, edit the corresponding .md file and run:
 #   gh aw compile
@@ -30,12 +30,12 @@
 # paired families (e.g., `gpt-5.4 claude-opus-4-7`), or neither paired
 # family (e.g., `gemini-2.5`, `human`-only), both reviewers run as the
 # documented fallback. See `jbaruch/coding-policy: author-model-declaration`.
-#
+# 
 # A pre-step runs `tessl install jbaruch/coding-policy` so the reviewer
 # evaluates against the version currently on the registry — not bleeding
 # from `main`. Fork PRs are skipped by gh-aw's fork-guard. Posts up to 10
 # inline comments plus one consolidated review verdict.
-#
+# 
 # Required repository secrets:
 # - OPENAI_API_KEY — Codex engine authentication
 # - TESSL_TOKEN    — tessl install authentication
@@ -52,17 +52,18 @@
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+#   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+#   - github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
 #   - tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
 #
 # Container images used:
-#   - ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a
-#   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb
-#   - ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474
-#   - ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f
-#   - ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95
+#   - ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504
+#   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280
+#   - ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51
+#   - ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c
+#   - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 name: "PR Policy Review (OpenAI)"
@@ -98,6 +99,7 @@ jobs:
       body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
+      engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
@@ -108,31 +110,35 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-openai.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "0.128.0"
       - name: Generate agentic run info
         id: generate_aw_info
         env:
           GH_AW_INFO_ENGINE_ID: "codex"
           GH_AW_INFO_ENGINE_NAME: "Codex"
           GH_AW_INFO_MODEL: "gpt-5.4"
-          GH_AW_INFO_VERSION: "0.121.0"
-          GH_AW_INFO_AGENT_VERSION: "0.121.0"
-          GH_AW_INFO_CLI_VERSION: "v0.71.0"
+          GH_AW_INFO_VERSION: "0.128.0"
+          GH_AW_INFO_AGENT_VERSION: "0.128.0"
+          GH_AW_INFO_CLI_VERSION: "v0.71.5"
           GH_AW_INFO_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
           GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","github","threat-detection","ab.chatgpt.com","chatgpt.com"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
-          GH_AW_INFO_AWF_VERSION: "v0.25.28"
+          GH_AW_INFO_AWF_VERSION: "v0.25.40"
           GH_AW_INFO_AWMG_VERSION: ""
           GH_AW_INFO_FIREWALL_TYPE: "squid"
           GH_AW_COMPILED_STRICT: "true"
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -157,17 +163,18 @@ jobs:
             .crush
             .gemini
             .opencode
+            .pi
           sparse-checkout-cone-mode: true
           fetch-depth: 1
       - name: Save agent config folders for base branch restoration
         env:
-          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode"
-          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md opencode.jsonc"
+          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode .pi"
+          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
         # poutine:ignore untrusted_checkout_exec
         run: bash "${RUNNER_TEMP}/gh-aw/actions/save_base_github_folders.sh"
       - name: Check workflow lock file
         id: check-lock-file
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_WORKFLOW_FILE: "review-openai.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
@@ -178,9 +185,9 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_workflow_timestamp_api.cjs');
             await main();
       - name: Check compile-agentic version
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_COMPILED_VERSION: "v0.71.0"
+          GH_AW_COMPILED_VERSION: "v0.71.5"
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -189,7 +196,7 @@ jobs:
             await main();
       - name: Compute current body text
         id: sanitized
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,172.30.0.1,ab.chatgpt.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.openai.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,chatgpt.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openai.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
         with:
@@ -226,6 +233,9 @@ jobs:
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:10), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
+          GH_AW_PROMPT_ca8d2939940acf0d_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
+          cat << 'GH_AW_PROMPT_ca8d2939940acf0d_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -253,7 +263,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-
+          
           GH_AW_PROMPT_ca8d2939940acf0d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           cat << 'GH_AW_PROMPT_ca8d2939940acf0d_EOF'
@@ -262,9 +272,10 @@ jobs:
           GH_AW_PROMPT_ca8d2939940acf0d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_ENGINE_ID: "codex"
           GH_AW_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
@@ -275,7 +286,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/interpolate_prompt.cjs');
             await main();
       - name: Substitute placeholders
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
@@ -287,14 +298,15 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
-
+            
             const substitutePlaceholders = require('${{ runner.temp }}/gh-aw/actions/substitute_placeholders.cjs');
-
+            
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -308,6 +320,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
@@ -326,6 +339,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: activation
+          include-hidden-files: true
           path: |
             /tmp/gh-aw/aw_info.json
             /tmp/gh-aw/aw-prompts/prompt.txt
@@ -358,11 +372,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-openai.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "0.128.0"
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -408,7 +426,7 @@ jobs:
         id: checkout-pr
         if: |
           github.event.pull_request || github.event.issue.pull_request
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
@@ -424,9 +442,9 @@ jobs:
           node-version: '24'
           package-manager-cache: false
       - name: Install Codex CLI
-        run: npm install --ignore-scripts -g @openai/codex@0.121.0
+        run: npm install --ignore-scripts -g @openai/codex@0.128.0
       - name: Install AWF binary
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.28
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -437,9 +455,20 @@ jobs:
           script: |
             const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
             await determineAutomaticLockdown(github, context, core);
+      - name: Download activation artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: activation
+          path: /tmp/gh-aw
+      - name: Restore agent config folders from base branch
+        if: steps.checkout-pr.outcome == 'success'
+        env:
+          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode .pi"
+          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_base_github_folders.sh"
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474 ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
-      - name: Write Safe Outputs Config
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+      - name: Generate Safe Outputs Config
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
@@ -447,7 +476,7 @@ jobs:
           cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_eccf724259622db6_EOF'
           {"create_pull_request_review_comment":{"max":10,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["REQUEST_CHANGES","COMMENT"],"footer":"if-body","max":1,"target":"triggering"}}
           GH_AW_SAFE_OUTPUTS_CONFIG_eccf724259622db6_EOF
-      - name: Write Safe Outputs Tools
+      - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
@@ -589,7 +618,7 @@ jobs:
                 }
               }
             }
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -603,17 +632,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-
+          
           PORT=3001
-
+          
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-
+          
           echo "Safe Outputs MCP server will run on port ${PORT}"
-
+          
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -633,9 +662,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-
+          
           bash "${RUNNER_TEMP}/gh-aw/actions/start_safe_outputs_server.sh"
-
+          
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -649,10 +678,11 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p "${RUNNER_TEMP}/gh-aw/mcp-config"
-
+          
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="8080"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
+          export MCP_GATEWAY_HOST_DOMAIN="localhost"
           MCP_GATEWAY_API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${MCP_GATEWAY_API_KEY}"
           export MCP_GATEWAY_API_KEY
@@ -660,49 +690,49 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-
+          
           export GH_AW_ENGINE="codex"
           MCP_GATEWAY_UID=$(id -u 2>/dev/null || echo '0')
           MCP_GATEWAY_GID=$(id -g 2>/dev/null || echo '0')
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
-          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.30'
-
+          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
+          
           cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
           [history]
           persistence = "none"
-
+          
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "GH_AW_ASSETS_ALLOWED_EXTS", "GH_AW_ASSETS_BRANCH", "GH_AW_ASSETS_MAX_SIZE_KB", "GH_AW_SAFE_OUTPUTS", "GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_REPOSITORY", "GITHUB_SERVER_URL", "HOME", "OPENAI_API_KEY", "PATH"]
-
+          
           [mcp_servers.github]
           user_agent = "pr-policy-review-openai"
           startup_timeout_sec = 120
           tool_timeout_sec = 60
-          container = "ghcr.io/github/github-mcp-server:v1.0.0"
+          container = "ghcr.io/github/github-mcp-server:v1.0.3"
           env = { "GITHUB_HOST" = "$GITHUB_SERVER_URL", "GITHUB_PERSONAL_ACCESS_TOKEN" = "$GH_AW_GITHUB_TOKEN", "GITHUB_READ_ONLY" = "1", "GITHUB_TOOLSETS" = "pull_requests" }
           env_vars = ["GITHUB_HOST", "GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_READ_ONLY", "GITHUB_TOOLSETS"]
-
+          
           [mcp_servers.safeoutputs]
           type = "http"
           url = "http://host.docker.internal:$GH_AW_SAFE_OUTPUTS_PORT"
-
+          
           [mcp_servers.safeoutputs.headers]
           Authorization = "$GH_AW_SAFE_OUTPUTS_API_KEY"
-
+          
           [mcp_servers.safeoutputs."guard-policies"]
-
+          
           [mcp_servers.safeoutputs."guard-policies".write-sink]
           accept = ["*"]
           GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
-
+          
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
           cat << GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
-                "container": "ghcr.io/github/github-mcp-server:v1.0.0",
+                "container": "ghcr.io/github/github-mcp-server:v1.0.3",
                 "env": {
                   "GITHUB_HOST": "$GITHUB_SERVER_URL",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_MCP_SERVER_TOKEN",
@@ -739,7 +769,7 @@ jobs:
             }
           }
           GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
-
+          
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
           cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_39e89459ba2392c9_EOF
@@ -766,29 +796,37 @@ jobs:
           mkdir -p "${CODEX_HOME}"
           if [ "/tmp/gh-aw/mcp-config/config.toml" != "${CODEX_HOME}/config.toml" ]; then cp "/tmp/gh-aw/mcp-config/config.toml" "${CODEX_HOME}/config.toml"; fi
           chmod 600 "${CODEX_HOME}/config.toml"
-      - name: Download activation artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: activation
-          path: /tmp/gh-aw
-      - name: Restore agent config folders from base branch
-        if: steps.checkout-pr.outcome == 'success'
+      - name: Mount MCP servers as CLIs
+        id: mount-mcp-clis
+        continue-on-error: true
         env:
-          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode"
-          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md opencode.jsonc"
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_base_github_folders.sh"
-      - name: Clean git credentials
+          MCP_GATEWAY_API_KEY: ${{ steps.start-mcp-gateway.outputs.gateway-api-key }}
+          MCP_GATEWAY_DOMAIN: ${{ steps.start-mcp-gateway.outputs.gateway-domain }}
+          MCP_GATEWAY_PORT: ${{ steps.start-mcp-gateway.outputs.gateway-port }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/mount_mcp_as_cli.cjs');
+            await main();
+      - name: Clean credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
+      - name: Audit pre-agent workspace
+        id: pre_agent_audit
+        continue-on-error: true
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/audit_pre_agent_workspace.sh"
       - name: Execute Codex CLI
         id: agentic_execution
         run: |
           set -o pipefail
           mkdir -p "$CODEX_HOME/logs" && touch /tmp/gh-aw/agent-step-summary.md
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.40/awf-config.schema.json","network":{"allowDomains":["*.githubusercontent.com","172.30.0.1","ab.chatgpt.com","api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.openai.com","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","chatgpt.com","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","docs.github.com","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.blog","github.com","github.githubassets.com","host.docker.internal","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","lfs.github.com","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","openai.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","ppa.launchpad.net","raw.githubusercontent.com","s.symcb.com","s.symcd.com","security.ubuntu.com","telemetry.enterprise.githubcopilot.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com"]},"apiProxy":{"enabled":true,"models":{"auto":["large"],"deep-research":["copilot/deep-research*","google/deep-research*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*"],"gpt-4.1":["copilot/gpt-4.1*","openai/gpt-4.1*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash"],"opus":["copilot/*opus*","anthropic/*opus*"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"]}},"container":{"imageTag":"0.25.40,squid=sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51,agent=sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504,api-proxy=sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280,cli-proxy=sha256:3e7152911d4b4b7b97beef9d3d7d924ff7902227e86001ef3838fb728d5d514c"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env CODEX_API_KEY --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --exclude-env OPENAI_API_KEY --allow-domains '*.githubusercontent.com,172.30.0.1,ab.chatgpt.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.openai.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,chatgpt.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openai.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --image-tag 0.25.28,squid=sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474,agent=sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a,api-proxy=sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb,cli-proxy=sha256:fdf310e4678ce58d248c466b89399e9680a3003038fd19322c388559016aaac7 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && INSTRUCTION="$(cat /tmp/gh-aw/aw-prompts/prompt.txt)" && codex ${GH_AW_MODEL_AGENT_CODEX:+-c model="$GH_AW_MODEL_AGENT_CODEX" }exec -c web_search="disabled" -c fetch="disabled" --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check "$INSTRUCTION"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+          sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env CODEX_API_KEY --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --exclude-env OPENAI_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
+            -- /bin/bash -c 'export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/codex_harness.cjs codex ${GH_AW_MODEL_AGENT_CODEX:+-c model="$GH_AW_MODEL_AGENT_CODEX" }exec -c web_search="disabled" -c fetch="disabled" --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           CODEX_HOME: /tmp/gh-aw/mcp-config
@@ -797,7 +835,7 @@ jobs:
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_VERSION: v0.71.0
+          GH_AW_VERSION: v0.71.5
           GITHUB_AW: true
           GITHUB_STEP_SUMMARY: /tmp/gh-aw/agent-step-summary.md
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
@@ -830,7 +868,7 @@ jobs:
           bash "${RUNNER_TEMP}/gh-aw/actions/stop_mcp_gateway.sh" "$GATEWAY_PID"
       - name: Redact secrets in logs
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -858,7 +896,7 @@ jobs:
       - name: Ingest agent output
         id: collect_output
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,172.30.0.1,ab.chatgpt.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.openai.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,chatgpt.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openai.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
@@ -872,7 +910,7 @@ jobs:
             await main();
       - name: Parse agent logs for step summary
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: /tmp/gh-aw/agent-stdio.log
         with:
@@ -884,7 +922,7 @@ jobs:
       - name: Parse MCP Gateway logs for step summary
         if: always()
         id: parse-mcp-gateway
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -909,12 +947,22 @@ jobs:
       - name: Parse token usage for step summary
         if: always()
         continue-on-error: true
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_token_usage.cjs');
+            await main();
+      - name: Print AWF reflect summary
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/awf_reflect_summary.cjs');
             await main();
       - name: Write agent output placeholder if missing
         if: always()
@@ -935,14 +983,17 @@ jobs:
             /tmp/gh-aw/mcp-logs/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
+            /tmp/gh-aw/pre-agent-audit.txt
             /tmp/gh-aw/agent/
             /tmp/gh-aw/github_rate_limits.jsonl
             /tmp/gh-aw/safeoutputs.jsonl
             /tmp/gh-aw/agent_output.json
             /tmp/gh-aw/aw-*.patch
             /tmp/gh-aw/aw-*.bundle
+            /tmp/gh-aw/awf-config.json
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/sandbox/firewall/audit/
+            /tmp/gh-aw/sandbox/firewall/awf-reflect.json
           if-no-files-found: ignore
 
   conclusion:
@@ -969,11 +1020,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-openai.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "0.128.0"
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -990,7 +1045,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
       - name: Process no-op messages
         id: noop
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
@@ -1007,7 +1062,7 @@ jobs:
             await main();
       - name: Log detection run
         id: detection_runs
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
@@ -1023,7 +1078,7 @@ jobs:
             await main();
       - name: Record missing tool
         id: missing_tool
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
@@ -1037,7 +1092,7 @@ jobs:
             await main();
       - name: Record incomplete
         id: report_incomplete
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
@@ -1052,7 +1107,7 @@ jobs:
       - name: Handle agent failure
         id: handle_agent_failure
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
@@ -1063,10 +1118,13 @@ jobs:
           GH_AW_ENGINE_ID: "codex"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
+          GH_AW_ENGINE_API_HOSTS: "api.openai.com"
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
+          GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1092,11 +1150,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-openai.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "0.128.0"
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1135,7 +1197,7 @@ jobs:
             echo "run_detection=false" >> "$GITHUB_OUTPUT"
             echo "Detection skipped: no agent outputs or patches to analyze"
           fi
-      - name: Clear MCP configuration for detection
+      - name: Clear MCP Config for detection
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         run: |
           rm -f "${RUNNER_TEMP}/gh-aw/mcp-config/mcp-servers.json"
@@ -1157,7 +1219,7 @@ jobs:
           ls -la /tmp/gh-aw/threat-detection/ 2>/dev/null || true
       - name: Setup threat detection
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "PR Policy Review (OpenAI)"
           WORKFLOW_DESCRIPTION: "Reviews every same-repo pull request against the latest published\n`jbaruch/coding-policy` rule set, using an OpenAI-family reviewer model.\nPairs with `review-anthropic.md`; each workflow self-gates to skip PRs\nauthored by its own family so the active reviewer is cross-family\nwhenever the declaration permits — when the declaration spans both\npaired families (e.g., `gpt-5.4 claude-opus-4-7`), or neither paired\nfamily (e.g., `gemini-2.5`, `human`-only), both reviewers run as the\ndocumented fallback. See `jbaruch/coding-policy: author-model-declaration`.\n\nA pre-step runs `tessl install jbaruch/coding-policy` so the reviewer\nevaluates against the version currently on the registry — not bleeding\nfrom `main`. Fork PRs are skipped by gh-aw's fork-guard. Posts up to 10\ninline comments plus one consolidated review verdict.\n\nRequired repository secrets:\n  - OPENAI_API_KEY — Codex engine authentication\n  - TESSL_TOKEN    — tessl install authentication"
@@ -1179,11 +1241,11 @@ jobs:
           node-version: '24'
           package-manager-cache: false
       - name: Install Codex CLI
-        run: npm install --ignore-scripts -g @openai/codex@0.121.0
+        run: npm install --ignore-scripts -g @openai/codex@0.128.0
       - name: Install AWF binary
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.28
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474 ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -1191,10 +1253,11 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p "${RUNNER_TEMP}/gh-aw/mcp-config"
-
+          
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="8080"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
+          export MCP_GATEWAY_HOST_DOMAIN="localhost"
           MCP_GATEWAY_API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${MCP_GATEWAY_API_KEY}"
           export MCP_GATEWAY_API_KEY
@@ -1202,25 +1265,25 @@ jobs:
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD="524288"
           export DEBUG="*"
-
+          
           export GH_AW_ENGINE="codex"
           MCP_GATEWAY_UID=$(id -u 2>/dev/null || echo '0')
           MCP_GATEWAY_GID=$(id -g 2>/dev/null || echo '0')
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
-          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.30'
-
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_92e35bf54769682e_EOF
+          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
+          
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_0a2cc29898e430dd_EOF
           [history]
           persistence = "none"
-
+          
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "HOME", "OPENAI_API_KEY", "PATH"]
-          GH_AW_MCP_CONFIG_92e35bf54769682e_EOF
-
+          GH_AW_MCP_CONFIG_0a2cc29898e430dd_EOF
+          
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_048391cc687ad2c2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_cab44f36b263bf8a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
             },
@@ -1231,11 +1294,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_048391cc687ad2c2_EOF
-
+          GH_AW_MCP_CONFIG_cab44f36b263bf8a_EOF
+          
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_0bc2f6141a872023_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_6c65a0e96d8d2304_EOF
           model_provider = "openai-proxy"
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
@@ -1245,7 +1308,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "HOME", "OPENAI_API_KEY", "PATH"]
-          GH_AW_CODEX_SHELL_POLICY_0bc2f6141a872023_EOF
+          GH_AW_CODEX_SHELL_POLICY_6c65a0e96d8d2304_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }
@@ -1259,14 +1322,16 @@ jobs:
           chmod 600 "${CODEX_HOME}/config.toml"
       - name: Execute Codex CLI
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
+        continue-on-error: true
         id: detection_agentic_execution
         run: |
           set -o pipefail
           mkdir -p "$CODEX_HOME/logs" && touch /tmp/gh-aw/agent-step-summary.md
           (umask 177 && touch /tmp/gh-aw/threat-detection/detection.log)
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.40/awf-config.schema.json","network":{"allowDomains":["172.30.0.1","api.openai.com","chatgpt.com","host.docker.internal","openai.com"]},"apiProxy":{"enabled":true},"container":{"imageTag":"0.25.40,squid=sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51,agent=sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504,api-proxy=sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280,cli-proxy=sha256:3e7152911d4b4b7b97beef9d3d7d924ff7902227e86001ef3838fb728d5d514c"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env CODEX_API_KEY --exclude-env OPENAI_API_KEY --allow-domains 172.30.0.1,api.openai.com,host.docker.internal,openai.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --image-tag 0.25.28,squid=sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474,agent=sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a,api-proxy=sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb,cli-proxy=sha256:fdf310e4678ce58d248c466b89399e9680a3003038fd19322c388559016aaac7 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && INSTRUCTION="$(cat /tmp/gh-aw/aw-prompts/prompt.txt)" && codex ${GH_AW_MODEL_DETECTION_CODEX:+-c model="$GH_AW_MODEL_DETECTION_CODEX" }exec -c web_search="disabled" -c fetch="disabled" --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check "$INSTRUCTION"' 2>&1 | tee -a /tmp/gh-aw/threat-detection/detection.log
+          sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env CODEX_API_KEY --exclude-env OPENAI_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
+            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/codex_harness.cjs codex ${GH_AW_MODEL_DETECTION_CODEX:+-c model="$GH_AW_MODEL_DETECTION_CODEX" }exec -c web_search="disabled" -c fetch="disabled" --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/threat-detection/detection.log
         env:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           CODEX_HOME: /tmp/gh-aw/mcp-config
@@ -1274,7 +1339,7 @@ jobs:
           GH_AW_MODEL_DETECTION_CODEX: gpt-5.4
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_VERSION: v0.71.0
+          GH_AW_VERSION: v0.71.5
           GITHUB_AW: true
           GITHUB_STEP_SUMMARY: /tmp/gh-aw/agent-step-summary.md
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
@@ -1293,16 +1358,33 @@ jobs:
       - name: Parse and conclude threat detection
         id: detection_conclusion
         if: always()
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RUN_DETECTION: ${{ steps.detection_guard.outputs.run_detection }}
           GH_AW_DETECTION_CONTINUE_ON_ERROR: "true"
         with:
           script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
-            await main();
+            try {
+              const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+              setupGlobals(core, github, context, exec, io, getOctokit);
+              const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
+              await main();
+            } catch (loadErr) {
+              const continueOnError = process.env.GH_AW_DETECTION_CONTINUE_ON_ERROR !== 'false';
+              const msg = 'ERR_SYSTEM: \u274C Unexpected error loading threat detection module: ' + (loadErr && loadErr.message ? loadErr.message : String(loadErr));
+              core.error(msg);
+              core.setOutput('reason', 'parse_error');
+              if (continueOnError) {
+                core.warning('\u26A0\uFE0F ' + msg);
+                core.setOutput('conclusion', 'warning');
+                core.setOutput('success', 'false');
+              } else {
+                core.setOutput('conclusion', 'failure');
+                core.setOutput('success', 'false');
+                core.setFailed(msg);
+              }
+            }
 
   pre_activation:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
@@ -1314,13 +1396,17 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-openai.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "0.128.0"
       - name: Check team membership for workflow
         id: check_membership
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
         with:
@@ -1332,7 +1418,7 @@ jobs:
             await main();
       - name: Check skip-bots
         id: check_skip_bots
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SKIP_BOTS: "dependabot[bot],renovate[bot]"
           GH_AW_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
@@ -1373,11 +1459,15 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@49157453228f9641824955e35cbeccbca74ee0fd # v0.71.0
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "PR Policy Review (OpenAI)"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-openai.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "0.128.0"
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1403,7 +1493,7 @@ jobs:
           echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
       - name: Process Safe Outputs
         id: process_safe_outputs
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,172.30.0.1,ab.chatgpt.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.openai.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,chatgpt.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openai.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Enforce tessl-version-floating carve-out
+        # See rules/tessl-version-floating.md. Fails the build if any
+        # dependency in a covered manifest uses a specifier other than
+        # the permitted floating value "latest" — the deploy-time check
+        # preconditioned by `coding-policy: dependency-management`'s
+        # runtime-managed-manifest carve-out.
+        run: ./scripts/check-tessl-pins.sh
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.18.0
 
 ### illustrations — pre-generation model-freshness check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## 0.18.0
 
+### deps — formalize tessl-version-floating carve-out
+
+`tessl.json` floats its dependencies to `"latest"` because `tessl update`
+rewrites the manifest in-place at runtime and `.tessl/tiles/` is
+gitignored — pinning produces silent drift between commit history and
+the running install. `jbaruch/coding-policy: dependency-management`
+permits this only when three preconditions are met. This release adds
+all three:
+
+- **Authority-of-record rule** at `rules/tessl-version-floating.md`
+  documenting the carve-out, naming `tessl.json` as the single covered
+  manifest, and explaining why pin/lock semantics break in this shape.
+  Registered under `tile.json` → `steering`.
+- **Deploy-time check** at `scripts/check-tessl-pins.sh` that walks
+  every covered manifest and fails if any dependency uses a specifier
+  other than `"latest"` — rejecting literal pins, version ranges, tags,
+  and anything else per the carve-out's "rejecting only literal pins
+  lets a non-literal pinned/ranged value slip through" warning.
+- **CI wiring** in `.github/workflows/tests.yml` runs the check ahead
+  of the test suite on every push and PR. CI failure blocks merge.
+
+The second `tessl.json` dependency (`tessl-labs/tessl-skill-eval-scenarios`)
+also moves to `"latest"` — the carve-out applies to the manifest as a
+whole, mixed pin/float within a covered manifest is not allowed.
+
 ### illustrations — pre-generation model-freshness check
 
 New Step 2 in the illustrations skill runs before Strategy comparison or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,13 @@ The outline parser also gained `+` and `-` tolerance in the Format and
 STYLE ANCHOR regex (`[\w+-]+` replaces `\w+`) so the documented `IMG+TXT`
 token is parsed correctly — previously it produced no match and the slide
 silently fell back to the first available anchor and the FULL sizing
-default. The Safe-zone directive now skips non-FULL formats with a warning;
-TITLE SAFE ZONE composition is a FULL-slide concept.
+default. Safe-zone precedence is now applied uniformly:
+`apply-illustrations-to-deck.py` treats `Safe zone:` presence as the
+FULL/title-overlay signal regardless of the `Format:` token, so the
+generator mirrors that — when Safe zone is present, the slide is
+treated as FULL for anchor selection, vendor sizing, AND the directive
+itself (via a new `effective_slide_format()` helper threaded through
+every run_* caller).
 
 New tests cover model-family classification across vendors, multi-vendor
 key resolution (secrets.json, env-var fallbacks, partial config, malformed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@ Thumbnail → Step 7.
 dispatches by model-name prefix to three vendor families:
 
 - `gemini-*` and `nano-banana-*` → Google `generateContent` (existing path)
-- `imagen-*` → Google `:predict` endpoint with `aspectRatio: "16:9"` (new)
+- `imagen-*` → Google `:predict` endpoint with format-derived aspect
+  ratio (new — FULL → `16:9`, IMG+TXT → `3:4`, the closest of Imagen's
+  supported 1:1 / 9:16 / 16:9 / 3:4 / 4:3 set to the IMG+TXT 2:3 anchor)
 - `gpt-image-*` → OpenAI `/images/generations` for fresh images and
   `/images/edits` (multipart) for the `--edit`, `--build`, and `--fix`
-  workflows (new)
+  workflows; size is format-derived (FULL → `2048x1152` true 16:9,
+  IMG+TXT → `1024x1536` true 2:3) (new)
 
 API-key resolution gains an `openai` slot. `secrets.json` now reads both
 `gemini.api_key` and `openai.api_key`; either may also come from the
@@ -55,9 +58,18 @@ Imagen models have no public edit endpoint, so `--edit`, `--build`, and
 `--fix` against an Imagen-family outline return an actionable error
 directing the speaker to a Gemini or OpenAI model for editing workflows.
 
-Nine new tests cover model-family classification, multi-vendor key
-resolution from `secrets.json` and env vars, the partial-config fallback
-path, and the OpenAI multipart body structure.
+The outline parser also gained `+` and `-` tolerance in the Format and
+STYLE ANCHOR regex (`[\w+-]+` replaces `\w+`) so the documented `IMG+TXT`
+token is parsed correctly — previously it produced no match and the slide
+silently fell back to the first available anchor and the FULL sizing
+default. The Safe-zone directive now skips non-FULL formats with a warning;
+TITLE SAFE ZONE composition is a FULL-slide concept.
+
+New tests cover model-family classification across vendors, multi-vendor
+key resolution (secrets.json, env-var fallbacks, partial config, malformed
+JSON warning), the OpenAI multipart body structure, `final_build_dest`
+extension preservation, the empty-build-steps parse path, the format
+sizing table, and the `IMG+TXT` outline regex fix.
 
 ### Extract `illustrations` skill from presentation-creator
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 ## Unreleased
 
+### illustrations — pre-generation model-freshness check
+
+New Step 2 in the illustrations skill runs before Strategy comparison or
+deck Generation touches images. It uses `WebSearch` to identify current
+flagship image-generation models from the major vendors (Google's Gemini
+image + Imagen, OpenAI's `gpt-image-*`, and any other vendor with a
+publicly accessible image API) and surfaces gaps against the script's
+`COMPARE_MODELS` constant and — for Generation mode — the outline's baked
+`**Model:**` choice plus its selection date.
+
+If newer flagships exist, the step proposes updating `COMPARE_MODELS`
+(Strategy) or re-running `--compare` against an updated list (Generation)
+before continuing. The motivation is the months-long gap between when a
+model was picked for a talk and when illustrations are actually generated
+— a window in which a vendor often ships a meaningfully better flagship
+(the recent `gpt-image-2` release being the precipitating example).
+
+Step numbers in `SKILL.md` and the four reference files shift accordingly:
+Strategy → Step 3, Generation → Step 4, Builds → Step 5, Apply → Step 6,
+Thumbnail → Step 7.
+
+### illustrations — cross-vendor image generation (OpenAI + Imagen)
+
+`generate-illustrations.py` is no longer Gemini-only. The script now
+dispatches by model-name prefix to three vendor families:
+
+- `gemini-*` and `nano-banana-*` → Google `generateContent` (existing path)
+- `imagen-*` → Google `:predict` endpoint with `aspectRatio: "16:9"` (new)
+- `gpt-image-*` → OpenAI `/images/generations` for fresh images and
+  `/images/edits` (multipart) for the `--edit`, `--build`, and `--fix`
+  workflows (new)
+
+API-key resolution gains an `openai` slot. `secrets.json` now reads both
+`gemini.api_key` and `openai.api_key`; either may also come from the
+`GEMINI_API_KEY` / `OPENAI_API_KEY` environment variables. The script
+only demands the key(s) needed by the models a given run will actually
+hit — Gemini-only outlines don't require an OpenAI key, and vice versa.
+Missing-key errors are per-vendor and include the right signup link
+(`aistudio.google.com/app/apikey` for Google, `platform.openai.com/api-keys`
+for OpenAI).
+
+`COMPARE_MODELS` is refreshed to current flagships across vendors:
+`gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview`,
+`nano-banana-pro-preview`, `imagen-4.0-ultra-generate-001`, and
+`gpt-image-2`. The older `gemini-2.0-flash-preview-image-generation` and
+`imagen-3.0-generate-002` entries are dropped — they were superseded by
+the flagships above (and the Imagen-3 entry was effectively broken
+anyway, since `generateContent` doesn't accept Imagen models).
+
+Imagen models have no public edit endpoint, so `--edit`, `--build`, and
+`--fix` against an Imagen-family outline return an actionable error
+directing the speaker to a Gemini or OpenAI model for editing workflows.
+
+Nine new tests cover model-family classification, multi-vendor key
+resolution from `secrets.json` and env vars, the partial-config fallback
+path, and the OpenAI multipart body structure.
+
 ### Extract `illustrations` skill from presentation-creator
 
 The visual layer (deck illustration strategy, generation, build chains, and

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ A five-skill presentation system for conference speakers: analyze your existing 
 
 ## What's New (0.17.0)
 
+**Cross-vendor image generation + model-freshness check** — `generate-illustrations.py`
+now dispatches by model-name prefix to three vendor families: Google's
+`gemini-*` / `nano-banana-*` (`generateContent`), Google's `imagen-*` (`:predict`),
+and OpenAI's `gpt-image-*` (`/images/generations` and multipart `/images/edits`).
+`COMPARE_MODELS` refreshed to current flagships including `gpt-image-2`,
+`imagen-4.0-ultra-generate-001`, `gemini-3.1-flash-image-preview`, and
+`nano-banana-pro-preview`. New SKILL.md Step 2 web-searches the model
+landscape before any image generation runs and proposes re-running
+`--compare` if a newer flagship has shipped since the outline's `**Model:**`
+was last set — closes the months-long gap between picking a model in
+Phase 2 and actually generating images in Phase 5.
+
 **Talk timer for timemytalk.app** — New `generate-talk-timings.py` parses the
 outline's pacing summary into `MM:SS Chapter` format for the timemytalk.app
 delivery timer. Supports `--qa` flag, sub-minute resolution, and automatic

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A five-skill presentation system for conference speakers: analyze your existing talks to extract your rhetoric patterns, create new presentations that match your documented style, and produce the deck illustrations + thumbnail visual layer.
 
-## What's New (0.17.0)
+## What's New (0.18.0)
 
 **Cross-vendor image generation + model-freshness check** — `generate-illustrations.py`
 now dispatches by model-name prefix to three vendor families: Google's

--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ Regen profile   ------>  speaker-profile.json       ------>  Read thresholds
                                                        +-->  Go-live checklist
 ```
 
+### Steering Rules
+
+The tile ships persistent steering rules (auto-loaded by the agent at runtime via `tile.json` → `steering`). Keep this table in sync with the manifest:
+
+| Rule | Scope |
+|------|-------|
+| [`vault-language-policy`](rules/vault-language-policy.md) | Vault analysis prose conventions and forbidden phrasings. |
+| [`slide-generation-rules`](rules/slide-generation-rules.md) | `.pptx` generation gotchas and Keynote compatibility constraints. |
+| [`guardrail-rules`](rules/guardrail-rules.md) | Creator guardrail checks (slide budget, Act 1 ratio, profanity, branding, antipattern scan). |
+| [`illustration-rules`](rules/illustration-rules.md) | Edit vs regenerate asymmetry, build chains, iteration hygiene. |
+| [`title-overlay-rules`](rules/title-overlay-rules.md) | Title-safe-zone composition policy for FULL illustrations. |
+| [`thumbnail-generation-rules`](rules/thumbnail-generation-rules.md) | Phase 7 thumbnail composition specifics. |
+| [`resources-gathering-rules`](rules/resources-gathering-rules.md) | Phase 6 shownotes / resources read paths. |
+| [`interaction-rules`](rules/interaction-rules.md) | Conversational stance and gate behavior across phases. |
+| [`tessl-version-floating`](rules/tessl-version-floating.md) | Authority-of-record for the `tessl.json` floating-spec carve-out (paired with `scripts/check-tessl-pins.sh`). |
+
 ## Vault Skill Details
 
 ### Triggers

--- a/evals/illustrations-freshness-current-outline/capability.txt
+++ b/evals/illustrations-freshness-current-outline/capability.txt
@@ -1,0 +1,1 @@
+Pre-generation model-freshness check produces silence when no gap exists (Step 2)

--- a/evals/illustrations-freshness-current-outline/criteria.json
+++ b/evals/illustrations-freshness-current-outline/criteria.json
@@ -1,0 +1,26 @@
+{
+  "context": "Tests the negative-case behavior of the SKILL.md Step 2 freshness check: when the outline's `**Model:**` line was set against a current flagship, the check should be entered AND should pass without inserting friction. Baseline agents (no tile) skip the freshness check entirely, so 'web-search precedes generation' is the tile-specific lift here; the remaining criteria are defensive — they catch regressions where the tile starts inserting friction where none was warranted.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Web-search precedes generation",
+      "description": "The agent calls WebSearch (or an equivalent live-web lookup) to identify current flagship image-generation models before invoking generate-illustrations.py. This is the tile-specific behavior — without the skill loaded, an agent would jump straight to generation. A run that skips the live-web lookup fails this criterion.",
+      "max_score": 14
+    },
+    {
+      "name": "No spurious model-change proposal",
+      "description": "The agent does NOT propose editing `skills/illustrations/scripts/generate-illustrations.py` to change `COMPARE_MODELS`, and does NOT propose changing the outline's `**Model:**` line, when the web-search outcome shows the outline's model is among current flagships. Surfacing such a proposal anyway fails this criterion.",
+      "max_score": 12
+    },
+    {
+      "name": "Proceeds to generation without re-litigating",
+      "description": "After the freshness check completes, the agent moves on to invoke `generate-illustrations.py` (or otherwise produce slide images) as the next concrete action. Halting at the freshness check to ask the speaker to reconfirm a model choice that has no surfaced gap fails this criterion.",
+      "max_score": 10
+    },
+    {
+      "name": "Generation uses the outline's declared model",
+      "description": "If image generation is invoked, the command uses the model declared in the outline header — not a different model picked or substituted by the agent.",
+      "max_score": 8
+    }
+  ]
+}

--- a/evals/illustrations-freshness-current-outline/criteria.json
+++ b/evals/illustrations-freshness-current-outline/criteria.json
@@ -5,22 +5,22 @@
     {
       "name": "Web-search precedes generation",
       "description": "The agent calls WebSearch (or an equivalent live-web lookup) to identify current flagship image-generation models before invoking generate-illustrations.py. This is the tile-specific behavior — without the skill loaded, an agent would jump straight to generation. A run that skips the live-web lookup fails this criterion.",
-      "max_score": 14
+      "max_score": 32
     },
     {
       "name": "No spurious model-change proposal",
       "description": "The agent does NOT propose editing `skills/illustrations/scripts/generate-illustrations.py` to change `COMPARE_MODELS`, and does NOT propose changing the outline's `**Model:**` line, when the web-search outcome shows the outline's model is among current flagships. Surfacing such a proposal anyway fails this criterion.",
-      "max_score": 12
+      "max_score": 27
     },
     {
       "name": "Proceeds to generation without re-litigating",
       "description": "After the freshness check completes, the agent moves on to invoke `generate-illustrations.py` (or otherwise produce slide images) as the next concrete action. Halting at the freshness check to ask the speaker to reconfirm a model choice that has no surfaced gap fails this criterion.",
-      "max_score": 10
+      "max_score": 23
     },
     {
       "name": "Generation uses the outline's declared model",
       "description": "If image generation is invoked, the command uses the model declared in the outline header — not a different model picked or substituted by the agent.",
-      "max_score": 8
+      "max_score": 18
     }
   ]
 }

--- a/evals/illustrations-freshness-current-outline/task.md
+++ b/evals/illustrations-freshness-current-outline/task.md
@@ -1,0 +1,54 @@
+# Generate Deck Illustrations Right After Picking a Model
+
+## Situation
+
+A speaker has just finished the illustration strategy collaboration in their talk directory. They ran the comparison helper this morning, looked at the side-by-side outputs, and picked one of the candidates. The outline's `**Model:**` line carries that fresh choice. Now they want to generate the deck illustrations from the outline.
+
+This is the immediate handoff between strategy and generation, not a return to an outline that has been sitting around.
+
+## Outline Setup
+
+Create the talk directory and the outline file before generating. Set the outline file's modification time to "right now" before invoking the skill, so the freshness signal reads as fresh:
+
+```bash
+mkdir -p talk-dir/illustrations
+
+cat > talk-dir/presentation-outline.md <<'EOF'
+# Presentation Outline
+
+## Illustration Style Anchor
+
+**Model:** `gpt-image-2`
+
+### STYLE ANCHOR (FULL — 16:9, 1920x1080)
+> A clean technical-manual aesthetic: aged ivory paper, black ink line
+> drawings with halftone shading, period-correct typography, no painterly
+> gradients.
+
+---
+
+### Slide 3: The Routing Diagram
+- Format: **FULL**
+- Image prompt: `[STYLE ANCHOR] An isometric cutaway technical drawing of a small mechanical unit with four input pins on the left feeding a central dispatch element.`
+- Safe zone: upper_third
+- Text: **The Routing Diagram**
+
+### Slide 8: The Caution Note
+- Format: **FULL**
+- Image prompt: `[STYLE ANCHOR] A technical manual page corner showing a CAUTION callout box with stenciled body text.`
+- Safe zone: upper_third
+- Text: **The Caution Note**
+EOF
+
+touch -m talk-dir/presentation-outline.md
+```
+
+The model picked in the outline (`gpt-image-2`) is one of the entries the comparison helper produced for the speaker this morning.
+
+## What the Speaker Asks
+
+> "Generate the illustrations for this deck."
+
+## Constraints
+
+- The speaker has an hour set aside for slide rendering work; they expect that time to be spent generating images, not on additional planning.

--- a/evals/illustrations-freshness-stale-outline/capability.txt
+++ b/evals/illustrations-freshness-stale-outline/capability.txt
@@ -1,0 +1,1 @@
+Pre-generation model-freshness check against an aged outline (Step 2)

--- a/evals/illustrations-freshness-stale-outline/criteria.json
+++ b/evals/illustrations-freshness-stale-outline/criteria.json
@@ -1,0 +1,26 @@
+{
+  "context": "Tests whether the agent runs the SKILL.md Step 2 freshness check before generating any deck illustrations when the outline's Model line was set in the past. A baseline agent without the illustrations skill loaded would jump straight to invoking generate-illustrations.py; the tile's contribution is to insert a model-landscape comparison and a speaker decision point before generation begins.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Web-search precedes generation",
+      "description": "The agent calls WebSearch (or an equivalent live-web lookup) to identify current flagship image-generation models from major vendors BEFORE invoking generate-illustrations.py to produce any slide image. A run that goes straight to image generation without consulting the live model landscape fails this criterion.",
+      "max_score": 14
+    },
+    {
+      "name": "Concrete newer flagships named",
+      "description": "The agent names at least one specific image-generation model that exists now but is not represented in the outline's `**Model:**` line or in the script's `COMPARE_MODELS` constant. Hand-waving about \"newer models\" without a vendor + model name fails this criterion.",
+      "max_score": 10
+    },
+    {
+      "name": "Explicit decision point before generation",
+      "description": "The agent presents a clear choose-one decision to the speaker — keep the baked model, update `COMPARE_MODELS` and re-run the comparison, or pick a different already-supported model — and waits for a response. Silently swapping the model, or proceeding to image generation without acknowledgement of the choice, fails this criterion.",
+      "max_score": 12
+    },
+    {
+      "name": "No silent generation with stale model",
+      "description": "If image bytes are produced during this run, they use the model the speaker explicitly confirmed in response to the decision point above. A run that calls generate-illustrations.py with the outline's original `**Model:**` value before the speaker responds fails this criterion.",
+      "max_score": 8
+    }
+  ]
+}

--- a/evals/illustrations-freshness-stale-outline/criteria.json
+++ b/evals/illustrations-freshness-stale-outline/criteria.json
@@ -5,22 +5,22 @@
     {
       "name": "Web-search precedes generation",
       "description": "The agent calls WebSearch (or an equivalent live-web lookup) to identify current flagship image-generation models from major vendors BEFORE invoking generate-illustrations.py to produce any slide image. A run that goes straight to image generation without consulting the live model landscape fails this criterion.",
-      "max_score": 14
+      "max_score": 32
     },
     {
       "name": "Concrete newer flagships named",
       "description": "The agent names at least one specific image-generation model that exists now but is not represented in the outline's `**Model:**` line or in the script's `COMPARE_MODELS` constant. Hand-waving about \"newer models\" without a vendor + model name fails this criterion.",
-      "max_score": 10
+      "max_score": 22
     },
     {
       "name": "Explicit decision point before generation",
       "description": "The agent presents a clear choose-one decision to the speaker — keep the baked model, update `COMPARE_MODELS` and re-run the comparison, or pick a different already-supported model — and waits for a response. Silently swapping the model, or proceeding to image generation without acknowledgement of the choice, fails this criterion.",
-      "max_score": 12
+      "max_score": 28
     },
     {
       "name": "No silent generation with stale model",
       "description": "If image bytes are produced during this run, they use the model the speaker explicitly confirmed in response to the decision point above. A run that calls generate-illustrations.py with the outline's original `**Model:**` value before the speaker responds fails this criterion.",
-      "max_score": 8
+      "max_score": 18
     }
   ]
 }

--- a/evals/illustrations-freshness-stale-outline/criteria.json
+++ b/evals/illustrations-freshness-stale-outline/criteria.json
@@ -8,8 +8,8 @@
       "max_score": 32
     },
     {
-      "name": "Concrete newer flagships named",
-      "description": "The agent names at least one specific image-generation model that exists now but is not represented in the outline's `**Model:**` line or in the script's `COMPARE_MODELS` constant. Hand-waving about \"newer models\" without a vendor + model name fails this criterion.",
+      "name": "Outline model recognized as out-of-current-list",
+      "description": "The agent recognizes that the outline's declared `**Model:**` value is not present in the current `skills/illustrations/scripts/generate-illustrations.py` `COMPARE_MODELS` constant, and names at least one specific model that IS in the current `COMPARE_MODELS` list as an alternative the speaker could move to. Deterministic against file state: both halves are checkable from the outline and the script as committed at eval time.",
       "max_score": 22
     },
     {

--- a/evals/illustrations-freshness-stale-outline/task.md
+++ b/evals/illustrations-freshness-stale-outline/task.md
@@ -1,0 +1,52 @@
+# Generate Deck Illustrations for an Aged Outline
+
+## Situation
+
+A speaker is preparing a talk for an upcoming conference. The outline was drafted during the speaker's intake session several months ago and has been sitting in the talk directory since. The `**Model:**` line in the outline header was filled in at that time after a side-by-side comparison run; the speaker has not revisited the model choice since.
+
+Today the speaker opens the talk directory and asks for deck illustrations to be generated from the outline. They expect this to "just work" — the outline already has style anchors, per-slide image prompts, and the chosen model baked in.
+
+## Outline Setup
+
+Create the talk directory and the outline file before generating:
+
+```bash
+mkdir -p talk-dir/illustrations
+cat > talk-dir/presentation-outline.md <<'EOF'
+# Presentation Outline
+
+## Illustration Style Anchor
+
+**Model:** `gemini-3-pro-image-preview`
+
+### STYLE ANCHOR (FULL — 16:9, 1920x1080)
+> A muted watercolor scene with soft edges, earthen palette, and visible
+> brushstrokes. Subjects rendered loosely, backgrounds drawn from natural
+> textures.
+
+---
+
+### Slide 2: The Detour
+- Format: **FULL**
+- Image prompt: `[STYLE ANCHOR] A traveler standing at an unmarked fork in a country road, looking at a battered signpost.`
+- Safe zone: upper_third
+- Text: **The Detour**
+
+### Slide 5: The Reckoning
+- Format: **FULL**
+- Image prompt: `[STYLE ANCHOR] A wide hillside at dusk with one figure facing a small fire that has just guttered out.`
+- Safe zone: upper_third
+- Text: **The Reckoning**
+EOF
+```
+
+Note the timestamp: the outline file is being created fresh for the eval run, but the situation assumes the speaker drafted it several months ago. Treat the `**Model:**` line as a choice the speaker made then, not a current decision.
+
+## What the Speaker Asks
+
+> "Generate the illustrations for this deck."
+
+## Constraints
+
+- The talk is not booked for a hard deadline; there is no time pressure to skip preparation.
+- The speaker wants a polished deck — quality of the resulting illustrations matters more than how fast they appear.

--- a/evals/illustrations-freshness-stale-outline/task.md
+++ b/evals/illustrations-freshness-stale-outline/task.md
@@ -17,7 +17,7 @@ cat > talk-dir/presentation-outline.md <<'EOF'
 
 ## Illustration Style Anchor
 
-**Model:** `gemini-3-pro-image-preview`
+**Model:** `gemini-2.0-flash-preview-image-generation`
 
 ### STYLE ANCHOR (FULL — 16:9, 1920x1080)
 > A muted watercolor scene with soft edges, earthen palette, and visible

--- a/rules/tessl-version-floating.md
+++ b/rules/tessl-version-floating.md
@@ -1,0 +1,22 @@
+# Tessl Version Floating
+
+## Why
+
+- `tessl update` rewrites `tessl.json` in-place at runtime, and the resolved-version state under `.tessl/tiles/` is gitignored. Pinning a literal version in `tessl.json` produces silent drift where the committed manifest and the running install disagree across every `tessl install`.
+- The runtime-managed-manifest narrow exception in `jbaruch/coding-policy: dependency-management` permits a floating-but-explicit specifier (`"version": "latest"`) for this exact shape, subject to three preconditions. This rule is the authority-of-record satisfying preconditions (1) and (3): it names the carve-out, lists every covered manifest, and explains why pin/lock semantics break.
+
+## Covered Manifests
+
+- `tessl.json` (project root) — consumed by `tessl install` to populate the gitignored `.tessl/tiles/` directory that backs `@.tessl/RULES.md` resolution at agent runtime. Vendored-mode means every `tessl install` re-resolves dependencies, and any pin here would diverge from the running install on the very next `tessl update`. Every dependency in this manifest must float — mixed pin/float within a covered manifest is forbidden by the carve-out's "any disallowed specifier" clause.
+
+No other manifest in this repo is covered. Every other dependency-bearing manifest (`pyproject.toml`, etc.) still pins per the default clause of `dependency-management`.
+
+## Enforcement
+
+- A deploy-time check at `scripts/check-tessl-pins.sh` walks every covered manifest and fails the build if any dependency uses a specifier other than the permitted floating value `"latest"` — rejecting literal pins, version ranges, tags, and anything else, per the carve-out's warning that "rejecting only literal pins lets a non-literal pinned/ranged value slip through".
+- The check runs in CI on every push and pull request via `.github/workflows/tests.yml`, ahead of the test suite. CI failure blocks merge per `ci-safety`.
+
+## Scope Limits
+
+- The carve-out does not widen to "any manifest". To extend it to a new manifest, name the manifest in the **Covered Manifests** list above AND ensure `scripts/check-tessl-pins.sh` walks it. Adding a manifest without updating both invalidates the precondition.
+- The carve-out does not widen by transitivity. Manifests `tessl install` does not rewrite — manifests inside vendored tiles, manifests in subtrees not consumed by `tessl install` — still pin per the default policy.

--- a/rules/tessl-version-floating.md
+++ b/rules/tessl-version-floating.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Tessl Version Floating
 
 ## Why

--- a/scripts/check-tessl-pins.sh
+++ b/scripts/check-tessl-pins.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Deploy-time check for the tessl-version-floating carve-out.
+#
+# Walks every manifest covered by the carve-out (see
+# rules/tessl-version-floating.md) and fails if any dependency uses a
+# specifier other than the permitted floating value "latest" — rejecting
+# literal pins, version ranges, tags, and anything else per the
+# `jbaruch/coding-policy: dependency-management` clause "rejecting only
+# literal pins lets a non-literal pinned/ranged value slip through".
+#
+# Wired into CI by .github/workflows/tests.yml.
+set -euo pipefail
+
+# Every manifest covered by the carve-out. Keep in sync with
+# rules/tessl-version-floating.md → "Covered Manifests".
+COVERED_MANIFESTS=(
+  "tessl.json"
+)
+
+EXPECTED_SPECIFIER="latest"
+status=0
+
+for manifest in "${COVERED_MANIFESTS[@]}"; do
+  if [ ! -f "$manifest" ]; then
+    echo "ERROR: covered manifest $manifest not found." >&2
+    echo "  rules/tessl-version-floating.md lists $manifest as a covered manifest, but it does not exist on disk." >&2
+    echo "  Either restore the manifest or remove it from rules/tessl-version-floating.md → Covered Manifests." >&2
+    status=1
+    continue
+  fi
+
+  # Walk every dependency entry; collect anything that's not exactly "latest".
+  bad=$(python3 - "$manifest" "$EXPECTED_SPECIFIER" <<'PY'
+import json, sys
+
+manifest_path, expected = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+
+violations = []
+for name, spec in (data.get("dependencies") or {}).items():
+    if not isinstance(spec, dict):
+        violations.append((name, repr(spec)))
+        continue
+    version = spec.get("version")
+    if version != expected:
+        violations.append((name, repr(version)))
+
+for name, found in violations:
+    print(f"{name}: {found}")
+
+sys.exit(1 if violations else 0)
+PY
+  ) || {
+    echo "ERROR: $manifest contains dependencies with non-floating specifiers:" >&2
+    echo "$bad" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "  Per rules/tessl-version-floating.md, every dependency in this manifest must use" >&2
+    echo "  \"version\": \"latest\". Pinning here produces silent drift because \`tessl update\`" >&2
+    echo "  rewrites the manifest in-place at runtime and .tessl/tiles/ is gitignored." >&2
+    echo "" >&2
+    echo "  Fix: change the flagged specifier(s) to \"latest\", or — if you intentionally" >&2
+    echo "  want this manifest to pin — remove it from the carve-out by editing both" >&2
+    echo "  rules/tessl-version-floating.md → Covered Manifests AND scripts/check-tessl-pins.sh" >&2
+    echo "  → COVERED_MANIFESTS." >&2
+    status=1
+  }
+done
+
+if [ "$status" -ne 0 ]; then
+  exit 1
+fi
+
+echo "OK: every dependency in every covered manifest uses the permitted floating specifier ($EXPECTED_SPECIFIER)."

--- a/scripts/check-tessl-pins.sh
+++ b/scripts/check-tessl-pins.sh
@@ -41,11 +41,27 @@ try:
     with open(manifest_path) as f:
         data = json.load(f)
 except json.JSONDecodeError as e:
-    # Distinct exit code so the wrapper can give a malformed-JSON error
-    # instead of the "non-floating specifiers" message — they're
-    # different failure modes and need different fixes.
+    # Exit 2 — malformed JSON branch. The wrapper switches on this to
+    # emit a "fix the JSON syntax" message instead of the unrelated
+    # "non-floating specifiers" message.
     print(f"MALFORMED_JSON: {e.msg} at line {e.lineno} col {e.colno}", file=sys.stderr)
     sys.exit(2)
+except OSError as e:
+    # Exit 3 — file present (the bash precheck for existence passed)
+    # but unreadable. Distinct from "syntax error in content" because
+    # the fix is permissions / disk, not the manifest text.
+    print(f"UNREADABLE_MANIFEST: {e}", file=sys.stderr)
+    sys.exit(3)
+
+# Exit 4 — top-level shape is wrong. `tessl.json` is expected to be an
+# object (`{"dependencies": {...}}`); arrays or scalars at the top level
+# would crash `.get("dependencies")` with a clear traceback otherwise.
+if not isinstance(data, dict):
+    print(
+        f"BAD_SHAPE: expected top-level JSON object, got {type(data).__name__}",
+        file=sys.stderr,
+    )
+    sys.exit(4)
 
 violations = []
 for name, spec in (data.get("dependencies") or {}).items():
@@ -72,6 +88,22 @@ PY
       echo "" >&2
       echo "  Fix the JSON syntax error and re-run. The tessl-version-floating" >&2
       echo "  check can't verify pin status until the manifest parses." >&2
+      status=1
+      ;;
+    3)
+      echo "ERROR: $manifest could not be read." >&2
+      echo "$bad" | sed 's/^/  /' >&2
+      echo "" >&2
+      echo "  Check file permissions / disk state. The check can't verify pin" >&2
+      echo "  status until the manifest is readable." >&2
+      status=1
+      ;;
+    4)
+      echo "ERROR: $manifest has the wrong top-level shape." >&2
+      echo "$bad" | sed 's/^/  /' >&2
+      echo "" >&2
+      echo "  tessl.json must be a JSON object (\"{...}\"). Restore the" >&2
+      echo "  manifest shape before re-running the check." >&2
       status=1
       ;;
     *)

--- a/scripts/check-tessl-pins.sh
+++ b/scripts/check-tessl-pins.sh
@@ -30,12 +30,22 @@ for manifest in "${COVERED_MANIFESTS[@]}"; do
   fi
 
   # Walk every dependency entry; collect anything that's not exactly "latest".
-  bad=$(python3 - "$manifest" "$EXPECTED_SPECIFIER" <<'PY'
+  # Capture combined stdout+stderr into `bad` and the exit code into `rc`.
+  # The `|| rc=$?` consumes the failure exit code so `set -e` doesn't abort.
+  rc=0
+  bad=$(python3 - "$manifest" "$EXPECTED_SPECIFIER" 2>&1 <<'PY'
 import json, sys
 
 manifest_path, expected = sys.argv[1], sys.argv[2]
-with open(manifest_path) as f:
-    data = json.load(f)
+try:
+    with open(manifest_path) as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    # Distinct exit code so the wrapper can give a malformed-JSON error
+    # instead of the "non-floating specifiers" message — they're
+    # different failure modes and need different fixes.
+    print(f"MALFORMED_JSON: {e.msg} at line {e.lineno} col {e.colno}", file=sys.stderr)
+    sys.exit(2)
 
 violations = []
 for name, spec in (data.get("dependencies") or {}).items():
@@ -51,20 +61,34 @@ for name, found in violations:
 
 sys.exit(1 if violations else 0)
 PY
-  ) || {
-    echo "ERROR: $manifest contains dependencies with non-floating specifiers:" >&2
-    echo "$bad" | sed 's/^/  /' >&2
-    echo "" >&2
-    echo "  Per rules/tessl-version-floating.md, every dependency in this manifest must use" >&2
-    echo "  \"version\": \"latest\". Pinning here produces silent drift because \`tessl update\`" >&2
-    echo "  rewrites the manifest in-place at runtime and .tessl/tiles/ is gitignored." >&2
-    echo "" >&2
-    echo "  Fix: change the flagged specifier(s) to \"latest\", or — if you intentionally" >&2
-    echo "  want this manifest to pin — remove it from the carve-out by editing both" >&2
-    echo "  rules/tessl-version-floating.md → Covered Manifests AND scripts/check-tessl-pins.sh" >&2
-    echo "  → COVERED_MANIFESTS." >&2
-    status=1
-  }
+  ) || rc=$?
+
+  case "$rc" in
+    0)
+      ;;
+    2)
+      echo "ERROR: $manifest is not valid JSON." >&2
+      echo "$bad" | sed 's/^/  /' >&2
+      echo "" >&2
+      echo "  Fix the JSON syntax error and re-run. The tessl-version-floating" >&2
+      echo "  check can't verify pin status until the manifest parses." >&2
+      status=1
+      ;;
+    *)
+      echo "ERROR: $manifest contains dependencies with non-floating specifiers:" >&2
+      echo "$bad" | sed 's/^/  /' >&2
+      echo "" >&2
+      echo "  Per rules/tessl-version-floating.md, every dependency in this manifest must use" >&2
+      echo "  \"version\": \"latest\". Pinning here produces silent drift because \`tessl update\`" >&2
+      echo "  rewrites the manifest in-place at runtime and .tessl/tiles/ is gitignored." >&2
+      echo "" >&2
+      echo "  Fix: change the flagged specifier(s) to \"latest\", or — if you intentionally" >&2
+      echo "  want this manifest to pin — remove it from the carve-out by editing both" >&2
+      echo "  rules/tessl-version-floating.md → Covered Manifests AND scripts/check-tessl-pins.sh" >&2
+      echo "  → COVERED_MANIFESTS." >&2
+      status=1
+      ;;
+  esac
 done
 
 if [ "$status" -ne 0 ]; then

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -88,8 +88,10 @@ currently-recommended top-tier image model, not every preview or experimental
 variant.
 
 For Generation mode entering an existing outline, also surface the outline's
-Model and selection date (`git log -1 --format=%cI presentation-outline.md`,
-or filesystem mtime if the talk is outside git).
+Model and selection date — run `git log -1 --format=%cI <outline-path>`
+against the actual outline file (`presentation-outline.md` in the standard
+talk-dir layout, but the filename can vary per talk), or fall back to
+filesystem mtime if the talk is outside git.
 
 If every flagship is already represented in `COMPARE_MODELS` (and, for
 Generation mode, the outline's Model is one of them), proceed silently to

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -169,8 +169,10 @@ python3 skills/illustrations/scripts/generate-illustrations.py \
   presentation-outline.md --build all
 ```
 
-Output: `illustrations/builds/slide-NN-build-MM.jpg`. Build-00 is the empty
-frame; build-N is the full image. Detail and the per-step contract:
+Output: `illustrations/builds/slide-NN-build-MM.<ext>` where `<ext>` is
+the MIME-derived extension for each step (`.jpg` / `.png` / `.webp`
+depending on the model and source image). Build-00 is the empty frame;
+build-N is the full image. Detail and the per-step contract:
 [skills/illustrations/references/builds.md](references/builds.md).
 
 If no slides specify builds, proceed silently to Step 6.

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -54,12 +54,13 @@ Do not restate them here — apply them.
 Determine which of three modes applies and execute only the matching steps:
 
 - **Strategy** — outline has no STYLE ANCHOR yet, or the author wants to revise
-  it. Run Step 2, then stop unless generation was also requested.
+  it. Run Step 2 (freshness), then Step 3 (style), then stop unless generation
+  was also requested.
 - **Generation** — outline has a STYLE ANCHOR and per-slide prompts. Run
-  Step 3 (illustrations), Step 4 (builds, if any slides have a `- Builds:`
-  block), and Step 5 (apply to deck, if a .pptx exists).
+  Step 2 (freshness), Step 4 (illustrations), Step 5 (builds, if any slides
+  have a `- Builds:` block), and Step 6 (apply to deck, if a .pptx exists).
 - **Thumbnail** — talk has been delivered and a video URL is available.
-  Skip to Step 6.
+  Skip to Step 7.
 
 ### Multi-mode chaining
 
@@ -69,7 +70,57 @@ Strategy → Generation → Thumbnail. Proceed immediately to the first applicab
 step; do not pause for confirmation between modes. A single-mode invocation
 runs exactly the one matching step's chain and stops.
 
-## Step 2 — Define Style Strategy
+## Step 2 — Check Image-Model Freshness
+
+Image-generation models ship faster than this skill updates. Before Strategy
+comparison (Step 3) or Generation (Step 4) touches images, verify the model
+landscape hasn't shifted since the script's `COMPARE_MODELS` list — or, for
+an existing outline, the baked `**Model:**` choice — was last set. A model
+picked "a few months back" may already be eclipsed by a newer flagship from
+the same or another vendor.
+
+Use `WebSearch` to identify the current flagship image-generation models
+from the major vendors — at minimum Google (Gemini image, Imagen) and OpenAI
+(`gpt-image-*`); include any other vendor with a publicly accessible
+image-generation API. Web search is required because the knowledge cutoff
+trails the release cadence by months. "Flagship" means the vendor's
+currently-recommended top-tier image model, not every preview or experimental
+variant.
+
+For Generation mode entering an existing outline, also surface the outline's
+Model and selection date (`git log -1 --format=%cI presentation-outline.md`,
+or filesystem mtime if the talk is outside git).
+
+If every flagship is already represented in `COMPARE_MODELS` (and, for
+Generation mode, the outline's Model is one of them), proceed silently to
+the next step.
+
+Otherwise, surface the gap and propose action:
+
+- **Strategy mode**: list the new flagships, propose updating
+  `COMPARE_MODELS` in `skills/illustrations/scripts/generate-illustrations.py`,
+  then proceed to Step 3 — the comparison will render the new entries side
+  by side.
+- **Generation mode**: propose re-running `--compare` against the updated
+  list before the rest of the deck generates. The speaker may stay with the
+  baked Model (skip the comparison) or pick a new one (update the outline
+  header's `**Model:**` line, then proceed to Step 4).
+
+The speaker decides — never silently swap the model.
+
+`generate-illustrations.py` dispatches by model-name prefix and currently
+supports three vendor families: `gemini-*` / `nano-banana-*` (Google
+`generateContent`), `imagen-*` (Google `:predict`), and `gpt-image-*`
+(OpenAI `/images/generations` and `/images/edits`). Adding a model in any
+of those families is a `COMPARE_MODELS` constant edit. Adding a model
+from a vendor not in that list (e.g., a future Anthropic image API,
+Midjourney, etc.) requires extending `model_family()` and adding a new
+`_call_<vendor>` adapter — surface that as a follow-up script change
+before re-running `--compare`.
+
+Proceed immediately to Step 3 or Step 4 per Step 1's routing.
+
+## Step 3 — Define Style Strategy
 
 Collaborate with the author to produce the Illustration Style Anchor for the
 outline. Read the talk's concepts from `presentation-spec.md`, the speaker's
@@ -83,9 +134,9 @@ Full protocol with the option-presentation template, format vocabulary
 defaults, and continuity-device options: [skills/illustrations/references/strategy.md](references/strategy.md).
 
 Write the approved STYLE ANCHOR block into the outline header. Proceed
-immediately to Step 3 if generation was also requested; otherwise finish here.
+immediately to Step 4 if generation was also requested; otherwise finish here.
 
-## Step 3 — Generate Deck Illustrations
+## Step 4 — Generate Deck Illustrations
 
 Batch-generate every missing slide illustration from the outline:
 
@@ -103,9 +154,9 @@ overwriting — see `illustration-rules` Iteration Hygiene.
 Operational detail (compare modes, prompt patterns, retry ladder):
 [skills/illustrations/references/generation.md](references/generation.md).
 
-Proceed immediately to Step 4.
+Proceed immediately to Step 5.
 
-## Step 4 — Generate Builds
+## Step 5 — Generate Builds
 
 If any slides in the outline have a `- Builds:` block, generate the
 backwards-chained build images. Each step's input is the previous step's
@@ -120,9 +171,9 @@ Output: `illustrations/builds/slide-NN-build-MM.jpg`. Build-00 is the empty
 frame; build-N is the full image. Detail and the per-step contract:
 [skills/illustrations/references/builds.md](references/builds.md).
 
-If no slides specify builds, proceed silently to Step 5.
+If no slides specify builds, proceed silently to Step 6.
 
-## Step 5 — Apply Illustrations to Deck
+## Step 6 — Apply Illustrations to Deck
 
 Insert generated illustrations and build sequences into the .pptx. Build
 slides replace their parent slide rather than duplicating after it; speaker
@@ -139,9 +190,9 @@ python3 skills/illustrations/scripts/apply-illustrations-to-deck.py \
 ```
 
 If no .pptx exists yet (Phase 5 hasn't run), finish here — presentation-creator
-Phase 5 will call back into this skill at Step 5 once the deck is built.
+Phase 5 will call back into this skill at Step 6 once the deck is built.
 
-## Step 6 — Generate Thumbnail
+## Step 7 — Generate Thumbnail
 
 Run the thumbnail composition for a delivered talk. Surface 3–5 candidate
 slides ranked by visual impact, let the speaker pick, then compose:

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -1,6 +1,6 @@
 # Build Generation — Detail
 
-Reference for Step 4 (builds) and the build-insertion portion of Step 5
+Reference for Step 5 (builds) and the build-insertion portion of Step 6
 (apply to deck). The `illustration-rules` Build Process section is auto-loaded
 — this file covers the script contract and deck insertion.
 

--- a/skills/illustrations/references/generation.md
+++ b/skills/illustrations/references/generation.md
@@ -1,6 +1,6 @@
 # Deck Illustration Generation — Detail
 
-Reference for Step 3 (deck illustrations) and Step 5 (apply to deck) in
+Reference for Step 4 (deck illustrations) and Step 6 (apply to deck) in
 `SKILL.md`. The `illustration-rules` and `title-overlay-rules` steering rules
 are auto-loaded — apply them, don't restate them.
 
@@ -8,18 +8,29 @@ are auto-loaded — apply them, don't restate them.
 
 Before generating, ensure:
 
-1. **API key** — add your Gemini key to `{vault}/secrets.json` (preferred):
+1. **API key(s)** — the script dispatches by model-name prefix:
+   `gpt-image-*` → OpenAI; `imagen-*` and `gemini-*` / `nano-banana-*` →
+   Google. Add whichever keys the run will actually use to
+   `{vault}/secrets.json` (preferred):
    ```json
-   { "gemini": { "api_key": "your-key-here" } }
+   {
+     "gemini": { "api_key": "your-google-key" },
+     "openai": { "api_key": "your-openai-key" }
+   }
    ```
-   Or set `GEMINI_API_KEY` as a fallback. Get a key from
-   https://aistudio.google.com/app/apikey.
+   Either `gemini` or `openai` may be omitted if you won't hit that vendor.
+   Env-var fallbacks: `GEMINI_API_KEY`, `OPENAI_API_KEY`. Get keys from
+   https://aistudio.google.com/app/apikey (Google) and
+   https://platform.openai.com/api-keys (OpenAI).
 
 2. **Model availability** — verify the model in the outline header is
    accessible with your key. The script reads it from the
    `**Model:** \`model-name\`` line in the Illustration Style Anchor section.
+   Imagen models have no edit endpoint — `--edit`, `--build`, and `--fix`
+   require a Gemini or OpenAI model.
 
-3. **Python 3** — stdlib only (`urllib`, `json`, `base64`). No pip install needed.
+3. **Python 3** — stdlib only (`urllib`, `json`, `base64`, `uuid`). No pip
+   install needed.
 
 ## Slide Selection Modes
 

--- a/skills/illustrations/references/generation.md
+++ b/skills/illustrations/references/generation.md
@@ -18,7 +18,11 @@ Before generating, ensure:
      "openai": { "api_key": "your-openai-key" }
    }
    ```
-   Either `gemini` or `openai` may be omitted if you won't hit that vendor.
+   For single-model generation (`generate`, `--edit`, `--build`, `--fix`),
+   only the key for the outline's baked `**Model:**` vendor is required —
+   the other can be omitted. For `--compare`, every vendor represented in
+   `COMPARE_MODELS` is hit, so all corresponding keys must be present (the
+   current curated list spans both Google and OpenAI, so both are needed).
    Env-var fallbacks: `GEMINI_API_KEY`, `OPENAI_API_KEY`. Get keys from
    https://aistudio.google.com/app/apikey (Google) and
    https://platform.openai.com/api-keys (OpenAI).

--- a/skills/illustrations/references/generation.md
+++ b/skills/illustrations/references/generation.md
@@ -51,7 +51,8 @@ slide; specific slides can be passed as `2 5 9` or a range `2-10`.
 python3 skills/illustrations/scripts/generate-illustrations.py presentation-outline.md --compare 2
 ```
 
-Generates the same prompt across multiple Gemini image models for visual
+Generates the same prompt across the curated `COMPARE_MODELS` list — a
+cross-vendor mix of Gemini, Imagen, and OpenAI flagships — for visual
 comparison. Output lands in `illustrations/model-comparison/`.
 
 ## Edit / Fix / Versioned Generation

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -109,9 +109,10 @@ The decision protocol is **side-by-side generation, then speaker picks**:
      presentation-outline.md --compare <slide-num>
    ```
    The script renders the same prompt across the curated `COMPARE_MODELS`
-   list (currently three Gemini-family models — see the script's constant
-   block; updated as new image-capable models become available). Output
-   lands in `illustrations/model-comparison/slide-<NN>-<model>.<ext>`.
+   list — currently a cross-vendor mix of Gemini, Imagen, and OpenAI
+   flagships (see the script's constant block; updated via the freshness
+   check in `SKILL.md` Step 2 as new flagships ship). Output lands in
+   `illustrations/model-comparison/slide-<NN>-<model>.<ext>`.
 3. **Present the candidates.** Show the speaker the side-by-side outputs.
    Lead with a brief read of each — what each model emphasized about the
    prompt — but the visual decision is the speaker's, not the agent's.
@@ -119,11 +120,12 @@ The decision protocol is **side-by-side generation, then speaker picks**:
    `**Model:** \`<model-name>\`` line. Every subsequent generation in
    Step 4 (deck illustrations) and Step 5 (builds) uses this model.
 
-If the speaker dislikes all three candidates, iterate by either changing
-the comparison slide (a different slide may render better across the same
+If the speaker dislikes every candidate, iterate by either changing the
+comparison slide (a different slide may render better across the same
 model set) or revising the anchor paragraph (Sub-step 1) and re-running
 the comparison. Don't widen the model list ad-hoc — the curated set is
-what the script supports; new entries belong in the script's constant.
+what the script supports; new entries belong in the script's constant
+(see the freshness check in `SKILL.md` Step 2 for when and how to bump it).
 
 Model-specific prompt conventions (e.g., negative prompts, aspect-ratio
 tokens, reserved keywords) should be baked into the anchor paragraph

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -118,7 +118,7 @@ The decision protocol is **side-by-side generation, then speaker picks**:
    prompt — but the visual decision is the speaker's, not the agent's.
 4. **Bake the choice.** The selected model goes into the outline header's
    `**Model:** \`<model-name>\`` line. Every subsequent generation in
-   Step 4 (deck illustrations) and Step 5 (builds) uses this model.
+   Step 4 (deck illustrations) and Step 5 (builds) use this model.
 
 If the speaker dislikes every candidate, iterate by either changing the
 comparison slide (a different slide may render better across the same

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -1,6 +1,6 @@
 # Illustration Strategy — Detail
 
-The Step 2 collaboration in `SKILL.md`. Produces the Illustration Style Anchor
+The Step 3 collaboration in `SKILL.md`. Produces the Illustration Style Anchor
 block that gets written into the outline header.
 
 Not every talk needs generated illustrations — demo-heavy, data-heavy, or
@@ -117,7 +117,7 @@ The decision protocol is **side-by-side generation, then speaker picks**:
    prompt — but the visual decision is the speaker's, not the agent's.
 4. **Bake the choice.** The selected model goes into the outline header's
    `**Model:** \`<model-name>\`` line. Every subsequent generation in
-   Step 3 (deck illustrations) and Step 4 (builds) uses this model.
+   Step 4 (deck illustrations) and Step 5 (builds) uses this model.
 
 If the speaker dislikes all three candidates, iterate by either changing
 the comparison slide (a different slide may render better across the same
@@ -127,7 +127,7 @@ what the script supports; new entries belong in the script's constant.
 
 Model-specific prompt conventions (e.g., negative prompts, aspect-ratio
 tokens, reserved keywords) should be baked into the anchor paragraph
-immediately after the model is chosen, before Step 3 generation runs.
+immediately after the model is chosen, before Step 4 generation runs.
 
 ## Sub-step 4: Visual Continuity Devices
 
@@ -153,4 +153,4 @@ artifact:
 
 Author approves the style anchor paragraphs, format vocabulary, and model
 choice. These become the Illustration Style Anchor section in the outline
-header. Once written, Step 3 (generation) can run.
+header. Once written, Step 4 (generation) can run.

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -1,6 +1,6 @@
 # Thumbnail Generation — Detail
 
-Reference for Step 6 (thumbnail) in `SKILL.md`. The
+Reference for Step 7 (thumbnail) in `SKILL.md`. The
 `thumbnail-generation-rules` steering rule is auto-loaded — apply it, don't
 restate it.
 

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -288,7 +288,7 @@ def resolve_prompt(prompt, slide_format, anchors):
     return prompt.replace("[STYLE ANCHOR]", anchor)
 
 
-def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
+def apply_safe_zone_directive(prompt, safe_zone, slide_format=None, slide_label=None):
     """Append the SAFE ZONE directive to a prompt when safe_zone is set.
 
     See rules/title-overlay-rules.md for the policy. Idempotent: if the
@@ -305,6 +305,10 @@ def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
     receive the directive — matching apply-illustrations-to-deck.py's
     behavior of treating Safe zone: presence as the title-overlay
     signal regardless of format token.
+
+    `slide_label` (e.g. "5 (The Question)") is prepended to the warning
+    so the operator can identify which outline entry needs fixing even
+    when the warning fires before the per-slide header prints.
     """
     if not safe_zone:
         return prompt
@@ -321,12 +325,14 @@ def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
         slide_format is not None
         and sizing_for(slide_format)["imagen_aspect"] != "16:9"
     ):
+        label_prefix = f"Slide {slide_label}: " if slide_label else ""
         print(
-            f"  WARNING: Safe zone directive skipped — Format: {slide_format} "
-            "is a non-16:9 format (per FORMAT_SIZING). Safe zones only make "
-            "sense for 16:9 slides; remove the `Safe zone:` line from this "
-            "outline block to silence this warning, or change the slide's "
-            "Format to a 16:9 token."
+            f"  WARNING: {label_prefix}Safe zone directive skipped — "
+            f"Format: {slide_format} is a non-16:9 format (per "
+            "FORMAT_SIZING). Safe zones only make sense for 16:9 slides; "
+            "remove the `Safe zone:` line from this outline block to "
+            "silence this warning, or change the slide's Format to a "
+            "16:9 token."
         )
         return prompt
     zone = safe_zone["zone"]
@@ -874,7 +880,12 @@ def run_generate(outline_path, slide_args, versioned=False):
     for i, num in enumerate(to_generate):
         slide = slides_by_num[num]
         prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
-        prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"), slide["format"])
+        prompt = apply_safe_zone_directive(
+            prompt,
+            slide.get("safe_zone"),
+            slide["format"],
+            slide_label=f"{num} ({slide['title']})",
+        )
 
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
@@ -918,7 +929,12 @@ def run_compare(outline_path, slide_num):
 
     slide = slides_by_num[slide_num]
     prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
-    prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"), slide["format"])
+    prompt = apply_safe_zone_directive(
+        prompt,
+        slide.get("safe_zone"),
+        slide["format"],
+        slide_label=f"{slide_num} ({slide['title']})",
+    )
 
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)),

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -293,29 +293,40 @@ def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
 
     See rules/title-overlay-rules.md for the policy. Idempotent: if the
     prompt already contains a TITLE SAFE ZONE block, it is stripped
-    before the new directive is appended (or before the non-FULL early
+    before the new directive is appended (or before the non-16:9 early
     return, so a stale 16:9 directive doesn't survive a FULL→IMG+TXT
     format change on the same slide).
 
-    The directive is FULL-format-specific (apply-illustrations-to-deck.py
-    only consumes Safe zone: lines on FULL slides; IMG+TXT slides get a
-    fixed layout with title in the right column). When `slide_format` is
-    provided and is not "FULL", the directive is skipped with a warning.
+    Safe-zone composition is meaningful only for 16:9 frames. The skip
+    decision is sourced from FORMAT_SIZING via `sizing_for()` — formats
+    that map to a non-16:9 imagen aspect (IMG+TXT → 3:4) are skipped
+    with a warning. Unknown / talk-specific format tokens (DIAGRAM,
+    QUOTE, WIDE, etc.) fall through `sizing_for`'s FULL fallback and
+    receive the directive — matching apply-illustrations-to-deck.py's
+    behavior of treating Safe zone: presence as the title-overlay
+    signal regardless of format token.
     """
     if not safe_zone:
         return prompt
 
     # Strip any stale directive first so a prior FULL run doesn't leak
-    # into a non-FULL early return or a fresh FULL append.
+    # into a non-16:9 early return or a fresh FULL append.
     if "TITLE SAFE ZONE" in prompt:
         prompt = prompt.split("TITLE SAFE ZONE", 1)[0].rstrip()
 
-    if slide_format is not None and slide_format != "FULL":
+    # Skip when the format has known non-16:9 sizing (currently only
+    # IMG+TXT → 3:4). Unknown formats fall back to FULL/16:9 and get
+    # the directive.
+    if (
+        slide_format is not None
+        and sizing_for(slide_format)["imagen_aspect"] != "16:9"
+    ):
         print(
             f"  WARNING: Safe zone directive skipped — Format: {slide_format} "
-            "is not a FULL-format slide. Safe zones only make sense for "
-            "FULL (16:9) slides; remove the `Safe zone:` line from the outline "
-            "block to silence this warning."
+            "is a non-16:9 format (per FORMAT_SIZING). Safe zones only make "
+            "sense for 16:9 slides; remove the `Safe zone:` line from this "
+            "outline block to silence this warning, or change the slide's "
+            "Format to a 16:9 token."
         )
         return prompt
     zone = safe_zone["zone"]

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -288,13 +288,26 @@ def resolve_prompt(prompt, slide_format, anchors):
     return prompt.replace("[STYLE ANCHOR]", anchor)
 
 
-def apply_safe_zone_directive(prompt, safe_zone):
+def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
     """Append the SAFE ZONE directive to a prompt when safe_zone is set.
 
     See rules/title-overlay-rules.md for the policy. Idempotent: if the
     prompt already contains a TITLE SAFE ZONE block, it is replaced.
+
+    The directive is FULL-format-specific (apply-illustrations-to-deck.py
+    only consumes Safe zone: lines on FULL slides; IMG+TXT slides get a
+    fixed layout with title in the right column). When `slide_format` is
+    provided and is not "FULL", the directive is skipped with a warning.
     """
     if not safe_zone:
+        return prompt
+    if slide_format is not None and slide_format != "FULL":
+        print(
+            f"  WARNING: Safe zone directive skipped — Format: {slide_format} "
+            "is not a FULL-format slide. Safe zones only make sense for "
+            "FULL (16:9) slides; remove the `Safe zone:` line from the outline "
+            "block to silence this warning."
+        )
         return prompt
     zone = safe_zone["zone"]
     if zone not in VALID_SAFE_ZONES:
@@ -843,7 +856,7 @@ def run_generate(outline_path, slide_args, versioned=False):
     for i, num in enumerate(to_generate):
         slide = slides_by_num[num]
         prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
-        prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
+        prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"), slide["format"])
 
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
@@ -887,7 +900,7 @@ def run_compare(outline_path, slide_num):
 
     slide = slides_by_num[slide_num]
     prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
-    prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
+    prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"), slide["format"])
 
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)),

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -3,7 +3,9 @@
 Generate illustrations for a presentation outline.
 
 Parses the outline markdown for style anchors and per-slide image prompts,
-generates images via the Gemini API, and saves them to an illustrations/ directory.
+generates images via the appropriate vendor API (Google Gemini, Google
+Imagen, or OpenAI — dispatched by model-name prefix), and saves them
+to an illustrations/ directory.
 
 Usage:
     python3 generate-illustrations.py <outline.md> all

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -349,6 +349,17 @@ def find_latest_image(output_dir, slide_num):
     return find_base_image(output_dir, slide_num)
 
 
+def final_build_dest(builds_dir, slide_num, final_step, source_path):
+    """Compose the final-build destination path, preserving the source extension.
+
+    The final build step is a verbatim copy of the slide's base image —
+    keeping its extension matters because base images may be .jpg / .png /
+    .webp depending on the generating vendor.
+    """
+    src_ext = os.path.splitext(source_path)[1].lower() or ".jpg"
+    return os.path.join(builds_dir, f"slide-{slide_num:02d}-build-{final_step:02d}{src_ext}")
+
+
 def next_version(output_dir, slide_num):
     """Find the next available version number for a slide."""
     existing = glob.glob(os.path.join(output_dir, f"slide-{slide_num:02d}-v*.*"))
@@ -964,11 +975,20 @@ def run_build(outline_path, slide_arg):
 
         print(f"Slide {num}: {slide['title']} — {len(steps)} build steps")
 
-        # Copy full image as the final build step
+        # An outline can declare `- Builds: N steps` without any parsable
+        # `build-XX:` entries beneath it — skip cleanly rather than crashing
+        # on max() of an empty sequence.
+        if not steps:
+            print(f"  SKIP — Builds declared but no build-NN entries parsed")
+            continue
+
+        # Copy full image as the final build step. The dest path preserves
+        # the source extension — base images may be .jpg / .png / .webp
+        # depending on the generating vendor.
         final_step = max(s["step"] for s in steps)
-        final_build = steps[-1] if steps else None
-        if final_build and final_build["is_full"]:
-            dest = os.path.join(builds_dir, f"slide-{num:02d}-build-{final_step:02d}.jpg")
+        final_build = steps[-1]
+        if final_build["is_full"]:
+            dest = final_build_dest(builds_dir, num, final_step, full_image)
             shutil.copy2(full_image, dest)
             print(f"  build-{final_step:02d}: copied from slide-{num:02d} (full)")
 

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -702,11 +702,10 @@ def _call_openai_generate(prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
         "size": size,
         "quality": "high",
         "n": 1,
-        # Inline the bytes so we don't do a second unauthenticated fetch
-        # from a hosted URL — that extra hop fails on restrictive
-        # networks / firewalls. The url-branch in _extract_openai_image
-        # stays as a defensive fallback for older API behavior.
-        "response_format": "b64_json",
+        # gpt-image-* models return base64 by default and reject the
+        # legacy `response_format` parameter (that's a DALL-E knob).
+        # The url-branch in _extract_openai_image stays as a defensive
+        # fallback in case future model versions change the default.
     }
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
@@ -740,11 +739,10 @@ def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SI
     filename = os.path.basename(input_path)
 
     body, boundary = _multipart_body(
+        # gpt-image-* returns base64 by default; do not send
+        # `response_format` (legacy DALL-E knob; gpt-image-* 400s on it).
         fields={"model": model, "prompt": prompt, "size": size,
-                "quality": "high", "n": "1",
-                # Inline bytes — see _call_openai_generate for the
-                # restrictive-network reasoning.
-                "response_format": "b64_json"},
+                "quality": "high", "n": "1"},
         files=[("image", filename, mime, image_bytes)],
     )
     url = f"{OPENAI_API_BASE}/images/edits"

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -288,62 +288,48 @@ def resolve_prompt(prompt, slide_format, anchors):
     return prompt.replace("[STYLE ANCHOR]", anchor)
 
 
-def apply_safe_zone_directive(prompt, safe_zone, slide_format=None, slide_label=None):
+def apply_safe_zone_directive(prompt, safe_zone):
     """Append the SAFE ZONE directive to a prompt when safe_zone is set.
 
     See rules/title-overlay-rules.md for the policy. Idempotent: if the
-    prompt already contains a TITLE SAFE ZONE block, it is stripped
-    before the new directive is appended (or before the non-16:9 early
-    return, so a stale 16:9 directive doesn't survive a FULL→IMG+TXT
-    format change on the same slide).
+    prompt already contains a TITLE SAFE ZONE block, it is replaced.
 
-    Safe-zone composition is meaningful only for 16:9 frames. The skip
-    decision is sourced from FORMAT_SIZING via `sizing_for()` — formats
-    that map to a non-16:9 imagen aspect (IMG+TXT → 3:4) are skipped
-    with a warning. Unknown / talk-specific format tokens (DIAGRAM,
-    QUOTE, WIDE, etc.) fall through `sizing_for`'s FULL fallback and
-    receive the directive — matching apply-illustrations-to-deck.py's
-    behavior of treating Safe zone: presence as the title-overlay
-    signal regardless of format token.
-
-    `slide_label` (e.g. "5 (The Question)") is prepended to the warning
-    so the operator can identify which outline entry needs fixing even
-    when the warning fires before the per-slide header prints.
+    Safe zone presence is the signal — apply-illustrations-to-deck.py
+    treats any slide with a `Safe zone:` line as FULL/title-overlay
+    regardless of the `Format:` token (Safe zone takes precedence, see
+    apply-illustrations-to-deck.py's `_imgtxt_slide_numbers` filter).
+    The generator mirrors that: when Safe zone is present, the slide is
+    rendered as FULL and the directive is unconditionally applied.
+    Callers also override per-format sizing to FULL whenever Safe zone
+    is set — see the `effective_format` computation in each run_* call.
     """
     if not safe_zone:
-        return prompt
-
-    # Strip any stale directive first so a prior FULL run doesn't leak
-    # into a non-16:9 early return or a fresh FULL append.
-    if "TITLE SAFE ZONE" in prompt:
-        prompt = prompt.split("TITLE SAFE ZONE", 1)[0].rstrip()
-
-    # Skip when the format has known non-16:9 sizing (currently only
-    # IMG+TXT → 3:4). Unknown formats fall back to FULL/16:9 and get
-    # the directive.
-    if (
-        slide_format is not None
-        and sizing_for(slide_format)["imagen_aspect"] != "16:9"
-    ):
-        label_prefix = f"Slide {slide_label}: " if slide_label else ""
-        print(
-            f"  WARNING: {label_prefix}Safe zone directive skipped — "
-            f"Format: {slide_format} is a non-16:9 format (per "
-            "FORMAT_SIZING). Safe zones only make sense for 16:9 slides; "
-            "remove the `Safe zone:` line from this outline block to "
-            "silence this warning, or change the slide's Format to a "
-            "16:9 token."
-        )
         return prompt
     zone = safe_zone["zone"]
     if zone not in VALID_SAFE_ZONES:
         return prompt
     surface = safe_zone.get("surface") or DEFAULT_SAFE_ZONE_SURFACE[zone]
+    if "TITLE SAFE ZONE" in prompt:
+        prompt = prompt.split("TITLE SAFE ZONE", 1)[0].rstrip()
     directive = SAFE_ZONE_DIRECTIVE_TEMPLATE.format(
         zone_words=zone.replace("_", " "),
         surface=surface,
     )
     return prompt + directive
+
+
+def effective_slide_format(slide_format, safe_zone):
+    """Resolve the format that should drive vendor sizing.
+
+    apply-illustrations-to-deck.py treats `Safe zone:` presence as the
+    FULL/title-overlay signal regardless of the Format token, so the
+    generator must size accordingly — a 2:3 portrait can't host a 16:9
+    safe zone meaningfully. Returns "FULL" whenever safe_zone is set;
+    otherwise returns the declared slide_format unchanged.
+    """
+    if safe_zone:
+        return "FULL"
+    return slide_format
 
 
 # --- Slide Number Selection ---
@@ -880,16 +866,13 @@ def run_generate(outline_path, slide_args, versioned=False):
     for i, num in enumerate(to_generate):
         slide = slides_by_num[num]
         prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
-        prompt = apply_safe_zone_directive(
-            prompt,
-            slide.get("safe_zone"),
-            slide["format"],
-            slide_label=f"{num} ({slide['title']})",
-        )
+        prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
 
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
-        image_bytes, result = generate_image(prompt, model, keys, slide["format"])
+        # Safe zone presence forces FULL sizing — see effective_slide_format
+        eff_format = effective_slide_format(slide["format"], slide.get("safe_zone"))
+        image_bytes, result = generate_image(prompt, model, keys, eff_format)
 
         if image_bytes is None:
             print(f"  FAILED: {result}")
@@ -929,12 +912,8 @@ def run_compare(outline_path, slide_num):
 
     slide = slides_by_num[slide_num]
     prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
-    prompt = apply_safe_zone_directive(
-        prompt,
-        slide.get("safe_zone"),
-        slide["format"],
-        slide_label=f"{slide_num} ({slide['title']})",
-    )
+    prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
+    eff_format = effective_slide_format(slide["format"], slide.get("safe_zone"))
 
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)),
@@ -959,7 +938,7 @@ def run_compare(outline_path, slide_num):
     for i, model in enumerate(models):
         print(f"[{i+1}/{len(models)}] {model}...", end=" ", flush=True)
 
-        image_bytes, result = generate_image(prompt, model, keys, slide["format"])
+        image_bytes, result = generate_image(prompt, model, keys, eff_format)
 
         if image_bytes is None:
             print(f"FAILED: {result[:100]}")
@@ -1004,7 +983,10 @@ def run_edit(outline_path, slide_num, edit_prompt):
         sys.exit(1)
 
     slide = next((s for s in outline["slides"] if s["slide_num"] == slide_num), None)
-    slide_format = slide["format"] if slide else None
+    eff_format = (
+        effective_slide_format(slide["format"], slide.get("safe_zone"))
+        if slide else None
+    )
 
     print(f"Model: {model}")
     print(f"Input: {input_path}")
@@ -1013,7 +995,7 @@ def run_edit(outline_path, slide_num, edit_prompt):
     # Save as versioned output (never overwrite)
     ver = next_version(output_dir, slide_num)
 
-    image_bytes, result = edit_image(input_path, edit_prompt, model, keys, slide_format)
+    image_bytes, result = edit_image(input_path, edit_prompt, model, keys, eff_format)
 
     if image_bytes is None:
         print(f"FAILED: {result}")
@@ -1105,7 +1087,8 @@ def run_build(outline_path, slide_arg):
             print(f"  build-{step_num:02d}: {desc[:60]}...", end=" ", flush=True)
 
             image_bytes, result = edit_image(
-                prev_image, desc, model, keys, slide["format"]
+                prev_image, desc, model, keys,
+                effective_slide_format(slide["format"], slide.get("safe_zone")),
             )
 
             if image_bytes is None:
@@ -1142,7 +1125,10 @@ def run_fix(outline_path, slide_num, fix_prompt):
         sys.exit(1)
 
     slide = next((s for s in outline["slides"] if s["slide_num"] == slide_num), None)
-    slide_format = slide["format"] if slide else None
+    eff_format = (
+        effective_slide_format(slide["format"], slide.get("safe_zone"))
+        if slide else None
+    )
 
     ver = next_version(output_dir, slide_num)
     print(f"Model: {model}")
@@ -1150,7 +1136,7 @@ def run_fix(outline_path, slide_num, fix_prompt):
     print(f"Fix: {fix_prompt}")
     print(f"Output: slide-{slide_num:02d}-v{ver}")
 
-    image_bytes, result = edit_image(input_path, fix_prompt, model, keys, slide_format)
+    image_bytes, result = edit_image(input_path, fix_prompt, model, keys, eff_format)
 
     if image_bytes is None:
         print(f"FAILED: {result}")

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -867,13 +867,16 @@ def run_generate(outline_path, slide_args, versioned=False):
 
     for i, num in enumerate(to_generate):
         slide = slides_by_num[num]
-        prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
+        # Safe zone presence forces FULL throughout — anchor selection,
+        # sizing, and the directive itself all use the effective format
+        # so the prompt, the image geometry, and the apply-step layout
+        # stay internally consistent.
+        eff_format = effective_slide_format(slide["format"], slide.get("safe_zone"))
+        prompt = resolve_prompt(slide["prompt"], eff_format, outline["anchors"])
         prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
 
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
-        # Safe zone presence forces FULL sizing — see effective_slide_format
-        eff_format = effective_slide_format(slide["format"], slide.get("safe_zone"))
         image_bytes, result = generate_image(prompt, model, keys, eff_format)
 
         if image_bytes is None:
@@ -913,9 +916,10 @@ def run_compare(outline_path, slide_num):
         sys.exit(1)
 
     slide = slides_by_num[slide_num]
-    prompt = resolve_prompt(slide["prompt"], slide["format"], outline["anchors"])
-    prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
+    # Safe zone presence forces FULL throughout (see effective_slide_format).
     eff_format = effective_slide_format(slide["format"], slide.get("safe_zone"))
+    prompt = resolve_prompt(slide["prompt"], eff_format, outline["anchors"])
+    prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
 
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)),

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -18,7 +18,12 @@ Usage:
     python3 generate-illustrations.py <outline.md> -v 2 5 9
 
 Requires:
-    - Gemini API key in {vault}/secrets.json (preferred) or GEMINI_API_KEY env var (fallback)
+    - For Google models (gemini-*, nano-banana-*, imagen-*):
+        Gemini API key in {vault}/secrets.json (preferred) or
+        GEMINI_API_KEY env var (fallback).
+    - For OpenAI models (gpt-image-*):
+        OpenAI API key in {vault}/secrets.json under "openai".api_key
+        or OPENAI_API_KEY env var (fallback).
     - Python 3.7+ (stdlib only — no pip install needed)
 """
 
@@ -33,18 +38,29 @@ import sys
 import time
 import urllib.error
 import urllib.request
+import uuid
 
 # --- Constants ---
 
 GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
+OPENAI_API_BASE = "https://api.openai.com/v1"
 
-# Curated list of Gemini models known to support image generation.
-# Used by --compare mode. Update as new models become available.
+# Curated list of current flagship image-generation models from major vendors.
+# Used by --compare mode. The illustrations skill's Step 2 (model-freshness
+# check) tracks this list — bump it when newer flagships ship rather than
+# leaving stale entries in place.
 COMPARE_MODELS = [
     "gemini-3-pro-image-preview",
-    "gemini-2.0-flash-preview-image-generation",
-    "imagen-3.0-generate-002",
+    "gemini-3.1-flash-image-preview",
+    "nano-banana-pro-preview",
+    "imagen-4.0-ultra-generate-001",
+    "gpt-image-2",
 ]
+
+# Default output sizes per vendor family. Gemini infers aspect from prompt
+# hints; OpenAI takes an explicit size param. 2048x1152 is the validated
+# true-16:9 size for gpt-image-2.
+OPENAI_DEFAULT_SIZE = "2048x1152"
 
 RATE_LIMIT_DELAY = 5  # seconds between API requests
 
@@ -87,6 +103,35 @@ _EXT_MIME_MAP[".jpeg"] = "image/jpeg"  # common alias
 _VERSION_RE = re.compile(r"-v(\d+)")
 
 _cli_vault_path = None  # set by main() from --vault arg
+
+
+# --- Model Family Dispatch ---
+
+def model_family(model_name):
+    """Classify a model into a vendor family for endpoint dispatch.
+
+    Families:
+        - "openai" — gpt-image-* (OpenAI /images/generations + /images/edits)
+        - "imagen" — imagen-* (Google /v1beta/models/<m>:predict)
+        - "gemini" — everything else, currently gemini-* and nano-banana-*
+          (Google /v1beta/models/<m>:generateContent)
+    """
+    name = model_name.lower()
+    if name.startswith("gpt-image"):
+        return "openai"
+    if name.startswith("imagen"):
+        return "imagen"
+    return "gemini"
+
+
+def family_key_name(family):
+    """Map a model family to the secrets.json key name it requires.
+
+    Imagen and Gemini both authenticate with the Google AI Studio key.
+    """
+    if family == "openai":
+        return "openai"
+    return "gemini"
 
 
 # --- Outline Parsing ---
@@ -323,51 +368,96 @@ def ext_to_mime(ext):
 
 # --- Shared Setup ---
 
-def _load_context(outline_path, require_model=True, vault_path=None):
-    """Common preamble: check API key, parse outline, compute paths.
+def load_secrets(vault_path=None):
+    """Load API keys from vault secrets.json with env-var fallbacks.
 
-    API key resolution order:
-        1. {vault}/secrets.json → gemini.api_key
-        2. GEMINI_API_KEY environment variable (backward compat)
+    Resolution order per vendor:
+        1. {vault}/secrets.json → gemini.api_key / openai.api_key
+        2. GEMINI_API_KEY / OPENAI_API_KEY env vars
 
     Returns:
-        tuple (api_key, outline, output_dir)
+        tuple (keys_dict, secrets_path) where keys_dict maps
+        "gemini" / "openai" → key string or None.
     """
-    api_key = None
+    keys = {"gemini": None, "openai": None}
 
-    # Try secrets.json first
     if vault_path is None:
         vault_path = _cli_vault_path
     if vault_path is None:
         vault_path = os.path.expanduser("~/.claude/rhetoric-knowledge-vault")
     secrets_path = os.path.join(vault_path, "secrets.json")
+
     if os.path.isfile(secrets_path):
         try:
             with open(secrets_path, "r", encoding="utf-8") as f:
                 secrets = json.load(f)
-            api_key = secrets.get("gemini", {}).get("api_key") or None
+            keys["gemini"] = secrets.get("gemini", {}).get("api_key") or None
+            keys["openai"] = secrets.get("openai", {}).get("api_key") or None
         except (json.JSONDecodeError, OSError):
             pass
 
-    # Fall back to env var
-    if not api_key:
-        api_key = os.environ.get("GEMINI_API_KEY")
+    if not keys["gemini"]:
+        keys["gemini"] = os.environ.get("GEMINI_API_KEY") or None
+    if not keys["openai"]:
+        keys["openai"] = os.environ.get("OPENAI_API_KEY") or None
 
-    if not api_key:
-        print("ERROR: No Gemini API key found.")
-        print("Get a key from https://aistudio.google.com/app/apikey")
-        print()
-        if not os.path.isfile(secrets_path):
-            print(f"Create {secrets_path}:")
-            print(f'  echo \'{{"gemini": {{"api_key": "YOUR_KEY"}}}}\' > {secrets_path}')
-            print(f"  chmod 600 {secrets_path}")
-        else:
-            print(f"Add to {secrets_path}:")
-            print('  "gemini": {"api_key": "YOUR_KEY"}')
-        print()
-        print("Or set the GEMINI_API_KEY environment variable as a fallback.")
-        sys.exit(1)
+    return keys, secrets_path
 
+
+def _require_keys_for_families(keys, families, secrets_path):
+    """Verify keys needed for the given model families are present.
+
+    Exits with an actionable per-vendor message if any required key
+    is missing.
+    """
+    needed = {family_key_name(f) for f in families}
+    missing = sorted(k for k in needed if not keys.get(k))
+    if not missing:
+        return
+
+    print("ERROR: Missing API key(s) for the model(s) you're using.")
+    secrets_exists = os.path.isfile(secrets_path)
+    for k in missing:
+        if k == "gemini":
+            print()
+            print("  Gemini and Imagen models need a Google AI Studio key.")
+            print("  Get one at: https://aistudio.google.com/app/apikey")
+            if secrets_exists:
+                print(f"  Add to {secrets_path}:")
+                print('    "gemini": {"api_key": "YOUR_KEY"}')
+            else:
+                print(f"  Create {secrets_path}:")
+                print(f'    echo \'{{"gemini": {{"api_key": "YOUR_KEY"}}}}\' > {secrets_path}')
+                print(f"    chmod 600 {secrets_path}")
+            print("  Or set the GEMINI_API_KEY environment variable.")
+        elif k == "openai":
+            print()
+            print("  OpenAI gpt-image-* models need an OpenAI API key.")
+            print("  Get one at: https://platform.openai.com/api-keys")
+            if secrets_exists:
+                print(f"  Add to {secrets_path}:")
+                print('    "openai": {"api_key": "YOUR_KEY"}')
+            else:
+                print(f"  Create {secrets_path}:")
+                print(f'    echo \'{{"openai": {{"api_key": "YOUR_KEY"}}}}\' > {secrets_path}')
+                print(f"    chmod 600 {secrets_path}")
+            print("  Or set the OPENAI_API_KEY environment variable.")
+    sys.exit(1)
+
+
+def _load_context(outline_path, require_model=True, vault_path=None, compare_mode=False):
+    """Common preamble: load API keys, parse outline, compute paths.
+
+    Determines which vendor families need keys based on:
+        - compare_mode=True → every family in COMPARE_MODELS + outline's
+          baked Model (if any)
+        - compare_mode=False → just the outline's Model family
+
+    Returns:
+        tuple (keys, outline, output_dir) where keys is a dict
+        {"gemini": str|None, "openai": str|None}.
+    """
+    keys, secrets_path = load_secrets(vault_path)
     outline = parse_outline(outline_path)
 
     if require_model and not outline["model"]:
@@ -375,10 +465,23 @@ def _load_context(outline_path, require_model=True, vault_path=None):
         print("to the Illustration Style Anchor section.")
         sys.exit(1)
 
+    families = set()
+    if compare_mode:
+        for m in COMPARE_MODELS:
+            families.add(model_family(m))
+        if outline["model"]:
+            families.add(model_family(outline["model"]))
+    elif outline["model"]:
+        families.add(model_family(outline["model"]))
+    else:
+        families.add("gemini")
+
+    _require_keys_for_families(keys, families, secrets_path)
+
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)), "illustrations"
     )
-    return api_key, outline, output_dir
+    return keys, outline, output_dir
 
 
 # --- Gemini API ---
@@ -435,33 +538,182 @@ def _call_gemini(parts, model, api_key):
     return None, f"No image in response: {json.dumps(body)[:500]}"
 
 
-def generate_image(prompt, model, api_key):
-    """Call the Gemini generateContent API to produce an image.
+def _call_imagen(prompt, model, api_key):
+    """Send a prompt to Google's Imagen :predict endpoint.
+
+    Imagen uses a different endpoint shape from Gemini's generateContent.
+    Aspect ratio is set via the parameters block, not inferred from prompt.
 
     Returns:
         tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
     """
-    return _call_gemini([{"text": prompt}], model, api_key)
+    url = f"{GEMINI_API_BASE}/{model}:predict?key={api_key}"
+    payload = {
+        "instances": [{"prompt": prompt}],
+        "parameters": {"sampleCount": 1, "aspectRatio": "16:9"},
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=180) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8", errors="replace")
+        return None, f"HTTP {e.code}: {error_body[:500]}"
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as e:
+        return None, str(e)
+
+    preds = body.get("predictions", [])
+    if preds and preds[0].get("bytesBase64Encoded"):
+        image_bytes = base64.b64decode(preds[0]["bytesBase64Encoded"])
+        mime = preds[0].get("mimeType", "image/png")
+        return image_bytes, mime
+    return None, f"No image in Imagen response: {json.dumps(body)[:500]}"
 
 
-def edit_image(input_path, edit_prompt, model, api_key):
-    """Call the Gemini API to edit an existing image.
+# --- OpenAI API ---
 
-    Sends the image as base64 inline data along with a text edit prompt.
-    Auto-appends safety suffixes to prevent unwanted additions.
+def _multipart_body(fields, files):
+    """Build a multipart/form-data body. Returns (bytes, boundary)."""
+    boundary = "----GenIllustBnd" + uuid.uuid4().hex
+    body = bytearray()
+    for k, v in fields.items():
+        body += f"--{boundary}\r\n".encode()
+        body += f'Content-Disposition: form-data; name="{k}"\r\n\r\n'.encode()
+        body += str(v).encode("utf-8")
+        body += b"\r\n"
+    for name, filename, mime, content in files:
+        body += f"--{boundary}\r\n".encode()
+        body += (
+            f'Content-Disposition: form-data; name="{name}"; '
+            f'filename="{filename}"\r\n'
+        ).encode()
+        body += f"Content-Type: {mime}\r\n\r\n".encode()
+        body += content
+        body += b"\r\n"
+    body += f"--{boundary}--\r\n".encode()
+    return bytes(body), boundary
 
-    Returns:
-        tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
-    """
-    # Read and encode the input image
+
+def _extract_openai_image(body):
+    """Pull image bytes + mime from an OpenAI Images API response body."""
+    data_arr = body.get("data", [])
+    if not data_arr:
+        return None, f"No data in OpenAI response: {json.dumps(body)[:500]}"
+    first = data_arr[0]
+    if first.get("b64_json"):
+        return base64.b64decode(first["b64_json"]), "image/png"
+    if first.get("url"):
+        try:
+            with urllib.request.urlopen(first["url"], timeout=120) as r:
+                return r.read(), "image/png"
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            return None, f"Failed to fetch image URL: {e}"
+    return None, f"OpenAI response has neither b64_json nor url: {json.dumps(first)[:500]}"
+
+
+def _call_openai_generate(prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
+    """Call OpenAI /images/generations to produce a fresh image."""
+    url = f"{OPENAI_API_BASE}/images/generations"
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "size": size,
+        "quality": "high",
+        "n": 1,
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8", errors="replace")
+        return None, f"HTTP {e.code}: {error_body[:500]}"
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as e:
+        return None, str(e)
+
+    return _extract_openai_image(body)
+
+
+def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
+    """Call OpenAI /images/edits to edit an existing image."""
     with open(input_path, "rb") as f:
-        image_data = base64.b64encode(f.read()).decode("utf-8")
-
-    # Detect MIME type from extension
+        image_bytes = f.read()
     ext = os.path.splitext(input_path)[1].lower()
-    input_mime = ext_to_mime(ext)
+    mime = ext_to_mime(ext)
+    filename = os.path.basename(input_path)
 
-    # Auto-append safety suffixes if not already present
+    body, boundary = _multipart_body(
+        fields={"model": model, "prompt": prompt, "size": size,
+                "quality": "high", "n": "1"},
+        files=[("image", filename, mime, image_bytes)],
+    )
+    url = f"{OPENAI_API_BASE}/images/edits"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+        "Content-Length": str(len(body)),
+    }
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=500) as resp:
+            resp_body = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8", errors="replace")
+        return None, f"HTTP {e.code}: {error_body[:500]}"
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as e:
+        return None, str(e)
+
+    return _extract_openai_image(resp_body)
+
+
+# --- Vendor-Agnostic Dispatchers ---
+
+def generate_image(prompt, model, keys):
+    """Generate a fresh image via the appropriate vendor endpoint.
+
+    Args:
+        prompt: text prompt
+        model: model name (dispatch is by name prefix — see model_family)
+        keys: dict from load_secrets() — {"gemini": ..., "openai": ...}
+
+    Returns:
+        tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
+    """
+    family = model_family(model)
+    if family == "openai":
+        return _call_openai_generate(prompt, model, keys["openai"])
+    if family == "imagen":
+        return _call_imagen(prompt, model, keys["gemini"])
+    return _call_gemini([{"text": prompt}], model, keys["gemini"])
+
+
+def edit_image(input_path, edit_prompt, model, keys):
+    """Edit an existing image via the appropriate vendor endpoint.
+
+    Auto-appends vendor-agnostic safety suffixes to the prompt to prevent
+    unwanted additions and patch artifacts.
+
+    Returns:
+        tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
+    """
     suffixes = []
     lower_prompt = edit_prompt.lower()
     if "do not add any new elements" not in lower_prompt:
@@ -471,18 +723,33 @@ def edit_image(input_path, edit_prompt, model, api_key):
     if suffixes:
         edit_prompt = edit_prompt.rstrip(". ") + ". " + " ".join(suffixes)
 
+    family = model_family(model)
+    if family == "openai":
+        return _call_openai_edit(input_path, edit_prompt, model, keys["openai"])
+    if family == "imagen":
+        return None, (
+            f"Image editing is not supported for Imagen models ({model}). "
+            "Imagen has no public edit endpoint — use a Gemini or OpenAI "
+            "model for --edit / --build / --fix workflows."
+        )
+
+    # Gemini path: send image as base64 inline data on generateContent
+    with open(input_path, "rb") as f:
+        image_data = base64.b64encode(f.read()).decode("utf-8")
+    ext = os.path.splitext(input_path)[1].lower()
+    input_mime = ext_to_mime(ext)
     parts = [
         {"inlineData": {"mimeType": input_mime, "data": image_data}},
         {"text": edit_prompt},
     ]
-    return _call_gemini(parts, model, api_key)
+    return _call_gemini(parts, model, keys["gemini"])
 
 
 # --- Main Commands ---
 
 def run_generate(outline_path, slide_args, versioned=False):
     """Generate illustrations for selected slides."""
-    api_key, outline, output_dir = _load_context(outline_path)
+    keys, outline, output_dir = _load_context(outline_path)
     model = outline["model"]
     os.makedirs(output_dir, exist_ok=True)
 
@@ -516,7 +783,7 @@ def run_generate(outline_path, slide_args, versioned=False):
 
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
-        image_bytes, result = generate_image(prompt, model, api_key)
+        image_bytes, result = generate_image(prompt, model, keys)
 
         if image_bytes is None:
             print(f"  FAILED: {result}")
@@ -545,7 +812,7 @@ def run_generate(outline_path, slide_args, versioned=False):
 
 def run_compare(outline_path, slide_num):
     """Generate the same prompt across multiple models for comparison."""
-    api_key, outline, _ = _load_context(outline_path, require_model=False)
+    keys, outline, _ = _load_context(outline_path, require_model=False, compare_mode=True)
 
     slides_by_num = {s["slide_num"]: s for s in outline["slides"]}
     if slide_num not in slides_by_num:
@@ -581,7 +848,7 @@ def run_compare(outline_path, slide_num):
     for i, model in enumerate(models):
         print(f"[{i+1}/{len(models)}] {model}...", end=" ", flush=True)
 
-        image_bytes, result = generate_image(prompt, model, api_key)
+        image_bytes, result = generate_image(prompt, model, keys)
 
         if image_bytes is None:
             print(f"FAILED: {result[:100]}")
@@ -615,8 +882,8 @@ def run_compare(outline_path, slide_num):
 
 
 def run_edit(outline_path, slide_num, edit_prompt):
-    """Edit an existing slide illustration using Gemini's image editing API."""
-    api_key, outline, output_dir = _load_context(outline_path)
+    """Edit an existing slide illustration via the model's edit endpoint."""
+    keys, outline, output_dir = _load_context(outline_path)
     model = outline["model"]
 
     input_path = find_base_image(output_dir, slide_num)
@@ -632,7 +899,7 @@ def run_edit(outline_path, slide_num, edit_prompt):
     # Save as versioned output (never overwrite)
     ver = next_version(output_dir, slide_num)
 
-    image_bytes, result = edit_image(input_path, edit_prompt, model, api_key)
+    image_bytes, result = edit_image(input_path, edit_prompt, model, keys)
 
     if image_bytes is None:
         print(f"FAILED: {result}")
@@ -650,7 +917,7 @@ def run_edit(outline_path, slide_num, edit_prompt):
 
 def run_build(outline_path, slide_arg):
     """Generate progressive-reveal build images using backwards-chaining."""
-    api_key, outline, output_dir = _load_context(outline_path)
+    keys, outline, output_dir = _load_context(outline_path)
     model = outline["model"]
     builds_dir = os.path.join(output_dir, "builds")
     os.makedirs(builds_dir, exist_ok=True)
@@ -714,7 +981,7 @@ def run_build(outline_path, slide_arg):
 
             print(f"  build-{step_num:02d}: {desc[:60]}...", end=" ", flush=True)
 
-            image_bytes, result = edit_image(prev_image, desc, model, api_key)
+            image_bytes, result = edit_image(prev_image, desc, model, keys)
 
             if image_bytes is None:
                 print(f"FAILED: {result[:100]}")
@@ -741,7 +1008,7 @@ def run_build(outline_path, slide_arg):
 
 def run_fix(outline_path, slide_num, fix_prompt):
     """Apply a targeted fix to an existing slide image, saving as a new version."""
-    api_key, outline, output_dir = _load_context(outline_path)
+    keys, outline, output_dir = _load_context(outline_path)
     model = outline["model"]
 
     input_path = find_latest_image(output_dir, slide_num)
@@ -755,7 +1022,7 @@ def run_fix(outline_path, slide_num, fix_prompt):
     print(f"Fix: {fix_prompt}")
     print(f"Output: slide-{slide_num:02d}-v{ver}")
 
-    image_bytes, result = edit_image(input_path, fix_prompt, model, api_key)
+    image_bytes, result = edit_image(input_path, fix_prompt, model, keys)
 
     if image_bytes is None:
         print(f"FAILED: {result}")

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -59,10 +59,29 @@ COMPARE_MODELS = [
     "gpt-image-2",
 ]
 
-# Default output sizes per vendor family. Gemini infers aspect from prompt
-# hints; OpenAI takes an explicit size param. 2048x1152 is the validated
-# true-16:9 size for gpt-image-2.
-OPENAI_DEFAULT_SIZE = "2048x1152"
+# Per-format sizing for vendors that take explicit size / aspect-ratio
+# params. Gemini infers aspect from prompt hints, so it doesn't appear
+# here. The "FULL" entry is also the unknown-format fallback.
+#   openai_size:  gpt-image-* accepts 2048x1152 (true 16:9) and
+#                 1024x1536 (true 2:3 portrait).
+#   imagen_aspect: Imagen :predict accepts 1:1, 9:16, 16:9, 3:4, 4:3.
+#                  3:4 is closest to the IMG+TXT 2:3 anchor (Imagen
+#                  has no native 2:3).
+FORMAT_SIZING = {
+    "FULL": {"openai_size": "2048x1152", "imagen_aspect": "16:9"},
+    "IMG+TXT": {"openai_size": "1024x1536", "imagen_aspect": "3:4"},
+}
+OPENAI_DEFAULT_SIZE = FORMAT_SIZING["FULL"]["openai_size"]
+IMAGEN_DEFAULT_ASPECT = FORMAT_SIZING["FULL"]["imagen_aspect"]
+
+
+def sizing_for(slide_format):
+    """Look up vendor-specific sizing for a slide format.
+
+    Unknown / missing formats fall back to FULL (16:9 landscape) — that's
+    the historical default and matches the typical deck slide.
+    """
+    return FORMAT_SIZING.get(slide_format, FORMAT_SIZING["FULL"])
 
 RATE_LIMIT_DELAY = 5  # seconds between API requests
 
@@ -162,8 +181,10 @@ def parse_outline(path):
         result["model"] = model_match.group(1)
 
     # Extract style anchors: ### STYLE ANCHOR (FORMAT — dimensions)\n> paragraph
+    # Format tokens may include `+` and `-` (e.g. IMG+TXT) — match the
+    # parser used by the per-slide Format: line below.
     anchor_pattern = re.compile(
-        r"###\s+STYLE ANCHOR\s+\((\w+)\s*—[^)]*\)\s*\n>\s*(.+?)(?=\n###|\n---|\n##|\Z)",
+        r"###\s+STYLE ANCHOR\s+\(([\w+-]+)\s*—[^)]*\)\s*\n>\s*(.+?)(?=\n###|\n---|\n##|\Z)",
         re.DOTALL,
     )
     for match in anchor_pattern.finditer(text):
@@ -183,7 +204,10 @@ def parse_outline(path):
         block = match.group(0)
 
         # Extract format
-        fmt_match = re.search(r"-\s*Format:\s*\*\*(\w+)\*\*", block)
+        # Allow `+` and `-` inside format tokens (e.g. IMG+TXT, IMG-TXT) on
+        # top of \w's alphanumerics+underscore. The downstream apply script's
+        # regex already permits IMG+TXT explicitly — keep these in sync.
+        fmt_match = re.search(r"-\s*Format:\s*\*\*([\w+-]+)\*\*", block)
         slide_format = fmt_match.group(1) if fmt_match else None
 
         # Extract image prompt
@@ -563,7 +587,7 @@ def _call_gemini(parts, model, api_key):
     return None, f"No image in response: {json.dumps(body)[:500]}"
 
 
-def _call_imagen(prompt, model, api_key):
+def _call_imagen(prompt, model, api_key, aspect_ratio=IMAGEN_DEFAULT_ASPECT):
     """Send a prompt to Google's Imagen :predict endpoint.
 
     Imagen uses a different endpoint shape from Gemini's generateContent.
@@ -575,7 +599,7 @@ def _call_imagen(prompt, model, api_key):
     url = f"{GEMINI_API_BASE}/{model}:predict?key={api_key}"
     payload = {
         "instances": [{"prompt": prompt}],
-        "parameters": {"sampleCount": 1, "aspectRatio": "16:9"},
+        "parameters": {"sampleCount": 1, "aspectRatio": aspect_ratio},
     }
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
@@ -711,30 +735,42 @@ def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SI
 
 # --- Vendor-Agnostic Dispatchers ---
 
-def generate_image(prompt, model, keys):
+def generate_image(prompt, model, keys, slide_format=None):
     """Generate a fresh image via the appropriate vendor endpoint.
 
     Args:
         prompt: text prompt
         model: model name (dispatch is by name prefix — see model_family)
         keys: dict from load_secrets() — {"gemini": ..., "openai": ...}
+        slide_format: outline format name (e.g. "FULL", "IMG+TXT") used to
+            pick the per-vendor size / aspect-ratio param. Falls back to
+            FULL (16:9 landscape) when None or unknown.
 
     Returns:
         tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
     """
     family = model_family(model)
+    sizing = sizing_for(slide_format)
     if family == "openai":
-        return _call_openai_generate(prompt, model, keys["openai"])
+        return _call_openai_generate(
+            prompt, model, keys["openai"], size=sizing["openai_size"]
+        )
     if family == "imagen":
-        return _call_imagen(prompt, model, keys["gemini"])
+        return _call_imagen(
+            prompt, model, keys["gemini"], aspect_ratio=sizing["imagen_aspect"]
+        )
     return _call_gemini([{"text": prompt}], model, keys["gemini"])
 
 
-def edit_image(input_path, edit_prompt, model, keys):
+def edit_image(input_path, edit_prompt, model, keys, slide_format=None):
     """Edit an existing image via the appropriate vendor endpoint.
 
     Auto-appends vendor-agnostic safety suffixes to the prompt to prevent
     unwanted additions and patch artifacts.
+
+    Args:
+        slide_format: see generate_image — controls OpenAI edit size so
+            the output matches the source slide's geometry.
 
     Returns:
         tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
@@ -749,8 +785,11 @@ def edit_image(input_path, edit_prompt, model, keys):
         edit_prompt = edit_prompt.rstrip(". ") + ". " + " ".join(suffixes)
 
     family = model_family(model)
+    sizing = sizing_for(slide_format)
     if family == "openai":
-        return _call_openai_edit(input_path, edit_prompt, model, keys["openai"])
+        return _call_openai_edit(
+            input_path, edit_prompt, model, keys["openai"], size=sizing["openai_size"]
+        )
     if family == "imagen":
         return None, (
             f"Image editing is not supported for Imagen models ({model}). "
@@ -808,7 +847,7 @@ def run_generate(outline_path, slide_args, versioned=False):
 
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
-        image_bytes, result = generate_image(prompt, model, keys)
+        image_bytes, result = generate_image(prompt, model, keys, slide["format"])
 
         if image_bytes is None:
             print(f"  FAILED: {result}")
@@ -873,7 +912,7 @@ def run_compare(outline_path, slide_num):
     for i, model in enumerate(models):
         print(f"[{i+1}/{len(models)}] {model}...", end=" ", flush=True)
 
-        image_bytes, result = generate_image(prompt, model, keys)
+        image_bytes, result = generate_image(prompt, model, keys, slide["format"])
 
         if image_bytes is None:
             print(f"FAILED: {result[:100]}")
@@ -917,6 +956,9 @@ def run_edit(outline_path, slide_num, edit_prompt):
         print("Generate the base image first, then edit it.")
         sys.exit(1)
 
+    slide = next((s for s in outline["slides"] if s["slide_num"] == slide_num), None)
+    slide_format = slide["format"] if slide else None
+
     print(f"Model: {model}")
     print(f"Input: {input_path}")
     print(f"Edit prompt: {edit_prompt}")
@@ -924,7 +966,7 @@ def run_edit(outline_path, slide_num, edit_prompt):
     # Save as versioned output (never overwrite)
     ver = next_version(output_dir, slide_num)
 
-    image_bytes, result = edit_image(input_path, edit_prompt, model, keys)
+    image_bytes, result = edit_image(input_path, edit_prompt, model, keys, slide_format)
 
     if image_bytes is None:
         print(f"FAILED: {result}")
@@ -1015,7 +1057,9 @@ def run_build(outline_path, slide_arg):
 
             print(f"  build-{step_num:02d}: {desc[:60]}...", end=" ", flush=True)
 
-            image_bytes, result = edit_image(prev_image, desc, model, keys)
+            image_bytes, result = edit_image(
+                prev_image, desc, model, keys, slide["format"]
+            )
 
             if image_bytes is None:
                 print(f"FAILED: {result[:100]}")
@@ -1050,13 +1094,16 @@ def run_fix(outline_path, slide_num, fix_prompt):
         print(f"ERROR: No existing image found for slide {slide_num}")
         sys.exit(1)
 
+    slide = next((s for s in outline["slides"] if s["slide_num"] == slide_num), None)
+    slide_format = slide["format"] if slide else None
+
     ver = next_version(output_dir, slide_num)
     print(f"Model: {model}")
     print(f"Input: {os.path.basename(input_path)}")
     print(f"Fix: {fix_prompt}")
     print(f"Output: slide-{slide_num:02d}-v{ver}")
 
-    image_bytes, result = edit_image(input_path, fix_prompt, model, keys)
+    image_bytes, result = edit_image(input_path, fix_prompt, model, keys, slide_format)
 
     if image_bytes is None:
         print(f"FAILED: {result}")

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -297,11 +297,13 @@ def apply_safe_zone_directive(prompt, safe_zone):
     Safe zone presence is the signal — apply-illustrations-to-deck.py
     treats any slide with a `Safe zone:` line as FULL/title-overlay
     regardless of the `Format:` token (Safe zone takes precedence, see
-    apply-illustrations-to-deck.py's `_imgtxt_slide_numbers` filter).
-    The generator mirrors that: when Safe zone is present, the slide is
+    apply-illustrations-to-deck.py's `parse_img_txt_slides()` which
+    excludes slides whose block also contains a Safe zone line). The
+    generator mirrors that: when Safe zone is present, the slide is
     rendered as FULL and the directive is unconditionally applied.
     Callers also override per-format sizing to FULL whenever Safe zone
-    is set — see the `effective_format` computation in each run_* call.
+    is set — see `effective_slide_format()` and the `eff_format` use
+    in each run_* call.
     """
     if not safe_zone:
         return prompt

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -26,7 +26,8 @@ Requires:
     - For OpenAI models (gpt-image-*):
         OpenAI API key in {vault}/secrets.json under "openai".api_key
         or OPENAI_API_KEY env var (fallback).
-    - Python 3.7+ (stdlib only — no pip install needed)
+    - Python 3.8+ (stdlib only — no pip install needed; uses the walrus
+      operator and other 3.8+ syntax)
 """
 
 import argparse

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -701,6 +701,11 @@ def _call_openai_generate(prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
         "size": size,
         "quality": "high",
         "n": 1,
+        # Inline the bytes so we don't do a second unauthenticated fetch
+        # from a hosted URL — that extra hop fails on restrictive
+        # networks / firewalls. The url-branch in _extract_openai_image
+        # stays as a defensive fallback for older API behavior.
+        "response_format": "b64_json",
     }
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
@@ -735,7 +740,10 @@ def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SI
 
     body, boundary = _multipart_body(
         fields={"model": model, "prompt": prompt, "size": size,
-                "quality": "high", "n": "1"},
+                "quality": "high", "n": "1",
+                # Inline bytes — see _call_openai_generate for the
+                # restrictive-network reasoning.
+                "response_format": "b64_json"},
         files=[("image", filename, mime, image_bytes)],
     )
     url = f"{OPENAI_API_BASE}/images/edits"

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -292,7 +292,10 @@ def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
     """Append the SAFE ZONE directive to a prompt when safe_zone is set.
 
     See rules/title-overlay-rules.md for the policy. Idempotent: if the
-    prompt already contains a TITLE SAFE ZONE block, it is replaced.
+    prompt already contains a TITLE SAFE ZONE block, it is stripped
+    before the new directive is appended (or before the non-FULL early
+    return, so a stale 16:9 directive doesn't survive a FULL→IMG+TXT
+    format change on the same slide).
 
     The directive is FULL-format-specific (apply-illustrations-to-deck.py
     only consumes Safe zone: lines on FULL slides; IMG+TXT slides get a
@@ -301,6 +304,12 @@ def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
     """
     if not safe_zone:
         return prompt
+
+    # Strip any stale directive first so a prior FULL run doesn't leak
+    # into a non-FULL early return or a fresh FULL append.
+    if "TITLE SAFE ZONE" in prompt:
+        prompt = prompt.split("TITLE SAFE ZONE", 1)[0].rstrip()
+
     if slide_format is not None and slide_format != "FULL":
         print(
             f"  WARNING: Safe zone directive skipped — Format: {slide_format} "
@@ -313,8 +322,6 @@ def apply_safe_zone_directive(prompt, safe_zone, slide_format=None):
     if zone not in VALID_SAFE_ZONES:
         return prompt
     surface = safe_zone.get("surface") or DEFAULT_SAFE_ZONE_SURFACE[zone]
-    if "TITLE SAFE ZONE" in prompt:
-        prompt = prompt.split("TITLE SAFE ZONE", 1)[0].rstrip()
     directive = SAFE_ZONE_DIRECTIVE_TEMPLATE.format(
         zone_words=zone.replace("_", " "),
         surface=surface,

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -406,8 +406,20 @@ def load_secrets(vault_path=None):
                 secrets = json.load(f)
             keys["gemini"] = secrets.get("gemini", {}).get("api_key") or None
             keys["openai"] = secrets.get("openai", {}).get("api_key") or None
-        except (json.JSONDecodeError, OSError):
-            pass
+        except json.JSONDecodeError as e:
+            print(
+                f"WARNING: {secrets_path} is not valid JSON ({e}); "
+                "falling back to environment variables. Fix the file or "
+                "delete it to silence this warning.",
+                file=sys.stderr,
+            )
+        except OSError as e:
+            print(
+                f"WARNING: {secrets_path} could not be read ({e}); "
+                "falling back to environment variables. Check file "
+                "permissions.",
+                file=sys.stderr,
+            )
 
     if not keys["gemini"]:
         keys["gemini"] = os.environ.get("GEMINI_API_KEY") or None

--- a/tessl.json
+++ b/tessl.json
@@ -3,7 +3,7 @@
   "mode": "vendored",
   "dependencies": {
     "tessl-labs/tessl-skill-eval-scenarios": {
-      "version": "0.1.0"
+      "version": "latest"
     },
     "jbaruch/coding-policy": {
       "version": "latest"

--- a/tessl.json
+++ b/tessl.json
@@ -6,7 +6,7 @@
       "version": "0.1.0"
     },
     "jbaruch/coding-policy": {
-      "version": "0.3.18"
+      "version": "latest"
     }
   }
 }

--- a/tessl.json
+++ b/tessl.json
@@ -6,7 +6,7 @@
       "version": "0.1.0"
     },
     "jbaruch/coding-policy": {
-      "version": "0.3.14"
+      "version": "0.3.18"
     }
   }
 }

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -232,77 +232,21 @@ def test_apply_safe_zone_default_surface(generate_illustrations):
     assert "left half" in result
 
 
-def test_apply_safe_zone_skipped_for_non_full_format(generate_illustrations, capsys):
-    # Safe zone composition only makes sense for FULL-format slides
-    # (apply-illustrations-to-deck.py uses a fixed right-column layout
-    # for IMG+TXT and ignores Safe zone: lines on those slides). The
-    # generator must skip the directive on non-FULL formats and warn.
-    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
-    result = generate_illustrations.apply_safe_zone_directive(
-        "A scene", safe_zone, slide_format="IMG+TXT",
-        slide_label="7 (Portrait slide)",
-    )
-    captured = capsys.readouterr()
-    assert "TITLE SAFE ZONE" not in result
-    assert result == "A scene"
-    assert "IMG+TXT" in captured.out
-    assert "Safe zone directive skipped" in captured.out
-    # Warning must identify the slide so the operator knows what to fix
-    assert "Slide 7" in captured.out
-    assert "Portrait slide" in captured.out
-
-
-def test_apply_safe_zone_unchanged_for_full_format(generate_illustrations):
-    # FULL slides still get the directive — the format-aware behavior is
-    # additive, not a regression on the default path
-    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
-    result = generate_illustrations.apply_safe_zone_directive(
-        "A scene", safe_zone, slide_format="FULL"
-    )
-    assert "TITLE SAFE ZONE" in result
-
-
-def test_apply_safe_zone_applied_for_unknown_format(generate_illustrations):
-    # Talk-specific formats (DIAGRAM, QUOTE, WIDE, etc.) fall through
-    # the FORMAT_SIZING FULL fallback (16:9) — the safe-zone directive
-    # should still apply. Matches apply-illustrations-to-deck.py treating
-    # Safe zone: presence as the title-overlay signal.
-    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
-    for fmt in ("WIDE", "DIAGRAM", "QUOTE"):
-        result = generate_illustrations.apply_safe_zone_directive(
-            "A scene", safe_zone, slide_format=fmt
-        )
-        assert "TITLE SAFE ZONE" in result, f"directive missing for {fmt}"
-
-
-def test_apply_safe_zone_strips_stale_directive_on_non_full(generate_illustrations, capsys):
-    # Regression: if a prompt already carries a TITLE SAFE ZONE block
-    # (e.g. from a prior FULL run, or a slide that was changed FULL →
-    # IMG+TXT mid-iteration), the non-FULL early-return path must still
-    # strip the stale directive — otherwise the prompt biases generation
-    # toward a 16:9 safe zone even though we're trying to skip it.
-    prompt_with_stale = (
-        "A scene "
-        "TITLE SAFE ZONE -- CRITICAL COMPOSITION RULE: Reserve the upper "
-        "third of the 16:9 frame as clean uninterrupted negative space..."
-    )
-    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
-    result = generate_illustrations.apply_safe_zone_directive(
-        prompt_with_stale, safe_zone, slide_format="IMG+TXT"
-    )
-    assert "TITLE SAFE ZONE" not in result
-    # The cleaned prompt should be only the leading content, no directive
-    assert result.startswith("A scene")
-    captured = capsys.readouterr()
-    assert "Safe zone directive skipped" in captured.out
-
-
-def test_apply_safe_zone_unchanged_when_format_omitted(generate_illustrations):
-    # Backward compatibility: callers that don't pass slide_format get
-    # the historical behavior (always apply when safe_zone present)
-    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
-    result = generate_illustrations.apply_safe_zone_directive("A scene", safe_zone)
-    assert "TITLE SAFE ZONE" in result
+def test_effective_slide_format_safe_zone_wins(generate_illustrations):
+    # apply-illustrations-to-deck.py gives Safe zone precedence over the
+    # Format token — slides with any Safe zone field are treated as
+    # FULL/title-overlay regardless of `Format: IMG+TXT` (see
+    # apply-illustrations-to-deck.py's `_imgtxt_slide_numbers` filter).
+    # The generator's effective_slide_format mirrors that precedence so
+    # sizing matches the downstream apply step.
+    sz = {"zone": "upper_third", "surface": "painted sky"}
+    assert generate_illustrations.effective_slide_format("IMG+TXT", sz) == "FULL"
+    assert generate_illustrations.effective_slide_format("FULL", sz) == "FULL"
+    assert generate_illustrations.effective_slide_format("DIAGRAM", sz) == "FULL"
+    # No safe zone → declared format flows through unchanged
+    assert generate_illustrations.effective_slide_format("IMG+TXT", None) == "IMG+TXT"
+    assert generate_illustrations.effective_slide_format("FULL", None) == "FULL"
+    assert generate_illustrations.effective_slide_format(None, None) is None
 
 
 # --- Model family dispatch ---

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -258,6 +258,28 @@ def test_apply_safe_zone_unchanged_for_full_format(generate_illustrations):
     assert "TITLE SAFE ZONE" in result
 
 
+def test_apply_safe_zone_strips_stale_directive_on_non_full(generate_illustrations, capsys):
+    # Regression: if a prompt already carries a TITLE SAFE ZONE block
+    # (e.g. from a prior FULL run, or a slide that was changed FULL →
+    # IMG+TXT mid-iteration), the non-FULL early-return path must still
+    # strip the stale directive — otherwise the prompt biases generation
+    # toward a 16:9 safe zone even though we're trying to skip it.
+    prompt_with_stale = (
+        "A scene "
+        "TITLE SAFE ZONE -- CRITICAL COMPOSITION RULE: Reserve the upper "
+        "third of the 16:9 frame as clean uninterrupted negative space..."
+    )
+    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
+    result = generate_illustrations.apply_safe_zone_directive(
+        prompt_with_stale, safe_zone, slide_format="IMG+TXT"
+    )
+    assert "TITLE SAFE ZONE" not in result
+    # The cleaned prompt should be only the leading content, no directive
+    assert result.startswith("A scene")
+    captured = capsys.readouterr()
+    assert "Safe zone directive skipped" in captured.out
+
+
 def test_apply_safe_zone_unchanged_when_format_omitted(generate_illustrations):
     # Backward compatibility: callers that don't pass slide_format get
     # the historical behavior (always apply when safe_zone present)

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -292,6 +292,23 @@ def test_load_secrets_env_fallback(generate_illustrations, tmp_path, monkeypatch
     assert keys["openai"] == "env-o"
 
 
+def test_load_secrets_malformed_json_warns(generate_illustrations, tmp_path, monkeypatch, capsys):
+    # Malformed secrets.json must not crash — load_secrets warns to stderr
+    # and falls through to env-var resolution
+    (tmp_path / "secrets.json").write_text("{not valid json")
+    monkeypatch.setenv("GEMINI_API_KEY", "env-fallback")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    keys, _ = generate_illustrations.load_secrets(str(tmp_path))
+    captured = capsys.readouterr()
+
+    assert keys["gemini"] == "env-fallback"
+    assert keys["openai"] is None
+    # Warning must mention the file path so the user knows what to fix
+    assert "secrets.json" in captured.err
+    assert "not valid JSON" in captured.err
+
+
 def test_load_secrets_partial_file(generate_illustrations, tmp_path, monkeypatch):
     # File has only gemini; openai should fall through to env
     (tmp_path / "secrets.json").write_text(json.dumps({"gemini": {"api_key": "g"}}))

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -236,7 +236,8 @@ def test_effective_slide_format_safe_zone_wins(generate_illustrations):
     # apply-illustrations-to-deck.py gives Safe zone precedence over the
     # Format token — slides with any Safe zone field are treated as
     # FULL/title-overlay regardless of `Format: IMG+TXT` (see
-    # apply-illustrations-to-deck.py's `_imgtxt_slide_numbers` filter).
+    # apply-illustrations-to-deck.py's `parse_img_txt_slides()`, which
+    # only returns IMG+TXT slides that do NOT carry a Safe zone line).
     # The generator's effective_slide_format mirrors that precedence so
     # sizing matches the downstream apply step.
     sz = {"zone": "upper_third", "surface": "painted sky"}

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -258,6 +258,19 @@ def test_apply_safe_zone_unchanged_for_full_format(generate_illustrations):
     assert "TITLE SAFE ZONE" in result
 
 
+def test_apply_safe_zone_applied_for_unknown_format(generate_illustrations):
+    # Talk-specific formats (DIAGRAM, QUOTE, WIDE, etc.) fall through
+    # the FORMAT_SIZING FULL fallback (16:9) — the safe-zone directive
+    # should still apply. Matches apply-illustrations-to-deck.py treating
+    # Safe zone: presence as the title-overlay signal.
+    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
+    for fmt in ("WIDE", "DIAGRAM", "QUOTE"):
+        result = generate_illustrations.apply_safe_zone_directive(
+            "A scene", safe_zone, slide_format=fmt
+        )
+        assert "TITLE SAFE ZONE" in result, f"directive missing for {fmt}"
+
+
 def test_apply_safe_zone_strips_stale_directive_on_non_full(generate_illustrations, capsys):
     # Regression: if a prompt already carries a TITLE SAFE ZONE block
     # (e.g. from a prior FULL run, or a slide that was changed FULL →

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -232,6 +232,40 @@ def test_apply_safe_zone_default_surface(generate_illustrations):
     assert "left half" in result
 
 
+def test_apply_safe_zone_skipped_for_non_full_format(generate_illustrations, capsys):
+    # Safe zone composition only makes sense for FULL-format slides
+    # (apply-illustrations-to-deck.py uses a fixed right-column layout
+    # for IMG+TXT and ignores Safe zone: lines on those slides). The
+    # generator must skip the directive on non-FULL formats and warn.
+    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
+    result = generate_illustrations.apply_safe_zone_directive(
+        "A scene", safe_zone, slide_format="IMG+TXT"
+    )
+    captured = capsys.readouterr()
+    assert "TITLE SAFE ZONE" not in result
+    assert result == "A scene"
+    assert "IMG+TXT" in captured.out
+    assert "Safe zone directive skipped" in captured.out
+
+
+def test_apply_safe_zone_unchanged_for_full_format(generate_illustrations):
+    # FULL slides still get the directive — the format-aware behavior is
+    # additive, not a regression on the default path
+    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
+    result = generate_illustrations.apply_safe_zone_directive(
+        "A scene", safe_zone, slide_format="FULL"
+    )
+    assert "TITLE SAFE ZONE" in result
+
+
+def test_apply_safe_zone_unchanged_when_format_omitted(generate_illustrations):
+    # Backward compatibility: callers that don't pass slide_format get
+    # the historical behavior (always apply when safe_zone present)
+    safe_zone = {"zone": "upper_third", "surface": "painted sky"}
+    result = generate_illustrations.apply_safe_zone_directive("A scene", safe_zone)
+    assert "TITLE SAFE ZONE" in result
+
+
 # --- Model family dispatch ---
 
 def test_model_family_openai(generate_illustrations):

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -304,6 +304,53 @@ def test_load_secrets_partial_file(generate_illustrations, tmp_path, monkeypatch
 
 # --- Multipart body for OpenAI edits ---
 
+def test_final_build_dest_preserves_extension(generate_illustrations, tmp_path):
+    builds_dir = str(tmp_path / "builds")
+    # Each base extension should propagate to the build dest path
+    assert generate_illustrations.final_build_dest(
+        builds_dir, 5, 3, "/tmp/slide-05.jpg"
+    ).endswith("slide-05-build-03.jpg")
+    assert generate_illustrations.final_build_dest(
+        builds_dir, 5, 3, "/tmp/slide-05.png"
+    ).endswith("slide-05-build-03.png")
+    assert generate_illustrations.final_build_dest(
+        builds_dir, 5, 3, "/tmp/slide-05.webp"
+    ).endswith("slide-05-build-03.webp")
+    # No extension on the source falls back to .jpg (matches the historic
+    # hard-coded default rather than producing a path without a suffix)
+    assert generate_illustrations.final_build_dest(
+        builds_dir, 5, 3, "/tmp/slide-05"
+    ).endswith("slide-05-build-03.jpg")
+
+
+def test_parse_builds_empty_step_list(generate_illustrations):
+    # An outline that declares `- Builds: N steps` without any parsable
+    # `build-XX:` entries must not crash the parser, and the resulting
+    # `steps` list must be empty so run_build's empty-guard fires.
+    import tempfile
+    outline = """\
+# Plan
+**Model:** `gemini-3-pro-image-preview`
+
+### STYLE ANCHOR (WIDE — 16:9, 1920x1080)
+> A style.
+
+### Slide 4: Empty builds
+- Format: **WIDE**
+- Image prompt: `[STYLE ANCHOR] something`
+- Builds: 5 steps
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(outline)
+        f.flush()
+        result = generate_illustrations.parse_outline(f.name)
+    os.unlink(f.name)
+
+    slide4 = next(s for s in result["slides"] if s["slide_num"] == 4)
+    assert slide4["builds"]["count"] == 5
+    assert slide4["builds"]["steps"] == []
+
+
 def test_multipart_body_structure(generate_illustrations):
     body, boundary = generate_illustrations._multipart_body(
         fields={"model": "gpt-image-2", "prompt": "edit this", "n": "1"},

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -239,13 +239,17 @@ def test_apply_safe_zone_skipped_for_non_full_format(generate_illustrations, cap
     # generator must skip the directive on non-FULL formats and warn.
     safe_zone = {"zone": "upper_third", "surface": "painted sky"}
     result = generate_illustrations.apply_safe_zone_directive(
-        "A scene", safe_zone, slide_format="IMG+TXT"
+        "A scene", safe_zone, slide_format="IMG+TXT",
+        slide_label="7 (Portrait slide)",
     )
     captured = capsys.readouterr()
     assert "TITLE SAFE ZONE" not in result
     assert result == "A scene"
     assert "IMG+TXT" in captured.out
     assert "Safe zone directive skipped" in captured.out
+    # Warning must identify the slide so the operator knows what to fix
+    assert "Slide 7" in captured.out
+    assert "Portrait slide" in captured.out
 
 
 def test_apply_safe_zone_unchanged_for_full_format(generate_illustrations):

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -1,5 +1,6 @@
 """Tests for generate-illustrations.py — outline parsing and slide selection (no API calls)."""
 
+import json
 import os
 
 SAMPLE_OUTLINE = """\
@@ -229,3 +230,95 @@ def test_apply_safe_zone_default_surface(generate_illustrations):
     result = generate_illustrations.apply_safe_zone_directive("A scene", safe_zone)
     assert "TITLE SAFE ZONE" in result
     assert "left half" in result
+
+
+# --- Model family dispatch ---
+
+def test_model_family_openai(generate_illustrations):
+    assert generate_illustrations.model_family("gpt-image-2") == "openai"
+    assert generate_illustrations.model_family("gpt-image-1") == "openai"
+
+
+def test_model_family_imagen(generate_illustrations):
+    assert generate_illustrations.model_family("imagen-4.0-ultra-generate-001") == "imagen"
+    assert generate_illustrations.model_family("imagen-3.0-generate-002") == "imagen"
+
+
+def test_model_family_gemini_default(generate_illustrations):
+    assert generate_illustrations.model_family("gemini-3-pro-image-preview") == "gemini"
+    assert generate_illustrations.model_family("gemini-3.1-flash-image-preview") == "gemini"
+    assert generate_illustrations.model_family("nano-banana-pro-preview") == "gemini"
+    assert generate_illustrations.model_family("some-unknown-model") == "gemini"
+
+
+def test_family_key_name(generate_illustrations):
+    # Gemini and Imagen both authenticate with the Google AI Studio key
+    assert generate_illustrations.family_key_name("gemini") == "gemini"
+    assert generate_illustrations.family_key_name("imagen") == "gemini"
+    assert generate_illustrations.family_key_name("openai") == "openai"
+
+
+def test_compare_models_curated_list(generate_illustrations):
+    # The freshness check in SKILL.md Step 2 tracks this list — it must
+    # contain at least one current-flagship entry per major vendor
+    families = {generate_illustrations.model_family(m)
+                for m in generate_illustrations.COMPARE_MODELS}
+    assert "openai" in families, "COMPARE_MODELS missing OpenAI entry"
+    assert "gemini" in families, "COMPARE_MODELS missing Gemini entry"
+    assert "imagen" in families, "COMPARE_MODELS missing Imagen entry"
+
+
+# --- Secrets loading ---
+
+def test_load_secrets_from_file(generate_illustrations, tmp_path, monkeypatch):
+    secrets = {"gemini": {"api_key": "g-key"}, "openai": {"api_key": "o-key"}}
+    (tmp_path / "secrets.json").write_text(json.dumps(secrets))
+    # Block env-var fallback so we're testing file resolution
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    keys, path = generate_illustrations.load_secrets(str(tmp_path))
+    assert keys["gemini"] == "g-key"
+    assert keys["openai"] == "o-key"
+    assert path == str(tmp_path / "secrets.json")
+
+
+def test_load_secrets_env_fallback(generate_illustrations, tmp_path, monkeypatch):
+    # No secrets.json file in this vault
+    monkeypatch.setenv("GEMINI_API_KEY", "env-g")
+    monkeypatch.setenv("OPENAI_API_KEY", "env-o")
+    keys, _ = generate_illustrations.load_secrets(str(tmp_path))
+    assert keys["gemini"] == "env-g"
+    assert keys["openai"] == "env-o"
+
+
+def test_load_secrets_partial_file(generate_illustrations, tmp_path, monkeypatch):
+    # File has only gemini; openai should fall through to env
+    (tmp_path / "secrets.json").write_text(json.dumps({"gemini": {"api_key": "g"}}))
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "env-o")
+    keys, _ = generate_illustrations.load_secrets(str(tmp_path))
+    assert keys["gemini"] == "g"
+    assert keys["openai"] == "env-o"
+
+
+# --- Multipart body for OpenAI edits ---
+
+def test_multipart_body_structure(generate_illustrations):
+    body, boundary = generate_illustrations._multipart_body(
+        fields={"model": "gpt-image-2", "prompt": "edit this", "n": "1"},
+        files=[("image", "input.png", "image/png", b"\x89PNG\r\n")],
+    )
+    assert boundary.startswith("----GenIllustBnd")
+    text = body.decode("utf-8", errors="replace")
+    # Every field present with form-data disposition
+    assert 'name="model"' in text
+    assert "gpt-image-2" in text
+    assert 'name="prompt"' in text
+    assert "edit this" in text
+    # File field carries filename + content-type
+    assert 'name="image"' in text
+    assert 'filename="input.png"' in text
+    assert "Content-Type: image/png" in text
+    # Body terminates with the closing boundary
+    assert body.endswith(f"--{boundary}--\r\n".encode())

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -321,6 +321,63 @@ def test_load_secrets_partial_file(generate_illustrations, tmp_path, monkeypatch
 
 # --- Multipart body for OpenAI edits ---
 
+def test_parse_outline_handles_img_plus_txt_format(generate_illustrations):
+    # Outline using the documented `IMG+TXT` portrait format must parse
+    # the `+` character — the original `\w+` regex silently dropped it.
+    # Mismatched parsing would route non-16:9 slides through the FULL
+    # sizing default in the cross-vendor dispatchers.
+    import tempfile
+    outline = """\
+# Plan
+**Model:** `gpt-image-2`
+
+### STYLE ANCHOR (FULL — 16:9, 1920x1080)
+> A FULL anchor.
+
+### STYLE ANCHOR (IMG+TXT — Portrait 2:3, 1024x1536)
+> An IMG+TXT anchor.
+
+### Slide 3: A wide slide
+- Format: **FULL**
+- Image prompt: `[STYLE ANCHOR] something wide`
+
+### Slide 7: A portrait slide
+- Format: **IMG+TXT**
+- Image prompt: `[STYLE ANCHOR] something tall`
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(outline)
+        f.flush()
+        result = generate_illustrations.parse_outline(f.name)
+    os.unlink(f.name)
+
+    assert "FULL" in result["anchors"]
+    assert "IMG+TXT" in result["anchors"]
+
+    slide3 = next(s for s in result["slides"] if s["slide_num"] == 3)
+    slide7 = next(s for s in result["slides"] if s["slide_num"] == 7)
+    assert slide3["format"] == "FULL"
+    assert slide7["format"] == "IMG+TXT"
+
+
+def test_sizing_for_format(generate_illustrations):
+    # FULL maps to 16:9 landscape on both vendors
+    full = generate_illustrations.sizing_for("FULL")
+    assert full["openai_size"] == "2048x1152"
+    assert full["imagen_aspect"] == "16:9"
+
+    # IMG+TXT maps to 2:3 portrait (Imagen has no native 2:3, 3:4 is
+    # closest of the supported aspect ratios)
+    portrait = generate_illustrations.sizing_for("IMG+TXT")
+    assert portrait["openai_size"] == "1024x1536"
+    assert portrait["imagen_aspect"] == "3:4"
+
+    # Unknown / missing falls back to FULL — historical default
+    assert generate_illustrations.sizing_for(None) == full
+    assert generate_illustrations.sizing_for("DIAGRAM") == full
+    assert generate_illustrations.sizing_for("") == full
+
+
 def test_final_build_dest_preserves_extension(generate_illustrations, tmp_path):
     builds_dir = str(tmp_path / "builds")
     # Each base extension should propagate to the build dest path

--- a/tile.json
+++ b/tile.json
@@ -46,6 +46,9 @@
     },
     "interaction-rules": {
       "rules": "rules/interaction-rules.md"
+    },
+    "tessl-version-floating": {
+      "rules": "rules/tessl-version-floating.md"
     }
   },
   "keywords": [

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/speaker-toolkit",
-  "version": "0.17.17",
+  "version": "0.18.0",
   "summary": "Five-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, and produce the deck illustrations + thumbnail visual layer. Includes a 102-entry Presentation Patterns taxonomy (91 observable, 11 unobservable go-live items) for scoring, brainstorming, and go-live preparation.",
   "description": "A speaker-neutral toolkit with five focused skills connected by a shared vault. Three vault skills handle the analysis pipeline: vault-ingress parses recorded talks to extract rhetoric patterns and score against the 91 observable entries of a 102-entry taxonomy; vault-clarification runs interactive sessions to validate findings and capture speaker intent; vault-profile generates a structured speaker profile. The presentation-creator skill reads that vault at runtime to help build new presentations that match the speaker's documented style, with a 4-tier Pattern Strategy for technique selection and a go-live checklist for delivery preparation. The illustrations skill owns the visual layer — deck illustration strategy, generation, build chains, and YouTube thumbnails — invoked by presentation-creator at the relevant phases. Any speaker can use all skills — all personalization lives in the vault data, not in the skill definitions.",
   "private": false,


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- **New SKILL.md Step 2 — Check Image-Model Freshness.** Before Strategy comparison or deck Generation touches images, web-searches the current flagship image-generation models from major vendors and surfaces gaps against `COMPARE_MODELS` and (in Generation mode) the outline's baked `**Model:**` + selection date. Proposes either updating `COMPARE_MODELS` or re-running `--compare` if a newer flagship has shipped. Closes the months-long gap between picking a model in Phase 2 and actually generating images in Phase 5. Step numbers in SKILL.md and the four reference files shift accordingly (Strategy → 3, Generation → 4, Builds → 5, Apply → 6, Thumbnail → 7).
- **Cross-vendor image generation.** `generate-illustrations.py` no longer Gemini-only. Dispatches by model-name prefix to three vendor families: `gemini-*` / `nano-banana-*` (Google `generateContent`), `imagen-*` (Google `:predict`), `gpt-image-*` (OpenAI `/images/generations` + multipart `/images/edits`). API-key resolution gains an `openai` slot; secrets.json reads both `gemini.api_key` and `openai.api_key` with per-vendor missing-key messages. `COMPARE_MODELS` refreshed to current flagships across vendors (now includes `gpt-image-2`, `imagen-4.0-ultra-generate-001`, `gemini-3.1-flash-image-preview`, `nano-banana-pro-preview`). Imagen has no public edit endpoint → `--edit`/`--build`/`--fix` return an actionable error.
- **Deps.** `jbaruch/coding-policy` floats to `@latest` per the runtime-managed-manifest carve-out in `rules/dependency-management.md` (`tessl update` rewrites `tessl.json` in-place and `.tessl/tiles/` is gitignored, so pinning produces silent drift).
- **CI fix — paired-reviewer lock files recompiled.** Both `.github/workflows/review-anthropic.lock.yml` and `.github/workflows/review-openai.lock.yml` pinned `awf v0.25.28`, which was yanked from `github/gh-aw-firewall` releases (latest is `v0.25.43`; `v0.25.28` returns 404). Every gh-aw run on this PR crashed at the "Install AWF binary" step before reading the diff. Recompiled via `gh aw compile` so both lock files now pull `awf v0.25.40`. Per `rules/ci-safety.md`, an unplanned CI edit was bundled here because the gh-aw gate is mandatory for merge and the failure was upstream-infrastructure-only (no policy concern about the diff itself).
- **Pre-existing bug fixes (Boy Scout).** Two issues in `run_build` flagged by Copilot review: (1) `max(s["step"] for s in steps)` crashed when an outline declared `- Builds: N steps` without parsable `build-NN:` entries — now guards the empty case and skips with a clear message; (2) the final-build copy hard-coded `.jpg` even when the base image was `.png` / `.webp` (and OpenAI generation always produces `.png`) — now preserves the source extension via a new `final_build_dest()` helper. Two new tests cover each fix.

## Test plan

- [x] 11 new pytest cases cover `model_family` classification across vendors, `family_key_name`, `COMPARE_MODELS` vendor coverage, `load_secrets` from file / env / partial-fallback, OpenAI multipart body structure, `final_build_dest` extension preservation, and the empty-steps parse path
- [x] Full illustration test suite (48 cases across `test_generate_illustrations.py` + `test_apply_illustrations.py`) green
- [x] Broader suite (188 cases) green minus 2 pre-existing missing-dependency files (`numpy`, `imagehash`/`Pillow`) untouched by this PR
- [x] Script imports clean; `model_family` smoke-tested against `gpt-image-2`, `imagen-4.0-ultra-generate-001`, `gemini-3-pro-image-preview`, `nano-banana-pro-preview`
- [x] gh-aw lock files recompiled cleanly (`gh aw compile`: 0 errors, 0 warnings); awf version bumped 0.25.28 → 0.25.40
- [ ] Manual: run `--compare` on a real outline to confirm cross-vendor dispatch hits all three endpoints (deferred to a follow-up with a live API key — verified shape against working reference scripts in the talk dir)