### PR TITLE
ci(publish-tile): migrate to changed-skills review loop

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Required by the skill-review composite action below: it
+          # diffs against `github.event.before` to detect changed
+          # skills, which needs full history reachable.
+          fetch-depth: 0
       - name: Enforce tessl-version-floating carve-out
         # See rules/tessl-version-floating.md. The
         # `jbaruch/coding-policy: dependency-management`
@@ -30,11 +35,16 @@ jobs:
       - uses: tesslio/setup-tessl@v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
-      - run: tessl skill review --threshold 85 skills/vault-ingress
-      - run: tessl skill review --threshold 85 skills/vault-clarification
-      - run: tessl skill review --threshold 85 skills/vault-profile
-      - run: tessl skill review --threshold 85 skills/presentation-creator
-      - run: tessl skill review --threshold 85 skills/illustrations
+      - name: Review changed skills only
+        # Per `jbaruch/coding-policy: context-artifacts` "Mandatory
+        # Review" (changed-skills-loop clause): tessl skill review is
+        # LLM-backed and credit-consuming; re-running against
+        # unchanged content reproduces the prior rubric output. The
+        # composite action iterates over skills whose files changed
+        # since `github.event.before`. On workflow_dispatch or initial
+        # push it falls back to reviewing every skill; on an
+        # unreachable base it hard-fails (no silent skip).
+        uses: jbaruch/coding-policy/.github/actions/skill-review@2a9df6575e153ce0d98900fdae26384c06df478f # main @ 2026-05-13
       - name: Run eval suite before publish
         # `jbaruch/coding-policy: plugin-evals` requires evals to run
         # on every publish (and on a recurring cadence — see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+### ci — migrate `tessl skill review` to changed-skills loop
+
+`publish-tile.yml` previously ran one static `tessl skill review` step per
+skill on every push to `main` (5 invocations per merge). After
+`jbaruch/coding-policy` 0.3.20 codified the changed-skills-loop pattern
+in `rules/context-artifacts.md`, those static steps became a policy
+violation — and a real cost: `tessl skill review` is LLM-backed, so
+re-reviewing unchanged content burns Tessl credits while reproducing the
+prior rubric output.
+
+This release replaces the 5 static steps with one `uses:` of the
+reference composite action shipped at
+`jbaruch/coding-policy/.github/actions/skill-review`, pinned to SHA
+`2a9df6575e153ce0d98900fdae26384c06df478f`. The action:
+
+- diffs `github.event.before..HEAD -- skills/` to identify changed skills
+- reviews only those skills at the configured threshold (85, unchanged)
+- falls back to reviewing every skill on `workflow_dispatch` or initial
+  push (no usable base)
+- hard-fails when the base SHA is set but unreachable in the clone, so
+  a missing review can never silently degrade to "review skipped"
+
+`actions/checkout@v4` gains `fetch-depth: 0` per the composite action's
+documented requirement (it needs the prior-push commit reachable).
+
+Steady-state effect: PRs that don't touch `skills/` cost zero skill-review
+invocations at merge; PRs that touch one skill cost one. Multi-skill PRs
+scale linearly with what they actually changed.
+
 ## 0.18.0
 
 ### deps — formalize tessl-version-floating carve-out


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

`jbaruch/coding-policy` 0.3.20 codified the changed-skills-loop pattern in `rules/context-artifacts.md` "Mandatory Review" — `tessl skill review` must be wired as a diff-driven loop, not as static per-skill steps, because the reviewer is LLM-backed and credit-consuming. Re-running it against unchanged content reproduces the prior rubric output.

This PR replaces the 5 static `tessl skill review` steps in `publish-tile.yml` with one `uses:` of the reference composite action shipped at `jbaruch/coding-policy/.github/actions/skill-review`, pinned to SHA `2a9df6575e153ce0d98900fdae26384c06df478f`.

- Adds `fetch-depth: 0` on `actions/checkout@v4` per the action's documented requirement (it diffs `github.event.before..HEAD`, needs full history reachable)
- Pins the composite action to a SHA per `jbaruch/coding-policy: dependency-management`
- CHANGELOG entry under `## Unreleased` documents the migration

## Why a CI-scope PR

CI changes are forbidden in non-CI-scope PRs by `jbaruch/coding-policy: ci-safety` "Hands Off CI Config". This PR's title and body explicitly scope the work as a CI change, making the PR itself the approval artifact.

## Behavior matrix after migration

| Trigger | Action behavior |
|---|---|
| Push to main with no skills/ changes | Reviews 0 skills, exits clean |
| Push to main with N skills/ changes | Reviews exactly N skills |
| workflow_dispatch / initial push (no base) | Reviews every skill (full re-review fallback) |
| Base SHA unreachable in clone | Hard-fails (no silent skip) |

## Sequencing

Merge this before #42 (eval prune). #42 touches no skills, so once this is in, #42's publish run will perform zero `tessl skill review` invocations — only `tessl eval run .` + `patch-version-publish`.

## Test plan

- [ ] CI green: `tests.yml`, `PR Policy Review (OpenAI)` (cross-family per author-model-declaration)
- [ ] After merge, watch the publish run and confirm the skill-review step prints "Reviewing 0 skill(s)" or "No skill changes — review skipped" (this PR doesn't touch `skills/`)
- [ ] Confirm `tessl eval run .` still fires and `tesslio/patch-version-publish` advances the registry past 0.18.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)