### PR TITLE
fix(shownotes-publisher): remove XML-tag-looking placeholders from description

### DIFF
--- a/skills/shownotes-publisher/SKILL.md
+++ b/skills/shownotes-publisher/SKILL.md
@@ -2,17 +2,18 @@
 name: shownotes-publisher
 description: >
   Publish a talk page to the Jekyll-based shownotes site (e.g.,
-  speaking.jbaru.ch). Composes the `_talks/<file>.md` markdown so the
-  custom Jekyll parser plugin extracts the right fields, the talk.html
-  layout renders correctly, and the "Video Coming Soon" badge fires
-  when the recording isn't ready yet. Use when the user says "publish
-  shownotes", "create shownotes page", "add talk to shownotes",
-  "shownotes for <talk>", "shownotes site", "speaking.jbaru.ch", or
-  asks to update a talk page (e.g., "add the video to the shownotes",
-  "the video is out", "update shownotes with the recording"). Also
-  trigger for first-time publishing before a talk is delivered, when
-  only the slides URL exists. The Jekyll site at `~/Projects/shownotes`
-  uses a custom markdown parser (`_plugins/markdown_parser.rb`) that
+  speaking.jbaru.ch). Composes a markdown file in the site's
+  `_talks/` collection so the custom Jekyll parser plugin extracts
+  the right fields, the talk.html layout renders correctly, and the
+  "Video Coming Soon" badge fires when the recording isn't ready
+  yet. Use when the user says "publish shownotes", "create shownotes
+  page", "add talk to shownotes", "shownotes for [some talk]",
+  "shownotes site", "speaking.jbaru.ch", or asks to update a talk
+  page (e.g., "add the video to the shownotes", "the video is out",
+  "update shownotes with the recording"). Also trigger for
+  first-time publishing before a talk is delivered, when only the
+  slides URL exists. The Jekyll site at `~/Projects/shownotes` uses
+  a custom markdown parser (`_plugins/markdown_parser.rb`) that
   imposes specific format rules — this skill encodes those rules so
   the agent doesn't author content that silently fails to render.
 user-invocable: true


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- Post-merge follow-up to PR #47. The publish pipeline on the #47
  merge commit (`9fc35d2`) failed `tessl skill review` with
  `description_field - 'description' must not contain XML tags`,
  blocking publish at registry version 0.18.4.
- The blocker is the shownotes-publisher description containing
  `_talks/<file>.md` and `"shownotes for <talk>"` — angle-bracket
  placeholders the validator heuristically reads as XML tags.
- Rewrite the description without angle-bracket placeholders:
  prose for the path (`a markdown file in the site's _talks/
  collection`) and square brackets for the trigger phrase
  (`"shownotes for [some talk]"`).

## Test plan

- [ ] `pytest -q` shows the prior 301+ test count, no regressions
- [ ] `./scripts/check-tessl-pins.sh` passes
- [ ] After merge, the publish workflow run on this merge commit
      hits `conclusion: success` AND
      `tessl tile info jbaruch/speaker-toolkit` shows the registry
      `Latest Version` advancing past `0.18.4`
- [ ] `grep -nE '<[a-z]+>' skills/shownotes-publisher/SKILL.md`
      returns no matches inside the frontmatter description