### PR TITLE
fix(shownotes-publisher): replace bare [link](url) example placeholder

### DIFF
--- a/skills/shownotes-publisher/references/common-mistakes.md
+++ b/skills/shownotes-publisher/references/common-mistakes.md
@@ -193,7 +193,7 @@ the frontmatter title field.
 ```markdown
 ## Resources
 
-- [link](url)
+- [link](https://example.org)
 
 ## Abstract
 
@@ -208,7 +208,7 @@ Resources scanner finds `## Resources` and captures everything
 after it — including the `## Abstract` line and its body. So:
 
 - `extracted_abstract` = "Prose." ✓ (this works)
-- `extracted_resources` = "- [link](url) ## Abstract Prose." ✗
+- `extracted_resources` = "- [link](https://example.org) ## Abstract Prose." ✗
   (Abstract content is folded into Resources)
 
 **Do:** Order sections Abstract first, Resources last. Parser


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- Fourth post-#47 follow-up. PR #50's merge (`a2b944a`) cleared
  the reference-path issue but `tessl publish` failed with
  `Missing tile content: File not found:
  skills/shownotes-publisher/references/url` because the
  publisher's link validator inspected entry 6's fenced markdown
  code block in `references/common-mistakes.md` and tried to
  resolve the literal `[link](url)` placeholder as a real
  filesystem link.
- Replace the `url` placeholder with `https://example.org` so the
  validator sees an absolute URL (which it doesn't try to fetch)
  while the example still reads as obviously synthetic.

## Test plan

- [ ] After merge, the publish workflow run on this merge commit
      hits `conclusion: success` AND
      `tessl tile info jbaruch/speaker-toolkit` shows the registry
      `Latest Version` advancing past `0.18.4`
- [ ] `grep -n ']( *url *)' skills/shownotes-publisher/` returns no
      matches in fenced code blocks (backtick-quoted instances of
      `[text](url)` in prose remain — they're inline literals)