### PR TITLE
docs(changelog): release Unreleased section as 0.18.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.18.7 — 2026-06-03
 
 ### feat(illustrations) — structured style selection + model registry
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- `## Unreleased` on main held 7 entries that are all **already published** — auto-publish (`patch-version-publish`) bumps the tile version on every merge (`tile.json` is at 0.18.7) but never consolidates the CHANGELOG, and the manual Unreleased→version step hadn't run since 0.18.0.
- Result: "what's new" showed shipped work (structured style selection + model registry, shownotes-publisher, outline.yaml source-of-truth, the eval/CI changes) as unreleased.
- Fix: promote the section to `## 0.18.7 — 2026-06-03`. No `Unreleased` holding section — in an auto-publish-on-merge model nothing on main is ever genuinely unreleased.

## Test plan
- [ ] CHANGELOG-only doc change; no code/tests affected.
- [ ] Note: repo CI appears stalled (no Actions runs created repo-wide since ~22:26 UTC 2026-06-02; suspected account Actions usage limit) — this PR can't merge until that clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)