### PR TITLE
ci(publish): auto-stamp the CHANGELOG version on publish (kill the Unreleased bucket)

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -45,6 +45,20 @@ jobs:
         # push it falls back to reviewing every skill; on an
         # unreachable base it hard-fails (no silent skip).
         uses: jbaruch/coding-policy/.github/actions/skill-review@2a9df6575e153ce0d98900fdae26384c06df478f # main @ 2026-05-13
+      - name: Stamp CHANGELOG with the version being published
+        # Publish-on-merge has no "Unreleased" bucket: PR authors add un-headed
+        # `### ` entries at the top of CHANGELOG.md. This stamps them with the
+        # version patch-version-publish is about to assign (same registry-latest
+        # +1 computation), so the published artifact and registry "what's new"
+        # show them under their real version. Commit only, no push — the publish
+        # step's own commit/push carries this commit along. [skip ci] guards the
+        # bump commits from re-triggering this workflow.
+        run: |
+          python3 scripts/stamp-changelog.py
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || git commit -m "Stamp CHANGELOG for the published version [skip ci]"
       # No explicit `tessl eval run .` step here: per
       # `jbaruch/coding-policy: plugin-evals` (Persistence), the
       # Tessl-publish layer owns persistence execution — the eval

--- a/scripts/stamp-changelog.py
+++ b/scripts/stamp-changelog.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Stamp the CHANGELOG's newest (un-headed) entries with the version being published.
+
+Run by the publish pipeline (`.github/workflows/publish-tile.yml`) immediately
+before `tesslio/patch-version-publish`. In a publish-on-merge model there is no
+"Unreleased" bucket: PR authors add `### ...` entry blocks at the TOP of
+`CHANGELOG.md` (below the `# Changelog` H1) with NO version heading. This script
+computes the version the publish step will assign and inserts a
+`## <version> — <date>` heading above those un-headed entries, so the published
+artifact (and the registry "what's new") shows them under their real version.
+
+Version computation MIRRORS `tesslio/patch-version-publish`: take the registry's
+latest published version and bump the patch, unless the local manifest is already
+ahead (a manual bump), in which case use the manifest version as-is. Keeping the
+two in lockstep is what makes the stamped heading match the published version.
+
+Idempotent: if the top section already carries a `## ` heading (nothing un-headed
+to stamp), it is a no-op.
+
+Usage:
+    stamp-changelog.py [--changelog CHANGELOG.md] [--manifest PATH]
+                       [--latest X.Y.Z] [--date YYYY-MM-DD]
+
+    --latest  skip the registry query and use this as the latest published
+              version (for testing / manual runs). Omit in CI to query the
+              registry via `tessl tile info`.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_H2_RE = re.compile(r"^## ")
+_ENTRY_RE = re.compile(r"^### ")
+
+
+def compute_version(local: str, latest: str | None) -> str:
+    """Return the version the publish step will assign.
+
+    Mirrors tesslio/patch-version-publish: first publish (no registry version)
+    uses the manifest version as-is; otherwise bump the registry latest's patch,
+    unless the manifest is already ahead.
+    """
+    for label, val in (("local", local), ("latest", latest)):
+        if val is not None and not _VERSION_RE.match(val):
+            raise ValueError(f"{label} version must be X.Y.Z, got {val!r}")
+    if latest is None:
+        return local
+    lp = [int(x) for x in local.split(".")]
+    rp = [int(x) for x in latest.split(".")]
+    local_num = lp[0] * 1_000_000 + lp[1] * 1_000 + lp[2]
+    latest_num = rp[0] * 1_000_000 + rp[1] * 1_000 + rp[2]
+    if local_num > latest_num:
+        return local
+    return f"{rp[0]}.{rp[1]}.{rp[2] + 1}"
+
+
+def stamp_changelog(text: str, version: str, date: str) -> tuple[str, bool]:
+    """Insert `## <version> — <date>` above the topmost un-headed `### ` entries.
+
+    Un-headed entries are `### ` blocks that appear before the first `## ` heading.
+    Returns (new_text, changed). No-op (changed=False) when the top section is
+    already under a `## ` heading.
+    """
+    lines = text.splitlines()
+    first_h2 = next((i for i, ln in enumerate(lines) if _H2_RE.match(ln)), None)
+    first_entry = next((i for i, ln in enumerate(lines) if _ENTRY_RE.match(ln)), None)
+
+    if first_entry is None:
+        return text, False
+    if first_h2 is not None and first_h2 < first_entry:
+        return text, False  # newest entries already sit under a version heading
+
+    heading = f"## {version} — {date}"
+    new_lines = lines[:first_entry] + [heading, ""] + lines[first_entry:]
+    new_text = "\n".join(new_lines)
+    if text.endswith("\n"):
+        new_text += "\n"
+    return new_text, True
+
+
+def query_latest_version(tile_name: str) -> str | None:
+    """Return the registry's latest published version, or None on first publish.
+
+    Mirrors patch-version-publish's handling: a 404 means the tile has never been
+    published; any other failure is surfaced so auth/network issues are not masked.
+    """
+    proc = subprocess.run(
+        ["tessl", "tile", "info", tile_name],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        if "404" in (proc.stdout + proc.stderr):
+            return None
+        raise RuntimeError(
+            f"`tessl tile info {tile_name}` failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    for line in proc.stdout.splitlines():
+        if "Latest Version" in line:
+            return line.split()[-1]
+    raise RuntimeError(
+        f"Could not find 'Latest Version' in `tessl tile info {tile_name}` output"
+    )
+
+
+def _read_manifest(manifest: Path | None) -> tuple[str, str]:
+    if manifest is None:
+        plugin = Path(".tessl-plugin/plugin.json")
+        manifest = plugin if plugin.is_file() else Path("tile.json")
+    data = json.loads(manifest.read_text())
+    name, version = data.get("name"), data.get("version")
+    if not name or not version:
+        raise SystemExit(f"{manifest} is missing a .name or .version field")
+    return name, version
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    ap.add_argument("--manifest", type=Path, default=None,
+                    help="Manifest path (default: .tessl-plugin/plugin.json, then tile.json)")
+    ap.add_argument("--latest", default=None,
+                    help="Latest published version (skip the registry query)")
+    ap.add_argument("--date", default=None, help="Heading date (default: today, UTC)")
+    args = ap.parse_args()
+
+    name, local = _read_manifest(args.manifest)
+    latest = args.latest if args.latest is not None else query_latest_version(name)
+    version = compute_version(local, latest)
+    date = args.date or datetime.now(timezone.utc).date().isoformat()
+
+    text = args.changelog.read_text()
+    new_text, changed = stamp_changelog(text, version, date)
+    if changed:
+        args.changelog.write_text(new_text)
+        print(f"Stamped {args.changelog} top entries as ## {version} — {date}")
+    else:
+        print(f"No un-headed entries to stamp in {args.changelog} (no-op)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ SCRIPTS_ILL = os.path.join(
     os.path.dirname(__file__), os.pardir,
     "skills", "illustrations", "scripts",
 )
+SCRIPTS_ROOT = os.path.join(os.path.dirname(__file__), os.pardir, "scripts")
 
 
 def _import_script(path, name):
@@ -55,6 +56,11 @@ def _import_script(path, name):
 @pytest.fixture(scope="session")
 def strip_template():
     return _import_script(os.path.join(SCRIPTS_PC, "strip-template.py"), "strip_template")
+
+
+@pytest.fixture(scope="session")
+def stamp_changelog():
+    return _import_script(os.path.join(SCRIPTS_ROOT, "stamp-changelog.py"), "stamp_changelog")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_stamp_changelog.py
+++ b/tests/test_stamp_changelog.py
@@ -1,0 +1,91 @@
+"""Tests for stamp-changelog.py — version computation and CHANGELOG stamping."""
+
+import pytest
+
+
+# ── compute_version: mirrors tesslio/patch-version-publish ──────────────
+
+
+def test_compute_version_first_publish_uses_local(stamp_changelog):
+    assert stamp_changelog.compute_version("0.1.0", None) == "0.1.0"
+
+
+def test_compute_version_bumps_registry_patch(stamp_changelog):
+    assert stamp_changelog.compute_version("0.18.7", "0.18.7") == "0.18.8"
+
+
+def test_compute_version_bumps_registry_when_local_behind(stamp_changelog):
+    # Local manifest stale vs registry — still bump the registry patch.
+    assert stamp_changelog.compute_version("0.18.0", "0.18.7") == "0.18.8"
+
+
+def test_compute_version_respects_manual_ahead_bump(stamp_changelog):
+    # Local manifest deliberately ahead of registry — publish as-is.
+    assert stamp_changelog.compute_version("0.19.0", "0.18.7") == "0.19.0"
+
+
+def test_compute_version_rejects_malformed(stamp_changelog):
+    with pytest.raises(ValueError):
+        stamp_changelog.compute_version("0.18", "0.18.7")
+    with pytest.raises(ValueError):
+        stamp_changelog.compute_version("0.18.7", "vNext")
+
+
+# ── stamp_changelog: insert heading above un-headed entries ─────────────
+
+
+_UNHEADED = """\
+# Changelog
+
+### feat(x) — new thing
+
+Body of x.
+
+### fix(y) — a bug
+
+## 0.18.7 — 2026-06-03
+
+### feat(prior) — already released
+"""
+
+
+def test_stamp_inserts_heading_above_unheaded_entries(stamp_changelog):
+    out, changed = stamp_changelog.stamp_changelog(_UNHEADED, "0.18.8", "2026-06-04")
+    assert changed is True
+    lines = out.splitlines()
+    # Heading inserted directly above the first un-headed entry…
+    h_idx = lines.index("## 0.18.8 — 2026-06-04")
+    assert lines[h_idx + 2] == "### feat(x) — new thing"
+    # …and above the prior released section, which is left intact.
+    assert lines.index("## 0.18.8 — 2026-06-04") < lines.index("## 0.18.7 — 2026-06-03")
+    assert "### feat(prior) — already released" in out
+
+
+def test_stamp_is_noop_when_top_already_headed(stamp_changelog):
+    already = (
+        "# Changelog\n\n## 0.18.7 — 2026-06-03\n\n### feat(x) — released\n"
+    )
+    out, changed = stamp_changelog.stamp_changelog(already, "0.18.8", "2026-06-04")
+    assert changed is False
+    assert out == already
+
+
+def test_stamp_is_noop_when_no_entries(stamp_changelog):
+    empty = "# Changelog\n"
+    out, changed = stamp_changelog.stamp_changelog(empty, "0.18.8", "2026-06-04")
+    assert changed is False
+    assert out == empty
+
+
+def test_stamp_preserves_trailing_newline(stamp_changelog):
+    out, changed = stamp_changelog.stamp_changelog(_UNHEADED, "0.18.8", "2026-06-04")
+    assert changed is True
+    assert out.endswith("\n")
+
+
+def test_stamp_idempotent(stamp_changelog):
+    once, _ = stamp_changelog.stamp_changelog(_UNHEADED, "0.18.8", "2026-06-04")
+    twice, changed = stamp_changelog.stamp_changelog(once, "0.18.9", "2026-06-05")
+    # Second run sees the heading already on top — no double stamp.
+    assert changed is False
+    assert twice == once


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
This is a **CI change** (touches `.github/workflows/publish-tile.yml`). In publish-on-merge, nothing on main is ever genuinely unreleased — every merge ships via `patch-version-publish`. The hand-maintained `## Unreleased` CHANGELOG bucket therefore always lied: already-published entries showed as unreleased in the registry "what's new".

New convention: **PR authors add un-headed `### ` entry blocks at the top of `CHANGELOG.md`** (no version, no `Unreleased`). A new publish step computes the version `patch-version-publish` is about to assign (same registry-latest+1 logic, manual-ahead respected) and stamps `## <version> — <date>` above those entries **before** publish, so the published artifact — and the registry "what's new" — show them under their real version.

## Changes
- `scripts/stamp-changelog.py` — pure `compute_version` (mirrors the action) + idempotent `stamp_changelog` + a `tessl tile info` registry query.
- `.github/workflows/publish-tile.yml` — stamp step inserted before `patch-version-publish`; commits the CHANGELOG `[skip ci]` so the publish step's own push carries it.
- `tests/test_stamp_changelog.py` (+ conftest fixture) — unit tests for version computation and stamping/idempotency.

## Follow-ups (separate)
- Update the `jbaruch/coding-policy` rule `context-artifacts.md` "CHANGELOG Hygiene" to describe the no-Unreleased convention (authorized; separate PR).
- Convert open PR #54's `## Unreleased` block to un-headed entries so the stamp picks it up on merge.

## Test plan
- [x] `pytest` green (363 passed locally); new tests cover version computation + stamping.
- [x] `stamp-changelog.py` validated end-to-end + idempotent on a temp CHANGELOG.
- [ ] Pipeline step itself only exercises on a real publish-to-main (untestable in PR CI by design); logic is covered by unit tests + the mirrored version computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)