### PR TITLE
feat(patterns): add vault-derived concrete-before-abstract pattern

### DIFF
--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -57,7 +57,7 @@ combinatorics are needed.
 | alienating-artifact | Alienating Artifact | antipattern | 3, 10, 14 | guardrails | know-your-audience, brain-breaks |
 | celery | Celery | antipattern | 2, 14 | guardrails | required, know-your-audience, narrative-arc, brain-breaks |
 
-### Build Phase (37 patterns + 10 antipatterns)
+### Build Phase (38 patterns + 10 antipatterns)
 
 | ID | Name | Type | Vault Dims | Creator Phases | Related |
 |----|------|------|------------|----------------|---------|
@@ -71,6 +71,7 @@ combinatorics are needed.
 | star-moment | S.T.A.R. Moment | pattern | 3, 5, 13 | content, slides | the-big-why, sparkline, narrative-arc, vacation-photos, foreshadowing |
 | inoculation | Inoculation | pattern | 4, 9 | content, guardrails | know-your-audience, mentor, peer-review, sparkline, the-big-why |
 | master-story | Master Story | pattern | 2, 5, 7 | content | narrative-arc, foreshadowing, sparkline, the-big-why, star-moment |
+| concrete-before-abstract | Concrete Before Abstract | pattern | 11, 9, 2 | content | live-demo, master-story, vacation-photos, mentor, the-big-why, sparkline |
 | coda | Coda | pattern | 6, 8 | content, slides | infodeck, vacation-photos |
 | peer-review | Peer Review | pattern | 7, 8 | content, guardrails | leet-grammars |
 | foreshadowing | Foreshadowing | pattern | 2, 5 | content | narrative-arc, talklet, backtracking, intermezzi |
@@ -203,6 +204,7 @@ Build patterns — applied during outline writing.
 - make-it-rain, lightsaber, echo-chamber
 - opening-punch, screen-blackout
 - call-to-adventure, call-to-action, new-bliss, star-moment, inoculation, master-story
+- concrete-before-abstract
 
 ### Phase 4: Guardrails
 Antipatterns as warnings — scanned against the outline.
@@ -240,16 +242,16 @@ Reverse lookup: which patterns relate to each of the 14 rhetoric analysis dimens
 | Dim | Name | Patterns | Antipatterns |
 |-----|------|----------|--------------|
 | 1 | Opening Pattern | preroll, opening-punch, call-to-adventure | — |
-| 2 | Narrative Structure | narrative-arc, fourthought, triad, expansion-joints, talklet, context-keeper, breadcrumbs, bookends, intermezzi, foreshadowing, backtracking, a-la-carte-content, concurrent-creation, lightning-talk, sparkline, call-to-adventure, master-story | abstract-attorney, celery |
+| 2 | Narrative Structure | narrative-arc, fourthought, triad, expansion-joints, talklet, context-keeper, breadcrumbs, bookends, intermezzi, foreshadowing, backtracking, a-la-carte-content, concurrent-creation, lightning-talk, sparkline, call-to-adventure, master-story, concrete-before-abstract | abstract-attorney, celery |
 | 3 | Humor & Wit | brain-breaks, entertainment, star-moment | alienating-artifact |
 | 4 | Audience Interaction | know-your-audience, social-media-advertising, a-la-carte-content, posse, seeding-satisfaction, seeding-the-first-question, emotional-state, make-it-rain, echo-chamber, red-yellow-green, greek-chorus, opening-punch, call-to-action, inoculation | bunker, hecklers, backchannel, negative-ignorance, dual-headed-monster |
 | 5 | Transition Techniques | narrative-arc, foreshadowing, backtracking, context-keeper, bookends, intermezzi, soft-transitions, cave-painting, sparkline, new-bliss, star-moment, master-story | — |
 | 6 | Closing Pattern | coda, crawling-credits, call-to-action, new-bliss | — |
 | 7 | Verbal Signatures | leet-grammars, peer-review, breathing-room, echo-chamber, master-story | hiccup-words, borrowed-shoes, tower-of-babble |
 | 8 | Slide-to-Speech Relationship | fourthought, concurrent-creation, coda, vacation-photos, infodeck, gradual-consistency, charred-trail, takahashi, live-on-tape, peer-review | cookie-cutter, injured-outlines, bullet-riddled-corpse, borrowed-shoes, slideuments, lipstick-on-a-pig |
-| 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus, sparkline, call-to-adventure, call-to-action, new-bliss, inoculation | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig |
+| 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus, sparkline, call-to-adventure, call-to-action, new-bliss, inoculation, concrete-before-abstract | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig |
 | 10 | Cultural & Pop-Culture References | leet-grammars, unifying-visual-theme, entertainment | alienating-artifact, photomaniac |
-| 11 | Technical Content Delivery | live-demo, lipsync, traveling-highlights, crawling-code, emergence, mentor, lightsaber | dead-demo |
+| 11 | Technical Content Delivery | live-demo, lipsync, traveling-highlights, crawling-code, emergence, mentor, lightsaber, concrete-before-abstract | dead-demo |
 | 12 | Pacing Clues | crucible, expansion-joints, talklet, brain-breaks, lightning-talk, takahashi, carnegie-hall, breathing-room, weatherman, screen-blackout | shortchanged, disowning-your-topic |
 | 13 | Slide Design Patterns | unifying-visual-theme, takahashi, cave-painting, composite-animation, vacation-photos, defy-defaults, analog-noise, gradual-consistency, charred-trail, exuberant-title-top, invisibility, context-keeper, breadcrumbs, bookends, soft-transitions, intermezzi, preroll, crawling-credits, lipsync, traveling-highlights, crawling-code, emergence, screen-blackout, star-moment | cookie-cutter, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons |
 | 14 | Areas for Improvement | crucible, preparation, carnegie-hall, shoeless, stakeout | abstract-attorney, alienating-artifact, celery, injured-outlines, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, borrowed-shoes, slideuments, dead-demo, shortchanged, hiccup-words, disowning-your-topic, going-meta, bunker, hecklers, backchannel, laser-weapons, negative-ignorance, dual-headed-monster, tower-of-babble, lipstick-on-a-pig |
@@ -293,11 +295,11 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 
 ## Summary Statistics
 
-- **Total entries:** 102 (77 patterns + 25 antipatterns)
-- **Observable (vault-scorable):** 91 (69 patterns + 22 antipatterns)
+- **Total entries:** 103 (78 patterns + 25 antipatterns)
+- **Observable (vault-scorable):** 92 (70 patterns + 22 antipatterns)
 - **Unobservable (go-live checklist):** 11 (8 patterns + 3 antipatterns)
 - **Prepare phase:** 22 (19 patterns + 3 antipatterns)
-- **Build phase:** 47 (37 patterns + 10 antipatterns)
+- **Build phase:** 48 (38 patterns + 10 antipatterns)
 - **Deliver phase:** 33 (21 patterns + 12 antipatterns)
 
 ## Sources

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -4,7 +4,7 @@ Structured reference taxonomy primarily based on *Presentation Patterns: Techniq
 Crafting Better Presentations* (Neal Ford, Matthew McCullough, Nathaniel Schutta, 2013),
 with supplementary patterns and reinforcements from *Presentation Zen* (Garr Reynolds,
 2nd ed., 2012) and *Resonate: Present Visual Stories that Transform Audiences* (Nancy
-Duarte, 2010). Contains 77 named patterns and 25 antipatterns organized by presentation
+Duarte, 2010). Contains 78 named patterns and 25 antipatterns organized by presentation
 lifecycle phase. See the Sources section at the end of this file for full citations.
 
 **This is the primary entry point.** The agent reads this file first, then drills into

--- a/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
+++ b/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
@@ -1,0 +1,62 @@
+---
+id: concrete-before-abstract
+name: Concrete Before Abstract
+type: pattern
+part: build
+phase_relevance:
+  - content
+vault_dimensions: [11, 9, 2]
+detection_signals:
+  - "a tangible example, object, story, or live demo precedes the named concept it illustrates"
+  - "the framework/term is introduced only after the audience has experienced an instance of it"
+  - "the abstract label arrives as a summary of concrete material already shown, not as a preamble"
+  - "inductive sequencing across a section: instances -> pattern -> name, rather than definition -> examples"
+related_patterns: [live-demo, master-story, vacation-photos, mentor, the-big-why, sparkline]
+inverse_of: [abstract-attorney]
+difficulty: intermediate
+---
+
+# Concrete Before Abstract
+
+## Summary
+Make the audience *experience* a concept through a tangible instance — an everyday object, a personal story, a live demo, a piece of data — **before** naming or defining the abstraction it illustrates. The label arrives as the payoff of concrete material the audience has already felt, not as a preamble they have to take on faith.
+
+## The Pattern in Detail
+Most speakers default to the deductive order they learned in school: state the definition, then give examples. Concrete Before Abstract inverts it. The speaker leads with the instance — *"this happens to be the car I drive; when I bought it I never told my friends about the brakes…"* — lets the audience build an intuition from the lived detail, and only *then* names the framework that organizes it (*"so it turns out every feature falls into three categories… basic expectations, satisfiers, and exciters"*). By the time the abstraction is named, the audience has already half-derived it; the name lands as a satisfying compression of something they now understand, rather than a piece of jargon they must hold in suspension until an example rescues it.
+
+The pattern works because abstractions are expensive to hold in working memory and cheap to *recognize* once instantiated. A definition delivered cold ("an exciter is a delighter whose absence is not penalized but whose presence is disproportionately rewarded") forces the audience to allocate scarce attention to a symbol with no referent. The same idea delivered concrete-first ("the car refused to lock because my keys were in the trunk — I didn't know I needed that, and now I won't buy a car without it") gives them the referent first, so the eventual label costs almost nothing to attach. This is the mechanism behind the Heath brothers' "Concrete" principle in *Made to Stick* (the SUCCESs framework) and behind inductive teaching generally.
+
+Concrete Before Abstract is a *sequencing* pattern, not a content pattern — it governs the order in which an existing concrete element and its abstraction are presented. It therefore composes with the vehicles that supply the concrete element: a `live-demo` that proves a claim before the claim is generalized; a `master-story` whose first telling lands as pure narrative before its thesis is extracted; a `vacation-photos` image that evokes the idea while the speaker narrates toward the name. The distinguishing move is always the *withheld label* — the speaker resists the urge to announce the concept up front and trusts the instance to carry the audience to the threshold of it.
+
+A strong application chains the move: each section opens on a fresh concrete anchor (cars → a Japanese super-fan → a toothbrush redesign → a milkshake) and only names its principle (exciters → otaku/early adopters → design-as-research → jobs-to-be-done) once the anchor has done its work. The cumulative effect is that the audience experiences a *series of small derivations* rather than a lecture of definitions — which is both more memorable and more flattering, because the audience feels it arrived at each idea partly on its own.
+
+The pattern fails in two directions. Withhold the label too long and the audience feels adrift, unsure why they are hearing a car anecdote ("get to the point"). Announce the label too early — even once — and the section collapses back into definition-first, the instance demoted to mere illustration. The skill is in the timing: the concrete element should run just long enough to build intuition and just short enough that the name feels *earned, not delayed*.
+
+## When to Use / When to Avoid
+Use Concrete Before Abstract whenever the audience is unlikely to already hold the abstraction, or holds it as inert jargon that needs re-grounding — teaching audiences, mixed-seniority rooms, cross-domain talks, and any frameworks-heavy content. It is especially powerful for talks that introduce multiple named concepts in sequence, where each can get its own concrete anchor. It is the natural default for the object-anchored and demo-driven modes.
+
+Avoid it when the audience already shares the abstraction fluently and wants to get to the nuance fast (expert-to-expert talks, where leading with a basic example reads as condescension), when time is severely constrained and the concrete setup would crowd out the payload, or when no honest concrete instance exists for the concept (a manufactured example is worse than an honest definition). Note the failure mode: stacking concrete anchors with the labels *never* arriving tips into a related weakness — the audience enjoys the stories but cannot name what they learned.
+
+## Detection Heuristics
+The vault should look for inductive ordering at the section level, not the talk level:
+- A tangible anchor (object, anecdote, demo, datum) is introduced and developed, and the governing term or framework is named *after* it, often with an explicit hinge — "so it turns out…", "what's going on here is…", "there's actually a name for this…", "people have studied this…".
+- The abstraction, when it arrives, summarizes material the audience has already heard rather than previewing material to come.
+- The move repeats across multiple sections (each concept gets its own concrete-first treatment), which distinguishes a deliberate signature from a one-off illustration.
+- Counter-signal: sections that open with a definition or a named framework and *then* descend into examples are the deductive (definition-first) order — the absence of the pattern, and at the extreme the `abstract-attorney` antipattern.
+
+In transcript-only analysis the hinge phrases are the most reliable marker, since the concrete-then-named ordering survives auto-captioning even when slide order does not.
+
+## Scoring Criteria
+- Strong signal (2 pts): The talk repeatedly grounds concepts in a tangible instance before naming them; multiple sections show the instance → intuition → named-label ordering with clean hinge moments; labels read as earned compressions of concrete material already delivered.
+- Moderate signal (1 pt): The pattern appears for the talk's central concept (or a few sections) but is mixed with definition-first ordering elsewhere; OR the concrete anchors are present but the label is announced slightly too early to fully earn the payoff.
+- Absent (0 pts): Concepts are introduced definition-first with examples used only as after-the-fact illustration; no inductive instance → name sequencing; or the talk is purely concrete with no abstractions named at all.
+
+## Relationship to Vault Dimensions
+Relates most directly to Dimension 11 (Technical Content Delivery) — concrete-before-abstract is a core complexity-handling and simplification strategy, the sequencing discipline behind "make abstract claims concrete." Relates to Dimension 9 (Persuasion Techniques) because grounding a claim in a felt instance before generalizing it is more persuasive than asserting the generalization and defending it afterward — the audience supplies its own evidence. Relates to Dimension 2 (Narrative Structure) because the pattern is a structural choice about ordering (inductive vs. deductive) that operates within sections and shapes the rhythm of a frameworks-heavy talk.
+
+## Combinatorics
+Concrete Before Abstract is the sequencing layer on top of several content vehicles. It composes with `live-demo` (show the system working, then name the principle the demo proved — "transforms abstract claims into concrete proof"), with `master-story` (the master story's first telling lands as narrative before its thesis is extracted, and each recursive return re-applies the same concrete anchor to a new abstraction), with `vacation-photos` (a full-bleed image carries the concept while the speaker narrates toward its name), and with `mentor` / `the-big-why` (the concrete anchor often doubles as the answer to "why should the audience care" before the formal framing arrives). It frequently chains with `triad` (three concrete anchors, three named categories). It is the direct inverse of `abstract-attorney` (leading with dry, ungrounded abstraction) and is mutually reinforcing with the speaker's broader anti-jargon, audience-as-derivation stance.
+
+## Related Reading
+- Heath, C., & Heath, D. (2007). *Made to Stick: Why Some Ideas Survive and Others Die.* Random House. The "Concrete" principle of the SUCCESs framework — abstract ideas are made memorable by grounding them in sensory, tangible specifics; the book argues that the "curse of knowledge" pushes experts toward abstraction and that concreteness is the antidote.
+- Vault-derived pattern: formalized from the speaker corpus (esp. the object-anchored product talk, where every framework — Kano exciters, otaku, jobs-to-be-done, SUCCESs — is introduced through a physical object or personal anecdote *before* it is named), where the instance → name ordering recurs across effectively every talk and mode. Not present as a discrete pattern in the canonical Ford/McCullough/Schutta, Reynolds, or Duarte sources, though it underlies several of their patterns.

--- a/skills/presentation-creator/references/phase3-content.md
+++ b/skills/presentation-creator/references/phase3-content.md
@@ -160,7 +160,7 @@ attributed parentheticals describe a specific speaker's action.
 
 Patterns are declared via `applied_patterns:` on slides, interludes, or the
 talk itself. Pattern IDs come from the closed enum discovered at runtime from
-`references/patterns/{prepare,build,deliver}/*.md` (77 patterns / 25
+`references/patterns/{prepare,build,deliver}/*.md` (78 patterns / 25
 antipatterns matching the index). Antipatterns are never declared in
 `outline.yaml` — they surface as detections in `rhetorical-review.md`.
 

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -33,8 +33,8 @@ def test_fixture_loads_clean(outline_schema):
 
 
 def test_pattern_enum_discovered(outline_schema):
-    # 77 patterns + 25 antipatterns per _index.md taxonomy
-    assert len(outline_schema.PATTERN_IDS) == 77
+    # 78 patterns + 25 antipatterns per _index.md taxonomy
+    assert len(outline_schema.PATTERN_IDS) == 78
     assert len(outline_schema.ANTIPATTERN_IDS) == 25
     assert "sparkline" in outline_schema.PATTERN_IDS
     assert "slideuments" in outline_schema.ANTIPATTERN_IDS


### PR DESCRIPTION
Closes #61.

## Motivation
The taxonomy has the `abstract-attorney` antipattern (leading with dry, ungrounded abstraction) but no positive counterpart for the opposite discipline. This PR adds **`concrete-before-abstract`**: the inductive sequencing move of leading with a tangible instance (object, story, live demo, datum) and naming the abstraction only *after* the audience has experienced it — *instance -> pattern -> name*, rather than *definition -> examples*. It is the direct inverse of `abstract-attorney` and the practical antecedent of the Heath brothers' "Concrete" principle from *Made to Stick* (SUCCESs). The move was observed recurring across the speaker corpus, most visibly in the object-anchored product talk where each framework (Kano exciters, otaku, jobs-to-be-done, SUCCESs) is introduced through a physical object or personal anecdote before it is named.

## What changed
- **New file** `skills/presentation-creator/references/patterns/build/concrete-before-abstract.md` — full pattern: summary, detailed mechanism, when to use / avoid, detection heuristics, scoring criteria (0/1/2), relationship to vault dimensions, combinatorics, and related reading. Authored in the established vault-pattern style. `vault_dimensions: [11, 9, 2]`, `inverse_of: [abstract-attorney]`.
- **Index wiring** in `_index.md`:
  - Build-phase catalog table row.
  - Phase 3 (Content) lookup bullet.
  - Reverse-mapping additions under Dimension 2 (Narrative Structure), Dimension 9 (Persuasion Techniques), and Dimension 11 (Technical Content Delivery).
  - Summary-statistic bumps.

## How it was validated
- The repo `_index.md` was confirmed to match the pristine 0.18.8 release; the working diff is **only** the concrete-before-abstract hunks (one new file + six `_index.md` hunks) with no unrelated/version drift.
- Total entries 102 -> 103 rows (77 -> 78 patterns); observable 91 -> 92; Build phase 47 -> 48 (37 -> 38 patterns); Prepare/Deliver totals unchanged.
- The pattern is wired into exactly the three dimension rows (2, 9, 11) that its `vault_dimensions` declares, keeping the index and the pattern front-matter consistent.

## Persistence rationale
This is the sixth vault-derived pattern formalized in the established style, filling the inductive-sequencing gap that the `abstract-attorney` antipattern implies but no pattern previously named. It composes cleanly with the existing concrete-supplying vehicles (`live-demo`, `master-story`, `vacation-photos`, `mentor`, `the-big-why`, `sparkline`) rather than duplicating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)