### PR TITLE
fix(shownotes-publisher): gate Step 6 so thumbnails stop being skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.18.10 — 2026-06-03
+
+### fix(shownotes-publisher) — stop agents skipping thumbnail generation
+
+Step 6 (Thumbnail) was opt-out: it stated the page "renders fine without one"
+(the `onerror` placeholder fallback), framed production as a vague conditional
+hand-off to the illustrations skill, and ended "Proceed immediately to Step 7"
+with no gate — so agents always skipped it and the talk card fell back to the
+placeholder SVG. Step 6 is now an explicit decision: check the convention-path
+file (`assets/images/thumbnails/{filename_stem}-thumbnail.png`); if absent,
+either produce it via `Skill(illustrations)` when a source image is available,
+or explicitly record it as deferred to Phase 7 (pre-talk publish with no
+slides/video). Never a silent fall-through. Fixes #58.
+
 ## 0.18.9 — 2026-06-03
 
 ### feat(presentation-creator) — PowerPoint-native deck editing (preserves illustrated backgrounds)

--- a/skills/shownotes-publisher/SKILL.md
+++ b/skills/shownotes-publisher/SKILL.md
@@ -271,14 +271,27 @@ read as a URL; see
 entry 1c and
 [references/template-conditionals.md](references/template-conditionals.md)
 for the three template locations that hard-code the slug-derived
-path. Missing thumbnails fall back via `onerror` to the placeholder
-SVG — page renders fine without one.
+path.
 
-If a thumbnail needs to be produced, hand off to
-`Skill(skill: "illustrations")` — this skill places files, doesn't
-generate images.
+**Decide explicitly — do not skip this step.** Check whether the
+convention-path file already exists in the shownotes repo
+(`assets/images/thumbnails/{filename_stem}-thumbnail.png`):
 
-Proceed immediately to Step 7.
+- **Exists** → done; the page uses it.
+- **Absent, and a source image is available** (the talk's slides
+  exist, or a YouTube thumbnail / video frame was already produced) →
+  produce it now: hand off to `Skill(skill: "illustrations")` to
+  generate the thumbnail (this skill places files, it does not generate
+  images), then drop the 4:3 PNG at the convention path.
+- **Absent, and no source image yet** (pre-talk publish, no slides or
+  video) → record that the thumbnail is deferred to Phase 7
+  (post-event). The placeholder SVG (`onerror` fallback) is the
+  intentional interim, not a silent skip; when the video lands and
+  Phase 7 runs, generate the thumbnail and drop it at the convention
+  path.
+
+Never fall through this step without either producing the thumbnail or
+explicitly recording the deferral. Then proceed to Step 7.
 
 ## Step 7 — Write the File
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
Fixes #58. Agents always skipped thumbnail generation when publishing shownotes — the talk card fell back to the placeholder SVG every time.

**Root cause:** `shownotes-publisher` Step 6 was opt-out — it told the agent the page "renders fine without one" (the `onerror` placeholder fallback), framed production as a vague conditional hand-off, and ended "Proceed immediately to Step 7" with no gate.

**Fix:** Step 6 is now an explicit decision (never a silent fall-through):
- file at `assets/images/thumbnails/{filename_stem}-thumbnail.png` exists → done;
- absent + a source image available (slides, or an already-produced YouTube thumbnail/frame) → produce it now via `Skill(illustrations)`;
- absent + no source yet (pre-talk publish) → explicitly record the deferral to Phase 7 — the placeholder SVG is the intentional interim, not a skip.

This also reconciles the Phase 6 (publish, often pre-video) vs Phase 7 (post-event thumbnail generation) mismatch that drove the skip.

## Test plan
- [x] `tessl skill review skills/shownotes-publisher --threshold 85` → **92%** (PASSED).
- [x] `tessl tile lint` valid.
- [ ] CI: Tests + changed-skills review + policy review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)