### PR TITLE
feat(presentation-creator): QR insertion via real PowerPoint (#57 Phase F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.18.13 — 2026-06-04
+
+### feat(presentation-creator) — QR insertion via real PowerPoint (#57 Phase F)
+
+Retires `generate-qr.py`'s python-pptx deck write (`insert_qr_on_slides` +
+`_remove_existing_qr` + `prs.save`) for an `InsertQR` VBA macro. `generate-qr.py`
+keeps everything else — URL/shortener resolve, per-slide background-color match
+(read-only), target-slide finding, and QR PNG generation — and calls
+`insert-qr.sh` for the write.
+
+- **`InsertQR`** (in `RunDeckOps.bas`) + `insert-qr.applescript` / `insert-qr.sh`
+  — places the QR bottom-right (2.0in, 0.3in margin) on the given 1-based slides,
+  removing any existing corner QR first (idempotent re-runs).
+- `generate-qr.py` threads the deck through uniquely-named intermediates (one
+  `InsertQR` pass per color variant) and moves the result back; the python-pptx
+  `Inches`/`Emu`/`RGBColor` imports and the QR-insert test are dropped.
+- The QR insert is now macOS + PowerPoint only (the rest of `generate-qr.py`
+  stays cross-platform). Completes #57's deck-writer retirement. Untestable in
+  Linux CI by design — validate by re-opening in PowerPoint and Keynote.
+
 ## 0.18.12 — 2026-06-04
 
 ### feat(presentation-creator) — placeholder slides via real PowerPoint (#57 Phase E)

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ speaker-toolkit-tile/
     |   +-- SKILL.md                          # Main creator workflow (7 phases)
     |   +-- scripts/
     |   |   +-- _pptx_repair.py               # Shared viewProps cleanup for PPTX integrity
-    |   |   +-- generate-qr.py                # QR code generation with bg-color matching
+    |   |   +-- generate-qr.py                # QR generation + bg-color match (insert via InsertQR)
     |   |   +-- extract-resources.py          # Resource link extraction from outlines
     |   |   +-- guardrail-check.py            # Outline guardrail validation
     |   |   +-- strip-template.py             # Strip demo slides from template
@@ -421,6 +421,8 @@ speaker-toolkit-tile/
     |   |   +-- inject-notes.sh                # Wrapper for SetSpeakerNotes (notes via real PowerPoint)
     |   |   +-- inject-notes.applescript       # AppleScript driver for SetSpeakerNotes (reads notes as UTF-8)
     |   |   +-- notes-to-packed.py             # Notes JSON -> SetSpeakerNotes wire format (tested)
+    |   |   +-- insert-qr.sh                    # Wrapper for InsertQR (QR PNG bottom-right via real PowerPoint)
+    |   |   +-- insert-qr.applescript           # AppleScript driver for InsertQR
     |   +-- references/
     |       +-- phase0-intake.md through phase7-post-event.md  # Phase detail docs
     |       +-- patterns/                     # Presentation Patterns taxonomy (102 entries)

--- a/skills/presentation-creator/scripts/RunDeckOps.bas
+++ b/skills/presentation-creator/scripts/RunDeckOps.bas
@@ -506,6 +506,89 @@ Fail6:
     MakePlaceholderSlide = -1
 End Function
 
+' Insert a QR PNG bottom-right on the given 1-based slides, replacing any
+' existing QR-sized picture already in that corner (idempotent re-runs).
+' Replaces the python-pptx write in generate-qr.py — that script keeps the URL
+' resolve + per-slide background-color match + PNG generation (reads only).
+' Invoked via:
+'   run VB macro macro name "InsertQR" list of parameters _
+'       {basePath, outPath, pngPath, slideNumsCSV}
+' slideNumsCSV = comma-separated 1-based slide numbers, e.g. "5,12".
+Public Function InsertQR(ByVal basePath As String, _
+                         ByVal outPath As String, _
+                         ByVal pngPath As String, _
+                         ByVal slideNumsCSV As String) As Long
+    Dim curTok As String
+    Dim base As Presentation
+    ' outer-boundary-process-contract — see the module-header error-handling contract.
+    On Error GoTo Fail7
+
+    curTok = "guard:base"
+    AssertNotOpen BaseName(basePath)
+    curTok = "open:base"
+    Set base = Presentations.Open(FileName:=basePath, WithWindow:=msoTrue)
+
+    ' QR geometry mirrors generate-qr.py: 2.0in square, 0.3in margin, ~0.1in
+    ' position/size tolerance for detecting an existing QR to replace (points).
+    Const QR_SIDE As Single = 144
+    Const QR_MARGIN As Single = 21.6
+    Const TOL As Single = 7.2
+    Dim sw As Single, sh As Single
+    sw = base.PageSetup.SlideWidth
+    sh = base.PageSetup.SlideHeight
+    Dim qrLeft As Single, qrTop As Single
+    qrLeft = sw - QR_SIDE - QR_MARGIN
+    qrTop = sh - QR_SIDE - QR_MARGIN
+
+    Dim nums() As String, k As Long, num As Long, placed As Long
+    nums = Split(slideNumsCSV, ",")
+    placed = 0
+    For k = LBound(nums) To UBound(nums)
+        If Len(Trim(nums(k))) > 0 Then
+            num = CLng(Trim(nums(k)))
+            curTok = "slide:" & num
+            If num < 1 Or num > base.Slides.Count Then Err.Raise vbObjectError + 520, , _
+                "QR slide " & num & " out of range (deck has " & base.Slides.Count & ")"
+            Dim s As Slide
+            Set s = base.Slides(num)
+            ' remove an existing QR-sized picture in the bottom-right corner
+            Dim i As Long, shp As Shape
+            For i = s.Shapes.Count To 1 Step -1
+                Set shp = s.Shapes(i)
+                If shp.Type = msoPicture Then
+                    If Abs(shp.Left - qrLeft) < TOL And Abs(shp.Top - qrTop) < TOL _
+                       And Abs(shp.Width - QR_SIDE) < TOL Then
+                        shp.Delete
+                    End If
+                End If
+            Next i
+            s.Shapes.AddPicture FileName:=pngPath, LinkToFile:=msoFalse, _
+                SaveWithDocument:=msoTrue, Left:=qrLeft, Top:=qrTop, Width:=QR_SIDE, Height:=QR_SIDE
+            placed = placed + 1
+        End If
+    Next k
+
+    curTok = "save"
+    base.SaveCopyAs FileName:=outPath
+    curTok = "close"
+    base.Close
+    InsertQR = placed
+    Exit Function
+
+Fail7:
+    Dim em As String
+    em = "InsertQR failed at [" & curTok & "]:" & vbCr & _
+         Err.Number & " - " & Err.Description
+    On Error Resume Next
+    If Not base Is Nothing Then
+        base.Saved = msoTrue
+        base.Close
+    End If
+    On Error GoTo 0
+    MsgBox em, vbCritical, "InsertQR"
+    InsertQR = -1
+End Function
+
 ' Filename portion of a POSIX path.
 Private Function BaseName(ByVal p As String) As String
     Dim k As Long

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -540,7 +540,14 @@ def insert_qr_via_powerpoint(deck_path, jobs, scripts_dir):
     for n, (png_path, slide_nums) in enumerate(jobs):
         out = f"{deck_path}.qrtmp{n}.pptx"  # distinct basename — no open-deck collision
         csv = ",".join(str(x) for x in slide_nums)
-        subprocess.run([wrapper, current, out, png_path, csv], check=True)
+        try:
+            subprocess.run([wrapper, current, out, png_path, csv], check=True)
+        except subprocess.CalledProcessError:
+            raise SystemExit(
+                f"ERROR: QR insertion failed in PowerPoint (insert-qr.sh on slide(s) {csv}). "
+                "Confirm DeckOps.pptm is open with macros enabled and Automation consent "
+                "granted — see skills/presentation-creator/references/deck-editing-setup.md"
+            )
         if current != deck_path:
             os.remove(current)  # drop the prior intermediate
         current = out

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -34,6 +34,8 @@ import argparse
 import datetime
 import json
 import os
+import shutil
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -51,9 +53,7 @@ except ImportError:
     print("ERROR: 'Pillow' package not installed. Run: pip install Pillow")
     sys.exit(1)
 
-from pptx import Presentation
-from pptx.util import Inches, Emu
-from pptx.dml.color import RGBColor
+from pptx import Presentation  # read-only: background-color match + slide-finding
 
 # --- Constants ---
 
@@ -520,77 +520,31 @@ def resolve_target_slide_indices(prs, config, shownotes_url):
 
 # --- QR Insertion ---
 
-def _remove_existing_qr(slide, expected_left, expected_top, expected_width, tolerance_emu=91440):
-    """Remove existing QR-sized picture shapes in the expected position.
+def insert_qr_via_powerpoint(deck_path, jobs, scripts_dir):
+    """Insert the QR PNG(s) into the deck via the real PowerPoint app.
 
-    Detects pictures that overlap the QR target area (bottom-right corner)
-    within a tolerance. This handles re-runs on reused decks.
+    Replaces the old python-pptx write (`insert-qr.sh` → InsertQR VBA macro), so
+    PowerPoint serializes a valid .pptx (see rules/deck-editing-rules.md). The
+    macro removes any existing corner QR before inserting (idempotent re-runs).
+    macOS + Microsoft PowerPoint only.
 
-    Args:
-        slide: Slide object
-        expected_left, expected_top, expected_width: Target position/size in EMUs
-        tolerance_emu: Position tolerance (default ~1 inch = 914400/10)
-
-    Returns:
-        Number of shapes removed.
+    jobs: list of (png_path, [1-based slide numbers]) — one per QR color variant.
+    Each variant is a separate InsertQR pass; the deck is threaded through
+    uniquely-named intermediates (PowerPoint keys open decks by filename) and the
+    final result is moved back to deck_path.
     """
-    to_remove = []
-    for shape in slide.shapes:
-        if not shape.shape_type == 13:  # MSO_SHAPE_TYPE.PICTURE
-            continue
-        # Check if this picture is roughly QR-sized and in the expected position
-        if (abs(shape.left - expected_left) < tolerance_emu
-                and abs(shape.top - expected_top) < tolerance_emu
-                and abs(shape.width - expected_width) < tolerance_emu):
-            to_remove.append(shape)
-
-    for shape in to_remove:
-        sp = shape._element
-        # Clean up image relationship to avoid orphaned refs
-        blip = sp.find('.//{http://schemas.openxmlformats.org/drawingml/2006/main}blip')
-        if blip is not None:
-            embed_rId = blip.get(
-                '{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed')
-            if embed_rId:
-                try:
-                    slide.part.drop_rel(embed_rId)
-                except KeyError:
-                    pass
-        sp.getparent().remove(sp)
-
-    return len(to_remove)
-
-
-def insert_qr_on_slides(prs, png_path, slide_indices):
-    """Insert the QR PNG on the specified slides, bottom-right corner.
-
-    If an existing QR-sized picture is found in the same position, it is
-    replaced (removed then re-added). This supports re-runs on reused decks.
-
-    Args:
-        prs: Presentation object (mutated in place)
-        png_path: Path to the QR PNG file
-        slide_indices: List of 0-based slide indices
-    """
-    slide_width = prs.slide_width
-    slide_height = prs.slide_height
-
-    qr_width = Inches(QR_WIDTH_INCHES)
-    # Maintain square aspect ratio
-    qr_height = qr_width
-
-    margin = Inches(QR_MARGIN_INCHES)
-    left = slide_width - qr_width - margin
-    top = slide_height - qr_height - margin
-
-    for idx in slide_indices:
-        slide = prs.slides[idx]
-        removed = _remove_existing_qr(slide, left, top, qr_width)
-        if removed:
-            print(f"  Replaced {removed} existing QR image(s) on slide {idx + 1}")
-        slide.shapes.add_picture(png_path, left, top, qr_width, qr_height)
-        if not removed:
-            print(f"  Inserted QR on slide {idx + 1}")
+    wrapper = os.path.join(scripts_dir, "insert-qr.sh")
+    if not os.path.isfile(wrapper):
+        raise SystemExit(f"insert-qr.sh not found at {wrapper} — reinstall the tile")
+    current = deck_path
+    for n, (png_path, slide_nums) in enumerate(jobs):
+        out = f"{deck_path}.qrtmp{n}.pptx"  # distinct basename — no open-deck collision
+        csv = ",".join(str(x) for x in slide_nums)
+        subprocess.run([wrapper, current, out, png_path, csv], check=True)
+        if current != deck_path:
+            os.remove(current)  # drop the prior intermediate
+        current = out
+    shutil.move(current, deck_path)
 
 
 # --- Tracking Database ---
@@ -773,6 +727,7 @@ def main():
 
         if not args.dry_run:
             qr_paths_generated = []
+            insert_jobs = []  # (png_path, [1-based slide numbers]) — one per color variant
             for (qr_bg, qr_fg), indices in color_groups.items():
                 if len(color_groups) == 1:
                     qr_filename = f"{args.talk_slug}-qr.png"
@@ -786,12 +741,14 @@ def main():
                 size_kb = os.path.getsize(qr_path) / 1024
                 print(f"  QR PNG saved: {qr_filename} ({size_kb:.1f} KB) — for slide(s) {[i + 1 for i in indices]}")
                 qr_paths_generated.append(qr_path)
+                insert_jobs.append((qr_path, [i + 1 for i in indices]))  # VBA is 1-based
 
-                # Insert this variant on its matching slides
-                insert_qr_on_slides(prs, qr_path, indices)
-
-            prs.save(args.deck)
-            print(f"Deck saved: {args.deck}")
+            # Release the read-only deck handle, then write via the real
+            # PowerPoint app (valid OOXML; see rules/deck-editing-rules.md).
+            prs = None
+            here = os.path.dirname(os.path.abspath(__file__))
+            insert_qr_via_powerpoint(args.deck, insert_jobs, here)
+            print(f"Deck updated via PowerPoint: {args.deck}")
             # Use first generated path for tracking DB
             qr_filename = os.path.basename(qr_paths_generated[0])
         else:

--- a/skills/presentation-creator/scripts/insert-qr.applescript
+++ b/skills/presentation-creator/scripts/insert-qr.applescript
@@ -1,0 +1,13 @@
+-- insert-qr.applescript
+-- Calls the InsertQR VBA macro: place a QR PNG bottom-right on the given 1-based
+-- slides (replacing any existing corner QR), then save a COPY.
+--   osascript insert-qr.applescript <basePath> <outPath> <pngPath> <slideNumsCSV>
+on run argv
+	if (count of argv) < 4 then error "Expected 4 args: basePath outPath pngPath slideNumsCSV"
+	tell application "Microsoft PowerPoint"
+		activate
+		set rc to run VB macro macro name "InsertQR" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv, item 4 of argv}
+	end tell
+	if rc < 0 then error "InsertQR failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	return "InsertQR returned: " & rc
+end run

--- a/skills/presentation-creator/scripts/insert-qr.sh
+++ b/skills/presentation-creator/scripts/insert-qr.sh
@@ -41,7 +41,8 @@ if [[ -f "$STAGE" ]]; then
   mkdir -p "$(dirname "$OUT")"
   mv -f "$STAGE" "$OUT"
   # Structured stdout (per jbaruch/coding-policy: script-delegation); diagnostics go to stderr.
-  printf '{"output": "%s"}\n' "$OUT"
+  # Emit via python3 so any path (quotes/backslashes/unicode) is correctly JSON-escaped.
+  python3 -c 'import json,sys; print(json.dumps({"output": sys.argv[1]}))' "$OUT"
 else
   echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1

--- a/skills/presentation-creator/scripts/insert-qr.sh
+++ b/skills/presentation-creator/scripts/insert-qr.sh
@@ -40,7 +40,8 @@ osascript "$DRIVER" "$BASE" "$STAGE" "$PNG" "$SLIDES"
 if [[ -f "$STAGE" ]]; then
   mkdir -p "$(dirname "$OUT")"
   mv -f "$STAGE" "$OUT"
-  echo "done -> $OUT"
+  # Structured stdout (per jbaruch/coding-policy: script-delegation); diagnostics go to stderr.
+  printf '{"output": "%s"}\n' "$OUT"
 else
   echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1

--- a/skills/presentation-creator/scripts/insert-qr.sh
+++ b/skills/presentation-creator/scripts/insert-qr.sh
@@ -35,7 +35,9 @@ mkdir -p "$STAGE_DIR"
 STAGE="$STAGE_DIR/$(basename "$OUT")"
 rm -f "$STAGE"
 
-osascript "$DRIVER" "$BASE" "$STAGE" "$PNG" "$SLIDES"
+# osascript prints the macro's "InsertQR returned: N" line — keep it off stdout
+# (stderr) so successful stdout is the documented JSON only.
+osascript "$DRIVER" "$BASE" "$STAGE" "$PNG" "$SLIDES" >&2
 
 if [[ -f "$STAGE" ]]; then
   mkdir -p "$(dirname "$OUT")"

--- a/skills/presentation-creator/scripts/insert-qr.sh
+++ b/skills/presentation-creator/scripts/insert-qr.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# insert-qr.sh — place a QR PNG bottom-right on the given slides via the real
+# PowerPoint app (InsertQR VBA macro), replacing any existing corner QR. Replaces
+# generate-qr.py's python-pptx insert; generate-qr.py keeps URL resolve + per-slide
+# background-color match + PNG generation, then calls this for the write.
+# See rules/deck-editing-rules.md. macOS + Microsoft PowerPoint only.
+#
+# Usage:
+#   insert-qr.sh <basePath> <outPath> <qr.png> <slideNumsCSV>
+#     basePath       deck to read (uniquely-named copy; base/out must not collide)
+#     outPath        where to write the COPY with the QR inserted
+#     qr.png         the (pre-generated, color-matched) QR PNG
+#     slideNumsCSV   comma-separated 1-based slide numbers, e.g. "5,12"
+#
+# Prerequisites: RunDeckOps.bas (which defines InsertQR) imported into an OPEN
+# macro-enabled deck (DeckOps.pptm), macros enabled, Automation consent granted.
+set -euo pipefail
+
+if [[ $# -lt 4 ]]; then
+  echo "usage: insert-qr.sh <basePath> <outPath> <qr.png> <slideNumsCSV>" >&2
+  exit 2
+fi
+BASE="$1"; OUT="$2"; PNG="$3"; SLIDES="$4"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER="$HERE/insert-qr.applescript"
+
+[[ -f "$BASE" ]]   || { echo "ERROR: base deck not found: $BASE — pass a uniquely-named copy of the deck." >&2; exit 1; }
+[[ -f "$PNG" ]]    || { echo "ERROR: QR PNG not found: $PNG — generate it first with generate-qr.py." >&2; exit 1; }
+[[ -f "$DRIVER" ]] || { echo "ERROR: driver not found: $DRIVER — reinstall the tile; insert-qr.applescript must sit next to this script." >&2; exit 1; }
+
+# Sandboxed PowerPoint can't create a file in a Google Drive folder (E_FAIL) —
+# stage locally, then move into place with the shell.
+STAGE_DIR="$HOME/.deckops-staging"
+mkdir -p "$STAGE_DIR"
+STAGE="$STAGE_DIR/$(basename "$OUT")"
+rm -f "$STAGE"
+
+osascript "$DRIVER" "$BASE" "$STAGE" "$PNG" "$SLIDES"
+
+if [[ -f "$STAGE" ]]; then
+  mkdir -p "$(dirname "$OUT")"
+  mv -f "$STAGE" "$OUT"
+  echo "done -> $OUT"
+else
+  echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  exit 1
+fi

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -99,3 +99,39 @@ def test_resolve_slide_bg_rgb_none_for_plain_deck(generate_qr, tmp_path):
     result = generate_qr.resolve_slide_bg_rgb(prs2.slides[0])
     # May be None or a default — both are acceptable
     assert result is None or isinstance(result, tuple)
+
+
+def test_insert_qr_via_powerpoint_orchestration(generate_qr, monkeypatch):
+    """The PowerPoint-write orchestration is deterministic and unit-tested with
+    the InsertQR wrapper (the actual VBA) mocked: one insert-qr.sh call per color
+    variant, the deck threaded through uniquely-named intermediates, intermediates
+    cleaned up, and the final result moved back onto the deck."""
+    calls = []
+    monkeypatch.setattr(generate_qr.subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+    removed = []
+    monkeypatch.setattr(generate_qr.os, "remove", lambda p: removed.append(p))
+    moved = []
+    monkeypatch.setattr(generate_qr.shutil, "move", lambda a, b: moved.append((a, b)))
+    monkeypatch.setattr(generate_qr.os.path, "isfile", lambda p: True)
+
+    deck = "/decks/talk.pptx"
+    jobs = [("/q/a.png", [1, 3]), ("/q/b.png", [5])]
+    generate_qr.insert_qr_via_powerpoint(deck, jobs, "/scripts")
+
+    wrapper = "/scripts/insert-qr.sh"
+    # one subprocess call per job; deck threaded through intermediates; CSV is 1-based, comma-joined
+    assert calls == [
+        [wrapper, "/decks/talk.pptx", "/decks/talk.pptx.qrtmp0.pptx", "/q/a.png", "1,3"],
+        [wrapper, "/decks/talk.pptx.qrtmp0.pptx", "/decks/talk.pptx.qrtmp1.pptx", "/q/b.png", "5"],
+    ]
+    # the prior intermediate is cleaned up; the final intermediate is moved onto the deck
+    assert removed == ["/decks/talk.pptx.qrtmp0.pptx"]
+    assert moved == [("/decks/talk.pptx.qrtmp1.pptx", "/decks/talk.pptx")]
+
+
+def test_insert_qr_via_powerpoint_missing_wrapper(generate_qr, monkeypatch):
+    """A missing insert-qr.sh fails fast with an actionable error, not a traceback."""
+    import pytest
+    monkeypatch.setattr(generate_qr.os.path, "isfile", lambda p: False)
+    with pytest.raises(SystemExit):
+        generate_qr.insert_qr_via_powerpoint("/decks/talk.pptx", [("/q/a.png", [1])], "/scripts")

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -90,25 +90,6 @@ def test_tracking_db_crud_update(generate_qr):
     assert db["qr_codes"][0]["created_at"] == "2024-01-01"
 
 
-def test_insert_qr_on_slides(generate_qr, tmp_path):
-    prs = make_deck(3)
-    path = str(tmp_path / "deck.pptx")
-    prs.save(path)
-
-    qr_path = str(tmp_path / "qr.png")
-    generate_qr.generate_qr_png("https://example.com", (0, 0, 0), (255, 255, 255), qr_path)
-
-    prs2 = Presentation(path)
-    generate_qr.insert_qr_on_slides(prs2, qr_path, [2])  # last slide
-    out = str(tmp_path / "with_qr.pptx")
-    prs2.save(out)
-
-    prs3 = Presentation(out)
-    # Verify the last slide has more shapes than before
-    last_slide = prs3.slides[2]
-    assert len(last_slide.shapes) >= 1
-
-
 def test_resolve_slide_bg_rgb_none_for_plain_deck(generate_qr, tmp_path):
     """A plain deck without explicit background returns None."""
     prs = make_deck(1)

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -135,3 +135,18 @@ def test_insert_qr_via_powerpoint_missing_wrapper(generate_qr, monkeypatch):
     monkeypatch.setattr(generate_qr.os.path, "isfile", lambda p: False)
     with pytest.raises(SystemExit):
         generate_qr.insert_qr_via_powerpoint("/decks/talk.pptx", [("/q/a.png", [1])], "/scripts")
+
+
+def test_insert_qr_via_powerpoint_wrapper_failure_is_actionable(generate_qr, monkeypatch):
+    """A wrapper (insert-qr.sh) failure surfaces as an actionable SystemExit
+    pointing at the DeckOps setup, not a raw CalledProcessError traceback."""
+    import pytest
+
+    def boom(cmd, **kw):
+        raise generate_qr.subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(generate_qr.subprocess, "run", boom)
+    monkeypatch.setattr(generate_qr.os.path, "isfile", lambda p: True)
+    with pytest.raises(SystemExit) as exc:
+        generate_qr.insert_qr_via_powerpoint("/decks/talk.pptx", [("/q/a.png", [1])], "/scripts")
+    assert "deck-editing-setup.md" in str(exc.value)

--- a/tests/test_insert_qr_wrapper.py
+++ b/tests/test_insert_qr_wrapper.py
@@ -1,0 +1,85 @@
+"""Tests for insert-qr.sh — the shell wrapper's deterministic behavior (arg
+validation, staging/move, JSON-only stdout, macro-failure path), with `osascript`
+(the real PowerPoint/VBA call) faked on PATH. Only the VBA macro itself is the
+manual-validation gap; the wrapper scaffolding around it is testable.
+"""
+import json
+import os
+import subprocess
+from pathlib import Path
+
+WRAPPER = (
+    Path(__file__).resolve().parents[1]
+    / "skills/presentation-creator/scripts/insert-qr.sh"
+)
+
+
+def _fake_osascript(dirpath, *, succeed):
+    """Write a fake `osascript` into dirpath. The wrapper calls
+    `osascript <driver> <base> <STAGE> <png> <slides>`, so the staged output path
+    is $3. On success the fake touches it (simulating the macro writing the COPY)
+    and echoes the macro return line; on failure it exits non-zero like the driver.
+    """
+    p = dirpath / "osascript"
+    if succeed:
+        p.write_text('#!/bin/bash\ntouch "$3"\necho "InsertQR returned: 1"\n')
+    else:
+        p.write_text('#!/bin/bash\necho "boom" >&2\nexit 1\n')
+    p.chmod(0o755)
+
+
+def _run(args, tmp_path):
+    env = dict(os.environ)
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"   # shadow the real osascript
+    env["HOME"] = str(tmp_path)                  # isolate ~/.deckops-staging
+    return subprocess.run(
+        ["bash", str(WRAPPER), *args], capture_output=True, text=True, env=env
+    )
+
+
+def test_success_emits_json_only_stdout(tmp_path):
+    base = tmp_path / "deck.pptx"; base.write_text("x")
+    png = tmp_path / "qr.png"; png.write_text("x")
+    out = tmp_path / "out.pptx"
+    _fake_osascript(tmp_path, succeed=True)
+
+    r = _run([str(base), str(out), str(png), "1,3"], tmp_path)
+    assert r.returncode == 0, r.stderr
+    # stdout is the documented JSON only (the macro return line went to stderr)
+    assert json.loads(r.stdout) == {"output": str(out)}
+    assert out.exists()
+
+
+def test_missing_base_fails_with_actionable_error(tmp_path):
+    png = tmp_path / "qr.png"; png.write_text("x")
+    _fake_osascript(tmp_path, succeed=True)
+
+    r = _run([str(tmp_path / "nope.pptx"), str(tmp_path / "o.pptx"), str(png), "1"], tmp_path)
+    assert r.returncode != 0
+    assert "base deck not found" in r.stderr
+
+
+def test_missing_png_fails(tmp_path):
+    base = tmp_path / "deck.pptx"; base.write_text("x")
+    _fake_osascript(tmp_path, succeed=True)
+
+    r = _run([str(base), str(tmp_path / "o.pptx"), str(tmp_path / "nope.png"), "1"], tmp_path)
+    assert r.returncode != 0
+    assert "QR PNG not found" in r.stderr
+
+
+def test_macro_failure_path(tmp_path):
+    base = tmp_path / "deck.pptx"; base.write_text("x")
+    png = tmp_path / "qr.png"; png.write_text("x")
+    out = tmp_path / "out.pptx"
+    _fake_osascript(tmp_path, succeed=False)
+
+    r = _run([str(base), str(out), str(png), "1"], tmp_path)
+    assert r.returncode != 0
+    assert not out.exists()
+
+
+def test_too_few_args(tmp_path):
+    r = _run([str(tmp_path / "deck.pptx")], tmp_path)
+    assert r.returncode == 2
+    assert "usage:" in r.stderr


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
#57 Phase F (completes A–F). Retires `generate-qr.py`'s python-pptx deck write for an `InsertQR` VBA macro.

- `generate-qr.py` keeps URL/shortener resolve, per-slide **background-color match (read-only)**, target-slide finding, and **QR PNG generation** — only the deck *write* moves to PowerPoint.
- `RunDeckOps.bas`: + `InsertQR` — QR bottom-right (2.0in, 0.3in margin) on the given 1-based slides, removing any existing corner QR first (idempotent). `insert-qr.{applescript,sh}` drive it (driver errors on negative rc → non-zero exit).
- `generate-qr.py` threads the deck through uniquely-named intermediates (one `InsertQR` pass per color variant) and moves the result back; drops the now-unused `Inches`/`Emu`/`RGBColor` imports + the QR-insert test.
- QR insert is now **macOS + PowerPoint only**; the rest of `generate-qr.py` stays cross-platform.

## Test plan
- [x] `pytest` green (338 passed); QR color/PNG/read tests retained, the python-pptx-write test removed with the function.
- [x] `tessl tile lint` valid; `insert-qr.applescript` compiles; `insert-qr.sh` syntax OK; `generate-qr.py` parses.
- [ ] **VBA untestable in CI** — manual: run `generate-qr.py` on a real deck, confirm the QR lands bottom-right (replacing any prior QR) and the deck opens in PowerPoint **and** Keynote.

Ships untestable VBA — the authorized #57 gap (jbaruch/coding-policy#116); deterministic pieces stay tested, the PowerPoint layer is manually validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)