### PR TITLE
fix(qr-generation): compose date-less talk slugs (QR + Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+### fix(qr-generation) — compose date-less talk slugs (QR + Phase 1) (#55)
+
+Completes the date-less-slug convention. #66 made the publisher consume
+`talk.slug` verbatim (date-less filename and URL); this drops the date prefix
+from how slugs are *composed*, so the QR back-half and the Phase 1 slug match the
+published page instead of pointing at a stale `YYYY-MM-DD`-prefixed back-half.
+
+- `rules/qr-generation-rules.md` §4: the QR back-half IS `talk.slug`, composed in
+  Phase 1 (per the speaker's `slug_convention.template`) and used VERBATIM — no
+  invent / rephrase / re-derive / date-prefix. Replaces the old
+  `{YYYY-MM-DD}-{conference-slug}-{talk-short-name}` format and removes the
+  self-contradictory derive-from-delivery-date guidance. §2 example date-less.
+- `rules/interaction-rules.md` and
+  `skills/presentation-creator/references/phase1-intent.md`: the Phase 1
+  slug-confirmation examples are now date-less (`jcon26-robocoders`).
+- QR eval scenarios (`qr-bitly-slug-from-outline`,
+  `qr-missing-shortener-detection`): fixtures + criteria updated to a date-less
+  slug, in a synthetic namespace (`froconf26-cache-stampedes`) distinct from the
+  `devnexus`/`robocoders` examples used in skill/rule context (no fixture/example
+  bleeding).
+- `generate-qr.py` needed no change — it already uses the passed `--talk-slug`
+  verbatim as the custom back-half.
+- Left intentionally: `url.template` date variables (URL *assembly*, configurable
+  per deployed site — tracked in #17), and legacy date-prefixed filenames already
+  published (the publisher's never-rename guard) or ingested into the vault.
+
 ## 0.18.16 — 2026-06-07
 
 ### fix(shownotes-publisher) — use talk.slug as the filename, drop the date prefix

--- a/eval-resources/qr-bitly-slug-from-outline/outline.yaml
+++ b/eval-resources/qr-bitly-slug-from-outline/outline.yaml
@@ -4,23 +4,23 @@
 # to satisfy schema validation.
 
 talk:
-  title: "Robocoders: Judgment Day"
-  slug: "2026-04-16-devnexus-robocoders-judgment-day"
+  title: "Surviving Cache Stampedes"
+  slug: "froconf26-cache-stampedes"
   speakers: ["Baruch Sadogursky"]
   duration_min: 45
   audience: "Senior developers and tech leads"
   mode: "keynote"
-  venue: "DevNexus 2026"
+  venue: "FroConf 2026"
   slide_budget: 60
   pacing_wpm: [135, 145]
   architecture: "narrative-arc"
   thesis: |
-    AI coding assistants are only as good as the judgment of the human
-    wielding them.
+    A cache stampede can take down a healthy service in seconds; request
+    coalescing and staggered TTLs keep the herd off the origin.
   shownotes_url_base: "https://jbaru.ch/"
   commercial_intent: "none"
   profanity_register: "mild"
-  must_include: ["live demo of AI pair programming"]
+  must_include: ["live demo of a thundering-herd cache failure"]
   must_avoid: ["vendor-specific tooling comparisons"]
 
 chapters:

--- a/eval-resources/qr-missing-shortener-detection/outline.yaml
+++ b/eval-resources/qr-missing-shortener-detection/outline.yaml
@@ -4,23 +4,23 @@
 # to satisfy schema validation.
 
 talk:
-  title: "Robocoders: Judgment Day"
-  slug: "2026-04-16-devnexus-robocoders-judgment-day"
+  title: "Surviving Cache Stampedes"
+  slug: "froconf26-cache-stampedes"
   speakers: ["Baruch Sadogursky"]
   duration_min: 45
   audience: "Senior developers and tech leads"
   mode: "keynote"
-  venue: "DevNexus 2026"
+  venue: "FroConf 2026"
   slide_budget: 60
   pacing_wpm: [135, 145]
   architecture: "narrative-arc"
   thesis: |
-    AI coding assistants are only as good as the judgment of the human
-    wielding them.
+    A cache stampede can take down a healthy service in seconds; request
+    coalescing and staggered TTLs keep the herd off the origin.
   shownotes_url_base: "https://jbaru.ch/"
   commercial_intent: "none"
   profanity_register: "mild"
-  must_include: ["live demo of AI pair programming"]
+  must_include: ["live demo of a thundering-herd cache failure"]
   must_avoid: ["vendor-specific tooling comparisons"]
 
 chapters:

--- a/evals/qr-bitly-slug-from-outline/criteria.json
+++ b/evals/qr-bitly-slug-from-outline/criteria.json
@@ -4,22 +4,22 @@
   "checklist": [
     {
       "name": "Talk slug read from outline.yaml",
-      "description": "The talk slug '2026-04-16-devnexus-robocoders-judgment-day' is read from outline.yaml (talk.slug field). The agent does not invent, abbreviate, or rephrase the slug. Any reference to --talk-slug uses this exact value",
+      "description": "The talk slug 'froconf26-cache-stampedes' is read from outline.yaml (talk.slug field). The agent does not invent, abbreviate, or rephrase the slug. Any reference to --talk-slug uses this exact value",
       "max_score": 15
     },
     {
       "name": "Shownotes URL constructed from pattern + outline.yaml slug",
-      "description": "The shownotes URL is exactly 'https://jbaru.ch/2026-04-16-devnexus-robocoders-judgment-day', constructed by substituting outline.yaml's talk.slug into the profile's shownotes_url_pattern. Not a made-up URL",
+      "description": "The shownotes URL is exactly 'https://jbaru.ch/froconf26-cache-stampedes', constructed by substituting outline.yaml's talk.slug into the profile's shownotes_url_pattern. Not a made-up URL",
       "max_score": 10
     },
     {
       "name": "Bitly custom back-half is the talk slug",
-      "description": "The planned bitly link uses the talk slug as the custom back-half: bit.ly/2026-04-16-devnexus-robocoders-judgment-day. NOT a random hash like bit.ly/a3xK9f. The plan explicitly references the slug being used as the back-half",
+      "description": "The planned bitly link uses the talk slug as the custom back-half: bit.ly/froconf26-cache-stampedes. NOT a random hash like bit.ly/a3xK9f. The plan explicitly references the slug being used as the back-half",
       "max_score": 15
     },
     {
       "name": "QR encodes bitly URL, not raw shownotes URL",
-      "description": "The QR code is planned to encode the bitly URL (https://bit.ly/2026-04-16-devnexus-robocoders-judgment-day), not the raw shownotes URL. The plan explains the decoupling rationale: if shownotes URL changes, update bitly target, printed QR stays valid",
+      "description": "The QR code is planned to encode the bitly URL (https://bit.ly/froconf26-cache-stampedes), not the raw shownotes URL. The plan explains the decoupling rationale: if shownotes URL changes, update bitly target, printed QR stays valid",
       "max_score": 15
     },
     {

--- a/evals/qr-missing-shortener-detection/criteria.json
+++ b/evals/qr-missing-shortener-detection/criteria.json
@@ -19,12 +19,12 @@
     },
     {
       "name": "Shownotes URL uses slug from outline.yaml (talk.slug)",
-      "description": "The shownotes URL is constructed as https://jbaru.ch/2026-04-16-devnexus-robocoders-judgment-day, using the exact slug from outline.yaml (talk.slug field). The agent does not invent, abbreviate, or rephrase the slug",
+      "description": "The shownotes URL is constructed as https://jbaru.ch/froconf26-cache-stampedes, using the exact slug from outline.yaml (talk.slug field). The agent does not invent, abbreviate, or rephrase the slug",
       "max_score": 15
     },
     {
       "name": "Talk slug matches spec exactly",
-      "description": "Any reference to the talk slug uses exactly '2026-04-16-devnexus-robocoders-judgment-day' as written in the outline.yaml (talk.slug), not a shortened or modified version",
+      "description": "Any reference to the talk slug uses exactly 'froconf26-cache-stampedes' as written in the outline.yaml (talk.slug), not a shortened or modified version",
       "max_score": 10
     },
     {

--- a/rules/interaction-rules.md
+++ b/rules/interaction-rules.md
@@ -39,7 +39,7 @@ GOOD — one AskUserQuestion per turn, sequentially:
   → wait for answer →
   "Any venue-specific context I should know about JCON Europe?"
   → wait for answer →
-  AskUserQuestion("Generated slug: 2026-06-23-jcon-robocoders — confirm?",
+  AskUserQuestion("Generated slug: jcon26-robocoders — confirm?",
     options=[{label:"Looks good (Recommended)", ...}, {label:"I want to adjust", ...}])
 ```
 

--- a/rules/qr-generation-rules.md
+++ b/rules/qr-generation-rules.md
@@ -17,8 +17,8 @@ python3 generate-qr.py --png-only --talk-slug SLUG --shownotes-url URL \
 ## 2. NEVER Use a Random Shortener Hash
 
 The custom back-half MUST be the talk slug. The script does this automatically:
-`--talk-slug 2026-04-16-devnexus-robocoders-judgment-day` creates
-`bit.ly/2026-04-16-devnexus-robocoders-judgment-day` (not `bit.ly/a3xK9f`).
+`--talk-slug devnexus26-robocoders` creates `bit.ly/devnexus26-robocoders`
+(not `bit.ly/a3xK9f`).
 
 Random hashes are untraceable and unprofessional. The back-half IS the slug.
 
@@ -33,22 +33,14 @@ URL is the only option.
 
 ## 4. Slug Convention
 
-Slug format: `{YYYY-MM-DD}-{conference-slug}-{talk-short-name}`
+The back-half IS `talk.slug` — composed and agreed with the author in Phase 1
+(per the speaker's `slug_convention.template`) and persisted in `outline.yaml` /
+`presentation-spec.md`. The QR step uses it VERBATIM: never invent, rephrase,
+re-derive, abbreviate, or date-prefix it. The back-half must equal the published
+shownotes slug.
 
-- Derive mechanically from: delivery date + conference name + talk title
 - Kebab-case, lowercase, no special characters
-- No abbreviations, no ambiguity
-- The slug is agreed with the author in Phase 1 and persisted in
-  `presentation-spec.md`. NEVER invent, rephrase, or re-derive it.
-
-Example: `2026-04-16-devnexus-robocoders-judgment-day`
-
-Read the speaker's convention from
-`publishing_process.shownotes.slug_convention.template` in the profile. If
-not set (or if it disagrees with recent shownotes entries under
-`publishing_process.shownotes.source.path_or_url` /
-`shownotes.source.talks_subdir`), treat the observed live convention as
-authoritative and offer to update the profile via vault-clarification.
+- No date prefix (e.g. `devnexus26-robocoders`, not `2026-04-16-devnexus-robocoders`)
 
 ## 5. Missing Shortener Config = STOP
 

--- a/skills/presentation-creator/references/phase1-intent.md
+++ b/skills/presentation-creator/references/phase1-intent.md
@@ -53,7 +53,7 @@ AskUserQuestion(
 → wait for answer →
 
 AskUserQuestion(
-  question: "Generated slug: 2026-06-23-jcon-robocoders — confirm?",
+  question: "Generated slug: jcon26-robocoders — confirm?",
   options: [
     {label: "Looks good (Recommended)", description: "Use this slug for shownotes and QR"},
     {label: "I want to adjust", description: "Let me edit the slug"}


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Completes the date-less-slug convention (the *composition* half). #66 made the publisher consume `talk.slug` verbatim so the shownotes filename/URL is date-less. This PR drops the date prefix from how slugs are **composed**, so the QR Bitly back-half and the Phase 1 slug match the published page instead of pointing at a stale `YYYY-MM-DD`-prefixed back-half (the "had to repoint the Bitly QR by hand" pain from #66).

- `rules/qr-generation-rules.md` §4 — the QR back-half IS `talk.slug` (date-less, per the speaker's `slug_convention.template`, e.g. `devnexus26-robocoders`), not the old `{YYYY-MM-DD}-{conference-slug}-{talk-short-name}` format. Removed the contradictory "derive mechanically from delivery date" bullet (the same rule also said NEVER re-derive). §2 example made date-less.
- `rules/interaction-rules.md` + `skills/presentation-creator/references/phase1-intent.md` — Phase 1 slug-confirmation examples are now date-less (`jcon26-robocoders`).

## Scope notes

- `generate-qr.py` needs **no change** — it already uses the passed `--talk-slug` verbatim as the custom back-half.
- **Left intentionally:** `url.template` date variables (URL *assembly*, configurable per deployed site — that's #17's domain), and legacy date-prefixed filenames already published (the publisher's never-rename guard) or ingested into the vault (`schemas-db.md` reflects real legacy data).

## Test plan

- [x] `tessl tile lint` valid
- [x] Grep confirms no remaining date-prefixed *new-slug* composition examples (only the intentional "not `2026-04-16-...`" counter-example remains)
- [ ] No code changed (rules + 1 skill reference + CHANGELOG); python tests unaffected