### PR TITLE
fix(shownotes-publisher): direct-push content via content-only gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ published page instead of pointing at a stale `YYYY-MM-DD`-prefixed back-half.
 - Left intentionally: `url.template` date variables (URL *assembly*, configurable
   per deployed site — tracked in #17), and legacy date-prefixed filenames already
   published (the publisher's never-rename guard) or ingested into the vault.
+### fix(shownotes-publisher) — content-only gate decides direct-push vs branch+PR
+
+Step 9 runs `skills/shownotes-publisher/scripts/content-only-gate.sh` against the
+shownotes repo before publishing. When every pending change touches only the
+declared content globs, the skill direct-pushes to `main`; any out-of-glob path,
+or an indeterminate state, falls back to branch + PR. This is the Form B
+client-side gate that `jbaruch/coding-policy: ci-safety`'s Content-Only
+Direct-Push Carve-Out permits where server-side allowlist enforcement is not
+expressible on a github.com personal repo (coding-policy#119, shipped in
+coding-policy 0.3.52). Fixes #65.
 
 ## 0.18.16 — 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ or an indeterminate state, falls back to branch + PR. This is the Form B
 client-side gate that `jbaruch/coding-policy: ci-safety`'s Content-Only
 Direct-Push Carve-Out permits where server-side allowlist enforcement is not
 expressible on a github.com personal repo (coding-policy#119, shipped in
-coding-policy 0.3.52). Fixes #65.
+coding-policy 0.3.52). The carve-out's precondition 1 is satisfied by a new
+authority-of-record steering rule, `rules/shownotes-content-publish.md`, naming
+the covered globs, the gate script, and the review the direct-push skips. Fixes #65.
 
 ## 0.18.16 — 2026-06-07
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ The tile ships persistent steering rules (auto-loaded by the agent at runtime vi
 | [`resources-gathering-rules`](rules/resources-gathering-rules.md) | Phase 6 shownotes / resources read paths. |
 | [`interaction-rules`](rules/interaction-rules.md) | Conversational stance and gate behavior across phases. |
 | [`tessl-version-floating`](rules/tessl-version-floating.md) | Authority-of-record for the `tessl.json` floating-spec carve-out (paired with `scripts/check-tessl-pins.sh`). |
+| [`shownotes-content-publish`](rules/shownotes-content-publish.md) | Authority-of-record for the shownotes content direct-push carve-out (paired with `skills/shownotes-publisher/scripts/content-only-gate.sh`). |
 
 ## Vault Skills Details
 

--- a/rules/shownotes-content-publish.md
+++ b/rules/shownotes-content-publish.md
@@ -1,0 +1,33 @@
+---
+alwaysApply: true
+---
+
+# Shownotes Content Publish
+
+## Why
+
+- The `shownotes-publisher` skill writes talk pages into the Jekyll shownotes site and pushes them to the site's default branch. These pages are prose and data a human audience reads directly, not code or agent-loaded context.
+- `jbaruch/coding-policy: ci-safety`'s Content-Only Direct-Push Carve-Out permits a direct push to `main` for such content under its Form B client-side gate, used where a platform cannot express server-side allowlist enforcement (github.com personal repos). This rule is the authority-of-record satisfying precondition 1: it names the carve-out, the covered path globs, the enforcing gate script, and the review the direct-push does not carry.
+
+## Covered Paths
+
+- `_talks/**` — the Jekyll `_talks/` collection; one markdown page per talk, authored for human reading on the shownotes site.
+- `assets/images/thumbnails/**` — talk thumbnail images the rendered pages reference.
+
+These are the only paths a direct push may modify, and both are content surfaces a reader consumes directly. No code, rule, skill, script, manifest, workflow file, or configuration is in scope. A push touching anything else is out of scope and forces branch + PR.
+
+## Enforcement
+
+- Form B client-side gate: `skills/shownotes-publisher/scripts/content-only-gate.sh` is the deterministic gate (per `jbaruch/coding-policy: script-delegation`). It enumerates every path the pending push would change in the target work tree and exits 0 only when every one matches a covered glob above; any out-of-glob path exits non-zero.
+- `shownotes-publisher` Step 9 runs the gate before publishing and direct-pushes only on exit 0. An out-of-glob path, or an indeterminate gate result, forces an automatic branch + PR fallback — never an operator override.
+- The allowlist is the `ALLOWED_PREFIXES` constant at the top of the gate script. The globs above and that constant stay in sync.
+
+## What Direct-Push Does NOT Carry
+
+- The direct push bypasses the pull-request review cycle on the shownotes site: no gh-aw policy review and no human or Copilot review runs on the content before it lands.
+- It does not bypass post-publish verification. `ci-safety` still requires watching the Pages deploy to a successful conclusion and confirming the live URL returns HTTP 200.
+
+## Scope Limits
+
+- The carve-out covers only the two globs above on the shownotes site. To extend it, name the new glob here AND add it to `ALLOWED_PREFIXES` in the gate script. Adding one without the other invalidates the precondition.
+- The carve-out does not widen to any other repo or branch. Every other path, and every change to this speaker-toolkit repo, still goes through pull requests.

--- a/rules/shownotes-content-publish.md
+++ b/rules/shownotes-content-publish.md
@@ -18,7 +18,7 @@ These are the only paths a direct push may modify, and both are content surfaces
 
 ## Enforcement
 
-- Form B client-side gate: `skills/shownotes-publisher/scripts/content-only-gate.sh` is the deterministic gate (per `jbaruch/coding-policy: script-delegation`). It enumerates every path the pending push would change in the target work tree and exits 0 only when every one matches a covered glob above; any out-of-glob path exits non-zero.
+- Form B client-side gate: `skills/shownotes-publisher/scripts/content-only-gate.sh` is the deterministic gate (per `jbaruch/coding-policy: script-delegation`). It enumerates every path the push would land on the protected branch (committed-but-unpushed commits in `origin/main..HEAD`, plus pending staged, unstaged, and untracked changes) and exits 0 only when every one matches a covered glob above. Any out-of-glob path exits non-zero.
 - `shownotes-publisher` Step 9 runs the gate before publishing and direct-pushes only on exit 0. An out-of-glob path, or an indeterminate gate result, forces an automatic branch + PR fallback — never an operator override.
 - The allowlist is the `ALLOWED_PREFIXES` constant at the top of the gate script. The globs above and that constant stay in sync.
 

--- a/skills/shownotes-publisher/SKILL.md
+++ b/skills/shownotes-publisher/SKILL.md
@@ -333,12 +333,38 @@ Proceed immediately to Step 9.
 
 ## Step 9 — Publish
 
-**Default flow — branch + PR.** Required under
-`jbaruch/coding-policy: ci-safety` unless the target repo has the
-Content-Only Direct-Push Carve-Out wired (authority-of-record rule
-+ server-side path enforcement on `_talks/**` /
-`assets/images/thumbnails/**` — see that rule for full
-preconditions).
+Pick the push flow with the **content-only gate**, then publish. Run
+the gate from the speaker-toolkit repo root, pointed at the shownotes
+repo — it inspects every pending change (staged, unstaged, untracked)
+and reports whether they touch only content paths:
+
+```bash
+bash skills/shownotes-publisher/scripts/content-only-gate.sh ~/Projects/shownotes
+```
+
+- **Exit 0** (content-only) → take the **direct-push** flow. This
+  satisfies the Form B client-side gate of `jbaruch/coding-policy:
+  ci-safety`'s Content-Only Direct-Push Carve-Out.
+- **Exit 1** (a change lies outside the content paths) or **exit 2**
+  (no pending changes, not a work tree, or can't tell) → take the
+  **branch + PR** flow. Never direct-push when the gate does not
+  return 0.
+
+The allowed content prefixes are the named `ALLOWED_PREFIXES` at the top
+of `scripts/content-only-gate.sh`.
+
+**Direct-push flow:**
+
+```bash
+cd ~/Projects/shownotes
+git add _talks/{talk_page_stem}.md [assets/images/thumbnails/{talk_page_stem}-thumbnail.png]
+git commit -m "Add shownotes: {Talk Title} at {Conference}"
+git push
+gh run watch --exit-status $(gh run list --workflow=pages-build-deployment --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')
+curl -fsI "{site.url}/talks/{talk_page_stem}/" | head -1   # expect: HTTP/2 200
+```
+
+**Branch + PR flow:**
 
 ```bash
 cd ~/Projects/shownotes
@@ -353,22 +379,8 @@ gh run watch --exit-status $(gh run list --workflow=pages-build-deployment --bra
 curl -fsI "{site.url}/talks/{talk_page_stem}/" | head -1   # expect: HTTP/2 200
 ```
 
-**Direct-push (carve-out wired AND changes touch only carve-out
-paths):**
-
-```bash
-cd ~/Projects/shownotes
-git add _talks/{talk_page_stem}.md [assets/images/thumbnails/{talk_page_stem}-thumbnail.png]
-git commit -m "Add shownotes: {Talk Title} at {Conference}"
-git push
-gh run watch --exit-status $(gh run list --workflow=pages-build-deployment --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')
-curl -fsI "{site.url}/talks/{talk_page_stem}/" | head -1   # expect: HTTP/2 200
-```
-
-The carve-out bypasses the PR cycle but NOT the CI/deploy watch —
-`ci-safety` requires both the run conclusion and the 200 to confirm
-the publish landed. If the carve-out status is unknown, default to
-the branch + PR flow.
+Either flow requires the CI/deploy watch + HTTP 200 — `ci-safety`
+confirms the publish via both the run conclusion and the 200, PR or not.
 
 If a QR code is needed for the live URL, hand off via
 `Skill(skill: "presentation-creator")` — the QR generation flow

--- a/skills/shownotes-publisher/SKILL.md
+++ b/skills/shownotes-publisher/SKILL.md
@@ -335,8 +335,9 @@ Proceed immediately to Step 9.
 
 Pick the push flow with the **content-only gate**, then publish. Run
 the gate from the speaker-toolkit repo root, pointed at the shownotes
-repo — it inspects every pending change (staged, unstaged, untracked)
-and reports whether they touch only content paths:
+repo — it enumerates every path the push would land on `main`
+(committed-but-unpushed commits plus pending staged, unstaged, and
+untracked changes) and reports whether they all touch content paths:
 
 ```bash
 bash skills/shownotes-publisher/scripts/content-only-gate.sh ~/Projects/shownotes
@@ -345,8 +346,8 @@ bash skills/shownotes-publisher/scripts/content-only-gate.sh ~/Projects/shownote
 - **Exit 0** (content-only) → take the **direct-push** flow. This
   satisfies the Form B client-side gate of `jbaruch/coding-policy:
   ci-safety`'s Content-Only Direct-Push Carve-Out.
-- **Exit 1** (a change lies outside the content paths) or **exit 2**
-  (no pending changes, not a work tree, or can't tell) → take the
+- **Exit 1** (a path lies outside the content paths) or **exit 2**
+  (not on `main`, no upstream, empty push, or can't tell) → take the
   **branch + PR** flow. Never direct-push when the gate does not
   return 0.
 

--- a/skills/shownotes-publisher/SKILL.md
+++ b/skills/shownotes-publisher/SKILL.md
@@ -352,7 +352,7 @@ bash skills/shownotes-publisher/scripts/content-only-gate.sh ~/Projects/shownote
   return 0.
 
 The allowed content prefixes are the named `ALLOWED_PREFIXES` at the top
-of `scripts/content-only-gate.sh`.
+of `skills/shownotes-publisher/scripts/content-only-gate.sh`.
 
 **Direct-push flow:**
 
@@ -360,7 +360,7 @@ of `scripts/content-only-gate.sh`.
 cd ~/Projects/shownotes
 git add _talks/{talk_page_stem}.md [assets/images/thumbnails/{talk_page_stem}-thumbnail.png]
 git commit -m "Add shownotes: {Talk Title} at {Conference}"
-git push
+git push origin main
 gh run watch --exit-status $(gh run list --workflow=pages-build-deployment --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')
 curl -fsI "{site.url}/talks/{talk_page_stem}/" | head -1   # expect: HTTP/2 200
 ```

--- a/skills/shownotes-publisher/scripts/content-only-gate.sh
+++ b/skills/shownotes-publisher/scripts/content-only-gate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# content-only-gate.sh — decide whether the pending changes in a git work
+# tree touch ONLY content paths, making a direct push to the default branch
+# safe under coding-policy ci-safety's content-publishing carve-out.
+# See jbaruch/coding-policy#119 for the carve-out rationale.
+#
+# ALLOWED_PREFIXES below is the allowlist: the only path prefixes a direct
+# push may modify. Any pending change outside them forces branch + PR.
+#
+# Contract:
+#   Usage: content-only-gate.sh [TARGET_REPO_DIR]   (default: .)
+#   Considers every pending change: staged, unstaged, and untracked.
+#   stdout (last line): JSON
+#     {"content_only": bool, "changed": [paths], "outside": [paths]}
+#   Exit 0 -> content_only true   (safe to direct-push)
+#   Exit 1 -> content_only false  (use branch + PR)
+#   Exit 2 -> error: not a git work tree, no HEAD, or no pending changes
+#             (caller falls back to branch + PR)
+set -euo pipefail
+
+ALLOWED_PREFIXES=(
+  "_talks/"
+  "assets/images/thumbnails/"
+)
+
+target="${1:-.}"
+
+err() { printf 'content-only-gate: %s\n' "$*" >&2; }
+
+json_str() { printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"; }
+
+if ! git -C "$target" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  err "not a git work tree: $target"
+  exit 2
+fi
+
+if ! git -C "$target" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+  err "no HEAD commit in $target — cannot diff pending changes"
+  exit 2
+fi
+
+content_only=true
+changed_json=""
+outside_json=""
+seen=""
+
+append() {
+  local path="$1" allowed=false p
+  case "$seen" in *"|$path|"*) return 0;; esac
+  seen="$seen|$path|"
+  for p in "${ALLOWED_PREFIXES[@]}"; do
+    case "$path" in "$p"*) allowed=true; break;; esac
+  done
+  changed_json="$changed_json${changed_json:+,}$(json_str "$path")"
+  if ! $allowed; then
+    content_only=false
+    outside_json="$outside_json${outside_json:+,}$(json_str "$path")"
+  fi
+}
+
+while IFS= read -r -d '' path; do
+  [ -n "$path" ] && append "$path"
+done < <(git -C "$target" diff --name-only -z HEAD --)
+
+while IFS= read -r -d '' path; do
+  [ -n "$path" ] && append "$path"
+done < <(git -C "$target" ls-files --others --exclude-standard -z --)
+
+if [ -z "$changed_json" ]; then
+  err "no pending changes in $target to evaluate"
+  exit 2
+fi
+
+printf '{"content_only":%s,"changed":[%s],"outside":[%s]}\n' \
+  "$content_only" "$changed_json" "$outside_json"
+
+if [ "$content_only" = true ]; then exit 0; else exit 1; fi

--- a/skills/shownotes-publisher/scripts/content-only-gate.sh
+++ b/skills/shownotes-publisher/scripts/content-only-gate.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
-# content-only-gate.sh — decide whether the pending changes in a git work
-# tree touch ONLY content paths, making a direct push to the default branch
-# safe under coding-policy ci-safety's content-publishing carve-out.
-# See jbaruch/coding-policy#119 for the carve-out rationale.
+# content-only-gate.sh — decide whether a direct push to the protected branch
+# would change ONLY content paths, per coding-policy ci-safety's Content-Only
+# Direct-Push Carve-Out (Form B client-side gate).
 #
-# ALLOWED_PREFIXES below is the allowlist: the only path prefixes a direct
-# push may modify. Any pending change outside them forces branch + PR.
+# It enumerates the FULL set of paths the push would land on the protected
+# branch — committed-but-unpushed changes (origin/<branch>..HEAD) AND pending
+# work-tree changes (staged, unstaged, untracked) about to be committed — so an
+# earlier non-content commit cannot ride along on the push. The push is
+# content-only iff every enumerated path matches an allowlisted content prefix.
 #
-# Contract:
-#   Usage: content-only-gate.sh [TARGET_REPO_DIR]   (default: .)
-#   Considers every pending change: staged, unstaged, and untracked.
-#   stdout (last line): JSON
-#     {"content_only": bool, "changed": [paths], "outside": [paths]}
-#   Exit 0 -> content_only true   (safe to direct-push)
-#   Exit 1 -> content_only false  (use branch + PR)
-#   Exit 2 -> error: not a git work tree, no HEAD, or no pending changes
-#             (caller falls back to branch + PR)
+# ALLOWED_PREFIXES below is the allowlist. Keep it in sync with the
+# authority-of-record rule (rules/shownotes-content-publish.md).
+#
+# Usage: content-only-gate.sh [TARGET_REPO_DIR] [PROTECTED_BRANCH]
+#   TARGET_REPO_DIR   default "."
+#   PROTECTED_BRANCH  default "main"
+# stdout (last line): JSON
+#   {"content_only": bool, "changed": [paths], "outside": [paths]}
+# Exit 0 -> content_only true   (safe to direct-push)
+# Exit 1 -> content_only false  (use branch + PR)
+# Exit 2 -> error: not a git work tree, no HEAD, not on the protected branch,
+#           no upstream to compare against, or an empty push (caller falls back
+#           to branch + PR)
 set -euo pipefail
 
 ALLOWED_PREFIXES=(
@@ -24,18 +30,34 @@ ALLOWED_PREFIXES=(
 )
 
 target="${1:-.}"
+branch="${2:-main}"
 
+g() { git -C "$target" "$@"; }
 err() { printf 'content-only-gate: %s\n' "$*" >&2; }
-
 json_str() { printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"; }
 
-if ! git -C "$target" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if ! g rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   err "not a git work tree: $target"
   exit 2
 fi
+if ! g rev-parse --verify -q HEAD >/dev/null 2>&1; then
+  err "no HEAD commit in $target"
+  exit 2
+fi
 
-if ! git -C "$target" rev-parse --verify -q HEAD >/dev/null 2>&1; then
-  err "no HEAD commit in $target — cannot diff pending changes"
+# A direct push advances the protected branch; the gate only applies there.
+current=$(g rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$current" != "$branch" ]; then
+  err "not on protected branch '$branch' (on '$current')"
+  exit 2
+fi
+
+# Refresh the upstream ref (best-effort; offline falls through to the local ref).
+g fetch -q origin "$branch" 2>/dev/null || true
+
+base=$(g rev-parse --verify -q "origin/$branch" 2>/dev/null || echo "")
+if [ -z "$base" ]; then
+  err "no origin/$branch to compare the push against"
   exit 2
 fi
 
@@ -58,16 +80,23 @@ append() {
   fi
 }
 
+# committed-but-unpushed changes the push would carry
 while IFS= read -r -d '' path; do
   [ -n "$path" ] && append "$path"
-done < <(git -C "$target" diff --name-only -z HEAD --)
+done < <(g diff --name-only -z "$base" HEAD --)
 
+# pending work-tree changes about to be committed (staged + unstaged)
 while IFS= read -r -d '' path; do
   [ -n "$path" ] && append "$path"
-done < <(git -C "$target" ls-files --others --exclude-standard -z --)
+done < <(g diff --name-only -z HEAD --)
+
+# untracked files about to be added
+while IFS= read -r -d '' path; do
+  [ -n "$path" ] && append "$path"
+done < <(g ls-files --others --exclude-standard -z --)
 
 if [ -z "$changed_json" ]; then
-  err "no pending changes in $target to evaluate"
+  err "no changes to publish in $target — the push would be empty"
   exit 2
 fi
 

--- a/tests/test_content_only_gate.py
+++ b/tests/test_content_only_gate.py
@@ -1,8 +1,10 @@
 """Tests for skills/shownotes-publisher/scripts/content-only-gate.sh.
 
-The gate decides whether a git work tree's pending changes touch only the
-content-path allowlist (safe to direct-push) or stray outside it (must use
-branch + PR). Exit codes: 0 content-only, 1 not, 2 error.
+The gate decides whether a direct push to the protected branch would change only
+the content-path allowlist (safe to direct-push, exit 0) or stray outside it
+(must use branch + PR, exit 1), with exit 2 for error/empty-push states. It
+covers the full push range: committed-but-unpushed changes (origin/main..HEAD)
+plus pending work-tree changes (staged, unstaged, untracked).
 """
 
 import json
@@ -20,58 +22,68 @@ def _git(repo: Path, *args: str) -> None:
                    capture_output=True, text=True)
 
 
+def _commit(repo: Path, rel: str, body: str = "x\n") -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    _git(repo, "add", rel)
+    _git(repo, "commit", "-qm", f"add {rel}")
+
+
 @pytest.fixture()
 def repo(tmp_path: Path) -> Path:
-    """A git repo with one committed file, so HEAD exists."""
-    _git(tmp_path, "init", "-q")
-    _git(tmp_path, "config", "user.email", "test@example.com")
-    _git(tmp_path, "config", "user.name", "Test")
-    (tmp_path / "seed.txt").write_text("seed\n")
-    _git(tmp_path, "add", "seed.txt")
-    _git(tmp_path, "commit", "-qm", "seed")
-    return tmp_path
+    """A work repo on `main` tracking a bare origin, seeded and pushed."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)],
+                   check=True, capture_output=True)
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", str(origin), str(work)],
+                   check=True, capture_output=True)
+    _git(work, "config", "user.email", "test@example.com")
+    _git(work, "config", "user.name", "Test")
+    _commit(work, "seed.txt", "seed\n")
+    _git(work, "push", "-q", "origin", "main")
+    return work
 
 
-def _run(target: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(["bash", str(GATE), str(target)],
+def _run(target: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["bash", str(GATE), str(target), *extra],
                           capture_output=True, text=True)
 
 
-def test_only_talk_file_is_content_only(repo: Path) -> None:
+def _payload(result: subprocess.CompletedProcess) -> dict:
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_content_only_worktree_change_direct_pushes(repo: Path) -> None:
     (repo / "_talks").mkdir()
     (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
     result = _run(repo)
     assert result.returncode == 0, result.stderr
-    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    payload = _payload(result)
     assert payload["content_only"] is True
     assert payload["changed"] == ["_talks/geecon-2026.md"]
     assert payload["outside"] == []
 
 
-def test_talk_plus_thumbnail_is_content_only(repo: Path) -> None:
+def test_content_plus_thumbnail_direct_pushes(repo: Path) -> None:
     (repo / "_talks").mkdir()
     (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
-    thumb_dir = repo / "assets" / "images" / "thumbnails"
-    thumb_dir.mkdir(parents=True)
-    (thumb_dir / "geecon-2026-thumbnail.png").write_bytes(b"\x89PNG\r\n")
+    thumb = repo / "assets" / "images" / "thumbnails"
+    thumb.mkdir(parents=True)
+    (thumb / "geecon-2026-thumbnail.png").write_bytes(b"\x89PNG\r\n")
     result = _run(repo)
     assert result.returncode == 0, result.stderr
-    payload = json.loads(result.stdout.strip().splitlines()[-1])
-    assert payload["content_only"] is True
-    assert set(payload["changed"]) == {
-        "_talks/geecon-2026.md",
-        "assets/images/thumbnails/geecon-2026-thumbnail.png",
-    }
-    assert payload["outside"] == []
+    assert _payload(result)["content_only"] is True
 
 
-def test_non_content_file_blocks_direct_push(repo: Path) -> None:
+def test_non_content_worktree_file_blocks(repo: Path) -> None:
     (repo / "_talks").mkdir()
     (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
     (repo / "_config.yml").write_text("url: https://example.com\n")
     result = _run(repo)
     assert result.returncode == 1, result.stderr
-    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    payload = _payload(result)
     assert payload["content_only"] is False
     assert payload["outside"] == ["_config.yml"]
 
@@ -80,18 +92,58 @@ def test_modified_tracked_non_content_file_blocks(repo: Path) -> None:
     (repo / "seed.txt").write_text("changed\n")
     result = _run(repo)
     assert result.returncode == 1, result.stderr
-    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert _payload(result)["outside"] == ["seed.txt"]
+
+
+def test_unpushed_non_content_commit_blocks(repo: Path) -> None:
+    # The carve-out scenario: an earlier non-content commit not yet pushed must
+    # not ride along on a direct push, even if the work tree is content-only.
+    _commit(repo, "_config.yml", "url: https://example.com\n")
+    (repo / "_talks").mkdir()
+    (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
+    result = _run(repo)
+    assert result.returncode == 1, result.stderr
+    payload = _payload(result)
     assert payload["content_only"] is False
-    assert payload["outside"] == ["seed.txt"]
+    assert "_config.yml" in payload["outside"]
+
+
+def test_unpushed_content_commit_direct_pushes(repo: Path) -> None:
+    _commit(repo, "_talks/devoxx.md", "# Talk\n")
+    result = _run(repo)
+    assert result.returncode == 0, result.stderr
+    payload = _payload(result)
+    assert payload["content_only"] is True
+    assert payload["changed"] == ["_talks/devoxx.md"]
 
 
 def test_no_pending_changes_is_error(repo: Path) -> None:
     result = _run(repo)
     assert result.returncode == 2
-    assert "no pending changes" in result.stderr
+    assert "empty" in result.stderr
+
+
+def test_not_on_protected_branch_is_error(repo: Path) -> None:
+    _git(repo, "checkout", "-q", "-b", "feature")
+    (repo / "_talks").mkdir()
+    (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
+    result = _run(repo)
+    assert result.returncode == 2
+    assert "protected branch" in result.stderr
+
+
+def test_missing_upstream_is_error(repo: Path) -> None:
+    _git(repo, "remote", "remove", "origin")
+    (repo / "_talks").mkdir()
+    (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
+    result = _run(repo)
+    assert result.returncode == 2
+    assert "origin/main" in result.stderr
 
 
 def test_not_a_git_repo_is_error(tmp_path: Path) -> None:
-    result = _run(tmp_path)
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    result = _run(plain)
     assert result.returncode == 2
     assert "not a git work tree" in result.stderr

--- a/tests/test_content_only_gate.py
+++ b/tests/test_content_only_gate.py
@@ -1,0 +1,97 @@
+"""Tests for skills/shownotes-publisher/scripts/content-only-gate.sh.
+
+The gate decides whether a git work tree's pending changes touch only the
+content-path allowlist (safe to direct-push) or stray outside it (must use
+branch + PR). Exit codes: 0 content-only, 1 not, 2 error.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE = REPO_ROOT / "skills" / "shownotes-publisher" / "scripts" / "content-only-gate.sh"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A git repo with one committed file, so HEAD exists."""
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "seed.txt").write_text("seed\n")
+    _git(tmp_path, "add", "seed.txt")
+    _git(tmp_path, "commit", "-qm", "seed")
+    return tmp_path
+
+
+def _run(target: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(["bash", str(GATE), str(target)],
+                          capture_output=True, text=True)
+
+
+def test_only_talk_file_is_content_only(repo: Path) -> None:
+    (repo / "_talks").mkdir()
+    (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
+    result = _run(repo)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["content_only"] is True
+    assert payload["changed"] == ["_talks/geecon-2026.md"]
+    assert payload["outside"] == []
+
+
+def test_talk_plus_thumbnail_is_content_only(repo: Path) -> None:
+    (repo / "_talks").mkdir()
+    (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
+    thumb_dir = repo / "assets" / "images" / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    (thumb_dir / "geecon-2026-thumbnail.png").write_bytes(b"\x89PNG\r\n")
+    result = _run(repo)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["content_only"] is True
+    assert set(payload["changed"]) == {
+        "_talks/geecon-2026.md",
+        "assets/images/thumbnails/geecon-2026-thumbnail.png",
+    }
+    assert payload["outside"] == []
+
+
+def test_non_content_file_blocks_direct_push(repo: Path) -> None:
+    (repo / "_talks").mkdir()
+    (repo / "_talks" / "geecon-2026.md").write_text("# Talk\n")
+    (repo / "_config.yml").write_text("url: https://example.com\n")
+    result = _run(repo)
+    assert result.returncode == 1, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["content_only"] is False
+    assert payload["outside"] == ["_config.yml"]
+
+
+def test_modified_tracked_non_content_file_blocks(repo: Path) -> None:
+    (repo / "seed.txt").write_text("changed\n")
+    result = _run(repo)
+    assert result.returncode == 1, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["content_only"] is False
+    assert payload["outside"] == ["seed.txt"]
+
+
+def test_no_pending_changes_is_error(repo: Path) -> None:
+    result = _run(repo)
+    assert result.returncode == 2
+    assert "no pending changes" in result.stderr
+
+
+def test_not_a_git_repo_is_error(tmp_path: Path) -> None:
+    result = _run(tmp_path)
+    assert result.returncode == 2
+    assert "not a git work tree" in result.stderr

--- a/tile.json
+++ b/tile.json
@@ -55,6 +55,9 @@
     },
     "tessl-version-floating": {
       "rules": "rules/tessl-version-floating.md"
+    },
+    "shownotes-content-publish": {
+      "rules": "rules/shownotes-content-publish.md"
     }
   },
   "keywords": [


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- Fixes #65: Step 9 now direct-pushes content via a deterministic **content-only gate** instead of always opening a PR.
- `skills/shownotes-publisher/scripts/content-only-gate.sh` (+ 6 tests) enumerates every pending change and exits 0 only when each path matches a content glob (`_talks/**`, `assets/images/thumbnails/**`); any out-of-glob path, or an indeterminate state, forces branch + PR. Either flow keeps the CI/deploy watch + HTTP 200 check.
- This is the **Form B** client-side gate that `jbaruch/coding-policy: ci-safety`'s Content-Only Direct-Push Carve-Out permits where server-side allowlist enforcement isn't expressible on a github.com personal repo (coding-policy#119, shipped in coding-policy 0.3.52).
- Adds `rules/shownotes-content-publish.md` as the carve-out's **authority-of-record** (precondition 1) — naming the globs, the gate script, and the PR review the direct-push skips — wired into `tile.json` steering + the README.

## Test plan
- [ ] `pytest` green (369 passed; 6 new gate tests)
- [ ] `tessl skill review --threshold 85` → 92% PASS
- [ ] Gate behavior: content-only change → direct push; mixed change → branch+PR; no pending changes → branch+PR

Fixes #65.