### PR TITLE
feat(presentation-creator): render narrative.md from a partial outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### feat(presentation-creator) — generate narrative.md during Phases 1–2 for early review
+
+`narrative.md` (the prose distillation of `talk.thesis` + `chapters[].argument_beats`)
+can now be generated and reviewed before any slide exists. Previously
+`extract-narrative.py` called `load_outline()`, which runs the full `Outline`
+schema — `slides[]` (min 1), the `big_idea` singleton, paired callbacks, and
+slide-budget math — so the human-readable narrative could not appear until Phase 3,
+after slide content development had already begun. The narrative itself is fully
+authored by the end of Phase 2, so the author had no readable artifact to approve
+at the point the argument was actually being shaped.
+
+- New `PartialOutline` model + `load_outline_partial()` in `outline_schema.py`
+  validate `talk` (+ optional `chapters`) without the slide-dependent
+  cross-validators. The full `Outline` stays the Phase 3+ source-of-truth contract.
+- `extract-narrative.py --partial` renders from the partial view and emits a
+  "narrative arc not yet authored" note when chapters are absent.
+- SKILL.md: Phase 1 emits a thesis-only stub; Phase 2 regenerates the full
+  narrative and the gate now requires author approval of narrative + architecture
+  before Phase 3. The plain (full-validation) extractor path is unchanged from
+  Phase 3 onward.
+
 ### fix(qr-generation) — compose date-less talk slugs (QR + Phase 1) (#55)
 
 Completes the date-less-slug convention. #66 made the publisher consume

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -59,9 +59,9 @@ thresholds (1.5 slides/min, 45% Act 1 cap), ask for template/publishing interact
 | Phase | What happens | Gate |
 |-------|-------------|------|
 | 0: Intake | Load vault, gather context | Topic and context captured |
-| 1: Intent Distillation | Clarifying questions → `talk:` block of `outline.yaml` | Author confirms metadata |
-| 2: Rhetorical Architecture | Joint instrument selection → `architecture`, `applied_patterns`, `chapters[]` in `outline.yaml` | Author approves architecture |
-| 3: Content Development | Fill `slides[]` + `interludes[]` in `outline.yaml`; generate `narrative.md`, `script.md`, `slides.md`, `rhetorical-review.md` | Draft delivered |
+| 1: Intent Distillation | Clarifying questions → `talk:` block of `outline.yaml`; generate thesis-only `narrative.md` (partial) | Author confirms metadata |
+| 2: Rhetorical Architecture | Joint instrument selection → `architecture`, `applied_patterns`, `chapters[]` in `outline.yaml`; regenerate `narrative.md` (partial) for review | Author approves narrative + architecture |
+| 3: Content Development | Fill `slides[]` + `interludes[]` in `outline.yaml`; finalize `narrative.md` (full) + generate `script.md`, `slides.md`, `rhetorical-review.md` | Draft delivered |
 | 4: Revision & Guardrails | Iterate on feedback, run guardrail checks against `outline.yaml` | Author declares outline done |
 | 5: Slide Generation | Build .pptx from template (or presenterm `{slug}.md`) using `slides.md` build-sheet | Author declares slides done |
 | 6: Publishing | Export, shownotes, QR per speaker's workflow | Published and ready |
@@ -93,6 +93,18 @@ python3 skills/presentation-creator/scripts/check-rhetorical.py  outline.yaml > 
 ```
 
 Validate the YAML with `python3 skills/presentation-creator/scripts/outline_schema.py outline.yaml` — exits non-zero with a typed error if any validator fails.
+
+`narrative.md` is the exception to "by end of Phase 3" — it is generated earlier
+in partial form during Phases 1–2 so the author can review and approve the
+narrative before slide content development:
+
+```bash
+python3 skills/presentation-creator/scripts/extract-narrative.py --partial outline.yaml > narrative.md
+```
+
+`--partial` validates `talk` + `chapters` without requiring `slides[]`. The
+plain (full-validation) commands above apply from Phase 3 onward, once `slides[]`
+exists.
 
 **Late entry (single-task requests).**
 
@@ -159,6 +171,15 @@ Gate: Author confirms or edits the metadata.
 
 Save the partial outline to: `{presentations-dir}/{conference}/{year}/{talk-slug}/outline.yaml`
 
+Then generate the narrative stub so the author can read the thesis in prose form:
+
+```bash
+python3 skills/presentation-creator/scripts/extract-narrative.py --partial outline.yaml > narrative.md
+```
+
+At this phase `narrative.md` carries the thesis only — the chapter body fills in
+at Phase 2. Surface it to the author for an early read. Proceed immediately to Phase 2.
+
 The talk block is the source of truth for the slug, duration, mode, and other
 metadata. Later phases (Phase 2 architecture, Phase 3 slides, Phase 6 publishing)
 extend the SAME file with `chapters[]`, `slides[]`, `interludes[]`, etc. — do not
@@ -184,6 +205,19 @@ STYLE ANCHOR block back into the outline header.
 For each: present options, recommend based on spec, let author choose.
 If co-presented, add role split and voice differentiation — see [references/phase1-intent.md](references/phase1-intent.md).
 
+Once the architecture is set, author `chapters[]` (section headings, `target_min`,
+`argument_beats[]`) into `outline.yaml`, then regenerate the narrative — now with
+its chapter body — for human review:
+
+```bash
+python3 skills/presentation-creator/scripts/extract-narrative.py --partial outline.yaml > narrative.md
+```
+
+Present `narrative.md` to the author. This is the narrative-approval point: the
+author reads the prose distillation and approves or revises the argument before
+any per-slide content is written in Phase 3. `argument_beats[].slide_refs` stays
+empty here — slides do not exist yet.
+
 **Slide budget** — read from `profile → guardrail_sources.slide_budgets` at runtime.
 If the profile is unavailable (summary-only mode), use these defaults:
 
@@ -195,7 +229,7 @@ If the profile is unavailable (summary-only mode), use these defaults:
 | 60 min | 90 | 1.5 |
 | 75 min | 110 | 1.5 |
 
-Gate: Author approves the architecture.
+Gate: Author approves the narrative (`narrative.md`) and the architecture.
 
 ## Step 3 — Content Development
 

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -215,8 +215,9 @@ python3 skills/presentation-creator/scripts/extract-narrative.py --partial outli
 
 Present `narrative.md` to the author. This is the narrative-approval point: the
 author reads the prose distillation and approves or revises the argument before
-any per-slide content is written in Phase 3. `argument_beats[].slide_refs` stays
-empty here — slides do not exist yet.
+any per-slide content is written in Phase 3. Leave `argument_beats[].slide_refs`
+empty here — slides do not exist yet, so `--partial` validation rejects any ref;
+wire them to real slides in Phase 3.
 
 **Slide budget** — read from `profile → guardrail_sources.slide_budgets` at runtime.
 If the profile is unavailable (summary-only mode), use these defaults:

--- a/skills/presentation-creator/scripts/extract-narrative.py
+++ b/skills/presentation-creator/scripts/extract-narrative.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError  # noqa: E402
 import outline_schema as _os  # noqa: E402
 
 
-def render(outline: _os.Outline) -> str:
+def render(outline: "_os.Outline | _os.PartialOutline") -> str:
     lines: list[str] = []
 
     lines.append(f"# {outline.talk.title} — Narrative Read")
@@ -49,9 +49,17 @@ def render(outline: _os.Outline) -> str:
             lines.append(para.strip())
             lines.append("")
 
-    chapter_total = sum(c.target_min for c in outline.chapters)
     lines.append("## Part 1 — The Talk as a Narrative")
     lines.append("")
+    if not outline.chapters:
+        lines.append(
+            "*Narrative arc not yet authored — chapters and argument beats "
+            "appear after Phase 2 (Rhetorical Architecture).*",
+        )
+        lines.append("")
+        return _finalize(lines)
+
+    chapter_total = sum(c.target_min for c in outline.chapters)
     lines.append(
         f"*Chapter time targets sum to {chapter_total:g} min "
         f"(talk slot: {outline.talk.duration_min:g} min).*",
@@ -80,7 +88,11 @@ def render(outline: _os.Outline) -> str:
                 lines.append(text)
             lines.append("")
 
-    # Collapse blank runs, ensure single trailing newline
+    return _finalize(lines)
+
+
+def _finalize(lines: list[str]) -> str:
+    """Collapse blank runs, ensure a single trailing newline."""
     cleaned: list[str] = []
     prev_blank = False
     for line in lines:
@@ -96,17 +108,23 @@ def render(outline: _os.Outline) -> str:
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 2:
+    args = argv[1:]
+    partial = "--partial" in args
+    args = [a for a in args if a != "--partial"]
+    if len(args) != 1:
         print(
-            "usage: extract-narrative.py <outline.yaml>\n"
-            "       prints narrative.md to stdout",
+            "usage: extract-narrative.py [--partial] <outline.yaml>\n"
+            "       prints narrative.md to stdout\n"
+            "       --partial: render the Phase 1–2 narrative scaffold "
+            "(talk + chapters, before slides are authored)",
             file=sys.stderr,
         )
         return 2
+    loader = _os.load_outline_partial if partial else _os.load_outline
     try:
-        outline = _os.load_outline(argv[1])
+        outline = loader(args[0])
     except (OSError, yaml.YAMLError, ValidationError) as exc:
-        print(f"failed to load {argv[1]}: {exc}", file=sys.stderr)
+        print(f"failed to load {args[0]}: {exc}", file=sys.stderr)
         return 1
     sys.stdout.write(render(outline))
     return 0

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -564,6 +564,27 @@ class Outline(_StrictModel):
         return self
 
 
+# ── Narrative-phase partial view ─────────────────────────────────────
+
+
+class PartialOutline(_StrictModel):
+    """Talk metadata plus an optional, slide-less narrative scaffold.
+
+    The narrative (`talk.thesis` + `chapters[].argument_beats`) is fully
+    authored by the end of Phase 2, before any slide exists. `extract-narrative.py`
+    renders from this view so the human can review and approve the narrative
+    during Phases 1–2. The full `Outline` (slides + every cross-field validator)
+    stays the Phase 3+ source-of-truth contract; this view runs only the
+    field-level validators on `talk` and `chapters`.
+    """
+
+    talk: TalkMetadata
+    style_anchor: StyleAnchor | None = None
+    chapters: list[Chapter] = Field(default_factory=list)
+    slides: list[Slide] = Field(default_factory=list)
+    interludes: list[Interlude] = Field(default_factory=list)
+
+
 # ── Loader + CLI guard ───────────────────────────────────────────────
 
 
@@ -571,6 +592,12 @@ def load_outline(path: Path | str) -> Outline:
     text = Path(path).read_text(encoding="utf-8")
     data = yaml.safe_load(text)
     return Outline.model_validate(data)
+
+
+def load_outline_partial(path: Path | str) -> PartialOutline:
+    text = Path(path).read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    return PartialOutline.model_validate(data)
 
 
 def main(argv: list[str]) -> int:

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -409,6 +409,35 @@ class Slide(_StrictModel):
         return self
 
 
+# ── Shared cross-field checks ────────────────────────────────────────
+
+
+def _check_beat_slide_refs(
+    chapters: list["Chapter"], slides: list["Slide"],
+) -> None:
+    """Reject argument_beat slide_refs that point at a non-existent slide.
+
+    Shared by `Outline` (full) and `PartialOutline` (narrative phase). When no
+    slide is authored yet, the slide set is empty, so any ref is invalid — beats
+    must leave slide_refs empty until Phase 3 wires them to real slides.
+    """
+    slide_ns = {s.n for s in slides}
+    for c in chapters:
+        for beat in c.argument_beats:
+            for ref in beat.slide_refs:
+                if ref not in slide_ns:
+                    hint = (
+                        " — no slides are authored yet; leave slide_refs "
+                        "empty until Phase 3"
+                        if not slide_ns
+                        else ""
+                    )
+                    raise ValueError(
+                        f"chapter '{c.id}' argument_beat slide_ref {ref} "
+                        f"does not match any slide in slides[]{hint}",
+                    )
+
+
 # ── Top-level outline ────────────────────────────────────────────────
 
 
@@ -445,15 +474,7 @@ class Outline(_StrictModel):
 
     @model_validator(mode="after")
     def _argument_beat_slide_refs_valid(self) -> "Outline":
-        slide_ns = {s.n for s in self.slides}
-        for c in self.chapters:
-            for beat in c.argument_beats:
-                for ref in beat.slide_refs:
-                    if ref not in slide_ns:
-                        raise ValueError(
-                            f"chapter '{c.id}' argument_beat slide_ref {ref} "
-                            f"does not match any slide in slides[]",
-                        )
+        _check_beat_slide_refs(self.chapters, self.slides)
         return self
 
     @model_validator(mode="after")
@@ -573,9 +594,16 @@ class PartialOutline(_StrictModel):
     The narrative (`talk.thesis` + `chapters[].argument_beats`) is fully
     authored by the end of Phase 2, before any slide exists. `extract-narrative.py`
     renders from this view so the human can review and approve the narrative
-    during Phases 1–2. The full `Outline` (slides + every cross-field validator)
-    stays the Phase 3+ source-of-truth contract; this view runs only the
-    field-level validators on `talk` and `chapters`.
+    during Phases 1–2.
+
+    Every present section is still validated by its own field- and model-level
+    validators (a `slides[]` entry, if present, still runs its build-step and
+    EXCEPTION checks), and slide_refs are still checked for integrity. What this
+    view *skips* are the `Outline`-level cross-field validators that presuppose a
+    complete deck: `chapters`/`slides` `min_length`, the `big_idea` singleton,
+    slide-budget arithmetic, callback pairing, slide ordering/uniqueness,
+    chapter/interlude anchoring, and speaker attribution. The full `Outline`
+    stays the Phase 3+ source-of-truth contract.
     """
 
     talk: TalkMetadata
@@ -583,6 +611,11 @@ class PartialOutline(_StrictModel):
     chapters: list[Chapter] = Field(default_factory=list)
     slides: list[Slide] = Field(default_factory=list)
     interludes: list[Interlude] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _argument_beat_slide_refs_valid(self) -> "PartialOutline":
+        _check_beat_slide_refs(self.chapters, self.slides)
+        return self
 
 
 # ── Loader + CLI guard ───────────────────────────────────────────────

--- a/tests/test_narrative_rhetorical.py
+++ b/tests/test_narrative_rhetorical.py
@@ -96,6 +96,64 @@ def test_narrative_renders_thesis_when_present(
     assert "two-sentence thesis" in out
 
 
+# ── extract-narrative.py — partial (narrative-phase) rendering ───────
+
+
+def test_narrative_partial_thesis_only_stub(
+    extract_narrative, outline_schema, base_data,
+):
+    """Phase 1 stub: thesis renders, chapter body is a 'not yet authored' note."""
+    data = {"talk": copy.deepcopy(base_data["talk"])}
+    data["talk"]["thesis"] = "Treat context as a first-class artifact."
+    partial = outline_schema.PartialOutline.model_validate(data)
+    out = extract_narrative.render(partial)
+    assert "## Thesis" in out
+    assert "Treat context as a first-class artifact." in out
+    assert "Narrative arc not yet authored" in out
+    assert "### The Setup" not in out  # no chapters yet
+
+
+def test_narrative_partial_renders_chapters_without_slides(
+    extract_narrative, outline_schema, base_data,
+):
+    """Phase 2: chapters present, slides absent — full chapter body renders."""
+    data = {
+        "talk": copy.deepcopy(base_data["talk"]),
+        "chapters": copy.deepcopy(base_data["chapters"]),
+    }
+    partial = outline_schema.PartialOutline.model_validate(data)
+    out = extract_narrative.render(partial)
+    assert "### The Setup" in out
+    assert "### The Turn" in out
+    assert "Open cold with the receipt" in out
+    assert "Narrative arc not yet authored" not in out
+
+
+def test_narrative_cli_partial_renders_talk_only(
+    extract_narrative, base_data, tmp_path, capsys,
+):
+    """CLI --partial renders a talk-only outline to stdout."""
+    data = {"talk": copy.deepcopy(base_data["talk"])}
+    path = tmp_path / "partial.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    rc = extract_narrative.main(["extract-narrative.py", "--partial", str(path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.startswith("# Demo Talk — Narrative Read")
+
+
+def test_narrative_cli_full_mode_rejects_slideless_outline(
+    extract_narrative, base_data, tmp_path, capsys,
+):
+    """Without --partial, a slides-less outline fails full validation (exit 1)."""
+    data = {"talk": copy.deepcopy(base_data["talk"])}
+    path = tmp_path / "slideless.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    rc = extract_narrative.main(["extract-narrative.py", str(path)])
+    assert rc == 1
+    assert "failed to load" in capsys.readouterr().err
+
+
 # ── check-rhetorical.py — happy path ─────────────────────────────────
 
 

--- a/tests/test_narrative_rhetorical.py
+++ b/tests/test_narrative_rhetorical.py
@@ -117,10 +117,11 @@ def test_narrative_partial_renders_chapters_without_slides(
     extract_narrative, outline_schema, base_data,
 ):
     """Phase 2: chapters present, slides absent — full chapter body renders."""
-    data = {
-        "talk": copy.deepcopy(base_data["talk"]),
-        "chapters": copy.deepcopy(base_data["chapters"]),
-    }
+    chapters = copy.deepcopy(base_data["chapters"])
+    for c in chapters:
+        for beat in c.get("argument_beats", []):
+            beat["slide_refs"] = []  # no slides exist yet in the narrative phase
+    data = {"talk": copy.deepcopy(base_data["talk"]), "chapters": chapters}
     partial = outline_schema.PartialOutline.model_validate(data)
     out = extract_narrative.render(partial)
     assert "### The Setup" in out

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -1,7 +1,6 @@
 """Tests for outline_schema.py — pydantic validators on the outline source-of-truth."""
 
 import copy
-import os
 from pathlib import Path
 
 import pytest
@@ -622,6 +621,52 @@ def test_rejects_argument_beat_slide_ref_to_missing_slide(outline_schema, base_d
     data["chapters"][0]["argument_beats"][0]["slide_refs"] = [999]
     with pytest.raises(ValidationError, match="slide_ref 999"):
         outline_schema.Outline.model_validate(data)
+
+
+# ── Partial (narrative-phase) loader ─────────────────────────────────
+
+
+def test_partial_accepts_talk_only(outline_schema, base_data):
+    """Phase 1: only the talk block exists — no chapters, no slides."""
+    data = {"talk": copy.deepcopy(base_data["talk"])}
+    partial = outline_schema.PartialOutline.model_validate(data)
+    assert partial.talk.title == "Demo Talk"
+    assert partial.chapters == []
+    assert partial.slides == []
+
+
+def test_partial_accepts_chapters_without_slides(outline_schema, base_data):
+    """Phase 2: chapters authored, slides not yet — no slide-dependent
+    cross-validator fires, so beats may carry slide_refs to not-yet-real slides."""
+    data = {
+        "talk": copy.deepcopy(base_data["talk"]),
+        "chapters": copy.deepcopy(base_data["chapters"]),
+    }
+    partial = outline_schema.PartialOutline.model_validate(data)
+    assert len(partial.chapters) == 3
+    assert partial.slides == []
+
+
+def test_partial_still_validates_talk_fields(outline_schema, base_data):
+    """Field-level validators on talk still fire in partial mode."""
+    data = {"talk": copy.deepcopy(base_data["talk"])}
+    data["talk"]["architecture"] = "freeform-vibes"
+    with pytest.raises(ValidationError, match="architecture"):
+        outline_schema.PartialOutline.model_validate(data)
+
+
+def test_partial_rejects_unknown_field(outline_schema, base_data):
+    """extra='forbid' holds — misspelled keys fail loud even in partial mode."""
+    data = {"talk": copy.deepcopy(base_data["talk"]), "chapterz": []}
+    with pytest.raises(ValidationError, match="chapterz"):
+        outline_schema.PartialOutline.model_validate(data)
+
+
+def test_partial_loader_accepts_full_outline(outline_schema):
+    """--partial works at any phase: a complete outline also loads partially."""
+    partial = outline_schema.load_outline_partial(FIXTURE)
+    assert len(partial.chapters) == 3
+    assert len(partial.slides) == 8
 
 
 # ── CLI: --emit-json contract ─────────────────────────────────────────

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -636,15 +636,26 @@ def test_partial_accepts_talk_only(outline_schema, base_data):
 
 
 def test_partial_accepts_chapters_without_slides(outline_schema, base_data):
-    """Phase 2: chapters authored, slides not yet — no slide-dependent
-    cross-validator fires, so beats may carry slide_refs to not-yet-real slides."""
-    data = {
-        "talk": copy.deepcopy(base_data["talk"]),
-        "chapters": copy.deepcopy(base_data["chapters"]),
-    }
+    """Phase 2: chapters authored, slides not yet. Beats carry no slide_refs —
+    slides do not exist, so there is nothing to reference."""
+    chapters = copy.deepcopy(base_data["chapters"])
+    for c in chapters:
+        for beat in c.get("argument_beats", []):
+            beat["slide_refs"] = []
+    data = {"talk": copy.deepcopy(base_data["talk"]), "chapters": chapters}
     partial = outline_schema.PartialOutline.model_validate(data)
     assert len(partial.chapters) == 3
     assert partial.slides == []
+
+
+def test_partial_rejects_slide_refs_without_slides(outline_schema, base_data):
+    """Phase 2 invariant: a beat may not reference a slide that does not exist.
+    With no slides authored, every slide_ref is invalid."""
+    chapters = copy.deepcopy(base_data["chapters"])
+    chapters[0]["argument_beats"][0]["slide_refs"] = [1]
+    data = {"talk": copy.deepcopy(base_data["talk"]), "chapters": chapters}
+    with pytest.raises(ValidationError, match="slide_ref 1"):
+        outline_schema.PartialOutline.model_validate(data)
 
 
 def test_partial_still_validates_talk_fields(outline_schema, base_data):


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Generate `narrative.md` during Phases 1–2 so the author can review and approve the talk's narrative *before* per-slide content development, instead of only seeing it in Phase 3 after slide work has begun.

The root cause was structural: `extract-narrative.py` called `load_outline()`, which runs the full `Outline` schema (`slides[]` min 1, `big_idea` singleton, paired callbacks, slide-budget math). The narrative is fully authored by the end of Phase 2 (`talk.thesis` + `chapters[].argument_beats`) and never needs slides — but the extractor couldn't render until a complete, valid outline existed.

- **`outline_schema.py`** — new `PartialOutline` model + `load_outline_partial()` validate `talk` (+ optional `chapters`) without the slide-dependent cross-validators. The full `Outline` is unchanged and stays the Phase 3+ source-of-truth contract.
- **`extract-narrative.py`** — `--partial` flag selects the partial loader; renders a "narrative arc not yet authored" note when chapters are absent. Plain (full-validation) path unchanged.
- **`SKILL.md`** — Phase 1 emits a thesis-only stub; Phase 2 regenerates the full narrative and the gate now requires author approval of **narrative + architecture** before Phase 3. Workflow table + artifacts note updated.

## Test plan

- [x] `tests/test_outline_schema.py` — 5 new tests for `PartialOutline` / `load_outline_partial` (talk-only, chapters-without-slides, talk-field validation still fires, `extra=forbid` holds, full outline also loads partially)
- [x] `tests/test_narrative_rhetorical.py` — 4 new tests for partial render (thesis-only stub, chapters-without-slides) + CLI `--partial` and full-mode-rejects-slideless
- [x] Full local suite green (110 passed across schema/narrative/extractor suites); `ruff` clean
- [x] Verified manually: `--partial` renders at Phase 1 (thesis-only) and Phase 2 (full narrative); plain mode still hard-fails on a slides-less outline