### PR TITLE
fix(illustrations): enforce Keep-clause preservation list in --build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### fix(illustrations) — --build enforces the Keep-clause preservation list (#46)
+
+`--build` previously passed each `build-NN` description to the image editor
+verbatim, auto-appending only safety clauses #1/#2; the mandatory preservation
+list (component #3 of Edit Prompt Safety) was never applied, so a step that
+erases a dense region left the element in place and the chain emitted visually
+identical intermediate stages. The build flow now validates that every erase
+step carries an explicit `Keep` clause and skips the slide with a stderr error
+and a non-zero exit when one is missing — instead of silently producing a broken
+chain. Build step descriptions must be authored as erase instructions with
+`Keep` clauses (see `skills/illustrations/references/builds.md`).
+
 ### feat(presentation-creator) — narrative.md becomes a TL;DR + slide-by-slide walk (#81)
 
 `narrative.md` used to print the full `talk.thesis` (in practice 3–4 elaborated

--- a/rules/illustration-rules.md
+++ b/rules/illustration-rules.md
@@ -23,6 +23,11 @@ Every image edit prompt MUST include:
 The `--edit` and `--fix` commands auto-append #1 and #2, but #3 must always
 be added manually.
 
+`--build` reads #3 from each build step's description (the erase instruction
+carries its own `Keep ...` list — see the Build Process section). It validates
+that every erase step contains a `Keep` clause and skips the slide with an
+error if any step is missing one — component #3 is never silently dropped.
+
 ## Style-Anchor Discipline
 
 Never simplify or rewrite the speaker's original style anchor when iterating.

--- a/rules/illustration-rules.md
+++ b/rules/illustration-rules.md
@@ -24,9 +24,11 @@ The `--edit` and `--fix` commands auto-append #1 and #2, but #3 must always
 be added manually.
 
 `--build` reads #3 from each build step's description (the erase instruction
-carries its own `Keep ...` list — see the Build Process section). It validates
-that every erase step contains a `Keep` clause and skips the slide with an
-error if any step is missing one — component #3 is never silently dropped.
+carries its own `Keep ...` list — see the Edit-Prompt Authoring section of
+`skills/illustrations/references/builds.md` for the authoring format). It
+validates that every erase step contains a `Keep` clause and skips the slide
+with an error if any step is missing one — component #3 is never silently
+dropped.
 
 ## Style-Anchor Discipline
 

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -52,17 +52,17 @@ previous one.
   "no new frames", "solid lines not dashed".
 - The edit safety suffixes (`DO NOT add any new elements`, `let background
   continue naturally`) are auto-appended by the script — don't repeat them.
+- Keep each `build-NN:` entry on a **single line**. The parser reads only the
+  text up to the first newline, so erase/Keep clauses on continuation lines are
+  silently dropped (and the step then fails Keep-clause validation).
 
-Example (slide with three trial panels revealed progressively):
+Example (slide with three trial panels revealed progressively — each entry is
+one line):
 
 ```
-- build-02: Erase Panel 3 and the "LIFT +81 PTS" stamp. Keep the page chrome
-  (header bar, FIG label, bottom rule). Keep the three panel frames and their
-  TRIAL labels. Keep Panel 1 and Panel 2 content.
-- build-01: Erase Panel 2 and the "STILL?" stamp. Keep the page chrome. Keep
-  the three panel frames and labels. Keep Panel 1 content.
-- build-00: Erase Panel 1 content and the "PLUGIN USELESS?" stamp. Keep the
-  page chrome. Keep the three empty panel frames and their TRIAL labels.
+- build-02: Erase Panel 3 and the "LIFT +81 PTS" stamp. Keep the page chrome (header bar, FIG label, bottom rule). Keep the three panel frames and their TRIAL labels. Keep Panel 1 and Panel 2 content.
+- build-01: Erase Panel 2 and the "STILL?" stamp. Keep the page chrome. Keep the three panel frames and labels. Keep Panel 1 content.
+- build-00: Erase Panel 1 content and the "PLUGIN USELESS?" stamp. Keep the page chrome. Keep the three empty panel frames and their TRIAL labels.
 ```
 
 For near-perfect results, use `--fix` for targeted corrections rather than

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -53,8 +53,9 @@ previous one.
 - The edit safety suffixes (`DO NOT add any new elements`, `let background
   continue naturally`) are auto-appended by the script — don't repeat them.
 - Keep each `build-NN:` entry on a **single line**. The parser reads only the
-  text up to the first newline, so erase/Keep clauses on continuation lines are
-  silently dropped (and the step then fails Keep-clause validation).
+  text up to the first newline, so any erase/Keep clauses on continuation lines
+  are silently dropped — losing those preservation items, and failing
+  Keep-clause validation outright when no `Keep` clause remains on the first line.
 
 Example (slide with three trial panels revealed progressively — each entry is
 one line):

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -34,12 +34,36 @@ Output: `illustrations/builds/slide-NN-build-MM.jpg`.
 
 ## Edit-Prompt Authoring
 
-- Each step description must explicitly say what to KEEP: "keep the road",
-  "keep the soldiers", etc.
-- Always include: "no parchment patch", "no new frames", "solid lines not
-  dashed".
+Each `build-NN:` description is the **erase instruction** that turns the next
+stage into this one (backwards chaining), not a description of the end state.
+"Panel 2 revealed — sergeant, STILL? stamp" does not tell the model to erase
+anything, so the element survives and the stage comes out identical to the
+previous one.
+
+- Name what to ERASE, then list what to KEEP — one `Keep` clause per element
+  that must persist (page chrome, frames, already-revealed panels, borders,
+  labels). This is component #3 of the Edit Prompt Safety rule, and it is
+  mandatory: `--build` validates that every erase step carries a `Keep` clause
+  and skips the slide with an error if one is missing.
+- Pull the persisting elements from the slide's full `Image prompt` — the
+  chrome that never appears in any build line (header bars, FIG labels, rules)
+  is exactly what drifts when it isn't named.
+- Include the visual-consistency clauses where relevant: "no parchment patch",
+  "no new frames", "solid lines not dashed".
 - The edit safety suffixes (`DO NOT add any new elements`, `let background
-  continue naturally`) are auto-appended by the script.
+  continue naturally`) are auto-appended by the script — don't repeat them.
+
+Example (slide with three trial panels revealed progressively):
+
+```
+- build-02: Erase Panel 3 and the "LIFT +81 PTS" stamp. Keep the page chrome
+  (header bar, FIG label, bottom rule). Keep the three panel frames and their
+  TRIAL labels. Keep Panel 1 and Panel 2 content.
+- build-01: Erase Panel 2 and the "STILL?" stamp. Keep the page chrome. Keep
+  the three panel frames and labels. Keep Panel 1 content.
+- build-00: Erase Panel 1 content and the "PLUGIN USELESS?" stamp. Keep the
+  page chrome. Keep the three empty panel frames and their TRIAL labels.
+```
 
 For near-perfect results, use `--fix` for targeted corrections rather than
 regenerating the entire chain.

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -1336,6 +1336,7 @@ def run_build(outline_path, slide_arg):
         sys.exit(0)
 
     total_steps = sum(s["builds"]["count"] for s in to_build)
+    validation_failed = False
     print(f"Model: {model}")
     print(f"Building {len(to_build)} slide(s), {total_steps} total build steps")
     print(f"Output: {builds_dir}/")
@@ -1382,14 +1383,17 @@ def run_build(outline_path, slide_arg):
         # before spending any edit API calls on a chain that can't work.
         missing_keep = steps_missing_keep_clause(edit_steps)
         if missing_keep:
+            validation_failed = True
             print(f"  ERROR: {len(missing_keep)} build step(s) lack an explicit "
-                  '"Keep ..." preservation list:')
+                  '"Keep ..." preservation list:', file=sys.stderr)
             for s in missing_keep:
-                print(f"    build-{s['step']:02d}: {s['description'][:70]}")
+                print(f"    build-{s['step']:02d}: {s['description'][:70]}",
+                      file=sys.stderr)
             print("  Phrase each step as an erase instruction naming every element "
-                  "that must persist")
+                  "that must persist", file=sys.stderr)
             print('  ("Erase X. Keep the Y. Keep the Z.") — see '
-                  "rules/illustration-rules.md component #3. Skipping slide.")
+                  "rules/illustration-rules.md component #3. Skipping slide.",
+                  file=sys.stderr)
             continue
 
         prev_image = full_image
@@ -1426,6 +1430,14 @@ def run_build(outline_path, slide_arg):
         print()
 
     print("Done. Review build images in:", builds_dir)
+
+    # Surface skipped chains in the exit code so `--build all` automation can
+    # detect that some slides produced no build sequence (file-hygiene policy:
+    # non-zero exit on failure).
+    if validation_failed:
+        print("ERROR: one or more slides were skipped for missing Keep clauses.",
+              file=sys.stderr)
+        sys.exit(1)
 
 
 def run_fix(outline_path, slide_num, fix_prompt):

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -406,18 +406,29 @@ def final_build_dest(builds_dir, slide_num, final_step, source_path):
     return os.path.join(builds_dir, f"slide-{slide_num:02d}-build-{final_step:02d}{src_ext}")
 
 
+def _has_keep_clause(description):
+    """True if the description has a positive "Keep <target>" sentence.
+
+    The bare token `keep` is not enough — "Do not keep Panel 3" is a removal,
+    not a preservation. Split on sentence boundaries and require a sentence that
+    *begins* with "Keep" followed by a target, matching the documented
+    "Keep the [X]." format and rejecting negated/non-clause wording.
+    """
+    return any(
+        re.match(r"\s*keep\s+\S", sentence, re.IGNORECASE)
+        for sentence in re.split(r"[.!?]+", description)
+    )
+
+
 def steps_missing_keep_clause(edit_steps):
-    """Build erase steps lacking an explicit "Keep ..." preservation list.
+    """Build erase steps lacking a positive "Keep <target>" preservation clause.
 
     Component #3 of the Edit Prompt Safety rule. An erase step with no Keep
     clause lets the model silently retain the element meant to be erased, so
     the build chain emits visually identical stages. Returns the offending
     steps (empty list means every step is compliant).
     """
-    return [
-        s for s in edit_steps
-        if not re.search(r"\bkeep\b", s["description"], re.IGNORECASE)
-    ]
+    return [s for s in edit_steps if not _has_keep_clause(s["description"])]
 
 
 def next_version(output_dir, slide_num):

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -1336,7 +1336,7 @@ def run_build(outline_path, slide_arg):
         sys.exit(0)
 
     total_steps = sum(s["builds"]["count"] for s in to_build)
-    validation_failed = False
+    build_failed = False
     print(f"Model: {model}")
     print(f"Building {len(to_build)} slide(s), {total_steps} total build steps")
     print(f"Output: {builds_dir}/")
@@ -1383,7 +1383,7 @@ def run_build(outline_path, slide_arg):
         # before spending any edit API calls on a chain that can't work.
         missing_keep = steps_missing_keep_clause(edit_steps)
         if missing_keep:
-            validation_failed = True
+            build_failed = True
             print(f"  ERROR: {len(missing_keep)} build step(s) lack an explicit "
                   '"Keep ..." preservation list:', file=sys.stderr)
             for s in missing_keep:
@@ -1410,8 +1410,10 @@ def run_build(outline_path, slide_arg):
             )
 
             if image_bytes is None:
-                print(f"FAILED: {result[:100]}")
-                print(f"  Aborting remaining build steps for slide {num} (chain broken)")
+                build_failed = True
+                print(f"FAILED: {result[:100]}", file=sys.stderr)
+                print(f"  Aborting remaining build steps for slide {num} (chain broken)",
+                      file=sys.stderr)
                 break
 
             ext = mime_to_ext(result)
@@ -1431,11 +1433,12 @@ def run_build(outline_path, slide_arg):
 
     print("Done. Review build images in:", builds_dir)
 
-    # Surface skipped chains in the exit code so `--build all` automation can
-    # detect that some slides produced no build sequence (file-hygiene policy:
-    # non-zero exit on failure).
-    if validation_failed:
-        print("ERROR: one or more slides were skipped for missing Keep clauses.",
+    # Surface any incomplete chain in the exit code so `--build all` automation
+    # can detect that some slides produced no build sequence — whether skipped
+    # for a missing Keep clause or aborted on an edit failure (file-hygiene
+    # policy: non-zero exit on failure).
+    if build_failed:
+        print("ERROR: one or more slides did not produce a complete build chain.",
               file=sys.stderr)
         sys.exit(1)
 

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -1362,16 +1362,6 @@ def run_build(outline_path, slide_arg):
             print(f"  SKIP — Builds declared but no build-NN entries parsed")
             continue
 
-        # Copy full image as the final build step. The dest path preserves
-        # the source extension — base images may be .jpg / .png / .webp
-        # depending on the generating vendor.
-        final_step = max(s["step"] for s in steps)
-        final_build = steps[-1]
-        if final_build["is_full"]:
-            dest = final_build_dest(builds_dir, num, final_step, full_image)
-            shutil.copy2(full_image, dest)
-            print(f"  build-{final_step:02d}: copied from slide-{num:02d} (full)")
-
         # Chain backwards: start from full, remove elements one at a time
         # Process steps in reverse order (excluding the final full step)
         edit_steps = [s for s in reversed(steps) if not s["is_full"]]
@@ -1379,8 +1369,9 @@ def run_build(outline_path, slide_arg):
         # Edit Prompt Safety component #3 (rules/illustration-rules.md): every
         # erase step must carry an explicit "Keep ..." preservation list. Without
         # it the model silently keeps the element that was meant to be erased, so
-        # the chain emits visually identical intermediate stages. Fail loud here,
-        # before spending any edit API calls on a chain that can't work.
+        # the chain emits visually identical intermediate stages. Validate before
+        # writing any artifact — a skipped slide must not leave a stray final
+        # build copy (or a "copied" log line) that misleads downstream checks.
         missing_keep = steps_missing_keep_clause(edit_steps)
         if missing_keep:
             build_failed = True
@@ -1395,6 +1386,16 @@ def run_build(outline_path, slide_arg):
                   "rules/illustration-rules.md component #3. Skipping slide.",
                   file=sys.stderr)
             continue
+
+        # Copy full image as the final build step. The dest path preserves
+        # the source extension — base images may be .jpg / .png / .webp
+        # depending on the generating vendor.
+        final_step = max(s["step"] for s in steps)
+        final_build = steps[-1]
+        if final_build["is_full"]:
+            dest = final_build_dest(builds_dir, num, final_step, full_image)
+            shutil.copy2(full_image, dest)
+            print(f"  build-{final_step:02d}: copied from slide-{num:02d} (full)")
 
         prev_image = full_image
 

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -1423,7 +1423,9 @@ def run_build(outline_path, slide_arg):
 
             if image_bytes is None:
                 build_failed = True
-                print(f"FAILED: {result[:100]}", file=sys.stderr)
+                print("FAILED")  # complete the stdout progress line opened above
+                print(f"  slide {num} build-{step_num:02d} edit failed: {result[:100]}",
+                      file=sys.stderr)
                 print(f"  Aborting remaining build steps for slide {num} (chain broken)",
                       file=sys.stderr)
                 break
@@ -1443,16 +1445,17 @@ def run_build(outline_path, slide_arg):
 
         print()
 
-    print("Done. Review build images in:", builds_dir)
-
     # Surface any incomplete chain in the exit code so `--build all` automation
     # can detect that some slides produced no build sequence — whether skipped
     # for a missing Keep clause or aborted on an edit failure (file-hygiene
-    # policy: non-zero exit on failure).
+    # policy: non-zero exit on failure). Exit before the success line so a failed
+    # run never prints a success-sounding "Done".
     if build_failed:
         print("ERROR: one or more slides did not produce a complete build chain.",
               file=sys.stderr)
         sys.exit(1)
+
+    print("Done. Review build images in:", builds_dir)
 
 
 def run_fix(outline_path, slide_num, fix_prompt):

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -406,6 +406,20 @@ def final_build_dest(builds_dir, slide_num, final_step, source_path):
     return os.path.join(builds_dir, f"slide-{slide_num:02d}-build-{final_step:02d}{src_ext}")
 
 
+def steps_missing_keep_clause(edit_steps):
+    """Build erase steps lacking an explicit "Keep ..." preservation list.
+
+    Component #3 of the Edit Prompt Safety rule. An erase step with no Keep
+    clause lets the model silently retain the element meant to be erased, so
+    the build chain emits visually identical stages. Returns the offending
+    steps (empty list means every step is compliant).
+    """
+    return [
+        s for s in edit_steps
+        if not re.search(r"\bkeep\b", s["description"], re.IGNORECASE)
+    ]
+
+
 def next_version(output_dir, slide_num):
     """Find the next available version number for a slide."""
     existing = glob.glob(os.path.join(output_dir, f"slide-{slide_num:02d}-v*.*"))
@@ -1360,6 +1374,24 @@ def run_build(outline_path, slide_arg):
         # Chain backwards: start from full, remove elements one at a time
         # Process steps in reverse order (excluding the final full step)
         edit_steps = [s for s in reversed(steps) if not s["is_full"]]
+
+        # Edit Prompt Safety component #3 (rules/illustration-rules.md): every
+        # erase step must carry an explicit "Keep ..." preservation list. Without
+        # it the model silently keeps the element that was meant to be erased, so
+        # the chain emits visually identical intermediate stages. Fail loud here,
+        # before spending any edit API calls on a chain that can't work.
+        missing_keep = steps_missing_keep_clause(edit_steps)
+        if missing_keep:
+            print(f"  ERROR: {len(missing_keep)} build step(s) lack an explicit "
+                  '"Keep ..." preservation list:')
+            for s in missing_keep:
+                print(f"    build-{s['step']:02d}: {s['description'][:70]}")
+            print("  Phrase each step as an erase instruction naming every element "
+                  "that must persist")
+            print('  ("Erase X. Keep the Y. Keep the Z.") — see '
+                  "rules/illustration-rules.md component #3. Skipping slide.")
+            continue
+
         prev_image = full_image
 
         for step in edit_steps:

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -196,7 +196,11 @@ def test_run_build_exits_nonzero_when_edit_fails(
         gi.run_build("ignored.md", "60")
 
     assert exc.value.code == 1
-    assert "FAILED" in capsys.readouterr().err
+    out = capsys.readouterr()
+    # Diagnostic on stderr carries slide + step context; the success-sounding
+    # "Done" line never prints on a failed run.
+    assert "build-00 edit failed" in out.err
+    assert "Done. Review build images" not in out.out
 
 
 def test_resolve_prompt_with_anchor(generate_illustrations):

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -135,6 +135,27 @@ def test_run_build_missing_keep_exits_nonzero_without_editing(
     assert list(builds_dir.glob("slide-60-build-*")) == []
 
 
+def test_run_build_negated_keep_is_not_a_preservation_clause(
+    generate_illustrations, monkeypatch, tmp_path
+):
+    # "Do not keep ..." is a removal, not a preservation clause: the slide is
+    # skipped (exit 1, no edit) exactly like a bare description, so the bare
+    # `keep` token can't satisfy the rule.
+    gi = generate_illustrations
+    outline = _single_build_slide([
+        {"step": 0, "description": "Erase Panel 1. Do not keep the old stamp.", "is_full": False},
+        {"step": 1, "description": "[FULL] all panels", "is_full": True},
+    ])
+    edit_calls = []
+    _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls)
+
+    with pytest.raises(SystemExit) as exc:
+        gi.run_build("ignored.md", "60")
+
+    assert exc.value.code == 1
+    assert edit_calls == []
+
+
 def test_run_build_with_keep_clause_runs_chain(
     generate_illustrations, monkeypatch, tmp_path
 ):

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -149,6 +149,31 @@ def test_run_build_with_keep_clause_runs_chain(
     assert len(edit_calls) == 1  # the single erase step was edited
 
 
+def test_run_build_exits_nonzero_when_edit_fails(
+    generate_illustrations, monkeypatch, tmp_path, capsys
+):
+    # Outcome: an edit failure mid-chain aborts the slide and still exits
+    # non-zero (file-hygiene: non-zero on failure), not only on validation.
+    gi = generate_illustrations
+    base = tmp_path / "slide-60.png"
+    base.write_bytes(b"img")
+    outline = _single_build_slide([
+        {"step": 0, "description": "Erase Panel 1. Keep the page chrome.", "is_full": False},
+        {"step": 1, "description": "[FULL] all panels", "is_full": True},
+    ])
+    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline, str(tmp_path)))
+    monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
+    monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
+    monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(gi, "edit_image", lambda *a, **k: (None, "api boom"))
+
+    with pytest.raises(SystemExit) as exc:
+        gi.run_build("ignored.md", "60")
+
+    assert exc.value.code == 1
+    assert "FAILED" in capsys.readouterr().err
+
+
 def test_resolve_prompt_with_anchor(generate_illustrations):
     anchors = {"WIDE": "A warm watercolor illustration."}
     prompt = "[STYLE ANCHOR] A confused developer"

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -85,6 +85,30 @@ def test_parse_builds(generate_illustrations):
     assert slide2["builds"]["steps"][-1]["is_full"] is True
 
 
+def test_steps_missing_keep_clause_flags_bare_descriptions(generate_illustrations):
+    # End-state descriptions with no "Keep" clause are exactly the buggy
+    # pattern: the model keeps the element meant to be erased.
+    steps = [
+        {"step": 0, "description": "Empty page with three panel frames"},
+        {"step": 1, "description": "Panel 1 revealed -- sergeant + recruit"},
+    ]
+    missing = generate_illustrations.steps_missing_keep_clause(steps)
+    assert [s["step"] for s in missing] == [0, 1]
+
+
+def test_steps_missing_keep_clause_passes_erase_plus_keep(generate_illustrations):
+    steps = [
+        {"step": 0, "description": "Erase Panel 1. Keep the page chrome. Keep the frames."},
+        {"step": 1, "description": "Erase Panel 2. Keep the page chrome. Keep Panel 1."},
+    ]
+    assert generate_illustrations.steps_missing_keep_clause(steps) == []
+
+
+def test_steps_missing_keep_clause_is_case_insensitive(generate_illustrations):
+    steps = [{"step": 0, "description": "Erase the stamp. KEEP the header bar."}]
+    assert generate_illustrations.steps_missing_keep_clause(steps) == []
+
+
 def test_resolve_prompt_with_anchor(generate_illustrations):
     anchors = {"WIDE": "A warm watercolor illustration."}
     prompt = "[STYLE ANCHOR] A confused developer"

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -3,6 +3,8 @@
 import json
 import os
 
+import pytest
+
 SAMPLE_OUTLINE = """\
 # Illustration Plan
 
@@ -85,28 +87,66 @@ def test_parse_builds(generate_illustrations):
     assert slide2["builds"]["steps"][-1]["is_full"] is True
 
 
-def test_steps_missing_keep_clause_flags_bare_descriptions(generate_illustrations):
-    # End-state descriptions with no "Keep" clause are exactly the buggy
-    # pattern: the model keeps the element meant to be erased.
-    steps = [
-        {"step": 0, "description": "Empty page with three panel frames"},
-        {"step": 1, "description": "Panel 1 revealed -- sergeant + recruit"},
-    ]
-    missing = generate_illustrations.steps_missing_keep_clause(steps)
-    assert [s["step"] for s in missing] == [0, 1]
+def _single_build_slide(steps):
+    return {
+        "model": "gemini-3-pro-image-preview",
+        "slides": [{
+            "slide_num": 60, "title": "Trials", "format": "WIDE",
+            "builds": {"count": len(steps), "steps": steps},
+        }],
+    }
 
 
-def test_steps_missing_keep_clause_passes_erase_plus_keep(generate_illustrations):
-    steps = [
-        {"step": 0, "description": "Erase Panel 1. Keep the page chrome. Keep the frames."},
-        {"step": 1, "description": "Erase Panel 2. Keep the page chrome. Keep Panel 1."},
-    ]
-    assert generate_illustrations.steps_missing_keep_clause(steps) == []
+def _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls):
+    base = tmp_path / "slide-60.png"
+    base.write_bytes(b"img")
+    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline, str(tmp_path)))
+    monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
+    monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
+    monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(
+        gi, "edit_image",
+        lambda *a, **k: (edit_calls.append(a), (b"x", "image/png"))[1],
+    )
 
 
-def test_steps_missing_keep_clause_is_case_insensitive(generate_illustrations):
-    steps = [{"step": 0, "description": "Erase the stamp. KEEP the header bar."}]
-    assert generate_illustrations.steps_missing_keep_clause(steps) == []
+def test_run_build_missing_keep_exits_nonzero_without_editing(
+    generate_illustrations, monkeypatch, tmp_path, capsys
+):
+    # Outcome: an erase step with no Keep clause skips the slide *before* any
+    # edit API call and exits non-zero so `--build all` automation can detect it.
+    gi = generate_illustrations
+    outline = _single_build_slide([
+        {"step": 0, "description": "Panel 1 revealed -- sergeant", "is_full": False},
+        {"step": 1, "description": "[FULL] all panels", "is_full": True},
+    ])
+    edit_calls = []
+    _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls)
+
+    with pytest.raises(SystemExit) as exc:
+        gi.run_build("ignored.md", "60")
+
+    assert exc.value.code == 1
+    assert edit_calls == []  # skipped before spending any edit API call
+    assert "preservation list" in capsys.readouterr().err
+
+
+def test_run_build_with_keep_clause_runs_chain(
+    generate_illustrations, monkeypatch, tmp_path
+):
+    # Outcome: a compliant erase step runs the edit chain. Uppercase KEEP also
+    # proves the clause check is case-insensitive at the behavior level.
+    gi = generate_illustrations
+    outline = _single_build_slide([
+        {"step": 0, "description": "Erase Panel 1. KEEP the page chrome.", "is_full": False},
+        {"step": 1, "description": "[FULL] all panels", "is_full": True},
+    ])
+    edit_calls = []
+    _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls)
+
+    gi.run_build("ignored.md", "60")  # no SystemExit
+
+    assert len(edit_calls) == 1  # the single erase step was edited
 
 
 def test_resolve_prompt_with_anchor(generate_illustrations):

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -129,6 +129,10 @@ def test_run_build_missing_keep_exits_nonzero_without_editing(
     assert exc.value.code == 1
     assert edit_calls == []  # skipped before spending any edit API call
     assert "preservation list" in capsys.readouterr().err
+    # A skipped slide must leave no build artifact behind (validation runs
+    # before the final-image copy), so downstream checks aren't misled.
+    builds_dir = tmp_path / "builds"
+    assert list(builds_dir.glob("slide-60-build-*")) == []
 
 
 def test_run_build_with_keep_clause_runs_chain(


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary
- Fixes #46 — `--build` silently skipped component #3 of the Edit Prompt Safety rule (the explicit `Keep …` preservation list). `run_build` passed each `build-NN` description verbatim and `edit_image` only auto-appended safety clauses #1/#2, so steps that erase a dense region left the element in place and the chain emitted visually identical intermediate stages.
- Applies **Option 1** (keeps the script deterministic per `script-delegation`): the outline author writes the `Keep` clauses into each erase step; `--build` validates them. New `steps_missing_keep_clause()` helper; `run_build` skips a slide with a clear error when any erase step lacks a `Keep` clause — **before** spending any edit API calls on a chain that can't work.
- Docs: `builds.md` rewrites "Edit-Prompt Authoring" — build steps are erase instructions (not end-state), must carry `Keep` clauses pulled from the slide's full `Image prompt`, with a worked 3-panel example. `illustration-rules.md` states `--build`'s handling of component #3.

## Why Option 1 (not auto-synthesis)
Auto-synthesizing the preservation list by regex-diffing build descriptions can't work — the chrome that drifts (header bars, FIG labels, rules) never appears in any build line, only in the full `Image prompt`. Doing it via an in-script LLM call would honor `script-delegation`'s letter but make the build pipeline non-deterministic. Option 1 is what `builds.md` already assumed; this PR enforces it instead of failing silently.

## Test plan
- [x] `pytest tests/test_generate_illustrations.py` — 58 passed (incl. 3 new: flags bare descriptions, passes `Erase + Keep`, case-insensitive)
- [x] Full suite: 384 passed (pre-existing `test_video_slide_extraction.py` failures are an unrelated missing-dep, untouched here)

Refs #46.