### PR TITLE
fix(qr-generation): legacy-link recreation + custom-domain capture (#56 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+### fix(qr-generation) — recreate legacy non-slug links; capture the custom-domain decision (#56)
+
+Follow-up to the QR shortlink work shipped via #79, which enforced the slug-only
+back-half for newly-created links but left two gaps.
+
+- Slug-only back-half now applies to EXISTING tracked links too: a cached entry
+  whose back-half isn't the slug is no longer reused or retargeted in place — it's
+  recreated with the slug back-half (regression-tested).
+- First short link captures the custom-domain decision: before creating a NEW
+  shortened link, an absent `publishing_process.qr_code.{shortener}_domain` key
+  STOPS so the agent asks the user and saves the answer — the domain, or `null`
+  for "no custom domain" — so a configured custom domain is never silently
+  skipped. Absent = never asked; `null` = decided (default domain), never
+  re-asked. The MCP path makes the same check.
+- Documented the `bitly_domain` knob in the profile schema (the code and the
+  clarification flow already used it). `rules/qr-generation-rules.md` §2 (the
+  custom domain must be used when configured) and new §7 (the three-state
+  decision); phase6-publishing and the clarification prompts save an explicit
+  `null`.
+
 ### fix(illustrations) — --build enforces the Keep-clause preservation list (#46)
 
 `--build` previously passed each `build-NN` description to the image editor

--- a/rules/qr-generation-rules.md
+++ b/rules/qr-generation-rules.md
@@ -17,9 +17,13 @@ python3 generate-qr.py --png-only --talk-slug SLUG --shownotes-url URL \
 ## 2. NEVER Use a Random Shortener Hash
 
 The short link's back-half MUST ALWAYS be the talk slug — the bit.ly custom
-back-half AND the rebrand.ly slashtag, with no override. The script does this
-automatically: `--talk-slug devnexus26-robocoders` creates
-`bit.ly/devnexus26-robocoders` (not `bit.ly/a3xK9f`).
+back-half AND the rebrand.ly slashtag, with no override. When a custom domain is
+configured in the vault profile (`bitly_domain` / `rebrandly_domain`), the short
+link MUST use it. The script does this automatically: `--talk-slug
+devnexus26-robocoders` with `bitly_domain: jbaru.ch` creates
+`jbaru.ch/devnexus26-robocoders` (not `bit.ly/a3xK9f`). If the slug back-half
+can't be set, the script fails to a raw-URL fallback rather than keeping a random
+hash.
 
 Random hashes are untraceable and unprofessional. The back-half IS the slug.
 
@@ -61,7 +65,23 @@ the user to create it. Do not silently degrade to a raw URL.
 The script prints actionable creation commands — but the agent must treat a
 missing token as a blocker, not a fallback trigger.
 
-## 7. Replace Existing QRs In Place
+## 7. First Short Link = ASK + SAVE the Custom Domain
+
+The first time a short link is created for the active shortener, the custom-domain
+decision MUST be recorded in the vault profile. Three states of
+`publishing_process.qr_code.{shortener}_domain`:
+
+- Key ABSENT → never asked. ASK whether the user has a custom domain (e.g.
+  `jbaru.ch`) and SAVE the answer before the link is created.
+- A domain string → use it for the short link.
+- `null` → recorded decision: no custom domain, use the shortener default (`bit.ly`).
+
+Save the decision either way — the domain string, or `null` for "no custom domain".
+A `null` is a recorded decision, not an absent value; never re-ask once saved. On
+the Direct API path `generate-qr.py` STOPS when the key is absent; on the MCP path
+the agent makes the same check before resolving the link.
+
+## 8. Replace Existing QRs In Place
 
 A deck adapted (trimmed) from another talk carries that talk's QR images. The QR
 step detects every existing QR — the closing slide AND any earlier shownotes

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -137,6 +137,14 @@ Read `publishing_process.qr_code`. If `enabled`:
 **None path (no shortening):**
 - Script encodes the raw shownotes URL directly into the QR code
 
+**First short link — confirm the custom domain:** before a short link is created
+for the first time, ensure `publishing_process.qr_code.{shortener}_domain` is
+recorded in the profile. If the key is absent, ASK the user whether they have a
+custom domain (e.g. `jbaru.ch`) and SAVE the answer — the domain, or `null` for
+"no custom domain" — then proceed. See `rules/qr-generation-rules.md` §7. The
+Direct API path enforces this (the script STOPS if the key is absent); on the MCP
+path make the check before resolving the link.
+
 3. Run the QR generation script:
    ```bash
    # MCP-preresolved mode:

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -271,6 +271,25 @@ def _print_missing_key_help(service, key_name, vault_path):
         print(f'    \"{service}\": {{\"{key_name}\": \"YOUR_KEY\"}}')
 
 
+def _require_domain_decision(config, shortener, vault_path):
+    """A custom-domain decision must be recorded before the FIRST short link is
+    created. An ABSENT `{shortener}_domain` key means the user was never asked —
+    STOP so the agent asks and saves the answer. A present value (a domain string,
+    or null for "no custom domain") is a recorded decision and proceeds.
+    """
+    key = f"{shortener}_domain"
+    if key in config:
+        return
+    default_domain = "bit.ly" if shortener == "bitly" else "the shortener default"
+    profile = os.path.join(vault_path, "speaker-profile.json") if vault_path else "the speaker profile"
+    print(f"ERROR: No custom-domain decision recorded for shortener '{shortener}'.")
+    print("  Before creating the first short link, ask the user whether they have a")
+    print(f"  custom domain (e.g. jbaru.ch), then save the answer under")
+    print(f"  publishing_process.qr_code.{key} in {profile}:")
+    print(f'    a domain string (e.g. "jbaru.ch"), or null for no custom domain ({default_domain}).')
+    sys.exit(1)
+
+
 def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db, dry_run=False, vault_path=None):
     """Resolve the short URL for a talk, using cache or API as needed.
 
@@ -296,6 +315,13 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db, dr
         if entry.get("talk_slug") == talk_slug:
             existing = entry
             break
+
+    # Enforce slug-only back-half on EXISTING links too: a tracked shortened link
+    # whose back-half isn't the slug is legacy — don't reuse it from cache or
+    # retarget it in place; drop it so a slug-based link is recreated below.
+    if existing and existing.get("shortener_link_id") and existing.get("short_path") != talk_slug:
+        print(f"  Legacy non-slug back-half '{existing.get('short_path')}' for '{talk_slug}' — recreating with the slug")
+        existing = None
 
     # If cached and target matches, reuse
     if existing and existing.get("target_url") == shownotes_url:
@@ -354,6 +380,7 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db, dr
                 meta["updated_at"] = datetime.date.today().isoformat()
                 return existing["short_url"], meta
             else:
+                _require_domain_decision(config, "bitly", vault_path)
                 # Create new link with talk slug as custom back-half
                 domain_label = bitly_domain or "bit.ly"
                 print(f"  Creating {domain_label} link for {shownotes_url} (back-half: {custom_back_half})")
@@ -384,6 +411,7 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db, dr
                 meta["updated_at"] = datetime.date.today().isoformat()
                 return existing["short_url"], meta
             else:
+                _require_domain_decision(config, "rebrandly", vault_path)
                 print(f"  Creating rebrand.ly link for {shownotes_url} (slashtag: {custom_back_half})")
                 result = create_rebrandly_link(shownotes_url, api_key, domain, custom_back_half)
                 meta = {

--- a/skills/vault-clarification/references/schemas-config.md
+++ b/skills/vault-clarification/references/schemas-config.md
@@ -24,8 +24,8 @@ only) when empty. The question column shows what to ask the speaker.
 | `publishing_process.export_method` | "How do you produce the PDF? (e.g., PowerPoint AppleScript, LibreOffice CLI, manual)" |
 | `publishing_process.qr_code` | "Do you put QR codes in your decks? If yes, what do they link to?" |
 | `publishing_process.qr_code.shortener` | "Do you use a URL shortener for QR links? Options: `bitly`, `rebrandly`, or `none`." |
-| `publishing_process.qr_code.bitly_domain` | _(Only if shortener=bitly)_ "Do you have a custom Bitly domain? (e.g., `jbaru.ch`, or leave blank for default `bit.ly`)" |
-| `publishing_process.qr_code.rebrandly_domain` | _(Only if shortener=rebrandly)_ "What custom domain do you use with Rebrandly? (e.g., `jbaru.ch`, or leave blank for default)" |
+| `publishing_process.qr_code.bitly_domain` | _(Only if shortener=bitly)_ "Do you have a custom Bitly domain? (e.g., `jbaru.ch`) — save the domain, or `null` to record no custom domain (default `bit.ly`)." |
+| `publishing_process.qr_code.rebrandly_domain` | _(Only if shortener=rebrandly)_ "What custom domain do you use with Rebrandly? (e.g., `jbaru.ch`) — save the domain, or `null` to record no custom domain (default)." |
 | `publishing_process.qr_code.shortener_setup` | _(Only if shortener=bitly or rebrandly)_ "Add your API key to `{vault_root}/secrets.json` (`chmod 600`). Format: `{\"bitly\": {\"api_token\": \"...\"}}` or `{\"rebrandly\": {\"api_key\": \"...\"}}`. Alternatively, install the Bitly or Rebrandly MCP server for agent-driven shortening." |
 | `gemini_api_key` | "Add your Gemini API key to `{vault_root}/secrets.json` under `gemini.api_key` (`chmod 600`). Format: `{\"gemini\": {\"api_key\": \"...\"}}`. Get a key from https://aistudio.google.com/app/apikey. The `GEMINI_API_KEY` env var also works as a fallback." |
 | `publishing_process.additional_steps` | "Any other distribution steps after exporting?" |

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -315,6 +315,7 @@ creation at runtime.
       "insert_into_deck": true,
       "slide_position": "shownotes_slide|closing|both",
       "shortener": "bitly|rebrandly|none",
+      "bitly_domain": "jbaru.ch | null",
       "rebrandly_domain": "jbaru.ch | null",
       "bg_color_match": true
     },

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -321,3 +321,91 @@ def test_create_bitly_link_raises_when_custom_back_half_fails(generate_qr, monke
         generate_qr.create_bitly_link(
             "https://example.com/notes", "tok", custom_back_half="my-slug", domain="jbaru.ch"
         )
+
+
+def test_legacy_non_slug_cache_entry_is_recreated_with_slug(generate_qr, monkeypatch):
+    """A tracked link with a legacy non-slug back-half is NOT reused/retargeted —
+    it is recreated with the slug, even when the cached target matches."""
+    created = {}
+
+    def fake_create_bitly_link(long_url, api_token, custom_back_half=None, domain=None):
+        created["back_half"] = custom_back_half
+        return {"short_url": f"https://jbaru.ch/{custom_back_half}", "link_id": "new-id", "short_path": custom_back_half}
+
+    def boom_update(*a, **k):
+        raise AssertionError("update_bitly_link must not be called for a legacy non-slug entry")
+
+    monkeypatch.setattr(generate_qr, "create_bitly_link", fake_create_bitly_link)
+    monkeypatch.setattr(generate_qr, "update_bitly_link", boom_update)
+    tracking_db = {"qr_codes": [{
+        "talk_slug": "my-slug",
+        "target_url": "https://jbaru.ch/my-slug",   # cached target matches → would reuse without the fix
+        "shortener": "bitly",
+        "short_path": "legacy-hash",                # NON-slug back-half
+        "short_url": "https://bit.ly/legacy-hash",
+        "shortener_link_id": "old-id",
+    }]}
+    short_url, meta = generate_qr.resolve_short_url(
+        "https://jbaru.ch/my-slug", "my-slug",
+        {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
+        {"bitly": {"api_token": "tok"}}, tracking_db, dry_run=False, vault_path=None,
+    )
+    assert created["back_half"] == "my-slug"
+    assert meta["short_path"] == "my-slug"
+    assert meta["shortener_link_id"] == "new-id"
+    assert short_url == "https://jbaru.ch/my-slug"
+
+
+def test_missing_custom_domain_decision_stops_before_first_link(generate_qr, monkeypatch):
+    """First short link with NO recorded custom-domain decision (key absent) STOPS
+    so the agent asks the user — it must not silently default to bit.ly."""
+    import pytest
+    monkeypatch.setattr(generate_qr, "create_bitly_link",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must STOP before creating")))
+    with pytest.raises(SystemExit):
+        generate_qr.resolve_short_url(
+            "https://jbaru.ch/my-slug", "my-slug",
+            {"shortener": "bitly"},   # no bitly_domain key → decision not recorded
+            {"bitly": {"api_token": "tok"}}, {}, dry_run=False, vault_path=None,
+        )
+
+
+def test_explicit_null_custom_domain_proceeds(generate_qr, monkeypatch):
+    """An explicit null custom-domain decision is recorded — proceed on the default
+    domain, no STOP, no re-ask."""
+    captured = {}
+
+    def fake_create_bitly_link(long_url, api_token, custom_back_half=None, domain=None):
+        captured["domain"] = domain
+        return {"short_url": f"https://bit.ly/{custom_back_half}", "link_id": "id", "short_path": custom_back_half}
+
+    monkeypatch.setattr(generate_qr, "create_bitly_link", fake_create_bitly_link)
+    short_url, meta = generate_qr.resolve_short_url(
+        "https://jbaru.ch/my-slug", "my-slug",
+        {"shortener": "bitly", "bitly_domain": None},   # recorded decision: no custom domain
+        {"bitly": {"api_token": "tok"}}, {}, dry_run=False, vault_path=None,
+    )
+    assert captured["domain"] is None
+    assert meta["short_path"] == "my-slug"
+
+
+def test_slug_cache_entry_is_reused(generate_qr, monkeypatch):
+    """A tracked entry whose back-half is already the slug is reused from cache —
+    no API call — when the target matches."""
+    def boom_create(*a, **k):
+        raise AssertionError("must reuse cache, not create a new link")
+
+    monkeypatch.setattr(generate_qr, "create_bitly_link", boom_create)
+    tracking_db = {"qr_codes": [{
+        "talk_slug": "my-slug",
+        "target_url": "https://jbaru.ch/my-slug",
+        "shortener": "bitly",
+        "short_path": "my-slug",
+        "short_url": "https://jbaru.ch/my-slug",
+        "shortener_link_id": "id",
+    }]}
+    short_url, meta = generate_qr.resolve_short_url(
+        "https://jbaru.ch/my-slug", "my-slug", {"shortener": "bitly"}, {}, tracking_db, dry_run=False,
+    )
+    assert short_url == "https://jbaru.ch/my-slug"
+    assert meta["short_path"] == "my-slug"


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Follow-up to #79, which was merged at the rework commit (`638a13c`) and enforced the slug-only back-half only for *newly-created* links. This lands the two pieces that didn't make that merge — the reviewer's legacy-cache finding and the custom-domain requirements.

## 1. Legacy non-slug links recreated (reviewer's boy-scout finding on #79)

`resolve_short_url` reused (cache) or retargeted-in-place any existing tracked link, including one whose back-half is a legacy non-slug hash. Such an entry is now dropped before the cache-reuse and update branches, so it's recreated with the slug back-half.

## 2. Custom-domain decision captured at first short link

The shortlink must use the vault's custom domain when one is configured, and that must never be silently skipped. Before creating a **new** shortened link, an absent `publishing_process.qr_code.{shortener}_domain` key **STOPS** so the agent asks the user and saves the answer:

- **absent** → never asked → ask + save
- **domain string** → use it
- **`null`** → recorded decision (no custom domain → default `bit.ly`), never re-asked

Also: `bitly_domain` documented in the profile schema (code + clarification already used it); rule §2 (use the custom domain when configured) + new §7 (three-state decision); phase6-publishing and clarification prompts save an explicit `null`.

## Test plan

- [x] `pytest tests/test_generate_qr.py` — 30 pass, incl. legacy-entry recreated, slug-current entry reused, absent-key STOPS, explicit-null proceeds
- [x] Full suite green (391 passed locally; numpy/cv2 env-only files excluded)
- [x] `tessl tile lint` valid
- [x] Pure Python + docs — no VBA change here (the `InsertQR` change shipped in #79), so no untestable-CI gap