### PR TITLE
feat(illustrations): add FULL-bleed mode + text_treatment anchor field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ fixes baked-text drift between slides. Step 5 now asks the speaker — never inf
 how titles + footers render: **Bleed** (baked into each image, stylized to the
 art, FULL-only, not editable; the noir reference deck) or **Overlay** (PowerPoint
 text over a safe zone, editable, uniform font). Choosing Bleed sets
-`style_anchor.composition: poster-theatrical` and locks every slide to FULL.
+`style_anchor.composition: poster-theatrical` and locks every illustrated slide
+to FULL (EXCEPTION/screenshot slides without an `image_prompt` are exempt).
 
 Adds `style_anchor.text_treatment` — the per-deck rendering directive for baked
 title + footer (e.g. "glowing hand-script neon on an in-scene surface"). It lives
-on the anchor and is applied to every slide, so titles/footers render identically;
-previously the model picked a treatment per call and they drifted.
+on the anchor and is applied to every illustrated slide's baked text, so
+titles/footers render identically; previously the model picked a treatment per
+call and they drifted.
 
 Codifies the anchor-vs-per-slide split: the anchor owns the style,
 `text_treatment`, and the full `embedded_footer` (everything that must stay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+### feat(illustrations) — FULL-bleed composition as a first-class choice + `text_treatment` anchor field
+
+Makes the poster-theatrical (full-bleed) path a deliberate, asked-for choice and
+fixes baked-text drift between slides. Step 5 now asks the speaker — never infers —
+how titles + footers render: **Bleed** (baked into each image, stylized to the
+art, FULL-only, not editable; the noir reference deck) or **Overlay** (PowerPoint
+text over a safe zone, editable, uniform font). Choosing Bleed sets
+`style_anchor.composition: poster-theatrical` and locks every slide to FULL.
+
+Adds `style_anchor.text_treatment` — the per-deck rendering directive for baked
+title + footer (e.g. "glowing hand-script neon on an in-scene surface"). It lives
+on the anchor and is applied to every slide, so titles/footers render identically;
+previously the model picked a treatment per call and they drifted.
+
+Codifies the anchor-vs-per-slide split: the anchor owns the style,
+`text_treatment`, and the full `embedded_footer` (everything that must stay
+consistent); the per-slide `image_prompt` carries only the scene and `text_overlay`
+carries only that slide's literal title string. Also completes the outline.yaml
+migration across all loaded context: stale markdown-format guidance in
+`presentation-creator/SKILL.md` (incl. the obsolete "illustrations expects
+markdown-style inputs" note), `phase2-architecture.md`, `generate-illustrations.py`
+runtime messages, `generate-thumbnail.py`, `title-overlay-rules.md` §0,
+`thumbnail-generation-rules.md`, and `resources-gathering-rules.md` now name the
+`style_anchor.*` YAML fields. The `test_outline_source_is_yaml.py` contract test
+scans skill prose + `rules/` (not just scripts) and fails on either a phantom
+`presentation-outline.md` reference or the legacy markdown bold-field syntax
+(`**Composition:**` / `**Embedded footer:**`) anywhere in loaded context.
+
 ### fix(illustrations) — read outline.yaml, not a phantom presentation-outline.md
 
 The three outline-consuming illustration scripts (`generate-illustrations.py`,

--- a/rules/resources-gathering-rules.md
+++ b/rules/resources-gathering-rules.md
@@ -11,8 +11,7 @@ matching, book patterns, RFC citations, and tool mentions consistently.
 Manual scanning misses items and introduces inconsistency.
 
 ```bash
-python3 skills/presentation-creator/scripts/extract-resources.py \
-  presentation-outline.md --spec presentation-spec.md
+python3 skills/presentation-creator/scripts/extract-resources.py outline.yaml
 ```
 
 ## 2. Speaker Review is Mandatory
@@ -38,8 +37,7 @@ higher in the review list and flag them as "from Coda section."
 ## 4. File Location
 
 `resources.json` lives in the talk working directory alongside
-`presentation-outline.md` and `presentation-spec.md`. It is talk-specific,
-not vault-level. Path:
+`outline.yaml`. It is talk-specific, not vault-level. Path:
 
 ```
 {presentations-dir}/{conference}/{year}/{talk-slug}/resources.json

--- a/rules/thumbnail-generation-rules.md
+++ b/rules/thumbnail-generation-rules.md
@@ -166,9 +166,9 @@ override the CLI default whenever the profile signals a clear illustrated
 brand.
 
 **Deck illustration anchor — `--portrait-style`.** When the deck has its
-own Illustration Style Anchor (Phase 2's `STYLE ANCHOR` block in
-`presentation-outline.md`), pass it to the script via `--portrait-style
-"<anchor>"`. The script pre-stylizes the speaker photo into the
+own style anchor (Phase 2's `style_anchor` block in `outline.yaml`), pass it
+to the script via `--portrait-style "<anchor>"`. The script pre-stylizes
+the speaker photo into the
 anchor's medium (sepia tech-manual, watercolor, pen-and-ink, retro
 poster, etc.) before composition. This fixes the palette mismatch that
 either standard aesthetic produces on illustrated decks: photographic

--- a/rules/thumbnail-generation-rules.md
+++ b/rules/thumbnail-generation-rules.md
@@ -166,9 +166,10 @@ override the CLI default whenever the profile signals a clear illustrated
 brand.
 
 **Deck illustration anchor — `--portrait-style`.** When the deck has its
-own style anchor (Phase 2's `style_anchor` block in `outline.yaml`), pass it
-to the script via `--portrait-style "<anchor>"`. The script pre-stylizes
-the speaker photo into the
+own style anchor (Phase 2's `style_anchor` block in `outline.yaml`), pass
+`style_anchor.full` (optionally combined with `style_anchor.conventions`) to
+the script via `--portrait-style "<anchor>"` — it takes a single prompt string,
+not the structured block. The script pre-stylizes the speaker photo into the
 anchor's medium (sepia tech-manual, watercolor, pen-and-ink, retro
 poster, etc.) before composition. This fixes the palette mismatch that
 either standard aesthetic produces on illustrated decks: photographic

--- a/rules/title-overlay-rules.md
+++ b/rules/title-overlay-rules.md
@@ -11,16 +11,18 @@ safety net that applies regardless of placement.
 ## 0. Poster-Theatrical Composition Opts Out Entirely
 
 Narrow exception for the poster-theatrical composition. When the deck's
-`style_anchor.composition` is `poster-theatrical`, every slide is FULL and the
-title and footer are rendered INTO the image as a stylized part of the scene —
-nothing in sections 1–7 applies to that deck:
+`style_anchor.composition` is `poster-theatrical`, every illustrated slide (one
+with an `image_prompt`) is FULL and the title and footer are rendered INTO the
+image as a stylized part of the scene — nothing in sections 1–7 applies to that
+deck. EXCEPTION / non-illustrated slides (real screenshots, no `image_prompt`)
+are not generated and keep their own treatment:
 
 - No `TITLE SAFE ZONE` directive — generation appends the `EMBEDDED TEXT`
   directive instead (`generate-illustrations.py` `apply_poster_embed_directive`),
   folding the slide's `text_overlay` and the deck's `style_anchor.embedded_footer`
   into the prompt, styled per `style_anchor.text_treatment`.
-- `style_anchor.text_treatment` is authored once and applied to every slide, so
-  baked titles and footers render identically across the deck.
+- `style_anchor.text_treatment` is authored once and applied to every illustrated
+  slide's baked text, so titles and footers render identically across the deck.
 - No `safe_zone` on poster slides; no zone assignment, no zone picker.
 - No scrim and no overlaid title text box at apply time — poster FULL slides get
   a background fill only (`apply-illustrations-to-deck.py` `parse_full_slides`).

--- a/rules/title-overlay-rules.md
+++ b/rules/title-overlay-rules.md
@@ -10,15 +10,18 @@ safety net that applies regardless of placement.
 
 ## 0. Poster-Theatrical Composition Opts Out Entirely
 
-Narrow exception for the poster-theatrical composition. When the deck's STYLE
-ANCHOR header declares `**Composition:** poster-theatrical`, the title and footer
-are rendered INTO the image as a stylized part of the scene — nothing in
-sections 1–7 applies to that deck:
+Narrow exception for the poster-theatrical composition. When the deck's
+`style_anchor.composition` is `poster-theatrical`, every slide is FULL and the
+title and footer are rendered INTO the image as a stylized part of the scene —
+nothing in sections 1–7 applies to that deck:
 
 - No `TITLE SAFE ZONE` directive — generation appends the `EMBEDDED TEXT`
   directive instead (`generate-illustrations.py` `apply_poster_embed_directive`),
-  folding the slide's `Text:` and the deck's `**Embedded footer:**` into the prompt.
-- No `Safe zone:` lines on poster slides; no zone assignment, no zone picker.
+  folding the slide's `text_overlay` and the deck's `style_anchor.embedded_footer`
+  into the prompt, styled per `style_anchor.text_treatment`.
+- `style_anchor.text_treatment` is authored once and applied to every slide, so
+  baked titles and footers render identically across the deck.
+- No `safe_zone` on poster slides; no zone assignment, no zone picker.
 - No scrim and no overlaid title text box at apply time — poster FULL slides get
   a background fill only (`apply-illustrations-to-deck.py` `parse_full_slides`).
 - The QR code is the only shape inserted after generation; everything else is

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -37,7 +37,7 @@ Do not restate them here — apply them.
 
 | File / Reference | Purpose |
 |------------------|---------|
-| `outline.yaml` | Source of truth — `style_anchor` (model, per-format anchors, composition, embedded_footer) + per-slide `format` / `image_prompt` / `safe_zone` / `builds` |
+| `outline.yaml` | Source of truth — `style_anchor` (model, per-format anchors, composition, embedded_footer, text_treatment) + per-slide `format` / `image_prompt` / `text_overlay` / `safe_zone` / `builds` |
 | `speaker-profile.json` → `visual_style_history` | Default style, departures, mode profiles, confirmed visual intents |
 | `speaker-profile.json` → `publishing_process.thumbnail` | Speaker photo path + aesthetic preference |
 | `illustrations/` (alongside outline) | Generated images, builds, model-comparison output |
@@ -138,12 +138,19 @@ silently — the priorities drive the shortlist in Step 6.
 
 Proceed immediately to Step 5.
 
-## Step 5 — Define Format Vocabulary
+## Step 5 — Define Format Vocabulary + Composition
 
-Define the slide format types for this talk: FULL / IMG+TXT / EXCEPTION + any
-talk-specific additions. Also decide the composition: standard overlay (titles +
-footers overlaid at apply time, per-slide safe zones) or poster-theatrical (all
-full-bleed; title + footer baked into the image, no safe zones, QR-only overlay).
+Ask the speaker — `AskUserQuestion`, never infer — how titles and footers are rendered:
+
+- **Bleed** — title + footer baked into every image, stylized to the art (the
+  example noir deck). Striking and consistent, but **not editable** after
+  generation. Sets `composition: poster-theatrical` and locks every slide to
+  **FULL** (no IMG+TXT, no safe zones); the text treatment + footer are recorded
+  in the anchor at Step 9.
+- **Overlay** — titles + footers added by PowerPoint over a per-slide safe zone.
+  Editable, uniform font, less integrated. Standard composition; the format
+  vocabulary is FULL / IMG+TXT / EXCEPTION + any talk-specific additions.
+
 Detail: [skills/illustrations/references/strategy.md](references/strategy.md).
 
 Proceed immediately to Step 6.
@@ -197,9 +204,22 @@ Proceed immediately to Step 9.
 
 Write the `style_anchor` block — chosen model + per-format anchors + visual
 continuity devices (`conventions`) — into `outline.yaml`. For poster-theatrical
-composition, also set `style_anchor.composition: poster-theatrical` and
-`style_anchor.embedded_footer: <text>`. Then run the deterministic precheck and
-report its verdict in one line; never skip this step silently:
+composition, also set `style_anchor.composition: poster-theatrical`,
+`style_anchor.embedded_footer: <text>`, and `style_anchor.text_treatment: <how
+baked title + footer are rendered>` (e.g. "glowing hand-script neon on an
+in-scene surface").
+
+Anchor vs per-slide split — everything that must look identical across slides
+lives in the anchor; only the scene and the literal title vary per slide:
+
+- **Anchor**: visual style (per-format anchors), `text_treatment` (the title +
+  footer rendering style), and `embedded_footer` (the full footer text). These
+  keep every baked title/footer consistent.
+- **Per slide**: `image_prompt` carries only the scene; `text_overlay` carries
+  only the literal title string for that slide — never the text styling.
+
+Then run the deterministic precheck and report its verdict in one line; never
+skip this step silently:
 
 ```bash
 python3 skills/illustrations/scripts/generate-illustrations.py \

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -145,8 +145,9 @@ Ask the speaker — `AskUserQuestion`, never infer — how titles and footers ar
 - **Bleed** — title + footer baked into every image, stylized to the art (the
   example noir deck). Striking and consistent, but **not editable** after
   generation. Sets `style_anchor.composition: poster-theatrical` and locks every
-  slide to **FULL** (no IMG+TXT, no safe zones); the text treatment + footer are recorded
-  in the anchor at Step 9.
+  **illustrated** slide to **FULL** (no IMG+TXT, no safe zones — EXCEPTION/screenshot
+  slides without an `image_prompt` are exempt); the text treatment + footer are
+  recorded in the anchor at Step 9.
 - **Overlay** — titles + footers added by PowerPoint over a per-slide safe zone.
   Editable, uniform font, less integrated. Standard composition; the format
   vocabulary is FULL / IMG+TXT / EXCEPTION + any talk-specific additions.

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -144,8 +144,8 @@ Ask the speaker — `AskUserQuestion`, never infer — how titles and footers ar
 
 - **Bleed** — title + footer baked into every image, stylized to the art (the
   example noir deck). Striking and consistent, but **not editable** after
-  generation. Sets `composition: poster-theatrical` and locks every slide to
-  **FULL** (no IMG+TXT, no safe zones); the text treatment + footer are recorded
+  generation. Sets `style_anchor.composition: poster-theatrical` and locks every
+  slide to **FULL** (no IMG+TXT, no safe zones); the text treatment + footer are recorded
   in the anchor at Step 9.
 - **Overlay** — titles + footers added by PowerPoint over a per-slide safe zone.
   Editable, uniform font, less integrated. Standard composition; the format

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -223,10 +223,18 @@ and `style_anchor.imgtxt`; the visual continuity devices go in
 prompts, aspect-ratio tokens, reserved keywords) into the anchor at the same time.
 
 When the composition is poster-theatrical, also set
-`style_anchor.composition: poster-theatrical` and
-`style_anchor.embedded_footer: <footer text>`. Generation reads these to embed the
+`style_anchor.composition: poster-theatrical`,
+`style_anchor.embedded_footer: <footer text>`, and
+`style_anchor.text_treatment: <how baked title + footer render>` (e.g. "glowing
+hand-script neon on an in-scene surface"). Generation reads these to embed the
 title + footer into each image and skip safe zones; apply and deck-build read them
-to leave titles/footers off the slide (QR only). Standard-overlay decks omit both.
+to leave titles/footers off the slide (QR only). Standard-overlay decks omit all three.
+
+The anchor owns everything that must stay consistent: the per-format style, the
+`text_treatment`, and the full `embedded_footer`. The per-slide `image_prompt`
+carries only the scene; `text_overlay` carries only that slide's literal title
+string — never the text styling. Putting the treatment in the anchor is what
+keeps every baked title and footer rendering identically across the deck.
 
 Then run the render-before-bake gate and report its one-line verdict:
 

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -131,12 +131,19 @@ POSTER_COMPOSITION = "poster-theatrical"
 
 POSTER_EMBED_DIRECTIVE_TEMPLATE = (
     " EMBEDDED TEXT -- CRITICAL COMPOSITION RULE: Render the title \"{title}\" "
-    "as an integral, stylized part of the scene itself — painted, carved, "
-    "printed, lit, woven, or sculpted into the composition in the artwork's "
-    "own lettering and materials, not pasted on as a flat overlay or caption. "
+    "as an integral, stylized part of the scene itself — {treatment} — not "
+    "pasted on as a flat overlay or caption. "
     "{footer_clause}All text must be fully blended and integrated into the "
     "illustration as if it belongs there. Do NOT reserve blank negative space "
     "for a title; the text is part of the artwork."
+)
+
+# Fallback when the style anchor declares no text_treatment. The anchor's
+# text_treatment (when set) makes every baked title/footer render identically;
+# without it the model picks a treatment per call, so titles drift between slides.
+DEFAULT_POSTER_TEXT_TREATMENT = (
+    "painted, carved, printed, lit, woven, or sculpted into the composition in "
+    "the artwork's own lettering and materials"
 )
 
 POSTER_FOOTER_CLAUSE_TEMPLATE = (
@@ -210,6 +217,7 @@ def parse_outline(path):
                 text / builds
             composition: str | None — "poster-theatrical" or None (standard)
             embedded_footer: str | None — poster-theatrical baked footer
+            text_treatment: str | None — anchor's baked-text rendering style
 
     Build steps map to the generator's backwards-chaining view: each step's
     `description` is the `erase` prompt (additive `desc` stays human-facing in
@@ -236,6 +244,7 @@ def parse_outline(path):
             anchor.composition.value if anchor and anchor.composition else None
         ),
         "embedded_footer": anchor.embedded_footer if anchor else None,
+        "text_treatment": anchor.text_treatment if anchor else None,
     }
 
     for slide in outline.slides:
@@ -319,13 +328,17 @@ def apply_safe_zone_directive(prompt, safe_zone):
     return prompt + directive
 
 
-def apply_poster_embed_directive(prompt, title_text, footer_text):
+def apply_poster_embed_directive(prompt, title_text, footer_text, text_treatment=None):
     """Append the poster-theatrical EMBEDDED TEXT directive to a prompt.
 
     Used when the deck's composition is poster-theatrical: the title (and, when
     present, the footer) are rendered into the image as a stylized part of the
     scene rather than overlaid afterward. The inverse of a safe zone — no
     negative space is reserved. See rules/title-overlay-rules.md.
+
+    `text_treatment` is the style anchor's per-deck rendering directive (how
+    baked text looks); passing the same value on every slide keeps titles and
+    footers visually consistent. When None, a generic treatment is used.
     Idempotent: an existing EMBEDDED TEXT block is replaced.
     """
     if not title_text:
@@ -341,8 +354,10 @@ def apply_poster_embed_directive(prompt, title_text, footer_text):
         footer_clause = POSTER_FOOTER_CLAUSE_TEMPLATE.format(
             footer=footer_text.replace('"', "'")
         )
+    treatment = (text_treatment or "").strip() or DEFAULT_POSTER_TEXT_TREATMENT
     directive = POSTER_EMBED_DIRECTIVE_TEMPLATE.format(
         title=title,
+        treatment=treatment,
         footer_clause=footer_clause,
     )
     return prompt + directive
@@ -588,8 +603,8 @@ def _load_context(outline_path, require_model=True, vault_path=None, compare_mod
     outline = parse_outline(outline_path)
 
     if require_model and not outline["model"]:
-        print("ERROR: No model found in outline. Add a **Model:** `model-name` line")
-        print("to the Illustration Style Anchor section.")
+        print("ERROR: No model found in outline. Add a `style_anchor.model` field")
+        print("to outline.yaml.")
         sys.exit(1)
 
     families = set()
@@ -954,7 +969,7 @@ def write_rendered_manifest(base_dir, outline_path, results):
 def check_style_explore(outline_path):
     """Render-before-bake gate: was the outline's baked model actually rendered?
 
-    Reads the baked **Model:** from the outline header and style-explore/
+    Reads the baked `style_anchor.model` from outline.yaml and style-explore/
     rendered.json. gate_passed is True iff the manifest exists and the baked
     model (resolved to its canonical id) is among the OK-rendered models.
     Returns a verdict dict; never raises on a missing/unbaked model.
@@ -977,7 +992,7 @@ def check_style_explore(outline_path):
 
     if not baked:
         verdict["error"] = (
-            "No **Model:** is baked into the outline header. Run the style "
+            "No `style_anchor.model` is baked into outline.yaml. Run the style "
             "exploration first and pick a model from the rendered grid: "
             f"generate-illustrations.py {outline_name} "
             "--style-explore style-explore/candidates.json"
@@ -1163,9 +1178,9 @@ def run_generate(outline_path, slide_args, versioned=False):
         if bad:
             print(
                 "ERROR: poster-theatrical composition requires every illustrated "
-                f"slide to be Format: FULL with no Safe zone. Offending slide(s): "
-                f"{', '.join(map(str, bad))}. Fix the outline or drop the "
-                "**Composition:** poster-theatrical header.",
+                f"slide to be format FULL with no safe_zone. Offending slide(s): "
+                f"{', '.join(map(str, bad))}. Fix the outline or drop "
+                "`style_anchor.composition: poster-theatrical`.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -1182,6 +1197,7 @@ def run_generate(outline_path, slide_args, versioned=False):
                 prompt,
                 slide.get("text") or slide["title"],
                 outline.get("embedded_footer"),
+                outline.get("text_treatment"),
             )
         else:
             # Safe zone presence forces FULL throughout — anchor selection,
@@ -1291,7 +1307,7 @@ def run_compare(outline_path, slide_num):
     print("=" * 70)
     print()
     print(f"Review images in: {output_dir}/")
-    print("Set your chosen model in the outline: **Model:** `model-name`")
+    print("Set your chosen model in outline.yaml: `style_anchor.model: model-name`")
 
 
 # --- Style Exploration (Phase 2 strategy: style x model x format grid) ---
@@ -1565,7 +1581,7 @@ def run_style_explore(outline_path, candidates_path):
     print()
     print(f"Wrote {index_path}")
     print(f"Wrote {manifest_path}")
-    print("Review the grid, pick a style + model, then bake them into the outline header.")
+    print("Review the grid, pick a style + model, then bake them into outline.yaml's style_anchor.")
 
 
 def run_edit(outline_path, slide_num, edit_prompt):
@@ -1628,7 +1644,7 @@ def run_build(outline_path, slide_arg):
         slide = slides_by_num[num]
         if "builds" not in slide:
             print(f"ERROR: Slide {num} has no build specification in the outline.")
-            print("Add a '- Builds: N steps' section with build-00 through build-NN entries.")
+            print("Add a `builds:` block (step 0 through N, each with desc + erase).")
             sys.exit(1)
         to_build = [slide]
 
@@ -1660,11 +1676,11 @@ def run_build(outline_path, slide_arg):
 
         print(f"Slide {num}: {slide['title']} — {len(steps)} build steps")
 
-        # An outline can declare `- Builds: N steps` without any parsable
-        # `build-XX:` entries beneath it — skip cleanly rather than crashing
-        # on max() of an empty sequence.
+        # Defensive: the schema guarantees a non-empty, contiguous-from-0
+        # `builds` list, so this can't fire from a valid outline.yaml — but guard
+        # against an empty sequence rather than crashing on max() of nothing.
         if not steps:
-            print(f"  SKIP — Builds declared but no build-NN entries parsed")
+            print(f"  SKIP — builds block has no steps")
             continue
 
         # Chain backwards: start from full, remove elements one at a time

--- a/skills/illustrations/scripts/generate-thumbnail.py
+++ b/skills/illustrations/scripts/generate-thumbnail.py
@@ -715,7 +715,7 @@ def main():
                              "anchor (e.g., retro tech-manual sepia, watercolor) "
                              "before composition — fixes palette mismatch on "
                              "decks with a strong visual style. Pass through from "
-                             "Phase 2's STYLE ANCHOR block when present.")
+                             "Phase 2's style_anchor block when present.")
     parser.add_argument("--title-position", choices=["top", "bottom", "overlay"],
                         default="top",
                         help="Title text position (default: top)")

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -212,7 +212,7 @@ Decision #12 (Illustration Strategy) is optional — only when the author wants
 AI-generated illustrations. Delegate to `Skill(skill: "illustrations")` for the full
 collaboration (style proposals grounded in vault `visual_style_history`, format
 vocabulary, model choice, visual continuity devices). The skill writes the approved
-STYLE ANCHOR block back into the outline header.
+`style_anchor` block into `outline.yaml`.
 
 For each: present options, recommend based on spec, let author choose.
 If co-presented, add role split and voice differentiation — see [references/phase1-intent.md](references/phase1-intent.md).
@@ -309,8 +309,8 @@ interludes:                 # production interludes between slides — usually l
 ```
 
 When an illustration strategy is defined, every non-EXCEPTION slide carries an
-`image_prompt`. The `[STYLE ANCHOR]` token in the prompt references the header
-anchor — the illustrations pipeline substitutes the actual anchor text at
+`image_prompt`. The `[STYLE ANCHOR]` token in the prompt references the
+`style_anchor` — the illustrations pipeline substitutes the actual anchor text at
 generation time. Talks without `style_anchor` use `visual:` + `text_overlay:` only.
 
 **Placeholders** — use typed, independent numbering (each type starts at 01):
@@ -420,7 +420,7 @@ slides get a slide BACKGROUND FILL (set by the PowerPoint `apply-backgrounds.sh`
 pass, so the layout's halftone-dot overlay covers them); IMG+TXT slides get a
 left-column picture shape via `apply-illustrations-to-deck.py`.
 
-When the outline's STYLE ANCHOR declares `**Composition:** poster-theatrical`,
+When `outline.yaml`'s `style_anchor.composition` is `poster-theatrical`,
 also **omit the `TITLE` and `FOOTER` ops** for the FULL slides — the title and
 footer are rendered into the illustration itself, so the only post-build inserts
 on those slides are the background fill and the QR code.
@@ -428,10 +428,8 @@ on those slides are the background fill and the QR code.
 After the build completes, if `outline.yaml` declares `style_anchor`, delegate
 to `Skill(skill: "illustrations")` to generate illustrations, generate any
 progressive-reveal builds, and apply them to the deck. The illustrations skill
-still expects markdown-style inputs (style anchor block + per-slide image
-prompts) — when invoked, surface the relevant fields from `outline.yaml` in the
-format the illustrations skill consumes. Updating the illustrations skill to
-consume `outline.yaml` natively is tracked separately.
+reads `outline.yaml` directly (`style_anchor` + per-slide `image_prompt` /
+`builds`) — no surfacing or format translation needed.
 
 If any slide has progressive-reveal builds, expand them FIRST with
 `skills/presentation-creator/scripts/expand-builds.sh` (manifest from

--- a/skills/presentation-creator/references/phase2-architecture.md
+++ b/skills/presentation-creator/references/phase2-architecture.md
@@ -155,7 +155,7 @@ visual continuity devices):
 Skill(skill: "illustrations")
 ```
 
-The skill writes the approved STYLE ANCHOR block back into the outline header,
+The skill writes the approved `style_anchor` block into `outline.yaml`,
 then returns control to Phase 2. Continue with the next decision (or the
 architecture gate) once the skill returns.
 

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -322,6 +322,12 @@ class StyleAnchor(_StrictModel):
     # the title (+ embedded_footer) into every image. See rules/title-overlay-rules.md.
     composition: Composition | None = None
     embedded_footer: str | None = None
+    # How baked title + footer text is rendered in poster-theatrical mode (e.g.
+    # "glowing hand-script neon on an in-scene surface"). Lives on the anchor so
+    # every slide's text is styled identically; the per-slide image_prompt carries
+    # only the scene and text_overlay carries only the literal title string. Only
+    # consumed in poster-theatrical mode; null falls back to a generic treatment.
+    text_treatment: str | None = None
 
 
 # ── Talk metadata ────────────────────────────────────────────────────

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -16,7 +16,8 @@ _FIXTURE_DATA = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
 
 
 def _write_outline(tmp_path, *, slides, model: str | None = "imagen-4",
-                   composition=None, embedded_footer=None, name="outline.yaml"):
+                   composition=None, embedded_footer=None, text_treatment=None,
+                   name="outline.yaml"):
     """Write a minimal valid outline.yaml (partial view) for parser tests.
 
     Reuses the canonical fixture's talk block, then sets the style anchor and
@@ -35,6 +36,8 @@ def _write_outline(tmp_path, *, slides, model: str | None = "imagen-4",
             anchor["composition"] = composition
         if embedded_footer is not None:
             anchor["embedded_footer"] = embedded_footer
+        if text_treatment is not None:
+            anchor["text_treatment"] = text_treatment
         data["style_anchor"] = anchor
     p = tmp_path / name
     p.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
@@ -978,10 +981,11 @@ def test_run_generate_proceeds_when_gate_passes(
 
 
 def _write_poster_outline(tmp_path, model="gemini-3-pro-image-preview",
-                          footer="jbaruch • Devoxx 2026", text="One team, one bench"):
+                          footer="jbaruch • Devoxx 2026", text="One team, one bench",
+                          text_treatment="glowing hand-script neon on an in-scene surface"):
     return _write_outline(
         tmp_path, model=model, composition="poster-theatrical",
-        embedded_footer=footer, slides=[
+        embedded_footer=footer, text_treatment=text_treatment, slides=[
             {"n": 3, "chapter": "c", "title": "The Coordination Tax",
              "format": "FULL", "text_overlay": text,
              "image_prompt": "[STYLE ANCHOR] one team at a shared workbench"},
@@ -995,6 +999,7 @@ def test_parse_poster_composition_and_footer(generate_illustrations, tmp_path):
     r = gi.parse_outline(str(outline))
     assert r["composition"] == "poster-theatrical"
     assert r["embedded_footer"] == "jbaruch • Devoxx 2026"
+    assert r["text_treatment"] == "glowing hand-script neon on an in-scene surface"
     assert r["slides"][0]["text"] == "One team, one bench"
 
 
@@ -1004,6 +1009,24 @@ def test_poster_embed_directive_includes_title_and_footer(generate_illustrations
     assert "EMBEDDED TEXT" in d
     assert "One team, one bench" in d
     assert "jbaruch • Devoxx 2026" in d
+
+
+def test_poster_embed_directive_uses_anchor_text_treatment(generate_illustrations):
+    # The anchor's text_treatment must appear verbatim in the directive so every
+    # slide's baked title/footer renders identically.
+    gi = generate_illustrations
+    d = gi.apply_poster_embed_directive(
+        "a scene", "One team, one bench", "footer",
+        "glowing hand-script neon on an in-scene surface",
+    )
+    assert "glowing hand-script neon on an in-scene surface" in d
+
+
+def test_poster_embed_directive_falls_back_to_default_treatment(generate_illustrations):
+    # With no anchor text_treatment, the generic default is used (back-compat).
+    gi = generate_illustrations
+    d = gi.apply_poster_embed_directive("a scene", "Title", None)
+    assert gi.DEFAULT_POSTER_TEXT_TREATMENT in d
     assert "TITLE SAFE ZONE" not in d
 
 
@@ -1045,6 +1068,8 @@ def test_run_generate_poster_embeds_text_and_skips_safe_zone(
     assert "EMBEDDED TEXT" in prompts[0]
     assert "One team, one bench" in prompts[0]
     assert "jbaruch • Devoxx 2026" in prompts[0]
+    # The anchor's text_treatment rides through run_generate into the prompt.
+    assert "glowing hand-script neon on an in-scene surface" in prompts[0]
     assert "TITLE SAFE ZONE" not in prompts[0]
 
 

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -664,6 +664,20 @@ def test_rejects_unknown_composition(outline_schema, base_data):
         outline_schema.Outline.model_validate(data)
 
 
+def test_accepts_style_anchor_text_treatment(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    data["style_anchor"]["text_treatment"] = (
+        "glowing hand-script neon rendered on an in-scene surface"
+    )
+    outline = outline_schema.Outline.model_validate(data)
+    assert outline.style_anchor.text_treatment.startswith("glowing hand-script")
+
+
+def test_style_anchor_text_treatment_defaults_none(outline_schema):
+    outline = outline_schema.load_outline(FIXTURE)
+    assert outline.style_anchor.text_treatment is None
+
+
 def test_accepts_slide_safe_zone(outline_schema, base_data):
     data = copy.deepcopy(base_data)
     data["slides"][0]["safe_zone"] = {

--- a/tests/test_outline_source_is_yaml.py
+++ b/tests/test_outline_source_is_yaml.py
@@ -135,7 +135,7 @@ def test_outline_consumers_use_shared_schema_loader(path):
 
 
 def _context_artifact_files() -> list[Path]:
-    """Repo-own scripts, skill prose, and rules — the context agents load.
+    """Repo-owned scripts, skill prose, and rules — the context agents load.
 
     CHANGELOG.md is excluded by construction (it lives at the repo root, not
     under skills/ or rules/): it is the archive and legitimately names the old

--- a/tests/test_outline_source_is_yaml.py
+++ b/tests/test_outline_source_is_yaml.py
@@ -16,11 +16,20 @@ from pathlib import Path
 
 import pytest
 
-SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+RULES_DIR = REPO_ROOT / "rules"
 
 # The phantom artifact the illustration scripts used to regex-parse. Nothing in
 # the toolkit generates it — the source of truth is outline.yaml.
 PHANTOM_MARKDOWN_OUTLINE = "presentation-outline.md"
+
+# Markdown bold-field syntax the legacy markdown outline used for deck-level
+# fields; outline.yaml carries these as style_anchor.composition / .embedded_footer.
+# The bold-field form must never appear in loaded context (it would teach the
+# agent the outline is markdown). `**Model:**` is deliberately NOT forbidden:
+# extract-slides.py legitimately renders it into the generated slides.md.
+FORBIDDEN_MD_OUTLINE_FIELDS = ("**Composition:**", "**Embedded footer:**")
 
 
 def _script_files() -> list[Path]:
@@ -125,10 +134,28 @@ def test_outline_consumers_use_shared_schema_loader(path):
     )
 
 
-def test_no_script_ingests_phantom_markdown_outline():
-    """No script anywhere references the phantom presentation-outline.md."""
+def _context_artifact_files() -> list[Path]:
+    """Repo-own scripts, skill prose, and rules — the context agents load.
+
+    CHANGELOG.md is excluded by construction (it lives at the repo root, not
+    under skills/ or rules/): it is the archive and legitimately names the old
+    `presentation-outline.md` in historical entries.
+    """
+    files = list(_script_files())
+    files += [p for p in SKILLS_DIR.glob("**/*.md")]
+    files += [p for p in RULES_DIR.glob("*.md")]
+    return sorted(set(files))
+
+
+def test_no_context_artifact_references_phantom_markdown_outline():
+    """No script, skill doc, or rule references the phantom presentation-outline.md.
+
+    Scripts, skill prose, and rules are all loaded as agent context, so a stale
+    reference there misleads the agent into hand-authoring a file nothing
+    generates. The source of truth is outline.yaml.
+    """
     offenders = []
-    for path in _script_files():
+    for path in _context_artifact_files():
         src = path.read_text(encoding="utf-8")
         if PHANTOM_MARKDOWN_OUTLINE in src:
             line_nos = [
@@ -136,8 +163,27 @@ def test_no_script_ingests_phantom_markdown_outline():
                 for i, line in enumerate(src.splitlines())
                 if PHANTOM_MARKDOWN_OUTLINE in line
             ]
-            offenders.append(f"{path.relative_to(SKILLS_DIR)}:{line_nos}")
+            offenders.append(f"{path.relative_to(REPO_ROOT)}:{line_nos}")
     assert not offenders, (
-        f"scripts reference the phantom '{PHANTOM_MARKDOWN_OUTLINE}' "
+        f"context artifacts reference the phantom '{PHANTOM_MARKDOWN_OUTLINE}' "
         f"(nothing generates it — use outline.yaml): {offenders}"
+    )
+
+
+def test_no_context_artifact_uses_markdown_outline_field_syntax():
+    """No loaded context uses the legacy markdown bold-field outline syntax.
+
+    Catches stale guidance that survives a filename swap — e.g. telling the agent
+    the deck declares `**Composition:** poster-theatrical` rather than setting
+    `style_anchor.composition` in outline.yaml.
+    """
+    offenders = []
+    for path in _context_artifact_files():
+        src = path.read_text(encoding="utf-8")
+        hits = [tok for tok in FORBIDDEN_MD_OUTLINE_FIELDS if tok in src]
+        if hits:
+            offenders.append(f"{path.relative_to(REPO_ROOT)}: {hits}")
+    assert not offenders, (
+        "context artifacts use legacy markdown outline field syntax — set the "
+        f"corresponding style_anchor.* field in outline.yaml instead: {offenders}"
     )


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- Makes the **FULL-bleed** (poster-theatrical) path a first-class, *asked-for* choice: the strategy flow now asks the speaker **Bleed** (baked, stylized, FULL-only, not editable) vs **Overlay** (PowerPoint text over a safe zone, editable) instead of inferring. Bleed sets `style_anchor.composition: poster-theatrical` and locks every slide to FULL.
- Adds **`style_anchor.text_treatment`** — the per-deck rendering directive for baked title + footer (e.g. "glowing hand-script neon on an in-scene surface"). It lives on the anchor and is applied to every slide via `apply_poster_embed_directive`, so titles/footers render identically; previously the model picked a treatment per call and they drifted.
- Codifies the **anchor-vs-per-slide split**: anchor owns style + `text_treatment` + full `embedded_footer`; per-slide `image_prompt` carries only the scene, `text_overlay` only the literal title string.
- Corrects stale markdown-format references in `generate-illustrations.py` runtime messages and `title-overlay-rules.md` §0 left from the outline.yaml migration.

## Out of scope (follow-up)
Two more outline.yaml-migration leftovers reference the phantom `presentation-outline.md` in *other* skills' rules — `thumbnail-generation-rules.md` and `resources-gathering-rules.md` — plus the `test_outline_source_is_yaml.py` contract test could be widened to scan `rules/` + skill prose, not just scripts. Left for a focused migration-completeness PR.

## Test plan
- [x] `pytest` green (497 passed, 3 skipped — local numpy/cv2 optional-dep gaps)
- [x] schema: `text_treatment` accepted + defaults None
- [x] `apply_poster_embed_directive` injects anchor `text_treatment` (and falls back to default when absent)
- [x] end-to-end: treatment rides through `run_generate` into the poster prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)