### PR TITLE
fix(illustrations): style-anchor conventions reach generation (#83) + style-only compose guard (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+### fix(illustrations) — style-anchor `conventions` reach every generation prompt
+
+`style_anchor.conventions` is a required field where `strategy.md` Step 9 tells authors
+to bake the deck-wide, generation-relevant style rules (palette constraints like strict
+grayscale, sequential numbering, recurring motifs). But `generate-illustrations.py`'s
+`parse_outline` only read `style_anchor.full`/`imgtxt` — it validated `conventions` via the
+schema and then threw it away, so those load-bearing rules never reached the image model.
+A deck whose `conventions` said "no sepia / no warm tint" still drifted sepia because the
+rule, though it "existed" in the outline, was never sent. `parse_outline` now folds the
+collapsed `conventions` into every per-format anchor (the `[STYLE ANCHOR]` token expands to
+"<format anchor> <conventions>") and surfaces the raw text under a new `conventions` key;
+an empty `conventions` appends no stray separator. Resolves #83.
+
+### fix(illustrations) — style anchor stays style-only; compose-only guard blocks furniture leak
+
+The style anchor is injected into every slide's prompt, so anything in it renders on every
+slide — yet nothing enforced that the anchor was *style-only*, and *Style-Anchor Discipline*
+pushed the other way ("be specific, don't prune"). For document-style aesthetics (instruction
+booklet, blueprint, newspaper), the page furniture — parts inventories, step strips, numbered
+stations, exploded diagrams — reads like a style convention but is per-slide content, so the
+whole deck's furniture cross-contaminated every slide (the title slide became "the entire deck
+on one image"). `generate-illustrations.py` now appends a `COMPOSE ONLY THE SCENE` directive to
+every fresh-generation prompt (generate / style-explore / compare — not erase-only edits),
+pinning the model to the per-slide scene and barring instruction-page furniture and
+other-slide elements. `rules/illustration-rules.md` (*Style-Anchor Discipline*) and
+`strategy.md` Step 9 are rewritten to mandate a style-only anchor and reconcile "append, don't
+prune" by axis: prune smuggled-in content, preserve and extend style specificity. Resolves #87.
+
 ### fix(illustrations) — secrets.json read no longer hangs on a cloud placeholder
 
 `load_secrets()` read `{vault}/secrets.json` with a plain `json.load(open(path))`. When that

--- a/rules/illustration-rules.md
+++ b/rules/illustration-rules.md
@@ -42,12 +42,36 @@ the element survives instead of being erased.
 
 ## Style-Anchor Discipline
 
+The style anchor is injected into **every** slide's prompt, so anything in it
+renders on **every** slide. The anchor therefore defines **STYLE ONLY** —
+medium, palette, rendering technique, lettering/text treatment, period
+vocabulary, material constraints, and recurring-character conventions. It must
+**never** contain per-slide scene content or recurring page-furniture: parts
+inventories, step strips, numbered stations, exploded diagrams, callouts.
+That furniture is per-slide **content** — it belongs in the individual slide's
+`image_prompt`, not the anchor.
+
+This is most dangerous for **document-style aesthetics** (instruction booklet,
+blueprint, newspaper, schematic), where the page furniture *reads* like a style
+convention but is actually content. Fold a parts-inventory or step-strip into
+the anchor and the whole deck's furniture renders on every slide — including
+the title slide, which becomes "the entire deck on one image." (See #87.)
+
 Never simplify or rewrite the speaker's original style anchor when iterating.
-The specificity of the anchor (period vocabulary, document conventions,
-material constraints) is what produces a coherent style across slides; pruning
+The specificity of the *style* (period vocabulary, document conventions,
+material constraints) is what produces a coherent look across slides; pruning
 it for "cleanliness" reverts the output to a generic illustrative default.
 
-Append to the anchor for new constraints — don't replace.
+Append to the anchor for new **style** constraints — don't replace. Reconcile
+the two halves of this rule by separating axes: **prune content** that crept in
+(scene elements, page furniture), but **preserve and extend style** specificity.
+"Don't prune" protects the style detail, not smuggled-in content.
+
+`generate-illustrations.py` appends a generation-time `COMPOSE ONLY THE SCENE`
+guard to every fresh-generation prompt as a backstop, telling the model to
+render only what the per-slide scene names. The guard reduces leakage; a
+style-only anchor prevents it. Both matter — don't rely on the guard to excuse
+a content-laden anchor.
 
 ## Build Process — Progressive Reveals
 

--- a/rules/illustration-rules.md
+++ b/rules/illustration-rules.md
@@ -51,11 +51,10 @@ inventories, step strips, numbered stations, exploded diagrams, callouts.
 That furniture is per-slide **content** — it belongs in the individual slide's
 `image_prompt`, not the anchor.
 
-This is most dangerous for **document-style aesthetics** (instruction booklet,
-blueprint, newspaper, schematic), where the page furniture *reads* like a style
-convention but is actually content. Fold a parts-inventory or step-strip into
-the anchor and the whole deck's furniture renders on every slide — including
-the title slide, which becomes "the entire deck on one image." (See #87.)
+This is most acute for **document-style aesthetics** (instruction booklet,
+blueprint, newspaper, schematic), where page furniture *reads* like a style
+convention but is per-slide content — keep it in each slide's `image_prompt`,
+never in the anchor.
 
 Never simplify or rewrite the speaker's original style anchor when iterating.
 The specificity of the *style* (period vocabulary, document conventions,

--- a/rules/illustration-rules.md
+++ b/rules/illustration-rules.md
@@ -42,14 +42,13 @@ the element survives instead of being erased.
 
 ## Style-Anchor Discipline
 
-The style anchor is injected into **every** slide's prompt, so anything in it
-renders on **every** slide. The anchor therefore defines **STYLE ONLY** —
-medium, palette, rendering technique, lettering/text treatment, period
-vocabulary, material constraints, and recurring-character conventions. It must
-**never** contain per-slide scene content or recurring page-furniture: parts
-inventories, step strips, numbered stations, exploded diagrams, callouts.
-That furniture is per-slide **content** — it belongs in the individual slide's
-`image_prompt`, not the anchor.
+The style anchor defines **STYLE ONLY** — medium, palette, rendering technique,
+lettering/text treatment, period vocabulary, material constraints, and
+recurring-character conventions. It renders on **every** slide. Keep per-slide
+scene content and recurring page-furniture out of it — parts inventories, step
+strips, numbered stations, exploded diagrams, callouts. That furniture is
+per-slide **content** — put it in the individual slide's `image_prompt`, not the
+anchor.
 
 This is most acute for **document-style aesthetics** (instruction booklet,
 blueprint, newspaper, schematic), where page furniture *reads* like a style

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -236,6 +236,15 @@ carries only the scene; `text_overlay` carries only that slide's literal title
 string — never the text styling. Putting the treatment in the anchor is what
 keeps every baked title and footer rendering identically across the deck.
 
+The anchor (and `conventions`) is injected into **every** slide, so it must be
+**STYLE ONLY** — medium, palette, rendering, lettering, recurring-character
+conventions. Keep per-slide scene content and page-furniture (parts
+inventories, step strips, numbered stations, exploded diagrams, callouts) out
+of it and in the slide's own `image_prompt`; otherwise the whole deck's
+furniture renders on every slide. This is acute for document-style aesthetics
+(instruction booklet, blueprint, newspaper) where furniture masquerades as a
+style convention. See *Style-Anchor Discipline* in `rules/illustration-rules.md`.
+
 Then run the render-before-bake gate and report its one-line verdict:
 
 ```bash

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -236,7 +236,7 @@ carries only the scene; `text_overlay` carries only that slide's literal title
 string — never the text styling. Putting the treatment in the anchor is what
 keeps every baked title and footer rendering identically across the deck.
 
-The anchor (and `conventions`) is injected into **every** slide, so it must be
+The anchor, including `conventions`, is injected into **every** slide, so it must be
 **STYLE ONLY** — medium, palette, rendering, lettering, recurring-character
 conventions. Keep per-slide scene content and page-furniture (parts
 inventories, step strips, numbered stations, exploded diagrams, callouts) out

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -225,7 +225,9 @@ def parse_outline(path):
 
         dict with keys:
             model: str | None — baked illustration model (style_anchor.model)
-            anchors: dict[str, str] — format token ("FULL"/"IMG+TXT") → anchor
+            anchors: dict[str, str] — format token ("FULL"/"IMG+TXT") → anchor,
+                with the deck-wide `conventions` rules folded in (see below)
+            conventions: str | None — the raw deck-wide convention rules
             slides: list[dict] — prompt-bearing slides only, each with
                 slide_num, title, format, prompt, and optional safe_zone /
                 text / builds
@@ -247,12 +249,27 @@ def parse_outline(path):
     outline = outline_schema.load_outline_partial(path)
     anchor = outline.style_anchor
 
+    # `conventions` holds the deck-wide, generation-relevant style rules
+    # (palette constraints, sequential numbering, recurring motifs — see
+    # strategy.md Step 9). It is a REQUIRED style_anchor field, but it only
+    # earns its keep if it reaches the model on every slide, so fold it into
+    # each per-format anchor: the `[STYLE ANCHOR]` token then expands to
+    # "<format anchor> <conventions>". Parsing it but never injecting it was
+    # issue #83's silent-drop failure (strict-grayscale / numbering rules that
+    # "existed" in the outline yet never reached generation).
+    conventions = _collapse_anchor(anchor.conventions) if anchor else ""
+
+    def _anchor_with_conventions(text):
+        text = _collapse_anchor(text)
+        return f"{text} {conventions}".strip() if conventions else text
+
     result = {
         "model": anchor.model if anchor else None,
         "anchors": {
-            "FULL": _collapse_anchor(anchor.full),
-            "IMG+TXT": _collapse_anchor(anchor.imgtxt),
+            "FULL": _anchor_with_conventions(anchor.full),
+            "IMG+TXT": _anchor_with_conventions(anchor.imgtxt),
         } if anchor else {},
+        "conventions": conventions or None,
         "slides": [],
         "composition": (
             anchor.composition.value if anchor and anchor.composition else None
@@ -375,6 +392,38 @@ def apply_poster_embed_directive(prompt, title_text, footer_text, text_treatment
         footer_clause=footer_clause,
     )
     return prompt + directive
+
+
+# Style anchors are injected into EVERY slide's prompt, so anything in them
+# renders on every slide. The anchor must stay STYLE-ONLY (medium, palette,
+# rendering, lettering, recurring-character conventions — see Style-Anchor
+# Discipline in rules/illustration-rules.md). This directive is the
+# generation-time backstop: it tells the model to render only what THIS slide's
+# scene describes, so deck-wide "page furniture" (parts inventories, step
+# strips, numbered stations, exploded diagrams, stray callouts) — which reads
+# like a style convention in document/instruction-page aesthetics but is
+# actually per-slide content — can't cross-contaminate every slide. See #87.
+COMPOSE_ONLY_DIRECTIVE = (
+    " COMPOSE ONLY THE SCENE -- CRITICAL COMPOSITION RULE: Render only the "
+    "subjects and objects this slide's scene names. Do NOT add instruction-page "
+    "furniture (parts inventories, step strips, numbered stations, exploded "
+    "assembly diagrams, callouts) or elements drawn from other slides unless "
+    "this scene explicitly asks for them."
+)
+
+
+def apply_compose_only_directive(prompt):
+    """Append the style-only COMPOSE ONLY guard to a fresh-generation prompt.
+
+    Keeps the always-injected style anchor from leaking per-slide content /
+    page-furniture onto every slide (issue #87). Applied to fresh generation
+    (generate / style-explore / compare), not to erase-only edits — those carry
+    their own "DO NOT add any new elements" suffix. Idempotent: an existing
+    COMPOSE ONLY block is replaced.
+    """
+    if "COMPOSE ONLY THE SCENE" in prompt:
+        prompt = prompt.split("COMPOSE ONLY THE SCENE", 1)[0].rstrip()
+    return prompt + COMPOSE_ONLY_DIRECTIVE
 
 
 def effective_slide_format(slide_format, safe_zone):
@@ -1263,6 +1312,10 @@ def run_generate(outline_path, slide_args, versioned=False):
             prompt = resolve_prompt(slide["prompt"], eff_format, outline["anchors"])
             prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
 
+        # Style-only guard: the anchor renders on every slide, so pin the model
+        # to this slide's scene and keep deck-wide page-furniture from leaking (#87).
+        prompt = apply_compose_only_directive(prompt)
+
         print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
         image_bytes, result = generate_image(prompt, model, keys, eff_format)
@@ -1308,6 +1361,7 @@ def run_compare(outline_path, slide_num):
     eff_format = effective_slide_format(slide["format"], slide.get("safe_zone"))
     prompt = resolve_prompt(slide["prompt"], eff_format, outline["anchors"])
     prompt = apply_safe_zone_directive(prompt, slide.get("safe_zone"))
+    prompt = apply_compose_only_directive(prompt)
 
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)),
@@ -1575,8 +1629,11 @@ def run_style_explore(outline_path, candidates_path):
             anchor = style["anchors"].get(eff_format) or style["anchors"].get(fmt)
             if not anchor:
                 continue
-            prompt = apply_safe_zone_directive(
-                resolve_prompt(scene_prompt, eff_format, {eff_format: anchor}), safe_zone
+            prompt = apply_compose_only_directive(
+                apply_safe_zone_directive(
+                    resolve_prompt(scene_prompt, eff_format, {eff_format: anchor}),
+                    safe_zone,
+                )
             )
             for model in candidates["models"]:
                 plan.append((style["name"], fmt, model, prompt, eff_format))

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -416,13 +416,18 @@ def apply_compose_only_directive(prompt):
     """Append the style-only COMPOSE ONLY guard to a fresh-generation prompt.
 
     Keeps the always-injected style anchor from leaking per-slide content /
-    page-furniture onto every slide (issue #87). Applied to fresh generation
-    (generate / style-explore / compare), not to erase-only edits — those carry
-    their own "DO NOT add any new elements" suffix. Idempotent: an existing
-    COMPOSE ONLY block is replaced.
+    page-furniture onto every slide. Applied to fresh generation (generate /
+    style-explore / compare), not to erase-only edits — those carry their own
+    "DO NOT add any new elements" suffix.
+
+    Idempotent without ever discarding caller text: we test for our exact
+    appended directive, not the bare phrase, so a speaker prompt that happens to
+    contain the words "COMPOSE ONLY THE SCENE" keeps all of its content (and the
+    safe-zone / poster directives appended before this) instead of being
+    truncated at the phrase.
     """
-    if "COMPOSE ONLY THE SCENE" in prompt:
-        prompt = prompt.split("COMPOSE ONLY THE SCENE", 1)[0].rstrip()
+    if COMPOSE_ONLY_DIRECTIVE in prompt:
+        return prompt
     return prompt + COMPOSE_ONLY_DIRECTIVE
 
 

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -403,6 +403,18 @@ def test_apply_compose_only_directive_idempotent(generate_illustrations):
     assert twice.count("COMPOSE ONLY THE SCENE") == 1
 
 
+def test_apply_compose_only_preserves_caller_text_with_phrase(generate_illustrations):
+    # A speaker prompt (or an already-appended safe-zone/poster directive) that
+    # happens to contain the words "COMPOSE ONLY THE SCENE" must NOT be truncated:
+    # the guard appends, it never splits away caller content.
+    gi = generate_illustrations
+    prompt = "A lab. COMPOSE ONLY THE SCENE as the author noted. TITLE SAFE ZONE -- reserve the top."
+    result = gi.apply_compose_only_directive(prompt)
+    assert result.startswith(prompt)            # nothing dropped
+    assert "TITLE SAFE ZONE" in result          # prior directive survives
+    assert result.endswith(gi.COMPOSE_ONLY_DIRECTIVE)
+
+
 def test_effective_slide_format_safe_zone_wins(generate_illustrations):
     # apply-illustrations-to-deck.py gives Safe zone precedence over the
     # Format token — slides with any Safe zone field are treated as

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -58,6 +58,28 @@ def test_parse_anchors(generate_illustrations):
     assert "Photorealistic" in result["anchors"]["FULL"]
 
 
+def test_parse_anchors_fold_in_conventions(generate_illustrations):
+    # #83: the required `conventions` block holds deck-wide, generation-relevant
+    # style rules. It must be folded into EVERY format's anchor so it reaches the
+    # model on every slide — parsing it but never injecting it was the bug.
+    result = generate_illustrations.parse_outline(FIXTURE)
+    assert "brass compass" in result["anchors"]["FULL"]
+    assert "brass compass" in result["anchors"]["IMG+TXT"]
+    # Also surfaced raw for callers/tests.
+    assert result["conventions"] and "brass compass" in result["conventions"]
+
+
+def test_parse_anchors_no_conventions_is_clean(generate_illustrations, tmp_path):
+    # An empty conventions string must not append a stray separator to the anchor.
+    data = copy.deepcopy(_FIXTURE_DATA)
+    data["style_anchor"]["conventions"] = ""
+    p = tmp_path / "outline.yaml"
+    p.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    result = generate_illustrations.parse_outline(str(p))
+    assert result["conventions"] is None
+    assert not result["anchors"]["FULL"].endswith(" ")
+
+
 def test_parse_slides_excludes_promptless(generate_illustrations):
     # Slide 7 is EXCEPTION (a real screenshot) with no image_prompt — it is not
     # an illustration target and must be excluded from the generator's view.
@@ -362,6 +384,23 @@ def test_apply_safe_zone_default_surface(generate_illustrations):
     result = generate_illustrations.apply_safe_zone_directive("A scene", safe_zone)
     assert "TITLE SAFE ZONE" in result
     assert "left half" in result
+
+
+def test_apply_compose_only_directive(generate_illustrations):
+    # #87: the style anchor renders on every slide, so the fresh-gen prompt must
+    # carry a guard pinning the model to THIS slide's scene and barring
+    # deck-wide page-furniture.
+    result = generate_illustrations.apply_compose_only_directive("A lone brick")
+    assert "COMPOSE ONLY THE SCENE" in result
+    assert result.startswith("A lone brick")
+    assert "instruction-page furniture" in result
+
+
+def test_apply_compose_only_directive_idempotent(generate_illustrations):
+    once = generate_illustrations.apply_compose_only_directive("A scene")
+    twice = generate_illustrations.apply_compose_only_directive(once)
+    assert once == twice
+    assert twice.count("COMPOSE ONLY THE SCENE") == 1
 
 
 def test_effective_slide_format_safe_zone_wins(generate_illustrations):


### PR DESCRIPTION
## What

Two clean prompt-assembly fixes in the illustration pipeline.

### #83 — `style_anchor.conventions` were parsed and thrown away
`conventions` is a **required** `style_anchor` field where `strategy.md` Step 9 tells authors to bake the deck-wide, generation-relevant style rules (strict-grayscale palettes, sequential numbering, recurring motifs). But `parse_outline` only read `full`/`imgtxt` — it validated `conventions` via the schema and then dropped it, so those load-bearing rules never reached the image model. A deck whose `conventions` said "no sepia / no warm tint" still drifted sepia. (The earlier markdown-bridge incident in the issue was the same silent-drop; removing the bridge just relocated the bug into the native parser.)

**Fix:** `parse_outline` folds the collapsed `conventions` into every per-format anchor (the `[STYLE ANCHOR]` token now expands to `<format anchor> <conventions>`) and surfaces the raw text under a new `conventions` key. Empty `conventions` appends no stray separator.

### #87 — anchor leaked per-slide page-furniture onto every slide
The anchor is injected into every prompt, so anything in it renders everywhere; nothing enforced it was *style-only*, and *Style-Anchor Discipline* pushed the other way. For document-style aesthetics the page furniture (parts inventories, step strips, numbered stations) reads like a style convention but is per-slide content, so the whole deck's furniture cross-contaminated every slide.

**Fix:** a `COMPOSE ONLY THE SCENE` directive is appended to every fresh-generation prompt (generate / style-explore / compare — not erase-only edits), pinning the model to the per-slide scene. `rules/illustration-rules.md` and `strategy.md` Step 9 are rewritten to mandate a style-only anchor and reconcile "append, don't prune" by axis (prune content, preserve style specificity).

## Tests
New unit tests cover conventions folding (including the empty-conventions clean case) and the compose-only directive (content + idempotency). Full suite: `183 passed`.

## Notes
`#90` (build-drift / masked edits) is intentionally **not** in this PR — it lands separately as it needs a schema change.

**Author-Model:** claude-opus-4-8[1m]

Resolves #83
Resolves #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)