### PR TITLE
fix(illustrations): masked/composited build edits keep static backgrounds pixel-stable (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+### fix(illustrations) — masked/composited build edits keep static backgrounds pixel-stable
+
+Backward-chaining progressive-reveal builds (`--build`) sent the whole frame to the image
+model with only a text prompt and no mask, so the model was free to redraw everything: a
+static background that must stay fixed across the reveal (a conveyor, a baseplate, a panel
+frame, blueprint chrome) drifted in position/size or silently lost elements between frames —
+even when the `erase` prompt named them in a `Keep` clause. A `Keep` clause reduces drift
+but a maskless edit cannot guarantee the kept pixels survive. Build steps now take an
+optional `erase_region` — a normalized `[x0, y0, x1, y1]` box (0..1, origin top-left, schema
+validated) around the element being erased. When set, `--build` confines the edit to that
+box: OpenAI receives a real edit mask (only the transparent box is regenerated), and for
+both vendors the returned image is composited back over the prior frame via Pillow so every
+pixel outside the box is the source pixel exactly. The box is still redrawn by the model
+(the erased area shows real background, not a flat fill). Without a region the historical
+whole-frame regeneration is unchanged, so existing outlines need no edits. Pillow (already a
+project dependency) is imported lazily only when a region is used. `Build.erase_region` is
+added to the outline schema; `rules/illustration-rules.md` and
+`skills/illustrations/references/builds.md` document when and how to use it. Resolves #90.
+
 ### fix(illustrations) — style-anchor `conventions` reach every generation prompt
 
 `style_anchor.conventions` is a required field where `strategy.md` Step 9 tells authors

--- a/rules/illustration-rules.md
+++ b/rules/illustration-rules.md
@@ -86,10 +86,25 @@ Each step's input is the PREVIOUS step's output (chained edits work because
 the per-step diff is small and the style is preserved on erasure — see the
 edit-vs-regenerate asymmetry rule above).
 
+**Static backgrounds drift unless you scope the edit.** A maskless edit sends
+the whole frame to the model and lets it redraw everything, so a background
+that must stay fixed across the reveal (a conveyor, a baseplate, a panel frame,
+blueprint chrome) can shift in position/size or silently lose elements — even
+when the `erase` prompt names them in a `Keep` clause. A `Keep` clause *reduces*
+drift but cannot *guarantee* pixel-stability. When a build has a static
+background that must not move, give the step an **`erase_region`**: a normalized
+`[x0, y0, x1, y1]` box (0..1, origin top-left) around the element being erased.
+`--build` then confines the edit to that box — OpenAI gets a real edit mask, and
+for both vendors the result is composited back over the prior frame so every
+pixel outside the box is the source pixel exactly. See
+`skills/illustrations/references/builds.md`.
+
 Don't:
 
-- Use PIL or parchment masking to "blank out" regions — the texture mismatch
-  is obvious. Always erase via image-edit, not pixel paste.
+- Use parchment masking or a flat-fill paste to "blank out" regions — the
+  texture mismatch is obvious. `erase_region` is NOT a flat fill: the box is
+  still redrawn by the image model (so the erased area shows real background),
+  and only the *unchanged* surroundings are taken from the prior frame.
 - Generate each build stage independently from prompts — visual drift
   between stages will be jarring even if each individual stage looks fine.
 

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -57,6 +57,32 @@ the previous one.
 - The edit safety suffixes (`DO NOT add any new elements`, `let background
   continue naturally`) are auto-appended by the script — don't repeat them.
 
+### `erase_region` — pixel-stable static backgrounds
+
+A step may also carry an optional **`erase_region`**: a normalized
+`[x0, y0, x1, y1]` bounding box (0..1, origin top-left) around the element being
+erased. It is the fix for build drift (#90): a maskless edit redraws the whole
+frame, so a static background can shift or lose elements between frames even
+with a `Keep` clause. With `erase_region`, `--build` confines the change to the
+box — OpenAI receives a real edit mask, and for both vendors the result is
+composited back over the prior frame, so every pixel **outside** the box is the
+source pixel exactly. The box is still redrawn by the model (the erased area
+shows real background, not a flat fill).
+
+Use it whenever a build has a background that must not move (conveyors,
+baseplates, panel frames, blueprint chrome). Omit it for free-form scenes where
+whole-frame regeneration is fine. The progress line marks masked steps
+`build-NN [masked]`. The final (full-image) step is a verbatim copy and never
+takes a region.
+
+```yaml
+builds:
+  - step: 1
+    desc: "Panel 1 content + PLUGIN USELESS? stamp"
+    erase: 'Erase Panel 2 and the "STILL?" stamp. Keep the page chrome. Keep the three panel frames and labels. Keep Panel 1 content.'
+    erase_region: [0.34, 0.18, 0.66, 0.82]   # the middle (Panel 2) column only
+```
+
 Example (slide with three trial panels revealed progressively):
 
 ```yaml

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -61,7 +61,7 @@ the previous one.
 
 A step may also carry an optional **`erase_region`**: a normalized
 `[x0, y0, x1, y1]` bounding box (0..1, origin top-left) around the element being
-erased. It is the fix for build drift (#90): a maskless edit redraws the whole
+erased. It is the fix for build drift: a maskless edit redraws the whole
 frame, so a static background can shift or lose elements between frames even
 with a `Keep` clause. With `erase_region`, `--build` confines the change to the
 box — OpenAI receives a real edit mask, and for both vendors the result is

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -27,13 +27,17 @@ Requires:
     - For OpenAI models (gpt-image-*):
         OpenAI API key in {vault}/secrets.json under "openai".api_key
         or OPENAI_API_KEY env var (fallback).
-    - Python 3.8+ (stdlib only — no pip install needed; uses the walrus
-      operator and other 3.8+ syntax)
+    - Python 3.8+ (uses the walrus operator and other 3.8+ syntax). The core
+      generation paths are stdlib-only. The masked-edit build path
+      (`--build` with a step `erase_region`) needs Pillow, a declared project
+      dependency (pyproject.toml); it is imported lazily only when a region is
+      used, so plain generation still runs without it.
 """
 
 import argparse
 import base64
 import glob
+import io
 import json
 import os
 import re
@@ -302,6 +306,12 @@ def parse_outline(path):
                     "step": b.step,
                     "description": b.erase or "",
                     "is_full": b.step == max_step,
+                    # Normalized [x0, y0, x1, y1] erase box, or None. Drives the
+                    # masked/composited edit path that keeps a static background
+                    # pixel-stable across build frames (#90).
+                    "erase_region": (
+                        list(b.erase_region) if b.erase_region else None
+                    ),
                 }
                 for b in sorted(slide.builds, key=lambda b: b.step)
             ]
@@ -828,6 +838,95 @@ def _call_imagen(prompt, model, api_key, aspect_ratio=IMAGEN_DEFAULT_ASPECT):
     return None, f"No image in Imagen response: {json.dumps(body)[:500]}"
 
 
+# --- Masked / composited edits (build static-background stability, #90) ---
+
+def _require_pil():
+    """Import Pillow lazily, exiting with an actionable message if it's absent.
+
+    Pillow is a declared project dependency (pyproject.toml) used across the
+    illustration scripts, but only the masked-edit build path needs it — the
+    import stays lazy so plain generation runs on a bare stdlib environment.
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        print(
+            "ERROR: a build step's `erase_region` needs Pillow, which isn't "
+            "importable. Install the project deps (Pillow is in pyproject.toml): "
+            "pip install Pillow",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return Image
+
+
+def _region_to_pixels(region, width, height):
+    """Convert a normalized [x0,y0,x1,y1] box to an integer pixel box.
+
+    Clamps to the image bounds and guarantees a non-empty (>=1px) box so a
+    rounding collapse can't produce a zero-area crop.
+    """
+    x0, y0, x1, y1 = region
+    left = max(0, min(width, round(x0 * width)))
+    top = max(0, min(height, round(y0 * height)))
+    right = max(0, min(width, round(x1 * width)))
+    bottom = max(0, min(height, round(y1 * height)))
+    if right <= left:
+        right = min(width, left + 1)
+    if bottom <= top:
+        bottom = min(height, top + 1)
+    return left, top, right, bottom
+
+
+def build_edit_mask_png(input_path, region):
+    """Build an OpenAI edit mask: transparent over `region`, opaque elsewhere.
+
+    OpenAI /images/edits regenerates only the fully-transparent (alpha=0) area
+    of the mask and leaves the rest untouched. The mask matches the input
+    image's pixel dimensions. Returns PNG bytes.
+    """
+    Image = _require_pil()
+    with Image.open(input_path) as im:
+        width, height = im.size
+    left, top, right, bottom = _region_to_pixels(region, width, height)
+    # Fully opaque = "keep"; punch a transparent hole over the erase box, the
+    # only region the model may redraw.
+    mask = Image.new("RGBA", (width, height), (0, 0, 0, 255))
+    hole = Image.new("RGBA", (right - left, bottom - top), (0, 0, 0, 0))
+    mask.paste(hole, (left, top))
+    buf = io.BytesIO()
+    mask.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def composite_region(prior_path, new_bytes, region):
+    """Paste the edited `region` from new_bytes onto the prior frame's pixels.
+
+    Everything OUTSIDE the box is taken verbatim from the prior frame, so a
+    static background stays pixel-identical across build frames; only the box is
+    replaced with the (resized-to-match) edited content. This is the guarantee
+    behind #90 — a maskless regeneration can drift the whole frame, but the
+    composite snaps the kept region back to the source pixels. Returns
+    (png_bytes, "image/png").
+    """
+    Image = _require_pil()
+    with Image.open(prior_path) as prior_im:
+        prior = prior_im.convert("RGB")
+    width, height = prior.size
+    with Image.open(io.BytesIO(new_bytes)) as new_im:
+        new = new_im.convert("RGB")
+        # The vendor may return a different geometry than the prior frame;
+        # align before cropping so the box lands on the same content.
+        if new.size != prior.size:
+            new = new.resize(prior.size)
+    left, top, right, bottom = _region_to_pixels(region, width, height)
+    out = prior.copy()
+    out.paste(new.crop((left, top, right, bottom)), (left, top))
+    buf = io.BytesIO()
+    out.save(buf, format="PNG")
+    return buf.getvalue(), "image/png"
+
+
 # --- OpenAI API ---
 
 def _multipart_body(fields, files):
@@ -906,20 +1005,29 @@ def _call_openai_generate(prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
     return _extract_openai_image(body)
 
 
-def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
-    """Call OpenAI /images/edits to edit an existing image."""
+def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SIZE,
+                      mask_png=None):
+    """Call OpenAI /images/edits to edit an existing image.
+
+    When `mask_png` is given (a PNG matching the image dimensions), only its
+    fully-transparent region is regenerated and the rest is preserved — the
+    build static-background fix (#90).
+    """
     with open(input_path, "rb") as f:
         image_bytes = f.read()
     ext = os.path.splitext(input_path)[1].lower()
     mime = ext_to_mime(ext)
     filename = os.path.basename(input_path)
 
+    files = [("image", filename, mime, image_bytes)]
+    if mask_png is not None:
+        files.append(("mask", "mask.png", "image/png", mask_png))
     body, boundary = _multipart_body(
         # gpt-image-* returns base64 by default; do not send
         # `response_format` (legacy DALL-E knob; gpt-image-* 400s on it).
         fields={"model": model, "prompt": prompt, "size": size,
                 "quality": "high", "n": "1"},
-        files=[("image", filename, mime, image_bytes)],
+        files=files,
     )
     url = f"{OPENAI_API_BASE}/images/edits"
     headers = {
@@ -971,7 +1079,8 @@ def generate_image(prompt, model, keys, slide_format=None):
     return _call_gemini([{"text": prompt}], model, keys["gemini"])
 
 
-def edit_image(input_path, edit_prompt, model, keys, slide_format=None):
+def edit_image(input_path, edit_prompt, model, keys, slide_format=None,
+               erase_region=None):
     """Edit an existing image via the appropriate vendor endpoint.
 
     Auto-appends vendor-agnostic safety suffixes to the prompt to prevent
@@ -980,6 +1089,11 @@ def edit_image(input_path, edit_prompt, model, keys, slide_format=None):
     Args:
         slide_format: see generate_image — controls OpenAI edit size so
             the output matches the source slide's geometry.
+        erase_region: optional normalized [x0,y0,x1,y1] box. When set, the edit
+            is confined to that box — OpenAI gets a real edit mask, and for
+            BOTH vendors the result is composited back over the prior frame so
+            the static background outside the box stays pixel-identical (#90).
+            When None, the historical whole-frame regeneration is used.
 
     Returns:
         tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
@@ -996,10 +1110,7 @@ def edit_image(input_path, edit_prompt, model, keys, slide_format=None):
     model = resolve_model_id(model)
     family = model_family(model)
     sizing = sizing_for(slide_format)
-    if family == "openai":
-        return _call_openai_edit(
-            input_path, edit_prompt, model, keys["openai"], size=sizing["openai_size"]
-        )
+
     if family == "imagen":
         return None, (
             f"Image editing is not supported for Imagen models ({model}). "
@@ -1007,16 +1118,33 @@ def edit_image(input_path, edit_prompt, model, keys, slide_format=None):
             "model for --edit / --build / --fix workflows."
         )
 
-    # Gemini path: send image as base64 inline data on generateContent
-    with open(input_path, "rb") as f:
-        image_data = base64.b64encode(f.read()).decode("utf-8")
-    ext = os.path.splitext(input_path)[1].lower()
-    input_mime = ext_to_mime(ext)
-    parts = [
-        {"inlineData": {"mimeType": input_mime, "data": image_data}},
-        {"text": edit_prompt},
-    ]
-    return _call_gemini(parts, model, keys["gemini"])
+    if family == "openai":
+        # A mask lets the model edit in-place with surrounding context; the
+        # composite below then guarantees the kept region byte-for-byte.
+        mask_png = build_edit_mask_png(input_path, erase_region) if erase_region else None
+        image_bytes, result = _call_openai_edit(
+            input_path, edit_prompt, model, keys["openai"],
+            size=sizing["openai_size"], mask_png=mask_png,
+        )
+    else:
+        # Gemini path: send image as base64 inline data on generateContent.
+        # Gemini has no mask param, so it always regenerates the whole frame;
+        # the composite below is what keeps its static background stable.
+        with open(input_path, "rb") as f:
+            image_data = base64.b64encode(f.read()).decode("utf-8")
+        ext = os.path.splitext(input_path)[1].lower()
+        input_mime = ext_to_mime(ext)
+        parts = [
+            {"inlineData": {"mimeType": input_mime, "data": image_data}},
+            {"text": edit_prompt},
+        ]
+        image_bytes, result = _call_gemini(parts, model, keys["gemini"])
+
+    # Confine the change to the erase box: paste the edited region back over the
+    # prior frame so everything outside it is the source pixels exactly (#90).
+    if erase_region and image_bytes is not None:
+        return composite_region(input_path, image_bytes, erase_region)
+    return image_bytes, result
 
 
 # --- Style-explore manifest + render-before-bake gate ---
@@ -1840,12 +1968,21 @@ def run_build(outline_path, slide_arg):
         for step in edit_steps:
             step_num = step["step"]
             desc = step["description"]
+            region = step.get("erase_region")
 
-            print(f"  build-{step_num:02d}: {desc[:60]}...", end=" ", flush=True)
+            label = "  build-{:02d}{}: {}...".format(
+                step_num, " [masked]" if region else "", desc[:60]
+            )
+            print(label, end=" ", flush=True)
 
+            # An erase_region confines the edit to that box and composites the
+            # rest from prev_image, so the static background stays pixel-stable
+            # down the chain (#90). Without a region, the whole frame is
+            # regenerated (historical behavior; may drift).
             image_bytes, result = edit_image(
                 prev_image, desc, model, keys,
                 effective_slide_format(slide["format"], slide.get("safe_zone")),
+                erase_region=region,
             )
 
             if image_bytes is None:

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -27,7 +27,8 @@ Requires:
     - For OpenAI models (gpt-image-*):
         OpenAI API key in {vault}/secrets.json under "openai".api_key
         or OPENAI_API_KEY env var (fallback).
-    - Python 3.8+ (uses the walrus operator and other 3.8+ syntax). The core
+    - Python 3.10+ (matches the project's requires-python in pyproject.toml;
+      uses union-type syntax via the shared outline_schema). The core
       generation paths are stdlib-only. The masked-edit build path
       (`--build` with a step `erase_region`) needs Pillow, a declared project
       dependency (pyproject.toml); it is imported lazily only when a region is
@@ -39,6 +40,7 @@ import base64
 import glob
 import io
 import json
+import math
 import os
 import re
 import shutil
@@ -863,18 +865,25 @@ def _require_pil():
 def _region_to_pixels(region, width, height):
     """Convert a normalized [x0,y0,x1,y1] box to an integer pixel box.
 
-    Clamps to the image bounds and guarantees a non-empty (>=1px) box so a
-    rounding collapse can't produce a zero-area crop.
+    Uses floor for the top-left edge and ceil for the bottom-right so any box
+    with positive normalized area maps to a crop of at least 1px per side —
+    including a box flush against the right/bottom edge (e.g. x1 == 1.0), where
+    rounding both edges would collapse them onto `width`/`height` and yield a
+    zero-width hole (Pillow then errors / the composite crops nothing). Clamps
+    to the image bounds, and as a final guard shifts a still-degenerate edge
+    back by 1px so the crop is never empty.
     """
     x0, y0, x1, y1 = region
-    left = max(0, min(width, round(x0 * width)))
-    top = max(0, min(height, round(y0 * height)))
-    right = max(0, min(width, round(x1 * width)))
-    bottom = max(0, min(height, round(y1 * height)))
+    left = max(0, min(width, math.floor(x0 * width)))
+    top = max(0, min(height, math.floor(y0 * height)))
+    right = max(0, min(width, math.ceil(x1 * width)))
+    bottom = max(0, min(height, math.ceil(y1 * height)))
     if right <= left:
-        right = min(width, left + 1)
+        left = max(0, min(left, width - 1))
+        right = left + 1
     if bottom <= top:
-        bottom = min(height, top + 1)
+        top = max(0, min(top, height - 1))
+        bottom = top + 1
     return left, top, right, bottom
 
 

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -258,6 +258,30 @@ class Build(_StrictModel):
     # slide image. Optional so slides whose builds are only deck-budget
     # placeholders validate; --build refuses any non-final step missing it.
     erase: str | None = None
+    # Optional erase region as a normalized bounding box [x0, y0, x1, y1] in
+    # 0..1 image coords (origin top-left). When set, --build confines the edit to
+    # this box: the static background outside it is preserved pixel-for-pixel
+    # (OpenAI gets a real edit mask; Gemini's full regeneration is composited back
+    # over the prior frame outside the box). Without it, the whole frame is
+    # regenerated and a static background can drift (#90). Belongs only on
+    # non-final steps — the final step is a verbatim copy, never edited.
+    erase_region: tuple[float, float, float, float] | None = None
+
+    @model_validator(mode="after")
+    def _check_erase_region(self) -> "Build":
+        if self.erase_region is None:
+            return self
+        x0, y0, x1, y1 = self.erase_region
+        if not all(0.0 <= v <= 1.0 for v in self.erase_region):
+            raise ValueError(
+                f"erase_region values must be in 0..1 (normalized), got {self.erase_region}"
+            )
+        if x0 >= x1 or y0 >= y1:
+            raise ValueError(
+                "erase_region must be [x0, y0, x1, y1] with x0 < x1 and y0 < y1, "
+                f"got {self.erase_region}"
+            )
+        return self
 
 
 # ── Screenplay-form script ───────────────────────────────────────────

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -5,6 +5,7 @@ onto the generator's view; these tests drive the canonical fixture.
 """
 
 import copy
+import io
 import json
 import os
 from pathlib import Path
@@ -205,6 +206,40 @@ def test_run_build_with_keep_clause_runs_chain(
     gi.run_build("ignored.yaml", "60")  # no SystemExit
 
     assert len(edit_calls) == 1  # the single erase step was edited
+
+
+def test_run_build_forwards_erase_region_to_edit(
+    generate_illustrations, monkeypatch, tmp_path
+):
+    # #90: a step's erase_region must reach edit_image as the erase_region
+    # kwarg so the masked/composited path engages; a step without one forwards
+    # None (historical whole-frame edit).
+    gi = generate_illustrations
+    outline = _single_build_slide([
+        {"step": 0, "description": "Erase Panel 0. Keep the chrome.",
+         "is_full": False, "erase_region": None},
+        {"step": 1, "description": "Erase Panel 1. Keep the chrome.",
+         "is_full": False, "erase_region": [0.1, 0.2, 0.5, 0.8]},
+        {"step": 2, "description": "[FULL] all panels", "is_full": True},
+    ])
+    base = tmp_path / "slide-60.png"
+    base.write_bytes(b"img")
+    calls = []
+    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline, str(tmp_path)))
+    monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
+    monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
+    monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(gi, "check_style_explore", lambda p: {"gate_passed": True, "error": ""})
+    monkeypatch.setattr(
+        gi, "edit_image",
+        lambda *a, **k: (calls.append(k.get("erase_region")), (b"x", "image/png"))[1],
+    )
+
+    gi.run_build("ignored.yaml", "60")
+
+    # Backwards chain edits step 1 then step 0; collect by region presence.
+    assert [0.1, 0.2, 0.5, 0.8] in calls
+    assert None in calls
 
 
 def test_run_build_exits_nonzero_when_edit_fails(
@@ -1382,3 +1417,82 @@ def test_gate_fails_closed_on_non_string_cell_model(generate_illustrations, tmp_
     })
     v = gi.check_style_explore(str(outline))  # must not raise
     assert v["gate_passed"] is False
+
+
+# --- #90: masked / composited build edits ---
+
+
+def test_parse_builds_surfaces_erase_region(generate_illustrations, tmp_path):
+    # parse_outline must surface a step's erase_region as a plain list (or None)
+    # so run_build can engage the masked/composited path.
+    data = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
+    slide2 = next(s for s in data["slides"] if s["n"] == 2)
+    for b in slide2["builds"][:-1]:
+        b["erase"] = f"Erase step {b['step']}. Keep the three frames."
+    slide2["builds"][0]["erase_region"] = [0.1, 0.2, 0.5, 0.8]
+    p = tmp_path / "outline.yaml"
+    p.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    result = generate_illustrations.parse_outline(str(p))
+    s2 = next(s for s in result["slides"] if s["slide_num"] == 2)
+    steps = s2["builds"]["steps"]
+    assert steps[0]["erase_region"] == [0.1, 0.2, 0.5, 0.8]
+    # A step without a region surfaces None, not a missing key.
+    assert steps[1]["erase_region"] is None
+
+
+def test_region_to_pixels_clamps_and_is_nonempty(generate_illustrations):
+    gi = generate_illustrations
+    # Normal box maps to rounded pixel coords.
+    assert gi._region_to_pixels([0.0, 0.0, 0.5, 0.5], 100, 200) == (0, 0, 50, 100)
+    # A degenerate (zero-width after rounding) box is widened to >= 1px, never empty.
+    left, top, right, bottom = gi._region_to_pixels([0.5, 0.5, 0.5001, 0.5001], 100, 100)
+    assert right > left and bottom > top
+
+
+def test_build_edit_mask_is_transparent_only_in_region(generate_illustrations, tmp_path):
+    # The OpenAI mask must be opaque (keep) everywhere except a transparent hole
+    # over the erase box (the only region the model may redraw).
+    from PIL import Image
+    gi = generate_illustrations
+    src = tmp_path / "frame.png"
+    Image.new("RGB", (100, 100), (10, 20, 30)).save(src)
+
+    mask_png = gi.build_edit_mask_png(str(src), [0.4, 0.4, 0.6, 0.6])
+    mask = Image.open(io.BytesIO(mask_png)).convert("RGBA")
+    assert mask.size == (100, 100)
+    assert mask.getpixel((50, 50))[3] == 0     # inside box -> transparent
+    assert mask.getpixel((5, 5))[3] == 255     # outside box -> opaque
+
+
+def test_composite_region_keeps_background_pixel_identical(generate_illustrations, tmp_path):
+    # The guarantee behind #90: outside the box, output == prior frame exactly;
+    # inside the box, output == the edited (new) content.
+    from PIL import Image
+    gi = generate_illustrations
+    prior = tmp_path / "prior.png"
+    Image.new("RGB", (100, 100), (10, 20, 30)).save(prior)
+    new_buf = io.BytesIO()
+    Image.new("RGB", (100, 100), (200, 100, 50)).save(new_buf, format="PNG")
+
+    out_bytes, mime = gi.composite_region(str(prior), new_buf.getvalue(), [0.4, 0.4, 0.6, 0.6])
+    assert mime == "image/png"
+    out = Image.open(io.BytesIO(out_bytes)).convert("RGB")
+    assert out.getpixel((5, 5)) == (10, 20, 30)    # background preserved
+    assert out.getpixel((50, 50)) == (200, 100, 50)  # box replaced with new content
+
+
+def test_composite_region_resizes_mismatched_new_image(generate_illustrations, tmp_path):
+    # When the vendor returns a different geometry, the new image is resized to
+    # the prior frame before compositing, so the box still lands correctly.
+    from PIL import Image
+    gi = generate_illustrations
+    prior = tmp_path / "prior.png"
+    Image.new("RGB", (100, 100), (0, 0, 0)).save(prior)
+    new_buf = io.BytesIO()
+    Image.new("RGB", (40, 40), (255, 255, 255)).save(new_buf, format="PNG")  # different size
+
+    out_bytes, _ = gi.composite_region(str(prior), new_buf.getvalue(), [0.0, 0.0, 1.0, 1.0])
+    out = Image.open(io.BytesIO(out_bytes)).convert("RGB")
+    assert out.size == (100, 100)
+    assert out.getpixel((50, 50)) == (255, 255, 255)

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -1443,11 +1443,23 @@ def test_parse_builds_surfaces_erase_region(generate_illustrations, tmp_path):
 
 def test_region_to_pixels_clamps_and_is_nonempty(generate_illustrations):
     gi = generate_illustrations
-    # Normal box maps to rounded pixel coords.
+    # Normal box maps to floor/ceil pixel coords.
     assert gi._region_to_pixels([0.0, 0.0, 0.5, 0.5], 100, 200) == (0, 0, 50, 100)
-    # A degenerate (zero-width after rounding) box is widened to >= 1px, never empty.
+    # A degenerate (zero-width after flooring) box is widened to >= 1px, never empty.
     left, top, right, bottom = gi._region_to_pixels([0.5, 0.5, 0.5001, 0.5001], 100, 100)
     assert right > left and bottom > top
+
+
+def test_region_to_pixels_edge_box_at_one_is_nonempty(generate_illustrations):
+    gi = generate_illustrations
+    # A thin box flush against the right/bottom edge (x1 == y1 == 1.0) must NOT
+    # collapse to width/height==left/top. round() on both edges would put left
+    # and right both at 100 (empty); floor/ceil + the boundary guard keep it >=1px.
+    left, top, right, bottom = gi._region_to_pixels([0.999, 0.999, 1.0, 1.0], 100, 100)
+    assert right > left and bottom > top
+    assert right <= 100 and bottom <= 100   # stays in bounds
+    # A full-frame box maps to the whole image.
+    assert gi._region_to_pixels([0.0, 0.0, 1.0, 1.0], 100, 80) == (0, 0, 100, 80)
 
 
 def test_build_edit_mask_is_transparent_only_in_region(generate_illustrations, tmp_path):

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -641,6 +641,34 @@ def test_rejects_unknown_build_field(outline_schema, base_data):
         outline_schema.Outline.model_validate(data)
 
 
+def test_accepts_build_erase_region(outline_schema, base_data):
+    """builds[].erase_region carries the optional normalized mask box (#90)."""
+    data = copy.deepcopy(base_data)
+    slide_with_builds = next(s for s in data["slides"] if s.get("builds"))
+    slide_with_builds["builds"][0]["erase_region"] = [0.1, 0.2, 0.5, 0.8]
+    outline = outline_schema.Outline.model_validate(data)
+    target = next(s for s in outline.slides if s.builds)
+    assert target.builds[0].erase_region == (0.1, 0.2, 0.5, 0.8)
+    # Steps without a region default to None (whole-frame edit).
+    assert target.builds[1].erase_region is None
+
+
+def test_rejects_erase_region_out_of_range(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    slide_with_builds = next(s for s in data["slides"] if s.get("builds"))
+    slide_with_builds["builds"][0]["erase_region"] = [0.1, 0.2, 1.5, 0.8]  # > 1
+    with pytest.raises(ValidationError, match="normalized"):
+        outline_schema.Outline.model_validate(data)
+
+
+def test_rejects_erase_region_inverted_box(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    slide_with_builds = next(s for s in data["slides"] if s.get("builds"))
+    slide_with_builds["builds"][0]["erase_region"] = [0.5, 0.2, 0.3, 0.8]  # x0 >= x1
+    with pytest.raises(ValidationError, match="x0 < x1"):
+        outline_schema.Outline.model_validate(data)
+
+
 def test_accepts_style_anchor_composition_and_footer(outline_schema, base_data):
     data = copy.deepcopy(base_data)
     data["style_anchor"]["composition"] = "poster-theatrical"


### PR DESCRIPTION
## Problem

Backward-chaining progressive-reveal builds (`--build`) sent the whole frame to the image model with only a text prompt and **no mask** (`_call_openai_edit` and `_call_gemini` both regenerate the full image). So the model was free to redraw everything: a static background that must stay fixed across the reveal — a conveyor, a baseplate, a panel frame, blueprint chrome — drifted in position/size or silently lost elements between frames, **even when the `erase` prompt named them in a `Keep` clause**. A `Keep` clause reduces drift but a maskless edit cannot guarantee the kept pixels survive.

## Fix

Build steps take an optional **`erase_region`** — a normalized `[x0, y0, x1, y1]` box (0..1, origin top-left, schema-validated) around the element being erased. When set, `--build` confines the edit to that box:

- **OpenAI** receives a real edit mask (`/images/edits` `mask` field — only the transparent box is regenerated).
- **Both vendors** then composite the returned image back over the prior frame via Pillow, so every pixel **outside** the box is the source pixel exactly.
- The box is still redrawn by the model (the erased area shows real background, **not** a flat fill — so the old "don't PIL-blank regions" guidance still holds).

Without a region, the historical whole-frame regeneration is unchanged — **existing outlines need no edits**. Pillow (already a declared project dependency, used by sibling scripts) is imported lazily, only when a region is used, so plain generation still runs on bare stdlib.

## Changes
- `Build.erase_region` added to the outline schema with range/ordering validation.
- `parse_outline` surfaces it; `edit_image` gains an `erase_region` arg (mask for OpenAI, composite for both); `_call_openai_edit` gains a `mask_png` arg; `run_build` forwards each step's region and marks masked steps `build-NN [masked]`.
- New helpers: `build_edit_mask_png`, `composite_region`, `_region_to_pixels`, `_require_pil`.
- Docs: `rules/illustration-rules.md` (Build Process) and `references/builds.md` (authoring contract + example).

## Tests
Schema validation (valid / out-of-range / inverted box), `parse_outline` surfacing, `_region_to_pixels` clamping, mask transparency, composite background-preservation + resize, and `run_build` region forwarding. Full suite: `555 passed, 3 skipped`.

**Author-Model:** claude-opus-4-8[1m]

Resolves #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)