### PR TITLE
fix(illustrations): bound secrets.json read so a cloud placeholder can't hang the tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-### fix(vault-ingress) — Step 4 persists structured fields deterministically
+### fix(illustrations) — secrets.json read no longer hangs on a cloud placeholder
+
+`load_secrets()` read `{vault}/secrets.json` with a plain `json.load(open(path))`. When that
+file is a cloud-synced (e.g. iCloud) "dataless" placeholder — listed in the directory but
+with its bytes evicted to the cloud — the read syscall blocks indefinitely while the OS
+tries to materialize it. If the cloud is unreachable, the call never returns, freezing every
+generate/build/edit run (and the test suite) before any work starts; `os.path.isfile()`
+returns instantly because the metadata is local, so the guard didn't help. The read now runs
+on a daemon thread with a bounded `SECRETS_READ_TIMEOUT` (10s); on overrun it raises
+TimeoutError and `load_secrets` falls back to the existing `GEMINI_API_KEY` / `OPENAI_API_KEY`
+env-var path with a loud stderr warning — the same degrade-don't-crash behavior it already had
+for malformed/unreadable files (no silent swallow). Found while working on the build-edit fix.
 
 vault-ingress Step 4 told the orchestrator to hand-copy each subagent field into the
 tracking DB, so anything it forgot was silently dropped: the rich `structured_data` the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ TimeoutError and `load_secrets` falls back to the existing `GEMINI_API_KEY` / `O
 env-var path with a loud stderr warning — the same degrade-don't-crash behavior it already had
 for malformed/unreadable files (no silent swallow). Found while working on the build-edit fix.
 
+### fix(vault-ingress) — Step 4 persists structured fields deterministically
+
 vault-ingress Step 4 told the orchestrator to hand-copy each subagent field into the
 tracking DB, so anything it forgot was silently dropped: the rich `structured_data` the
 subagents compute reached the per-talk analysis files but almost never landed in

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -39,6 +39,7 @@ import os
 import re
 import shutil
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -102,6 +103,13 @@ def sizing_for(slide_format):
     return FORMAT_SIZING.get(slide_format, FORMAT_SIZING["FULL"])
 
 RATE_LIMIT_DELAY = 5  # seconds between API requests
+
+# Max seconds to spend reading secrets.json before giving up and falling back to
+# env vars. A cloud-synced (e.g. iCloud) "dataless" placeholder can block the
+# read syscall indefinitely while the OS tries to materialize it; without a
+# bound, load_secrets() — and therefore every generate/build/edit run — hangs
+# forever. Generous enough to let a present-but-slow file finish downloading.
+SECRETS_READ_TIMEOUT = 10
 
 IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"]
 
@@ -504,6 +512,38 @@ def ext_to_mime(ext):
 
 # --- Shared Setup ---
 
+def _read_file_with_timeout(path, timeout):
+    """Read a file's bytes, abandoning the read if it overruns `timeout` seconds.
+
+    A cloud-synced (e.g. iCloud) "dataless" placeholder can block the read
+    syscall indefinitely while the OS tries to materialize it, so a plain
+    open().read() would hang forever. The read runs on a daemon thread; if it
+    doesn't finish in time we raise TimeoutError and let the caller fall back.
+    The abandoned thread stays blocked but is a daemon, so it never holds up
+    process exit. (A thread, not signal.alarm: signals only fire on the main
+    thread and aren't portable.)
+
+    Returns the file bytes, or raises TimeoutError / the underlying OSError.
+    """
+    result = {}
+
+    def _worker():
+        try:
+            with open(path, "rb") as f:
+                result["data"] = f.read()
+        except OSError as e:  # propagate to the caller's thread below
+            result["error"] = e
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    t.join(timeout)
+    if t.is_alive():
+        raise TimeoutError(f"reading {path} timed out after {timeout}s")
+    if "error" in result:
+        raise result["error"]
+    return result["data"]
+
+
 def load_secrets(vault_path=None):
     """Load API keys from vault secrets.json with env-var fallbacks.
 
@@ -525,11 +565,20 @@ def load_secrets(vault_path=None):
 
     if os.path.isfile(secrets_path):
         try:
-            with open(secrets_path, "r", encoding="utf-8") as f:
-                secrets = json.load(f)
+            raw = _read_file_with_timeout(secrets_path, SECRETS_READ_TIMEOUT)
+            secrets = json.loads(raw.decode("utf-8"))
             keys["gemini"] = secrets.get("gemini", {}).get("api_key") or None
             keys["openai"] = secrets.get("openai", {}).get("api_key") or None
-        except json.JSONDecodeError as e:
+        except TimeoutError:
+            print(
+                f"WARNING: reading {secrets_path} timed out after "
+                f"{SECRETS_READ_TIMEOUT}s; falling back to environment "
+                "variables. A cloud-synced (e.g. iCloud) 'dataless' placeholder "
+                "can block until it downloads — open the file once to "
+                "materialize it, or set GEMINI_API_KEY / OPENAI_API_KEY.",
+                file=sys.stderr,
+            )
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
             print(
                 f"WARNING: {secrets_path} is not valid JSON ({e}); "
                 "falling back to environment variables. Fix the file or "

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -6,6 +6,7 @@ onto the generator's view; these tests drive the canonical fixture.
 
 import copy
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -474,6 +475,46 @@ def test_load_secrets_partial_file(generate_illustrations, tmp_path, monkeypatch
     keys, _ = generate_illustrations.load_secrets(str(tmp_path))
     assert keys["gemini"] == "g"
     assert keys["openai"] == "env-o"
+
+
+def test_read_file_with_timeout_returns_bytes(generate_illustrations, tmp_path):
+    p = tmp_path / "f.bin"
+    p.write_bytes(b"hello")
+    assert generate_illustrations._read_file_with_timeout(str(p), 5) == b"hello"
+
+
+def test_read_file_with_timeout_raises_on_stall(generate_illustrations, tmp_path):
+    # A named pipe with no writer blocks the open/read forever — the closest
+    # portable stand-in for a cloud "dataless" placeholder that never
+    # materializes. The reader must give up and raise TimeoutError, not hang.
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("os.mkfifo not available on this platform")
+    fifo = tmp_path / "stalled.json"
+    os.mkfifo(fifo)
+    with pytest.raises(TimeoutError):
+        generate_illustrations._read_file_with_timeout(str(fifo), 0.5)
+
+
+def test_load_secrets_timeout_warns_and_falls_back(
+    generate_illustrations, tmp_path, monkeypatch, capsys
+):
+    # A stalled secrets read must degrade to env vars with a loud warning —
+    # never hang, never silently swallow.
+    gi = generate_illustrations
+    (tmp_path / "secrets.json").write_text(json.dumps({"gemini": {"api_key": "g"}}))
+
+    def _boom(path, timeout):
+        raise TimeoutError(f"reading {path} timed out after {timeout}s")
+
+    monkeypatch.setattr(gi, "_read_file_with_timeout", _boom)
+    monkeypatch.setenv("GEMINI_API_KEY", "env-g")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    keys, _ = gi.load_secrets(str(tmp_path))
+    err = capsys.readouterr().err
+    assert keys["gemini"] == "env-g"   # fell back to env
+    assert keys["openai"] is None
+    assert "timed out" in err and "secrets.json" in err
 
 
 # --- Multipart body for OpenAI edits ---


### PR DESCRIPTION
## Problem

`load_secrets()` read `{vault}/secrets.json` with a plain `json.load(open(path))`. When that file is a **cloud-synced (iCloud) "dataless" placeholder** — present in the directory listing but with its bytes evicted to the cloud — the read syscall blocks **indefinitely** while the OS tries to materialize it. If the cloud is unreachable or the file is offline, the call never returns and the whole tool freezes before doing any work.

This is not just a test artifact: every real generate/build/edit run calls `load_secrets()`, so a stalled placeholder hangs actual image generation. `os.path.isfile()` returns instantly (metadata is local), so the existing guard didn't catch it — the hang is in `json.load` → `read()`.

(Surfaced while working on the #90 build-edit fix: the full pytest suite froze at the first test that calls `load_secrets()` with the default vault path.)

## Fix

Read the secrets file on a daemon thread with a bounded `SECRETS_READ_TIMEOUT` (10s, generous enough for a present-but-slow download). On overrun it raises `TimeoutError` and `load_secrets` falls back to the existing `GEMINI_API_KEY` / `OPENAI_API_KEY` env-var path with a loud stderr warning — the **same degrade-don't-crash behavior** it already has for malformed/unreadable files. Nothing is swallowed silently. A thread (not `signal.alarm`) because signals only fire on the main thread and aren't portable; the abandoned read thread is a daemon, so it never holds up process exit.

## Tests
- `_read_file_with_timeout` returns bytes for a normal file, and raises `TimeoutError` on a never-materializing read (simulated with an `os.mkfifo` named pipe that has no writer — the closest portable stand-in for a dataless placeholder).
- `load_secrets` warns and falls back to env vars when the read times out.

Verified the real win: with this change the full suite completes against the actual stalled iCloud file (previously it hung forever) — `549 passed, 3 skipped`.

**Author-Model:** claude-opus-4-8[1m]

🤖 Generated with [Claude Code](https://claude.com/claude-code)