### PR TITLE
feat(vault-ingress): version the video slide-extraction pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### feat(vault-ingress) — version the video slide-extraction pipeline
+
+The video slide-extraction pipeline (`video-slide-extraction.py`) carried no version
+marker, so video-extracted vault artifacts couldn't record which extraction iteration
+produced them — and output depends on tunable knobs (`--fps`, `--threshold`, the 720p
+download tier). A new `PIPELINE_VERSION` constant (starting at `0.7.0`, successor to the
+pre-split monolith's ≈`0.6.0`) is stamped into the vault DB row
+(`structured_data.video_extraction.pipeline_version`) and the output PDF's
+producer/creator metadata. A `--version` flag prints `{"pipeline_version": "<version>"}`
+(JSON, queryable without the extraction dependencies installed). The dependency import was
+deferred so the version/help paths answer in a minimal environment.
+`references/video-slide-extraction.md` documents a bump-on-behavior-change policy and
+`references/schemas-db.md` records the new field. Resolves #103.
+
 ### fix(illustrations) — masked/composited build edits keep static backgrounds pixel-stable
 
 Backward-chaining progressive-reveal builds (`--build`) sent the whole frame to the image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ pre-split monolith's ≈`0.6.0`) is stamped into the vault DB row
 (`structured_data.video_extraction.pipeline_version`) and the output PDF's
 producer/creator metadata. A `--version` flag prints `{"pipeline_version": "<version>"}`
 (JSON, queryable without the extraction dependencies installed). The dependency import was
-deferred so the version/help paths answer in a minimal environment.
-`references/video-slide-extraction.md` documents a bump-on-behavior-change policy and
-`references/schemas-db.md` records the new field. Resolves #103.
+deferred so the version/help paths answer in a minimal environment. The
+`structured_data.video_extraction` record also gains a `schema_version` (record-shape
+version, distinct from the behavior-tracking `pipeline_version`) with a documented
+reader/default contract for legacy entries. `references/video-slide-extraction.md`
+documents a bump-on-behavior-change policy and `references/schemas-db.md` records both
+fields and the reader contract. Resolves #103.
 
 ### fix(illustrations) — masked/composited build edits keep static backgrounds pixel-stable
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -206,8 +206,8 @@ Stored in `structured_data.video_extraction` on the talk entry:
 }
 ```
 
-The owner of this record's shape is `scripts/video-slide-extraction.py`. Two version
-fields track two independent axes:
+The owner of this record's shape is `skills/vault-ingress/scripts/video-slide-extraction.py`.
+Two version fields track two independent axes:
 
 - `schema_version` (integer) — the record's **field shape**. Current value: `1`. The
   script bumps it on any field add/remove/rename. **Reader contract:** a record with no
@@ -217,7 +217,8 @@ fields track two independent axes:
   migrate in place — the owner script rewrites the record on the next extraction.
 - `pipeline_version` (string) — the extractor **behavior** (`PIPELINE_VERSION`) that
   produced the entry. The script bumps it when extraction behavior changes (see
-  `references/video-slide-extraction.md` — "Pipeline Versioning"). The same value is
+  `skills/vault-ingress/references/video-slide-extraction.md` — "Pipeline Versioning").
+  The same value is
   mirrored in the output PDF's producer/creator metadata. A pre-versioning entry has no
   `pipeline_version`.
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -194,6 +194,7 @@ Stored in `structured_data.video_extraction` on the talk entry:
 ```json
 {
   "slide_source": "video_extracted",
+  "pipeline_version": "0.7.0",
   "total_frames_extracted": 1500,
   "unique_slides_count": 85,
   "hash_threshold_used": 8,
@@ -203,6 +204,14 @@ Stored in `structured_data.video_extraction` on the talk entry:
   "fps_used": 0.5
 }
 ```
+
+`pipeline_version` records the `PIPELINE_VERSION` of `video-slide-extraction.py` that
+produced the entry. The owner of this shape is the video-extraction script; it bumps the
+value whenever extraction behavior changes (see
+`references/video-slide-extraction.md` — "Pipeline Versioning"). Readers treat the field
+as additive: an older entry written before the field existed has no `pipeline_version`,
+which means "produced by a pre-versioning iteration." The same value is mirrored in the
+output PDF's producer/creator metadata.
 
 The resulting PDF is named `{youtube_id}.pdf` in the `slides/` directory and analyzed
 the same as a Google Drive PDF for dimension 13 (slide design patterns).

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -194,6 +194,7 @@ Stored in `structured_data.video_extraction` on the talk entry:
 ```json
 {
   "slide_source": "video_extracted",
+  "schema_version": 1,
   "pipeline_version": "0.7.0",
   "total_frames_extracted": 1500,
   "unique_slides_count": 85,
@@ -205,13 +206,20 @@ Stored in `structured_data.video_extraction` on the talk entry:
 }
 ```
 
-`pipeline_version` records the `PIPELINE_VERSION` of `video-slide-extraction.py` that
-produced the entry. The owner of this shape is the video-extraction script; it bumps the
-value whenever extraction behavior changes (see
-`references/video-slide-extraction.md` — "Pipeline Versioning"). Readers treat the field
-as additive: an older entry written before the field existed has no `pipeline_version`,
-which means "produced by a pre-versioning iteration." The same value is mirrored in the
-output PDF's producer/creator metadata.
+The owner of this record's shape is `scripts/video-slide-extraction.py`. Two version
+fields track two independent axes:
+
+- `schema_version` (integer) — the record's **field shape**. Current value: `1`. The
+  script bumps it on any field add/remove/rename. **Reader contract:** a record with no
+  `schema_version` is the legacy pre-versioning shape — treat it as `schema_version 0`
+  and read the fields that are present; a record with a `schema_version` higher than the
+  reader accepts is "no usable prior state" (re-extract to refresh). Readers never
+  migrate in place — the owner script rewrites the record on the next extraction.
+- `pipeline_version` (string) — the extractor **behavior** (`PIPELINE_VERSION`) that
+  produced the entry. The script bumps it when extraction behavior changes (see
+  `references/video-slide-extraction.md` — "Pipeline Versioning"). The same value is
+  mirrored in the output PDF's producer/creator metadata. A pre-versioning entry has no
+  `pipeline_version`.
 
 The resulting PDF is named `{youtube_id}.pdf` in the `slides/` directory and analyzed
 the same as a Google Drive PDF for dimension 13 (slide design patterns).

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -122,7 +122,9 @@ artifact in two places:
 - **PDF metadata** — the producer/creator fields of `slides/{youtube_id}.pdf`
   read `speaker-toolkit/video-slide-extraction <version>`.
 
-Query the running version with `video-slide-extraction.py --version`.
+Query the running version with `video-slide-extraction.py --version`, which
+prints `{"pipeline_version": "<version>"}` (JSON, queryable without the
+extraction dependencies installed).
 
 **Bump policy:** increment `PIPELINE_VERSION` in the same change that alters
 extraction *behavior* — the default `--fps` or `--threshold`, the 720p download

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -113,8 +113,8 @@ Update the talk's DB entry: `slide_source: "video_extracted"`,
 ## Pipeline Versioning
 
 The extractor carries a `PIPELINE_VERSION` constant (top of
-`scripts/video-slide-extraction.py`). It is stamped into every video-extracted
-artifact in two places:
+`skills/vault-ingress/scripts/video-slide-extraction.py`). It is stamped into every
+video-extracted artifact in two places:
 
 - **Vault DB row** — the script's JSON output includes `pipeline_version`, which
   lands in `structured_data.video_extraction.pipeline_version` when you record

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -107,8 +107,28 @@ Update the talk's DB entry: `slide_source: "video_extracted"`,
 | Output | Location | Purpose |
 |--------|----------|---------|
 | Slide PDF | `slides/{youtube_id}.pdf` | Visual analysis (same as Google Drive PDFs) |
-| Extraction metadata | `structured_data.video_extraction` | Frame counts, region detection, threshold |
+| Extraction metadata | `structured_data.video_extraction` | Frame counts, region detection, threshold, pipeline version |
 | Intermediate frames | Deleted after PDF generation | Saves disk space |
+
+## Pipeline Versioning
+
+The extractor carries a `PIPELINE_VERSION` constant (top of
+`scripts/video-slide-extraction.py`). It is stamped into every video-extracted
+artifact in two places:
+
+- **Vault DB row** — the script's JSON output includes `pipeline_version`, which
+  lands in `structured_data.video_extraction.pipeline_version` when you record
+  the DB entry.
+- **PDF metadata** — the producer/creator fields of `slides/{youtube_id}.pdf`
+  read `speaker-toolkit/video-slide-extraction <version>`.
+
+Query the running version with `video-slide-extraction.py --version`.
+
+**Bump policy:** increment `PIPELINE_VERSION` in the same change that alters
+extraction *behavior* — the default `--fps` or `--threshold`, the 720p download
+tier, region-detection logic, the dedup hashing, or PDF assembly. A bump pairs
+with the behavior change so re-ingested vaults are comparable across iterations.
+Pure refactors, comments, and doc edits that don't change output do not bump.
 
 ## Layout Detection Heuristics
 

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -25,6 +25,13 @@ import os
 import sys
 from pathlib import Path
 
+# Pipeline version — stamped into every video-extracted vault entry (DB row +
+# PDF metadata) so artifacts record which extraction iteration produced them.
+# Bump this whenever extraction BEHAVIOR changes: default --fps or --threshold,
+# the download tier, region-detection logic, dedup hashing, or PDF assembly.
+# See references/video-slide-extraction.md ("Pipeline Versioning") for the policy.
+PIPELINE_VERSION = "0.7.0"
+
 # Check dependencies
 try:
     import imagehash
@@ -158,6 +165,9 @@ def combine_to_pdf(unique_slides, output_pdf, slide_region=None):
     Saves FULL (uncropped) frames — the crop region was only used for
     hash comparison. The full frame preserves speaker PiP context which
     can be useful for analyzing co-presentation dynamics.
+
+    Stamps PIPELINE_VERSION into the PDF's producer/creator metadata so the
+    durable artifact itself records which extraction iteration produced it.
     """
     images = []
     for frame_path, _ in unique_slides:
@@ -168,7 +178,11 @@ def combine_to_pdf(unique_slides, output_pdf, slide_region=None):
         print("  WARNING: No unique slides found")
         return None
 
-    images[0].save(output_pdf, save_all=True, append_images=images[1:])
+    producer = f"speaker-toolkit/video-slide-extraction {PIPELINE_VERSION}"
+    images[0].save(
+        output_pdf, save_all=True, append_images=images[1:],
+        producer=producer, creator=producer,
+    )
     size_mb = os.path.getsize(output_pdf) / (1024 * 1024)
     print(f"  Saved PDF: {output_pdf} ({len(images)} pages, {size_mb:.1f} MB)")
     return output_pdf
@@ -217,6 +231,7 @@ def extract_slides_from_video(video_path, output_dir, youtube_id,
 
     result = {
         "slide_source": "video_extracted",
+        "pipeline_version": PIPELINE_VERSION,
         "total_frames_extracted": len(frames),
         "unique_slides_count": len(unique_slides),
         "hash_threshold_used": hash_threshold,
@@ -234,6 +249,8 @@ def main():
     parser = argparse.ArgumentParser(
         description="Extract slide images from conference talk videos."
     )
+    parser.add_argument("--version", action="version",
+                        version=f"%(prog)s {PIPELINE_VERSION}")
     parser.add_argument("video", help="Path to downloaded MP4 video")
     parser.add_argument("outdir", help="Directory for intermediate files and output PDF")
     parser.add_argument("youtube_id", help="YouTube video ID (used for naming)")

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -28,14 +28,15 @@ import sys
 # PDF metadata) so artifacts record which extraction iteration produced them.
 # Bump this whenever extraction BEHAVIOR changes: default --fps or --threshold,
 # the download tier, region-detection logic, dedup hashing, or PDF assembly.
-# See references/video-slide-extraction.md ("Pipeline Versioning") for the policy.
+# See skills/vault-ingress/references/video-slide-extraction.md ("Pipeline
+# Versioning") for the policy.
 PIPELINE_VERSION = "0.7.0"
 
 # Shape version of the structured_data.video_extraction record (distinct from
 # PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
 # field shape). Bump on any field add/remove/rename. Records written before this
 # field existed have no schema_version and are read as the legacy shape (0).
-# See references/schemas-db.md ("Video Extraction Output Schema").
+# See skills/vault-ingress/references/schemas-db.md ("Video Extraction Output Schema").
 SCHEMA_VERSION = 1
 
 # Heavy deps are only needed for the extraction pipeline itself. Import them

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -31,6 +31,13 @@ import sys
 # See references/video-slide-extraction.md ("Pipeline Versioning") for the policy.
 PIPELINE_VERSION = "0.7.0"
 
+# Shape version of the structured_data.video_extraction record (distinct from
+# PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
+# field shape). Bump on any field add/remove/rename. Records written before this
+# field existed have no schema_version and are read as the legacy shape (0).
+# See references/schemas-db.md ("Video Extraction Output Schema").
+SCHEMA_VERSION = 1
+
 # Heavy deps are only needed for the extraction pipeline itself. Import them
 # without exiting on failure so the module stays importable (and --version /
 # --help stay answerable) in a minimal environment. main() enforces presence
@@ -235,6 +242,7 @@ def extract_slides_from_video(video_path, output_dir, youtube_id,
 
     result = {
         "slide_source": "video_extracted",
+        "schema_version": SCHEMA_VERSION,
         "pipeline_version": PIPELINE_VERSION,
         "total_frames_extracted": len(frames),
         "unique_slides_count": len(unique_slides),

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -23,7 +23,6 @@ import glob
 import json
 import os
 import sys
-from pathlib import Path
 
 # Pipeline version — stamped into every video-extracted vault entry (DB row +
 # PDF metadata) so artifacts record which extraction iteration produced them.
@@ -32,13 +31,18 @@ from pathlib import Path
 # See references/video-slide-extraction.md ("Pipeline Versioning") for the policy.
 PIPELINE_VERSION = "0.7.0"
 
-# Check dependencies
+# Heavy deps are only needed for the extraction pipeline itself. Import them
+# without exiting on failure so the module stays importable (and --version /
+# --help stay answerable) in a minimal environment. main() enforces presence
+# before any extraction runs.
 try:
     import imagehash
     from PIL import Image
-except ImportError:
-    print("ERROR: Install dependencies: pip install imagehash Pillow")
-    sys.exit(1)
+    _DEPS_ERROR = None
+except ImportError as exc:
+    imagehash = None
+    Image = None
+    _DEPS_ERROR = exc
 
 
 def extract_frames(video_path, frames_dir, fps=0.5):
@@ -249,16 +253,33 @@ def main():
     parser = argparse.ArgumentParser(
         description="Extract slide images from conference talk videos."
     )
-    parser.add_argument("--version", action="version",
-                        version=f"%(prog)s {PIPELINE_VERSION}")
-    parser.add_argument("video", help="Path to downloaded MP4 video")
-    parser.add_argument("outdir", help="Directory for intermediate files and output PDF")
-    parser.add_argument("youtube_id", help="YouTube video ID (used for naming)")
+    parser.add_argument("--version", action="store_true",
+                        help="Print the pipeline version as JSON and exit")
+    parser.add_argument("video", nargs="?", help="Path to downloaded MP4 video")
+    parser.add_argument("outdir", nargs="?",
+                        help="Directory for intermediate files and output PDF")
+    parser.add_argument("youtube_id", nargs="?",
+                        help="YouTube video ID (used for naming)")
     parser.add_argument("--fps", type=float, default=0.5,
                         help="Frames per second to extract (default: 0.5)")
     parser.add_argument("--threshold", type=int, default=8,
                         help="Perceptual hash distance threshold (default: 8)")
     args = parser.parse_args()
+
+    # Structured version query — JSON, not prose, per script-delegation. Handled
+    # before the dependency guard so the version stays queryable in a minimal env.
+    if args.version:
+        print(json.dumps({"pipeline_version": PIPELINE_VERSION}))
+        return
+
+    if None in (args.video, args.outdir, args.youtube_id):
+        parser.error("video, outdir, and youtube_id are required")
+
+    if _DEPS_ERROR is not None:
+        print(json.dumps(
+            {"error": "Install dependencies: pip install imagehash Pillow"}),
+            file=sys.stderr)
+        sys.exit(1)
 
     os.makedirs(args.outdir, exist_ok=True)
     result = extract_slides_from_video(

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -1,11 +1,18 @@
 """Tests for video-slide-extraction.py — frame extraction, dedup, PDF output."""
 
+import json
 import os
 import shutil
 import subprocess
+import sys
 
 import pytest
 from PIL import Image
+
+SCRIPT_PATH = os.path.join(
+    os.path.dirname(__file__), os.pardir,
+    "skills", "vault-ingress", "scripts", "video-slide-extraction.py",
+)
 
 
 def test_crop_frame_none_region(video_slide_extraction):
@@ -82,6 +89,16 @@ def test_pipeline_version_is_semver(video_slide_extraction):
     assert all(p.isdigit() for p in parts)
 
 
+def test_version_flag_emits_json(video_slide_extraction):
+    """`--version` prints structured JSON (not prose) per script-delegation."""
+    proc = subprocess.run(
+        [sys.executable, SCRIPT_PATH, "--version"],
+        capture_output=True, text=True, check=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload == {"pipeline_version": video_slide_extraction.PIPELINE_VERSION}
+
+
 def test_combine_to_pdf_stamps_version_metadata(video_slide_extraction, tmp_path):
     """The output PDF records PIPELINE_VERSION in its producer/creator metadata."""
     frames = []
@@ -94,7 +111,8 @@ def test_combine_to_pdf_stamps_version_metadata(video_slide_extraction, tmp_path
     output = str(tmp_path / "slides.pdf")
     video_slide_extraction.combine_to_pdf(frames, output)
 
-    raw = open(output, "rb").read()
+    with open(output, "rb") as f:
+        raw = f.read()
     version = video_slide_extraction.PIPELINE_VERSION
     # Pillow serializes PDF metadata strings as UTF-16BE; match either encoding.
     def present(s):

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -74,6 +74,35 @@ def test_combine_to_pdf_empty(video_slide_extraction, tmp_path):
     assert result is None
 
 
+def test_pipeline_version_is_semver(video_slide_extraction):
+    """PIPELINE_VERSION is a defined dotted version string."""
+    version = video_slide_extraction.PIPELINE_VERSION
+    parts = version.split(".")
+    assert len(parts) == 3
+    assert all(p.isdigit() for p in parts)
+
+
+def test_combine_to_pdf_stamps_version_metadata(video_slide_extraction, tmp_path):
+    """The output PDF records PIPELINE_VERSION in its producer/creator metadata."""
+    frames = []
+    for i in range(2):
+        img = Image.new("RGB", (320, 180), (i * 80, 0, 0))
+        path = str(tmp_path / f"frame_{i:05d}.jpg")
+        img.save(path)
+        frames.append((path, i))
+
+    output = str(tmp_path / "slides.pdf")
+    video_slide_extraction.combine_to_pdf(frames, output)
+
+    raw = open(output, "rb").read()
+    version = video_slide_extraction.PIPELINE_VERSION
+    # Pillow serializes PDF metadata strings as UTF-16BE; match either encoding.
+    def present(s):
+        return s.encode() in raw or s.encode("utf-16-be") in raw
+    assert present("video-slide-extraction")
+    assert present(version)
+
+
 @pytest.mark.skipif(not shutil.which("ffmpeg"), reason="ffmpeg not installed")
 def test_extract_frames_from_synthetic_video(video_slide_extraction, tmp_path):
     """Generate a tiny video with ffmpeg and verify frame extraction."""
@@ -116,4 +145,5 @@ def test_full_pipeline(video_slide_extraction, tmp_path):
     )
     assert result["unique_slides_count"] >= 1
     assert result["slide_source"] == "video_extracted"
+    assert result["pipeline_version"] == video_slide_extraction.PIPELINE_VERSION
     assert os.path.isfile(result["output_pdf"])

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -89,6 +89,13 @@ def test_pipeline_version_is_semver(video_slide_extraction):
     assert all(p.isdigit() for p in parts)
 
 
+def test_schema_version_is_positive_int(video_slide_extraction):
+    """SCHEMA_VERSION is a positive integer record-shape version."""
+    sv = video_slide_extraction.SCHEMA_VERSION
+    assert isinstance(sv, int)
+    assert sv >= 1
+
+
 def test_version_flag_emits_json(video_slide_extraction):
     """`--version` prints structured JSON (not prose) per script-delegation."""
     proc = subprocess.run(
@@ -164,4 +171,5 @@ def test_full_pipeline(video_slide_extraction, tmp_path):
     assert result["unique_slides_count"] >= 1
     assert result["slide_source"] == "video_extracted"
     assert result["pipeline_version"] == video_slide_extraction.PIPELINE_VERSION
+    assert result["schema_version"] == video_slide_extraction.SCHEMA_VERSION
     assert os.path.isfile(result["output_pdf"])


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary
- Adds a `PIPELINE_VERSION` constant (`0.7.0`, successor to the pre-reorg monolith's ≈0.6.0) to `video-slide-extraction.py`.
- Stamps the version into both the vault DB row (`structured_data.video_extraction.pipeline_version`) and the output PDF's producer/creator metadata, so video-extracted artifacts record which extraction iteration produced them.
- Adds a `--version` flag (prints JSON `{"pipeline_version": "<version>"}`, queryable without the extraction deps) and documents the version + bump-on-behavior-change policy in `references/video-slide-extraction.md`; records the new field in `references/schemas-db.md`.

Closes #103.

## Test plan
- [x] `pytest tests/test_video_slide_extraction.py` — 11 passed (new: version-is-dotted-string, `--version` JSON output, PDF metadata stamp, pipeline_version in full-pipeline result)
- [x] Full suite: 567 passed, 3 skipped
- [x] `video-slide-extraction.py --version` prints `{"pipeline_version": "0.7.0"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)