### PR TITLE
fix(presentation-creator): surface deck-driver VBA errors to the CLI (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### fix(presentation-creator) — deck drivers surface VBA errors to the CLI instead of a modal (#85)
+
+Every RunDeckOps macro's failure handler popped a `MsgBox` and returned a bare `-1`. Under
+osascript automation no human dismisses that modal, so it hung the run and then blocked every
+subsequent macro call (PowerPoint `-18`) — the `BuildDeck -18`-on-large-decks symptom reported in
+#85 — while the real `Err.Description` died in a dialog the CLI cannot read. All eight Public macros
+are now typed `As Variant` and return `"ERROR: <macro> failed at [<token>]: <Err.Number> -
+<Err.Description>"` on failure (the success path still returns the numeric count); each AppleScript
+driver surfaces an `ERROR:`-prefixed return as an `osascript` error, so the description reaches
+stderr. No macro calls `MsgBox`. This closes the last open item in #85 — the driver/`.bas`
+packaging restore and the 1800s `with timeout` wrap already shipped.
+
 ### feat(presentation-creator) — add the Flyover antipattern (audience condescension)
 
 The Presentation Patterns taxonomy had no entry for the speaker who treats the room in

--- a/skills/presentation-creator/scripts/RunDeckOps.bas
+++ b/skills/presentation-creator/scripts/RunDeckOps.bas
@@ -45,13 +45,20 @@ Attribute VB_Name = "DeckOps"
 '
 ' ERROR-HANDLING CONTRACT (applies to every Public macro below):
 ' outer-boundary-process-contract — each Public macro is the OUTERMOST boundary,
-' invoked from AppleScript which reads the return code, and the shell wrapper
+' invoked from AppleScript which reads the return value, and the shell wrapper
 ' treats a MISSING output file as failure. VBA has no typed exception catching,
 ' so each macro uses a catch-all `On Error GoTo FailN`. Caller's silent-failure
-' shape: no return code + no output file. What the catch emits: a MsgBox + a -1
-' return so the caller observes the failure. Why propagation breaks the contract:
-' an unhandled VBA error would leave the deck open with no return code and no
-' output, silently breaking the AppleScript/shell failure signal.
+' shape: no return value + no output file. What the catch emits: each macro is
+' typed `As Variant` and RETURNS the diagnostic string "ERROR: <macro> failed at
+' [<token>]: <Err.Number> - <Err.Description>"; the success path returns the
+' numeric count. The driver surfaces an "ERROR:"-prefixed return as an osascript
+' error, so Err.Description reaches the CLI instead of dying in a dialog. A MsgBox
+' here would be FATAL: an osascript-driven run has no human to dismiss the modal,
+' so it hangs the call and then blocks every subsequent macro run (PowerPoint
+' error -18) — that regression is why this layer never calls MsgBox. Why
+' propagation breaks the contract: an unhandled VBA error would leave the deck
+' open with no return value and no output, silently breaking the AppleScript/shell
+' failure signal.
 ' =====================================================================
 Option Explicit
 
@@ -59,7 +66,7 @@ Public Function RunDeckOps(ByVal basePath As String, _
                            ByVal outPath As String, _
                            ByVal importSpec As String, _
                            ByVal orderStr As String, _
-                           ByVal replaceStr As String) As Long
+                           ByVal replaceStr As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -149,16 +156,14 @@ Public Function RunDeckOps(ByVal basePath As String, _
 
 Fail:
     Dim em As String
-    em = "RunDeckOps failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: RunDeckOps failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "RunDeckOps"
-    RunDeckOps = -1
+    RunDeckOps = em
 End Function
 
 ' Create a 1-slide deck: clone a comic TEMPLATE slide (inherits the layout's
@@ -173,7 +178,7 @@ Public Function MakeBgImageSlide(ByVal basePath As String, _
                                  ByVal templateNum As String, _
                                  ByVal imagePath As String, _
                                  ByVal titleText As String, _
-                                 ByVal outPath As String) As Long
+                                 ByVal outPath As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -234,16 +239,14 @@ Public Function MakeBgImageSlide(ByVal basePath As String, _
 
 Fail2:
     Dim em As String
-    em = "MakeBgImageSlide failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: MakeBgImageSlide failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "MakeBgImageSlide"
-    MakeBgImageSlide = -1
+    MakeBgImageSlide = em
 End Function
 
 ' Set per-slide BACKGROUND FILLS in bulk — the creation-time counterpart of
@@ -258,7 +261,7 @@ End Function
 ' specStr = "<1-based slide #>=/posix/path[;<#>=/posix/path2 ...]"
 Public Function ApplyBackgrounds(ByVal basePath As String, _
                                  ByVal outPath As String, _
-                                 ByVal specStr As String) As Long
+                                 ByVal specStr As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -300,16 +303,14 @@ Public Function ApplyBackgrounds(ByVal basePath As String, _
 
 Fail3:
     Dim em As String
-    em = "ApplyBackgrounds failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: ApplyBackgrounds failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "ApplyBackgrounds"
-    ApplyBackgrounds = -1
+    ApplyBackgrounds = em
 End Function
 
 ' Expand progressive-reveal BUILD sequences: replace each parent slide with its
@@ -334,7 +335,7 @@ End Function
 '       {basePath, outPath, packedSpec}
 Public Function ExpandBuilds(ByVal basePath As String, _
                              ByVal outPath As String, _
-                             ByVal packedSpec As String) As Long
+                             ByVal packedSpec As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -387,16 +388,14 @@ Public Function ExpandBuilds(ByVal basePath As String, _
 
 FailEB:
     Dim em As String
-    em = "ExpandBuilds failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: ExpandBuilds failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "ExpandBuilds"
-    ExpandBuilds = -1
+    ExpandBuilds = em
 End Function
 
 ' Set per-slide speaker notes via real PowerPoint, which serializes valid notes
@@ -411,7 +410,7 @@ End Function
 '       {basePath, outPath, packedNotes}
 Public Function SetSpeakerNotes(ByVal basePath As String, _
                                 ByVal outPath As String, _
-                                ByVal packedNotes As String) As Long
+                                ByVal packedNotes As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -452,16 +451,14 @@ Public Function SetSpeakerNotes(ByVal basePath As String, _
 
 Fail4:
     Dim em As String
-    em = "SetSpeakerNotes failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: SetSpeakerNotes failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "SetSpeakerNotes"
-    SetSpeakerNotes = -1
+    SetSpeakerNotes = em
 End Function
 
 ' Write noteText into a slide's notes body placeholder (creating the notes page
@@ -504,7 +501,7 @@ End Sub
 Public Function MakePlaceholderSlide(ByVal basePath As String, _
                                      ByVal outPath As String, _
                                      ByVal titleText As String, _
-                                     ByVal subtitleText As String) As Long
+                                     ByVal subtitleText As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -582,16 +579,14 @@ Public Function MakePlaceholderSlide(ByVal basePath As String, _
 
 Fail6:
     Dim em As String
-    em = "MakePlaceholderSlide failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: MakePlaceholderSlide failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "MakePlaceholderSlide"
-    MakePlaceholderSlide = -1
+    MakePlaceholderSlide = em
 End Function
 
 ' Insert a QR PNG on the given slides. Python identifies existing QR pictures by
@@ -610,7 +605,7 @@ End Function
 Public Function InsertQR(ByVal basePath As String, _
                          ByVal outPath As String, _
                          ByVal pngPath As String, _
-                         ByVal slidesSpec As String) As Long
+                         ByVal slidesSpec As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -697,16 +692,14 @@ Public Function InsertQR(ByVal basePath As String, _
 
 Fail7:
     Dim em As String
-    em = "InsertQR failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: InsertQR failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "InsertQR"
-    InsertQR = -1
+    InsertQR = em
 End Function
 
 ' Build a whole deck from a flat op sequence via the real PowerPoint app — the
@@ -732,7 +725,7 @@ End Function
 '   run VB macro macro name "BuildDeck" list of parameters {basePath, outPath, opsText}
 Public Function BuildDeck(ByVal basePath As String, _
                           ByVal outPath As String, _
-                          ByVal opsText As String) As Long
+                          ByVal opsText As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -847,16 +840,14 @@ Public Function BuildDeck(ByVal basePath As String, _
 
 Fail8:
     Dim em As String
-    em = "BuildDeck failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: BuildDeck failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "BuildDeck"
-    BuildDeck = -1
+    BuildDeck = em
 End Function
 
 ' Set a placeholder's text by type (ppPlaceholderTitle / Subtitle / Body). If the

--- a/skills/presentation-creator/scripts/RunDeckOps.bas.txt
+++ b/skills/presentation-creator/scripts/RunDeckOps.bas.txt
@@ -45,13 +45,20 @@ Attribute VB_Name = "DeckOps"
 '
 ' ERROR-HANDLING CONTRACT (applies to every Public macro below):
 ' outer-boundary-process-contract — each Public macro is the OUTERMOST boundary,
-' invoked from AppleScript which reads the return code, and the shell wrapper
+' invoked from AppleScript which reads the return value, and the shell wrapper
 ' treats a MISSING output file as failure. VBA has no typed exception catching,
 ' so each macro uses a catch-all `On Error GoTo FailN`. Caller's silent-failure
-' shape: no return code + no output file. What the catch emits: a MsgBox + a -1
-' return so the caller observes the failure. Why propagation breaks the contract:
-' an unhandled VBA error would leave the deck open with no return code and no
-' output, silently breaking the AppleScript/shell failure signal.
+' shape: no return value + no output file. What the catch emits: each macro is
+' typed `As Variant` and RETURNS the diagnostic string "ERROR: <macro> failed at
+' [<token>]: <Err.Number> - <Err.Description>"; the success path returns the
+' numeric count. The driver surfaces an "ERROR:"-prefixed return as an osascript
+' error, so Err.Description reaches the CLI instead of dying in a dialog. A MsgBox
+' here would be FATAL: an osascript-driven run has no human to dismiss the modal,
+' so it hangs the call and then blocks every subsequent macro run (PowerPoint
+' error -18) — that regression is why this layer never calls MsgBox. Why
+' propagation breaks the contract: an unhandled VBA error would leave the deck
+' open with no return value and no output, silently breaking the AppleScript/shell
+' failure signal.
 ' =====================================================================
 Option Explicit
 
@@ -59,7 +66,7 @@ Public Function RunDeckOps(ByVal basePath As String, _
                            ByVal outPath As String, _
                            ByVal importSpec As String, _
                            ByVal orderStr As String, _
-                           ByVal replaceStr As String) As Long
+                           ByVal replaceStr As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -149,16 +156,14 @@ Public Function RunDeckOps(ByVal basePath As String, _
 
 Fail:
     Dim em As String
-    em = "RunDeckOps failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: RunDeckOps failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "RunDeckOps"
-    RunDeckOps = -1
+    RunDeckOps = em
 End Function
 
 ' Create a 1-slide deck: clone a comic TEMPLATE slide (inherits the layout's
@@ -173,7 +178,7 @@ Public Function MakeBgImageSlide(ByVal basePath As String, _
                                  ByVal templateNum As String, _
                                  ByVal imagePath As String, _
                                  ByVal titleText As String, _
-                                 ByVal outPath As String) As Long
+                                 ByVal outPath As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -234,16 +239,14 @@ Public Function MakeBgImageSlide(ByVal basePath As String, _
 
 Fail2:
     Dim em As String
-    em = "MakeBgImageSlide failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: MakeBgImageSlide failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "MakeBgImageSlide"
-    MakeBgImageSlide = -1
+    MakeBgImageSlide = em
 End Function
 
 ' Set per-slide BACKGROUND FILLS in bulk — the creation-time counterpart of
@@ -258,7 +261,7 @@ End Function
 ' specStr = "<1-based slide #>=/posix/path[;<#>=/posix/path2 ...]"
 Public Function ApplyBackgrounds(ByVal basePath As String, _
                                  ByVal outPath As String, _
-                                 ByVal specStr As String) As Long
+                                 ByVal specStr As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -300,16 +303,14 @@ Public Function ApplyBackgrounds(ByVal basePath As String, _
 
 Fail3:
     Dim em As String
-    em = "ApplyBackgrounds failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: ApplyBackgrounds failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "ApplyBackgrounds"
-    ApplyBackgrounds = -1
+    ApplyBackgrounds = em
 End Function
 
 ' Expand progressive-reveal BUILD sequences: replace each parent slide with its
@@ -334,7 +335,7 @@ End Function
 '       {basePath, outPath, packedSpec}
 Public Function ExpandBuilds(ByVal basePath As String, _
                              ByVal outPath As String, _
-                             ByVal packedSpec As String) As Long
+                             ByVal packedSpec As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -387,16 +388,14 @@ Public Function ExpandBuilds(ByVal basePath As String, _
 
 FailEB:
     Dim em As String
-    em = "ExpandBuilds failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: ExpandBuilds failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "ExpandBuilds"
-    ExpandBuilds = -1
+    ExpandBuilds = em
 End Function
 
 ' Set per-slide speaker notes via real PowerPoint, which serializes valid notes
@@ -411,7 +410,7 @@ End Function
 '       {basePath, outPath, packedNotes}
 Public Function SetSpeakerNotes(ByVal basePath As String, _
                                 ByVal outPath As String, _
-                                ByVal packedNotes As String) As Long
+                                ByVal packedNotes As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -452,16 +451,14 @@ Public Function SetSpeakerNotes(ByVal basePath As String, _
 
 Fail4:
     Dim em As String
-    em = "SetSpeakerNotes failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: SetSpeakerNotes failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "SetSpeakerNotes"
-    SetSpeakerNotes = -1
+    SetSpeakerNotes = em
 End Function
 
 ' Write noteText into a slide's notes body placeholder (creating the notes page
@@ -504,7 +501,7 @@ End Sub
 Public Function MakePlaceholderSlide(ByVal basePath As String, _
                                      ByVal outPath As String, _
                                      ByVal titleText As String, _
-                                     ByVal subtitleText As String) As Long
+                                     ByVal subtitleText As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -582,16 +579,14 @@ Public Function MakePlaceholderSlide(ByVal basePath As String, _
 
 Fail6:
     Dim em As String
-    em = "MakePlaceholderSlide failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: MakePlaceholderSlide failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "MakePlaceholderSlide"
-    MakePlaceholderSlide = -1
+    MakePlaceholderSlide = em
 End Function
 
 ' Insert a QR PNG on the given slides. Python identifies existing QR pictures by
@@ -610,7 +605,7 @@ End Function
 Public Function InsertQR(ByVal basePath As String, _
                          ByVal outPath As String, _
                          ByVal pngPath As String, _
-                         ByVal slidesSpec As String) As Long
+                         ByVal slidesSpec As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -697,16 +692,14 @@ Public Function InsertQR(ByVal basePath As String, _
 
 Fail7:
     Dim em As String
-    em = "InsertQR failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: InsertQR failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "InsertQR"
-    InsertQR = -1
+    InsertQR = em
 End Function
 
 ' Build a whole deck from a flat op sequence via the real PowerPoint app — the
@@ -732,7 +725,7 @@ End Function
 '   run VB macro macro name "BuildDeck" list of parameters {basePath, outPath, opsText}
 Public Function BuildDeck(ByVal basePath As String, _
                           ByVal outPath As String, _
-                          ByVal opsText As String) As Long
+                          ByVal opsText As String) As Variant
     Dim curTok As String
     Dim base As Presentation
     ' outer-boundary-process-contract — see the module-header error-handling contract.
@@ -847,16 +840,14 @@ Public Function BuildDeck(ByVal basePath As String, _
 
 Fail8:
     Dim em As String
-    em = "BuildDeck failed at [" & curTok & "]:" & vbCr & _
-         Err.Number & " - " & Err.Description
+    em = "ERROR: BuildDeck failed at [" & curTok & "]: " & Err.Number & " - " & Err.Description
     On Error Resume Next
     If Not base Is Nothing Then
         base.Saved = msoTrue
         base.Close
     End If
     On Error GoTo 0
-    MsgBox em, vbCritical, "BuildDeck"
-    BuildDeck = -1
+    BuildDeck = em
 End Function
 
 ' Set a placeholder's text by type (ppPlaceholderTitle / Subtitle / Body). If the

--- a/skills/presentation-creator/scripts/apply-backgrounds.applescript
+++ b/skills/presentation-creator/scripts/apply-backgrounds.applescript
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "ApplyBackgrounds" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "ApplyBackgrounds failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "ApplyBackgrounds returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/apply-backgrounds.applescript.txt
+++ b/skills/presentation-creator/scripts/apply-backgrounds.applescript.txt
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "ApplyBackgrounds" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "ApplyBackgrounds failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "ApplyBackgrounds returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/apply-backgrounds.sh
+++ b/skills/presentation-creator/scripts/apply-backgrounds.sh
@@ -73,6 +73,6 @@ if [[ -f "$STAGE" ]]; then
   mv -f "$STAGE" "$OUT"
   echo "done -> $OUT"
 else
-  echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged file. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi

--- a/skills/presentation-creator/scripts/build-deck.applescript
+++ b/skills/presentation-creator/scripts/build-deck.applescript
@@ -12,6 +12,6 @@ on run argv
 			set rc to run VB macro macro name "BuildDeck" list of parameters {item 1 of argv, item 2 of argv, ops}
 		end timeout
 	end tell
-	if rc < 0 then error "BuildDeck failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "BuildDeck returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/build-deck.applescript.txt
+++ b/skills/presentation-creator/scripts/build-deck.applescript.txt
@@ -12,6 +12,6 @@ on run argv
 			set rc to run VB macro macro name "BuildDeck" list of parameters {item 1 of argv, item 2 of argv, ops}
 		end timeout
 	end tell
-	if rc < 0 then error "BuildDeck failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "BuildDeck returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/build-deck.sh
+++ b/skills/presentation-creator/scripts/build-deck.sh
@@ -55,6 +55,6 @@ if [[ -f "$STAGE" ]]; then
   mv -f "$STAGE" "$OUT"
   python3 -c 'import json,sys; print(json.dumps({"output": sys.argv[1]}))' "$OUT"
 else
-  echo "ERROR: macro did not produce the staged deck. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged deck. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi

--- a/skills/presentation-creator/scripts/expand-builds.applescript
+++ b/skills/presentation-creator/scripts/expand-builds.applescript
@@ -15,6 +15,6 @@ on run argv
 			set rc to run VB macro macro name "ExpandBuilds" list of parameters {basePath, outPath, packed}
 		end timeout
 	end tell
-	if rc < 0 then error "ExpandBuilds failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "ExpandBuilds returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/expand-builds.applescript.txt
+++ b/skills/presentation-creator/scripts/expand-builds.applescript.txt
@@ -15,6 +15,6 @@ on run argv
 			set rc to run VB macro macro name "ExpandBuilds" list of parameters {basePath, outPath, packed}
 		end timeout
 	end tell
-	if rc < 0 then error "ExpandBuilds failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "ExpandBuilds returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/expand-builds.sh
+++ b/skills/presentation-creator/scripts/expand-builds.sh
@@ -74,6 +74,6 @@ if [[ -f "$STAGE" ]]; then
   mv -f "$STAGE" "$OUT"
   echo "done -> $OUT"
 else
-  echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged file. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi

--- a/skills/presentation-creator/scripts/inject-notes.applescript
+++ b/skills/presentation-creator/scripts/inject-notes.applescript
@@ -14,6 +14,6 @@ on run argv
 			set rc to run VB macro macro name "SetSpeakerNotes" list of parameters {basePath, outPath, packed}
 		end timeout
 	end tell
-	if rc < 0 then error "SetSpeakerNotes failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "SetSpeakerNotes returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/inject-notes.applescript.txt
+++ b/skills/presentation-creator/scripts/inject-notes.applescript.txt
@@ -14,6 +14,6 @@ on run argv
 			set rc to run VB macro macro name "SetSpeakerNotes" list of parameters {basePath, outPath, packed}
 		end timeout
 	end tell
-	if rc < 0 then error "SetSpeakerNotes failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "SetSpeakerNotes returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/inject-notes.sh
+++ b/skills/presentation-creator/scripts/inject-notes.sh
@@ -52,6 +52,6 @@ if [[ -f "$STAGE" ]]; then
   mv -f "$STAGE" "$OUT"
   echo "done -> $OUT"
 else
-  echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged file. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi

--- a/skills/presentation-creator/scripts/insert-qr.applescript
+++ b/skills/presentation-creator/scripts/insert-qr.applescript
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "InsertQR" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv, item 4 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "InsertQR failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "InsertQR returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/insert-qr.applescript.txt
+++ b/skills/presentation-creator/scripts/insert-qr.applescript.txt
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "InsertQR" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv, item 4 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "InsertQR failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "InsertQR returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/insert-qr.sh
+++ b/skills/presentation-creator/scripts/insert-qr.sh
@@ -50,6 +50,6 @@ if [[ -f "$STAGE" ]]; then
   # Emit via python3 so any path (quotes/backslashes/unicode) is correctly JSON-escaped.
   python3 -c 'import json,sys; print(json.dumps({"output": sys.argv[1]}))' "$OUT"
 else
-  echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged file. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi

--- a/skills/presentation-creator/scripts/make-bg-slide.applescript
+++ b/skills/presentation-creator/scripts/make-bg-slide.applescript
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "MakeBgImageSlide" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv, item 4 of argv, item 5 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "MakeBgImageSlide failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "MakeBgImageSlide returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/make-bg-slide.applescript.txt
+++ b/skills/presentation-creator/scripts/make-bg-slide.applescript.txt
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "MakeBgImageSlide" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv, item 4 of argv, item 5 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "MakeBgImageSlide failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "MakeBgImageSlide returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/make-bg-slide.sh
+++ b/skills/presentation-creator/scripts/make-bg-slide.sh
@@ -51,6 +51,6 @@ if [[ -f "$STAGE" ]]; then
   mv -f "$STAGE" "$OUT"
   echo "done -> $OUT"
 else
-  echo "ERROR: macro did not produce the staged slide. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged slide. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi

--- a/skills/presentation-creator/scripts/make-placeholder-slide.applescript
+++ b/skills/presentation-creator/scripts/make-placeholder-slide.applescript
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "MakePlaceholderSlide" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv, item 4 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "MakePlaceholderSlide failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "MakePlaceholderSlide returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/make-placeholder-slide.applescript.txt
+++ b/skills/presentation-creator/scripts/make-placeholder-slide.applescript.txt
@@ -10,6 +10,6 @@ on run argv
 			set rc to run VB macro macro name "MakePlaceholderSlide" list of parameters {item 1 of argv, item 2 of argv, item 3 of argv, item 4 of argv}
 		end timeout
 	end tell
-	if rc < 0 then error "MakePlaceholderSlide failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "MakePlaceholderSlide returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/make-placeholder-slide.sh
+++ b/skills/presentation-creator/scripts/make-placeholder-slide.sh
@@ -49,6 +49,6 @@ if [[ -f "$STAGE" ]]; then
   mv -f "$STAGE" "$OUT"
   echo "done -> $OUT"
 else
-  echo "ERROR: macro did not produce the staged slide. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged slide. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi

--- a/skills/presentation-creator/scripts/run-deck-ops.applescript
+++ b/skills/presentation-creator/scripts/run-deck-ops.applescript
@@ -28,6 +28,6 @@ on run argv
 			set rc to run VB macro macro name "RunDeckOps" list of parameters {basePath, outPath, importSpec, orderStr, replaceStr}
 		end timeout
 	end tell
-	if rc < 0 then error "RunDeckOps failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "RunDeckOps returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/run-deck-ops.applescript.txt
+++ b/skills/presentation-creator/scripts/run-deck-ops.applescript.txt
@@ -28,6 +28,6 @@ on run argv
 			set rc to run VB macro macro name "RunDeckOps" list of parameters {basePath, outPath, importSpec, orderStr, replaceStr}
 		end timeout
 	end tell
-	if rc < 0 then error "RunDeckOps failed (rc=" & rc & ") — see the PowerPoint error dialog; confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
+	if (rc as string) starts with "ERROR" then error (rc as string) & " — confirm DeckOps.pptm is open with macros enabled and Automation consent granted."
 	return "RunDeckOps returned: " & rc
 end run

--- a/skills/presentation-creator/scripts/run-deck-ops.sh
+++ b/skills/presentation-creator/scripts/run-deck-ops.sh
@@ -49,6 +49,6 @@ if [[ -f "$STAGE" ]]; then
   mv -f "$STAGE" "$OUT"
   echo "done -> $OUT"
 else
-  echo "ERROR: macro did not produce the staged file. Check the PowerPoint error dialog, and confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
+  echo "ERROR: macro did not produce the staged file. On a macro error the osascript step above already aborted with the VBA Err.Description; reaching here means the macro returned without error but wrote no file. Confirm DeckOps.pptm is open with macros enabled and Automation consent granted — see skills/presentation-creator/references/deck-editing-setup.md." >&2
   exit 1
 fi


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

Fixes the last open item in #85: the `BuildDeck -18` robustness bug.

## Root cause
Every RunDeckOps macro's `FailN` handler ended in `MsgBox em ...` then returned `-1`. Under osascript automation nothing dismisses that modal, so it hangs the run and then blocks every subsequent macro call (PowerPoint `-18`) — the BuildDeck-on-large-decks symptom in #85 — while the real `Err.Description` dies in a dialog the CLI can't read.

## Fix
- All 8 Public macros typed `As Variant`; on failure they return `"ERROR: <macro> failed at [<token>]: <Err.Number> - <Err.Description>"` (success still returns the numeric count). No macro calls `MsgBox`.
- Each of the 8 AppleScript drivers raises an `osascript` error when the return starts with `ERROR`, so the description reaches stderr / the CLI.
- 8 shell-wrapper fallback messages updated (the dialog they referenced no longer appears).
- Module-header error-handling contract rewritten; `.txt` mirrors regenerated and in sync.

## Scope
The other two #85 problems already shipped in earlier releases: driver/`.bas` packaging restore via `.txt` mirrors, and the 1800s `with timeout` wrap.

## Testing
The VBA/AppleScript layer is the documented platform-bound-untestable carve-out (needs PowerPoint + macOS Automation). Deterministic tests pass: full suite **568 passed / 3 skipped**, including the committed-mirror sync guard (`test_deck_driver_mirrors.py`). Manual validation: run a large all-BLANK `BuildDeck`, force an error, and confirm it surfaces on the CLI (osascript error with `Err.Description`) instead of a modal dialog.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
