### PR TITLE
chore(release): bump to 0.18.44 to recover blocked 0.18.43 publish

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/speaker-toolkit",
-  "version": "0.18.43",
+  "version": "0.18.44",
   "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 102-entry Presentation Patterns taxonomy (91 observable, 11 unobservable go-live items) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.18.44 — 2026-06-30
+
 ### fix(vault-ingress,vault-profile) — strip suspicious download-URL patterns from skill instructions
 
 The `.tessl-plugin/plugin.json` migration (0.18.43) packages skills as directories, so vault-ingress's


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

Recovers the stuck publish after #110. The #110 merge's publish run failed: the manifest was at `0.18.43` (bumped when migration #106 published), but **0.18.43 already exists** on the registry — it published but is moderation-blocked on the E005 finding that #110 fixes — so `tesslio/patch-version-publish` refused to re-publish that version.

## Fix
- Bump `.tessl-plugin/plugin.json` to **0.18.44** so the E005 fix ships as a fresh version that can clear moderation.
- Manually head the existing hotfix CHANGELOG entry as `## 0.18.44 — 2026-06-30` (the wired stamp step no-ops on an already-headed top).

`0.18.43` is left as an orphaned, moderation-blocked version; `0.18.44` supersedes it. On merge this publishes 0.18.44; I'll verify moderation clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
