### PR TITLE
feat(patterns): map The Whole Brain Business Book and wire cover-or-match into intake

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jbaruch/speaker-toolkit",
   "version": "0.18.50",
-  "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 102-entry Presentation Patterns taxonomy (91 observable, 11 unobservable go-live items) for scoring, brainstorming, and go-live preparation.",
+  "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (99 observable, 12 unobservable go-live items) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [
     "skills/vault-ingress",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,78 +2,49 @@
 
 ### feat(presentation-creator) — wire the cover-or-match decision into intake and enforce it
 
-The `walk-around` cover-or-match call is worth nothing as a retrospective score — by review time the
-talk is already built in one register. It now enters at intake and is enforced deterministically.
+The `walk-around` cover-or-match call is worthless as a retrospective score — by review time the talk is
+already built in one register. It now enters at intake and is enforced.
 
-- **Intake** — `phase0-intake.md` gains Step 0.4 ("Read the Audience Spread"), asked right after the
-  audience-as-hero stance: *is this room mixed in what it accepts as proof, or does it all speak one
-  language?* Step 0.4 (Report and Advance) renumbers to 0.5. The step heads off both failure modes:
-  homogeneity asserted from job titles ("they're all engineers" describes badges, not what persuades
-  them — unverified ⇒ heterogeneous, since coverage is the safe default and matching is the bet), and
-  the speaker's own register answering for the room.
-- **Schema** — `talk.audience_spread` (`heterogeneous` | `homogeneous`) is required; `talk.dominant_register`
-  (`A`/`B`/`C`/`D`) is required iff homogeneous and rejected otherwise. `walk-around` gains `registers`
-  instance metadata declaring which questions an application answers, alongside `star-moment`'s `subtype`
-  and `opening-punch`'s `flavors`.
-- **Check** — `check-rhetorical.py` gains `_check_register_coverage`, mirroring `_check_sparkline_requirements`:
-  a heterogeneous talk must answer all four registers across its declared walk-arounds; a homogeneous talk
-  must actually answer its declared dominant register. The split follows `script-delegation` — the agent
-  judges which registers a claim lands (reasoning), the script checks the union (deterministic). Detecting
-  register from prose would be the regex trap.
+- **Intake** — `phase0-intake.md` Step 0.4 ("Read the Audience Spread") asks whether the room is mixed in
+  what it accepts as proof; the old Step 0.4 renumbers to 0.5. The step heads off homogeneity asserted from
+  job titles (unverified ⇒ heterogeneous) and the speaker's own register answering for the room.
+- **Schema** — `talk.audience_spread` required; `talk.dominant_register` required iff homogeneous, rejected
+  otherwise. `walk-around` gains `registers` instance metadata.
+- **Check** — `check-rhetorical.py` gains `_check_register_coverage`, mirroring `_check_sparkline_requirements`.
+  The `script-delegation` split: the agent judges which registers a claim lands, the script checks the union.
+  Detecting register from prose would be the regex trap.
 
-**Breaking:** `audience_spread` is required, so outlines predating this release fail validation with an
-actionable message. That is deliberate — the field exists to force the question, and defaulting it would
-let the decision be skipped, which is the failure the change addresses.
+**Breaking:** `audience_spread` is required, so older outlines fail validation with an actionable message —
+deliberate, since a default would let the question be skipped, which is the failure being fixed. The six
+`eval-resources/` outline fixtures are migrated here (all mixed-room conference talks ⇒ `heterogeneous`);
+every `outline*.yaml` in the repo validates. Twelve tests cover the validators and both check branches.
 
-The fixture now exercises the full loop: a heterogeneous room walked around A+B on the Big Idea claim and
-C+D on the S.T.A.R. claim. Twelve tests cover the validators and both check branches.
-
-Also suppresses a pre-existing pyright finding on `SlideFormat.title` (a str-Enum member named after a str
-method — Enum members shadow inherited methods by design, so the assignment-type error is a false positive),
-inline with a stated reason per `language-diagnostics`.
+Also suppresses a pre-existing pyright finding on `SlideFormat.title` inline with a stated reason per
+`language-diagnostics` — a str-Enum member named after a str method is a false positive.
 
 ### feat(patterns) — map *The Whole Brain Business Book* into the taxonomy
 
 Adds `walk-around` and the `golden-rule` antipattern from Ned Herrmann's *The Whole Brain Business Book*
 (2nd ed., 2015), Ch. 8 and Ch. 13. Taxonomy: 109 → 111 entries (83 patterns + 28 antipatterns; 99
-observable). Fills a real gap — the catalog had no entry for audience heterogeneity in *what counts as
-proof*.
+observable). The catalog had no entry for audience heterogeneity in *what counts as proof*.
 
-`walk-around` audits each load-bearing claim against four standing questions (what exactly / how does it
-work / who does it affect / where does it lead) and revises until all four are answered. `golden-rule` is
-its null case: building the talk you would want to receive, defending every claim in your own preferred
-register, and mistaking your satisfaction for the room's.
+**Why this is not the learning-styles error.** `know-your-audience`'s "Learning Styles Are a Myth" would
+condemn a naive HBDI import. Herrmann prescribes *coverage* — assume the room is diverse, hit everything,
+identify nobody — which is the opposite of the meshing hypothesis (identify a style, tailor to it) that
+Pashler et al. refuted. The quadrant vocabulary is imported as a recognizable handle; the brain model, the
+HBDI instrument, audience typing, and the book's gender-differences section (sourced to *Men Are from Mars,
+Women Are from Venus*) stay out. `walk-around.md` states the boundary, the anti-meshing warning, and the
+replicable premise the pattern rests on.
 
-**Why this book does not repeat the learning-styles error.** HBDI is a self-report typology with
-brain-based claims, and `know-your-audience`'s "Learning Styles Are a Myth" (previous release) would
-condemn a naive import. Herrmann's actual prescription is not meshing: "The fail-safe assumption is that
-the population you'll be communicating with will be mentally diverse. Therefore, I recommend delivering
-each significant communication point in all quadrants and modes." That is *coverage* — assume
-heterogeneity, hit everything, identify nobody — and it is the opposite of the meshing hypothesis
-(identify a person's style, tailor to it), which is the only claim Pashler et al. refuted. Herrmann also
-disavows the left/right dichotomy himself (Ch. 2, "The 'Right-Brain/Left-Brain' Trap") and frames the
-model as a metaphor.
+**Resolves a contradiction in the source.** Ch. 8 says cover all four quadrants; Ch. 13's MIT/CMU story says
+the opposite — a metaphor-driven introduction was rejected by engineering faculty and the identical model
+re-registered as "a first-order engineering approximation" won them over. The discriminator is audience
+spread. Deliberately not filed under `leet-grammars`: that governs vocabulary and belonging, this governs the
+epistemic form of the justification.
 
-**What is imported and what is not.** The Walk-Around procedure and the A/B/C/D quadrant vocabulary come
-in — the vocabulary is retained as a recognizable handle for readers who have met it, not as a theory.
-The physiological grounding, the HBDI instrument, audience typing, and the book's Ch. 8 gender-differences
-section (which cites *Men Are from Mars, Women Are from Venus* as support) stay out. The premise the
-pattern actually needs — audiences differ in what evidence persuades them — rests on the Elaboration
-Likelihood Model and need-for-cognition, and predates all of it in Aristotle. Both files state the
-boundary and the anti-meshing warning explicitly.
-
-**Resolves a contradiction in the source.** Ch. 8 prescribes covering all four quadrants; Ch. 13's
-MIT/CMU story prescribes the opposite — a metaphor-driven introduction was rejected by engineering
-faculty ("the walls went up") and the identical model re-registered as "a first-order engineering
-approximation to mental diversity" won them over. `walk-around` resolves it on audience spread: cover a
-heterogeneous room, match a homogeneous one, and verify homogeneity rather than assuming it from job
-titles. The catalog had nothing on this distinction. The re-registering move is deliberately not filed
-under `leet-grammars` — that pattern governs vocabulary and belonging, while this governs the epistemic
-form of the justification; a speaker can deploy flawless jargon and still offer the wrong kind of proof.
-
-`golden-rule` joins `nodding-room` in a distinct corner of Dimension 14: failures that draw good feedback.
-Both are talks a subset of the room genuinely enjoys, which is why neither self-corrects — and both mislead
-`crucible` when the feedback it consumes comes from inside the speaker's own register.
+`golden-rule` joins `nodding-room` in Dimension 14's corner of failures that draw good feedback — both are
+talks a subset of the room enjoys, which is why neither self-corrects, and both mislead `crucible` when its
+feedback comes from inside the speaker's own register.
 
 ## 0.18.50 — 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+### feat(presentation-creator) — wire the cover-or-match decision into intake and enforce it
+
+The `walk-around` cover-or-match call is worth nothing as a retrospective score — by review time the
+talk is already built in one register. It now enters at intake and is enforced deterministically.
+
+- **Intake** — `phase0-intake.md` gains Step 0.4 ("Read the Audience Spread"), asked right after the
+  audience-as-hero stance: *is this room mixed in what it accepts as proof, or does it all speak one
+  language?* Step 0.4 (Report and Advance) renumbers to 0.5. The step heads off both failure modes:
+  homogeneity asserted from job titles ("they're all engineers" describes badges, not what persuades
+  them — unverified ⇒ heterogeneous, since coverage is the safe default and matching is the bet), and
+  the speaker's own register answering for the room.
+- **Schema** — `talk.audience_spread` (`heterogeneous` | `homogeneous`) is required; `talk.dominant_register`
+  (`A`/`B`/`C`/`D`) is required iff homogeneous and rejected otherwise. `walk-around` gains `registers`
+  instance metadata declaring which questions an application answers, alongside `star-moment`'s `subtype`
+  and `opening-punch`'s `flavors`.
+- **Check** — `check-rhetorical.py` gains `_check_register_coverage`, mirroring `_check_sparkline_requirements`:
+  a heterogeneous talk must answer all four registers across its declared walk-arounds; a homogeneous talk
+  must actually answer its declared dominant register. The split follows `script-delegation` — the agent
+  judges which registers a claim lands (reasoning), the script checks the union (deterministic). Detecting
+  register from prose would be the regex trap.
+
+**Breaking:** `audience_spread` is required, so outlines predating this release fail validation with an
+actionable message. That is deliberate — the field exists to force the question, and defaulting it would
+let the decision be skipped, which is the failure the change addresses.
+
+The fixture now exercises the full loop: a heterogeneous room walked around A+B on the Big Idea claim and
+C+D on the S.T.A.R. claim. Twelve tests cover the validators and both check branches.
+
+Also suppresses a pre-existing pyright finding on `SlideFormat.title` (a str-Enum member named after a str
+method — Enum members shadow inherited methods by design, so the assignment-type error is a false positive),
+inline with a stated reason per `language-diagnostics`.
+
 ### feat(patterns) — map *The Whole Brain Business Book* into the taxonomy
 
 Adds `walk-around` and the `golden-rule` antipattern from Ned Herrmann's *The Whole Brain Business Book*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ already built in one register. It now enters at intake and is enforced.
   otherwise. `walk-around` gains `registers` instance metadata.
 - **Check** — `check-rhetorical.py` gains `_check_register_coverage`, mirroring `_check_sparkline_requirements`.
   The `script-delegation` split: the agent judges which registers a claim lands, the script checks the union.
-  Detecting register from prose would be the regex trap.
+  Detecting register from prose would be the regex trap. Zero walk-arounds FLAGs under either spread (an
+  `N/A` there would let a homogeneous talk name a dominant register it never answers), and a `walk-around`
+  without `registers:` FLAGs by location rather than reading as absent — mirroring `_check_opening_punch`'s
+  treatment of a flavorless `opening-punch`.
 
 **Breaking:** `audience_spread` is required, so older outlines fail validation with an actionable message —
 deliberate, since a default would let the question be skipped, which is the failure being fixed. The six

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+### feat(patterns) — map *The Whole Brain Business Book* into the taxonomy
+
+Adds `walk-around` and the `golden-rule` antipattern from Ned Herrmann's *The Whole Brain Business Book*
+(2nd ed., 2015), Ch. 8 and Ch. 13. Taxonomy: 109 → 111 entries (83 patterns + 28 antipatterns; 99
+observable). Fills a real gap — the catalog had no entry for audience heterogeneity in *what counts as
+proof*.
+
+`walk-around` audits each load-bearing claim against four standing questions (what exactly / how does it
+work / who does it affect / where does it lead) and revises until all four are answered. `golden-rule` is
+its null case: building the talk you would want to receive, defending every claim in your own preferred
+register, and mistaking your satisfaction for the room's.
+
+**Why this book does not repeat the learning-styles error.** HBDI is a self-report typology with
+brain-based claims, and `know-your-audience`'s "Learning Styles Are a Myth" (previous release) would
+condemn a naive import. Herrmann's actual prescription is not meshing: "The fail-safe assumption is that
+the population you'll be communicating with will be mentally diverse. Therefore, I recommend delivering
+each significant communication point in all quadrants and modes." That is *coverage* — assume
+heterogeneity, hit everything, identify nobody — and it is the opposite of the meshing hypothesis
+(identify a person's style, tailor to it), which is the only claim Pashler et al. refuted. Herrmann also
+disavows the left/right dichotomy himself (Ch. 2, "The 'Right-Brain/Left-Brain' Trap") and frames the
+model as a metaphor.
+
+**What is imported and what is not.** The Walk-Around procedure and the A/B/C/D quadrant vocabulary come
+in — the vocabulary is retained as a recognizable handle for readers who have met it, not as a theory.
+The physiological grounding, the HBDI instrument, audience typing, and the book's Ch. 8 gender-differences
+section (which cites *Men Are from Mars, Women Are from Venus* as support) stay out. The premise the
+pattern actually needs — audiences differ in what evidence persuades them — rests on the Elaboration
+Likelihood Model and need-for-cognition, and predates all of it in Aristotle. Both files state the
+boundary and the anti-meshing warning explicitly.
+
+**Resolves a contradiction in the source.** Ch. 8 prescribes covering all four quadrants; Ch. 13's
+MIT/CMU story prescribes the opposite — a metaphor-driven introduction was rejected by engineering
+faculty ("the walls went up") and the identical model re-registered as "a first-order engineering
+approximation to mental diversity" won them over. `walk-around` resolves it on audience spread: cover a
+heterogeneous room, match a homogeneous one, and verify homogeneity rather than assuming it from job
+titles. The catalog had nothing on this distinction. The re-registering move is deliberately not filed
+under `leet-grammars` — that pattern governs vocabulary and belonging, while this governs the epistemic
+form of the justification; a speaker can deploy flawless jargon and still offer the wrong kind of proof.
+
+`golden-rule` joins `nodding-room` in a distinct corner of Dimension 14: failures that draw good feedback.
+Both are talks a subset of the room genuinely enjoys, which is why neither self-corrects — and both mislead
+`crucible` when the feedback it consumes comes from inside the speaker's own register.
+
 ## 0.18.50 — 2026-07-16
 
 ### feat(patterns) — add `second-look`

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The vault skill will:
 2. Scan for talks and .pptx files
 3. Process talks in parallel batches of 5
 4. Extract rhetoric patterns across 14 dimensions
-5. Score each talk against the 86 observable Presentation Patterns
+5. Score each talk against the 99 observable Presentation Patterns entries
 6. Build a running narrative summary and slide design spec
 7. Run an interactive clarification session to validate findings and capture your intent
 8. Generate a structured speaker profile with pattern mastery data (after 10+ talks)

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ notes which named patterns and antipatterns are detected per talk.
 - Talks are processed in **parallel batches of 5** subagents
 - Transcripts are downloaded via `yt-dlp` (with `youtube-transcript-api` fallback)
 - Slides are acquired from PPTX files (preferred, richer data) or downloaded as PDFs via `gdown`
-- Each talk is scored against the taxonomy's 97 observable entries (73 patterns + 24 antipatterns)
+- Each talk is scored against the taxonomy's 99 observable entries (74 patterns + 25 antipatterns)
 - Each batch updates the summary, per-talk analysis files, and triggers profile regeneration
 - An interactive clarification session resolves ambiguities and captures confirmed intent
 
@@ -376,24 +376,25 @@ two are invoked via typed `Skill(...)` handoffs.
 
 ### Presentation Patterns Taxonomy
 
-The creator includes a structured reference taxonomy of 109 presentation patterns and
+The creator includes a structured reference taxonomy of 111 presentation patterns and
 antipatterns from *Presentation Patterns* (Ford, McCullough, Schutta 2013) supplemented
 by *Presentation Zen* (Reynolds, 2nd ed. 2012), *Resonate* (Duarte 2010), *Make It Stick*
-(Brown, Roediger, McDaniel 2014), and a small set of vault-derived patterns observed
+(Brown, Roediger, McDaniel 2014), *The Whole Brain Business Book* (Herrmann, 2nd ed.
+2015), and a small set of vault-derived patterns observed
 across the corpus (`delayed-self-introduction`, `three-part-close`, `progressive-reveal`,
 `anti-sell`, `meme-as-argument`, `second-look`), organized by presentation lifecycle:
 
-- **Prepare** (22): Know Your Audience, Narrative Arc, Triad, Talklet, Brain Breaks, Takahashi, Cave Painting, Opening PUNCH, and more
+- **Prepare** (24): Know Your Audience, Narrative Arc, Triad, Talklet, Brain Breaks, Takahashi, Cave Painting, Opening PUNCH, Walk-Around, and more
 - **Build** (51): Foreshadowing, Bookends, Defy Defaults, Vacation Photos, Traveling Highlights, Emergence, Sparkline, Call to Adventure, Call to Action, New Bliss, S.T.A.R. Moment, Three-Part Close, Progressive Reveal, Meme as Argument, Guess First, Retrieval Beat, Second Look, and more
 - **Deliver** (36): Carnegie Hall, Breathing Room, Echo Chamber, Seeding the First Question, Screen Blackout, Delayed Self-Introduction, Anti-Sell, Flyover, Spaced Follow-Up, The Nodding Room, and more
 
-Of the 109 entries, **97 are observable** (detectable from transcripts and slides) and
+Of the 111 entries, **99 are observable** (detectable from transcripts and slides) and
 **12 are unobservable** (pre-event logistics, physical stage behaviors, post-event
 follow-up, and external systems that leave no trace in recordings).
 
 **How it integrates:**
 
-| Integration point | Observable patterns (97) | Unobservable patterns (12) |
+| Integration point | Observable patterns (99) | Unobservable patterns (12) |
 |---|---|---|
 | **Vault scoring** (Step 3 B2) | Scored per talk, aggregated into `pattern_profile` | Excluded from scoring |
 | **Creator Phase 2** | 4-tier Pattern Strategy (Signature / Contextual / New to You / Shake It Up) | Included in recommendations |
@@ -488,9 +489,9 @@ speaker-toolkit/
     |   |   +-- insert-qr.applescript           # AppleScript driver for InsertQR
     |   +-- references/
     |       +-- phase0-intake.md through phase7-post-event.md  # Phase detail docs
-    |       +-- patterns/                     # Presentation Patterns taxonomy (109 entries)
+    |       +-- patterns/                     # Presentation Patterns taxonomy (111 entries)
     |           +-- _index.md                 # Master index, phase mapping, dimension lookup
-    |           +-- prepare/                  # 19 patterns + 3 antipatterns
+    |           +-- prepare/                  # 20 patterns + 4 antipatterns
     |           +-- build/                    # 41 patterns + 10 antipatterns
     |           +-- deliver/                  # 22 patterns + 14 antipatterns (12 unobservable)
     +-- illustrations/

--- a/eval-resources/qr-bitly-slug-from-outline/outline.yaml
+++ b/eval-resources/qr-bitly-slug-from-outline/outline.yaml
@@ -9,6 +9,7 @@ talk:
   speakers: ["Baruch Sadogursky"]
   duration_min: 45
   audience: "Senior developers and tech leads"
+  audience_spread: "heterogeneous"
   mode: "keynote"
   venue: "FroConf 2026"
   slide_budget: 60

--- a/eval-resources/qr-missing-shortener-detection/outline.yaml
+++ b/eval-resources/qr-missing-shortener-detection/outline.yaml
@@ -9,6 +9,7 @@ talk:
   speakers: ["Baruch Sadogursky"]
   duration_min: 45
   audience: "Senior developers and tech leads"
+  audience_spread: "heterogeneous"
   mode: "keynote"
   venue: "FroConf 2026"
   slide_budget: 60

--- a/eval-resources/shownotes-publisher-omit-placeholder/outline-2026-05-22.yaml
+++ b/eval-resources/shownotes-publisher-omit-placeholder/outline-2026-05-22.yaml
@@ -7,6 +7,7 @@ talk:
   speakers: ["Riley Hayes"]
   duration_min: 35
   audience: "Infrastructure and platform engineers"
+  audience_spread: "heterogeneous"
   mode: "war-stories"
   venue: "KafkaEU 2026"
   slide_budget: 8

--- a/eval-resources/shownotes-publisher-publish-no-date/outline-2026-05-22.yaml
+++ b/eval-resources/shownotes-publisher-publish-no-date/outline-2026-05-22.yaml
@@ -8,6 +8,7 @@ talk:
   speakers: ["Riley Hayes"]
   duration_min: 40
   audience: "Backend engineers using AI coding agents in CI/CD"
+  audience_spread: "heterogeneous"
   mode: "cautionary-tale"
   venue: "GeeCON 2026"
   slide_budget: 8

--- a/eval-resources/shownotes-publisher-publish-with-date/outline-2026-05-22.yaml
+++ b/eval-resources/shownotes-publisher-publish-with-date/outline-2026-05-22.yaml
@@ -10,6 +10,7 @@ talk:
   speakers: ["Riley Hayes"]
   duration_min: 45
   audience: "ML platform engineers, infrastructure leads"
+  audience_spread: "heterogeneous"
   mode: "lessons-from-production"
   venue: "MLOpsCon 2026"
   slide_budget: 10

--- a/eval-resources/shownotes-publisher-update-add-video/outline-2026-05-22.yaml
+++ b/eval-resources/shownotes-publisher-update-add-video/outline-2026-05-22.yaml
@@ -9,6 +9,7 @@ talk:
   speakers: ["Riley Hayes"]
   duration_min: 45
   audience: "ML platform engineers, infrastructure leads"
+  audience_spread: "heterogeneous"
   mode: "lessons-from-production"
   venue: "MLOpsCon 2026"
   slide_budget: 10

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -350,9 +350,10 @@ python3 skills/presentation-creator/scripts/guardrail-check.py   outline.yaml pa
 
 `check-rhetorical.py` enforces the **closed pattern taxonomy** (opening PUNCH,
 big-idea singleton, thesis preview/payoff ordering, sparkline structural
-elements when applicable, master-story threading, callback ledger, inoculation
-count, progressive-list contiguity, duration accounting). Output is the
-`rhetorical-review.md` artifact — PASS / FLAG / N/A per check.
+elements when applicable, register coverage or match, master-story threading,
+callback ledger, inoculation count, progressive-list contiguity, duration
+accounting). Output is the `rhetorical-review.md` artifact — PASS / FLAG / N/A
+per check.
 
 `guardrail-check.py` enforces **speaker-profile-aware rules** that depend on
 runtime profile data — currently: slide budget, Act 1 ratio limits, branding,

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -150,6 +150,8 @@ talk:
   speakers: ["Speaker Name"]        # multi-speaker talks list every speaker here
   duration_min: 50
   audience: "who, in one sentence"
+  audience_spread: "heterogeneous"    # or "homogeneous" — set at intake (Step 0.4)
+  # dominant_register: "A"           # REQUIRED iff homogeneous; omit otherwise
   mode: "from profile presentation_modes"
   venue: "Conference Year, City"
   slide_budget: 75                  # from profile guardrail_sources.slide_budgets

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -5,8 +5,9 @@ Crafting Better Presentations* (Neal Ford, Matthew McCullough, Nathaniel Schutta
 with supplementary patterns and reinforcements from *Presentation Zen* (Garr Reynolds,
 2nd ed., 2012), *Resonate: Present Visual Stories that Transform Audiences* (Nancy
 Duarte, 2010), and *Make It Stick: The Science of Successful Learning* (Peter C. Brown,
-Henry L. Roediger III, Mark A. McDaniel, 2014), plus a set of vault-derived patterns
-observed across the speaker's corpus. Contains 82 named patterns and 27 antipatterns
+Henry L. Roediger III, Mark A. McDaniel, 2014), and *The Whole Brain Business Book* (Ned
+Herrmann, 2nd ed., 2015), plus a set of vault-derived patterns observed across the
+speaker's corpus. Contains 83 named patterns and 28 antipatterns
 organized by presentation lifecycle phase. See the Sources section at the end of this file for full citations.
 
 **This is the primary entry point.** The agent reads this file first, then drills into
@@ -33,11 +34,12 @@ combinatorics are needed.
 
 ## Pattern Catalog
 
-### Prepare Phase (19 patterns + 3 antipatterns)
+### Prepare Phase (20 patterns + 4 antipatterns)
 
 | ID | Name | Type | Vault Dims | Creator Phases | Related |
 |----|------|------|------------|----------------|---------|
 | know-your-audience | Know Your Audience | pattern | 4, 9 | intake | emotional-state, seeding-satisfaction |
+| walk-around | Walk-Around | pattern | 4, 9 | architecture, content, guardrails | know-your-audience, inoculation, leet-grammars, crucible, peer-review, concrete-before-abstract |
 | opening-punch | Opening PUNCH | pattern | 1, 4 | intent, content | bookends, narrative-arc, foreshadowing, preroll, know-your-audience |
 | social-media-advertising | Social Media Advertising | pattern | 4 | publishing | seeding-satisfaction |
 | required | Required | pattern | 9 | intake, intent | proposed, posse, concurrent-creation, crucible |
@@ -59,6 +61,7 @@ combinatorics are needed.
 | abstract-attorney | Abstract Attorney | antipattern | 2, 14 | intent, guardrails | preroll, narrative-arc, fourthought, triad, crucible, carnegie-hall |
 | alienating-artifact | Alienating Artifact | antipattern | 3, 10, 14 | guardrails | know-your-audience, brain-breaks |
 | celery | Celery | antipattern | 2, 14 | guardrails | required, know-your-audience, narrative-arc, brain-breaks |
+| golden-rule | The Golden Rule | antipattern | 4, 9, 14 | guardrails | walk-around, know-your-audience, leet-grammars, crucible |
 
 ### Build Phase (41 patterns + 10 antipatterns)
 
@@ -182,6 +185,7 @@ Planning patterns — inform spec construction.
 - proposed
 - mentor
 - opening-punch
+- walk-around *(audit load-bearing claims for register spread)*
 - abstract-attorney *(antipattern — warn about abstract drift)*
 
 ### Phase 2: Architecture
@@ -197,7 +201,7 @@ Structural patterns relevant here:
 - narrative-arc, triad, talklet, expansion-joints, lightning-talk, takahashi, cave-painting
 - a-la-carte-content, context-keeper, bookends, intermezzi
 - unifying-visual-theme, vacation-photos, infodeck
-- brain-breaks, greek-chorus, retrieval-beat
+- brain-breaks, greek-chorus, retrieval-beat, walk-around
 - live-demo *(if demo-driven mode)*
 - sparkline *(if persuasive mode — alternative to narrative-arc)*
 - call-to-adventure *(architectural placement of sparkline turning point 1)*
@@ -215,11 +219,12 @@ Build patterns — applied during outline writing.
 - call-to-adventure, call-to-action, new-bliss, star-moment, inoculation, master-story
 - concrete-before-abstract
 - guess-first, retrieval-beat
+- walk-around
 
 ### Phase 4: Guardrails
 Antipatterns as warnings — scanned against the outline.
 
-**All 27 antipatterns**, with two flag types:
+**All 28 antipatterns**, with two flag types:
 - `[RECURRING]` — from `pattern_profile.antipattern_frequency` (speaker-specific)
 - `[CONTEXTUAL]` — detected in the current outline (new detection)
 
@@ -258,17 +263,17 @@ Reverse lookup: which patterns relate to each of the 14 rhetoric analysis dimens
 | 1 | Opening Pattern | preroll, opening-punch, call-to-adventure | — |
 | 2 | Narrative Structure | narrative-arc, fourthought, triad, expansion-joints, talklet, context-keeper, breadcrumbs, bookends, intermezzi, foreshadowing, backtracking, a-la-carte-content, concurrent-creation, lightning-talk, sparkline, call-to-adventure, master-story, concrete-before-abstract, guess-first | abstract-attorney, celery |
 | 3 | Humor & Wit | brain-breaks, entertainment, star-moment | alienating-artifact |
-| 4 | Audience Interaction | know-your-audience, social-media-advertising, a-la-carte-content, posse, seeding-satisfaction, seeding-the-first-question, emotional-state, make-it-rain, echo-chamber, red-yellow-green, greek-chorus, opening-punch, call-to-action, inoculation, guess-first, retrieval-beat | bunker, hecklers, backchannel, negative-ignorance, dual-headed-monster, flyover, nodding-room |
+| 4 | Audience Interaction | know-your-audience, social-media-advertising, a-la-carte-content, posse, seeding-satisfaction, seeding-the-first-question, emotional-state, make-it-rain, echo-chamber, red-yellow-green, greek-chorus, opening-punch, call-to-action, inoculation, guess-first, retrieval-beat, walk-around | bunker, hecklers, backchannel, negative-ignorance, dual-headed-monster, flyover, nodding-room, golden-rule |
 | 5 | Transition Techniques | narrative-arc, foreshadowing, backtracking, context-keeper, bookends, intermezzi, soft-transitions, cave-painting, sparkline, new-bliss, star-moment, master-story | — |
 | 6 | Closing Pattern | coda, crawling-credits, call-to-action, new-bliss, spaced-followup | — |
 | 7 | Verbal Signatures | leet-grammars, peer-review, breathing-room, echo-chamber, master-story | hiccup-words, borrowed-shoes, tower-of-babble |
 | 8 | Slide-to-Speech Relationship | fourthought, concurrent-creation, coda, vacation-photos, infodeck, gradual-consistency, charred-trail, takahashi, live-on-tape, peer-review, second-look | cookie-cutter, injured-outlines, bullet-riddled-corpse, borrowed-shoes, slideuments, lipstick-on-a-pig |
-| 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus, sparkline, call-to-adventure, call-to-action, new-bliss, inoculation, concrete-before-abstract | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig |
+| 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus, sparkline, call-to-adventure, call-to-action, new-bliss, inoculation, concrete-before-abstract, walk-around | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig, golden-rule |
 | 10 | Cultural & Pop-Culture References | leet-grammars, unifying-visual-theme, entertainment | alienating-artifact, photomaniac |
 | 11 | Technical Content Delivery | live-demo, lipsync, traveling-highlights, crawling-code, emergence, mentor, lightsaber, concrete-before-abstract, guess-first | dead-demo |
 | 12 | Pacing Clues | crucible, expansion-joints, talklet, brain-breaks, lightning-talk, takahashi, carnegie-hall, breathing-room, weatherman, screen-blackout, retrieval-beat | shortchanged, disowning-your-topic, nodding-room |
 | 13 | Slide Design Patterns | unifying-visual-theme, takahashi, cave-painting, composite-animation, vacation-photos, defy-defaults, analog-noise, gradual-consistency, charred-trail, exuberant-title-top, invisibility, context-keeper, breadcrumbs, bookends, soft-transitions, intermezzi, preroll, crawling-credits, lipsync, traveling-highlights, crawling-code, emergence, screen-blackout, star-moment, second-look | cookie-cutter, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons |
-| 14 | Areas for Improvement | crucible, preparation, carnegie-hall, shoeless, stakeout | abstract-attorney, alienating-artifact, celery, injured-outlines, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, borrowed-shoes, slideuments, dead-demo, shortchanged, hiccup-words, disowning-your-topic, going-meta, bunker, hecklers, backchannel, laser-weapons, negative-ignorance, dual-headed-monster, tower-of-babble, lipstick-on-a-pig, flyover, nodding-room |
+| 14 | Areas for Improvement | crucible, preparation, carnegie-hall, shoeless, stakeout | abstract-attorney, alienating-artifact, celery, injured-outlines, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, borrowed-shoes, slideuments, dead-demo, shortchanged, hiccup-words, disowning-your-topic, going-meta, bunker, hecklers, backchannel, laser-weapons, negative-ignorance, dual-headed-monster, tower-of-babble, lipstick-on-a-pig, flyover, nodding-room, golden-rule |
 
 ---
 
@@ -314,10 +319,10 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 
 ## Summary Statistics
 
-- **Total entries:** 109 (82 patterns + 27 antipatterns)
-- **Observable (vault-scorable):** 97 (73 patterns + 24 antipatterns)
+- **Total entries:** 111 (83 patterns + 28 antipatterns)
+- **Observable (vault-scorable):** 99 (74 patterns + 25 antipatterns)
 - **Unobservable (go-live checklist):** 12 (9 patterns + 3 antipatterns)
-- **Prepare phase:** 22 (19 patterns + 3 antipatterns)
+- **Prepare phase:** 24 (20 patterns + 4 antipatterns)
 - **Build phase:** 51 (41 patterns + 10 antipatterns)
 - **Deliver phase:** 36 (22 patterns + 14 antipatterns)
 
@@ -327,4 +332,5 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 - Reynolds, G. (2012). *Presentation Zen: Simple Ideas on Presentation Design and Delivery* (2nd ed.). New Riders. — supplementary source; reinforces ~17 existing patterns and contributes the `opening-punch` and `screen-blackout` patterns plus three refinement subsections folded into existing patterns: "Hara Hachi Bu — The 90–95% Finish Line" (in `breathing-room.md`), "Plan Analog Before Going Digital" (in `concurrent-creation.md`), and "The Elevator Test" (in `the-big-why.md`).
 - Vault-derived patterns — observed across the speaker's own corpus rather than sourced from a book: `delayed-self-introduction`, `three-part-close`, `progressive-reveal`, `anti-sell`, `meme-as-argument`, `second-look`. Mechanism support is cited per-file where a literature basis exists (e.g. `second-look` cites Loewenstein's information-gap account of curiosity); the evidence is field observation.
 - Brown, P. C., Roediger, H. L., III, & McDaniel, M. A. (2014). *Make It Stick: The Science of Successful Learning.* Belknap Press / Harvard University Press. — supplementary source; the catalog's only retention-science source. Contributes three new patterns (`guess-first`, `retrieval-beat`, `spaced-followup`) and one new antipattern (`nodding-room`), plus five refinement subsections folded into existing patterns: "Rehearse by Retrieval, Not Rereading" (in `carnegie-hall.md`), "The Consolidation Pause" (in `brain-breaks.md`), "Learning Styles Are a Myth" (in `know-your-audience.md`), "Smile Sheets Do Not Measure Retention" (in `red-yellow-green.md`), and "Do Not Make It Hard to Read" (in `analog-noise.md`, which corrects a retracted disfluency claim the file previously carried).
+- Herrmann, N., & Herrmann-Nehdi, A. (2015). *The Whole Brain Business Book* (2nd ed.). McGraw-Hill. — supplementary source; contributes `walk-around` and the `golden-rule` antipattern from Ch. 8 (Communicating Across Thinking Styles) and Ch. 13 (Influencing and Getting Buy-In). The catalog imports the four-question Walk-Around procedure and the A/B/C/D quadrant vocabulary as a recognizable handle; it does not import the Whole Brain Model's physiological claims, the HBDI instrument, audience typing, or the book's gender-differences section. See `walk-around.md` Related Reading for the boundary and for the replicable premise (Elaboration Likelihood / need for cognition) the pattern actually rests on.
 - Duarte, N. (2010). *Resonate: Present Visual Stories that Transform Audiences.* Wiley. — supplementary source; reinforces ~20 existing patterns and contributes seven new build-phase patterns (`sparkline`, `call-to-adventure`, `call-to-action`, `new-bliss`, `star-moment`, `inoculation`, `master-story`) plus six refinement subsections folded into existing patterns: "Adopting the Stance — Planning Implications" (in `mentor.md`), "The Big Idea — Statement Format" (in `the-big-why.md`), "Numerical Narrative — Making Numbers Land" (in `vacation-photos.md`), "Screening with Critics — Beyond Copyediting" (in `peer-review.md`), "Murder Your Darlings — The Pre-Delivery Cut Pass" (in `crucible.md`), and "The Three Contrast Types — Engine of the Middle" (in `sparkline.md`).

--- a/skills/presentation-creator/references/patterns/prepare/_anti_golden-rule.md
+++ b/skills/presentation-creator/references/patterns/prepare/_anti_golden-rule.md
@@ -1,0 +1,84 @@
+---
+id: golden-rule
+name: The Golden Rule
+type: antipattern
+part: prepare
+phase_relevance:
+  - guardrails
+vault_dimensions: [4, 9, 14]
+detection_signals:
+  - "every claim defended in the speaker's single preferred register"
+  - "talk mirrors the speaker's own thinking style rather than the room's spread"
+  - "human-consequence or mechanism questions never answered because the speaker never asks them"
+  - "speaker's stated reason for believing the claim is the only reason offered"
+related_patterns: [walk-around, know-your-audience, leet-grammars, crucible]
+inverse_of: [walk-around]
+difficulty: intermediate
+---
+
+# The Golden Rule
+
+## Summary
+Building the talk you would want to receive. The speaker defends every claim in the register they personally find convincing, mistakes their own satisfaction for the room's, and delivers a talk that lands hard with the fraction of the audience who thinks like them and glances off everyone else.
+
+## The Antipattern in Detail
+Do unto others as you would have them do unto you is excellent ethics and poor audience analysis. Applied to a talk it produces a speaker who gives the audience what *they* would want in that seat — which is a reliable guide only if the audience is a room full of the speaker.
+
+The mechanism is invisible from the inside, which is what makes this worth naming. A speaker does not choose their default register; it is simply the kind of reason that feels like a reason to them. The benchmark-minded speaker builds a talk of benchmarks and finds it airtight, because for them a benchmark *is* airtight. They are not neglecting the human-consequence question out of contempt. They are neglecting it because it never occurred to them to ask, and the talk feels complete without it. Every re-read confirms the feeling: the talk answers all the questions the author has.
+
+Herrmann's counter is the Platinum Rule — treat others as *they* want to be treated — and the gap between the two rules is the whole antipattern. The Golden Rule speaker projects; the Platinum Rule speaker models.
+
+The tell in the wild is uniformity of defense. Watch a talk and ask what *kind* of thing gets offered every time a claim needs support:
+
+- **All numbers.** Every point lands on a benchmark, a chart, a p99. The room learns the thing is fast and never learns what it is like to operate, who it disrupts, or why it matters next year.
+- **All story.** Every point lands on an anecdote. The room is charmed and cannot evaluate the claim, because no one has been given a number, and the engineers in row four have quietly filed the whole talk under marketing.
+- **All architecture.** Every point lands on a diagram of how it fits together. Nobody has been told what it costs or who has to migrate.
+- **All process.** Every point lands on a sequence of steps. The room knows exactly how to do a thing nobody has argued is worth doing.
+
+Each version has a constituency that loves it, which is the trap: the Golden Rule talk gets warm feedback from the subset of the room that shares the speaker's register, and that feedback reads as success. This is the same measurement failure `red-yellow-green.md` describes — the people who fill in the green card are disproportionately the ones you were already speaking to.
+
+**The severity scales with the stakes.** For a talk meant to be admired, one register is a stylistic limitation. For a talk meant to get something *adopted*, it is usually fatal, and it fails in a predictable direction: technical speakers cut the mechanism and human-consequence answers first, and those are precisely the two an organization needs before it will adopt anything. The idea does not die in the room. It dies three weeks later, when someone asks who has to retrain the team and nobody has an answer.
+
+## How It Manifests
+- **The confident claim.** The point the speaker considers self-evident gets the thinnest support, in exactly one register. Confidence marks the spot where the default went unexamined.
+- **Projected Q&A prep.** The speaker rehearses answers to the questions *they* would ask, then gets blindsided by the question the room actually asks — usually the C question, about who this hurts.
+- **The mirrored reviewer.** Feedback sought from a colleague with the same background as the speaker, who finds the talk complete. Two people sharing a blind spot confirm each other.
+- **"They're all engineers."** Homogeneity asserted from job titles and never verified — see `walk-around.md`'s coverage-or-match discussion. A room of engineers still contains the person who wants to know who gets paged.
+- **The one-register close.** The summary reprises the same kind of evidence the talk ran on throughout, since it never occurred to the speaker there was another kind.
+
+## How to Avoid It
+Run `walk-around.md` on the load-bearing claims — it is the direct antidote, and it is mechanical precisely so it does not depend on the judgment this antipattern has already compromised.
+
+Start with the claim you are surest of.
+
+Get a reviewer who does *not* share your background, and ask them for the question the talk fails to answer rather than for their opinion of it. A reviewer who finds nothing missing is either a confirmation of the work or a mirror; the way to tell is whether they think in your register.
+
+Read the room's spread before assuming it is homogeneous. Matching a homogeneous room is legitimate and often correct — but that decision has to be made from evidence, not from the comfort of already being fluent in the register you were going to use anyway.
+
+## Detection Heuristics
+The vault detects this by register uniformity across the talk's defended claims:
+- Every load-bearing claim supported by the same *kind* of evidence — all quantitative, all anecdotal, all structural, all procedural
+- Entire archetypes absent: no numbers anywhere, or no human consequence anywhere, across a talk long enough that the absence is a choice
+- Q&A clustering: multiple audience questions attacking the same missing register is the strongest available signal, since the room is telling the speaker directly which question the talk skipped
+- Speaker language that projects rather than models — "obviously the interesting part here is…", "the thing you really care about is…" — where the stated interest matches the speaker's own register
+- Counter-signal: a homogeneous room deliberately matched, with evidence the speaker considered the alternatives. That is `walk-around`'s match mode, not this antipattern. The distinguishing question is whether the single register was *chosen* or *defaulted into*
+
+Do not flag a short talk for thin coverage — a lightning talk has room for one register and choosing it is correct. The flag needs a talk long enough that the missing archetypes are an omission rather than a budget.
+
+## Scoring Criteria
+- Strong signal (2 pts — antipattern present): Every load-bearing claim in a full-length talk defended in a single register; at least one archetype wholly absent; ideally corroborated by Q&A clustering on the gap or by projecting language
+- Moderate signal (1 pt): Two registers present but heavily lopsided, with a conspicuous archetype missing on the talk's central claim
+- Absent (0 pts): Claims defended across multiple registers, or a homogeneous room matched with evident deliberation
+
+## Relationship to Vault Dimensions
+Relates to Dimension 4 (Audience Interaction) — the antipattern is a failure of audience modeling, with the speaker's own preferences substituted for the room's. Relates to Dimension 9 (Persuasion Techniques), since it determines what the talk offers as proof and to whom that proof is legible. Relates to Dimension 14 (Areas for Improvement), where it belongs with `_anti_nodding-room.md` in the category of failures that draw good feedback: both are talks a subset of the room genuinely enjoys, which is exactly why neither gets corrected.
+
+## Combinatorics
+The direct inverse is `walk-around` — this antipattern is its null case, and a single walked-around claim is the minimum refutation.
+
+It is adjacent to but distinct from `_anti_tower-of-babble.md` (incomprehensible jargon — the Golden Rule talk can be perfectly comprehensible and still answer only one of four questions) and from `_anti_flyover.md` (contempt for the audience — the Golden Rule speaker respects the room and is generous toward it, and that is the point: this failure requires no bad intent). It shares its feedback-blindness with `_anti_nodding-room.md`: both antipatterns are rewarded by the instruments speakers actually have.
+
+`know-your-audience` is the upstream dependency — the spread read that would have exposed the projection. `crucible` fixes this only if the feedback it consumes comes from outside the speaker's register; fed mirrored feedback, it optimizes the talk deeper into the antipattern.
+
+## Related Reading
+- Herrmann, N., & Herrmann-Nehdi, A. (2015). *The Whole Brain Business Book* (2nd ed.). McGraw-Hill. Ch. 13 — the Golden Rule / Platinum Rule contrast (attributed to Tony Alessandra) and the pharmaceutical-rep story, in which seven years of clinical data failed on a physician who turned out to be moved by possibility rather than evidence. Ch. 8 — the Walter/John dialogue, a sustained worked example of two competent people failing to communicate while each defends in their own register. The catalog imports the projection failure, not the book's underlying model — see `walk-around.md` Related Reading.

--- a/skills/presentation-creator/references/patterns/prepare/walk-around.md
+++ b/skills/presentation-creator/references/patterns/prepare/walk-around.md
@@ -1,0 +1,90 @@
+---
+id: walk-around
+name: Walk-Around
+type: pattern
+part: prepare
+phase_relevance:
+  - architecture
+  - content
+  - guardrails
+vault_dimensions: [4, 9]
+detection_signals:
+  - "each major claim answers precision, process, impact, and implication questions"
+  - "talk supplies numbers, mechanism, human consequence, and long-range framing for the same point"
+  - "evidence register matched to a homogeneous room rather than spread across four"
+  - "counter-signal: every claim defended in one register only"
+related_patterns: [know-your-audience, inoculation, leet-grammars, crucible, peer-review, concrete-before-abstract]
+inverse_of: [golden-rule]
+difficulty: intermediate
+---
+
+# Walk-Around
+
+## Summary
+Take each load-bearing claim and walk it around four standing questions — *what exactly?*, *how does it work?*, *who does it hit?*, *where does it lead?* — then revise until the talk answers all four. Any room large enough to be interesting contains all four questions, and a claim defended in one register only lands with the fraction of the room that speaks it.
+
+## The Pattern in Detail
+Every speaker has a default register. Ask a data-minded engineer why their approach is right and you get a benchmark; ask a designer and you get a story about a user; ask an architect and you get a diagram of where it all leads. Each answer is correct and each is *partial*, and the speaker rarely notices the partiality — the register they reach for is the one they find convincing, so a talk built entirely in it feels complete from the inside.
+
+It is not complete from the outside. A conference room holds people who want to know the number, people who want to know the sequence, people who want to know who gets hurt, and people who want to know what it means in five years. Give them one of the four and three-quarters of the room is politely waiting for their question to be answered. They will not raise a hand about it. They will conclude the talk was fine and forget it.
+
+The Walk-Around is a preparation audit borrowed from Ned Herrmann's Whole Brain Communication Walk-Around. Herrmann labels the four as quadrants — **A** (Analyzer), **B** (Organizer), **C** (Personalizer), **D** (Strategizer) — and the labels are worth keeping because a chunk of any business audience has met them. What this catalog imports is the *procedure*, not the psychology:
+
+- **A — "What exactly, and how do you know?"** Precision and evidence. The number, its units, its source, its error bars. The claim "we made it faster" fails here; "p99 dropped from 800ms to 120ms across three months of production traffic" passes.
+- **B — "How does it work, in what order?"** Mechanism and sequence. What happens first, what depends on what, what the steps actually are. The room that asks this is not slow; it is the room that will have to implement the thing on Monday.
+- **C — "Who does this affect, and how will it land?"** Human consequence. Whose job changes, who has to be retrained, who is going to hate this, what it feels like to be on the receiving end. Technical talks skip this question almost universally, and it is the one that decides whether the idea survives contact with an organization.
+- **D — "Where does this lead, and what does it connect to?"** Implication and frame. Why this matters beyond the immediate case, what it composes with, what it means in three years.
+
+Herrmann's own worked example is a one-sentence corporate statement — *"it is our strategic intent to double this business in the next five years"* — walked around four ways. **A** asks *double what — revenue, headcount, profit?* **B** asks *with what reorganization?* **C** asks *does this mean doubling everyone's workload?* **D** asks *and then what, is there a plan past year five?* Four questions, one sentence, and the sentence was ambiguous on all four. The revised version answers each. The procedure is mechanical and that is its whole value: it does not depend on the author's judgment about which questions matter, which is precisely the judgment their default register has already corrupted.
+
+**The vocabulary is a handle, not a theory.** Nobody *is* a quadrant. This catalog does not import Herrmann's brain model, his physiological grounding, or the HBDI instrument — and `know-your-audience.md`'s "Learning Styles Are a Myth" applies here with full force. The Walk-Around is not the meshing hypothesis and must not be mistaken for it: meshing says *identify a person's style and tailor delivery to it*, which has no evidential support. The Walk-Around says *assume the room is heterogeneous and cover everything*, which identifies nobody and tailors to no one. Coverage and matching are opposite moves, and only the second one was ever debunked. What the pattern needs to be true is that audiences differ in what evidence persuades them — which is uncontroversial, well-supported, and old enough that Aristotle divided it into ethos, pathos, and logos.
+
+### Coverage or Match — Read the Room's Spread First
+Herrmann's book contains a contradiction worth resolving before applying it, because the two halves prescribe opposite things.
+
+Ch. 8 says cover all four quadrants for every significant point. Ch. 13 tells the story of a Whole Brain leadership program taught to engineering faculty at MIT, CMU, and Berkeley, where the model was introduced as a colorful, metaphor-driven visual — and the audience rejected it. As the facilitator put it, the walls went up: they read a metaphor literally, analyzed it as a claim, and found it wanting. Re-introducing the identical model as *"a first-order engineering approximation to mental diversity"* changed the response dramatically. That is not coverage. That is *matching* — same content, re-registered.
+
+Both are right, and the discriminator is the room's spread:
+
+- **Heterogeneous room** — a conference keynote, an all-hands, a mixed-seniority audience. Cover. You cannot know who is out there, so answer all four questions and let each person find theirs.
+- **Homogeneous room** — one engineering team, a board, a room of clinicians. Match. Spending airtime on registers nobody in the room uses is airtime stolen from the register everyone uses. A room of engineers does not need the metaphor softened for them; it needs the claim stated as an approximation with stated error.
+
+The failure mode of matching is the more dangerous of the two, since homogeneity is usually assumed rather than verified. "They're all engineers" is a statement about job titles, not about what persuades them, and the engineer who asks *who does this affect* exists in quantity. Verify the spread through `know-your-audience` before betting the talk on it; when in doubt, cover.
+
+Note what the MIT move is *not*. It is not `leet-grammars` — the facilitators did not change their vocabulary, they changed the epistemic form of the argument, from metaphor to approximation. A speaker can deploy flawless insider jargon and still lose a room by offering the wrong *kind* of justification.
+
+## When to Use / When to Avoid
+Run the Walk-Around during architecture and again during content, on the talk's load-bearing claims only. It is an audit, not a template: a talk that answers all four questions about all twenty of its claims is a talk nobody has time to sit through. Three or four claims carry a talk; walk those around.
+
+Use it hardest on the claim you are most confident about, since confidence is the tell for default-register blindness — the claim that needs no defense is the one you have only ever defended one way.
+
+Use it in any talk aimed at getting something adopted rather than admired. Adoption requires the B and C answers (how does it work, who does it disrupt), and those are the two that technical speakers cut first.
+
+Avoid mechanical application to every sentence; the Walk-Around is a filter for the claims that matter. Avoid it as an audience-typing exercise — the moment it turns into "the C-quadrant people in the back need a story," it has become the meshing hypothesis with extra steps and should be stopped. Avoid the coverage form in a genuinely homogeneous room, where it dilutes.
+
+## Detection Heuristics
+The vault should look for register spread across a claim's defense, not for the vocabulary:
+- A load-bearing claim supported by a number *and* a mechanism *and* a human consequence *and* a forward implication, rather than by one of the four repeated
+- Explicit answers to the unasked questions: "you're probably wondering what this costs" (A), "here's the order you'd actually do this in" (B), "this means your on-call rotation changes" (C), "and in three years this is table stakes" (D)
+- Q&A evidence: questions from the floor that the talk already answered indicate coverage; a cluster of questions all attacking the same missing register indicates a gap the speaker did not see
+- Register matching: a homogeneous room addressed in its own dominant register throughout, with the other three deliberately thin
+- Counter-signal: every claim in the talk defended the same way. A talk that is all benchmarks, or all anecdote, or all architecture diagram, is running one register and has not been walked around — score it under `_anti_golden-rule.md`
+
+## Scoring Criteria
+- Strong signal (2 pts): The talk's major claims are each defended across multiple registers; at least one claim visibly answers all four; the human-consequence and mechanism questions are answered without being asked, which is the rarest evidence of a real audit
+- Moderate signal (1 pt): Claims are defended in two or three registers, or the coverage is uneven — one claim walked around, the rest single-register; or a homogeneous room is matched well without evidence the alternatives were considered
+- Absent (0 pts): Every claim defended in the speaker's single default register; the unasked questions stay unasked and unanswered
+
+## Relationship to Vault Dimensions
+Relates to Dimension 9 (Persuasion Techniques) as the primary axis — the pattern is about what counts as proof to whom, which is a persuasion question rather than a structural one. Relates to Dimension 4 (Audience Interaction) through audience modeling, the same pairing `know-your-audience` carries.
+
+## Combinatorics
+Walk-Around is the systematic counterpart to `inoculation`, and the two are worth holding apart. Inoculation voices *one* objection — the strongest, steel-manned — and answers it on stage as a persuasion move. Walk-Around answers *four standing questions* nobody has voiced yet, and it operates in preparation: it changes what gets built rather than what gets said about opposition. A claim that survives the Walk-Around often needs no inoculation, since the objection inoculation would have addressed was usually a register the talk had simply omitted.
+
+It depends on `know-your-audience` for the spread read that decides coverage-versus-match, and the two compose directly: know-your-audience supplies who is in the room, Walk-Around decides what each of them needs to hear. It is distinct from `leet-grammars` (vocabulary and belonging) — Walk-Around governs the *form of the justification*, not the words.
+
+It pairs with `concrete-before-abstract`, which is frequently the vehicle for the C answer — a human consequence lands as a story, not as a bullet. It feeds `crucible` and `peer-review`: both are review passes, and the Walk-Around gives a reviewer four specific things to look for rather than a general request to find problems. Its direct inverse is `_anti_golden-rule.md` — a talk built entirely in the speaker's own preferred register is the null case of this pattern.
+
+## Related Reading
+- Herrmann, N., & Herrmann-Nehdi, A. (2015). *The Whole Brain Business Book* (2nd ed.). McGraw-Hill. Ch. 8 — "Communicating Across Thinking Styles" contains the Walk-Around procedure and the doubled-revenue worked example; Ch. 13 — "Influencing, Getting Buy-In, and Connecting with Your Customers" contains the MIT/CMU re-registering story. The catalog imports the procedure and the quadrant vocabulary as a recognizable handle. It does not import the Whole Brain Model's physiological claims, the HBDI instrument, or the book's Ch. 8 section on gender-based communication differences, which rests on popular rather than empirical sources.
+- Petty, R. E., & Cacioppo, J. T. — the Elaboration Likelihood Model and the need-for-cognition literature supply the defensible version of the premise this pattern needs: audiences differ in what evidence moves them, and argument quality persuades some listeners where peripheral cues persuade others. No brain-dominance claim is required to justify covering more than one register.

--- a/skills/presentation-creator/references/phase0-intake.md
+++ b/skills/presentation-creator/references/phase0-intake.md
@@ -67,7 +67,7 @@ This is the `walk-around` cover-or-match decision (see `references/patterns/prep
 Two failure modes to head off while the speaker is still answering:
 
 1. **Homogeneity asserted from job titles.** "They're all engineers" describes badges, not what persuades them — the engineer who wants to know who gets paged is in that room. Push once: "what makes you confident they all want the same kind of proof?" Unverified ⇒ `heterogeneous`. Coverage is the safe default; matching is the bet.
-2. **The speaker's own register answering for the room.** The register a speaker reaches for is the one they find convincing, which makes it invisible to them. Ask what kind of evidence *they* would want, note it, and treat it as the register most at risk of crowding out the other three (see `_anti_golden-rule.md`).
+2. **The speaker's own register answering for the room.** The register a speaker reaches for is the one they find convincing, which makes it invisible to them. Ask what kind of evidence *they* would want, note it, and treat it as the register most at risk of crowding out the other three (see `references/patterns/prepare/_anti_golden-rule.md`).
 
 Record the answer in the spec. `check-rhetorical.py` enforces it at Phase 4 — heterogeneous talks must answer all four registers across their declared `walk-around` applications; homogeneous talks must actually answer their declared dominant register. Neither is a judgment the script makes: the agent decides which registers a claim lands, the script checks the union.
 

--- a/skills/presentation-creator/references/phase0-intake.md
+++ b/skills/presentation-creator/references/phase0-intake.md
@@ -69,7 +69,9 @@ Two failure modes to head off while the speaker is still answering:
 1. **Homogeneity asserted from job titles.** "They're all engineers" describes badges, not what persuades them — the engineer who wants to know who gets paged is in that room. Push once: "what makes you confident they all want the same kind of proof?" Unverified ⇒ `heterogeneous`. Coverage is the safe default; matching is the bet.
 2. **The speaker's own register answering for the room.** The register a speaker reaches for is the one they find convincing, which makes it invisible to them. Ask what kind of evidence *they* would want, note it, and treat it as the register most at risk of crowding out the other three (see `references/patterns/prepare/_anti_golden-rule.md`).
 
-Record the answer in the spec. `check-rhetorical.py` enforces it at Phase 4 — heterogeneous talks must answer all four registers across their declared `walk-around` applications; homogeneous talks must actually answer their declared dominant register. Neither is a judgment the script makes: the agent decides which registers a claim lands, the script checks the union.
+Record the answer in the spec. `check-rhetorical.py` enforces the declaration at Phase 4; its decision contract lives in `_check_register_coverage`'s docstring.
+
+What this step owes that check: `talk.audience_spread`, `talk.dominant_register` when the room is homogeneous, and — during Phase 3 — a `registers:` list on each `walk-around` application naming which questions that claim answers. Judging which registers a claim lands is the agent's call; the script only reads what the agent declared.
 
 ### Step 0.5: Report and Advance
 

--- a/skills/presentation-creator/references/phase0-intake.md
+++ b/skills/presentation-creator/references/phase0-intake.md
@@ -53,6 +53,24 @@ This is not just a delivery posture; it shapes every Phase 0–6 decision. Befor
 
 The answer surfaces three things at once: who the hero is, what their current ordinary world looks like, and what the special world (the proposed change) is. If the speaker frames the answer as "I want to talk about X" (presenter-as-hero — your topic at the center), redirect: "What does the audience need to walk away with, that they don't currently have?" The reframe matters because every downstream decision (thesis, structure, examples, asks, visuals) is sized differently depending on whether the speaker is at the center or the audience is.
 
-### Step 0.4: Report and Advance
+### Step 0.4: Read the Audience Spread
+
+Ask a second audience question, and ask it now rather than at review time — it decides what gets built, not just what gets scored:
+
+> "Is this room mixed in what it accepts as proof, or does it all speak one language?"
+
+This is the `walk-around` cover-or-match decision (see `references/patterns/prepare/walk-around.md`), and it sets the required `talk.audience_spread` field.
+
+- **`heterogeneous`** — a conference keynote, an all-hands, a mixed-seniority room. The talk covers all four registers: **A** precision and evidence, **B** process and sequence, **C** human impact, **D** implication. Each register left unanswered is a slice of the room whose question the talk never reaches.
+- **`homogeneous`** — one engineering team, a board, a room of clinicians. The talk matches the room's register, and `talk.dominant_register` names it. Airtime spent on registers nobody in the room uses is stolen from the one everybody uses.
+
+Two failure modes to head off while the speaker is still answering:
+
+1. **Homogeneity asserted from job titles.** "They're all engineers" describes badges, not what persuades them — the engineer who wants to know who gets paged is in that room. Push once: "what makes you confident they all want the same kind of proof?" Unverified ⇒ `heterogeneous`. Coverage is the safe default; matching is the bet.
+2. **The speaker's own register answering for the room.** The register a speaker reaches for is the one they find convincing, which makes it invisible to them. Ask what kind of evidence *they* would want, note it, and treat it as the register most at risk of crowding out the other three (see `_anti_golden-rule.md`).
+
+Record the answer in the spec. `check-rhetorical.py` enforces it at Phase 4 — heterogeneous talks must answer all four registers across their declared `walk-around` applications; homogeneous talks must actually answer their declared dominant register. Neither is a judgment the script makes: the agent decides which registers a claim lands, the script checks the union.
+
+### Step 0.5: Report and Advance
 
 Summarize what you know and what you need.

--- a/skills/presentation-creator/references/phase3-content.md
+++ b/skills/presentation-creator/references/phase3-content.md
@@ -29,6 +29,8 @@ Authored in Phase 1; never re-edited carelessly. Field reference (see
 | `speakers` | yes | List of speaker names; multi-speaker talks force `speaker:` on every script line |
 | `duration_min` | yes | Slot length in minutes |
 | `audience`, `mode`, `venue` | yes | Short prose |
+| `audience_spread` | yes | `heterogeneous` (cover all four registers) or `homogeneous` (match one). Set at intake — see `phase0-intake.md` Step 0.4 and `patterns/prepare/walk-around.md` |
+| `dominant_register` | conditional | `A` \| `B` \| `C` \| `D`. Required iff `audience_spread: homogeneous`; rejected otherwise |
 | `slide_budget` | yes | Integer; expanded build count is validated against this |
 | `pacing_wpm` | yes | `[low, high]` integer tuple |
 | `architecture` | yes | One of: `narrative-arc`, `sparkline`, `fourthought`, `triad`, `talklet`, `expansion-joints`, `lightning-talk`, `takahashi`, `cave-painting` |
@@ -93,6 +95,7 @@ Slides are the deck-facing units; interludes are between-slide events
     - { speaker: "Patrick", line: "..." }               # multi-speaker
   applied_patterns:
     - { id: star-moment, subtype: shocking-statistic }
+    - { id: walk-around, registers: [C, D] }   # which questions this claim answers
   callbacks:
     - { kind: plant, id: receipt-motif }
     - { kind: pay,   id: same-model-same-task, variation: "Same model. Same question." }

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -4,7 +4,7 @@ Phase 4 runs two complementary checkers against `outline.yaml`:
 
 | Script | Surface | Output |
 |--------|---------|--------|
-| `scripts/check-rhetorical.py outline.yaml` | Closed pattern taxonomy — opening PUNCH, big-idea singleton, thesis preview/payoff, sparkline elements, master-story threading, callback ledger, inoculation count, progressive-list contiguity, running gags, duration accounting | `rhetorical-review.md` |
+| `scripts/check-rhetorical.py outline.yaml` | Closed pattern taxonomy — opening PUNCH, big-idea singleton, thesis preview/payoff, sparkline elements, register coverage or match, master-story threading, callback ledger, inoculation count, progressive-list contiguity, running gags, duration accounting | `rhetorical-review.md` |
 | `scripts/guardrail-check.py outline.yaml <speaker-profile.json>` | Profile-aware rules — slide budget, Act 1 ratio, branding, profanity, data attribution, closing completeness, cut-line availability (conditional on `modular_design`) | stdout report |
 
 Anti-pattern frequency from `profile.pattern_profile.antipattern_frequency` and

--- a/skills/presentation-creator/scripts/check-rhetorical.py
+++ b/skills/presentation-creator/scripts/check-rhetorical.py
@@ -297,11 +297,11 @@ def _check_register_coverage(outline: _os.Outline) -> list[CheckResult]:
             f"(covered: {sorted(declared)}). Every register left unanswered is "
             f"a slice of the room whose question the talk never reaches.",
         )]
+    by_register = dict(sorted(declared.items()))
     return [CheckResult(
         "Register coverage",
         "PASS",
-        f"All four registers answered: "
-        f"{ {k: v for k, v in sorted(declared.items())} }",
+        f"All four registers answered: {by_register}",
     )]
 
 

--- a/skills/presentation-creator/scripts/check-rhetorical.py
+++ b/skills/presentation-creator/scripts/check-rhetorical.py
@@ -205,6 +205,77 @@ def _check_sparkline_requirements(outline: _os.Outline) -> list[CheckResult]:
     return out
 
 
+def _check_register_coverage(outline: _os.Outline) -> list[CheckResult]:
+    """Enforce the `walk-around` cover-or-match decision declared at intake.
+
+    - `heterogeneous` — the union of registers declared across every
+      walk-around application must cover all four. A mixed room contains all
+      four questions; leaving one unanswered leaves that slice of the room
+      waiting.
+    - `homogeneous` — the declared `dominant_register` must actually appear
+      among the declared registers. A room matched on paper and not in the
+      talk is matched nowhere.
+
+    Zero walk-around applications is a FLAG on a heterogeneous talk (nothing
+    was audited) and N/A on a homogeneous one (matching needs no audit trail
+    beyond the dominant register, which is checked when walk-arounds exist).
+    """
+    spread = outline.talk.audience_spread
+    declared: dict[str, list[str]] = {}
+    for location, p in _all_applied_patterns(outline):
+        if p.id == "walk-around" and p.registers:
+            for r in p.registers:
+                declared.setdefault(r.value, []).append(location)
+
+    if spread == _os.AudienceSpread.homogeneous:
+        dom = outline.talk.dominant_register
+        assert dom is not None  # schema validator guarantees this
+        if not declared:
+            return [CheckResult(
+                "Register match",
+                "N/A",
+                f"Homogeneous room declared (register `{dom.value}`); no "
+                f"walk-around applications to check.",
+            )]
+        if dom.value not in declared:
+            return [CheckResult(
+                "Register match",
+                "FLAG",
+                f"Room declared homogeneous on register `{dom.value}`, but no "
+                f"walk-around answers it (declared: "
+                f"{sorted(declared)}). Match the room or re-declare the spread.",
+            )]
+        return [CheckResult(
+            "Register match",
+            "PASS",
+            f"Homogeneous room matched on `{dom.value}` at {declared[dom.value]}",
+        )]
+
+    missing = [r.value for r in _os.Register if r.value not in declared]
+    if not declared:
+        return [CheckResult(
+            "Register coverage",
+            "FLAG",
+            "Room declared heterogeneous, but no claim declares a walk-around. "
+            "A mixed room contains all four questions — audit the load-bearing "
+            "claims, or re-declare the spread as homogeneous.",
+        )]
+    if missing:
+        return [CheckResult(
+            "Register coverage",
+            "FLAG",
+            f"Room declared heterogeneous; registers {missing} unanswered "
+            f"(covered: {sorted(declared)}). Every register left unanswered is "
+            f"a slice of the room whose question the talk never reaches.",
+        )]
+    return [CheckResult(
+        "Register coverage",
+        "PASS",
+        f"All four registers answered: "
+        f"{ {k: v for k, v in sorted(declared.items())} }",
+    )]
+
+
 def _check_master_story_threading(outline: _os.Outline) -> CheckResult:
     """Each master-story id must have `introduce` before any `recall-N`,
     and recall indexes should appear in increasing order."""
@@ -415,6 +486,7 @@ def render(outline: _os.Outline) -> tuple[str, int]:
         _check_big_idea(outline),
         _check_thesis_ordering(outline),
         *_check_sparkline_requirements(outline),
+        *_check_register_coverage(outline),
         _check_master_story_threading(outline),
         _check_inoculation_count(outline),
         _check_progressive_lists(outline),

--- a/skills/presentation-creator/scripts/check-rhetorical.py
+++ b/skills/presentation-creator/scripts/check-rhetorical.py
@@ -216,16 +216,34 @@ def _check_register_coverage(outline: _os.Outline) -> list[CheckResult]:
       among the declared registers. A room matched on paper and not in the
       talk is matched nowhere.
 
-    Zero walk-around applications is a FLAG on a heterogeneous talk (nothing
-    was audited) and N/A on a homogeneous one (matching needs no audit trail
-    beyond the dominant register, which is checked when walk-arounds exist).
+    Zero walk-around applications FLAGs under either spread — a declared
+    spread with no audit is an undefended claim, and `N/A` would let a
+    homogeneous talk name a dominant register it never answers.
+
+    A `walk-around` declared without `registers:` also FLAGs, naming the
+    locations, rather than being silently skipped (mirrors
+    `_check_opening_punch`'s treatment of a flavorless `opening-punch`).
     """
     spread = outline.talk.audience_spread
     declared: dict[str, list[str]] = {}
+    unannotated: list[str] = []
     for location, p in _all_applied_patterns(outline):
-        if p.id == "walk-around" and p.registers:
-            for r in p.registers:
-                declared.setdefault(r.value, []).append(location)
+        if p.id != "walk-around":
+            continue
+        if not p.registers:
+            unannotated.append(location)
+            continue
+        for r in p.registers:
+            declared.setdefault(r.value, []).append(location)
+
+    if unannotated:
+        return [CheckResult(
+            "Register coverage",
+            "FLAG",
+            f"`walk-around` declared at {unannotated} with no `registers:` set "
+            f"— name which of {{A, B, C, D}} each claim answers, or the audit "
+            f"cannot be checked.",
+        )]
 
     if spread == _os.AudienceSpread.homogeneous:
         dom = outline.talk.dominant_register
@@ -233,9 +251,12 @@ def _check_register_coverage(outline: _os.Outline) -> list[CheckResult]:
         if not declared:
             return [CheckResult(
                 "Register match",
-                "N/A",
-                f"Homogeneous room declared (register `{dom.value}`); no "
-                f"walk-around applications to check.",
+                "FLAG",
+                f"Room declared homogeneous on register `{dom.value}`, but no "
+                f"claim declares a walk-around answering it. Matching a room "
+                f"is a claim about the talk, not just about the audience — "
+                f"answer `{dom.value}` on the load-bearing claims, or "
+                f"re-declare the spread as heterogeneous.",
             )]
         if dom.value not in declared:
             return [CheckResult(

--- a/skills/presentation-creator/scripts/check-rhetorical.py
+++ b/skills/presentation-creator/scripts/check-rhetorical.py
@@ -236,9 +236,17 @@ def _check_register_coverage(outline: _os.Outline) -> list[CheckResult]:
         for r in p.registers:
             declared.setdefault(r.value, []).append(location)
 
+    # Label tracks the spread so the section header stays stable for readers
+    # and for anything parsing the report.
+    label = (
+        "Register match"
+        if spread == _os.AudienceSpread.homogeneous
+        else "Register coverage"
+    )
+
     if unannotated:
         return [CheckResult(
-            "Register coverage",
+            label,
             "FLAG",
             f"`walk-around` declared at {unannotated} with no `registers:` set "
             f"— name which of {{A, B, C, D}} each claim answers, or the audit "

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -85,6 +85,31 @@ ARCHITECTURE_IDS: frozenset[str] = frozenset({
 # ── Closed enums for instance metadata ───────────────────────────────
 
 
+class AudienceSpread(str, Enum):
+    """Whether the room is mixed in what it accepts as proof.
+
+    Drives `walk-around`'s cover-or-match decision. Homogeneity is a claim
+    about what persuades the room, never about job titles.
+    """
+
+    heterogeneous = "heterogeneous"
+    homogeneous = "homogeneous"
+
+
+class Register(str, Enum):
+    """The four question archetypes a `walk-around` answers.
+
+    Herrmann's quadrant letters, kept as a recognizable handle. These name
+    kinds of question, never kinds of person — see
+    `references/patterns/prepare/walk-around.md`.
+    """
+
+    a_precision = "A"  # what exactly, and how do you know?
+    b_process = "B"  # how does it work, in what order?
+    c_impact = "C"  # who does this affect, and how will it land?
+    d_implication = "D"  # where does this lead, what does it connect to?
+
+
 class PunchFlavor(str, Enum):
     personal = "personal"
     unexpected = "unexpected"
@@ -122,7 +147,10 @@ class SlideFormat(str, Enum):
     img_txt = "IMG+TXT"
     exception = "EXCEPTION"
     demo = "DEMO"
-    title = "TITLE"
+    # Enum members shadow inherited str methods by design — `SlideFormat.title`
+    # resolves to the member, never to `str.title`. The assignment-type finding
+    # is a false positive on every str-Enum member named after a str method.
+    title = "TITLE"  # pyright: ignore[reportAssignmentType]
 
 
 class Composition(str, Enum):
@@ -169,11 +197,13 @@ _PATTERN_INSTANCE_FIELDS: dict[str, frozenset[str]] = {
     "foreshadowing": frozenset({"plant_id"}),
     "call-to-adventure": frozenset({"big_idea_text"}),
     "call-to-action": frozenset({"asks"}),
+    "walk-around": frozenset({"registers"}),
 }
 
 _ALL_INSTANCE_FIELDS: frozenset[str] = frozenset({
     "flavors", "subtype", "resistance_vector",
     "story_id", "beat", "plant_id", "big_idea_text", "asks",
+    "registers",
 })
 
 
@@ -189,6 +219,10 @@ class AppliedPattern(_StrictModel):
     plant_id: str | None = None
     big_idea_text: str | None = None
     asks: dict[AudienceTemperament, str] | None = None
+    # Which of the four question archetypes this walk-around application
+    # answers. The agent judges which registers a claim actually lands;
+    # check-rhetorical.py checks the union across the talk.
+    registers: list[Register] | None = Field(default=None, min_length=1)
 
     @field_validator("id")
     @classmethod
@@ -363,12 +397,39 @@ class TalkMetadata(_StrictModel):
     speakers: list[str] = Field(min_length=1)
     duration_min: float = Field(gt=0)
     audience: str
+    # Whether the room is mixed in what it accepts as proof, or uniform.
+    # Drives the `walk-around` cover-or-match decision: a heterogeneous room
+    # gets all four registers, a homogeneous one gets its own. Declared at
+    # intake so the choice is made deliberately rather than defaulted into.
+    audience_spread: AudienceSpread
+    # Which register a homogeneous room speaks. Required iff the room is
+    # homogeneous; forbidden otherwise (there is no single register to name
+    # for a mixed room).
+    dominant_register: Register | None = None
     mode: str
     venue: str
     slide_budget: int = Field(gt=0)
     pacing_wpm: tuple[int, int]
     architecture: str
     applied_patterns: list[AppliedPattern] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _register_matches_spread(self) -> "TalkMetadata":
+        if self.audience_spread == AudienceSpread.homogeneous:
+            if self.dominant_register is None:
+                raise ValueError(
+                    "audience_spread 'homogeneous' requires 'dominant_register' "
+                    "(A=precision/evidence, B=process/sequence, C=human impact, "
+                    "D=implication) — name the register the room speaks, or set "
+                    "audience_spread to 'heterogeneous' and cover all four",
+                )
+        elif self.dominant_register is not None:
+            raise ValueError(
+                "audience_spread 'heterogeneous' does not accept "
+                "'dominant_register' — a mixed room has no single register; "
+                "cover all four via walk-around instead",
+            )
+        return self
 
     # Spec metadata (collapsed from the legacy presentation-spec.md).
     # All optional — older outlines without these fields still validate.

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -415,18 +415,21 @@ class TalkMetadata(_StrictModel):
 
     @model_validator(mode="after")
     def _walk_around_is_per_claim(self) -> "TalkMetadata":
-        """`walk-around` audits a claim, and claims live on slides.
+        """`walk-around` audits a claim, and a claim has a location.
 
-        A talk-level application is a blanket assertion that the talk answers
-        a register somewhere, with nothing to check it against — the
-        unfalsifiable shape the audit exists to prevent.
+        Slides and interludes both carry claims and are individually
+        checkable — a live demo answering "how does it work in what order"
+        is a B answer no slide can match. Talk level carries no claim: it
+        asserts that the talk answers a register somewhere, with nothing to
+        check it against, which is the unfalsifiable shape the audit exists
+        to prevent.
         """
         if any(p.id == "walk-around" for p in self.applied_patterns):
             raise ValueError(
                 "`walk-around` is a per-claim audit and cannot be declared at "
-                "talk level — attach it to the slides carrying the "
-                "load-bearing claims, with `registers:` naming what each one "
-                "answers",
+                "talk level — attach it to the slides or interludes carrying "
+                "the load-bearing claims, with `registers:` naming what each "
+                "one answers",
             )
         return self
 

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -414,6 +414,23 @@ class TalkMetadata(_StrictModel):
     applied_patterns: list[AppliedPattern] = Field(default_factory=list)
 
     @model_validator(mode="after")
+    def _walk_around_is_per_claim(self) -> "TalkMetadata":
+        """`walk-around` audits a claim, and claims live on slides.
+
+        A talk-level application is a blanket assertion that the talk answers
+        a register somewhere, with nothing to check it against — the
+        unfalsifiable shape the audit exists to prevent.
+        """
+        if any(p.id == "walk-around" for p in self.applied_patterns):
+            raise ValueError(
+                "`walk-around` is a per-claim audit and cannot be declared at "
+                "talk level — attach it to the slides carrying the "
+                "load-bearing claims, with `registers:` naming what each one "
+                "answers",
+            )
+        return self
+
+    @model_validator(mode="after")
     def _register_matches_spread(self) -> "TalkMetadata":
         if self.audience_spread == AudienceSpread.homogeneous:
             if self.dominant_register is None:

--- a/tests/fixtures/outline-example.yaml
+++ b/tests/fixtures/outline-example.yaml
@@ -4,7 +4,8 @@
 # builds expansion, EXCEPTION format with justification, opening-punch
 # with flavors, sparkline architecture with all four required patterns,
 # foreshadowing plant + payoff via callbacks, big-idea singleton,
-# master-story across two chapters, inoculation with resistance vector.
+# master-story across two chapters, inoculation with resistance vector,
+# heterogeneous audience walked around all four registers (A+B, then C+D).
 
 talk:
   title: "Demo Talk"
@@ -12,6 +13,7 @@ talk:
   speakers: ["Speaker One"]
   duration_min: 30
   audience: "Senior engineers"
+  audience_spread: "heterogeneous"
   mode: "keynote"
   venue: "DemoConf 2026"
   slide_budget: 20
@@ -157,6 +159,8 @@ slides:
     applied_patterns:
       - id: call-to-adventure
         big_idea_text: "Treat context as an engineering artifact."
+      - id: walk-around
+        registers: [A, B]
     big_idea: true
     thesis: preview
 
@@ -172,6 +176,8 @@ slides:
     callbacks:
       - { kind: pay, id: receipt-motif, variation: "Revealed in full" }
     applied_patterns:
+      - id: walk-around
+        registers: [C, D]
       - id: star-moment
         subtype: shocking-statistic
       - id: inoculation

--- a/tests/test_narrative_rhetorical.py
+++ b/tests/test_narrative_rhetorical.py
@@ -205,6 +205,85 @@ def test_rhetorical_passes_opening_punch(check_rhetorical, outline):
     assert "### Opening PUNCH — ✅ **PASS**" in content
 
 
+# ── check-rhetorical.py — register coverage (walk-around) ────────────
+
+
+def _outline_from(outline_schema, base_data, mutate):
+    data = copy.deepcopy(base_data)
+    mutate(data)
+    return outline_schema.Outline.model_validate(data)
+
+
+def test_register_coverage_passes_when_all_four_answered(
+    check_rhetorical, outline,
+):
+    content, flag_count = check_rhetorical.render(outline)
+    assert "### Register coverage — ✅ **PASS**" in content
+    assert flag_count == 0
+
+
+def test_register_coverage_flags_missing_register(
+    check_rhetorical, outline_schema, base_data,
+):
+    """Dropping the C+D walk-around leaves a heterogeneous room half-answered."""
+    def mutate(data):
+        for slide in data["slides"]:
+            slide["applied_patterns"] = [
+                p for p in slide.get("applied_patterns", [])
+                if p.get("id") != "walk-around" or p.get("registers") != ["C", "D"]
+            ]
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, flag_count = check_rhetorical.render(o)
+    assert "Register coverage" in content
+    assert "['C', 'D'] unanswered" in content
+    assert flag_count >= 1
+
+
+def test_register_coverage_flags_heterogeneous_with_no_walk_around(
+    check_rhetorical, outline_schema, base_data,
+):
+    def mutate(data):
+        for slide in data["slides"]:
+            slide["applied_patterns"] = [
+                p for p in slide.get("applied_patterns", [])
+                if p.get("id") != "walk-around"
+            ]
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, flag_count = check_rhetorical.render(o)
+    assert "no claim declares a walk-around" in content
+    assert flag_count >= 1
+
+
+def test_register_match_flags_unmatched_homogeneous_room(
+    check_rhetorical, outline_schema, base_data,
+):
+    """A room declared homogeneous on C, with no walk-around answering C."""
+    def mutate(data):
+        data["talk"]["audience_spread"] = "homogeneous"
+        data["talk"]["dominant_register"] = "C"
+        for slide in data["slides"]:
+            slide["applied_patterns"] = [
+                p for p in slide.get("applied_patterns", [])
+                if p.get("id") != "walk-around" or p.get("registers") != ["C", "D"]
+            ]
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, flag_count = check_rhetorical.render(o)
+    assert "Register match" in content
+    assert "no walk-around answers it" in content
+    assert flag_count >= 1
+
+
+def test_register_match_passes_when_dominant_answered(
+    check_rhetorical, outline_schema, base_data,
+):
+    def mutate(data):
+        data["talk"]["audience_spread"] = "homogeneous"
+        data["talk"]["dominant_register"] = "C"
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, _ = check_rhetorical.render(o)
+    assert "### Register match — ✅ **PASS**" in content
+
+
 def test_rhetorical_reports_big_idea_location(check_rhetorical, outline):
     content, _ = check_rhetorical.render(outline)
     # Fixture has big_idea on slide 5 (Call to Adventure)

--- a/tests/test_narrative_rhetorical.py
+++ b/tests/test_narrative_rhetorical.py
@@ -323,6 +323,57 @@ def test_register_coverage_flags_walk_around_without_registers(
     assert flag_count >= 1
 
 
+def test_register_coverage_counts_interlude_walk_around(
+    check_rhetorical, outline_schema, base_data,
+):
+    """An interlude is a located, claim-bearing unit — its walk-around counts.
+
+    A live demo answering "how does it work, in what order" is a B answer no
+    slide can match. Only talk-level (which has no claim to locate) is barred.
+    """
+    def mutate(data):
+        # Drop the slide-level C+D audit, and answer C+D from a demo instead.
+        for slide in data["slides"]:
+            slide["applied_patterns"] = [
+                p for p in slide.get("applied_patterns", [])
+                if p.get("id") != "walk-around" or p.get("registers") != ["C", "D"]
+            ]
+        data["interludes"] = [{
+            "id": "demo-migration",
+            "after_slide": 8,
+            "title": "Live: migrating a service",
+            "chapter": "ch2",
+            "script": [{"line": "Watch who has to be paged."}],
+            "applied_patterns": [{"id": "walk-around", "registers": ["C", "D"]}],
+        }]
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, flag_count = check_rhetorical.render(o)
+    assert "### Register coverage — ✅ **PASS**" in content
+    assert "interlude demo-migration" in content
+    assert flag_count == 0
+
+
+def test_unannotated_walk_around_label_tracks_spread(
+    check_rhetorical, outline_schema, base_data,
+):
+    """The section header must stay 'Register match' for a homogeneous room.
+
+    A homogeneous run that emits 'Register coverage' breaks the header any
+    reader — or downstream parse — keys on.
+    """
+    def mutate(data):
+        data["talk"]["audience_spread"] = "homogeneous"
+        data["talk"]["dominant_register"] = "A"
+        for slide in data["slides"]:
+            for p in slide.get("applied_patterns", []):
+                if p.get("id") == "walk-around":
+                    p.pop("registers", None)
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, _ = check_rhetorical.render(o)
+    assert "### Register match — ⚠️" in content
+    assert "### Register coverage" not in content
+
+
 def test_register_coverage_flags_unannotated_before_absent(
     check_rhetorical, outline_schema, base_data,
 ):

--- a/tests/test_narrative_rhetorical.py
+++ b/tests/test_narrative_rhetorical.py
@@ -284,6 +284,65 @@ def test_register_match_passes_when_dominant_answered(
     assert "### Register match — ✅ **PASS**" in content
 
 
+def test_register_match_flags_homogeneous_with_zero_walk_arounds(
+    check_rhetorical, outline_schema, base_data,
+):
+    """A homogeneous room with no audit at all must not pass as N/A.
+
+    Declaring `dominant_register: C` and supplying no register evidence is an
+    unanswered claim, not an inapplicable check.
+    """
+    def mutate(data):
+        data["talk"]["audience_spread"] = "homogeneous"
+        data["talk"]["dominant_register"] = "C"
+        for slide in data["slides"]:
+            slide["applied_patterns"] = [
+                p for p in slide.get("applied_patterns", [])
+                if p.get("id") != "walk-around"
+            ]
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, flag_count = check_rhetorical.render(o)
+    assert "Register match — ⚠️" in content
+    assert "no claim declares a walk-around answering it" in content
+    assert flag_count >= 1
+    assert "N/A" not in content.split("### Register match")[1].split("###")[0]
+
+
+def test_register_coverage_flags_walk_around_without_registers(
+    check_rhetorical, outline_schema, base_data,
+):
+    """A walk-around with no `registers:` is unverifiable, not absent."""
+    def mutate(data):
+        for slide in data["slides"]:
+            for p in slide.get("applied_patterns", []):
+                if p.get("id") == "walk-around":
+                    p.pop("registers", None)
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, flag_count = check_rhetorical.render(o)
+    assert "no `registers:` set" in content
+    assert flag_count >= 1
+
+
+def test_register_coverage_flags_unannotated_before_absent(
+    check_rhetorical, outline_schema, base_data,
+):
+    """The unannotated message must win over 'no claim declares a walk-around'.
+
+    Reporting an unannotated walk-around as absent misdescribes the outline.
+    """
+    def mutate(data):
+        data["talk"]["audience_spread"] = "homogeneous"
+        data["talk"]["dominant_register"] = "A"
+        for slide in data["slides"]:
+            for p in slide.get("applied_patterns", []):
+                if p.get("id") == "walk-around":
+                    p.pop("registers", None)
+    o = _outline_from(outline_schema, base_data, mutate)
+    content, _ = check_rhetorical.render(o)
+    assert "no `registers:` set" in content
+    assert "no claim declares a walk-around" not in content
+
+
 def test_rhetorical_reports_big_idea_location(check_rhetorical, outline):
     content, _ = check_rhetorical.render(outline)
     # Fixture has big_idea on slide 5 (Call to Adventure)

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -90,6 +90,16 @@ def test_rejects_unknown_register(outline_schema, base_data):
         outline_schema.Outline.model_validate(data)
 
 
+def test_walk_around_rejected_at_talk_level(outline_schema, base_data):
+    """A talk-level walk-around would satisfy coverage with no per-claim evidence."""
+    data = copy.deepcopy(base_data)
+    data["talk"]["applied_patterns"].append(
+        {"id": "walk-around", "registers": ["A", "B", "C", "D"]},
+    )
+    with pytest.raises(ValidationError, match="per-claim"):
+        outline_schema.Outline.model_validate(data)
+
+
 def test_registers_rejected_on_other_patterns(outline_schema, base_data):
     """`registers` is walk-around's instance metadata — no other pattern takes it."""
     data = copy.deepcopy(base_data)

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -41,6 +41,65 @@ def test_pattern_enum_discovered(outline_schema):
     assert "slideuments" in outline_schema.ANTIPATTERN_IDS
 
 
+# ── Audience spread / register (walk-around) ─────────────────────────
+
+
+def test_homogeneous_requires_dominant_register(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    data["talk"]["audience_spread"] = "homogeneous"
+    with pytest.raises(ValidationError, match="dominant_register"):
+        outline_schema.Outline.model_validate(data)
+
+
+def test_heterogeneous_rejects_dominant_register(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    data["talk"]["audience_spread"] = "heterogeneous"
+    data["talk"]["dominant_register"] = "A"
+    with pytest.raises(ValidationError, match="dominant_register"):
+        outline_schema.Outline.model_validate(data)
+
+
+def test_homogeneous_with_register_validates(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    data["talk"]["audience_spread"] = "homogeneous"
+    data["talk"]["dominant_register"] = "A"
+    outline = outline_schema.Outline.model_validate(data)
+    assert outline.talk.dominant_register.value == "A"
+
+
+def test_rejects_unknown_audience_spread(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    data["talk"]["audience_spread"] = "mostly-engineers"
+    with pytest.raises(ValidationError, match="audience_spread"):
+        outline_schema.Outline.model_validate(data)
+
+
+def test_audience_spread_is_required(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    del data["talk"]["audience_spread"]
+    with pytest.raises(ValidationError, match="audience_spread"):
+        outline_schema.Outline.model_validate(data)
+
+
+def test_rejects_unknown_register(outline_schema, base_data):
+    data = copy.deepcopy(base_data)
+    data["talk"]["applied_patterns"].append(
+        {"id": "walk-around", "registers": ["E"]},
+    )
+    with pytest.raises(ValidationError, match="registers"):
+        outline_schema.Outline.model_validate(data)
+
+
+def test_registers_rejected_on_other_patterns(outline_schema, base_data):
+    """`registers` is walk-around's instance metadata — no other pattern takes it."""
+    data = copy.deepcopy(base_data)
+    data["talk"]["applied_patterns"].append(
+        {"id": "mentor", "registers": ["A"]},
+    )
+    with pytest.raises(ValidationError, match="registers"):
+        outline_schema.Outline.model_validate(data)
+
+
 # ── Talk-level validators ────────────────────────────────────────────
 
 

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -35,8 +35,8 @@ def test_pattern_enum_discovered(outline_schema):
     # Discovered from references/patterns/{prepare,build,deliver}/*.md — the
     # filesystem is the source of truth. _index.md mirrors these totals for
     # human readers; adding a pattern means updating both.
-    assert len(outline_schema.PATTERN_IDS) == 82
-    assert len(outline_schema.ANTIPATTERN_IDS) == 27
+    assert len(outline_schema.PATTERN_IDS) == 83
+    assert len(outline_schema.ANTIPATTERN_IDS) == 28
     assert "sparkline" in outline_schema.PATTERN_IDS
     assert "slideuments" in outline_schema.ANTIPATTERN_IDS
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary

Taxonomy 109 → 111 entries (83 patterns + 28 antipatterns; 99 observable), plus the prep-side wiring that makes the new pattern's central decision actionable rather than retrospective.

- **`walk-around`** (prepare) — audit each load-bearing claim against four standing questions (*what exactly? / how does it work? / who does it hit? / where does it lead?*) and revise until all four are answered. **`golden-rule`** (antipattern) — its null case: building the talk you'd want to receive, defending everything in your own preferred register.

- **Wired into intake, not just review.** `phase0-intake.md` gains **Step 0.4 — Read the Audience Spread** (old 0.4 → 0.5). `talk.audience_spread` is required; `talk.dominant_register` is required iff homogeneous and rejected otherwise. `check-rhetorical.py` gains `_check_register_coverage`, mirroring `_check_sparkline_requirements`. The `script-delegation` split: **the agent judges which registers a claim lands; the script checks the union.** Detecting register from prose would be the regex trap.

### Why this book does not repeat the learning-styles error

`know-your-audience`'s "Learning Styles Are a Myth" (shipped in 0.18.50) would condemn a naive HBDI import — it's a self-report typology with brain-based claims. It doesn't apply, and the distinction is load-bearing:

> "The fail-safe assumption is that the population you'll be communicating with will be mentally diverse. Therefore, I recommend delivering each significant communication point in all quadrants and modes." — Ch. 8

That's **coverage** (assume heterogeneity, hit everything, identify nobody), the *opposite* of the **meshing hypothesis** (identify a person's style, tailor to it) — and meshing is the only claim Pashler et al. refuted. Herrmann also disavows left/right himself (Ch. 2, "The 'Right-Brain/Left-Brain' Trap") and frames the model as metaphor.

**Imported:** the Walk-Around procedure and the A/B/C/D vocabulary, as a recognizable handle. **Not imported:** the physiological grounding, the HBDI instrument, audience typing, and the Ch. 8 gender-differences section (sourced to *Men Are from Mars, Women Are from Venus*). The premise the pattern actually needs — audiences differ in what evidence persuades them — rests on the Elaboration Likelihood Model and need-for-cognition. Both files carry the anti-meshing warning explicitly so the trap isn't re-derived later.

### Resolves a contradiction in the source

Ch. 8 prescribes covering all four quadrants. Ch. 13 prescribes the opposite: a metaphor-driven introduction to MIT/CMU/Berkeley engineering faculty was rejected ("the walls went up"), and the identical model re-registered as *"a first-order engineering approximation to mental diversity"* landed. The discriminator is audience spread — cover a heterogeneous keynote, match a homogeneous team, and **verify homogeneity rather than inferring it from job titles**. Deliberately not filed under `leet-grammars`: that governs vocabulary and belonging, this governs the epistemic form of the justification.

`golden-rule` joins `nodding-room` in Dimension 14's corner of *failures that draw good feedback*.

## Breaking change

`audience_spread` is required — older outlines fail validation with an actionable message. Deliberate: a default would let the question be skipped, which is the failure this fixes. Blast radius checked rather than assumed — the six `eval-resources/` outline fixtures are migrated here (mixed-room conference talks ⇒ `heterogeneous`). They were a latent **publish-blocker**: the eval suite runs inside `tesslio/patch-version-publish`, and they'd become fixtures that don't conform to the schema they exercise. The only other affected outlines (a delivered talk, an abandoned project) are confirmed dead.

## Test plan

- [x] `pytest` — 580 passed, 3 skipped (12 new: schema validators + both check branches)
- [x] `tessl plugin lint` — valid; `./scripts/check-tessl-pins.sh` — OK
- [x] Counts verified against the filesystem, not asserted: 83 + 28 = 111; prepare 20+4, build 41+10, deliver 22+14; observable 99 / unobservable 12
- [x] Every pattern file has an `_index.md` row; every `related_patterns`/`inverse_of` target resolves; filename↔id holds for all 111
- [x] Every `outline*.yaml` in the repo validates against the new schema
- [x] Check verified end-to-end, both directions: clean fixture → `Register coverage ✅ PASS · {'A': ['slide 5'], 'B': ['slide 5'], 'C': ['slide 7'], 'D': ['slide 7']}`; deliberately broken (homogeneous-on-C, answers only A+B) → `Register match ⚠️ FLAG · no walk-around answers it`
- [x] Pre-existing pyright finding on `SlideFormat.title` suppressed inline with a stated reason per `language-diagnostics`

Rebased onto `origin/main` to pick up the 0.18.50 stamp + version bump before opening.
