### PR TITLE
docs(vault-ingress): record that stale vault artifacts are not inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 A vault can hold files left by tools that predate this skill. `extract_pptx_visual.py` and its
 `pptx-extraction-results.json` are the known case — orphaned when per-file extraction replaced them, and
-read by nothing: not the skill, not the vault's own scripts or docs. `scripts/pptx-extraction.py` runs per
-PPTX and feeds the analysis directly; no step consumes an aggregate results file.
+read by nothing: not the skill, not the vault's own scripts or docs. `skills/vault-ingress/scripts/pptx-extraction.py`
+runs per PPTX and feeds the analysis directly; no step consumes an aggregate results file.
 
 Worth a note because the fossil is convincing. While building the (since-dropped) #116 reprocess migration,
 it was mistaken for a live input and a migration was written against it — correct-looking code reading data
-nothing consumes. Issue #120 was filed on the same unverified premise and is closed as invalid. The
+nothing consumes. Issue #120 was filed on the same unverified premise and is closed (`not planned`). The
 durable rule: confirm a step reads a file before treating it as an input; a plausible filename in the vault
 root is not a contract.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### docs(vault-ingress) — record that stale vault artifacts are not inputs
+
+A vault can hold files left by tools that predate this skill. `extract_pptx_visual.py` and its
+`pptx-extraction-results.json` are the known case — orphaned when per-file extraction replaced them, and
+read by nothing: not the skill, not the vault's own scripts or docs. `scripts/pptx-extraction.py` runs per
+PPTX and feeds the analysis directly; no step consumes an aggregate results file.
+
+Worth a note because the fossil is convincing. While building the (since-dropped) #116 reprocess migration,
+it was mistaken for a live input and a migration was written against it — correct-looking code reading data
+nothing consumes. Issue #120 was filed on the same unverified premise and is closed as invalid. The
+durable rule: confirm a step reads a file before treating it as an input; a plausible filename in the vault
+root is not a contract.
+
 ## 0.18.52 — 2026-07-16
 
 ### fix(vault-ingress) — stop reporting unreadable slides as wordless (#116)

--- a/skills/vault-ingress/references/known-issues.md
+++ b/skills/vault-ingress/references/known-issues.md
@@ -4,6 +4,21 @@ Edge cases and recovery strategies that don't change the happy-path workflow
 but matter when the input data is degraded. Linked from `SKILL.md`'s
 Important Notes section as one-line summaries.
 
+## Stale Vault Artifacts Are Not Inputs
+
+A vault may hold files left by tools that predate this skill. The known case is
+a vault-root `extract_pptx_visual.py` and its `pptx-extraction-results.json`,
+orphaned when per-file extraction replaced them.
+
+Nothing in this skill reads them. `skills/vault-ingress/scripts/pptx-extraction.py`
+runs per PPTX and feeds the analysis directly; no step consumes an aggregate
+results file. [schemas-db.md](schemas-db.md) describes what that script emits,
+which is not what the orphaned file contains.
+
+Before treating any vault file as an input, confirm a step reads it. A
+plausible filename in the vault root is not a contract, and building against
+one produces code that runs clean against data nothing consumes.
+
 ## Shape Extraction Is Blind to Text Baked Into Images
 
 `skills/vault-ingress/scripts/pptx-extraction.py` reads text out of PPTX


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary

A vault can hold files left by tools that predate this skill. Adds a `known-issues.md` entry so the next reader does not mistake one for an input.

The known case: a vault-root `extract_pptx_visual.py` and its `pptx-extraction-results.json`, orphaned when per-file extraction replaced them.

**Nothing reads them** — verified across the repo, the vault's scripts, and the vault's docs. `skills/vault-ingress/scripts/pptx-extraction.py` runs per PPTX (`subagent-instructions.md:61` in Step 3, `SKILL.md:176` in Step 6) and feeds the analysis directly. No step consumes an aggregate results file; the design has no such artifact.

| | |
|---|---|
| `extract_pptx_visual.py` last modified | 2026-02-21 |
| repo's `pptx-extraction.py` added | **2026-04-12** |
| `pptx-extraction-results.json` written | 2026-05-01 |

The vault script predates the skill's extractor by seven weeks.

## Why this is worth a note

The fossil is convincing. While building the (since-dropped) #116 reprocess migration I mistook it for a live input and wrote a migration against it — code that got progressively more correct at reading data nothing consumes, with #119's reviewers catching its bugs one layer at a time. I then filed **#120** asserting the same unverified premise; it is closed as invalid.

The question that dissolved it — *who reads this?* — was one grep. The entry gives the next reader the rule directly: **confirm a step reads a file before treating it as an input. A plausible filename in the vault root is not a contract.**

## Test plan

- [x] `pytest` — 595 passed, 3 skipped (docs-only; no behavior change)
- [x] `tessl plugin lint` — valid
- [x] Verified the claim rather than asserting it: no reference to `pptx-extraction-results` or `extract_pptx_visual` in the repo (excluding the CHANGELOG describing it), nor in any vault `.md` / `.py` / `.sh`
- [x] Repo scripts referenced repo-relative per `skill-authoring`; the vault-root fossils are named bare because no repo path exists for them
- [x] Added prose swept for banned connectives and intensifiers — clean
- [x] Rebased onto `origin/main` to pick up the 0.18.52 stamp + version bump
