### PR TITLE
feat(vault-ingress): OCR baked-in text on low-confidence slides

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
-# Renewal mechanism for pinned GitHub Actions, per
+# Renewal mechanism for pinned dependencies, per
 # jbaruch/coding-policy: dependency-management (every pinned dependency needs an
 # automated renewal mechanism). Dependabot opens a weekly PR when a newer
-# version of a pinned action is released; that PR's CI gate is the acceptance
-# check for the bump.
+# version is released; that PR's CI gate is the acceptance check for the bump.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -20,3 +19,10 @@ updates:
       - dependency-name: "actions/setup-node"
       - dependency-name: "actions/upload-artifact"
       - dependency-name: "github/gh-aw-actions*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,12 +38,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/apt-cache
-          key: apt-${{ runner.os }}-ffmpeg-libreoffice-impress-v1
-      - name: Install system dependencies (ffmpeg, libreoffice-impress)
+          key: apt-${{ runner.os }}-ffmpeg-libreoffice-tesseract-v1
+      - name: Install system dependencies (ffmpeg, libreoffice-impress, tesseract)
         # ffmpeg drives the video-slide-extraction tests; libreoffice-impress
-        # drives the PPTX->PDF export tests. Both test groups skipif their
-        # binary is absent, so an install hiccup degrades coverage rather than
-        # red-failing the suite.
+        # drives the PPTX->PDF export tests; tesseract drives OCR of baked-in
+        # picture text in pptx-extraction. Video/PDF groups skipif their binary
+        # is absent; OCR unit tests inject a fake engine, integration tests
+        # skipif tesseract is missing — install hiccup degrades coverage
+        # rather than red-failing the suite.
         #
         # Why this is verbose instead of a plain `apt-get install`: the plain
         # form intermittently wedged for the full 6h job limit (the identical
@@ -68,6 +70,6 @@ jobs:
           CONF
           stamp() { while IFS= read -r line; do printf '%s %s\n' "$(date -u +%H:%M:%S)" "$line"; done; }
           timeout 300 sudo -E apt-get update 2>&1 | stamp
-          timeout 600 sudo -E apt-get install -y ffmpeg libreoffice-impress 2>&1 | stamp
+          timeout 600 sudo -E apt-get install -y ffmpeg libreoffice-impress tesseract-ocr 2>&1 | stamp
       - run: pip install ".[test]"
       - run: pytest -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,10 @@ jobs:
           CONF
           stamp() { while IFS= read -r line; do printf '%s %s\n' "$(date -u +%H:%M:%S)" "$line"; done; }
           timeout 300 sudo -E apt-get update 2>&1 | stamp
-          timeout 600 sudo -E apt-get install -y ffmpeg libreoffice-impress tesseract-ocr 2>&1 | stamp
+          # tesseract-ocr pin: Ubuntu noble package version. No Dependabot
+          # ecosystem for apt — renew quarterly, or when noble's package
+          # advances (bump version + apt cache key suffix above).
+          timeout 600 sudo -E apt-get install -y ffmpeg libreoffice-impress \
+            tesseract-ocr=5.3.4-1build5 2>&1 | stamp
       - run: pip install ".[test]"
       - run: pytest -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+### feat(vault-ingress) — OCR baked-in slide text on low-confidence slides (#129)
+
+#116 / #119 stopped the extractor from **asserting absence** on full-bleed /
+image-baked decks (`text_extraction_confidence: low` + analyst looks at pixels).
+That fixed inverted "wordless backdrop" scoring. It did not extract the actual
+words baked into those pictures.
+
+This closes the other half: when confidence is low and PICTURE shapes exist,
+`pptx-extraction.py` OCRs the picture blobs (tesseract via pytesseract) into
+`ocr_text` and records `text_extraction_method` (`shapes` | `shapes+ocr` |
+`shapes+ocr_unavailable`). Shape text stays in `text_content_preview`. Design
+judgment (density, two-layer legibility, Dim 8/13) still needs rendered pages —
+OCR is inventory for cites, transcript cross-checks, language policy, and
+patterns like `second-look`.
+
+- Soft-fail if tesseract is missing (one stderr warning; method
+  `shapes+ocr_unavailable`); `--no-ocr` for shape-only runs
+- CI installs `tesseract-ocr`; tests inject a fake engine for the contract and
+  hit real tesseract for integration (skipif absent)
+- Docs: `schemas-db.md`, `known-issues.md`, `subagent-instructions.md`,
+  `second-look` detection heuristics
+
 ## 0.18.53 — 2026-07-17
 
 ### docs(vault-ingress) — record that stale vault artifacts are not inputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ### feat(vault-ingress) — OCR baked-in slide text on low-confidence slides (#129)
 
 #116 / #119 stopped the extractor from **asserting absence** on full-bleed /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "lxml",
     "qrcode",
     "Pillow",
-    "pytesseract",
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "pytesseract==0.3.13",
     "imagehash",
     "numpy",
     "pydantic==2.13.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "lxml",
     "qrcode",
     "Pillow",
+    "pytesseract",
     "imagehash",
     "numpy",
     "pydantic==2.13.4",

--- a/skills/presentation-creator/references/patterns/build/second-look.md
+++ b/skills/presentation-creator/references/patterns/build/second-look.md
@@ -49,9 +49,9 @@ Avoid it with no destination — density with nowhere to go is `_anti_ant-fonts.
 Be honest about the ceiling. The conversion is real but it is a fraction of a room, and this pattern will not rescue a talk nobody cared about. It compounds interest on attention you have already earned; it does not create attention.
 
 ## Detection Heuristics
-**Extraction caveat first, because it inverts the result.** This pattern is typically executed with text rendered *inside* images rather than in text boxes. Structural PPTX inspection will report these slides as "a single full-bleed image with no text" and score them as `vacation-photos` or `cave-painting` — the exact opposite of what is on screen. Second Look can only be detected from **rendered slide images**, never from shape-level text extraction. A deck reporting near-zero text shapes alongside consistently large image fills is a candidate to re-examine visually, not a confirmed image-only deck.
+**Extraction caveat first, because it inverts the result.** This pattern is typically executed with text rendered *inside* images rather than in text boxes. Structural PPTX inspection alone will report these slides as "a single full-bleed image with no text" and score them as `vacation-photos` or `cave-painting` — the exact opposite of what is on screen. After #129 the extractor OCRs picture blobs into `ocr_text` on low-confidence slides — use that inventory for cites (fine labels, buried jokes) and for the "transcript never mentions the fine labels" check. Two-layer **legibility** structure still requires **rendered slide images**; OCR is not a size hierarchy. A deck with near-zero text shapes, large image fills, and dense `ocr_text` is a strong candidate, not an image-only deck.
 
-Given rendered images, look for:
+Given rendered images (and `ocr_text` where present), look for:
 - A clear two-layer legibility split: a small number of elements sized for the back row, surrounded by a much finer stratum
 - Detail that goes unnarrated — the transcript never mentions the fine labels, footnotes, or marginalia
 - Buried payoffs at the fine scale: jokes, stamps, easter eggs, contradictory classifications, annotations that reward magnification

--- a/skills/vault-ingress/references/known-issues.md
+++ b/skills/vault-ingress/references/known-issues.md
@@ -25,10 +25,10 @@ one produces code that runs clean against data nothing consumes.
 **shapes**. AI-generated
 illustration decks render every title, callout label, stamp, and annotation
 *inside the picture*, where python-pptx cannot see any of it. Such a slide
-extracts as one full-bleed image with no text.
+extracts as one full-bleed image with empty shape text.
 
-Read that way, Dimension 8 inverts: the densest decks in the corpus score as
-wordless backdrops.
+Read that way, Dimension 8 used to invert: the densest decks in the corpus
+scored as wordless backdrops (#116).
 
 **Mitigations:**
 
@@ -36,19 +36,28 @@ wordless backdrops.
   `text_extraction_confidence` per slide. What trips it to `"low"` is the
   script's to decide — see `skills/vault-ingress/scripts/pptx-extraction.py`,
   the `_TEXT_BEARING_IMAGE_AREA_RATIO` constant comment.
+- **OCR inventory (#129).** On low-confidence slides that have PICTURE shapes,
+  the same script OCRs the picture blobs into `ocr_text` and sets
+  `text_extraction_method` to `shapes+ocr` (or `shapes+ocr_unavailable` if
+  tesseract is missing). Use `ocr_text` for word lists, transcript cross-checks,
+  language policy on slide text, and citational pattern evidence (`second-look`,
+  etc.). Empty `text_content_preview` still means *shapes could not read it*,
+  not *the slide is blank*.
 - **Read the confidence, never `image_area_ratio`.** The two are independent: a
   slide can be `"low"` with a ratio of `0.0`. Deriving your own trigger from the
   ratio reproduces the bug this entry exists to prevent.
-- On any low-confidence slide, judge Dimensions 8 and 13 from the **rendered
-  image**, never the JSON — see `subagent-instructions.md` § "Slides with
-  `text_extraction_confidence: low`". An empty `text_content_preview` there
-  means unreadable, not wordless.
+- On any low-confidence slide, judge Dimensions 8 and 13 **design** (density,
+  two-layer structure, composition) from the **rendered image** — OCR is not a
+  layout oracle. See `subagent-instructions.md` § "Slides with
+  `text_extraction_confidence: low`".
+- Image *backgrounds* without a PICTURE shape are still low-confidence but have
+  no blob to OCR in this path — fall back to the rendered-page pass.
 - `has_text_frame_shapes` (formerly `has_text_placeholder`) names what it
   measures: shapes with text frames. It is not a claim about on-screen text.
 
 **Applies to:** any deck with full-bleed or near-full-bleed imagery —
 increasingly the norm as illustration generation gets cheaper. Never conclude
-"the slides are wordless" from extraction output alone.
+"the slides are wordless" from empty shape text alone.
 
 ## Wide-Angle Room Recordings Defeat Slide Dedup
 

--- a/skills/vault-ingress/references/rhetoric-dimensions.md
+++ b/skills/vault-ingress/references/rhetoric-dimensions.md
@@ -44,9 +44,10 @@ How do slides complement the spoken word? Are slides dense or minimal? Does the 
 
 Answer this dimension from the **rendered slides** whenever any slide reports
 `text_extraction_confidence: low`. Shape-level extraction cannot see text baked
-into a picture, so "image-heavy vs. text-heavy" is the judgment its output is
-least able to support. Slides can carry far more than the narration
-does — that excess is a Dimension 8 finding, not an absence.
+into a picture; use `ocr_text` for the word inventory and transcript
+cross-check, but density / two-layer structure still need the rendered page.
+Slides can carry far more than the narration does — that excess is a Dimension 8
+finding, not an absence.
 
 **Related Patterns:** Fourthought, Concurrent Creation, Coda, Vacation Photos, Infodeck, Gradual Consistency, Charred Trail, Takahashi, Live on Tape, Peer Review | **Antipatterns:** Cookie Cutter, Injured Outlines, Bullet-Riddled Corpse, Borrowed Shoes, Slideuments, Lipstick on a Pig
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -272,6 +272,8 @@ Produced by `scripts/pptx-extraction.py`.
       "image_area_ratio": 0.0,
       "text_extraction_confidence": "high|low",
       "text_content_preview": "Talk Title",
+      "ocr_text": "",
+      "text_extraction_method": "shapes|shapes+ocr|shapes+ocr_unavailable",
       "footer_text": "@handle | #conf | #topic | website",
       "has_speaker_notes": true,
       "shapes_summary": [
@@ -293,12 +295,22 @@ Produced by `scripts/pptx-extraction.py`.
 }
 ```
 
-**`text_extraction_confidence` gates how the text fields may be read.** These
-come from PPTX *shapes*; text rendered inside a picture is invisible to the
-extractor. On a `"low"` slide an empty `text_content_preview` means unreadable,
-never wordless — judge Dimensions 8 and 13 from the rendered image instead (see
-[known-issues.md](known-issues.md) § "Shape Extraction Is Blind to Text Baked
-Into Images" and [subagent-instructions.md](subagent-instructions.md)).
+**`text_extraction_confidence` gates how the text fields may be read.**
+`text_content_preview` comes from PPTX *shapes*; text rendered inside a picture
+is invisible to the shape walk. On a `"low"` slide:
+
+- empty `text_content_preview` means *unreadable by shapes*, never wordless
+- `ocr_text` holds the script-owned OCR inventory from picture blobs when the
+  engine ran (`text_extraction_method: "shapes+ocr"`). Use it for cites,
+  transcript cross-checks, language policy on slide text, and pattern evidence
+- `text_extraction_method` is `"shapes"` when OCR was not attempted (high
+  confidence, `--no-ocr`, or no picture blob), `"shapes+ocr"` when it ran,
+  `"shapes+ocr_unavailable"` when the engine was missing
+- Dimensions 8/13 **design** judgment (density, two-layer legibility, composition)
+  still requires the rendered image — OCR is inventory, not layout (see
+  [known-issues.md](known-issues.md) § "Shape Extraction Is Blind to Text Baked
+  Into Images" and [subagent-instructions.md](subagent-instructions.md))
+
 `has_text_frame_shapes` reports shapes carrying text frames — not whether the
 slide shows text.
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -99,24 +99,40 @@ Apply all 14 dimensions from
 `"English translation" (original text)`. Never quote non-English text without
 an English translation preceding it.
 
-### Slides with `text_extraction_confidence: low` — look at the pixels
+### Slides with `text_extraction_confidence: low` — inventory + pixels
 
 `skills/vault-ingress/scripts/pptx-extraction.py` reads text out of PPTX
 *shapes*. Text rendered inside a picture — the norm for AI-generated illustration decks, where titles, callout
 labels, stamps, and annotations are all baked into the image — is invisible to
-it. On those slides the extractor emits `text_extraction_confidence: "low"`
-and its `text_content_preview` is empty or partial.
+the shape walk. On those slides the extractor emits
+`text_extraction_confidence: "low"`, keeps `text_content_preview` as
+shape-only (often empty), and — when PICTURE blobs exist — fills `ocr_text`
+via tesseract (`text_extraction_method: "shapes+ocr"`).
 
 **An empty `text_content_preview` on a low-confidence slide is not evidence of
-a wordless slide.** It means the extractor could not read the slide at all.
-Reading it as absence inverts Dimension 8 — see
+a wordless slide.** It means shapes could not read the text. Prefer `ocr_text`
+for the word inventory; if that is also empty (engine missing, image
+background with no picture blob, or genuinely blank art), still do not treat
+absence as proof — look at the rendered page. Reading shape emptiness as
+"wordless" inverts Dimension 8 — see
 [known-issues.md](known-issues.md) § "Shape Extraction Is Blind to Text Baked
 Into Images".
 
+**Use the two channels for different jobs:**
+
+| Job | Source |
+|---|---|
+| Word inventory, transcript cross-check, slide-text language policy, citational pattern evidence (`second-look` labels, buried jokes) | `ocr_text` (and shape `text_content_preview` when present) |
+| Density / two-layer legibility / composition / Dim 8–13 design judgment | **Rendered page images** (OCR is not a layout oracle) |
+
 When any slide in a deck reports `text_extraction_confidence: "low"`:
 
-1. Get a PDF to render. Which one depends on `slide_source` — the `pptx` path
-   never downloads one, so it has to be produced:
+1. Read `ocr_text` and `text_extraction_method` from the extraction JSON first.
+   Non-empty `ocr_text` is the citeable inventory. `shapes+ocr_unavailable`
+   means install tesseract next time; do not invent words.
+
+2. Get a PDF to render for design judgment. Which one depends on `slide_source`
+   — the `pptx` path never downloads one, so it has to be produced:
 
    | `slide_source` | PDF |
    |---|---|
@@ -134,22 +150,22 @@ When any slide in a deck reports `text_extraction_confidence: "low"`:
    ```
 
    If the export fails and no PDF exists for the talk, say so in the analysis
-   and mark Dimensions 8 and 13 low-confidence rather than judging them from
-   the extraction JSON — an unreadable deck is not a wordless one.
+   and mark Dimensions 8 and 13 design fields low-confidence rather than
+   judging layout from shape JSON alone — an unreadable deck is not a wordless
+   one. Still use any `ocr_text` that the extractor produced from picture blobs.
 
-2. Render the pages and read them:
+3. Render the pages and read them for design:
 
    ```bash
    pdftoppm -png -r 100 -f <first> -l <last> "{pdf_path}" "{tmp}/slide"
    ```
 
-3. Judge **Dimension 8** (Slide-to-Speech Relationship) and **Dimension 13**
-   (Slide Design) from the rendered images, never from the extraction JSON.
-   The question Dimension 8 asks — dense or minimal, image-heavy or
-   text-heavy — is the one the JSON cannot answer for these slides.
-4. Count `image_only_slide_count` from what the rendered slide *shows*, not
-   from what the extractor could reach. A slide carrying baked-in text is not
-   image-only, whatever the JSON says.
+4. Judge **Dimension 8** structure (dense vs minimal, room vs reward layer) and
+   **Dimension 13** (Slide Design) from the rendered images. Cross-check the
+   spoken word against `ocr_text` where the inventory exists.
+5. Count `image_only_slide_count` from what the rendered slide *shows* (and
+   from non-empty `ocr_text`), not from empty shape text alone. A slide
+   carrying baked-in text is not image-only.
 
 Structural fields stay authoritative for what they actually measure —
 `shape_count`, `background_color_hex`, `layout_name`, fonts, and

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -404,7 +404,9 @@ def extract_pptx(pptx_path, *, ocr=True, ocr_fn=None):
                     max_image_ratio = ratio
                 try:
                     picture_entries.append((ratio, shape.image.blob))
-                except Exception as e:
+                except ValueError as e:
+                    # python-pptx raises ValueError when the picture has no
+                    # embedded image (missing blip rId) — skip that shape.
                     sys.stderr.write(
                         f"WARN: could not read picture blob on slide "
                         f"{i + 1}: {e}\n"

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -53,6 +53,9 @@ _OCR_TEXT_MAX_CHARS = 8000
 # per slide on a 100-slide deck.
 _ocr_unavailable_warned = False
 
+# Cached tesseract availability for this process: None = not checked yet.
+_tesseract_available = None
+
 
 class OcrUnavailableError(Exception):
     """Tesseract (or its Python binding) is not available on this machine."""
@@ -79,17 +82,25 @@ def normalize_ocr_text(text):
     return re.sub(r"\s+", " ", text).strip()
 
 
-def ocr_image_bytes(blob):
-    """OCR a single image blob. Returns normalized text (maybe empty).
+def _require_tesseract():
+    """Ensure tesseract + bindings are available; cache the result per process.
 
-    Raises OcrUnavailableError when the engine or its binding is missing.
-    Unreadable blobs and per-image OCR failures return "" so one bad picture
-    does not abort the deck.
+    Raises OcrUnavailableError when missing. Subsequent calls in the same
+    process do not re-spawn the version check.
     """
+    global _tesseract_available
+    if _tesseract_available is True:
+        return
+    if _tesseract_available is False:
+        raise OcrUnavailableError(
+            "tesseract binary not found; install tesseract-ocr (apt) or "
+            "tesseract (brew)"
+        )
+
     try:
         import pytesseract
-        from PIL import Image
     except ImportError as e:
+        _tesseract_available = False
         raise OcrUnavailableError(
             "OCR requires Pillow and pytesseract; install project dependencies"
         ) from e
@@ -97,9 +108,31 @@ def ocr_image_bytes(blob):
     try:
         pytesseract.get_tesseract_version()
     except pytesseract.TesseractNotFoundError as e:
+        _tesseract_available = False
         raise OcrUnavailableError(
             "tesseract binary not found; install tesseract-ocr (apt) or "
             "tesseract (brew)"
+        ) from e
+
+    _tesseract_available = True
+
+
+def ocr_image_bytes(blob):
+    """OCR a single image blob. Returns normalized text (maybe empty).
+
+    Raises OcrUnavailableError when the engine or its binding is missing.
+    Unreadable blobs and per-image OCR failures return "" so one bad picture
+    does not abort the deck.
+    """
+    global _tesseract_available
+    _require_tesseract()
+
+    try:
+        import pytesseract
+        from PIL import Image
+    except ImportError as e:
+        raise OcrUnavailableError(
+            "OCR requires Pillow and pytesseract; install project dependencies"
         ) from e
 
     try:
@@ -114,6 +147,7 @@ def ocr_image_bytes(blob):
     try:
         raw = pytesseract.image_to_string(img)
     except pytesseract.TesseractNotFoundError as e:
+        _tesseract_available = False
         raise OcrUnavailableError(
             "tesseract binary not found; install tesseract-ocr (apt) or "
             "tesseract (brew)"

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -4,11 +4,17 @@
 Produces per-slide visual data and global design statistics as JSON.
 Skips static exports, conflict copies, and template files.
 
+On slides where a picture is large enough to hide baked-in text (see
+text_extraction_confidence), picture blobs are OCR'd so the analysis has a
+word inventory — not just "unreadable by shapes." Design judgment (density,
+two-layer legibility) still needs rendered pages; OCR is inventory only.
+
 Usage:
-    pptx-extraction.py <path> [--skip template]
+    pptx-extraction.py <path> [--skip template] [--no-ocr]
 
     <path>       Path to a single .pptx file or a directory to scan recursively
     --skip       Additional skip patterns (case-insensitive substring match on filename)
+    --no-ocr     Skip OCR even on low-confidence slides (shape walk only)
 
 Examples:
     pptx-extraction.py /path/to/talk.pptx
@@ -17,6 +23,7 @@ Examples:
 
 import argparse
 import glob
+import io
 import json
 import os
 import re
@@ -28,7 +35,6 @@ from pptx.dml.color import RGBColor
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.util import Emu, Inches, Pt
 
-
 # A picture covering at least this fraction of the slide is large enough to be
 # carrying rendered text — AI-generated illustration decks bake titles, callout
 # labels, and annotations into the image, where python-pptx cannot see them.
@@ -38,6 +44,18 @@ from pptx.util import Emu, Inches, Pt
 # frames are also present, since a text overlay does not prove the picture
 # underneath is wordless.
 _TEXT_BEARING_IMAGE_AREA_RATIO = 0.5
+
+# Cap so one dense manual page cannot blow out the JSON. Inventory is for
+# cites and transcript cross-checks, not a full document dump.
+_OCR_TEXT_MAX_CHARS = 8000
+
+# One stderr warning per process when the OCR engine is missing — not once
+# per slide on a 100-slide deck.
+_ocr_unavailable_warned = False
+
+
+class OcrUnavailableError(Exception):
+    """Tesseract (or its Python binding) is not available on this machine."""
 
 
 def picture_area_ratio(shape, prs):
@@ -52,6 +70,114 @@ def picture_area_ratio(shape, prs):
     if not shape.width or not shape.height:
         return 0.0
     return min((shape.width * shape.height) / slide_area, 1.0)
+
+
+def normalize_ocr_text(text):
+    """Collapse whitespace and strip; empty input stays empty."""
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def ocr_image_bytes(blob):
+    """OCR a single image blob. Returns normalized text (maybe empty).
+
+    Raises OcrUnavailableError when the engine or its binding is missing.
+    Unreadable blobs and per-image OCR failures return "" so one bad picture
+    does not abort the deck.
+    """
+    try:
+        import pytesseract
+        from PIL import Image
+    except ImportError as e:
+        raise OcrUnavailableError(
+            "OCR requires Pillow and pytesseract; install project dependencies"
+        ) from e
+
+    try:
+        pytesseract.get_tesseract_version()
+    except pytesseract.TesseractNotFoundError as e:
+        raise OcrUnavailableError(
+            "tesseract binary not found; install tesseract-ocr (apt) or "
+            "tesseract (brew)"
+        ) from e
+
+    try:
+        img = Image.open(io.BytesIO(blob))
+    except OSError as e:
+        sys.stderr.write(f"WARN: OCR skipped unreadable image blob: {e}\n")
+        return ""
+
+    if img.mode not in ("RGB", "L"):
+        img = img.convert("RGB")
+
+    try:
+        raw = pytesseract.image_to_string(img)
+    except pytesseract.TesseractNotFoundError as e:
+        raise OcrUnavailableError(
+            "tesseract binary not found; install tesseract-ocr (apt) or "
+            "tesseract (brew)"
+        ) from e
+    except pytesseract.TesseractError as e:
+        sys.stderr.write(f"WARN: OCR failed on image blob: {e}\n")
+        return ""
+
+    return normalize_ocr_text(raw)
+
+
+def ocr_picture_blobs(blobs):
+    """OCR picture blobs; join non-empty results with ' | '.
+
+    Raises OcrUnavailableError if the engine is missing. Returns "" when every
+    blob is empty or unreadable. Caller is responsible for sort order.
+    """
+    parts = []
+    for blob in blobs:
+        text = ocr_image_bytes(blob)
+        if text:
+            parts.append(text)
+    joined = " | ".join(parts)
+    if len(joined) > _OCR_TEXT_MAX_CHARS:
+        return joined[:_OCR_TEXT_MAX_CHARS]
+    return joined
+
+
+def apply_ocr_to_slide(slide_data, picture_blobs, *, ocr=True, ocr_fn=None):
+    """Fill ocr_text + text_extraction_method on a per-slide dict.
+
+    OCR runs only when confidence is low and at least one picture blob is
+    available. Image-background slides with no PICTURE shapes have no blob to
+    OCR here (rendering the page is out of this script's scope).
+
+    ocr_fn is injectable for tests (signature: list[bytes] -> str). Default
+    is ocr_picture_blobs.
+    """
+    slide_data["ocr_text"] = ""
+    slide_data["text_extraction_method"] = "shapes"
+
+    if slide_data.get("text_extraction_confidence") != "low":
+        return slide_data
+    if not ocr:
+        return slide_data
+    if not picture_blobs:
+        # Low confidence without a picture blob (image background only) —
+        # nothing this path can inventory.
+        return slide_data
+
+    run_ocr = ocr_fn if ocr_fn is not None else ocr_picture_blobs
+    global _ocr_unavailable_warned
+    try:
+        slide_data["ocr_text"] = run_ocr(picture_blobs)
+        slide_data["text_extraction_method"] = "shapes+ocr"
+    except OcrUnavailableError as e:
+        slide_data["text_extraction_method"] = "shapes+ocr_unavailable"
+        if not _ocr_unavailable_warned:
+            sys.stderr.write(
+                f"WARN: OCR unavailable ({e}); low-confidence slides will "
+                f"have empty ocr_text. Install tesseract to enable.\n"
+            )
+            _ocr_unavailable_warned = True
+    return slide_data
 
 
 def rgb_to_hex(rgb):
@@ -189,8 +315,14 @@ def extract_template_layouts(prs):
     return layouts
 
 
-def extract_pptx(pptx_path):
-    """Main extraction function."""
+def extract_pptx(pptx_path, *, ocr=True, ocr_fn=None):
+    """Main extraction function.
+
+    ocr: when True (default), low-confidence slides with PICTURE shapes get
+         an OCR inventory in ocr_text.
+    ocr_fn: optional callable(list[bytes]) -> str for tests; default uses
+            tesseract via ocr_picture_blobs.
+    """
     prs = Presentation(pptx_path)
     result = {
         "pptx_path": pptx_path,
@@ -227,15 +359,20 @@ def extract_pptx(pptx_path):
             # "high" — no picture is large enough to be carrying rendered text,
             #          so extractable text is the whole story for this slide.
             # "low"  — a picture covers enough of the slide to carry text the
-            #          shape-level extractor cannot see. Absence of extracted
-            #          text proves nothing; judge this slide from the rendered
-            #          image, never from these fields.
+            #          shape-level extractor cannot see. Absence of shape text
+            #          proves nothing; read ocr_text for inventory and still
+            #          judge design dimensions from the rendered image.
             "text_extraction_confidence": "high",
             "has_speaker_notes": bool(
                 slide.has_notes_slide and
                 slide.notes_slide.notes_text_frame.text.strip()
             ),
+            # Shape-frame text only. Baked-in picture text lands in ocr_text.
             "text_content_preview": "",
+            # OCR inventory when confidence is low and picture blobs exist.
+            "ocr_text": "",
+            # shapes | shapes+ocr | shapes+ocr_unavailable
+            "text_extraction_method": "shapes",
             "footer_text": "",
             "shapes_summary": []
         }
@@ -244,6 +381,9 @@ def extract_pptx(pptx_path):
         # Unrounded — the threshold compares against true geometry; the
         # reported value is rounded only for readability.
         max_image_ratio = 0.0
+        # (ratio, blob) pairs — sorted largest-first before OCR so the primary
+        # full-bleed image is inventoried first.
+        picture_entries = []
         for shape in slide.shapes:
             shape_info = extract_shape_info(shape)
             slide_data["shapes_summary"].append(shape_info)
@@ -262,6 +402,13 @@ def extract_pptx(pptx_path):
                 ratio = picture_area_ratio(shape, prs)
                 if ratio > max_image_ratio:
                     max_image_ratio = ratio
+                try:
+                    picture_entries.append((ratio, shape.image.blob))
+                except Exception as e:
+                    sys.stderr.write(
+                        f"WARN: could not read picture blob on slide "
+                        f"{i + 1}: {e}\n"
+                    )
 
             # Check for text-frame shapes
             if shape.has_text_frame:
@@ -286,6 +433,12 @@ def extract_pptx(pptx_path):
             or bg_type == "image"
         ):
             slide_data["text_extraction_confidence"] = "low"
+
+        picture_entries.sort(key=lambda item: item[0], reverse=True)
+        picture_blobs = [blob for _, blob in picture_entries]
+        apply_ocr_to_slide(
+            slide_data, picture_blobs, ocr=ocr, ocr_fn=ocr_fn,
+        )
 
         # Track background colors
         if bg_hex:
@@ -318,7 +471,7 @@ def should_skip(basename, skip_patterns):
     return False, None
 
 
-def batch_extract(directory, skip_patterns):
+def batch_extract(directory, skip_patterns, *, ocr=True):
     """Extract from all .pptx files in a directory, skipping unwanted files."""
     results = []
     skipped = []
@@ -332,7 +485,7 @@ def batch_extract(directory, skip_patterns):
             continue
 
         try:
-            data = extract_pptx(pptx_path)
+            data = extract_pptx(pptx_path, ocr=ocr)
             results.append(data)
             print(f"OK:   {pptx_path} ({data['slide_count']} slides)", file=sys.stderr)
         except Exception as e:
@@ -349,13 +502,19 @@ def main():
     parser.add_argument("path", help="Single .pptx file or directory to scan recursively")
     parser.add_argument("--skip", action="append", default=["template"],
                         help="Skip patterns (case-insensitive, default: template)")
+    parser.add_argument(
+        "--no-ocr",
+        action="store_true",
+        help="Skip OCR on low-confidence slides (shape walk only)",
+    )
     args = parser.parse_args()
+    ocr = not args.no_ocr
 
     if os.path.isfile(args.path):
-        result = extract_pptx(args.path)
+        result = extract_pptx(args.path, ocr=ocr)
         print(json.dumps(result, indent=2))
     elif os.path.isdir(args.path):
-        results, skipped = batch_extract(args.path, args.skip)
+        results, skipped = batch_extract(args.path, args.skip, ocr=ocr)
         output = {"results": results, "skipped": skipped}
         print(json.dumps(output, indent=2))
     else:

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -332,3 +332,204 @@ def test_area_ratio_is_not_rounded_across_the_threshold(pptx_extraction):
     ratio = pptx_extraction.picture_area_ratio(_Shape(), _Prs())
     assert ratio < pptx_extraction._TEXT_BEARING_IMAGE_AREA_RATIO
     assert ratio == pytest.approx(0.4996)
+
+
+# ── OCR inventory on low-confidence slides (issue #129) ──────────────
+#
+# #116/#119 stopped asserting absence. #129 fills a word inventory from
+# picture blobs so analysis can cite and cross-check, without replacing
+# the vision pass for design dimensions.
+
+
+def _png_with_text(path, text="VENUE PREPARATION", w=800, h=200):
+    """Build a high-contrast PNG with clear text via Pillow (no binary fixture)."""
+    from PIL import Image, ImageDraw, ImageFont
+
+    img = Image.new("RGB", (w, h), "white")
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.load_default(size=48)
+    except TypeError:
+        font = ImageFont.load_default()
+    draw.text((20, 60), text, fill="black", font=font)
+    img.save(path, format="PNG")
+    return str(path)
+
+
+def test_normalize_ocr_text(pptx_extraction):
+    assert pptx_extraction.normalize_ocr_text("  a \n\tb  ") == "a b"
+    assert pptx_extraction.normalize_ocr_text("") == ""
+    assert pptx_extraction.normalize_ocr_text(None) == ""
+
+
+def test_high_confidence_slide_method_is_shapes_only(pptx_extraction, tmp_path):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    slide.shapes.title.text = "A real title"
+    data = _first_slide(pptx_extraction, prs, tmp_path)
+    assert data["text_extraction_confidence"] == "high"
+    assert data["text_extraction_method"] == "shapes"
+    assert data["ocr_text"] == ""
+
+
+def test_full_bleed_runs_ocr_fn_and_records_inventory(
+    pptx_extraction, tmp_path,
+):
+    """Low-confidence picture slide gets ocr_text from the OCR path."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_picture(
+        _png_with_text(tmp_path / "labeled.png"), 0, 0,
+        width=prs.slide_width, height=prs.slide_height,
+    )
+    path = str(tmp_path / "deck.pptx")
+    prs.save(path)
+
+    data = pptx_extraction.extract_pptx(
+        path, ocr_fn=lambda blobs: "VENUE PREPARATION",
+    )["per_slide_visual"][0]
+
+    assert data["text_extraction_confidence"] == "low"
+    assert data["text_content_preview"] == ""  # shapes still empty
+    assert data["ocr_text"] == "VENUE PREPARATION"
+    assert data["text_extraction_method"] == "shapes+ocr"
+
+
+def test_no_ocr_flag_skips_inventory(pptx_extraction, tmp_path):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_picture(
+        _png_with_text(tmp_path / "labeled.png"), 0, 0,
+        width=prs.slide_width, height=prs.slide_height,
+    )
+    path = str(tmp_path / "deck.pptx")
+    prs.save(path)
+
+    called = []
+
+    def spy(blobs):
+        called.append(blobs)
+        return "SHOULD NOT APPEAR"
+
+    data = pptx_extraction.extract_pptx(
+        path, ocr=False, ocr_fn=spy,
+    )["per_slide_visual"][0]
+
+    assert called == []
+    assert data["ocr_text"] == ""
+    assert data["text_extraction_method"] == "shapes"
+    assert data["text_extraction_confidence"] == "low"
+
+
+def test_small_decorative_image_does_not_ocr(pptx_extraction, tmp_path):
+    """High-confidence slides must not pay for OCR."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    slide.shapes.title.text = "Title"
+    slide.shapes.add_picture(
+        _png_with_text(tmp_path / "logo.png", text="LOGO"), 0, 0,
+        width=int(prs.slide_width * 0.1), height=int(prs.slide_height * 0.1),
+    )
+    path = str(tmp_path / "deck.pptx")
+    prs.save(path)
+
+    called = []
+    data = pptx_extraction.extract_pptx(
+        path, ocr_fn=lambda blobs: called.append(blobs) or "X",
+    )["per_slide_visual"][0]
+
+    assert data["text_extraction_confidence"] == "high"
+    assert called == []
+    assert data["ocr_text"] == ""
+    assert data["text_extraction_method"] == "shapes"
+
+
+def test_ocr_unavailable_records_method_not_crash(pptx_extraction, tmp_path):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_picture(
+        _png(tmp_path / "i.png"), 0, 0,
+        width=prs.slide_width, height=prs.slide_height,
+    )
+    path = str(tmp_path / "deck.pptx")
+    prs.save(path)
+
+    def boom(_blobs):
+        raise pptx_extraction.OcrUnavailableError("no engine")
+
+    data = pptx_extraction.extract_pptx(path, ocr_fn=boom)["per_slide_visual"][0]
+    assert data["ocr_text"] == ""
+    assert data["text_extraction_method"] == "shapes+ocr_unavailable"
+    assert data["text_extraction_confidence"] == "low"
+
+
+def test_image_background_without_picture_does_not_claim_ocr(
+    pptx_extraction, tmp_path, monkeypatch,
+):
+    """Image background is low-confidence but has no PICTURE blob to OCR."""
+    monkeypatch.setattr(
+        pptx_extraction, "get_background_color", lambda slide: (None, "image"),
+    )
+    prs = Presentation()
+    prs.slides.add_slide(prs.slide_layouts[6])
+    path = str(tmp_path / "deck.pptx")
+    prs.save(path)
+
+    called = []
+    data = pptx_extraction.extract_pptx(
+        path, ocr_fn=lambda blobs: called.append(blobs) or "X",
+    )["per_slide_visual"][0]
+
+    assert data["text_extraction_confidence"] == "low"
+    assert called == []
+    assert data["ocr_text"] == ""
+    assert data["text_extraction_method"] == "shapes"
+
+
+def test_ocr_text_capped(pptx_extraction, monkeypatch):
+    monkeypatch.setattr(
+        pptx_extraction, "ocr_image_bytes", lambda blob: "A" * 9000,
+    )
+    out = pptx_extraction.ocr_picture_blobs([b"x"])
+    assert len(out) == pptx_extraction._OCR_TEXT_MAX_CHARS
+
+
+def test_ocr_image_bytes_reads_clear_text(pptx_extraction, tmp_path):
+    """Integration: real tesseract on a programmatic text PNG."""
+    pytesseract = pytest.importorskip("pytesseract")
+    try:
+        pytesseract.get_tesseract_version()
+    except pytesseract.TesseractNotFoundError:
+        pytest.skip("tesseract binary not installed")
+
+    path = tmp_path / "clear.png"
+    _png_with_text(path, text="VENUE PREPARATION")
+    text = pptx_extraction.ocr_image_bytes(path.read_bytes())
+    assert "VENUE" in text.upper()
+    assert "PREPARATION" in text.upper()
+
+
+def test_full_bleed_with_baked_text_end_to_end(pptx_extraction, tmp_path):
+    """Integration: full-bleed labeled picture yields non-empty ocr_text."""
+    pytesseract = pytest.importorskip("pytesseract")
+    try:
+        pytesseract.get_tesseract_version()
+    except pytesseract.TesseractNotFoundError:
+        pytest.skip("tesseract binary not installed")
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_picture(
+        _png_with_text(tmp_path / "labeled.png", text="VENUE PREPARATION"),
+        0, 0, width=prs.slide_width, height=prs.slide_height,
+    )
+    path = str(tmp_path / "deck.pptx")
+    prs.save(path)
+
+    data = pptx_extraction.extract_pptx(path)["per_slide_visual"][0]
+    assert data["text_extraction_confidence"] == "low"
+    assert data["text_content_preview"] == ""
+    assert data["text_extraction_method"] == "shapes+ocr"
+    assert "VENUE" in data["ocr_text"].upper()
+    assert "PREPARATION" in data["ocr_text"].upper()
+

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -342,16 +342,37 @@ def test_area_ratio_is_not_rounded_across_the_threshold(pptx_extraction):
 
 
 def _png_with_text(path, text="VENUE PREPARATION", w=800, h=200):
-    """Build a high-contrast PNG with clear text via Pillow (no binary fixture)."""
+    """Build a high-contrast PNG with clear text via Pillow (no binary fixture).
+
+    Prefer a TrueType font when the OS has one; otherwise draw with the
+    default bitmap font on a small canvas and nearest-neighbor upscale so OCR
+    stays reliable without fixtures.
+    """
     from PIL import Image, ImageDraw, ImageFont
 
-    img = Image.new("RGB", (w, h), "white")
-    draw = ImageDraw.Draw(img)
-    try:
-        font = ImageFont.load_default(size=48)
-    except TypeError:
-        font = ImageFont.load_default()
-    draw.text((20, 60), text, fill="black", font=font)
+    font = None
+    for candidate in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",  # CI (Ubuntu)
+        "/System/Library/Fonts/Supplemental/Arial Bold.ttf",     # macOS
+        "/Library/Fonts/Arial Bold.ttf",
+    ):
+        try:
+            font = ImageFont.truetype(candidate, 48)
+            break
+        except OSError:
+            continue
+
+    if font is None:
+        scale = 8
+        small = Image.new("RGB", (max(w // scale, 100), max(h // scale, 40)), "white")
+        ImageDraw.Draw(small).text(
+            (2, 2), text, fill="black", font=ImageFont.load_default(),
+        )
+        img = small.resize((w, h), Image.Resampling.NEAREST)
+    else:
+        img = Image.new("RGB", (w, h), "white")
+        ImageDraw.Draw(img).text((20, 60), text, fill="black", font=font)
+
     img.save(path, format="PNG")
     return str(path)
 

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -532,4 +532,3 @@ def test_full_bleed_with_baked_text_end_to_end(pptx_extraction, tmp_path):
     assert data["text_extraction_method"] == "shapes+ocr"
     assert "VENUE" in data["ocr_text"].upper()
     assert "PREPARATION" in data["ocr_text"].upper()
-


### PR DESCRIPTION
## Summary

Closes #129 — the other half of #116 / #119.

#119 stopped the extractor from **asserting absence** on full-bleed / image-baked decks. Analysis still had no word inventory for cites, transcript cross-checks, language policy on slide text, or `second-look` evidence. That inventory is now script-owned.

- Low-confidence slides with PICTURE shapes: OCR picture blobs (tesseract via `pytesseract`) → `ocr_text`
- `text_extraction_method`: `shapes` | `shapes+ocr` | `shapes+ocr_unavailable`
- Shape text stays in `text_content_preview` (honest about what shapes can see)
- Soft-fail if tesseract is missing; `--no-ocr` for shape-only runs
- Design judgment (density, two-layer legibility, Dim 8/13) still requires rendered pages — OCR is inventory, not a layout oracle
- Image backgrounds without a PICTURE shape remain low-confidence but have no blob here (render path still required)

## Test plan

- [x] `pytest` — 605 passed, 3 skipped (local)
- [x] Contract tests inject a fake OCR engine (no tesseract required)
- [x] Integration tests hit real tesseract on programmatic text PNGs (skipif absent)
- [x] CI installs `tesseract-ocr` (apt cache key bumped)
- [x] High-confidence / decorative images do not OCR
- [x] Unavailable engine records method, does not crash extraction