### PR TITLE
fix(packaging): ship skills/*/scripts and gate package contents

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
       TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
     with:
       stamp-changelog: true
-      # Enforce the tessl-version-floating carve-out before publishing.
-      pre-publish-script: scripts/check-tessl-pins.sh
+      # Repo-side pre-publish gates: the tessl-version-floating carve-out and
+      # the package-contents check. Composed because this input takes one path.
+      pre-publish-script: scripts/pre-publish-checks.sh
       skill-review-credit-outage: skip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,12 @@ jobs:
         # preconditioned by `coding-policy: dependency-management`'s
         # runtime-managed-manifest carve-out.
         run: ./scripts/check-tessl-pins.sh
+      - name: Verify the published package ships every declared file
+        # Fails the build when a .tesslignore pattern would strip content the
+        # manifest declares. .tesslignore is gitignore semantics, so an
+        # unanchored "scripts/" silently stripped all 59 skills/*/scripts/
+        # files from 0.18.43 through 0.18.61 while publish reported success.
+        run: ./scripts/check-package-contents.sh
       - name: Cache apt package downloads
         # Cache the downloaded .deb archives (kept in a runner-writable dir via
         # Dir::Cache::Archives below), so the slow libreoffice fetch only hits

--- a/.tesslignore
+++ b/.tesslignore
@@ -1,30 +1,37 @@
 # Exclude build artifacts, CI, and dev/test files from the published plugin.
 # The plugin ships its context surfaces — skills/, rules/, evals/,
-# .tessl-plugin/plugin.json, README.md, CHANGELOG.md (see
-# jbaruch/coding-policy: context-artifacts; evals/ is a standard plugin
-# directory the publish layer runs, so it is NOT excluded). Everything
-# below is repo-side tooling consumers never load.
+# .tessl-plugin/plugin.json, README.md (see jbaruch/coding-policy:
+# context-artifacts; evals/ is a standard plugin directory the publish layer
+# runs, so it is NOT excluded). Everything below is repo-side tooling
+# consumers never load.
+#
+# PATTERNS ARE GITIGNORE SEMANTICS: an unanchored "foo/" matches a directory
+# named foo at EVERY depth, not just the repo root. Anchor repo-root artifacts
+# with a leading slash so they cannot reach into skills/<name>/. Enforced by
+# scripts/check-package-contents.sh.
 
 # CI / workflows
-.github/
+/.github/
 
 # Tests + dev/test config
-tests/
-pyproject.toml
+/tests/
+/pyproject.toml
 
 # Repo-side CI helper scripts (plugin runtime scripts live under skills/*/scripts/)
-scripts/
+/scripts/
 
 # Project-consumer config, not plugin content
-tessl.json
-.env.example
+/tessl.json
+/.env.example
+# .mcp.json is NOT excluded: tessl treats it as a manifest-referenced plugin
+# surface (the tessl MCP server the skills call), and packing fails without it.
 
 # Local install / build state
-.tessl/
-.venv/
+/.tessl/
+/.venv/
 node_modules/
 package-lock.json
 
 # VCS metadata
-.gitignore
-.gitattributes
+/.gitignore
+/.gitattributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+### fix(packaging) — ship the skill scripts again, and gate it so they can't vanish
+
+Every published version from **0.18.43 through 0.18.61** shipped with **zero**
+of the 59 `skills/*/scripts/` files. Consumers got SKILL.md files instructing
+them to run scripts that were not in the package.
+
+Cause: `.tesslignore` uses gitignore pattern semantics, where an unanchored
+`scripts/` matches a directory of that name at *every* depth. The entry was
+added in the tile.json → plugin.json migration (0.18.43) to exclude the
+repo-root CI helper directory — its own comment reads "plugin runtime scripts
+live under skills/*/scripts/", which is exactly what it was silently deleting.
+`tests/` had the same defect. `tessl plugin publish` reported success either
+way: its "manifest references excluded paths" check inspects paths named
+literally in the manifest, and the manifest declares skill *directories*.
+
+- `.tesslignore`: anchored every repo-root-only pattern with a leading slash,
+  and documented the depth-matching semantics at the top of the file
+- `scripts/check-package-contents.sh`: new gate. Walks every tracked file under
+  the manifest's declared `skills` / `rules` entries and fails when
+  `.tesslignore` would strip any of them, naming the offending pattern and line.
+  Matching runs against a throwaway empty git repo with `core.excludesFile`
+  pointed at `.tesslignore`, so the repo's own `.gitignore` can neither mask a
+  violation nor invent one
+- Wired at both gates: `tests.yml` (pre-merge) and, via the new
+  `scripts/pre-publish-checks.sh` composer, the publish workflow's
+  `pre-publish-script` (which takes a single path)
+- `.mcp.json` stays packed — tessl treats it as a manifest-referenced surface
+  and packing fails without it
+
 ## 0.18.61 — 2026-07-25
 
 ### feat(vault-ingress) — OCR baked-in slide text on low-confidence slides (#129)

--- a/scripts/check-package-contents.sh
+++ b/scripts/check-package-contents.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Gate: every file the plugin manifest declares as plugin content must survive
+# .tesslignore filtering into the published package.
+#
+# The failure this catches: .tesslignore uses gitignore pattern semantics, so an
+# unanchored directory pattern ("scripts/") matches a directory of that name at
+# ANY depth — including skills/<name>/scripts/. A pattern written for the
+# repo-side helper directory silently strips every skill's runtime scripts from
+# the package, and `tessl plugin publish` still reports success.
+#
+# Matching runs against a throwaway empty git repo with core.excludesFile
+# pointed at .tesslignore, so only .tesslignore patterns are consulted — the
+# repo's own .gitignore can neither mask a match nor invent one.
+#
+# Usage: check-package-contents.sh [<repo-root>]   (default: this repo)
+# Exit 0 when every declared content file packs, non-zero otherwise.
+#
+# Wired into CI by .github/workflows/tests.yml, and into the publish run by
+# scripts/pre-publish-checks.sh.
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$REPO_ROOT"
+REPO_ROOT="$(pwd)"
+
+MANIFEST=".tessl-plugin/plugin.json"
+IGNORE_FILE=".tesslignore"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: plugin manifest $MANIFEST not found under $REPO_ROOT." >&2
+  echo "  Point this check at the plugin repo root, or restore the manifest." >&2
+  exit 1
+fi
+
+if [ ! -f "$IGNORE_FILE" ]; then
+  echo "OK: no $IGNORE_FILE present — nothing can be excluded from the package."
+  exit 0
+fi
+
+# Declared content paths, one per line: every entry of `skills` and `rules`.
+rc=0
+declared=$(python3 - "$MANIFEST" 2>&1 <<'PY'
+import json
+import sys
+
+manifest_path = sys.argv[1]
+try:
+    with open(manifest_path) as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    # Exit 2 — malformed JSON. The wrapper switches on this to say "fix the
+    # syntax" instead of the unrelated "content is excluded" message.
+    print(f"MALFORMED_JSON: {e.msg} at line {e.lineno} col {e.colno}", file=sys.stderr)
+    sys.exit(2)
+except OSError as e:
+    # Exit 3 — file present (the bash existence precheck passed) but unreadable.
+    print(f"UNREADABLE_MANIFEST: {e}", file=sys.stderr)
+    sys.exit(3)
+
+# Exit 4 — wrong shape. `skills` / `rules` are each a directory-path string or
+# an array of paths; anything else would crash the walk below with a traceback.
+if not isinstance(data, dict):
+    print(f"BAD_SHAPE: expected top-level JSON object, got {type(data).__name__}", file=sys.stderr)
+    sys.exit(4)
+
+entries = []
+for field in ("skills", "rules"):
+    value = data.get(field)
+    if value is None:
+        continue
+    if isinstance(value, str):
+        entries.append(value)
+    elif isinstance(value, list):
+        entries.extend(str(item) for item in value)
+    else:
+        print(
+            f"BAD_SHAPE: manifest field {field!r} must be a string or array, "
+            f"got {type(value).__name__}",
+            file=sys.stderr,
+        )
+        sys.exit(4)
+
+# Exit 5 — a manifest declaring no content has nothing to protect, which means
+# the gate would pass vacuously on a plugin that ships nothing.
+if not entries:
+    print("NO_CONTENT: manifest declares neither `skills` nor `rules`", file=sys.stderr)
+    sys.exit(5)
+
+for entry in entries:
+    print(entry.rstrip("/"))
+PY
+) || rc=$?
+
+case "$rc" in
+  0)
+    ;;
+  2)
+    echo "ERROR: $MANIFEST is not valid JSON." >&2
+    echo "$declared" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "  Fix the JSON syntax error and re-run. The package-contents check" >&2
+    echo "  can't tell what the plugin ships until the manifest parses." >&2
+    exit 1
+    ;;
+  3)
+    echo "ERROR: $MANIFEST could not be read." >&2
+    echo "$declared" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "  Check file permissions / disk state, then re-run." >&2
+    exit 1
+    ;;
+  4)
+    echo "ERROR: $MANIFEST has the wrong shape." >&2
+    echo "$declared" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "  \`skills\` and \`rules\` must each be a path string or an array of" >&2
+    echo "  paths (see jbaruch/coding-policy: skill-authoring -> plugin.json" >&2
+    echo "  Manifest Reference)." >&2
+    exit 1
+    ;;
+  5)
+    echo "ERROR: $MANIFEST declares no plugin content." >&2
+    echo "$declared" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "  Add the plugin's \`skills\` and/or \`rules\` entries. Without them the" >&2
+    echo "  published package is empty and this gate has nothing to verify." >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: reading $MANIFEST failed (exit $rc)." >&2
+    echo "$declared" | sed 's/^/  /' >&2
+    exit 1
+    ;;
+esac
+
+# Empty scratch repo so check-ignore consults ONLY .tesslignore.
+scratch="$(mktemp -d)"
+cleanup() {
+  rm -rf "$scratch"
+  return 0
+}
+trap cleanup EXIT
+git init -q "$scratch"
+
+content_list="$scratch/content.txt"
+: > "$content_list"
+
+missing=0
+while IFS= read -r declared_path; do
+  [ -n "$declared_path" ] || continue
+  count=0
+  while IFS= read -r tracked; do
+    printf '%s\n' "$tracked" >> "$content_list"
+    count=$((count + 1))
+  done < <(git ls-files -- "$declared_path")
+  if [ "$count" -eq 0 ]; then
+    echo "ERROR: $MANIFEST declares \"$declared_path\" but no tracked files live there." >&2
+    echo "  Restore the path, or drop it from the manifest (see" >&2
+    echo "  jbaruch/coding-policy: context-artifacts -> Surface Sync)." >&2
+    missing=1
+  fi
+done <<< "$declared"
+
+if [ "$missing" -ne 0 ]; then
+  exit 1
+fi
+
+total=$(wc -l < "$content_list" | tr -d ' ')
+
+rc=0
+violations=$(git -C "$scratch" -c core.excludesFile="$REPO_ROOT/$IGNORE_FILE" \
+  check-ignore --no-index -v --stdin < "$content_list") || rc=$?
+
+case "$rc" in
+  1)
+    # check-ignore exits 1 when no path matched — every declared file packs.
+    echo "OK: all $total declared plugin content files survive $IGNORE_FILE into the package."
+    exit 0
+    ;;
+  0)
+    ;;
+  *)
+    echo "ERROR: git check-ignore failed (exit $rc) while testing $IGNORE_FILE patterns." >&2
+    echo "$violations" | sed 's/^/  /' >&2
+    exit 1
+    ;;
+esac
+
+excluded=$(printf '%s\n' "$violations" | wc -l | tr -d ' ')
+
+echo "ERROR: $IGNORE_FILE excludes $excluded of $total declared plugin content files." >&2
+echo "  These are declared in $MANIFEST but would NOT ship in the published package:" >&2
+echo "" >&2
+printf '%s\n' "$violations" | sed 's/^/  /' >&2
+echo "" >&2
+echo "  Format above: <ignore-file>:<line>:<pattern>	<excluded file>" >&2
+echo "" >&2
+echo "  Cause: $IGNORE_FILE uses gitignore pattern semantics. A pattern with no" >&2
+echo "  leading slash matches at every depth, so \"foo/\" strips a repo-root" >&2
+echo "  foo/ AND skills/<name>/foo/." >&2
+echo "" >&2
+echo "  Fix: anchor the flagged pattern to the repo root with a leading slash" >&2
+echo "  (\"scripts/\" -> \"/scripts/\"), or narrow it so it stops matching plugin" >&2
+echo "  content. Re-run this check to confirm." >&2
+exit 1

--- a/scripts/pre-publish-checks.sh
+++ b/scripts/pre-publish-checks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Composer for the publish workflow's `pre-publish-script` input, which takes a
+# single path. Runs every repo-side pre-publish gate in order; the first
+# failure aborts the publish.
+#
+# Wired into CI by .github/workflows/publish.yml.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$REPO_ROOT/scripts/check-tessl-pins.sh"
+"$REPO_ROOT/scripts/check-package-contents.sh"

--- a/tests/test_package_contents_gate.py
+++ b/tests/test_package_contents_gate.py
@@ -1,0 +1,193 @@
+"""Tests for scripts/check-package-contents.sh.
+
+The gate answers one question: does every file the plugin manifest declares as
+plugin content survive .tesslignore filtering into the published package? It
+exists because .tesslignore uses gitignore pattern semantics — an unanchored
+"scripts/" strips skills/<name>/scripts/ along with the repo-root helper
+directory, and the publish still succeeds.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE = REPO_ROOT / "scripts" / "check-package-contents.sh"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def _write(repo: Path, rel: str, body: str) -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def _run(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(["bash", str(GATE), str(repo)],
+                          capture_output=True, text=True)
+
+
+@pytest.fixture()
+def plugin(tmp_path: Path) -> Path:
+    """A committed plugin repo: one skill with a script, one rule, no ignores."""
+    repo = tmp_path / "plugin"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)],
+                   check=True, capture_output=True)
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+    _write(repo, ".tessl-plugin/plugin.json", json.dumps({
+        "name": "acme/widget",
+        "version": "1.0.0",
+        "description": "Test plugin",
+        "skills": ["skills/builder"],
+        "rules": ["rules/house-style.md"],
+    }))
+    _write(repo, "skills/builder/SKILL.md", "# Builder\n")
+    _write(repo, "skills/builder/scripts/build.py", "print('build')\n")
+    _write(repo, "skills/builder/references/notes.md", "notes\n")
+    _write(repo, "rules/house-style.md", "# House Style\n")
+    _write(repo, "scripts/ci-helper.sh", "echo helper\n")
+    _write(repo, "tests/test_build.py", "def test_x():\n    pass\n")
+
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "seed")
+    return repo
+
+
+def test_no_ignore_file_passes(plugin: Path) -> None:
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+    assert "no .tesslignore" in result.stdout
+
+
+def test_clean_ignore_file_passes(plugin: Path) -> None:
+    _write(plugin, ".tesslignore", "/scripts/\n/tests/\n")
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+    assert "all 4 declared plugin content files survive" in result.stdout
+
+
+def test_unanchored_directory_pattern_strips_skill_scripts(plugin: Path) -> None:
+    """The shipped bug: "scripts/" matches skills/<name>/scripts/ too."""
+    _write(plugin, ".tesslignore", "scripts/\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "skills/builder/scripts/build.py" in result.stderr
+    assert "excludes 1 of 4" in result.stderr
+    assert "leading slash" in result.stderr
+
+
+def test_anchored_pattern_keeps_skill_scripts(plugin: Path) -> None:
+    """Anchoring excludes the repo-root helper dir and nothing deeper."""
+    _write(plugin, ".tesslignore", "/scripts/\n")
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+
+
+def test_unanchored_pattern_strips_skill_references(plugin: Path) -> None:
+    """Any depth-crossing pattern is caught, not just the scripts/ case."""
+    _write(plugin, ".tesslignore", "references/\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "skills/builder/references/notes.md" in result.stderr
+
+
+def test_excluded_rule_file_is_caught(plugin: Path) -> None:
+    _write(plugin, ".tesslignore", "house-style.md\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "rules/house-style.md" in result.stderr
+
+
+def test_repo_gitignore_cannot_mask_a_violation(plugin: Path) -> None:
+    """Matching consults .tesslignore alone — .gitignore must not shadow it."""
+    _write(plugin, ".gitignore", "scripts/\n")
+    _write(plugin, ".tesslignore", "scripts/\n")
+    _git(plugin, "add", "-A")
+    _git(plugin, "commit", "-qm", "add gitignore")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "skills/builder/scripts/build.py" in result.stderr
+
+
+def test_repo_gitignore_cannot_invent_a_violation(plugin: Path) -> None:
+    _write(plugin, ".gitignore", "scripts/\n")
+    _write(plugin, ".tesslignore", "/scripts/\n")
+    _git(plugin, "add", "-A")
+    _git(plugin, "commit", "-qm", "add gitignore")
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_manifest_fails(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    result = _run(empty)
+    assert result.returncode == 1
+    assert "plugin manifest .tessl-plugin/plugin.json not found" in result.stderr
+
+
+def test_malformed_manifest_fails(plugin: Path) -> None:
+    _write(plugin, ".tessl-plugin/plugin.json", "{not json")
+    _write(plugin, ".tesslignore", "/scripts/\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "not valid JSON" in result.stderr
+
+
+def test_wrong_field_shape_fails(plugin: Path) -> None:
+    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
+        "name": "acme/widget", "version": "1.0.0", "description": "d",
+        "skills": 42,
+    }))
+    _write(plugin, ".tesslignore", "/scripts/\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "wrong shape" in result.stderr
+
+
+def test_manifest_declaring_no_content_fails(plugin: Path) -> None:
+    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
+        "name": "acme/widget", "version": "1.0.0", "description": "d",
+    }))
+    _write(plugin, ".tesslignore", "/scripts/\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "declares no plugin content" in result.stderr
+
+
+def test_declared_path_with_no_tracked_files_fails(plugin: Path) -> None:
+    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
+        "name": "acme/widget", "version": "1.0.0", "description": "d",
+        "skills": ["skills/builder", "skills/ghost"],
+    }))
+    _write(plugin, ".tesslignore", "/scripts/\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert 'declares "skills/ghost" but no tracked files live there' in result.stderr
+
+
+def test_skills_declared_as_directory_string(plugin: Path) -> None:
+    """`skills` may be a directory path instead of an array of paths."""
+    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
+        "name": "acme/widget", "version": "1.0.0", "description": "d",
+        "skills": "skills/",
+    }))
+    _write(plugin, ".tesslignore", "scripts/\n")
+    result = _run(plugin)
+    assert result.returncode == 1
+    assert "skills/builder/scripts/build.py" in result.stderr
+
+
+def test_this_repo_ships_every_declared_file() -> None:
+    """Regression guard: speaker-toolkit's own package must be complete."""
+    result = subprocess.run(["bash", str(GATE)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## What shipped broken

Every published version from **0.18.43 through 0.18.61** contained **zero** of the 59 `skills/*/scripts/` files. Consumers installed skills whose SKILL.md tells them to run scripts that aren't in the package.

Verified against the live registry:

```
$ tessl install jbaruch/speaker-toolkit   # 0.18.61, clean project
$ find .tessl/plugins/jbaruch/speaker-toolkit -path '*/scripts/*' | wc -l
0
$ git ls-files 'skills/*/scripts/*' | wc -l
59
```

## Cause

`.tesslignore` uses gitignore pattern semantics: an unanchored `scripts/` matches a directory of that name at *every* depth, not just the repo root.

The entry was added in the tile.json → plugin.json migration (89e4094, released as 0.18.43) to exclude the repo-root CI helper directory. Its own comment reads *"plugin runtime scripts live under skills/\*/scripts/"* — precisely the files it was deleting. `tests/` had the same defect.

`tessl plugin publish` reported success throughout. Its "manifest references excluded paths" check inspects paths named **literally** in the manifest; the manifest declares skill *directories*, so nothing under them was ever checked.

## Fix

1. **`.tesslignore`** — anchored every repo-root-only pattern with a leading slash, and documented the depth-matching semantics at the top of the file so the next editor doesn't repeat it.
2. **`scripts/check-package-contents.sh`** (new gate) — walks every tracked file under the manifest's declared `skills` / `rules` entries and fails when `.tesslignore` would strip any of them, naming the offending pattern and line number. Matching runs against a throwaway empty git repo with `core.excludesFile` pointed at `.tesslignore`, so the repo's own `.gitignore` can neither mask a violation nor invent one.
3. **`scripts/pre-publish-checks.sh`** (new composer) — the publish workflow's `pre-publish-script` input takes a single path; this runs the pins check and the package-contents check in order.

## CI wiring

This PR is scoped to include CI changes (`coding-policy: ci-safety` → Hands Off CI Config):

- `tests.yml` — added a `check-package-contents.sh` step next to the existing pins check. Needs no new tooling: plain `git` and `python3`.
- `publish.yml` — `pre-publish-script` repointed from `check-tessl-pins.sh` to the composer.

Pre-merge and pre-publish both gate, so this class of silent drop can't ship again.

## Verification

Before (`origin/main` `.tesslignore`):
```
ERROR: .tesslignore excludes 59 of 220 declared plugin content files.
  .tesslignore:16:scripts/	skills/vault-ingress/scripts/persist-results.py
  ...
```

After:
```
OK: all 220 declared plugin content files survive .tesslignore into the package.
```

Real `tessl plugin pack` on this branch: **59** skill scripts present, **0** repo-side `scripts/`, `tests/`, or `.github/` leaked.

15 new tests in `tests/test_package_contents_gate.py` cover the unanchored-pattern bug, the anchored fix, both `.gitignore`-interference directions, every manifest error branch, and a regression guard asserting this repo's own package is complete.

## Note

`.mcp.json` stays packed — tessl treats it as a manifest-referenced surface and packing hard-fails without it. Noted inline in `.tesslignore` so it doesn't get "cleaned up" later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgXN53xMRPodyjBMTWFXhM