### PR TITLE
fix(vault-ingress): stamp processed_date when a subagent return omits it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### fix(vault-ingress) — stamp `processed_date` when a subagent return omits it
+
+`persist-results.py` copied `processed_date` only when the return carried it.
+Subagent returns routinely omit the field — three of three in one batch of the
+2026-07-26 full reparse — so a talk merged with `status: processed` kept
+whatever date the *previous* run had written. Two talks reparsed that day still
+read `2026-04-09`, and one read `2026-05-01`.
+
+The damage is to queryability, not to the analysis: every scalar and the pattern
+score landed correctly. But "which talks has this reparse covered" is answered
+from `processed_date`, and that question drives batch selection, the Section 15
+recount, and the operator's read on progress. The DB reported 2 talks touched
+when the real figure was 5.
+
+`merge_talk` now takes an injectable `run_date` and stamps it when the return
+omits or empties the field; a date the return *does* supply still wins. The CLI
+resolves one date for the whole batch — so a run straddling midnight doesn't
+split across two — and `--run-date` pins it for tests. The stdout summary gained
+`run_date` plus a per-talk `stamped_processed_date` flag, so a stamp is visible
+in the batch report rather than silent.
+
 ## 0.18.63 — 2026-07-26
 
 ### test(packaging) — guard against exec-bit-dependent script invocation

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -11,7 +11,10 @@ and the queryable scalars are promoted to the talk's top level.
 
 For each return (matched to a talk by `filename`) it:
   1. Sets the scalar result fields (status, processed_date, rhetoric_notes,
-     areas_for_improvement, adherence_assessment, transcript_source).
+     areas_for_improvement, adherence_assessment, transcript_source). A return
+     that omits `processed_date` is stamped with the run date, because otherwise
+     the talk keeps whatever date the previous run set and the DB cannot answer
+     "which talks has this reparse actually covered".
   2. Deep-merges the full `structured_data` and `verbatim_examples` blocks —
      additive: dicts recurse, new non-empty values win, existing data is never
      clobbered by missing/empty values (re-runs refine, never wipe).
@@ -26,14 +29,18 @@ It does NOT touch rhetoric-style-summary.md or the analysis files — those are
 written elsewhere in Step 4/Step 5. It owns only the tracking-DB merge.
 
 Usage:
-    persist-results.py <tracking-database.json> <batch-returns.json>
+    persist-results.py <tracking-database.json> <batch-returns.json> [--run-date YYYY-MM-DD]
 
     batch-returns.json is a JSON array of subagent return objects (the shape in
     references/schemas-db.md -> "Per-Talk Subagent Return Schema"). The DB is
     rewritten in place; a structured JSON summary is printed to stdout:
-        {"persisted": <int>, "db_path": "<path>",
-         "talks": [{"filename": "...", "status": "...", "promoted": ["..."]}]}
+        {"persisted": <int>, "db_path": "<path>", "run_date": "<YYYY-MM-DD>",
+         "talks": [{"filename": "...", "status": "...", "promoted": ["..."],
+                    "stamped_processed_date": <bool>}]}
     Diagnostics and errors go to stderr; exit code is non-zero on failure.
+
+    --run-date pins the stamp instead of reading the clock; the whole batch
+    shares one date so a run that straddles midnight does not split across two.
 
 Example:
     persist-results.py ~/.claude/rhetoric-knowledge-vault/tracking-database.json batch-returns.json
@@ -41,6 +48,7 @@ Example:
 
 import json
 import sys
+from datetime import date
 
 # Queryable scalars promoted from the subagent return onto the talk's top level.
 # (top_level_field, dotted source path within the return). To add a new queryable
@@ -121,10 +129,22 @@ def normalize_pattern_observations(existing, incoming):
     return obs
 
 
-def merge_talk(talk, ret):
+def merge_talk(talk, ret, run_date=None):
+    """Merge one return into its talk. Returns (promoted_fields, stamped_date).
+
+    `run_date` stamps `processed_date` when the return omits it. Callers that
+    care about reproducibility pass it explicitly; it is never read from the
+    clock inside the merge.
+    """
     for f in SCALARS:
         if f in ret and not is_empty(ret[f]):
             talk[f] = ret[f]
+    # A return that reports a status but no date would otherwise leave the
+    # previous run's date in place, making the talk look untouched by this run.
+    stamped = False
+    if run_date and is_empty(ret.get("processed_date")):
+        talk["processed_date"] = run_date
+        stamped = True
     if isinstance(ret.get("structured_data"), dict):
         talk["structured_data"] = deep_merge(talk.get("structured_data") or {}, ret["structured_data"])
     if isinstance(ret.get("verbatim_examples"), dict):
@@ -138,7 +158,7 @@ def merge_talk(talk, ret):
         if not is_empty(val):
             talk[field] = val
             promoted.append(field)
-    return promoted
+    return promoted, stamped
 
 
 def load_json(path, label):
@@ -162,11 +182,41 @@ def load_json(path, label):
         sys.exit(1)
 
 
-def main():
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} <tracking-database.json> <batch-returns.json>", file=sys.stderr)
+def parse_args(argv):
+    """Split positional paths from the optional --run-date flag.
+
+    Returns (db_path, batch_path, run_date). An absent flag resolves to today,
+    so the common call site needs no extra argument.
+    """
+    args, run_date = [], None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--run-date":
+            if i + 1 >= len(argv):
+                print("ERROR: --run-date requires a YYYY-MM-DD value", file=sys.stderr)
+                sys.exit(1)
+            run_date = argv[i + 1]
+            i += 2
+            continue
+        args.append(argv[i])
+        i += 1
+    if len(args) != 2:
+        print(f"Usage: {sys.argv[0]} <tracking-database.json> <batch-returns.json> "
+              f"[--run-date YYYY-MM-DD]", file=sys.stderr)
         sys.exit(1)
-    db_path, batch_path = sys.argv[1], sys.argv[2]
+    if run_date is None:
+        run_date = date.today().isoformat()
+    else:
+        try:
+            date.fromisoformat(run_date)
+        except ValueError:
+            print(f"ERROR: --run-date must be YYYY-MM-DD, got {run_date!r}", file=sys.stderr)
+            sys.exit(1)
+    return args[0], args[1], run_date
+
+
+def main():
+    db_path, batch_path, run_date = parse_args(sys.argv[1:])
 
     db = load_json(db_path, "tracking database")
     returns = load_json(batch_path, "batch-returns")
@@ -185,14 +235,15 @@ def main():
             # mismatch, not something to silently skip.
             print(f"ERROR: no talk in DB matches return filename: {name!r}", file=sys.stderr)
             sys.exit(1)
-        promoted = merge_talk(talk, ret)
-        summary.append({"filename": name, "status": talk.get("status"), "promoted": promoted})
+        promoted, stamped = merge_talk(talk, ret, run_date)
+        summary.append({"filename": name, "status": talk.get("status"),
+                        "promoted": promoted, "stamped_processed_date": stamped})
 
     with open(db_path, "w", encoding="utf-8") as f:
         json.dump(db, f, indent=2, ensure_ascii=False)
 
-    json.dump({"persisted": len(summary), "db_path": db_path, "talks": summary},
-              sys.stdout, ensure_ascii=False)
+    json.dump({"persisted": len(summary), "db_path": db_path, "run_date": run_date,
+               "talks": summary}, sys.stdout, ensure_ascii=False)
     sys.stdout.write("\n")
 
 

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -111,6 +111,74 @@ def test_scalar_result_fields_copied(persist_results):
     assert talk["transcript_source"] == "youtube_auto"
 
 
+def test_run_date_stamped_when_return_omits_processed_date(persist_results):
+    """The reparse regression: a return that reports status but no date left the
+    previous run's date in place, so the DB could not say which talks it covered."""
+    ret = _return()
+    del ret["processed_date"]
+    talk = _talk(processed_date="2026-04-09")
+    _, stamped = persist_results.merge_talk(talk, ret, run_date="2026-07-26")
+    assert talk["processed_date"] == "2026-07-26"
+    assert stamped is True
+
+
+def test_return_processed_date_wins_over_run_date(persist_results):
+    talk = _talk()
+    _, stamped = persist_results.merge_talk(talk, _return(), run_date="2026-07-26")
+    assert talk["processed_date"] == "2026-06-18"
+    assert stamped is False
+
+
+def test_empty_processed_date_is_stamped(persist_results):
+    talk = _talk(processed_date="2026-04-09")
+    _, stamped = persist_results.merge_talk(talk, _return(processed_date=""),
+                                            run_date="2026-07-26")
+    assert talk["processed_date"] == "2026-07-26"
+    assert stamped is True
+
+
+def test_no_run_date_leaves_processed_date_untouched(persist_results):
+    ret = _return()
+    del ret["processed_date"]
+    talk = _talk(processed_date="2026-04-09")
+    _, stamped = persist_results.merge_talk(talk, ret)
+    assert talk["processed_date"] == "2026-04-09"
+    assert stamped is False
+
+
+def test_cli_run_date_pins_the_stamp(persist_results, tmp_path):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    del ret["processed_date"]
+    db.write_text(json.dumps({"talks": [_talk(processed_date="2026-04-09")]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch),
+         "--run-date", "2026-07-26"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(db.read_text())["talks"][0]["processed_date"] == "2026-07-26"
+    report = json.loads(result.stdout)
+    assert report["run_date"] == "2026-07-26"
+    assert report["talks"][0]["stamped_processed_date"] is True
+
+
+def test_cli_rejects_malformed_run_date(persist_results, tmp_path):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([_return()]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch),
+         "--run-date", "26-07-2026"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "YYYY-MM-DD" in result.stderr
+
+
 def test_cli_writes_db_and_reports(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"


### PR DESCRIPTION
## What

`persist-results.py` copied `processed_date` only when the subagent return carried it. Returns routinely omit it — **three of three** in one batch of the 2026-07-26 full reparse — so a talk merged with `status: processed` kept whatever date the *previous* run wrote.

Observed in the live vault: two talks reparsed on 2026-07-26 still read `processed_date: 2026-04-09`, one read `2026-05-01`. The DB reported 2 talks touched by that run when the real figure was 5.

## Why it matters

The analysis itself landed fine — every promoted scalar and the pattern score were correct. The damage is to **queryability**: "which talks has this reparse covered" is answered from `processed_date`, and that question drives batch selection, the Section 15 recount, and the operator's read on progress.

It fails silently. Nothing in the merge reports that a date was left stale.

## How

- `merge_talk(talk, ret, run_date=None)` stamps `run_date` when the return omits or empties `processed_date`. A date the return *does* supply still wins.
- `run_date` is **injected, never read from the clock inside the merge** — per `testing-standards` Determinism.
- The CLI resolves one date for the whole batch, so a run straddling midnight doesn't split across two dates. `--run-date YYYY-MM-DD` pins it; malformed values fail with an actionable message.
- The stdout summary gained `run_date` and a per-talk `stamped_processed_date` flag, so a stamp shows up in the batch report instead of being invisible.

## Tests

6 new tests in `tests/test_persist_results.py` covering: stamp on omission, stamp on empty string, return-supplied date wins, no-run-date leaves the field untouched, CLI pinning + summary fields, and malformed `--run-date` rejection. All use fixed dates.

`653 passed, 3 skipped` on the full suite.