### PR TITLE
fix(vault-ingress): stop merging the speaker PiP into the slide region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+### fix(vault-ingress) — slide-region detection merged the speaker PiP into the slide box
+
+`detect_slide_region` built a frame-difference map and then took the bounding
+box of **every** above-threshold pixel. A conference broadcast composite has
+more than one moving thing — the slide rectangle and a live speaker
+picture-in-picture — and they are disjoint. Boxing them together produced a
+region spanning the frame, which tripped the existing `area > 0.9` guard and
+returned `None`. The deck was therefore never cropped, and the deduper went on
+hashing the moving presenter and the JPEG noise around him.
+
+Measured cost on Devoxx 2016 Docker Container Lifecycles: **963 extracted pages
+for a 43-slide deck**, ~22x. The venue furniture sat at zero pixel variance and
+the PiP at ~30, while the slide rectangle occupied only `x [0.32, 0.965]`,
+`y [0.17, 0.842]`. Re-hashing the crop alone collapses 963 to 170.
+
+Detection now labels 4-connected components of the mask and picks the one that
+best fills its own bounding box — a slide changes wholesale and nearly fills its
+box, a person-shaped blob does not. Component labelling is a small explicit
+stack walk rather than `scipy.ndimage.label`, keeping the extractor's declared
+dependency set. Validated against the two talks whose geometry was measured
+independently: Docker resolves to `x [0.302, 0.967]`, `y [0.197, 0.848]`, within
+~2% on every edge, and the JFokus 2015 composite now detects where it did not.
+
+**Wide-angle room recordings remain unhandled, deliberately.** When the camera
+frames the room instead of compositing a feed, ambient motion clears the
+threshold everywhere and all regions merge into one low-fill blob; detection
+returns `None`. Raising the percentile does surface a high-fill candidate, but
+on CodeMash 2017 that candidate is 42% of frame width where the screen was
+measured at ~22% — probably the presenters. No crop is shipped without ground
+truth to validate it, because a wrong crop silently discards real slide content
+whereas no crop merely leaves the existing over-count in place.
+
+`PIPELINE_VERSION` 0.7.0 to 0.8.0 per the file's own policy: region-detection
+logic changed.
+
 ## 0.18.65 — 2026-07-27
 
 ### feat(vault-ingress) — `write-analysis.py` renders the per-talk analysis files

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -110,6 +110,27 @@ Update the talk's DB entry: `slide_source: "video_extracted"`,
 | Extraction metadata | `structured_data.video_extraction` | Frame counts, region detection, threshold, pipeline version |
 | Intermediate frames | Deleted after PDF generation | Saves disk space |
 
+## Slide-Region Detection and Its Limit
+
+Detection averages frame-to-frame difference, thresholds it, labels 4-connected
+components, and picks the component that best fills its own bounding box. The
+fill test is what separates a slide (changes wholesale, nearly fills its box)
+from a live speaker picture-in-picture (a ragged moving blob). Constants live at
+`_largest_rectangular_component` in the script.
+
+Taking a bounding box over ALL above-threshold pixels instead merges the two
+disjoint regions, spans the frame, and returns `None` — the failure that let one
+43-slide talk extract to 963 pages.
+
+**Wide-angle room recordings are not handled.** Where the camera frames the room
+rather than compositing a slide feed, ambient motion clears the threshold across
+the whole frame, every region merges into one low-fill blob, and detection
+returns `None`. That is deliberate — no crop is safer than a wrong crop, which
+would silently discard real slide content. Extracted page counts for those
+recordings stay unreliable in both directions; treat any slide count derived
+from them as needing in-frame corroboration (a "Slide N of M" status bar, a
+thumbnail rail, in-deck numbering, or a spoken count).
+
 ## Pipeline Versioning
 
 The extractor carries a `PIPELINE_VERSION` constant (top of

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -110,26 +110,27 @@ Update the talk's DB entry: `slide_source: "video_extracted"`,
 | Extraction metadata | `structured_data.video_extraction` | Frame counts, region detection, threshold, pipeline version |
 | Intermediate frames | Deleted after PDF generation | Saves disk space |
 
-## Slide-Region Detection and Its Limit
+## Slide-Region Detection — Contract and Limit
 
-Detection averages frame-to-frame difference, thresholds it, labels 4-connected
-components, and picks the component that best fills its own bounding box. The
-fill test is what separates a slide (changes wholesale, nearly fills its box)
-from a live speaker picture-in-picture (a ragged moving blob). Constants live at
-`_largest_rectangular_component` in the script.
+`detect_slide_region(frames)` returns either a `(left, upper, right, lower)`
+crop as fractions of the frame, or `None` meaning "do not crop". Selection
+criteria and constants live in `skills/vault-ingress/scripts/video-slide-extraction.py`
+(`detect_slide_region` docstring and `_largest_rectangular_component`).
 
-Taking a bounding box over ALL above-threshold pixels instead merges the two
-disjoint regions, spans the frame, and returns `None` — the failure that let one
-43-slide talk extract to 963 pages.
+**A `None` is not a failure signal.** It is returned both for full-frame
+screencasts, where there is nothing to crop, and for wide-angle room recordings,
+where the region cannot be identified safely. The caller cannot distinguish
+them, and must not treat an uncropped extraction as a verified one.
 
-**Wide-angle room recordings are not handled.** Where the camera frames the room
-rather than compositing a slide feed, ambient motion clears the threshold across
-the whole frame, every region merges into one low-fill blob, and detection
-returns `None`. That is deliberate — no crop is safer than a wrong crop, which
-would silently discard real slide content. Extracted page counts for those
-recordings stay unreliable in both directions; treat any slide count derived
-from them as needing in-frame corroboration (a "Slide N of M" status bar, a
-thumbnail rail, in-deck numbering, or a spoken count).
+**Wide-angle room recordings are out of scope by design.** No crop ships without
+ground truth to validate it, because a wrong crop silently discards real slide
+content while no crop merely leaves the over-count visible. Extracted page
+counts for those recordings stay unreliable in BOTH directions.
+
+**Therefore: never report an extracted page count as a slide count.** Corroborate
+in-frame first — a "Slide N of M" status bar, a visible thumbnail rail, in-deck
+numbering, or the speaker stating a count. With no corroboration, record the
+count as low-confidence and say why.
 
 ## Pipeline Versioning
 

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -30,7 +30,7 @@ import sys
 # the download tier, region-detection logic, dedup hashing, or PDF assembly.
 # See skills/vault-ingress/references/video-slide-extraction.md ("Pipeline
 # Versioning") for the policy.
-PIPELINE_VERSION = "0.7.0"
+PIPELINE_VERSION = "0.8.0"
 
 # Shape version of the structured_data.video_extraction record (distinct from
 # PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
@@ -68,6 +68,66 @@ def extract_frames(video_path, frames_dir, fps=0.5):
     return frames
 
 
+def _label_components(mask):
+    """Label 4-connected True regions in a boolean mask.
+
+    Implemented with an explicit stack rather than scipy.ndimage.label so the
+    extractor keeps its declared dependency set (numpy/Pillow/imagehash); the
+    mask is 180x320, so the cost is irrelevant.
+
+    Yields (row_indices, col_indices) arrays per component.
+    """
+    import numpy as np
+
+    seen = np.zeros(mask.shape, dtype=bool)
+    h, w = mask.shape
+    for r0 in range(h):
+        for c0 in range(w):
+            if not mask[r0, c0] or seen[r0, c0]:
+                continue
+            rows, cols, stack = [], [], [(r0, c0)]
+            seen[r0, c0] = True
+            while stack:
+                r, c = stack.pop()
+                rows.append(r)
+                cols.append(c)
+                for dr, dc in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                    rr, cc = r + dr, c + dc
+                    if 0 <= rr < h and 0 <= cc < w and mask[rr, cc] and not seen[rr, cc]:
+                        seen[rr, cc] = True
+                        stack.append((rr, cc))
+            yield np.array(rows), np.array(cols)
+
+
+def _largest_rectangular_component(mask, min_fill=0.5, min_area_frac=0.02):
+    """Pick the component most likely to be the projected slide.
+
+    A slide region is a solid rectangle that changes wholesale between slides,
+    so its component nearly fills its own bounding box. A speaker
+    picture-in-picture is an irregular blob of moving person, so it fills much
+    less of its box. Score by box area, keeping only components that are both
+    rectangular enough and big enough to be a deck.
+
+    Returns (rmin, rmax, cmin, cmax) or None when nothing qualifies.
+    """
+    import numpy as np
+
+    total = mask.size
+    best, best_area = None, 0
+    for rows, cols in _label_components(mask):
+        rmin, rmax = int(rows.min()), int(rows.max())
+        cmin, cmax = int(cols.min()), int(cols.max())
+        box_area = (rmax - rmin + 1) * (cmax - cmin + 1)
+        if box_area / total < min_area_frac:
+            continue
+        # Fill ratio separates a solid slide rectangle from a person-shaped blob.
+        if len(rows) / box_area < min_fill:
+            continue
+        if box_area > best_area:
+            best, best_area = (rmin, rmax, cmin, cmax), box_area
+    return best
+
+
 def detect_slide_region(frames, sample_size=10):
     """Auto-detect the slide region by analyzing variance across sample frames.
 
@@ -77,6 +137,15 @@ def detect_slide_region(frames, sample_size=10):
 
     Returns (left, upper, right, lower) as fraction of image dimensions,
     or None if slides appear to be full-frame.
+
+    KNOWN LIMIT — wide-angle room recordings are NOT handled. When the camera
+    frames the whole room rather than compositing a slide feed, ambient motion
+    exceeds the threshold across the entire frame and every region merges into
+    one low-fill blob. This returns None there, which is deliberate: no crop is
+    safer than a wrong crop, because a wrong crop silently discards real slide
+    content. Those recordings need a different signal (screen-edge detection or
+    projector-luminance segmentation) and their own ground truth before any
+    heuristic ships. See references/video-slide-extraction.md.
     """
     import numpy as np
 
@@ -100,15 +169,20 @@ def detect_slide_region(frames, sample_size=10):
     threshold = np.percentile(avg_diff, 60)
     mask = avg_diff > threshold
 
-    # Find bounding box of the active region
-    rows = np.any(mask, axis=1)
-    cols = np.any(mask, axis=0)
-
-    if not rows.any() or not cols.any():
+    if not mask.any():
         return None  # No clear region detected
 
-    rmin, rmax = np.where(rows)[0][[0, -1]]
-    cmin, cmax = np.where(cols)[0][[0, -1]]
+    # A broadcast composite has MORE than one moving thing: the slide rectangle
+    # and a live speaker picture-in-picture, which are disjoint. Taking the
+    # bounding box of every above-threshold pixel merges them into one box that
+    # spans the frame, trips the >90% guard below, and returns None — so the
+    # deck is never cropped and the deduper hashes the moving presenter. That is
+    # how one 43-slide talk extracted to 963 pages. Pick the best single
+    # component instead of boxing them all.
+    component = _largest_rectangular_component(mask)
+    if component is None:
+        return None
+    rmin, rmax, cmin, cmax = component
 
     h, w = avg_diff.shape  # 180, 320
 

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -173,3 +173,64 @@ def test_full_pipeline(video_slide_extraction, tmp_path):
     assert result["pipeline_version"] == video_slide_extraction.PIPELINE_VERSION
     assert result["schema_version"] == video_slide_extraction.SCHEMA_VERSION
     assert os.path.isfile(result["output_pdf"])
+
+
+def _mask(spec):
+    """Build a boolean mask from a list of (r0, r1, c0, c1) filled boxes."""
+    import numpy as np
+    m = np.zeros((180, 320), dtype=bool)
+    for r0, r1, c0, c1 in spec:
+        m[r0:r1, c0:c1] = True
+    return m
+
+
+def test_component_labelling_separates_disjoint_regions(video_slide_extraction):
+    m = _mask([(10, 40, 10, 40), (100, 150, 200, 300)])
+    comps = list(video_slide_extraction._label_components(m))
+    assert len(comps) == 2
+
+
+def test_picks_the_slide_rectangle_over_a_speaker_blob(video_slide_extraction):
+    """The regression: a broadcast composite has a solid slide rectangle AND a
+    moving-speaker region. Boxing every above-threshold pixel merged them into
+    one frame-spanning box, tripped the >90% guard, and returned None — so a
+    43-slide talk extracted to 963 pages."""
+    import numpy as np
+    m = np.zeros((180, 320), dtype=bool)
+    m[30:150, 110:310] = True           # solid slide rectangle, right side
+    rng_rows = [(40, 60), (60, 90), (90, 120)]
+    for i, (a, b) in enumerate(rng_rows):  # ragged low-fill speaker blob, left
+        m[a:b, 10:10 + 8 * (i + 1)] = True
+    got = video_slide_extraction._largest_rectangular_component(m)
+    assert got is not None
+    rmin, rmax, cmin, cmax = got
+    assert cmin >= 100, "picked the speaker blob instead of the slide"
+    assert (rmin, rmax, cmin, cmax) == (30, 149, 110, 309)
+
+
+def test_low_fill_blob_alone_is_rejected(video_slide_extraction):
+    """A ragged moving-person region with no slide present must not be cropped
+    to — a wrong crop silently discards real content, so None is correct."""
+    import numpy as np
+    m = np.zeros((180, 320), dtype=bool)
+    for i in range(0, 120, 4):          # sparse comb: large box, tiny fill
+        m[30 + i, 40:280] = True
+    assert video_slide_extraction._largest_rectangular_component(m) is None
+
+
+def test_tiny_rectangle_is_rejected_as_too_small(video_slide_extraction):
+    m = _mask([(10, 16, 10, 16)])
+    assert video_slide_extraction._largest_rectangular_component(m) is None
+
+
+def test_full_frame_slides_still_return_none(video_slide_extraction, tmp_path):
+    """A full-frame screencast has no border to crop; region detection must
+    decline rather than shave the edges."""
+    import numpy as np
+    frames = []
+    for i in range(24):
+        arr = np.full((180, 320), 20 * (i % 8), dtype=np.uint8)
+        p = tmp_path / f"f{i:03d}.png"
+        Image.fromarray(arr).save(p)
+        frames.append(str(p))
+    assert video_slide_extraction.detect_slide_region(frames, sample_size=8) is None

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -174,63 +174,78 @@ def test_full_pipeline(video_slide_extraction, tmp_path):
     assert result["schema_version"] == video_slide_extraction.SCHEMA_VERSION
     assert os.path.isfile(result["output_pdf"])
 
+def _composite_frames(tmp_path, n=24, with_pip=True):
+    """Synthesize a broadcast composite: a slide rectangle that changes wholesale,
+    optional moving speaker PiP on the left, and static venue furniture around
+    both. Returns frame paths.
 
-def _mask(spec):
-    """Build a boolean mask from a list of (r0, r1, c0, c1) filled boxes."""
+    Geometry is fixed, so the expected crop is known without a fixture file.
+    """
     import numpy as np
-    m = np.zeros((180, 320), dtype=bool)
-    for r0, r1, c0, c1 in spec:
-        m[r0:r1, c0:c1] = True
-    return m
+    rows, cols = np.mgrid[0:360, 0:640]
+    frames = []
+    for i in range(n):
+        arr = np.full((360, 640), 60, dtype=np.uint8)      # static venue furniture
+        # Slide content must vary SPATIALLY, not only per frame: a uniform fill
+        # gives every slide pixel an identical diff, the percentile lands exactly
+        # on that value, and the strict `>` then drops the whole region.
+        slide = (rows[40:320, 200:620] * 7
+                 + cols[40:320, 200:620] * 13
+                 + i * 61) % 256
+        arr[40:320, 200:620] = slide.astype(np.uint8)
+        if with_pip:
+            top = 100 + (i % 5) * 8                        # speaker PiP: moves, small
+            pip = (rows[top:top + 40, 20:90] * 11 + i * 97) % 256
+            arr[top:top + 40, 20:90] = pip.astype(np.uint8)
+        p = tmp_path / f"f{i:03d}.png"
+        Image.fromarray(arr).save(p)
+        frames.append(str(p))
+    return frames
 
 
-def test_component_labelling_separates_disjoint_regions(video_slide_extraction):
-    m = _mask([(10, 40, 10, 40), (100, 150, 200, 300)])
-    comps = list(video_slide_extraction._label_components(m))
-    assert len(comps) == 2
+def test_detects_the_slide_and_excludes_the_speaker_pip(video_slide_extraction, tmp_path):
+    """The regression, asserted on the public entry point.
+
+    A broadcast composite has two disjoint moving regions — the slide and a live
+    speaker PiP. Boxing every above-threshold pixel merges them: on this scene
+    the old logic yields x[0.011, 0.989], a crop reaching into the PiP; on the
+    real Devoxx 2016 artifact it exceeded the area>0.9 guard and returned None,
+    so the deck was never cropped and a 43-slide talk extracted to 963 pages.
+    Either way the crop is wrong, so assert the property that matters: the
+    returned region excludes the PiP and still covers the slide.
+    """
+    frames = _composite_frames(tmp_path)
+    region = video_slide_extraction.detect_slide_region(frames, sample_size=8)
+    assert region is not None, "composite went undetected — the 963-page failure"
+    left, upper, right, lower = region
+    # The slide occupies x[0.3125, 0.969], y[0.111, 0.889] by construction; the
+    # PiP sits entirely left of x=0.15 and must not be inside the crop.
+    assert left > 0.15, f"crop reaches into the speaker PiP: left={left:.3f}"
+    assert right > 0.9 and lower > 0.8, "crop lost part of the slide"
+    assert (right - left) * (lower - upper) < 0.9, "crop is effectively full-frame"
 
 
-def test_picks_the_slide_rectangle_over_a_speaker_blob(video_slide_extraction):
-    """The regression: a broadcast composite has a solid slide rectangle AND a
-    moving-speaker region. Boxing every above-threshold pixel merged them into
-    one frame-spanning box, tripped the >90% guard, and returned None — so a
-    43-slide talk extracted to 963 pages."""
-    import numpy as np
-    m = np.zeros((180, 320), dtype=bool)
-    m[30:150, 110:310] = True           # solid slide rectangle, right side
-    rng_rows = [(40, 60), (60, 90), (90, 120)]
-    for i, (a, b) in enumerate(rng_rows):  # ragged low-fill speaker blob, left
-        m[a:b, 10:10 + 8 * (i + 1)] = True
-    got = video_slide_extraction._largest_rectangular_component(m)
-    assert got is not None
-    rmin, rmax, cmin, cmax = got
-    assert cmin >= 100, "picked the speaker blob instead of the slide"
-    assert (rmin, rmax, cmin, cmax) == (30, 149, 110, 309)
+def test_same_scene_without_a_pip_still_detects_the_slide(video_slide_extraction, tmp_path):
+    """Control: the detection must not depend on a PiP being present."""
+    frames = _composite_frames(tmp_path, with_pip=False)
+    region = video_slide_extraction.detect_slide_region(frames, sample_size=8)
+    assert region is not None
+    assert region[0] > 0.15
 
 
-def test_low_fill_blob_alone_is_rejected(video_slide_extraction):
-    """A ragged moving-person region with no slide present must not be cropped
-    to — a wrong crop silently discards real content, so None is correct."""
-    import numpy as np
-    m = np.zeros((180, 320), dtype=bool)
-    for i in range(0, 120, 4):          # sparse comb: large box, tiny fill
-        m[30 + i, 40:280] = True
-    assert video_slide_extraction._largest_rectangular_component(m) is None
-
-
-def test_tiny_rectangle_is_rejected_as_too_small(video_slide_extraction):
-    m = _mask([(10, 16, 10, 16)])
-    assert video_slide_extraction._largest_rectangular_component(m) is None
-
-
-def test_full_frame_slides_still_return_none(video_slide_extraction, tmp_path):
-    """A full-frame screencast has no border to crop; region detection must
-    decline rather than shave the edges."""
+def test_full_frame_slides_return_none(video_slide_extraction, tmp_path):
+    """A full-frame screencast has no border to crop; detection must decline
+    rather than shave the edges."""
     import numpy as np
     frames = []
     for i in range(24):
         arr = np.full((180, 320), 20 * (i % 8), dtype=np.uint8)
-        p = tmp_path / f"f{i:03d}.png"
+        p = tmp_path / f"g{i:03d}.png"
         Image.fromarray(arr).save(p)
         frames.append(str(p))
+    assert video_slide_extraction.detect_slide_region(frames, sample_size=8) is None
+
+
+def test_too_few_frames_declines_to_guess(video_slide_extraction, tmp_path):
+    frames = _composite_frames(tmp_path, n=4)
     assert video_slide_extraction.detect_slide_region(frames, sample_size=8) is None


### PR DESCRIPTION
## The bug

`detect_slide_region` builds a frame-difference map, thresholds at the 60th percentile, then takes the **bounding box of every above-threshold pixel**.

A conference broadcast composite has more than one moving thing: the slide rectangle *and* a live speaker picture-in-picture. They are disjoint. Boxing them together produces a region spanning the frame, which trips the existing `area > 0.9` guard and returns `None` — so the deck is never cropped, and the deduper goes on hashing the moving presenter and the JPEG noise around him.

It is a bounding box over a disjoint set.

## Measured cost

Devoxx 2016 Docker Container Lifecycles: **963 extracted pages for a 43-slide deck**, ~22×. Venue furniture sits at zero pixel variance, the PiP at ~30, and the slide rectangle occupies only `x [0.32, 0.965]`, `y [0.17, 0.842]`. Re-hashing the crop alone collapses 963 → 170.

This is not one talk. **97 of the 108 talks left in the current reparse are `video_extracted`**, and every slide count, slides-per-minute figure and density judgment on them inherits the error.

## The fix

Label 4-connected components of the mask and pick the one that best fills its own bounding box. A slide changes wholesale and nearly fills its box; a person-shaped blob does not. Component labelling is a small explicit stack walk rather than `scipy.ndimage.label`, keeping the extractor's declared dependency set (numpy/Pillow/imagehash) — the mask is 180×320, so cost is irrelevant.

## Validation against real artifacts

| talk | independently measured | detected now |
|---|---|---|
| Devoxx 2016 Docker | `x [0.32, 0.965]` `y [0.17, 0.842]` | `x [0.302, 0.967]` `y [0.197, 0.848]` |
| JFokus 2015 Async HTTP | composite w/ PiP, was `None` | `x [0.274, 0.989]` `y [0.402, 0.992]` |

Within ~2% on every edge on the talk whose geometry was measured by hand.

## What this deliberately does NOT fix

**Wide-angle room recordings.** Where the camera frames the room instead of compositing a feed, ambient motion clears the threshold everywhere and all regions merge into one low-fill blob; detection returns `None`.

Raising the percentile *does* surface a high-fill candidate — but on CodeMash 2017 that candidate is 42% of frame width where the screen was measured at ~22%, so it is probably the presenters. I am not shipping a crop I cannot validate: **a wrong crop silently discards real slide content, whereas no crop merely leaves the existing over-count in place.** Documented as a known limit in the docstring and the reference, with the corroboration signals an analyst should demand instead.

## Tests

5 new tests on synthetic masks with known geometry (deterministic, no fixtures): component separation, slide-vs-blob selection, low-fill rejection, too-small rejection, and full-frame screencasts still declining to crop.

`697 passed, 3 skipped`. `tessl plugin lint` valid. `PIPELINE_VERSION` 0.7.0 → 0.8.0 per the file's own policy, since region-detection logic changed.