### PR TITLE
fix(vault-ingress): gate slide-region detection on plausibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+### fix(vault-ingress) — gate slide-region detection on plausibility, and stop overclaiming it
+
+0.18.66 replaced the all-pixels bounding box with connected-component selection.
+That fixed the broadcast-composite case and introduced a worse one: with no size
+or shape constraint, the chosen component can be the changing TEXT BLOCK inside
+a full-frame slide. Cropping to it discards the rest of the deck. Confirmed on a
+corpus talk whose "HELLO My name is Baruch" title slide was cropped to a 9%
+fragment with the name cut off — content loss, where the previous code had
+safely declined to crop.
+
+Selection now requires the component to look like a projected display: at least
+15% of frame area and an aspect ratio between 1.0 and 2.4. Measured over 94
+corpus decks, ungated selection returned boxes with aspect ratios from 0.32 to
+9.45; the gate cuts 55 detections to 26 and turns the confirmed content-loss
+case into a `None`.
+
+**The 26 survivors are not thereby correct.** A by-eye check found the gate still
+passes a presenter's torso on a talk with no visible screen — rectangular,
+well-filled, right size, right aspect. Fill, area and aspect cannot separate a
+person from a screen. The docstring and the reference now say so directly: a
+returned region is a hint to verify, never ground truth, and no slide count
+should be derived from a crop nobody looked at.
+
+Reliable use is the case it was built for — a broadcast composite with a fixed
+slide rectangle beside static venue furniture. Room recordings need a signal
+this function does not have (screen-edge geometry, projector luminance, or
+boundary stability across frames) and ground truth to validate against.
+
 ## 0.18.66 — 2026-07-27
 
 ### fix(vault-ingress) — slide-region detection merged the speaker PiP into the slide box

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -122,6 +122,14 @@ screencasts, where there is nothing to crop, and for wide-angle room recordings,
 where the region cannot be identified safely. The caller cannot distinguish
 them, and must not treat an uncropped extraction as a verified one.
 
+**A returned region is not a verified one either.** Detection is dependable only
+for broadcast composites — a fixed slide rectangle beside static venue
+furniture. On room recordings it returns the speaker about as readily as the
+screen: a torso is rectangular, well-filled, and the right size and aspect. A
+by-eye check of 94 corpus decks found correct screen crops and confident crops
+of a presenter's chest in the same pass. Look at the crop before trusting
+anything derived from it.
+
 **Wide-angle room recordings are out of scope by design.** No crop ships without
 ground truth to validate it, because a wrong crop silently discards real slide
 content while no crop merely leaves the over-count visible. Extracted page

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -30,7 +30,7 @@ import sys
 # the download tier, region-detection logic, dedup hashing, or PDF assembly.
 # See skills/vault-ingress/references/video-slide-extraction.md ("Pipeline
 # Versioning") for the policy.
-PIPELINE_VERSION = "0.8.0"
+PIPELINE_VERSION = "0.8.1"
 
 # Shape version of the structured_data.video_extraction record (distinct from
 # PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
@@ -99,14 +99,33 @@ def _label_components(mask):
             yield np.array(rows), np.array(cols)
 
 
-def _largest_rectangular_component(mask, min_fill=0.5, min_area_frac=0.02):
+# A crop is only taken when the chosen component actually looks like a projected
+# display. These bounds exist because component selection alone will happily
+# return a text block inside a FULL-FRAME slide — cropping a deck into a fragment
+# of itself and silently discarding the rest. Measured over 94 corpus decks,
+# unconstrained selection produced boxes with aspect ratios from 0.32 to 9.45;
+# the gate leaves 26. A missed crop leaves an over-count visible; a
+# wrong crop destroys content, so these are deliberately strict.
+_MIN_REGION_AREA_FRAC = 0.15   # smaller than this is a slide element, not a slide
+_MIN_REGION_ASPECT = 1.0       # 4:3 is 1.33, 16:9 is 1.78; allow margin either way
+_MAX_REGION_ASPECT = 2.4
+
+
+def _largest_rectangular_component(mask, min_fill=0.5,
+                                   min_area_frac=_MIN_REGION_AREA_FRAC,
+                                   min_aspect=_MIN_REGION_ASPECT,
+                                   max_aspect=_MAX_REGION_ASPECT):
     """Pick the component most likely to be the projected slide.
 
-    A slide region is a solid rectangle that changes wholesale between slides,
-    so its component nearly fills its own bounding box. A speaker
-    picture-in-picture is an irregular blob of moving person, so it fills much
-    less of its box. Score by box area, keeping only components that are both
-    rectangular enough and big enough to be a deck.
+    A slide region is a solid rectangle that changes wholesale between slides, so
+    its component nearly fills its own bounding box; a speaker picture-in-picture
+    is an irregular blob of moving person and fills much less. Fill ratio
+    separates those two. Area and aspect then reject the other failure mode —
+    a localized text block inside a full-frame deck, which is rectangular and
+    well-filled but is not the display.
+
+    The mask is 320x180, so its pixel aspect equals the source frame's aspect for
+    16:9 recordings and box_w/box_h is directly comparable to a display ratio.
 
     Returns (rmin, rmax, cmin, cmax) or None when nothing qualifies.
     """
@@ -117,11 +136,15 @@ def _largest_rectangular_component(mask, min_fill=0.5, min_area_frac=0.02):
     for rows, cols in _label_components(mask):
         rmin, rmax = int(rows.min()), int(rows.max())
         cmin, cmax = int(cols.min()), int(cols.max())
-        box_area = (rmax - rmin + 1) * (cmax - cmin + 1)
+        box_h, box_w = rmax - rmin + 1, cmax - cmin + 1
+        box_area = box_h * box_w
         if box_area / total < min_area_frac:
             continue
         # Fill ratio separates a solid slide rectangle from a person-shaped blob.
         if len(rows) / box_area < min_fill:
+            continue
+        # Aspect rejects strips and columns — neither is a projected display.
+        if not (min_aspect <= box_w / box_h <= max_aspect):
             continue
         if box_area > best_area:
             best, best_area = (rmin, rmax, cmin, cmax), box_area
@@ -138,14 +161,21 @@ def detect_slide_region(frames, sample_size=10):
     Returns (left, upper, right, lower) as fraction of image dimensions,
     or None if slides appear to be full-frame.
 
-    KNOWN LIMIT — wide-angle room recordings are NOT handled. When the camera
-    frames the whole room rather than compositing a slide feed, ambient motion
-    exceeds the threshold across the entire frame and every region merges into
-    one low-fill blob. This returns None there, which is deliberate: no crop is
-    safer than a wrong crop, because a wrong crop silently discards real slide
-    content. Those recordings need a different signal (screen-edge detection or
-    projector-luminance segmentation) and their own ground truth before any
-    heuristic ships. See references/video-slide-extraction.md.
+    A RETURNED REGION IS NOT A VERIFIED ONE. Detection is reliable only for the
+    extreme case it was built for: a broadcast composite where a fixed slide
+    rectangle sits beside static venue furniture. On room recordings it can and
+    does return the speaker — a torso is rectangular, well-filled, and passes
+    every size and aspect gate a screen passes. Spot-checking 94 corpus decks by
+    eye found correct screen crops and confident crops of a presenter's chest in
+    the same pass. Treat the output as a hint to verify, never as ground truth,
+    and never derive a slide count from a crop nobody looked at.
+
+    KNOWN LIMIT — wide-angle room recordings are NOT reliably handled. Ambient
+    motion clears the threshold across the frame and the largest plausible
+    component is as often a person as a screen. Separating them needs a signal
+    this function does not have (screen-edge geometry, projector luminance, or
+    boundary stability across frames) plus ground truth to validate against.
+    See references/video-slide-extraction.md.
     """
     import numpy as np
 

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -249,3 +249,70 @@ def test_full_frame_slides_return_none(video_slide_extraction, tmp_path):
 def test_too_few_frames_declines_to_guess(video_slide_extraction, tmp_path):
     frames = _composite_frames(tmp_path, n=4)
     assert video_slide_extraction.detect_slide_region(frames, sample_size=8) is None
+
+
+def _fullframe_slide_frames(tmp_path, n=24):
+    """A FULL-FRAME deck: the whole frame is the slide, and only a text block
+    changes between slides. There is no border to crop."""
+    import numpy as np
+    rows, cols = np.mgrid[0:360, 0:640]
+    frames = []
+    for i in range(n):
+        arr = np.full((360, 640), 245, dtype=np.uint8)     # slide background
+        block = (rows[120:200, 180:460] * 3 + i * 83) % 256  # the changing text
+        arr[120:200, 180:460] = block.astype(np.uint8)
+        p = tmp_path / f"s{i:03d}.png"
+        Image.fromarray(arr).save(p)
+        frames.append(str(p))
+    return frames
+
+
+def test_full_frame_deck_is_not_cropped_into_its_own_text_block(
+        video_slide_extraction, tmp_path):
+    """Regression on the plausibility gate.
+
+    Component selection alone returns the changing text block inside a
+    full-frame slide — a well-filled rectangle that is NOT the display. Cropping
+    to it discards the rest of the deck. Observed on a real corpus talk whose
+    'HELLO My name is Baruch' title slide was cropped to a 9% fragment with the
+    name cut off.
+    """
+    frames = _fullframe_slide_frames(tmp_path)
+    assert video_slide_extraction.detect_slide_region(frames, sample_size=8) is None
+
+
+def test_region_smaller_than_the_area_floor_is_rejected(video_slide_extraction):
+    import numpy as np
+    m = np.zeros((180, 320), dtype=bool)
+    m[60:90, 100:180] = True                 # solid, 4:3-ish, but only ~4% of frame
+    assert video_slide_extraction._largest_rectangular_component(m) is None
+
+
+def test_strip_and_column_shapes_are_rejected(video_slide_extraction):
+    """Aspect gate: a wide strip or a tall column is never a projected display.
+
+    Both shapes are sized ABOVE the 15% area floor on purpose. A strip that also
+    fails on area would pass this test while the aspect gate silently regressed.
+    """
+    import numpy as np
+    total = 180 * 320
+
+    strip = np.zeros((180, 320), dtype=bool)
+    strip[60:110, 5:315] = True              # 50x310 -> aspect 6.2, 27% of frame
+    assert (50 * 310) / total > 0.15, "strip must clear the area floor to test aspect"
+    assert video_slide_extraction._largest_rectangular_component(strip) is None
+
+    column = np.zeros((180, 320), dtype=bool)
+    column[5:175, 100:220] = True            # 170x120 -> aspect 0.71, 35% of frame
+    assert (170 * 120) / total > 0.15, "column must clear the area floor to test aspect"
+    assert video_slide_extraction._largest_rectangular_component(column) is None
+
+
+def test_a_plausible_screen_of_the_same_area_is_accepted(video_slide_extraction):
+    """Control for the two shape tests: same size band, display-like aspect, so
+    the rejections above are attributable to aspect and nothing else."""
+    import numpy as np
+    m = np.zeros((180, 320), dtype=bool)
+    m[40:150, 60:260] = True                 # 110x200 -> aspect 1.82, 38% of frame
+    got = video_slide_extraction._largest_rectangular_component(m)
+    assert got == (40, 149, 60, 259)


### PR DESCRIPTION
## What I broke in 0.18.66

Replacing the all-pixels bounding box with connected-component selection fixed the broadcast-composite case — and introduced a worse one.

With no size or shape constraint, the chosen component can be the changing **text block inside a full-frame slide**. Cropping to it discards the rest of the deck. Confirmed on a corpus talk whose "HELLO My name is Baruch" title slide was cropped to a **9% fragment with the name cut off**.

That is strictly worse than the bug it replaced. The pre-0.8.0 code boxed everything, tripped the `area > 0.9` guard, and safely declined to crop. My version silently destroyed content instead.

## The gate

Selection now requires the component to look like a projected display: **≥15% of frame area**, **aspect ratio 1.0–2.4**.

Measured over 94 corpus decks, ungated selection returned boxes with aspect ratios from **0.32 to 9.45** — strips and columns that cannot be screens. The gate cuts 55 detections to 26, and the confirmed content-loss case becomes `None`. The known-good detections are unchanged (the JNation screen crop is byte-identical before and after).

## What this does NOT fix, stated plainly

**The 26 survivors are not verified.** I rendered them and looked. The gate still passes a **presenter's torso** on a talk with no visible screen — rectangular, well-filled, ~20% of frame, aspect ~1.5. Every gate a screen passes, a chest passes.

Fill, area and aspect cannot separate a person from a screen. Doing so needs a signal this function doesn't have — screen-edge geometry, projector luminance, or bounding-box stability across frames — plus ground truth to validate against.

So the docstring and the reference now say it outright: **a returned region is a hint to verify, never ground truth, and no slide count should be derived from a crop nobody looked at.** Detection is dependable only for the case it was built for: a broadcast composite with a fixed slide rectangle beside static venue furniture.

## Tests

3 new: a full-frame deck whose text block must NOT be cropped to (the regression), sub-floor area rejection, and strip/column aspect rejection.

`699 passed, 3 skipped`. `PIPELINE_VERSION` 0.8.0 → 0.8.1.