### PR TITLE
feat(vault-profile): partition talks by extractor generation for baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ from is exactly what does not survive a long run.
 An undated talk counts as stale — excluding one only narrows the sample, while
 including it silently contaminates the baseline.
 
+The instrumentation gap is not the only reason the cohorts are incomparable, and
+the epoch happens to separate both. Pre-reparse observations put patterns and
+antipatterns in ONE undifferentiated list, so a stored per-mode average such as
+mode (i)'s 19.35 counts antipatterns alongside patterns. A reparsed score is
+`count(patterns) - count(antipatterns)`. Comparing the two compares different
+quantities and reads as "on baseline" where the talk may be well above it.
+
 At the time of writing the split is 95/0, because the stale-scored talks all sit
 at `needs-reprocessing` and were never eligible for the baseline. The guard costs
 nothing and catches the case it exists for: generating a profile from a vault

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,6 @@ Each now opens its detection section with an explicit NAME TRAP warning.
   minutes without deploying the pattern.
 - `crawling-code` is an authored deck reveal, not a live IDE screencast where
   code happens to scroll.
-||||||| parent of f6c08f1 (feat(vault-profile): partition talks by extractor generation for baselines)
 
 ## 0.18.67 — 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+### feat(vault-profile) — partition talks by extractor generation before computing baselines
+
+`load-vault.py` fed every `processed` talk into the profile's `pattern_score`
+baselines regardless of which extractor scored it. Talks scored before the
+2026-07-26 reparse were measured by an extractor blind to text baked into images
+and to payload held in OOXML tables, so their scores record scan depth rather
+than delivery — the same talk moved 13 to 39 on re-scan with no change in the
+recording.
+
+The payload now carries `baseline_talks` and `stale_instrumentation_talks` plus a
+`baseline_note` stating why, and the skill binds `average_pattern_score`,
+`by_mode`, `score_trend`, `pattern_breadth` and every adherence comparison to the
+former. A mode with too few current-instrumentation talks emits `stable: false`
+rather than being topped up from the stale cohort.
+
+Partitioning in the script rather than in skill prose is the point: the filter is
+deterministic, and prose asking an agent to remember which cohort a number came
+from is exactly what does not survive a long run.
+
+An undated talk counts as stale — excluding one only narrows the sample, while
+including it silently contaminates the baseline.
+
+At the time of writing the split is 95/0, because the stale-scored talks all sit
+at `needs-reprocessing` and were never eligible for the baseline. The guard costs
+nothing and catches the case it exists for: generating a profile from a vault
+that is partway through a reparse.
+
 ## 0.18.68 — 2026-07-27
 
 ### fix(presentation-creator) — antipattern scoring polarity was inverted in 26 of 28 files
@@ -46,6 +73,7 @@ Each now opens its detection section with an explicit NAME TRAP warning.
   minutes without deploying the pattern.
 - `crawling-code` is an authored deck reveal, not a live IDE screencast where
   code happens to scroll.
+||||||| parent of f6c08f1 (feat(vault-profile): partition talks by extractor generation for baselines)
 
 ## 0.18.67 — 2026-07-27
 

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -119,8 +119,18 @@ patterns in the `never_tried` and `rare` tiers of `mastery_levels`, kept only wh
 the pattern's taxonomy Vault Dims fit the speaker's `presentation_modes`. This is the
 positive-space coaching signal, framed as growth, not deficiency.
 
+**Every `pattern_score` baseline comes from `baseline_talks`, never from
+`processed_talks`.** `load-vault.py` partitions processed talks by which
+extractor generation scored them and states the reason in `baseline_note`. Talks
+in `stale_instrumentation_talks` were scored blind to text baked into images and
+to payload held in OOXML tables, so their scores measure scan depth rather than
+delivery; a mean over both cohorts tracks reparse progress rather than the
+speaker. This binds `average_pattern_score`, `by_mode`, `score_trend`,
+`pattern_breadth`, and every adherence comparison. Where `baseline_talks` is too
+small for a mode, emit `stable: false` — never top it up from the stale cohort.
+
 Compute `pattern_profile.by_mode` — the per-mode baseline. The tracking DB has no
-per-talk mode field. Assign each `processed_talk` to the `presentation_modes` entry
+per-talk mode field. Assign each `baseline_talk` to the `presentation_modes` entry
 whose `when_to_use` best matches the talk's `structured_data` — `slide_count` and
 `meme_count` density, `audience_interaction_count`, `opening_type`,
 `narrative_arc_type`, and `slide_design_style`. This assignment is a classification

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -50,7 +50,8 @@ python3 skills/vault-profile/scripts/load-vault.py > /tmp/vault-payload.json
 
 **I/O contract:**
 - Args: optional vault-root path; defaults to `~/.claude/rhetoric-knowledge-vault`.
-- Stdout (JSON): `{vault_root, config, confirmed_intents, talks, processed_talks, summary, design_spec}`.
+- Stdout (JSON): `{vault_root, config, confirmed_intents, talks, processed_talks, baseline_talks, stale_instrumentation_talks, baseline_note, summary, design_spec}`.
+- `baseline_talks` and `stale_instrumentation_talks` partition `processed_talks` by which extractor generation scored them; `baseline_note` states the consequence. Partition criterion: see `skills/vault-profile/scripts/load-vault.py` — `partition_by_instrumentation` and the `INSTRUMENTATION_EPOCH` constant above it.
 - Exit non-zero with stderr message if `tracking-database.json` or `rhetoric-style-summary.md` are missing or malformed.
 
 If the script aborts on missing `rhetoric-style-summary.md`, run vault-ingress first. If `slide-design-spec.md` is missing, `design_spec` is `""` and the design-spec section of the profile remains empty — continue without aborting.
@@ -120,14 +121,10 @@ the pattern's taxonomy Vault Dims fit the speaker's `presentation_modes`. This i
 positive-space coaching signal, framed as growth, not deficiency.
 
 **Every `pattern_score` baseline comes from `baseline_talks`, never from
-`processed_talks`.** `load-vault.py` partitions processed talks by which
-extractor generation scored them and states the reason in `baseline_note`. Talks
-in `stale_instrumentation_talks` were scored blind to text baked into images and
-to payload held in OOXML tables, so their scores measure scan depth rather than
-delivery; a mean over both cohorts tracks reparse progress rather than the
-speaker. This binds `average_pattern_score`, `by_mode`, `score_trend`,
+`processed_talks`** — `average_pattern_score`, `by_mode`, `score_trend`,
 `pattern_breadth`, and every adherence comparison. Where `baseline_talks` is too
-small for a mode, emit `stable: false` — never top it up from the stale cohort.
+small for a mode, emit `stable: false`; never top it up from
+`stale_instrumentation_talks`.
 
 Compute `pattern_profile.by_mode` — the per-mode baseline. The tracking DB has no
 per-talk mode field. Assign each `baseline_talk` to the `presentation_modes` entry

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -18,6 +18,9 @@ Stdout (JSON):
       "confirmed_intents": [ ... ]   # tracking-database.json `confirmed_intents`
       "talks":             [ ... ]   # all talks
       "processed_talks":   [ ... ]   # talks with status processed* only
+      "baseline_talks":    [ ... ]   # processed talks scored on current instrumentation
+      "stale_instrumentation_talks": [ ... ]   # processed, but scored pre-epoch
+      "baseline_note":     "...",    # why baselines must use baseline_talks only
       "summary":           "...",    # rhetoric-style-summary.md contents
       "design_spec":       "..."     # slide-design-spec.md contents (or "")
     }
@@ -36,6 +39,28 @@ import sys
 
 
 DEFAULT_VAULT = "~/.claude/rhetoric-knowledge-vault"
+
+# Talks processed on or after this date were scored by an extractor that can read
+# text baked into images and payload held in OOXML tables; talks processed before
+# it were not. The gap is not noise — measured across the corpus mid-reparse, the
+# two cohorts averaged 28.0 and 11.8, and a mixed mean tracks how far the reparse
+# has got rather than anything about the speaker. Partitioning here rather than in
+# skill prose keeps the two cohorts from being averaged together by accident.
+INSTRUMENTATION_EPOCH = "2026-07-26"
+
+
+def partition_by_instrumentation(processed_talks, epoch=INSTRUMENTATION_EPOCH):
+    """Split processed talks into (current-instrumentation, stale) cohorts.
+
+    A talk with no `processed_date` cannot be dated and is treated as stale — the
+    safe direction, since including it would silently contaminate a baseline
+    while excluding it only narrows the sample.
+    """
+    current, stale = [], []
+    for talk in processed_talks:
+        date = talk.get("processed_date") or ""
+        (current if date >= epoch else stale).append(talk)
+    return current, stale
 
 
 def main(argv: list[str]) -> int:
@@ -76,12 +101,25 @@ def main(argv: list[str]) -> int:
     processed_statuses = {"processed", "processed_partial"}
     processed_talks = [t for t in talks if t.get("status") in processed_statuses]
 
+    scoreable, stale = partition_by_instrumentation(processed_talks)
+
     payload = {
         "vault_root": str(vault_root),
         "config": db.get("config", {}),
         "confirmed_intents": db.get("confirmed_intents", []),
         "talks": talks,
         "processed_talks": processed_talks,
+        "baseline_talks": scoreable,
+        "stale_instrumentation_talks": stale,
+        "baseline_note": (
+            f"pattern_score baselines MUST be computed from baseline_talks only "
+            f"({len(scoreable)} talks). The {len(stale)} talks in "
+            f"stale_instrumentation_talks were scored before "
+            f"{INSTRUMENTATION_EPOCH} against an extractor blind to text baked "
+            f"into images and to OOXML-table payload; their scores measure scan "
+            f"depth, not delivery. Mixing the two cohorts produces an average "
+            f"that tracks reparse progress rather than the speaker."
+        ),
         "summary": summary,
         "design_spec": design_spec,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,3 +283,8 @@ def deck_with_text(tmp_path):
 def make_deck(slide_count):
     """Public helper for tests that need a Presentation without saving."""
     return _make_deck(slide_count)
+
+
+@pytest.fixture(scope="session")
+def load_vault():
+    return _import_script(os.path.join(SCRIPTS_VP, "load-vault.py"), "load_vault")

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -68,3 +68,34 @@ def test_profile_with_outdated_schema_version_is_invalid(validate_profile, tmp_p
     assert rc == 1
     assert out["valid"] is False
     assert out["schema_version"] == 1
+
+
+# --- load-vault instrumentation partitioning -------------------------------
+
+def _talks(*dates):
+    return [{"filename": f"t{i}.md", "status": "processed", "processed_date": d}
+            for i, d in enumerate(dates)]
+
+
+def test_partition_splits_on_the_epoch(load_vault):
+    current, stale = load_vault.partition_by_instrumentation(
+        _talks("2026-07-27", "2026-07-26", "2026-07-25", "2026-05-01"))
+    assert [t["processed_date"] for t in current] == ["2026-07-27", "2026-07-26"]
+    assert [t["processed_date"] for t in stale] == ["2026-07-25", "2026-05-01"]
+
+
+def test_undated_talks_are_treated_as_stale(load_vault):
+    """Excluding an undated talk only narrows the sample; including it would
+    silently contaminate the baseline."""
+    talks = _talks("2026-07-27")
+    talks.append({"filename": "x.md", "status": "processed"})
+    talks.append({"filename": "y.md", "status": "processed", "processed_date": None})
+    current, stale = load_vault.partition_by_instrumentation(talks)
+    assert len(current) == 1
+    assert {t["filename"] for t in stale} == {"x.md", "y.md"}
+
+
+def test_epoch_is_injectable_for_callers(load_vault):
+    current, stale = load_vault.partition_by_instrumentation(
+        _talks("2020-01-01"), epoch="2019-01-01")
+    assert len(current) == 1 and not stale


### PR DESCRIPTION
## Why

`load-vault.py` fed every `processed` talk into the profile's `pattern_score` baselines regardless of which extractor scored it.

Talks scored before the 2026-07-26 reparse were measured by an extractor blind to text baked into images and to payload held in OOXML tables. Their scores record **scan depth, not delivery** — one talk moved 13 → 39 on re-scan with no change to the recording, and another 14 → 42. Averaging the two cohorts yields a baseline that tracks how far the reparse has got.

## What

`load-vault.py` emits `baseline_talks`, `stale_instrumentation_talks`, and a `baseline_note` explaining the split. The skill binds `average_pattern_score`, `by_mode`, `score_trend`, `pattern_breadth` and every adherence comparison to `baseline_talks`; a mode with too few current-instrumentation talks emits `stable: false` rather than being topped up from the stale cohort.

Partitioning in the **script** rather than in skill prose is the point. The filter is deterministic (`script-delegation`), and prose asking an agent to remember which cohort a number came from is precisely what does not survive a long run.

An undated talk counts as stale: excluding one only narrows the sample, while including it silently contaminates the baseline.

## Honest scope note

**At the time of writing the split is 95/0.** The stale-scored talks all sit at `needs-reprocessing`, which `load-vault.py` already filtered out, so the profile's baseline was never actually contaminated.

I originally believed it was — I had measured a mixed average across every talk carrying a `pattern_score` and attributed the mixing to the artifact rather than to my own query. It was worth correcting anyway: the guard costs nothing, and it catches the real case, which is generating a profile from a vault partway through a reparse.

## Tests

3 new in `tests/test_validate_profile.py`: epoch boundary (inclusive), undated-talk handling, injectable epoch. `1096 passed, 3 skipped`.