### PR TITLE
fix(vault-ingress): stamp processed_date at second resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### fix(vault-ingress) — stamp `processed_date` at second resolution, not day
+
+0.18.64 made the merge stamp `processed_date` when a return omitted it, and gave
+the stamp a day's resolution. That is too coarse for the case it exists to serve.
+
+During the 2026-07-26 reparse, 90 talks landed under a single date while four
+scoring fixes shipped across the same two days. Nothing in the DB could order a
+talk against a fix that published that afternoon, so the re-check backlog had to
+flag every talk in the run rather than the subset that actually predated each
+fix — 100 flagged where the true number is smaller and unknowable.
+
+The default stamp is now a UTC ISO-8601 timestamp at second resolution. A
+date-only `--run-date` is still accepted so callers can pin a stamp for tests
+and so records written before this change stay readable; the instrumentation
+partition in `load-vault.py` compares stamps lexically, and ISO-8601 sorts
+correctly against a bare date either way.
+
 ## 0.18.68 — 2026-07-27
 
 ### fix(presentation-creator) — antipattern scoring polarity was inverted in 26 of 28 files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and so records written before this change stay readable; the instrumentation
 partition in `load-vault.py` compares stamps lexically, and ISO-8601 sorts
 correctly against a bare date either way.
 
+The clock is injectable. `default_stamp(now=None)` takes the moment as an
+argument so the regression test freezes it rather than asserting whatever the
+run-time clock produced — the first cut tested the default path through a live
+subprocess clock, which `testing-standards` Determinism forbids and which cannot
+assert an exact stamp at all.
+
+A `--run-date` timestamp must now carry a timezone offset, and is normalized to
+UTC at second resolution before it is stored. Ordering talks across machines is
+the point of the stamp and a naive timestamp has no defined position in that
+order; the first cut accepted one and preserved whatever offset it arrived with.
+
 ## 0.18.68 — 2026-07-27
 
 ### fix(presentation-creator) — antipattern scoring polarity was inverted in 26 of 28 files

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -29,18 +29,23 @@ It does NOT touch rhetoric-style-summary.md or the analysis files — those are
 written elsewhere in Step 4/Step 5. It owns only the tracking-DB merge.
 
 Usage:
-    persist-results.py <tracking-database.json> <batch-returns.json> [--run-date YYYY-MM-DD]
+    persist-results.py <tracking-database.json> <batch-returns.json>
+                       [--run-date YYYY-MM-DD|<ISO-8601 timestamp>]
 
     batch-returns.json is a JSON array of subagent return objects (the shape in
     references/schemas-db.md -> "Per-Talk Subagent Return Schema"). The DB is
     rewritten in place; a structured JSON summary is printed to stdout:
-        {"persisted": <int>, "db_path": "<path>", "run_date": "<YYYY-MM-DD>",
+        {"persisted": <int>, "db_path": "<path>",
+         "run_date": "<YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+00:00>",
          "talks": [{"filename": "...", "status": "...", "promoted": ["..."],
                     "stamped_processed_date": <bool>}]}
     Diagnostics and errors go to stderr; exit code is non-zero on failure.
 
-    --run-date pins the stamp instead of reading the clock; the whole batch
-    shares one date so a run that straddles midnight does not split across two.
+    Absent --run-date, the stamp is the current UTC time at second resolution.
+    --run-date pins it instead of reading the clock; the whole batch shares one
+    stamp so a run that straddles midnight does not split across two. It accepts
+    either a bare YYYY-MM-DD or an ISO-8601 timestamp; a timestamp must carry a
+    timezone offset and is normalized to UTC at second resolution.
 
 Example:
     persist-results.py ~/.claude/rhetoric-knowledge-vault/tracking-database.json batch-returns.json
@@ -48,27 +53,41 @@ Example:
 
 import json
 import sys
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 
-def _parse_stamp(value):
-    """Accept a bare date or a full ISO-8601 timestamp.
+def default_stamp(now=None):
+    """Resolve the default run stamp: UTC, second resolution.
 
-    Date-only is still accepted so a caller can pin a stamp for tests and so
-    existing records stay readable, but the default is second-resolution: a
-    day-granular stamp cannot answer "was this talk scored before or after the
-    fix that shipped this afternoon".
+    `now` is injectable so a test can freeze it; the production call site passes
+    nothing and reads the clock once per batch. Second resolution rather than
+    day: a day-granular stamp cannot answer "was this talk scored before or
+    after the fix that shipped this afternoon".
+    """
+    moment = datetime.now(timezone.utc) if now is None else now
+    return moment.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def normalize_stamp(value):
+    """Normalize a --run-date value to the stamp to store, or raise ValueError.
+
+    A bare YYYY-MM-DD passes through unchanged, so a caller can still pin a day
+    and records written before second resolution stay readable. A timestamp must
+    carry a timezone — ordering talks against a same-day fix is the whole point
+    of the stamp, and a naive timestamp from another machine cannot be ordered
+    against one from this one — and is normalized to UTC at second resolution.
     """
     try:
-        date.fromisoformat(value)
-        return True
+        datetime.strptime(value, "%Y-%m-%d")
+        return value
     except ValueError:
         pass
-    try:
-        datetime.fromisoformat(value)
-        return True
-    except ValueError:
-        return False
+    moment = datetime.fromisoformat(value)  # raises ValueError on anything else
+    if moment.tzinfo is None:
+        raise ValueError(
+            f"timestamp {value!r} has no timezone — append an offset "
+            f"(e.g. {value}+00:00) so stamps from different machines order")
+    return default_stamp(moment)
 
 # Queryable scalars promoted from the subagent return onto the talk's top level.
 # (top_level_field, dotted source path within the return). To add a new queryable
@@ -232,11 +251,13 @@ def parse_args(argv):
         # during an active reparse: 90 talks in one run all stamped the same
         # date, and the re-check backlog had to flag every one of them because
         # ordering was unknowable.
-        run_date = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        run_date = default_stamp()
     else:
-        if not _parse_stamp(run_date):
-            print(f"ERROR: --run-date must be YYYY-MM-DD or an ISO-8601 timestamp, "
-                  f"got {run_date!r}", file=sys.stderr)
+        try:
+            run_date = normalize_stamp(run_date)
+        except ValueError as e:
+            print(f"ERROR: --run-date must be YYYY-MM-DD or a timezone-aware "
+                  f"ISO-8601 timestamp: {e}", file=sys.stderr)
             sys.exit(1)
     return args[0], args[1], run_date
 

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -48,7 +48,27 @@ Example:
 
 import json
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
+
+
+def _parse_stamp(value):
+    """Accept a bare date or a full ISO-8601 timestamp.
+
+    Date-only is still accepted so a caller can pin a stamp for tests and so
+    existing records stay readable, but the default is second-resolution: a
+    day-granular stamp cannot answer "was this talk scored before or after the
+    fix that shipped this afternoon".
+    """
+    try:
+        date.fromisoformat(value)
+        return True
+    except ValueError:
+        pass
+    try:
+        datetime.fromisoformat(value)
+        return True
+    except ValueError:
+        return False
 
 # Queryable scalars promoted from the subagent return onto the talk's top level.
 # (top_level_field, dotted source path within the return). To add a new queryable
@@ -185,15 +205,17 @@ def load_json(path, label):
 def parse_args(argv):
     """Split positional paths from the optional --run-date flag.
 
-    Returns (db_path, batch_path, run_date). An absent flag resolves to today,
-    so the common call site needs no extra argument.
+    Returns (db_path, batch_path, run_date). An absent flag resolves to the
+    current UTC timestamp at second resolution, so the common call site needs no
+    extra argument and the stamp can order talks against a same-day fix.
     """
     args, run_date = [], None
     i = 0
     while i < len(argv):
         if argv[i] == "--run-date":
             if i + 1 >= len(argv):
-                print("ERROR: --run-date requires a YYYY-MM-DD value", file=sys.stderr)
+                print("ERROR: --run-date requires a YYYY-MM-DD or ISO-8601 value",
+                      file=sys.stderr)
                 sys.exit(1)
             run_date = argv[i + 1]
             i += 2
@@ -202,15 +224,19 @@ def parse_args(argv):
         i += 1
     if len(args) != 2:
         print(f"Usage: {sys.argv[0]} <tracking-database.json> <batch-returns.json> "
-              f"[--run-date YYYY-MM-DD]", file=sys.stderr)
+              f"[--run-date YYYY-MM-DD|ISO-8601]", file=sys.stderr)
         sys.exit(1)
     if run_date is None:
-        run_date = date.today().isoformat()
+        # Second resolution, not day. A date-only stamp cannot order a talk
+        # against a fix that shipped the same day, which is the normal case
+        # during an active reparse: 90 talks in one run all stamped the same
+        # date, and the re-check backlog had to flag every one of them because
+        # ordering was unknowable.
+        run_date = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     else:
-        try:
-            date.fromisoformat(run_date)
-        except ValueError:
-            print(f"ERROR: --run-date must be YYYY-MM-DD, got {run_date!r}", file=sys.stderr)
+        if not _parse_stamp(run_date):
+            print(f"ERROR: --run-date must be YYYY-MM-DD or an ISO-8601 timestamp, "
+                  f"got {run_date!r}", file=sys.stderr)
             sys.exit(1)
     return args[0], args[1], run_date
 

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -7,6 +7,9 @@ the tracking DB, with the declared queryable scalars promoted to the talk top le
 import json
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
 
 
 def _return(**overrides):
@@ -251,25 +254,47 @@ def test_cli_non_array_batch_is_actionable(persist_results, tmp_path):
     assert "must be a JSON array" in result.stderr
 
 
-def test_default_stamp_is_second_resolution(persist_results, tmp_path):
+def test_default_stamp_is_second_resolution(persist_results):
     """A day-granular stamp cannot order a talk against a fix that shipped the
     same day — during the 2026-07-26 reparse, 90 talks shared one date and the
-    re-check backlog had to flag every one because ordering was unknowable."""
+    re-check backlog had to flag every one because ordering was unknowable.
+
+    The clock is injected, not read: a test asserting a stamp produced from the
+    live wall clock is non-deterministic by construction."""
+    frozen = datetime(2026, 7, 27, 14, 3, 22, 456789, tzinfo=timezone.utc)
+    assert persist_results.default_stamp(frozen) == "2026-07-27T14:03:22+00:00"
+
+
+def test_default_stamp_normalizes_to_utc(persist_results):
+    """Stamps written on machines in different zones must order against each other."""
+    frozen = datetime(2026, 7, 27, 16, 3, 22, tzinfo=timezone(timedelta(hours=2)))
+    assert persist_results.default_stamp(frozen) == "2026-07-27T14:03:22+00:00"
+
+
+def test_explicit_offset_timestamp_is_normalized_to_utc(persist_results):
+    assert persist_results.normalize_stamp(
+        "2026-07-27T16:03:22.987654+02:00") == "2026-07-27T14:03:22+00:00"
+
+
+def test_naive_timestamp_is_rejected_with_an_actionable_message(persist_results):
+    """A naive timestamp cannot be ordered against one from another machine."""
+    with pytest.raises(ValueError) as excinfo:
+        persist_results.normalize_stamp("2026-07-27T14:03:22")
+    assert "+00:00" in str(excinfo.value)
+
+
+def test_cli_rejects_a_naive_timestamp(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    ret = _return()
-    del ret["processed_date"]
     db.write_text(json.dumps({"talks": [_talk()]}))
-    batch.write_text(json.dumps([ret]))
+    batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        [sys.executable, persist_results.__file__, str(db), str(batch),
+         "--run-date", "2026-07-27T14:03:22"],
         capture_output=True, text=True,
     )
-    assert result.returncode == 0, result.stderr
-    stamp = json.loads(db.read_text())["talks"][0]["processed_date"]
-    assert "T" in stamp and len(stamp) > 10, f"not a timestamp: {stamp!r}"
-    from datetime import datetime
-    datetime.fromisoformat(stamp)  # parses or raises
+    assert result.returncode == 1
+    assert "timezone-aware" in result.stderr
 
 
 def test_explicit_date_only_stamp_is_still_accepted(persist_results, tmp_path):

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -249,3 +249,58 @@ def test_cli_non_array_batch_is_actionable(persist_results, tmp_path):
     )
     assert result.returncode == 1
     assert "must be a JSON array" in result.stderr
+
+
+def test_default_stamp_is_second_resolution(persist_results, tmp_path):
+    """A day-granular stamp cannot order a talk against a fix that shipped the
+    same day — during the 2026-07-26 reparse, 90 talks shared one date and the
+    re-check backlog had to flag every one because ordering was unknowable."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    del ret["processed_date"]
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    stamp = json.loads(db.read_text())["talks"][0]["processed_date"]
+    assert "T" in stamp and len(stamp) > 10, f"not a timestamp: {stamp!r}"
+    from datetime import datetime
+    datetime.fromisoformat(stamp)  # parses or raises
+
+
+def test_explicit_date_only_stamp_is_still_accepted(persist_results, tmp_path):
+    """Callers pinning a stamp for reproducibility keep working, and records
+    written before this change stay readable."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    del ret["processed_date"]
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch),
+         "--run-date", "2026-07-26"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(db.read_text())["talks"][0]["processed_date"] == "2026-07-26"
+
+
+def test_explicit_timestamp_is_accepted(persist_results, tmp_path):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    del ret["processed_date"]
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch),
+         "--run-date", "2026-07-27T14:03:22+00:00"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(db.read_text())["talks"][0]["processed_date"].startswith("2026-07-27T14:03:22")


### PR DESCRIPTION
## The defect, in my own fix

0.18.64 made the merge stamp `processed_date` when a subagent return omitted it — and gave the stamp a day's resolution.

That is too coarse for the exact job it exists to do. During the 2026-07-26 reparse **90 talks landed under a single date** while four scoring fixes shipped across the same two days. Nothing in the DB can order a talk against a fix that published that afternoon.

The consequence is concrete: the re-check backlog had to flag **all 100** reparsed talks, because for any same-day fix the ordering is unknowable. The true number is smaller and now unrecoverable for that run.

## Fix

Default stamp is a UTC ISO-8601 timestamp at second resolution.

Date-only `--run-date` is still accepted — callers pinning a stamp for reproducibility keep working, and records written before this change stay readable. The instrumentation partition in `load-vault.py` (#142) compares stamps lexically, and ISO-8601 sorts correctly against a bare date in both directions:

```
'2026-07-25'                 >= '2026-07-26' -> False
'2026-07-26T09:00:00+00:00'  >= '2026-07-26' -> True
```

## Tests

3 new: default is a parseable timestamp, explicit date-only still round-trips, explicit timestamp round-trips. `1096 passed, 3 skipped`.