### PR TITLE
fix(tests): catch bare scripts/foo.py invocations in the exec-bit guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ fixes it surfaced land together. That is more sites than the seven the issue
 listed, and one of them — the `apply-backgrounds.sh` fenced block — was not on
 that list at all.
 
+An environment-assignment prefix counts as an invocation: `FOO=1 scripts/x.sh`
+runs the script and needs the exec bit, which is how the `$VAR` detector has
+always classified `FOO=1 "$HERE/x.sh"`. The first cut of the bare detector read
+the assignment as "not command position" and passed it — a false negative in a
+guard, which is worse than no guard. An assignment OF a path
+(`DRIVER=skills/x/scripts/y.sh`) still stores rather than runs; the whitespace
+after the `=` is what separates the two.
+
 Every one of those invocations also moves to a repo-relative path that actually
 resolves (`skills/<name>/scripts/<file>`, per `skill-authoring` Script
 References). The first cut added the interpreter and kept the `scripts/<file>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ fixes it surfaced land together. That is more sites than the seven the issue
 listed, and one of them — the `apply-backgrounds.sh` fenced block — was not on
 that list at all.
 
+Every one of those invocations also moves to a repo-relative path that actually
+resolves (`skills/<name>/scripts/<file>`, per `skill-authoring` Script
+References). The first cut added the interpreter and kept the `scripts/<file>`
+shorthand, which resolves from nowhere. Six further sites carrying the same
+shorthand are corrected in the same pass: they sit in the files being edited, so
+fixing only the flagged lines would have left each file mixing two conventions —
+the state `skill-authoring` explicitly forbids.
+
 ## 0.18.70 — 2026-07-27
 
 ### fix(vault-ingress) — stamp `processed_date` at second resolution, not day

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+### fix(tests) — the invocation guard now catches bare `scripts/foo.py` commands
+
+`tests/test_script_invocation_style.py` guards the outcome "no invocation
+consults the exec bit", because `tessl install` strips it from every packaged
+script. Its two detectors matched `./foo.py` and `$VAR/foo.py`, and a bare
+repo-relative `scripts/foo.py` is neither — so a line reading ``Run
+`scripts/foo.py` `` passed CI and still failed in a consumer install, which is
+the exact failure shape the guard exists to prevent (#138).
+
+Not hypothetical: `watch-pr-reviews.sh` exited 126 during the 0.18.70 release
+because the mounted copy is mode 644, and the fenced block in
+`illustrations/references/generation.md` would have handed a consumer
+`skills/presentation-creator/scripts/apply-backgrounds.sh` to copy and run.
+
+A bare path is genuinely ambiguous where the other two forms are not — it is a
+valid FILE NAME as well as a valid COMMAND, and `script-as-black-box` REQUIRES
+skills to cite scripts by path, so a detector that flagged every bare path would
+push authors to stop citing scripts at all. Classification is therefore by
+markdown structure, never by parsing prose:
+
+- Inside a fenced code block — the surface a consumer copies verbatim — a bare
+  path at command position with no interpreter is unsafe. Exhaustive.
+- In prose, only a code span introduced by an enumerated execution verb (run,
+  invoke, execute, through) counts. Pointer verbs that also precede script paths
+  in these docs (see, in, from, live in, defined in) are excluded deliberately.
+- Table rows are pointers by construction and are never flagged.
+
+The prose half is an approximation with a stated gap — a novel execution verb
+slips through it — and stands as a second net over the fenced-block rule rather
+than as the primary guard. Naming the limit beats implying a completeness the
+check does not have.
+
+`.py` files are scanned as prose rather than as shell. Treating them as shell
+false-positived two docstring references that wrapped across a line boundary,
+and Python reaches a script through `subprocess`, where the path sits inside
+brackets and quotes and never lands at command position.
+
+Per `language-diagnostics` Adopting on a Dirty Tree, the detector and the 14
+fixes it surfaced land together. That is more sites than the seven the issue
+listed, and one of them — the `apply-backgrounds.sh` fenced block — was not on
+that list at all.
+
 ## 0.18.70 — 2026-07-27
 
 ### fix(vault-ingress) — stamp `processed_date` at second resolution, not day

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -117,7 +117,7 @@ python3 skills/illustrations/scripts/build-expansion-manifest.py \
     --notes notes.json --out builds-manifest.json
 
 # 2. Expand: replace each parent slide with its frames as full-bleed bg-fill slides
-skills/presentation-creator/scripts/expand-builds.sh \
+bash skills/presentation-creator/scripts/expand-builds.sh \
     <deck-copy.pptx> <deck-expanded.pptx> builds-manifest.json
 ```
 

--- a/skills/illustrations/references/generation.md
+++ b/skills/illustrations/references/generation.md
@@ -144,7 +144,7 @@ Run this as the FINAL write of the build, AFTER speaker notes are injected:
 ```bash
 # operate on a uniquely-named copy — PowerPoint keys open decks by filename
 cp deck-with-titles.pptx deck-bg-src.pptx
-skills/presentation-creator/scripts/apply-backgrounds.sh \
+bash skills/presentation-creator/scripts/apply-backgrounds.sh \
   deck-bg-src.pptx deck-final.pptx deck-with-titles.backgrounds.json
 ```
 

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -415,7 +415,7 @@ template's demo slides and creates every slide from the ops. See
 
 ```bash
 python3 scripts/validate-deckops.py ops.txt
-scripts/build-deck.sh "{template_copy_pptx_path}" "{output_path}" ops.txt
+bash scripts/build-deck.sh "{template_copy_pptx_path}" "{output_path}" ops.txt
 ```
 
 For non-illustrated slides and EXCEPTION-format slides, emit the content inline

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -414,8 +414,8 @@ template's demo slides and creates every slide from the ops. See
 [references/deckops-spec.md](references/deckops-spec.md).
 
 ```bash
-python3 scripts/validate-deckops.py ops.txt
-bash scripts/build-deck.sh "{template_copy_pptx_path}" "{output_path}" ops.txt
+python3 skills/presentation-creator/scripts/validate-deckops.py ops.txt
+bash skills/presentation-creator/scripts/build-deck.sh "{template_copy_pptx_path}" "{output_path}" ops.txt
 ```
 
 For non-illustrated slides and EXCEPTION-format slides, emit the content inline

--- a/skills/presentation-creator/references/deckops-spec.md
+++ b/skills/presentation-creator/references/deckops-spec.md
@@ -9,8 +9,8 @@ You (the agent) emit the op sequence from `slides.md` + the profile layout map â
 layout, placeholder, and content choices are your judgment. Then:
 
 ```bash
-python3 scripts/validate-deckops.py ops.txt          # exit 0 + {"slides":N,"ops":M}, or exit 1 + errors
-bash scripts/build-deck.sh <template-copy.pptx> <out.pptx> ops.txt
+python3 skills/presentation-creator/scripts/validate-deckops.py ops.txt          # exit 0 + {"slides":N,"ops":M}, or exit 1 + errors
+bash skills/presentation-creator/scripts/build-deck.sh <template-copy.pptx> <out.pptx> ops.txt
 ```
 
 `build-deck.sh` re-runs the validator first, so a malformed sequence fails fast

--- a/skills/presentation-creator/references/deckops-spec.md
+++ b/skills/presentation-creator/references/deckops-spec.md
@@ -10,7 +10,7 @@ layout, placeholder, and content choices are your judgment. Then:
 
 ```bash
 python3 scripts/validate-deckops.py ops.txt          # exit 0 + {"slides":N,"ops":M}, or exit 1 + errors
-scripts/build-deck.sh <template-copy.pptx> <out.pptx> ops.txt
+bash scripts/build-deck.sh <template-copy.pptx> <out.pptx> ops.txt
 ```
 
 `build-deck.sh` re-runs the validator first, so a malformed sequence fails fast

--- a/skills/presentation-creator/references/phase5-slides.md
+++ b/skills/presentation-creator/references/phase5-slides.md
@@ -36,8 +36,8 @@ saves the output. You emit the ops while walking the outline (Step 5.2), then
 validate and build:
 
 ```bash
-python3 scripts/validate-deckops.py ops.txt
-bash scripts/build-deck.sh '{template_copy_pptx_path}' '{output_path}' ops.txt
+python3 skills/presentation-creator/scripts/validate-deckops.py ops.txt
+bash skills/presentation-creator/scripts/build-deck.sh '{template_copy_pptx_path}' '{output_path}' ops.txt
 ```
 
 Op vocabulary, field layout, and state rules: `references/deckops-spec.md`. The
@@ -181,7 +181,7 @@ so the `<p:notesMasterIdLst>` Keynote patch the old python-pptx pass needed is n
 longer required (see `rules/deck-editing-rules.md`):
 
 ```bash
-bash scripts/inject-notes.sh <uniquely-named deck copy> <out.pptx> notes.json
+bash skills/presentation-creator/scripts/inject-notes.sh <uniquely-named deck copy> <out.pptx> notes.json
 ```
 
 Run this AFTER slide generation, and BEFORE the final `apply-backgrounds.sh`
@@ -239,7 +239,7 @@ editing strips each slide's per-slide background fill — on illustrated decks t
 silently flattens full-bleed art to bare color. See `rules/deck-editing-rules.md`.
 
 ```bash
-bash scripts/run-deck-ops.sh <basePath> <outPath> <importSpec> <orderStr> <replaceStr>
+bash skills/presentation-creator/scripts/run-deck-ops.sh <basePath> <outPath> <importSpec> <orderStr> <replaceStr>
 ```
 
 `orderStr` is the FINAL slide sequence as space-separated `<alias>:<1-based #>`
@@ -293,7 +293,7 @@ speaker's `publishing_process.export_method` and platform.
 Run the export script — it auto-detects PowerPoint (macOS AppleScript) or LibreOffice:
 
 ```bash
-python3 scripts/export-pdf.py path/to/deck.pptx [path/to/output.pdf]
+python3 skills/presentation-creator/scripts/export-pdf.py path/to/deck.pptx [path/to/output.pdf]
 ```
 
 If `output.pdf` is omitted, uses the same name with `.pdf` extension.

--- a/skills/presentation-creator/references/phase5-slides.md
+++ b/skills/presentation-creator/references/phase5-slides.md
@@ -37,7 +37,7 @@ validate and build:
 
 ```bash
 python3 scripts/validate-deckops.py ops.txt
-scripts/build-deck.sh '{template_copy_pptx_path}' '{output_path}' ops.txt
+bash scripts/build-deck.sh '{template_copy_pptx_path}' '{output_path}' ops.txt
 ```
 
 Op vocabulary, field layout, and state rules: `references/deckops-spec.md`. The
@@ -181,7 +181,7 @@ so the `<p:notesMasterIdLst>` Keynote patch the old python-pptx pass needed is n
 longer required (see `rules/deck-editing-rules.md`):
 
 ```bash
-scripts/inject-notes.sh <uniquely-named deck copy> <out.pptx> notes.json
+bash scripts/inject-notes.sh <uniquely-named deck copy> <out.pptx> notes.json
 ```
 
 Run this AFTER slide generation, and BEFORE the final `apply-backgrounds.sh`
@@ -239,7 +239,7 @@ editing strips each slide's per-slide background fill — on illustrated decks t
 silently flattens full-bleed art to bare color. See `rules/deck-editing-rules.md`.
 
 ```bash
-scripts/run-deck-ops.sh <basePath> <outPath> <importSpec> <orderStr> <replaceStr>
+bash scripts/run-deck-ops.sh <basePath> <outPath> <importSpec> <orderStr> <replaceStr>
 ```
 
 `orderStr` is the FINAL slide sequence as space-separated `<alias>:<1-based #>`

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -87,7 +87,7 @@ Default status is always `"pending"` for new entries.
 **Scan for .pptx files:** Recursively glob `**/*.pptx` in `pptx_source_dir`; fuzzy-match
 to `talks[]` entries. Report counts. See [references/schemas-db.md](references/schemas-db.md)
 for the PPTX extraction output schema (per-slide visual data, shape types, global design stats).
-Run `python3 scripts/pptx-extraction.py` for extraction.
+Run `python3 skills/vault-ingress/scripts/pptx-extraction.py` for extraction.
 
 **Pattern taxonomy migration:** See [references/processing-rules.md](references/processing-rules.md) for migration
 logic. In brief: talks with `status` `"processed"` or `"processed_partial"` that
@@ -124,7 +124,7 @@ phase). Mechanical persistence of the batch's subagent JSON returns:
 
 - **Update tracking DB — deterministic merge, NOT hand-mapping.** Collect the
   batch's subagent JSON returns into an array file (`batch-returns.json`) and run
-  `python3 scripts/persist-results.py {vault_root}/tracking-database.json batch-returns.json`.
+  `python3 skills/vault-ingress/scripts/persist-results.py {vault_root}/tracking-database.json batch-returns.json`.
   The script merges each return into its matching talk entry, promotes the declared
   queryable scalars to the talk top level, and rewrites the DB in place; it prints a
   JSON merge summary to stdout and exits non-zero if a return's `filename` matches no
@@ -135,7 +135,7 @@ phase). Mechanical persistence of the batch's subagent JSON returns:
   a new field queryable, extend the return schema and that list; never reintroduce
   manual mapping.
 - **Write per-talk analysis files — run the script, do NOT hand-write them.** Run
-  `python3 scripts/write-analysis.py batch-returns.json {vault_root}/analyses --talks {vault_root}/tracking-database.json`
+  `python3 skills/vault-ingress/scripts/write-analysis.py batch-returns.json {vault_root}/analyses --talks {vault_root}/tracking-database.json`
   over the SAME `batch-returns.json` the merge consumed, so the DB and the files
   cannot diverge. It renders `{vault_root}/analyses/{talk_filename}.md` per return —
   14 dimensions, structured data, verbatim examples, "Presentation Patterns Scoring",
@@ -178,7 +178,7 @@ Runs once after all Step 3 batches have completed.
 Process PPTX files not yet extracted during Step 3: unmatched catalog entries, talks
 that used PDF as primary but have a PPTX available, or entries with
 `pptx_visual_status: "pending"`. Skip if already `"extracted"`.
-Run `python3 scripts/pptx-extraction.py <path.pptx>` for each file.
+Run `python3 skills/vault-ingress/scripts/pptx-extraction.py <path.pptx>` for each file.
 
 **PPTX matching rules:** The .pptx files are in `Conference/Year/TalkName.pptx` and
 shownotes entries have `conference` and `title` fields. Fuzzy-match by: normalize

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -87,7 +87,7 @@ Default status is always `"pending"` for new entries.
 **Scan for .pptx files:** Recursively glob `**/*.pptx` in `pptx_source_dir`; fuzzy-match
 to `talks[]` entries. Report counts. See [references/schemas-db.md](references/schemas-db.md)
 for the PPTX extraction output schema (per-slide visual data, shape types, global design stats).
-Run `scripts/pptx-extraction.py` for extraction.
+Run `python3 scripts/pptx-extraction.py` for extraction.
 
 **Pattern taxonomy migration:** See [references/processing-rules.md](references/processing-rules.md) for migration
 logic. In brief: talks with `status` `"processed"` or `"processed_partial"` that
@@ -178,7 +178,7 @@ Runs once after all Step 3 batches have completed.
 Process PPTX files not yet extracted during Step 3: unmatched catalog entries, talks
 that used PDF as primary but have a PPTX available, or entries with
 `pptx_visual_status: "pending"`. Skip if already `"extracted"`.
-Run `scripts/pptx-extraction.py <path.pptx>` for each file.
+Run `python3 scripts/pptx-extraction.py <path.pptx>` for each file.
 
 **PPTX matching rules:** The .pptx files are in `Conference/Year/TalkName.pptx` and
 shownotes entries have `conference` and `title` fields. Fuzzy-match by: normalize

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -41,7 +41,7 @@ block per the return schema — never to leave them buried only in `rhetoric_not
 text. If it's in the analysis, it must be in `structured_data`.
 
 Persisting those fields is deterministic and script-owned, not a manual per-run mapping —
-SKILL.md Step 4 uses `scripts/persist-results.py` for the merge. Authors do not re-derive
+SKILL.md Step 4 uses `skills/vault-ingress/scripts/persist-results.py` for the merge. Authors do not re-derive
 that logic here.
 
 ## Adherence Assessment

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -41,7 +41,7 @@ block per the return schema — never to leave them buried only in `rhetoric_not
 text. If it's in the analysis, it must be in `structured_data`.
 
 Persisting those fields is deterministic and script-owned, not a manual per-run mapping —
-SKILL.md Step 4 runs `scripts/persist-results.py` for the merge. Authors do not re-derive
+SKILL.md Step 4 uses `scripts/persist-results.py` for the merge. Authors do not re-derive
 that logic here.
 
 ## Adherence Assessment

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -76,7 +76,7 @@ Google Drive PDFs used elsewhere in the vault.
 
 ## Usage
 
-Run `python3 scripts/video-slide-extraction.py` for each video after downloading it:
+Run `python3 skills/vault-ingress/scripts/video-slide-extraction.py` for each video after downloading it:
 
 ```bash
 # Download video at 720p
@@ -86,7 +86,7 @@ yt-dlp -f "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720]"
   "https://www.youtube.com/watch?v={youtube_id}"
 
 # Extract slides
-python3 scripts/video-slide-extraction.py \
+python3 skills/vault-ingress/scripts/video-slide-extraction.py \
   "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
   "{vault_root}/slides-rebuild/{youtube_id}" \
   "{youtube_id}"

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -76,7 +76,7 @@ Google Drive PDFs used elsewhere in the vault.
 
 ## Usage
 
-Run `scripts/video-slide-extraction.py` for each video after downloading it:
+Run `python3 scripts/video-slide-extraction.py` for each video after downloading it:
 
 ```bash
 # Download video at 720p

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -42,7 +42,7 @@ Process the steps below in order; each step's output (vault payload, aggregated 
 
 ## Step 1 — Load Vault Sources
 
-Run `python3 scripts/load-vault.py` to read `tracking-database.json`, `rhetoric-style-summary.md`, and `slide-design-spec.md` from the vault root. The script emits a single JSON payload on stdout.
+Run `python3 skills/vault-profile/scripts/load-vault.py` to read `tracking-database.json`, `rhetoric-style-summary.md`, and `slide-design-spec.md` from the vault root. The script emits a single JSON payload on stdout.
 
 ```bash
 python3 skills/vault-profile/scripts/load-vault.py > /tmp/vault-payload.json
@@ -143,7 +143,7 @@ This is the positive-space counterpart to `recurring_issues`/`underused_patterns
 keep it distinct from Step 8 badges (badges are celebratory, strengths are actionable
 reinforcement the creator skill amplifies).
 
-Compute `pacing.adherence` by running `python3 scripts/compute-pacing-adherence.py`. The
+Compute `pacing.adherence` by running `python3 skills/vault-profile/scripts/compute-pacing-adherence.py`. The
 deterministic arithmetic — duration parsing, slides-per-minute, budget-band
 classification, over-budget counts, rate, and trend — lives in the script per
 `script-delegation`, not in this prose.
@@ -177,7 +177,7 @@ Proceed immediately to Step 5.
 
 ## Step 5 — Validate the Profile
 
-Pipe the constructed profile dict through `python3 scripts/validate-profile.py` to verify all required top-level keys exist and `schema_version` is `2`.
+Pipe the constructed profile dict through `python3 skills/vault-profile/scripts/validate-profile.py` to verify all required top-level keys exist and `schema_version` is `2`.
 
 ```bash
 echo "$PROFILE_JSON" | python3 skills/vault-profile/scripts/validate-profile.py

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -42,7 +42,7 @@ Process the steps below in order; each step's output (vault payload, aggregated 
 
 ## Step 1 — Load Vault Sources
 
-Run `scripts/load-vault.py` to read `tracking-database.json`, `rhetoric-style-summary.md`, and `slide-design-spec.md` from the vault root. The script emits a single JSON payload on stdout.
+Run `python3 scripts/load-vault.py` to read `tracking-database.json`, `rhetoric-style-summary.md`, and `slide-design-spec.md` from the vault root. The script emits a single JSON payload on stdout.
 
 ```bash
 python3 skills/vault-profile/scripts/load-vault.py > /tmp/vault-payload.json
@@ -143,7 +143,7 @@ This is the positive-space counterpart to `recurring_issues`/`underused_patterns
 keep it distinct from Step 8 badges (badges are celebratory, strengths are actionable
 reinforcement the creator skill amplifies).
 
-Compute `pacing.adherence` by running `scripts/compute-pacing-adherence.py`. The
+Compute `pacing.adherence` by running `python3 scripts/compute-pacing-adherence.py`. The
 deterministic arithmetic — duration parsing, slides-per-minute, budget-band
 classification, over-budget counts, rate, and trend — lives in the script per
 `script-delegation`, not in this prose.
@@ -177,7 +177,7 @@ Proceed immediately to Step 5.
 
 ## Step 5 — Validate the Profile
 
-Pipe the constructed profile dict through `scripts/validate-profile.py` to verify all required top-level keys exist and `schema_version` is `2`.
+Pipe the constructed profile dict through `python3 scripts/validate-profile.py` to verify all required top-level keys exist and `schema_version` is `2`.
 
 ```bash
 echo "$PROFILE_JSON" | python3 skills/vault-profile/scripts/validate-profile.py

--- a/tests/test_script_invocation_style.py
+++ b/tests/test_script_invocation_style.py
@@ -62,6 +62,87 @@ NON_EXECUTING = re.compile(
 # Shell separators. Only the segment holding the reference decides its fate.
 SEGMENT_SEPARATOR = re.compile(r"&&|\|\||;|\|")
 
+# A bare repo-relative path: `scripts/foo.py`, `skills/x/scripts/y.sh`. No
+# leading `./`, no `$VAR`. This form is genuinely ambiguous in a way the other
+# two are not — it is a valid FILE NAME as well as a valid COMMAND, and
+# `rules/script-as-black-box.md` actively requires skills to name script paths
+# as pointers ("see skills/release/resolve-publish-run.sh"). So a bare path
+# cannot be flagged on sight; the classification below is by markdown STRUCTURE,
+# not by parsing the surrounding prose.
+BARE_PATH_REFERENCE = re.compile(
+    r"(?:^|[^A-Za-z0-9_/.$-])((?:scripts|skills)/[A-Za-z0-9_./-]*\.(?:sh|py))\b"
+)
+
+FENCE = re.compile(r"^\s*```")
+
+# A markdown table row. Key Files tables name scripts in code spans and are
+# pointers by construction, never commands.
+TABLE_ROW = re.compile(r"^\s*\|")
+
+# An inline code span.
+CODE_SPAN = re.compile(r"`([^`]+)`")
+
+# Prose verbs that make the code span after them a command rather than a name.
+# Deliberately tight and enumerable (`rules/script-delegation.md` The Regex
+# Trap): every entry means "execute this", and pointer verbs that also precede
+# script paths in these docs — see, in, from, live(s) in, defined in, owned by,
+# with, via — are deliberately excluded, because flagging those would fight
+# `script-as-black-box`.
+#
+# Known limit, stated rather than papered over: a novel execution verb slips
+# through this list. The fenced-block rule below has no such gap, and a fenced
+# block is the surface a consumer actually copies from — this inline rule is a
+# second net over prose, not the primary guard.
+RUN_VERB_BEFORE = re.compile(
+    r"(?:^|[^A-Za-z0-9_-])(?:run|runs|running|invoke|invokes|invoking|"
+    r"execute|executes|executing|through)\s+$",
+    re.IGNORECASE,
+)
+
+
+def _bare_is_at_command_position(segment: str, match: re.Match) -> bool:
+    """True when a bare path opens its segment, i.e. it IS the command word.
+
+    A bare path appearing as an ARGUMENT (`cat skills/x/scripts/y.py`,
+    `--manifest scripts/z.json`) is data, not an invocation, so only a
+    segment-initial reference counts.
+    """
+    before = segment[:match.start(1)]
+    while True:
+        peeled = CONTROL_PREFIX.sub("", before, count=1)
+        if peeled == before:
+            break
+        before = peeled
+    return not before.strip()
+
+
+def _unsafe_bare_references(line: str, in_fence: bool) -> list[str]:
+    """Bare-path invocations on this line, classified by markdown structure."""
+    if line.lstrip().startswith("#") and not in_fence:
+        return []
+    if TABLE_ROW.match(line):
+        return []
+
+    unsafe = []
+    if in_fence:
+        # Inside a fence the reader copies the line verbatim. A bare path at
+        # command position with no interpreter needs the stripped exec bit.
+        for segment in SEGMENT_SEPARATOR.split(line):
+            for match in BARE_PATH_REFERENCE.finditer(segment):
+                if _bare_is_at_command_position(segment, match):
+                    unsafe.append(match.group(1))
+        return unsafe
+
+    # In prose, only a span introduced by an execution verb is a command.
+    for span in CODE_SPAN.finditer(line):
+        if not RUN_VERB_BEFORE.search(line[:span.start()]):
+            continue
+        content = span.group(1)
+        match = BARE_PATH_REFERENCE.search(" " + content)
+        if match and _bare_is_at_command_position(" " + content, match):
+            unsafe.append(match.group(1))
+    return unsafe
+
 
 def _reference_is_safe(segment: str, match: re.Match) -> bool:
     """True when this specific reference is named without needing the exec bit."""
@@ -120,6 +201,34 @@ def _scan(skill_files: list[Path], reference: re.Pattern) -> list[str]:
     return offenders
 
 
+def _scan_bare(skill_files: list[Path]) -> list[str]:
+    """Scan for bare-path invocations, tracking fenced-block state per file.
+
+    Fence state is why this cannot reuse `_scan`: the same line means different
+    things inside and outside a code fence, so classification is not a pure
+    function of the line.
+
+    Shell scripts are shell top to bottom, so every line counts as fenced. A
+    `.py` file is NOT — a bare path at the start of one of its lines is a
+    docstring continuation, never a command, and two such wrapped references
+    false-positived when `.py` was treated as shell. Python invokes a script
+    through `subprocess`, where the path sits inside brackets and quotes and so
+    is never at command position anyway.
+    """
+    offenders = []
+    for path in skill_files:
+        is_markdown = path.suffix == ".md"
+        in_fence = path.suffix == ".sh"
+        for lineno, line in _lines(path):
+            if is_markdown and FENCE.match(line):
+                in_fence = not in_fence
+                continue
+            if _unsafe_bare_references(line, in_fence):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+    return offenders
+
+
 @pytest.fixture(scope="module")
 def skill_files() -> list[Path]:
     """Every skill doc and skill script — the surfaces a consumer executes."""
@@ -162,6 +271,75 @@ def test_no_exec_bit_dependent_sibling_invocations(skill_files: list[Path]) -> N
         "install strips the executable bit; use `source \"$HERE/x.sh\"` or "
         "`bash \"$HERE/x.sh\"`.\n" + "\n".join(offenders)
     )
+
+
+def test_no_exec_bit_dependent_bare_path_invocations(skill_files: list[Path]) -> None:
+    """A bare `scripts/foo.py` command needs the exec bit just like `./foo.py`.
+
+    This is the gap that let the #137 defect reach CI green (issue #138): the
+    other two detectors match `./foo.py` and `$VAR/foo.py`, and a bare
+    repo-relative path is neither.
+    """
+    offenders = _scan_bare(skill_files)
+    assert not offenders, (
+        "Scripts invoked through a bare repo-relative path with no interpreter. "
+        "tessl install strips the executable bit, so these work in this checkout "
+        "and fail for consumers. Prefix with `bash` / `python3`.\n"
+        + "\n".join(offenders)
+    )
+
+
+UNSAFE_BARE_FENCED = [
+    'skills/presentation-creator/scripts/apply-backgrounds.sh \\',
+    'scripts/load-vault.py > /tmp/out.json',
+    'if scripts/poll.sh; then',
+]
+
+SAFE_BARE_FENCED = [
+    'python3 skills/vault-profile/scripts/load-vault.py > /tmp/out.json',
+    'bash skills/presentation-creator/scripts/apply-backgrounds.sh a b c',
+    'cp skills/x/scripts/RunDeckOps.bas "$DEST"',
+    'cat skills/x/scripts/y.py',
+    'DRIVER=skills/x/scripts/y.sh',
+    'cp deck-with-titles.pptx deck-bg-src.pptx',
+]
+
+UNSAFE_BARE_PROSE = [
+    'Run `scripts/load-vault.py` to read the vault sources.',
+    'Compute it by running `scripts/compute-pacing-adherence.py`. The',
+    'Pipe the profile dict through `scripts/validate-profile.py` to verify keys.',
+]
+
+# Pointers, not commands. `rules/script-as-black-box.md` REQUIRES these — a
+# detector that flagged them would push authors to stop citing scripts at all.
+SAFE_BARE_PROSE = [
+    'Partition criterion: see `skills/vault-profile/scripts/load-vault.py` — the constant.',
+    'The validator (`scripts/validate-profile.py`, schema_version 2) checks keys.',
+    'Per-model attributes live in `skills/illustrations/scripts/model_registry.py`.',
+    '| `scripts/load-vault.py` | Read vault sources, emit JSON to stdout |',
+    '| `skills/illustrations/scripts/model_registry.py` | Model roster |',
+    'Run `python3 scripts/load-vault.py` to read the vault sources.',
+]
+
+
+@pytest.mark.parametrize("line", UNSAFE_BARE_FENCED)
+def test_bare_detector_flags_fenced_invocations(line: str) -> None:
+    assert _unsafe_bare_references(line, in_fence=True), f"should have been flagged: {line}"
+
+
+@pytest.mark.parametrize("line", SAFE_BARE_FENCED)
+def test_bare_detector_accepts_fenced_non_invocations(line: str) -> None:
+    assert not _unsafe_bare_references(line, in_fence=True), f"should have been accepted: {line}"
+
+
+@pytest.mark.parametrize("line", UNSAFE_BARE_PROSE)
+def test_bare_detector_flags_prose_invocations(line: str) -> None:
+    assert _unsafe_bare_references(line, in_fence=False), f"should have been flagged: {line}"
+
+
+@pytest.mark.parametrize("line", SAFE_BARE_PROSE)
+def test_bare_detector_accepts_prose_pointers(line: str) -> None:
+    assert not _unsafe_bare_references(line, in_fence=False), f"should have been accepted: {line}"
 
 
 UNSAFE_LINES = [

--- a/tests/test_script_invocation_style.py
+++ b/tests/test_script_invocation_style.py
@@ -52,6 +52,11 @@ ASSIGNMENT_BEFORE = re.compile(r"=[\"']?$")
 # `if "$HERE/x.sh"; then` executes the script exactly like a bare call.
 CONTROL_PREFIX = re.compile(r"^\s*(?:if|elif|while|until|then|else|do|!|time)\s+")
 
+# An environment-assignment PREFIX: `FOO=1 scripts/x.sh` runs the script. The
+# trailing `\s+` is what separates this from an assignment OF a path
+# (`DRIVER=skills/x/scripts/y.sh`), which stores it and never runs it.
+ENV_ASSIGNMENT_PREFIX = re.compile(r"^\s*[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+
 # Commands that name a path without executing it. `[` / `[[` sit outside the \b
 # group: no word boundary exists between a bracket and the space after it.
 NON_EXECUTING = re.compile(
@@ -106,10 +111,16 @@ def _bare_is_at_command_position(segment: str, match: re.Match) -> bool:
     A bare path appearing as an ARGUMENT (`cat skills/x/scripts/y.py`,
     `--manifest scripts/z.json`) is data, not an invocation, so only a
     segment-initial reference counts.
+
+    Environment-assignment PREFIXES are peeled, because `FOO=1 scripts/x.sh`
+    still executes the script and still needs the exec bit — the same call the
+    `$VAR` detector already treats as unsafe. An assignment OF the path
+    (`DRIVER=skills/x/scripts/y.sh`) stores it instead, and survives the peel
+    because no whitespace separates the `=` from the value.
     """
     before = segment[:match.start(1)]
     while True:
-        peeled = CONTROL_PREFIX.sub("", before, count=1)
+        peeled = ENV_ASSIGNMENT_PREFIX.sub("", CONTROL_PREFIX.sub("", before, count=1), count=1)
         if peeled == before:
             break
         before = peeled
@@ -293,6 +304,11 @@ UNSAFE_BARE_FENCED = [
     'skills/presentation-creator/scripts/apply-backgrounds.sh \\',
     'scripts/load-vault.py > /tmp/out.json',
     'if scripts/poll.sh; then',
+    # Environment-assignment PREFIX: the script still executes. Matches how the
+    # `$VAR` detector already classifies `FOO=1 "$HERE/ensure-drivers.sh"`.
+    'FOO=1 scripts/poll.sh',
+    'A=1 B=2 skills/x/scripts/y.sh',
+    'DEBUG=1 skills/presentation-creator/scripts/apply-backgrounds.sh a b',
 ]
 
 SAFE_BARE_FENCED = [
@@ -300,7 +316,9 @@ SAFE_BARE_FENCED = [
     'bash skills/presentation-creator/scripts/apply-backgrounds.sh a b c',
     'cp skills/x/scripts/RunDeckOps.bas "$DEST"',
     'cat skills/x/scripts/y.py',
+    # Assignment OF the path stores it; no whitespace after the `=`.
     'DRIVER=skills/x/scripts/y.sh',
+    'FOO=1 bash scripts/poll.sh',
     'cp deck-with-titles.pptx deck-bg-src.pptx',
 ]
 


### PR DESCRIPTION
Closes #138.

## The gap

`tests/test_script_invocation_style.py` guards "no invocation consults the exec bit" — `tessl install` strips it from every packaged script. Its detectors matched `./foo.py` and `$VAR/foo.py`. A bare `scripts/foo.py` is neither, so ``Run `scripts/foo.py` `` passed CI and still failed for consumers.

**It fired for real this session.** `watch-pr-reviews.sh` exited 126 during the 0.18.70 release because the mounted copy is mode 644. And `illustrations/references/generation.md` had a fenced `bash` block handing consumers `skills/presentation-creator/scripts/apply-backgrounds.sh` to copy and run — a site the issue did not list.

## Why this isn't just a third regex

A bare path is ambiguous where the other two forms are not: it's a valid file NAME as well as a valid COMMAND. `script-as-black-box` *requires* skills to cite scripts by path, so flagging every bare path would push authors to stop citing scripts at all — one rule fighting another.

Classification is by markdown structure, never by parsing prose:

| context | rule |
|---|---|
| fenced code block | bare path at command position, no interpreter → unsafe. **Exhaustive** |
| prose code span | only after an enumerated execution verb (run/invoke/execute/through) |
| table row | pointer by construction, never flagged |

Pointer verbs that also precede script paths in these docs — see, in, from, live in, defined in — are excluded deliberately.

**Stated limit:** a novel execution verb slips past the prose half. It's a second net over the fenced-block rule, not the primary guard. Documented in the docstring rather than implied away.

`.py` files are scanned as prose, not shell — treating them as shell false-positived two docstring references that wrapped across a line boundary, and Python reaches scripts via `subprocess` where the path never lands at command position.

## Scope

Per `language-diagnostics` Adopting on a Dirty Tree, the detector lands with the **14 fixes** it surfaced (issue listed 7). 19 new tests, including both-direction detector tests per context. Full suite 1122 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AW91SuWHRNW1mHL6MZCfZ