### PR TITLE
feat(vault-ingress): fetch transcripts with a real script that validates

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -23,6 +23,7 @@
     "rules/resources-gathering-rules.md",
     "rules/interaction-rules.md",
     "rules/tessl-version-floating.md",
-    "rules/shownotes-content-publish.md"
+    "rules/shownotes-content-publish.md",
+    "rules/transcript-fetch-authority.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+### feat(vault-ingress) — a real transcript fetcher that validates before it writes
+
+Four of the vault's transcripts were Python tracebacks. Not truncated files —
+the fetcher's own crash, written to the transcript path:
+
+> `AttributeError: type object 'YouTubeTranscriptApi' has no attribute 'get_transcript'`
+
+`youtube-transcript-api` 1.0 removed that classmethod, every fetch raised, and
+the traceback landed where speech belongs. The error handler then raised too
+(`NameError: name 'sys' is not defined`), so the failure path failed as well.
+Two more transcripts are zero bytes. Nothing validated any of it, so a talk with
+a stack trace for a transcript was indistinguishable from a talk with a real one
+— and `0MGvxG-sc6g` (Java Puzzlers NG S01) was marked `processed` off an empty
+file and recorded that nowhere.
+
+The traceback reads `File "<string>"`. The fetch was a `python3 -c` heredoc and
+no committed fetcher existed anywhere in `skills/`. That is the root cause, and
+it is what `rules/script-delegation.md` Scripts Are Real Files prevents: a real
+script gets an exit code, a stderr channel, and tests. An inline heredoc gets to
+write its stack trace into the corpus and exit 0.
+
+`scripts/fetch-transcript.py` tries the caption track, falls back to local
+Whisper, and validates before writing — empty, a Python-error signature at the
+head, a word floor, mostly-`[Music]` caption tracks, and a words-per-minute floor
+when a runtime is supplied. The write is atomic and happens only after validation
+passes, so a failed fetch leaves no file rather than a crash report.
+
+The validation is pure, so CI exercises every failure mode from fixtures — no
+network, no YouTube, no Apple-Silicon Whisper. Two bugs surfaced while repairing
+the real corpus with it, both caught before merge and both now regression-tested:
+
+- Library exceptions propagated instead of falling through, so a video with
+  captions disabled crashed the fetcher rather than reaching Whisper — the
+  original defect one layer up. `YouTubeTranscriptApiException` is now caught and
+  returns `None`.
+- One test passed `not-a-video` as an unresolvable id. It is eleven characters
+  drawn from the id alphabet, so it IS well-formed, and the test reached YouTube.
+  Replaced with a URL carrying no id, which fails at resolution before any
+  network call.
+
+`segments_to_text` accepts both the pre-1.0 dict shape and the 1.0 object shape;
+pinning to one shape is what broke the previous fetch.
+
+`youtube-transcript-api` is pinned at 1.2.4 and declared. The pin is deliberate
+rather than habitual: an uncontrolled upgrade of this exact library is what
+corrupted the data, so the next API break arrives as a Dependabot PR instead of
+as tracebacks in the corpus.
+
 ## 0.18.71 — 2026-07-27
 
 ### fix(tests) — the invocation guard now catches bare `scripts/foo.py` commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,33 @@ the real corpus with it, both caught before merge and both now regression-tested
 `segments_to_text` accepts both the pre-1.0 dict shape and the 1.0 object shape;
 pinning to one shape is what broke the previous fetch.
 
+**The inline fetch that caused all of this was still committed.** The reviewer
+found it: `references/subagent-instructions.md` still told every subagent to run
+
+```
+"{python_path}" -c "
+from youtube_transcript_api import YouTubeTranscriptApi
+transcript = YouTubeTranscriptApi.get_transcript(...)
+" > "{vault_root}/transcripts/{youtube_id}.txt"
+```
+
+— the literal heredoc whose output is in the corpus, redirect and all. Fixing
+`SKILL.md` while leaving that in the reference agents are sent to would have
+changed nothing about what agents actually do. The section is now one call to
+the script, with its exit-code contract tabled and a note that a transcript
+already on disk is not proof of a transcript.
+
+Tool-state failures now honour the JSON contract. A missing `yt-dlp` raised
+`FileNotFoundError` and the script died without printing its documented object —
+the same silent-failure shape it exists to prevent, one level up. `yt-dlp` and
+`mlx_whisper.transcribe()` are both guarded, and both return `None` so the caller
+emits the failure JSON and exits 1.
+
+`rules/transcript-fetch-authority.md` is the authority of record for the Whisper
+layer's Platform-Bound Untestable Carve-Out, naming the exempt wrapper and its
+four-step manual validation — including the step that proves a missing `yt-dlp`
+still yields the JSON contract and still leaves no file behind.
+
 `youtube-transcript-api` is pinned at 1.2.4 and declared. The pin is deliberate
 rather than habitual: an uncontrolled upgrade of this exact library is what
 corrupted the data, so the next API break arrives as a Dependabot PR instead of

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ The plugin ships persistent rules (auto-loaded by the agent at runtime via `.tes
 | [`interaction-rules`](rules/interaction-rules.md) | Conversational stance and gate behavior across phases. |
 | [`tessl-version-floating`](rules/tessl-version-floating.md) | Authority-of-record for the `tessl.json` floating-spec carve-out (paired with `scripts/check-tessl-pins.sh`). |
 | [`shownotes-content-publish`](rules/shownotes-content-publish.md) | Authority-of-record for the shownotes content direct-push carve-out (paired with `skills/shownotes-publisher/scripts/content-only-gate.sh`). |
+| [`transcript-fetch-authority`](rules/transcript-fetch-authority.md) | Authority-of-record for the Whisper layer's platform-bound untestable carve-out (paired with `skills/vault-ingress/scripts/fetch-transcript.py`). |
 
 ## Vault Skills Details
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,12 @@ dependencies = [
     "numpy",
     "pydantic==2.13.4",
     "PyYAML==6.0.3",
+    # Pinned deliberately, not by habit: 1.0 removed the `get_transcript`
+    # classmethod, and that uncontrolled API change is what put four Python
+    # tracebacks into the vault's transcripts. Pin + Dependabot pip ecosystem
+    # in .github/dependabot.yml (weekly), so the next break lands as a reviewed
+    # bump rather than as corrupt data.
+    "youtube-transcript-api==1.2.4",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,15 @@ dependencies = [
 test = [
     "pytest",
 ]
+# Local Whisper transcription, used by vault-ingress/scripts/fetch-transcript.py
+# when a video has no caption track. Optional and not in the base dependency set
+# because mlx-whisper requires Apple Silicon and cannot install on the Linux CI
+# runners — see `rules/testing-standards.md` Platform-Bound Untestable Carve-Out.
+# The script imports it lazily and degrades with an actionable message, so the
+# caption path works everywhere without it.
+whisper = [
+    "mlx-whisper==0.4.3",
+]
 
 [tool.setuptools]
 py-modules = []

--- a/rules/transcript-fetch-authority.md
+++ b/rules/transcript-fetch-authority.md
@@ -14,8 +14,9 @@ description: Authority of record for the Whisper transcription layer's Platform-
 
 ## Covered Artifact
 
-- `fetch_whisper()` in `skills/vault-ingress/scripts/fetch-transcript.py` — the audio download plus `mlx_whisper.transcribe()` call. Nothing else in the file is exempt.
+- `transcribe_audio()` in `skills/vault-ingress/scripts/fetch-transcript.py` — the `mlx_whisper.transcribe()` call — and `fetch_whisper()`, which downloads audio and delegates to it. Both the YouTube `--method whisper` path and the non-YouTube `--audio` path reach the exemption through `transcribe_audio()`; nothing else in the file is exempt.
 - `mlx-whisper` is declared as the optional `whisper` extra in `pyproject.toml`, never a base dependency. The caption path and every validator work without it.
+- Non-YouTube talks route through `--audio` on this same script. Transcription is deterministic script work per `jbaruch/coding-policy: script-delegation`, so no skill prose may call `mlx_whisper.transcribe()` directly — a hand-rolled call carries none of the validation, atomic write, or JSON contract, which is the defect class this script was written to end.
 
 ## Precondition 1 — CI-Runnable Pieces Are Extracted and Tested
 
@@ -32,8 +33,9 @@ Run against a talk whose caption track is disabled, on Apple Silicon with the
 2. Observe: exit 0, one JSON object on stdout with `"method": "whisper"` and a `words` count plausible for the runtime (conference delivery is 110–160 wpm).
 3. Confirm `/tmp/t.txt` holds prose, not `[Music]` markers or a traceback.
 4. Re-run with `yt-dlp` removed from `PATH`. Expect exit 1, a stderr line naming the install command, one JSON object with `"ok": false`, and NO file at the output path.
+5. `--audio <local file> --out /tmp/a.txt` on a non-YouTube recording: exit 0, `"method": "whisper"`, prose at the output path.
 
-A pass requires all four. Step 4 is the one that matters: it proves a tool-state failure still honours the JSON contract and still leaves nothing behind.
+A pass requires all five. Step 4 is the one that matters: it proves a tool-state failure still honours the JSON contract and still leaves nothing behind.
 
 ## Scope Limits
 

--- a/rules/transcript-fetch-authority.md
+++ b/rules/transcript-fetch-authority.md
@@ -6,11 +6,11 @@ description: Authority of record for the Whisper transcription layer's Platform-
 
 # Transcript Fetch Authority
 
-## Why
+## Carve-Out Claimed
 
-- `skills/vault-ingress/scripts/fetch-transcript.py` acquires a talk transcript from a caption track, falling back to local Whisper transcription of the downloaded audio.
-- The Whisper layer needs `mlx-whisper`, which requires Apple Silicon and cannot install on the project's Linux CI runners.
-- `jbaruch/coding-policy: testing-standards` Platform-Bound Untestable Carve-Out permits an exempt layer under three preconditions. This rule is the authority of record satisfying precondition 3: it names the carve-out, the exempt artifact, and where the manual validation procedure lives.
+- `jbaruch/coding-policy: testing-standards` Platform-Bound Untestable Carve-Out.
+- This rule is the authority of record satisfying precondition 3 — it names the carve-out, the exempt artifact, and where the manual validation procedure lives.
+- Qualifying condition: `mlx-whisper` requires Apple Silicon and cannot install on the project's Linux CI runners.
 
 ## Covered Artifact
 

--- a/rules/transcript-fetch-authority.md
+++ b/rules/transcript-fetch-authority.md
@@ -1,0 +1,42 @@
+---
+alwaysApply: false
+applyTo: "skills/vault-ingress/scripts/fetch-transcript.py, pyproject.toml — when changing transcript acquisition or the mlx-whisper dependency"
+description: Authority of record for the Whisper transcription layer's Platform-Bound Untestable Carve-Out
+---
+
+# Transcript Fetch Authority
+
+## Why
+
+- `skills/vault-ingress/scripts/fetch-transcript.py` acquires a talk transcript from a caption track, falling back to local Whisper transcription of the downloaded audio.
+- The Whisper layer needs `mlx-whisper`, which requires Apple Silicon and cannot install on the project's Linux CI runners.
+- `jbaruch/coding-policy: testing-standards` Platform-Bound Untestable Carve-Out permits an exempt layer under three preconditions. This rule is the authority of record satisfying precondition 3: it names the carve-out, the exempt artifact, and where the manual validation procedure lives.
+
+## Covered Artifact
+
+- `fetch_whisper()` in `skills/vault-ingress/scripts/fetch-transcript.py` — the audio download plus `mlx_whisper.transcribe()` call. Nothing else in the file is exempt.
+- `mlx-whisper` is declared as the optional `whisper` extra in `pyproject.toml`, never a base dependency. The caption path and every validator work without it.
+
+## Precondition 1 — CI-Runnable Pieces Are Extracted and Tested
+
+- `validate_transcript()`, `count_words()`, `resolve_video_id()`, `segments_to_text()` and `write_atomically()` are pure and carry tests in `tests/test_fetch_transcript.py`.
+- Those tests cover every validation failure mode from fixtures: empty, Python-error signature, word floor, mostly-`[Music]`, words-per-minute floor, Cyrillic word counting, both caption-segment shapes, atomic write, and caption-exception fall-through.
+- Only the audio-download-and-transcribe wrapper is exempt.
+
+## Precondition 2 — Manual Validation Procedure
+
+Run against a talk whose caption track is disabled, on Apple Silicon with the
+`whisper` extra installed:
+
+1. `python3 skills/vault-ingress/scripts/fetch-transcript.py <youtube_id> --out /tmp/t.txt --method whisper`
+2. Observe: exit 0, one JSON object on stdout with `"method": "whisper"` and a `words` count plausible for the runtime (conference delivery is 110–160 wpm).
+3. Confirm `/tmp/t.txt` holds prose, not `[Music]` markers or a traceback.
+4. Re-run with `yt-dlp` removed from `PATH`. Expect exit 1, a stderr line naming the install command, one JSON object with `"ok": false`, and NO file at the output path.
+
+A pass requires all four. Step 4 is the one that matters: it proves a tool-state failure still honours the JSON contract and still leaves nothing behind.
+
+## Scope Limits
+
+- The carve-out covers this one wrapper. It does not extend to another script, another dependency, or the caption path.
+- Adding a second exempt artifact requires naming it here AND documenting its own validation procedure. Adding one without both invalidates the precondition.
+- "Hard to install in CI" does not qualify — see `jbaruch/coding-policy: ci-safety` Install, Don't Skip. `mlx-whisper` qualifies because it cannot run on the runner's architecture at all.

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -38,13 +38,13 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/video-slide-extraction.md](references/video-slide-extraction.md) | Video-to-slides pipeline — layout heuristics, tuning, limitations |
 | [references/processing-rules.md](references/processing-rules.md) | Language policy, pattern migration logic, structured field rules |
 | [references/known-issues.md](references/known-issues.md) | Edge cases — wide-angle recordings, Whisper hallucination, non-speaker talks |
-| `scripts/persist-results.py` | Deterministically merge batch subagent returns into the tracking DB (Step 4) |
-| `scripts/write-analysis.py` | Render per-talk `analyses/*.md` from the same batch returns (Step 4) |
-| `scripts/pptx-extraction.py` | Extract visual design data from .pptx files |
-| `scripts/video-slide-extraction.py` | Extract slides from video via ffmpeg + perceptual dedup |
-| `scripts/batch-download-videos.sh` | Parallel video download for batch processing |
-| `scripts/vtt-cleanup.py` | Clean VTT subtitles into plain transcript text |
-| `scripts/fetch-transcript.py` | Fetch a transcript, validate it, write only if real (captions → local Whisper) |
+| `skills/vault-ingress/scripts/persist-results.py` | Deterministically merge batch subagent returns into the tracking DB (Step 4) |
+| `skills/vault-ingress/scripts/write-analysis.py` | Render per-talk `analyses/*.md` from the same batch returns (Step 4) |
+| `skills/vault-ingress/scripts/pptx-extraction.py` | Extract visual design data from .pptx files |
+| `skills/vault-ingress/scripts/video-slide-extraction.py` | Extract slides from video via ffmpeg + perceptual dedup |
+| `skills/vault-ingress/scripts/batch-download-videos.sh` | Parallel video download for batch processing |
+| `skills/vault-ingress/scripts/vtt-cleanup.py` | Clean VTT subtitles into plain transcript text |
+| `skills/vault-ingress/scripts/fetch-transcript.py` | Fetch a transcript, validate it, write only if real (captions → local Whisper) |
 
 A talk is processable when it has `video_url`. Slide sources, in order of preference:
 1. `pptx_path` — richest data (exact colors, fonts, shapes via python-pptx)
@@ -117,7 +117,7 @@ Full procedure — slide acquisition per `slide_source`, rhetoric/style analysis
 pattern-taxonomy tagging, and the return-JSON shape — lives in
 [references/subagent-instructions.md](references/subagent-instructions.md).
 
-Transcripts come from `scripts/fetch-transcript.py`, never from inline fetch
+Transcripts come from `skills/vault-ingress/scripts/fetch-transcript.py`, never from inline fetch
 code. It tries the caption track, falls back to local Whisper, validates the
 result, and writes atomically only on success — so a failed fetch leaves no file
 rather than leaving a crash report where speech belongs:
@@ -146,7 +146,7 @@ phase). Mechanical persistence of the batch's subagent JSON returns:
   talk. Do NOT hand-copy fields one at a time — that is what dropped structured data
   before (it was computed and reached the analysis files but never landed in the DB).
   Contract, the promoted-scalar allowlist, and merge semantics live in
-  `scripts/persist-results.py` (top-of-file docstring and the `PROMOTE` list) — to make
+  `skills/vault-ingress/scripts/persist-results.py` (top-of-file docstring and the `PROMOTE` list) — to make
   a new field queryable, extend the return schema and that list; never reintroduce
   manual mapping.
 - **Write per-talk analysis files — run the script, do NOT hand-write them.** Run
@@ -156,7 +156,7 @@ phase). Mechanical persistence of the batch's subagent JSON returns:
   14 dimensions, structured data, verbatim examples, "Presentation Patterns Scoring",
   and catalog feedback — creates `analyses/` if missing, prints a JSON summary, and
   exits non-zero on a return with no `filename`. Section list and field handling live
-  in `scripts/write-analysis.py` (top-of-file docstring).
+  in `skills/vault-ingress/scripts/write-analysis.py` (top-of-file docstring).
 
 Proceed immediately to Step 5.
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -44,6 +44,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | `scripts/video-slide-extraction.py` | Extract slides from video via ffmpeg + perceptual dedup |
 | `scripts/batch-download-videos.sh` | Parallel video download for batch processing |
 | `scripts/vtt-cleanup.py` | Clean VTT subtitles into plain transcript text |
+| `scripts/fetch-transcript.py` | Fetch a transcript, validate it, write only if real (captions → local Whisper) |
 
 A talk is processable when it has `video_url`. Slide sources, in order of preference:
 1. `pptx_path` — richest data (exact colors, fonts, shapes via python-pptx)
@@ -112,10 +113,24 @@ batch. When all batches have finished, proceed to Step 6.
 
 Each subagent receives the talk's DB entry and current
 `rhetoric-style-summary.md`, runs A → B → B2 → C, and returns a JSON payload.
-Full procedure — transcript download (YouTube auto-subs → youtube-transcript-api
-→ Whisper fallback chain), slide acquisition per `slide_source`, rhetoric/style
-analysis, pattern-taxonomy tagging, and the return-JSON shape — lives in
+Full procedure — slide acquisition per `slide_source`, rhetoric/style analysis,
+pattern-taxonomy tagging, and the return-JSON shape — lives in
 [references/subagent-instructions.md](references/subagent-instructions.md).
+
+Transcripts come from `scripts/fetch-transcript.py`, never from inline fetch
+code. It tries the caption track, falls back to local Whisper, validates the
+result, and writes atomically only on success — so a failed fetch leaves no file
+rather than leaving a crash report where speech belongs:
+
+```bash
+python3 skills/vault-ingress/scripts/fetch-transcript.py <video-id-or-url> \
+    --out {vault_root}/transcripts/<youtube_id>.txt [--duration-seconds N]
+```
+
+Exit 0 wrote (or kept) a valid transcript; exit 1 means no source produced one
+and the talk is `processed_partial` at best; exit 2 is an argument or tool-state
+error. Validation thresholds and failure signatures are the script's own — see
+its module docstring and the constants above `validate_transcript`.
 
 ## Step 4 — Persist Subagent Results
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -188,7 +188,7 @@ Each subagent returns this JSON after processing one talk:
 
 ## Video Extraction Output Schema
 
-Produced by `scripts/video-slide-extraction.py`.
+Produced by `skills/vault-ingress/scripts/video-slide-extraction.py`.
 Stored in `structured_data.video_extraction` on the talk entry:
 
 ```json
@@ -227,7 +227,7 @@ the same as a Google Drive PDF for dimension 13 (slide design patterns).
 
 ## PPTX Extraction Output Schema
 
-Produced by `scripts/pptx-extraction.py`.
+Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
 
 ### What the Script Extracts (mapped to slide-design-spec.md sections)
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -40,10 +40,19 @@ Record the detected language as `delivery_language`.
 were empty, a traceback, or a stub. Running the script without `--force` is the
 check: it validates any existing file and either keeps it or replaces it.
 
-**Non-YouTube talks** (InfoQ, Vimeo, conference platforms): the script resolves
-only YouTube ids. Acquire the audio by hand, transcribe with
-`mlx_whisper.transcribe()`, and set `transcript_source: whisper` — or fall back
-to `processed_partial` when no audio is obtainable.
+**Non-YouTube talks** (InfoQ, Vimeo, conference platforms): acquire the audio or
+video file, then pass it to the same script with `--audio`. Do not call
+`mlx_whisper.transcribe()` yourself — the validation, the atomic write and the
+JSON contract all live in the script, and a hand-rolled call has none of them.
+
+```bash
+python3 skills/vault-ingress/scripts/fetch-transcript.py {talk_label} \
+  --audio "{path_to_audio_or_video}" \
+  --out "{vault_root}/transcripts/{talk_id}.txt"
+```
+
+Set `transcript_source: whisper` on exit 0. Fall back to `processed_partial`
+when no audio is obtainable at all.
 
 ### Slide acquisition (per `slide_source`)
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -8,52 +8,42 @@ returns the JSON shape in [schemas-db.md](schemas-db.md).
 
 ### Transcript download
 
-**YouTube talks** — `yt-dlp` with auto-subtitles across likely languages:
+One command. Do NOT hand-roll a fetch — an inline `python3 -c` fetch here is
+what wrote four Python tracebacks into `transcripts/` when the upstream library
+renamed a method, and nothing noticed because nothing validated the output.
 
 ```bash
-yt-dlp --write-auto-sub --sub-lang "en,ru,he,fr,de,es,ja" --skip-download \
-  --sub-format vtt \
-  -o "{vault_root}/transcripts/{youtube_id}" \
-  "https://www.youtube.com/watch?v={youtube_id}"
+python3 skills/vault-ingress/scripts/fetch-transcript.py {youtube_id} \
+  --out "{vault_root}/transcripts/{youtube_id}.txt" \
+  [--duration-seconds {seconds}]
 ```
 
-The VTT filename includes the language code (e.g., `{youtube_id}.ru.vtt`).
-Record the detected language as `delivery_language`. After download, clean the
-VTT:
+The script owns the whole chain — caption track first, local Whisper fallback,
+validation, atomic write. It prints one JSON object and never leaves a file
+behind on failure. Exit codes and the JSON shape are the script's contract; see
+its module docstring.
 
-```bash
-python3 skills/vault-ingress/scripts/vtt-cleanup.py \
-  "{vault_root}/transcripts/{youtube_id}.{lang}.vtt"
-```
+| exit | meaning | what to do |
+|---|---|---|
+| 0 | a valid transcript is at `--out` | continue; read `method` to set `transcript_source` |
+| 1 | no source produced a valid transcript | `processed_partial` at best — say so in `rhetoric_notes` |
+| 2 | argument or tool-state error | the id or the environment is wrong, not the talk |
 
-This strips timestamps, cue markers, and deduplicates lines. Output:
-`transcripts/{youtube_id}.txt`.
+Set `transcript_source` from the returned `method`: `youtube_auto` for
+`captions`, `whisper` for `whisper`. Pass `--duration-seconds` when the runtime
+is known — it enables the words-per-minute check that catches a caption track
+returning only its opening minute.
 
-**Fallback 1 — `youtube-transcript-api`** (when yt-dlp has no auto-captions):
+Record the detected language as `delivery_language`.
 
-```bash
-"{python_path}" -c "
-from youtube_transcript_api import YouTubeTranscriptApi
-transcript = YouTubeTranscriptApi.get_transcript('{youtube_id}', languages=['en','ru','he','fr','de'])
-for entry in transcript:
-    print(entry['text'])
-" > "{vault_root}/transcripts/{youtube_id}.txt"
-```
+**A transcript already on disk is not proof of a transcript.** Ten corpus files
+were empty, a traceback, or a stub. Running the script without `--force` is the
+check: it validates any existing file and either keeps it or replaces it.
 
-**Fallback 2 — Whisper** (no captions at all; requires downloaded video/audio):
-
-```bash
-ffmpeg -i "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
-  -vn -acodec libmp3lame \
-  "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp3"
-```
-
-Then transcribe with MLX Whisper (`mlx_whisper.transcribe()`) or OpenAI
-Whisper. Set `transcript_source: "whisper"`.
-
-**Non-YouTube talks** (InfoQ, Vimeo, conference platforms): attempt audio
-download via yt-dlp, then transcribe locally with Whisper. Falls back to
-`processed_partial` if audio fails.
+**Non-YouTube talks** (InfoQ, Vimeo, conference platforms): the script resolves
+only YouTube ids. Acquire the audio by hand, transcribe with
+`mlx_whisper.transcribe()`, and set `transcript_source: whisper` — or fall back
+to `processed_partial` when no audio is obtainable.
 
 ### Slide acquisition (per `slide_source`)
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -29,12 +29,26 @@ its module docstring.
 | 1 | no source produced a valid transcript | `processed_partial` at best — say so in `rhetoric_notes` |
 | 2 | argument or tool-state error | the id or the environment is wrong, not the talk |
 
-Set `transcript_source` from the returned `method`: `youtube_auto` for
-`captions`, `whisper` for `whisper`. Pass `--duration-seconds` when the runtime
-is known — it enables the words-per-minute check that catches a caption track
-returning only its opening minute.
+Map the returned `method` to `transcript_source`:
 
-Record the detected language as `delivery_language`.
+| `method` | `transcript_source` |
+|---|---|
+| `captions` | `youtube_auto` |
+| `whisper` | `whisper` |
+| `existing` | leave the talk's current `transcript_source` unchanged; set `manual` only when the field is absent |
+
+`existing` means a valid transcript was already on disk and no fetch ran, so the
+script learned nothing about where it came from — overwriting the recorded source
+would replace a known value with a guess.
+
+Set `delivery_language` from the returned `language`: the caption track's own
+language code, or Whisper's detected language. It is `null` on the `existing`
+path — keep whatever the talk already records, and leave the field unset rather
+than guessing when there is nothing to copy.
+
+Pass `--duration-seconds` when the runtime is known — it enables the
+words-per-minute check that catches a caption track returning only its opening
+minute.
 
 **A transcript already on disk is not proof of a transcript.** Ten corpus files
 were empty, a traceback, or a stub. Running the script without `--force` is the

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -96,7 +96,7 @@ cp "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.pdf" "{vault_root}/sli
 rm "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4"
 ```
 
-For batch downloads: `scripts/batch-download-videos.sh <vault_root> ID1 ID2 ...`
+For batch downloads: `skills/vault-ingress/scripts/batch-download-videos.sh <vault_root> ID1 ID2 ...`
 
 Update the talk's DB entry: `slide_source: "video_extracted"`,
 `slides_local_path: "slides/{youtube_id}.pdf"`,

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -35,7 +35,11 @@ positional argument is then just a label for the JSON output.
 
 Output: one JSON object on stdout, on EVERY exit path including argument errors —
     {"ok": bool, "video_id": "...", "method": "captions|whisper|existing|none",
-     "words": int, "path": "...", "reason": "..."}
+     "words": int, "path": "...", "reason": "...", "language": "en"|null}
+
+`language` is the caption track's own language code, or Whisper's detected
+language — the source of the talk's `delivery_language`. It is null on the
+`existing` path, because a file already on disk carries no language signal.
 Exit:   0 wrote a valid transcript (or --force absent and a valid one existed)
         1 could not obtain a valid transcript — nothing was written
         2 argument or tool-state error
@@ -148,7 +152,7 @@ def segments_to_text(segments):
 
 
 def fetch_captions(video_id, languages):
-    """Return caption text, or None when no track is available.
+    """Return (caption text, language code), or (None, None) when unavailable.
 
     The 1.0 API is instance-based (`YouTubeTranscriptApi().fetch`); the older one
     was a classmethod (`.get_transcript`). Both are tried so the script survives
@@ -161,7 +165,7 @@ def fetch_captions(video_id, languages):
         print("youtube-transcript-api is not installed — "
               "`pip install youtube-transcript-api`, or pass --method whisper",
               file=sys.stderr)
-        return None
+        return None, None
 
     api = YouTubeTranscriptApi()
     try:
@@ -172,7 +176,7 @@ def fetch_captions(video_id, languages):
         else:
             print("youtube-transcript-api exposes neither .fetch nor .get_transcript; "
                   "the API changed again — update fetch_captions()", file=sys.stderr)
-            return None
+            return None, None
     except YouTubeTranscriptApiException as exc:
         # Every "this video has no usable caption track" case — subtitles
         # disabled, no track in the requested languages, age restriction, IP
@@ -181,12 +185,16 @@ def fetch_captions(video_id, languages):
         # previous fetch ended up writing its own traceback into the corpus.
         print(f"caption track unavailable for {video_id}: "
               f"{type(exc).__name__}: {str(exc).splitlines()[0]}", file=sys.stderr)
-        return None
-    return segments_to_text(segments)
+        return None, None
+    # The track's own language, not the first preference we asked for — they
+    # differ whenever the requested language is unavailable and the API falls
+    # back. `delivery_language` is derived from this, so guessing is not an option.
+    language = getattr(segments, "language_code", None)
+    return segments_to_text(segments), language
 
 
 def transcribe_audio(audio_path, video_id, model):
-    """Transcribe a local audio/video file. Returns text, or None on failure."""
+    """Transcribe a local audio/video file. Returns (text, language) or (None, None)."""
     try:
         import mlx_whisper
     except ImportError:
@@ -194,7 +202,7 @@ def transcribe_audio(audio_path, video_id, model):
               "`pip install 'speaker-toolkit[whisper]'`, or supply the transcript "
               "by hand. On other platforms use a caption track or an external "
               "transcription service.", file=sys.stderr)
-        return None
+        return None, None
 
     try:
         result = mlx_whisper.transcribe(str(audio_path), path_or_hf_repo=model)
@@ -203,16 +211,18 @@ def transcribe_audio(audio_path, video_id, model):
         # Must not escape as a traceback — callers parse this script's stdout.
         print(f"mlx_whisper could not transcribe {video_id}: "
               f"{type(exc).__name__}: {exc}", file=sys.stderr)
-        return None
+        return None, None
     text = result.get("text") if isinstance(result, dict) else None
     if not text:
         print(f"mlx_whisper returned no text for {video_id}", file=sys.stderr)
-        return None
-    return text
+        return None, None
+    # Whisper detects the spoken language; this is the only language signal on
+    # the audio path, and `delivery_language` is derived from it.
+    return text, (result.get("language") if isinstance(result, dict) else None)
 
 
 def fetch_whisper(video_id, work_dir, model):
-    """Download audio and transcribe locally. Returns text, or None on failure."""
+    """Download audio and transcribe. Returns (text, language) or (None, None)."""
     url = f"https://www.youtube.com/watch?v={video_id}"
     audio = Path(work_dir) / "audio.mp3"
     try:
@@ -227,11 +237,11 @@ def fetch_whisper(video_id, work_dir, model):
         # the same silent-failure shape the whole file exists to prevent.
         print(f"cannot run yt-dlp ({exc}) — install it with "
               "`brew install yt-dlp` or `pip install yt-dlp`", file=sys.stderr)
-        return None
+        return None, None
     if download.returncode != 0 or not audio.exists():
         print(f"yt-dlp could not download audio for {video_id}: "
               f"{download.stderr.strip()[:400]}", file=sys.stderr)
-        return None
+        return None, None
 
     return transcribe_audio(audio, video_id, model)
 
@@ -258,7 +268,8 @@ def write_atomically(path, text):
             os.unlink(tmp)
 
 
-def emit(ok, video_id, method, words, path, reason, code) -> NoReturn:
+def emit(ok, video_id, method, words, path, reason, code,
+         language=None) -> NoReturn:
     """Print the contract object and exit. Never returns — hence `NoReturn`.
 
     The annotation is load-bearing, not decoration: callers rely on `emit` ending
@@ -266,7 +277,8 @@ def emit(ok, video_id, method, words, path, reason, code) -> NoReturn:
     reachable and every value guarded by one as possibly unbound.
     """
     print(json.dumps({"ok": ok, "video_id": video_id, "method": method,
-                      "words": words, "path": str(path), "reason": reason}))
+                      "words": words, "path": str(path), "reason": reason,
+                      "language": language}))
     sys.exit(code)
 
 
@@ -305,7 +317,7 @@ def main(argv=None):
             emit(False, args.video, "none", 0, args.out,
                  f"--audio file does not exist: {audio_path}", 2)
         out = Path(args.out)
-        text = transcribe_audio(audio_path, args.video, args.whisper_model)
+        text, language = transcribe_audio(audio_path, args.video, args.whisper_model)
         if text is None:
             emit(False, args.video, "none", 0, out,
                  "local transcription produced no text — see stderr", 1)
@@ -313,14 +325,17 @@ def main(argv=None):
             text, min_words=args.min_words,
             duration_seconds=args.duration_seconds)
         if not ok:
-            emit(False, args.video, "whisper", count_words(text), out, reason, 1)
+            emit(False, args.video, "whisper", count_words(text), out, reason, 1,
+                 language)
         try:
             write_atomically(out, text)
         except OSError as exc:
             print(f"cannot write the transcript to {out}: {exc}", file=sys.stderr)
             emit(False, args.video, "whisper", count_words(text), out,
-                 f"transcript produced but could not be written: {exc}", 2)
-        emit(True, args.video, "whisper", count_words(text), out, reason, 0)
+                 f"transcript produced but could not be written: {exc}", 2,
+                 language)
+        emit(True, args.video, "whisper", count_words(text), out, reason, 0,
+             language)
 
     video_id = resolve_video_id(args.video)
     if not video_id:
@@ -360,10 +375,10 @@ def main(argv=None):
     failures = []
     for name in attempts:
         if name == "captions":
-            text = fetch_captions(video_id, languages)
+            text, language = fetch_captions(video_id, languages)
         else:
             with tempfile.TemporaryDirectory() as work_dir:
-                text = fetch_whisper(video_id, work_dir, args.whisper_model)
+                text, language = fetch_whisper(video_id, work_dir, args.whisper_model)
         if text is None:
             failures.append(f"{name}: unavailable")
             continue
@@ -378,8 +393,9 @@ def main(argv=None):
                 print(f"cannot write the transcript to {out}: {exc}",
                       file=sys.stderr)
                 emit(False, video_id, name, count_words(text), out,
-                     f"transcript fetched but could not be written: {exc}", 2)
-            emit(True, video_id, name, count_words(text), out, reason, 0)
+                     f"transcript fetched but could not be written: {exc}", 2,
+                     language)
+            emit(True, video_id, name, count_words(text), out, reason, 0, language)
         failures.append(f"{name}: {reason}")
 
     emit(False, video_id, "none", 0, out,

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Fetch a talk transcript, validate it, and write it only if it is real.
+
+This exists because the previous transcript fetch was an inline `python3 -c`
+heredoc. When `youtube-transcript-api` 1.0 removed the `YouTubeTranscriptApi.
+get_transcript` classmethod, every call raised, and the heredoc's traceback was
+written to the transcript path. Its error handler then raised too (`NameError:
+name 'sys' is not defined`), so the failure path failed as well.
+
+Four vault "transcripts" are that traceback. Two more are zero bytes. Nothing
+validated the output, so a talk with a stack trace for a transcript was
+indistinguishable from a talk with a transcript, and one talk was marked
+`processed` off an empty file.
+
+The fix is not a better heredoc. Per `rules/script-delegation.md` Scripts Are
+Real Files, a deterministic operation gets a real file with an exit code, a
+stderr channel, and tests. The validation below is the part that matters, and it
+is pure so CI can test every failure mode without a network.
+
+Sources, in order:
+  1. YouTube caption track (fast, no audio download)
+  2. Local Whisper transcription of the downloaded audio (fallback, and the only
+     option when a video has no caption track)
+
+Usage:
+    fetch-transcript.py <video-id-or-url> --out <path> [--languages en,ru,he]
+                        [--method auto|captions|whisper] [--force]
+                        [--duration-seconds N] [--min-words N]
+
+Output: one JSON object on stdout —
+    {"ok": bool, "video_id": "...", "method": "captions|whisper|none",
+     "words": int, "path": "...", "reason": "..."}
+Exit:   0 wrote a valid transcript (or --force absent and a valid one existed)
+        1 could not obtain a valid transcript — nothing was written
+        2 argument or tool-state error
+
+The output path is written ATOMICALLY and only after validation passes, so a
+failed fetch can never leave a corrupt file where a transcript belongs.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Text that proves the "transcript" is a crash report rather than speech. Anchored
+# at the head of the file: a talk about Python may legitimately say "traceback".
+FAILURE_SIGNATURES = (
+    "Traceback (most recent call last)",
+    "AttributeError:",
+    "NameError:",
+    "ModuleNotFoundError:",
+    "ImportError:",
+)
+FAILURE_SCAN_CHARS = 400
+
+# A caption track that is almost entirely these markers carries no speech.
+NON_SPEECH_MARKERS = ("[Music]", "[Applause]", "[Laughter]", "[музыка]")
+
+WORD = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+DEFAULT_MIN_WORDS = 400
+# Words per minute below which a transcript cannot plausibly cover the runtime.
+# Conference delivery runs 110-160 wpm; 30 is a floor no real talk crosses, so
+# this catches a caption track that returned only its first minute.
+MIN_WORDS_PER_MINUTE = 30
+
+
+def count_words(text):
+    """Words, counting Cyrillic and accented Latin — not just [a-z]."""
+    return len(WORD.findall(text))
+
+
+def validate_transcript(text, *, min_words=DEFAULT_MIN_WORDS, duration_seconds=None):
+    """Return (ok, reason). Pure — every failure mode is CI-testable.
+
+    `reason` is actionable on failure per `rules/error-handling.md`: it names
+    what was found, not merely that something was wrong.
+    """
+    if not text or not text.strip():
+        return False, "transcript is empty"
+
+    head = text[:FAILURE_SCAN_CHARS]
+    for signature in FAILURE_SIGNATURES:
+        if signature in head:
+            return False, (
+                f"transcript begins with a Python error ({signature.rstrip(':')}) — "
+                "this is a captured crash, not speech; re-fetch it")
+
+    words = count_words(text)
+    if words < min_words:
+        return False, (
+            f"transcript has {words} words, below the {min_words}-word floor — "
+            "too short to be a talk; the fetch probably returned a stub")
+
+    marker_chars = sum(text.count(m) * len(m) for m in NON_SPEECH_MARKERS)
+    if marker_chars > len(text) * 0.5:
+        return False, (
+            "transcript is mostly non-speech markers ([Music]/[Applause]) — "
+            "the caption track carries no usable speech; transcribe the audio")
+
+    if duration_seconds:
+        minutes = duration_seconds / 60.0
+        if minutes > 0 and words / minutes < MIN_WORDS_PER_MINUTE:
+            return False, (
+                f"transcript has {words} words for {minutes:.0f} minutes "
+                f"({words / minutes:.0f} wpm), below the {MIN_WORDS_PER_MINUTE} "
+                "wpm floor — it likely covers only part of the talk")
+
+    return True, f"{words} words"
+
+
+VIDEO_ID = re.compile(r"(?:v=|youtu\.be/|/embed/|/shorts/)([A-Za-z0-9_-]{11})")
+
+
+def resolve_video_id(value):
+    """Accept a bare 11-character id or any YouTube URL carrying one."""
+    if re.fullmatch(r"[A-Za-z0-9_-]{11}", value):
+        return value
+    match = VIDEO_ID.search(value)
+    return match.group(1) if match else None
+
+
+def segments_to_text(segments):
+    """Flatten caption segments to text.
+
+    Handles both shapes the library has used: dicts with a "text" key (<=0.6)
+    and objects with a .text attribute (>=1.0). Pinning to one shape is what
+    broke the previous fetch.
+    """
+    lines = []
+    for segment in segments:
+        text = segment.get("text") if isinstance(segment, dict) else getattr(segment, "text", None)
+        if text:
+            lines.append(text)
+    return "\n".join(lines)
+
+
+def fetch_captions(video_id, languages):
+    """Return caption text, or None when no track is available.
+
+    The 1.0 API is instance-based (`YouTubeTranscriptApi().fetch`); the older one
+    was a classmethod (`.get_transcript`). Both are tried so the script survives
+    the next rename instead of writing a traceback into the corpus.
+    """
+    try:
+        from youtube_transcript_api import YouTubeTranscriptApi
+        from youtube_transcript_api import YouTubeTranscriptApiException
+    except ImportError:
+        print("youtube-transcript-api is not installed — "
+              "`pip install youtube-transcript-api`, or pass --method whisper",
+              file=sys.stderr)
+        return None
+
+    api = YouTubeTranscriptApi()
+    try:
+        if hasattr(api, "fetch"):
+            segments = api.fetch(video_id, languages=languages)
+        elif hasattr(YouTubeTranscriptApi, "get_transcript"):
+            segments = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+        else:
+            print("youtube-transcript-api exposes neither .fetch nor .get_transcript; "
+                  "the API changed again — update fetch_captions()", file=sys.stderr)
+            return None
+    except YouTubeTranscriptApiException as exc:
+        # Every "this video has no usable caption track" case — subtitles
+        # disabled, no track in the requested languages, age restriction, IP
+        # block. All are normal and all must fall through to Whisper rather than
+        # propagating: an uncaught library exception here is precisely how the
+        # previous fetch ended up writing its own traceback into the corpus.
+        print(f"caption track unavailable for {video_id}: "
+              f"{type(exc).__name__}: {str(exc).splitlines()[0]}", file=sys.stderr)
+        return None
+    return segments_to_text(segments)
+
+
+def fetch_whisper(video_id, work_dir, model):
+    """Download audio and transcribe locally. Returns text, or None on failure."""
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    audio = Path(work_dir) / "audio.mp3"
+    download = subprocess.run(
+        ["yt-dlp", "-x", "--audio-format", "mp3", "--no-playlist",
+         "-o", str(Path(work_dir) / "audio.%(ext)s"), url],
+        capture_output=True, text=True,
+    )
+    if download.returncode != 0 or not audio.exists():
+        print(f"yt-dlp could not download audio for {video_id}: "
+              f"{download.stderr.strip()[:400]}", file=sys.stderr)
+        return None
+
+    transcribe = subprocess.run(
+        [sys.executable, "-m", "mlx_whisper", "--model", model,
+         "--output-dir", str(work_dir), "--output-format", "txt", str(audio)],
+        capture_output=True, text=True,
+    )
+    if transcribe.returncode != 0:
+        print(f"mlx_whisper failed for {video_id}: "
+              f"{transcribe.stderr.strip()[:400]}", file=sys.stderr)
+        return None
+
+    produced = list(Path(work_dir).glob("*.txt"))
+    if not produced:
+        print(f"mlx_whisper wrote no .txt for {video_id}", file=sys.stderr)
+        return None
+    return produced[0].read_text(encoding="utf-8")
+
+
+def write_atomically(path, text):
+    """Write via a temp file in the same directory, then replace.
+
+    A half-written transcript is the same defect class as a traceback-as-
+    transcript: it looks like data.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".partial")
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def emit(ok, video_id, method, words, path, reason, code):
+    print(json.dumps({"ok": ok, "video_id": video_id, "method": method,
+                      "words": words, "path": str(path), "reason": reason}))
+    sys.exit(code)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("video", help="YouTube video id, or any URL containing one")
+    parser.add_argument("--out", required=True, help="transcript output path")
+    parser.add_argument("--languages", default="en,ru,he,fr,de",
+                        help="comma-separated caption language preference")
+    parser.add_argument("--method", default="auto",
+                        choices=("auto", "captions", "whisper"))
+    parser.add_argument("--force", action="store_true",
+                        help="refetch even when a valid transcript already exists")
+    parser.add_argument("--duration-seconds", type=int, default=None,
+                        help="video runtime, enabling the words-per-minute check")
+    parser.add_argument("--min-words", type=int, default=DEFAULT_MIN_WORDS)
+    parser.add_argument("--whisper-model",
+                        default="mlx-community/whisper-large-v3-turbo")
+    args = parser.parse_args(argv)
+
+    video_id = resolve_video_id(args.video)
+    if not video_id:
+        print(f"cannot find an 11-character video id in {args.video!r} — "
+              "pass a bare id or a YouTube URL", file=sys.stderr)
+        return 2
+
+    out = Path(args.out)
+    if out.exists() and not args.force:
+        existing = out.read_text(encoding="utf-8", errors="replace")
+        ok, reason = validate_transcript(
+            existing, min_words=args.min_words,
+            duration_seconds=args.duration_seconds)
+        if ok:
+            emit(True, video_id, "existing", count_words(existing), out,
+                 f"kept existing transcript ({reason})", 0)
+        print(f"existing transcript at {out} is not usable: {reason}", file=sys.stderr)
+
+    languages = [lang.strip() for lang in (args.languages or "").split(",") if lang.strip()]
+    attempts = [name for name in ("captions", "whisper")
+                if args.method in ("auto", name)]
+
+    failures = []
+    for name in attempts:
+        if name == "captions":
+            text = fetch_captions(video_id, languages)
+        else:
+            with tempfile.TemporaryDirectory() as work_dir:
+                text = fetch_whisper(video_id, work_dir, args.whisper_model)
+        if text is None:
+            failures.append(f"{name}: unavailable")
+            continue
+        ok, reason = validate_transcript(
+            text, min_words=args.min_words, duration_seconds=args.duration_seconds)
+        if ok:
+            write_atomically(out, text)
+            emit(True, video_id, name, count_words(text), out, reason, 0)
+        failures.append(f"{name}: {reason}")
+
+    emit(False, video_id, "none", 0, out,
+         "no source produced a valid transcript — " + "; ".join(failures), 1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -182,11 +182,19 @@ def fetch_whisper(video_id, work_dir, model):
     """Download audio and transcribe locally. Returns text, or None on failure."""
     url = f"https://www.youtube.com/watch?v={video_id}"
     audio = Path(work_dir) / "audio.mp3"
-    download = subprocess.run(
-        ["yt-dlp", "-x", "--audio-format", "mp3", "--no-playlist",
-         "-o", str(Path(work_dir) / "audio.%(ext)s"), url],
-        capture_output=True, text=True,
-    )
+    try:
+        download = subprocess.run(
+            ["yt-dlp", "-x", "--audio-format", "mp3", "--no-playlist",
+             "-o", str(Path(work_dir) / "audio.%(ext)s"), url],
+            capture_output=True, text=True,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        # A missing yt-dlp must not escape as a traceback: this script's callers
+        # parse its stdout JSON, and a script that dies without emitting it is
+        # the same silent-failure shape the whole file exists to prevent.
+        print(f"cannot run yt-dlp ({exc}) — install it with "
+              "`brew install yt-dlp` or `pip install yt-dlp`", file=sys.stderr)
+        return None
     if download.returncode != 0 or not audio.exists():
         print(f"yt-dlp could not download audio for {video_id}: "
               f"{download.stderr.strip()[:400]}", file=sys.stderr)
@@ -204,7 +212,14 @@ def fetch_whisper(video_id, work_dir, model):
               "transcription service.", file=sys.stderr)
         return None
 
-    result = mlx_whisper.transcribe(str(audio), path_or_hf_repo=model)
+    try:
+        result = mlx_whisper.transcribe(str(audio), path_or_hf_repo=model)
+    except (OSError, ValueError, RuntimeError) as exc:
+        # Model download failure, unreadable audio, or an unsupported runtime.
+        # Same contract reason as the yt-dlp guard above.
+        print(f"mlx_whisper could not transcribe {video_id}: "
+              f"{type(exc).__name__}: {exc}", file=sys.stderr)
+        return None
     text = result.get("text") if isinstance(result, dict) else None
     if not text:
         print(f"mlx_whisper returned no text for {video_id}", file=sys.stderr)

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -52,6 +52,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import NoReturn
 
 # Text that proves the "transcript" is a crash report rather than speech. Anchored
 # at the head of the file: a talk about Python may legitimately say "traceback".
@@ -257,7 +258,13 @@ def write_atomically(path, text):
             os.unlink(tmp)
 
 
-def emit(ok, video_id, method, words, path, reason, code):
+def emit(ok, video_id, method, words, path, reason, code) -> NoReturn:
+    """Print the contract object and exit. Never returns — hence `NoReturn`.
+
+    The annotation is load-bearing, not decoration: callers rely on `emit` ending
+    the process, and without it a type checker reads the code after an `emit` as
+    reachable and every value guarded by one as possibly unbound.
+    """
     print(json.dumps({"ok": ok, "video_id": video_id, "method": method,
                       "words": words, "path": str(path), "reason": reason}))
     sys.exit(code)
@@ -307,7 +314,12 @@ def main(argv=None):
             duration_seconds=args.duration_seconds)
         if not ok:
             emit(False, args.video, "whisper", count_words(text), out, reason, 1)
-        write_atomically(out, text)
+        try:
+            write_atomically(out, text)
+        except OSError as exc:
+            print(f"cannot write the transcript to {out}: {exc}", file=sys.stderr)
+            emit(False, args.video, "whisper", count_words(text), out,
+                 f"transcript produced but could not be written: {exc}", 2)
         emit(True, args.video, "whisper", count_words(text), out, reason, 0)
 
     video_id = resolve_video_id(args.video)
@@ -321,7 +333,18 @@ def main(argv=None):
 
     out = Path(args.out)
     if out.exists() and not args.force:
-        existing = out.read_text(encoding="utf-8", errors="replace")
+        try:
+            existing = out.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            # Unreadable existing file: emit rather than traceback. Refusing is
+            # deliberate — silently refetching would overwrite a file we could
+            # not inspect, and the point of this script is never to destroy data
+            # it has not validated.
+            print(f"cannot read the existing transcript at {out}: {exc} — "
+                  "fix the permissions, or delete the file to refetch",
+                  file=sys.stderr)
+            emit(False, video_id, "none", 0, out,
+                 f"existing transcript unreadable: {exc}", 2)
         ok, reason = validate_transcript(
             existing, min_words=args.min_words,
             duration_seconds=args.duration_seconds)
@@ -347,7 +370,15 @@ def main(argv=None):
         ok, reason = validate_transcript(
             text, min_words=args.min_words, duration_seconds=args.duration_seconds)
         if ok:
-            write_atomically(out, text)
+            try:
+                write_atomically(out, text)
+            except OSError as exc:
+                # write_atomically's `finally` has already removed the temp file,
+                # so the output path is untouched. Emit rather than traceback.
+                print(f"cannot write the transcript to {out}: {exc}",
+                      file=sys.stderr)
+                emit(False, video_id, name, count_words(text), out,
+                     f"transcript fetched but could not be written: {exc}", 2)
             emit(True, video_id, name, count_words(text), out, reason, 0)
         failures.append(f"{name}: {reason}")
 

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -26,9 +26,15 @@ Usage:
     fetch-transcript.py <video-id-or-url> --out <path> [--languages en,ru,he]
                         [--method auto|captions|whisper] [--force]
                         [--duration-seconds N] [--min-words N]
+    fetch-transcript.py <label> --audio <file> --out <path>   # non-YouTube talk
 
-Output: one JSON object on stdout —
-    {"ok": bool, "video_id": "...", "method": "captions|whisper|none",
+`--audio` transcribes a local audio or video file instead of downloading one, so
+InfoQ / Vimeo / conference-platform talks route through this script rather than
+through hand-rolled `mlx_whisper.transcribe()` calls in skill prose. The
+positional argument is then just a label for the JSON output.
+
+Output: one JSON object on stdout, on EVERY exit path including argument errors —
+    {"ok": bool, "video_id": "...", "method": "captions|whisper|existing|none",
      "words": int, "path": "...", "reason": "..."}
 Exit:   0 wrote a valid transcript (or --force absent and a valid one existed)
         1 could not obtain a valid transcript — nothing was written
@@ -178,6 +184,32 @@ def fetch_captions(video_id, languages):
     return segments_to_text(segments)
 
 
+def transcribe_audio(audio_path, video_id, model):
+    """Transcribe a local audio/video file. Returns text, or None on failure."""
+    try:
+        import mlx_whisper
+    except ImportError:
+        print("mlx-whisper is not installed (Apple Silicon only) — "
+              "`pip install 'speaker-toolkit[whisper]'`, or supply the transcript "
+              "by hand. On other platforms use a caption track or an external "
+              "transcription service.", file=sys.stderr)
+        return None
+
+    try:
+        result = mlx_whisper.transcribe(str(audio_path), path_or_hf_repo=model)
+    except (OSError, ValueError, RuntimeError) as exc:
+        # Model download failure, unreadable audio, or an unsupported runtime.
+        # Must not escape as a traceback — callers parse this script's stdout.
+        print(f"mlx_whisper could not transcribe {video_id}: "
+              f"{type(exc).__name__}: {exc}", file=sys.stderr)
+        return None
+    text = result.get("text") if isinstance(result, dict) else None
+    if not text:
+        print(f"mlx_whisper returned no text for {video_id}", file=sys.stderr)
+        return None
+    return text
+
+
 def fetch_whisper(video_id, work_dir, model):
     """Download audio and transcribe locally. Returns text, or None on failure."""
     url = f"https://www.youtube.com/watch?v={video_id}"
@@ -200,31 +232,7 @@ def fetch_whisper(video_id, work_dir, model):
               f"{download.stderr.strip()[:400]}", file=sys.stderr)
         return None
 
-    # The Python API, not a CLI. `python -m mlx_whisper` has no `__main__` and
-    # the console-script name is not reliably on PATH for every caller, so
-    # shelling out drifts; `transcribe()` returns the text directly.
-    try:
-        import mlx_whisper
-    except ImportError:
-        print("mlx-whisper is not installed (Apple Silicon only) — "
-              "`pip install mlx-whisper`, or supply the transcript by hand. "
-              "On other platforms use a caption track or an external "
-              "transcription service.", file=sys.stderr)
-        return None
-
-    try:
-        result = mlx_whisper.transcribe(str(audio), path_or_hf_repo=model)
-    except (OSError, ValueError, RuntimeError) as exc:
-        # Model download failure, unreadable audio, or an unsupported runtime.
-        # Same contract reason as the yt-dlp guard above.
-        print(f"mlx_whisper could not transcribe {video_id}: "
-              f"{type(exc).__name__}: {exc}", file=sys.stderr)
-        return None
-    text = result.get("text") if isinstance(result, dict) else None
-    if not text:
-        print(f"mlx_whisper returned no text for {video_id}", file=sys.stderr)
-        return None
-    return text
+    return transcribe_audio(audio, video_id, model)
 
 
 def write_atomically(path, text):
@@ -270,13 +278,46 @@ def main(argv=None):
     parser.add_argument("--min-words", type=int, default=DEFAULT_MIN_WORDS)
     parser.add_argument("--whisper-model",
                         default="mlx-community/whisper-large-v3-turbo")
-    args = parser.parse_args(argv)
+    parser.add_argument("--audio", default=None,
+                        help="transcribe this local audio/video file instead of "
+                             "downloading one (non-YouTube talks)")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        # argparse writes usage to stderr and exits without stdout. The contract
+        # promises one JSON object on EVERY non-zero exit, so a wrapper parsing
+        # stdout must not get silence when the arguments are wrong. `--help`
+        # exits 0 and is re-raised untouched.
+        if exc.code:
+            emit(False, "", "none", 0, "", "invalid arguments — see stderr", 2)
+        raise
+
+    if args.audio:
+        audio_path = Path(args.audio)
+        if not audio_path.exists():
+            emit(False, args.video, "none", 0, args.out,
+                 f"--audio file does not exist: {audio_path}", 2)
+        out = Path(args.out)
+        text = transcribe_audio(audio_path, args.video, args.whisper_model)
+        if text is None:
+            emit(False, args.video, "none", 0, out,
+                 "local transcription produced no text — see stderr", 1)
+        ok, reason = validate_transcript(
+            text, min_words=args.min_words,
+            duration_seconds=args.duration_seconds)
+        if not ok:
+            emit(False, args.video, "whisper", count_words(text), out, reason, 1)
+        write_atomically(out, text)
+        emit(True, args.video, "whisper", count_words(text), out, reason, 0)
 
     video_id = resolve_video_id(args.video)
     if not video_id:
         print(f"cannot find an 11-character video id in {args.video!r} — "
-              "pass a bare id or a YouTube URL", file=sys.stderr)
-        return 2
+              "pass a bare id, a YouTube URL, or use --audio for a "
+              "non-YouTube talk", file=sys.stderr)
+        emit(False, args.video, "none", 0, args.out,
+             "no YouTube video id in the argument; use --audio for a "
+             "non-YouTube talk", 2)
 
     out = Path(args.out)
     if out.exists() and not args.force:

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -192,21 +192,24 @@ def fetch_whisper(video_id, work_dir, model):
               f"{download.stderr.strip()[:400]}", file=sys.stderr)
         return None
 
-    transcribe = subprocess.run(
-        [sys.executable, "-m", "mlx_whisper", "--model", model,
-         "--output-dir", str(work_dir), "--output-format", "txt", str(audio)],
-        capture_output=True, text=True,
-    )
-    if transcribe.returncode != 0:
-        print(f"mlx_whisper failed for {video_id}: "
-              f"{transcribe.stderr.strip()[:400]}", file=sys.stderr)
+    # The Python API, not a CLI. `python -m mlx_whisper` has no `__main__` and
+    # the console-script name is not reliably on PATH for every caller, so
+    # shelling out drifts; `transcribe()` returns the text directly.
+    try:
+        import mlx_whisper
+    except ImportError:
+        print("mlx-whisper is not installed (Apple Silicon only) — "
+              "`pip install mlx-whisper`, or supply the transcript by hand. "
+              "On other platforms use a caption track or an external "
+              "transcription service.", file=sys.stderr)
         return None
 
-    produced = list(Path(work_dir).glob("*.txt"))
-    if not produced:
-        print(f"mlx_whisper wrote no .txt for {video_id}", file=sys.stderr)
+    result = mlx_whisper.transcribe(str(audio), path_or_hf_repo=model)
+    text = result.get("text") if isinstance(result, dict) else None
+    if not text:
+        print(f"mlx_whisper returned no text for {video_id}", file=sys.stderr)
         return None
-    return produced[0].read_text(encoding="utf-8")
+    return text
 
 
 def write_atomically(path, text):

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -225,10 +225,13 @@ def write_atomically(path, text):
         with os.fdopen(handle, "w", encoding="utf-8") as fh:
             fh.write(text)
         os.replace(tmp, path)
-    except BaseException:
+    finally:
+        # `finally`, not a catch: cleanup must also run on KeyboardInterrupt and
+        # SystemExit, and neither may be swallowed (`rules/error-handling.md`).
+        # After a successful os.replace the temp path is gone, so this is a no-op
+        # on the happy path.
         if os.path.exists(tmp):
             os.unlink(tmp)
-        raise
 
 
 def emit(ok, video_id, method, words, path, reason, code):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,11 @@ def write_analysis():
 
 
 @pytest.fixture(scope="session")
+def fetch_transcript():
+    return _import_script(os.path.join(SCRIPTS_VI, "fetch-transcript.py"), "fetch_transcript")
+
+
+@pytest.fixture(scope="session")
 def extract_resources():
     return _import_script(
         os.path.join(SCRIPTS_PC, "extract-resources.py"), "extract_resources"

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -128,7 +128,31 @@ def test_caption_errors_fall_through_instead_of_propagating(fetch_transcript, mo
         raise TranscriptsDisabled("eg6gqvUFh6Q")
 
     monkeypatch.setattr(YouTubeTranscriptApi, "fetch", boom, raising=False)
-    assert fetch_transcript.fetch_captions("eg6gqvUFh6Q", ["en"]) is None
+    assert fetch_transcript.fetch_captions("eg6gqvUFh6Q", ["en"]) == (None, None)
+
+
+def test_captions_report_the_track_language(fetch_transcript, monkeypatch):
+    """`delivery_language` derives from this, so the TRACK's language is what counts.
+
+    It differs from the first requested preference whenever that language has no
+    track and the API falls back — returning the request would silently mislabel
+    every such talk.
+    """
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    class Segment:
+        def __init__(self, text):
+            self.text = text
+
+    class Fetched(list):
+        language_code = "ru"
+
+    monkeypatch.setattr(YouTubeTranscriptApi, "fetch",
+                        lambda self, *a, **k: Fetched([Segment("привет")]),
+                        raising=False)
+    text, language = fetch_transcript.fetch_captions("x", ["en", "ru"])
+    assert text == "привет"
+    assert language == "ru"
 
 
 def test_write_is_atomic_and_leaves_no_partial(fetch_transcript, tmp_path):

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -1,0 +1,172 @@
+"""Tests for fetch-transcript.py — the validation that keeps crashes out of the corpus.
+
+Regression coverage for the defect that motivated the script: an inline fetch
+heredoc wrote its own Python traceback to the transcript path when
+`youtube-transcript-api` 1.0 removed `get_transcript`. Four vault transcripts
+are that traceback and two are zero bytes; nothing noticed, and one talk was
+marked `processed` off an empty file.
+
+Every check here is on pure functions, so the whole failure surface is testable
+in CI without a network, without YouTube, and without Apple-Silicon Whisper.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+TRACEBACK_FIXTURE = """Traceback (most recent call last):
+  File "<string>", line 4, in <module>
+    transcript = YouTubeTranscriptApi.get_transcript('eg6gqvUFh6Q', languages=['en'])
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: type object 'YouTubeTranscriptApi' has no attribute 'get_transcript'
+"""
+
+MUSIC_FIXTURE = "\n".join(["[Music]", "[Applause]"] * 60 + ["then", "with them"])
+
+
+def _talk(words=600, word="alpha"):
+    return " ".join([word] * words)
+
+
+def test_traceback_is_rejected(fetch_transcript):
+    """The exact corpus defect: a crash report sitting where speech belongs."""
+    ok, reason = fetch_transcript.validate_transcript(TRACEBACK_FIXTURE)
+    assert not ok
+    assert "Python error" in reason and "re-fetch" in reason
+
+
+def test_traceback_padded_to_length_is_still_rejected(fetch_transcript):
+    """Length alone cannot clear a crash — the signature check comes first."""
+    ok, reason = fetch_transcript.validate_transcript(TRACEBACK_FIXTURE + _talk(800))
+    assert not ok
+    assert "Python error" in reason
+
+
+@pytest.mark.parametrize("text", ["", "   \n  \t "])
+def test_empty_is_rejected(fetch_transcript, text):
+    ok, reason = fetch_transcript.validate_transcript(text)
+    assert not ok
+    assert "empty" in reason
+
+
+def test_short_stub_is_rejected(fetch_transcript):
+    ok, reason = fetch_transcript.validate_transcript(_talk(125))
+    assert not ok
+    assert "125 words" in reason
+
+
+def test_mostly_non_speech_markers_is_rejected(fetch_transcript):
+    """A caption track of [Music]/[Applause] parses fine and says nothing."""
+    ok, reason = fetch_transcript.validate_transcript(MUSIC_FIXTURE, min_words=10)
+    assert not ok
+    assert "non-speech markers" in reason
+
+
+def test_transcript_far_too_short_for_runtime_is_rejected(fetch_transcript):
+    """A caption track that returned only its opening minute."""
+    ok, reason = fetch_transcript.validate_transcript(
+        _talk(500), duration_seconds=60 * 60)
+    assert not ok
+    assert "wpm" in reason
+
+
+def test_plausible_transcript_passes(fetch_transcript):
+    ok, reason = fetch_transcript.validate_transcript(
+        _talk(7000), duration_seconds=50 * 60)
+    assert ok
+    assert "7000 words" in reason
+
+
+def test_cyrillic_words_are_counted(fetch_transcript):
+    """A Russian talk must not read as empty — `[a-z]` would count zero words."""
+    russian = " ".join(["получается"] * 600)
+    assert fetch_transcript.count_words(russian) == 600
+    ok, _ = fetch_transcript.validate_transcript(russian)
+    assert ok
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("eg6gqvUFh6Q", "eg6gqvUFh6Q"),
+    ("https://www.youtube.com/watch?v=eg6gqvUFh6Q", "eg6gqvUFh6Q"),
+    ("https://youtu.be/wb2C2ju_xRg", "wb2C2ju_xRg"),
+    ("https://www.youtube.com/embed/0MGvxG-sc6g", "0MGvxG-sc6g"),
+    ("https://www.youtube.com/watch?v=OeTtYIjcxpc&t=42s", "OeTtYIjcxpc"),
+])
+def test_video_id_resolution(fetch_transcript, value, expected):
+    assert fetch_transcript.resolve_video_id(value) == expected
+
+
+def test_video_id_resolution_rejects_a_non_url(fetch_transcript):
+    assert fetch_transcript.resolve_video_id("https://www.infoq.com/presentations/x") is None
+
+
+def test_segments_accepts_both_library_shapes(fetch_transcript):
+    """Pinning to one shape is exactly what broke the previous fetch."""
+    class Segment:
+        def __init__(self, text):
+            self.text = text
+
+    assert fetch_transcript.segments_to_text(
+        [{"text": "hello"}, {"text": "world"}]) == "hello\nworld"
+    assert fetch_transcript.segments_to_text(
+        [Segment("hello"), Segment("world")]) == "hello\nworld"
+
+
+def test_caption_errors_fall_through_instead_of_propagating(fetch_transcript, monkeypatch):
+    """A video with captions disabled must return None, never raise.
+
+    This is the original defect's exact shape one layer up: the first cut of
+    this script let `TranscriptsDisabled` propagate, so a talk with no caption
+    track crashed the fetcher instead of falling back to Whisper — and a
+    crashing fetcher is what wrote tracebacks into the corpus.
+    """
+    from youtube_transcript_api import TranscriptsDisabled, YouTubeTranscriptApi
+
+    def boom(self, *args, **kwargs):
+        raise TranscriptsDisabled("eg6gqvUFh6Q")
+
+    monkeypatch.setattr(YouTubeTranscriptApi, "fetch", boom, raising=False)
+    assert fetch_transcript.fetch_captions("eg6gqvUFh6Q", ["en"]) is None
+
+
+def test_write_is_atomic_and_leaves_no_partial(fetch_transcript, tmp_path):
+    out = tmp_path / "nested" / "abc.txt"
+    fetch_transcript.write_atomically(out, "content")
+    assert out.read_text(encoding="utf-8") == "content"
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_cli_rejects_an_unresolvable_video(fetch_transcript, tmp_path):
+    """Resolution fails before any network call, so this test never leaves the box.
+
+    The argument is deliberately long: `not-a-video` is 11 characters drawn from
+    the id alphabet, so it IS a well-formed video id and the first version of
+    this test reached YouTube.
+    """
+    result = subprocess.run(
+        [sys.executable, fetch_transcript.__file__,
+         "https://www.infoq.com/presentations/java-puzzle/",
+         "--out", str(tmp_path / "x.txt")],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "11-character video id" in result.stderr
+    assert not (tmp_path / "x.txt").exists()
+
+
+def test_cli_keeps_a_valid_existing_transcript_without_refetching(
+        fetch_transcript, tmp_path):
+    """No network: a good file short-circuits before any fetch is attempted."""
+    out = tmp_path / "eg6gqvUFh6Q.txt"
+    out.write_text(_talk(900), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, fetch_transcript.__file__, "eg6gqvUFh6Q", "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["method"] == "existing"
+    assert payload["words"] == 900

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -153,6 +153,45 @@ def test_cli_rejects_an_unresolvable_video(fetch_transcript, tmp_path):
     )
     assert result.returncode == 2
     assert "11-character video id" in result.stderr
+    assert json.loads(result.stdout)["ok"] is False
+    assert not (tmp_path / "x.txt").exists()
+
+
+def test_cli_emits_json_on_an_argument_error(fetch_transcript, tmp_path):
+    """The contract promises JSON on every non-zero exit, argparse included.
+
+    A wrapper that parses stdout must not get silence when the invocation is
+    malformed — silence is the failure mode this whole script exists to end.
+    """
+    result = subprocess.run(
+        [sys.executable, fetch_transcript.__file__, "eg6gqvUFh6Q"],  # no --out
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert json.loads(result.stdout)["ok"] is False
+
+
+def test_cli_help_still_exits_zero(fetch_transcript):
+    """`--help` is a success path and must not be turned into a JSON error."""
+    result = subprocess.run(
+        [sys.executable, fetch_transcript.__file__, "--help"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "--audio" in result.stdout
+
+
+def test_cli_rejects_a_missing_audio_file(fetch_transcript, tmp_path):
+    result = subprocess.run(
+        [sys.executable, fetch_transcript.__file__, "infoq-java-puzzlers",
+         "--audio", str(tmp_path / "absent.mp3"),
+         "--out", str(tmp_path / "x.txt")],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "does not exist" in payload["reason"]
     assert not (tmp_path / "x.txt").exists()
 
 

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -171,6 +171,31 @@ def test_cli_emits_json_on_an_argument_error(fetch_transcript, tmp_path):
     assert json.loads(result.stdout)["ok"] is False
 
 
+def test_cli_emits_json_when_the_existing_transcript_is_unreadable(
+        fetch_transcript, tmp_path):
+    """An unreadable file must not traceback past the JSON contract.
+
+    It also must not be silently refetched — overwriting a file the script could
+    not inspect is exactly the data loss it exists to prevent.
+    """
+    out = tmp_path / "eg6gqvUFh6Q.txt"
+    out.write_text(_talk(900), encoding="utf-8")
+    out.chmod(0o000)
+    try:
+        result = subprocess.run(
+            [sys.executable, fetch_transcript.__file__, "eg6gqvUFh6Q",
+             "--out", str(out)],
+            capture_output=True, text=True,
+        )
+    finally:
+        out.chmod(0o644)
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "unreadable" in payload["reason"]
+    assert out.read_text(encoding="utf-8") == _talk(900), "existing file was clobbered"
+
+
 def test_cli_help_still_exits_zero(fetch_transcript):
     """`--help` is a success path and must not be turned into a JSON error."""
     result = subprocess.run(


### PR DESCRIPTION
## The defect

Four of the vault's transcripts are Python tracebacks. Not truncated — the fetcher's own crash, written to the transcript path:

```
AttributeError: type object 'YouTubeTranscriptApi' has no attribute 'get_transcript'
```

`youtube-transcript-api` 1.0 removed that classmethod. Every fetch raised, and the traceback landed where speech belongs. The error handler then raised too (`NameError: name 'sys' is not defined`) — the failure path failed as well. Two more transcripts are zero bytes.

Nothing validated any of it. **A talk with a stack trace for a transcript looked exactly like a talk with a transcript**, and `0MGvxG-sc6g` (Java Puzzlers NG S01) was marked `processed` off an empty file, recording that nowhere.

## Root cause is the absent script, not a buggy one

The traceback reads `File "<string>"` — the fetch was a `python3 -c` heredoc, and no committed fetcher existed anywhere in `skills/`. That is precisely what `script-delegation` Scripts Are Real Files prevents: a real script gets an exit code, a stderr channel, and tests. An inline heredoc gets to write its stack trace into the corpus and exit 0.

## What this adds

`skills/vault-ingress/scripts/fetch-transcript.py` — captions → local Whisper fallback, validated before write, written atomically so a failed fetch leaves **no file** rather than a corrupt one.

Validation rejects: empty, a Python-error signature at the head, below a word floor, mostly-`[Music]` caption tracks, and below a words-per-minute floor when a runtime is supplied.

The validation is pure, so CI covers every failure mode from fixtures — no network, no YouTube, no Apple-Silicon Whisper. 20 tests.

## Two bugs found by using it on the real corpus

Both caught before merge, both now regression-tested:

1. **Library exceptions propagated instead of falling through.** A video with captions disabled crashed the fetcher rather than reaching Whisper — the original defect one layer up. Now catches `YouTubeTranscriptApiException` and returns `None`.
2. **A test reached the network.** It passed `not-a-video` as an unresolvable id — that string is eleven characters from the id alphabet, so it IS well-formed and the run hit YouTube. Replaced with a URL carrying no id, failing at resolution before any network call.

`segments_to_text` accepts both the pre-1.0 dict shape and the 1.0 object shape. Pinning to one shape is what broke the previous fetch.

## Pin

`youtube-transcript-api==1.2.4`, declared. Deliberate rather than habitual: an uncontrolled upgrade of this exact library is what corrupted the data, so the next API break should arrive as a Dependabot PR instead of as tracebacks in the corpus.

Full suite 1146 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AW91SuWHRNW1mHL6MZCfZ