### PR TITLE
fix(vault-ingress): reject raw VTT payloads, stop inventing a transcript source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+### fix(vault-ingress) — a bare-int `pattern_score` no longer silently drops the scalar
+
+Subagents write `"pattern_score": 19` instead of the declared
+`{"patterns_used": 22, "antipatterns_detected": 3, "score": 19}` on roughly a
+third of returns — 5 of 16 across two batches, from independent agents that never
+see each other's work.
+
+It looked cosmetic and is not. `normalize_pattern_observations` already accepted
+the int, so the nested value landed and the return looked fine. But PROMOTE
+resolves `pattern_observations.pattern_score.score`, `dig` returns None on an
+int, and the queryable top-level `pattern_score` **was silently dropped** — the
+exact missing-scalar defect this script was written to fix (1 of 200 talks had
+`slide_count` before it), reintroduced through the input shape.
+
+`canonicalize_pattern_score` now rebuilds the dict before promotion, and
+**recomputes rather than trusting**: a supplied int that disagrees with the
+arrays exits 1 naming both numbers, because that is a real inconsistency, not a
+formatting slip. `True` is not read as a score of 1.
+
+Each coercion is reported as `coerced_pattern_score` in the stdout summary rather
+than fixed silently, so the rate stays visible.
+
+The schema invites the error twice over — the field is NAMED for a number but
+holds a dict, and `antipatterns_detected` means an array of objects one level up
+and an integer count inside `pattern_score`. Restating the requirement in the
+brief did not move the rate across four batches, so the tooling absorbs the
+variant instead. `merge_talk` now returns a third element; its four existing test
+call sites are updated.
+
 ### fix(vault-ingress) — reject raw VTT payloads, stop inventing a transcript source
 
 Two defects in the transcript work shipped in 0.18.72, both found by running it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,25 @@ brief did not move the rate across four batches, so the tooling absorbs the
 variant instead. `merge_talk` now returns a third element; its four existing test
 call sites are updated.
 
+### fix(vault-ingress) — version the talk record, validate the score inside the dict
+
+`persist-results.py` now stamps `schema_version` on every talk record it merges.
+v1 is the implicit unversioned shape all pre-2026-07-28 records carry, in which
+`transcript_source` was documented as always present — though 95 of 209 records
+never had it. v2 documents the field as optional and gives ABSENT a meaning:
+provenance unknown, distinct from the explicit `none`.
+
+The bump is additive, which `stateful-artifacts` Cross-Pipeline Schema Bumps
+permits without a staged rollout — a v1 reader reads a v2 record unchanged,
+because v2 removes a guarantee rather than adding a field. Readers do not gate on
+the value yet; that contract is #147, sequenced after the in-flight reparse so
+writer and readers cannot skew mid-run.
+
+Type-checking only the BARE `pattern_score` left the declared dict unexamined, so
+`{"score": True}` or `{"score": "19"}` still reached the DB — the same defect one
+level in. The inner value now gets the same check, with tests across `True`,
+`False`, `"19"` and `["19"]` at both levels.
+
 ### fix(vault-ingress) — reject raw VTT payloads, stop inventing a transcript source
 
 Two defects in the transcript work shipped in 0.18.72, both found by running it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ formatting slip. `True` is not read as a score of 1.
 Each coercion is reported as `coerced_pattern_score` in the stdout summary rather
 than fixed silently, so the rate stays visible.
 
+A reviewer then caught a second bug that the first version of the bool test had
+HIDDEN. That test asserted `canonicalize_pattern_score` in isolation and passed,
+while `merge_talk` still persisted `pattern_score: True` — `isinstance(True, int)`
+holds in Python, so a bool sailed through `normalize_pattern_observations`'s
+numeric branch and reached the DB as a numeric score. Every non-dict, non-numeric
+shape now exits 1, and the test asserts the persisted OUTCOME across `True`,
+`False`, `"19"` and `["19"]`. All four fail without the fix — verified by
+reverting the guard alone, which is the only way to know a regression test
+regresses on anything.
+
 The schema invites the error twice over — the field is NAMED for a number but
 holds a dict, and `antipatterns_detected` means an array of objects one level up
 and an integer count inside `pattern_score`. Restating the requirement in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,13 @@ writer and readers cannot skew mid-run.
 
 Type-checking only the BARE `pattern_score` left the declared dict unexamined, so
 `{"score": True}` or `{"score": "19"}` still reached the DB — the same defect one
-level in. The inner value now gets the same check, with tests across `True`,
-`False`, `"19"` and `["19"]` at both levels.
+level in. The inner value now gets the same check.
+
+Both checks require an **integer**, not merely a number. The talk schema declares
+`pattern_score` an integer and it is count(patterns) minus count(antipatterns),
+so a float is never right however numeric it looks — `1.5` would have persisted
+into an integer field. Tested across `True`, `False`, `"19"`, `["19"]`, `1.5` and
+`1.0` at both levels.
 
 ### fix(vault-ingress) — reject raw VTT payloads, stop inventing a transcript source
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,49 @@ brief did not move the rate across four batches, so the tooling absorbs the
 variant instead. `merge_talk` now returns a third element; its four existing test
 call sites are updated.
 
+### fix(vault-ingress) — one validator for the merge, not several disagreeing ones
+
+Six review rounds each found a different hole in `pattern_score` validation, and
+patching them one at a time was treating symptoms. The cause was structural: TWO
+functions independently decided what a valid score was — `canonicalize_pattern_score`
+checking the incoming shape, `normalize_pattern_observations` re-deciding with its
+own `isinstance(score, (int, float))`, and PROMOTE resolving the top-level scalar
+through a third path, a dotted lookup. Every round tightened one and left the
+others, so they disagreed in a new way each time.
+
+`resolve_pattern_score` now decides once. `normalize_pattern_observations` takes
+already-validated inputs and decides nothing. `pattern_score` leaves PROMOTE
+entirely and is set from the resolved value — the dotted path
+`pattern_observations.pattern_score.score` is what silently dropped the scalar
+whenever a subagent sent the bare int, because `dig` returns None on an int.
+
+Reading the file properly then turned up three more silent-drop defects that no
+review round had reached:
+
+- **A wrong-typed content block was skipped and the merge reported success.**
+  `structured_data`, `verbatim_examples` and `pattern_observations` were each
+  guarded by a bare `isinstance(..., dict)`; a `structured_data` arriving as a
+  list lost the entire analysis and still exited 0.
+- **A detection array of bare id strings killed the script mid-merge.**
+  `p.get("pattern_id")` raised `AttributeError` before any JSON was printed —
+  the exact die-without-saying-so shape this file exists to prevent.
+- **A detection array supplied as a plain string had its CHARACTERS counted as
+  detections**, feeding a silently wrong number into the score cross-check.
+
+All three now fail loudly, and validation runs before any write so a malformed
+return leaves the talk untouched rather than half-merged. An incomplete score
+object — present but missing `score` — is malformed too, not absent.
+
+`migrate_records` stamps every record rather than only the talks a batch touched;
+partial stamping would leave the artifact permanently mixed-version, so a reader
+could not distinguish an unversioned record from an untouched one. The count is
+reported as `migrated_records`.
+
+Each of the eight new tests was verified to FAIL with its guard reverted. A
+regression test nobody has watched fail guards nothing — which this PR already
+demonstrated the hard way, when a bool test asserting the helper in isolation
+passed while the DB was taking `pattern_score: True`.
+
 ### fix(vault-ingress) — version the talk record, validate the score inside the dict
 
 `persist-results.py` now stamps `schema_version` on every talk record it merges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+### fix(vault-ingress) — reject raw VTT payloads, stop inventing a transcript source
+
+Two defects in the transcript work shipped in 0.18.72, both found by running it
+against the real corpus.
+
+**A raw VTT dump passes every validator.** 26 of the vault's 206 transcripts held
+YouTube's karaoke caption payload rather than cleaned text — each line once with
+inline `<00:00:01.020><c>word</c>` timing tags, then again as plain text. Word
+counts read **3.6× high**, uniformly: a 37-minute meetup talk measured 18,543
+words, implying a two-hour session and a wildly wrong words-per-minute figure.
+
+The length floor cannot catch this, because a doubled transcript has MORE words,
+not fewer. `validate_transcript` now rejects the timing-tag signature and names
+`vtt-cleanup.py` — which already existed for exactly this and had simply never
+been run on those files. A test asserts the fixture clears the word floor before
+the VTT check fires, so the guard cannot pass for the wrong reason.
+
+**`method: "existing"` told agents to write `manual`.** The mapping said to fall
+back to `manual` when `transcript_source` was absent. `manual` means a human
+produced the transcript; a batch-24 agent dutifully wrote it onto a file that is
+unmistakably YouTube ASR, then flagged the result as a placeholder. An absent
+field now stays absent — the script learns nothing about provenance on that path,
+and a downstream reader weighing transcript reliability would trust `manual` more
+than the ASR it probably is.
+
 ## 0.18.72 — 2026-07-27
 
 ### feat(vault-ingress) — a real transcript fetcher that validates before it writes

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -34,7 +34,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
     "video_url": "YouTube watch URL (required — only source needed for processing)",
     "youtube_id": "aBcDeFg", "google_drive_id": "1AbCdEfGhIjK",
     "pptx_path": "Conference/Year/Talk Name.pptx  (optional — highest quality slide source when available)",
-    "transcript_source": "youtube_auto|whisper|manual|none  (how the transcript was obtained)",
+    "transcript_source": "youtube_auto|whisper|manual|none  (how the transcript was obtained; MAY BE ABSENT — see below)",
     "slide_source": "pptx|pdf|both|video_extracted|none  (set in Step 2 per slide source hierarchy)",
     "pptx_visual_status": "pending|extracted|no_pptx",
     "status": "pending|processed|processed_partial|needs-reprocessing|skipped_no_sources|skipped_download_failed",
@@ -55,6 +55,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
       "antipatterns_detected": []
     }
   }],
+  "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "pptx_path": "Conference/Year/Talk Name.pptx",
     "talk_filename": "2024-04-10-talk-slug.md or null",
@@ -95,7 +96,7 @@ Each subagent returns this JSON after processing one talk:
   "filename": "the .md filename",
   "rhetoric_notes": "500-1000 words: qualitative observations across dimensions 1-13",
   "areas_for_improvement": "100-300 words: honest critical reflection (Dimension 14); name the related antipattern ID + severity per issue where a Dimension 14 antipattern applies",
-  "transcript_source": "youtube_auto|whisper|manual  (how the transcript was obtained)",
+  "transcript_source": "youtube_auto|whisper|manual  (how the transcript was obtained; OMIT the key entirely when provenance is unknown — see Absent transcript_source in the DB schema above)",
   "structured_data": {
     "delivery_language": "en|de|ru|etc  (primary language of the talk)",
     "co_presenter": false,

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -34,6 +34,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
     "video_url": "YouTube watch URL (required — only source needed for processing)",
     "youtube_id": "aBcDeFg", "google_drive_id": "1AbCdEfGhIjK",
     "pptx_path": "Conference/Year/Talk Name.pptx  (optional — highest quality slide source when available)",
+    "schema_version": 2,
     "transcript_source": "youtube_auto|whisper|manual|none  (how the transcript was obtained; MAY BE ABSENT — see below)",
     "slide_source": "pptx|pdf|both|video_extracted|none  (set in Step 2 per slide source hierarchy)",
     "pptx_visual_status": "pending|extracted|no_pptx",
@@ -55,6 +56,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
       "antipatterns_detected": []
     }
   }],
+  "_comment_schema_version": "Talk-record schema version, stamped by persist-results.py (TALK_SCHEMA_VERSION) on every merge. v1 is the implicit unversioned shape every pre-2026-07-28 record carries, in which transcript_source was documented as always present. v2 documents it as optional and gives ABSENT a meaning. The bump is additive — a v1 reader reads a v2 record unchanged, since v2 removes a guarantee rather than adding a field — so no staged rollout is required (stateful-artifacts Cross-Pipeline Schema Bumps). Readers do not gate on this value yet; that contract is issue #147, sequenced after the in-flight reparse so writer and readers cannot skew mid-run.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "pptx_path": "Conference/Year/Talk Name.pptx",

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -101,9 +101,16 @@ when no audio is obtainable at all.
 
 ### `transcript_source` is required
 
-Set `transcript_source` on the talk entry: `youtube_auto` (yt-dlp captions),
+Set `transcript_source` on the talk entry: `youtube_auto` (caption track),
 `whisper` (local transcription), or `manual`. Downstream tools use it to gauge
 transcript reliability.
+
+**One exception, and only one:** `method: "existing"` from the fetcher. No fetch
+ran, so provenance is unknown — leave the recorded value alone, and leave the
+field absent when it was already absent. `manual` asserts a human produced the
+transcript; writing it on an unknown file is a false claim that makes a
+downstream reader trust ASR more than it should. Absent is honest; invented is
+not.
 
 ## B. Analyze for Rhetoric & Style (NOT content)
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -35,11 +35,15 @@ Map the returned `method` to `transcript_source`:
 |---|---|
 | `captions` | `youtube_auto` |
 | `whisper` | `whisper` |
-| `existing` | leave the talk's current `transcript_source` unchanged; set `manual` only when the field is absent |
+| `existing` | leave the talk's current `transcript_source` unchanged; when the field is absent, leave it absent |
 
 `existing` means a valid transcript was already on disk and no fetch ran, so the
 script learned nothing about where it came from — overwriting the recorded source
-would replace a known value with a guess.
+would replace a known value with a guess, and inventing one where the field is
+absent is the same error with no prior value to lose. `manual` in particular
+means a human produced the transcript; writing it on an unknown-provenance file
+asserts something false, and a downstream reader weighing transcript reliability
+would trust it more than the ASR it probably is.
 
 Set `delivery_language` from the returned `language`: the caption track's own
 language code, or Whisper's detected language. It is `null` on the `existing`

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -118,8 +118,8 @@ def validate_transcript(text, *, min_words=DEFAULT_MIN_WORDS, duration_seconds=N
         return False, (
             "transcript is a raw VTT caption payload — it carries inline "
             "<00:00:00.000><c> timing tags and stores every line twice, so word "
-            "counts read ~3.6x high; clean it with vault-ingress/scripts/"
-            "vtt-cleanup.py before use")
+            "counts read ~3.6x high; clean it with "
+            "skills/vault-ingress/scripts/vtt-cleanup.py before use")
 
     marker_chars = sum(text.count(m) * len(m) for m in NON_SPEECH_MARKERS)
     if marker_chars > len(text) * 0.5:

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -69,6 +69,12 @@ FAILURE_SIGNATURES = (
 )
 FAILURE_SCAN_CHARS = 400
 
+# Raw WebVTT karaoke markup. A raw dump has MORE words than the cleaned text
+# (every line is stored twice), so the length floor below cannot catch it —
+# 26 corpus transcripts sat in this shape reading 3.6x their true length.
+VTT_TIMING_TAG = re.compile(r"<\d\d:\d\d:\d\d\.\d\d\d>|</?c>")
+VTT_SCAN_CHARS = 4000
+
 # A caption track that is almost entirely these markers carries no speech.
 NON_SPEECH_MARKERS = ("[Music]", "[Applause]", "[Laughter]", "[музыка]")
 
@@ -107,6 +113,13 @@ def validate_transcript(text, *, min_words=DEFAULT_MIN_WORDS, duration_seconds=N
         return False, (
             f"transcript has {words} words, below the {min_words}-word floor — "
             "too short to be a talk; the fetch probably returned a stub")
+
+    if VTT_TIMING_TAG.search(text[:VTT_SCAN_CHARS]):
+        return False, (
+            "transcript is a raw VTT caption payload — it carries inline "
+            "<00:00:00.000><c> timing tags and stores every line twice, so word "
+            "counts read ~3.6x high; clean it with vault-ingress/scripts/"
+            "vtt-cleanup.py before use")
 
     marker_chars = sum(text.count(m) * len(m) for m in NON_SPEECH_MARKERS)
     if marker_chars > len(text) * 0.5:

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -38,8 +38,14 @@ Usage:
         {"persisted": <int>, "db_path": "<path>",
          "run_date": "<YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+00:00>",
          "talks": [{"filename": "...", "status": "...", "promoted": ["..."],
-                    "stamped_processed_date": <bool>}]}
+                    "stamped_processed_date": <bool>,
+                    "coerced_pattern_score": <bool>}]}
     Diagnostics and errors go to stderr; exit code is non-zero on failure.
+
+    `coerced_pattern_score` is true when the return supplied `pattern_score` as a
+    bare int and it was rebuilt into the declared dict. The coercion is reported
+    rather than silent so the rate stays visible — a return shape that needs
+    fixing this often is a schema problem, not a one-off.
 
     Absent --run-date, the stamp is the current UTC time at second resolution.
     --run-date pins it instead of reading the clock; the whole batch shares one
@@ -144,6 +150,48 @@ def deep_merge(dst, src):
     return dst
 
 
+def canonicalize_pattern_score(incoming):
+    """Coerce a bare-int `pattern_score` into the declared dict shape.
+
+    Returns True when a coercion happened. Raises ValueError when the supplied
+    integer contradicts the arrays.
+
+    Subagents write `"pattern_score": 19` instead of
+    `{"patterns_used": 22, "antipatterns_detected": 3, "score": 19}` on roughly a
+    third of returns, and the schema invites it twice over: the field is NAMED
+    for a number but holds a dict, and `antipatterns_detected` means an array of
+    objects one level up and an integer count inside `pattern_score`.
+
+    The bare int is not harmless. `normalize_pattern_observations` accepts it, so
+    the nested value lands and the return looks fine — but PROMOTE resolves
+    `pattern_observations.pattern_score.score`, `dig` returns None on an int, and
+    the queryable top-level `pattern_score` scalar is **silently dropped**. That
+    is precisely the missing-scalar defect this script was written to fix,
+    reintroduced through the input shape.
+
+    Restating the requirement in the brief has not moved the rate across four
+    batches, so the tooling absorbs the variant instead — and recomputes rather
+    than trusting it, because a coerced value that disagrees with the arrays is a
+    real inconsistency, not a formatting slip.
+    """
+    if not isinstance(incoming, dict):
+        return False
+    score = incoming.get("pattern_score")
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
+        return False
+    used = len(incoming.get("patterns_detected") or [])
+    against = len(incoming.get("antipatterns_detected") or [])
+    if used - against != score:
+        raise ValueError(
+            f"pattern_score is the bare int {score}, but patterns_detected "
+            f"({used}) minus antipatterns_detected ({against}) is {used - against}. "
+            "Refusing to guess which is right — fix the return so pattern_score is "
+            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
+    incoming["pattern_score"] = {
+        "patterns_used": used, "antipatterns_detected": against, "score": score}
+    return True
+
+
 def normalize_pattern_observations(existing, incoming):
     """Map the subagent return shape onto the DB shape, keeping both views.
 
@@ -169,12 +217,15 @@ def normalize_pattern_observations(existing, incoming):
 
 
 def merge_talk(talk, ret, run_date=None):
-    """Merge one return into its talk. Returns (promoted_fields, stamped_date).
+    """Merge one return into its talk. Returns (promoted, stamped, coerced_score).
 
     `run_date` stamps `processed_date` when the return omits it. Callers that
     care about reproducibility pass it explicitly; it is never read from the
     clock inside the merge.
     """
+    # Before PROMOTE digs `pattern_observations.pattern_score.score`, which a
+    # bare int cannot satisfy.
+    coerced_score = canonicalize_pattern_score(ret.get("pattern_observations"))
     for f in SCALARS:
         if f in ret and not is_empty(ret[f]):
             talk[f] = ret[f]
@@ -197,7 +248,7 @@ def merge_talk(talk, ret, run_date=None):
         if not is_empty(val):
             talk[field] = val
             promoted.append(field)
-    return promoted, stamped
+    return promoted, stamped, coerced_score
 
 
 def load_json(path, label):
@@ -282,9 +333,14 @@ def main():
             # mismatch, not something to silently skip.
             print(f"ERROR: no talk in DB matches return filename: {name!r}", file=sys.stderr)
             sys.exit(1)
-        promoted, stamped = merge_talk(talk, ret, run_date)
+        try:
+            promoted, stamped, coerced = merge_talk(talk, ret, run_date)
+        except ValueError as exc:
+            print(f"ERROR: {name}: {exc}", file=sys.stderr)
+            sys.exit(1)
         summary.append({"filename": name, "status": talk.get("status"),
-                        "promoted": promoted, "stamped_processed_date": stamped})
+                        "promoted": promoted, "stamped_processed_date": stamped,
+                        "coerced_pattern_score": coerced})
 
     with open(db_path, "w", encoding="utf-8") as f:
         json.dump(db, f, indent=2, ensure_ascii=False)

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -177,8 +177,17 @@ def canonicalize_pattern_score(incoming):
     if not isinstance(incoming, dict):
         return False
     score = incoming.get("pattern_score")
-    if not isinstance(score, (int, float)) or isinstance(score, bool):
+    if score is None or isinstance(score, dict):
         return False
+    if isinstance(score, bool) or not isinstance(score, (int, float)):
+        # `True` satisfies isinstance(x, int) in Python, so a bool would sail
+        # through the numeric branch below AND through
+        # normalize_pattern_observations, persisting as a numeric score. Reject
+        # every non-numeric shape here rather than letting one reach the DB.
+        raise ValueError(
+            f"pattern_score is {score!r} ({type(score).__name__}), which is "
+            "neither the declared dict nor a number. Emit "
+            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
     used = len(incoming.get("patterns_detected") or [])
     against = len(incoming.get("antipatterns_detected") or [])
     if used - against != score:

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -202,20 +202,23 @@ def canonicalize_pattern_score(incoming):
         inner = score.get("score")
         if inner is None:
             return False
-        if isinstance(inner, bool) or not isinstance(inner, (int, float)):
+        if isinstance(inner, bool) or not isinstance(inner, int):
             raise ValueError(
                 f"pattern_score.score is {inner!r} ({type(inner).__name__}), "
-                "which is not a number. Emit "
+                "but the talk schema declares pattern_score an integer — it is "
+                "count(patterns) minus count(antipatterns), so a float cannot be "
+                "right. Emit "
                 '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
         return False
-    if isinstance(score, bool) or not isinstance(score, (int, float)):
-        # `True` satisfies isinstance(x, int) in Python, so a bool would sail
-        # through the numeric branch below AND through
-        # normalize_pattern_observations, persisting as a numeric score. Reject
-        # every non-numeric shape here rather than letting one reach the DB.
+    if isinstance(score, bool) or not isinstance(score, int):
+        # Two traps in one check. `True` satisfies isinstance(x, int), so a bool
+        # would sail through here AND through normalize_pattern_observations,
+        # persisting as a numeric score. And the talk schema declares
+        # pattern_score an INTEGER — it is count minus count — so a float is
+        # never right, however numeric it looks.
         raise ValueError(
             f"pattern_score is {score!r} ({type(score).__name__}), which is "
-            "neither the declared dict nor a number. Emit "
+            "neither the declared dict nor an integer. Emit "
             '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
     used = len(incoming.get("patterns_detected") or [])
     against = len(incoming.get("antipatterns_detected") or [])

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -95,6 +95,21 @@ def normalize_stamp(value):
             f"(e.g. {value}+00:00) so stamps from different machines order")
     return default_stamp(moment)
 
+# Tracking-DB talk-record schema version, stamped by this writer on every merge.
+#
+# v1 is the implicit, unversioned shape every pre-2026-07-28 record carries:
+# `transcript_source` was documented as always present, though 95 of 209 records
+# never had it.
+# v2 documents `transcript_source` as optional and gives ABSENT a meaning —
+# provenance unknown, distinct from the explicit value `none` (no transcript).
+#
+# The bump is ADDITIVE, which `rules/stateful-artifacts.md` Cross-Pipeline Schema
+# Bumps permits without a staged rollout: a v1 reader reads a v2 record
+# unchanged, because v2 removes a guarantee rather than adding a field. Readers
+# do not gate on this value yet — that contract is #147, deliberately sequenced
+# after the in-flight reparse so writer and readers do not skew mid-run.
+TALK_SCHEMA_VERSION = 2
+
 # Queryable scalars promoted from the subagent return onto the talk's top level.
 # (top_level_field, dotted source path within the return). To add a new queryable
 # scalar, add it here AND to the return schema — never reintroduce hand-mapping.
@@ -177,7 +192,21 @@ def canonicalize_pattern_score(incoming):
     if not isinstance(incoming, dict):
         return False
     score = incoming.get("pattern_score")
-    if score is None or isinstance(score, dict):
+    if score is None:
+        return False
+    if isinstance(score, dict):
+        # The declared shape — but its `score` is what PROMOTE writes to the DB,
+        # so it needs the same type check the bare form gets. A dict carrying
+        # `{"score": True}` or `{"score": "19"}` would otherwise reach the DB
+        # unexamined, which is the same defect one level in.
+        inner = score.get("score")
+        if inner is None:
+            return False
+        if isinstance(inner, bool) or not isinstance(inner, (int, float)):
+            raise ValueError(
+                f"pattern_score.score is {inner!r} ({type(inner).__name__}), "
+                "which is not a number. Emit "
+                '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
         return False
     if isinstance(score, bool) or not isinstance(score, (int, float)):
         # `True` satisfies isinstance(x, int) in Python, so a bool would sail
@@ -235,6 +264,7 @@ def merge_talk(talk, ret, run_date=None):
     # Before PROMOTE digs `pattern_observations.pattern_score.score`, which a
     # bare int cannot satisfy.
     coerced_score = canonicalize_pattern_score(ret.get("pattern_observations"))
+    talk["schema_version"] = TALK_SCHEMA_VERSION
     for f in SCALARS:
         if f in ret and not is_empty(ret[f]):
             talk[f] = ret[f]

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -123,8 +123,11 @@ PROMOTE = [
     ("audience_interaction_count", "structured_data.audience_interaction_count"),
     ("co_presenter",               "structured_data.co_presenter"),
     ("delivery_language",          "structured_data.delivery_language"),
-    ("pattern_score",              "pattern_observations.pattern_score.score"),
 ]
+
+# NOT in PROMOTE: `pattern_score`. It is set explicitly in merge_talk from
+# resolve_pattern_score, because a dotted-path lookup silently yields nothing
+# when a subagent sends the bare int instead of the declared dict.
 
 # Scalar result fields copied verbatim when present in the return.
 SCALARS = [
@@ -165,94 +168,129 @@ def deep_merge(dst, src):
     return dst
 
 
-def canonicalize_pattern_score(incoming):
-    """Coerce a bare-int `pattern_score` into the declared dict shape.
+def require_mapping(ret, field):
+    """Return `ret[field]` as a dict, or None when absent. Raise on any other type.
 
-    Returns True when a coercion happened. Raises ValueError when the supplied
-    integer contradicts the arrays.
+    The three blocks carrying a return's actual content — `structured_data`,
+    `verbatim_examples`, `pattern_observations` — were each guarded by a bare
+    `isinstance(..., dict)` test that SKIPPED a malformed block and reported
+    success. A return whose `structured_data` arrived as a list lost the entire
+    analysis and still exited 0.
 
-    Subagents write `"pattern_score": 19` instead of
-    `{"patterns_used": 22, "antipatterns_detected": 3, "score": 19}` on roughly a
-    third of returns, and the schema invites it twice over: the field is NAMED
-    for a number but holds a dict, and `antipatterns_detected` means an array of
-    objects one level up and an integer count inside `pattern_score`.
-
-    The bare int is not harmless. `normalize_pattern_observations` accepts it, so
-    the nested value lands and the return looks fine — but PROMOTE resolves
-    `pattern_observations.pattern_score.score`, `dig` returns None on an int, and
-    the queryable top-level `pattern_score` scalar is **silently dropped**. That
-    is precisely the missing-scalar defect this script was written to fix,
-    reintroduced through the input shape.
-
-    Restating the requirement in the brief has not moved the rate across four
-    batches, so the tooling absorbs the variant instead — and recomputes rather
-    than trusting it, because a coerced value that disagrees with the arrays is a
-    real inconsistency, not a formatting slip.
+    That is the silent-drop shape this script exists to eliminate, so a wrong
+    type is now loud. Absent stays legal: a return need not carry every block.
     """
-    if not isinstance(incoming, dict):
-        return False
-    score = incoming.get("pattern_score")
-    if score is None:
-        return False
-    if isinstance(score, dict):
-        # The declared shape — but its `score` is what PROMOTE writes to the DB,
-        # so it needs the same type check the bare form gets. A dict carrying
-        # `{"score": True}` or `{"score": "19"}` would otherwise reach the DB
-        # unexamined, which is the same defect one level in.
-        inner = score.get("score")
-        if inner is None:
-            return False
-        if isinstance(inner, bool) or not isinstance(inner, int):
+    if field not in ret or ret[field] is None:
+        return None
+    value = ret[field]
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"{field} is a {type(value).__name__}, but the return schema declares "
+            f"it a JSON object. Refusing to skip it silently — a dropped {field} "
+            "loses the whole block while the merge still reports success.")
+    return value
+
+
+def require_detections(observations, field):
+    """Return a detection array as a list of dicts, or None when absent.
+
+    Both consumers assume list-of-dicts: one calls `len()` on it to recompute the
+    score, the other calls `p.get("pattern_id")` on each element. A list of bare
+    id STRINGS — a plausible return shape — raises AttributeError mid-merge and
+    kills the script before it prints its JSON, and a plain string makes `len()`
+    count characters as detections.
+    """
+    if field not in observations or observations[field] is None:
+        return None
+    value = observations[field]
+    if not isinstance(value, list):
+        raise ValueError(
+            f"pattern_observations.{field} is a {type(value).__name__}, but the "
+            "return schema declares it an array of detection objects.")
+    bad = next((e for e in value if not isinstance(e, dict)), None)
+    if bad is not None:
+        raise ValueError(
+            f"pattern_observations.{field} contains {bad!r} "
+            f"({type(bad).__name__}); every element must be an object carrying a "
+            "`pattern_id`.")
+    return value
+
+
+def resolve_pattern_score(observations, patterns, antipatterns):
+    """Single source of truth for the talk's `pattern_score`.
+
+    Returns (score, coerced); `score` is None when the return carries none.
+
+    Every defect here came from TWO functions independently deciding what a valid
+    score was — one normalizing the nested DB value, the other resolving the
+    promoted top-level scalar through a dotted path. Each review round tightened
+    one and left the other, so they disagreed in a new way each time. One
+    function decides now, and both consumers read its answer.
+
+    Subagents emit `"pattern_score": 19` instead of the declared
+    `{"patterns_used": N, "antipatterns_detected": M, "score": N-M}` on roughly a
+    third of returns. The schema invites it twice over: the field is NAMED for a
+    number but holds a dict, and `antipatterns_detected` means an array of
+    objects one level up and an integer count inside `pattern_score`. Restating
+    the requirement in the brief has not moved the rate across four batches, so
+    the tooling absorbs the variant — and recomputes rather than trusting it.
+
+    The score is count(patterns) minus count(antipatterns), so it is an INTEGER
+    by construction. `True` satisfies `isinstance(x, int)` in Python and a float
+    looks numeric; neither is a score.
+    """
+    if "pattern_score" not in observations or observations["pattern_score"] is None:
+        return None, False
+
+    raw = observations["pattern_score"]
+    coerced = not isinstance(raw, dict)
+    nested = raw if coerced else raw.get("score")
+    if nested is None:
+        if coerced:
+            return None, False
+        # A `pattern_score` object present but missing `score` is malformed, not
+        # absent: the declared shape carries the number, so silently returning
+        # "no score" here would drop it exactly like the bare int used to.
+        raise ValueError(
+            "pattern_score is an object with no `score` key "
+            f"(got keys {sorted(raw)}). Emit "
+            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
+
+    label = "pattern_score" if coerced else "pattern_score.score"
+    if isinstance(nested, bool) or not isinstance(nested, int):
+        raise ValueError(
+            f"{label} is {nested!r} ({type(nested).__name__}). It must be an "
+            "integer — the score is count(patterns) minus count(antipatterns), "
+            "so a float, a string and a bool are all wrong. Emit "
+            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
+
+    # Only the coerced form is cross-checked. It is the shape that arrived
+    # without its accompanying counts, so the arrays are the only evidence that
+    # the number is right.
+    if coerced:
+        used, against = len(patterns or []), len(antipatterns or [])
+        if used - against != nested:
             raise ValueError(
-                f"pattern_score.score is {inner!r} ({type(inner).__name__}), "
-                "but the talk schema declares pattern_score an integer — it is "
-                "count(patterns) minus count(antipatterns), so a float cannot be "
-                "right. Emit "
-                '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
-        return False
-    if isinstance(score, bool) or not isinstance(score, int):
-        # Two traps in one check. `True` satisfies isinstance(x, int), so a bool
-        # would sail through here AND through normalize_pattern_observations,
-        # persisting as a numeric score. And the talk schema declares
-        # pattern_score an INTEGER — it is count minus count — so a float is
-        # never right, however numeric it looks.
-        raise ValueError(
-            f"pattern_score is {score!r} ({type(score).__name__}), which is "
-            "neither the declared dict nor an integer. Emit "
-            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
-    used = len(incoming.get("patterns_detected") or [])
-    against = len(incoming.get("antipatterns_detected") or [])
-    if used - against != score:
-        raise ValueError(
-            f"pattern_score is the bare int {score}, but patterns_detected "
-            f"({used}) minus antipatterns_detected ({against}) is {used - against}. "
-            "Refusing to guess which is right — fix the return so pattern_score is "
-            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
-    incoming["pattern_score"] = {
-        "patterns_used": used, "antipatterns_detected": against, "score": score}
-    return True
+                f"pattern_score is the bare int {nested}, but patterns_detected "
+                f"({used}) minus antipatterns_detected ({against}) is "
+                f"{used - against}. Refusing to guess which is right.")
+    return nested, coerced
 
 
-def normalize_pattern_observations(existing, incoming):
+def normalize_pattern_observations(existing, patterns, antipatterns, score):
     """Map the subagent return shape onto the DB shape, keeping both views.
 
-    Subagent returns {patterns_detected, antipatterns_detected, pattern_score:{score}}.
-    The DB declares {pattern_ids, antipattern_ids, pattern_score:int}. Section 15
-    aggregation reads the detailed *_detected arrays, so keep those too.
+    Takes already-validated inputs and decides nothing about their shape, so it
+    cannot drift from the validator the way its predecessor did.
     """
     obs = dict(existing) if isinstance(existing, dict) else {}
-    patterns = incoming.get("patterns_detected")
-    antipatterns = incoming.get("antipatterns_detected")
     if patterns is not None:
         obs["patterns_detected"] = patterns
         obs["pattern_ids"] = [p.get("pattern_id") for p in patterns if p.get("pattern_id")]
     if antipatterns is not None:
         obs["antipatterns_detected"] = antipatterns
         obs["antipattern_ids"] = [p.get("pattern_id") for p in antipatterns if p.get("pattern_id")]
-    score = incoming.get("pattern_score")
-    if isinstance(score, dict) and "score" in score:
-        obs["pattern_score"] = score["score"]
-    elif isinstance(score, (int, float)):
+    if score is not None:
         obs["pattern_score"] = score
     return obs
 
@@ -260,13 +298,18 @@ def normalize_pattern_observations(existing, incoming):
 def merge_talk(talk, ret, run_date=None):
     """Merge one return into its talk. Returns (promoted, stamped, coerced_score).
 
-    `run_date` stamps `processed_date` when the return omits it. Callers that
-    care about reproducibility pass it explicitly; it is never read from the
-    clock inside the merge.
+    Every block is validated BEFORE anything is written, so a malformed return
+    leaves the talk untouched rather than half-merged. `run_date` stamps
+    `processed_date` when the return omits it; it is never read from the clock
+    inside the merge.
     """
-    # Before PROMOTE digs `pattern_observations.pattern_score.score`, which a
-    # bare int cannot satisfy.
-    coerced_score = canonicalize_pattern_score(ret.get("pattern_observations"))
+    structured = require_mapping(ret, "structured_data")
+    verbatim = require_mapping(ret, "verbatim_examples")
+    observations = require_mapping(ret, "pattern_observations") or {}
+    patterns = require_detections(observations, "patterns_detected")
+    antipatterns = require_detections(observations, "antipatterns_detected")
+    score, coerced_score = resolve_pattern_score(observations, patterns, antipatterns)
+
     talk["schema_version"] = TALK_SCHEMA_VERSION
     for f in SCALARS:
         if f in ret and not is_empty(ret[f]):
@@ -277,20 +320,50 @@ def merge_talk(talk, ret, run_date=None):
     if run_date and is_empty(ret.get("processed_date")):
         talk["processed_date"] = run_date
         stamped = True
-    if isinstance(ret.get("structured_data"), dict):
-        talk["structured_data"] = deep_merge(talk.get("structured_data") or {}, ret["structured_data"])
-    if isinstance(ret.get("verbatim_examples"), dict):
-        talk["verbatim_examples"] = deep_merge(talk.get("verbatim_examples") or {}, ret["verbatim_examples"])
-    if isinstance(ret.get("pattern_observations"), dict):
+    if structured is not None:
+        talk["structured_data"] = deep_merge(talk.get("structured_data") or {}, structured)
+    if verbatim is not None:
+        talk["verbatim_examples"] = deep_merge(talk.get("verbatim_examples") or {}, verbatim)
+    if observations:
         talk["pattern_observations"] = normalize_pattern_observations(
-            talk.get("pattern_observations"), ret["pattern_observations"])
+            talk.get("pattern_observations"), patterns, antipatterns, score)
+
     promoted = []
     for field, path in PROMOTE:
         val = dig(ret, path)
         if not is_empty(val):
             talk[field] = val
             promoted.append(field)
+    # `pattern_score` is set from the resolved value rather than dug out of the
+    # return. The dotted path `pattern_observations.pattern_score.score` is what
+    # silently dropped the scalar whenever a subagent sent the bare int, because
+    # `dig` returns None on an int — the promoted scalar and the nested value
+    # must come from one decision, not two lookups.
+    if score is not None:
+        talk["pattern_score"] = score
+        promoted.append("pattern_score")
     return promoted, stamped, coerced_score
+
+
+def migrate_records(db):
+    """Bring every talk record to the current schema version. Returns the count.
+
+    `stateful-artifacts` puts migration on the OWNER skill, and this script is
+    the tracking DB's only writer. Stamping just the talks a batch happened to
+    touch would leave the file permanently mixed-version — a reader could not
+    tell an unversioned record from one this writer had never seen, which is the
+    ambiguity the version exists to remove.
+
+    The migration is a stamp, not a transform: v1 to v2 removes a documented
+    guarantee about `transcript_source` rather than changing any stored value,
+    so no record needs rewriting to satisfy v2.
+    """
+    migrated = 0
+    for talk in db.get("talks", []):
+        if talk.get("schema_version") != TALK_SCHEMA_VERSION:
+            talk["schema_version"] = TALK_SCHEMA_VERSION
+            migrated += 1
+    return migrated
 
 
 def load_json(path, label):
@@ -365,6 +438,9 @@ def main():
               f"got {type(returns).__name__}", file=sys.stderr)
         sys.exit(1)
 
+    # Migrate the whole artifact, not just the talks this batch touches.
+    migrated = migrate_records(db)
+
     by_name = {t.get("filename"): t for t in db.get("talks", [])}
     summary = []
     for ret in returns:
@@ -388,6 +464,7 @@ def main():
         json.dump(db, f, indent=2, ensure_ascii=False)
 
     json.dump({"persisted": len(summary), "db_path": db_path, "run_date": run_date,
+               "schema_version": TALK_SCHEMA_VERSION, "migrated_records": migrated,
                "talks": summary}, sys.stdout, ensure_ascii=False)
     sys.stdout.write("\n")
 

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -57,6 +57,35 @@ def test_short_stub_is_rejected(fetch_transcript):
     assert "125 words" in reason
 
 
+def _raw_vtt(lines=200):
+    """YouTube's karaoke caption payload: each line once tagged, once plain."""
+    out = []
+    for n in range(lines):
+        stamp = f"00:00:{n // 60:02d}.{n % 60:03d}"
+        out.append(f"so<{stamp}><c> before</c><{stamp}><c> we</c><{stamp}><c> start</c>")
+        out.append("so before we start")
+    return "\n".join(out)
+
+
+RAW_VTT_FIXTURE = _raw_vtt()
+
+
+def test_raw_vtt_payload_is_rejected(fetch_transcript):
+    """A raw VTT dump has MORE words than the cleaned text, so the length floor
+    cannot catch it — 26 corpus transcripts sat in this shape reading 3.6x their
+    true length, and a meetup talk read as an 18,543-word two-hour session."""
+    ok, reason = fetch_transcript.validate_transcript(RAW_VTT_FIXTURE)
+    assert not ok
+    assert "raw VTT" in reason and "vtt-cleanup.py" in reason
+
+
+def test_raw_vtt_is_caught_despite_passing_the_word_floor(fetch_transcript):
+    """Guard the guard: prove the fixture is long enough to clear the floor."""
+    stripped = fetch_transcript.VTT_TIMING_TAG.sub("", RAW_VTT_FIXTURE)
+    assert fetch_transcript.count_words(stripped) > fetch_transcript.DEFAULT_MIN_WORDS
+    assert fetch_transcript.validate_transcript(stripped)[0] is True
+
+
 def test_mostly_non_speech_markers_is_rejected(fetch_transcript):
     """A caption track of [Music]/[Applause] parses fine and says nothing."""
     ok, reason = fetch_transcript.validate_transcript(MUSIC_FIXTURE, min_words=10)

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -474,3 +474,104 @@ def test_schema_version_is_stamped_over_an_older_value(persist_results, tmp_path
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(db.read_text())["talks"][0]["schema_version"] == 2
+
+
+@pytest.mark.parametrize("block", ["structured_data", "verbatim_examples",
+                                   "pattern_observations"])
+def test_a_malformed_content_block_fails_loudly(persist_results, tmp_path, block):
+    """A wrong-typed block used to be SKIPPED while the merge reported success.
+
+    `structured_data` arriving as a list lost the entire analysis and still
+    exited 0 — the silent-drop shape this script exists to eliminate.
+    """
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret[block] = [{"slide_count": 60}]  # a list where an object is declared
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1, f"{block} was skipped silently: {result.stdout}"
+    assert block in result.stderr
+
+
+@pytest.mark.parametrize("bad", [
+    ["narrative-arc", "bookends"],          # bare id strings
+    "narrative-arc",                        # a string: len() counts characters
+    {"pattern_id": "narrative-arc"},        # a single object, not an array
+])
+def test_malformed_detection_arrays_fail_loudly(persist_results, tmp_path, bad):
+    """List-of-strings raised AttributeError mid-merge and killed the script
+    before it printed its JSON; a plain string made `len()` count characters as
+    detections and fed a silently wrong number into the score cross-check."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret["pattern_observations"]["patterns_detected"] = bad
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1, f"{bad!r} was accepted: {result.stdout}"
+    assert "patterns_detected" in result.stderr
+    assert "Traceback" not in result.stderr, "died instead of reporting"
+
+
+def test_a_malformed_return_leaves_the_talk_untouched(persist_results, tmp_path):
+    """Validation runs before any write, so a bad return is not half-merged."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret["pattern_observations"]["patterns_detected"] = ["narrative-arc"]
+    original = _talk()
+    db.write_text(json.dumps({"talks": [original]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert json.loads(db.read_text())["talks"][0] == original
+
+
+def test_migration_stamps_every_record_not_just_merged_ones(persist_results, tmp_path):
+    """Stamping only touched talks leaves the artifact permanently mixed-version,
+    so a reader cannot tell an unversioned record from an untouched one."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    merged, untouched = _talk(), _talk()
+    untouched["filename"] = "other-talk.md"
+    db.write_text(json.dumps({"talks": [merged, untouched]}))
+    batch.write_text(json.dumps([_return()]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["migrated_records"] == 2
+    for talk in json.loads(db.read_text())["talks"]:
+        assert talk["schema_version"] == persist_results.TALK_SCHEMA_VERSION
+
+
+def test_score_object_without_a_score_key_fails_loudly(persist_results, tmp_path):
+    """Present-but-incomplete is malformed, not absent — returning "no score"
+    would drop the value exactly like the bare int used to."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret["pattern_observations"]["pattern_score"] = {
+        "patterns_used": 2, "antipatterns_detected": 1}
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "no `score` key" in result.stderr
+    assert "pattern_score" not in json.loads(db.read_text())["talks"][0]

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -394,9 +394,27 @@ def test_bare_int_contradicting_the_arrays_fails_loudly(persist_results, tmp_pat
     assert "42" in result.stderr
 
 
-def test_bare_float_and_bool_scores(persist_results):
-    """`True` is an int in Python — it must not be read as a score of 1."""
-    obs = {"patterns_detected": [{"pattern_id": "a"}], "antipatterns_detected": [],
-           "pattern_score": True}
-    assert persist_results.canonicalize_pattern_score(obs) is False
-    assert obs["pattern_score"] is True
+@pytest.mark.parametrize("bad", [True, False, "19", ["19"]])
+def test_non_numeric_pattern_score_never_reaches_the_db(persist_results, tmp_path, bad):
+    """Assert the persisted OUTCOME, not the helper.
+
+    An earlier version of this test called `canonicalize_pattern_score` directly
+    and passed while `merge_talk` still persisted `pattern_score: True` — because
+    `isinstance(True, int)` holds in Python, so a bool sailed through
+    `normalize_pattern_observations`'s numeric branch. Testing the helper in
+    isolation is exactly what hid the bug.
+    """
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret["pattern_observations"]["pattern_score"] = bad
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1, f"{bad!r} was accepted: {result.stdout}"
+    assert "pattern_score" in result.stderr
+    stored = json.loads(db.read_text())["talks"][0]
+    assert "pattern_score" not in stored, f"{bad!r} reached the DB as {stored.get('pattern_score')!r}"

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -120,21 +120,21 @@ def test_run_date_stamped_when_return_omits_processed_date(persist_results):
     ret = _return()
     del ret["processed_date"]
     talk = _talk(processed_date="2026-04-09")
-    _, stamped = persist_results.merge_talk(talk, ret, run_date="2026-07-26")
+    _, stamped, _ = persist_results.merge_talk(talk, ret, run_date="2026-07-26")
     assert talk["processed_date"] == "2026-07-26"
     assert stamped is True
 
 
 def test_return_processed_date_wins_over_run_date(persist_results):
     talk = _talk()
-    _, stamped = persist_results.merge_talk(talk, _return(), run_date="2026-07-26")
+    _, stamped, _ = persist_results.merge_talk(talk, _return(), run_date="2026-07-26")
     assert talk["processed_date"] == "2026-06-18"
     assert stamped is False
 
 
 def test_empty_processed_date_is_stamped(persist_results):
     talk = _talk(processed_date="2026-04-09")
-    _, stamped = persist_results.merge_talk(talk, _return(processed_date=""),
+    _, stamped, _ = persist_results.merge_talk(talk, _return(processed_date=""),
                                             run_date="2026-07-26")
     assert talk["processed_date"] == "2026-07-26"
     assert stamped is True
@@ -144,7 +144,7 @@ def test_no_run_date_leaves_processed_date_untouched(persist_results):
     ret = _return()
     del ret["processed_date"]
     talk = _talk(processed_date="2026-04-09")
-    _, stamped = persist_results.merge_talk(talk, ret)
+    _, stamped, _ = persist_results.merge_talk(talk, ret)
     assert talk["processed_date"] == "2026-04-09"
     assert stamped is False
 
@@ -329,3 +329,74 @@ def test_explicit_timestamp_is_accepted(persist_results, tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(db.read_text())["talks"][0]["processed_date"].startswith("2026-07-27T14:03:22")
+
+
+def test_bare_int_pattern_score_is_coerced_and_promoted(persist_results, tmp_path):
+    """The bare int is not harmless: PROMOTE digs
+    `pattern_observations.pattern_score.score`, `dig` returns None on an int, and
+    the queryable top-level scalar is silently dropped — the exact missing-scalar
+    defect this script exists to fix, reintroduced through the input shape.
+
+    Roughly a third of returns arrive this way; the schema invites it.
+    """
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret["pattern_observations"]["pattern_score"] = 1  # 2 patterns - 1 antipattern
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["talks"][0]["coerced_pattern_score"] is True
+    assert "pattern_score" in payload["talks"][0]["promoted"]
+    talk = json.loads(db.read_text())["talks"][0]
+    assert talk["pattern_score"] == 1
+
+
+def test_dict_pattern_score_is_not_reported_as_coerced(persist_results, tmp_path):
+    """Guard the guard: the flag must distinguish the two shapes."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([_return()]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["talks"][0]["coerced_pattern_score"] is False
+    assert "pattern_score" in payload["talks"][0]["promoted"]
+
+
+def test_bare_int_contradicting_the_arrays_fails_loudly(persist_results, tmp_path):
+    """A coerced value that disagrees with the arrays is a real inconsistency.
+
+    Recomputing silently would launder it; the script refuses to guess which
+    number is right.
+    """
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret["pattern_observations"]["pattern_score"] = 42  # arrays say 2 - 1 = 1
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "Refusing to guess" in result.stderr
+    assert "42" in result.stderr
+
+
+def test_bare_float_and_bool_scores(persist_results):
+    """`True` is an int in Python — it must not be read as a score of 1."""
+    obs = {"patterns_detected": [{"pattern_id": "a"}], "antipatterns_detected": [],
+           "pattern_score": True}
+    assert persist_results.canonicalize_pattern_score(obs) is False
+    assert obs["pattern_score"] is True

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -418,3 +418,59 @@ def test_non_numeric_pattern_score_never_reaches_the_db(persist_results, tmp_pat
     assert "pattern_score" in result.stderr
     stored = json.loads(db.read_text())["talks"][0]
     assert "pattern_score" not in stored, f"{bad!r} reached the DB as {stored.get('pattern_score')!r}"
+
+
+@pytest.mark.parametrize("inner", [True, False, "19", ["19"]])
+def test_invalid_score_inside_the_declared_dict_is_rejected(
+        persist_results, tmp_path, inner):
+    """The dict is the declared shape, but its `score` is what PROMOTE writes.
+
+    Type-checking only the bare form left `{"score": True}` reaching the DB
+    unexamined — the same defect one level in.
+    """
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    ret = _return()
+    ret["pattern_observations"]["pattern_score"] = {
+        "patterns_used": 2, "antipatterns_detected": 1, "score": inner}
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([ret]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1, f"{inner!r} was accepted: {result.stdout}"
+    assert "pattern_score.score" in result.stderr
+    stored = json.loads(db.read_text())["talks"][0]
+    assert "pattern_score" not in stored
+
+
+def test_merge_stamps_the_talk_schema_version(persist_results, tmp_path):
+    """stateful-artifacts requires a schema_version on every record."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([_return()]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    talk = json.loads(db.read_text())["talks"][0]
+    assert talk["schema_version"] == persist_results.TALK_SCHEMA_VERSION
+
+
+def test_schema_version_is_stamped_over_an_older_value(persist_results, tmp_path):
+    """A v1 record merged by this writer becomes v2 — that is the migration."""
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    old = _talk()
+    old["schema_version"] = 1
+    db.write_text(json.dumps({"talks": [old]}))
+    batch.write_text(json.dumps([_return()]))
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(db.read_text())["talks"][0]["schema_version"] == 2

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -394,7 +394,7 @@ def test_bare_int_contradicting_the_arrays_fails_loudly(persist_results, tmp_pat
     assert "42" in result.stderr
 
 
-@pytest.mark.parametrize("bad", [True, False, "19", ["19"]])
+@pytest.mark.parametrize("bad", [True, False, "19", ["19"], 1.5, 1.0])
 def test_non_numeric_pattern_score_never_reaches_the_db(persist_results, tmp_path, bad):
     """Assert the persisted OUTCOME, not the helper.
 
@@ -420,7 +420,7 @@ def test_non_numeric_pattern_score_never_reaches_the_db(persist_results, tmp_pat
     assert "pattern_score" not in stored, f"{bad!r} reached the DB as {stored.get('pattern_score')!r}"
 
 
-@pytest.mark.parametrize("inner", [True, False, "19", ["19"]])
+@pytest.mark.parametrize("inner", [True, False, "19", ["19"], 1.5, 1.0])
 def test_invalid_score_inside_the_declared_dict_is_rejected(
         persist_results, tmp_path, inner):
     """The dict is the declared shape, but its `score` is what PROMOTE writes.


### PR DESCRIPTION
Two defects in the transcript work shipped in 0.18.72, both found by running it against the real corpus rather than by reading it.

## A raw VTT dump passes every validator

26 of the vault's 206 transcripts held YouTube's karaoke caption payload instead of cleaned text — each line once with inline `<00:00:01.020><c>word</c>` timing tags, then again as plain text. **Word counts read 3.6× high, uniformly.** A 37-minute meetup talk measured 18,543 words, implying a two-hour session.

The length floor cannot catch this: **a doubled transcript has MORE words, not fewer.** `validate_transcript` now rejects the timing-tag signature and points at `vtt-cleanup.py`, which already existed for exactly this and had simply never been run on those files.

A second test asserts the fixture clears the word floor *before* the VTT check fires — so the guard cannot pass for the wrong reason.

## `method: "existing"` told agents to write `manual`

The mapping I shipped said to fall back to `manual` when `transcript_source` was absent. `manual` means a human produced the transcript. A batch-24 agent dutifully wrote it onto a file that is unmistakably YouTube ASR, then flagged it as a placeholder.

An absent field now stays absent. The script learns nothing about provenance on that path, and a reader weighing transcript reliability would trust `manual` more than the ASR it probably is — inventing provenance is worse than recording none.

1153 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AW91SuWHRNW1mHL6MZCfZ