### PR TITLE
fix(vault-ingress): require source-located evidence

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jbaruch/speaker-toolkit",
   "version": "0.18.73",
-  "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (99 observable, 12 unobservable go-live items) for scoring, brainstorming, and go-live preparation.",
+  "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (89 observable, 22 unobservable go-live items) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [
     "skills/vault-ingress",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### fix(vault-ingress) — require source-located evidence for observable patterns
+
+Pattern detections now carry validated transcript, slide, video, or allowlisted
+talk-metadata citations instead of treating a free-form evidence string as proof.
+Caption, Whisper, and VTT ingestion preserve hash-bound timing sidecars; legacy
+evidence remains readable but renders as unverified, and ten process-only
+patterns move out of automatic observation when the available artifacts cannot
+establish how the talk was prepared.
+
 ## 0.18.73 — 2026-07-28
 
 ### fix(vault-ingress) — a bare-int `pattern_score` no longer silently drops the scalar

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ The vault skill will:
 2. Scan for talks and .pptx files
 3. Process talks in parallel batches of 5
 4. Extract rhetoric patterns across 14 dimensions
-5. Score each talk against the 99 observable Presentation Patterns entries
+5. Score each talk against the 89 observable Presentation Patterns entries using
+   source-located, channel-permitted evidence
 6. Build a running narrative summary and slide design spec
 7. Run an interactive clarification session to validate findings and capture your intent
 8. Generate a structured speaker profile with pattern mastery data (after 10+ talks)
@@ -314,9 +315,11 @@ notes which named patterns and antipatterns are detected per talk.
 ### Processing Pipeline
 
 - Talks are processed in **parallel batches of 5** subagents
-- Transcripts are downloaded via `yt-dlp` (with `youtube-transcript-api` fallback)
+- Transcripts use YouTube captions first, with local Whisper audio transcription as fallback;
+  source timing is retained in a hash-bound sidecar when available
 - Slides are acquired from PPTX files (preferred, richer data) or downloaded as PDFs via `gdown`
-- Each talk is scored against the taxonomy's 99 observable entries (74 patterns + 25 antipatterns)
+- Each talk is scored against the taxonomy's 89 observable entries (66 patterns + 23 antipatterns),
+  with source-located evidence restricted to the artifact channels each entry permits
 - Each batch updates the summary, per-talk analysis files, and triggers profile regeneration
 - An interactive clarification session resolves ambiguities and captures confirmed intent
 
@@ -389,13 +392,14 @@ across the corpus (`delayed-self-introduction`, `three-part-close`, `progressive
 - **Build** (51): Foreshadowing, Bookends, Defy Defaults, Vacation Photos, Traveling Highlights, Emergence, Sparkline, Call to Adventure, Call to Action, New Bliss, S.T.A.R. Moment, Three-Part Close, Progressive Reveal, Meme as Argument, Guess First, Retrieval Beat, Second Look, and more
 - **Deliver** (36): Carnegie Hall, Breathing Room, Echo Chamber, Seeding the First Question, Screen Blackout, Delayed Self-Introduction, Anti-Sell, Flyover, Spaced Follow-Up, The Nodding Room, and more
 
-Of the 111 entries, **99 are observable** (detectable from transcripts and slides) and
-**12 are unobservable** (pre-event logistics, physical stage behaviors, post-event
-follow-up, and external systems that leave no trace in recordings).
+Of the 111 entries, **89 are observable** (directly detectable through their declared
+transcript, slide, video, or metadata evidence channels) and **22 are unobservable**
+(pre-event logistics, hidden authoring/provenance processes, physical stage behaviors,
+post-event follow-up, and external systems the current artifacts cannot prove).
 
 **How it integrates:**
 
-| Integration point | Observable patterns (99) | Unobservable patterns (12) |
+| Integration point | Observable patterns (89) | Unobservable patterns (22) |
 |---|---|---|
 | **Vault scoring** (Step 3 B2) | Scored per talk, aggregated into `pattern_profile` | Excluded from scoring |
 | **Creator Phase 2** | 4-tier Pattern Strategy (Signature / Contextual / New to You / Shake It Up) | Included in recommendations |

--- a/rules/transcript-fetch-authority.md
+++ b/rules/transcript-fetch-authority.md
@@ -30,12 +30,14 @@ Run against a talk whose caption track is disabled, on Apple Silicon with the
 `whisper` extra installed:
 
 1. `python3 skills/vault-ingress/scripts/fetch-transcript.py <youtube_id> --out /tmp/t.txt --method whisper`
-2. Observe: exit 0, one JSON object on stdout with `"method": "whisper"` and a `words` count plausible for the runtime (conference delivery is 110–160 wpm).
-3. Confirm `/tmp/t.txt` holds prose, not `[Music]` markers or a traceback.
-4. Re-run with `yt-dlp` removed from `PATH`. Expect exit 1, a stderr line naming the install command, one JSON object with `"ok": false`, and NO file at the output path.
-5. `--audio <local file> --out /tmp/a.txt` on a non-YouTube recording: exit 0, `"method": "whisper"`, prose at the output path.
+2. Observe: exit 0, one JSON object on stdout with `"method": "whisper"`, `"timed_path": "/tmp/t.segments.json"`, and a `words` count plausible for the runtime (conference delivery is 110–160 wpm).
+3. `jq -e '.schema_version == 1 and .source == "whisper" and (.segments | length > 0) and all(.segments[]; .start_seconds >= 0 and .end_seconds > .start_seconds and (.text | length > 0))' /tmp/t.segments.json` exits 0.
+4. `test "$(jq -r .transcript_sha256 /tmp/t.segments.json)" = "$(shasum -a 256 /tmp/t.txt | awk '{print $1}')"` exits 0.
+5. Confirm `/tmp/t.txt` holds prose, not `[Music]` markers or a traceback.
+6. Re-run with `yt-dlp` removed from `PATH` and a fresh output path. Expect exit 1, a stderr line naming the install command, one JSON object with `"ok": false`, and no transcript or sidecar at that output path.
+7. `--audio <local file> --out /tmp/a.txt` on a non-YouTube recording: exit 0, `"method": "whisper"`, `"timed_path": "/tmp/a.segments.json"`, prose at the output path, and a sidecar that passes steps 3–4 after substituting `/tmp/a` for `/tmp/t`.
 
-A pass requires all five. Step 4 is the one that matters: it proves a tool-state failure still honours the JSON contract and still leaves nothing behind.
+A pass requires all seven checks.
 
 ## Scope Limits
 

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -21,8 +21,11 @@ combinatorics are needed.
    for the ones you want to present as options.
 2. **During vault Step 3 (Analysis):** Scan against observable patterns only — skip
    patterns marked `observable: false` (pre-event logistics, physical stage behaviors,
-   post-event follow-up, and external systems that leave no trace in transcripts or
-   slides).
+   post-event follow-up, hidden authoring processes, and external systems that the
+   acquired artifacts cannot directly prove). Every observable entry declares
+   `evidence_channels`, and every detection needs source-located evidence through one of
+   those channels. A polished outcome is not evidence that a named preparation process
+   occurred.
 3. **During creator Phase 4 (Guardrails):** Read all antipatterns and compare against
    the outline. Flag matches as `[RECURRING]` (from speaker profile) or `[CONTEXTUAL]`
    (new detection). Skip unobservable antipatterns.
@@ -281,8 +284,9 @@ Reverse lookup: which patterns relate to each of the 14 rhetoric analysis dimens
 
 ## Unobservable Patterns — Go-Live Checklist
 
-These patterns involve pre-event logistics, physical stage behaviors, post-event
-follow-up, or external systems that leave **no trace in transcripts or slides**. The vault cannot score them. Instead,
+These patterns involve pre-event logistics, hidden authoring processes, physical stage
+behaviors, post-event follow-up, or external systems that the current ingress artifacts
+cannot directly prove. The vault cannot score them. Instead,
 they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation checklist.
 
 **Do not include these in vault scoring or the speaker profile's `pattern_profile`.**
@@ -290,6 +294,13 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 ### Pre-Event Preparation
 | ID | Name | Checklist Action |
 |----|------|-----------------|
+| know-your-audience | Know Your Audience | Capture the audience/organizer research and note which talk choices it changed |
+| required | Required | Confirm whether the talk is assigned/mandatory and use the low-risk practice opportunity deliberately |
+| fourthought | Fourthought | Ideate, capture, and organize before opening the slide tool; retain the preparation artifacts |
+| proposed | Proposed | Keep the accepted CFP submission and compare the final scope against its promises |
+| concurrent-creation | Concurrent Creation | When collaborating, name one Slide Wrangler and preserve the creation history |
+| peer-review | Peer Review | Have a colleague/editor review the text and retain the review comments |
+| social-media-advertising | Social Media Advertising | Publish and retain dated promotional posts that link to the talk |
 | preparation | Preparation | Pack duplicate cables, backup deck to USB/cloud, hydrate, check room layout and schedule |
 | carnegie-hall | Carnegie Hall | Complete 4 structured rehearsals: (1) pace/timing, (2) delivery, (3) fix notes from 1-2, (4) find the groove |
 | stakeout | The Stakeout | Locate a productive staging area near the venue, arrive with ample buffer time |
@@ -306,11 +317,14 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 ### Post-Event
 | ID | Name | Checklist Action |
 |----|------|-----------------|
+| crucible | Crucible | Record feedback and the concrete revisions made before the next delivery |
 | spaced-followup | Spaced Follow-Up | 1–2 weeks after the talk, send the opt-in list 2–3 recall questions — ask, do not summarize. Only collect addresses if you will actually send it |
 
 ### Antipatterns to Avoid (unobservable)
 | ID | Name | What to Watch For |
 |----|------|------------------|
+| abstract-attorney | Abstract Attorney | Compare the final talk directly with the accepted abstract before delivery; do not infer compliance from the talk alone |
+| borrowed-shoes | Borrowed Shoes | Confirm deck authorship and substantially adapt another author's material before presenting it |
 | laser-weapons | Laser Weapons | Don't wave the pointer constantly — build highlights into slides instead |
 | bunker | Bunker | Step out from behind the podium, walk the stage, make eye contact |
 | backchannel | Backchannel | Don't monitor social media during your talk — use it as feedback after |
@@ -320,8 +334,8 @@ they surface during **creator Phase 6 (Publishing / Go-Live)** as a preparation 
 ## Summary Statistics
 
 - **Total entries:** 111 (83 patterns + 28 antipatterns)
-- **Observable (vault-scorable):** 99 (74 patterns + 25 antipatterns)
-- **Unobservable (go-live checklist):** 12 (9 patterns + 3 antipatterns)
+- **Observable (vault-scorable):** 89 (66 patterns + 23 antipatterns)
+- **Unobservable (go-live checklist):** 22 (17 patterns + 5 antipatterns)
 - **Prepare phase:** 24 (20 patterns + 4 antipatterns)
 - **Build phase:** 51 (41 patterns + 10 antipatterns)
 - **Deliver phase:** 36 (22 patterns + 14 antipatterns)

--- a/skills/presentation-creator/references/patterns/build/_anti_ant-fonts.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_ant-fonts.md
@@ -7,6 +7,7 @@ phase_relevance:
   - guardrails
   - slides
 vault_dimensions: [13, 14]
+evidence_channels: [slides, video]
 detection_signals:
   - "small font sizes"
   - "cramped text"

--- a/skills/presentation-creator/references/patterns/build/_anti_borrowed-shoes.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_borrowed-shoes.md
@@ -7,12 +7,12 @@ phase_relevance:
   - guardrails
 vault_dimensions: [7, 8, 14]
 detection_signals:
-  - "mismatch between speaker style and slides"
-  - "uncomfortable delivery rhythm"
-  - "borrowed material without adaptation"
+  - "deck provenance identifies a different author"
+  - "version history shows no substantive adaptation by the presenter"
 related_patterns: [crucible, narrative-arc, carnegie-hall]
 inverse_of: []
 difficulty: foundational
+observable: false
 ---
 
 # Borrowed Shoes
@@ -37,12 +37,16 @@ This is an antipattern and should always be avoided. If you must present materia
 The one exception is a deliberate, rehearsed co-presentation where the original creator coaches the second presenter through the material, transfers the contextual knowledge, and helps the second presenter internalize the timing and emphasis. This transforms Borrowed Shoes into a genuine collaboration.
 
 ## Detection Heuristics
-When scoring talks, watch for signs of disconnect between the presenter and the slides: hesitation at transitions (suggesting unfamiliarity with slide order), mismatched verbal emphasis (the presenter stresses different points than the slide design emphasizes), visual style inconsistent with the presenter's other materials, and inability to answer detailed questions about design or content choices. A presenter who says "I believe this slide is about..." or "I think the original author intended..." is exhibiting classic Borrowed Shoes signals.
+Awkward delivery or an unfamiliar visual style does not prove who authored a
+deck. Verify Borrowed Shoes only when deck provenance identifies another author
+and version history shows the presenter did not substantially adapt it. Without
+both facts, treat the cause of the mismatch as unknown.
 
 ## Scoring Criteria
-- Strong signal (2 pts — antipattern present): Presenter clearly working from someone else's slides with no adaptation — visible discomfort at transitions, mismatched emphasis, inability to explain design choices
-- Moderate signal (1 pt): Some adaptation of borrowed material visible — speaker notes in the presenter's voice, some slides modified — but occasional friction between presenter style and slide design
-- Absent (0 pts — antipattern not present): Slides clearly reflect the presenter's own style, voice, and rhythm, with seamless integration between spoken delivery and visual design
+- Strong signal (2 pts — antipattern present): Deck provenance identifies another author and version history shows no substantive adaptation by the presenter
+- Moderate signal (1 pt): Provenance identifies borrowed material and version history shows only superficial adaptation
+- Absent (0 pts — antipattern not present): Provenance/version history shows original authorship or substantial adaptation into the presenter's own material
+- Unevaluable: Authorship or version history is unavailable
 
 ## Relationship to Vault Dimensions
 Dimension 7 (Language and Communication): Borrowed Shoes creates a mismatch between the presenter's natural communication style and the language embedded in the slides. Dimension 8 (Slide Design): The design choices in borrowed slides reflect someone else's visual thinking. Dimension 14 (Overall Quality Indicators): A presenter working from borrowed material almost always delivers at a lower quality level than their natural capability.

--- a/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
@@ -7,6 +7,7 @@ phase_relevance:
   - guardrails
   - slides
 vault_dimensions: [8, 13, 14]
+evidence_channels: [slides, video]
 detection_signals:
   - "text-heavy bullet slides"
   - "audience reading ahead"

--- a/skills/presentation-creator/references/patterns/build/_anti_cookie-cutter.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_cookie-cutter.md
@@ -7,6 +7,7 @@ phase_relevance:
   - guardrails
   - slides
 vault_dimensions: [8, 13]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "ideas forced into single slides"
   - "information cramming"

--- a/skills/presentation-creator/references/patterns/build/_anti_dead-demo.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_dead-demo.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - guardrails
 vault_dimensions: [11, 14]
+evidence_channels: [video]
 detection_signals:
   - "purposeless demo"
   - "demo as time filler"

--- a/skills/presentation-creator/references/patterns/build/_anti_floodmarks.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_floodmarks.md
@@ -7,6 +7,7 @@ phase_relevance:
   - guardrails
   - slides
 vault_dimensions: [13, 14]
+evidence_channels: [slides, video]
 detection_signals:
   - "pervasive branding on every slide"
   - "excessive corporate template elements"

--- a/skills/presentation-creator/references/patterns/build/_anti_fontaholic.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_fontaholic.md
@@ -7,6 +7,7 @@ phase_relevance:
   - guardrails
   - slides
 vault_dimensions: [13, 14]
+evidence_channels: [slides, video]
 detection_signals:
   - "excessive font variety"
   - "inconsistent typography"

--- a/skills/presentation-creator/references/patterns/build/_anti_injured-outlines.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_injured-outlines.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - guardrails
 vault_dimensions: [8, 14]
+evidence_channels: [slides, video]
 detection_signals:
   - "single sub-bullet under headers"
   - "orphaned outline items"

--- a/skills/presentation-creator/references/patterns/build/_anti_photomaniac.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_photomaniac.md
@@ -7,6 +7,7 @@ phase_relevance:
   - guardrails
   - slides
 vault_dimensions: [10, 13, 14]
+evidence_channels: [slides, video]
 detection_signals:
   - "random stock photos"
   - "images disconnected from narrative"

--- a/skills/presentation-creator/references/patterns/build/_anti_slideuments.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_slideuments.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - guardrails
 vault_dimensions: [8, 14]
+evidence_channels: [slides, video]
 detection_signals:
   - "dense slides meant to be read"
   - "dual-purpose document/presentation"

--- a/skills/presentation-creator/references/patterns/build/a-la-carte-content.md
+++ b/skills/presentation-creator/references/patterns/build/a-la-carte-content.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [2, 4]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "audience choice mechanism"
   - "hyperlinked menu slide"

--- a/skills/presentation-creator/references/patterns/build/analog-noise.md
+++ b/skills/presentation-creator/references/patterns/build/analog-noise.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [13]
+evidence_channels: [slides, video]
 detection_signals:
   - "hand-drawn elements"
   - "rough/sketch aesthetic"

--- a/skills/presentation-creator/references/patterns/build/backtracking.md
+++ b/skills/presentation-creator/references/patterns/build/backtracking.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - content
 vault_dimensions: [2, 5]
+evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "explicit callbacks to earlier content"
   - "context reset moments"

--- a/skills/presentation-creator/references/patterns/build/bookends.md
+++ b/skills/presentation-creator/references/patterns/build/bookends.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [2, 5, 13]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "section opener/closer slides"
   - "distinct visual style for section boundaries"

--- a/skills/presentation-creator/references/patterns/build/breadcrumbs.md
+++ b/skills/presentation-creator/references/patterns/build/breadcrumbs.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [2, 13]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "agenda slides with highlighting"
   - "progress indicators"

--- a/skills/presentation-creator/references/patterns/build/call-to-action.md
+++ b/skills/presentation-creator/references/patterns/build/call-to-action.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - publishing
 vault_dimensions: [4, 6, 9]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "explicit imperative ask in the closing zone"
   - "asks are specific and immediately executable, not generic"

--- a/skills/presentation-creator/references/patterns/build/call-to-adventure.md
+++ b/skills/presentation-creator/references/patterns/build/call-to-adventure.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [1, 2, 9]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "explicit gap-reveal moment between current reality and proposed future"
   - "Big Idea stated at the structural transition from setup to body"

--- a/skills/presentation-creator/references/patterns/build/charred-trail.md
+++ b/skills/presentation-creator/references/patterns/build/charred-trail.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [8, 13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "sequential item reveal"
   - "dimming of previous items"

--- a/skills/presentation-creator/references/patterns/build/coda.md
+++ b/skills/presentation-creator/references/patterns/build/coda.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [6, 8]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "reference slides at end"
   - "bibliography or resource list"

--- a/skills/presentation-creator/references/patterns/build/composite-animation.md
+++ b/skills/presentation-creator/references/patterns/build/composite-animation.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [13]
+evidence_channels: [video]
 detection_signals:
   - "layered animations"
   - "simultaneous animation effects"

--- a/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
+++ b/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - content
 vault_dimensions: [11, 9, 2]
+evidence_channels: [timed_transcript, slide_sequence, video]
 detection_signals:
   - "a tangible example, object, story, or live demo precedes the named concept it illustrates"
   - "the framework/term is introduced only after the audience has experienced an instance of it"

--- a/skills/presentation-creator/references/patterns/build/context-keeper.md
+++ b/skills/presentation-creator/references/patterns/build/context-keeper.md
@@ -8,6 +8,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [2, 5, 13]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "visible progress indicator"
   - "structural navigation cues"

--- a/skills/presentation-creator/references/patterns/build/crawling-code.md
+++ b/skills/presentation-creator/references/patterns/build/crawling-code.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [11, 13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "scrolling code display"
   - "highlighted active lines"

--- a/skills/presentation-creator/references/patterns/build/crawling-credits.md
+++ b/skills/presentation-creator/references/patterns/build/crawling-credits.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [6, 13]
+evidence_channels: [video]
 detection_signals:
   - "scrolling credits animation"
   - "multi-contributor acknowledgment"

--- a/skills/presentation-creator/references/patterns/build/defy-defaults.md
+++ b/skills/presentation-creator/references/patterns/build/defy-defaults.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [13]
+evidence_channels: [slides, video]
 detection_signals:
   - "custom color palette"
   - "non-default fonts"

--- a/skills/presentation-creator/references/patterns/build/emergence.md
+++ b/skills/presentation-creator/references/patterns/build/emergence.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [11, 13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "incremental diagram building"
   - "piece-by-piece reveal"

--- a/skills/presentation-creator/references/patterns/build/exuberant-title-top.md
+++ b/skills/presentation-creator/references/patterns/build/exuberant-title-top.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "animated title positioning"
   - "emphasis through motion"

--- a/skills/presentation-creator/references/patterns/build/foreshadowing.md
+++ b/skills/presentation-creator/references/patterns/build/foreshadowing.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - content
 vault_dimensions: [2, 5]
+evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "early planted clues"
   - "later callbacks to planted elements"

--- a/skills/presentation-creator/references/patterns/build/gradual-consistency.md
+++ b/skills/presentation-creator/references/patterns/build/gradual-consistency.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [8, 13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "build animations revealing final state"
   - "incremental content reveal"

--- a/skills/presentation-creator/references/patterns/build/guess-first.md
+++ b/skills/presentation-creator/references/patterns/build/guess-first.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [2, 4, 11]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "audience asked to commit an answer before the reveal"
   - "prediction solicited ahead of a demo, result, or number"

--- a/skills/presentation-creator/references/patterns/build/infodeck.md
+++ b/skills/presentation-creator/references/patterns/build/infodeck.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - architecture
 vault_dimensions: [8]
+evidence_channels: [slides, video]
 detection_signals:
   - "self-contained document format"
   - "dense information without animations"

--- a/skills/presentation-creator/references/patterns/build/inoculation.md
+++ b/skills/presentation-creator/references/patterns/build/inoculation.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - guardrails
 vault_dimensions: [4, 9]
+evidence_channels: [transcript, timed_transcript, slides, video]
 detection_signals:
   - "speaker preemptively voices an objection the audience would otherwise raise"
   - "transition language signaling self-counterargument ('You might be thinking…', 'I know what you're going to say…', 'The natural objection is…')"

--- a/skills/presentation-creator/references/patterns/build/intermezzi.md
+++ b/skills/presentation-creator/references/patterns/build/intermezzi.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [2, 5, 13]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "section divider slides"
   - "thematic shift markers"

--- a/skills/presentation-creator/references/patterns/build/invisibility.md
+++ b/skills/presentation-creator/references/patterns/build/invisibility.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "hidden elements revealed during presentation"
   - "surprise reveals"

--- a/skills/presentation-creator/references/patterns/build/lipsync.md
+++ b/skills/presentation-creator/references/patterns/build/lipsync.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [11, 13]
+evidence_channels: [video]
 detection_signals:
   - "recorded demo playback"
   - "embedded video of tool interaction"

--- a/skills/presentation-creator/references/patterns/build/live-demo.md
+++ b/skills/presentation-creator/references/patterns/build/live-demo.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [11]
+evidence_channels: [video]
 detection_signals:
   - "live software demonstration"
   - "real-time tool interaction"

--- a/skills/presentation-creator/references/patterns/build/live-on-tape.md
+++ b/skills/presentation-creator/references/patterns/build/live-on-tape.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - publishing
 vault_dimensions: [8]
+evidence_channels: [video]
 detection_signals:
   - "recorded full presentation"
   - "video artifact of talk"

--- a/skills/presentation-creator/references/patterns/build/master-story.md
+++ b/skills/presentation-creator/references/patterns/build/master-story.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - content
 vault_dimensions: [2, 5, 7]
+evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "single anecdote introduced early and referenced 3+ times across the talk"
   - "each return to the story deepens or reframes its meaning"

--- a/skills/presentation-creator/references/patterns/build/meme-as-argument.md
+++ b/skills/presentation-creator/references/patterns/build/meme-as-argument.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [4, 7, 12]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "internet memes carry argumentative weight, not decoration"
   - "memes function as visual shorthand for claims"

--- a/skills/presentation-creator/references/patterns/build/new-bliss.md
+++ b/skills/presentation-creator/references/patterns/build/new-bliss.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - content
 vault_dimensions: [5, 6, 9]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "vivid future-state description in the closing zone"
   - "talk ends on a higher emotional plane than it started"

--- a/skills/presentation-creator/references/patterns/build/peer-review.md
+++ b/skills/presentation-creator/references/patterns/build/peer-review.md
@@ -8,13 +8,12 @@ phase_relevance:
   - guardrails
 vault_dimensions: [7, 8]
 detection_signals:
-  - "clean grammar"
-  - "consistent style"
-  - "polished text"
-  - "no typos on slides"
+  - "review comments or copyediting artifact are available"
+  - "speaker identifies the colleague or editor who reviewed the text"
 related_patterns: [leet-grammars]
 inverse_of: [tower-of-babble]
 difficulty: foundational
+observable: false
 ---
 
 # Peer Review
@@ -65,12 +64,16 @@ Use Peer Review for any presentation you care about. At minimum, always complete
 Avoid skipping Peer Review on the claim that you "know the material." Expertise in a subject does not guarantee clear communication of that subject. In fact, domain experts are often the worst at spotting their own unclear writing.
 
 ## Detection Heuristics
-When scoring talks, look for the absence of errors rather than the presence of editing marks. Clean grammar, consistent capitalization, uniform punctuation style, and the absence of typos on slides are all strong indicators that Peer Review was applied. Inconsistent formatting — some slides with periods at the end of bullets, others without — suggests the pattern was not followed.
+Do not infer a review process from clean output. Error-free text may be
+self-edited, while reviewed text may still contain mistakes. Verify Peer Review
+only from review comments, a copyediting artifact, or speaker confirmation that
+identifies the reviewer and the material they reviewed.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Zero visible typos or grammatical errors on slides, consistent style throughout, polished and professional text quality
-- Moderate signal (1 pt): Mostly clean text with one or two minor errors, generally consistent style with occasional lapses
-- Absent (0 pts): Multiple typos, grammatical errors, inconsistent capitalization or punctuation, or unclear phrasing on slides
+- Strong signal (2 pts): Review comments or copyediting artifacts identify a reviewer and show substantive issues addressed
+- Moderate signal (1 pt): A reviewer and reviewed material are confirmed, but the change record is incomplete
+- Absent (0 pts): Available creation history shows no external review before delivery
+- Unevaluable: Review artifacts and speaker confirmation are unavailable
 
 ## Relationship to Vault Dimensions
 Dimension 7 (Language and Communication): Peer Review covers language quality across the presentation. Dimension 8 (Slide Design): clean, error-free text is part of professional slide design.

--- a/skills/presentation-creator/references/patterns/build/preroll.md
+++ b/skills/presentation-creator/references/patterns/build/preroll.md
@@ -7,6 +7,7 @@ phase_relevance:
   - slides
   - publishing
 vault_dimensions: [1, 13]
+evidence_channels: [video]
 detection_signals:
   - "pre-talk info slide"
   - "looping intro display"

--- a/skills/presentation-creator/references/patterns/build/progressive-reveal.md
+++ b/skills/presentation-creator/references/patterns/build/progressive-reveal.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [4, 7]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "single base image annotated across multiple slides"
   - "elements added one per slide to build a cumulative argument"

--- a/skills/presentation-creator/references/patterns/build/retrieval-beat.md
+++ b/skills/presentation-creator/references/patterns/build/retrieval-beat.md
@@ -8,6 +8,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [4, 12]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "audience asked to recall earlier material from memory"
   - "speaker withholds a restatement and makes the room supply it"

--- a/skills/presentation-creator/references/patterns/build/second-look.md
+++ b/skills/presentation-creator/references/patterns/build/second-look.md
@@ -7,6 +7,7 @@ phase_relevance:
   - slides
   - publishing
 vault_dimensions: [8, 13]
+evidence_channels: [slides, video]
 detection_signals:
   - "slide carries a room-legible layer and a deliberately unreadable reward layer"
   - "detail is never narrated and the argument does not depend on it"

--- a/skills/presentation-creator/references/patterns/build/soft-transitions.md
+++ b/skills/presentation-creator/references/patterns/build/soft-transitions.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [5, 13]
+evidence_channels: [video]
 detection_signals:
   - "dissolve transitions"
   - "seamless slide flow"

--- a/skills/presentation-creator/references/patterns/build/sparkline.md
+++ b/skills/presentation-creator/references/patterns/build/sparkline.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [2, 5, 9]
+evidence_channels: [timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "establishes 'what is' baseline before introducing thesis"
   - "explicit gap-revelation moment (call to adventure)"

--- a/skills/presentation-creator/references/patterns/build/star-moment.md
+++ b/skills/presentation-creator/references/patterns/build/star-moment.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [3, 5, 13]
+evidence_channels: [video]
 detection_signals:
   - "deliberately constructed peak moment that audiences quote afterward"
   - "single beat carries disproportionate weight in audience recall"

--- a/skills/presentation-creator/references/patterns/build/three-part-close.md
+++ b/skills/presentation-creator/references/patterns/build/three-part-close.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [2, 10]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "closing sequence has summary slide, CTA slide, and thanks slide"
   - "three distinct closing slides in sequence"

--- a/skills/presentation-creator/references/patterns/build/traveling-highlights.md
+++ b/skills/presentation-creator/references/patterns/build/traveling-highlights.md
@@ -6,6 +6,7 @@ part: build
 phase_relevance:
   - slides
 vault_dimensions: [11, 13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "animated focus indicators"
   - "zoom-to-detail on code"

--- a/skills/presentation-creator/references/patterns/build/vacation-photos.md
+++ b/skills/presentation-creator/references/patterns/build/vacation-photos.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - slides
 vault_dimensions: [8, 13]
+evidence_channels: [slides, video]
 detection_signals:
   - "full-bleed image slides"
   - "minimal text on image slides"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_disowning-your-topic.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_disowning-your-topic.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [9, 12, 14]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "pace acceleration mid-talk"
   - "skipping prepared material"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_dual-headed-monster.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_dual-headed-monster.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [4, 14]
+evidence_channels: [video]
 detection_signals:
   - "split attention between audiences"
   - "hybrid format compromises"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_flyover.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_flyover.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [4, 14]
+evidence_channels: [transcript, video]
 detection_signals:
   - "speaker disparages or diminishes the local audience or region"
   - "speaker valorizes their home region/employer as the place where things really happen"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_going-meta.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_going-meta.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [9, 14]
+evidence_channels: [transcript, video]
 detection_signals:
   - "speaker discusses preparation process"
   - "equipment apologies"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_hecklers.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_hecklers.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [4, 14]
+evidence_channels: [video]
 detection_signals:
   - "disruptive audience interaction"
   - "hijacked Q&A"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_hiccup-words.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_hiccup-words.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [7, 14]
+evidence_channels: [timed_transcript]
 detection_signals:
   - "frequent filler words"
   - "um/ah patterns"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_lipstick-on-a-pig.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_lipstick-on-a-pig.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [8, 9, 14]
+evidence_channels: [video]
 detection_signals:
   - "beautiful slides but shallow content"
   - "style over substance"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_negative-ignorance.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_negative-ignorance.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [4, 14]
+evidence_channels: [transcript, video]
 detection_signals:
   - "negative polling questions"
   - "audience asked to admit ignorance"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_nodding-room.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_nodding-room.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [4, 12, 14]
+evidence_channels: [video]
 detection_signals:
   - "uninterrupted tell-only delivery with no moment the audience must produce anything"
   - "every callback is a restatement; every question is rhetorical and self-answered"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_shortchanged.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_shortchanged.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [12, 14]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "rushing through material"
   - "visible time pressure"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_tower-of-babble.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_tower-of-babble.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [7, 9, 14]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "unexplained acronyms"
   - "audience confusion from jargon"

--- a/skills/presentation-creator/references/patterns/deliver/anti-sell.md
+++ b/skills/presentation-creator/references/patterns/deliver/anti-sell.md
@@ -7,6 +7,7 @@ phase_relevance:
   - delivery
   - rehearsal
 vault_dimensions: [11, 6]
+evidence_channels: [transcript, video]
 detection_signals:
   - "speaker downplays own product, employer, or work"
   - "self-deprecating framing of own credentials"

--- a/skills/presentation-creator/references/patterns/deliver/breathing-room.md
+++ b/skills/presentation-creator/references/patterns/deliver/breathing-room.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - content
 vault_dimensions: [7, 12]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "strategic pauses"
   - "comfortable silences"

--- a/skills/presentation-creator/references/patterns/deliver/delayed-self-introduction.md
+++ b/skills/presentation-creator/references/patterns/deliver/delayed-self-introduction.md
@@ -7,6 +7,7 @@ phase_relevance:
   - delivery
   - rehearsal
 vault_dimensions: [2, 11]
+evidence_channels: [timed_transcript, slides, video]
 detection_signals:
   - "speaker opens with hook/content rather than name and role"
   - "self-introduction appears after an initial slide or two"

--- a/skills/presentation-creator/references/patterns/deliver/display-of-high-value.md
+++ b/skills/presentation-creator/references/patterns/deliver/display-of-high-value.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - content
 vault_dimensions: [9]
+evidence_channels: [video]
 detection_signals:
   - "confident delivery"
   - "no unnecessary apologies"

--- a/skills/presentation-creator/references/patterns/deliver/echo-chamber.md
+++ b/skills/presentation-creator/references/patterns/deliver/echo-chamber.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - publishing
 vault_dimensions: [4, 7]
+evidence_channels: [video]
 detection_signals:
   - "questions repeated before answering"
   - "audience questions restated"

--- a/skills/presentation-creator/references/patterns/deliver/emotional-state.md
+++ b/skills/presentation-creator/references/patterns/deliver/emotional-state.md
@@ -7,6 +7,7 @@ phase_relevance:
   - intake
   - content
 vault_dimensions: [4, 9]
+evidence_channels: [video]
 detection_signals:
   - "tone calibrated to audience mood"
   - "contextual references to current events"

--- a/skills/presentation-creator/references/patterns/deliver/entertainment.md
+++ b/skills/presentation-creator/references/patterns/deliver/entertainment.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - content
 vault_dimensions: [3, 10]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "humor used for engagement"
   - "stories woven into content"

--- a/skills/presentation-creator/references/patterns/deliver/greek-chorus.md
+++ b/skills/presentation-creator/references/patterns/deliver/greek-chorus.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [4, 9]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "supporting character on slides"
   - "ally-assisted delivery"

--- a/skills/presentation-creator/references/patterns/deliver/make-it-rain.md
+++ b/skills/presentation-creator/references/patterns/deliver/make-it-rain.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - content
 vault_dimensions: [4]
+evidence_channels: [video]
 detection_signals:
   - "physical props used"
   - "audience interaction through objects"

--- a/skills/presentation-creator/references/patterns/deliver/mentor.md
+++ b/skills/presentation-creator/references/patterns/deliver/mentor.md
@@ -7,6 +7,7 @@ phase_relevance:
   - intent
   - content
 vault_dimensions: [9, 11]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "audience positioned as hero"
   - "knowledge-sharing framing"

--- a/skills/presentation-creator/references/patterns/deliver/screen-blackout.md
+++ b/skills/presentation-creator/references/patterns/deliver/screen-blackout.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [12, 13]
+evidence_channels: [video]
 detection_signals:
   - "deliberate blank or black slide between sections"
   - "B-key blackout during digression or audience question"

--- a/skills/presentation-creator/references/patterns/deliver/seeding-the-first-question.md
+++ b/skills/presentation-creator/references/patterns/deliver/seeding-the-first-question.md
@@ -7,6 +7,7 @@ phase_relevance:
   - content
   - publishing
 vault_dimensions: [4]
+evidence_channels: [video]
 detection_signals:
   - "deliberate question bait planted"
   - "obvious curiosity gap left open"

--- a/skills/presentation-creator/references/patterns/deliver/weatherman.md
+++ b/skills/presentation-creator/references/patterns/deliver/weatherman.md
@@ -6,6 +6,7 @@ part: deliver
 phase_relevance:
   - publishing
 vault_dimensions: [12]
+evidence_channels: [video]
 detection_signals:
   - "speaker faces audience"
   - "uses presenter display"

--- a/skills/presentation-creator/references/patterns/prepare/_anti_abstract-attorney.md
+++ b/skills/presentation-creator/references/patterns/prepare/_anti_abstract-attorney.md
@@ -8,11 +8,12 @@ phase_relevance:
   - guardrails
 vault_dimensions: [2, 14]
 detection_signals:
-  - "abstract doesn't match delivery"
-  - "significant deviation from published description"
+  - "submitted abstract and final delivery are both available for direct comparison"
+  - "promised scope or takeaways are absent from the delivered talk"
 related_patterns: [preroll, narrative-arc, fourthought, triad, crucible, carnegie-hall]
 inverse_of: []
 difficulty: foundational
+observable: false
 ---
 
 # Abstract Attorney
@@ -35,12 +36,16 @@ The deeper lesson of the Abstract Attorney antipattern is that your abstract is 
 Be aware of this antipattern whenever you have pre-published a description of your talk. The defenses are most critical for conference presentations where the abstract was reviewed and approved by a program committee, as these carry the strongest implicit contract. Less critical for internal presentations where expectations are more fluid.
 
 ## Detection Heuristics
-The vault should look for signs of disconnect between the apparent description of the talk and the delivered content. Significant structural deviations from what the talk claims to cover, missing promised topics, or unexpected diversions all trigger this antipattern.
+Do not infer this from the talk alone: the accepted abstract is the comparison
+artifact. Verify it only by comparing that exact submission with the delivered
+scope and takeaways. Without the submission, the pattern is unevaluable rather
+than absent.
 
 ## Scoring Criteria
-- Strong signal (2 pts — antipattern present): Significant disconnect between described and delivered content; audience likely feels misled about what the talk would cover
-- Moderate signal (1 pt): Generally follows the described topics but some promised elements are missing or replaced without explanation
-- Absent (0 pts — antipattern not present): Content closely matches what was promised; any deviations are explicitly acknowledged and justified
+- Strong signal (2 pts — antipattern present): Direct comparison with the accepted abstract shows promised scope or takeaways missing from the delivery
+- Moderate signal (1 pt): Direct comparison shows smaller unexplained drift from the accepted abstract
+- Absent (0 pts — antipattern not present): Direct comparison shows the delivered scope matches the accepted abstract, or deviations are explicitly acknowledged and justified
+- Unevaluable: The exact accepted abstract is unavailable
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 2 (Structure/Organization). Relates to Dimension 14 (Overall Impression/Polish).

--- a/skills/presentation-creator/references/patterns/prepare/_anti_alienating-artifact.md
+++ b/skills/presentation-creator/references/patterns/prepare/_anti_alienating-artifact.md
@@ -6,6 +6,7 @@ part: prepare
 phase_relevance:
   - guardrails
 vault_dimensions: [3, 10, 14]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "offensive humor attempts"
   - "exclusionary references"

--- a/skills/presentation-creator/references/patterns/prepare/_anti_celery.md
+++ b/skills/presentation-creator/references/patterns/prepare/_anti_celery.md
@@ -6,6 +6,7 @@ part: prepare
 phase_relevance:
   - guardrails
 vault_dimensions: [2, 14]
+evidence_channels: [video]
 detection_signals:
   - "low content-to-time ratio"
   - "audience disengagement visible"

--- a/skills/presentation-creator/references/patterns/prepare/_anti_golden-rule.md
+++ b/skills/presentation-creator/references/patterns/prepare/_anti_golden-rule.md
@@ -6,6 +6,7 @@ part: prepare
 phase_relevance:
   - guardrails
 vault_dimensions: [4, 9, 14]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "every claim defended in the speaker's single preferred register"
   - "talk mirrors the speaker's own thinking style rather than the room's spread"

--- a/skills/presentation-creator/references/patterns/prepare/brain-breaks.md
+++ b/skills/presentation-creator/references/patterns/prepare/brain-breaks.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [3, 12]
+evidence_channels: [timed_transcript, video]
 detection_signals:
   - "humor/story every 10-20 minutes"
   - "attention pattern breaks"

--- a/skills/presentation-creator/references/patterns/prepare/cave-painting.md
+++ b/skills/presentation-creator/references/patterns/prepare/cave-painting.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - slides
 vault_dimensions: [5, 13]
+evidence_channels: [slide_sequence, video]
 detection_signals:
   - "canvas-based layout"
   - "zoom transitions"

--- a/skills/presentation-creator/references/patterns/prepare/concurrent-creation.md
+++ b/skills/presentation-creator/references/patterns/prepare/concurrent-creation.md
@@ -7,12 +7,13 @@ phase_relevance:
   - content
 vault_dimensions: [2, 8]
 detection_signals:
-  - "multi-author collaboration"
-  - "consistent template usage across sections"
-  - "placeholder slides visible"
+  - "creation history documents non-linear authoring"
+  - "collaboration record names one Slide Wrangler"
+  - "speaker confirms the shared-deck workflow"
 related_patterns: [talklet, unifying-visual-theme]
 inverse_of: []
 difficulty: intermediate
+observable: false
 ---
 
 # Concurrent Creation
@@ -42,12 +43,16 @@ The practical translation: if Concurrent Creation is the *workflow*, analog plan
 Use this pattern for any presentation where you have the flexibility to work non-linearly, and especially for group presentations. Avoid for very short presentations (five minutes or less) where sequential creation is natural and the overhead of assembly exceeds the benefit. Also avoid when all collaborators are not aligned on the template and visual standards — Concurrent Creation without visual consistency produces a Frankenstein deck.
 
 ## Detection Heuristics
-The vault should look for signs of collaborative creation: consistent templates across sections created by different authors, uniform visual styling, and smooth integration between segments. For individual speakers, look for the richness that comes from inspired creation — sections where depth and enthusiasm are uniformly high rather than trailing off toward the end.
+Do not infer an authoring workflow from a coherent final deck. Consistent styling
+and even section quality can come from many processes. Verify Concurrent Creation
+only from creation history, collaboration records, or speaker confirmation that
+the work was authored out of order or coordinated through one Slide Wrangler.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Multi-author sections feel unified; consistent template and voice throughout; smooth transitions between collaborators' sections
-- Moderate signal (1 pt): Some consistency in collaborative sections but occasional style or formatting shifts between authors
-- Absent (0 pts): Obvious visual or tonal inconsistencies between sections; "Frankenstein deck" feel where different parts clearly had different creators with no integration
+- Strong signal (2 pts): Creation history or collaboration records show non-linear/shared authoring coordinated through one Slide Wrangler
+- Moderate signal (1 pt): Records show shared or non-linear authoring, but ownership/coordination was inconsistent
+- Absent (0 pts): Records show a strictly sequential workflow or uncoordinated shared editing
+- Unevaluable: No creation history, collaboration record, or speaker confirmation is available
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 2 (Structure/Organization). Relates to Dimension 8 (Slide Design/Visual Quality).

--- a/skills/presentation-creator/references/patterns/prepare/crucible.md
+++ b/skills/presentation-creator/references/patterns/prepare/crucible.md
@@ -7,12 +7,13 @@ phase_relevance:
   - content
 vault_dimensions: [12, 14]
 detection_signals:
-  - "evidence of iterative refinement"
-  - "talk evolves across deliveries"
-  - "responsive to audience feedback"
+  - "versioned deliveries show concrete revisions"
+  - "feedback records are linked to subsequent changes"
+  - "speaker confirms the iteration history"
 related_patterns: [brain-breaks, fourthought, carnegie-hall, traveling-highlights]
 inverse_of: []
 difficulty: intermediate
+observable: false
 ---
 
 # Crucible
@@ -52,12 +53,16 @@ Murder Your Darlings is not the same as the post-delivery Crucible refinement: t
 Use this pattern whenever you deliver a presentation more than once. Even single-delivery talks benefit from a post-mortem analysis. Avoid using the Crucible as an excuse to under-prepare — "I'll fix it after the first delivery" is not a substitute for thorough initial preparation. The Crucible refines good material into great material; it cannot rescue material that was never good.
 
 ## Detection Heuristics
-The vault should look for evidence that the presentation has been refined through multiple deliveries. Polished transitions, precisely calibrated timing, and the kind of confident spontaneity that only comes from deep familiarity with material are strong indicators.
+Polish is not proof of repeated delivery. Verify Crucible only from versioned
+deliveries or feedback records that show specific changes between performances.
+Without that history, the workflow is unevaluable even when the talk appears
+highly practiced.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Presentation shows evidence of iterative refinement; timing is precise; transitions are seamless; speaker handles unexpected moments with grace born of experience
-- Moderate signal (1 pt): Presentation is competent but shows signs of being relatively new — some rough transitions, occasional timing issues
-- Absent (0 pts): Presentation feels like a first draft delivered live; structural issues that one delivery would have revealed remain unaddressed
+- Strong signal (2 pts): Versioned deliveries and linked feedback show multiple concrete revisions after live performance
+- Moderate signal (1 pt): At least one post-delivery revision is directly documented, but the feedback-to-change trail is incomplete
+- Absent (0 pts): Version history shows no revision after prior delivery despite captured feedback
+- Unevaluable: Prior versions, feedback records, or speaker confirmation are unavailable
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 12 (Time/Pacing). Relates to Dimension 14 (Overall Impression/Polish).

--- a/skills/presentation-creator/references/patterns/prepare/expansion-joints.md
+++ b/skills/presentation-creator/references/patterns/prepare/expansion-joints.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [2, 12]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "modular content sections"
   - "cut lines present"

--- a/skills/presentation-creator/references/patterns/prepare/fourthought.md
+++ b/skills/presentation-creator/references/patterns/prepare/fourthought.md
@@ -8,12 +8,12 @@ phase_relevance:
   - architecture
 vault_dimensions: [2, 8]
 detection_signals:
-  - "well-organized thought flow"
-  - "ideas not constrained to slide boundaries"
-  - "organic concept grouping"
+  - "ideation, capture, and organization artifacts predate slide authoring"
+  - "speaker confirms the four-phase preparation workflow"
 related_patterns: [unifying-visual-theme, backtracking, narrative-arc]
 inverse_of: [cookie-cutter]
 difficulty: foundational
+observable: false
 ---
 
 # Fourthought
@@ -36,12 +36,16 @@ Fourthought also makes revision dramatically easier. When your ideas live in a m
 Use this pattern for every presentation of any significance. The only exception might be a quick internal update where you are essentially filling in a pre-existing template with new data. Even then, spending five minutes thinking before opening the tool will improve the result. The pattern scales — a five-minute lightning talk benefits from Fourthought just as much as a 90-minute keynote.
 
 ## Detection Heuristics
-The vault should look for evidence of pre-design thinking. Well-organized thought flow, ideas that span multiple slides naturally rather than being artificially constrained, and organic concept grouping all suggest the speaker invested in ideation and organization before touching the tool.
+Do not infer preparation order from a well-organized result. Verify Fourthought
+only from ideation, capture, and organization artifacts that predate the deck, or
+from speaker confirmation of the four-phase workflow. A coherent talk without
+those sources is unevaluable, not evidence that the process occurred.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Ideas flow organically across slides; concepts are grouped by logic rather than by slide boundaries; overall structure feels intentional and well-considered
-- Moderate signal (1 pt): Some evidence of pre-design thinking but occasional sections feel tool-driven; structure is reasonable but not exceptional
-- Absent (0 pts): Slides feel like the first draft; ideas are chopped into uniform slide-sized pieces; no evidence of structural planning
+- Strong signal (2 pts): Dated ideation, capture, and organization artifacts all predate slide authoring and show the four-phase workflow
+- Moderate signal (1 pt): Some pre-slide ideation/organization artifacts exist, but one phase is undocumented
+- Absent (0 pts): Creation history shows slide authoring began before any captured ideation or organization
+- Unevaluable: Preparation artifacts or speaker confirmation are unavailable
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 2 (Structure/Organization). Relates to Dimension 8 (Slide Design/Visual Quality).

--- a/skills/presentation-creator/references/patterns/prepare/know-your-audience.md
+++ b/skills/presentation-creator/references/patterns/prepare/know-your-audience.md
@@ -7,12 +7,12 @@ phase_relevance:
   - intake
 vault_dimensions: [4, 9]
 detection_signals:
-  - "audience-specific references"
-  - "calibrated vocabulary level"
-  - "referenced prior event context"
+  - "audience research notes or organizer brief are available"
+  - "speaker documents how research changed the talk"
 related_patterns: [emotional-state, seeding-satisfaction]
 inverse_of: []
 difficulty: foundational
+observable: false
 ---
 
 # Know Your Audience
@@ -48,12 +48,16 @@ The corollary matters for anyone teaching from the stage: the difficulty an audi
 Use this pattern always — there is no scenario where understanding your audience is detrimental. Even for impromptu talks, spend whatever time you have gathering intelligence. The only caution is over-researching to the point of paralysis; at some point you must commit to a direction and trust your preparation.
 
 ## Detection Heuristics
-The vault should look for evidence that the speaker has tailored content to a specific audience rather than delivering a generic, one-size-fits-all talk. Audience-specific references, correctly calibrated vocabulary, and acknowledgment of the event context or community norms are strong signals.
+Audience-specific references prove tailoring in the delivered talk; they do not
+prove the research process this pattern names. Verify Know Your Audience only
+from audience research notes, an organizer brief, or speaker confirmation that
+identifies what was learned and how it changed the talk.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Multiple audience-specific references; vocabulary precisely calibrated to audience level; explicit acknowledgment of event context or community
-- Moderate signal (1 pt): Some audience awareness evident but inconsistent; occasional generic sections that could apply to any audience
-- Absent (0 pts): Entirely generic content with no evidence of audience research or adaptation
+- Strong signal (2 pts): Audience/organizer research is available and the speaker documents multiple talk choices it changed
+- Moderate signal (1 pt): Research is available and linked to at least one concrete adaptation
+- Absent (0 pts): Available preparation records show no audience research or no resulting adaptation
+- Unevaluable: Audience research records and speaker confirmation are unavailable
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 4 (Audience Engagement). Relates to Dimension 9 (Speaker Credibility/Ethos).

--- a/skills/presentation-creator/references/patterns/prepare/leet-grammars.md
+++ b/skills/presentation-creator/references/patterns/prepare/leet-grammars.md
@@ -6,6 +6,7 @@ part: prepare
 phase_relevance:
   - content
 vault_dimensions: [7, 10]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "correct use of community jargon"
   - "insider references"

--- a/skills/presentation-creator/references/patterns/prepare/lightning-talk.md
+++ b/skills/presentation-creator/references/patterns/prepare/lightning-talk.md
@@ -6,6 +6,8 @@ part: prepare
 phase_relevance:
   - architecture
 vault_dimensions: [2, 12]
+evidence_channels: [timed_transcript, slides, slide_sequence, video, talk_metadata]
+evidence_metadata_fields: [title, conference, slide_count]
 detection_signals:
   - "5-minute format"
   - "fixed slide count"

--- a/skills/presentation-creator/references/patterns/prepare/narrative-arc.md
+++ b/skills/presentation-creator/references/patterns/prepare/narrative-arc.md
@@ -8,6 +8,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [2, 5]
+evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "clear three-act structure"
   - "problem-solution arc"

--- a/skills/presentation-creator/references/patterns/prepare/opening-punch.md
+++ b/skills/presentation-creator/references/patterns/prepare/opening-punch.md
@@ -7,6 +7,7 @@ phase_relevance:
   - intent
   - content
 vault_dimensions: [1, 4]
+evidence_channels: [timed_transcript, slides, video]
 detection_signals:
   - "personal story in opening 1-2 minutes"
   - "unexpected fact or surprise as hook"

--- a/skills/presentation-creator/references/patterns/prepare/proposed.md
+++ b/skills/presentation-creator/references/patterns/prepare/proposed.md
@@ -8,11 +8,12 @@ phase_relevance:
   - intent
 vault_dimensions: [9]
 detection_signals:
-  - "clear abstract structure"
-  - "CFP-quality description"
+  - "submitted CFP proposal is available"
+  - "accepted scope is compared directly with the delivered talk"
 related_patterns: [required, peer-review, know-your-audience]
 inverse_of: []
 difficulty: foundational
+observable: false
 ---
 
 # Proposed
@@ -35,12 +36,15 @@ Treat submission as commitment. The moment you click "submit," you are making a 
 Use this pattern whenever you want to speak at a conference or event with a CFP process. The discipline of writing a strong abstract also helps clarify your thinking even if you never submit it. Avoid submitting proposals you are not genuinely committed to delivering — the conference ecosystem depends on speaker reliability.
 
 ## Detection Heuristics
-The vault should look for evidence that the presentation was developed from a clear, well-structured proposal. A talk with a crisp thesis, well-defined scope, and promised takeaways likely originated from a strong CFP submission.
+A crisp talk does not prove that a proposal was submitted or treated as binding.
+Verify Proposed from the actual submitted CFP artifact and compare its promised
+scope with the delivered talk. Without that artifact, the pattern is unevaluable.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Clear thesis and scope consistent with a well-crafted abstract; promised takeaways delivered; content matches published description
-- Moderate signal (1 pt): Reasonable structure but some drift from what might have been proposed; scope somewhat fuzzy
-- Absent (0 pts): No evidence of structured planning; talk feels improvised or unfocused
+- Strong signal (2 pts): The submitted/accepted CFP artifact is available and the delivered talk fulfills its scope and promised takeaways
+- Moderate signal (1 pt): The proposal is available and the talk fulfills most promises with limited, explainable drift
+- Absent (0 pts): Records show no proposal was submitted for this talk or the submitted scope was not treated as a commitment
+- Unevaluable: The submitted CFP artifact is unavailable
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 9 (Speaker Credibility/Ethos).

--- a/skills/presentation-creator/references/patterns/prepare/required.md
+++ b/skills/presentation-creator/references/patterns/prepare/required.md
@@ -8,11 +8,12 @@ phase_relevance:
   - intent
 vault_dimensions: [9]
 detection_signals:
-  - "corporate context mentioned"
-  - "mandatory presentation scenario"
+  - "organizer or employer record identifies the presentation as required"
+  - "speaker confirms the mandatory context"
 related_patterns: [proposed, posse, concurrent-creation, crucible]
 inverse_of: []
 difficulty: foundational
+observable: false
 ---
 
 # Required
@@ -35,12 +36,15 @@ Remember that presentations change under the pressure of delivery. A required ta
 This pattern applies whenever a presentation is mandated rather than voluntary. It reframes the obligation as an opportunity. Avoid the bare-minimum trap. The audience deserves your best effort regardless of how the talk originated.
 
 ## Detection Heuristics
-The vault should look for contextual clues that suggest a corporate or mandatory presentation scenario. References to internal tools, team structures, project timelines, or organizational processes are indicators.
+Corporate subject matter does not prove that presenting was mandatory. Verify
+Required only from organizer/employer context or speaker confirmation that the
+talk was assigned as part of the job. Otherwise treat the scenario as unknown.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Speaker treats mandatory context as an opportunity; content is polished beyond minimum requirements; collaborative preparation evident
-- Moderate signal (1 pt): Adequate preparation for a required talk but no evidence of going beyond the minimum
-- Absent (0 pts): Presentation feels like a checkbox exercise with minimal effort or engagement
+- Strong signal (2 pts): Organizer/employer evidence confirms the talk was required and preparation records show the obligation was used deliberately as practice
+- Moderate signal (1 pt): Mandatory context is confirmed, with adequate but minimally documented deliberate preparation
+- Absent (0 pts): Context confirms the talk was voluntary, so this pattern does not apply
+- Unevaluable: No organizer/employer record or speaker confirmation establishes whether the talk was required
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 9 (Speaker Credibility/Ethos).

--- a/skills/presentation-creator/references/patterns/prepare/social-media-advertising.md
+++ b/skills/presentation-creator/references/patterns/prepare/social-media-advertising.md
@@ -7,12 +7,12 @@ phase_relevance:
   - publishing
 vault_dimensions: [4]
 detection_signals:
-  - "mentions social handles"
-  - "references hashtags"
-  - "promotes resources URL"
+  - "dated promotional posts link to the talk"
+  - "campaign or referral record shows pre-event promotion"
 related_patterns: [seeding-satisfaction]
 inverse_of: []
 difficulty: foundational
+observable: false
 ---
 
 # Social Media Advertising
@@ -35,12 +35,15 @@ The key is authenticity. Promotion should feel like genuine enthusiasm for shari
 Use for any public-facing presentation where attendance is voluntary. Especially valuable for conference talks and meetup presentations. Less applicable for mandatory internal presentations where attendance is already guaranteed, though even there, building anticipation can improve audience engagement. Avoid over-promotion that feels spammy — quality of posts matters more than quantity.
 
 ## Detection Heuristics
-The vault should look for evidence that the speaker has promoted the talk through digital channels. Mentions of social handles, hashtags, or resource URLs within the presentation itself suggest the speaker is building a broader conversation around their content.
+A social handle or resource URL inside the deck is not evidence of pre-event
+promotion. Verify this pattern from dated promotional posts or campaign/referral
+records that link to the talk. Without those external artifacts it is unevaluable.
 
 ## Scoring Criteria
-- Strong signal (2 pts): Presentation references social channels, hashtags, or URLs for further engagement; evidence of pre-event community building
-- Moderate signal (1 pt): Minimal social references; a single URL or handle mentioned in passing
-- Absent (0 pts): No social media or promotional elements present in the talk materials
+- Strong signal (2 pts): Multiple dated pre-event promotional posts link to the talk and show deliberate campaign/community building
+- Moderate signal (1 pt): One dated promotional post links to the talk before the event
+- Absent (0 pts): Available account/campaign history shows no pre-event promotion
+- Unevaluable: Relevant account or campaign history is unavailable
 
 ## Relationship to Vault Dimensions
 Relates to Dimension 4 (Audience Engagement).

--- a/skills/presentation-creator/references/patterns/prepare/takahashi.md
+++ b/skills/presentation-creator/references/patterns/prepare/takahashi.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - slides
 vault_dimensions: [8, 12, 13]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "one element per slide"
   - "very high slide count"

--- a/skills/presentation-creator/references/patterns/prepare/talklet.md
+++ b/skills/presentation-creator/references/patterns/prepare/talklet.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [2, 12]
+evidence_channels: [timed_transcript, slides, video]
 detection_signals:
   - "self-contained 20-minute modules"
   - "modular structure"

--- a/skills/presentation-creator/references/patterns/prepare/the-big-why.md
+++ b/skills/presentation-creator/references/patterns/prepare/the-big-why.md
@@ -6,6 +6,7 @@ part: prepare
 phase_relevance:
   - intake
 vault_dimensions: [9]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "clear motivation stated"
   - "strong personal connection to topic"

--- a/skills/presentation-creator/references/patterns/prepare/triad.md
+++ b/skills/presentation-creator/references/patterns/prepare/triad.md
@@ -7,6 +7,7 @@ phase_relevance:
   - intent
   - architecture
 vault_dimensions: [2]
+evidence_channels: [transcript, slides, slide_sequence, video]
 detection_signals:
   - "three major sections"
   - "three-act structure"

--- a/skills/presentation-creator/references/patterns/prepare/unifying-visual-theme.md
+++ b/skills/presentation-creator/references/patterns/prepare/unifying-visual-theme.md
@@ -7,6 +7,7 @@ phase_relevance:
   - architecture
   - slides
 vault_dimensions: [10, 13]
+evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "consistent visual metaphor"
   - "recurring visual elements"

--- a/skills/presentation-creator/references/patterns/prepare/walk-around.md
+++ b/skills/presentation-creator/references/patterns/prepare/walk-around.md
@@ -8,6 +8,7 @@ phase_relevance:
   - content
   - guardrails
 vault_dimensions: [4, 9]
+evidence_channels: [transcript, slides, video]
 detection_signals:
   - "each major claim answers precision, process, impact, and implication questions"
   - "talk supplies numbers, mechanism, human consequence, and long-range framing for the same point"

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -242,8 +242,9 @@ Before delivery, surface a delivery-readiness checklist composed of two strands:
 
 1. **Unobservable patterns** from [patterns/_index.md](patterns/_index.md) (the
    "Unobservable Patterns — Go-Live Checklist" section). These are patterns the vault
-   **cannot score retroactively** because they involve pre-event logistics, physical
-   stage behaviors, or external systems.
+   **cannot score retroactively** because they involve pre-event logistics, hidden
+   authoring/provenance processes, physical stage behaviors, post-event follow-up,
+   or external systems the current artifacts cannot prove.
 2. **Observable delivery reminders** that the speaker can decide to apply on the day —
    venue setup choices (lights, lectern, mic), opening discipline, time discipline,
    and screen-blackout tactics. These *are* observable post-talk, but the speaker
@@ -265,6 +266,13 @@ VENUE SETUP:
     shouting
 
 PRE-EVENT:
+[ ] Know Your Audience — audience/organizer research captured; concrete adaptations noted
+[ ] Required — mandatory/assigned context confirmed and used deliberately as practice
+[ ] Fourthought — ideation/capture/organization completed before slide authoring
+[ ] Proposed — accepted CFP artifact retained; final scope checked against its promises
+[ ] Concurrent Creation — one Slide Wrangler named; collaboration history retained
+[ ] Peer Review — colleague/editor review completed; comments retained
+[ ] Social Media Advertising — dated promotional posts published and retained, if relevant
 [ ] Preparation — backups, cables, hydration, room layout check
 [ ] Carnegie Hall — completed 4 rehearsals (pace, delivery, fixes, groove)
 [ ] The Stakeout — staging area identified near venue
@@ -293,9 +301,15 @@ DURING DELIVERY:
 [ ] Red/Yellow/Green — exit feedback cards set up (if venue supports)
 
 AVOID:
+[ ] Abstract Attorney — compare the final talk directly with the accepted abstract
+[ ] Borrowed Shoes — confirm authorship and substantially adapt borrowed material
 [ ] Laser Weapons — don't wave the pointer; use built-in highlights
 [ ] Bunker — step out from behind the podium
 [ ] Backchannel — don't monitor social media during the talk
+
+POST-EVENT:
+[ ] Crucible — record feedback and the concrete revisions made before the next delivery
+[ ] Spaced Follow-Up — after 1–2 weeks, send opt-in attendees 2–3 recall questions
 ==================================
 ```
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -121,8 +121,8 @@ pattern-taxonomy tagging, and the return-JSON shape — lives in
 
 Transcripts come from `skills/vault-ingress/scripts/fetch-transcript.py`, never from inline fetch
 code. It tries the caption track, falls back to local Whisper, validates the
-result, and writes atomically only on success — so a failed fetch never replaces
-the transcript with a crash report or partial speech:
+result, and writes atomically only on success. A failed fetch never replaces the
+transcript with a crash report or partial speech:
 
 ```bash
 python3 skills/vault-ingress/scripts/fetch-transcript.py <video-id-or-url> \

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -30,7 +30,8 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | `slide-design-spec.md` | Visual design rules from PDF + PPTX analysis |
 | `speaker-profile.json` | Machine-readable bridge to presentation-creator |
 | `analyses/{talk_filename}.md` | Per-talk rhetoric analysis (one file per processed talk) |
-| `transcripts/{youtube_id}.txt` | Downloaded/cleaned transcripts |
+| `transcripts/{transcript_id}.txt` | Downloaded/cleaned transcripts (`youtube_id` for YouTube talks) |
+| `transcripts/{transcript_id}.segments.json` | Optional hash-bound source timing for the matching transcript |
 | `slides/{id}.pdf` | Slide PDFs (from Google Drive, PPTX export, or video extraction) |
 | [references/schemas-db.md](references/schemas-db.md) | DB + subagent schemas; extraction output schemas |
 | [references/rhetoric-dimensions.md](references/rhetoric-dimensions.md) | 14 analysis dimensions |
@@ -45,6 +46,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | `skills/vault-ingress/scripts/batch-download-videos.sh` | Parallel video download for batch processing |
 | `skills/vault-ingress/scripts/vtt-cleanup.py` | Clean VTT subtitles into plain transcript text |
 | `skills/vault-ingress/scripts/fetch-transcript.py` | Fetch a transcript, validate it, write only if real (captions → local Whisper) |
+| `skills/vault-ingress/scripts/transcript_timing.py` | Own timed-transcript sidecar writes, validation, and quote resolution |
 
 A talk is processable when it has `video_url`. Slide sources, in order of preference:
 1. `pptx_path` — richest data (exact colors, fonts, shapes via python-pptx)
@@ -119,8 +121,8 @@ pattern-taxonomy tagging, and the return-JSON shape — lives in
 
 Transcripts come from `skills/vault-ingress/scripts/fetch-transcript.py`, never from inline fetch
 code. It tries the caption track, falls back to local Whisper, validates the
-result, and writes atomically only on success — so a failed fetch leaves no file
-rather than leaving a crash report where speech belongs:
+result, and writes atomically only on success — so a failed fetch never replaces
+the transcript with a crash report or partial speech:
 
 ```bash
 python3 skills/vault-ingress/scripts/fetch-transcript.py <video-id-or-url> \
@@ -130,7 +132,10 @@ python3 skills/vault-ingress/scripts/fetch-transcript.py <video-id-or-url> \
 Exit 0 wrote (or kept) a valid transcript; exit 1 means no source produced one
 and the talk is `processed_partial` at best; exit 2 is an argument or tool-state
 error. Validation thresholds and failure signatures are the script's own — see
-its module docstring and the constants above `validate_transcript`.
+its module docstring and the constants above `validate_transcript`. Its JSON
+`timed_path` is non-null only when a schema- and hash-verified segment sidecar is
+available. A missing sidecar does not invalidate ordinary transcript evidence,
+but it cannot support patterns whose semantics depend on position or timing.
 
 ## Step 4 — Persist Subagent Results
 
@@ -148,7 +153,10 @@ phase). Mechanical persistence of the batch's subagent JSON returns:
   Contract, the promoted-scalar allowlist, and merge semantics live in
   `skills/vault-ingress/scripts/persist-results.py` (top-of-file docstring and the `PROMOTE` list) — to make
   a new field queryable, extend the return schema and that list; never reintroduce
-  manual mapping.
+  manual mapping. The same script validates each new pattern detection against
+  the catalog's observability and evidence-channel policy, verifies its cited
+  source location, and refuses the whole batch before mutation when evidence is
+  absent or unverifiable.
 - **Write per-talk analysis files — run the script, do NOT hand-write them.** Run
   `python3 skills/vault-ingress/scripts/write-analysis.py batch-returns.json {vault_root}/analyses --talks {vault_root}/tracking-database.json`
   over the SAME `batch-returns.json` the merge consumed, so the DB and the files
@@ -277,6 +285,8 @@ auto-invoke.
 - Create `transcripts/`, `slides/`, `analyses/` dirs if missing.
 - Re-read tracking DB before writing (single source of truth).
 - Preserve all summary content — add/refine, never delete.
+- Auto-score only source-located observations for `observable: true` catalog entries.
+  Hidden preparation/provenance belongs in clarification, not pattern inference.
 - After 10+ scored talks, produce per-talk adherence assessments against the
   Section 15 baseline — definition in
   [references/processing-rules.md](references/processing-rules.md) Adherence Assessment.

--- a/skills/vault-ingress/references/known-issues.md
+++ b/skills/vault-ingress/references/known-issues.md
@@ -91,6 +91,23 @@ text that wasn't said.
 - Set `transcript_quality: "partial"` on talks where whole sections are
   unreliable.
 
+## Timed Sidecars Can Be Missing or Stale
+
+Legacy transcripts have no `{id}.segments.json`, and a manually edited `.txt`
+can no longer match the timing file that was generated with it. This does not
+make the transcript unusable, but applying those timestamps would attach
+evidence to the wrong moment.
+
+**Mitigations:**
+
+- `transcript_timing.py` binds every sidecar to the exact transcript text with
+  `transcript_sha256`; readers reject a missing, malformed, unsupported, empty,
+  or hash-mismatched sidecar.
+- Use ordinary `transcript` citations when exact timing is irrelevant.
+- When a pattern requires position or timing, regenerate the transcript bundle
+  from captions/Whisper/VTT or review the video directly. Do not silently
+  downgrade it to an unlocated quote.
+
 ## Non-Speaker Talks Slip into Playlists
 
 Conference playlists sometimes mix talks from multiple speakers, and a vault

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -9,6 +9,11 @@ MUST be written in English regardless of the talk's delivery language. For non-E
   parentheses. Never the reverse. Format: `"English text" (оригинальный текст)`.
   Example: `"That's the whole point" (В этом весь смысл)` — NOT
   `"В этом весь смысл" (That's the whole point)`
+- **Evidence-citation exception**: `evidence_citations[].quote` is the
+  machine-verification field and MUST contain only the exact source-language span.
+  Put its English rendering in `evidence_citations[].translation`; renderers show
+  the translation first and label the original. Keep the human `evidence` summary
+  in English.
 - **Verbal signatures**: store separately tagged with language code (e.g.,
   `[ru] "получается что"`) — do NOT merge into the main English signature list
 - **Slide text**: translate in the analysis, note original language
@@ -27,11 +32,38 @@ but any talks with status `"processed"` or `"processed_partial"` have no
 
 Scan observations against the pattern taxonomy index at
 `skills/presentation-creator/references/patterns/_index.md` (path relative to plugin root).
-Skip patterns marked `observable: false` — these are pre-event logistics and physical
-stage behaviors that cannot be detected from transcripts or slides. For each observable
-pattern/antipattern, determine if the talk exhibits it (strong/moderate/weak confidence),
-record evidence, and compute per-talk pattern score:
-count(patterns) − count(antipatterns). Return in the `pattern_observations` field.
+Skip every pattern marked `observable: false`. These include hidden preparation,
+provenance, decision, and post-event processes as well as behavior that the available
+artifacts cannot establish. A polished outcome is not proof that a named process
+produced it: for example, audience fit does not prove `know-your-audience`, coherent
+art does not prove `fourthought`, and incorporated feedback does not prove
+`peer-review`.
+
+For each observable pattern/antipattern:
+
+1. Apply the entry's stated detection semantics, not just keyword or thematic
+   similarity. A quote that mentions a concept does not prove a structural pattern.
+2. Use only direct evidence from the artifacts actually inspected. The allowed
+   channels are `transcript`, `timed_transcript`, `slides`, `slide_sequence`,
+   `video`, and `talk_metadata`. Every observable entry declares
+   `evidence_channels`; every citation must use one of those channels. An entry
+   that permits `talk_metadata` also declares the narrower
+   `evidence_metadata_fields` it may cite.
+3. Return confidence (`strong|moderate|weak`), a short `evidence` explanation, and a
+   non-empty `evidence_citations` array using the shapes in
+   [schemas-db.md](schemas-db.md) Pattern Evidence Citation Schema. Do not launder a
+   timing, sequence, motion, or delivery claim through generic transcript/slide
+   prose: use `timed_transcript`, `slide_sequence`, or `video` as required.
+4. Omit a detection when no allowed source-located citation proves it. Put useful
+   but unverified hypotheses in clarification notes, not the score.
+
+`persist-results.py` deterministically validates the catalog ID/type, bucket,
+uniqueness, observability, channel, quote, slide range, and available artifact context before writing. It also
+replaces model-supplied transcript lines/timestamps and metadata values with locations
+resolved from the source artifacts.
+
+Compute the per-talk score as count(patterns) − count(antipatterns) and return it in
+`pattern_observations`.
 
 ## Structured Field Extraction
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -34,8 +34,9 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
     "video_url": "YouTube watch URL (required — only source needed for processing)",
     "youtube_id": "aBcDeFg", "google_drive_id": "1AbCdEfGhIjK",
     "pptx_path": "Conference/Year/Talk Name.pptx  (optional — highest quality slide source when available)",
-    "schema_version": 2,
+    "schema_version": 3,
     "transcript_source": "youtube_auto|whisper|manual|none  (how the transcript was obtained; MAY BE ABSENT — see below)",
+    "transcript_path": "transcripts/{id}.txt  (optional vault-relative path; required for non-YouTube transcript evidence)",
     "slide_source": "pptx|pdf|both|video_extracted|none  (set in Step 2 per slide source hierarchy)",
     "pptx_visual_status": "pending|extracted|no_pptx",
     "status": "pending|processed|processed_partial|needs-reprocessing|skipped_no_sources|skipped_download_failed",
@@ -49,6 +50,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
     "opening_type": null, "closing_type": null, "narrative_arc_type": null,
     "audience_interaction_count": 0, "pattern_score": 0,
     "pattern_observations": {
+      "evidence_schema_version": 1,
       "pattern_ids": [],
       "antipattern_ids": [],
       "pattern_score": 0,
@@ -56,7 +58,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
       "antipatterns_detected": []
     }
   }],
-  "_comment_schema_version": "Talk-record schema version, stamped by persist-results.py (TALK_SCHEMA_VERSION) on every merge. v1 is the implicit unversioned shape every pre-2026-07-28 record carries, in which transcript_source was documented as always present. v2 documents it as optional and gives ABSENT a meaning. The bump is additive — a v1 reader reads a v2 record unchanged, since v2 removes a guarantee rather than adding a field — so no staged rollout is required (stateful-artifacts Cross-Pipeline Schema Bumps). Readers do not gate on this value yet; that contract is issue #147, sequenced after the in-flight reparse so writer and readers cannot skew mid-run.",
+  "_comment_schema_version": "Talk-record schema version, stamped by persist-results.py (TALK_SCHEMA_VERSION) on every merge. v1 is the implicit unversioned shape every pre-2026-07-28 record carries. v2 documents transcript_source as optional and gives ABSENT a meaning. v3 adds optional transcript_path, pattern_observations.evidence_schema_version, and additive evidence_citations arrays on detections. Migration gives legacy detections an empty evidence_citations array: that explicitly means unlocated legacy evidence, not verified evidence. New detections must carry at least one source-located citation. Older readers may ignore the additive fields; current readers must tolerate empty arrays on migrated records.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "pptx_path": "Conference/Year/Talk Name.pptx",
@@ -99,6 +101,7 @@ Each subagent returns this JSON after processing one talk:
   "rhetoric_notes": "500-1000 words: qualitative observations across dimensions 1-13",
   "areas_for_improvement": "100-300 words: honest critical reflection (Dimension 14); name the related antipattern ID + severity per issue where a Dimension 14 antipattern applies",
   "transcript_source": "youtube_auto|whisper|manual  (how the transcript was obtained; OMIT the key entirely when provenance is unknown — see Absent transcript_source in the DB schema above)",
+  "transcript_path": "transcripts/{id}.txt  (vault-relative; return for non-YouTube talks)",
   "structured_data": {
     "delivery_language": "en|de|ru|etc  (primary language of the talk)",
     "co_presenter": false,
@@ -166,17 +169,23 @@ Each subagent returns this JSON after processing one talk:
   "pattern_observations": {
     "patterns_detected": [
       {
-        "pattern_id": "narrative-arc",
+        "pattern_id": "progressive-reveal",
         "confidence": "strong|moderate|weak",
-        "evidence": "brief description of what was observed",
-        "dimensions": [2, 5]
+        "evidence": "Three consecutive slides add one element at a time.",
+        "evidence_citations": [
+          {"channel": "slide_sequence", "slide_numbers": [21, 22, 23]}
+        ],
+        "dimensions": [8, 13]
       }
     ],
     "antipatterns_detected": [
       {
         "pattern_id": "shortchanged",
         "confidence": "strong|moderate|weak",
-        "evidence": "brief description of what was observed",
+        "evidence": "The talk announces the close before beginning a new topic.",
+        "evidence_citations": [
+          {"channel": "timed_transcript", "quote": "Before I finish, there is one more architecture topic."}
+        ],
         "dimensions": [12, 14]
       }
     ],
@@ -188,6 +197,79 @@ Each subagent returns this JSON after processing one talk:
   }
 }
 ```
+
+### Pattern Evidence Citation Schema
+
+`evidence` remains the concise human explanation. `evidence_citations` is the
+auditable proof. Every newly returned detection requires one or more citations;
+`persist-results.py` rejects missing citations, unknown or duplicate pattern IDs,
+pattern/antipattern bucket swaps, `observable: false` patterns, and citation
+channels not permitted by that pattern's required `evidence_channels`
+frontmatter. An observable catalog entry without that field is itself invalid
+and stops persistence.
+
+Allowed citation shapes:
+
+```json
+{"channel": "transcript", "quote": "A unique source-language span of at least four words", "translation": "Optional English translation"}
+{"channel": "timed_transcript", "quote": "A unique source-language span of at least four words", "translation": "Optional English translation"}
+{"channel": "slides", "slide_numbers": [4, 17]}
+{"channel": "slide_sequence", "slide_numbers": [21, 22, 23]}
+{"channel": "video", "start_seconds": 42.5, "end_seconds": 48.0}
+{"channel": "talk_metadata", "field": "slide_count"}
+```
+
+For transcript citations, `quote` is always the exact source-language text needed
+for matching; on a non-English talk, put the English rendering in optional
+`translation` so readers still see English first. The model never supplies a
+translated composite string as `quote`, because that string does not occur in the
+source transcript.
+`persist-results.py` verifies that the normalized quote occurs exactly once in
+the local transcript and stamps `line_start`/`line_end`; for
+`timed_transcript`, it also stamps `start_seconds`/`end_seconds` from a verified
+timing sidecar. Model-supplied locations are discarded. A `slide_sequence` must
+contain at least two consecutive ascending slide numbers. Slide numbers are
+checked against the talk's slide source/count. A video citation is valid only
+when the video was directly reviewed at that interval; the writer checks its
+range and that the talk has a video URL. `talk_metadata.value` is likewise
+writer-owned and copied from the actual record. Citation objects use these
+closed field sets; unknown model-supplied fields are rejected.
+`talk_metadata.field` is restricted to source/provenance fields declared by `persist-results.py`'s
+`TALK_METADATA_FIELDS` and then to the pattern's narrower
+`evidence_metadata_fields`; generated prose such as `rhetoric_notes` cannot cite
+itself, and an irrelevant metadata field cannot stand in for pattern evidence.
+
+Migrated v1/v2 records may contain `evidence_citations: []`. That is a deliberate
+legacy marker: readers may render the old `evidence` prose, but must not present
+it as source-verified. The v3 writer never accepts an empty array for a new
+detection.
+
+## Timed Transcript Sidecar Schema
+
+`fetch-transcript.py` and `vtt-cleanup.py` keep the readable transcript at
+`transcripts/{id}.txt` and replace `transcripts/{id}.segments.json` with every
+fresh transcript bundle:
+
+```json
+{
+  "schema_version": 1,
+  "transcript_sha256": "SHA-256 of the exact UTF-8 transcript text",
+  "source": "captions|whisper|vtt",
+  "segments": [
+    {"text": "Timed source text", "start_seconds": 1.2, "end_seconds": 3.4}
+  ]
+}
+```
+
+The owner is `skills/vault-ingress/scripts/transcript_timing.py`; its current
+sidecar schema version is `1`. `persist-results.py` is the reader. It accepts a
+sidecar only when the schema is supported and `transcript_sha256` matches the
+exact `.txt` content. Missing, malformed, empty, or hash-stale sidecars leave the
+plain transcript usable but make `timed_transcript` evidence unavailable. Never
+copy timestamps from a stale sidecar or silently downgrade a pattern whose
+semantics require timing. Writers deliberately emit an empty sidecar when an
+upstream source supplies no usable segments; this invalidates any older timing
+rather than letting it appear current. `timed_path` remains `null` in that case.
 
 ## Video Extraction Output Schema
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -19,9 +19,11 @@ python3 skills/vault-ingress/scripts/fetch-transcript.py {youtube_id} \
 ```
 
 The script owns the whole chain — caption track first, local Whisper fallback,
-validation, atomic write. It prints one JSON object and never leaves a file
-behind on failure. Exit codes and the JSON shape are the script's contract; see
-its module docstring.
+validation, atomic write. It prints one JSON object and never leaves a corrupt
+transcript behind on failure. A sidecar written just before a transcript-write
+failure is hash-stale and therefore unusable by readers. When source segment timing exists, `timed_path` names the
+hash-bound `{id}.segments.json` sidecar; otherwise it is `null`. Exit codes and
+the JSON shape are the script's contract; see its module docstring.
 
 | exit | meaning | what to do |
 |---|---|---|
@@ -54,6 +56,11 @@ Pass `--duration-seconds` when the runtime is known — it enables the
 words-per-minute check that catches a caption track returning only its opening
 minute.
 
+Treat `timed_path: null` literally. The plain transcript is still usable for a
+`transcript` quote, but it cannot establish opening/closing position, pauses, or
+other timing-dependent claims. Never invent a timestamp or reuse an unverified
+sidecar; the persistence step rejects both.
+
 **A transcript already on disk is not proof of a transcript.** Ten corpus files
 were empty, a traceback, or a stub. Running the script without `--force` is the
 check: it validates any existing file and either keeps it or replaces it.
@@ -70,7 +77,10 @@ python3 skills/vault-ingress/scripts/fetch-transcript.py {talk_label} \
 ```
 
 Set `transcript_source: whisper` on exit 0. Fall back to `processed_partial`
-when no audio is obtainable at all.
+when no audio is obtainable at all. Also return the exact vault-relative
+`transcript_path` (for example `transcripts/infoq-talk-id.txt`); without it the
+persistence validator cannot locate a non-YouTube transcript reliably. YouTube
+talks may omit the field because `youtube_id` remains the canonical fallback.
 
 ### Slide acquisition (per `slide_source`)
 
@@ -119,9 +129,11 @@ Apply all 14 dimensions from
 (Areas for Improvement). Follow language policy and verbatim-quote rules in
 [processing-rules.md](processing-rules.md).
 
-**Quote rule:** verbatim quotes must be English-first —
-`"English translation" (original text)`. Never quote non-English text without
-an English translation preceding it.
+**Quote rule:** human-readable verbatim examples must be English-first —
+`"English translation" (original text)`. The `evidence_citations[].quote` field
+is the deliberate exception: return only the exact source-language span there so
+persistence can match it, and put the English rendering in the adjacent
+`translation` field. The analysis renderer displays translation first.
 
 ### Slides with `text_extraction_confidence: low` — inventory + pixels
 
@@ -199,8 +211,13 @@ Structural fields stay authoritative for what they actually measure —
 
 Scan observations against the pattern taxonomy at
 `skills/presentation-creator/references/patterns/_index.md`. Skip patterns
-marked `observable: false`. Record confidence (strong/moderate/weak) and
-evidence per pattern. Compute per-talk score:
+marked `observable: false`; do not infer hidden preparation or provenance from a
+polished result. For each detection, record confidence (strong/moderate/weak), a
+brief evidence explanation, and at least one direct source citation through a
+channel allowed by the pattern's `evidence_channels`. Timing claims require a
+verified timed transcript or direct video review; sequence claims require the
+actual consecutive slides; motion/delivery claims require direct video review.
+Do not cite a video interval unless you inspected that interval. Compute per-talk score:
 `count(patterns) − count(antipatterns)`. Store in `pattern_observations`.
 See [processing-rules.md](processing-rules.md) for full tagging rules.
 
@@ -211,15 +228,28 @@ structure:
 
 ```json
 {
-  "talk_id": "...",
+  "filename": "talk.md",
   "status": "processed",
-  "transcript_source": "youtube",
+  "transcript_source": "youtube_auto",
   "slide_source": "pdf",
-  "pattern_observations": [
-    {"pattern_id": "...", "confidence": "strong", "evidence": "..."}
-  ],
-  "new_patterns": ["..."],
-  "summary_updates": [{"section": 1, "content": "..."}],
+  "pattern_observations": {
+    "patterns_detected": [{
+      "pattern_id": "progressive-reveal",
+      "confidence": "strong",
+      "evidence": "Three consecutive slides add one element at a time.",
+      "evidence_citations": [
+        {"channel": "slide_sequence", "slide_numbers": [21, 22, 23]}
+      ]
+    }],
+    "antipatterns_detected": [],
+    "pattern_score": {
+      "patterns_used": 1,
+      "antipatterns_detected": 0,
+      "score": 1
+    }
+  },
+  "new_patterns": "",
+  "summary_updates": "",
   "structured_data": {"delivery_language": "en", "co_presenter": false}
 }
 ```

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -35,7 +35,8 @@ positional argument is then just a label for the JSON output.
 
 Output: one JSON object on stdout, on EVERY exit path including argument errors —
     {"ok": bool, "video_id": "...", "method": "captions|whisper|existing|none",
-     "words": int, "path": "...", "reason": "...", "language": "en"|null}
+     "words": int, "path": "...", "timed_path": "..."|null,
+     "reason": "...", "language": "en"|null}
 
 `language` is the caption track's own language code, or Whisper's detected
 language — the source of the talk's `delivery_language`. It is null on the
@@ -45,18 +46,26 @@ Exit:   0 wrote a valid transcript (or --force absent and a valid one existed)
         2 argument or tool-state error
 
 The output path is written ATOMICALLY and only after validation passes, so a
-failed fetch can never leave a corrupt file where a transcript belongs.
+failed fetch can never leave a corrupt file where a transcript belongs. If the
+timing sidecar is replaced just before a transcript-write failure, its hash does
+not match the old transcript and readers reject it.
 """
 
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import NoReturn
+
+from transcript_timing import (
+    load_verified_segments,
+    sidecar_path,
+    write_atomically,
+    write_transcript_bundle,
+)
 
 # Text that proves the "transcript" is a crash report rather than speech. Anchored
 # at the head of the file: a talk about Python may legitimately say "traceback".
@@ -165,7 +174,7 @@ def segments_to_text(segments):
 
 
 def fetch_captions(video_id, languages):
-    """Return (caption text, language code), or (None, None) when unavailable.
+    """Return ``(text, language, timed segments)`` or three ``None`` values.
 
     The 1.0 API is instance-based (`YouTubeTranscriptApi().fetch`); the older one
     was a classmethod (`.get_transcript`). Both are tried so the script survives
@@ -178,7 +187,7 @@ def fetch_captions(video_id, languages):
         print("youtube-transcript-api is not installed — "
               "`pip install youtube-transcript-api`, or pass --method whisper",
               file=sys.stderr)
-        return None, None
+        return None, None, None
 
     api = YouTubeTranscriptApi()
     try:
@@ -189,7 +198,7 @@ def fetch_captions(video_id, languages):
         else:
             print("youtube-transcript-api exposes neither .fetch nor .get_transcript; "
                   "the API changed again — update fetch_captions()", file=sys.stderr)
-            return None, None
+            return None, None, None
     except YouTubeTranscriptApiException as exc:
         # Every "this video has no usable caption track" case — subtitles
         # disabled, no track in the requested languages, age restriction, IP
@@ -198,16 +207,16 @@ def fetch_captions(video_id, languages):
         # previous fetch ended up writing its own traceback into the corpus.
         print(f"caption track unavailable for {video_id}: "
               f"{type(exc).__name__}: {str(exc).splitlines()[0]}", file=sys.stderr)
-        return None, None
+        return None, None, None
     # The track's own language, not the first preference we asked for — they
     # differ whenever the requested language is unavailable and the API falls
     # back. `delivery_language` is derived from this, so guessing is not an option.
     language = getattr(segments, "language_code", None)
-    return segments_to_text(segments), language
+    return segments_to_text(segments), language, segments
 
 
 def transcribe_audio(audio_path, video_id, model):
-    """Transcribe a local audio/video file. Returns (text, language) or (None, None)."""
+    """Return ``(text, language, timed segments)`` from local Whisper."""
     try:
         import mlx_whisper
     except ImportError:
@@ -215,7 +224,7 @@ def transcribe_audio(audio_path, video_id, model):
               "`pip install 'speaker-toolkit[whisper]'`, or supply the transcript "
               "by hand. On other platforms use a caption track or an external "
               "transcription service.", file=sys.stderr)
-        return None, None
+        return None, None, None
 
     try:
         result = mlx_whisper.transcribe(str(audio_path), path_or_hf_repo=model)
@@ -224,18 +233,20 @@ def transcribe_audio(audio_path, video_id, model):
         # Must not escape as a traceback — callers parse this script's stdout.
         print(f"mlx_whisper could not transcribe {video_id}: "
               f"{type(exc).__name__}: {exc}", file=sys.stderr)
-        return None, None
+        return None, None, None
     text = result.get("text") if isinstance(result, dict) else None
     if not text:
         print(f"mlx_whisper returned no text for {video_id}", file=sys.stderr)
-        return None, None
+        return None, None, None
     # Whisper detects the spoken language; this is the only language signal on
     # the audio path, and `delivery_language` is derived from it.
-    return text, (result.get("language") if isinstance(result, dict) else None)
+    language = result.get("language") if isinstance(result, dict) else None
+    segments = result.get("segments") if isinstance(result, dict) else None
+    return text, language, segments
 
 
 def fetch_whisper(video_id, work_dir, model):
-    """Download audio and transcribe. Returns (text, language) or (None, None)."""
+    """Download audio and return Whisper text, language, and timed segments."""
     url = f"https://www.youtube.com/watch?v={video_id}"
     audio = Path(work_dir) / "audio.mp3"
     try:
@@ -250,39 +261,17 @@ def fetch_whisper(video_id, work_dir, model):
         # the same silent-failure shape the whole file exists to prevent.
         print(f"cannot run yt-dlp ({exc}) — install it with "
               "`brew install yt-dlp` or `pip install yt-dlp`", file=sys.stderr)
-        return None, None
+        return None, None, None
     if download.returncode != 0 or not audio.exists():
         print(f"yt-dlp could not download audio for {video_id}: "
               f"{download.stderr.strip()[:400]}", file=sys.stderr)
-        return None, None
+        return None, None, None
 
     return transcribe_audio(audio, video_id, model)
 
 
-def write_atomically(path, text):
-    """Write via a temp file in the same directory, then replace.
-
-    A half-written transcript is the same defect class as a traceback-as-
-    transcript: it looks like data.
-    """
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    handle, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".partial")
-    try:
-        with os.fdopen(handle, "w", encoding="utf-8") as fh:
-            fh.write(text)
-        os.replace(tmp, path)
-    finally:
-        # `finally`, not a catch: cleanup must also run on KeyboardInterrupt and
-        # SystemExit, and neither may be swallowed (`rules/error-handling.md`).
-        # After a successful os.replace the temp path is gone, so this is a no-op
-        # on the happy path.
-        if os.path.exists(tmp):
-            os.unlink(tmp)
-
-
 def emit(ok, video_id, method, words, path, reason, code,
-         language=None) -> NoReturn:
+         language=None, timed_path=None) -> NoReturn:
     """Print the contract object and exit. Never returns — hence `NoReturn`.
 
     The annotation is load-bearing, not decoration: callers rely on `emit` ending
@@ -291,7 +280,8 @@ def emit(ok, video_id, method, words, path, reason, code,
     """
     print(json.dumps({"ok": ok, "video_id": video_id, "method": method,
                       "words": words, "path": str(path), "reason": reason,
-                      "language": language}))
+                      "language": language,
+                      "timed_path": str(timed_path) if timed_path else None}))
     sys.exit(code)
 
 
@@ -330,7 +320,8 @@ def main(argv=None):
             emit(False, args.video, "none", 0, args.out,
                  f"--audio file does not exist: {audio_path}", 2)
         out = Path(args.out)
-        text, language = transcribe_audio(audio_path, args.video, args.whisper_model)
+        text, language, segments = transcribe_audio(
+            audio_path, args.video, args.whisper_model)
         if text is None:
             emit(False, args.video, "none", 0, out,
                  "local transcription produced no text — see stderr", 1)
@@ -341,14 +332,15 @@ def main(argv=None):
             emit(False, args.video, "whisper", count_words(text), out, reason, 1,
                  language)
         try:
-            write_atomically(out, text)
+            timed_path = write_transcript_bundle(
+                out, text, segments, source="whisper")
         except OSError as exc:
-            print(f"cannot write the transcript to {out}: {exc}", file=sys.stderr)
+            print(f"cannot write the transcript bundle to {out}: {exc}", file=sys.stderr)
             emit(False, args.video, "whisper", count_words(text), out,
-                 f"transcript produced but could not be written: {exc}", 2,
+                 f"transcript produced but its bundle could not be written: {exc}", 2,
                  language)
         emit(True, args.video, "whisper", count_words(text), out, reason, 0,
-             language)
+             language, timed_path)
 
     video_id = resolve_video_id(args.video)
     if not video_id:
@@ -377,8 +369,11 @@ def main(argv=None):
             existing, min_words=args.min_words,
             duration_seconds=args.duration_seconds)
         if ok:
+            timed_segments, _ = load_verified_segments(out, existing)
+            timed_path = sidecar_path(out) if timed_segments else None
             emit(True, video_id, "existing", count_words(existing), out,
-                 f"kept existing transcript ({reason})", 0)
+                 f"kept existing transcript ({reason})", 0,
+                 timed_path=timed_path)
         print(f"existing transcript at {out} is not usable: {reason}", file=sys.stderr)
 
     languages = [lang.strip() for lang in (args.languages or "").split(",") if lang.strip()]
@@ -388,10 +383,11 @@ def main(argv=None):
     failures = []
     for name in attempts:
         if name == "captions":
-            text, language = fetch_captions(video_id, languages)
+            text, language, segments = fetch_captions(video_id, languages)
         else:
             with tempfile.TemporaryDirectory() as work_dir:
-                text, language = fetch_whisper(video_id, work_dir, args.whisper_model)
+                text, language, segments = fetch_whisper(
+                    video_id, work_dir, args.whisper_model)
         if text is None:
             failures.append(f"{name}: unavailable")
             continue
@@ -399,16 +395,19 @@ def main(argv=None):
             text, min_words=args.min_words, duration_seconds=args.duration_seconds)
         if ok:
             try:
-                write_atomically(out, text)
+                timed_path = write_transcript_bundle(
+                    out, text, segments, source=name)
             except OSError as exc:
-                # write_atomically's `finally` has already removed the temp file,
-                # so the output path is untouched. Emit rather than traceback.
-                print(f"cannot write the transcript to {out}: {exc}",
+                # Each atomic writer has removed its own temporary file. A
+                # sidecar replaced before a transcript failure is hash-stale and
+                # therefore rejected by readers rather than misapplied.
+                print(f"cannot write the transcript bundle to {out}: {exc}",
                       file=sys.stderr)
                 emit(False, video_id, name, count_words(text), out,
-                     f"transcript fetched but could not be written: {exc}", 2,
+                     f"transcript fetched but its bundle could not be written: {exc}", 2,
                      language)
-            emit(True, video_id, name, count_words(text), out, reason, 0, language)
+            emit(True, video_id, name, count_words(text), out, reason, 0,
+                 language, timed_path)
         failures.append(f"{name}: {reason}")
 
     emit(False, video_id, "none", 0, out,

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -11,7 +11,8 @@ and the queryable scalars are promoted to the talk's top level.
 
 For each return (matched to a talk by `filename`) it:
   1. Sets the scalar result fields (status, processed_date, rhetoric_notes,
-     areas_for_improvement, adherence_assessment, transcript_source). A return
+     areas_for_improvement, adherence_assessment, transcript_source,
+     transcript_path). A return
      that omits `processed_date` is stamped with the run date, because otherwise
      the talk keeps whatever date the previous run set and the DB cannot answer
      "which talks has this reparse actually covered".
@@ -22,6 +23,9 @@ For each return (matched to a talk by `filename`) it:
      {patterns_detected, antipatterns_detected, pattern_score:{score}} shape into
      the DB's {pattern_ids, antipattern_ids, pattern_score:int} shape, keeping the
      detailed arrays too (Section 15 aggregation reads antipatterns_detected).
+     New detections must cite direct, catalog-permitted evidence. Transcript
+     quotes, slide ranges, and metadata are verified against local artifacts;
+     source-owned locations replace any model-supplied line/time/value fields.
   4. Promotes the declared queryable scalars (PROMOTE) to the talk's top level so
      they are directly queryable, not buried in structured_data or rhetoric_notes.
 
@@ -58,8 +62,16 @@ Example:
 """
 
 import json
+import math
+import re
 import sys
+from copy import deepcopy
 from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from transcript_timing import load_verified_segments, resolve_quote
 
 
 def default_stamp(now=None):
@@ -103,12 +115,82 @@ def normalize_stamp(value):
 # v2 documents `transcript_source` as optional and gives ABSENT a meaning —
 # provenance unknown, distinct from the explicit value `none` (no transcript).
 #
-# The bump is ADDITIVE, which `rules/stateful-artifacts.md` Cross-Pipeline Schema
-# Bumps permits without a staged rollout: a v1 reader reads a v2 record
-# unchanged, because v2 removes a guarantee rather than adding a field. Readers
-# do not gate on this value yet — that contract is #147, deliberately sequenced
-# after the in-flight reparse so writer and readers do not skew mid-run.
-TALK_SCHEMA_VERSION = 2
+# v3 adds optional `transcript_path`,
+# `pattern_observations.evidence_schema_version`, and each detection's additive
+# `evidence_citations` array. Existing evidence prose remains readable; migration
+# adds an empty array to old detections, explicitly distinguishing legacy
+# unlocated evidence from source-verified new observations.
+TALK_SCHEMA_VERSION = 3
+PATTERN_EVIDENCE_SCHEMA_VERSION = 1
+
+EVIDENCE_CHANNELS = frozenset(
+    {
+        "transcript",
+        "timed_transcript",
+        "slides",
+        "slide_sequence",
+        "video",
+        "talk_metadata",
+    }
+)
+EVIDENCE_CITATION_FIELDS = {
+    "transcript": frozenset(
+        {
+            "channel",
+            "quote",
+            "translation",
+            "line_start",
+            "line_end",
+            "start_seconds",
+            "end_seconds",
+        }
+    ),
+    "timed_transcript": frozenset(
+        {
+            "channel",
+            "quote",
+            "translation",
+            "line_start",
+            "line_end",
+            "start_seconds",
+            "end_seconds",
+        }
+    ),
+    "slides": frozenset({"channel", "slide_numbers"}),
+    "slide_sequence": frozenset({"channel", "slide_numbers"}),
+    "video": frozenset({"channel", "start_seconds", "end_seconds"}),
+    "talk_metadata": frozenset({"channel", "field", "value"}),
+}
+USABLE_SLIDE_SOURCES = frozenset({"pptx", "pdf", "both", "video_extracted"})
+CONFIDENCE_VALUES = frozenset({"strong", "moderate", "weak"})
+MIN_TRANSCRIPT_QUOTE_WORDS = 4
+_WORD = re.compile(r"[^\W\d_]+", re.UNICODE)
+_YOUTUBE_ID = re.compile(r"[A-Za-z0-9_-]{11}")
+TALK_METADATA_FIELDS = frozenset(
+    {
+        "filename",
+        "title",
+        "conference",
+        "date",
+        "slides_url",
+        "video_url",
+        "youtube_id",
+        "google_drive_id",
+        "pptx_path",
+        "transcript_path",
+        "transcript_source",
+        "slide_source",
+        "slide_count",
+        "co_presenter",
+        "delivery_language",
+    }
+)
+_PATTERN_ROOT = (
+    Path(__file__).resolve().parents[2]
+    / "presentation-creator"
+    / "references"
+    / "patterns"
+)
 
 # Queryable scalars promoted from the subagent return onto the talk's top level.
 # (top_level_field, dotted source path within the return). To add a new queryable
@@ -132,7 +214,7 @@ PROMOTE = [
 # Scalar result fields copied verbatim when present in the return.
 SCALARS = [
     "status", "processed_date", "rhetoric_notes", "areas_for_improvement",
-    "adherence_assessment", "transcript_source",
+    "adherence_assessment", "transcript_source", "transcript_path",
 ]
 
 
@@ -191,7 +273,417 @@ def require_mapping(ret, field):
     return value
 
 
-def require_detections(observations, field):
+def load_pattern_catalog(pattern_root=_PATTERN_ROOT):
+    """Load stable IDs plus observability/evidence-channel policy from frontmatter."""
+    catalog = {}
+    for path in sorted(Path(pattern_root).glob("*/*.md")):
+        text = path.read_text(encoding="utf-8")
+        parts = text.split("---", 2)
+        if len(parts) < 3:
+            raise ValueError(f"pattern entry has no YAML frontmatter: {path}")
+        try:
+            metadata = yaml.safe_load(parts[1])
+        except yaml.YAMLError as exc:
+            raise ValueError(f"pattern entry has invalid YAML frontmatter: {path}: {exc}") from exc
+        if (
+            not isinstance(metadata, dict)
+            or not isinstance(metadata.get("id"), str)
+            or not metadata["id"].strip()
+        ):
+            raise ValueError(f"pattern entry has no string `id`: {path}")
+        pattern_id = metadata["id"]
+        pattern_type = metadata.get("type")
+        if pattern_type not in {"pattern", "antipattern"}:
+            raise ValueError(
+                f"pattern entry {pattern_id!r} has invalid type {pattern_type!r}: {path}"
+            )
+        if pattern_id in catalog:
+            raise ValueError(
+                f"duplicate pattern id {pattern_id!r}: {catalog[pattern_id]['path']} and {path}"
+            )
+        observable = metadata.get("observable") is not False
+        channels = metadata.get("evidence_channels")
+        if channels is None:
+            if observable:
+                raise ValueError(
+                    f"observable pattern {pattern_id!r} has no evidence_channels: {path}"
+                )
+            channels = []
+        if (
+            not isinstance(channels, list)
+            or (observable and not channels)
+            or not all(
+                isinstance(channel, str) and channel in EVIDENCE_CHANNELS
+                for channel in channels
+            )
+            or len(set(channels)) != len(channels)
+        ):
+            raise ValueError(
+                f"pattern {pattern_id!r} has invalid evidence_channels {channels!r}; "
+                f"allowed values are {sorted(EVIDENCE_CHANNELS)}"
+            )
+        metadata_fields = metadata.get("evidence_metadata_fields", [])
+        if (
+            not isinstance(metadata_fields, list)
+            or not all(
+                isinstance(field, str) and field in TALK_METADATA_FIELDS
+                for field in metadata_fields
+            )
+            or len(set(metadata_fields)) != len(metadata_fields)
+            or ("talk_metadata" in channels and not metadata_fields)
+            or ("talk_metadata" not in channels and metadata_fields)
+        ):
+            raise ValueError(
+                f"pattern {pattern_id!r} has invalid evidence_metadata_fields "
+                f"{metadata_fields!r}; declare a non-empty subset of "
+                f"{sorted(TALK_METADATA_FIELDS)} iff talk_metadata is permitted"
+            )
+        catalog[pattern_id] = {
+            "type": pattern_type,
+            "observable": observable,
+            "evidence_channels": frozenset(channels),
+            "evidence_metadata_fields": frozenset(metadata_fields),
+            "path": str(path),
+        }
+    return catalog
+
+
+def validate_transcript_path(value):
+    """Return a safe vault-relative transcript path or raise ``ValueError``."""
+    if not isinstance(value, str):
+        raise ValueError("transcript_path must be a vault-relative string")
+    relative = Path(value)
+    if (
+        relative.is_absolute()
+        or "\\" in value
+        or ".." in relative.parts
+        or not relative.parts
+        or relative.parts[0] != "transcripts"
+        or relative.suffix.lower() != ".txt"
+    ):
+        raise ValueError(
+            "transcript_path must name a .txt file under the vault's "
+            "transcripts/ directory (for example transcripts/talk-id.txt)"
+        )
+    return relative
+
+
+def resolve_transcript_path(vault_root, talk, ret):
+    """Resolve a transcript path inside the vault, including non-YouTube talks."""
+    vault_root = Path(vault_root)
+    explicit = ret.get("transcript_path")
+    if is_empty(explicit):
+        explicit = talk.get("transcript_path")
+    if not is_empty(explicit):
+        relative = validate_transcript_path(explicit)
+        youtube_id = talk.get("youtube_id")
+        if isinstance(youtube_id, str) and _YOUTUBE_ID.fullmatch(youtube_id):
+            canonical = Path("transcripts") / f"{youtube_id}.txt"
+            if relative != canonical:
+                raise ValueError(
+                    f"transcript_path {explicit!r} does not match this talk's "
+                    f"youtube_id; expected {str(canonical)!r}"
+                )
+        return vault_root / relative, f"resolved explicit transcript_path {explicit}"
+
+    youtube_id = talk.get("youtube_id")
+    if isinstance(youtube_id, str) and youtube_id:
+        if _YOUTUBE_ID.fullmatch(youtube_id) is None:
+            raise ValueError(
+                f"youtube_id {youtube_id!r} is not an 11-character YouTube id; "
+                "set a safe transcript_path explicitly for non-YouTube talks"
+            )
+        path = vault_root / "transcripts" / f"{youtube_id}.txt"
+        return path, f"resolved transcript from youtube_id {youtube_id}"
+
+    filename = talk.get("filename") or ret.get("filename")
+    if isinstance(filename, str) and filename:
+        safe_name = Path(filename.replace("\\", "/")).name
+        candidate = vault_root / "transcripts" / f"{Path(safe_name).stem}.txt"
+        if candidate.exists():
+            return candidate, f"resolved legacy non-YouTube transcript from {filename}"
+    return None, (
+        "talk has neither youtube_id nor transcript_path, and no transcript named "
+        "after its filename was found"
+    )
+
+
+def build_evidence_context(vault_root, talk, ret):
+    """Resolve the local artifacts a deterministic evidence validator may inspect."""
+    transcript_text = None
+    timed_segments = []
+    timing_reason = "timed transcript is unavailable"
+    transcript_path, transcript_reason = resolve_transcript_path(vault_root, talk, ret)
+    if transcript_path is not None:
+        try:
+            transcript_text = transcript_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            transcript_reason = f"transcript file is missing: {transcript_path}"
+        except OSError as exc:
+            transcript_reason = f"cannot read transcript file {transcript_path}: {exc}"
+        else:
+            transcript_reason = f"loaded transcript {transcript_path}"
+            timed_segments, timing_reason = load_verified_segments(
+                transcript_path, transcript_text
+            )
+
+    slide_count = dig(ret, "structured_data.slide_count")
+    if slide_count is None:
+        slide_count = talk.get("slide_count")
+    slide_source = ret.get("slide_source") or talk.get("slide_source")
+    metadata = {
+        field: talk[field]
+        for field in TALK_METADATA_FIELDS
+        if field in talk and not is_empty(talk[field])
+    }
+    if not is_empty(ret.get("transcript_path")):
+        metadata["transcript_path"] = ret["transcript_path"]
+    if not is_empty(ret.get("transcript_source")):
+        metadata["transcript_source"] = ret["transcript_source"]
+    if not is_empty(slide_source):
+        metadata["slide_source"] = slide_source
+    if not is_empty(slide_count):
+        metadata["slide_count"] = slide_count
+    for field, path in PROMOTE:
+        if field not in TALK_METADATA_FIELDS:
+            continue
+        value = dig(ret, path)
+        if not is_empty(value):
+            metadata[field] = value
+    return {
+        "transcript_text": transcript_text,
+        "transcript_reason": transcript_reason,
+        "timed_segments": timed_segments,
+        "timing_reason": timing_reason,
+        "slide_count": slide_count,
+        "slide_source": slide_source,
+        "video_url": talk.get("video_url"),
+        "metadata": metadata,
+    }
+
+
+def _nonnegative_number(value):
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+        and value >= 0
+    )
+
+
+def _validate_transcript_citation(citation, *, timed, context):
+    quote = citation.get("quote")
+    if not isinstance(quote, str) or not quote.strip():
+        raise ValueError("transcript evidence requires a non-empty verbatim `quote`")
+    if len(_WORD.findall(quote)) < MIN_TRANSCRIPT_QUOTE_WORDS:
+        raise ValueError(
+            f"transcript evidence quote {quote!r} has fewer than "
+            f"{MIN_TRANSCRIPT_QUOTE_WORDS} words; use a distinctive, auditable span"
+        )
+    translation = citation.get("translation")
+    if translation is not None and (
+        not isinstance(translation, str) or not translation.strip()
+    ):
+        raise ValueError(
+            "transcript evidence `translation` must be a non-empty string when present"
+        )
+    for model_owned in ("line_start", "line_end", "start_seconds", "end_seconds"):
+        citation.pop(model_owned, None)
+    if context is None:
+        return
+    transcript_text = context.get("transcript_text")
+    if not isinstance(transcript_text, str):
+        raise ValueError(
+            f"transcript evidence cannot be verified: {context.get('transcript_reason')}"
+        )
+    try:
+        resolved = resolve_quote(
+            transcript_text,
+            quote,
+            segments=context.get("timed_segments") or [],
+        )
+    except ValueError as exc:
+        raise ValueError(f"transcript evidence quote {quote!r}: {exc}") from exc
+    citation.update(resolved)
+    if timed and "start_seconds" not in citation:
+        raise ValueError(
+            f"timing-dependent evidence quote {quote!r} has no verified timestamp: "
+            f"{context.get('timing_reason')}"
+        )
+
+
+def _validate_slide_citation(citation, *, sequence, context):
+    slide_numbers = citation.get("slide_numbers")
+    if not isinstance(slide_numbers, list) or not slide_numbers:
+        raise ValueError("slide evidence requires a non-empty `slide_numbers` array")
+    if any(
+        isinstance(number, bool) or not isinstance(number, int) or number < 1
+        for number in slide_numbers
+    ):
+        raise ValueError("slide_numbers must contain positive integer slide numbers")
+    if len(set(slide_numbers)) != len(slide_numbers):
+        raise ValueError("slide_numbers must not contain duplicates")
+    if sequence and (
+        len(slide_numbers) < 2
+        or any(right != left + 1 for left, right in zip(slide_numbers, slide_numbers[1:]))
+    ):
+        raise ValueError(
+            "slide_sequence evidence requires at least two consecutive, ascending slide numbers"
+        )
+    if context is None:
+        return
+    source = context.get("slide_source")
+    count = context.get("slide_count")
+    if (
+        source not in USABLE_SLIDE_SOURCES
+        or isinstance(count, bool)
+        or not isinstance(count, int)
+        or count < 1
+    ):
+        raise ValueError(
+            "slide evidence cannot be verified because this talk has no usable slide source/count"
+        )
+    if any(number > count for number in slide_numbers):
+        raise ValueError(
+            f"slide evidence cites {slide_numbers!r}, but the talk has {count} slides"
+        )
+
+
+def _validate_video_citation(citation, context):
+    start = citation.get("start_seconds")
+    end = citation.get("end_seconds")
+    if not _nonnegative_number(start) or not _nonnegative_number(end) or end <= start:
+        raise ValueError(
+            "video evidence requires numeric start_seconds/end_seconds with end after start"
+        )
+    if context is not None and not context.get("video_url"):
+        raise ValueError("video evidence cannot be verified because the talk has no video_url")
+
+
+def _validate_metadata_citation(citation, context, allowed_fields):
+    field = citation.get("field")
+    if not isinstance(field, str) or not field.strip():
+        raise ValueError("talk_metadata evidence requires a non-empty `field`")
+    if field not in TALK_METADATA_FIELDS:
+        raise ValueError(
+            f"talk_metadata evidence field {field!r} is not source metadata; "
+            f"expected one of {sorted(TALK_METADATA_FIELDS)}"
+        )
+    if field not in allowed_fields:
+        raise ValueError(
+            f"talk_metadata field {field!r} is not permitted for this pattern; "
+            f"expected one of {sorted(allowed_fields)}"
+        )
+    citation.pop("value", None)
+    if context is None:
+        return
+    metadata = context.get("metadata") or {}
+    if field not in metadata or is_empty(metadata[field]):
+        raise ValueError(
+            f"talk_metadata evidence cites absent/empty field {field!r}"
+        )
+    citation["value"] = metadata[field]
+
+
+def validate_detection(detection, *, field, catalog=None, evidence_context=None):
+    """Validate one new detection and stamp deterministic citation locations."""
+    pattern_id = detection.get("pattern_id")
+    if not isinstance(pattern_id, str) or not pattern_id:
+        raise ValueError(f"pattern_observations.{field} entry has no string `pattern_id`")
+    policy = catalog.get(pattern_id) if catalog is not None else None
+    if catalog is not None and policy is None:
+        raise ValueError(f"pattern_observations.{field} references unknown id {pattern_id!r}")
+    expected_type = {
+        "patterns_detected": "pattern",
+        "antipatterns_detected": "antipattern",
+    }.get(field)
+    if policy is not None and expected_type is not None and policy["type"] != expected_type:
+        raise ValueError(
+            f"pattern {pattern_id!r} is cataloged as {policy['type']!r}, so it cannot "
+            f"appear in pattern_observations.{field}"
+        )
+    if policy is not None and not policy["observable"]:
+        raise ValueError(
+            f"pattern {pattern_id!r} is observable:false and cannot be auto-scored; "
+            "surface it as a preparation/clarification item instead"
+        )
+    confidence = detection.get("confidence")
+    if confidence not in CONFIDENCE_VALUES:
+        raise ValueError(
+            f"pattern {pattern_id!r} has confidence {confidence!r}; "
+            f"expected one of {sorted(CONFIDENCE_VALUES)}"
+        )
+    evidence = detection.get("evidence")
+    if not isinstance(evidence, str) or not evidence.strip():
+        raise ValueError(f"pattern {pattern_id!r} requires a non-empty evidence summary")
+    citations = detection.get("evidence_citations")
+    if not isinstance(citations, list) or not citations:
+        raise ValueError(
+            f"pattern {pattern_id!r} requires a non-empty evidence_citations array"
+        )
+    allowed_channels = policy["evidence_channels"] if policy is not None else EVIDENCE_CHANNELS
+    validated = []
+    for raw_citation in citations:
+        if not isinstance(raw_citation, dict):
+            raise ValueError(
+                f"pattern {pattern_id!r} evidence_citations entries must be objects"
+            )
+        citation = dict(raw_citation)
+        channel = citation.get("channel")
+        if channel not in EVIDENCE_CHANNELS:
+            raise ValueError(
+                f"pattern {pattern_id!r} has unsupported evidence channel {channel!r}; "
+                f"expected one of {sorted(EVIDENCE_CHANNELS)}"
+            )
+        unknown_fields = sorted(set(citation) - EVIDENCE_CITATION_FIELDS[channel])
+        if unknown_fields:
+            raise ValueError(
+                f"pattern {pattern_id!r} {channel!r} citation has unknown fields "
+                f"{unknown_fields!r}; expected only "
+                f"{sorted(EVIDENCE_CITATION_FIELDS[channel])}"
+            )
+        if channel not in allowed_channels:
+            raise ValueError(
+                f"pattern {pattern_id!r} cannot be proved through {channel!r}; "
+                f"its catalog permits {sorted(allowed_channels)}"
+            )
+        if channel in {"transcript", "timed_transcript"}:
+            _validate_transcript_citation(
+                citation,
+                timed=channel == "timed_transcript",
+                context=evidence_context,
+            )
+        elif channel in {"slides", "slide_sequence"}:
+            _validate_slide_citation(
+                citation,
+                sequence=channel == "slide_sequence",
+                context=evidence_context,
+            )
+        elif channel == "video":
+            _validate_video_citation(citation, evidence_context)
+        else:
+            metadata_fields = (
+                policy["evidence_metadata_fields"]
+                if policy is not None
+                else TALK_METADATA_FIELDS
+            )
+            _validate_metadata_citation(
+                citation,
+                evidence_context,
+                metadata_fields,
+            )
+        validated.append(citation)
+    detection["evidence_citations"] = validated
+    return detection
+
+
+def require_detections(
+    observations,
+    field,
+    *,
+    catalog=None,
+    evidence_context=None,
+):
     """Return a detection array as a list of dicts, or None when absent.
 
     Both consumers assume list-of-dicts: one calls `len()` on it to recompute the
@@ -213,7 +705,29 @@ def require_detections(observations, field):
             f"pattern_observations.{field} contains {bad!r} "
             f"({type(bad).__name__}); every element must be an object carrying a "
             "`pattern_id`.")
-    return value
+    copied = deepcopy(value)
+    validated = [
+        validate_detection(
+            detection,
+            field=field,
+            catalog=catalog,
+            evidence_context=evidence_context,
+        )
+        for detection in copied
+    ]
+    seen = set()
+    duplicates = set()
+    for detection in validated:
+        pattern_id = detection["pattern_id"]
+        if pattern_id in seen:
+            duplicates.add(pattern_id)
+        seen.add(pattern_id)
+    if duplicates:
+        raise ValueError(
+            f"pattern_observations.{field} contains duplicate pattern IDs "
+            f"{sorted(duplicates)!r}"
+        )
+    return validated
 
 
 def resolve_pattern_score(observations, patterns, antipatterns):
@@ -284,6 +798,7 @@ def normalize_pattern_observations(existing, patterns, antipatterns, score):
     cannot drift from the validator the way its predecessor did.
     """
     obs = dict(existing) if isinstance(existing, dict) else {}
+    obs["evidence_schema_version"] = PATTERN_EVIDENCE_SCHEMA_VERSION
     if patterns is not None:
         obs["patterns_detected"] = patterns
         obs["pattern_ids"] = [p.get("pattern_id") for p in patterns if p.get("pattern_id")]
@@ -295,7 +810,14 @@ def normalize_pattern_observations(existing, patterns, antipatterns, score):
     return obs
 
 
-def merge_talk(talk, ret, run_date=None):
+def merge_talk(
+    talk,
+    ret,
+    run_date=None,
+    *,
+    catalog=None,
+    evidence_context=None,
+):
     """Merge one return into its talk. Returns (promoted, stamped, coerced_score).
 
     Every block is validated BEFORE anything is written, so a malformed return
@@ -306,8 +828,20 @@ def merge_talk(talk, ret, run_date=None):
     structured = require_mapping(ret, "structured_data")
     verbatim = require_mapping(ret, "verbatim_examples")
     observations = require_mapping(ret, "pattern_observations") or {}
-    patterns = require_detections(observations, "patterns_detected")
-    antipatterns = require_detections(observations, "antipatterns_detected")
+    if not is_empty(ret.get("transcript_path")):
+        validate_transcript_path(ret["transcript_path"])
+    patterns = require_detections(
+        observations,
+        "patterns_detected",
+        catalog=catalog,
+        evidence_context=evidence_context,
+    )
+    antipatterns = require_detections(
+        observations,
+        "antipatterns_detected",
+        catalog=catalog,
+        evidence_context=evidence_context,
+    )
     score, coerced_score = resolve_pattern_score(observations, patterns, antipatterns)
 
     talk["schema_version"] = TALK_SCHEMA_VERSION
@@ -354,15 +888,53 @@ def migrate_records(db):
     tell an unversioned record from one this writer had never seen, which is the
     ambiguity the version exists to remove.
 
-    The migration is a stamp, not a transform: v1 to v2 removes a documented
-    guarantee about `transcript_source` rather than changing any stored value,
-    so no record needs rewriting to satisfy v2.
+    v1 to v2 was a stamp-only migration. v3 adds a citation array, so older
+    detections receive the additive empty default. Empty is deliberate: legacy
+    prose was never source-located and must not be relabeled as verified.
     """
+    if not isinstance(db, dict) or not isinstance(db.get("talks"), list):
+        raise ValueError("tracking database must be an object with a `talks` array")
+    talks = db["talks"]
+
+    # Validate every version before mutating the first record. A future-version
+    # entry late in the file must not leave an in-memory caller half-migrated.
+    for talk in talks:
+        if not isinstance(talk, dict):
+            raise ValueError("tracking database `talks` entries must be objects")
+        version = talk.get("schema_version")
+        if version == TALK_SCHEMA_VERSION:
+            continue
+        if isinstance(version, bool) or (
+            version is not None and not isinstance(version, int)
+        ):
+            raise ValueError(
+                f"talk {talk.get('filename')!r} has invalid schema_version {version!r}"
+            )
+        if isinstance(version, int) and version > TALK_SCHEMA_VERSION:
+            raise ValueError(
+                f"talk {talk.get('filename')!r} has future schema_version {version}; "
+                f"this writer supports at most {TALK_SCHEMA_VERSION} and will not downgrade it"
+            )
+        if isinstance(version, int) and version < 0:
+            raise ValueError(
+                f"talk {talk.get('filename')!r} has invalid schema_version {version}"
+            )
+
     migrated = 0
-    for talk in db.get("talks", []):
-        if talk.get("schema_version") != TALK_SCHEMA_VERSION:
-            talk["schema_version"] = TALK_SCHEMA_VERSION
-            migrated += 1
+    for talk in talks:
+        if talk.get("schema_version") == TALK_SCHEMA_VERSION:
+            continue
+        observations = talk.get("pattern_observations")
+        if isinstance(observations, dict):
+            observations["evidence_schema_version"] = PATTERN_EVIDENCE_SCHEMA_VERSION
+            for field in ("patterns_detected", "antipatterns_detected"):
+                detections = observations.get(field)
+                if isinstance(detections, list):
+                    for detection in detections:
+                        if isinstance(detection, dict):
+                            detection.setdefault("evidence_citations", [])
+        talk["schema_version"] = TALK_SCHEMA_VERSION
+        migrated += 1
     return migrated
 
 
@@ -438,12 +1010,28 @@ def main():
               f"got {type(returns).__name__}", file=sys.stderr)
         sys.exit(1)
 
+    try:
+        catalog = load_pattern_catalog()
+    except (OSError, ValueError) as exc:
+        print(f"ERROR: cannot load the pattern catalog: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     # Migrate the whole artifact, not just the talks this batch touches.
-    migrated = migrate_records(db)
+    try:
+        migrated = migrate_records(db)
+    except ValueError as exc:
+        print(f"ERROR: cannot migrate tracking database: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     by_name = {t.get("filename"): t for t in db.get("talks", [])}
     summary = []
     for ret in returns:
+        if not isinstance(ret, dict):
+            print(
+                f"ERROR: batch return entry is a {type(ret).__name__}, not an object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         name = ret.get("filename")
         talk = by_name.get(name)
         if talk is None:
@@ -452,7 +1040,14 @@ def main():
             print(f"ERROR: no talk in DB matches return filename: {name!r}", file=sys.stderr)
             sys.exit(1)
         try:
-            promoted, stamped, coerced = merge_talk(talk, ret, run_date)
+            evidence_context = build_evidence_context(Path(db_path).parent, talk, ret)
+            promoted, stamped, coerced = merge_talk(
+                talk,
+                ret,
+                run_date,
+                catalog=catalog,
+                evidence_context=evidence_context,
+            )
         except ValueError as exc:
             print(f"ERROR: {name}: {exc}", file=sys.stderr)
             sys.exit(1)

--- a/skills/vault-ingress/scripts/transcript_timing.py
+++ b/skills/vault-ingress/scripts/transcript_timing.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Own the timed-transcript sidecar used by vault-ingress.
+
+Plain ``transcripts/<id>.txt`` remains the human- and model-readable transcript.
+When caption or Whisper segment timing is available, the writer also creates
+``transcripts/<id>.segments.json`` with this shape::
+
+    {
+      "schema_version": 1,
+      "transcript_sha256": "...",
+      "source": "captions|whisper|vtt",
+      "segments": [
+        {"text": "...", "start_seconds": 1.2, "end_seconds": 3.4}
+      ]
+    }
+
+The hash binds the sidecar to the exact text file. Readers reject a stale or
+partially-written pair rather than applying old timestamps to new words. The
+sidecar is written before the transcript: if the second atomic replace fails,
+the new hash cannot match the old transcript and the sidecar safely reads as
+unusable.
+
+This module is deterministic and intentionally contains no network or model
+logic. Fetchers supply source segments; persistence uses :func:`resolve_quote`
+to verify model-supplied quotes and stamp engine-owned line/time locations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import tempfile
+import unicodedata
+from pathlib import Path
+from typing import Any, Iterable
+
+SIDECAR_SCHEMA_VERSION = 1
+SIDECAR_SOURCES = frozenset({"captions", "whisper", "vtt"})
+_SPACE = re.compile(r"\s+")
+_SMART_PUNCTUATION = str.maketrans(
+    {
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u00a0": " ",
+    }
+)
+
+
+def normalize_for_match(text: str) -> str:
+    """Normalize harmless transcript/quote typography without paraphrasing."""
+    normalized = unicodedata.normalize("NFKC", text).translate(_SMART_PUNCTUATION)
+    return _SPACE.sub(" ", normalized).strip().casefold()
+
+
+def transcript_sha256(text: str) -> str:
+    """Hash the exact UTF-8 transcript bytes represented by ``text``."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sidecar_path(transcript_path: str | os.PathLike[str]) -> Path:
+    """Return ``<stem>.segments.json`` beside a transcript path."""
+    return Path(transcript_path).with_suffix(".segments.json")
+
+
+def _field(segment: object, name: str) -> Any:
+    if isinstance(segment, dict):
+        return segment.get(name)
+    return getattr(segment, name, None)
+
+
+def normalize_segments(segments: Iterable[object] | None) -> list[dict[str, object]]:
+    """Convert caption-library and Whisper segment shapes to the sidecar shape.
+
+    A segment without text or a finite non-negative start/end pair cannot locate
+    evidence and is omitted. Output is ordered by time so quote resolution is
+    deterministic even if an upstream library returns an unusual collection.
+    """
+    normalized: list[dict[str, object]] = []
+    for segment in segments or []:
+        text = _field(segment, "text")
+        start = _field(segment, "start_seconds")
+        if start is None:
+            start = _field(segment, "start")
+        end = _field(segment, "end_seconds")
+        if end is None:
+            end = _field(segment, "end")
+        if end is None:
+            duration = _field(segment, "duration")
+            if isinstance(start, (int, float)) and isinstance(duration, (int, float)):
+                end = float(start) + float(duration)
+        if (
+            not isinstance(text, str)
+            or not text.strip()
+            or isinstance(start, bool)
+            or not isinstance(start, (int, float))
+            or isinstance(end, bool)
+            or not isinstance(end, (int, float))
+            or not math.isfinite(float(start))
+            or not math.isfinite(float(end))
+            or float(start) < 0
+            or float(end) <= float(start)
+        ):
+            continue
+        rounded_start = round(float(start), 3)
+        rounded_end = round(float(end), 3)
+        if rounded_end <= rounded_start:
+            continue
+        normalized.append(
+            {
+                "text": text.strip(),
+                "start_seconds": rounded_start,
+                "end_seconds": rounded_end,
+            }
+        )
+    normalized.sort(key=lambda item: (item["start_seconds"], item["end_seconds"]))
+    return normalized
+
+
+def write_atomically(path: str | os.PathLike[str], text: str) -> None:
+    """Write text through a same-directory temporary file, then replace."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    handle, temporary = tempfile.mkstemp(dir=str(destination.parent), suffix=".partial")
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            stream.write(text)
+        os.replace(temporary, destination)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def write_transcript_bundle(
+    transcript_path: str | os.PathLike[str],
+    text: str,
+    segments: Iterable[object] | None,
+    *,
+    source: str,
+) -> Path | None:
+    """Atomically write transcript text plus its hash-bound timing sidecar.
+
+    An empty ``segments`` collection still writes a valid empty sidecar. That
+    invalidates any older timing file whose text no longer matches while making
+    the absence of timing explicit. The return is the sidecar path only when it
+    contains usable timed segments.
+    """
+    if source not in SIDECAR_SOURCES:
+        raise ValueError(
+            f"unsupported transcript timing source {source!r}; "
+            f"expected one of {sorted(SIDECAR_SOURCES)}"
+        )
+    normalized = normalize_segments(segments)
+    timing_path = sidecar_path(transcript_path)
+    payload = {
+        "schema_version": SIDECAR_SCHEMA_VERSION,
+        "transcript_sha256": transcript_sha256(text),
+        "source": source,
+        "segments": normalized,
+    }
+    write_atomically(
+        timing_path,
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+    )
+    write_atomically(transcript_path, text)
+    return timing_path if normalized else None
+
+
+def load_verified_segments(
+    transcript_path: str | os.PathLike[str], text: str
+) -> tuple[list[dict[str, object]], str]:
+    """Load a sidecar iff its schema and transcript hash are current.
+
+    Returns ``(segments, reason)``. An empty list is never silently ambiguous:
+    ``reason`` states whether timing is absent, stale, malformed, or simply
+    unavailable from the source.
+    """
+    timing_path = sidecar_path(transcript_path)
+    try:
+        payload = json.loads(timing_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return [], f"timed transcript sidecar is missing: {timing_path}"
+    except OSError as exc:
+        return [], f"cannot read timed transcript sidecar {timing_path}: {exc}"
+    except json.JSONDecodeError as exc:
+        return [], f"timed transcript sidecar {timing_path} is invalid JSON: {exc}"
+    if not isinstance(payload, dict):
+        return [], f"timed transcript sidecar {timing_path} is not a JSON object"
+    if payload.get("schema_version") != SIDECAR_SCHEMA_VERSION:
+        return [], (
+            f"timed transcript sidecar {timing_path} has unsupported schema_version "
+            f"{payload.get('schema_version')!r}; regenerate it"
+        )
+    if payload.get("source") not in SIDECAR_SOURCES:
+        return [], (
+            f"timed transcript sidecar {timing_path} has unsupported source "
+            f"{payload.get('source')!r}; regenerate it"
+        )
+    if payload.get("transcript_sha256") != transcript_sha256(text):
+        return [], (
+            f"timed transcript sidecar {timing_path} does not match the transcript; "
+            "regenerate both files together"
+        )
+    raw_segments = payload.get("segments")
+    if not isinstance(raw_segments, list):
+        return [], f"timed transcript sidecar {timing_path} has no segments array"
+    segments = normalize_segments(raw_segments)
+    if len(segments) != len(raw_segments):
+        return [], (
+            f"timed transcript sidecar {timing_path} contains malformed or "
+            "zero-duration segments; regenerate it"
+        )
+    if not segments:
+        return [], f"transcript source recorded no timed segments in {timing_path}"
+    return segments, f"{len(segments)} verified timed segments"
+
+
+def _joined_offsets(parts: Iterable[tuple[int, str]]) -> tuple[str, list[tuple[int, int, int]]]:
+    joined: list[str] = []
+    offsets: list[tuple[int, int, int]] = []
+    cursor = 0
+    for identity, raw_text in parts:
+        text = normalize_for_match(raw_text)
+        if not text:
+            continue
+        if joined:
+            joined.append(" ")
+            cursor += 1
+        start = cursor
+        joined.append(text)
+        cursor += len(text)
+        offsets.append((identity, start, cursor))
+    return "".join(joined), offsets
+
+
+def _unique_span(haystack: str, needle: str) -> tuple[int, int] | None:
+    first = haystack.find(needle)
+    if first < 0:
+        return None
+    if haystack.find(needle, first + 1) >= 0:
+        raise ValueError(
+            "quote appears more than once in the transcript; provide a longer unique quote"
+        )
+    return first, first + len(needle)
+
+
+def _identities_for_span(
+    offsets: list[tuple[int, int, int]], start: int, end: int
+) -> list[int]:
+    return [identity for identity, item_start, item_end in offsets if item_end > start and item_start < end]
+
+
+def resolve_quote(
+    transcript_text: str,
+    quote: str,
+    *,
+    segments: Iterable[object] | None = None,
+) -> dict[str, object]:
+    """Verify one unique quote and return engine-owned line/time locations.
+
+    Raises ``ValueError`` for missing or ambiguous quotes. A caller may supply a
+    verified sidecar's segments; when their text cannot resolve the same quote,
+    line locations still succeed but no timestamps are invented.
+    """
+    normalized_quote = normalize_for_match(quote)
+    if not normalized_quote:
+        raise ValueError("quote is empty after normalization")
+
+    line_haystack, line_offsets = _joined_offsets(
+        (line_number, line) for line_number, line in enumerate(transcript_text.splitlines(), 1)
+    )
+    span = _unique_span(line_haystack, normalized_quote)
+    if span is None:
+        raise ValueError("quote does not appear verbatim in the transcript")
+    line_numbers = _identities_for_span(line_offsets, *span)
+    if not line_numbers:
+        raise ValueError("quote matched transcript text but could not be assigned to a line")
+    resolved: dict[str, object] = {
+        "line_start": line_numbers[0],
+        "line_end": line_numbers[-1],
+    }
+
+    normalized_segments = normalize_segments(segments)
+    if normalized_segments:
+        segment_haystack, segment_offsets = _joined_offsets(
+            (index, str(segment["text"]))
+            for index, segment in enumerate(normalized_segments)
+        )
+        segment_span = _unique_span(segment_haystack, normalized_quote)
+        if segment_span is not None:
+            segment_indexes = _identities_for_span(segment_offsets, *segment_span)
+            if segment_indexes:
+                first = normalized_segments[segment_indexes[0]]
+                last = normalized_segments[segment_indexes[-1]]
+                resolved["start_seconds"] = first["start_seconds"]
+                resolved["end_seconds"] = last["end_seconds"]
+    return resolved

--- a/skills/vault-ingress/scripts/vtt-cleanup.py
+++ b/skills/vault-ingress/scripts/vtt-cleanup.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Clean a WebVTT subtitle file into plain transcript text.
+"""Clean WebVTT into plain text plus a hash-bound timed-segment sidecar.
 
-Strips timestamps, cue position markers, blank lines, and deduplicates
-consecutive identical lines. VTT is a rigid format — this handles it reliably.
+The ``.txt`` output stays timestamp-free for readers and models. Cue timings are
+preserved beside it as ``.segments.json`` via :mod:`transcript_timing`, so a
+later pattern observation can cite the opening (or any other timed position)
+without trusting a model-supplied timestamp.
 
 Usage:
     vtt-cleanup.py <input.vtt> [<output.txt>]
@@ -14,48 +16,117 @@ Examples:
     vtt-cleanup.py transcripts/aBcDeFg.ru.vtt transcripts/aBcDeFg.txt
 """
 
+import json
 import re
 import sys
+from pathlib import Path
+
+from transcript_timing import write_transcript_bundle
+
+_TIMING_LINE = re.compile(
+    r"(?P<start>\d{2}:\d{2}:\d{2}\.\d{3})\s+-->\s+"
+    r"(?P<end>\d{2}:\d{2}:\d{2}\.\d{3})"
+)
+
+
+def _seconds(timestamp):
+    hours, minutes, remainder = timestamp.split(":")
+    seconds, milliseconds = remainder.split(".")
+    return (
+        int(hours) * 3600
+        + int(minutes) * 60
+        + int(seconds)
+        + int(milliseconds) / 1000
+    )
+
+
+def parse_vtt(vtt_text):
+    """Return ``(plain text, timed segments)`` from a WebVTT payload."""
+    cleaned = []
+    segments = []
+    previous_line = None
+    cue_start = cue_end = None
+    cue_lines = []
+    skip_block = False
+
+    def flush_cue():
+        nonlocal previous_line, cue_start, cue_end, cue_lines
+        new_lines = []
+        for line in cue_lines:
+            if line != previous_line:
+                cleaned.append(line)
+                new_lines.append(line)
+                previous_line = line
+        text = " ".join(new_lines).strip()
+        if text and cue_start is not None and cue_end is not None:
+            segments.append(
+                {"text": text, "start_seconds": cue_start, "end_seconds": cue_end}
+            )
+        cue_start = cue_end = None
+        cue_lines = []
+
+    lines = vtt_text.splitlines()
+    next_nonblank_lines = [""] * len(lines)
+    next_nonblank = ""
+    for index in range(len(lines) - 1, -1, -1):
+        next_nonblank_lines[index] = next_nonblank
+        if lines[index].strip():
+            next_nonblank = lines[index].strip()
+    for index, raw_line in enumerate(lines):
+        line = raw_line.strip()
+
+        if not line:
+            flush_cue()
+            skip_block = False
+            continue
+
+        if skip_block:
+            continue
+        if cue_start is None and line.startswith(("NOTE", "STYLE", "REGION")):
+            flush_cue()
+            skip_block = True
+            continue
+
+        if cue_start is None and line.startswith(("WEBVTT", "Kind:", "Language:")):
+            continue
+
+        timing = _TIMING_LINE.match(line)
+        if timing:
+            flush_cue()
+            cue_start = _seconds(timing.group("start"))
+            cue_end = _seconds(timing.group("end"))
+            continue
+
+        if re.fullmatch(r"\d+", line):
+            # Numeric cue identifiers are unambiguous even in lax VTT files that
+            # omit the blank line between cues.
+            if cue_start is not None and _TIMING_LINE.match(next_nonblank_lines[index]):
+                flush_cue()
+            continue
+        if cue_start is None and _TIMING_LINE.match(next_nonblank_lines[index]):
+            # Named cue identifiers sit immediately before timing in a fresh cue.
+            continue
+        if re.match(r"(?:align|position|size|line|vertical):", line):
+            continue
+
+        line = re.sub(r"<[^>]+>", "", line).strip()
+        if not line:
+            continue
+        if cue_start is not None:
+            cue_lines.append(line)
+        elif line != previous_line:
+            # Preserve the cleaner's historical behavior for subtitle-like text
+            # without cue timing, but naturally omit it from the timed sidecar.
+            cleaned.append(line)
+            previous_line = line
+
+    flush_cue()
+    return "\n".join(cleaned), segments
 
 
 def clean_vtt(vtt_text):
     """Clean VTT content into plain text."""
-    lines = vtt_text.split('\n')
-    cleaned = []
-    prev_line = None
-
-    for line in lines:
-        line = line.strip()
-
-        # Skip WebVTT header
-        if line.startswith('WEBVTT') or line.startswith('Kind:') or line.startswith('Language:'):
-            continue
-
-        # Skip timestamp lines: 00:00:01.234 --> 00:00:04.567
-        if re.match(r'\d{2}:\d{2}.*-->', line):
-            continue
-
-        # Skip cue position markers: align:start position:0%
-        if re.match(r'(align|position|size|line|vertical):', line):
-            continue
-
-        # Skip numeric cue identifiers (standalone numbers)
-        if re.match(r'^\d+$', line):
-            continue
-
-        # Skip blank lines
-        if not line:
-            continue
-
-        # Strip HTML tags (<c>, </c>, <b>, etc.) that appear in some VTTs
-        line = re.sub(r'<[^>]+>', '', line)
-
-        # Deduplicate consecutive identical lines
-        if line != prev_line:
-            cleaned.append(line)
-            prev_line = line
-
-    return '\n'.join(cleaned)
+    return parse_vtt(vtt_text)[0]
 
 
 def main():
@@ -63,25 +134,43 @@ def main():
         print(f"Usage: {sys.argv[0]} <input.vtt> [<output.txt>]", file=sys.stderr)
         sys.exit(1)
 
-    input_path = sys.argv[1]
+    input_path = Path(sys.argv[1])
     if len(sys.argv) >= 3:
-        output_path = sys.argv[2]
+        output_path = Path(sys.argv[2])
     else:
-        output_path = re.sub(r'\.[^.]+\.vtt$', '.txt', input_path)
+        derived = re.sub(r"\.[^.]+\.vtt$", ".txt", str(input_path))
+        output_path = Path(derived)
         if output_path == input_path:
-            output_path = input_path.rsplit('.', 1)[0] + '.txt'
+            output_path = input_path.with_suffix(".txt")
 
-    with open(input_path, encoding='utf-8') as f:
-        vtt_text = f.read()
+    try:
+        vtt_text = input_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"ERROR: cannot read WebVTT input {input_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    cleaned = clean_vtt(vtt_text)
+    cleaned, segments = parse_vtt(vtt_text)
 
-    with open(output_path, 'w', encoding='utf-8') as f:
-        f.write(cleaned)
+    try:
+        timed_path = write_transcript_bundle(
+            output_path, cleaned, segments, source="vtt")
+    except OSError as exc:
+        print(f"ERROR: cannot write transcript bundle at {output_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    input_lines = len(vtt_text.split('\n'))
-    output_lines = len(cleaned.split('\n'))
-    print(f"Cleaned {input_path}: {input_lines} lines → {output_lines} lines → {output_path}")
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "input_path": str(input_path),
+                "path": str(output_path),
+                "timed_path": str(timed_path) if timed_path else None,
+                "input_lines": len(vtt_text.splitlines()),
+                "output_lines": len(cleaned.splitlines()),
+                "segments": len(segments),
+            }
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/skills/vault-ingress/scripts/vtt-cleanup.py
+++ b/skills/vault-ingress/scripts/vtt-cleanup.py
@@ -24,16 +24,22 @@ from pathlib import Path
 from transcript_timing import write_transcript_bundle
 
 _TIMING_LINE = re.compile(
-    r"(?P<start>\d{2}:\d{2}:\d{2}\.\d{3})\s+-->\s+"
-    r"(?P<end>\d{2}:\d{2}:\d{2}\.\d{3})"
+    r"(?P<start>(?:\d{2,}:)?\d{2}:\d{2}\.\d{3})\s+-->\s+"
+    r"(?P<end>(?:\d{2,}:)?\d{2}:\d{2}\.\d{3})"
 )
 
 
 def _seconds(timestamp):
-    hours, minutes, remainder = timestamp.split(":")
+    parts = timestamp.split(":")
+    if len(parts) == 2:
+        hours = 0
+        minutes, remainder = parts
+    else:
+        hours_text, minutes, remainder = parts
+        hours = int(hours_text)
     seconds, milliseconds = remainder.split(".")
     return (
-        int(hours) * 3600
+        hours * 3600
         + int(minutes) * 60
         + int(seconds)
         + int(milliseconds) / 1000

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -33,8 +33,10 @@ Usage:
     write-analysis.py <batch-returns.json> <analyses-dir> [--run-date YYYY-MM-DD]
                       [--talks <tracking-database.json>]
 
-    --talks supplies talk titles for the H1; without it the H1 falls back to the
-    return's own `title`, then to the filename stem.
+    --talks supplies talk titles for the H1 and the source-validated pattern
+    citations written by persist-results.py. Without it the H1 falls back to the
+    return's own `title`, then to the filename stem, and citation locations are
+    rendered explicitly as unverified.
     --run-date sets the "Processed" line when a return omits `processed_date`,
     matching persist-results.py's stamping so the DB and the file agree.
 
@@ -135,22 +137,76 @@ def render_table(rows):
     return out
 
 
-def render_pattern_table(entries):
+def render_pattern_table(entries, *, evidence_verified=False):
     """Render patterns_detected / antipatterns_detected as an evidence table."""
     if not entries:
         return ["_None recorded._"]
-    out = ["| Pattern ID | Confidence | Evidence |", "|---|---|---|"]
+    out = [
+        "| Pattern ID | Confidence | Evidence | Source citations |",
+        "|---|---|---|---|",
+    ]
     for e in entries:
         if not isinstance(e, dict):
-            out.append(f"| {md_escape_cell(e)} | | |")
+            out.append(f"| {md_escape_cell(e)} | | | |")
             continue
         pid = e.get("pattern_id", "")
-        out.append("| `{}` | {} | {} |".format(
-            md_escape_cell(pid),
-            md_escape_cell(e.get("confidence", "")),
-            md_escape_cell(e.get("evidence", "")),
-        ))
+        citations = e.get("evidence_citations")
+        if not isinstance(citations, list) or not citations:
+            rendered_citations = "legacy/unverified"
+        else:
+            rendered_citations = "; ".join(
+                render_evidence_citation(
+                    citation,
+                    evidence_verified=evidence_verified,
+                )
+                for citation in citations
+            )
+        out.append(
+            "| `{}` | {} | {} | {} |".format(
+                md_escape_cell(pid),
+                md_escape_cell(e.get("confidence", "")),
+                md_escape_cell(e.get("evidence", "")),
+                md_escape_cell(rendered_citations),
+            )
+        )
     return out
+
+
+def render_evidence_citation(citation, *, evidence_verified=False):
+    """Render one citation compactly; label locations not sourced from the DB."""
+    if not isinstance(citation, dict):
+        rendered = str(citation)
+        return rendered if evidence_verified else f"unverified: {rendered}"
+    channel = citation.get("channel")
+    if channel in {"transcript", "timed_transcript"}:
+        line_start = citation.get("line_start")
+        line_end = citation.get("line_end")
+        location = "transcript"
+        if line_start is not None:
+            location += f" lines {line_start}–{line_end or line_start}"
+        if citation.get("start_seconds") is not None:
+            location += (
+                f" ({citation['start_seconds']}s–{citation.get('end_seconds')}s)"
+            )
+        quote = citation.get("quote")
+        translation = citation.get("translation")
+        if quote and translation:
+            rendered = f'{location}: “{translation}” (original: “{quote}”)'
+        else:
+            rendered = f'{location}: “{quote}”' if quote else location
+    elif channel in {"slides", "slide_sequence"}:
+        label = "slide sequence" if channel == "slide_sequence" else "slides"
+        numbers = citation.get("slide_numbers") or []
+        rendered = f"{label} {', '.join(str(number) for number in numbers)}"
+    elif channel == "video":
+        rendered = (
+            f"video {citation.get('start_seconds')}s–{citation.get('end_seconds')}s"
+        )
+    elif channel == "talk_metadata":
+        rendered = f"metadata {citation.get('field')}={citation.get('value')!r}"
+    else:
+        rendered = json.dumps(citation, ensure_ascii=False)
+    return rendered if evidence_verified else f"unverified: {rendered}"
 
 
 def render_structured_data(sd):
@@ -211,7 +267,7 @@ def render_catalog_feedback(feedback):
     return out
 
 
-def render_analysis(ret, title=None, run_date=None):
+def render_analysis(ret, title=None, run_date=None, *, evidence_verified=False):
     """Build the full markdown document for one subagent return."""
     filename = ret.get("filename", "")
     heading = title or ret.get("title") or filename.removesuffix(".md")
@@ -256,9 +312,15 @@ def render_analysis(ret, title=None, run_date=None):
         elif score is not None:
             out.append(f"**Pattern score:** {score}")
         out += ["", "### Patterns Detected", "",
-                *render_pattern_table(obs.get("patterns_detected")), "",
+                *render_pattern_table(
+                    obs.get("patterns_detected"),
+                    evidence_verified=evidence_verified,
+                ), "",
                 "### Antipatterns Detected", "",
-                *render_pattern_table(obs.get("antipatterns_detected")), ""]
+                *render_pattern_table(
+                    obs.get("antipatterns_detected"),
+                    evidence_verified=evidence_verified,
+                ), ""]
         unevaluable = obs.get("unevaluable_from_pdf")
         if unevaluable:
             out += ["### Unevaluable From Available Artifacts", "", "```json",
@@ -288,6 +350,80 @@ def safe_output_name(filename):
     # Match the extension case-insensitively so `TALK.MD` does not become
     # `TALK.MD.md`.
     return base if base.lower().endswith(".md") else base + ".md"
+
+
+def citation_claim(citation):
+    """Return the model-owned portion used to bind raw and persisted evidence."""
+    if not isinstance(citation, dict):
+        return citation
+    channel = citation.get("channel")
+    engine_owned = {
+        "transcript": {"line_start", "line_end", "start_seconds", "end_seconds"},
+        "timed_transcript": {"line_start", "line_end", "start_seconds", "end_seconds"},
+        "talk_metadata": {"value"},
+    }.get(channel, set())
+    return {key: value for key, value in citation.items() if key not in engine_owned}
+
+
+def detection_claim(detection):
+    """Return a detection without persistence-owned citation locations."""
+    if not isinstance(detection, dict):
+        return detection
+    claim = {
+        key: value
+        for key, value in detection.items()
+        if key != "evidence_citations"
+    }
+    citations = detection.get("evidence_citations")
+    claim["evidence_citations"] = (
+        [citation_claim(citation) for citation in citations]
+        if isinstance(citations, list)
+        else citations
+    )
+    return claim
+
+
+def detection_arrays_match(raw, persisted):
+    """True when persisted detections validate this batch, not an older one."""
+    return (
+        isinstance(raw, list)
+        and isinstance(persisted, list)
+        and [detection_claim(item) for item in raw]
+        == [detection_claim(item) for item in persisted]
+    )
+
+
+def overlay_persisted_evidence(ret, talk):
+    """Overlay source-validated detections from the just-persisted talk record.
+
+    The batch file intentionally remains the immutable handoff between scripts,
+    so deterministic line/time/value stamps exist only in the tracking DB. Keep
+    the return's rich score object, but source both detailed detection arrays from
+    the DB before rendering. Returns ``(effective_return, evidence_verified)``.
+    """
+    raw = ret.get("pattern_observations")
+    persisted = talk.get("pattern_observations") if isinstance(talk, dict) else None
+    if not isinstance(raw, dict) or not isinstance(persisted, dict):
+        return ret, False
+    fields = [
+        field
+        for field in ("patterns_detected", "antipatterns_detected")
+        if field in raw
+    ]
+    if not fields or any(
+        field not in persisted
+        or not detection_arrays_match(raw[field], persisted[field])
+        for field in fields
+    ):
+        return ret, False
+    observations = dict(raw)
+    for field in fields:
+        observations[field] = persisted[field]
+    if "evidence_schema_version" in persisted:
+        observations["evidence_schema_version"] = persisted["evidence_schema_version"]
+    effective = dict(ret)
+    effective["pattern_observations"] = observations
+    return effective, True
 
 
 def load_json(path, label):
@@ -347,7 +483,7 @@ def main():
               f"got {type(returns).__name__}", file=sys.stderr)
         sys.exit(1)
 
-    titles = {}
+    talks = {}
     if talks_path:
         db = load_json(talks_path, "tracking database")
         if not isinstance(db, dict) or not isinstance(db.get("talks"), list):
@@ -355,8 +491,11 @@ def main():
                   f"object with a `talks` array; pass the vault's "
                   f"tracking-database.json or drop --talks", file=sys.stderr)
             sys.exit(1)
-        titles = {t.get("filename"): t.get("title")
-                  for t in db["talks"] if isinstance(t, dict)}
+        talks = {
+            talk.get("filename"): talk
+            for talk in db["talks"]
+            if isinstance(talk, dict)
+        }
 
     try:
         os.makedirs(out_dir, exist_ok=True)
@@ -383,7 +522,14 @@ def main():
             continue
         safe_name = safe_output_name(name)
         path = os.path.join(out_dir, safe_name)
-        body = render_analysis(ret, title=titles.get(name), run_date=run_date)
+        talk = talks.get(name)
+        effective, evidence_verified = overlay_persisted_evidence(ret, talk)
+        body = render_analysis(
+            effective,
+            title=talk.get("title") if isinstance(talk, dict) else None,
+            run_date=run_date,
+            evidence_verified=evidence_verified,
+        )
         try:
             with open(path, "w", encoding="utf-8") as f:
                 f.write(body)

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -319,7 +319,7 @@ Current `schema_version`: **2**. The validator (`scripts/validate-profile.py`,
       }
     ],
     "strengths_note": "The positive counterpart to recurring_issues and underused_patterns: what the speaker already does well, framed as 'lean in / double down', so coaching is not purely deficit-oriented. Sourced from mastery_levels.signature and signature_combinations. Distinct from badges (which are fun/celebratory) — strengths are actionable reinforcement the creator skill can amplify. For kind='signature_combination', pattern_id holds the combination label.",
-    "note": "Only observable patterns are included. Patterns marked observable: false in the taxonomy (pre-event logistics, physical stage behaviors, external systems) are excluded from scoring and surfaced as a go-live checklist in creator Phase 6 instead.",
+    "note": "Only observable patterns are included. Patterns marked observable: false in the taxonomy (pre-event logistics, hidden authoring/provenance processes, physical stage behaviors, post-event follow-up, and external systems the current artifacts cannot prove) are excluded from scoring and surfaced as a go-live checklist in creator Phase 6 instead.",
     "pattern_usage": [
       {
         "pattern_id": "narrative-arc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,13 @@ def fetch_transcript():
 
 
 @pytest.fixture(scope="session")
+def transcript_timing():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "transcript_timing.py"), "transcript_timing"
+    )
+
+
+@pytest.fixture(scope="session")
 def extract_resources():
     return _import_script(
         os.path.join(SCRIPTS_PC, "extract-resources.py"), "extract_resources"

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -157,7 +157,11 @@ def test_caption_errors_fall_through_instead_of_propagating(fetch_transcript, mo
         raise TranscriptsDisabled("eg6gqvUFh6Q")
 
     monkeypatch.setattr(YouTubeTranscriptApi, "fetch", boom, raising=False)
-    assert fetch_transcript.fetch_captions("eg6gqvUFh6Q", ["en"]) == (None, None)
+    assert fetch_transcript.fetch_captions("eg6gqvUFh6Q", ["en"]) == (
+        None,
+        None,
+        None,
+    )
 
 
 def test_captions_report_the_track_language(fetch_transcript, monkeypatch):
@@ -170,8 +174,10 @@ def test_captions_report_the_track_language(fetch_transcript, monkeypatch):
     from youtube_transcript_api import YouTubeTranscriptApi
 
     class Segment:
-        def __init__(self, text):
+        def __init__(self, text, start=1.0, duration=2.0):
             self.text = text
+            self.start = start
+            self.duration = duration
 
     class Fetched(list):
         language_code = "ru"
@@ -179,9 +185,10 @@ def test_captions_report_the_track_language(fetch_transcript, monkeypatch):
     monkeypatch.setattr(YouTubeTranscriptApi, "fetch",
                         lambda self, *a, **k: Fetched([Segment("привет")]),
                         raising=False)
-    text, language = fetch_transcript.fetch_captions("x", ["en", "ru"])
+    text, language, segments = fetch_transcript.fetch_captions("x", ["en", "ru"])
     assert text == "привет"
     assert language == "ru"
+    assert segments[0].start == 1.0
 
 
 def test_write_is_atomic_and_leaves_no_partial(fetch_transcript, tmp_path):
@@ -287,3 +294,26 @@ def test_cli_keeps_a_valid_existing_transcript_without_refetching(
     assert payload["ok"] is True
     assert payload["method"] == "existing"
     assert payload["words"] == 900
+    assert payload["timed_path"] is None
+
+
+def test_cli_reports_a_verified_existing_timing_sidecar(fetch_transcript, tmp_path):
+    out = tmp_path / "eg6gqvUFh6Q.txt"
+    text = _talk(900)
+    fetch_transcript.write_transcript_bundle(
+        out,
+        text,
+        [{"text": text, "start": 0.0, "end": 600.0}],
+        source="captions",
+    )
+
+    result = subprocess.run(
+        [sys.executable, fetch_transcript.__file__, "eg6gqvUFh6Q", "--out", str(out)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["method"] == "existing"
+    assert payload["timed_path"] == str(tmp_path / "eg6gqvUFh6Q.segments.json")

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -19,6 +19,7 @@ import os
 import re
 
 import pytest
+import yaml
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PATTERNS = os.path.join(
@@ -45,6 +46,16 @@ def _read(path):
 def _front(path, key):
     m = re.search(rf"^{key}:\s*(\S+)\s*$", _read(path), re.M)
     return m.group(1) if m else None
+
+
+def _metadata(path):
+    parts = _read(path).split("---", 2)
+    assert len(parts) == 3, f"{path}: missing YAML frontmatter"
+    return yaml.safe_load(parts[1])
+
+
+def _entry(pattern_id):
+    return next(path for path in ENTRY_FILES if _metadata(path)["id"] == pattern_id)
 
 
 def test_catalog_is_present():
@@ -143,3 +154,95 @@ def test_index_summary_statistics_are_accurate():
             f"{anti - unobs_anti} antipatterns)") in index
     assert (f"**Unobservable (go-live checklist):** {unobs} "
             f"({unobs - unobs_anti} patterns + {unobs_anti} antipatterns)") in index
+
+
+def test_evidence_channels_use_the_closed_source_channel_vocabulary():
+    allowed = {
+        "transcript",
+        "timed_transcript",
+        "slides",
+        "slide_sequence",
+        "video",
+        "talk_metadata",
+    }
+    for path in ENTRY_FILES:
+        channels = _metadata(path).get("evidence_channels")
+        if _metadata(path).get("observable") is not False:
+            assert isinstance(channels, list) and channels, (
+                f"{os.path.basename(path)}: every observable entry needs a "
+                "non-empty evidence_channels list")
+            assert set(channels) <= allowed, (
+                f"{os.path.basename(path)}: unknown channels {set(channels) - allowed}")
+
+
+def test_metadata_channel_declares_the_fields_it_can_use():
+    for path in ENTRY_FILES:
+        metadata = _metadata(path)
+        channels = metadata.get("evidence_channels") or []
+        fields = metadata.get("evidence_metadata_fields") or []
+        assert bool(fields) == ("talk_metadata" in channels), (
+            f"{os.path.basename(path)}: talk_metadata and evidence_metadata_fields "
+            "must be declared together")
+        assert len(fields) == len(set(fields)), (
+            f"{os.path.basename(path)}: duplicate evidence metadata fields")
+
+
+@pytest.mark.parametrize(
+    "pattern_id,channels",
+    [
+        ("opening-punch", {"timed_transcript", "slides", "video"}),
+        ("call-to-adventure", {"timed_transcript", "video"}),
+        ("progressive-reveal", {"slide_sequence", "video"}),
+        ("composite-animation", {"video"}),
+        ("preroll", {"video"}),
+        ("make-it-rain", {"video"}),
+        ("weatherman", {"video"}),
+        ("ant-fonts", {"slides", "video"}),
+        ("three-part-close", {"slide_sequence", "video"}),
+        ("screen-blackout", {"video"}),
+        ("takahashi", {"slides", "slide_sequence", "video"}),
+    ],
+)
+def test_channel_sensitive_patterns_cannot_fall_back_to_transcript_guessing(
+        pattern_id, channels):
+    assert set(_metadata(_entry(pattern_id))["evidence_channels"]) == channels
+
+
+def test_hidden_process_and_provenance_ids_are_not_auto_scorable():
+    hidden = {
+        "abstract-attorney",
+        "borrowed-shoes",
+        "concurrent-creation",
+        "crucible",
+        "fourthought",
+        "know-your-audience",
+        "peer-review",
+        "proposed",
+        "required",
+        "social-media-advertising",
+    }
+    assert {
+        pattern_id
+        for pattern_id in hidden
+        if _metadata(_entry(pattern_id)).get("observable") is not False
+    } == set()
+
+
+@pytest.mark.parametrize(
+    "pattern_id,anchors",
+    [
+        ("takahashi", ("one word, phrase, or image per slide", "hundreds of slides")),
+        ("cookie-cutter", ("forcing each idea into exactly one slide",)),
+        ("progressive-reveal", ("same base image", "adding one annotation per slide")),
+        ("meme-as-argument", ("internet memes", "argumentative devices")),
+        ("dead-demo", ("time filler", "no narrative connection")),
+        ("three-part-close", ("three distinct slides", "summary, call to action, thanks")),
+        ("anti-sell", ("products, employer, or credentials", "expects a pitch")),
+        ("negative-ignorance", ('who here is not familiar with x?',)),
+        ("shortchanged", ("last-minute reduction", "previous speakers running long")),
+    ],
+)
+def test_stable_ids_retain_their_distinguishing_source_meaning(pattern_id, anchors):
+    text = _read(_entry(pattern_id)).casefold()
+    for anchor in anchors:
+        assert anchor.casefold() in text, f"{pattern_id}: missing source-meaning anchor {anchor!r}"

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -34,10 +34,33 @@ def _return(**overrides):
         "verbatim_examples": {"jokes": ["j1"]},
         "pattern_observations": {
             "patterns_detected": [
-                {"pattern_id": "narrative-arc", "confidence": "strong"},
-                {"pattern_id": "bookends", "confidence": "moderate"},
+                {
+                    "pattern_id": "narrative-arc",
+                    "confidence": "strong",
+                    "evidence": "The deck follows a problem-to-resolution arc.",
+                    "evidence_citations": [
+                        {"channel": "slides", "slide_numbers": [1, 20, 60]}
+                    ],
+                },
+                {
+                    "pattern_id": "bookends",
+                    "confidence": "moderate",
+                    "evidence": "Matching dividers bracket the main sections.",
+                    "evidence_citations": [
+                        {"channel": "slides", "slide_numbers": [2, 18]}
+                    ],
+                },
             ],
-            "antipatterns_detected": [{"pattern_id": "shortchanged", "confidence": "weak"}],
+            "antipatterns_detected": [
+                {
+                    "pattern_id": "ant-fonts",
+                    "confidence": "weak",
+                    "evidence": "One code slide uses text below the readable threshold.",
+                    "evidence_citations": [
+                        {"channel": "slides", "slide_numbers": [8]}
+                    ],
+                }
+            ],
             "pattern_score": {"patterns_used": 8, "antipatterns_detected": 1, "score": 7},
         },
     }
@@ -49,6 +72,8 @@ def _talk(**overrides):
     talk = {
         "filename": "talk.md",
         "status": "pending",
+        "slide_source": "pptx",
+        "slide_count": 62,
         "structured_data": {},
         "verbatim_examples": {},
         "pattern_observations": {"pattern_ids": [], "antipattern_ids": [], "pattern_score": 0},
@@ -100,7 +125,7 @@ def test_pattern_observations_normalized(persist_results):
     persist_results.merge_talk(talk, _return())
     obs = talk["pattern_observations"]
     assert obs["pattern_ids"] == ["narrative-arc", "bookends"]
-    assert obs["antipattern_ids"] == ["shortchanged"]
+    assert obs["antipattern_ids"] == ["ant-fonts"]
     assert obs["pattern_score"] == 7  # flattened from {"score": 7}
     assert len(obs["patterns_detected"]) == 2  # detailed arrays kept for Section 15
 
@@ -461,7 +486,7 @@ def test_merge_stamps_the_talk_schema_version(persist_results, tmp_path):
 
 
 def test_schema_version_is_stamped_over_an_older_value(persist_results, tmp_path):
-    """A v1 record merged by this writer becomes v2 — that is the migration."""
+    """A v1 record merged by this writer becomes v3 — that is the migration."""
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     old = _talk()
@@ -473,7 +498,7 @@ def test_schema_version_is_stamped_over_an_older_value(persist_results, tmp_path
         capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
-    assert json.loads(db.read_text())["talks"][0]["schema_version"] == 2
+    assert json.loads(db.read_text())["talks"][0]["schema_version"] == 3
 
 
 @pytest.mark.parametrize("block", ["structured_data", "verbatim_examples",
@@ -575,3 +600,426 @@ def test_score_object_without_a_score_key_fails_loudly(persist_results, tmp_path
     assert result.returncode == 1
     assert "no `score` key" in result.stderr
     assert "pattern_score" not in json.loads(db.read_text())["talks"][0]
+
+
+def test_detection_requires_source_located_evidence(persist_results):
+    detection = {
+        "pattern_id": "narrative-arc",
+        "confidence": "strong",
+        "evidence": "A clear problem-to-resolution arc.",
+    }
+    with pytest.raises(ValueError, match="evidence_citations"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+        )
+
+
+def test_transcript_quote_is_verified_and_locations_are_engine_owned(persist_results):
+    detection = {
+        "pattern_id": "opening-punch",
+        "confidence": "strong",
+        "evidence": "A concrete incident opens the talk.",
+        "evidence_citations": [
+            {
+                "channel": "timed_transcript",
+                "quote": "The production deploy failed on Friday night.",
+                "line_start": 999,
+                "start_seconds": 999,
+            }
+        ],
+    }
+    context = {
+        "transcript_text": (
+            "The production deploy failed on Friday night.\n"
+            "That incident changed our release process."
+        ),
+        "transcript_reason": "loaded fixture transcript",
+        "timed_segments": [
+            {
+                "text": "The production deploy failed on Friday night.",
+                "start_seconds": 2.0,
+                "end_seconds": 6.0,
+            },
+            {
+                "text": "That incident changed our release process.",
+                "start_seconds": 6.0,
+                "end_seconds": 10.0,
+            },
+        ],
+        "timing_reason": "2 verified timed segments",
+    }
+
+    validated = persist_results.validate_detection(
+        detection,
+        field="patterns_detected",
+        catalog=persist_results.load_pattern_catalog(),
+        evidence_context=context,
+    )
+
+    citation = validated["evidence_citations"][0]
+    assert citation["line_start"] == 1
+    assert citation["line_end"] == 1
+    assert citation["start_seconds"] == 2.0
+    assert citation["end_seconds"] == 6.0
+
+
+def test_non_english_citation_matches_original_and_keeps_translation(persist_results):
+    detection = {
+        "pattern_id": "narrative-arc",
+        "confidence": "strong",
+        "evidence": "The speaker frames the incident as the turning point.",
+        "evidence_citations": [
+            {
+                "channel": "transcript",
+                "quote": "Этот сбой изменил весь наш процесс.",
+                "translation": "That failure changed our entire process.",
+            }
+        ],
+    }
+    validated = persist_results.validate_detection(
+        detection,
+        field="patterns_detected",
+        catalog=persist_results.load_pattern_catalog(),
+        evidence_context={
+            "transcript_text": "Этот сбой изменил весь наш процесс.",
+            "timed_segments": [],
+        },
+    )
+    citation = validated["evidence_citations"][0]
+    assert citation["translation"] == "That failure changed our entire process."
+    assert citation["line_start"] == 1
+
+
+def test_citation_shapes_reject_unknown_model_fields(persist_results):
+    detection = {
+        "pattern_id": "narrative-arc",
+        "confidence": "strong",
+        "evidence": "A clear problem-to-resolution arc.",
+        "evidence_citations": [
+            {
+                "channel": "slides",
+                "slide_numbers": [1, 2],
+                "model_reasoning": "trust me",
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="unknown fields"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+        )
+
+
+def test_timing_dependent_pattern_fails_closed_without_sidecar(persist_results):
+    detection = {
+        "pattern_id": "opening-punch",
+        "confidence": "strong",
+        "evidence": "A concrete incident opens the talk.",
+        "evidence_citations": [
+            {
+                "channel": "timed_transcript",
+                "quote": "The production deploy failed on Friday night.",
+            }
+        ],
+    }
+    context = {
+        "transcript_text": "The production deploy failed on Friday night.",
+        "transcript_reason": "loaded fixture transcript",
+        "timed_segments": [],
+        "timing_reason": "timed transcript sidecar is missing",
+    }
+    with pytest.raises(ValueError, match="no verified timestamp"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+            evidence_context=context,
+        )
+
+
+def test_catalog_rejects_wrong_channel_and_hidden_process_inference(persist_results):
+    catalog = persist_results.load_pattern_catalog()
+    transcript_guess = {
+        "pattern_id": "composite-animation",
+        "confidence": "moderate",
+        "evidence": "The speaker describes several movements.",
+        "evidence_citations": [
+            {
+                "channel": "transcript",
+                "quote": "Watch this element move across the whole screen.",
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="cannot be proved through"):
+        persist_results.validate_detection(
+            transcript_guess,
+            field="patterns_detected",
+            catalog=catalog,
+        )
+
+    hidden_process = {
+        "pattern_id": "fourthought",
+        "confidence": "strong",
+        "evidence": "The final talk is well organized.",
+        "evidence_citations": [
+            {"channel": "slides", "slide_numbers": [1, 2]}
+        ],
+    }
+    with pytest.raises(ValueError, match="observable:false"):
+        persist_results.validate_detection(
+            hidden_process,
+            field="patterns_detected",
+            catalog=catalog,
+        )
+
+
+def test_catalog_rejects_pattern_antipattern_bucket_swaps(persist_results):
+    detection = {
+        "pattern_id": "ant-fonts",
+        "confidence": "strong",
+        "evidence": "The slide text is too small to read.",
+        "evidence_citations": [
+            {"channel": "slides", "slide_numbers": [8]}
+        ],
+    }
+    with pytest.raises(ValueError, match="cataloged as 'antipattern'"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+        )
+
+
+def test_duplicate_pattern_ids_are_rejected(persist_results):
+    observations = _return()["pattern_observations"]
+    observations["patterns_detected"] = [
+        observations["patterns_detected"][0],
+        observations["patterns_detected"][0],
+    ]
+    with pytest.raises(ValueError, match="duplicate pattern IDs"):
+        persist_results.require_detections(
+            observations,
+            "patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+        )
+
+
+def test_v3_migration_marks_legacy_evidence_unlocated(persist_results):
+    db = {
+        "talks": [
+            _talk(
+                schema_version=2,
+                pattern_observations={
+                    "patterns_detected": [
+                        {
+                            "pattern_id": "narrative-arc",
+                            "confidence": "strong",
+                            "evidence": "Legacy prose only.",
+                        }
+                    ],
+                    "antipatterns_detected": [],
+                    "pattern_score": 1,
+                },
+            )
+        ]
+    }
+    assert persist_results.migrate_records(db) == 1
+    talk = db["talks"][0]
+    assert talk["schema_version"] == 3
+    assert talk["pattern_observations"]["evidence_schema_version"] == 1
+    assert talk["pattern_observations"]["patterns_detected"][0][
+        "evidence_citations"
+    ] == []
+
+
+def test_non_youtube_transcript_path_is_resolved_inside_vault(persist_results, tmp_path):
+    transcript_dir = tmp_path / "transcripts"
+    transcript_dir.mkdir()
+    transcript = transcript_dir / "infoq-talk.txt"
+    transcript.write_text(
+        "The production deploy failed on Friday night.",
+        encoding="utf-8",
+    )
+    talk = _talk(filename="infoq.md")
+    ret = _return(
+        filename="infoq.md",
+        transcript_path="transcripts/infoq-talk.txt",
+    )
+
+    context = persist_results.build_evidence_context(tmp_path, talk, ret)
+
+    assert context["transcript_text"] == transcript.read_text(encoding="utf-8")
+    assert "loaded transcript" in context["transcript_reason"]
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    ["../secret.txt", "/tmp/secret.txt", "analyses/talk.txt", "transcripts/talk.json"],
+)
+def test_transcript_path_cannot_escape_its_vault_directory(
+    persist_results,
+    tmp_path,
+    bad_path,
+):
+    with pytest.raises(ValueError, match="under the vault's transcripts"):
+        persist_results.build_evidence_context(
+            tmp_path,
+            _talk(filename="infoq.md"),
+            _return(filename="infoq.md", transcript_path=bad_path),
+        )
+
+
+def test_invalid_youtube_id_cannot_become_a_transcript_path(persist_results, tmp_path):
+    with pytest.raises(ValueError, match="11-character YouTube id"):
+        persist_results.build_evidence_context(
+            tmp_path,
+            _talk(youtube_id="../../escape"),
+            _return(),
+        )
+
+
+def test_youtube_talk_cannot_redirect_evidence_to_another_transcript(
+    persist_results,
+    tmp_path,
+):
+    with pytest.raises(ValueError, match="does not match this talk's youtube_id"):
+        persist_results.build_evidence_context(
+            tmp_path,
+            _talk(youtube_id="eg6gqvUFh6Q"),
+            _return(transcript_path="transcripts/someone-else.txt"),
+        )
+
+
+def test_slide_citation_requires_a_declared_usable_source(persist_results):
+    detection = {
+        "pattern_id": "narrative-arc",
+        "confidence": "strong",
+        "evidence": "The deck follows a problem-to-resolution arc.",
+        "evidence_citations": [
+            {"channel": "slides", "slide_numbers": [1, 2]}
+        ],
+    }
+    with pytest.raises(ValueError, match="no usable slide source/count"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+            evidence_context={"slide_source": "model_guess", "slide_count": 2},
+        )
+
+
+def test_video_citation_rejects_nonfinite_timestamps(persist_results):
+    detection = {
+        "pattern_id": "make-it-rain",
+        "confidence": "strong",
+        "evidence": "Objects are thrown to audience members.",
+        "evidence_citations": [
+            {"channel": "video", "start_seconds": 2.0, "end_seconds": float("inf")}
+        ],
+    }
+    with pytest.raises(ValueError, match="numeric start_seconds/end_seconds"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+            evidence_context={"video_url": "https://example.test/video"},
+        )
+
+
+def test_talk_metadata_cannot_cite_generated_analysis_prose(persist_results):
+    detection = {
+        "pattern_id": "lightning-talk",
+        "confidence": "strong",
+        "evidence": "The return calls itself a lightning talk.",
+        "evidence_citations": [
+            {"channel": "talk_metadata", "field": "rhetoric_notes"}
+        ],
+    }
+    with pytest.raises(ValueError, match="is not source metadata"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+        )
+
+
+def test_pattern_metadata_policy_rejects_irrelevant_source_fields(persist_results):
+    detection = {
+        "pattern_id": "lightning-talk",
+        "confidence": "strong",
+        "evidence": "A transcript artifact exists.",
+        "evidence_citations": [
+            {"channel": "talk_metadata", "field": "transcript_path"}
+        ],
+    }
+    with pytest.raises(ValueError, match="not permitted for this pattern"):
+        persist_results.validate_detection(
+            detection,
+            field="patterns_detected",
+            catalog=persist_results.load_pattern_catalog(),
+        )
+
+
+def test_talk_metadata_value_is_stamped_from_promoted_source_field(
+    persist_results,
+    tmp_path,
+):
+    ret = _return()
+    context = persist_results.build_evidence_context(tmp_path, _talk(), ret)
+    detection = {
+        "pattern_id": "lightning-talk",
+        "confidence": "moderate",
+        "evidence": "The deck uses the fixed 20-slide format.",
+        "evidence_citations": [
+            {"channel": "talk_metadata", "field": "slide_count", "value": 999}
+        ],
+    }
+
+    validated = persist_results.validate_detection(
+        detection,
+        field="patterns_detected",
+        catalog=persist_results.load_pattern_catalog(),
+        evidence_context=context,
+    )
+
+    assert validated["evidence_citations"][0]["value"] == 62
+
+
+def test_catalog_rejects_duplicate_evidence_channels(persist_results, tmp_path):
+    category = tmp_path / "build"
+    category.mkdir()
+    (category / "duplicate.md").write_text(
+        """---
+id: duplicate
+type: pattern
+observable: true
+evidence_channels: [video, video]
+---
+# Duplicate
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="invalid evidence_channels"):
+        persist_results.load_pattern_catalog(tmp_path)
+
+
+def test_migration_refuses_to_downgrade_a_future_schema(persist_results):
+    db = {"talks": [_talk(schema_version=persist_results.TALK_SCHEMA_VERSION + 1)]}
+    with pytest.raises(ValueError, match="will not downgrade"):
+        persist_results.migrate_records(db)
+    assert db["talks"][0]["schema_version"] == persist_results.TALK_SCHEMA_VERSION + 1
+
+
+def test_future_schema_preflight_leaves_earlier_legacy_record_untouched(persist_results):
+    legacy = _talk(schema_version=2)
+    future = _talk(
+        filename="future.md",
+        schema_version=persist_results.TALK_SCHEMA_VERSION + 1,
+    )
+    db = {"talks": [legacy, future]}
+    with pytest.raises(ValueError, match="will not downgrade"):
+        persist_results.migrate_records(db)
+    assert legacy["schema_version"] == 2

--- a/tests/test_transcript_timing.py
+++ b/tests/test_transcript_timing.py
@@ -1,0 +1,140 @@
+"""Tests for the transcript/timing artifact contract."""
+
+import json
+
+import pytest
+
+
+def test_normalizes_caption_and_whisper_segment_shapes(transcript_timing):
+    class Caption:
+        text = "caption text"
+        start = 1.25
+        duration = 2.5
+
+    assert transcript_timing.normalize_segments(
+        [Caption(), {"text": "whisper text", "start": 4.0, "end": 6.0}]
+    ) == [
+        {"text": "caption text", "start_seconds": 1.25, "end_seconds": 3.75},
+        {"text": "whisper text", "start_seconds": 4.0, "end_seconds": 6.0},
+    ]
+
+
+def test_normalization_rejects_nonfinite_and_zero_duration_segments(transcript_timing):
+    assert transcript_timing.normalize_segments(
+        [
+            {"text": "zero", "start": 1.0, "end": 1.0},
+            {"text": "nan", "start": float("nan"), "end": 2.0},
+            {"text": "infinite", "start": 1.0, "end": float("inf")},
+            {"text": "rounds to zero", "start": 1.0001, "end": 1.0002},
+        ]
+    ) == []
+
+
+def test_bundle_rejects_an_unknown_source(transcript_timing, tmp_path):
+    with pytest.raises(ValueError, match="unsupported transcript timing source"):
+        transcript_timing.write_transcript_bundle(
+            tmp_path / "talk.txt",
+            "Real transcript text.",
+            [{"text": "Real transcript text.", "start": 0.0, "end": 1.0}],
+            source="model_guess",
+        )
+
+
+def test_bundle_hash_binds_sidecar_to_exact_transcript(transcript_timing, tmp_path):
+    transcript = tmp_path / "talk.txt"
+    timed = transcript_timing.write_transcript_bundle(
+        transcript,
+        "The opening claim.\nNow the explanation.",
+        [
+            {"text": "The opening claim.", "start": 2.0, "duration": 3.0},
+            {"text": "Now the explanation.", "start": 5.0, "duration": 4.0},
+        ],
+        source="captions",
+    )
+
+    assert timed == tmp_path / "talk.segments.json"
+    payload = json.loads(timed.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == transcript_timing.SIDECAR_SCHEMA_VERSION
+    assert payload["source"] == "captions"
+    segments, reason = transcript_timing.load_verified_segments(
+        transcript, transcript.read_text(encoding="utf-8")
+    )
+    assert len(segments) == 2
+    assert "verified timed segments" in reason
+
+    transcript.write_text("A different transcript.", encoding="utf-8")
+    segments, reason = transcript_timing.load_verified_segments(
+        transcript, transcript.read_text(encoding="utf-8")
+    )
+    assert segments == []
+    assert "does not match" in reason
+
+
+def test_empty_timing_invalidates_an_older_sidecar(transcript_timing, tmp_path):
+    transcript = tmp_path / "talk.txt"
+    transcript_timing.write_transcript_bundle(
+        transcript,
+        "First version.",
+        [{"text": "First version.", "start": 1.0, "end": 2.0}],
+        source="captions",
+    )
+    timed = transcript_timing.write_transcript_bundle(
+        transcript, "Replacement without timing.", [], source="whisper"
+    )
+    assert timed is None
+    segments, reason = transcript_timing.load_verified_segments(
+        transcript, transcript.read_text(encoding="utf-8")
+    )
+    assert segments == []
+    assert "recorded no timed segments" in reason
+
+
+def test_reader_rejects_a_partially_malformed_sidecar(transcript_timing, tmp_path):
+    transcript = tmp_path / "talk.txt"
+    text = "A real transcript."
+    transcript.write_text(text, encoding="utf-8")
+    sidecar = tmp_path / "talk.segments.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema_version": transcript_timing.SIDECAR_SCHEMA_VERSION,
+                "transcript_sha256": transcript_timing.transcript_sha256(text),
+                "source": "captions",
+                "segments": [
+                    {"text": text, "start_seconds": 0.0, "end_seconds": 1.0},
+                    {"text": "bad", "start_seconds": 2.0, "end_seconds": 2.0},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    segments, reason = transcript_timing.load_verified_segments(transcript, text)
+    assert segments == []
+    assert "malformed or zero-duration" in reason
+
+
+def test_resolves_unique_quote_to_engine_owned_lines_and_times(transcript_timing):
+    transcript = "Welcome everyone.\nThe deploy went out on Friday.\nWe restored it by noon."
+    resolved = transcript_timing.resolve_quote(
+        transcript,
+        "The deploy went out on Friday. We restored it by noon.",
+        segments=[
+            {"text": "Welcome everyone.", "start": 0.0, "end": 1.0},
+            {"text": "The deploy went out on Friday.", "start": 1.0, "end": 4.0},
+            {"text": "We restored it by noon.", "start": 4.0, "end": 6.5},
+        ],
+    )
+    assert resolved == {
+        "line_start": 2,
+        "line_end": 3,
+        "start_seconds": 1.0,
+        "end_seconds": 6.5,
+    }
+
+
+def test_rejects_missing_or_ambiguous_quotes(transcript_timing):
+    with pytest.raises(ValueError, match="does not appear verbatim"):
+        transcript_timing.resolve_quote("A real sentence.", "An invented sentence.")
+    with pytest.raises(ValueError, match="more than once"):
+        transcript_timing.resolve_quote("same phrase\nsame phrase", "same phrase")

--- a/tests/test_vtt_cleanup.py
+++ b/tests/test_vtt_cleanup.py
@@ -1,5 +1,9 @@
 """Tests for vtt-cleanup.py — WebVTT to plain text conversion."""
 
+import json
+import subprocess
+import sys
+
 
 def test_strip_webvtt_header(vtt_cleanup):
     raw = "WEBVTT\nKind: captions\nLanguage: en\n\n00:00:01.000 --> 00:00:03.000\nHello world"
@@ -36,6 +40,13 @@ def test_strip_html_tags(vtt_cleanup):
     assert vtt_cleanup.clean_vtt(raw) == "Hello world"
 
 
+def test_note_word_inside_a_cue_is_speech_not_a_control_block(vtt_cleanup):
+    raw = "00:00:01.000 --> 00:00:03.000\nNOTE that this is important"
+    text, segments = vtt_cleanup.parse_vtt(raw)
+    assert text == "NOTE that this is important"
+    assert segments[0]["text"] == "NOTE that this is important"
+
+
 def test_skip_blank_lines(vtt_cleanup):
     raw = "Line one\n\n\n\nLine two"
     assert vtt_cleanup.clean_vtt(raw) == "Line one\nLine two"
@@ -60,3 +71,76 @@ welcome to the talk
 """
     result = vtt_cleanup.clean_vtt(vtt)
     assert result == "Hello everyone\nwelcome to the talk\nLet's get started"
+
+
+def test_rolling_captions_keep_timing_aligned_with_deduplicated_text(vtt_cleanup):
+    raw = """\
+WEBVTT
+
+00:00:01.000 --> 00:00:03.000
+Hello everyone
+
+00:00:03.000 --> 00:00:05.000
+Hello everyone
+welcome to the talk
+
+00:00:05.000 --> 00:00:08.000
+welcome to the talk
+Let's get started
+"""
+    text, segments = vtt_cleanup.parse_vtt(raw)
+    assert text == "Hello everyone\nwelcome to the talk\nLet's get started"
+    assert segments == [
+        {"text": "Hello everyone", "start_seconds": 1.0, "end_seconds": 3.0},
+        {"text": "welcome to the talk", "start_seconds": 3.0, "end_seconds": 5.0},
+        {"text": "Let's get started", "start_seconds": 5.0, "end_seconds": 8.0},
+    ]
+
+
+def test_parse_vtt_preserves_cue_timing(vtt_cleanup):
+    raw = """\
+WEBVTT
+
+00:00:01.250 --> 00:00:03.500
+The opening claim
+
+00:00:03.500 --> 00:00:07.000
+Now the explanation
+continues here
+"""
+    text, segments = vtt_cleanup.parse_vtt(raw)
+    assert text == "The opening claim\nNow the explanation\ncontinues here"
+    assert segments == [
+        {
+            "text": "The opening claim",
+            "start_seconds": 1.25,
+            "end_seconds": 3.5,
+        },
+        {
+            "text": "Now the explanation continues here",
+            "start_seconds": 3.5,
+            "end_seconds": 7.0,
+        },
+    ]
+
+
+def test_cli_writes_plain_text_and_timed_sidecar(vtt_cleanup, tmp_path):
+    source = tmp_path / "talk.en.vtt"
+    output = tmp_path / "talk.txt"
+    source.write_text(
+        "WEBVTT\n\n00:00:02.000 --> 00:00:04.000\nOpening words\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, vtt_cleanup.__file__, str(source), str(output)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert output.read_text(encoding="utf-8") == "Opening words"
+    assert payload["timed_path"] == str(tmp_path / "talk.segments.json")
+    sidecar = json.loads((tmp_path / "talk.segments.json").read_text(encoding="utf-8"))
+    assert sidecar["segments"][0]["start_seconds"] == 2.0

--- a/tests/test_vtt_cleanup.py
+++ b/tests/test_vtt_cleanup.py
@@ -124,6 +124,21 @@ continues here
     ]
 
 
+def test_parse_vtt_accepts_timestamps_without_hours(vtt_cleanup):
+    raw = "WEBVTT\n\n01:02.250 --> 01:04.500\nShort-form timestamp\n"
+
+    text, segments = vtt_cleanup.parse_vtt(raw)
+
+    assert text == "Short-form timestamp"
+    assert segments == [
+        {
+            "text": "Short-form timestamp",
+            "start_seconds": 62.25,
+            "end_seconds": 64.5,
+        }
+    ]
+
+
 def test_cli_writes_plain_text_and_timed_sidecar(vtt_cleanup, tmp_path):
     source = tmp_path / "talk.en.vtt"
     output = tmp_path / "talk.txt"

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -39,11 +39,17 @@ def _return(**overrides):
         "pattern_observations": {
             "patterns_detected": [
                 {"pattern_id": "narrative-arc", "confidence": "strong",
-                 "evidence": "Four-act catalog."},
+                 "evidence": "Four-act catalog.",
+                 "evidence_citations": [
+                     {"channel": "slides", "slide_numbers": [1, 8, 20, 31]}
+                 ]},
             ],
             "antipatterns_detected": [
                 {"pattern_id": "ant-fonts", "confidence": "moderate",
-                 "evidence": "7.5pt body text."},
+                 "evidence": "7.5pt body text.",
+                 "evidence_citations": [
+                     {"channel": "slides", "slide_numbers": [17]}
+                 ]},
             ],
             "pattern_score": {"patterns_used": 25, "antipatterns_detected": 3, "score": 22},
         },
@@ -74,10 +80,10 @@ def test_title_from_db_wins_over_filename(write_analysis):
 
 
 def test_scoring_tables_carry_evidence(write_analysis):
-    md = write_analysis.render_analysis(_return())
+    md = write_analysis.render_analysis(_return(), evidence_verified=True)
     assert "**Pattern score:** 22 (25 patterns − 3 antipatterns)" in md
-    assert "| `narrative-arc` | strong | Four-act catalog. |" in md
-    assert "| `ant-fonts` | moderate | 7.5pt body text. |" in md
+    assert "| `narrative-arc` | strong | Four-act catalog. | slides 1, 8, 20, 31 |" in md
+    assert "| `ant-fonts` | moderate | 7.5pt body text. | slides 17 |" in md
 
 
 def test_per_slide_visual_becomes_a_table(write_analysis):
@@ -100,8 +106,59 @@ def test_pipes_and_newlines_do_not_break_table_rows(write_analysis):
     # Splitting on UNESCAPED pipes is what a markdown renderer does; escaped
     # ones stay inside the cell.
     cells = [c for c in re.split(r"(?<!\\)\|", row)[1:-1]]
-    assert len(cells) == 3
+    assert len(cells) == 4
     assert "\\|" in cells[2]
+
+
+def test_timed_transcript_citation_renders_engine_locations(write_analysis):
+    ret = _return()
+    ret["pattern_observations"]["patterns_detected"] = [
+        {
+            "pattern_id": "opening-punch",
+            "confidence": "strong",
+            "evidence": "A concrete failure story opens the talk.",
+            "evidence_citations": [
+                {
+                    "channel": "timed_transcript",
+                    "quote": "The deploy failed on Friday night.",
+                    "line_start": 1,
+                    "line_end": 1,
+                    "start_seconds": 2.0,
+                    "end_seconds": 5.5,
+                }
+            ],
+        }
+    ]
+    md = write_analysis.render_analysis(ret, evidence_verified=True)
+    assert "transcript lines 1–1 (2.0s–5.5s)" in md
+    assert "The deploy failed on Friday night." in md
+
+
+def test_non_english_citation_renders_translation_before_original(write_analysis):
+    rendered = write_analysis.render_evidence_citation(
+        {
+            "channel": "transcript",
+            "quote": "Этот сбой изменил весь наш процесс.",
+            "translation": "That failure changed our entire process.",
+            "line_start": 4,
+            "line_end": 4,
+        },
+        evidence_verified=True,
+    )
+    assert rendered.index("That failure changed") < rendered.index("Этот сбой")
+    assert "original:" in rendered
+
+
+def test_raw_return_locations_are_labeled_unverified(write_analysis):
+    md = write_analysis.render_analysis(_return())
+    assert "unverified: slides 1, 8, 20, 31" in md
+
+
+def test_missing_citations_are_explicitly_legacy_unverified(write_analysis):
+    ret = _return()
+    del ret["pattern_observations"]["patterns_detected"][0]["evidence_citations"]
+    md = write_analysis.render_analysis(ret)
+    assert "legacy/unverified" in md
 
 
 def test_absent_sections_are_skipped_not_stubbed(write_analysis):
@@ -191,6 +248,100 @@ def test_cli_uses_titles_from_tracking_db(write_analysis, tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert (out / "talk.md").read_text().startswith("# Rhetoric Analysis: Real Title")
+
+
+def test_cli_renders_persisted_locations_not_model_locations(write_analysis, tmp_path):
+    batch = tmp_path / "batch-returns.json"
+    db = tmp_path / "tracking-database.json"
+    out = tmp_path / "analyses"
+    ret = _return()
+    ret["pattern_observations"]["patterns_detected"] = [
+        {
+            "pattern_id": "opening-punch",
+            "confidence": "strong",
+            "evidence": "The talk opens on a failure.",
+            "evidence_citations": [
+                {
+                    "channel": "timed_transcript",
+                    "quote": "The deploy failed on Friday night.",
+                    "line_start": 999,
+                    "line_end": 999,
+                    "start_seconds": 999.0,
+                    "end_seconds": 1000.0,
+                }
+            ],
+        }
+    ]
+    persisted = json.loads(json.dumps(ret["pattern_observations"]))
+    persisted["evidence_schema_version"] = 1
+    persisted["patterns_detected"][0]["evidence_citations"][0].update(
+        {
+            "line_start": 1,
+            "line_end": 1,
+            "start_seconds": 2.0,
+            "end_seconds": 5.5,
+        }
+    )
+    batch.write_text(json.dumps([ret]))
+    db.write_text(
+        json.dumps(
+            {
+                "talks": [
+                    {
+                        "filename": "talk.md",
+                        "title": "Real Title",
+                        "pattern_observations": persisted,
+                    }
+                ]
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    rendered = (out / "talk.md").read_text()
+    assert "transcript lines 1–1 (2.0s–5.5s)" in rendered
+    assert "999" not in rendered
+    assert "unverified:" not in rendered
+
+
+def test_stale_persisted_detections_are_not_labeled_verified(write_analysis):
+    ret = _return()
+    talk = {
+        "pattern_observations": {
+            "patterns_detected": [
+                {
+                    "pattern_id": "bookends",
+                    "confidence": "strong",
+                    "evidence": "Old evidence from a previous batch.",
+                    "evidence_citations": [
+                        {"channel": "slides", "slide_numbers": [1, 31]}
+                    ],
+                }
+            ],
+            "antipatterns_detected": [],
+        }
+    }
+
+    effective, verified = write_analysis.overlay_persisted_evidence(ret, talk)
+
+    assert effective is ret
+    assert verified is False
+    rendered = write_analysis.render_analysis(effective, evidence_verified=verified)
+    assert "unverified: slides 1, 8, 20, 31" in rendered
+    assert "Old evidence from a previous batch" not in rendered
 
 
 def test_cli_fails_visibly_on_return_without_filename(write_analysis, tmp_path):


### PR DESCRIPTION
## Summary

- Require observable pattern detections to carry source-located citations from catalog-approved evidence channels.
- Preserve hash-bound timing for caption, Whisper, and VTT transcripts while keeping legacy evidence readable and explicitly unverified.
- Reclassify preparation and provenance patterns that runtime artifacts cannot prove, then align the catalog, schemas, renderer, and documentation.

## Root cause

Pattern evidence was a free-form string and transcript timing was discarded. Unsupported claims could therefore appear verified, survive source changes, or infer preparation process from the polished talk alone.

## User impact

Pattern scoring and rendered analyses now distinguish verified citations from legacy or unverifiable claims and retain line, time, slide, sequence, video, or allowlisted metadata locations.

## Test plan

- [x] `.venv/bin/python -m pytest -q --tb=short` — 1,245 passed, 3 skipped
- [x] `.venv/bin/python -m compileall -q skills/vault-ingress/scripts tests`
- [x] `tessl plugin lint`
- [x] `scripts/pre-publish-checks.sh`
- [x] Tessl quality review — vault-ingress 92, presentation-creator 91, vault-profile 93
