### PR TITLE
fix(vault-ingress): Serialize tracking database access

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/speaker-toolkit",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (81 observable: 62 patterns + 19 antipatterns; 30 unobservable: 21 patterns + 9 antipatterns) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
 
-## 0.20.0 — 2026-08-01
+### fix(vault-ingress) — serialize tracking-database access and close owner schemas
 
-### fix(vault-ingress) — close the tracking-database transaction and owner schemas
-
-Tracking-database staging now retains a no-follow file descriptor and opened parent
-directory through installation. The writer revalidates staged bytes, hash, inode,
-generation, type, link count, and directory-relative identity at the install boundary;
-a substituted staged name fails closed and is never unlinked. Immediate post-install
-verification detects observable non-cooperative edits. Once replace/link succeeds,
-verification, directory sync/close, staged cleanup, and lock unlock/close failures are
-reported truthfully as installed warnings rather than generic not-installed errors.
+All toolkit tracking-database writers now share one persistent sibling lock and one
+strict exact-generation transaction. Reads reject duplicate keys, non-standard JSON
+numbers, non-object roots, symlinks, and generation swaps before network or mutation
+work. Writes retain no-follow file and directory descriptors through staged `fsync`,
+revalidate bytes and identity at the install boundary, atomically replace, and sync the
+parent directory. Staged-name substitution fails closed; immediate post-install checks
+detect observable non-cooperative edits. Installed-but-not-fully-synced outcomes are
+reported truthfully, semantic no-ops preserve bytes and inode, and source-repair
+backups are never-overwritten copies bound to the exact input hash.
 
 Owner-plan and source-repair equality is now recursive and JSON-type-sensitive:
 object order is irrelevant, array order is significant, and `true`, `1`, and `1.0`
@@ -31,25 +31,6 @@ reference documents post-install outcomes plus the residual non-cooperating-writ
 last-instruction race.
 
 ## 0.19.0 — 2026-08-01
-
-### fix(vault-ingress) — serialize every tracking-database writer and fail ambiguous reads closed
-
-All toolkit tracking-database writers now share one persistent sibling lock and
-one exact-generation transaction: strict no-follow snapshot, typed validation,
-staged file `fsync`, a second byte-and-inode precondition check, atomic replace,
-and parent-directory `fsync`. No-op writes preserve bytes and inode; installed-
-but-not-directory-synced results are explicit. Source-repair backups are
-never-overwritten copies bound to the exact input hash.
-
-Agent-owned config, PPTX, intent, coaching, resource, thumbnail, and publishing
-changes now use one typed dry-run/apply command with exact semantic expectations
-and an input-SHA precondition. Queue, persistence, shownotes import, source repair,
-and QR writers use the same transaction rather than private atomic-write helpers.
-
-Every public tracking-database consumer now uses the same strict UTF-8 JSON
-reader. Duplicate keys at any depth, `NaN`/infinities, non-object roots, symlinks,
-and generation swaps fail before network work, profile generation, analysis
-rendering, or mutation can occur.
 
 ### feat(vault-ingress) — make reparses exhaustive, source-bound, and freshness-bound
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,52 @@
 # Changelog
 
+## 0.20.0 — 2026-08-01
+
+### fix(vault-ingress) — close the tracking-database transaction and owner schemas
+
+Tracking-database staging now retains a no-follow file descriptor and opened parent
+directory through installation. The writer revalidates staged bytes, hash, inode,
+generation, type, link count, and directory-relative identity at the install boundary;
+a substituted staged name fails closed and is never unlinked. Immediate post-install
+verification detects observable non-cooperative edits. Once replace/link succeeds,
+verification, directory sync/close, staged cleanup, and lock unlock/close failures are
+reported truthfully as installed warnings rather than generic not-installed errors.
+
+Owner-plan and source-repair equality is now recursive and JSON-type-sensitive:
+object order is irrelevant, array order is significant, and `true`, `1`, and `1.0`
+are distinct. Semantic no-ops, including QR metadata writes, preserve the original
+bytes and inode. Mutation records are closed and type-validated for PPTX, confirmed
+intent, improvement goal, resource, thumbnail, publishing, and optional schema-v1
+metadata. Clarification can persist complete blind-spot/humor structures, and exact
+record retirement changes only a goal's status while preserving legacy provenance.
+
+Clarification, profile, thumbnail, and resource instructions now bootstrap through
+the strict owner reader, use the configured interpreter after that single bootstrap,
+and route every tracking change through the dry-run/hash-bound owner mutation. The
+resource rule uses the canonical `category_breakdown` shape, and the transaction
+reference documents post-install outcomes plus the residual non-cooperating-writer
+last-instruction race.
+
 ## 0.19.0 — 2026-08-01
+
+### fix(vault-ingress) — serialize every tracking-database writer and fail ambiguous reads closed
+
+All toolkit tracking-database writers now share one persistent sibling lock and
+one exact-generation transaction: strict no-follow snapshot, typed validation,
+staged file `fsync`, a second byte-and-inode precondition check, atomic replace,
+and parent-directory `fsync`. No-op writes preserve bytes and inode; installed-
+but-not-directory-synced results are explicit. Source-repair backups are
+never-overwritten copies bound to the exact input hash.
+
+Agent-owned config, PPTX, intent, coaching, resource, thumbnail, and publishing
+changes now use one typed dry-run/apply command with exact semantic expectations
+and an input-SHA precondition. Queue, persistence, shownotes import, source repair,
+and QR writers use the same transaction rather than private atomic-write helpers.
+
+Every public tracking-database consumer now uses the same strict UTF-8 JSON
+reader. Duplicate keys at any depth, `NaN`/infinities, non-object roots, symlinks,
+and generation swaps fail before network work, profile generation, analysis
+rendering, or mutation can occur.
 
 ### feat(vault-ingress) — make reparses exhaustive, source-bound, and freshness-bound
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ Owner-plan and source-repair equality is now recursive and JSON-type-sensitive:
 object order is irrelevant, array order is significant, and `true`, `1`, and `1.0`
 are distinct. Semantic no-ops, including QR metadata writes, preserve the original
 bytes and inode. Mutation records are closed and type-validated for PPTX, confirmed
-intent, improvement goal, resource, thumbnail, publishing, and optional schema-v1
-metadata. Clarification can persist complete blind-spot/humor structures, and exact
+intent, improvement goal, resource, thumbnail, and publishing metadata. New PPTX,
+QR, confirmed-intent, resource, and thumbnail records carry required schema-v1
+identities. Backups are deferred until the staged candidate passes its final integrity
+checks, followed by one more live-generation and stage verification before install.
+Clarification can persist complete blind-spot/humor structures, and exact
 record retirement changes only a goal's status while preserving legacy provenance.
 
 Clarification, profile, thumbnail, and resource instructions now bootstrap through

--- a/rules/resources-gathering-rules.md
+++ b/rules/resources-gathering-rules.md
@@ -15,9 +15,9 @@ manually scan the outline first — the script handles URL detection, repo
 matching, book patterns, RFC citations, and tool mentions consistently.
 Manual scanning misses items and introduces inconsistency.
 
-```bash
-python3 skills/presentation-creator/scripts/extract-resources.py outline.yaml
-```
+Use the installed-root, configured-interpreter command in
+`skills/presentation-creator/references/phase6-publishing.md`; do not duplicate
+or improvise its invocation here.
 
 ## 2. Speaker Review is Mandatory
 
@@ -43,10 +43,7 @@ higher in the review list and flag them as "from Coda section."
 
 `resources.json` lives in the talk working directory alongside
 `outline.yaml`. It is talk-specific, not vault-level. Path:
-
-```
-{presentations-dir}/{conference}/{year}/{talk-slug}/resources.json
-```
+`{presentations-dir}/{conference}/{year}/{talk-slug}/resources.json`.
 
 ## 5. Shownotes Integration
 
@@ -63,22 +60,15 @@ adds resources manually, check for duplicates before appending.
 
 ## 7. Tracking Database
 
-After resources are approved, prepare this complete `resources[]` record:
+After resources are approved, prepare a complete `resources[]` record with
+exactly these fields:
 
-```json
-{
-  "schema_version": 1,
-  "talk_slug": "...",
-  "item_count": 12,
-  "category_breakdown": {
-    "urls": 5,
-    "repos": 1,
-    "tools": 3,
-    "books": 2,
-    "rfcs": 1
-  }
-}
-```
+- `schema_version`: exact integer `1`.
+- `talk_slug`: non-empty string without leading or trailing whitespace.
+- `item_count`: exact non-negative integer.
+- `category_breakdown`: object mapping non-empty category names without leading
+  or trailing whitespace to exact non-negative integer counts. Use `urls`,
+  `repos`, `tools`, `books`, and `rfcs` for the standard categories.
 
 `item_count` must equal the sum of the non-negative integer category counts.
 Persist the record only with the ingress owner's `upsert_resource` mutation,

--- a/rules/resources-gathering-rules.md
+++ b/rules/resources-gathering-rules.md
@@ -63,18 +63,29 @@ adds resources manually, check for duplicates before appending.
 
 ## 7. Tracking Database
 
-After resources are approved, update `tracking-database.json` with a
-`resources[]` entry:
+After resources are approved, prepare this complete `resources[]` record:
 
 ```json
 {
   "talk_slug": "...",
-  "resources_json_path": "...",
   "item_count": 12,
-  "categories": {"urls": 5, "repos": 1, "tools": 3, "books": 2, "rfcs": 1},
-  "created_at": "..."
+  "category_breakdown": {
+    "urls": 5,
+    "repos": 1,
+    "tools": 3,
+    "books": 2,
+    "rfcs": 1
+  }
 }
 ```
+
+`item_count` must equal the sum of the non-negative integer category counts.
+Persist the record only with the ingress owner's `upsert_resource` mutation,
+expecting the exact existing record for the slug or `{"$missing": true}`. In
+the same typed plan, use `update_talk_publishing` for any talk publishing flags,
+with exact field expectations. Dry-run the whole plan, review its changes, apply
+against the reported input SHA, and re-read through the owner contract. Never
+open or rewrite `tracking-database.json` directly.
 
 ## 8. Shownotes Publishing Destination
 

--- a/rules/resources-gathering-rules.md
+++ b/rules/resources-gathering-rules.md
@@ -67,6 +67,7 @@ After resources are approved, prepare this complete `resources[]` record:
 
 ```json
 {
+  "schema_version": 1,
   "talk_slug": "...",
   "item_count": 12,
   "category_breakdown": {

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -15,6 +15,25 @@ Before any thumbnail work, confirm the inputs:
 4. **`outline.yaml`** — slide references; the
    `style_anchor` block (if present) feeds `--portrait-style`.
 5. **YouTube video URL** — provided by the speaker at trigger time.
+6. **Tracking database** — load through the ingress owner's strict reader and
+   retain its SHA-256. Use the exact non-empty `config.python_path` for the
+   mutation in Sub-step 10. Missing or invalid config stops this flow and invokes
+   `Skill(skill: "vault-ingress")` at Step 1.
+
+Set `host_python` to the current host's explicit absolute interpreter path (not
+a PATH lookup). The sole interpreter-bootstrap exception is one stdlib-only
+owner read:
+
+```bash
+"{host_python}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py" \
+  "~/.claude/rhetoric-knowledge-vault/tracking-database.json"
+```
+
+Resolve `vault_root` and `python_path` from that report, then immediately repeat
+the read with `"{python_path}"` against the resolved database and require the
+same database bytes/SHA-256. The unconfigured `host_python` is authorized only for the first
+owner-reader invocation. Every command below uses the configured interpreter;
+never fall back to a PATH interpreter.
 
 If shownotes are needed too (Step 7.2 in presentation-creator) and don't
 exist yet, STOP and ask before generating the thumbnail.
@@ -42,7 +61,7 @@ Resolution chain:
    `slide-{NN}.*` matching the chosen slide.
 2. **PPTX extraction** — use the helper mode:
    ```bash
-   python3 "{speaker_toolkit_root}/skills/illustrations/scripts/generate-thumbnail.py" \
+   "{python_path}" "{speaker_toolkit_root}/skills/illustrations/scripts/generate-thumbnail.py" \
      --extract-slide deck.pptx 15 --output slide-15.png
    ```
    Uses LibreOffice headless or PowerPoint AppleScript on macOS.
@@ -107,7 +126,7 @@ If Phase 2 didn't produce a style anchor (stock-image-only deck), omit
 
 ```bash
 # Single recommended candidate (the precedence-chain winner)
-python3 "{speaker_toolkit_root}/skills/illustrations/scripts/generate-thumbnail.py" \
+"{python_path}" "{speaker_toolkit_root}/skills/illustrations/scripts/generate-thumbnail.py" \
   --slide-image illustrations/slide-15.png \
   --speaker-photo ~/photos/headshot.jpg \
   --title "JUDGMENT DAY" \
@@ -120,7 +139,7 @@ python3 "{speaker_toolkit_root}/skills/illustrations/scripts/generate-thumbnail.
   --output thumbnail.png
 
 # Anchor-matched (when the deck has a style_anchor block)
-python3 "{speaker_toolkit_root}/skills/illustrations/scripts/generate-thumbnail.py" \
+"{python_path}" "{speaker_toolkit_root}/skills/illustrations/scripts/generate-thumbnail.py" \
   --slide-image illustrations/slide-15.png \
   --speaker-photo ~/photos/headshot.jpg \
   --title "JUDGMENT DAY" \
@@ -184,7 +203,7 @@ redesign to re-derive the path convention. Don't reinvent it from folklore.
 
 ## Sub-step 10: Tracking Database Update
 
-Add to `thumbnails[]` in `tracking-database.json`:
+Prepare this complete `thumbnails[]` record:
 
 ```json
 {
@@ -201,4 +220,10 @@ Add to `thumbnails[]` in `tracking-database.json`:
 }
 ```
 
-Also set `thumbnail_generated: true` on the talk's entry in `talks[]`.
+Persist it with the ingress owner's `upsert_thumbnail` mutation, expecting the
+exact existing record for the slug or `{"$missing": true}`. In the same plan, use
+`update_talk_publishing` to set `thumbnail_generated: true` on the exact talk
+filename, expecting its current value. Dry-run the whole plan, review it, apply
+against the reported input SHA, and re-read as specified by the
+[owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
+Never rewrite `tracking-database.json` directly.

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -207,6 +207,7 @@ Prepare this complete `thumbnails[]` record:
 
 ```json
 {
+  "schema_version": 1,
   "talk_slug": "judgment-day",
   "youtube_url": "https://youtube.com/watch?v=...",
   "source_slide_num": 15,

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -64,7 +64,7 @@ Then load local references per phase:
 Then run:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/pattern_history_status.py" \
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/pattern_history_status.py" \
   path/to/speaker-profile.json path/to/rhetoric-style-summary.md
 ```
 
@@ -91,7 +91,7 @@ entries do not authorize history. Current-taxonomy scans of the new outline rema
 exists, run in **summary-only mode**: use default guardrail thresholds (1.5
 slides/min, 45% Act 1 cap) and ask for template/publishing data interactively. Section
 15 classifications are usable only when its uniquely delimited current block passes
-`python3 "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"` and the same strict
+`"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"` and the same strict
 pattern-profile assessment with `classification_fields_available: true`; ordinary,
 stale, or occurrence-only Section 15 data authorizes taxonomy-only recommendations,
 never speaker-history claims.
@@ -133,20 +133,20 @@ By end of Phase 3, the talk directory contains:
 Regenerate the four derived artifacts after every edit to `outline.yaml`:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" outline.yaml > narrative.md
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-script.py"    outline.yaml > script.md
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-slides.py"    outline.yaml > slides.md
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/check-rhetorical.py"  outline.yaml > rhetorical-review.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" outline.yaml > narrative.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-script.py"    outline.yaml > script.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-slides.py"    outline.yaml > slides.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/check-rhetorical.py"  outline.yaml > rhetorical-review.md
 ```
 
-Validate the YAML with `python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py" outline.yaml` — exits non-zero with a typed error if any validator fails.
+Validate the YAML with `"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py" outline.yaml` — exits non-zero with a typed error if any validator fails.
 
 `narrative.md` is the exception to "by end of Phase 3" — it is generated earlier
 in partial form during Phases 1–2 so the author can review and approve the
 narrative before slide content development:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" --partial outline.yaml > narrative.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" --partial outline.yaml > narrative.md
 ```
 
 `--partial` validates `talk` + `chapters` without requiring `slides[]`. The
@@ -162,7 +162,7 @@ action:
 - `speaker-profile.json` — publishing config, shortener, URL patterns
 - `secrets.json` — API keys for shorteners and Gemini
 - `outline.yaml` — source of truth for talk slug, metadata, slides, and shownotes URL.
-  Read it via `python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py"` (the pydantic model exposes `talk.slug`,
+  Read it via `"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py"` (the pydantic model exposes `talk.slug`,
   `talk.title`, `talk.shownotes_url_base`, etc.) — never re-parse the YAML by hand.
 
 If the file is missing or fails to validate, STOP and ask. Do not guess values that
@@ -230,7 +230,7 @@ Save the partial outline to: `{presentations-dir}/{conference}/{year}/{talk-slug
 Then generate the narrative stub so the author can read the TL;DR early:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" --partial outline.yaml > narrative.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" --partial outline.yaml > narrative.md
 ```
 
 At this phase `narrative.md` carries the TL;DR only — the chapter body fills in
@@ -275,7 +275,7 @@ Once the architecture is set, author `chapters[]` (section headings, `target_min
 its chapter body — for human review:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" --partial outline.yaml > narrative.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" --partial outline.yaml > narrative.md
 ```
 
 Present `narrative.md` to the author. This is the narrative-approval point: the
@@ -376,11 +376,11 @@ placeholder definitions and meme-brief format.
 After saving `outline.yaml`, validate and regenerate the derived artifacts:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py" outline.yaml      # validates; non-zero on error
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" outline.yaml > narrative.md
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-script.py"    outline.yaml > script.md
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-slides.py"    outline.yaml > slides.md
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/check-rhetorical.py"  outline.yaml > rhetorical-review.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py" outline.yaml      # validates; non-zero on error
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-narrative.py" outline.yaml > narrative.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-script.py"    outline.yaml > script.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-slides.py"    outline.yaml > slides.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/check-rhetorical.py"  outline.yaml > rhetorical-review.md
 ```
 
 The four `.md` files are read-only — never edit them directly; they regenerate
@@ -391,8 +391,8 @@ deterministically from `outline.yaml`.
 Run two checkers — they cover different surfaces:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/check-rhetorical.py" outline.yaml > rhetorical-review.md
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/guardrail-check.py"   outline.yaml path/to/speaker-profile.json
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/check-rhetorical.py" outline.yaml > rhetorical-review.md
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/guardrail-check.py"   outline.yaml path/to/speaker-profile.json
 ```
 
 `check-rhetorical.py` enforces the **closed pattern taxonomy** (opening PUNCH,
@@ -461,7 +461,7 @@ template's demo slides and creates every slide from the ops. See
 [references/deckops-spec.md](references/deckops-spec.md).
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/validate-deckops.py" ops.txt
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/validate-deckops.py" ops.txt
 bash "{speaker_toolkit_root}/skills/presentation-creator/scripts/build-deck.sh" "{template_copy_pptx_path}" "{output_path}" ops.txt
 ```
 

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -38,7 +38,12 @@ joint effort — the skill brings rhetoric knowledge, the author brings topic ex
 ## Before You Start: Load the Vault
 
 The vault lives at `~/.claude/rhetoric-knowledge-vault/` (may be a symlink to a custom
-location). Read `tracking-database.json` from there to get `config.vault_root`.
+location). Load `tracking-database.json` with the strict owner reader at
+`{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py` to
+get `config.vault_root`; never parse it directly. The reader is stdlib-only, so the
+host interpreter may bootstrap this first read. Afterward, use only the exact
+non-empty `config.python_path` for every toolkit command. Missing or unusable
+configuration stops this flow and invokes `Skill(skill: "vault-ingress")` at Step 1.
 
 Load from vault root: `rhetoric-style-summary.md` (constitution — all patterns),
 `slide-design-spec.md` (visual rules), `speaker-profile.json` (structured data).

--- a/skills/presentation-creator/references/deck-editing-setup.md
+++ b/skills/presentation-creator/references/deck-editing-setup.md
@@ -42,7 +42,7 @@ deck must never carry the macro.
 already has them, so this is a no-op there):
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/sync-deck-drivers.py" materialize
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/sync-deck-drivers.py" materialize
 ```
 
 This recreates `RunDeckOps.bas` and the eight `.applescript` drivers from their

--- a/skills/presentation-creator/references/deckops-spec.md
+++ b/skills/presentation-creator/references/deckops-spec.md
@@ -9,7 +9,7 @@ You (the agent) emit the op sequence from `slides.md` + the profile layout map â
 layout, placeholder, and content choices are your judgment. Then:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/validate-deckops.py" ops.txt          # exit 0 + {"slides":N,"ops":M}, or exit 1 + errors
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/validate-deckops.py" ops.txt # exit 0 + {"slides":N,"ops":M}, or exit 1 + errors
 bash "{speaker_toolkit_root}/skills/presentation-creator/scripts/build-deck.sh" <template-copy.pptx> <out.pptx> ops.txt
 ```
 

--- a/skills/presentation-creator/references/phase0-intake.md
+++ b/skills/presentation-creator/references/phase0-intake.md
@@ -34,7 +34,7 @@ counts, or rules — read the profile.
 > Run 'update speaker profile' to sync, or proceed with the current profile?"
 
 **Pattern-history authorization:** run
-`python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/pattern_history_status.py"` against the loaded
+`"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/pattern_history_status.py"` against the loaded
 profile and summary before reading any catalog-derived history. Use `-` as its profile
 argument when no profile exists. Its JSON `history_enabled` value is the sole creator
 classification gate; surface a disabled result's exact `warning`.
@@ -58,7 +58,7 @@ If the profile is absent, malformed, or history-disabled, Section 15 does not re
 history by implication. Use Section 15 history only when its current block carries
 explicit provenance matching the bundled catalog/scoring generation and a complete
 structured contract accepted by
-`python3 "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"`. That parser delegates the
+`"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"`. That parser delegates the
 payload to the shared profile provenance assessor, and classifications still require
 `classification_fields_available: true`. A date, a recent heading, an
 unlabeled count, or ordinary prose is insufficient; use taxonomy-only fallback when

--- a/skills/presentation-creator/references/phase3-content.md
+++ b/skills/presentation-creator/references/phase3-content.md
@@ -2,7 +2,7 @@
 
 `outline.yaml` is the source of truth for the talk's content. The schema is
 defined in `scripts/outline_schema.py` (pydantic v2 model); validate any draft
-with `python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py" outline.yaml`. The four derived
+with `"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/outline_schema.py" outline.yaml`. The four derived
 artifacts (`narrative.md`, `script.md`, `slides.md`, `rhetorical-review.md`)
 regenerate deterministically — never hand-edit them.
 

--- a/skills/presentation-creator/references/phase5-slides.md
+++ b/skills/presentation-creator/references/phase5-slides.md
@@ -36,7 +36,7 @@ saves the output. You emit the ops while walking the outline (Step 5.2), then
 validate and build:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/validate-deckops.py" ops.txt
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/validate-deckops.py" ops.txt
 bash "{speaker_toolkit_root}/skills/presentation-creator/scripts/build-deck.sh" '{template_copy_pptx_path}' '{output_path}' ops.txt
 ```
 
@@ -293,7 +293,7 @@ speaker's `publishing_process.export_method` and platform.
 Run the export script — it auto-detects PowerPoint (macOS AppleScript) or LibreOffice:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/export-pdf.py" path/to/deck.pptx [path/to/output.pdf]
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/export-pdf.py" path/to/deck.pptx [path/to/output.pdf]
 ```
 
 If `output.pdf` is omitted, uses the same name with `.pdf` extension.

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -44,8 +44,8 @@ and Coda slides are easy to miss — this step catches them systematically.
    and edits entries. Save the approved list back to `resources.json` with
    `approved: true` on accepted items.
 
-5. Persist a complete `resources[]` entry recording the talk slug, item count,
-   and category breakdown with the ingress owner's `upsert_resource` mutation.
+5. Persist a complete `resources[]` entry with `schema_version: 1`, the talk slug,
+   item count, and category breakdown through the ingress owner's `upsert_resource` mutation.
    Expect the exact existing record for the slug, or `{"$missing": true}` for a
    first entry. Dry-run, review, apply against the reported input SHA, and re-read
    as specified by the
@@ -182,8 +182,8 @@ path make the check before resolving the link.
    - Auto-select foreground color (black on light backgrounds, white on dark) using
      WCAG relative luminance
    - Insert the QR as a 2" square in the bottom-right corner
-   - Persist QR metadata in `qr_codes[]` through the shared tracking-database
-     transaction used by `generate-qr.py`
+   - Persist schema-v1 QR metadata in `qr_codes[]` through the shared
+     tracking-database transaction used by `generate-qr.py`
 
 5. Re-running for the same `talk_slug` with a different target URL will PATCH the
    existing short link (keeping QR codes already printed valid) rather than creating

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -44,8 +44,12 @@ and Coda slides are easy to miss — this step catches them systematically.
    and edits entries. Save the approved list back to `resources.json` with
    `approved: true` on accepted items.
 
-5. Update `tracking-database.json` with a `resources[]` entry recording the
-   talk slug, item count, and category breakdown.
+5. Persist a complete `resources[]` entry recording the talk slug, item count,
+   and category breakdown with the ingress owner's `upsert_resource` mutation.
+   Expect the exact existing record for the slug, or `{"$missing": true}` for a
+   first entry. Dry-run, review, apply against the reported input SHA, and re-read
+   as specified by the
+   [owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
 
 If the speaker declines resource gathering, skip this step — Step 6.1 will
 omit the resource links section from shownotes.
@@ -96,6 +100,13 @@ be null.
 Before passing the URL downstream (QR code, bit.ly target, post-event video
 description), verify the URL is reachable — a 404 on the deployed site
 breaks printed QR codes with no recovery path.
+
+After the page is live and verified, persist `shownotes_url` and
+`shownotes_published: true` on the matching talk with one
+`update_talk_publishing` mutation. Its `expect` object must cover those same
+fields with their exact values from the latest strict read. Apply it through the
+[owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract),
+never by rewriting the database.
 
 If not enabled, skip.
 
@@ -171,7 +182,8 @@ path make the check before resolving the link.
    - Auto-select foreground color (black on light backgrounds, white on dark) using
      WCAG relative luminance
    - Insert the QR as a 2" square in the bottom-right corner
-   - Update `tracking-database.json` with the QR metadata in the `qr_codes[]` array
+   - Persist QR metadata in `qr_codes[]` through the shared tracking-database
+     transaction used by `generate-qr.py`
 
 5. Re-running for the same `talk_slug` with a different target URL will PATCH the
    existing short link (keeping QR codes already printed valid) rather than creating

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -29,7 +29,7 @@ and Coda slides are easy to miss — this step catches them systematically.
 
 1. Run the extraction script against `outline.yaml`:
    ```bash
-   python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-resources.py" outline.yaml
+   "{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/extract-resources.py" outline.yaml
    ```
 
 2. The script produces `resources.json` in the talk working directory with
@@ -158,20 +158,20 @@ path make the check before resolving the link.
 3. Run the QR generation script:
    ```bash
    # MCP-preresolved mode:
-   python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" deck.pptx \
+   "{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" deck.pptx \
      --talk-slug SLUG --short-url SHORT_URL
 
    # Direct API mode:
-   python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" deck.pptx \
+   "{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" deck.pptx \
      --talk-slug SLUG --shownotes-url SHOWNOTES_URL \
      --vault /path/to/vault
 
    # No shortening:
-   python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" deck.pptx \
+   "{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" deck.pptx \
      --talk-slug SLUG --shownotes-url SHOWNOTES_URL
 
    # PNG-only (no deck — for presenterm, PDF, or standalone use):
-   python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" --png-only \
+   "{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-qr.py" --png-only \
      --talk-slug SLUG --shownotes-url SHOWNOTES_URL \
      --output /path/to/qr.png --bg-color 128,0,128
    ```
@@ -218,11 +218,11 @@ Generate a plain-text timing file for [timemytalk.app](https://timemytalk.app)
 by running:
 
 ```bash
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-talk-timings.py" \
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-talk-timings.py" \
   outline.yaml --output talk-timings.txt
 
 # If the talk slot includes Q&A time:
-python3 "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-talk-timings.py" \
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/generate-talk-timings.py" \
   outline.yaml --qa 5 --output talk-timings.txt
 ```
 

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -42,7 +42,7 @@ Update the existing shownotes page with the video recording link.
 #### 1. Verify Shownotes Exist
 
 Check that shownotes were published in Phase 6 Step 6.1. Look for:
-- The shownotes URL in `tracking-database.json` for this talk
+- The shownotes URL in the strict owner-reader result for this talk
 - Or construct from `publishing_process.shownotes.url.base` +
   `publishing_process.shownotes.url.template` (substitute `{slug}` and any
   date variables) — see phase6-publishing.md for the full template semantics
@@ -84,9 +84,12 @@ Use the same publishing method as Phase 6 Step 6.1:
 
 #### 5. Tracking Database Update
 
-Set `video_added_to_shownotes: true` on the talk's entry in `talks[]`.
-
-Add the YouTube URL to the talk entry if not already present.
+Persist `video_added_to_shownotes: true` and the YouTube `video_url` (plus the
+derived `youtube_id` when absent) with one `update_talk_publishing` mutation.
+The `expect` object must cover exactly the fields being set with values from the
+latest strict read. Dry-run, review, apply against the reported input SHA, and
+re-read through the
+[owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
 
 ---
 

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -977,7 +977,8 @@ def main():
             print(
                 "Tracking DB SHA-256: "
                 f"{write_result.input_sha256} -> {write_result.output_sha256} "
-                f"({write_result.durability_state})"
+                f"({write_result.durability_state})",
+                file=sys.stderr,
             )
             for warning in write_result.warnings:
                 print(f"WARNING: {warning}", file=sys.stderr)

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -994,7 +994,10 @@ def main():
             except ValueError as exc:
                 print(f"ERROR: {exc}", file=sys.stderr)
                 sys.exit(1)
-            print(f"Tracking DB updated: {tdb_path}")
+            if write_result.installed:
+                print(f"Tracking DB updated: {tdb_path}")
+            else:
+                print(f"Tracking DB unchanged: {tdb_path}")
             print(
                 "Tracking DB SHA-256: "
                 f"{write_result.input_sha256} -> {write_result.output_sha256} "

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -142,15 +142,23 @@ def load_vault_config(vault_path, profile_path=None):
     return speaker_profile, secrets, tracking_db, tracking_db_snapshot
 
 
-def write_tracking_db(tracking_db_snapshot, tracking_db):
-    """Commit QR metadata against the generation loaded before QR work."""
+def _require_tracking_db_snapshot(
+    tracking_db_snapshot: object,
+) -> TrackingDatabaseSnapshot:
+    """Return the loaded snapshot or reject a vault that cannot be persisted."""
     if not isinstance(tracking_db_snapshot, TrackingDatabaseSnapshot):
         raise ValueError(
             "tracking-database.json is missing; initialize it through "
             "vault-ingress mutate-tracking-database.py before generating a QR"
         )
+    return tracking_db_snapshot
+
+
+def write_tracking_db(tracking_db_snapshot, tracking_db):
+    """Commit QR metadata against the generation loaded before QR work."""
+    snapshot = _require_tracking_db_snapshot(tracking_db_snapshot)
     try:
-        return write_json_object(tracking_db_snapshot, tracking_db)
+        return write_json_object(snapshot, tracking_db)
     except TrackingDatabaseIOError as exc:
         raise ValueError(f"cannot safely update tracking database: {exc}") from exc
 
@@ -820,10 +828,26 @@ def main():
         print(f"ERROR: Deck file not found: {args.deck}")
         sys.exit(1)
 
+    # Validate local inputs before URL shortening can create or retarget a link.
+    explicit_bg = None
+    if args.bg_color:
+        try:
+            parts = [int(x.strip()) for x in args.bg_color.split(",")]
+            if len(parts) != 3 or not all(0 <= x <= 255 for x in parts):
+                raise ValueError
+            explicit_bg = tuple(parts)
+        except ValueError:
+            print(
+                "ERROR: --bg-color must be R,G,B with values 0-255 "
+                f"(got: {args.bg_color})"
+            )
+            sys.exit(1)
+
     # Determine vault path
     vault_path = args.vault
     if not vault_path:
         vault_path = os.path.expanduser("~/.claude/rhetoric-knowledge-vault")
+    vault_present_at_start = os.path.isdir(vault_path)
 
     # Load config
     (
@@ -833,6 +857,12 @@ def main():
         tracking_db_snapshot,
     ) = load_vault_config(vault_path, args.profile)
     qr_config = speaker_profile.get("publishing_process", {}).get("qr_code", {})
+    if not args.dry_run and vault_present_at_start:
+        try:
+            _require_tracking_db_snapshot(tracking_db_snapshot)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(1)
 
     # Determine the URL to encode in the QR
     if args.short_url:
@@ -858,18 +888,6 @@ def main():
         )
 
     print(f"QR will encode: {qr_url}")
-
-    # Parse --bg-color if provided
-    explicit_bg = None
-    if args.bg_color:
-        try:
-            parts = [int(x.strip()) for x in args.bg_color.split(",")]
-            if len(parts) != 3 or not all(0 <= x <= 255 for x in parts):
-                raise ValueError
-            explicit_bg = tuple(parts)
-        except ValueError:
-            print(f"ERROR: --bg-color must be R,G,B with values 0-255 (got: {args.bg_color})")
-            sys.exit(1)
 
     # --- PNG-only mode: no deck needed ---
     if args.png_only:
@@ -967,7 +985,7 @@ def main():
 
     if not args.dry_run:
         tdb_path = os.path.join(vault_path, "tracking-database.json")
-        if os.path.isdir(vault_path):
+        if vault_present_at_start:
             try:
                 write_result = write_tracking_db(
                     tracking_db_snapshot,

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -32,6 +32,7 @@ Requires:
 
 import argparse
 import datetime
+import io
 import json
 import os
 import shutil
@@ -39,6 +40,7 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 try:
     import qrcode
@@ -53,11 +55,23 @@ except ImportError:
     print("ERROR: 'Pillow' package not installed. Run: pip install Pillow")
     sys.exit(1)
 
-import io
-
 from pptx import Presentation  # read-only: background-color match + slide-finding
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.util import Inches
+
+VAULT_INGRESS_SCRIPTS = (
+    Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts"
+)
+if str(VAULT_INGRESS_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(VAULT_INGRESS_SCRIPTS))
+
+from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    TrackingDatabaseIOError,
+    TrackingDatabaseSnapshot,
+    decode_json_object,
+    snapshot_tracking_database,
+    write_json_object,
+)
 
 # --- Constants ---
 
@@ -94,12 +108,13 @@ def load_vault_config(vault_path, profile_path=None):
     """Load speaker profile, secrets, and tracking database from the vault.
 
     Returns:
-        tuple (speaker_profile, secrets, tracking_db)
+        tuple (speaker_profile, secrets, tracking_db, tracking_db_snapshot)
         Any of these may be empty dicts if the file doesn't exist.
     """
     speaker_profile = {}
     secrets = {}
     tracking_db = {}
+    tracking_db_snapshot = None
 
     # Speaker profile
     sp_path = profile_path or os.path.join(vault_path, "speaker-profile.json")
@@ -116,10 +131,26 @@ def load_vault_config(vault_path, profile_path=None):
     # Tracking database
     tdb_path = os.path.join(vault_path, "tracking-database.json")
     if os.path.isfile(tdb_path):
-        with open(tdb_path, "r", encoding="utf-8") as f:
-            tracking_db = json.load(f)
+        try:
+            tracking_db_snapshot = snapshot_tracking_database(tdb_path)
+            tracking_db = decode_json_object(tracking_db_snapshot)
+        except TrackingDatabaseIOError as exc:
+            raise SystemExit(f"ERROR: cannot load tracking database: {exc}") from exc
 
-    return speaker_profile, secrets, tracking_db
+    return speaker_profile, secrets, tracking_db, tracking_db_snapshot
+
+
+def write_tracking_db(tracking_db_snapshot, tracking_db):
+    """Commit QR metadata against the generation loaded before QR work."""
+    if not isinstance(tracking_db_snapshot, TrackingDatabaseSnapshot):
+        raise ValueError(
+            "tracking-database.json is missing; initialize it through "
+            "vault-ingress mutate-tracking-database.py before generating a QR"
+        )
+    try:
+        return write_json_object(tracking_db_snapshot, tracking_db)
+    except TrackingDatabaseIOError as exc:
+        raise ValueError(f"cannot safely update tracking database: {exc}") from exc
 
 
 # --- URL Shortening ---
@@ -175,7 +206,7 @@ def create_bitly_link(long_url, api_token, custom_back_half=None, domain=None):
     if custom_back_half:
         try:
             _http_request(
-                f"https://api-ssl.bitly.com/v4/custom_bitlinks",
+                "https://api-ssl.bitly.com/v4/custom_bitlinks",
                 data={
                     "bitlink_id": link_id,
                     "custom_bitlink": f"{bitly_domain}/{custom_back_half}",
@@ -262,7 +293,7 @@ def _print_missing_key_help(service, key_name, vault_path):
     secrets_path = os.path.join(vault_path, "secrets.json") if vault_path else "secrets.json"
     if vault_path and not os.path.isfile(secrets_path):
         print(f"  WARNING: No {service}.{key_name} found — secrets.json does not exist. Falling back to raw URL.")
-        print(f"  Create it:")
+        print("  Create it:")
         print(f'    echo \'{{\"{service}\": {{\"{key_name}\": \"YOUR_KEY\"}}}}\' > {secrets_path}')
         print(f"    chmod 600 {secrets_path}")
     else:
@@ -284,7 +315,7 @@ def _require_domain_decision(config, shortener, vault_path):
     profile = os.path.join(vault_path, "speaker-profile.json") if vault_path else "the speaker profile"
     print(f"ERROR: No custom-domain decision recorded for shortener '{shortener}'.")
     print("  Before creating the first short link, ask the user whether they have a")
-    print(f"  custom domain (e.g. jbaru.ch), then save the answer under")
+    print("  custom domain (e.g. jbaru.ch), then save the answer under")
     print(f"  publishing_process.qr_code.{key} in {profile}:")
     print(f'    a domain string (e.g. "jbaru.ch"), or null for no custom domain ({default_domain}).')
     sys.exit(1)
@@ -792,7 +823,12 @@ def main():
         vault_path = os.path.expanduser("~/.claude/rhetoric-knowledge-vault")
 
     # Load config
-    speaker_profile, secrets, tracking_db = load_vault_config(vault_path, args.profile)
+    (
+        speaker_profile,
+        secrets,
+        tracking_db,
+        tracking_db_snapshot,
+    ) = load_vault_config(vault_path, args.profile)
     qr_config = speaker_profile.get("publishing_process", {}).get("qr_code", {})
 
     # Determine the URL to encode in the QR
@@ -929,9 +965,22 @@ def main():
     if not args.dry_run:
         tdb_path = os.path.join(vault_path, "tracking-database.json")
         if os.path.isdir(vault_path):
-            with open(tdb_path, "w", encoding="utf-8") as f:
-                json.dump(tracking_db, f, indent=2, ensure_ascii=False)
+            try:
+                write_result = write_tracking_db(
+                    tracking_db_snapshot,
+                    tracking_db,
+                )
+            except ValueError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                sys.exit(1)
             print(f"Tracking DB updated: {tdb_path}")
+            print(
+                "Tracking DB SHA-256: "
+                f"{write_result.input_sha256} -> {write_result.output_sha256} "
+                f"({write_result.durability_state})"
+            )
+            for warning in write_result.warnings:
+                print(f"WARNING: {warning}", file=sys.stderr)
         else:
             print(f"  NOTE: Vault path {vault_path} not found, tracking DB not persisted")
 

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -82,6 +82,7 @@ QR_ERROR_CORRECTION = ERROR_CORRECT_M
 # QR placement: bottom-right, 2 inches wide, 0.3 inch margin from edges
 QR_WIDTH_INCHES = 2.0
 QR_MARGIN_INCHES = 0.3
+QR_CODE_RECORD_SCHEMA_VERSION = 1
 
 # Existing-QR detection (content-based, size-independent). A QR is a SQUARE
 # picture that is BOTH essentially two colors AND roughly balanced between them:
@@ -754,6 +755,7 @@ def update_tracking_db(tracking_db, entry, qr_png_rel_path):
     talk_slug = entry["talk_slug"]
 
     new_entry = {
+        "schema_version": QR_CODE_RECORD_SCHEMA_VERSION,
         "talk_slug": talk_slug,
         "target_url": entry["target_url"],
         "shortener": entry["shortener"],

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -65,6 +65,7 @@ VAULT_INGRESS_SCRIPTS = (
 if str(VAULT_INGRESS_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(VAULT_INGRESS_SCRIPTS))
 
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
     TrackingDatabaseSnapshot,

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -173,9 +173,9 @@ in prose.
 Retire goals the speaker no longer wants with `retire_improvement_goal`, naming
 its exact `id` and expecting the complete current record. That operation changes
 only `status` to `retired`, so legacy fields and fixed provenance survive unchanged;
-leave `achieved` goals in place as history. A schema-v1 pattern goal is historical
-and unverifiable, not a baseline to restamp. Compatibility shorthand:
-schema-v1 pattern goal is historical and unverifiable. If the speaker explicitly chooses to
+leave `achieved` goals in place as history.
+A schema-v1 pattern goal is historical and unverifiable, never a baseline to restamp.
+If the speaker explicitly chooses to
 rebaseline one, retire the old record and create a new schema-v2 record whose
 `supersedes_goal_id` points to it. This preserves the old fixed yardstick rather than
 silently overwriting it.

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -24,10 +24,31 @@ Run after vault-ingress has processed talks. Purpose: resolve ambiguities, valid
 findings, capture intent, and fill in speaker infrastructure config.
 
 The vault lives at `~/.claude/rhetoric-knowledge-vault/` (may be a symlink).
-Read `tracking-database.json` from there to get `vault_root`.
-Before invoking a toolkit script, set `python_path` to the exact non-empty
-`config.python_path` value in that database. Stop and route missing or unusable
-configuration through vault-ingress Step 1; never fall back to `python3` on `PATH`.
+Set `host_python` to the current host's explicit absolute interpreter path (not
+a PATH lookup). The sole interpreter-bootstrap exception is this one stdlib-only
+strict-owner read; never parse the database directly:
+
+```bash
+"{host_python}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py" \
+  "~/.claude/rhetoric-knowledge-vault/tracking-database.json"
+```
+
+Use the report's database and SHA-256 to resolve `vault_root` and the exact
+non-empty `config.python_path`. Set `python_path` to that value, immediately
+repeat the owner read with `"{python_path}"` against the resolved
+`{vault_root}/tracking-database.json`, and require the database and SHA-256 to
+match the bootstrap report. The unconfigured `host_python` is authorized only
+for that first owner-reader invocation. For missing, changed, or unusable
+configuration, stop and invoke `Skill(skill: "vault-ingress")` at Step 1; never
+fall back to `python3` on `PATH` for another toolkit script.
+
+For every tracking-database change, compose a schema-v1 typed plan and run
+`mutate-tracking-database.py` in its default dry-run mode. Review `changes`, then
+run the same plan with `--apply --expected-sha256 <input_sha256>` and re-read the
+database. Every mutation carries an exact value/record expectation; use
+`{"$missing": true}` only when absence is expected. A failed precondition applies
+nothing. The canonical command and operation contract is in
+[../vault-ingress/references/schemas-db.md](../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
 
 ## Key Files & References
 
@@ -45,6 +66,8 @@ configuration through vault-ingress Step 1; never fall back to `python3` on `PAT
 For each surprising, contradictory, or ambiguous observation, ask one topic at a time
 via `AskUserQuestion`: intentional vs accidental patterns, invisible context,
 conflicting signals, and flagged improvement areas. Update summary and DB after each answer.
+Use the typed mutation protocol above for the DB portion; do not batch answers into
+one unreviewed write at the end.
 
 Example clarification question:
 ```
@@ -81,12 +104,15 @@ If `config.clarification_sessions_completed` is already ≥ 1, skip this step �
 
 Otherwise, ask for any empty config fields (`speaker_name` through `publishing_process.*`).
 See [references/schemas-config.md](references/schemas-config.md) for the full field list and questions to ask.
+Persist each confirmed answer with `set_config`, expecting the exact value observed
+by the latest strict read.
 
 Proceed immediately to Step 5.
 
 ## Step 5 — Structured Intent Capture
 
-Store confirmed intents in the `confirmed_intents` array of the tracking DB.
+Persist each confirmed intent with `upsert_confirmed_intent`, expecting either the
+exact existing record for that pattern or `{"$missing": true}`.
 Example:
 ```json
 {
@@ -108,10 +134,12 @@ the speaker (via `AskUserQuestion`, one topic at a time) which
 **1–2** they want to focus on before the next batch of talks. Coaching only works when
 the speaker owns the target, so never auto-pick more than they choose.
 
-For each chosen focus area, write a **complete** schema-v2 `improvement_goals` record
-to the tracking DB — every field, not a subset. A partial record cannot be verified:
+For each chosen focus area, persist a **complete** schema-v2 `improvement_goals`
+record with `upsert_improvement_goal`, expecting either the exact existing record
+or `{"$missing": true}` — every field, not a subset. A partial record cannot be verified:
 vault-ingress needs `metric` to compute `current_value`, and `id`/`issue`/`kind` to
 identify and route the goal. Set `id` (kebab-case), `issue`, `kind`, `metric`,
+`antipattern_id` (the exact ID only for an `antipattern` goal, otherwise `null`),
 `baseline_value`, the speaker's stated `target`, `status: "active"`, `set_date` to
 today, `set_by: "vault-clarification"`, `current_value: ""`, `last_checked: null`,
 `checked_by: null`, `verification_state: "pending"`, `verification_reasons: []`,
@@ -142,10 +170,13 @@ Malformed JSON or a contract violation exits 1, writes no stdout, and writes
 owns generation comparability; do not reproduce its fingerprint/schema comparison
 in prose.
 
-Retire goals the speaker no longer wants (`status: "retired"`); leave `achieved`
-goals in place as history. A schema-v1 pattern goal is historical and unverifiable,
-not a baseline to restamp. If the speaker explicitly chooses to rebaseline one,
-retire the old record and create a new schema-v2 record whose
+Retire goals the speaker no longer wants with `retire_improvement_goal`, naming
+its exact `id` and expecting the complete current record. That operation changes
+only `status` to `retired`, so legacy fields and fixed provenance survive unchanged;
+leave `achieved` goals in place as history. A schema-v1 pattern goal is historical
+and unverifiable, not a baseline to restamp. Compatibility shorthand:
+schema-v1 pattern goal is historical and unverifiable. If the speaker explicitly chooses to
+rebaseline one, retire the old record and create a new schema-v2 record whose
 `supersedes_goal_id` points to it. This preserves the old fixed yardstick rather than
 silently overwriting it.
 Full field list and `kind` values:
@@ -164,14 +195,17 @@ Proceed immediately to Step 7.
 
 ## Step 7 — Mark Session Complete
 
-Increment `config.clarification_sessions_completed` in the tracking DB. This counter
-gates profile generation (vault-profile skill requires >= 1).
+Using the latest strict read, persist
+`config.clarification_sessions_completed + 1` with `set_config`, expecting the
+exact prior integer. This counter gates profile generation (vault-profile skill
+requires >= 1).
 
 Finish here.
 
 ## Important Notes
 
 - One topic at a time — don't dump all questions at once.
-- Update the summary and DB after each answer, not in a batch at the end.
+- Update the summary and apply one reviewed typed DB plan after each answer, not in
+  a batch at the end.
 - After completing a session, suggest running the **vault-profile** skill if 10+ talks
   are processed and the profile hasn't been generated yet.

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -116,6 +116,7 @@ exact existing record for that pattern or `{"$missing": true}`.
 Example:
 ```json
 {
+  "schema_version": 1,
   "pattern": "delayed_self_introduction",
   "intent": "deliberate",
   "rule": "Use two-phase intro: brief bio at slide 3, full re-intro mid-talk",

--- a/skills/vault-clarification/references/blind-spot-moments.md
+++ b/skills/vault-clarification/references/blind-spot-moments.md
@@ -19,4 +19,9 @@ cannot measure — then ask the speaker about each one. Examples:
 
 These blind spots are inherent to transcript+slides analysis. Asking about them captures
 data that no amount of parsing can recover. Store responses as `blind_spot_observations`
-in the talk's tracking DB entry and integrate into the rhetoric summary.
+in the talk's tracking DB entry and integrate into the rhetoric summary. Persist the
+DB value only through the ingress owner's `update_talk_clarification` mutation: name
+the exact talk filename, set `blind_spot_observations` to one complete JSON object or
+array, and expect that field's exact current object/array or `{"$missing": true}`.
+Dry-run, review, hash-bind apply, and re-read through the owner contract; never edit
+the tracking database directly.

--- a/skills/vault-clarification/references/humor-post-mortem.md
+++ b/skills/vault-clarification/references/humor-post-mortem.md
@@ -23,4 +23,9 @@ This is particularly important for recent talks where memory is fresh. For older
 (2+ years), compress to: "Any jokes you remember landing particularly well or badly?"
 
 Store results in `humor_postmortem` on the talk's DB entry and update the rhetoric
-summary Section 3 (Humor & Wit) with confirmed effectiveness data.
+summary Section 3 (Humor & Wit) with confirmed effectiveness data. Persist the DB
+value only through the ingress owner's `update_talk_clarification` mutation: name
+the exact talk filename, set `humor_postmortem` to one complete JSON object or array,
+and expect that field's exact current object/array or `{"$missing": true}`. Dry-run,
+review, hash-bind apply, and re-read through the owner contract; never edit the
+tracking database directly.

--- a/skills/vault-clarification/references/schemas-config.md
+++ b/skills/vault-clarification/references/schemas-config.md
@@ -58,8 +58,8 @@ records only with the ingress owner's `upsert_confirmed_intent` mutation; see th
 }
 ```
 
-The complete record has exactly required string fields `pattern`, `intent`,
-`rule`, and `note`, plus optional exact integer `schema_version: 1` and optional
+The complete record has required exact integer `schema_version: 1` and string
+fields `pattern`, `intent`, `rule`, and `note`, plus optional
 speaker-confirmation provenance. Provenance may use one of singular `source_talk`
 or legacy alias `talk`, or the non-empty unique string array `source_talks`;
 `confirmed_date` is canonical `YYYY-MM-DD`, and `retrofit_targets` is an optional

--- a/skills/vault-clarification/references/schemas-config.md
+++ b/skills/vault-clarification/references/schemas-config.md
@@ -40,18 +40,32 @@ unified `shownotes` block.
 ## Confirmed Intents Schema
 
 Stored in the `confirmed_intents` array of the tracking database. Populated during
-clarification sessions when the speaker confirms a pattern is intentional.
+clarification sessions when the speaker confirms a pattern is intentional. Persist
+records only with the ingress owner's `upsert_confirmed_intent` mutation; see the
+[owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
 
 ```json
 {
   "confirmed_intents": [{
+    "schema_version": 1,
     "pattern": "delayed_self_introduction",
-    "intent": "deliberate|accidental|context_dependent",
+    "intent": "deliberate",
     "rule": "Use two-phase intro: brief bio at slide 3, full re-intro mid-talk",
-    "note": "Speaker confirmed this is an intentional rhetorical device"
+    "note": "Speaker confirmed this is an intentional rhetorical device",
+    "confirmed_date": "2026-08-01",
+    "source_talk": "2026-08-01-example.md"
   }]
 }
 ```
+
+The complete record has exactly required string fields `pattern`, `intent`,
+`rule`, and `note`, plus optional exact integer `schema_version: 1` and optional
+speaker-confirmation provenance. Provenance may use one of singular `source_talk`
+or legacy alias `talk`, or the non-empty unique string array `source_talks`;
+`confirmed_date` is canonical `YYYY-MM-DD`, and `retrofit_targets` is an optional
+non-empty unique string array. Existing speaker-owned intent labels outside the
+three recommended labels remain valid non-empty classifications and must not be
+discarded during an exact-record update. Unknown fields are rejected.
 
 ## Improvement Goals Schema
 
@@ -61,10 +75,13 @@ later ingress run checks whether the targeted issue actually moved. Without it t
 system diagnoses but never verifies that the speaker acted.
 
 **Owner:** vault-clarification owns the record shape and migrations (it creates and
-retires goals during a session). **Reader/updater:** vault-ingress reads active
-goals and writes only the verification fields (`status`, `current_value`,
+retires goals during a session through `upsert_improvement_goal`). **Reader/updater:**
+vault-ingress reads active goals and changes only the verification fields through
+`patch_improvement_goal_verification` (`status`, `current_value`,
 `last_checked`, `checked_by`, `verification_state`, `verification_reasons`) — never
-the owner shape or fixed baseline. On a record whose `schema_version` it does not
+the owner shape or fixed baseline. Both operations use the
+[owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
+On a record whose `schema_version` it does not
 recognize, vault-ingress treats it as read-only and skips verification.
 
 Schema v2 binds every catalog-derived goal to the exact pattern-scoring generation

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -160,7 +160,7 @@ for the complete report and mutation contract.
 
 **Scan for .pptx files:** Recursively glob `**/*.pptx` in `pptx_source_dir`; fuzzy-match
 to `talks[]` entries. Report counts, then persist each reviewed result with a
-`record_pptx` mutation, including the exact prior catalog record and, for a match,
+`record_pptx` mutation and `schema_version: 1`, including the exact prior catalog record and, for a match,
 the talk's exact prior `pptx_path` expectation. See [references/schemas-db.md](references/schemas-db.md)
 for the PPTX extraction output schema (per-slide visual data, shape types, global design stats).
 Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py"` for extraction.

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -67,6 +67,14 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | `skills/vault-ingress/scripts/audit-pattern-catalog.py` | Read-only pattern catalog graph and contract gate before analysis |
 | `skills/vault-ingress/scripts/apply-source-repairs.py` | Guarded dry-run/apply workflow for evidence-backed source metadata repairs |
 | `skills/vault-ingress/scripts/aggregate-catalog-feedback.py` | Validate and aggregate return feedback without editing the pattern catalog |
+| `skills/vault-ingress/scripts/read-tracking-database.py` | Strict, hash-reporting owner read for agent workflows |
+| `skills/vault-ingress/scripts/mutate-tracking-database.py` | Typed, expectation-bound owner mutations for config and catalog metadata |
+
+Every agent-driven read of `tracking-database.json` must go through
+`read-tracking-database.py`. Every agent-driven write not already owned by a
+specialized toolkit script must go through `mutate-tracking-database.py`; never
+parse or rewrite the file directly. Both commands and the mutation-plan contract
+are documented in [references/schemas-db.md](references/schemas-db.md#owner-read-and-mutation-contract).
 
 A talk is processable when preflight confirms at least one usable transcript,
 slide, or video source. A talk may be transcript-only or slides-only and
@@ -85,13 +93,17 @@ files to shownotes entries.
 
 **Vault discovery** — canonical path is always `~/.claude/rhetoric-knowledge-vault/`.
 
-1. **Path exists** — use as `vault_root`, read `tracking-database.json`.
+1. **Path exists** — use as `vault_root`, then load the database with the strict
+   owner read command in
+   [references/schemas-db.md](references/schemas-db.md#owner-read-and-mutation-contract).
 2. **Path missing** — first-time setup: ask preferred location via `AskUserQuestion`,
-   create directory (and symlink if custom path chosen), initialize empty
-   `tracking-database.json` with empty `config`, `talks`, `pptx_catalog`.
+   create the directory (and symlink if a custom path was chosen), then use a sole
+   `initialize_database` mutation. Review its dry-run and apply it with
+   `--expected-sha256 missing`; never create the JSON file directly.
 
 **Config bootstrapping** — ask once per missing field and persist to the tracking
-database. Core fields: `shownotes` (enabled, source.type, source.path_or_url,
+database with expectation-bound `set_config` mutations. Re-read after every
+successful apply and use the new hash for the next plan. Core fields: `shownotes` (enabled, source.type, source.path_or_url,
 source.talks_subdir, url.base, url.template, thumbnail_path_template,
 slug_convention), `pptx_source_dir`, `python_path`, `template_skip_patterns`.
 See [references/schemas-db.md](references/schemas-db.md) for the full schema
@@ -147,7 +159,9 @@ atomic and rejects a tracking-database symlink. See
 for the complete report and mutation contract.
 
 **Scan for .pptx files:** Recursively glob `**/*.pptx` in `pptx_source_dir`; fuzzy-match
-to `talks[]` entries. Report counts. See [references/schemas-db.md](references/schemas-db.md)
+to `talks[]` entries. Report counts, then persist each reviewed result with a
+`record_pptx` mutation, including the exact prior catalog record and, for a match,
+the talk's exact prior `pptx_path` expectation. See [references/schemas-db.md](references/schemas-db.md)
 for the PPTX extraction output schema (per-slide visual data, shape types, global design stats).
 Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py"` for extraction.
 Consume current schema v2 for timing/build evidence. A v0/v1 record has unknown
@@ -615,7 +629,10 @@ stop without changing any goal. Only a `comparable` assessment authorizes metric
 calculation. Record `needs_rebaseline` for a pattern-generation mismatch and
 `unverifiable` for a missing current baseline or legacy pattern goal; preserve its
 `current_value` and do not assign an outcome status. Pacing and independent goals
-remain comparable through their separate provenance lanes. The full write rubric
+remain comparable through their separate provenance lanes. Persist each assessment
+with a `patch_improvement_goal_verification` mutation whose `expect` object exactly
+matches every verification field being set. Dry-run the complete plan, review it,
+apply it against the reported input SHA, then re-read the database. The full write rubric
 is in [references/processing-rules.md](references/processing-rules.md) Improvement
 Goal Verification. Report current comparable outcomes first, then every goal that
 needs rebaselining or is unverifiable.

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -7,7 +7,9 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
 
 ```json
 {
+  "schema_version": 1,
   "config": {
+    "schema_version": 1,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
     "vault_storage_path": "/actual/path/if/custom (null when using default location)",
     "pptx_source_dir": "/path/to/Presentations",
@@ -133,6 +135,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
   "_comment_schema_version": "Talk-record schema version, stamped by persist-results.py. v1 is the implicit unversioned shape. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, evidence ledger v2, and current scoring schema v5. Migration preserves v1-v4 evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
+    "schema_version": 1,
     "pptx_path": "Conference/Year/Talk Name.pptx",
     "talk_filename": "2024-04-10-talk-slug.md or null",
     "matched": true,
@@ -140,6 +143,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
     "visual_extracted": false
   }],
   "qr_codes": [{
+    "schema_version": 1,
     "talk_slug": "arc-of-ai",
     "target_url": "canonical talk URL",
     "shortener": "bitly|rebrandly|none",
@@ -202,20 +206,19 @@ exact-type rule. The supported mutation kinds are:
 |---|---|
 | `initialize_database` | Sole mutation for a missing database; carries initial `config` |
 | `set_config` | Set or delete one nested config path against its exact prior value |
-| `record_pptx` | Replace/add one complete PPTX catalog record and, when matched, bind the talk's expected `pptx_path` |
-| `upsert_confirmed_intent` | Replace/add one complete record identified by `pattern` |
+| `record_pptx` | Replace/add one complete schema-v1 PPTX catalog record and, when matched, bind the talk's expected `pptx_path` |
+| `upsert_confirmed_intent` | Replace/add one complete schema-v1 record identified by `pattern` |
 | `upsert_improvement_goal` | Replace/add one complete record identified by `id` |
 | `patch_improvement_goal_verification` | Set only verification fields, with `expect` covering exactly the same fields |
 | `retire_improvement_goal` | Expect one complete current goal record and change only its `status` to `retired`, preserving legacy fields |
-| `upsert_resource` | Replace/add one complete record identified by `talk_slug` |
-| `upsert_thumbnail` | Replace/add one complete record identified by `talk_slug` |
+| `upsert_resource` | Replace/add one complete schema-v1 record identified by `talk_slug` |
+| `upsert_thumbnail` | Replace/add one complete schema-v1 record identified by `talk_slug` |
 | `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
 | `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |
 
 The command owns each operation's closed fields and record validation; do not
 reimplement those allowlists in skill prose. PPTX, resource, thumbnail, and
-confirmed-intent records accept the optional exact integer `schema_version: 1`
-used by the owner-versioned database generation; a boolean or future version is
+confirmed-intent records require exact integer `schema_version: 1`; a boolean or future version is
 not equivalent. Complete resource category counts must sum to `item_count`, and
 publishing scalar/identifier types are checked before patching. Run the plan without `--apply`,
 review its `changes`, then bind apply to that report's exact input hash:
@@ -229,8 +232,9 @@ review its `changes`, then bind apply to that report's exact input hash:
   --apply --expected-sha256 <input-sha256-from-dry-run>
 ```
 
-Initialization uses a sole `initialize_database` mutation, defaults to dry-run,
-and applies with the literal `--expected-sha256 missing`. All other applies
+Initialization uses a sole `initialize_database` mutation, stamps database and
+config schema version 1, defaults to dry-run, and applies with the literal
+`--expected-sha256 missing`. All other applies
 require the dry-run SHA. The complete plan is one transaction: one failed type,
 record, semantic expectation, or file-generation precondition installs nothing.
 Re-read after apply rather than assuming the candidate is still current.

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -155,6 +155,112 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
 }
 ```
 
+## Owner Read and Mutation Contract
+
+Agent workflows never open or rewrite the tracking database directly. Read it
+through the owner command:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py" \
+  "{vault_root}/tracking-database.json"
+```
+
+The command accepts only a no-follow regular file and strictly decodes one UTF-8
+JSON object. Duplicate keys at any depth, non-finite numbers, invalid JSON, and
+non-object roots fail closed. Success returns report schema v1 with
+`database_path`, the exact-byte `sha256`, and `database`; failure exits `2` with
+`ok: false` and no database value. During first-time initialization or while
+setting an absent `config.python_path`, the host Python may run the stdlib-only
+owner read/mutation commands. Re-read immediately after setting it. All later
+commands use that exact configured interpreter.
+
+Agent-owned config and catalog changes use a typed plan:
+
+```json
+{
+  "schema_version": 1,
+  "mutations": [{
+    "kind": "set_config",
+    "path": ["shownotes", "enabled"],
+    "expect": {"$missing": true},
+    "value": true
+  }]
+}
+```
+
+Every plan is strict JSON with exactly `schema_version` and a non-empty
+`mutations` array. Every expectation is either the exact decoded value/record
+seen by the owner reader or the exact missing marker `{"$missing": true}`. JSON
+`null` is a present value and is never interchangeable with that marker.
+Equality is recursive JSON equality: object key order is irrelevant, array order
+is significant, and booleans, integers, and decimals are distinct types. Thus
+`true`, `1`, and `1.0` never satisfy one another, and `{"$missing": 1}` is an
+ordinary object rather than the missing marker. Schema versions use the same
+exact-type rule. The supported mutation kinds are:
+
+| Kind | Typed purpose |
+|---|---|
+| `initialize_database` | Sole mutation for a missing database; carries initial `config` |
+| `set_config` | Set or delete one nested config path against its exact prior value |
+| `record_pptx` | Replace/add one complete PPTX catalog record and, when matched, bind the talk's expected `pptx_path` |
+| `upsert_confirmed_intent` | Replace/add one complete record identified by `pattern` |
+| `upsert_improvement_goal` | Replace/add one complete record identified by `id` |
+| `patch_improvement_goal_verification` | Set only verification fields, with `expect` covering exactly the same fields |
+| `retire_improvement_goal` | Expect one complete current goal record and change only its `status` to `retired`, preserving legacy fields |
+| `upsert_resource` | Replace/add one complete record identified by `talk_slug` |
+| `upsert_thumbnail` | Replace/add one complete record identified by `talk_slug` |
+| `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
+| `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |
+
+The command owns each operation's closed fields and record validation; do not
+reimplement those allowlists in skill prose. PPTX, resource, thumbnail, and
+confirmed-intent records accept the optional exact integer `schema_version: 1`
+used by the owner-versioned database generation; a boolean or future version is
+not equivalent. Complete resource category counts must sum to `item_count`, and
+publishing scalar/identifier types are checked before patching. Run the plan without `--apply`,
+review its `changes`, then bind apply to that report's exact input hash:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/mutate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" mutation-plan.json
+
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/mutate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" mutation-plan.json \
+  --apply --expected-sha256 <input-sha256-from-dry-run>
+```
+
+Initialization uses a sole `initialize_database` mutation, defaults to dry-run,
+and applies with the literal `--expected-sha256 missing`. All other applies
+require the dry-run SHA. The complete plan is one transaction: one failed type,
+record, semantic expectation, or file-generation precondition installs nothing.
+Re-read after apply rather than assuming the candidate is still current.
+
+All toolkit writers share a persistent sibling lock, stage and `fsync` complete
+bytes through a retained no-follow descriptor, and retain the opened parent
+directory. Immediately before installation they recheck exact input bytes/file
+generation plus the staged descriptor's bytes, hash, generation, type, link count,
+and directory-relative visible identity. Replacement/link and cleanup use names
+anchored to that same directory descriptor. A substituted staged name fails closed
+and is deliberately left untouched rather than unlinking an attacker's path.
+Cooperative writers therefore serialize; a same-bytes inode replacement still
+conflicts.
+
+Filesystem editors that ignore the sibling lock are outside that exclusion
+guarantee. The final pre-install check is defense in depth, and an immediate
+post-install inode/byte verification reports an observed last-moment edit as
+`installed_verification_failed`. There remains an irreducible last-instruction race:
+a non-cooperating process can change the path during the install instruction or
+immediately after verification. No userspace lock protocol can make that actor
+cooperate, so every caller must re-read the live database after an installed result.
+No-op transactions preserve the original bytes and inode. Reports distinguish
+`durable`, `unchanged`, `installed_directory_fsync_failed`, and
+`installed_verification_failed`. Once the install syscall succeeds, verification,
+directory-fsync, staged-name cleanup, directory close, and lock unlock/close
+failures return `database_written: true` with warnings; they never masquerade as
+a pre-install exception. Inspect the live database and reported output SHA before
+any retry. Backup-using writers bind a never-overwritten backup to the exact input
+SHA under the same transaction.
+
 ## Shownotes Scan/Import Report
 
 Run `scan-shownotes.py` against the canonical tracking database. The scanner
@@ -164,16 +270,20 @@ reads `config.shownotes.source` for local sources and resolves
 migration. `remote_url`, `none`, and disabled sources return a structured no-op
 without reading Markdown or writing the database.
 
-The command emits report schema v1:
+The command emits report schema v2:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "ok": true,
   "mode": "dry-run|apply",
   "operation": "scan|skipped_disabled|skipped_nonlocal",
   "apply_requested": false,
   "database_written": false,
+  "input_sha256": "64 lowercase hex characters",
+  "output_sha256": "64 lowercase hex characters",
+  "durability_state": "dry_run|unchanged|durable|installed_directory_fsync_failed|installed_verification_failed",
+  "warnings": [],
   "mutation_count": 1,
   "scanned_file_count": 1,
   "existing_talk_count": 10,
@@ -207,7 +317,11 @@ with current talk schema and status `pending`, or fills empty fields on an exact
 filename match. Established values are not overwritten. Conflicting,
 incomplete, and normalized-collision entries stay `review_required` and never
 mutate. `mutation_count` counts deterministic `add` and `update` candidates;
-`database_written` records whether an atomic replacement occurred.
+`database_written` records whether an atomic replacement occurred. Input and
+output SHA-256 values bind the report to exact database generations. An
+`installed_directory_fsync_failed` or `installed_verification_failed` result
+means the install syscall succeeded; inspect the live database and reported
+output hash before retrying.
 
 Supported Markdown metadata includes YAML, TOML, and JSON frontmatter plus a
 body H1 and labeled `Conference`, `Event`, `Venue`, `Date`, `Video`, `Recording`,

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -18,9 +18,17 @@ database is itself a blocking integrity finding.
 Use `scripts/apply-source-repairs.py` for catalog metadata fixes. Its plan
 requires an exact `expect` map for every record, permits only source/queue
 repair fields, supports explicit `set` and `clear` operations, and is dry-run by
-default. `--apply` refuses active claims, creates an exact backup in `.backups`,
-then replaces the database atomically. Use `{"$missing": true}` in `expect`
-when absence rather than JSON null is the required precondition.
+default. `--apply` refuses active claims, then uses the shared owner transaction
+to create an exact backup in `.backups` and replace the database. The never-
+overwritten backup name includes the exact input SHA-256 and the transaction
+verifies that binding under its lock. Use `{"$missing": true}` in `expect` when
+absence rather than JSON null is the required precondition.
+
+Its report schema is v2. In addition to the reviewed `changes`, it returns
+`input_sha256`, `output_sha256`, `database_written`, `backup`,
+`durability_state`, and `warnings`. `installed_directory_fsync_failed` and
+`installed_verification_failed` mean the install syscall succeeded; inspect the
+live database and exact output hash before retrying.
 
 When fresh provider facts are needed, run the networked, read-only
 `scripts/audit-source-identities.py` after this offline gate and before writing

--- a/skills/vault-ingress/scripts/apply-source-repairs.py
+++ b/skills/vault-ingress/scripts/apply-source-repairs.py
@@ -28,16 +28,26 @@ from __future__ import annotations
 
 import argparse
 import copy
-from datetime import datetime, timezone
+import hashlib
 import json
-import os
 from pathlib import Path
 import sys
-import tempfile
 from typing import Any
+
+from tracking_database_io import (
+    BackupRequest,
+    TrackingDatabaseIOError,
+    TrackingDatabaseSnapshot,
+    commit_tracking_database,
+    decode_json_object,
+    json_values_equal,
+    render_json_object,
+    snapshot_tracking_database,
+)
 
 
 PLAN_SCHEMA_VERSION = 1
+REPORT_SCHEMA_VERSION = 2
 MISSING_MARKER = {"$missing": True}
 ALLOWED_FIELDS = frozenset({
     "video_url",
@@ -68,11 +78,36 @@ class SourceRepairError(ValueError):
 
 def load_object(path: Path, label: str) -> tuple[dict[str, Any], str]:
     try:
-        raw = path.read_text(encoding="utf-8")
+        raw_bytes = path.read_bytes()
     except OSError as exc:
         raise SourceRepairError(f"cannot read {label} {path}: {exc}") from exc
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise SourceRepairError(
+                    f"{label} {path} contains duplicate object key {key!r}"
+                )
+            result[key] = value
+        return result
+
+    def reject_non_finite(value: str) -> None:
+        raise SourceRepairError(
+            f"{label} {path} contains non-standard JSON number {value}"
+        )
+
     try:
-        value = json.loads(raw)
+        raw = raw_bytes.decode("utf-8")
+        value = json.loads(
+            raw,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_non_finite,
+        )
+    except SourceRepairError:
+        raise
+    except UnicodeDecodeError as exc:
+        raise SourceRepairError(f"{label} {path} is not valid UTF-8: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise SourceRepairError(
             f"{label} {path} is invalid JSON at line {exc.lineno}, column {exc.colno}"
@@ -82,6 +117,17 @@ def load_object(path: Path, label: str) -> tuple[dict[str, Any], str]:
     return value, raw
 
 
+def load_database(
+    path: Path,
+) -> tuple[dict[str, Any], TrackingDatabaseSnapshot]:
+    """Load strict JSON and retain the exact generation used for validation."""
+    try:
+        snapshot = snapshot_tracking_database(path)
+        return decode_json_object(snapshot), snapshot
+    except TrackingDatabaseIOError as exc:
+        raise SourceRepairError(str(exc)) from exc
+
+
 def require_nonempty(value: Any, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise SourceRepairError(f"{label} must be a nonempty string")
@@ -89,7 +135,7 @@ def require_nonempty(value: Any, label: str) -> str:
 
 
 def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
-    if plan.get("schema_version") != PLAN_SCHEMA_VERSION:
+    if not json_values_equal(plan.get("schema_version"), PLAN_SCHEMA_VERSION):
         raise SourceRepairError(
             f"plan schema_version must be {PLAN_SCHEMA_VERSION}"
         )
@@ -152,9 +198,9 @@ def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _matches_expected(talk: dict[str, Any], field: str, expected: Any) -> bool:
-    if expected == MISSING_MARKER:
+    if json_values_equal(expected, MISSING_MARKER):
         return field not in talk
-    return field in talk and talk[field] == expected
+    return field in talk and json_values_equal(talk[field], expected)
 
 
 def build_repaired_database(
@@ -209,74 +255,93 @@ def build_repaired_database(
                 talk.pop(field)
                 after[field] = MISSING_MARKER
         for field, value in repair.get("set", {}).items():
+            if field in talk and json_values_equal(talk[field], value):
+                continue
             before[field] = talk[field] if field in talk else MISSING_MARKER
             talk[field] = copy.deepcopy(value)
             after[field] = value
-        changes.append({
-            "filename": filename,
-            "reason": repair["reason"],
-            "before": before,
-            "after": after,
-        })
+        if before:
+            changes.append({
+                "filename": filename,
+                "reason": repair["reason"],
+                "before": before,
+                "after": after,
+            })
     return result, changes
 
 
-def atomic_write(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temp_name = tempfile.mkstemp(
-        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent,
-    )
-    installed = False
+def atomic_write(
+    path: Path,
+    text: str | bytes,
+    *,
+    expected_snapshot: TrackingDatabaseSnapshot | None = None,
+    backup: BackupRequest | None = None,
+):
+    """Commit text against the exact generation captured before validation."""
     try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-            handle.write(text)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temp_name, path)
-        installed = True
-    finally:
-        if not installed:
-            try:
-                os.unlink(temp_name)
-            except FileNotFoundError:
-                pass
-
-
-def backup_original(database_path: Path, raw: str, backup_dir: Path) -> Path:
-    backup_dir.mkdir(parents=True, exist_ok=True)
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    candidate = backup_dir / f"{database_path.stem}.source-repair-{stamp}.json"
-    counter = 1
-    while candidate.exists():
-        candidate = backup_dir / (
-            f"{database_path.stem}.source-repair-{stamp}-{counter}.json"
+        snapshot = expected_snapshot or snapshot_tracking_database(path)
+        return commit_tracking_database(
+            snapshot,
+            text.encode("utf-8") if isinstance(text, str) else text,
+            backup=backup,
         )
-        counter += 1
-    candidate.write_text(raw, encoding="utf-8")
-    return candidate
+    except TrackingDatabaseIOError as exc:
+        raise SourceRepairError(str(exc)) from exc
 
 
 def execute(
     database_path: Path, plan_path: Path, *, apply: bool,
     backup_dir: Path | None = None,
 ) -> dict[str, Any]:
-    database, raw = load_object(database_path, "database")
+    database, database_snapshot = load_database(database_path)
     plan, _ = load_object(plan_path, "repair plan")
     repairs = validate_plan(plan)
     repaired, changes = build_repaired_database(database, repairs)
-    backup_path = None
+    if changes:
+        try:
+            rendered = render_json_object(repaired)
+        except TrackingDatabaseIOError as exc:
+            raise SourceRepairError(str(exc)) from exc
+    else:
+        rendered = database_snapshot.raw
+    output_sha256 = hashlib.sha256(rendered).hexdigest()
+    backup_path: str | None = None
+    database_written = False
+    durability_state = "dry_run"
+    warnings: list[str] = []
     if apply:
         target_backup_dir = backup_dir or database_path.parent / ".backups"
-        backup_path = backup_original(database_path, raw, target_backup_dir)
-        rendered = json.dumps(repaired, indent=2, ensure_ascii=False) + "\n"
-        atomic_write(database_path, rendered)
+        backup_request = BackupRequest(
+            path=(
+                target_backup_dir
+                / f"{database_path.name}.source-repair-"
+                f"{database_snapshot.sha256}.bak"
+            ),
+            input_sha256=database_snapshot.sha256,
+        )
+        result = atomic_write(
+            database_path,
+            rendered,
+            expected_snapshot=database_snapshot,
+            backup=backup_request,
+        )
+        backup_path = result.backup
+        output_sha256 = result.output_sha256
+        database_written = result.installed
+        durability_state = result.durability_state
+        warnings = list(result.warnings)
     return {
-        "schema_version": PLAN_SCHEMA_VERSION,
+        "schema_version": REPORT_SCHEMA_VERSION,
         "mode": "apply" if apply else "dry-run",
         "database": str(database_path.resolve(strict=False)),
         "plan": str(plan_path.resolve(strict=False)),
         "repair_count": len(changes),
-        "backup": str(backup_path.resolve()) if backup_path else None,
+        "backup": backup_path,
+        "input_sha256": database_snapshot.sha256,
+        "output_sha256": output_sha256,
+        "database_written": database_written,
+        "durability_state": durability_state,
+        "warnings": warnings,
         "changes": changes,
     }
 
@@ -293,7 +358,16 @@ def main(argv: list[str] | None = None) -> int:
             args.database, args.plan, apply=args.apply, backup_dir=args.backup_dir,
         )
     except (SourceRepairError, OSError) as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "ok": False,
+                    "error": str(exc),
+                },
+                sort_keys=True,
+            )
+        )
         print(f"source repair failed: {exc}", file=sys.stderr)
         return 2
     print(json.dumps({"ok": True, **report}, indent=2, sort_keys=True))

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -28,6 +28,11 @@ from source_identity_matching import (
     normalized_words,
     titles_agree,
 )
+from tracking_database_io import (
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
+)
 
 
 REPORT_SCHEMA_VERSION = 1
@@ -682,10 +687,11 @@ def audit_path(
     captured_at: str | datetime | None = None,
 ) -> dict[str, Any]:
     """Read and audit a vault/database path without writing any file."""
-    database_path = resolve_input(value).resolve(strict=False)
+    database_path = resolve_input(value).absolute()
     try:
-        database = json.loads(database_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        snapshot = snapshot_tracking_database(database_path)
+        database = decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
         report = audit_database(
             {}, database_path=database_path,
             metadata_fetcher=metadata_fetcher, captured_at=captured_at,

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1,0 +1,1224 @@
+#!/usr/bin/env python3
+"""Apply typed, expectation-bound owner mutations to tracking-database.json.
+
+The default mode is a dry run.  ``--apply`` requires ``--expected-sha256`` from
+that dry run (or the literal ``missing`` for initialization).  Every operation
+declares the exact record or field value it expects, so a reviewed plan cannot
+silently target a different logical state even when its file hash is current.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+from datetime import date
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any, NoReturn
+
+from tracking_database_io import (
+    TrackingDatabaseIOError,
+    commit_tracking_database,
+    decode_json_object,
+    initialize_tracking_database,
+    json_values_equal,
+    render_json_object,
+    snapshot_tracking_database,
+)
+
+
+PLAN_SCHEMA_VERSION = 1
+OWNER_RECORD_SCHEMA_VERSION = 1
+MISSING_MARKER = {"$missing": True}
+COLLECTION_IDENTITIES = {
+    "upsert_confirmed_intent": ("confirmed_intents", "pattern"),
+    "upsert_improvement_goal": ("improvement_goals", "id"),
+    "upsert_resource": ("resources", "talk_slug"),
+    "upsert_thumbnail": ("thumbnails", "talk_slug"),
+}
+PUBLISHING_TALK_FIELDS = frozenset(
+    {
+        "shownotes_url",
+        "shownotes_published",
+        "thumbnail_generated",
+        "video_added_to_shownotes",
+        "video_url",
+        "youtube_id",
+    }
+)
+CLARIFICATION_TALK_FIELDS = frozenset(
+    {"blind_spot_observations", "humor_postmortem"}
+)
+GOAL_VERIFICATION_FIELDS = frozenset(
+    {
+        "status",
+        "current_value",
+        "last_checked",
+        "checked_by",
+        "verification_state",
+        "verification_reasons",
+    }
+)
+GOAL_REQUIRED_FIELDS = frozenset(
+    {
+        "id",
+        "schema_version",
+        "issue",
+        "kind",
+        "antipattern_id",
+        "metric",
+        "baseline_value",
+        "target",
+        "set_date",
+        "set_by",
+        "status",
+        "current_value",
+        "last_checked",
+        "checked_by",
+        "verification_state",
+        "verification_reasons",
+        "supersedes_goal_id",
+        "baseline_provenance",
+    }
+)
+CONFIRMED_INTENT_REQUIRED_FIELDS = frozenset(
+    {"pattern", "intent", "rule", "note"}
+)
+CONFIRMED_INTENT_OPTIONAL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "confirmed_date",
+        "source_talk",
+        "source_talks",
+        "talk",
+        "retrofit_targets",
+    }
+)
+RESOURCE_REQUIRED_FIELDS = frozenset(
+    {"talk_slug", "item_count", "category_breakdown"}
+)
+PPTX_REQUIRED_FIELDS = frozenset(
+    {
+        "pptx_path",
+        "talk_filename",
+        "matched",
+        "slide_count",
+        "visual_extracted",
+    }
+)
+THUMBNAIL_REQUIRED_FIELDS = frozenset(
+    {
+        "talk_slug",
+        "youtube_url",
+        "source_slide_num",
+        "speaker_photo_used",
+        "thumbnail_path",
+        "shownotes_thumbnail_path",
+        "dimensions",
+        "file_size_kb",
+        "created_at",
+        "approved",
+    }
+)
+RECORD_SCHEMA_FIELD = frozenset({"schema_version"})
+
+
+class TrackingDatabaseMutationError(ValueError):
+    """A mutation plan, precondition, or database shape is invalid."""
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        raise TrackingDatabaseMutationError(f"invalid arguments: {message}")
+
+
+def _strict_json_object(raw: bytes, path: Path, label: str) -> dict[str, Any]:
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise TrackingDatabaseMutationError(
+                    f"{label} {path} contains duplicate object key {key!r}"
+                )
+            result[key] = value
+        return result
+
+    def reject_non_finite(value: str) -> NoReturn:
+        raise TrackingDatabaseMutationError(
+            f"{label} {path} contains non-standard JSON number {value}"
+        )
+
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_non_finite,
+        )
+    except TrackingDatabaseMutationError:
+        raise
+    except UnicodeDecodeError as exc:
+        raise TrackingDatabaseMutationError(
+            f"{label} {path} is not UTF-8: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise TrackingDatabaseMutationError(
+            f"{label} {path} is invalid JSON at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise TrackingDatabaseMutationError(f"{label} root must be a JSON object")
+    return value
+
+
+def load_plan(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise TrackingDatabaseMutationError(f"cannot read mutation plan {path}: {exc}") from exc
+    plan = _strict_json_object(raw, path, "mutation plan")
+    if not json_values_equal(plan.get("schema_version"), PLAN_SCHEMA_VERSION):
+        raise TrackingDatabaseMutationError(
+            f"mutation plan schema_version must be {PLAN_SCHEMA_VERSION}"
+        )
+    if set(plan) != {"schema_version", "mutations"}:
+        raise TrackingDatabaseMutationError(
+            "mutation plan must contain only schema_version and mutations"
+        )
+    mutations = plan.get("mutations")
+    if not isinstance(mutations, list) or not mutations:
+        raise TrackingDatabaseMutationError("mutation plan mutations must be a nonempty array")
+    if any(not isinstance(mutation, dict) for mutation in mutations):
+        raise TrackingDatabaseMutationError("every mutation must be a JSON object")
+    return plan
+
+
+def _require_keys(
+    value: dict[str, Any],
+    *,
+    required: set[str] | frozenset[str],
+    optional: set[str] | frozenset[str] = frozenset(),
+    label: str,
+) -> None:
+    missing = set(required) - set(value)
+    unknown = set(value) - set(required) - set(optional)
+    if missing:
+        raise TrackingDatabaseMutationError(f"{label} is missing {sorted(missing)}")
+    if unknown:
+        raise TrackingDatabaseMutationError(f"{label} has unknown fields {sorted(unknown)}")
+
+
+def _nonempty(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TrackingDatabaseMutationError(f"{label} must be a nonempty string")
+    if value != value.strip():
+        raise TrackingDatabaseMutationError(
+            f"{label} must not contain leading or trailing whitespace"
+        )
+    return value
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise TrackingDatabaseMutationError(f"{label} must be a string")
+    return value
+
+
+def _exact_integer(value: object, label: str, *, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise TrackingDatabaseMutationError(
+            f"{label} must be an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def _iso_date(value: object, label: str) -> str:
+    text = _nonempty(value, label)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as exc:
+        raise TrackingDatabaseMutationError(
+            f"{label} must be an ISO-8601 calendar date"
+        ) from exc
+    if parsed.isoformat() != text:
+        raise TrackingDatabaseMutationError(
+            f"{label} must use canonical YYYY-MM-DD form"
+        )
+    return text
+
+
+def _string_array(value: object, label: str, *, nonempty: bool = False) -> list[str]:
+    if not isinstance(value, list) or (nonempty and not value):
+        suffix = "a nonempty" if nonempty else "an"
+        raise TrackingDatabaseMutationError(
+            f"{label} must be {suffix} array of unique nonempty strings"
+        )
+    normalized = [_nonempty(item, f"{label}[{index}]") for index, item in enumerate(value)]
+    if len(normalized) != len(set(normalized)):
+        raise TrackingDatabaseMutationError(
+            f"{label} must contain unique nonempty strings"
+        )
+    return normalized
+
+
+def _validate_optional_record_schema(record: dict[str, Any], label: str) -> None:
+    if "schema_version" not in record:
+        return
+    if not json_values_equal(record["schema_version"], OWNER_RECORD_SCHEMA_VERSION):
+        raise TrackingDatabaseMutationError(
+            f"{label}.schema_version must be exact integer "
+            f"{OWNER_RECORD_SCHEMA_VERSION}"
+        )
+
+
+def _validate_publishing_values(values: object, label: str) -> None:
+    if not isinstance(values, dict):
+        raise TrackingDatabaseMutationError(f"{label} must be an object")
+    for field, value in values.items():
+        field_label = f"{label}.{field}"
+        if field in {
+            "shownotes_published",
+            "thumbnail_generated",
+            "video_added_to_shownotes",
+        }:
+            if type(value) is not bool:
+                raise TrackingDatabaseMutationError(f"{field_label} must be boolean")
+        elif field in {"shownotes_url", "video_url"}:
+            _nonempty(value, field_label)
+        elif field == "youtube_id":
+            video_id = _nonempty(value, field_label)
+            if re.fullmatch(r"[A-Za-z0-9_-]{11}", video_id) is None:
+                raise TrackingDatabaseMutationError(
+                    f"{field_label} must be an 11-character YouTube ID"
+                )
+
+
+def _validate_clarification_values(values: object, label: str) -> None:
+    if not isinstance(values, dict):
+        raise TrackingDatabaseMutationError(f"{label} must be an object")
+    for field, value in values.items():
+        if field not in CLARIFICATION_TALK_FIELDS:
+            continue
+        if not isinstance(value, (dict, list)):
+            raise TrackingDatabaseMutationError(
+                f"{label}.{field} must be a JSON object or array"
+            )
+
+
+def _validate_goal_verification_values(values: object, label: str) -> None:
+    if not isinstance(values, dict):
+        raise TrackingDatabaseMutationError(f"{label} must be an object")
+    for field, value in values.items():
+        field_label = f"{label}.{field}"
+        if field == "status":
+            status = _nonempty(value, field_label)
+            if status not in (
+                "active",
+                "improving",
+                "achieved",
+                "stalled",
+                "regressed",
+                "retired",
+            ):
+                raise TrackingDatabaseMutationError(f"{field_label} is unsupported")
+        if field == "current_value":
+            _string(value, field_label)
+        elif field == "last_checked" and value is not None:
+            _iso_date(value, field_label)
+        elif field == "checked_by" and value is not None:
+            _nonempty(value, field_label)
+        elif field == "verification_state":
+            state = _nonempty(value, field_label)
+            if state not in (
+                "pending",
+                "current",
+                "needs_rebaseline",
+                "unverifiable",
+            ):
+                raise TrackingDatabaseMutationError(f"{field_label} is unsupported")
+        elif field == "verification_reasons":
+            _string_array(value, field_label)
+
+
+def _expect_value(
+    *,
+    exists: bool,
+    actual: object,
+    expected: object,
+    label: str,
+) -> None:
+    if json_values_equal(expected, MISSING_MARKER):
+        if exists:
+            raise TrackingDatabaseMutationError(
+                f"{label} expected a missing value, found {actual!r}"
+            )
+        return
+    if not exists or not json_values_equal(actual, expected):
+        found = actual if exists else MISSING_MARKER
+        raise TrackingDatabaseMutationError(
+            f"{label} precondition failed: expected {expected!r}, found {found!r}"
+        )
+
+
+def _collection(
+    database: dict[str, Any],
+    key: str,
+) -> list[dict[str, Any]]:
+    value = database.setdefault(key, [])
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise TrackingDatabaseMutationError(f"database {key} must be an array of objects")
+    return value
+
+
+def _find_unique_record(
+    records: list[dict[str, Any]],
+    identity_field: str,
+    identity: str,
+    *,
+    label: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    matches = [
+        (index, record)
+        for index, record in enumerate(records)
+        if record.get(identity_field) == identity
+    ]
+    if len(matches) > 1:
+        raise TrackingDatabaseMutationError(
+            f"{label} repeats {identity_field} {identity!r}; repair duplicates first"
+        )
+    return matches[0] if matches else (None, None)
+
+
+def _record_change(
+    changes: list[dict[str, Any]],
+    *,
+    kind: str,
+    identity: str,
+    before: object,
+    after: object,
+) -> None:
+    if json_values_equal(before, after):
+        return
+    changes.append(
+        {
+            "kind": kind,
+            "identity": identity,
+            "before": copy.deepcopy(before),
+            "after": copy.deepcopy(after),
+        }
+    )
+
+
+def _validate_collection_record(kind: str, record: dict[str, Any]) -> None:
+    if kind == "upsert_confirmed_intent":
+        label = "confirmed-intent record"
+        _require_keys(
+            record,
+            required=CONFIRMED_INTENT_REQUIRED_FIELDS,
+            optional=CONFIRMED_INTENT_OPTIONAL_FIELDS,
+            label=label,
+        )
+        _validate_optional_record_schema(record, label)
+        _nonempty(record["pattern"], f"{label}.pattern")
+        _nonempty(record["intent"], f"{label}.intent")
+        _nonempty(record["rule"], f"{label}.rule")
+        _string(record["note"], f"{label}.note")
+        if "confirmed_date" in record:
+            _iso_date(record["confirmed_date"], f"{label}.confirmed_date")
+        provenance_fields = [
+            field
+            for field in ("talk", "source_talk", "source_talks")
+            if field in record
+        ]
+        if len(provenance_fields) > 1:
+            raise TrackingDatabaseMutationError(
+                f"{label} may use only one of talk, source_talk, or source_talks"
+            )
+        for field in ("talk", "source_talk"):
+            if field in record:
+                _nonempty(record[field], f"{label}.{field}")
+        for field in ("source_talks", "retrofit_targets"):
+            if field in record:
+                _string_array(record[field], f"{label}.{field}", nonempty=True)
+    elif kind == "upsert_improvement_goal":
+        label = "improvement-goal record"
+        _require_keys(record, required=GOAL_REQUIRED_FIELDS, label=label)
+        if not json_values_equal(record["schema_version"], 2):
+            raise TrackingDatabaseMutationError(
+                f"{label}.schema_version must be exact integer 2"
+            )
+        for field in (
+            "id",
+            "issue",
+            "metric",
+            "baseline_value",
+            "target",
+            "set_by",
+        ):
+            _nonempty(record[field], f"{label}.{field}")
+        _iso_date(record["set_date"], f"{label}.set_date")
+        kind_value = _nonempty(record["kind"], f"{label}.kind")
+        if kind_value not in ("antipattern", "underuse", "pacing", "other"):
+            raise TrackingDatabaseMutationError(
+                f"{label}.kind must be antipattern, underuse, pacing, or other"
+            )
+        antipattern_id = record["antipattern_id"]
+        if kind_value == "antipattern":
+            _nonempty(antipattern_id, f"{label}.antipattern_id")
+        elif antipattern_id is not None:
+            raise TrackingDatabaseMutationError(
+                f"{label}.antipattern_id must be null unless kind is antipattern"
+            )
+        status = _nonempty(record["status"], f"{label}.status")
+        if status not in (
+            "active",
+            "improving",
+            "achieved",
+            "stalled",
+            "regressed",
+            "retired",
+        ):
+            raise TrackingDatabaseMutationError(f"{label}.status is unsupported")
+        _string(record["current_value"], f"{label}.current_value")
+        for field in ("last_checked", "checked_by", "supersedes_goal_id"):
+            value = record[field]
+            if value is not None:
+                if field == "last_checked":
+                    _iso_date(value, f"{label}.{field}")
+                else:
+                    _nonempty(value, f"{label}.{field}")
+        if (record["last_checked"] is None) != (record["checked_by"] is None):
+            raise TrackingDatabaseMutationError(
+                f"{label}.last_checked and checked_by must both be null or both set"
+            )
+        verification_state = _nonempty(
+            record["verification_state"],
+            f"{label}.verification_state",
+        )
+        if verification_state not in (
+            "pending",
+            "current",
+            "needs_rebaseline",
+            "unverifiable",
+        ):
+            raise TrackingDatabaseMutationError(
+                f"{label}.verification_state is unsupported"
+            )
+        _string_array(
+            record["verification_reasons"],
+            f"{label}.verification_reasons",
+        )
+        provenance = record["baseline_provenance"]
+        if not isinstance(provenance, dict):
+            raise TrackingDatabaseMutationError(
+                f"{label}.baseline_provenance must be an object"
+            )
+        _require_keys(
+            provenance,
+            required={"lane"},
+            optional={"pattern_baseline"},
+            label=f"{label}.baseline_provenance",
+        )
+        expected_lane = {
+            "antipattern": "pattern_scoring",
+            "underuse": "pattern_scoring",
+            "pacing": "pacing",
+            "other": "independent",
+        }[kind_value]
+        lane = _nonempty(
+            provenance["lane"],
+            f"{label}.baseline_provenance.lane",
+        )
+        if lane != expected_lane:
+            raise TrackingDatabaseMutationError(
+                f"{label}.baseline_provenance.lane must be {expected_lane!r}"
+            )
+        if kind_value in {"antipattern", "underuse"}:
+            if not isinstance(provenance.get("pattern_baseline"), dict):
+                raise TrackingDatabaseMutationError(
+                    f"{label}.baseline_provenance.pattern_baseline must be an object"
+                )
+        elif "pattern_baseline" in provenance:
+            raise TrackingDatabaseMutationError(
+                f"{label}.baseline_provenance.pattern_baseline is valid only for "
+                "pattern goals"
+            )
+    elif kind == "upsert_resource":
+        label = "resource record"
+        _require_keys(
+            record,
+            required=RESOURCE_REQUIRED_FIELDS,
+            optional=RECORD_SCHEMA_FIELD,
+            label=label,
+        )
+        _validate_optional_record_schema(record, label)
+        _nonempty(record["talk_slug"], f"{label}.talk_slug")
+        item_count = _exact_integer(record["item_count"], f"{label}.item_count")
+        breakdown = record["category_breakdown"]
+        if not isinstance(breakdown, dict):
+            raise TrackingDatabaseMutationError(
+                f"{label}.category_breakdown must be an object"
+            )
+        category_total = 0
+        for category, count in breakdown.items():
+            _nonempty(category, f"{label}.category_breakdown key")
+            category_total += _exact_integer(
+                count,
+                f"{label}.category_breakdown[{category!r}]",
+            )
+        if item_count != category_total:
+            raise TrackingDatabaseMutationError(
+                f"{label}.item_count must equal the category_breakdown total"
+            )
+    elif kind == "upsert_thumbnail":
+        label = "thumbnail record"
+        _require_keys(
+            record,
+            required=THUMBNAIL_REQUIRED_FIELDS,
+            optional=RECORD_SCHEMA_FIELD,
+            label=label,
+        )
+        _validate_optional_record_schema(record, label)
+        for field in (
+            "talk_slug",
+            "youtube_url",
+            "speaker_photo_used",
+            "thumbnail_path",
+            "shownotes_thumbnail_path",
+        ):
+            _nonempty(record[field], f"{label}.{field}")
+        _exact_integer(record["source_slide_num"], f"{label}.source_slide_num", minimum=1)
+        dimensions = _nonempty(record["dimensions"], f"{label}.dimensions")
+        match = re.fullmatch(r"([1-9][0-9]*)x([1-9][0-9]*)", dimensions)
+        if match is None:
+            raise TrackingDatabaseMutationError(
+                f"{label}.dimensions must use positive WIDTHxHEIGHT form"
+            )
+        _exact_integer(record["file_size_kb"], f"{label}.file_size_kb")
+        _iso_date(record["created_at"], f"{label}.created_at")
+        if type(record["approved"]) is not bool:
+            raise TrackingDatabaseMutationError(f"{label}.approved must be boolean")
+
+
+def _apply_collection_upsert(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    kind = str(mutation.get("kind"))
+    _require_keys(
+        mutation,
+        required={"kind", "expect", "record"},
+        label=f"mutations[{index}]",
+    )
+    record = mutation["record"]
+    if not isinstance(record, dict):
+        raise TrackingDatabaseMutationError(f"mutations[{index}].record must be an object")
+    _validate_collection_record(kind, record)
+    collection_name, identity_field = COLLECTION_IDENTITIES[kind]
+    identity = _nonempty(record.get(identity_field), f"mutations[{index}].record.{identity_field}")
+    records = _collection(database, collection_name)
+    record_index, current = _find_unique_record(
+        records,
+        identity_field,
+        identity,
+        label=collection_name,
+    )
+    _expect_value(
+        exists=current is not None,
+        actual=current,
+        expected=mutation["expect"],
+        label=f"{collection_name}[{identity!r}]",
+    )
+    replacement = copy.deepcopy(record)
+    before: object = current if current is not None else MISSING_MARKER
+    if record_index is None:
+        records.append(replacement)
+    else:
+        records[record_index] = replacement
+    _record_change(
+        changes,
+        kind=kind,
+        identity=identity,
+        before=before,
+        after=replacement,
+    )
+
+
+def _apply_set_config(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    _require_keys(
+        mutation,
+        required={"kind", "path", "expect"},
+        optional={"value", "delete"},
+        label=f"mutations[{index}]",
+    )
+    has_value = "value" in mutation
+    delete = mutation.get("delete", False)
+    if not isinstance(delete, bool) or has_value == delete:
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}] must set exactly one of value or delete:true"
+        )
+    path = mutation["path"]
+    if (
+        not isinstance(path, list)
+        or not path
+        or any(not isinstance(part, str) or not part for part in path)
+        or path[0] == "schema_version"
+    ):
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].path must be nonempty config keys outside schema_version"
+        )
+    config = database.setdefault("config", {})
+    if not isinstance(config, dict):
+        raise TrackingDatabaseMutationError("database config must be an object")
+    parent = config
+    for offset, part in enumerate(path[:-1]):
+        child = parent.get(part)
+        if child is None and part not in parent:
+            child = {}
+            parent[part] = child
+        if not isinstance(child, dict):
+            prefix = ".".join(path[: offset + 1])
+            raise TrackingDatabaseMutationError(f"config.{prefix} must be an object")
+        parent = child
+    leaf = path[-1]
+    exists = leaf in parent
+    actual = parent.get(leaf)
+    label = "config." + ".".join(path)
+    _expect_value(exists=exists, actual=actual, expected=mutation["expect"], label=label)
+    before: object = actual if exists else MISSING_MARKER
+    if delete:
+        parent.pop(leaf, None)
+        after: object = MISSING_MARKER
+    else:
+        after = copy.deepcopy(mutation["value"])
+        parent[leaf] = after
+    _record_change(
+        changes,
+        kind="set_config",
+        identity=".".join(path),
+        before=before,
+        after=after,
+    )
+
+
+def _talk_by_filename(
+    database: dict[str, Any],
+    filename: object,
+) -> dict[str, Any]:
+    identity = _nonempty(filename, "talk filename")
+    talks = _collection(database, "talks")
+    _, talk = _find_unique_record(talks, "filename", identity, label="talks")
+    if talk is None:
+        raise TrackingDatabaseMutationError(f"talk {identity!r} does not exist")
+    return talk
+
+
+def _apply_record_patch(
+    record: dict[str, Any],
+    *,
+    expect: object,
+    set_values: object,
+    allowed_fields: frozenset[str],
+    label: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not isinstance(expect, dict) or not isinstance(set_values, dict) or not set_values:
+        raise TrackingDatabaseMutationError(f"{label} expect/set must be nonempty objects")
+    if set(set_values) - allowed_fields:
+        raise TrackingDatabaseMutationError(
+            f"{label} set has unsupported fields {sorted(set(set_values) - allowed_fields)}"
+        )
+    if set(expect) != set(set_values):
+        raise TrackingDatabaseMutationError(
+            f"{label} expect must cover exactly the fields being changed"
+        )
+    before: dict[str, Any] = {}
+    after: dict[str, Any] = {}
+    for field, value in set_values.items():
+        exists = field in record
+        actual = record.get(field)
+        _expect_value(
+            exists=exists,
+            actual=actual,
+            expected=expect[field],
+            label=f"{label}.{field}",
+        )
+        before[field] = copy.deepcopy(actual) if exists else MISSING_MARKER
+        record[field] = copy.deepcopy(value)
+        after[field] = copy.deepcopy(value)
+    return before, after
+
+
+def _apply_update_talk(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    _require_keys(
+        mutation,
+        required={"kind", "filename", "expect", "set"},
+        label=f"mutations[{index}]",
+    )
+    filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
+    talk = _talk_by_filename(database, filename)
+    _validate_publishing_values(mutation["set"], f"mutations[{index}].set")
+    before, after = _apply_record_patch(
+        talk,
+        expect=mutation["expect"],
+        set_values=mutation["set"],
+        allowed_fields=PUBLISHING_TALK_FIELDS,
+        label=f"talks[{filename!r}]",
+    )
+    _record_change(
+        changes,
+        kind="update_talk_publishing",
+        identity=filename,
+        before=before,
+        after=after,
+    )
+
+
+def _apply_update_talk_clarification(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    _require_keys(
+        mutation,
+        required={"kind", "filename", "expect", "set"},
+        label=f"mutations[{index}]",
+    )
+    filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
+    talk = _talk_by_filename(database, filename)
+    _validate_clarification_values(mutation["set"], f"mutations[{index}].set")
+    before, after = _apply_record_patch(
+        talk,
+        expect=mutation["expect"],
+        set_values=mutation["set"],
+        allowed_fields=CLARIFICATION_TALK_FIELDS,
+        label=f"talks[{filename!r}]",
+    )
+    _record_change(
+        changes,
+        kind="update_talk_clarification",
+        identity=filename,
+        before=before,
+        after=after,
+    )
+
+
+def _apply_goal_verification(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    _require_keys(
+        mutation,
+        required={"kind", "id", "expect", "set"},
+        label=f"mutations[{index}]",
+    )
+    identity = _nonempty(mutation["id"], f"mutations[{index}].id")
+    goals = _collection(database, "improvement_goals")
+    _, goal = _find_unique_record(goals, "id", identity, label="improvement_goals")
+    if goal is None:
+        raise TrackingDatabaseMutationError(f"improvement goal {identity!r} does not exist")
+    _validate_goal_verification_values(
+        mutation["set"],
+        f"mutations[{index}].set",
+    )
+    before, after = _apply_record_patch(
+        goal,
+        expect=mutation["expect"],
+        set_values=mutation["set"],
+        allowed_fields=GOAL_VERIFICATION_FIELDS,
+        label=f"improvement_goals[{identity!r}]",
+    )
+    _record_change(
+        changes,
+        kind="patch_improvement_goal_verification",
+        identity=identity,
+        before=before,
+        after=after,
+    )
+
+
+def _apply_retire_improvement_goal(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    _require_keys(
+        mutation,
+        required={"kind", "id", "expect"},
+        label=f"mutations[{index}]",
+    )
+    identity = _nonempty(mutation["id"], f"mutations[{index}].id")
+    expected = mutation["expect"]
+    if not isinstance(expected, dict):
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].expect must be the complete expected goal record"
+        )
+    goals = _collection(database, "improvement_goals")
+    _, goal = _find_unique_record(goals, "id", identity, label="improvement_goals")
+    if goal is None:
+        raise TrackingDatabaseMutationError(
+            f"improvement goal {identity!r} does not exist"
+        )
+    _expect_value(
+        exists=True,
+        actual=goal,
+        expected=expected,
+        label=f"improvement_goals[{identity!r}]",
+    )
+    if "status" not in goal:
+        raise TrackingDatabaseMutationError(
+            f"improvement_goals[{identity!r}] has no status field to retire"
+        )
+    before = copy.deepcopy(goal)
+    goal["status"] = "retired"
+    _record_change(
+        changes,
+        kind="retire_improvement_goal",
+        identity=identity,
+        before=before,
+        after=goal,
+    )
+
+
+def _apply_record_pptx(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    _require_keys(
+        mutation,
+        required={"kind", "expect", "record"},
+        optional={"expect_talk_pptx_path"},
+        label=f"mutations[{index}]",
+    )
+    record = mutation["record"]
+    if not isinstance(record, dict):
+        raise TrackingDatabaseMutationError(f"mutations[{index}].record must be an object")
+    record_label = f"mutations[{index}].record"
+    _require_keys(
+        record,
+        required=PPTX_REQUIRED_FIELDS,
+        optional=RECORD_SCHEMA_FIELD,
+        label=record_label,
+    )
+    _validate_optional_record_schema(record, record_label)
+    pptx_path = _nonempty(record["pptx_path"], f"{record_label}.pptx_path")
+    if type(record["matched"]) is not bool:
+        raise TrackingDatabaseMutationError(f"mutations[{index}].record.matched must be boolean")
+    _exact_integer(record["slide_count"], f"{record_label}.slide_count")
+    if type(record["visual_extracted"]) is not bool:
+        raise TrackingDatabaseMutationError(
+            f"{record_label}.visual_extracted must be boolean"
+        )
+    talk_filename = record.get("talk_filename")
+    if talk_filename is not None:
+        talk_filename = _nonempty(talk_filename, f"mutations[{index}].record.talk_filename")
+    if record["matched"] != (talk_filename is not None):
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}] matched must be true exactly when talk_filename is set"
+        )
+    records = _collection(database, "pptx_catalog")
+    record_index, current = _find_unique_record(
+        records,
+        "pptx_path",
+        pptx_path,
+        label="pptx_catalog",
+    )
+    _expect_value(
+        exists=current is not None,
+        actual=current,
+        expected=mutation["expect"],
+        label=f"pptx_catalog[{pptx_path!r}]",
+    )
+    replacement = copy.deepcopy(record)
+    before: object = current if current is not None else MISSING_MARKER
+    if record_index is None:
+        records.append(replacement)
+    else:
+        records[record_index] = replacement
+    _record_change(
+        changes,
+        kind="record_pptx",
+        identity=pptx_path,
+        before=before,
+        after=replacement,
+    )
+    if talk_filename is None:
+        if "expect_talk_pptx_path" in mutation:
+            raise TrackingDatabaseMutationError(
+                f"mutations[{index}] unmatched record must omit expect_talk_pptx_path"
+            )
+        return
+    if "expect_talk_pptx_path" not in mutation:
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}] matched record requires expect_talk_pptx_path"
+        )
+    talk = _talk_by_filename(database, talk_filename)
+    exists = "pptx_path" in talk
+    actual = talk.get("pptx_path")
+    _expect_value(
+        exists=exists,
+        actual=actual,
+        expected=mutation["expect_talk_pptx_path"],
+        label=f"talks[{talk_filename!r}].pptx_path",
+    )
+    talk["pptx_path"] = pptx_path
+    _record_change(
+        changes,
+        kind="match_pptx_talk",
+        identity=talk_filename,
+        before=actual if exists else MISSING_MARKER,
+        after=pptx_path,
+    )
+
+
+def _validate_database_shape(database: dict[str, Any]) -> None:
+    config = database.get("config")
+    talks = database.get("talks")
+    if not isinstance(config, dict):
+        raise TrackingDatabaseMutationError("database config must be an object")
+    if not isinstance(talks, list) or any(not isinstance(talk, dict) for talk in talks):
+        raise TrackingDatabaseMutationError("database talks must be an array of objects")
+    seen: set[str] = set()
+    for index, talk in enumerate(talks):
+        filename = _nonempty(talk.get("filename"), f"talks[{index}].filename")
+        if filename in seen:
+            raise TrackingDatabaseMutationError(f"database repeats talk filename {filename!r}")
+        seen.add(filename)
+
+
+def initial_database(mutation: dict[str, Any], *, index: int) -> dict[str, Any]:
+    _require_keys(
+        mutation,
+        required={"kind", "config"},
+        label=f"mutations[{index}]",
+    )
+    config = mutation["config"]
+    if not isinstance(config, dict):
+        raise TrackingDatabaseMutationError(f"mutations[{index}].config must be an object")
+    return {
+        "config": copy.deepcopy(config),
+        "talks": [],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+
+
+def build_candidate(
+    database: dict[str, Any],
+    mutations: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    candidate = copy.deepcopy(database)
+    _validate_database_shape(candidate)
+    changes: list[dict[str, Any]] = []
+    for index, mutation in enumerate(mutations):
+        kind = mutation.get("kind")
+        if kind == "initialize_database":
+            raise TrackingDatabaseMutationError(
+                "initialize_database is valid only when the database is missing and "
+                "must be the plan's sole mutation"
+            )
+        if kind == "set_config":
+            _apply_set_config(candidate, mutation, changes, index=index)
+        elif kind in COLLECTION_IDENTITIES:
+            _apply_collection_upsert(candidate, mutation, changes, index=index)
+        elif kind == "record_pptx":
+            _apply_record_pptx(candidate, mutation, changes, index=index)
+        elif kind == "update_talk_publishing":
+            _apply_update_talk(candidate, mutation, changes, index=index)
+        elif kind == "update_talk_clarification":
+            _apply_update_talk_clarification(
+                candidate,
+                mutation,
+                changes,
+                index=index,
+            )
+        elif kind == "patch_improvement_goal_verification":
+            _apply_goal_verification(candidate, mutation, changes, index=index)
+        elif kind == "retire_improvement_goal":
+            _apply_retire_improvement_goal(candidate, mutation, changes, index=index)
+        else:
+            raise TrackingDatabaseMutationError(
+                f"mutations[{index}].kind {kind!r} is unsupported"
+            )
+    _validate_database_shape(candidate)
+    return candidate, changes
+
+
+def _validate_digest(value: str) -> None:
+    if value == "missing":
+        return
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise TrackingDatabaseMutationError(
+            "--expected-sha256 must be `missing` or 64 lowercase hexadecimal characters"
+        )
+
+
+def execute(
+    database_path: Path,
+    plan_path: Path,
+    *,
+    apply: bool,
+    expected_sha256: str | None,
+) -> dict[str, Any]:
+    plan = load_plan(plan_path)
+    mutations = plan["mutations"]
+    if expected_sha256 is not None:
+        _validate_digest(expected_sha256)
+    if apply and expected_sha256 is None:
+        raise TrackingDatabaseMutationError(
+            "--apply requires --expected-sha256 from the reviewed dry-run report"
+        )
+
+    initialize = len(mutations) == 1 and mutations[0].get("kind") == "initialize_database"
+    if any(mutation.get("kind") == "initialize_database" for mutation in mutations) and not initialize:
+        raise TrackingDatabaseMutationError(
+            "initialize_database must be the mutation plan's sole mutation"
+        )
+    database_path = Path(os.path.abspath(database_path.expanduser()))
+    if initialize:
+        if database_path.exists() or database_path.is_symlink():
+            raise TrackingDatabaseMutationError(
+                f"tracking database already exists at {database_path}; use typed mutations"
+            )
+        if expected_sha256 not in {None, "missing"}:
+            raise TrackingDatabaseMutationError(
+                "initialization precondition is `missing`, not a file SHA-256"
+            )
+        candidate = initial_database(mutations[0], index=0)
+        _validate_database_shape(candidate)
+        rendered = render_json_object(candidate)
+        output_sha256 = hashlib.sha256(rendered).hexdigest()
+        if apply:
+            try:
+                result = initialize_tracking_database(database_path, candidate)
+            except TrackingDatabaseIOError as exc:
+                raise TrackingDatabaseMutationError(str(exc)) from exc
+            durability_state = result.durability_state
+            warnings = list(result.warnings)
+            database_written = result.installed
+        else:
+            durability_state = "dry_run"
+            warnings = []
+            database_written = False
+        return {
+            "schema_version": PLAN_SCHEMA_VERSION,
+            "ok": True,
+            "mode": "apply" if apply else "dry-run",
+            "database": str(database_path),
+            "input_sha256": None,
+            "input_state": "missing",
+            "output_sha256": output_sha256,
+            "changed": True,
+            "database_written": database_written,
+            "durability_state": durability_state,
+            "warnings": warnings,
+            "changes": [
+                {
+                    "kind": "initialize_database",
+                    "identity": str(database_path),
+                    "before": MISSING_MARKER,
+                    "after": candidate,
+                }
+            ],
+        }
+
+    try:
+        snapshot = snapshot_tracking_database(database_path)
+        database = decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
+    if expected_sha256 == "missing":
+        raise TrackingDatabaseMutationError(
+            "tracking database exists; use its dry-run input_sha256 precondition"
+        )
+    if expected_sha256 is not None and expected_sha256 != snapshot.sha256:
+        raise TrackingDatabaseMutationError(
+            f"input sha256 precondition failed: expected {expected_sha256}, "
+            f"found {snapshot.sha256}"
+        )
+    candidate, changes = build_candidate(database, mutations)
+    rendered = render_json_object(candidate) if changes else snapshot.raw
+    output_sha256 = hashlib.sha256(rendered).hexdigest()
+    if apply:
+        try:
+            result = commit_tracking_database(snapshot, rendered)
+        except TrackingDatabaseIOError as exc:
+            raise TrackingDatabaseMutationError(str(exc)) from exc
+        database_written = result.installed
+        durability_state = result.durability_state
+        warnings = list(result.warnings)
+        output_sha256 = result.output_sha256
+    else:
+        database_written = False
+        durability_state = "dry_run"
+        warnings = []
+    return {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "ok": True,
+        "mode": "apply" if apply else "dry-run",
+        "database": str(database_path),
+        "input_sha256": snapshot.sha256,
+        "input_state": "present",
+        "output_sha256": output_sha256,
+        "changed": bool(changes),
+        "database_written": database_written,
+        "durability_state": durability_state,
+        "warnings": warnings,
+        "changes": changes,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument("database", type=Path)
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--expected-sha256")
+    try:
+        args = parser.parse_args(argv)
+        report = execute(
+            args.database,
+            args.plan,
+            apply=args.apply,
+            expected_sha256=args.expected_sha256,
+        )
+    except TrackingDatabaseMutationError as exc:
+        print(json.dumps({"schema_version": 1, "ok": False, "error": str(exc)}))
+        print(f"tracking-database mutation failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -33,6 +33,8 @@ from tracking_database_io import (
 
 PLAN_SCHEMA_VERSION = 1
 OWNER_RECORD_SCHEMA_VERSION = 1
+TRACKING_DATABASE_SCHEMA_VERSION = 1
+CONFIG_RECORD_SCHEMA_VERSION = 1
 MISSING_MARKER = {"$missing": True}
 COLLECTION_IDENTITIES = {
     "upsert_confirmed_intent": ("confirmed_intents", "pattern"),
@@ -86,11 +88,10 @@ GOAL_REQUIRED_FIELDS = frozenset(
     }
 )
 CONFIRMED_INTENT_REQUIRED_FIELDS = frozenset(
-    {"pattern", "intent", "rule", "note"}
+    {"schema_version", "pattern", "intent", "rule", "note"}
 )
 CONFIRMED_INTENT_OPTIONAL_FIELDS = frozenset(
     {
-        "schema_version",
         "confirmed_date",
         "source_talk",
         "source_talks",
@@ -99,10 +100,11 @@ CONFIRMED_INTENT_OPTIONAL_FIELDS = frozenset(
     }
 )
 RESOURCE_REQUIRED_FIELDS = frozenset(
-    {"talk_slug", "item_count", "category_breakdown"}
+    {"schema_version", "talk_slug", "item_count", "category_breakdown"}
 )
 PPTX_REQUIRED_FIELDS = frozenset(
     {
+        "schema_version",
         "pptx_path",
         "talk_filename",
         "matched",
@@ -112,6 +114,7 @@ PPTX_REQUIRED_FIELDS = frozenset(
 )
 THUMBNAIL_REQUIRED_FIELDS = frozenset(
     {
+        "schema_version",
         "talk_slug",
         "youtube_url",
         "source_slide_num",
@@ -124,9 +127,6 @@ THUMBNAIL_REQUIRED_FIELDS = frozenset(
         "approved",
     }
 )
-RECORD_SCHEMA_FIELD = frozenset({"schema_version"})
-
-
 class TrackingDatabaseMutationError(ValueError):
     """A mutation plan, precondition, or database shape is invalid."""
 
@@ -263,9 +263,7 @@ def _string_array(value: object, label: str, *, nonempty: bool = False) -> list[
     return normalized
 
 
-def _validate_optional_record_schema(record: dict[str, Any], label: str) -> None:
-    if "schema_version" not in record:
-        return
+def _validate_record_schema(record: dict[str, Any], label: str) -> None:
     if not json_values_equal(record["schema_version"], OWNER_RECORD_SCHEMA_VERSION):
         raise TrackingDatabaseMutationError(
             f"{label}.schema_version must be exact integer "
@@ -420,7 +418,7 @@ def _validate_collection_record(kind: str, record: dict[str, Any]) -> None:
             optional=CONFIRMED_INTENT_OPTIONAL_FIELDS,
             label=label,
         )
-        _validate_optional_record_schema(record, label)
+        _validate_record_schema(record, label)
         _nonempty(record["pattern"], f"{label}.pattern")
         _nonempty(record["intent"], f"{label}.intent")
         _nonempty(record["rule"], f"{label}.rule")
@@ -550,10 +548,9 @@ def _validate_collection_record(kind: str, record: dict[str, Any]) -> None:
         _require_keys(
             record,
             required=RESOURCE_REQUIRED_FIELDS,
-            optional=RECORD_SCHEMA_FIELD,
             label=label,
         )
-        _validate_optional_record_schema(record, label)
+        _validate_record_schema(record, label)
         _nonempty(record["talk_slug"], f"{label}.talk_slug")
         item_count = _exact_integer(record["item_count"], f"{label}.item_count")
         breakdown = record["category_breakdown"]
@@ -577,10 +574,9 @@ def _validate_collection_record(kind: str, record: dict[str, Any]) -> None:
         _require_keys(
             record,
             required=THUMBNAIL_REQUIRED_FIELDS,
-            optional=RECORD_SCHEMA_FIELD,
             label=label,
         )
-        _validate_optional_record_schema(record, label)
+        _validate_record_schema(record, label)
         for field in (
             "talk_slug",
             "youtube_url",
@@ -923,10 +919,9 @@ def _apply_record_pptx(
     _require_keys(
         record,
         required=PPTX_REQUIRED_FIELDS,
-        optional=RECORD_SCHEMA_FIELD,
         label=record_label,
     )
-    _validate_optional_record_schema(record, record_label)
+    _validate_record_schema(record, record_label)
     pptx_path = _nonempty(record["pptx_path"], f"{record_label}.pptx_path")
     if type(record["matched"]) is not bool:
         raise TrackingDatabaseMutationError(f"mutations[{index}].record.matched must be boolean")
@@ -1021,8 +1016,19 @@ def initial_database(mutation: dict[str, Any], *, index: int) -> dict[str, Any]:
     config = mutation["config"]
     if not isinstance(config, dict):
         raise TrackingDatabaseMutationError(f"mutations[{index}].config must be an object")
+    initial_config = copy.deepcopy(config)
+    if "schema_version" in initial_config and not json_values_equal(
+        initial_config["schema_version"],
+        CONFIG_RECORD_SCHEMA_VERSION,
+    ):
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].config.schema_version must be exact integer "
+            f"{CONFIG_RECORD_SCHEMA_VERSION}"
+        )
+    initial_config["schema_version"] = CONFIG_RECORD_SCHEMA_VERSION
     return {
-        "config": copy.deepcopy(config),
+        "schema_version": TRACKING_DATABASE_SCHEMA_VERSION,
+        "config": initial_config,
         "talks": [],
         "pptx_catalog": [],
         "qr_codes": [],

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -678,11 +678,21 @@ def _apply_set_config(
     if not isinstance(config, dict):
         raise TrackingDatabaseMutationError("database config must be an object")
     parent = config
+    label = "config." + ".".join(path)
     for offset, part in enumerate(path[:-1]):
-        child = parent.get(part)
-        if child is None and part not in parent:
+        if part not in parent:
+            if delete:
+                _expect_value(
+                    exists=False,
+                    actual=None,
+                    expected=mutation["expect"],
+                    label=label,
+                )
+                return
             child = {}
             parent[part] = child
+        else:
+            child = parent[part]
         if not isinstance(child, dict):
             prefix = ".".join(path[: offset + 1])
             raise TrackingDatabaseMutationError(f"config.{prefix} must be an object")
@@ -690,7 +700,6 @@ def _apply_set_config(
     leaf = path[-1]
     exists = leaf in parent
     actual = parent.get(leaf)
-    label = "config." + ".".join(path)
     _expect_value(exists=exists, actual=actual, expected=mutation["expect"], label=label)
     before: object = actual if exists else MISSING_MARKER
     if delete:

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -79,7 +79,6 @@ import copy
 import json
 import os
 import sys
-import tempfile
 from datetime import datetime, timezone
 
 from adherence_baseline import (
@@ -87,9 +86,7 @@ from adherence_baseline import (
     build_current_cohort_baseline,
 )
 from ingress_contract import (
-    IngressContractError,
     TALK_SCHEMA_VERSION,
-    reject_tracking_database_symlink,
     validate_talk_record_schemas,
 )
 from pattern_evidence import (
@@ -130,6 +127,13 @@ from return_validation import (
     validate_v2_structured_policy_shapes,
     validate_verbatim_examples,
     validate_v5_adherence_opportunity,
+)
+from tracking_database_io import (
+    TrackingDatabaseIOError,
+    TrackingDatabaseSnapshot,
+    decode_json_object,
+    snapshot_tracking_database,
+    write_json_object,
 )
 
 
@@ -790,29 +794,31 @@ def migrate_records(db):
     return migrated
 
 
-def atomic_write_json(path, payload):
-    """Replace a JSON artifact atomically after flushing the complete temp file."""
-    directory = os.path.dirname(os.path.abspath(path)) or "."
-    basename = os.path.basename(path)
+def atomic_write_json(
+    path,
+    payload,
+    *,
+    expected_snapshot: TrackingDatabaseSnapshot | None = None,
+):
+    """Commit JSON against the exact generation captured before validation."""
     try:
-        fd, temp_path = tempfile.mkstemp(prefix=f".{basename}.", suffix=".tmp", dir=directory)
-        installed = False
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                json.dump(payload, handle, indent=2, ensure_ascii=False)
-                handle.write("\n")
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(temp_path, path)
-            installed = True
-        finally:
-            if not installed:
-                try:
-                    os.unlink(temp_path)
-                except FileNotFoundError:
-                    pass
-    except OSError as exc:
-        raise ValueError(f"cannot atomically write tracking database {path}: {exc}") from exc
+        snapshot = expected_snapshot or snapshot_tracking_database(path)
+        return write_json_object(snapshot, payload)
+    except TrackingDatabaseIOError as exc:
+        raise ValueError(f"cannot safely write tracking database {path}: {exc}") from exc
+
+
+def load_tracking_database(path):
+    """Load strict JSON and retain the exact generation used for validation."""
+    try:
+        snapshot = snapshot_tracking_database(path)
+        return decode_json_object(snapshot), snapshot
+    except TrackingDatabaseIOError as exc:
+        message = str(exc)
+        if "tracking database is missing at" in message:
+            message = f"tracking database file not found: {path} — {message}"
+        print(f"ERROR: {message}", file=sys.stderr)
+        sys.exit(1)
 
 
 def load_json(path, label):
@@ -880,12 +886,7 @@ def parse_args(argv):
 def main():
     db_path, batch_path, run_date = parse_args(sys.argv[1:])
 
-    try:
-        reject_tracking_database_symlink(db_path)
-    except IngressContractError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        sys.exit(1)
-    db = load_json(db_path, "tracking database")
+    db, database_snapshot = load_tracking_database(db_path)
     returns = load_json(batch_path, "batch-returns")
     try:
         catalog = validate_batch(returns)
@@ -1006,7 +1007,11 @@ def main():
         sys.exit(1)
 
     try:
-        atomic_write_json(db_path, db)
+        write_result = atomic_write_json(
+            db_path,
+            db,
+            expected_snapshot=database_snapshot,
+        )
     except ValueError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
@@ -1016,6 +1021,11 @@ def main():
                "pattern_scoring_schema_version": PATTERN_SCORING_SCHEMA_VERSION,
                "pattern_catalog_fingerprint": catalog.fingerprint,
                "current_adherence_baseline": current_adherence_baseline,
+               "input_sha256": write_result.input_sha256,
+               "output_sha256": write_result.output_sha256,
+               "database_written": write_result.installed,
+               "durability_state": write_result.durability_state,
+               "warnings": list(write_result.warnings),
                "talks": summary}, sys.stdout, ensure_ascii=False)
     sys.stdout.write("\n")
 

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -49,6 +49,11 @@ from source_identity_matching import (
     known_event_aliases,
     titles_agree,
 )
+from tracking_database_io import (
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
+)
 
 
 REPORT_SCHEMA_VERSION = 1
@@ -1393,23 +1398,23 @@ def run_preflight(value: str | Path) -> dict[str, Any]:
     """Load and validate a vault, returning a report without mutating it."""
     vault_root, database_path = resolve_input(value)
     try:
-        raw = database_path.read_text(encoding="utf-8")
-    except UnicodeError as exc:
+        snapshot = snapshot_tracking_database(database_path)
+        database = decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
+        message = str(exc)
+        if "not valid UTF-8" in message:
+            code = "database_encoding_invalid"
+        elif "not valid JSON" in message or "duplicate object key" in message or (
+            "non-standard JSON number" in message
+        ) or "root must be a JSON object" in message:
+            code = "database_json_invalid"
+        else:
+            code = "database_unreadable"
         return error_report(
-            vault_root, database_path, "database_encoding_invalid",
-            f"tracking database is not valid UTF-8: {exc}",
-        )
-    except OSError as exc:
-        return error_report(
-            vault_root, database_path, "database_unreadable",
-            f"cannot read tracking database: {exc}",
-        )
-    try:
-        database = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        return error_report(
-            vault_root, database_path, "database_json_invalid",
-            f"tracking database is not valid JSON at line {exc.lineno}, column {exc.colno}",
+            vault_root,
+            database_path,
+            code,
+            message,
         )
     return VaultPreflight(database, vault_root, database_path).run()
 

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -64,16 +64,13 @@ import json
 import os
 import re
 import sys
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
 from ingress_contract import (
-    IngressContractError,
     has_video_source,
-    reject_tracking_database_symlink,
 )
 from adherence_baseline import (
     ADHERENCE_BASELINE_SCHEMA_VERSION,
@@ -98,6 +95,15 @@ from return_validation import (
     ReturnValidationError,
     assess_current_persisted_pattern_evidence_freshness,
     load_catalog,
+)
+from tracking_database_io import (
+    TrackingDatabaseIOError,
+    TrackingDatabaseSnapshot,
+    TrackingDatabaseWriteResult,
+    decode_json_object,
+    snapshot_tracking_database,
+    unchanged_write_result,
+    write_json_object,
 )
 
 
@@ -655,55 +661,56 @@ def upgrade_claim_for_write(claim):
         claim["result_payload_sha256"] = None
 
 
-def load_database(path, *, allow_claim_status_drift=False):
+def load_database_snapshot(path, *, allow_claim_status_drift=False):
+    """Load strict JSON together with the exact generation validation observed."""
     try:
-        reject_tracking_database_symlink(path)
-    except IngressContractError as exc:
+        snapshot = snapshot_tracking_database(path)
+        database = decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
         raise QueueStateError(str(exc)) from exc
-    try:
-        with path.open(encoding="utf-8") as handle:
-            database = json.load(handle)
-    except FileNotFoundError as exc:
-        raise QueueStateError(
-            f"tracking database not found at {path} — pass the vault's "
-            "tracking-database.json"
-        ) from exc
-    except json.JSONDecodeError as exc:
-        raise QueueStateError(
-            f"tracking database at {path} is invalid JSON at line {exc.lineno}, "
-            f"column {exc.colno}"
-        ) from exc
-    except OSError as exc:
-        raise QueueStateError(f"cannot read tracking database at {path}: {exc}") from exc
     validate_database(
         database,
+        allow_claim_status_drift=allow_claim_status_drift,
+    )
+    return database, snapshot
+
+
+def load_database(path, *, allow_claim_status_drift=False):
+    """Compatibility wrapper returning only the decoded database."""
+    database, _ = load_database_snapshot(
+        path,
         allow_claim_status_drift=allow_claim_status_drift,
     )
     return database
 
 
-def write_database_atomically(path, database):
-    """Replace the database only after a complete same-directory write."""
+def write_database_atomically(
+    path,
+    database,
+    *,
+    expected_snapshot: TrackingDatabaseSnapshot | None = None,
+) -> TrackingDatabaseWriteResult:
+    """Commit against the exact generation captured before validation."""
     try:
-        mode = path.stat().st_mode & 0o777
-        handle, temporary = tempfile.mkstemp(
-            dir=str(path.parent), prefix=f".{path.name}.", suffix=".partial"
-        )
-        try:
-            os.chmod(temporary, mode)
-            with os.fdopen(handle, "w", encoding="utf-8") as output:
-                json.dump(database, output, indent=2, ensure_ascii=False)
-                output.write("\n")
-                output.flush()
-                os.fsync(output.fileno())
-            os.replace(temporary, path)
-        finally:
-            if os.path.exists(temporary):
-                os.unlink(temporary)
-    except OSError as exc:
+        snapshot = expected_snapshot or snapshot_tracking_database(path)
+        return write_json_object(snapshot, database)
+    except TrackingDatabaseIOError as exc:
         raise QueueStateError(
-            f"cannot atomically write tracking database at {path}: {exc}"
+            f"cannot safely write tracking database at {path}: {exc}"
         ) from exc
+
+
+def write_result_fields(
+    result: TrackingDatabaseWriteResult,
+) -> dict[str, object]:
+    """Expose generation identities without changing queue's `changed` count."""
+    return {
+        "input_sha256": result.input_sha256,
+        "output_sha256": result.output_sha256,
+        "database_written": result.installed,
+        "durability_state": result.durability_state,
+        "warnings": list(result.warnings),
+    }
 
 
 def normalize_legacy_statuses(database, *, capability_assessor):
@@ -861,7 +868,7 @@ def claim_talk(
     return item
 
 
-def command_normalize(database, path, _args):
+def command_normalize(database, path, _args, *, expected_snapshot):
     candidate = copy.deepcopy(database)
     capability_assessor = artifact_capability_assessor(candidate, path)
     normalizations = normalize_legacy_statuses(
@@ -878,17 +885,24 @@ def command_normalize(database, path, _args):
     )
     if normalizations:
         validate_database(candidate)
-        write_database_atomically(path, candidate)
+        write_result = write_database_atomically(
+            path,
+            candidate,
+            expected_snapshot=expected_snapshot,
+        )
+    else:
+        write_result = unchanged_write_result(expected_snapshot)
     return {
         "ok": True,
         "action": "normalize",
         "db_path": str(path),
         "changed": len(normalizations),
         "normalizations": normalizations,
+        **write_result_fields(write_result),
     }
 
 
-def command_claim(database, path, args):
+def command_claim(database, path, args, *, expected_snapshot):
     run_id = require_identifier(args.run_id, "run_id")
     batch_id = require_identifier(args.batch_id, "batch_id")
     now_text = timestamp_text(parse_timestamp(args.now, "--now"))
@@ -914,6 +928,7 @@ def command_claim(database, path, args):
             )
         latest_states = {item["state"] for item in latest}
         if latest_states <= {"claimed", "completed"}:
+            write_result = unchanged_write_result(expected_snapshot)
             return {
                 "ok": True,
                 "action": "claim",
@@ -924,6 +939,7 @@ def command_claim(database, path, args):
                 "normalizations": [],
                 "claimed": latest,
                 "remaining_eligible": None,
+                **write_result_fields(write_result),
             }
         if latest_states == {"stale_recovered"}:
             # Recovery restores the talks to their prior claimable statuses.
@@ -1018,7 +1034,13 @@ def command_claim(database, path, args):
     )
     if normalizations or claimed:
         validate_database(candidate)
-        write_database_atomically(path, candidate)
+        write_result = write_database_atomically(
+            path,
+            candidate,
+            expected_snapshot=expected_snapshot,
+        )
+    else:
+        write_result = unchanged_write_result(expected_snapshot)
     return {
         "ok": True,
         "action": "claim",
@@ -1030,10 +1052,11 @@ def command_claim(database, path, args):
         "normalizations": normalizations,
         "claimed": claimed,
         "remaining_eligible": remaining,
+        **write_result_fields(write_result),
     }
 
 
-def command_recover(database, path, args):
+def command_recover(database, path, args, *, expected_snapshot):
     now = parse_timestamp(args.now, "--now")
     now_text = timestamp_text(now)
     run_id = require_identifier(args.run_id, "run_id") if args.run_id else None
@@ -1079,7 +1102,13 @@ def command_recover(database, path, args):
         recovered.append(recovered_item)
     if recovered:
         validate_database(database)
-        write_database_atomically(path, database)
+        write_result = write_database_atomically(
+            path,
+            database,
+            expected_snapshot=expected_snapshot,
+        )
+    else:
+        write_result = unchanged_write_result(expected_snapshot)
     return {
         "ok": True,
         "action": "recover",
@@ -1087,16 +1116,19 @@ def command_recover(database, path, args):
         "now": now_text,
         "stale_after_seconds": args.stale_after_seconds,
         "recovered": recovered,
+        **write_result_fields(write_result),
     }
 
 
-def command_inspect(database, path, args):
+def command_inspect(database, path, args, *, expected_snapshot):
+    write_result = unchanged_write_result(expected_snapshot)
     run_id = require_identifier(args.run_id, "run_id")
     return {
         "ok": True,
         "action": "inspect",
         "db_path": str(path),
         **reconstruct_run(database, run_id),
+        **write_result_fields(write_result),
     }
 
 
@@ -1145,7 +1177,7 @@ def main(argv=None):
     try:
         args = parser.parse_args(argv)
         path = Path(os.path.abspath(Path(args.database).expanduser()))
-        database = load_database(
+        database, snapshot = load_database_snapshot(
             path,
             allow_claim_status_drift=args.action == "recover",
         )
@@ -1155,7 +1187,12 @@ def main(argv=None):
             "recover": command_recover,
             "inspect": command_inspect,
         }
-        payload = commands[args.action](database, path, args)
+        payload = commands[args.action](
+            database,
+            path,
+            args,
+            expected_snapshot=snapshot,
+        )
     except QueueStateError as exc:
         payload = {"ok": False, "error": str(exc)}
         print(str(exc), file=sys.stderr)

--- a/skills/vault-ingress/scripts/read-tracking-database.py
+++ b/skills/vault-ingress/scripts/read-tracking-database.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Read one tracking database through the owner strict snapshot contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from tracking_database_io import (
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
+)
+
+
+REPORT_SCHEMA_VERSION = 1
+
+
+def execute(path: Path) -> dict[str, object]:
+    snapshot = snapshot_tracking_database(path)
+    database = decode_json_object(snapshot)
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "ok": True,
+        "database_path": str(snapshot.path),
+        "sha256": snapshot.sha256,
+        "database": database,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument("database", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = execute(args.database)
+    except TrackingDatabaseIOError as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "ok": False,
+                    "error": str(exc),
+                }
+            )
+        )
+        print(f"tracking-database read failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -17,7 +17,6 @@ import os
 import re
 import stat
 import sys
-import tempfile
 import unicodedata
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -30,14 +29,21 @@ import yaml
 from catalog_io import load_catalog_yaml
 from ingress_contract import (
     GOOGLE_DRIVE_ID_RE,
-    IngressContractError,
     TALK_SCHEMA_VERSION,
     YOUTUBE_ID_RE,
     is_youtube_url,
     parse_google_drive_id,
     parse_youtube_id,
-    reject_tracking_database_symlink,
     validate_talk_record_schemas,
+)
+from tracking_database_io import (
+    TrackingDatabaseConflictError,
+    TrackingDatabaseIOError,
+    TrackingDatabaseSnapshot,
+    decode_json_object,
+    snapshot_tracking_database,
+    unchanged_write_result,
+    write_json_object,
 )
 
 try:  # Python 3.11+.
@@ -49,7 +55,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10 only
         tomllib = None
 
 
-REPORT_SCHEMA_VERSION = 1
+REPORT_SCHEMA_VERSION = 2
 LOCAL_SOURCE_TYPES = frozenset(
     {"local_jekyll", "local_hugo", "local_eleventy", "local_astro"}
 )
@@ -97,13 +103,6 @@ FileGeneration = tuple[int, int, int, int, int]
 
 class ShownotesScanError(ValueError):
     """Input or state prevents a deterministic shownotes scan."""
-
-
-def _reject_database_symlink(path: Path) -> None:
-    try:
-        reject_tracking_database_symlink(path)
-    except IngressContractError as exc:
-        raise ShownotesScanError(str(exc)) from exc
 
 
 class _ArgumentParser(argparse.ArgumentParser):
@@ -165,85 +164,14 @@ def _file_generation(metadata: os.stat_result) -> FileGeneration:
     )
 
 
-def _database_path_metadata(path: Path) -> os.stat_result:
+def _load_database(
+    path: Path,
+) -> tuple[dict[str, Any], TrackingDatabaseSnapshot]:
     try:
-        metadata = path.lstat()
-    except FileNotFoundError as exc:
-        raise ShownotesScanError(
-            f"tracking database is missing at {path}; pass its canonical file path"
-        ) from exc
-    except OSError as exc:
-        raise ShownotesScanError(
-            f"cannot inspect tracking database {path}: {exc}; repair access and retry"
-        ) from exc
-    if stat.S_ISLNK(metadata.st_mode):
-        _reject_database_symlink(path)
-    if not stat.S_ISREG(metadata.st_mode):
-        raise ShownotesScanError(
-            f"tracking database {path} is not a regular file; pass the canonical file"
-        )
-    return metadata
-
-
-def _regular_database_bytes(path: Path) -> tuple[bytes, os.stat_result]:
-    path_metadata = _database_path_metadata(path)
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
-    try:
-        descriptor = os.open(path, flags)
-    except OSError as exc:
-        raise ShownotesScanError(
-            f"cannot open tracking database {path} without following symlinks: {exc}; "
-            "pass its canonical regular-file path and retry"
-        ) from exc
-    try:
-        with os.fdopen(descriptor, "rb") as handle:
-            opened_metadata = os.fstat(handle.fileno())
-            if not stat.S_ISREG(opened_metadata.st_mode):
-                raise ShownotesScanError(
-                    f"tracking database {path} changed to a non-regular file; retry"
-                )
-            if _file_generation(opened_metadata) != _file_generation(path_metadata):
-                raise ShownotesScanError(
-                    "tracking database changed while it was opened; rerun the scan"
-                )
-            raw = handle.read()
-            read_metadata = os.fstat(handle.fileno())
-    except OSError as exc:
-        raise ShownotesScanError(
-            f"cannot read tracking database {path}: {exc}; repair access and retry"
-        ) from exc
-    if _file_generation(read_metadata) != _file_generation(opened_metadata):
-        raise ShownotesScanError(
-            "tracking database changed while it was read; rerun the scan"
-        )
-    final_metadata = _database_path_metadata(path)
-    if _file_generation(final_metadata) != _file_generation(read_metadata):
-        raise ShownotesScanError(
-            "tracking database path changed while it was read; rerun the scan"
-        )
-    return raw, read_metadata
-
-
-def _require_database_generation(path: Path, expected: FileGeneration) -> None:
-    current = _database_path_metadata(path)
-    if _file_generation(current) != expected:
-        raise ShownotesScanError(
-            "tracking database generation changed after the scan; rerun before applying"
-        )
-
-
-def _load_database(path: Path) -> tuple[dict[str, Any], bytes, os.stat_result]:
-    raw, metadata = _regular_database_bytes(path)
-    try:
-        payload = json.loads(raw)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ShownotesScanError(
-            f"tracking database {path} is not valid UTF-8 JSON: {exc}; repair it and retry"
-        ) from exc
-    if not isinstance(payload, dict):
-        raise ShownotesScanError(
-            "tracking database root must be a JSON object; repair it before scanning"
-        )
+        snapshot = snapshot_tracking_database(path)
+        payload = decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
+        raise ShownotesScanError(str(exc)) from exc
     try:
         validate_talk_record_schemas(payload.get("talks"))
     except ValueError as exc:
@@ -254,7 +182,7 @@ def _load_database(path: Path) -> tuple[dict[str, Any], bytes, os.stat_result]:
         raise ShownotesScanError(
             "tracking database config must be a JSON object; run vault-ingress Step 1"
         )
-    return payload, raw, metadata
+    return payload, snapshot
 
 
 def _safe_local_location(
@@ -993,70 +921,24 @@ def _atomic_write_database(
     path: Path,
     database: dict[str, Any],
     *,
-    expected_raw: bytes,
-    original_metadata: os.stat_result,
-) -> None:
-    expected_generation = _file_generation(original_metadata)
-    current_raw, current_metadata = _regular_database_bytes(path)
-    if (
-        current_raw != expected_raw
-        or _file_generation(current_metadata) != expected_generation
-    ):
+    expected_snapshot: TrackingDatabaseSnapshot,
+):
+    """Commit against the exact generation captured before shownotes scanning."""
+    try:
+        return write_json_object(expected_snapshot, database)
+    except TrackingDatabaseConflictError as exc:
         raise ShownotesScanError(
             "tracking database content or generation changed after the scan; "
             "rerun before applying"
-        )
-    rendered = (json.dumps(database, indent=2, ensure_ascii=False) + "\n").encode(
-        "utf-8"
-    )
-    descriptor, temp_name = tempfile.mkstemp(
-        prefix=f".{path.name}.", suffix=".shownotes.tmp", dir=path.parent
-    )
-    installed = False
-    try:
-        os.fchmod(descriptor, stat.S_IMODE(original_metadata.st_mode))
-        with os.fdopen(descriptor, "wb") as handle:
-            handle.write(rendered)
-            handle.flush()
-            os.fsync(handle.fileno())
-        final_raw, final_metadata = _regular_database_bytes(path)
-        if (
-            final_raw != expected_raw
-            or _file_generation(final_metadata) != expected_generation
-        ):
-            raise ShownotesScanError(
-                "tracking database content or generation changed during apply; "
-                "rerun the shownotes scan"
-            )
-        _require_database_generation(path, expected_generation)
-        os.replace(temp_name, path)
-        installed = True
-        try:
-            directory_descriptor = os.open(path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_descriptor)
-            finally:
-                os.close(directory_descriptor)
-        except OSError as exc:
-            print(
-                f"warning: database replaced, but directory sync failed: {exc}",
-                file=sys.stderr,
-            )
-    except OSError as exc:
-        raise ShownotesScanError(
-            f"cannot atomically update tracking database {path}: {exc}; "
-            "repair destination access and retry"
         ) from exc
-    finally:
-        if not installed:
-            try:
-                os.unlink(temp_name)
-            except FileNotFoundError:
-                pass
+    except TrackingDatabaseIOError as exc:
+        raise ShownotesScanError(
+            f"cannot atomically update tracking database {path}: {exc}"
+        ) from exc
 
 
 def execute(database_path: Path, *, apply_requested: bool) -> dict[str, Any]:
-    database, raw, metadata = _load_database(database_path)
+    database, database_snapshot = _load_database(database_path)
     location = resolve_shownotes_location(database["config"])
     report, candidate = build_scan_report(
         database_path,
@@ -1064,14 +946,31 @@ def execute(database_path: Path, *, apply_requested: bool) -> dict[str, Any]:
         location,
         apply_requested=apply_requested,
     )
-    if apply_requested and report["mutation_count"]:
-        _atomic_write_database(
-            database_path,
-            candidate,
-            expected_raw=raw,
-            original_metadata=metadata,
-        )
-        report["database_written"] = True
+    if apply_requested:
+        if report["mutation_count"]:
+            write_result = _atomic_write_database(
+                database_path,
+                candidate,
+                expected_snapshot=database_snapshot,
+            )
+        else:
+            write_result = unchanged_write_result(database_snapshot)
+        write_fields = {
+            "input_sha256": write_result.input_sha256,
+            "output_sha256": write_result.output_sha256,
+            "database_written": write_result.installed,
+            "durability_state": write_result.durability_state,
+            "warnings": list(write_result.warnings),
+        }
+    else:
+        write_fields = {
+            "input_sha256": database_snapshot.sha256,
+            "output_sha256": database_snapshot.sha256,
+            "database_written": False,
+            "durability_state": "dry_run",
+            "warnings": [],
+        }
+    report.update(write_fields)
     return report
 
 

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -1,0 +1,1000 @@
+"""Safe snapshots and cooperative write transactions for the tracking database.
+
+Every toolkit writer must capture a :class:`TrackingDatabaseSnapshot` before
+validating a mutation and commit against that same snapshot.  The commit path
+uses one persistent sibling lock, then rechecks the exact bytes and file
+generation before and after staging.  The lock coordinates toolkit writers;
+the second no-follow generation check remains defense against a non-cooperative
+filesystem edit that lands before replacement.
+
+The lock file is never removed.  Removing or replacing it would allow two
+processes to lock different inodes and is outside the cooperative contract.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import stat
+from typing import Any, Iterator, NoReturn
+
+
+READ_CHUNK_SIZE = 1024 * 1024
+
+
+class TrackingDatabaseIOError(ValueError):
+    """The tracking database could not be read or installed safely."""
+
+
+class TrackingDatabaseConflictError(TrackingDatabaseIOError):
+    """The expected database generation is no longer current."""
+
+
+@dataclass(frozen=True)
+class FileGeneration:
+    """Stable identity fields for one observed regular-file generation."""
+
+    device: int
+    inode: int
+    size: int
+    modified_ns: int
+    changed_ns: int
+
+    @classmethod
+    def from_stat(cls, metadata: os.stat_result) -> "FileGeneration":
+        return cls(
+            device=metadata.st_dev,
+            inode=metadata.st_ino,
+            size=metadata.st_size,
+            modified_ns=metadata.st_mtime_ns,
+            changed_ns=metadata.st_ctime_ns,
+        )
+
+
+@dataclass(frozen=True)
+class TrackingDatabaseSnapshot:
+    """Exact bytes, digest, mode, and generation captured before validation."""
+
+    path: Path
+    raw: bytes
+    sha256: str
+    generation: FileGeneration
+    mode: int
+
+
+@dataclass(frozen=True)
+class BackupRequest:
+    """Exact-input backup required before installing a candidate generation."""
+
+    path: Path
+    input_sha256: str
+
+
+@dataclass(frozen=True)
+class TrackingDatabaseWriteResult:
+    """Unambiguous outcome of one write transaction."""
+
+    input_sha256: str | None
+    output_sha256: str
+    changed: bool
+    installed: bool
+    durability_state: str
+    warnings: tuple[str, ...]
+    backup: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "input_sha256": self.input_sha256,
+            "output_sha256": self.output_sha256,
+            "changed": self.changed,
+            "database_written": self.installed,
+            "durability_state": self.durability_state,
+            "warnings": list(self.warnings),
+            "backup": self.backup,
+        }
+
+
+@dataclass
+class _DatabaseLock:
+    """One acquired lock plus cleanup warnings collected after the body."""
+
+    descriptor: int
+    path: Path
+    warnings: list[str]
+
+
+@dataclass
+class StagedCandidate:
+    """Open, directory-anchored staged bytes retained through installation."""
+
+    path: Path
+    name: str
+    descriptor: int
+    directory_descriptor: int
+    generation: FileGeneration
+    sha256: str
+    size: int
+
+
+def unchanged_write_result(
+    snapshot: TrackingDatabaseSnapshot,
+) -> TrackingDatabaseWriteResult:
+    """Describe a validated no-op without rewriting its original bytes."""
+    return TrackingDatabaseWriteResult(
+        input_sha256=snapshot.sha256,
+        output_sha256=snapshot.sha256,
+        changed=False,
+        installed=False,
+        durability_state="unchanged",
+        warnings=(),
+        backup=None,
+    )
+
+
+def _absolute_path(path: str | os.PathLike[str]) -> Path:
+    return Path(os.path.abspath(Path(path).expanduser()))
+
+
+def _sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def json_values_equal(left: object, right: object) -> bool:
+    """Compare decoded JSON values without Python's bool/number coercions."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        if not isinstance(right, dict) or set(left) != set(right):
+            return False
+        return all(json_values_equal(left[key], right[key]) for key in left)
+    if isinstance(left, list):
+        if not isinstance(right, list) or len(left) != len(right):
+            return False
+        return all(
+            json_values_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right)
+        )
+    return left == right
+
+
+def lock_path_for(path: str | os.PathLike[str]) -> Path:
+    """Return the persistent cooperative lock shared by every toolkit writer."""
+    database_path = _absolute_path(path)
+    return database_path.parent / f".{database_path.name}.lock"
+
+
+def _path_metadata(path: Path, *, subject: str) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as exc:
+        raise TrackingDatabaseIOError(
+            f"{subject} is missing at {path}; pass its canonical file path "
+            "(a regular file)"
+        ) from exc
+    except OSError as exc:
+        raise TrackingDatabaseIOError(f"cannot inspect {subject} {path}: {exc}") from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        raise TrackingDatabaseIOError(
+            f"{subject} {path} is a symbolic link; pass its canonical regular-file path"
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        raise TrackingDatabaseIOError(
+            f"{subject} {path} is not a regular file; repair it before retrying"
+        )
+    return metadata
+
+
+def _read_descriptor(descriptor: int) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(descriptor, READ_CHUNK_SIZE)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+
+
+def snapshot_tracking_database(
+    path: str | os.PathLike[str],
+) -> TrackingDatabaseSnapshot:
+    """Read one stable regular-file generation without following the final link."""
+    database_path = _absolute_path(path)
+    path_before = _path_metadata(database_path, subject="tracking database")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(database_path, flags)
+    except OSError as exc:
+        raise TrackingDatabaseIOError(
+            f"cannot open tracking database {database_path} without following "
+            f"symlinks: {exc}"
+        ) from exc
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise TrackingDatabaseIOError(
+                f"tracking database {database_path} changed to a non-regular file; retry"
+            )
+        if FileGeneration.from_stat(opened) != FileGeneration.from_stat(path_before):
+            raise TrackingDatabaseConflictError(
+                "tracking database changed while it was opened; rerun the operation"
+            )
+        raw = _read_descriptor(descriptor)
+        read_complete = os.fstat(descriptor)
+    except OSError as exc:
+        raise TrackingDatabaseIOError(
+            f"cannot read tracking database {database_path}: {exc}"
+        ) from exc
+    finally:
+        os.close(descriptor)
+    if FileGeneration.from_stat(read_complete) != FileGeneration.from_stat(opened):
+        raise TrackingDatabaseConflictError(
+            "tracking database changed while it was read; rerun the operation"
+        )
+    path_after = _path_metadata(database_path, subject="tracking database")
+    generation = FileGeneration.from_stat(read_complete)
+    if FileGeneration.from_stat(path_after) != generation:
+        raise TrackingDatabaseConflictError(
+            "tracking database path changed while it was read; rerun the operation"
+        )
+    return TrackingDatabaseSnapshot(
+        path=database_path,
+        raw=raw,
+        sha256=_sha256(raw),
+        generation=generation,
+        mode=stat.S_IMODE(read_complete.st_mode),
+    )
+
+
+def decode_json_object_bytes(
+    raw: bytes,
+    path: str | os.PathLike[str],
+    *,
+    label: str = "tracking database",
+) -> dict[str, Any]:
+    """Decode strict UTF-8 JSON while rejecting duplicate keys and non-finite values."""
+    artifact_path = _absolute_path(path)
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise TrackingDatabaseIOError(
+                    f"{label} {artifact_path} contains duplicate object key {key!r}"
+                )
+            result[key] = value
+        return result
+
+    def reject_non_finite(value: str) -> NoReturn:
+        raise TrackingDatabaseIOError(
+            f"{label} {artifact_path} contains non-standard JSON number {value}"
+        )
+
+    try:
+        payload = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_non_finite,
+        )
+    except TrackingDatabaseIOError:
+        raise
+    except UnicodeDecodeError as exc:
+        raise TrackingDatabaseIOError(
+            f"{label} {artifact_path} is not valid UTF-8: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise TrackingDatabaseIOError(
+            f"{label} {artifact_path} is not valid JSON at line {exc.lineno}, "
+            f"column {exc.colno}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise TrackingDatabaseIOError(
+            f"{label} {artifact_path} root must be a JSON object"
+        )
+    return payload
+
+
+def decode_json_object(
+    snapshot: TrackingDatabaseSnapshot,
+    *,
+    label: str = "tracking database",
+) -> dict[str, Any]:
+    """Decode a captured tracking-database snapshot through the strict contract."""
+    return decode_json_object_bytes(snapshot.raw, snapshot.path, label=label)
+
+
+def render_json_object(payload: dict[str, Any]) -> bytes:
+    """Render the canonical human-readable tracking-database JSON form."""
+    try:
+        rendered = json.dumps(
+            payload,
+            indent=2,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise TrackingDatabaseIOError(
+            f"tracking-database candidate is not strict JSON: {exc}"
+        ) from exc
+    return rendered.encode("utf-8") + b"\n"
+
+
+def _lock_identity(metadata: os.stat_result) -> tuple[int, int]:
+    return metadata.st_dev, metadata.st_ino
+
+
+def _append_close_warning(
+    descriptor: int,
+    *,
+    label: str,
+    warnings: list[str],
+) -> None:
+    """Close a post-operation descriptor without masking the operation outcome."""
+    try:
+        os.close(descriptor)
+    except OSError as exc:
+        warnings.append(f"could not close {label}: {exc}")
+
+
+@contextmanager
+def _exclusive_database_lock(path: Path) -> Iterator[_DatabaseLock]:
+    lock_path = lock_path_for(path)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise TrackingDatabaseIOError(
+            f"cannot open cooperative tracking-database lock {lock_path}: {exc}"
+        ) from exc
+    acquired = False
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+            raise TrackingDatabaseIOError(
+                f"cooperative tracking-database lock {lock_path} must be one regular file"
+            )
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        acquired = True
+        try:
+            visible = lock_path.lstat()
+        except OSError as exc:
+            raise TrackingDatabaseIOError(
+                f"cannot verify cooperative tracking-database lock {lock_path}: {exc}"
+            ) from exc
+        locked = os.fstat(descriptor)
+        if (
+            stat.S_ISLNK(visible.st_mode)
+            or not stat.S_ISREG(visible.st_mode)
+            or _lock_identity(visible) != _lock_identity(locked)
+            or locked.st_nlink != 1
+        ):
+            raise TrackingDatabaseIOError(
+                f"cooperative tracking-database lock {lock_path} changed while locking; "
+                "restore the persistent regular lock file and retry"
+            )
+    except OSError as exc:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise TrackingDatabaseIOError(
+            f"cannot acquire tracking-database lock through {lock_path}: {exc}"
+        ) from exc
+    except BaseException:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+
+    lock = _DatabaseLock(descriptor=descriptor, path=lock_path, warnings=[])
+    try:
+        yield lock
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            except OSError as exc:
+                lock.warnings.append(
+                    f"could not unlock cooperative tracking-database lock "
+                    f"{lock_path}: {exc}"
+                )
+        _append_close_warning(
+            descriptor,
+            label=f"cooperative tracking-database lock {lock_path}",
+            warnings=lock.warnings,
+        )
+
+
+def _require_expected_generation(
+    expected: TrackingDatabaseSnapshot,
+) -> TrackingDatabaseSnapshot:
+    current = snapshot_tracking_database(expected.path)
+    if current.raw != expected.raw or current.generation != expected.generation:
+        raise TrackingDatabaseConflictError(
+            "tracking database content or generation changed after validation; "
+            "rerun the operation against the current database"
+        )
+    return current
+
+
+def _require_missing_database(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise TrackingDatabaseIOError(
+            f"cannot inspect tracking-database initialization target {path}: {exc}"
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        raise TrackingDatabaseIOError(
+            f"tracking-database initialization target {path} is a symbolic link; "
+            "remove it or pass the canonical missing path"
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        raise TrackingDatabaseIOError(
+            f"tracking-database initialization target {path} is not a regular file"
+        )
+    raise TrackingDatabaseConflictError(
+        f"tracking database already exists at {path}; load and mutate that generation"
+    )
+
+
+def _open_directory(path: Path, *, label: str) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise TrackingDatabaseIOError(f"cannot open {label} {path}: {exc}") from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise TrackingDatabaseIOError(f"{label} {path} is not a directory")
+    return descriptor
+
+
+def _fsync_directory(descriptor: int) -> None:
+    os.fsync(descriptor)
+
+
+def _ensure_backup_directory(path: Path) -> int:
+    created = False
+    try:
+        os.mkdir(path, mode=0o700)
+        created = True
+    except FileExistsError:
+        pass
+    except OSError as exc:
+        raise TrackingDatabaseIOError(
+            f"cannot create tracking-database backup directory {path}: {exc}"
+        ) from exc
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise TrackingDatabaseIOError(
+            f"tracking-database backup directory {path} must be a real directory: {exc}"
+        ) from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise TrackingDatabaseIOError(
+            f"tracking-database backup directory {path} must be a real directory"
+        )
+    if created:
+        parent_descriptor = _open_directory(path.parent, label="backup parent directory")
+        try:
+            _fsync_directory(parent_descriptor)
+        except OSError as exc:
+            os.close(descriptor)
+            raise TrackingDatabaseIOError(
+                f"cannot durably create tracking-database backup directory {path}: {exc}"
+            ) from exc
+        finally:
+            os.close(parent_descriptor)
+    return descriptor
+
+
+def _write_exact_backup(
+    request: BackupRequest,
+    expected: TrackingDatabaseSnapshot,
+) -> str:
+    if request.input_sha256 != expected.sha256:
+        raise TrackingDatabaseIOError(
+            "backup input_sha256 does not match the validated tracking-database bytes"
+        )
+    backup_path = _absolute_path(request.path)
+    directory_descriptor = _ensure_backup_directory(backup_path.parent)
+    read_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    read_flags |= getattr(os, "O_NOFOLLOW", 0)
+    create_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    create_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    created = False
+    descriptor: int | None = None
+    try:
+        try:
+            descriptor = os.open(
+                backup_path.name,
+                create_flags,
+                expected.mode,
+                dir_fd=directory_descriptor,
+            )
+            created = True
+        except FileExistsError:
+            descriptor = os.open(
+                backup_path.name,
+                read_flags,
+                dir_fd=directory_descriptor,
+            )
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise TrackingDatabaseIOError(
+                f"tracking-database backup {backup_path} must be a regular file"
+            )
+        if created:
+            with os.fdopen(descriptor, "wb") as handle:
+                descriptor = None
+                handle.write(expected.raw)
+                handle.flush()
+                os.fsync(handle.fileno())
+        else:
+            existing = _read_descriptor(descriptor)
+            os.close(descriptor)
+            descriptor = None
+            if existing != expected.raw:
+                raise TrackingDatabaseIOError(
+                    f"existing tracking-database backup {backup_path} does not match "
+                    "the validated input bytes; choose a new hash-bound backup path"
+                )
+        _fsync_directory(directory_descriptor)
+    except OSError as exc:
+        if created:
+            try:
+                os.unlink(backup_path.name, dir_fd=directory_descriptor)
+            except OSError:
+                pass
+        raise TrackingDatabaseIOError(
+            f"cannot durably write tracking-database backup {backup_path}: {exc}"
+        ) from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(directory_descriptor)
+    return str(backup_path)
+
+
+def _write_descriptor(descriptor: int, raw: bytes) -> None:
+    offset = 0
+    while offset < len(raw):
+        written = os.write(descriptor, raw[offset:])
+        if written <= 0:
+            raise OSError("staged tracking-database write made no progress")
+        offset += written
+
+
+def _pread_descriptor(descriptor: int, size: int) -> bytes:
+    chunks: list[bytes] = []
+    offset = 0
+    while offset < size:
+        chunk = os.pread(descriptor, min(READ_CHUNK_SIZE, size - offset), offset)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        offset += len(chunk)
+    return b"".join(chunks)
+
+
+def _visible_descriptor_identity(
+    name: str,
+    descriptor: int,
+    directory_descriptor: int,
+) -> bool:
+    try:
+        opened = os.fstat(descriptor)
+        visible = os.stat(
+            name,
+            dir_fd=directory_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(opened.st_mode)
+        and stat.S_ISREG(visible.st_mode)
+        and _lock_identity(opened) == _lock_identity(visible)
+    )
+
+
+def _unlink_staged_name(stage: StagedCandidate, warnings: list[str]) -> None:
+    try:
+        os.stat(
+            stage.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        warnings.append(f"could not inspect staged candidate {stage.path}: {exc}")
+        return
+    if not _visible_descriptor_identity(
+        stage.name,
+        stage.descriptor,
+        stage.directory_descriptor,
+    ):
+        warnings.append(
+            f"staged candidate name {stage.path} was substituted; left it untouched"
+        )
+        return
+    try:
+        os.unlink(stage.name, dir_fd=stage.directory_descriptor)
+    except OSError as exc:
+        warnings.append(f"could not remove staged candidate {stage.path}: {exc}")
+
+
+def _close_staged_candidate(stage: StagedCandidate, warnings: list[str]) -> None:
+    _unlink_staged_name(stage, warnings)
+    _append_close_warning(
+        stage.descriptor,
+        label=f"staged tracking-database candidate {stage.path}",
+        warnings=warnings,
+    )
+    _append_close_warning(
+        stage.directory_descriptor,
+        label=f"tracking-database directory {stage.path.parent}",
+        warnings=warnings,
+    )
+
+
+def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate:
+    directory_descriptor = _open_directory(
+        path.parent,
+        label="tracking-database directory",
+    )
+    descriptor: int | None = None
+    name: str | None = None
+    try:
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for _ in range(128):
+            candidate_name = (
+                f".{path.name}.{secrets.token_hex(12)}.tracking-db.tmp"
+            )
+            try:
+                descriptor = os.open(
+                    candidate_name,
+                    flags,
+                    0o600,
+                    dir_fd=directory_descriptor,
+                )
+                name = candidate_name
+                break
+            except FileExistsError:
+                continue
+        if descriptor is None or name is None:
+            raise TrackingDatabaseIOError(
+                f"cannot allocate a unique staged candidate beside {path}"
+            )
+        os.fchmod(descriptor, mode)
+        _write_descriptor(descriptor, candidate)
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise TrackingDatabaseIOError(
+                f"staged tracking-database candidate {path.parent / name} "
+                "must be one regular file"
+            )
+        stage = StagedCandidate(
+            path=path.parent / name,
+            name=name,
+            descriptor=descriptor,
+            directory_descriptor=directory_descriptor,
+            generation=FileGeneration.from_stat(metadata),
+            sha256=_sha256(candidate),
+            size=len(candidate),
+        )
+        _verify_staged_candidate(stage, candidate)
+        return stage
+    except BaseException:
+        if descriptor is not None and name is not None:
+            if _visible_descriptor_identity(name, descriptor, directory_descriptor):
+                try:
+                    os.unlink(name, dir_fd=directory_descriptor)
+                except OSError:
+                    pass
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        try:
+            os.close(directory_descriptor)
+        except OSError:
+            pass
+        raise
+
+
+def _verify_staged_candidate(stage: StagedCandidate, candidate: bytes) -> None:
+    try:
+        opened_before = os.fstat(stage.descriptor)
+        visible_before = os.stat(
+            stage.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+        raw = _pread_descriptor(stage.descriptor, stage.size)
+        opened_after = os.fstat(stage.descriptor)
+        visible_after = os.stat(
+            stage.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        raise TrackingDatabaseConflictError(
+            f"staged tracking-database candidate {stage.path} changed before install: {exc}"
+        ) from exc
+    expected_generation = stage.generation
+    if (
+        not stat.S_ISREG(opened_before.st_mode)
+        or opened_before.st_nlink != 1
+        or not stat.S_ISREG(visible_before.st_mode)
+        or visible_before.st_nlink != 1
+        or FileGeneration.from_stat(opened_before) != expected_generation
+        or FileGeneration.from_stat(visible_before) != expected_generation
+        or FileGeneration.from_stat(opened_after) != expected_generation
+        or FileGeneration.from_stat(visible_after) != expected_generation
+        or opened_after.st_nlink != 1
+        or visible_after.st_nlink != 1
+        or raw != candidate
+        or _sha256(raw) != stage.sha256
+    ):
+        raise TrackingDatabaseConflictError(
+            f"staged tracking-database candidate {stage.path} content or generation "
+            "changed before install"
+        )
+
+
+def _replace_staged_candidate(stage: StagedCandidate, target: Path) -> None:
+    if os.replace in os.supports_dir_fd:
+        os.replace(
+            stage.name,
+            target.name,
+            src_dir_fd=stage.directory_descriptor,
+            dst_dir_fd=stage.directory_descriptor,
+        )
+    else:  # pragma: no cover - supported on the Unix platforms this plugin targets.
+        os.replace(stage.path, target)
+
+
+def _link_staged_candidate(stage: StagedCandidate, target: Path) -> None:
+    if os.link in os.supports_dir_fd:
+        os.link(
+            stage.name,
+            target.name,
+            src_dir_fd=stage.directory_descriptor,
+            dst_dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+    else:  # pragma: no cover - supported on the Unix platforms this plugin targets.
+        os.link(stage.path, target, follow_symlinks=False)
+
+
+def _installed_target_warning(
+    stage: StagedCandidate,
+    target: Path,
+    candidate: bytes,
+) -> str | None:
+    try:
+        opened_before = os.fstat(stage.descriptor)
+        visible_before = os.stat(
+            target.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+        raw = _pread_descriptor(stage.descriptor, stage.size)
+        opened_after = os.fstat(stage.descriptor)
+        visible_after = os.stat(
+            target.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        return f"could not verify installed tracking database {target}: {exc}"
+    if (
+        not stat.S_ISREG(opened_before.st_mode)
+        or not stat.S_ISREG(visible_before.st_mode)
+        or not stat.S_ISREG(opened_after.st_mode)
+        or not stat.S_ISREG(visible_after.st_mode)
+        or _lock_identity(opened_before) != _lock_identity(visible_before)
+        or _lock_identity(opened_after) != _lock_identity(visible_after)
+        or _lock_identity(opened_before) != _lock_identity(opened_after)
+        or opened_before.st_size != stage.size
+        or visible_before.st_size != stage.size
+        or opened_after.st_size != stage.size
+        or visible_after.st_size != stage.size
+        or raw != candidate
+        or _sha256(raw) != stage.sha256
+    ):
+        return (
+            f"installed tracking database {target} no longer matches the staged "
+            "candidate; inspect the live path and output SHA before retrying"
+        )
+    return None
+
+
+def commit_tracking_database(
+    expected: TrackingDatabaseSnapshot,
+    candidate: bytes,
+    *,
+    backup: BackupRequest | None = None,
+) -> TrackingDatabaseWriteResult:
+    """Install ``candidate`` iff ``expected`` is still the exact live generation.
+
+    Once replacement succeeds, verification and cleanup failures are returned as
+    an installed result with warnings. Exceptions are reserved for failures
+    observed before the replacement syscall reports success.
+    """
+    if not isinstance(candidate, bytes):
+        raise TypeError("tracking-database candidate must be bytes")
+    decode_json_object(expected)
+    decode_json_object_bytes(
+        candidate,
+        expected.path,
+        label="tracking-database candidate",
+    )
+    output_sha256 = _sha256(candidate)
+    backup_path: str | None = None
+    warnings: list[str] = []
+    result: TrackingDatabaseWriteResult | None = None
+    with _exclusive_database_lock(expected.path) as lock:
+        current = _require_expected_generation(expected)
+        if candidate == current.raw:
+            result = unchanged_write_result(expected)
+        else:
+            if backup is not None:
+                backup_path = _write_exact_backup(backup, expected)
+            stage = _stage_candidate(expected.path, candidate, current.mode)
+            try:
+                _require_expected_generation(expected)
+                _verify_staged_candidate(stage, candidate)
+                try:
+                    _replace_staged_candidate(stage, expected.path)
+                except OSError as exc:
+                    raise TrackingDatabaseIOError(
+                        f"cannot install tracking database {expected.path}: {exc}"
+                    ) from exc
+
+                durability_state = "durable"
+                verification_warning = _installed_target_warning(
+                    stage,
+                    expected.path,
+                    candidate,
+                )
+                if verification_warning is not None:
+                    durability_state = "installed_verification_failed"
+                    warnings.append(verification_warning)
+                try:
+                    _fsync_directory(stage.directory_descriptor)
+                except OSError as exc:
+                    if durability_state == "durable":
+                        durability_state = "installed_directory_fsync_failed"
+                    warnings.append(
+                        "tracking database was installed, but its parent-directory "
+                        f"fsync failed: {exc}; inspect the installed output SHA before "
+                        "retrying"
+                    )
+                result = TrackingDatabaseWriteResult(
+                    input_sha256=expected.sha256,
+                    output_sha256=output_sha256,
+                    changed=True,
+                    installed=True,
+                    durability_state=durability_state,
+                    warnings=(),
+                    backup=backup_path,
+                )
+            finally:
+                _close_staged_candidate(stage, warnings)
+
+    if result is None:  # pragma: no cover - context contract.
+        raise AssertionError("tracking-database transaction produced no result")
+    return TrackingDatabaseWriteResult(
+        input_sha256=result.input_sha256,
+        output_sha256=result.output_sha256,
+        changed=result.changed,
+        installed=result.installed,
+        durability_state=result.durability_state,
+        warnings=result.warnings + tuple(warnings) + tuple(lock.warnings),
+        backup=result.backup,
+    )
+
+
+def initialize_tracking_database(
+    path: str | os.PathLike[str],
+    payload: dict[str, Any],
+    *,
+    mode: int = 0o600,
+) -> TrackingDatabaseWriteResult:
+    """Atomically create a missing database without overwriting a concurrent file."""
+    database_path = _absolute_path(path)
+    candidate = render_json_object(payload)
+    output_sha256 = _sha256(candidate)
+    warnings: list[str] = []
+    result: TrackingDatabaseWriteResult | None = None
+    with _exclusive_database_lock(database_path) as lock:
+        _require_missing_database(database_path)
+        stage = _stage_candidate(database_path, candidate, mode)
+        try:
+            _require_missing_database(database_path)
+            _verify_staged_candidate(stage, candidate)
+            try:
+                _link_staged_candidate(stage, database_path)
+            except FileExistsError as exc:
+                raise TrackingDatabaseConflictError(
+                    "tracking database appeared during initialization; load the new "
+                    "generation and rerun the intended mutation"
+                ) from exc
+            except OSError as exc:
+                raise TrackingDatabaseIOError(
+                    f"cannot install initial tracking database {database_path}: {exc}"
+                ) from exc
+
+            durability_state = "durable"
+            verification_warning = _installed_target_warning(
+                stage,
+                database_path,
+                candidate,
+            )
+            if verification_warning is not None:
+                durability_state = "installed_verification_failed"
+                warnings.append(verification_warning)
+            _unlink_staged_name(stage, warnings)
+            try:
+                _fsync_directory(stage.directory_descriptor)
+            except OSError as exc:
+                if durability_state == "durable":
+                    durability_state = "installed_directory_fsync_failed"
+                warnings.append(
+                    "tracking database was initialized, but its parent-directory "
+                    f"fsync failed: {exc}; inspect the output SHA before retrying"
+                )
+            result = TrackingDatabaseWriteResult(
+                input_sha256=None,
+                output_sha256=output_sha256,
+                changed=True,
+                installed=True,
+                durability_state=durability_state,
+                warnings=(),
+                backup=None,
+            )
+        finally:
+            _close_staged_candidate(stage, warnings)
+
+    if result is None:  # pragma: no cover - context contract.
+        raise AssertionError("tracking-database initialization produced no result")
+    return TrackingDatabaseWriteResult(
+        input_sha256=result.input_sha256,
+        output_sha256=result.output_sha256,
+        changed=result.changed,
+        installed=result.installed,
+        durability_state=result.durability_state,
+        warnings=result.warnings + tuple(warnings) + tuple(lock.warnings),
+        backup=result.backup,
+    )
+
+
+def write_json_object(
+    expected: TrackingDatabaseSnapshot,
+    payload: dict[str, Any],
+    *,
+    backup: BackupRequest | None = None,
+) -> TrackingDatabaseWriteResult:
+    """Commit one JSON object, preserving raw bytes for a semantic no-op."""
+    current = decode_json_object(expected)
+    if json_values_equal(current, payload):
+        return commit_tracking_database(expected, expected.raw, backup=backup)
+    return commit_tracking_database(expected, render_json_object(payload), backup=backup)

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -857,12 +857,14 @@ def commit_tracking_database(
         if candidate == current.raw:
             result = unchanged_write_result(expected)
         else:
-            if backup is not None:
-                backup_path = _write_exact_backup(backup, expected)
             stage = _stage_candidate(expected.path, candidate, current.mode)
             try:
                 _require_expected_generation(expected)
                 _verify_staged_candidate(stage, candidate)
+                if backup is not None:
+                    backup_path = _write_exact_backup(backup, expected)
+                    _require_expected_generation(expected)
+                    _verify_staged_candidate(stage, candidate)
                 try:
                     _replace_staged_candidate(stage, expected.path)
                 except OSError as exc:

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -352,45 +352,44 @@ def _exclusive_database_lock(path: Path) -> Iterator[_DatabaseLock]:
             f"cannot open cooperative tracking-database lock {lock_path}: {exc}"
         ) from exc
     acquired = False
+    initialized = False
     try:
-        opened = os.fstat(descriptor)
-        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
-            raise TrackingDatabaseIOError(
-                f"cooperative tracking-database lock {lock_path} must be one regular file"
-            )
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        acquired = True
         try:
-            visible = lock_path.lstat()
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+                raise TrackingDatabaseIOError(
+                    f"cooperative tracking-database lock {lock_path} must be one regular file"
+                )
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            acquired = True
+            try:
+                visible = lock_path.lstat()
+            except OSError as exc:
+                raise TrackingDatabaseIOError(
+                    f"cannot verify cooperative tracking-database lock {lock_path}: {exc}"
+                ) from exc
+            locked = os.fstat(descriptor)
+            if (
+                stat.S_ISLNK(visible.st_mode)
+                or not stat.S_ISREG(visible.st_mode)
+                or _lock_identity(visible) != _lock_identity(locked)
+                or locked.st_nlink != 1
+            ):
+                raise TrackingDatabaseIOError(
+                    f"cooperative tracking-database lock {lock_path} changed while locking; "
+                    "restore the persistent regular lock file and retry"
+                )
         except OSError as exc:
             raise TrackingDatabaseIOError(
-                f"cannot verify cooperative tracking-database lock {lock_path}: {exc}"
+                f"cannot acquire tracking-database lock through {lock_path}: {exc}"
             ) from exc
-        locked = os.fstat(descriptor)
-        if (
-            stat.S_ISLNK(visible.st_mode)
-            or not stat.S_ISREG(visible.st_mode)
-            or _lock_identity(visible) != _lock_identity(locked)
-            or locked.st_nlink != 1
-        ):
-            raise TrackingDatabaseIOError(
-                f"cooperative tracking-database lock {lock_path} changed while locking; "
-                "restore the persistent regular lock file and retry"
-            )
-    except OSError as exc:
-        try:
-            os.close(descriptor)
-        except OSError:
-            pass
-        raise TrackingDatabaseIOError(
-            f"cannot acquire tracking-database lock through {lock_path}: {exc}"
-        ) from exc
-    except BaseException:
-        try:
-            os.close(descriptor)
-        except OSError:
-            pass
-        raise
+        initialized = True
+    finally:
+        if not initialized:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
 
     lock = _DatabaseLock(descriptor=descriptor, path=lock_path, warnings=[])
     try:
@@ -659,6 +658,7 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
     )
     descriptor: int | None = None
     name: str | None = None
+    completed = False
     try:
         flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
@@ -700,23 +700,24 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
             size=len(candidate),
         )
         _verify_staged_candidate(stage, candidate)
+        completed = True
         return stage
-    except BaseException:
-        if descriptor is not None and name is not None:
-            if _visible_descriptor_identity(name, descriptor, directory_descriptor):
+    finally:
+        if not completed:
+            if descriptor is not None and name is not None:
+                if _visible_descriptor_identity(name, descriptor, directory_descriptor):
+                    try:
+                        os.unlink(name, dir_fd=directory_descriptor)
+                    except OSError:
+                        pass
                 try:
-                    os.unlink(name, dir_fd=directory_descriptor)
+                    os.close(descriptor)
                 except OSError:
                     pass
             try:
-                os.close(descriptor)
+                os.close(directory_descriptor)
             except OSError:
                 pass
-        try:
-            os.close(directory_descriptor)
-        except OSError:
-            pass
-        raise
 
 
 def _verify_staged_candidate(stage: StagedCandidate, candidate: bytes) -> None:

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -66,7 +66,6 @@ import sys
 import tempfile
 import unicodedata
 
-from ingress_contract import IngressContractError, reject_tracking_database_symlink
 from pattern_evidence import (
     LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION,
     PATTERN_EVIDENCE_SCHEMA_VERSION,
@@ -88,6 +87,11 @@ from return_validation import (
     validate_batch,
     validate_persisted_v2_analysis_state,
     validate_persisted_catalog_generation,
+)
+from tracking_database_io import (
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
 )
 
 # structured_data keys rendered as their own table rather than inline, because
@@ -1001,11 +1005,24 @@ def load_json(path, label):
     except FileNotFoundError:
         print(f"ERROR: {label} file not found: {path}", file=sys.stderr)
         sys.exit(1)
-    except OSError as e:
-        print(f"ERROR: cannot read {label} file {path}: {e}", file=sys.stderr)
+    except OSError as exc:
+        print(f"ERROR: cannot read {label} file {path}: {exc}", file=sys.stderr)
         sys.exit(1)
-    except json.JSONDecodeError as e:
-        print(f"ERROR: {label} file {path} is not valid JSON: {e}", file=sys.stderr)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: {label} file {path} is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def load_tracking_database(path):
+    """Load the owner artifact through its strict shared decoder."""
+    try:
+        snapshot = snapshot_tracking_database(path)
+        return decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
+        message = str(exc)
+        if "root must be a JSON object" in message:
+            message += "; expected an object with a `talks` array"
+        print(f"ERROR: {message}", file=sys.stderr)
         sys.exit(1)
 
 
@@ -1062,12 +1079,7 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
-    try:
-        reject_tracking_database_symlink(talks_path)
-    except IngressContractError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        sys.exit(1)
-    db = load_json(talks_path, "tracking database")
+    db = load_tracking_database(talks_path)
     if not isinstance(db, dict) or not isinstance(db.get("talks"), list):
         print(
             f"ERROR: {talks_path} is not a tracking database — expected a JSON "

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -24,13 +24,26 @@ Generate or update `speaker-profile.json` from vault data. This profile is the
 structured bridge between the vault and the presentation-creator skill.
 
 The vault lives at `~/.claude/rhetoric-knowledge-vault/` (may be a symlink).
-Read `tracking-database.json` from there to get `vault_root`.
+Set `host_python` to the current host's explicit absolute interpreter path (not
+a PATH lookup). The sole interpreter-bootstrap exception is one stdlib-only
+strict-owner read:
 
-Before running any toolkit script, read `config.python_path` from that tracking
+```bash
+"{host_python}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py" \
+  "~/.claude/rhetoric-knowledge-vault/tracking-database.json"
+```
+
+Use its JSON report to resolve `vault_root` and the exact non-empty
+`database.config.python_path`. Set `python_path` to that value, then immediately
+repeat the same owner-read command with `"{python_path}"` and the resolved
+`{vault_root}/tracking-database.json`; require its database and SHA-256 to match
+the bootstrap report. The unconfigured `host_python` above is authorized for
+that one owner-reader invocation only, never for another toolkit script.
+If vault-ingress Step 7 invoked this skill, accept its resolved `{vault_root}`
+and `{python_path}` as handoff context, then re-read the database and require the stored value to match.
+Before running any other toolkit script, read `config.python_path` from that tracking
 database and set `python_path` to that exact value. It is the interpreter
-authority for every operational command in this skill. If vault-ingress Step 7
-invoked this skill, accept its resolved `{vault_root}` and `{python_path}` as
-handoff context, then re-read the database and require the stored value to match.
+authority for every operational command in this skill.
 If `python_path` is absent, empty, mismatched, or cannot execute the core runtime
 probe below, stop and direct the speaker to vault-ingress Step 1 to repair the
 configuration. Never fall back to whichever `python3` happens to be on `PATH`.

--- a/skills/vault-profile/references/schemas-config.md
+++ b/skills/vault-profile/references/schemas-config.md
@@ -163,10 +163,21 @@ clarification sessions when the speaker confirms a pattern is intentional.
 ```json
 {
   "confirmed_intents": [{
+    "schema_version": 1,
     "pattern": "delayed_self_introduction",
-    "intent": "deliberate|accidental|context_dependent",
+    "intent": "deliberate",
     "rule": "Use two-phase intro: brief bio at slide 3, full re-intro mid-talk",
-    "note": "Speaker confirmed this is an intentional rhetorical device"
+    "note": "Speaker confirmed this is an intentional rhetorical device",
+    "confirmed_date": "2026-08-01",
+    "source_talk": "2026-08-01-example.md"
   }]
 }
 ```
+
+Required fields are `pattern`, `intent`, `rule`, and `note`. The owner also
+accepts optional exact integer `schema_version: 1` and the clarification
+provenance fields `confirmed_date`, one of `source_talk` / legacy `talk` /
+`source_talks`, and `retrofit_targets`. The plural fields are non-empty unique
+string arrays. Existing speaker-owned non-empty intent labels remain readable;
+the three labels in the example are the recommended vocabulary. Unknown fields
+are not part of the record.

--- a/skills/vault-profile/references/schemas-config.md
+++ b/skills/vault-profile/references/schemas-config.md
@@ -174,8 +174,8 @@ clarification sessions when the speaker confirms a pattern is intentional.
 }
 ```
 
-Required fields are `pattern`, `intent`, `rule`, and `note`. The owner also
-accepts optional exact integer `schema_version: 1` and the clarification
+Required fields are exact integer `schema_version: 1`, `pattern`, `intent`,
+`rule`, and `note`. The owner also accepts the clarification
 provenance fields `confirmed_date`, one of `source_talk` / legacy `talk` /
 `source_talks`, and `retrofit_targets`. The plural fields are non-empty unique
 string arrays. Existing speaker-owned non-empty intent labels remain readable;

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -161,6 +161,7 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
 
   "confirmed_intents": [
     {
+      "schema_version": 1,
       "pattern": "name of the pattern",
       "intent": "deliberate",
       "rule": "what the presentation-creator should do about it",

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -162,7 +162,7 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
   "confirmed_intents": [
     {
       "pattern": "name of the pattern",
-      "intent": "deliberate|accidental|context_dependent",
+      "intent": "deliberate",
       "rule": "what the presentation-creator should do about it",
       "note": "additional context from the speaker"
     }
@@ -280,7 +280,7 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
     "confirmed_visual_intents": [
       {
         "pattern": "name of the visual pattern",
-        "intent": "deliberate|accidental|context_dependent",
+        "intent": "deliberate",
         "rule": "what the presentation-creator should do about it",
         "note": "additional context from the speaker"
       }
@@ -472,6 +472,11 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
   }
 }
 ```
+
+Confirmed-intent `intent` values are non-empty speaker-owned classification labels,
+not a closed three-value enum. `deliberate`, `accidental`, and
+`context_dependent` are recommended defaults, while established labels such as
+`accepted_tradeoff`, `fact`, or `deliberate_signature` remain authoritative.
 
 ### Pattern Cohort Provenance
 

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -71,6 +71,7 @@ from return_validation import (  # noqa: E402
     ReturnValidationError,
     load_catalog,
 )
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
     decode_json_object,

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -71,6 +71,11 @@ from return_validation import (  # noqa: E402
     ReturnValidationError,
     load_catalog,
 )
+from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
+)
 
 
 DEFAULT_VAULT = "~/.claude/rhetoric-knowledge-vault"
@@ -156,12 +161,10 @@ def main(argv: list[str]) -> int:
         )
         return 1
     try:
-        db = json.loads(db_path.read_text())
-    except (json.JSONDecodeError, OSError) as exc:
+        database_snapshot = snapshot_tracking_database(db_path)
+        db = decode_json_object(database_snapshot)
+    except TrackingDatabaseIOError as exc:
         print(f"ERROR: tracking-database.json is malformed: {exc}", file=sys.stderr)
-        return 1
-    if not isinstance(db, dict):
-        print("ERROR: tracking-database.json root must be an object", file=sys.stderr)
         return 1
 
     summary_path = vault_root / "rhetoric-style-summary.md"

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -57,6 +57,11 @@ from pattern_opportunities import PatternOpportunityError  # noqa: E402
 from return_validation import (  # noqa: E402
     ReturnValidationError,
 )
+from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
+)
 
 
 BLOCK_SCHEMA_VERSION = 2
@@ -569,6 +574,16 @@ def _load_json(path: Path) -> object:
         ) from exc
 
 
+def _load_tracking_database(path: Path) -> dict[str, Any]:
+    try:
+        snapshot = snapshot_tracking_database(path)
+        return decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
+        raise Section15PatternHistoryError(
+            f"cannot load strict tracking database from {path}: {exc}"
+        ) from exc
+
+
 def _pattern_profile_candidate(value: object) -> object:
     if isinstance(value, Mapping) and "pattern_profile" in value:
         return value["pattern_profile"]
@@ -669,7 +684,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0 if assessment.current_contract else 1
 
         candidate = _pattern_profile_candidate(_load_json(args.pattern_profile))
-        tracking_database = _load_json(args.tracking_database)
+        tracking_database = _load_tracking_database(args.tracking_database)
         result = replace_section15_current_block(
             args.summary,
             candidate,

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -57,6 +57,7 @@ from pattern_opportunities import PatternOpportunityError  # noqa: E402
 from return_validation import (  # noqa: E402
     ReturnValidationError,
 )
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
     decode_json_object,

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -40,6 +40,9 @@ from typing import Any
 _PROFILE_SCRIPTS = pathlib.Path(__file__).resolve().parent
 if str(_PROFILE_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_PROFILE_SCRIPTS))
+_INGRESS_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts"
+if str(_INGRESS_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_INGRESS_SCRIPTS))
 
 from profile_pattern_provenance import (  # noqa: E402
     active_pattern_generation_identity as _active_pattern_generation_identity,
@@ -49,6 +52,11 @@ from pattern_cohort_snapshot import (  # noqa: E402
     PatternCohortSnapshot,
     build_current_pattern_snapshot,
     configured_evidence_freshness_assessor,
+)
+from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
 )
 
 
@@ -157,9 +165,11 @@ def _load_live_pattern_snapshot(
 ) -> PatternCohortSnapshot:
     """Recompute the source-exact payload used by ``load-vault.py``."""
     database_path = vault_root / "tracking-database.json"
-    database = json.loads(database_path.read_text(encoding="utf-8"))
-    if not isinstance(database, Mapping):
-        raise ValueError("tracking-database.json root must be an object")
+    try:
+        database_snapshot = snapshot_tracking_database(database_path)
+        database = decode_json_object(database_snapshot)
+    except TrackingDatabaseIOError as exc:
+        raise ValueError(f"tracking-database.json is invalid: {exc}") from exc
     talks = database.get("talks")
     if not isinstance(talks, list) or any(
         not isinstance(talk, Mapping) for talk in talks

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -53,6 +53,7 @@ from pattern_cohort_snapshot import (  # noqa: E402
     build_current_pattern_snapshot,
     configured_evidence_freshness_assessor,
 )
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
     decode_json_object,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,46 @@ def persist_results():
 
 
 @pytest.fixture(scope="session")
+def tracking_database_io():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "tracking_database_io.py"),
+        "tracking_database_io",
+    )
+
+
+@pytest.fixture(scope="session")
+def mutate_tracking_database():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "mutate-tracking-database.py"),
+        "mutate_tracking_database",
+    )
+
+
+@pytest.fixture(scope="session")
+def read_tracking_database():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "read-tracking-database.py"),
+        "read_tracking_database",
+    )
+
+
+@pytest.fixture(scope="session")
+def queue_state():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "queue-state.py"),
+        "queue_state",
+    )
+
+
+@pytest.fixture(scope="session")
+def scan_shownotes_module():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "scan-shownotes.py"),
+        "scan_shownotes_module",
+    )
+
+
+@pytest.fixture(scope="session")
 def return_validation():
     return _import_script(
         os.path.join(SCRIPTS_VI, "return_validation.py"), "return_validation")
@@ -343,3 +383,11 @@ def make_deck(slide_count):
 @pytest.fixture(scope="session")
 def load_vault():
     return _import_script(os.path.join(SCRIPTS_VP, "load-vault.py"), "load_vault")
+
+
+@pytest.fixture(scope="session")
+def section15_pattern_history():
+    return _import_script(
+        os.path.join(SCRIPTS_VP, "section15_pattern_history.py"),
+        "section15_pattern_history",
+    )

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -1,6 +1,8 @@
 """Tests for guarded, auditable vault source repairs."""
 
+import hashlib
 import json
+from pathlib import Path
 
 import pytest
 
@@ -58,9 +60,15 @@ def test_dry_run_reports_changes_without_writing(
         database_path, plan_path, apply=False,
     )
 
+    assert report["schema_version"] == 2
     assert report["mode"] == "dry-run"
     assert report["repair_count"] == 1
     assert report["backup"] is None
+    assert report["input_sha256"] == hashlib.sha256(before).hexdigest()
+    assert report["output_sha256"] != report["input_sha256"]
+    assert report["database_written"] is False
+    assert report["durability_state"] == "dry_run"
+    assert report["warnings"] == []
     assert database_path.read_bytes() == before
 
 
@@ -87,25 +95,76 @@ def test_apply_writes_atomically_and_creates_exact_backup(
     assert report["mode"] == "apply"
     assert report["repair_count"] == 1
     assert report["backup"] is not None
+    assert report["schema_version"] == 2
+    assert report["input_sha256"] == hashlib.sha256(before).hexdigest()
+    assert report["output_sha256"] == hashlib.sha256(
+        database_path.read_bytes()
+    ).hexdigest()
+    assert report["database_written"] is True
+    assert report["durability_state"] == "durable"
+    assert report["input_sha256"] in Path(report["backup"]).name
     assert next(backup_dir.iterdir()).read_bytes() == before
 
 
+def test_idempotent_apply_preserves_exact_bytes_inode_and_skips_backup(
+    apply_source_repairs,
+    tmp_path,
+):
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    backup_dir = tmp_path / "backups"
+    raw = json.dumps(base_database(), separators=(",", ":")).encode("utf-8") + b"\n"
+    database_path.write_bytes(raw)
+    inode = database_path.stat().st_ino
+    write_json(
+        plan_path,
+        {
+            "schema_version": 1,
+            "repairs": [{
+                "filename": "talk.md",
+                "reason": "idempotent replay",
+                "expect": {"transcript_source": "youtube_auto"},
+                "set": {"transcript_source": "youtube_auto"},
+            }],
+        },
+    )
+
+    report = apply_source_repairs.execute(
+        database_path,
+        plan_path,
+        apply=True,
+        backup_dir=backup_dir,
+    )
+
+    assert report["repair_count"] == 0
+    assert report["database_written"] is False
+    assert report["durability_state"] == "unchanged"
+    assert report["input_sha256"] == report["output_sha256"]
+    assert report["backup"] is None
+    assert database_path.read_bytes() == raw
+    assert database_path.stat().st_ino == inode
+    assert not backup_dir.exists()
+
+
 def test_atomic_write_cleans_stage_and_propagates_interrupt(
-    apply_source_repairs, tmp_path, monkeypatch,
+    apply_source_repairs, tracking_database_io, tmp_path, monkeypatch,
 ):
     target = tmp_path / "tracking-database.json"
-    target.write_text("old\n", encoding="utf-8")
+    target.write_text('{"value": "old"}\n', encoding="utf-8")
 
     def interrupt(_source, _target):
         raise KeyboardInterrupt
 
-    monkeypatch.setattr(apply_source_repairs.os, "replace", interrupt)
+    monkeypatch.setattr(tracking_database_io.os, "replace", interrupt)
 
     with pytest.raises(KeyboardInterrupt):
-        apply_source_repairs.atomic_write(target, "new\n")
+        apply_source_repairs.atomic_write(target, '{"value": "new"}\n')
 
-    assert target.read_text(encoding="utf-8") == "old\n"
-    assert [path.name for path in tmp_path.iterdir()] == [target.name]
+    assert target.read_text(encoding="utf-8") == '{"value": "old"}\n'
+    assert {path.name for path in tmp_path.iterdir()} == {
+        target.name,
+        ".tracking-database.json.lock",
+    }
 
 
 def test_expectation_mismatch_aborts_whole_plan_without_backup(
@@ -181,3 +240,66 @@ def test_plan_rejects_out_of_scope_mutations(apply_source_repairs, mutation):
 
     with pytest.raises(apply_source_repairs.SourceRepairError):
         apply_source_repairs.validate_plan(plan)
+
+
+def test_source_repair_schema_and_expectations_are_type_sensitive(
+    apply_source_repairs,
+) -> None:
+    with pytest.raises(
+        apply_source_repairs.SourceRepairError,
+        match="schema_version must be 1",
+    ):
+        apply_source_repairs.validate_plan(
+            {"schema_version": True, "repairs": [repair_plan()["repairs"][0]]}
+        )
+
+    database = base_database()
+    database["talks"][0]["source_identity"] = {"verified": True}
+    repair = {
+        "filename": "talk.md",
+        "reason": "type-sensitive expectation",
+        "expect": {"source_identity": {"verified": 1}},
+        "set": {"source_identity": {"verified": False}},
+    }
+    with pytest.raises(
+        apply_source_repairs.SourceRepairError,
+        match="preconditions failed",
+    ):
+        apply_source_repairs.build_repaired_database(database, [repair])
+
+
+def test_source_repair_type_change_is_not_a_noop(apply_source_repairs) -> None:
+    database = base_database()
+    database["talks"][0]["source_identity"] = {"verified": True}
+    repaired, changes = apply_source_repairs.build_repaired_database(
+        database,
+        [
+            {
+                "filename": "talk.md",
+                "reason": "replace boolean with numeric evidence",
+                "expect": {"source_identity": {"verified": True}},
+                "set": {"source_identity": {"verified": 1}},
+            }
+        ],
+    )
+
+    assert changes
+    assert type(repaired["talks"][0]["source_identity"]["verified"]) is int
+
+
+def test_malformed_missing_marker_is_an_exact_object_not_absence(
+    apply_source_repairs,
+) -> None:
+    database = base_database()
+    repair = {
+        "filename": "talk.md",
+        "reason": "malformed marker must not bypass absence check",
+        "expect": {"source_identity": {"$missing": 1}},
+        "set": {"source_identity": {}},
+    }
+
+    with pytest.raises(
+        apply_source_repairs.SourceRepairError,
+        match="preconditions failed",
+    ):
+        apply_source_repairs.build_repaired_database(database, [repair])

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -1,10 +1,12 @@
 """Tests for generate-qr.py — QR generation (no network calls)."""
 
+import json
 import os
 
 from PIL import Image
 from pptx import Presentation
 from pptx.util import Inches
+import pytest
 
 from conftest import make_deck
 
@@ -153,6 +155,158 @@ def test_tracking_db_semantic_noop_preserves_raw_bytes_and_inode(
     assert result.installed is False
     assert path.read_bytes() == raw
     assert path.stat().st_ino == snapshot.generation.inode
+
+
+@pytest.mark.parametrize("mode", ["png", "deck"])
+def test_main_existing_vault_without_database_stops_before_side_effects(
+    generate_qr,
+    tmp_path,
+    monkeypatch,
+    capsys,
+    mode,
+):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    output = tmp_path / "talk-qr.png"
+    deck = tmp_path / "talk.pptx"
+    arguments = ["generate-qr.py"]
+    if mode == "png":
+        arguments.extend(["--png-only", "--output", str(output)])
+    else:
+        deck.write_bytes(b"unchanged deck")
+        arguments.append(str(deck))
+    arguments.extend(
+        [
+            "--talk-slug",
+            "talk",
+            "--shownotes-url",
+            "https://example.com/talk",
+            "--vault",
+            str(vault),
+        ]
+    )
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("QR side effect ran before tracking DB validation")
+
+    monkeypatch.setattr(generate_qr.sys, "argv", arguments)
+    monkeypatch.setattr(generate_qr, "resolve_short_url", forbidden)
+    monkeypatch.setattr(generate_qr, "generate_qr_png", forbidden)
+    monkeypatch.setattr(generate_qr, "Presentation", forbidden)
+    monkeypatch.setattr(generate_qr, "insert_qr_via_powerpoint", forbidden)
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_qr.main()
+
+    assert exc_info.value.code == 1
+    assert "tracking-database.json is missing" in capsys.readouterr().err
+    assert not output.exists()
+    if mode == "deck":
+        assert deck.read_bytes() == b"unchanged deck"
+
+
+def test_main_dry_run_allows_existing_vault_without_database(
+    generate_qr,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("dry run performed a write")
+
+    monkeypatch.setattr(
+        generate_qr.sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "talk",
+            "--short-url",
+            "https://example.com/talk",
+            "--vault",
+            str(vault),
+            "--dry-run",
+        ],
+    )
+    monkeypatch.setattr(generate_qr, "generate_qr_png", forbidden)
+    monkeypatch.setattr(generate_qr, "write_tracking_db", forbidden)
+
+    generate_qr.main()
+
+    assert "DRY RUN: would save QR" in capsys.readouterr().out
+
+
+def test_main_invalid_background_stops_before_url_resolution(
+    generate_qr,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("URL resolution ran before local validation")
+
+    monkeypatch.setattr(
+        generate_qr.sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "talk",
+            "--shownotes-url",
+            "https://example.com/talk",
+            "--vault",
+            str(tmp_path / "missing-vault"),
+            "--bg-color",
+            "not-rgb",
+        ],
+    )
+    monkeypatch.setattr(generate_qr, "resolve_short_url", forbidden)
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_qr.main()
+
+    assert exc_info.value.code == 1
+    assert "--bg-color must be R,G,B" in capsys.readouterr().out
+
+
+def test_main_valid_snapshot_generates_png_and_persists_metadata(
+    generate_qr,
+    tmp_path,
+    monkeypatch,
+):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    database_path = vault / "tracking-database.json"
+    database_path.write_text(
+        json.dumps({"config": {}, "talks": []}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        generate_qr.sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "talk",
+            "--short-url",
+            "https://example.com/talk",
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    generate_qr.main()
+
+    assert (tmp_path / "talk-qr.png").is_file()
+    database = json.loads(database_path.read_text(encoding="utf-8"))
+    assert database["qr_codes"][0]["talk_slug"] == "talk"
 
 
 def test_resolve_slide_bg_rgb_none_for_plain_deck(generate_qr, tmp_path):

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -1,7 +1,6 @@
 """Tests for generate-qr.py — QR generation (no network calls)."""
 
 import os
-import json
 
 from PIL import Image
 from pptx import Presentation
@@ -130,6 +129,28 @@ def test_tracking_db_crud_update(generate_qr):
     assert db["qr_codes"][0]["qr_png_rel_path"] == "new.png"
     # created_at preserved from original
     assert db["qr_codes"][0]["created_at"] == "2024-01-01"
+
+
+def test_tracking_db_semantic_noop_preserves_raw_bytes_and_inode(
+    generate_qr,
+    tmp_path,
+):
+    path = tmp_path / "tracking-database.json"
+    raw = b'{"qr_codes":[],"config":{"enabled":true},"talks":[]}\n'
+    path.write_bytes(raw)
+    snapshot = generate_qr.snapshot_tracking_database(path)
+    equivalent = {
+        "talks": [],
+        "config": {"enabled": True},
+        "qr_codes": [],
+    }
+
+    result = generate_qr.write_tracking_db(snapshot, equivalent)
+
+    assert result.changed is False
+    assert result.installed is False
+    assert path.read_bytes() == raw
+    assert path.stat().st_ino == snapshot.generation.inode
 
 
 def test_resolve_slide_bg_rgb_none_for_plain_deck(generate_qr, tmp_path):

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -103,6 +103,7 @@ def test_tracking_db_crud_insert(generate_qr):
     }
     generate_qr.update_tracking_db(db, entry, "test-talk-qr.png")
     assert len(db["qr_codes"]) == 1
+    assert db["qr_codes"][0]["schema_version"] == 1
     assert db["qr_codes"][0]["talk_slug"] == "test-talk"
     assert db["qr_codes"][0]["qr_png_rel_path"] == "test-talk-qr.png"
 
@@ -125,6 +126,7 @@ def test_tracking_db_crud_update(generate_qr):
     }
     generate_qr.update_tracking_db(db, entry, "new.png")
     assert len(db["qr_codes"]) == 1
+    assert db["qr_codes"][0]["schema_version"] == 1
     assert db["qr_codes"][0]["target_url"] == "https://new-url.com"
     assert db["qr_codes"][0]["qr_png_rel_path"] == "new.png"
     # created_at preserved from original

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -278,6 +278,7 @@ def test_main_valid_snapshot_generates_png_and_persists_metadata(
     generate_qr,
     tmp_path,
     monkeypatch,
+    capsys,
 ):
     vault = tmp_path / "vault"
     vault.mkdir()
@@ -307,6 +308,11 @@ def test_main_valid_snapshot_generates_png_and_persists_metadata(
     assert (tmp_path / "talk-qr.png").is_file()
     database = json.loads(database_path.read_text(encoding="utf-8"))
     assert database["qr_codes"][0]["talk_slug"] == "talk"
+    assert "Tracking DB updated:" in capsys.readouterr().out
+
+    generate_qr.main()
+
+    assert "Tracking DB unchanged:" in capsys.readouterr().out
 
 
 def test_resolve_slide_bg_rgb_none_for_plain_deck(generate_qr, tmp_path):

--- a/tests/test_installed_plugin_paths.py
+++ b/tests/test_installed_plugin_paths.py
@@ -58,9 +58,14 @@ def _rule_paths() -> tuple[Path, ...]:
     return tuple(sorted((REPO_ROOT / "rules").glob("*.md")))
 
 
-def _vault_workflow_doc_paths() -> tuple[Path, ...]:
+def _configured_interpreter_workflow_doc_paths() -> tuple[Path, ...]:
     paths: set[Path] = set()
-    for skill_name in ("vault-clarification", "vault-ingress", "vault-profile"):
+    for skill_name in (
+        "presentation-creator",
+        "vault-clarification",
+        "vault-ingress",
+        "vault-profile",
+    ):
         skill_root = SKILLS_ROOT / skill_name
         paths.add(skill_root / "SKILL.md")
         paths.update((skill_root / "references").rglob("*.md"))
@@ -199,9 +204,9 @@ def test_every_shipped_rule_declares_an_explicit_scope() -> None:
     assert not failures, "\n" + "\n".join(failures)
 
 
-def test_vault_workflows_use_the_configured_interpreter() -> None:
+def test_interpreter_bound_workflows_use_the_configured_interpreter() -> None:
     failures: list[str] = []
-    for path in _vault_workflow_doc_paths():
+    for path in _configured_interpreter_workflow_doc_paths():
         text = path.read_text(encoding="utf-8")
         command_surfaces = [
             *_shell_command_lines(text),

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -339,7 +339,10 @@ def test_initialization_dry_run_and_missing_precondition(
         expected_sha256="missing",
     )
     assert applied["database_written"] is True
-    assert json.loads(database_path.read_text(encoding="utf-8"))["talks"] == []
+    initialized = json.loads(database_path.read_text(encoding="utf-8"))
+    assert initialized["schema_version"] == 1
+    assert initialized["config"]["schema_version"] == 1
+    assert initialized["talks"] == []
 
 
 def test_initialization_surfaces_owner_io_failure_as_mutation_error(
@@ -589,3 +592,34 @@ def test_boolean_plan_and_record_schema_versions_are_rejected(
         match="schema_version must be exact integer 1",
     ):
         mutate_tracking_database.build_candidate(_base_database(), [mutation])
+
+
+@pytest.mark.parametrize("mutation_index", [1, 2, 5, 6])
+def test_versioned_owner_records_require_schema_version(
+    mutate_tracking_database,
+    mutation_index: int,
+) -> None:
+    mutation = copy.deepcopy(_complete_plan()["mutations"][mutation_index])
+    del mutation["record"]["schema_version"]
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="missing .*schema_version",
+    ):
+        mutate_tracking_database.build_candidate(_base_database(), [mutation])
+
+
+def test_initialization_rejects_noninteger_config_schema_version(
+    mutate_tracking_database,
+) -> None:
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="config.schema_version must be exact integer 1",
+    ):
+        mutate_tracking_database.initial_database(
+            {
+                "kind": "initialize_database",
+                "config": {"schema_version": True},
+            },
+            index=0,
+        )

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1,0 +1,591 @@
+"""Tests for the typed owner mutation-plan surface."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+
+MISSING = {"$missing": True}
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def _base_database() -> dict[str, object]:
+    return {
+        "config": {},
+        "talks": [{"filename": "talk.md", "status": "processed"}],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+
+
+def _goal() -> dict[str, object]:
+    return {
+        "id": "reduce-shortchanged",
+        "schema_version": 2,
+        "issue": "Rushed close",
+        "kind": "pacing",
+        "antipattern_id": None,
+        "metric": "closing minutes",
+        "baseline_value": "2",
+        "target": "5",
+        "set_date": "2026-07-31",
+        "set_by": "vault-clarification",
+        "status": "active",
+        "current_value": "",
+        "last_checked": None,
+        "checked_by": None,
+        "verification_state": "pending",
+        "verification_reasons": [],
+        "supersedes_goal_id": None,
+        "baseline_provenance": {"lane": "pacing"},
+    }
+
+
+def _complete_plan() -> dict[str, object]:
+    goal = _goal()
+    return {
+        "schema_version": 1,
+        "mutations": [
+            {
+                "kind": "set_config",
+                "path": ["shownotes", "enabled"],
+                "expect": MISSING,
+                "value": True,
+            },
+            {
+                "kind": "record_pptx",
+                "expect": MISSING,
+                "expect_talk_pptx_path": MISSING,
+                "record": {
+                    "schema_version": 1,
+                    "pptx_path": "Conference/Talk.pptx",
+                    "talk_filename": "talk.md",
+                    "matched": True,
+                    "slide_count": 10,
+                    "visual_extracted": False,
+                },
+            },
+            {
+                "kind": "upsert_confirmed_intent",
+                "expect": MISSING,
+                "record": {
+                    "schema_version": 1,
+                    "pattern": "delayed-self-introduction",
+                    "intent": "deliberate",
+                    "rule": "Hook before credentials",
+                    "note": "Speaker confirmed",
+                    "confirmed_date": "2026-08-01",
+                    "source_talk": "talk.md",
+                    "retrofit_targets": ["opening guidance"],
+                },
+            },
+            {
+                "kind": "upsert_improvement_goal",
+                "expect": MISSING,
+                "record": goal,
+            },
+            {
+                "kind": "patch_improvement_goal_verification",
+                "id": goal["id"],
+                "expect": {
+                    "current_value": "",
+                    "last_checked": None,
+                    "checked_by": None,
+                    "verification_state": "pending",
+                    "verification_reasons": [],
+                },
+                "set": {
+                    "current_value": "3",
+                    "last_checked": "2026-08-01",
+                    "checked_by": "vault-ingress",
+                    "verification_state": "current",
+                    "verification_reasons": [],
+                },
+            },
+            {
+                "kind": "upsert_resource",
+                "expect": MISSING,
+                "record": {
+                    "schema_version": 1,
+                    "talk_slug": "talk",
+                    "item_count": 3,
+                    "category_breakdown": {"url": 2, "book": 1},
+                },
+            },
+            {
+                "kind": "upsert_thumbnail",
+                "expect": MISSING,
+                "record": {
+                    "schema_version": 1,
+                    "talk_slug": "talk",
+                    "youtube_url": "https://youtu.be/AbCdEfGhI_1",
+                    "source_slide_num": 5,
+                    "speaker_photo_used": "headshot.jpg",
+                    "thumbnail_path": "illustrations/thumbnail.png",
+                    "shownotes_thumbnail_path": "assets/images/thumbnails/talk-thumbnail.png",
+                    "dimensions": "1280x720",
+                    "file_size_kb": 185,
+                    "created_at": "2026-08-01",
+                    "approved": True,
+                },
+            },
+            {
+                "kind": "update_talk_publishing",
+                "filename": "talk.md",
+                "expect": {
+                    "shownotes_url": MISSING,
+                    "shownotes_published": MISSING,
+                    "thumbnail_generated": MISSING,
+                    "video_added_to_shownotes": MISSING,
+                    "video_url": MISSING,
+                    "youtube_id": MISSING,
+                },
+                "set": {
+                    "shownotes_url": "https://example.com/talk",
+                    "shownotes_published": True,
+                    "thumbnail_generated": True,
+                    "video_added_to_shownotes": True,
+                    "video_url": "https://youtu.be/AbCdEfGhI_1",
+                    "youtube_id": "AbCdEfGhI_1",
+                },
+            },
+        ],
+    }
+
+
+def test_dry_run_then_hash_bound_apply_covers_every_typed_operation(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    database = _base_database()
+    _write_json(database_path, database)
+    _write_json(plan_path, _complete_plan())
+    before = database_path.read_bytes()
+
+    dry_run = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=False,
+        expected_sha256=None,
+    )
+    assert dry_run["changed"] is True
+    assert dry_run["database_written"] is False
+    assert database_path.read_bytes() == before
+
+    applied = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=True,
+        expected_sha256=dry_run["input_sha256"],
+    )
+
+    result = json.loads(database_path.read_text(encoding="utf-8"))
+    assert applied["database_written"] is True
+    assert applied["input_sha256"] == dry_run["input_sha256"]
+    assert applied["output_sha256"] == dry_run["output_sha256"]
+    assert result["config"]["shownotes"]["enabled"] is True
+    assert result["talks"][0]["pptx_path"] == "Conference/Talk.pptx"
+    assert result["talks"][0]["thumbnail_generated"] is True
+    assert result["talks"][0]["video_added_to_shownotes"] is True
+    assert result["pptx_catalog"][0]["talk_filename"] == "talk.md"
+    assert result["confirmed_intents"][0]["intent"] == "deliberate"
+    assert result["improvement_goals"][0]["current_value"] == "3"
+    assert result["resources"][0]["item_count"] == 3
+    assert result["thumbnails"][0]["approved"] is True
+
+
+def test_noop_plan_preserves_noncanonical_bytes_and_inode(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "tracking-database.json"
+    raw = b'{"config":{"speaker_name":"Ada"},"talks":[]}\n'
+    database_path.write_bytes(raw)
+    plan_path = tmp_path / "plan.json"
+    _write_json(
+        plan_path,
+        {
+            "schema_version": 1,
+            "mutations": [
+                {
+                    "kind": "set_config",
+                    "path": ["speaker_name"],
+                    "expect": "Ada",
+                    "value": "Ada",
+                }
+            ],
+        },
+    )
+    dry_run = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=False,
+        expected_sha256=None,
+    )
+    inode = database_path.stat().st_ino
+
+    applied = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=True,
+        expected_sha256=dry_run["input_sha256"],
+    )
+
+    assert applied["changed"] is False
+    assert applied["database_written"] is False
+    assert applied["input_sha256"] == applied["output_sha256"]
+    assert database_path.read_bytes() == raw
+    assert database_path.stat().st_ino == inode
+
+
+def test_apply_requires_reviewed_exact_hash(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    _write_json(database_path, _base_database())
+    _write_json(plan_path, _complete_plan())
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="requires --expected-sha256",
+    ):
+        mutate_tracking_database.execute(
+            database_path,
+            plan_path,
+            apply=True,
+            expected_sha256=None,
+        )
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="input sha256 precondition failed",
+    ):
+        mutate_tracking_database.execute(
+            database_path,
+            plan_path,
+            apply=True,
+            expected_sha256="0" * 64,
+        )
+
+
+def test_plan_expectation_mismatch_is_whole_plan_noop(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    database = _base_database()
+    _write_json(database_path, database)
+    plan = _complete_plan()
+    plan["mutations"][0]["expect"] = False
+    _write_json(plan_path, plan)
+    before = database_path.read_bytes()
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="precondition failed",
+    ):
+        mutate_tracking_database.execute(
+            database_path,
+            plan_path,
+            apply=False,
+            expected_sha256=None,
+        )
+
+    assert database_path.read_bytes() == before
+
+
+def test_initialization_dry_run_and_missing_precondition(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    _write_json(
+        plan_path,
+        {
+            "schema_version": 1,
+            "mutations": [{"kind": "initialize_database", "config": {}}],
+        },
+    )
+
+    dry_run = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=False,
+        expected_sha256=None,
+    )
+    assert dry_run["input_state"] == "missing"
+    assert not database_path.exists()
+
+    applied = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=True,
+        expected_sha256="missing",
+    )
+    assert applied["database_written"] is True
+    assert json.loads(database_path.read_text(encoding="utf-8"))["talks"] == []
+
+
+def test_initialization_surfaces_owner_io_failure_as_mutation_error(
+    mutate_tracking_database,
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    _write_json(
+        plan_path,
+        {
+            "schema_version": 1,
+            "mutations": [{"kind": "initialize_database", "config": {}}],
+        },
+    )
+    outside_lock = tmp_path / "outside.lock"
+    outside_lock.write_bytes(b"")
+    tracking_database_io.lock_path_for(database_path).symlink_to(outside_lock)
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="cooperative tracking-database lock",
+    ):
+        mutate_tracking_database.execute(
+            database_path,
+            plan_path,
+            apply=True,
+            expected_sha256="missing",
+        )
+
+    assert not database_path.exists()
+
+
+def test_plan_strict_json_rejects_duplicate_keys(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        '{"schema_version":1,"schema_version":1,"mutations":[]}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="duplicate object key 'schema_version'",
+    ):
+        mutate_tracking_database.load_plan(plan_path)
+
+
+def test_talk_clarification_operation_accepts_only_structured_exact_fields(
+    mutate_tracking_database,
+) -> None:
+    candidate, changes = mutate_tracking_database.build_candidate(
+        _base_database(),
+        [
+            {
+                "kind": "update_talk_clarification",
+                "filename": "talk.md",
+                "expect": {
+                    "blind_spot_observations": MISSING,
+                    "humor_postmortem": MISSING,
+                },
+                "set": {
+                    "blind_spot_observations": {"room_energy": "high"},
+                    "humor_postmortem": ["opening joke landed"],
+                },
+            }
+        ],
+    )
+
+    assert candidate["talks"][0]["blind_spot_observations"] == {
+        "room_energy": "high"
+    }
+    assert candidate["talks"][0]["humor_postmortem"] == ["opening joke landed"]
+    assert changes[0]["kind"] == "update_talk_clarification"
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="must be a JSON object or array",
+    ):
+        mutate_tracking_database.build_candidate(
+            _base_database(),
+            [
+                {
+                    "kind": "update_talk_clarification",
+                    "filename": "talk.md",
+                    "expect": {"humor_postmortem": MISSING},
+                    "set": {"humor_postmortem": "unstructured"},
+                }
+            ],
+        )
+
+
+def test_legacy_goal_retirement_preserves_every_other_field(
+    mutate_tracking_database,
+) -> None:
+    database = _base_database()
+    legacy = {
+        "id": "legacy-goal",
+        "schema_version": 1,
+        "status": "active",
+        "legacy_note": {"must": "survive"},
+        "verification_reasons": ["historical"],
+    }
+    database["improvement_goals"] = [copy.deepcopy(legacy)]
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database,
+        [
+            {
+                "kind": "retire_improvement_goal",
+                "id": "legacy-goal",
+                "expect": legacy,
+            }
+        ],
+    )
+
+    retired = candidate["improvement_goals"][0]
+    assert retired == {**legacy, "status": "retired"}
+    assert changes == [
+        {
+            "kind": "retire_improvement_goal",
+            "identity": "legacy-goal",
+            "before": legacy,
+            "after": {**legacy, "status": "retired"},
+        }
+    ]
+
+
+@pytest.mark.parametrize("mutation_index", [1, 2, 3, 5, 6])
+def test_complete_collection_records_reject_unknown_fields(
+    mutate_tracking_database,
+    mutation_index: int,
+) -> None:
+    mutation = copy.deepcopy(_complete_plan()["mutations"][mutation_index])
+    mutation["record"]["unexpected"] = "drift"
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="unknown fields.*unexpected",
+    ):
+        mutate_tracking_database.build_candidate(_base_database(), [mutation])
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("shownotes_published", 1, "must be boolean"),
+        ("shownotes_url", "", "must be a nonempty string"),
+        ("youtube_id", "too-short", "11-character YouTube ID"),
+    ],
+)
+def test_publishing_fields_are_type_validated(
+    mutate_tracking_database,
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match=message,
+    ):
+        mutate_tracking_database.build_candidate(
+            _base_database(),
+            [
+                {
+                    "kind": "update_talk_publishing",
+                    "filename": "talk.md",
+                    "expect": {field: MISSING},
+                    "set": {field: value},
+                }
+            ],
+        )
+
+
+def test_json_preconditions_and_noops_are_type_sensitive(
+    mutate_tracking_database,
+) -> None:
+    database = _base_database()
+    database["config"] = {"enabled": True}
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="precondition failed",
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                {
+                    "kind": "set_config",
+                    "path": ["enabled"],
+                    "expect": 1,
+                    "value": False,
+                }
+            ],
+        )
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database,
+        [
+            {
+                "kind": "set_config",
+                "path": ["enabled"],
+                "expect": True,
+                "value": 1,
+            }
+        ],
+    )
+    assert candidate["config"]["enabled"] == 1
+    assert type(candidate["config"]["enabled"]) is int
+    assert changes
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="precondition failed",
+    ):
+        mutate_tracking_database.build_candidate(
+            _base_database(),
+            [
+                {
+                    "kind": "set_config",
+                    "path": ["absent"],
+                    "expect": {"$missing": 1},
+                    "value": "new",
+                }
+            ],
+        )
+
+
+def test_boolean_plan_and_record_schema_versions_are_rejected(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.json"
+    _write_json(plan_path, {"schema_version": True, "mutations": [{}]})
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="schema_version must be 1",
+    ):
+        mutate_tracking_database.load_plan(plan_path)
+
+    mutation = copy.deepcopy(_complete_plan()["mutations"][5])
+    mutation["record"]["schema_version"] = True
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="schema_version must be exact integer 1",
+    ):
+        mutate_tracking_database.build_candidate(_base_database(), [mutation])

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -573,6 +573,70 @@ def test_json_preconditions_and_noops_are_type_sensitive(
         )
 
 
+def test_delete_missing_nested_config_does_not_materialize_parents(
+    mutate_tracking_database,
+) -> None:
+    candidate, changes = mutate_tracking_database.build_candidate(
+        _base_database(),
+        [
+            {
+                "kind": "set_config",
+                "path": ["shownotes", "legacy", "enabled"],
+                "expect": MISSING,
+                "delete": True,
+            },
+            {
+                "kind": "set_config",
+                "path": ["shownotes", "enabled"],
+                "expect": MISSING,
+                "value": True,
+            },
+        ],
+    )
+
+    assert candidate["config"] == {"shownotes": {"enabled": True}}
+    assert len(changes) == 1
+    assert changes[0]["identity"] == "shownotes.enabled"
+
+
+def test_delete_missing_nested_config_preserves_exact_expectations(
+    mutate_tracking_database,
+) -> None:
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="precondition failed",
+    ):
+        mutate_tracking_database.build_candidate(
+            _base_database(),
+            [
+                {
+                    "kind": "set_config",
+                    "path": ["shownotes", "legacy", "enabled"],
+                    "expect": {"$missing": 1},
+                    "delete": True,
+                }
+            ],
+        )
+
+    database = _base_database()
+    database["config"] = {"shownotes": {"legacy": None}}
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match=r"config\.shownotes\.legacy must be an object",
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                {
+                    "kind": "set_config",
+                    "path": ["shownotes", "legacy", "enabled"],
+                    "expect": MISSING,
+                    "delete": True,
+                }
+            ],
+        )
+
+
 def test_boolean_plan_and_record_schema_versions_are_rejected(
     mutate_tracking_database,
     tmp_path: Path,

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -31,7 +31,10 @@ def test_atomic_json_write_cleans_stage_and_propagates_interrupt(
         persist_results.atomic_write_json(target, {"new": True})
 
     assert json.loads(target.read_text(encoding="utf-8")) == {"old": True}
-    assert [path.name for path in tmp_path.iterdir()] == [target.name]
+    assert {path.name for path in tmp_path.iterdir()} == {
+        target.name,
+        ".tracking-database.json.lock",
+    }
 
 
 def _return(**overrides):

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -17,7 +17,7 @@ from pptx import Presentation
 
 
 def test_atomic_json_write_cleans_stage_and_propagates_interrupt(
-    persist_results, tmp_path, monkeypatch,
+    persist_results, tracking_database_io, tmp_path, monkeypatch,
 ):
     target = tmp_path / "tracking-database.json"
     target.write_text('{"old": true}\n', encoding="utf-8")
@@ -25,7 +25,7 @@ def test_atomic_json_write_cleans_stage_and_propagates_interrupt(
     def interrupt(_source, _target):
         raise KeyboardInterrupt
 
-    monkeypatch.setattr(persist_results.os, "replace", interrupt)
+    monkeypatch.setattr(tracking_database_io.os, "replace", interrupt)
 
     with pytest.raises(KeyboardInterrupt):
         persist_results.atomic_write_json(target, {"new": True})

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -1123,10 +1123,8 @@ def test_identity_date_and_duration_types_are_validated(
 
     report = preflight_vault.run_preflight(vault_fixture["root"])
 
-    assert {
-        "source_identity_date_invalid",
-        "source_identity_duration_invalid",
-    } <= finding_codes(report, "blocking")
+    assert finding_codes(report, "blocking") == {"database_json_invalid"}
+    assert "non-standard JSON number Infinity" in report["findings"][0]["message"]
     # The report remains strict JSON even when Python's input decoder accepted
     # a non-standard Infinity token from a legacy artifact.
     json.dumps(report, allow_nan=False)

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import os
@@ -97,9 +98,14 @@ def test_dry_run_parses_jekyll_links_and_derives_exact_source_ids(
 
     report = scan_shownotes.execute(database_path, apply_requested=False)
 
+    assert report["schema_version"] == 2
     assert report["ok"] is True
     assert report["mode"] == "dry-run"
     assert report["database_written"] is False
+    assert report["input_sha256"] == hashlib.sha256(before).hexdigest()
+    assert report["output_sha256"] == report["input_sha256"]
+    assert report["durability_state"] == "dry_run"
+    assert report["warnings"] == []
     assert report["mutation_count"] == 1
     assert report["counts"] == {
         "add": 1,
@@ -144,6 +150,12 @@ def test_apply_adds_only_complete_proposal_and_preserves_file_mode(
         }
     ]
     assert report["database_written"] is True
+    assert report["schema_version"] == 2
+    assert report["input_sha256"] != report["output_sha256"]
+    assert report["output_sha256"] == hashlib.sha256(
+        database_path.read_bytes()
+    ).hexdigest()
+    assert report["durability_state"] == "durable"
     assert report["entries"][0]["applied"] is True
     assert database_path.stat().st_mode & 0o777 == 0o640
     assert not list(tmp_path.glob(".*.shownotes.tmp"))

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -518,7 +518,8 @@ def test_atomic_replace_failure_leaves_database_and_cleans_stage(
     def fail_replace(_source: object, _destination: object) -> None:
         raise OSError("simulated replacement failure")
 
-    monkeypatch.setattr(scan_shownotes.os, "replace", fail_replace)
+    tracking_database_os = getattr(sys.modules["tracking_database_io"], "os")
+    monkeypatch.setattr(tracking_database_os, "replace", fail_replace)
 
     with pytest.raises(
         scan_shownotes.ShownotesScanError,

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -339,6 +339,11 @@ def test_commit_rejects_substituted_stage_without_unlinking_it(
     expected = tracking_database_io.snapshot_tracking_database(path)
     attacker = tmp_path / "attacker.json"
     attacker_raw = _write(attacker, {"attacker": True})
+    backup = tmp_path / "backups" / "tracking-database.bak"
+    request = tracking_database_io.BackupRequest(
+        path=backup,
+        input_sha256=expected.sha256,
+    )
     original_stage = tracking_database_io._stage_candidate
     substituted: list[Path] = []
 
@@ -361,11 +366,13 @@ def test_commit_rejects_substituted_stage_without_unlinking_it(
         tracking_database_io.commit_tracking_database(
             expected,
             tracking_database_io.render_json_object({"talks": [], "config": {}}),
+            backup=request,
         )
 
     assert path.read_bytes() == original
     assert attacker.read_bytes() == attacker_raw
     assert substituted[0].is_symlink()
+    assert not backup.exists()
 
 
 def test_initialization_rejects_substituted_stage_without_unlinking_it(

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -270,6 +270,65 @@ def test_replace_interrupt_cleans_stage_but_keeps_persistent_lock(
     assert tracking_database_io.lock_path_for(path).is_file()
 
 
+def test_lock_acquisition_interrupt_closes_descriptor(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    lock_path = tracking_database_io.lock_path_for(path)
+    real_flock = tracking_database_io.fcntl.flock
+
+    def interrupt_after_acquire(descriptor: int, operation: int) -> object:
+        result = real_flock(descriptor, operation)
+        if operation == fcntl.LOCK_EX:
+            raise KeyboardInterrupt
+        return result
+
+    monkeypatch.setattr(tracking_database_io.fcntl, "flock", interrupt_after_acquire)
+    with pytest.raises(KeyboardInterrupt):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+        )
+
+    assert path.read_bytes() == original
+    probe = os.open(lock_path, os.O_RDWR)
+    try:
+        real_flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        real_flock(probe, fcntl.LOCK_UN)
+    finally:
+        os.close(probe)
+
+
+def test_staging_interrupt_cleans_candidate_and_preserves_database(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    real_write = tracking_database_io._write_descriptor
+
+    def interrupt_after_write(descriptor: int, raw: bytes) -> None:
+        real_write(descriptor, raw)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(tracking_database_io, "_write_descriptor", interrupt_after_write)
+    with pytest.raises(KeyboardInterrupt):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+        )
+
+    assert path.read_bytes() == original
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+    assert tracking_database_io.lock_path_for(path).is_file()
+
+
 def test_commit_rejects_substituted_stage_without_unlinking_it(
     tracking_database_io,
     tmp_path: Path,

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -1,0 +1,678 @@
+"""Adversarial contract tests for the shared tracking-database transaction."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+
+import pytest
+
+
+def _write(path: Path, value: object) -> bytes:
+    raw = json.dumps(value, indent=2).encode("utf-8") + b"\n"
+    path.write_bytes(raw)
+    return raw
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        (b'{"talks": [], "talks": [{"filename": "lost.md"}]}\n', "duplicate object key 'talks'"),
+        (
+            b'{"talks": [{"filename": "a.md", "source_identity": '
+            b'{"video_id": "one", "video_id": "two"}}]}\n',
+            "duplicate object key 'video_id'",
+        ),
+        (b'{"talks": [], "value": NaN}\n', "non-standard JSON number NaN"),
+        (b'{"talks": [], "value": Infinity}\n', "non-standard JSON number Infinity"),
+        (b'{"talks": [], "value": -Infinity}\n', "non-standard JSON number -Infinity"),
+        (b'{"talks": ["\xff"]}\n', "not valid UTF-8"),
+        (b'["not", "an", "object"]\n', "root must be a JSON object"),
+    ],
+)
+def test_strict_decoder_rejects_ambiguous_json_without_changing_bytes(
+    tracking_database_io,
+    tmp_path: Path,
+    raw: bytes,
+    message: str,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    path.write_bytes(raw)
+
+    snapshot = tracking_database_io.snapshot_tracking_database(path)
+    with pytest.raises(tracking_database_io.TrackingDatabaseIOError, match=message):
+        tracking_database_io.decode_json_object(snapshot)
+
+    assert path.read_bytes() == raw
+
+
+def test_snapshot_rejects_final_symlink(tracking_database_io, tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    _write(target, {"talks": []})
+    link = tmp_path / "tracking-database.json"
+    link.symlink_to(target)
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="symbolic link",
+    ):
+        tracking_database_io.snapshot_tracking_database(link)
+
+
+def test_renderer_refuses_to_create_non_standard_json(tracking_database_io) -> None:
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="candidate is not strict JSON",
+    ):
+        tracking_database_io.render_json_object({"value": float("nan")})
+
+
+def test_commit_refuses_an_invalid_candidate_before_locking(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="candidate.*non-standard JSON number NaN",
+    ):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            b'{"talks": [], "value": NaN}\n',
+        )
+
+    assert path.read_bytes() == original
+    assert not tracking_database_io.lock_path_for(path).exists()
+
+
+def test_commit_rejects_symlinked_cooperative_lock(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    lock_target = tmp_path / "outside.lock"
+    lock_target.write_bytes(b"")
+    tracking_database_io.lock_path_for(path).symlink_to(lock_target)
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="cooperative tracking-database lock",
+    ):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+        )
+
+    assert path.read_bytes() == original
+
+
+def test_same_bytes_inode_replacement_fails_closed(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    raw = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    replacement = tmp_path / "replacement.json"
+    replacement.write_bytes(raw)
+    os.replace(replacement, path)
+    replacement_generation = path.stat().st_ino
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseConflictError,
+        match="content or generation changed",
+    ):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+        )
+
+    assert path.read_bytes() == raw
+    assert path.stat().st_ino == replacement_generation
+
+
+def test_symlink_substitution_before_commit_is_preserved(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    concurrent = tmp_path / "concurrent.json"
+    concurrent_raw = _write(concurrent, {"talks": [{"filename": "new.md"}]})
+    path.unlink()
+    path.symlink_to(concurrent)
+
+    with pytest.raises(tracking_database_io.TrackingDatabaseIOError, match="symbolic link"):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+        )
+
+    assert path.is_symlink()
+    assert concurrent.read_bytes() == concurrent_raw
+
+
+def test_noop_is_byte_and_inode_stable(tracking_database_io, tmp_path: Path) -> None:
+    path = tmp_path / "tracking-database.json"
+    raw = b'{"talks":[]}\n'
+    path.write_bytes(raw)
+    expected = tracking_database_io.snapshot_tracking_database(path)
+
+    result = tracking_database_io.commit_tracking_database(expected, expected.raw)
+
+    assert result.changed is False
+    assert result.installed is False
+    assert result.input_sha256 == result.output_sha256 == expected.sha256
+    assert path.read_bytes() == raw
+    assert path.stat().st_ino == expected.generation.inode
+
+
+def test_semantic_json_noop_is_byte_and_inode_stable(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    raw = b'{"nested":{"b":2,"a":1},"ordered":[true,1,1.0]}\n'
+    path.write_bytes(raw)
+    expected = tracking_database_io.snapshot_tracking_database(path)
+
+    result = tracking_database_io.write_json_object(
+        expected,
+        {"ordered": [True, 1, 1.0], "nested": {"a": 1, "b": 2}},
+    )
+
+    assert result.changed is False
+    assert result.installed is False
+    assert path.read_bytes() == raw
+    assert path.stat().st_ino == expected.generation.inode
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "equal"),
+    [
+        ({"a": 1, "b": [2, 3]}, {"b": [2, 3], "a": 1}, True),
+        ([1, 2], [2, 1], False),
+        (True, 1, False),
+        (1, 1.0, False),
+        ({"$missing": 1}, {"$missing": True}, False),
+    ],
+)
+def test_json_values_equal_is_recursive_and_type_sensitive(
+    tracking_database_io,
+    left: object,
+    right: object,
+    equal: bool,
+) -> None:
+    assert tracking_database_io.json_values_equal(left, right) is equal
+
+
+def test_backup_collision_never_overwrites_database_or_backup(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    backup = tmp_path / ".backups" / "tracking-database.hash.bak"
+    backup.parent.mkdir()
+    backup.write_bytes(b"different generation\n")
+    request = tracking_database_io.BackupRequest(
+        path=backup,
+        input_sha256=expected.sha256,
+    )
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="does not match the validated input bytes",
+    ):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+            backup=request,
+        )
+
+    assert path.read_bytes() == original
+    assert backup.read_bytes() == b"different generation\n"
+
+
+def test_replace_interrupt_cleans_stage_but_keeps_persistent_lock(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+
+    def interrupt(_source: object, _target: object) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(tracking_database_io.os, "replace", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+        )
+
+    assert path.read_bytes() == original
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+    assert tracking_database_io.lock_path_for(path).is_file()
+
+
+def test_commit_rejects_substituted_stage_without_unlinking_it(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    attacker = tmp_path / "attacker.json"
+    attacker_raw = _write(attacker, {"attacker": True})
+    original_stage = tracking_database_io._stage_candidate
+    substituted: list[Path] = []
+
+    def substitute_stage(target: Path, candidate: bytes, mode: int):
+        stage = original_stage(target, candidate, mode)
+        os.unlink(stage.name, dir_fd=stage.directory_descriptor)
+        os.symlink(
+            attacker.name,
+            stage.name,
+            dir_fd=stage.directory_descriptor,
+        )
+        substituted.append(stage.path)
+        return stage
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", substitute_stage)
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseConflictError,
+        match="staged tracking-database candidate.*changed before install",
+    ):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+        )
+
+    assert path.read_bytes() == original
+    assert attacker.read_bytes() == attacker_raw
+    assert substituted[0].is_symlink()
+
+
+def test_initialization_rejects_substituted_stage_without_unlinking_it(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    attacker = tmp_path / "attacker.json"
+    attacker_raw = _write(attacker, {"attacker": True})
+    original_stage = tracking_database_io._stage_candidate
+    substituted: list[Path] = []
+
+    def substitute_stage(target: Path, candidate: bytes, mode: int):
+        stage = original_stage(target, candidate, mode)
+        os.unlink(stage.name, dir_fd=stage.directory_descriptor)
+        os.symlink(
+            attacker.name,
+            stage.name,
+            dir_fd=stage.directory_descriptor,
+        )
+        substituted.append(stage.path)
+        return stage
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", substitute_stage)
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseConflictError,
+        match="staged tracking-database candidate.*changed before install",
+    ):
+        tracking_database_io.initialize_tracking_database(path, {"talks": []})
+
+    assert not path.exists()
+    assert attacker.read_bytes() == attacker_raw
+    assert substituted[0].is_symlink()
+
+
+def test_directory_fsync_failure_reports_installed_generation(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+
+    def fail_directory_sync(_descriptor: int) -> None:
+        raise OSError("simulated directory sync failure")
+
+    monkeypatch.setattr(tracking_database_io, "_fsync_directory", fail_directory_sync)
+    result = tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert result.installed is True
+    assert result.durability_state == "installed_directory_fsync_failed"
+    assert result.output_sha256 == tracking_database_io.snapshot_tracking_database(path).sha256
+    assert path.read_bytes() == candidate
+    assert "inspect the installed output SHA before retrying" in result.warnings[0]
+
+
+@pytest.mark.parametrize("initialize", [False, True], ids=["commit", "initialize"])
+def test_directory_close_failure_is_an_installed_warning(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    initialize: bool,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    payload = {"talks": [], "config": {}}
+    expected = None
+    if not initialize:
+        _write(path, {"talks": []})
+        expected = tracking_database_io.snapshot_tracking_database(path)
+    original_stage = tracking_database_io._stage_candidate
+    real_close = tracking_database_io.os.close
+    directory_descriptors: set[int] = set()
+    injected = False
+
+    def capture_stage(target: Path, candidate: bytes, mode: int):
+        stage = original_stage(target, candidate, mode)
+        directory_descriptors.add(stage.directory_descriptor)
+        return stage
+
+    def fail_directory_close(descriptor: int) -> None:
+        nonlocal injected
+        if descriptor in directory_descriptors and not injected:
+            injected = True
+            real_close(descriptor)
+            raise OSError("simulated directory close failure")
+        real_close(descriptor)
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", capture_stage)
+    monkeypatch.setattr(tracking_database_io.os, "close", fail_directory_close)
+    if initialize:
+        result = tracking_database_io.initialize_tracking_database(path, payload)
+    else:
+        assert expected is not None
+        result = tracking_database_io.write_json_object(expected, payload)
+
+    assert result.installed is True
+    assert tracking_database_io.decode_json_object_bytes(path.read_bytes(), path) == payload
+    assert any("could not close tracking-database directory" in w for w in result.warnings)
+
+
+@pytest.mark.parametrize("initialize", [False, True], ids=["commit", "initialize"])
+def test_lock_cleanup_failure_is_an_installed_warning(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    initialize: bool,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    payload = {"talks": [], "config": {}}
+    expected = None
+    if not initialize:
+        _write(path, {"talks": []})
+        expected = tracking_database_io.snapshot_tracking_database(path)
+    real_flock = tracking_database_io.fcntl.flock
+
+    def fail_unlock(descriptor: int, operation: int) -> object:
+        outcome = real_flock(descriptor, operation)
+        if operation == fcntl.LOCK_UN:
+            raise OSError("simulated unlock failure")
+        return outcome
+
+    monkeypatch.setattr(tracking_database_io.fcntl, "flock", fail_unlock)
+    if initialize:
+        result = tracking_database_io.initialize_tracking_database(path, payload)
+    else:
+        assert expected is not None
+        result = tracking_database_io.write_json_object(expected, payload)
+
+    assert result.installed is True
+    assert tracking_database_io.decode_json_object_bytes(path.read_bytes(), path) == payload
+    assert any("could not unlock cooperative" in w for w in result.warnings)
+
+
+@pytest.mark.parametrize("initialize", [False, True], ids=["commit", "initialize"])
+def test_lock_close_failure_is_an_installed_warning(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    initialize: bool,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    payload = {"talks": [], "config": {}}
+    expected = None
+    if not initialize:
+        _write(path, {"talks": []})
+        expected = tracking_database_io.snapshot_tracking_database(path)
+    lock_path = tracking_database_io.lock_path_for(path)
+    real_close = tracking_database_io.os.close
+    injected = False
+
+    def fail_lock_close(descriptor: int) -> None:
+        nonlocal injected
+        metadata = os.fstat(descriptor)
+        lock_metadata = lock_path.stat() if lock_path.exists() else None
+        is_lock = lock_metadata is not None and (
+            metadata.st_dev,
+            metadata.st_ino,
+        ) == (
+            lock_metadata.st_dev,
+            lock_metadata.st_ino,
+        )
+        if is_lock and not injected:
+            injected = True
+            real_close(descriptor)
+            raise OSError("simulated lock close failure")
+        real_close(descriptor)
+
+    monkeypatch.setattr(tracking_database_io.os, "close", fail_lock_close)
+    if initialize:
+        result = tracking_database_io.initialize_tracking_database(path, payload)
+    else:
+        assert expected is not None
+        result = tracking_database_io.write_json_object(expected, payload)
+
+    assert result.installed is True
+    assert tracking_database_io.decode_json_object_bytes(path.read_bytes(), path) == payload
+    assert any("could not close cooperative" in w for w in result.warnings)
+
+
+def test_postinstall_verification_failure_reports_installed_unknown_state(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    concurrent = tracking_database_io.render_json_object({"writer": "noncooperative"})
+    original_replace = tracking_database_io._replace_staged_candidate
+
+    def replace_then_mutate(stage, target: Path) -> None:
+        original_replace(stage, target)
+        target.write_bytes(concurrent)
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_replace_staged_candidate",
+        replace_then_mutate,
+    )
+    result = tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert result.installed is True
+    assert result.durability_state == "installed_verification_failed"
+    assert result.output_sha256 != tracking_database_io.snapshot_tracking_database(path).sha256
+    assert path.read_bytes() == concurrent
+    assert any("no longer matches" in warning for warning in result.warnings)
+
+
+def test_initialization_postinstall_verification_failure_reports_installed_state(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    candidate_payload = {"talks": [], "config": {}}
+    concurrent = tracking_database_io.render_json_object({"writer": "noncooperative"})
+    concurrent_path = tmp_path / "concurrent.json"
+    original_link = tracking_database_io._link_staged_candidate
+
+    def link_then_replace(stage, target: Path) -> None:
+        original_link(stage, target)
+        concurrent_path.write_bytes(concurrent)
+        os.replace(concurrent_path, target)
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_link_staged_candidate",
+        link_then_replace,
+    )
+    result = tracking_database_io.initialize_tracking_database(
+        path,
+        candidate_payload,
+    )
+
+    assert result.installed is True
+    assert result.durability_state == "installed_verification_failed"
+    assert result.output_sha256 != tracking_database_io.snapshot_tracking_database(path).sha256
+    assert path.read_bytes() == concurrent
+    assert any("no longer matches" in warning for warning in result.warnings)
+
+
+def test_persistent_lock_excludes_another_process(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"talks": []})
+    lock_path = tracking_database_io.lock_path_for(path)
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
+    probe = (
+        "import fcntl, os, sys\n"
+        "fd = os.open(sys.argv[1], os.O_RDWR)\n"
+        "try:\n"
+        "    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+        "except BlockingIOError:\n"
+        "    print('blocked')\n"
+        "else:\n"
+        "    print('acquired')\n"
+        "finally:\n"
+        "    os.close(fd)\n"
+    )
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", probe, str(lock_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+    assert completed.stdout.strip() == "blocked"
+
+
+def test_cross_writer_waits_then_rejects_its_stale_generation(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"talks": []})
+    first_snapshot = tracking_database_io.snapshot_tracking_database(path)
+    second_snapshot = tracking_database_io.snapshot_tracking_database(path)
+    first_candidate = tracking_database_io.render_json_object(
+        {"talks": [], "writer": "first"}
+    )
+    second_candidate = tracking_database_io.render_json_object(
+        {"talks": [], "writer": "second"}
+    )
+    original_stage = tracking_database_io._stage_candidate
+    real_flock = tracking_database_io.fcntl.flock
+    second_attempted = threading.Event()
+    second_errors: list[Exception] = []
+    second_thread: threading.Thread | None = None
+
+    def observed_flock(descriptor: int, operation: int) -> object:
+        if (
+            threading.current_thread().name == "second-toolkit-writer"
+            and operation == fcntl.LOCK_EX
+        ):
+            second_attempted.set()
+        return real_flock(descriptor, operation)
+
+    def second_writer() -> None:
+        try:
+            tracking_database_io.commit_tracking_database(
+                second_snapshot,
+                second_candidate,
+            )
+        except Exception as exc:
+            second_errors.append(exc)
+
+    def stage_and_contend(target: Path, candidate: bytes, mode: int) -> str:
+        nonlocal second_thread
+        temporary = original_stage(target, candidate, mode)
+        second_thread = threading.Thread(
+            target=second_writer,
+            name="second-toolkit-writer",
+        )
+        second_thread.start()
+        assert second_attempted.wait(timeout=5)
+        assert second_errors == []
+        return temporary
+
+    monkeypatch.setattr(tracking_database_io.fcntl, "flock", observed_flock)
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", stage_and_contend)
+
+    first_result = tracking_database_io.commit_tracking_database(
+        first_snapshot,
+        first_candidate,
+    )
+    assert second_thread is not None
+    second_thread.join(timeout=5)
+
+    assert not second_thread.is_alive()
+    assert first_result.installed is True
+    assert len(second_errors) == 1
+    assert isinstance(
+        second_errors[0],
+        tracking_database_io.TrackingDatabaseConflictError,
+    )
+    assert path.read_bytes() == first_candidate
+
+
+def test_initialization_is_exclusive_and_reports_missing_input(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    payload = {"config": {}, "talks": []}
+
+    result = tracking_database_io.initialize_tracking_database(path, payload)
+
+    assert result.input_sha256 is None
+    assert result.installed is True
+    assert tracking_database_io.decode_json_object(
+        tracking_database_io.snapshot_tracking_database(path)
+    ) == payload
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseConflictError,
+        match="already exists",
+    ):
+        tracking_database_io.initialize_tracking_database(path, payload)

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -688,7 +688,7 @@ def test_cross_writer_waits_then_rejects_its_stale_generation(
                 second_snapshot,
                 second_candidate,
             )
-        except Exception as exc:
+        except tracking_database_io.TrackingDatabaseConflictError as exc:
             second_errors.append(exc)
 
     def stage_and_contend(target: Path, candidate: bytes, mode: int) -> str:

--- a/tests/test_tracking_database_strict_readers.py
+++ b/tests/test_tracking_database_strict_readers.py
@@ -1,0 +1,198 @@
+"""Every public tracking-database reader shares the owner strict decoder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+STRICT_INVALID_CASES = (
+    pytest.param(
+        b'{"talks": [], "talks": [{"filename": "lost.md"}]}\n',
+        "duplicate object key 'talks'",
+        id="duplicate-top-level",
+    ),
+    pytest.param(
+        b'{"config": {}, "talks": [{"filename": "a.md", '
+        b'"source_identity": {"video_id": "one", "video_id": "two"}}]}\n',
+        "duplicate object key 'video_id'",
+        id="duplicate-nested",
+    ),
+    pytest.param(
+        b'{"config": {}, "talks": [], "value": NaN}\n',
+        "non-standard JSON number NaN",
+        id="nan",
+    ),
+    pytest.param(
+        b'{"config": {}, "talks": [], "value": Infinity}\n',
+        "non-standard JSON number Infinity",
+        id="infinity",
+    ),
+    pytest.param(
+        b'{"config": {}, "talks": [], "value": -Infinity}\n',
+        "non-standard JSON number -Infinity",
+        id="negative-infinity",
+    ),
+    pytest.param(
+        b'{"config": {}, "talks": ["\xff"]}\n',
+        "not valid UTF-8",
+        id="invalid-utf8",
+    ),
+    pytest.param(
+        b'["not", "an", "object"]\n',
+        "root must be a JSON object",
+        id="non-object-root",
+    ),
+)
+
+
+def _database(tmp_path: Path, raw: bytes) -> Path:
+    path = tmp_path / "tracking-database.json"
+    path.write_bytes(raw)
+    return path
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_owner_reader_rejects_every_strict_json_defect_without_rewrite(
+    read_tracking_database,
+    tracking_database_io,
+    tmp_path: Path,
+    raw: bytes,
+    message: str,
+) -> None:
+    database = _database(tmp_path, raw)
+
+    with pytest.raises(tracking_database_io.TrackingDatabaseIOError, match=message):
+        read_tracking_database.execute(database)
+
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_preflight_blocks_every_strict_json_defect_without_rewrite(
+    preflight_vault,
+    tmp_path: Path,
+    raw: bytes,
+    message: str,
+) -> None:
+    database = _database(tmp_path, raw)
+
+    report = preflight_vault.run_preflight(database)
+
+    assert report["blocking_count"] == 1
+    assert report["warning_count"] == 0
+    assert report["findings"][0]["code"] in {
+        "database_encoding_invalid",
+        "database_json_invalid",
+    }
+    assert message in report["findings"][0]["message"]
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_source_audit_stops_before_metadata_fetch_without_rewrite(
+    audit_source_identities,
+    tmp_path: Path,
+    raw: bytes,
+    message: str,
+) -> None:
+    database = _database(tmp_path, raw)
+    fetched: list[str] = []
+
+    def unexpected_fetch(video_id: str) -> dict[str, object]:
+        fetched.append(video_id)
+        return {}
+
+    report = audit_source_identities.audit_path(
+        database,
+        metadata_fetcher=unexpected_fetch,
+        captured_at="2026-08-01T12:00:00+00:00",
+    )
+
+    assert report["complete"] is False
+    assert report["findings"][0]["code"] == "database_unreadable"
+    assert message in report["findings"][0]["evidence"]["error"]
+    assert fetched == []
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_analysis_reader_fails_before_output_without_rewrite(
+    write_analysis,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    raw: bytes,
+    message: str,
+) -> None:
+    database = _database(tmp_path, raw)
+
+    with pytest.raises(SystemExit) as stopped:
+        write_analysis.load_tracking_database(database)
+
+    assert stopped.value.code == 1
+    assert message in capsys.readouterr().err
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_profile_loader_fails_before_reading_other_vault_outputs(
+    load_vault,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    raw: bytes,
+    message: str,
+) -> None:
+    database = _database(tmp_path, raw)
+
+    result = load_vault.main(
+        ["load-vault.py", str(tmp_path), "--as-of", "2026-08-01T12:00:00+00:00"]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert message in captured.err
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_section15_reader_fails_before_summary_replacement(
+    section15_pattern_history,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    raw: bytes,
+    message: str,
+) -> None:
+    database = _database(tmp_path, raw)
+    profile = tmp_path / "pattern-profile.json"
+    profile.write_text("{}\n", encoding="utf-8")
+    summary = tmp_path / "rhetoric-style-summary.md"
+    original_summary = b"## 15. Pattern History\n\nOriginal.\n"
+    summary.write_bytes(original_summary)
+
+    result = section15_pattern_history.main(
+        ["replace", str(summary), str(profile), str(database)]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert message in captured.err
+    assert summary.read_bytes() == original_summary
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_profile_validator_rejects_live_database_before_snapshot_generation(
+    validate_profile,
+    tmp_path: Path,
+    raw: bytes,
+    message: str,
+) -> None:
+    database = _database(tmp_path, raw)
+
+    with pytest.raises(ValueError, match=message):
+        validate_profile._load_live_pattern_snapshot(tmp_path, {})
+
+    assert database.read_bytes() == raw

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -248,7 +248,7 @@ def test_queue_and_persistence_writers_serialize_then_reject_stale_input(
                 {"config": {}, "talks": [], "writer": "persistence"},
                 expected_snapshot=persistence_snapshot,
             )
-        except Exception as exc:
+        except ValueError as exc:
             persistence_errors.append(exc)
 
     def stage_queue_and_contend(target: Path, candidate: bytes, mode: int) -> str:

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -1,0 +1,286 @@
+"""Every public tracking-database writer rejects a final-window generation swap."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from pathlib import Path
+import threading
+
+import pytest
+
+
+def _write(path: Path, value: object) -> bytes:
+    raw = json.dumps(value, indent=2).encode("utf-8") + b"\n"
+    path.write_bytes(raw)
+    return raw
+
+
+def _inject_final_window_replacement(
+    tracking_database_io,
+    monkeypatch: pytest.MonkeyPatch,
+    concurrent_payload: dict[str, object],
+) -> bytes:
+    original_stage = tracking_database_io._stage_candidate
+    concurrent_raw = json.dumps(concurrent_payload, indent=2).encode("utf-8") + b"\n"
+
+    def stage_then_replace(path: Path, candidate: bytes, mode: int) -> str:
+        temporary = original_stage(path, candidate, mode)
+        replacement = path.parent / "concurrent-generation.json"
+        replacement.write_bytes(concurrent_raw)
+        os.replace(replacement, path)
+        return temporary
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", stage_then_replace)
+    return concurrent_raw
+
+
+def test_queue_writer_preserves_final_window_generation(
+    queue_state,
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"config": {}, "talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    concurrent = _inject_final_window_replacement(
+        tracking_database_io,
+        monkeypatch,
+        {"config": {}, "talks": [], "writer": "concurrent"},
+    )
+
+    with pytest.raises(queue_state.QueueStateError, match="generation changed"):
+        queue_state.write_database_atomically(
+            path,
+            {"config": {}, "talks": [], "writer": "queue"},
+            expected_snapshot=expected,
+        )
+
+    assert path.read_bytes() == concurrent
+
+
+def test_persist_results_writer_preserves_final_window_generation(
+    persist_results,
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"config": {}, "talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    concurrent = _inject_final_window_replacement(
+        tracking_database_io,
+        monkeypatch,
+        {"config": {}, "talks": [], "writer": "concurrent"},
+    )
+
+    with pytest.raises(ValueError, match="generation changed"):
+        persist_results.atomic_write_json(
+            path,
+            {"config": {}, "talks": [], "writer": "persist-results"},
+            expected_snapshot=expected,
+        )
+
+    assert path.read_bytes() == concurrent
+
+
+def test_source_repair_writer_preserves_final_window_generation(
+    apply_source_repairs,
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"config": {}, "talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    concurrent = _inject_final_window_replacement(
+        tracking_database_io,
+        monkeypatch,
+        {"config": {}, "talks": [], "writer": "concurrent"},
+    )
+
+    with pytest.raises(
+        apply_source_repairs.SourceRepairError,
+        match="generation changed",
+    ):
+        apply_source_repairs.atomic_write(
+            path,
+            json.dumps({"config": {}, "talks": [], "writer": "source-repair"})
+            + "\n",
+            expected_snapshot=expected,
+        )
+
+    assert path.read_bytes() == concurrent
+
+
+def test_shownotes_writer_preserves_final_window_generation(
+    scan_shownotes_module,
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"config": {}, "talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    concurrent = _inject_final_window_replacement(
+        tracking_database_io,
+        monkeypatch,
+        {"config": {}, "talks": [], "writer": "concurrent"},
+    )
+
+    with pytest.raises(
+        scan_shownotes_module.ShownotesScanError,
+        match="generation changed after the scan",
+    ):
+        scan_shownotes_module._atomic_write_database(
+            path,
+            {"config": {}, "talks": [], "writer": "shownotes"},
+            expected_snapshot=expected,
+        )
+
+    assert path.read_bytes() == concurrent
+
+
+def test_qr_writer_preserves_final_window_generation(
+    generate_qr,
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"config": {}, "talks": [], "qr_codes": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    concurrent = _inject_final_window_replacement(
+        tracking_database_io,
+        monkeypatch,
+        {"config": {}, "talks": [], "qr_codes": [], "writer": "concurrent"},
+    )
+
+    with pytest.raises(ValueError, match="generation changed"):
+        generate_qr.write_tracking_db(
+            expected,
+            {"config": {}, "talks": [], "qr_codes": [], "writer": "qr"},
+        )
+
+    assert path.read_bytes() == concurrent
+
+
+def test_owner_mutation_cli_preserves_final_window_generation(
+    mutate_tracking_database,
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"config": {}, "talks": []})
+    plan = tmp_path / "plan.json"
+    _write(
+        plan,
+        {
+            "schema_version": 1,
+            "mutations": [
+                {
+                    "kind": "set_config",
+                    "path": ["speaker_name"],
+                    "expect": {"$missing": True},
+                    "value": "Ada",
+                }
+            ],
+        },
+    )
+    dry_run = mutate_tracking_database.execute(
+        path,
+        plan,
+        apply=False,
+        expected_sha256=None,
+    )
+    concurrent = _inject_final_window_replacement(
+        tracking_database_io,
+        monkeypatch,
+        {"config": {}, "talks": [], "writer": "concurrent"},
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="generation changed",
+    ):
+        mutate_tracking_database.execute(
+            path,
+            plan,
+            apply=True,
+            expected_sha256=dry_run["input_sha256"],
+        )
+
+    assert path.read_bytes() == concurrent
+
+
+def test_queue_and_persistence_writers_serialize_then_reject_stale_input(
+    queue_state,
+    persist_results,
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"config": {}, "talks": []})
+    queue_snapshot = tracking_database_io.snapshot_tracking_database(path)
+    persistence_snapshot = tracking_database_io.snapshot_tracking_database(path)
+    original_stage = tracking_database_io._stage_candidate
+    real_flock = tracking_database_io.fcntl.flock
+    persistence_attempted = threading.Event()
+    persistence_errors: list[Exception] = []
+    persistence_thread: threading.Thread | None = None
+
+    def observed_flock(descriptor: int, operation: int) -> object:
+        if (
+            threading.current_thread().name == "persistence-writer"
+            and operation == fcntl.LOCK_EX
+        ):
+            persistence_attempted.set()
+        return real_flock(descriptor, operation)
+
+    def persistence_writer() -> None:
+        try:
+            persist_results.atomic_write_json(
+                path,
+                {"config": {}, "talks": [], "writer": "persistence"},
+                expected_snapshot=persistence_snapshot,
+            )
+        except Exception as exc:
+            persistence_errors.append(exc)
+
+    def stage_queue_and_contend(target: Path, candidate: bytes, mode: int) -> str:
+        nonlocal persistence_thread
+        temporary = original_stage(target, candidate, mode)
+        persistence_thread = threading.Thread(
+            target=persistence_writer,
+            name="persistence-writer",
+        )
+        persistence_thread.start()
+        assert persistence_attempted.wait(timeout=5)
+        assert persistence_errors == []
+        return temporary
+
+    monkeypatch.setattr(tracking_database_io.fcntl, "flock", observed_flock)
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_stage_candidate",
+        stage_queue_and_contend,
+    )
+
+    queue_result = queue_state.write_database_atomically(
+        path,
+        {"config": {}, "talks": [], "writer": "queue"},
+        expected_snapshot=queue_snapshot,
+    )
+    assert persistence_thread is not None
+    persistence_thread.join(timeout=5)
+
+    assert not persistence_thread.is_alive()
+    assert queue_result.installed is True
+    assert len(persistence_errors) == 1
+    assert isinstance(persistence_errors[0], ValueError)
+    assert "generation changed" in str(persistence_errors[0])
+    assert json.loads(path.read_text(encoding="utf-8"))["writer"] == "queue"


### PR DESCRIPTION
## Summary

- centralize every tracking-database reader and writer on a strict, generation-bound transaction with cooperative locking, retained descriptors, post-install verification, and truthful installed-warning outcomes
- add a typed dry-run/SHA-bound owner mutation command for config, PPTX, clarification, goal, resource, thumbnail, and publishing records; preserve semantic no-ops byte-for-byte
- route existing ingress, profile, shownotes, QR, clarification, and resource workflows through the owner contract and add deterministic race/security regressions

Closes #165.
Closes #166.

## Test plan

- [x] `pytest -q` — 3,083 passed, 3 skipped
- [x] Ruff on every changed Python file
- [x] Pyright on the changed production surface — 0 errors
- [x] `scripts/pre-publish-checks.sh`
- [x] `tessl plugin lint .`
- [x] `git diff --check`
