### PR TITLE
feat(vault-ingress): own tracking database schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+### fix(vault-ingress) — give the tracking database one versioned owner
+
+Vault-ingress now owns tracking-database shape changes and migration (#147).
+The database root, config, talks, PPTX catalog entries, QR records, resource
+records, thumbnails, confirmed intents, improvement goals, and source-rejection
+entries carry explicit schema versions. A deterministic schema-0 migration
+refuses active queue writers, binds apply to the dry-run SHA-256, saves the exact
+original bytes, and replaces only the validated generation atomically. Historical
+talk records remain in their original schema generation; migration adds only the
+missing implicit-v1 version and never fabricates current pattern evidence.
+
+Legacy queue inspection and recovery can close leases before migration without
+schema stamping. Mutating tools require current state; non-owner readers accept
+legacy and current state without rewriting either. Migration rejects duplicate
+JSON keys, non-finite numbers, malformed owner records, and unknown owner schema
+generations before backup or mutation. Profile generation projects semantic
+confirmed-intent fields without leaking database schema metadata.
+
+Owner assessment now classifies root, record, queue-claim, and adherence-baseline
+versions before interpreting older identities or nested shapes. One shared pure
+queue contract validates complete claim/history lifecycles, generation/status
+coherence, receipts, and immutable batch baselines before migration or queue use,
+while preserving the status-drift recovery lane. The strict decoder rejects a
+finite JSON number when it cannot round-trip through the toolkit without changing
+its mathematical value, before backup or write; harmless lexical variants remain
+accepted. It also bounds JSON nesting at 200 containers and rejects unpaired
+UTF-16 surrogates before recursive consumers, rendering, backup, or write.
+Section 15 pattern-history replacement now applies the owner schema gate before
+interpreting configured storage paths or constructing freshness assessors.
+Publishing and clarification patches require talk schema v5. Legacy
+pattern goals remain report-only, legacy pacing/independent goals can patch only
+their historical status/check fields, and schema-v2 goals retain the full
+verification contract.
+
 ### fix(vault-ingress) — serialize tracking-database access and close owner schemas
 
 All toolkit tracking-database writers now share one persistent sibling lock and one

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -35,6 +35,15 @@ same database bytes/SHA-256. The unconfigured `host_python` is authorized only f
 owner-reader invocation. Every command below uses the configured interpreter;
 never fall back to a PATH interpreter.
 
+Read `tracking-database.json` through the vault path used by
+presentation-creator. Selection and composition may read legacy database schema
+0 or current schema 1 without mutation. Before copying the approved thumbnail or
+writing tracking state, require database schema 1, current independent records,
+and talk schema 5. Invoke `Skill(skill: "vault-ingress")` for schema 0 and stop
+this run. Unknown future generations are no usable prior state. Preserve every
+schema field and use the presentation-creator exact-generation atomic-write
+contract.
+
 If shownotes are needed too (Step 7.2 in presentation-creator) and don't
 exist yet, STOP and ask before generating the thumbnail.
 
@@ -227,4 +236,6 @@ exact existing record for the slug or `{"$missing": true}`. In the same plan, us
 filename, expecting its current value. Dry-run the whole plan, review it, apply
 against the reported input SHA, and re-read as specified by the
 [owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
+Keep that talk at `schema_version: 5`. illustrations is an authorized writer of
+current thumbnail and talk records; vault-ingress remains their schema owner.
 Never rewrite `tracking-database.json` directly.

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -40,10 +40,18 @@ joint effort — the skill brings rhetoric knowledge, the author brings topic ex
 The vault lives at `~/.claude/rhetoric-knowledge-vault/` (may be a symlink to a custom
 location). Load `tracking-database.json` with the strict owner reader at
 `{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py` to
-get `config.vault_root`; never parse it directly. The reader is stdlib-only, so the
-host interpreter may bootstrap this first read. Afterward, use only the exact
-non-empty `config.python_path` for every toolkit command. Missing or unusable
-configuration stops this flow and invokes `Skill(skill: "vault-ingress")` at Step 1.
+get `config.vault_root`; never parse it directly. The stdlib-only reader may use
+the host interpreter for this one bootstrap read. It accepts legacy database
+schema 0 and current schema 1 without rewriting either. Stop on unsupported root
+or owner-record generations and route migration to `Skill(skill: "vault-ingress")`.
+
+Discover the exact non-empty `config.python_path`, then immediately re-read the
+same canonical database path with that interpreter and require the same SHA-256;
+restart discovery if the generation changed. Use only that configured interpreter
+for every later toolkit command. Missing or unusable configuration stops this flow
+and invokes vault-ingress Step 1. Read-only phases may continue on schema 0, but
+publishing and post-event writes require schema 1 before their paired network,
+deck, image, or tracking side effects. Route schema 0 through vault-ingress first.
 
 Load from vault root: `rhetoric-style-summary.md` (constitution — all patterns),
 `slide-design-spec.md` (visual rules), `speaker-profile.json` (structured data).

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -49,9 +49,11 @@ Discover the exact non-empty `config.python_path`, then immediately re-read the
 same canonical database path with that interpreter and require the same SHA-256;
 restart discovery if the generation changed. Use only that configured interpreter
 for every later toolkit command. Missing or unusable configuration stops this flow
-and invokes vault-ingress Step 1. Read-only phases may continue on schema 0, but
+and invokes `Skill(skill: "vault-ingress")` with Step 1 as the handoff context.
+Read-only phases may continue on schema 0, but
 publishing and post-event writes require schema 1 before their paired network,
-deck, image, or tracking side effects. Route schema 0 through vault-ingress first.
+deck, image, or tracking side effects. For schema 0, invoke
+`Skill(skill: "vault-ingress")` with a Step 1 migration handoff before continuing.
 
 Load from vault root: `rhetoric-style-summary.md` (constitution — all patterns),
 `slide-design-spec.md` (visual rules), `speaker-profile.json` (structured data).

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -176,6 +176,12 @@ path make the check before resolving the link.
      --output /path/to/qr.png --bg-color 128,0,128
    ```
 
+   The script is a non-owner dual reader and a current-schema writer. Dry-run
+   accepts legacy database schema 0 or current schema 1 without changing either.
+   A real run requires database schema 1 before URL-shortener calls, deck edits,
+   or tracking persistence. Route a legacy database through vault-ingress Step 1.
+   An unsupported future database or record version is no usable prior state.
+
 4. The script will:
    - Match the QR background color to the target slide (walks slide → layout → master
      for solid fill; falls back to white with a warning for theme-colored fills)
@@ -184,6 +190,8 @@ path make the check before resolving the link.
    - Insert the QR as a 2" square in the bottom-right corner
    - Persist schema-v1 QR metadata in `qr_codes[]` through the shared
      tracking-database transaction used by `generate-qr.py`
+   - Refuse a concurrent database generation and replace the verified current
+     database atomically
 
 5. Re-running for the same `talk_slug` with a different target URL will PATCH the
    existing short link (keeping QR codes already printed valid) rather than creating

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -14,6 +14,13 @@ Before ANY Phase 7 action, load these files. If any is missing, STOP and ask.
    Load via `scripts/outline_schema.py`.
 4. **YouTube video URL** — provided by the speaker at trigger time
 
+Read the tracking database through the main presentation-creator compatibility
+gate. Thumbnail and shownotes lookup may read schema 0 or 1. Any database update
+in this phase requires current database schema 1 and talk schema 5 before the
+thumbnail, shownotes, or video side effect paired with it. Route schema 0 through
+`Skill(skill: "vault-ingress")`; preserve all schema fields and apply the main
+skill's exact-generation atomic-write contract.
+
 If shownotes don't exist and the speaker wants Step 7.2, STOP and ask — either
 run Phase 6 Step 6.1 first, or get the shownotes URL manually.
 
@@ -90,6 +97,8 @@ The `expect` object must cover exactly the fields being set with values from the
 latest strict read. Dry-run, review, apply against the reported input SHA, and
 re-read through the
 [owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
+Keep that talk record at `schema_version: 5`; this workflow is an authorized
+current writer, not a schema owner or migrator.
 
 ---
 

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -35,12 +35,12 @@ import datetime
 import io
 import json
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import sys
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 try:
     import qrcode
@@ -65,6 +65,12 @@ VAULT_INGRESS_SCRIPTS = (
 if str(VAULT_INGRESS_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(VAULT_INGRESS_SCRIPTS))
 
+from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    QR_CODE_RECORD_SCHEMA_VERSION,
+    TrackingDatabaseError,
+    assess_tracking_database,
+    require_current_tracking_database,
+)
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
@@ -83,7 +89,6 @@ QR_ERROR_CORRECTION = ERROR_CORRECT_M
 # QR placement: bottom-right, 2 inches wide, 0.3 inch margin from edges
 QR_WIDTH_INCHES = 2.0
 QR_MARGIN_INCHES = 0.3
-QR_CODE_RECORD_SCHEMA_VERSION = 1
 
 # Existing-QR detection (content-based, size-independent). A QR is a SQUARE
 # picture that is BOTH essentially two colors AND roughly balanced between them:
@@ -158,8 +163,9 @@ def write_tracking_db(tracking_db_snapshot, tracking_db):
     """Commit QR metadata against the generation loaded before QR work."""
     snapshot = _require_tracking_db_snapshot(tracking_db_snapshot)
     try:
+        require_current_tracking_database(tracking_db)
         return write_json_object(snapshot, tracking_db)
-    except TrackingDatabaseIOError as exc:
+    except (TrackingDatabaseError, TrackingDatabaseIOError) as exc:
         raise ValueError(f"cannot safely update tracking database: {exc}") from exc
 
 
@@ -856,6 +862,21 @@ def main():
         tracking_db,
         tracking_db_snapshot,
     ) = load_vault_config(vault_path, args.profile)
+    if tracking_db_snapshot is not None:
+        try:
+            database_assessment = assess_tracking_database(tracking_db)
+        except TrackingDatabaseError as exc:
+            raise SystemExit(f"ERROR: cannot use tracking database: {exc}") from exc
+        if not database_assessment.usable:
+            raise SystemExit(
+                "ERROR: tracking database has no usable prior state for this reader: "
+                + ", ".join(database_assessment.reason_codes)
+            )
+        if not args.dry_run and database_assessment.state != "current":
+            raise SystemExit(
+                "ERROR: QR persistence requires the current tracking schema; run "
+                "vault-ingress migration before generating the short link"
+            )
     qr_config = speaker_profile.get("publishing_process", {}).get("qr_code", {})
     if not args.dry_run and vault_present_at_start:
         try:

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -65,6 +65,7 @@ VAULT_INGRESS_SCRIPTS = (
 if str(VAULT_INGRESS_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(VAULT_INGRESS_SCRIPTS))
 
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     QR_CODE_RECORD_SCHEMA_VERSION,
     TrackingDatabaseError,

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -12,7 +12,7 @@ user_invocable: true
 
 # Vault Clarification — Interactive Session
 
-Process the steps below in order; each step's output informs the next, and the first-session infrastructure capture in Step 4 gates profile generation downstream. Do not skip ahead.
+Process the steps below in order; each step's output informs the next, and the first-session infrastructure capture in Step 5 gates profile generation downstream. Do not skip ahead.
 
 Resolve the absolute path of this loaded `SKILL.md`, then set
 `speaker_toolkit_root` to the plugin root two directories above the directory
@@ -61,7 +61,34 @@ nothing. The canonical command and operation contract is in
 | [references/humor-post-mortem.md](references/humor-post-mortem.md) | Protocol for grading humor effectiveness |
 | [references/blind-spot-moments.md](references/blind-spot-moments.md) | Protocol for capturing audience/room data |
 
-## Step 1 — Rhetoric Clarification
+## Step 1 — Verify Tracking Schema
+
+Run the vault-ingress owner migration in dry-run mode before reading session
+state:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json"
+```
+
+Exit 0 writes one JSON object with `from_schema_version`,
+`to_schema_version`, `changed`, `database_written: false`, `input_sha256`, and
+`record_counts`. Continue only for `changed: false` at database schema v1. A
+legacy report requires the owner workflow; invoke `Skill(skill: "vault-ingress")`
+with the migration report as handoff context, then finish this clarification run.
+Exit 2 writes one error object to stdout plus an `ERROR:` diagnostic to stderr;
+stop without changing session state.
+
+Every tracking write in Steps 2–8 is current-only. Preserve database schema 1,
+config schema 1, talk schema 5, and every unrelated record. Stamp confirmed
+intents with schema 1 and new improvement goals with schema 2. Capture the exact
+input bytes immediately before each write, reject a changed generation, validate
+the complete current shape, and use a same-directory atomic replacement. Never
+turn this authorized writer into an implicit migrator.
+
+Proceed immediately to Step 2.
+
+## Step 2 — Rhetoric Clarification
 
 For each surprising, contradictory, or ambiguous observation, ask one topic at a time
 via `AskUserQuestion`: intentional vs accidental patterns, invisible context,
@@ -82,34 +109,34 @@ AskUserQuestion(
 )
 ```
 
-Proceed immediately to Step 2.
+Proceed immediately to Step 3.
 
-## Step 2 — Blind Spot Moments
+## Step 3 — Blind Spot Moments
 
 Follow [references/blind-spot-moments.md](references/blind-spot-moments.md) — ask about audience reactions,
 physical performance, and room context that transcripts cannot capture.
 
-Proceed immediately to Step 3.
+Proceed immediately to Step 4.
 
-## Step 3 — Humor Post-Mortem
+## Step 4 — Humor Post-Mortem
 
 Follow [references/humor-post-mortem.md](references/humor-post-mortem.md) — walk through detected humor beats,
 grade effectiveness, capture spontaneous material.
 
-Proceed immediately to Step 4.
+Proceed immediately to Step 5.
 
-## Step 4 — Speaker Infrastructure (first session only)
+## Step 5 — Speaker Infrastructure (first session only)
 
-If `config.clarification_sessions_completed` is already ≥ 1, skip this step — infrastructure was captured in the first session. Proceed immediately to Step 5.
+If `config.clarification_sessions_completed` is already ≥ 1, skip this step — infrastructure was captured in the first session. Proceed immediately to Step 6.
 
 Otherwise, ask for any empty config fields (`speaker_name` through `publishing_process.*`).
 See [references/schemas-config.md](references/schemas-config.md) for the full field list and questions to ask.
 Persist each confirmed answer with `set_config`, expecting the exact value observed
 by the latest strict read.
 
-Proceed immediately to Step 5.
+Proceed immediately to Step 6.
 
-## Step 5 — Structured Intent Capture
+## Step 6 — Structured Intent Capture
 
 Persist each confirmed intent with `upsert_confirmed_intent`, expecting either the
 exact existing record for that pattern or `{"$missing": true}`.
@@ -125,9 +152,9 @@ Example:
 ```
 See [references/schemas-config.md](references/schemas-config.md) for the full schema.
 
-Proceed immediately to Step 6.
+Proceed immediately to Step 7.
 
-## Step 6 — Set Improvement Goals
+## Step 7 — Set Improvement Goals
 
 Close the coaching loop. Review Section 15 of `rhetoric-style-summary.md` as narrative
 coaching context, plus any `regressed`/`stalled` goals from a prior session, then ask
@@ -189,17 +216,19 @@ Improvement Goal Verification.
 
 If Section 15 has no speaker-selected pattern target, or the validated profile has no
 non-empty matching raw-score-comparable current pattern cohort, say so and skip
-pattern goal-setting — proceed to Step 7. Independent pacing goals may still be
+pattern goal-setting — proceed to Step 8. Independent pacing goals may still be
 available.
 
-Proceed immediately to Step 7.
+Proceed immediately to Step 8.
 
-## Step 7 — Mark Session Complete
+## Step 8 — Mark Session Complete
 
 Using the latest strict read, persist
 `config.clarification_sessions_completed + 1` with `set_config`, expecting the
 exact prior integer. This counter gates profile generation (vault-profile skill
 requires >= 1).
+The owner mutation preserves `config.schema_version: 1` and every unrelated
+field.
 
 Finish here.
 

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -130,8 +130,8 @@ Proceed immediately to Step 5.
 
 ## Step 5 — Speaker Infrastructure (first session only)
 
-If `config.clarification_sessions_completed` is already ≥ 1, skip this step.
-Proceed immediately to Step 6.
+If `config.clarification_sessions_completed` is already ≥ 1, skip this step and
+proceed immediately to Step 6.
 
 Otherwise, ask for any empty config fields (`speaker_name` through `publishing_process.*`).
 See [references/schemas-config.md](references/schemas-config.md) for the full field list and questions to ask.

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -12,7 +12,10 @@ user_invocable: true
 
 # Vault Clarification — Interactive Session
 
-Process the steps below in order; each step's output informs the next, and the first-session infrastructure capture in Step 5 gates profile generation downstream. Do not skip ahead.
+Process steps in order. Do not skip ahead.
+
+Each step's output informs the next. The first-session infrastructure capture in
+Step 5 gates profile generation downstream.
 
 Resolve the absolute path of this loaded `SKILL.md`, then set
 `speaker_toolkit_root` to the plugin root two directories above the directory

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -130,7 +130,8 @@ Proceed immediately to Step 5.
 
 ## Step 5 — Speaker Infrastructure (first session only)
 
-If `config.clarification_sessions_completed` is already ≥ 1, skip this step — infrastructure was captured in the first session. Proceed immediately to Step 6.
+If `config.clarification_sessions_completed` is already ≥ 1, skip this step.
+Proceed immediately to Step 6.
 
 Otherwise, ask for any empty config fields (`speaker_name` through `publishing_process.*`).
 See [references/schemas-config.md](references/schemas-config.md) for the full field list and questions to ask.
@@ -219,7 +220,7 @@ Improvement Goal Verification.
 
 If Section 15 has no speaker-selected pattern target, or the validated profile has no
 non-empty matching raw-score-comparable current pattern cohort, say so and skip
-pattern goal-setting — proceed to Step 8. Independent pacing goals may still be
+pattern goal-setting. Proceed to Step 8. Independent pacing goals may still be
 available.
 
 Proceed immediately to Step 8.

--- a/skills/vault-clarification/references/schemas-config.md
+++ b/skills/vault-clarification/references/schemas-config.md
@@ -2,7 +2,7 @@
 
 ## Config Fields — Clarification Session Questions
 
-Fields below `template_skip_patterns` are asked during Step 4 (first session
+Fields below `template_skip_patterns` are asked during Step 5 (first session
 only) when empty. The question column shows what to ask the speaker.
 
 | Config field | Question |
@@ -74,8 +74,9 @@ artifact that closes the coaching loop: the speaker picks 1–2 focus areas, and
 later ingress run checks whether the targeted issue actually moved. Without it the
 system diagnoses but never verifies that the speaker acted.
 
-**Owner:** vault-clarification owns the record shape and migrations (it creates and
-retires goals during a session through `upsert_improvement_goal`). **Reader/updater:**
+**Artifact owner:** vault-ingress owns the tracking database, record shapes, and
+migrations. **Authorized writer:** vault-clarification creates and retires goals
+during a session through `upsert_improvement_goal`. **Reader/updater:**
 vault-ingress reads active goals and changes only the verification fields through
 `patch_improvement_goal_verification` (`status`, `current_value`,
 `last_checked`, `checked_by`, `verification_state`, `verification_reasons`) — never

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -51,6 +51,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/processing-rules.md](references/processing-rules.md) | Language policy, pattern migration logic, structured field rules |
 | [references/known-issues.md](references/known-issues.md) | Edge cases — wide-angle recordings, Whisper hallucination, non-speaker talks |
 | `skills/vault-ingress/scripts/persist-results.py` | Deterministically merge batch subagent returns into the tracking DB (Step 4) |
+| `skills/vault-ingress/scripts/migrate-tracking-database.py` | Owner-only tracking schema migration with hash precondition, backup, and atomic replacement (Step 1) |
 | `skills/vault-ingress/scripts/check-runtime.py` | Stdlib-only configured-interpreter and lane dependency probe |
 | `skills/vault-ingress/scripts/write-analysis.py` | Render per-talk `analyses/*.md` from persisted effective state authorized by the same batch returns (Step 4) |
 | `skills/vault-ingress/scripts/validate-returns.py` | Reject malformed schemas, statuses, scores, and catalog observations before either Step 4 writer runs |
@@ -98,8 +99,51 @@ files to shownotes entries.
    [references/schemas-db.md](references/schemas-db.md#owner-read-and-mutation-contract).
 2. **Path missing** — first-time setup: ask preferred location via `AskUserQuestion`,
    create the directory (and symlink if a custom path was chosen), then use a sole
-   `initialize_database` mutation. Review its dry-run and apply it with
-   `--expected-sha256 missing`; never create the JSON file directly.
+   `initialize_database` mutation. Include database `schema_version: 1`, config
+   `schema_version: 1`, and empty `talks`, `pptx_catalog`, `qr_codes`, `resources`,
+   `thumbnails`, `confirmed_intents`, and `improvement_goals` arrays. Review the
+   dry-run and apply it with `--expected-sha256 missing`; never create the JSON
+   file directly.
+
+**Schema gate** — vault-ingress owns the tracking database shape and migrations.
+The stdlib-only strict reader may use the host interpreter for the initial
+bootstrap read only. Read `config.python_path` from an existing database, or ask
+for the interpreter path without writing the database when that field is absent.
+Immediately re-read the same canonical path with that configured interpreter and
+require the same SHA-256; restart discovery if the generation changed. Use the
+configured interpreter for migration, queue commands, and every later toolkit
+command. Run the owner migration before any other database mutation:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json"
+```
+
+Exit 0 writes one dry-run JSON report with `input_sha256`, source and target
+schema versions, `output_sha256`, `record_counts`, `changed`,
+`database_written: false`, `warnings`, and the deterministic backup path. A
+changed report authorizes this exact apply command:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" --apply --expected-sha256 "{input_sha256}"
+```
+
+Exit 0 from apply writes one JSON report with `database_written: true`, preserves
+the complete original bytes under `{vault_root}/.backups/`, and atomically
+installs database schema v1. A non-empty `warnings` array means replacement
+completed with a durability warning and must not be reported as a failed/no-write
+run. Exit 2 writes one error object to stdout plus a diagnostic to stderr and
+leaves the database unchanged. Recover or
+complete every active queue claim named by the diagnostic. For an unversioned
+database, use `queue-state.py ... inspect` to identify the lease and
+`queue-state.py ... recover` to close it. Those two commands accept schema 0;
+recovery changes only queue-lease/status state and does not stamp or migrate the
+database or talk record. The existing queue transition may advance a recovered
+legacy claim receipt from schema v1 to v2 while adding its release fields. Rerun
+migration dry-run, then apply its new exact digest. Do not copy a digest across
+runs. `queue-state.py ... normalize` and `queue-state.py ... claim` require
+database schema 1.
 
 **Config bootstrapping** — ask once per missing field and persist to the tracking
 database with expectation-bound `set_config` mutations. Re-read after every
@@ -119,6 +163,12 @@ runtime with the shipped stdlib-only checker:
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
   --lanes core,pdf,pptx
 ```
+
+All owner-authored tracking writes below require database schema 1 after this
+gate. Preserve every independent record version and validate the complete
+candidate before installing it. Only `migrate-tracking-database.py` may move
+schema 0 to schema 1; its hash precondition binds replacement to the exact input
+bytes as documented above.
 
 Core requires Python 3.10+ and PyYAML and is blocking. The PDF and PPTX lanes
 require pypdf and python-pptx respectively; a missing optional lane is reported
@@ -158,8 +208,8 @@ atomic and rejects a tracking-database symlink. See
 [references/schemas-db.md](references/schemas-db.md#shownotes-scanimport-report)
 for the complete report and mutation contract.
 
-**Scan for .pptx files:** Recursively glob `**/*.pptx` in `pptx_source_dir`; fuzzy-match
-to `talks[]` entries. Report counts, then persist each reviewed result with a
+**Scan for .pptx files:** Recursively glob `**/*.pptx` in `pptx_source_dir`;
+fuzzy-match to `talks[]` entries. Report counts, then persist each reviewed result with a
 `record_pptx` mutation and `schema_version: 1`, including the exact prior catalog record and, for a match,
 the talk's exact prior `pptx_path` expectation. See [references/schemas-db.md](references/schemas-db.md)
 for the PPTX extraction output schema (per-slide visual data, shape types, global design stats).
@@ -436,7 +486,8 @@ phase). Mechanical persistence of the batch's subagent JSON returns:
   `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/persist-results.py" {vault_root}/tracking-database.json batch-returns.json`.
   The script first requires the return filenames to equal every live member of one
   run/batch claim; partial, extra, mixed-identity, duplicate, closed, or stranded
-  batches fail before migration or merge. It then merges each return into its matching
+  batches fail before merge. The script requires database schema v1 and current
+  independent record versions; Step 1 is the sole migration path. It then merges each return into its matching
   talk entry, promotes the declared queryable scalars to the talk top level, and
   rewrites the DB in place. Do NOT hand-copy fields one at a time — that is what
   dropped structured data before (it was computed and reached the analysis files
@@ -489,7 +540,7 @@ phase). Mechanical persistence of the batch's subagent JSON returns:
   interrupted batch is recovered with
   `queue-state.py ... recover --now <ISO> --stale-after-seconds <N>`, not by
   replaying whichever old return files happen to exist.
-  Future talk-record schemas are rejected before migration so this writer never
+  Future talk-record schemas are rejected before merge so this writer never
   stamps a newer record down to its current version. Pass the canonical tracking
   DB path: queue and persistence tools reject a final-component symlink before
   opening it, preventing atomic replacement from splitting the link and target.
@@ -613,10 +664,10 @@ Proceed immediately to Step 8.
 
 ## Step 8 — Verify Improvement Goals
 
-If the tracking DB has no `improvement_goals` in a verifiable state (none whose
-`status` is outside `achieved`/`retired`), skip this step silently. Otherwise, with the
-post-batch full-cohort pattern baseline current, pass the complete active-goal array
-and that structured baseline to:
+If the tracking DB has no active `improvement_goals` (none whose `status` is
+outside `achieved`/`retired`), skip this step silently. Otherwise, with the
+post-batch full-cohort pattern baseline current, pass the complete active-goal
+array and that structured baseline to:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-clarification/scripts/goal_generation_provenance.py" \
@@ -625,15 +676,32 @@ and that structured baseline to:
 
 The input object contains `goals` and `current_pattern_baseline`; stdout is one
 schema-v1 assessment per goal. Exit 1 is a malformed owner record or baseline:
-stop without changing any goal. Only a `comparable` assessment authorizes metric
-calculation. Record `needs_rebaseline` for a pattern-generation mismatch and
-`unverifiable` for a missing current baseline or legacy pattern goal; preserve its
-`current_value` and do not assign an outcome status. Pacing and independent goals
-remain comparable through their separate provenance lanes. Persist each assessment
-with a `patch_improvement_goal_verification` mutation whose `expect` object exactly
-matches every verification field being set. Dry-run the complete plan, review it,
-apply it against the reported input SHA, then re-read the database. The full write rubric
-is in [references/processing-rules.md](references/processing-rules.md) Improvement
+stop before constructing a mutation plan and change no goal. Require exactly one
+assessment for every active goal before calculating or writing anything. Only a
+`comparable` assessment authorizes metric calculation.
+
+Apply the assessment according to the stored goal record schema; never restamp a
+legacy goal:
+
+- A schema-v1 `antipattern` or `underuse` goal is report-only
+  `unverifiable`. Preserve the complete record and create no mutation for it.
+- A schema-v1 `pacing` or `other` goal may be comparable through its independent
+  provenance lane. For a comparable goal, patch only `current_value`,
+  `last_checked`, `checked_by`, and `status`; never add `verification_state` or
+  `verification_reasons`. A non-comparable assessment is report-only.
+- A schema-v2 goal uses the full verification contract. Persist
+  `needs_rebaseline` or `unverifiable` in `verification_state` with the exact
+  assessment reasons while preserving `current_value` and `status`. For a
+  comparable goal, persist the calculated metric, check metadata, outcome status,
+  `verification_state: "current"`, and empty `verification_reasons`.
+
+For every mutation, `expect` must contain exactly the fields being set with the
+values from the latest strict read. If no assessment authorizes a write, do not
+invoke the mutator. Otherwise dry-run the complete multi-goal plan as one
+transaction, review it, apply it against the reported input SHA, then re-read the
+database; one failed assessment or mutation precondition must never leave a
+partial goal update. The full write rubric is in
+[references/processing-rules.md](references/processing-rules.md) Improvement
 Goal Verification. Report current comparable outcomes first, then every goal that
 needs rebaselining or is unverifiable.
 

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -402,17 +402,25 @@ Before calculating any metric, run
 `"{python_path}" "{speaker_toolkit_root}/skills/vault-clarification/scripts/goal_generation_provenance.py"` with the complete
 active-goal array and the structured post-batch full-cohort pattern baseline. The
 script emits one assessment with a stable `decision` and `reason_codes` per goal;
-exit 1 blocks all goal writes. It is the sole authority for generation
+exit 1 blocks all goal writes. Require exactly one assessment for every active
+goal before constructing a mutation plan. It is the sole authority for generation
 comparability—do not reproduce its fingerprint/schema predicate and never parse
 Section 15 prose as its baseline.
 
 - A `comparable` assessment authorizes the metric and outcome rubric below.
-- For `needs_rebaseline` or `unverifiable`, copy the assessment decision to
-  `verification_state` and its codes to `verification_reasons`. In either case,
-  preserve `current_value` and must not set `status` to
-  `achieved`, `improving`, `stalled`, or `regressed`. A speaker-confirmed
-  rebaseline is owned by vault-clarification; ingress never restamps the fixed
-  baseline.
+- A schema-v1 `antipattern` or `underuse` goal is historical, report-only
+  `unverifiable`. Preserve the complete record and do not create a mutation for
+  it.
+- A schema-v1 `pacing` or `other` goal may remain comparable through its
+  independent provenance lane. If comparable, patch only `current_value`,
+  `last_checked`, `checked_by`, and `status`. Never add `verification_state` or
+  `verification_reasons` to a schema-v1 record. A non-comparable assessment is
+  report-only.
+- For a schema-v2 `needs_rebaseline` or `unverifiable` assessment, copy the
+  decision to `verification_state` and its codes to `verification_reasons`.
+  In either case, preserve `current_value` and must not set `status` to
+  `achieved`, `improving`, `stalled`, or `regressed`. A speaker-confirmed rebaseline is owned by
+  vault-clarification; ingress never restamps the fixed baseline.
 - Pacing and independent goals continue through their own provenance lanes and
   are not invalidated by a pattern-catalog generation change.
 
@@ -422,9 +430,11 @@ For each comparable goal with `status` not in (`achieved`, `retired`):
   speaker profile (this step runs after Step 7, so `pacing.adherence` and
   `pattern_profile.by_mode` are current). Examples by `kind`: `antipattern` → the
   antipattern's frequency over recent talks; `underuse` → the pattern's recent usage
-  or distinct-pattern breadth; `pacing` → `pacing.adherence.over_budget_rate`. Write
-  `current_value`, `last_checked` (today), `checked_by: "vault-ingress"`,
-  `verification_state: "current"`, and empty `verification_reasons`.
+  or distinct-pattern breadth; `pacing` → `pacing.adherence.over_budget_rate`.
+  For schema v1, write only `current_value`, `last_checked` (today),
+  `checked_by: "vault-ingress"`, and `status`. For schema v2, write those
+  fields plus `verification_state: "current"` and empty
+  `verification_reasons`.
 - Set `status` by comparing `current_value` against `baseline_value` and `target`:
   - `achieved` — `current_value` meets or beats `target`.
   - `improving` — moved toward `target` versus `baseline_value` but not there yet.
@@ -433,7 +443,16 @@ For each comparable goal with `status` not in (`achieved`, `retired`):
 - Only count talks processed after `set_date` toward movement — a goal can't
   be judged on talks that predate it.
 - Never overwrite `baseline_value`, `target`, `issue`, or `set_date` — those are the
-  fixed yardstick; verification is non-owner and touches status fields only.
+  fixed yardstick; the verification writer changes only the schema-authorized
+  verification and status fields above.
+
+Use one `patch_improvement_goal_verification` mutation per writable assessment.
+Each mutation's `expect` object must contain exactly the fields it sets with the
+values from the latest strict read. If every assessment is report-only, do not
+invoke the mutator. Otherwise dry-run the complete multi-goal plan, review it,
+apply the whole plan against the reported input SHA, and re-read the database.
+An assessment failure, malformed plan, stale expectation, or changed database
+generation installs no partial goal update.
 
 Report each goal's status in the run summary. A `regressed` or `stalled` goal is the
 strongest signal to surface — it is the speaker's own priority, not a machine-chosen

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -5,6 +5,83 @@
 The tracking database (`tracking-database.json`) is the single source of truth.
 Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
 
+**Owner:** vault-ingress owns the artifact shape, every independent record
+shape, and all migrations. vault-clarification may write current config,
+confirmed-intent, and improvement-goal records. presentation-creator may write
+current QR records. vault-profile and the remaining presentation consumers are
+read-only. Non-owner readers accept legacy database schema 0 and current schema
+1 during rollout. They never rewrite legacy state. An unsupported future
+database or record version is no usable prior state.
+
+The independently versioned records are the database root, `config`, each
+`talks[]`, `pptx_catalog[]`, `qr_codes[]`, `resources[]`, `thumbnails[]`,
+`confirmed_intents[]`, `improvement_goals[]`, and
+`talks[].source_rejections[]`. Queue claims, source identities, adherence
+baselines, and evidence ledgers retain their existing domain schema fields.
+Objects embedded inside a versioned record are part of that containing record
+unless this reference declares a separate schema.
+
+Current constants live in
+`skills/vault-ingress/scripts/tracking_database.py`. Database schema 0 is the
+implicit unversioned corpus. Within that root, a missing talk version is the
+historical talk schema v1, not a request to synthesize v5 evidence; missing
+config, PPTX, QR, resource, thumbnail, confirmed-intent, source-rejection, and
+goal versions likewise map only to their validated historical v1 shapes. Run the
+owner migration in vault-ingress Step 1.
+Dry-run emits the exact input SHA-256. Apply requires that digest, refuses active
+queue claims, stores the complete original bytes under `.backups/`, and replaces
+the verified generation atomically. Backup directory and file opens do not
+follow symbolic links. The writer repeats its byte-and-file-generation check
+after staging and immediately before replacement. A current schema-v1 database
+is an idempotent no-op. Before migration, queue `inspect` may read schema 0 and
+queue `recover` may close an active schema-0 lease in place. Recovery changes
+only queue lease/status state and never stamps database or talk schema fields;
+the established queue transition may advance a recovered claim receipt from v1
+to v2 while adding its release fields.
+
+The schema-0 migration is a preservation migration. Its only allowed semantic
+changes are adding root schema v1, adding the validated historical version to an
+unversioned owner record, and creating absent owned arrays as empty arrays. It
+preserves every other JSON value and missing-vs-present distinction, including
+legacy-v1 `pattern_observations` objects, arrays, or nulls and every historical
+citation/source-inspection field. Explicit version 0 sentinels, future owner
+versions, ambiguous or malformed historical records, and active claims fail
+before backup or write. An exact current database is a byte-and-inode-preserving
+no-op.
+
+| Independent record | Current schema |
+|---|---:|
+| database root | 1 |
+| config | 1 |
+| talk | 5 |
+| PPTX catalog | 1 |
+| QR code | 1 |
+| resource summary | 1 |
+| thumbnail | 1 |
+| confirmed intent | 1 |
+| source rejection | 1 |
+| improvement goal | 2 (schema 1 remains readable historical state) |
+
+| Component | Access | Contract |
+|---|---|---|
+| vault-ingress migration | owner read/write | Accept schema 0 or 1; migrate 0 exactly once; never downgrade future state |
+| vault-ingress queue inspection/recovery | owner compatibility transition | Inspect schema 0/1; recover active leases in schema 0/1; never stamp artifact or talk schema versions |
+| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 1 plus supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
+| vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0 and 1; gate through existing finding/error channels; never rewrite |
+| vault-clarification | current read/write | Route schema migration to vault-ingress; stamp config v1, confirmed intent v1, improvement goal v2 |
+| presentation-creator QR writer | dual reader/current writer | Read schemas 0 and 1; require schema 1 before URL creation or QR metadata persistence; stamp QR v1 |
+| presentation-creator publishing/post-event | authorized current writer | Require schema 1 before tracking writes; stamp resource v1 and preserve talk v5 |
+| illustrations thumbnail workflow | authorized current writer | Require schema 1 before tracking writes; stamp thumbnail v1 and preserve talk v5 |
+| vault-profile | dual reader | Parse schemas 0 and 1; treat unsupported generations as unavailable; never migrate |
+
+Current database schema 1 requires all eight top-level state fields shown below.
+Missing legacy arrays become empty during owner migration. Current writers do
+not create them opportunistically. A schema-v1 improvement goal remains valid
+historical state; migration never fabricates the schema-v2 baseline provenance
+needed for current pattern-goal verification. Talks v1-v5 remain readable under
+the current root and are promoted only when the talk-domain writer legitimately
+persists that exact talk.
+
 ```json
 {
   "schema_version": 1,
@@ -48,6 +125,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
     },
     "source_relation": {"type": "duplicate|borrowed_recording", "target_filename": "canonical-talk.md"},
     "source_rejections": [{
+      "schema_version": 1,
       "source_type": "video|slides", "url": "known-bad upstream URL",
       "reason": "non_delivery_clip|wrong_delivery|unrelated_recording",
       "evidence": "how the rejection was verified",
@@ -132,7 +210,7 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
       "not_evaluable": []
     }
   }],
-  "_comment_schema_version": "Talk-record schema version, stamped by persist-results.py. v1 is the implicit unversioned shape. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, evidence ledger v2, and current scoring schema v5. Migration preserves v1-v4 evidence and never synthesizes v5 outcomes.",
+  "_comment_schema_version": "Database schema v1 is owner-migrated by vault-ingress. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, evidence ledger v2, and current scoring schema v5. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "schema_version": 1,
@@ -154,7 +232,32 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
     "created_at": "2026-04-15",
     "updated_at": "2026-04-15"
   }],
-  "confirmed_intents": [],
+  "resources": [{
+    "schema_version": 1,
+    "talk_slug": "arc-of-ai",
+    "item_count": 12,
+    "category_breakdown": {"urls": 7, "repos": 3, "books_papers": 2}
+  }],
+  "thumbnails": [{
+    "schema_version": 1,
+    "talk_slug": "arc-of-ai",
+    "youtube_url": "https://youtube.com/watch?v=dQw4w9WgXcQ",
+    "source_slide_num": 15,
+    "speaker_photo_used": "photos/speaker-headshot.png",
+    "thumbnail_path": "illustrations/thumbnail.png",
+    "shownotes_thumbnail_path": "assets/images/thumbnails/arc-of-ai-thumbnail.png",
+    "dimensions": "1280x720",
+    "file_size_kb": 185,
+    "created_at": "2026-04-20",
+    "approved": true
+  }],
+  "confirmed_intents": [{
+    "schema_version": 1,
+    "pattern": "delayed_self_introduction",
+    "intent": "deliberate",
+    "rule": "Use two-phase introduction",
+    "note": "Speaker-confirmed intent"
+  }],
   "improvement_goals": []
 }
 ```
@@ -170,13 +273,20 @@ through the owner command:
 ```
 
 The command accepts only a no-follow regular file and strictly decodes one UTF-8
-JSON object. Duplicate keys at any depth, non-finite numbers, invalid JSON, and
-non-object roots fail closed. Success returns report schema v1 with
+JSON object. Duplicate keys at any depth, non-finite numbers, finite numbers that
+cannot round-trip through the toolkit without changing mathematical value,
+nesting deeper than 200 JSON containers, unpaired UTF-16 surrogate escapes,
+invalid JSON, and non-object roots fail closed. After decoding, owner schema
+assessment is the first semantic operation: an unsupported root, record,
+queue-claim, or adherence-baseline generation returns no database payload and is
+never interpreted with an older identity or nested shape. Success returns report schema v1 with
 `database_path`, the exact-byte `sha256`, and `database`; failure exits `2` with
-`ok: false` and no database value. During first-time initialization or while
-setting an absent `config.python_path`, the host Python may run the stdlib-only
-owner read/mutation commands. Re-read immediately after setting it. All later
-commands use that exact configured interpreter.
+`ok: false` and no database value. The host Python may run only this stdlib-only
+bootstrap read until `config.python_path` is discovered or supplied by the user.
+Immediately repeat the read against the same canonical path with that configured
+interpreter and require the same SHA-256; restart if the generation changed. Use
+the configured interpreter for initialization, migration, queue recovery, typed
+mutation, and every later toolkit command.
 
 Agent-owned config and catalog changes use a typed plan:
 
@@ -196,6 +306,9 @@ Every plan is strict JSON with exactly `schema_version` and a non-empty
 `mutations` array. Every expectation is either the exact decoded value/record
 seen by the owner reader or the exact missing marker `{"$missing": true}`. JSON
 `null` is a present value and is never interchangeable with that marker.
+The plan decoder applies the same finite-number round-trip, 200-container depth,
+and Unicode-scalar gates as the database decoder, so a reviewed value cannot
+silently change or fail later during rendering.
 Equality is recursive JSON equality: object key order is irrelevant, array order
 is significant, and booleans, integers, and decimals are distinct types. Thus
 `true`, `1`, and `1.0` never satisfy one another, and `{"$missing": 1}` is an
@@ -430,9 +543,9 @@ its source locations and evidence ledger v1 but migration never fabricates v5
 applicability assessments, outcomes, or opportunity identity.
 
 `improvement_goals` is the coaching-loop artifact — speaker-chosen focus areas that
-a later ingress run verifies. vault-clarification owns the record shape; vault-ingress
-writes only the verification fields. Record schema, lifecycle, and owner/reader
-contract:
+a later ingress run verifies. vault-ingress owns the record shape and migrations;
+vault-clarification creates and retires current records. Ingress verification writes
+only the verification fields. Record schema, lifecycle, and writer/reader contract:
 [../../vault-clarification/references/schemas-config.md](../../vault-clarification/references/schemas-config.md)
 Improvement Goals Schema. Verification rubric: [processing-rules.md](processing-rules.md)
 Improvement Goal Verification.
@@ -1016,7 +1129,7 @@ closed field sets; unknown model-supplied fields are rejected.
 `evidence_metadata_fields`; generated prose such as `rhetoric_notes` cannot cite
 itself, and an irrelevant metadata field cannot stand in for pattern evidence.
 
-Migrated v1–v3 records may contain `evidence_citations: []`. That is a deliberate
+Historical v1–v3 records may contain `evidence_citations: []`. That is a deliberate
 legacy marker: readers may render the old `evidence` prose, but must not present
 it as source-verified. The v4/v5 writer never accepts an empty array for a new
 detection. `evidence_schema_version` is writer-owned persisted state; workers

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -155,6 +155,7 @@ the decision on the talk so a later scan cannot reintroduce it:
 ```json
 {
   "source_rejections": [{
+    "schema_version": 1,
     "source_type": "video",
     "url": "https://youtu.be/AbCdEfGhI_1",
     "reason": "non_delivery_clip",

--- a/skills/vault-ingress/scripts/apply-source-repairs.py
+++ b/skills/vault-ingress/scripts/apply-source-repairs.py
@@ -34,6 +34,10 @@ from pathlib import Path
 import sys
 from typing import Any
 
+from tracking_database import (
+    TrackingDatabaseError,
+    require_current_tracking_database,
+)
 from tracking_database_io import (
     BackupRequest,
     TrackingDatabaseIOError,
@@ -294,6 +298,10 @@ def execute(
     backup_dir: Path | None = None,
 ) -> dict[str, Any]:
     database, database_snapshot = load_database(database_path)
+    try:
+        require_current_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        raise SourceRepairError(str(exc)) from exc
     plan, _ = load_object(plan_path, "repair plan")
     repairs = validate_plan(plan)
     repaired, changes = build_repaired_database(database, repairs)
@@ -309,6 +317,12 @@ def execute(
     database_written = False
     durability_state = "dry_run"
     warnings: list[str] = []
+    try:
+        require_current_tracking_database(repaired)
+    except TrackingDatabaseError as exc:
+        raise SourceRepairError(
+            f"repair would violate the current tracking schema: {exc}"
+        ) from exc
     if apply:
         target_backup_dir = backup_dir or database_path.parent / ".backups"
         backup_request = BackupRequest(

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -28,6 +28,10 @@ from source_identity_matching import (
     normalized_words,
     titles_agree,
 )
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
 from tracking_database_io import (
     TrackingDatabaseIOError,
     decode_json_object,
@@ -52,6 +56,8 @@ ERROR_CODES = frozenset({
     "provider_webpage_identity_mismatch",
     "talk_shape_invalid",
     "talks_shape_invalid",
+    "tracking_database_schema_invalid",
+    "tracking_database_schema_unsupported",
 })
 
 
@@ -371,24 +377,56 @@ def audit_database(
     sources: list[dict[str, Any]] = []
     groups: defaultdict[str, list[tuple[int, dict[str, Any]]]] = defaultdict(list)
 
+    talks: list[Any] = []
     if not isinstance(database, dict):
         findings.append(_finding(
             "database_shape_invalid", None, [], [],
             "tracking database must be a JSON object",
             {"actual": type(database).__name__}, "high",
         ))
-        talks: list[Any] = []
     else:
-        raw_talks = database.get("talks")
-        if not isinstance(raw_talks, list):
-            findings.append(_finding(
-                "talks_shape_invalid", None, [], [],
-                "tracking database talks must be an array",
-                {"actual": type(raw_talks).__name__}, "high",
-            ))
+        try:
+            assessment = assess_tracking_database(database)
+        except TrackingDatabaseError as exc:
+            findings.append(
+                _finding(
+                    "tracking_database_schema_invalid",
+                    None,
+                    [],
+                    [],
+                    str(exc),
+                    {},
+                    "high",
+                )
+            )
             talks = []
         else:
-            talks = raw_talks
+            if not assessment.usable:
+                findings.append(
+                    _finding(
+                        "tracking_database_schema_unsupported",
+                        None,
+                        [],
+                        [],
+                        "tracking database is not usable by this reader",
+                        {
+                            "schema_version": assessment.schema_version,
+                            "reason_codes": list(assessment.reason_codes),
+                        },
+                        "high",
+                    )
+                )
+                talks = []
+            else:
+                raw_talks = database.get("talks")
+                if not isinstance(raw_talks, list):
+                    findings.append(_finding(
+                        "talks_shape_invalid", None, [], [],
+                        "tracking database talks must be an array",
+                        {"actual": type(raw_talks).__name__}, "high",
+                    ))
+                else:
+                    talks = raw_talks
 
     event_aliases = known_event_aliases(talks)
 

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+from tracking_database import TALK_RECORD_SCHEMA_VERSION
 
-TALK_SCHEMA_VERSION = 5
+TALK_SCHEMA_VERSION = TALK_RECORD_SCHEMA_VERSION
 TRANSCRIPT_ARTIFACT_FIELDS = ("transcript_path",)
 PDF_SOURCE_FIELDS = (
     "slides_url",

--- a/skills/vault-ingress/scripts/migrate-tracking-database.py
+++ b/skills/vault-ingress/scripts/migrate-tracking-database.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Migrate one tracking database with a hash precondition and exact backup."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+from typing import NoReturn
+
+from tracking_database import (
+    TrackingDatabaseError,
+    migrate_tracking_database,
+)
+from tracking_database_io import (
+    BackupRequest,
+    TrackingDatabaseIOError,
+    commit_tracking_database,
+    decode_json_object,
+    render_json_object,
+    snapshot_tracking_database,
+)
+
+
+REPORT_SCHEMA_VERSION = 1
+
+
+class TrackingDatabaseMigrationError(ValueError):
+    """Migration input or filesystem state failed a precondition."""
+
+
+class JsonArgumentParser(argparse.ArgumentParser):
+    """Route command-line mistakes through the JSON error contract."""
+
+    def error(self, message: str) -> NoReturn:
+        raise TrackingDatabaseMigrationError(f"invalid arguments: {message}")
+
+
+def _backup_path(path: Path, digest: str) -> Path:
+    return path.parent / ".backups" / f"{path.name}.schema-v0-{digest}.bak"
+
+
+def _validate_expected_digest(value: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise TrackingDatabaseMigrationError(
+            "--expected-sha256 must be a 64-character lowercase hexadecimal digest"
+        )
+
+
+def execute(
+    path: Path,
+    *,
+    apply: bool,
+    expected_sha256: str | None,
+) -> dict[str, object]:
+    database_path = path.expanduser().absolute()
+    if expected_sha256 is not None:
+        _validate_expected_digest(expected_sha256)
+    if apply and expected_sha256 is None:
+        raise TrackingDatabaseMigrationError(
+            "--apply requires --expected-sha256 from a dry-run report"
+        )
+
+    try:
+        snapshot = snapshot_tracking_database(database_path)
+        database = decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
+        raise TrackingDatabaseMigrationError(str(exc)) from exc
+    database_path = snapshot.path
+    if expected_sha256 is not None and expected_sha256 != snapshot.sha256:
+        raise TrackingDatabaseMigrationError(
+            "input sha256 precondition failed: "
+            f"expected {expected_sha256}, found {snapshot.sha256}"
+        )
+
+    try:
+        migration = migrate_tracking_database(database)
+        rendered = (
+            render_json_object(migration.database)
+            if migration.changed
+            else snapshot.raw
+        )
+    except (TrackingDatabaseError, TrackingDatabaseIOError) as exc:
+        raise TrackingDatabaseMigrationError(str(exc)) from exc
+
+    predicted_backup = (
+        _backup_path(database_path, snapshot.sha256) if migration.changed else None
+    )
+    output_sha256 = hashlib.sha256(rendered).hexdigest()
+    database_written = False
+    durability_state = "dry_run"
+    warnings: list[str] = []
+    reported_backup = str(predicted_backup) if predicted_backup is not None else None
+
+    if apply:
+        backup_request = (
+            BackupRequest(
+                path=predicted_backup,
+                input_sha256=snapshot.sha256,
+            )
+            if predicted_backup is not None
+            else None
+        )
+        try:
+            result = commit_tracking_database(
+                snapshot,
+                rendered,
+                backup=backup_request,
+            )
+        except TrackingDatabaseIOError as exc:
+            raise TrackingDatabaseMigrationError(str(exc)) from exc
+        output_sha256 = result.output_sha256
+        database_written = result.installed
+        durability_state = result.durability_state
+        warnings = list(result.warnings)
+        reported_backup = result.backup
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "ok": True,
+        "mode": "apply" if apply else "dry-run",
+        "database": str(database_path),
+        "input_sha256": snapshot.sha256,
+        "from_schema_version": migration.from_schema_version,
+        "to_schema_version": migration.to_schema_version,
+        "changed": migration.changed,
+        "database_written": database_written,
+        "backup": reported_backup,
+        "output_sha256": output_sha256,
+        "record_counts": dict(migration.record_counts),
+        "durability_state": durability_state,
+        "warnings": warnings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = JsonArgumentParser(description=__doc__)
+    parser.add_argument("database", type=Path)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--expected-sha256")
+    try:
+        args = parser.parse_args(argv)
+        report = execute(
+            args.database,
+            apply=args.apply,
+            expected_sha256=args.expected_sha256,
+        )
+    except TrackingDatabaseMigrationError as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "ok": False,
+                    "error": str(exc),
+                }
+            )
+        )
+        print(f"tracking-database migration failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -20,10 +20,29 @@ import re
 import sys
 from typing import Any, NoReturn
 
+from tracking_database import (
+    CONFIG_RECORD_SCHEMA_VERSION,
+    CONFIRMED_INTENT_OPTIONAL_FIELDS,
+    CONFIRMED_INTENT_RECORD_SCHEMA_VERSION,
+    CONFIRMED_INTENT_REQUIRED_FIELDS as OWNER_CONFIRMED_INTENT_REQUIRED_FIELDS,
+    IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+    IMPROVEMENT_GOAL_REQUIRED_FIELDS as OWNER_IMPROVEMENT_GOAL_REQUIRED_FIELDS,
+    PPTX_CATALOG_RECORD_SCHEMA_VERSION,
+    PPTX_CATALOG_REQUIRED_FIELDS,
+    RESOURCE_RECORD_SCHEMA_VERSION,
+    RESOURCE_REQUIRED_FIELDS as OWNER_RESOURCE_REQUIRED_FIELDS,
+    THUMBNAIL_RECORD_SCHEMA_VERSION,
+    THUMBNAIL_REQUIRED_FIELDS as OWNER_THUMBNAIL_REQUIRED_FIELDS,
+    TALK_RECORD_SCHEMA_VERSION,
+    TRACKING_DATABASE_SCHEMA_VERSION,
+    TrackingDatabaseError,
+    require_current_tracking_database,
+)
 from tracking_database_io import (
     TrackingDatabaseIOError,
     commit_tracking_database,
     decode_json_object,
+    decode_json_object_bytes,
     initialize_tracking_database,
     json_values_equal,
     render_json_object,
@@ -32,9 +51,16 @@ from tracking_database_io import (
 
 
 PLAN_SCHEMA_VERSION = 1
-OWNER_RECORD_SCHEMA_VERSION = 1
-TRACKING_DATABASE_SCHEMA_VERSION = 1
-CONFIG_RECORD_SCHEMA_VERSION = 1
+OWNER_RECORD_SCHEMA_VERSION = CONFIRMED_INTENT_RECORD_SCHEMA_VERSION
+if len(
+    {
+        OWNER_RECORD_SCHEMA_VERSION,
+        PPTX_CATALOG_RECORD_SCHEMA_VERSION,
+        RESOURCE_RECORD_SCHEMA_VERSION,
+        THUMBNAIL_RECORD_SCHEMA_VERSION,
+    }
+) != 1:
+    raise RuntimeError("typed owner collection versions require per-kind validation")
 MISSING_MARKER = {"$missing": True}
 COLLECTION_IDENTITIES = {
     "upsert_confirmed_intent": ("confirmed_intents", "pattern"),
@@ -65,68 +91,16 @@ GOAL_VERIFICATION_FIELDS = frozenset(
         "verification_reasons",
     }
 )
-GOAL_REQUIRED_FIELDS = frozenset(
-    {
-        "id",
-        "schema_version",
-        "issue",
-        "kind",
-        "antipattern_id",
-        "metric",
-        "baseline_value",
-        "target",
-        "set_date",
-        "set_by",
-        "status",
-        "current_value",
-        "last_checked",
-        "checked_by",
-        "verification_state",
-        "verification_reasons",
-        "supersedes_goal_id",
-        "baseline_provenance",
-    }
+LEGACY_GOAL_VERIFICATION_FIELDS = frozenset(
+    {"status", "current_value", "last_checked", "checked_by"}
 )
-CONFIRMED_INTENT_REQUIRED_FIELDS = frozenset(
-    {"schema_version", "pattern", "intent", "rule", "note"}
-)
-CONFIRMED_INTENT_OPTIONAL_FIELDS = frozenset(
-    {
-        "confirmed_date",
-        "source_talk",
-        "source_talks",
-        "talk",
-        "retrofit_targets",
-    }
-)
-RESOURCE_REQUIRED_FIELDS = frozenset(
-    {"schema_version", "talk_slug", "item_count", "category_breakdown"}
-)
-PPTX_REQUIRED_FIELDS = frozenset(
-    {
-        "schema_version",
-        "pptx_path",
-        "talk_filename",
-        "matched",
-        "slide_count",
-        "visual_extracted",
-    }
-)
-THUMBNAIL_REQUIRED_FIELDS = frozenset(
-    {
-        "schema_version",
-        "talk_slug",
-        "youtube_url",
-        "source_slide_num",
-        "speaker_photo_used",
-        "thumbnail_path",
-        "shownotes_thumbnail_path",
-        "dimensions",
-        "file_size_kb",
-        "created_at",
-        "approved",
-    }
-)
+GOAL_REQUIRED_FIELDS = OWNER_IMPROVEMENT_GOAL_REQUIRED_FIELDS | {"schema_version"}
+CONFIRMED_INTENT_REQUIRED_FIELDS = OWNER_CONFIRMED_INTENT_REQUIRED_FIELDS | {
+    "schema_version"
+}
+RESOURCE_REQUIRED_FIELDS = OWNER_RESOURCE_REQUIRED_FIELDS | {"schema_version"}
+PPTX_REQUIRED_FIELDS = PPTX_CATALOG_REQUIRED_FIELDS | {"schema_version"}
+THUMBNAIL_REQUIRED_FIELDS = OWNER_THUMBNAIL_REQUIRED_FIELDS | {"schema_version"}
 class TrackingDatabaseMutationError(ValueError):
     """A mutation plan, precondition, or database shape is invalid."""
 
@@ -137,40 +111,14 @@ class _ArgumentParser(argparse.ArgumentParser):
 
 
 def _strict_json_object(raw: bytes, path: Path, label: str) -> dict[str, Any]:
-    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-        result: dict[str, Any] = {}
-        for key, value in pairs:
-            if key in result:
-                raise TrackingDatabaseMutationError(
-                    f"{label} {path} contains duplicate object key {key!r}"
-                )
-            result[key] = value
-        return result
-
-    def reject_non_finite(value: str) -> NoReturn:
-        raise TrackingDatabaseMutationError(
-            f"{label} {path} contains non-standard JSON number {value}"
-        )
-
     try:
-        value = json.loads(
-            raw.decode("utf-8"),
-            object_pairs_hook=reject_duplicate_keys,
-            parse_constant=reject_non_finite,
+        return decode_json_object_bytes(
+            raw,
+            path,
+            label=label,
         )
-    except TrackingDatabaseMutationError:
-        raise
-    except UnicodeDecodeError as exc:
-        raise TrackingDatabaseMutationError(
-            f"{label} {path} is not UTF-8: {exc}"
-        ) from exc
-    except json.JSONDecodeError as exc:
-        raise TrackingDatabaseMutationError(
-            f"{label} {path} is invalid JSON at line {exc.lineno}, column {exc.colno}"
-        ) from exc
-    if not isinstance(value, dict):
-        raise TrackingDatabaseMutationError(f"{label} root must be a JSON object")
-    return value
+    except TrackingDatabaseIOError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
 
 
 def load_plan(path: Path) -> dict[str, Any]:
@@ -443,9 +391,13 @@ def _validate_collection_record(kind: str, record: dict[str, Any]) -> None:
     elif kind == "upsert_improvement_goal":
         label = "improvement-goal record"
         _require_keys(record, required=GOAL_REQUIRED_FIELDS, label=label)
-        if not json_values_equal(record["schema_version"], 2):
+        if not json_values_equal(
+            record["schema_version"],
+            IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+        ):
             raise TrackingDatabaseMutationError(
-                f"{label}.schema_version must be exact integer 2"
+                f"{label}.schema_version must be exact integer "
+                f"{IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION}"
             )
         for field in (
             "id",
@@ -764,6 +716,19 @@ def _apply_record_patch(
     return before, after
 
 
+def _require_current_talk_record(
+    talk: dict[str, Any],
+    *,
+    filename: str,
+) -> None:
+    version = talk.get("schema_version")
+    if type(version) is not int or version != TALK_RECORD_SCHEMA_VERSION:
+        raise TrackingDatabaseMutationError(
+            f"talks[{filename!r}].schema_version must be exact current talk "
+            f"schema {TALK_RECORD_SCHEMA_VERSION} before this mutation"
+        )
+
+
 def _apply_update_talk(
     database: dict[str, Any],
     mutation: dict[str, Any],
@@ -778,6 +743,7 @@ def _apply_update_talk(
     )
     filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
     talk = _talk_by_filename(database, filename)
+    _require_current_talk_record(talk, filename=filename)
     _validate_publishing_values(mutation["set"], f"mutations[{index}].set")
     before, after = _apply_record_patch(
         talk,
@@ -809,6 +775,7 @@ def _apply_update_talk_clarification(
     )
     filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
     talk = _talk_by_filename(database, filename)
+    _require_current_talk_record(talk, filename=filename)
     _validate_clarification_values(mutation["set"], f"mutations[{index}].set")
     before, after = _apply_record_patch(
         talk,
@@ -843,6 +810,23 @@ def _apply_goal_verification(
     _, goal = _find_unique_record(goals, "id", identity, label="improvement_goals")
     if goal is None:
         raise TrackingDatabaseMutationError(f"improvement goal {identity!r} does not exist")
+    goal_version = goal.get("schema_version")
+    goal_kind = goal.get("kind")
+    if goal_version == 1:
+        if goal_kind in {"antipattern", "underuse"}:
+            raise TrackingDatabaseMutationError(
+                f"improvement goal {identity!r} is a historical schema-v1 "
+                f"{goal_kind} goal; skip and report it instead of partially "
+                "upgrading it"
+            )
+        allowed_fields = LEGACY_GOAL_VERIFICATION_FIELDS
+    elif goal_version == IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION:
+        allowed_fields = GOAL_VERIFICATION_FIELDS
+    else:
+        raise TrackingDatabaseMutationError(
+            f"improvement goal {identity!r} has unsupported schema_version "
+            f"{goal_version!r}"
+        )
     _validate_goal_verification_values(
         mutation["set"],
         f"mutations[{index}].set",
@@ -851,7 +835,7 @@ def _apply_goal_verification(
         goal,
         expect=mutation["expect"],
         set_values=mutation["set"],
-        allowed_fields=GOAL_VERIFICATION_FIELDS,
+        allowed_fields=allowed_fields,
         label=f"improvement_goals[{identity!r}]",
     )
     _record_change(
@@ -1052,6 +1036,10 @@ def build_candidate(
     database: dict[str, Any],
     mutations: list[dict[str, Any]],
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    try:
+        require_current_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
     candidate = copy.deepcopy(database)
     _validate_database_shape(candidate)
     changes: list[dict[str, Any]] = []
@@ -1086,6 +1074,12 @@ def build_candidate(
                 f"mutations[{index}].kind {kind!r} is unsupported"
             )
     _validate_database_shape(candidate)
+    try:
+        require_current_tracking_database(candidate)
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseMutationError(
+            f"mutation candidate violates the tracking-database schema: {exc}"
+        ) from exc
     return candidate, changes
 
 
@@ -1131,6 +1125,12 @@ def execute(
             )
         candidate = initial_database(mutations[0], index=0)
         _validate_database_shape(candidate)
+        try:
+            require_current_tracking_database(candidate)
+        except TrackingDatabaseError as exc:
+            raise TrackingDatabaseMutationError(
+                f"initial database violates the tracking-database schema: {exc}"
+            ) from exc
         rendered = render_json_object(candidate)
         output_sha256 = hashlib.sha256(rendered).hexdigest()
         if apply:

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -89,9 +89,8 @@ from ingress_contract import (
     TALK_SCHEMA_VERSION,
     validate_talk_record_schemas,
 )
+from tracking_database import TrackingDatabaseError, require_current_tracking_database
 from pattern_evidence import (
-    LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION,
-    PATTERN_EVIDENCE_SCHEMA_VERSION,
     PatternEvidenceError,
     assess_batch_artifact_capabilities,
     canonicalize_return_evidence,
@@ -744,56 +743,6 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
     return promoted, stamped, coerced_score, cleared
 
 
-def migrate_records(db):
-    """Bring every talk record to the current schema version. Returns the count.
-
-    `stateful-artifacts` puts migration on the OWNER skill, and this script is
-    the tracking DB's only writer. Stamping just the talks a batch happened to
-    touch would leave the file permanently mixed-version — a reader could not
-    tell an unversioned record from one this writer had never seen, which is the
-    ambiguity the version exists to remove.
-
-    Talk schema v4 unifies the queue/catalog lineage with source-located
-    evidence. Talk schema v5 adds exhaustive applicability/outcome state and an
-    opportunity-coverage identity. Historical detections receive the explicit
-    empty-citation sentinel, but migration never fabricates v5 assessments,
-    outcomes, identity, or current evidence: an unverified location cannot
-    become current proof.
-    """
-    talks = validate_talk_record_schemas(db.get("talks"))
-    migrated = 0
-    for talk in talks:
-        changed = False
-        observations = talk.get("pattern_observations")
-        located_evidence = (
-            isinstance(observations, dict)
-            and observations.get("evidence_schema_version") in {
-                LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION,
-                PATTERN_EVIDENCE_SCHEMA_VERSION,
-            }
-        )
-        if isinstance(observations, dict) and not located_evidence:
-            if observations.pop("evidence_schema_version", None) is not None:
-                changed = True
-            if observations.pop("source_inspection", None) is not None:
-                changed = True
-            for lane in ("patterns_detected", "antipatterns_detected"):
-                detections = observations.get(lane)
-                if not isinstance(detections, list):
-                    continue
-                for detection in detections:
-                    if (isinstance(detection, dict) and
-                            detection.get("evidence_citations") != []):
-                        detection["evidence_citations"] = []
-                        changed = True
-        if talk.get("schema_version") != TALK_SCHEMA_VERSION:
-            talk["schema_version"] = TALK_SCHEMA_VERSION
-            changed = True
-        if changed:
-            migrated += 1
-    return migrated
-
-
 def atomic_write_json(
     path,
     payload,
@@ -812,13 +761,19 @@ def load_tracking_database(path):
     """Load strict JSON and retain the exact generation used for validation."""
     try:
         snapshot = snapshot_tracking_database(path)
-        return decode_json_object(snapshot), snapshot
+        database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
         message = str(exc)
         if "tracking database is missing at" in message:
             message = f"tracking database file not found: {path} — {message}"
         print(f"ERROR: {message}", file=sys.stderr)
         sys.exit(1)
+    try:
+        require_current_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    return database, snapshot
 
 
 def load_json(path, label):
@@ -894,10 +849,6 @@ def main():
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    if not isinstance(db, dict) or not isinstance(db.get("talks"), list):
-        print(f"ERROR: {db_path} is not a tracking database — expected a JSON "
-              "object with a `talks` array", file=sys.stderr)
-        sys.exit(1)
     raw_config = db.get("config")
     source_roots: dict[str, object] = (
         copy.deepcopy(raw_config) if isinstance(raw_config, dict) else {})
@@ -954,7 +905,6 @@ def main():
 
     # All input, catalog and identity validation is complete before the in-memory
     # artifact changes. A bad final return cannot leave an earlier return applied.
-    migrated = migrate_records(db)
     summary = []
     for ret, canonical_ret in zip(returns, canonical_returns):
         name = ret.get("filename")
@@ -1017,7 +967,8 @@ def main():
         sys.exit(1)
 
     json.dump({"persisted": len(summary), "db_path": db_path, "run_date": run_date,
-               "schema_version": TALK_SCHEMA_VERSION, "migrated_records": migrated,
+               "schema_version": TALK_SCHEMA_VERSION,
+               "migrated_records": 0,
                "pattern_scoring_schema_version": PATTERN_SCORING_SCHEMA_VERSION,
                "pattern_catalog_fingerprint": catalog.fingerprint,
                "current_adherence_baseline": current_adherence_baseline,

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -49,6 +49,10 @@ from source_identity_matching import (
     known_event_aliases,
     titles_agree,
 )
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
 from tracking_database_io import (
     TrackingDatabaseIOError,
     decode_json_object,
@@ -194,6 +198,27 @@ class VaultPreflight:
                 expected="object", actual=type(self.database).__name__,
             )
             return self.report(0)
+
+        try:
+            assessment = assess_tracking_database(self.database)
+        except TrackingDatabaseError as exc:
+            self.add(
+                "blocking",
+                "tracking_database_schema_invalid",
+                str(exc),
+                field="schema_version",
+            )
+        else:
+            if not assessment.usable:
+                self.add(
+                    "blocking",
+                    "tracking_database_schema_unsupported",
+                    "tracking database is not usable by this reader",
+                    field="schema_version",
+                    expected=assessment.as_dict()["accepted_schema_versions"],
+                    actual=assessment.schema_version,
+                )
+                return self.report(0)
 
         config = self.database.get("config", {})
         if isinstance(config, dict):

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -72,18 +72,31 @@ from urllib.parse import parse_qs, urlparse
 from ingress_contract import (
     has_video_source,
 )
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+    require_current_tracking_database,
+)
+from queue_claim_contract import (
+    ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS,
+    CLAIMABLE_STATUSES,
+    CURRENT_QUEUE_CLAIM_SCHEMA_VERSION,
+    INFLIGHT_STATUS,
+    LEGACY_QUEUE_CLAIM_SCHEMA_VERSION,
+    LEGACY_STATUSES,
+    PATTERN_SCORING_REPROCESS_REASON_PREFIX,
+    PATTERN_SCORING_REPROCESS_REASON_SEQUENCES,
+    QueueClaimContractError,
+    RECEIPT_QUEUE_CLAIM_SCHEMA_VERSION,
+    SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS,
+    validate_queue_claim,
+    validate_queue_claim_database,
+    validate_talk_queue_claim_state,
+)
 from adherence_baseline import (
-    ADHERENCE_BASELINE_SCHEMA_VERSION,
     AdherenceBaselineError,
-    CATALOG_FINGERPRINT_MISMATCH_REASON,
-    LEGACY_GENERATION_REASON,
-    LEGACY_ADHERENCE_BASELINE_SCHEMA_VERSION,
-    MISSING_GENERATION_STATUS_REASON,
-    PERSISTED_EVIDENCE_STALE_REASON,
-    SCORING_SCHEMA_VERSION_MISMATCH_REASON,
     build_adherence_baseline,
     partition_pattern_scoring_cohort,
-    validate_adherence_baseline,
 )
 from pattern_evidence import (
     assess_talk_artifact_capabilities,
@@ -107,55 +120,21 @@ from tracking_database_io import (
 )
 
 
-CLAIM_SCHEMA_VERSION = QUEUE_CLAIM_SCHEMA_VERSION
+CLAIM_SCHEMA_VERSION = CURRENT_QUEUE_CLAIM_SCHEMA_VERSION
+if CLAIM_SCHEMA_VERSION != QUEUE_CLAIM_SCHEMA_VERSION:
+    raise RuntimeError(
+        "shared queue-claim and return-validation claim versions must match"
+    )
 if CLAIM_SCHEMA_VERSION != RETURN_SCHEMA_VERSION:
     raise RuntimeError(
         "current queue-claim and ingress-return schema versions must match"
     )
-LEGACY_CLAIM_SCHEMA_VERSION = 1
-RECEIPT_CLAIM_SCHEMA_VERSION = 2
-ADHERENCE_CLAIM_SCHEMA_VERSION = 3
-SUPPORTED_CLAIM_SCHEMA_VERSIONS = frozenset(range(1, CLAIM_SCHEMA_VERSION + 1))
-RECEIPT_CLAIM_SCHEMA_VERSIONS = frozenset(
-    range(RECEIPT_CLAIM_SCHEMA_VERSION, CLAIM_SCHEMA_VERSION + 1)
-)
-ADHERENCE_CLAIM_SCHEMA_VERSIONS = frozenset(
-    range(ADHERENCE_CLAIM_SCHEMA_VERSION, CLAIM_SCHEMA_VERSION + 1)
-)
-INFLIGHT_STATUS = "reprocessing-inflight"
-CLAIMABLE_STATUSES = frozenset({
-    "pending",
-    "needs-reprocessing",
-    "skipped_download_failed",
-})
-LEGACY_STATUSES = frozenset({"skipped_no_video", "skipped_no_transcript"})
-KNOWN_STATUSES = frozenset({
-    *CLAIMABLE_STATUSES,
-    *LEGACY_STATUSES,
-    INFLIGHT_STATUS,
-    "processed",
-    "processed_partial",
-    "skipped_no_sources",
-    "skipped_duplicate",
-})
-CLAIM_STATES = frozenset({"claimed", "completed", "stale_recovered", "superseded"})
+LEGACY_CLAIM_SCHEMA_VERSION = LEGACY_QUEUE_CLAIM_SCHEMA_VERSION
+RECEIPT_CLAIM_SCHEMA_VERSION = RECEIPT_QUEUE_CLAIM_SCHEMA_VERSION
+SUPPORTED_CLAIM_SCHEMA_VERSIONS = SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS
+ADHERENCE_CLAIM_SCHEMA_VERSIONS = ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS
 YOUTUBE_ID = re.compile(r"^[A-Za-z0-9_-]{11}$")
 PLAYLIST_FILENAME = re.compile(r"^playlist-([A-Za-z0-9_-]{11})\.md$")
-PATTERN_SCORING_REPROCESS_REASON_PREFIX = "pattern_scoring_generation:"
-PATTERN_SCORING_REPROCESS_REASON_SEQUENCES = frozenset({
-    (MISSING_GENERATION_STATUS_REASON,),
-    (LEGACY_GENERATION_REASON,),
-    (CATALOG_FINGERPRINT_MISMATCH_REASON,),
-    (SCORING_SCHEMA_VERSION_MISMATCH_REASON,),
-    (PERSISTED_EVIDENCE_STALE_REASON,),
-    (
-        CATALOG_FINGERPRINT_MISMATCH_REASON,
-        SCORING_SCHEMA_VERSION_MISMATCH_REASON,
-    ),
-})
-LEGACY_REPROCESS_REASONS = frozenset({
-    "pattern_scoring_added", "source_identity_correction",
-})
 CAPABILITY_ORDER = ("video", "slides", "transcript")
 
 
@@ -331,159 +310,23 @@ def pattern_scoring_reprocess_reason(reason_codes):
     return PATTERN_SCORING_REPROCESS_REASON_PREFIX + "+".join(exact_codes)
 
 
-def is_deliberate_reprocess_reason(value):
-    if not isinstance(value, str):
-        return False
-    if value in LEGACY_REPROCESS_REASONS:
-        return True
-    if not value.startswith(PATTERN_SCORING_REPROCESS_REASON_PREFIX):
-        return False
-    encoded_codes = value.removeprefix(
-        PATTERN_SCORING_REPROCESS_REASON_PREFIX).split("+")
-    return tuple(encoded_codes) in PATTERN_SCORING_REPROCESS_REASON_SEQUENCES
-
-
 def validate_claim(claim, filename, *, historical=False):
-    if not isinstance(claim, dict):
-        raise QueueStateError(f"{filename}: queue claim must be a JSON object")
-    version = claim.get("schema_version")
-    if (isinstance(version, int) and not isinstance(version, bool)
-            and version > CLAIM_SCHEMA_VERSION):
-        raise QueueStateError(
-            f"{filename}: queue claim schema_version {version} is newer than "
-            f"supported version {CLAIM_SCHEMA_VERSION}; upgrade queue-state "
-            "before continuing")
-    if (isinstance(version, bool) or not isinstance(version, int)
-            or version not in SUPPORTED_CLAIM_SCHEMA_VERSIONS):
-        raise QueueStateError(
-            f"{filename}: queue claim schema_version is "
-            f"{version!r}; expected one of "
-            f"{sorted(SUPPORTED_CLAIM_SCHEMA_VERSIONS)}"
-        )
-    require_identifier(claim.get("run_id"), f"{filename}: claim.run_id")
-    require_identifier(claim.get("batch_id"), f"{filename}: claim.batch_id")
-    claimed_at = timestamp_text(parse_timestamp(
-        claim.get("claimed_at"), f"{filename}: claim.claimed_at"))
-    previous = claim.get("previous_status")
-    if previous not in CLAIMABLE_STATUSES:
-        raise QueueStateError(
-            f"{filename}: claim.previous_status {previous!r} cannot be restored; "
-            f"expected one of {sorted(CLAIMABLE_STATUSES)}"
-        )
-    generation = claim.get("reprocess_generation")
-    if isinstance(generation, bool) or not isinstance(generation, int) or generation < 1:
-        raise QueueStateError(
-            f"{filename}: claim.reprocess_generation must be a positive integer"
-        )
-    state = claim.get("state")
-    if state not in CLAIM_STATES:
-        raise QueueStateError(
-            f"{filename}: claim.state {state!r} is invalid; expected {sorted(CLAIM_STATES)}"
-        )
-    if version in ADHERENCE_CLAIM_SCHEMA_VERSIONS:
-        if claim.get("claimed_at") != claimed_at:
-            raise QueueStateError(
-                f"{filename}: schema-v{version} claim.claimed_at must use "
-                "canonical UTC "
-                f"whole-second form {claimed_at!r}"
-            )
-        required_return = claim.get("required_return_schema_version")
-        if (isinstance(required_return, bool) or
-                not isinstance(required_return, int) or
-                required_return != version):
-            raise QueueStateError(
-                f"{filename}: schema-v{version} "
-                "claim.required_return_schema_version must equal its claim "
-                f"schema version {version}"
-            )
-        try:
-            baseline = validate_adherence_baseline(
-                claim.get("adherence_baseline"))
-        except AdherenceBaselineError as exc:
-            raise QueueStateError(
-                f"{filename}: invalid schema-v{version} claim "
-                f"adherence_baseline: {exc}"
-            ) from exc
-        expected_baseline_schema = (
-            ADHERENCE_BASELINE_SCHEMA_VERSION
-            if version == CLAIM_SCHEMA_VERSION
-            else LEGACY_ADHERENCE_BASELINE_SCHEMA_VERSION
-        )
-        if baseline.get("schema_version") != expected_baseline_schema:
-            raise QueueStateError(
-                f"{filename}: schema-v{version} claim requires adherence "
-                f"baseline schema {expected_baseline_schema}"
-            )
-        if baseline["as_of"] != claim["claimed_at"]:
-            raise QueueStateError(
-                f"{filename}: claim adherence_baseline.as_of must equal "
-                "claim.claimed_at"
-            )
-        if baseline["active_batch_excluded"] is not True:
-            raise QueueStateError(
-                f"{filename}: schema-v{version} claim adherence_baseline must "
-                "exclude "
-                "the active batch"
-            )
-    elif ("required_return_schema_version" in claim or
-          "adherence_baseline" in claim):
-        raise QueueStateError(
-            f"{filename}: schema-v{version} claim cannot carry adherence-claim "
-            "return or adherence-baseline fields"
-        )
-    released_at = claim.get("released_at")
-    if released_at is not None:
-        parse_timestamp(released_at, f"{filename}: claim.released_at")
-    if state == "claimed" and released_at is not None:
-        raise QueueStateError(f"{filename}: an active claim cannot carry released_at")
-    if state != "claimed" and released_at is None:
-        raise QueueStateError(f"{filename}: a closed claim must carry released_at")
-    if state != "claimed" and not isinstance(claim.get("release_reason"), str):
-        raise QueueStateError(f"{filename}: a closed claim must carry release_reason")
-    if state == "completed":
-        if claim.get("result_status") not in {
-                "processed", "processed_partial", "skipped_no_sources",
-                "skipped_download_failed", "skipped_duplicate"}:
-            raise QueueStateError(
-                f"{filename}: a completed claim must carry a terminal result_status")
-        if (version in RECEIPT_CLAIM_SCHEMA_VERSIONS
-                and "result_payload_sha256" not in claim):
-            raise QueueStateError(
-                f"{filename}: a schema-v{version} completed claim must carry "
-                "result_payload_sha256")
-        receipt = claim.get("result_payload_sha256")
-        if (receipt is None and
-                version in RECEIPT_CLAIM_SCHEMA_VERSIONS and
-                not historical):
-            raise QueueStateError(
-                f"{filename}: a current schema-v{version} completed claim must "
-                "carry a "
-                "return-payload SHA-256 receipt")
-        if (receipt is not None
-                and (not isinstance(receipt, str)
-                     or re.fullmatch(r"[0-9a-f]{64}", receipt) is None)):
-            raise QueueStateError(
-                f"{filename}: completed claim result_payload_sha256 must be null "
-                "for a migrated legacy claim or a lowercase SHA-256 receipt")
-    if historical and state == "claimed":
-        raise QueueStateError(f"{filename}: historical claims must be closed")
+    try:
+        validate_queue_claim(claim, filename, historical=historical)
+    except QueueClaimContractError as exc:
+        raise QueueStateError(str(exc)) from exc
 
 
 def validate_talk(talk, index, *, allow_claim_status_drift=False):
-    if not isinstance(talk, dict):
-        raise QueueStateError(f"talks[{index}] must be a JSON object")
-    filename = talk.get("filename")
-    if not isinstance(filename, str) or not filename or Path(filename).name != filename:
-        raise QueueStateError(
-            f"talks[{index}].filename must be a non-empty basename, got {filename!r}"
+    try:
+        validate_talk_queue_claim_state(
+            talk,
+            index,
+            allow_claim_status_drift=allow_claim_status_drift,
         )
-    if not filename.endswith(".md"):
-        raise QueueStateError(f"{filename}: filename must end in .md")
-    status = talk.get("status")
-    if status not in KNOWN_STATUSES:
-        raise QueueStateError(
-            f"{filename}: status {status!r} is unknown; reconcile it before queueing"
-        )
+    except QueueClaimContractError as exc:
+        raise QueueStateError(str(exc)) from exc
+    filename = talk["filename"]
 
     explicit_id = talk.get("youtube_id")
     if explicit_id in (None, ""):
@@ -514,142 +357,20 @@ def validate_talk(talk, index, *, allow_claim_status_drift=False):
                 f"youtube_id {explicit_id}"
             )
 
-    generation = talk.get("reprocess_generation", 0)
-    if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
-        raise QueueStateError(
-            f"{filename}: reprocess_generation must be a non-negative integer"
-        )
-    current = talk.get("_queue_claim")
-    history = talk.get("_queue_claim_history", [])
-    if not isinstance(history, list):
-        raise QueueStateError(f"{filename}: _queue_claim_history must be a JSON array")
-    identities = set()
-    for claim in history:
-        validate_claim(claim, filename, historical=True)
-        identity = (claim["run_id"], claim["batch_id"], claim["reprocess_generation"])
-        if identity in identities:
-            raise QueueStateError(f"{filename}: duplicate claim history entry {identity!r}")
-        identities.add(identity)
-    if current is not None:
-        validate_claim(current, filename)
-        identity = (current["run_id"], current["batch_id"], current["reprocess_generation"])
-        if identity in identities:
-            raise QueueStateError(f"{filename}: current claim duplicates claim history")
-        if current["reprocess_generation"] != generation:
-            raise QueueStateError(
-                f"{filename}: current claim generation "
-                f"{current['reprocess_generation']} disagrees with talk generation {generation}"
-            )
-    if status == INFLIGHT_STATUS:
-        if current is None:
-            raise QueueStateError(
-                f"{filename}: {INFLIGHT_STATUS} has no reconstructable _queue_claim"
-            )
-        if current["state"] != "claimed":
-            raise QueueStateError(
-                f"{filename}: {INFLIGHT_STATUS} requires claim.state='claimed'"
-            )
-    if (current is not None and current["state"] == "claimed" and
-            status != INFLIGHT_STATUS and not allow_claim_status_drift):
-        raise QueueStateError(
-            f"{filename}: claim.state='claimed' requires status "
-            f"{INFLIGHT_STATUS!r}, got {status!r}; run recover to repair the "
-            "stranded lease"
-        )
-    deliberate_requeue = (
-        status == "needs-reprocessing" and
-        is_deliberate_reprocess_reason(talk.get("reprocess_reason"))
-    )
-    if (current is not None and current["state"] == "completed" and
-            status != current.get("result_status") and not deliberate_requeue):
-        raise QueueStateError(
-            f"{filename}: completed claim result_status "
-            f"{current.get('result_status')!r} disagrees with talk status {status!r}"
-        )
-
-
 def validate_database(database, *, allow_claim_status_drift=False):
-    if not isinstance(database, dict):
-        raise QueueStateError("tracking database root must be a JSON object")
-    talks = database.get("talks")
-    if not isinstance(talks, list):
-        raise QueueStateError("tracking database must contain a talks array")
-    seen = set()
-    for index, talk in enumerate(talks):
+    try:
+        validate_queue_claim_database(
+            database,
+            allow_claim_status_drift=allow_claim_status_drift,
+        )
+    except QueueClaimContractError as exc:
+        raise QueueStateError(str(exc)) from exc
+    for index, talk in enumerate(database["talks"]):
         validate_talk(
             talk,
             index,
             allow_claim_status_drift=allow_claim_status_drift,
         )
-        filename = talk["filename"]
-        if filename in seen:
-            raise QueueStateError(
-                f"duplicate talk filename {filename!r} — filenames are queue identities"
-            )
-        seen.add(filename)
-    _validate_adherence_claim_batches(talks)
-
-
-def _validate_adherence_claim_batches(talks):
-    """Require every stored claim-v3/v4/v5 batch snapshot to be exact and shared."""
-    current_batches = {}
-    claim_epochs = {}
-    for talk in talks:
-        current = talk.get("_queue_claim")
-        if (isinstance(current, dict) and
-                current.get("schema_version") in ADHERENCE_CLAIM_SCHEMA_VERSIONS):
-            identity = (current["run_id"], current["batch_id"])
-            current_batches.setdefault(identity, []).append(
-                (talk["filename"], current))
-            epoch = (*identity, current["claimed_at"])
-            claim_epochs.setdefault(epoch, []).append(
-                (talk["filename"], current))
-        for claim in talk.get("_queue_claim_history", []):
-            if claim.get("schema_version") not in ADHERENCE_CLAIM_SCHEMA_VERSIONS:
-                continue
-            epoch = (
-                claim["run_id"],
-                claim["batch_id"],
-                claim["claimed_at"],
-            )
-            claim_epochs.setdefault(epoch, []).append(
-                (talk["filename"], claim))
-    for identity, members in current_batches.items():
-        claimed_at = members[0][1]["claimed_at"]
-        if any(claim["claimed_at"] != claimed_at for _, claim in members):
-            raise QueueStateError(
-                f"adherence current claims for run {identity[0]!r} batch "
-                f"{identity[1]!r} do not share one claimed_at timestamp"
-            )
-    for epoch, members in claim_epochs.items():
-        _validate_adherence_claim_batch_members(epoch[:2], members)
-
-
-def _validate_adherence_claim_batch_members(identity, members):
-    """Validate one current batch or one historical retry epoch."""
-    expected_filenames = sorted(filename for filename, _ in members)
-    canonical = members[0][1]["adherence_baseline"]
-    canonical_version = members[0][1]["schema_version"]
-    for filename, claim in members:
-        if claim["schema_version"] != canonical_version:
-            raise QueueStateError(
-                f"{filename}: claims for run {identity[0]!r} batch "
-                f"{identity[1]!r} mix adherence schema versions"
-            )
-        if claim["adherence_baseline"] != canonical:
-            raise QueueStateError(
-                f"{filename}: schema-v{canonical_version} claims for run "
-                f"{identity[0]!r} "
-                f"batch {identity[1]!r} do not share one immutable "
-                "adherence_baseline"
-            )
-        if claim["adherence_baseline"]["excluded_filenames"] != \
-                expected_filenames:
-            raise QueueStateError(
-                f"{filename}: schema-v{canonical_version} adherence_baseline "
-                "excluded_filenames "
-                f"must equal the exact stored batch {expected_filenames}"
-            )
 
 
 def upgrade_claim_for_write(claim):
@@ -661,12 +382,30 @@ def upgrade_claim_for_write(claim):
         claim["result_payload_sha256"] = None
 
 
-def load_database_snapshot(path, *, allow_claim_status_drift=False):
+def load_database_snapshot(
+    path,
+    *,
+    allow_claim_status_drift=False,
+    require_current=True,
+):
     """Load strict JSON together with the exact generation validation observed."""
     try:
         snapshot = snapshot_tracking_database(path)
         database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
+        raise QueueStateError(str(exc)) from exc
+    try:
+        if require_current:
+            require_current_tracking_database(database)
+        else:
+            assessment = assess_tracking_database(database)
+            if not assessment.usable:
+                reasons = ", ".join(assessment.reason_codes)
+                raise TrackingDatabaseError(
+                    "tracking database is not a supported legacy/current "
+                    f"generation ({reasons})"
+                )
+    except TrackingDatabaseError as exc:
         raise QueueStateError(str(exc)) from exc
     validate_database(
         database,
@@ -675,11 +414,17 @@ def load_database_snapshot(path, *, allow_claim_status_drift=False):
     return database, snapshot
 
 
-def load_database(path, *, allow_claim_status_drift=False):
+def load_database(
+    path,
+    *,
+    allow_claim_status_drift=False,
+    require_current=True,
+):
     """Compatibility wrapper returning only the decoded database."""
     database, _ = load_database_snapshot(
         path,
         allow_claim_status_drift=allow_claim_status_drift,
+        require_current=require_current,
     )
     return database
 
@@ -1180,6 +925,7 @@ def main(argv=None):
         database, snapshot = load_database_snapshot(
             path,
             allow_claim_status_drift=args.action == "recover",
+            require_current=args.action not in {"inspect", "recover"},
         )
         commands = {
             "normalize": command_normalize,

--- a/skills/vault-ingress/scripts/queue_claim_contract.py
+++ b/skills/vault-ingress/scripts/queue_claim_contract.py
@@ -1,0 +1,621 @@
+"""Pure validation for queue claims stored in the tracking database.
+
+This module is the single owner of queue-claim, claim-history, talk lifecycle,
+and adherence-batch validation.  It deliberately has no tracking-database or
+queue command imports so both the database schema owner and queue-state can use
+the same contract without a circular dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+
+from adherence_baseline import (
+    ADHERENCE_BASELINE_SCHEMA_VERSION,
+    AdherenceBaselineError,
+    CATALOG_FINGERPRINT_MISMATCH_REASON,
+    LEGACY_ADHERENCE_BASELINE_SCHEMA_VERSION,
+    LEGACY_GENERATION_REASON,
+    MISSING_GENERATION_STATUS_REASON,
+    PERSISTED_EVIDENCE_STALE_REASON,
+    SCORING_SCHEMA_VERSION_MISMATCH_REASON,
+    validate_adherence_baseline,
+)
+
+
+CURRENT_QUEUE_CLAIM_SCHEMA_VERSION = 5
+LEGACY_QUEUE_CLAIM_SCHEMA_VERSION = 1
+RECEIPT_QUEUE_CLAIM_SCHEMA_VERSION = 2
+ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSION = 3
+SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS = frozenset(
+    range(
+        LEGACY_QUEUE_CLAIM_SCHEMA_VERSION,
+        CURRENT_QUEUE_CLAIM_SCHEMA_VERSION + 1,
+    )
+)
+RECEIPT_QUEUE_CLAIM_SCHEMA_VERSIONS = frozenset(
+    range(
+        RECEIPT_QUEUE_CLAIM_SCHEMA_VERSION,
+        CURRENT_QUEUE_CLAIM_SCHEMA_VERSION + 1,
+    )
+)
+ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS = frozenset(
+    range(
+        ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSION,
+        CURRENT_QUEUE_CLAIM_SCHEMA_VERSION + 1,
+    )
+)
+INFLIGHT_STATUS = "reprocessing-inflight"
+CLAIMABLE_STATUSES = frozenset(
+    {
+        "pending",
+        "needs-reprocessing",
+        "skipped_download_failed",
+    }
+)
+LEGACY_STATUSES = frozenset({"skipped_no_video", "skipped_no_transcript"})
+KNOWN_STATUSES = frozenset(
+    {
+        *CLAIMABLE_STATUSES,
+        *LEGACY_STATUSES,
+        INFLIGHT_STATUS,
+        "processed",
+        "processed_partial",
+        "skipped_no_sources",
+        "skipped_duplicate",
+    }
+)
+QUEUE_CLAIM_STATES = frozenset(
+    {"claimed", "completed", "stale_recovered", "superseded"}
+)
+TERMINAL_RESULT_STATUSES = frozenset(
+    {
+        "processed",
+        "processed_partial",
+        "skipped_no_sources",
+        "skipped_download_failed",
+        "skipped_duplicate",
+    }
+)
+
+PATTERN_SCORING_REPROCESS_REASON_PREFIX = "pattern_scoring_generation:"
+PATTERN_SCORING_REPROCESS_REASON_SEQUENCES = frozenset(
+    {
+        (MISSING_GENERATION_STATUS_REASON,),
+        (LEGACY_GENERATION_REASON,),
+        (CATALOG_FINGERPRINT_MISMATCH_REASON,),
+        (SCORING_SCHEMA_VERSION_MISMATCH_REASON,),
+        (PERSISTED_EVIDENCE_STALE_REASON,),
+        (
+            CATALOG_FINGERPRINT_MISMATCH_REASON,
+            SCORING_SCHEMA_VERSION_MISMATCH_REASON,
+        ),
+    }
+)
+LEGACY_REPROCESS_REASONS = frozenset(
+    {"pattern_scoring_added", "source_identity_correction"}
+)
+
+QUEUE_CLAIM_SCHEMA_UNSUPPORTED_REASON = "queue_claim_schema_version_unsupported"
+ADHERENCE_BASELINE_SCHEMA_UNSUPPORTED_REASON = (
+    "adherence_baseline_schema_version_unsupported"
+)
+
+
+class QueueClaimContractError(ValueError):
+    """Stored queue lifecycle state violates the shared pure contract."""
+
+
+def parse_queue_timestamp(value: object, label: str) -> datetime:
+    """Parse a timezone-aware timestamp and normalize it to UTC seconds."""
+    if not isinstance(value, str) or not value:
+        raise QueueClaimContractError(
+            f"{label} must be a non-empty ISO-8601 timestamp"
+        )
+    candidate = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        moment = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise QueueClaimContractError(
+            f"{label} {value!r} is malformed — use a timezone-aware ISO-8601 "
+            "timestamp such as 2026-07-31T18:00:00+00:00"
+        ) from exc
+    if moment.tzinfo is None or moment.utcoffset() is None:
+        raise QueueClaimContractError(
+            f"{label} {value!r} has no timezone — append an explicit UTC offset"
+        )
+    return moment.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def queue_timestamp_text(moment: datetime) -> str:
+    return moment.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def require_queue_identifier(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise QueueClaimContractError(
+            f"{label} must be a non-empty string without edge whitespace"
+        )
+    if any(character.isspace() for character in value):
+        raise QueueClaimContractError(
+            f"{label} {value!r} contains whitespace — use a stable token"
+        )
+    return value
+
+
+def is_deliberate_reprocess_reason(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    if value in LEGACY_REPROCESS_REASONS:
+        return True
+    if not value.startswith(PATTERN_SCORING_REPROCESS_REASON_PREFIX):
+        return False
+    encoded_codes = value.removeprefix(
+        PATTERN_SCORING_REPROCESS_REASON_PREFIX
+    ).split("+")
+    return tuple(encoded_codes) in PATTERN_SCORING_REPROCESS_REASON_SEQUENCES
+
+
+def _classify_queue_claim_version(
+    claim: object,
+    *,
+    label: str,
+) -> str | None:
+    if not isinstance(claim, Mapping):
+        raise QueueClaimContractError(f"{label} must be a JSON object")
+    version = claim.get("schema_version")
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise QueueClaimContractError(
+            f"{label}.schema_version must be an integer, got {version!r}"
+        )
+    if version > CURRENT_QUEUE_CLAIM_SCHEMA_VERSION:
+        return QUEUE_CLAIM_SCHEMA_UNSUPPORTED_REASON
+    if version not in SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS:
+        raise QueueClaimContractError(
+            f"{label}.schema_version {version!r} is unsupported; expected "
+            f"one of {sorted(SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS)}"
+        )
+    if version not in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS:
+        return None
+    baseline = claim.get("adherence_baseline")
+    if not isinstance(baseline, Mapping) or "schema_version" not in baseline:
+        return None
+    baseline_version = baseline["schema_version"]
+    if isinstance(baseline_version, bool) or not isinstance(baseline_version, int):
+        raise QueueClaimContractError(
+            f"{label}.adherence_baseline.schema_version must be an integer, "
+            f"got {baseline_version!r}"
+        )
+    if baseline_version > ADHERENCE_BASELINE_SCHEMA_VERSION:
+        return ADHERENCE_BASELINE_SCHEMA_UNSUPPORTED_REASON
+    return None
+
+
+def classify_queue_claim_versions(
+    talks: Sequence[Mapping[str, object]],
+) -> tuple[str, ...]:
+    """Classify future claim/baseline generations before old-shape checks.
+
+    Malformed or explicit pre-versioning sentinels raise.  A well-formed future
+    version returns a no-usable-state reason so callers never interpret its
+    fields using an older schema.
+    """
+    for index, talk in enumerate(talks):
+        current = talk.get("_queue_claim")
+        if current is not None:
+            reason = _classify_queue_claim_version(
+                current,
+                label=f"talks[{index}]._queue_claim",
+            )
+            if reason is not None:
+                return (reason,)
+        history = talk.get("_queue_claim_history", [])
+        if not isinstance(history, list):
+            raise QueueClaimContractError(
+                f"talks[{index}]._queue_claim_history must be an array"
+            )
+        for history_index, claim in enumerate(history):
+            reason = _classify_queue_claim_version(
+                claim,
+                label=f"talks[{index}]._queue_claim_history[{history_index}]",
+            )
+            if reason is not None:
+                return (reason,)
+    return ()
+
+
+def validate_queue_claim(
+    claim: object,
+    filename: str,
+    *,
+    historical: bool = False,
+) -> None:
+    if not isinstance(claim, Mapping):
+        raise QueueClaimContractError(
+            f"{filename}: queue claim must be a JSON object"
+        )
+    version = claim.get("schema_version")
+    if (
+        isinstance(version, int)
+        and not isinstance(version, bool)
+        and version > CURRENT_QUEUE_CLAIM_SCHEMA_VERSION
+    ):
+        raise QueueClaimContractError(
+            f"{filename}: queue claim schema_version {version} is newer than "
+            f"supported version {CURRENT_QUEUE_CLAIM_SCHEMA_VERSION}; upgrade "
+            "queue-state before continuing"
+        )
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version not in SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS
+    ):
+        raise QueueClaimContractError(
+            f"{filename}: queue claim schema_version is {version!r}; expected one "
+            f"of {sorted(SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS)}"
+        )
+    require_queue_identifier(claim.get("run_id"), f"{filename}: claim.run_id")
+    require_queue_identifier(
+        claim.get("batch_id"), f"{filename}: claim.batch_id"
+    )
+    claimed_at = queue_timestamp_text(
+        parse_queue_timestamp(
+            claim.get("claimed_at"), f"{filename}: claim.claimed_at"
+        )
+    )
+    previous = claim.get("previous_status")
+    if previous not in CLAIMABLE_STATUSES:
+        raise QueueClaimContractError(
+            f"{filename}: claim.previous_status {previous!r} cannot be restored; "
+            f"expected one of {sorted(CLAIMABLE_STATUSES)}"
+        )
+    generation = claim.get("reprocess_generation")
+    if (
+        isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or generation < 1
+    ):
+        raise QueueClaimContractError(
+            f"{filename}: claim.reprocess_generation must be a positive integer"
+        )
+    state = claim.get("state")
+    if state not in QUEUE_CLAIM_STATES:
+        raise QueueClaimContractError(
+            f"{filename}: claim.state {state!r} is invalid; expected "
+            f"{sorted(QUEUE_CLAIM_STATES)}"
+        )
+
+    if version in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS:
+        if claim.get("claimed_at") != claimed_at:
+            raise QueueClaimContractError(
+                f"{filename}: schema-v{version} claim.claimed_at must use "
+                f"canonical UTC whole-second form {claimed_at!r}"
+            )
+        required_return = claim.get("required_return_schema_version")
+        if (
+            isinstance(required_return, bool)
+            or not isinstance(required_return, int)
+            or required_return != version
+        ):
+            raise QueueClaimContractError(
+                f"{filename}: schema-v{version} "
+                "claim.required_return_schema_version must equal its claim "
+                f"schema version {version}"
+            )
+        try:
+            baseline = validate_adherence_baseline(
+                claim.get("adherence_baseline")
+            )
+        except AdherenceBaselineError as exc:
+            raise QueueClaimContractError(
+                f"{filename}: invalid schema-v{version} claim "
+                f"adherence_baseline: {exc}"
+            ) from exc
+        expected_baseline_schema = (
+            ADHERENCE_BASELINE_SCHEMA_VERSION
+            if version == CURRENT_QUEUE_CLAIM_SCHEMA_VERSION
+            else LEGACY_ADHERENCE_BASELINE_SCHEMA_VERSION
+        )
+        if baseline.get("schema_version") != expected_baseline_schema:
+            raise QueueClaimContractError(
+                f"{filename}: schema-v{version} claim requires adherence "
+                f"baseline schema {expected_baseline_schema}"
+            )
+        if baseline["as_of"] != claim["claimed_at"]:
+            raise QueueClaimContractError(
+                f"{filename}: claim adherence_baseline.as_of must equal "
+                "claim.claimed_at"
+            )
+        if baseline["active_batch_excluded"] is not True:
+            raise QueueClaimContractError(
+                f"{filename}: schema-v{version} claim adherence_baseline must "
+                "exclude the active batch"
+            )
+    elif (
+        "required_return_schema_version" in claim
+        or "adherence_baseline" in claim
+    ):
+        raise QueueClaimContractError(
+            f"{filename}: schema-v{version} claim cannot carry adherence-claim "
+            "return or adherence-baseline fields"
+        )
+
+    released_at = claim.get("released_at")
+    if released_at is not None:
+        parse_queue_timestamp(released_at, f"{filename}: claim.released_at")
+    if state == "claimed" and released_at is not None:
+        raise QueueClaimContractError(
+            f"{filename}: an active claim cannot carry released_at"
+        )
+    if state != "claimed" and released_at is None:
+        raise QueueClaimContractError(
+            f"{filename}: a closed claim must carry released_at"
+        )
+    if state != "claimed" and not isinstance(claim.get("release_reason"), str):
+        raise QueueClaimContractError(
+            f"{filename}: a closed claim must carry release_reason"
+        )
+    if state == "completed":
+        if claim.get("result_status") not in TERMINAL_RESULT_STATUSES:
+            raise QueueClaimContractError(
+                f"{filename}: a completed claim must carry a terminal "
+                "result_status"
+            )
+        if (
+            version in RECEIPT_QUEUE_CLAIM_SCHEMA_VERSIONS
+            and "result_payload_sha256" not in claim
+        ):
+            raise QueueClaimContractError(
+                f"{filename}: a schema-v{version} completed claim must carry "
+                "result_payload_sha256"
+            )
+        receipt = claim.get("result_payload_sha256")
+        if (
+            receipt is None
+            and version in RECEIPT_QUEUE_CLAIM_SCHEMA_VERSIONS
+            and not historical
+        ):
+            raise QueueClaimContractError(
+                f"{filename}: a current schema-v{version} completed claim must "
+                "carry a return-payload SHA-256 receipt"
+            )
+        if receipt is not None and (
+            not isinstance(receipt, str)
+            or re.fullmatch(r"[0-9a-f]{64}", receipt) is None
+        ):
+            raise QueueClaimContractError(
+                f"{filename}: completed claim result_payload_sha256 must be null "
+                "for a migrated legacy claim or a lowercase SHA-256 receipt"
+            )
+    if historical and state == "claimed":
+        raise QueueClaimContractError(
+            f"{filename}: historical claims must be closed"
+        )
+
+
+def validate_talk_queue_claim_state(
+    talk: object,
+    index: int,
+    *,
+    allow_claim_status_drift: bool = False,
+) -> None:
+    if not isinstance(talk, Mapping):
+        raise QueueClaimContractError(
+            f"talks[{index}] must be a JSON object"
+        )
+    filename = talk.get("filename")
+    if (
+        not isinstance(filename, str)
+        or not filename
+        or Path(filename).name != filename
+    ):
+        raise QueueClaimContractError(
+            f"talks[{index}].filename must be a non-empty basename, got "
+            f"{filename!r}"
+        )
+    if not filename.endswith(".md"):
+        raise QueueClaimContractError(f"{filename}: filename must end in .md")
+    status = talk.get("status")
+    if status not in KNOWN_STATUSES:
+        raise QueueClaimContractError(
+            f"{filename}: status {status!r} is unknown; reconcile it before "
+            "queueing"
+        )
+
+    generation = talk.get("reprocess_generation", 0)
+    if (
+        isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or generation < 0
+    ):
+        raise QueueClaimContractError(
+            f"{filename}: reprocess_generation must be a non-negative integer"
+        )
+    current = talk.get("_queue_claim")
+    history = talk.get("_queue_claim_history", [])
+    if not isinstance(history, list):
+        raise QueueClaimContractError(
+            f"{filename}: _queue_claim_history must be a JSON array"
+        )
+    identities: set[tuple[object, object, object]] = set()
+    for claim in history:
+        validate_queue_claim(claim, filename, historical=True)
+        assert isinstance(claim, Mapping)
+        identity = (
+            claim["run_id"],
+            claim["batch_id"],
+            claim["reprocess_generation"],
+        )
+        if identity in identities:
+            raise QueueClaimContractError(
+                f"{filename}: duplicate claim history entry {identity!r}"
+            )
+        identities.add(identity)
+    if current is not None:
+        validate_queue_claim(current, filename)
+        assert isinstance(current, Mapping)
+        identity = (
+            current["run_id"],
+            current["batch_id"],
+            current["reprocess_generation"],
+        )
+        if identity in identities:
+            raise QueueClaimContractError(
+                f"{filename}: current claim duplicates claim history"
+            )
+        if current["reprocess_generation"] != generation:
+            raise QueueClaimContractError(
+                f"{filename}: current claim generation "
+                f"{current['reprocess_generation']} disagrees with talk "
+                f"generation {generation}"
+            )
+    if status == INFLIGHT_STATUS:
+        if current is None:
+            raise QueueClaimContractError(
+                f"{filename}: {INFLIGHT_STATUS} has no reconstructable "
+                "_queue_claim"
+            )
+        assert isinstance(current, Mapping)
+        if current["state"] != "claimed":
+            raise QueueClaimContractError(
+                f"{filename}: {INFLIGHT_STATUS} requires claim.state='claimed'"
+            )
+    if (
+        isinstance(current, Mapping)
+        and current["state"] == "claimed"
+        and status != INFLIGHT_STATUS
+        and not allow_claim_status_drift
+    ):
+        raise QueueClaimContractError(
+            f"{filename}: claim.state='claimed' requires status "
+            f"{INFLIGHT_STATUS!r}, got {status!r}; run recover to repair the "
+            "stranded lease"
+        )
+    deliberate_requeue = status == "needs-reprocessing" and (
+        is_deliberate_reprocess_reason(talk.get("reprocess_reason"))
+    )
+    if (
+        isinstance(current, Mapping)
+        and current["state"] == "completed"
+        and status != current.get("result_status")
+        and not deliberate_requeue
+    ):
+        raise QueueClaimContractError(
+            f"{filename}: completed claim result_status "
+            f"{current.get('result_status')!r} disagrees with talk status "
+            f"{status!r}"
+        )
+
+
+def validate_queue_claim_database(
+    database: object,
+    *,
+    allow_claim_status_drift: bool = False,
+) -> None:
+    if not isinstance(database, Mapping):
+        raise QueueClaimContractError(
+            "tracking database root must be a JSON object"
+        )
+    talks = database.get("talks")
+    if not isinstance(talks, list):
+        raise QueueClaimContractError(
+            "tracking database must contain a talks array"
+        )
+    seen: set[str] = set()
+    typed_talks: list[Mapping[str, object]] = []
+    for index, talk in enumerate(talks):
+        validate_talk_queue_claim_state(
+            talk,
+            index,
+            allow_claim_status_drift=allow_claim_status_drift,
+        )
+        assert isinstance(talk, Mapping)
+        filename = talk["filename"]
+        assert isinstance(filename, str)
+        if filename in seen:
+            raise QueueClaimContractError(
+                f"duplicate talk filename {filename!r} — filenames are queue "
+                "identities"
+            )
+        seen.add(filename)
+        typed_talks.append(talk)
+    _validate_adherence_claim_batches(typed_talks)
+
+
+def _validate_adherence_claim_batches(
+    talks: Sequence[Mapping[str, object]],
+) -> None:
+    """Require every stored v3/v4/v5 batch snapshot to be exact and shared."""
+    current_batches: dict[
+        tuple[object, object], list[tuple[str, Mapping[str, object]]]
+    ] = {}
+    claim_epochs: dict[
+        tuple[object, object, object],
+        list[tuple[str, Mapping[str, object]]],
+    ] = {}
+    for talk in talks:
+        filename = talk["filename"]
+        assert isinstance(filename, str)
+        current = talk.get("_queue_claim")
+        if isinstance(current, Mapping) and current.get(
+            "schema_version"
+        ) in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS:
+            identity = (current["run_id"], current["batch_id"])
+            current_batches.setdefault(identity, []).append((filename, current))
+            epoch = (*identity, current["claimed_at"])
+            claim_epochs.setdefault(epoch, []).append((filename, current))
+        history = talk.get("_queue_claim_history", [])
+        assert isinstance(history, list)
+        for claim in history:
+            assert isinstance(claim, Mapping)
+            if claim.get(
+                "schema_version"
+            ) not in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS:
+                continue
+            epoch = (
+                claim["run_id"],
+                claim["batch_id"],
+                claim["claimed_at"],
+            )
+            claim_epochs.setdefault(epoch, []).append((filename, claim))
+    for identity, members in current_batches.items():
+        claimed_at = members[0][1]["claimed_at"]
+        if any(claim["claimed_at"] != claimed_at for _, claim in members):
+            raise QueueClaimContractError(
+                f"adherence current claims for run {identity[0]!r} batch "
+                f"{identity[1]!r} do not share one claimed_at timestamp"
+            )
+    for epoch, members in claim_epochs.items():
+        _validate_adherence_claim_batch_members(epoch[:2], members)
+
+
+def _validate_adherence_claim_batch_members(
+    identity: tuple[object, object],
+    members: list[tuple[str, Mapping[str, object]]],
+) -> None:
+    expected_filenames = sorted(filename for filename, _ in members)
+    canonical = members[0][1]["adherence_baseline"]
+    canonical_version = members[0][1]["schema_version"]
+    for filename, claim in members:
+        if claim["schema_version"] != canonical_version:
+            raise QueueClaimContractError(
+                f"{filename}: claims for run {identity[0]!r} batch "
+                f"{identity[1]!r} mix adherence schema versions"
+            )
+        if claim["adherence_baseline"] != canonical:
+            raise QueueClaimContractError(
+                f"{filename}: schema-v{canonical_version} claims for run "
+                f"{identity[0]!r} batch {identity[1]!r} do not share one "
+                "immutable adherence_baseline"
+            )
+        baseline = claim["adherence_baseline"]
+        assert isinstance(baseline, Mapping)
+        if baseline["excluded_filenames"] != expected_filenames:
+            raise QueueClaimContractError(
+                f"{filename}: schema-v{canonical_version} adherence_baseline "
+                "excluded_filenames must equal the exact stored batch "
+                f"{expected_filenames}"
+            )

--- a/skills/vault-ingress/scripts/read-tracking-database.py
+++ b/skills/vault-ingress/scripts/read-tracking-database.py
@@ -8,6 +8,10 @@ import json
 from pathlib import Path
 import sys
 
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
 from tracking_database_io import (
     TrackingDatabaseIOError,
     decode_json_object,
@@ -21,6 +25,18 @@ REPORT_SCHEMA_VERSION = 1
 def execute(path: Path) -> dict[str, object]:
     snapshot = snapshot_tracking_database(path)
     database = decode_json_object(snapshot)
+    try:
+        assessment = assess_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseIOError(
+            f"tracking database owner assessment failed: {exc}"
+        ) from exc
+    if not assessment.usable:
+        reasons = ", ".join(assessment.reason_codes) or "unsupported_owner_state"
+        raise TrackingDatabaseIOError(
+            "tracking database has no usable legacy/current owner state "
+            f"({reasons})"
+        )
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
         "ok": True,

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -36,6 +36,11 @@ from ingress_contract import (
     parse_youtube_id,
     validate_talk_record_schemas,
 )
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+    require_current_tracking_database,
+)
 from tracking_database_io import (
     TrackingDatabaseConflictError,
     TrackingDatabaseIOError,
@@ -172,6 +177,15 @@ def _load_database(
         payload = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
         raise ShownotesScanError(str(exc)) from exc
+    try:
+        assessment = assess_tracking_database(payload)
+    except TrackingDatabaseError as exc:
+        raise ShownotesScanError(str(exc)) from exc
+    if not assessment.usable:
+        raise ShownotesScanError(
+            "tracking database is not usable by this reader: "
+            + ", ".join(assessment.reason_codes)
+        )
     try:
         validate_talk_record_schemas(payload.get("talks"))
     except ValueError as exc:
@@ -939,6 +953,11 @@ def _atomic_write_database(
 
 def execute(database_path: Path, *, apply_requested: bool) -> dict[str, Any]:
     database, database_snapshot = _load_database(database_path)
+    if apply_requested:
+        try:
+            require_current_tracking_database(database)
+        except TrackingDatabaseError as exc:
+            raise ShownotesScanError(str(exc)) from exc
     location = resolve_shownotes_location(database["config"])
     report, candidate = build_scan_report(
         database_path,

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1,0 +1,1033 @@
+"""Version and migration contract for ``tracking-database.json``.
+
+``vault-ingress`` owns this artifact's shape and all migrations.  Other skills
+may read the legacy and current generations during rollout.  They must never
+rewrite a legacy generation or infer a migration from fields that happen to be
+present.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+import datetime as dt
+import re
+from typing import Any, Mapping
+
+from queue_claim_contract import (
+    QueueClaimContractError,
+    classify_queue_claim_versions,
+    validate_queue_claim_database,
+)
+
+
+LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
+TRACKING_DATABASE_SCHEMA_VERSION = 1
+LEGACY_TALK_RECORD_SCHEMA_VERSION = 1
+TALK_RECORD_SCHEMA_VERSION = 5
+CONFIG_RECORD_SCHEMA_VERSION = 1
+PPTX_CATALOG_RECORD_SCHEMA_VERSION = 1
+QR_CODE_RECORD_SCHEMA_VERSION = 1
+RESOURCE_RECORD_SCHEMA_VERSION = 1
+THUMBNAIL_RECORD_SCHEMA_VERSION = 1
+CONFIRMED_INTENT_RECORD_SCHEMA_VERSION = 1
+SOURCE_REJECTION_RECORD_SCHEMA_VERSION = 1
+LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION = 1
+IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION = 2
+
+READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS = frozenset(
+    {
+        LEGACY_TRACKING_DATABASE_SCHEMA_VERSION,
+        TRACKING_DATABASE_SCHEMA_VERSION,
+    }
+)
+_READABLE_PATTERN_EVIDENCE_SCHEMA_VERSIONS = frozenset({1, 2})
+
+_TOP_LEVEL_COLLECTIONS = (
+    "talks",
+    "pptx_catalog",
+    "qr_codes",
+    "resources",
+    "thumbnails",
+    "confirmed_intents",
+    "improvement_goals",
+)
+_RECORD_COUNT_KEYS = (
+    "config",
+    "talks",
+    "pptx_catalog",
+    "qr_codes",
+    "resources",
+    "thumbnails",
+    "confirmed_intents",
+    "improvement_goals",
+    "source_rejections",
+)
+
+PPTX_CATALOG_REQUIRED_FIELDS = frozenset(
+    {"pptx_path", "talk_filename", "matched", "slide_count", "visual_extracted"}
+)
+QR_CODE_REQUIRED_FIELDS = frozenset(
+    {
+        "talk_slug",
+        "target_url",
+        "shortener",
+        "short_path",
+        "short_url",
+        "shortener_link_id",
+        "qr_png_rel_path",
+        "created_at",
+        "updated_at",
+    }
+)
+RESOURCE_REQUIRED_FIELDS = frozenset(
+    {"talk_slug", "item_count", "category_breakdown"}
+)
+THUMBNAIL_REQUIRED_FIELDS = frozenset(
+    {
+        "talk_slug",
+        "youtube_url",
+        "source_slide_num",
+        "speaker_photo_used",
+        "thumbnail_path",
+        "shownotes_thumbnail_path",
+        "dimensions",
+        "file_size_kb",
+        "created_at",
+        "approved",
+    }
+)
+CONFIRMED_INTENT_REQUIRED_FIELDS = frozenset(
+    {"pattern", "intent", "rule", "note"}
+)
+CONFIRMED_INTENT_OPTIONAL_FIELDS = frozenset(
+    {
+        "confirmed_date",
+        "source_talk",
+        "source_talks",
+        "talk",
+        "retrofit_targets",
+    }
+)
+SOURCE_REJECTION_REQUIRED_FIELDS = frozenset(
+    {"source_type", "url", "reason", "evidence", "verified_at"}
+)
+LEGACY_IMPROVEMENT_GOAL_REQUIRED_FIELDS = frozenset(
+    {
+        "id",
+        "issue",
+        "kind",
+        "antipattern_id",
+        "metric",
+        "baseline_value",
+        "target",
+        "set_date",
+        "set_by",
+        "status",
+        "current_value",
+        "last_checked",
+        "checked_by",
+    }
+)
+IMPROVEMENT_GOAL_REQUIRED_FIELDS = frozenset(
+    {
+        *LEGACY_IMPROVEMENT_GOAL_REQUIRED_FIELDS,
+        "verification_state",
+        "verification_reasons",
+        "supersedes_goal_id",
+        "baseline_provenance",
+    }
+)
+
+
+class TrackingDatabaseError(ValueError):
+    """The tracking database cannot be read or migrated safely."""
+
+
+@dataclass(frozen=True)
+class TrackingDatabaseAssessment:
+    """Compatibility decision for one in-memory database generation."""
+
+    usable: bool
+    state: str
+    schema_version: int
+    reason_codes: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "usable": self.usable,
+            "state": self.state,
+            "schema_version": self.schema_version,
+            "accepted_schema_versions": sorted(
+                READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS
+            ),
+            "reason_codes": list(self.reason_codes),
+        }
+
+
+@dataclass(frozen=True)
+class TrackingDatabaseMigration:
+    """Pure migration result; callers own backup and replacement I/O."""
+
+    database: dict[str, Any]
+    changed: bool
+    from_schema_version: int
+    to_schema_version: int
+    record_counts: Mapping[str, int]
+
+
+def _empty_record_counts() -> dict[str, int]:
+    """Return stable child-version insertion counters (root uses from/to)."""
+    return {key: 0 for key in _RECORD_COUNT_KEYS}
+
+
+def _record_version(
+    record: Mapping[str, object], label: str, *, missing_version: int = 0
+) -> int:
+    version = record.get("schema_version", missing_version)
+    if isinstance(version, bool) or not isinstance(version, int) or version < 0:
+        raise TrackingDatabaseError(
+            f"{label}.schema_version must be a non-negative integer, got {version!r}"
+        )
+    return version
+
+
+def tracking_database_schema_version(database: object) -> int:
+    if not isinstance(database, Mapping):
+        raise TrackingDatabaseError("tracking database root must be a JSON object")
+    return _record_version(database, "tracking database")
+
+
+def _object_collection(
+    database: Mapping[str, object], key: str, *, required: bool
+) -> list[dict[str, Any]]:
+    if key not in database:
+        if required:
+            raise TrackingDatabaseError(
+                f"tracking database schema v{TRACKING_DATABASE_SCHEMA_VERSION} "
+                f"requires a {key!r} array"
+            )
+        return []
+    value = database[key]
+    if not isinstance(value, list):
+        raise TrackingDatabaseError(f"tracking database {key!r} must be an array")
+    records: list[dict[str, Any]] = []
+    for index, record in enumerate(value):
+        if not isinstance(record, dict):
+            raise TrackingDatabaseError(
+                f"{key}[{index}] must be a JSON object, got {type(record).__name__}"
+            )
+        records.append(record)
+    return records
+
+
+def _version_reason(
+    records: list[dict[str, Any]],
+    *,
+    label: str,
+    accepted_versions: frozenset[int],
+    require_explicit: bool,
+    missing_version: int,
+) -> str | None:
+    for index, record in enumerate(records):
+        if require_explicit and "schema_version" not in record:
+            return f"{label}_schema_version_missing"
+        version = _record_version(
+            record,
+            f"{label}[{index}]",
+            missing_version=missing_version,
+        )
+        if version not in accepted_versions:
+            return f"{label}_schema_version_unsupported"
+    return None
+
+
+def _require_closed_shape(
+    record: Mapping[str, object],
+    *,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+    label: str,
+) -> None:
+    fields = set(record) - {"schema_version"}
+    missing = set(required) - fields
+    unknown = fields - set(required) - set(optional)
+    if missing:
+        raise TrackingDatabaseError(f"{label} is missing fields {sorted(missing)}")
+    if unknown:
+        raise TrackingDatabaseError(f"{label} has unknown fields {sorted(unknown)}")
+
+
+def _require_nonempty_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise TrackingDatabaseError(f"{label} must be a non-empty trimmed string")
+    return value
+
+
+def _require_string(value: object, label: str) -> None:
+    if not isinstance(value, str):
+        raise TrackingDatabaseError(f"{label} must be a string")
+
+
+def _require_optional_nonempty_string(value: object, label: str) -> None:
+    if value is not None:
+        _require_nonempty_string(value, label)
+
+
+def _require_exact_integer(
+    value: object,
+    label: str,
+    *,
+    minimum: int = 0,
+) -> int:
+    if type(value) is not int or value < minimum:
+        raise TrackingDatabaseError(
+            f"{label} must be an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def _require_iso_date(value: object, label: str) -> None:
+    date_text = _require_nonempty_string(value, label)
+    try:
+        parsed = dt.date.fromisoformat(date_text)
+    except ValueError as exc:
+        raise TrackingDatabaseError(f"{label} must be a canonical YYYY-MM-DD date") from exc
+    if parsed.isoformat() != date_text:
+        raise TrackingDatabaseError(f"{label} must be a canonical YYYY-MM-DD date")
+
+
+def _require_string_array(
+    value: object,
+    label: str,
+    *,
+    nonempty: bool = False,
+) -> None:
+    if not isinstance(value, list) or (nonempty and not value):
+        qualifier = "non-empty " if nonempty else ""
+        raise TrackingDatabaseError(f"{label} must be a {qualifier}array of strings")
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        _require_nonempty_string(item, f"{label}[{index}]")
+        if item in seen:
+            raise TrackingDatabaseError(f"{label} contains duplicate value {item!r}")
+        seen.add(item)
+
+
+def _validate_improvement_goal(
+    record: Mapping[str, object],
+    *,
+    version: int,
+    label: str,
+) -> None:
+    required = (
+        LEGACY_IMPROVEMENT_GOAL_REQUIRED_FIELDS
+        if version == LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION
+        else IMPROVEMENT_GOAL_REQUIRED_FIELDS
+    )
+    _require_closed_shape(record, required=required, label=label)
+    for field in (
+        "id",
+        "issue",
+        "metric",
+        "baseline_value",
+        "target",
+        "set_by",
+    ):
+        _require_nonempty_string(record[field], f"{label}.{field}")
+    _require_iso_date(record["set_date"], f"{label}.set_date")
+    kind = _require_nonempty_string(record["kind"], f"{label}.kind")
+    if kind not in {"antipattern", "underuse", "pacing", "other"}:
+        raise TrackingDatabaseError(f"{label}.kind is unsupported")
+    antipattern_id = record["antipattern_id"]
+    if kind == "antipattern":
+        _require_nonempty_string(antipattern_id, f"{label}.antipattern_id")
+    elif antipattern_id is not None:
+        raise TrackingDatabaseError(
+            f"{label}.antipattern_id must be null unless kind is antipattern"
+        )
+    status = _require_nonempty_string(record["status"], f"{label}.status")
+    if status not in {
+        "active",
+        "improving",
+        "achieved",
+        "stalled",
+        "regressed",
+        "retired",
+    }:
+        raise TrackingDatabaseError(f"{label}.status is unsupported")
+    _require_string(record["current_value"], f"{label}.current_value")
+    _require_optional_nonempty_string(record["last_checked"], f"{label}.last_checked")
+    if record["last_checked"] is not None:
+        _require_iso_date(record["last_checked"], f"{label}.last_checked")
+    _require_optional_nonempty_string(record["checked_by"], f"{label}.checked_by")
+    if (record["last_checked"] is None) != (record["checked_by"] is None):
+        raise TrackingDatabaseError(
+            f"{label}.last_checked and checked_by must both be null or both set"
+        )
+    if version == LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION:
+        return
+
+    verification_state = _require_nonempty_string(
+        record["verification_state"],
+        f"{label}.verification_state",
+    )
+    if verification_state not in {
+        "pending",
+        "current",
+        "needs_rebaseline",
+        "unverifiable",
+    }:
+        raise TrackingDatabaseError(f"{label}.verification_state is unsupported")
+    _require_string_array(
+        record["verification_reasons"],
+        f"{label}.verification_reasons",
+    )
+    _require_optional_nonempty_string(
+        record["supersedes_goal_id"],
+        f"{label}.supersedes_goal_id",
+    )
+    provenance = record["baseline_provenance"]
+    if not isinstance(provenance, Mapping):
+        raise TrackingDatabaseError(f"{label}.baseline_provenance must be an object")
+    _require_closed_shape(
+        provenance,
+        required=frozenset({"lane"}),
+        optional=frozenset({"pattern_baseline"}),
+        label=f"{label}.baseline_provenance",
+    )
+    lane = _require_nonempty_string(
+        provenance["lane"],
+        f"{label}.baseline_provenance.lane",
+    )
+    expected_lane = {
+        "antipattern": "pattern_scoring",
+        "underuse": "pattern_scoring",
+        "pacing": "pacing",
+        "other": "independent",
+    }[kind]
+    if lane != expected_lane:
+        raise TrackingDatabaseError(
+            f"{label}.baseline_provenance.lane must be {expected_lane!r}"
+        )
+    pattern_baseline = provenance.get("pattern_baseline")
+    if kind in {"antipattern", "underuse"}:
+        if not isinstance(pattern_baseline, Mapping):
+            raise TrackingDatabaseError(
+                f"{label}.baseline_provenance.pattern_baseline must be an object"
+            )
+    elif "pattern_baseline" in provenance:
+        raise TrackingDatabaseError(
+            f"{label}.baseline_provenance.pattern_baseline is valid only for "
+            "pattern goals"
+        )
+
+
+def _validate_schema_one_record(
+    collection: str,
+    record: Mapping[str, object],
+    *,
+    label: str,
+) -> None:
+    if collection == "pptx_catalog":
+        _require_closed_shape(
+            record,
+            required=PPTX_CATALOG_REQUIRED_FIELDS,
+            label=label,
+        )
+        _require_nonempty_string(record["pptx_path"], f"{label}.pptx_path")
+        talk_filename = record["talk_filename"]
+        if talk_filename is not None:
+            _require_nonempty_string(talk_filename, f"{label}.talk_filename")
+        if type(record["matched"]) is not bool:
+            raise TrackingDatabaseError(f"{label}.matched must be a boolean")
+        if record["matched"] != (talk_filename is not None):
+            raise TrackingDatabaseError(
+                f"{label}.matched must equal whether talk_filename is non-null"
+            )
+        _require_exact_integer(record["slide_count"], f"{label}.slide_count")
+        if type(record["visual_extracted"]) is not bool:
+            raise TrackingDatabaseError(
+                f"{label}.visual_extracted must be a boolean"
+            )
+        return
+    if collection == "qr_codes":
+        _require_closed_shape(record, required=QR_CODE_REQUIRED_FIELDS, label=label)
+        for field in (
+            "talk_slug",
+            "target_url",
+            "shortener",
+            "short_url",
+            "qr_png_rel_path",
+            "created_at",
+            "updated_at",
+        ):
+            _require_nonempty_string(record[field], f"{label}.{field}")
+        for field in ("short_path", "shortener_link_id"):
+            if record[field] is not None:
+                _require_nonempty_string(record[field], f"{label}.{field}")
+        _require_iso_date(record["created_at"], f"{label}.created_at")
+        _require_iso_date(record["updated_at"], f"{label}.updated_at")
+        return
+    if collection == "resources":
+        _require_closed_shape(record, required=RESOURCE_REQUIRED_FIELDS, label=label)
+        _require_nonempty_string(record["talk_slug"], f"{label}.talk_slug")
+        item_count = _require_exact_integer(
+            record["item_count"],
+            f"{label}.item_count",
+        )
+        breakdown = record["category_breakdown"]
+        if not isinstance(breakdown, Mapping):
+            raise TrackingDatabaseError(
+                f"{label}.category_breakdown must be an object"
+            )
+        category_total = 0
+        for category, count in breakdown.items():
+            _require_nonempty_string(category, f"{label}.category_breakdown key")
+            category_total += _require_exact_integer(
+                count,
+                f"{label}.category_breakdown[{category!r}]",
+            )
+        if item_count != category_total:
+            raise TrackingDatabaseError(
+                f"{label}.item_count must equal the category_breakdown total"
+            )
+        return
+    if collection == "thumbnails":
+        _require_closed_shape(record, required=THUMBNAIL_REQUIRED_FIELDS, label=label)
+        for field in (
+            "talk_slug",
+            "youtube_url",
+            "speaker_photo_used",
+            "thumbnail_path",
+            "shownotes_thumbnail_path",
+        ):
+            _require_nonempty_string(record[field], f"{label}.{field}")
+        _require_exact_integer(
+            record["source_slide_num"],
+            f"{label}.source_slide_num",
+            minimum=1,
+        )
+        dimensions = _require_nonempty_string(
+            record["dimensions"],
+            f"{label}.dimensions",
+        )
+        if re.fullmatch(r"[1-9][0-9]*x[1-9][0-9]*", dimensions) is None:
+            raise TrackingDatabaseError(
+                f"{label}.dimensions must use positive WIDTHxHEIGHT form"
+            )
+        _require_exact_integer(record["file_size_kb"], f"{label}.file_size_kb")
+        _require_iso_date(record["created_at"], f"{label}.created_at")
+        if type(record["approved"]) is not bool:
+            raise TrackingDatabaseError(f"{label}.approved must be a boolean")
+        return
+    if collection == "confirmed_intents":
+        _require_closed_shape(
+            record,
+            required=CONFIRMED_INTENT_REQUIRED_FIELDS,
+            optional=CONFIRMED_INTENT_OPTIONAL_FIELDS,
+            label=label,
+        )
+        for field in ("pattern", "intent", "rule"):
+            _require_nonempty_string(record[field], f"{label}.{field}")
+        _require_string(record["note"], f"{label}.note")
+        if "confirmed_date" in record:
+            _require_iso_date(record["confirmed_date"], f"{label}.confirmed_date")
+        provenance_fields = {
+            field
+            for field in ("talk", "source_talk", "source_talks")
+            if field in record
+        }
+        if len(provenance_fields) > 1:
+            raise TrackingDatabaseError(
+                f"{label} may use only one of talk, source_talk, or source_talks"
+            )
+        for field in ("talk", "source_talk"):
+            if field in record:
+                _require_nonempty_string(record[field], f"{label}.{field}")
+        for field in ("source_talks", "retrofit_targets"):
+            if field in record:
+                _require_string_array(
+                    record[field],
+                    f"{label}.{field}",
+                    nonempty=True,
+                )
+        return
+    if collection == "improvement_goals":
+        _validate_improvement_goal(
+            record,
+            version=LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+            label=label,
+        )
+        return
+    raise AssertionError(f"no schema-v1 validator for {collection}")
+
+
+def _validate_source_rejection(
+    rejection: Mapping[str, object],
+    *,
+    label: str,
+) -> None:
+    _require_closed_shape(
+        rejection,
+        required=SOURCE_REJECTION_REQUIRED_FIELDS,
+        label=label,
+    )
+    for field in ("url", "reason", "evidence"):
+        _require_nonempty_string(rejection[field], f"{label}.{field}")
+    source_type = _require_nonempty_string(
+        rejection["source_type"],
+        f"{label}.source_type",
+    )
+    if source_type not in {"video", "slides"}:
+        raise TrackingDatabaseError(f"{label}.source_type must be video or slides")
+    verified_at = _require_nonempty_string(
+        rejection["verified_at"],
+        f"{label}.verified_at",
+    )
+    try:
+        parsed = dt.datetime.fromisoformat(verified_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TrackingDatabaseError(
+            f"{label}.verified_at must be a timezone-aware ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise TrackingDatabaseError(
+            f"{label}.verified_at must be a timezone-aware ISO-8601 timestamp"
+        )
+
+
+def _validate_talk_observation_shape(
+    talk: Mapping[str, object],
+    index: int,
+    *,
+    talk_version: int,
+) -> None:
+    observations = talk.get("pattern_observations")
+    if (
+        talk_version > LEGACY_TALK_RECORD_SCHEMA_VERSION
+        and observations is not None
+        and not isinstance(observations, Mapping)
+    ):
+        raise TrackingDatabaseError(
+            f"talks[{index}].pattern_observations must be a JSON object"
+        )
+
+
+def _validate_record_identities(database: Mapping[str, object]) -> None:
+    identity_specs = (
+        ("talks", "filename"),
+        ("pptx_catalog", "pptx_path"),
+        ("qr_codes", "talk_slug"),
+        ("resources", "talk_slug"),
+        ("thumbnails", "talk_slug"),
+        ("confirmed_intents", "pattern"),
+        ("improvement_goals", "id"),
+    )
+    for collection, field in identity_specs:
+        if collection not in database:
+            continue
+        records = _object_collection(database, collection, required=False)
+        seen: set[str] = set()
+        for index, record in enumerate(records):
+            identity = record.get(field)
+            if not isinstance(identity, str) or not identity.strip():
+                raise TrackingDatabaseError(
+                    f"{collection}[{index}].{field} must be a non-empty string"
+                )
+            if identity in seen:
+                qualifier = "talk " if collection == "talks" else ""
+                raise TrackingDatabaseError(
+                    f"{collection} contains duplicate {qualifier}{field} {identity!r}"
+                )
+            seen.add(identity)
+
+
+def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
+    """Assess legacy/current compatibility without mutating ``database``.
+
+    Malformed JSON shapes raise.  Unsupported future generations return an
+    explicit no-usable-prior-state decision so non-owner readers can fail
+    closed without treating a lagging reader as a migration opportunity.
+    """
+    if not isinstance(database, Mapping):
+        raise TrackingDatabaseError("tracking database root must be a JSON object")
+    root_version_is_explicit = "schema_version" in database
+    root_version = tracking_database_schema_version(database)
+    if (
+        root_version not in READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS
+        or (
+            root_version_is_explicit
+            and root_version == LEGACY_TRACKING_DATABASE_SCHEMA_VERSION
+        )
+    ):
+        return TrackingDatabaseAssessment(
+            usable=False,
+            state="unsupported",
+            schema_version=root_version,
+            reason_codes=("tracking_database_schema_version_unsupported",),
+        )
+
+    current = root_version == TRACKING_DATABASE_SCHEMA_VERSION
+    if current and "config" not in database:
+        raise TrackingDatabaseError(
+            f"tracking database schema v{TRACKING_DATABASE_SCHEMA_VERSION} "
+            "requires a 'config' object"
+        )
+    config = database.get("config", {})
+    if not isinstance(config, Mapping):
+        raise TrackingDatabaseError("tracking database 'config' must be an object")
+    collections = {
+        key: _object_collection(database, key, required=current or key == "talks")
+        for key in _TOP_LEVEL_COLLECTIONS
+    }
+
+    reasons: list[str] = []
+    if current and "schema_version" not in config:
+        reasons.append("config_schema_version_missing")
+    if _record_version(
+        config,
+        "config",
+        missing_version=CONFIG_RECORD_SCHEMA_VERSION,
+    ) != CONFIG_RECORD_SCHEMA_VERSION:
+        reasons.append("config_schema_version_unsupported")
+
+    accepted_versions_by_collection = {
+        "talks": frozenset(
+            range(
+                LEGACY_TALK_RECORD_SCHEMA_VERSION,
+                TALK_RECORD_SCHEMA_VERSION + 1,
+            )
+        ),
+        "pptx_catalog": frozenset({PPTX_CATALOG_RECORD_SCHEMA_VERSION}),
+        "qr_codes": frozenset({QR_CODE_RECORD_SCHEMA_VERSION}),
+        "resources": frozenset({RESOURCE_RECORD_SCHEMA_VERSION}),
+        "thumbnails": frozenset({THUMBNAIL_RECORD_SCHEMA_VERSION}),
+        "confirmed_intents": frozenset({CONFIRMED_INTENT_RECORD_SCHEMA_VERSION}),
+        "improvement_goals": frozenset(
+            {
+                LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+                IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+            }
+        ),
+    }
+    for key, records in collections.items():
+        reason = _version_reason(
+            records,
+            label=key,
+            accepted_versions=accepted_versions_by_collection[key],
+            require_explicit=current,
+            missing_version=(
+                LEGACY_TALK_RECORD_SCHEMA_VERSION
+                if key == "talks"
+                else LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION
+                if key == "improvement_goals"
+                else 1
+            ),
+        )
+        if reason is not None:
+            reasons.append(reason)
+
+    # A future or explicitly ambiguous top-level owner record may have an
+    # entirely different identity and nested shape.  Never interpret it with
+    # the old schema merely to produce a more detailed error.
+    if reasons:
+        return TrackingDatabaseAssessment(
+            usable=False,
+            state="unsupported",
+            schema_version=root_version,
+            reason_codes=tuple(sorted(set(reasons))),
+        )
+
+    accepted_rejection_versions = frozenset(
+        {SOURCE_REJECTION_RECORD_SCHEMA_VERSION}
+    )
+    supported_talks: list[Mapping[str, object]] = []
+    for talk_index, talk in enumerate(collections["talks"]):
+        talk_version = _record_version(
+            talk,
+            f"talks[{talk_index}]",
+            missing_version=LEGACY_TALK_RECORD_SCHEMA_VERSION,
+        )
+        if talk_version not in accepted_versions_by_collection["talks"]:
+            continue
+        supported_talks.append(talk)
+        observations = talk.get("pattern_observations")
+        if isinstance(observations, Mapping) and (
+            "evidence_schema_version" in observations
+        ):
+            evidence_version = observations["evidence_schema_version"]
+            if (
+                isinstance(evidence_version, bool)
+                or not isinstance(evidence_version, int)
+                or evidence_version < 0
+            ):
+                raise TrackingDatabaseError(
+                    f"talks[{talk_index}].pattern_observations."
+                    "evidence_schema_version must be a non-negative integer, "
+                    f"got {evidence_version!r}"
+                )
+            if evidence_version not in _READABLE_PATTERN_EVIDENCE_SCHEMA_VERSIONS:
+                reasons.append("pattern_evidence_schema_version_unsupported")
+
+        rejections = talk.get("source_rejections", [])
+        if not isinstance(rejections, list):
+            continue
+        for rejection_index, rejection in enumerate(rejections):
+            if not isinstance(rejection, Mapping):
+                continue
+            if current and "schema_version" not in rejection:
+                reasons.append("source_rejections_schema_version_missing")
+                break
+            rejection_version = _record_version(
+                rejection,
+                f"talks[{talk_index}].source_rejections[{rejection_index}]",
+                missing_version=SOURCE_REJECTION_RECORD_SCHEMA_VERSION,
+            )
+            if rejection_version not in accepted_rejection_versions:
+                reasons.append("source_rejections_schema_version_unsupported")
+                break
+
+    try:
+        reasons.extend(classify_queue_claim_versions(supported_talks))
+    except QueueClaimContractError as exc:
+        raise TrackingDatabaseError(str(exc)) from exc
+
+    # The independent nested version gates have now classified every shape
+    # that this reader can safely understand.  Future state stops here.
+    if reasons:
+        return TrackingDatabaseAssessment(
+            usable=False,
+            state="unsupported",
+            schema_version=root_version,
+            reason_codes=tuple(sorted(set(reasons))),
+        )
+
+    _validate_record_identities(database)
+
+    for key in (
+        "pptx_catalog",
+        "qr_codes",
+        "resources",
+        "thumbnails",
+        "confirmed_intents",
+        "improvement_goals",
+    ):
+        for index, record in enumerate(collections[key]):
+            version = _record_version(
+                record,
+                f"{key}[{index}]",
+                missing_version=1,
+            )
+            if key == "improvement_goals" and version in {
+                LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+                IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+            }:
+                _validate_improvement_goal(
+                    record,
+                    version=version,
+                    label=f"{key}[{index}]",
+                )
+            elif version == 1:
+                _validate_schema_one_record(key, record, label=f"{key}[{index}]")
+
+    for talk_index, talk in enumerate(collections["talks"]):
+        talk_version = _record_version(
+            talk,
+            f"talks[{talk_index}]",
+            missing_version=LEGACY_TALK_RECORD_SCHEMA_VERSION,
+        )
+        _validate_talk_observation_shape(
+            talk,
+            talk_index,
+            talk_version=talk_version,
+        )
+        rejections = talk.get("source_rejections", [])
+        if not isinstance(rejections, list):
+            raise TrackingDatabaseError(
+                f"talks[{talk_index}].source_rejections must be an array"
+            )
+        for rejection_index, rejection in enumerate(rejections):
+            if not isinstance(rejection, Mapping):
+                raise TrackingDatabaseError(
+                    f"talks[{talk_index}].source_rejections[{rejection_index}] "
+                    "must be a JSON object"
+                )
+            _validate_source_rejection(
+                rejection,
+                label=f"talks[{talk_index}].source_rejections[{rejection_index}]",
+            )
+
+    try:
+        # Assessment intentionally admits claim/status drift so schema-0 queue
+        # recovery can reach its dedicated repair transition.  Every other
+        # claim/history/generation/batch invariant remains mandatory.
+        validate_queue_claim_database(
+            database,
+            allow_claim_status_drift=True,
+        )
+    except QueueClaimContractError as exc:
+        raise TrackingDatabaseError(str(exc)) from exc
+
+    return TrackingDatabaseAssessment(
+        usable=True,
+        state="current" if current else "legacy",
+        schema_version=root_version,
+        reason_codes=(),
+    )
+
+
+def require_current_tracking_database(database: object) -> dict[str, Any]:
+    """Return a current database or raise with owner-migration guidance."""
+    version = tracking_database_schema_version(database)
+    try:
+        assessment = assess_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        if version == TRACKING_DATABASE_SCHEMA_VERSION:
+            raise TrackingDatabaseError(
+                "tracking database schema v1 has malformed owner-managed state; "
+                "update speaker-toolkit or repair the owner-managed state. Schema "
+                f"migration will refuse this state ({exc})"
+            ) from exc
+        raise
+    if assessment.usable and assessment.state == "current":
+        if not isinstance(database, dict):
+            raise TrackingDatabaseError(
+                "tracking database root must be a JSON object"
+            )
+        return database
+    if assessment.usable and assessment.state == "legacy":
+        raise TrackingDatabaseError(
+            "tracking database uses legacy schema 0; run "
+            "skills/vault-ingress/scripts/migrate-tracking-database.py first"
+        )
+    reasons = ", ".join(assessment.reason_codes) or "unsupported_owner_state"
+    raise TrackingDatabaseError(
+        f"tracking database schema v{assessment.schema_version} contains "
+        "unsupported owner-managed state; update speaker-toolkit or repair the "
+        "owner-managed state. Schema migration will refuse this state "
+        f"({reasons})"
+    )
+
+
+def _active_claim_filenames(talks: list[dict[str, Any]]) -> list[str]:
+    active: list[str] = []
+    for index, talk in enumerate(talks):
+        claim = talk.get("_queue_claim")
+        if talk.get("status") == "reprocessing-inflight" or (
+            isinstance(claim, Mapping) and claim.get("state") == "claimed"
+        ):
+            filename = talk.get("filename")
+            active.append(filename if isinstance(filename, str) else f"talks[{index}]")
+    return sorted(active)
+
+
+def _migrate_talk_record(talk: dict[str, Any]) -> bool:
+    """Make implicit v1 record versions explicit without changing evidence."""
+    talk_version_added = "schema_version" not in talk
+    rejections = talk.get("source_rejections", [])
+    if isinstance(rejections, list):
+        for rejection in rejections:
+            if (
+                isinstance(rejection, dict)
+                and "schema_version" not in rejection
+            ):
+                rejection["schema_version"] = SOURCE_REJECTION_RECORD_SCHEMA_VERSION
+    if talk_version_added:
+        talk["schema_version"] = LEGACY_TALK_RECORD_SCHEMA_VERSION
+    return talk_version_added
+
+
+def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
+    """Build the deterministic owner migration from legacy schema 0 to 1."""
+    assessment = assess_tracking_database(database)
+    if not assessment.usable:
+        raise TrackingDatabaseError(
+            "tracking database cannot be migrated by this owner version: "
+            + ", ".join(assessment.reason_codes)
+        )
+    if assessment.state == "current":
+        current = require_current_tracking_database(database)
+        return TrackingDatabaseMigration(
+            database=copy.deepcopy(current),
+            changed=False,
+            from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+            to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+            record_counts=_empty_record_counts(),
+        )
+    if not isinstance(database, dict):
+        raise TrackingDatabaseError("tracking database root must be a JSON object")
+
+    candidate: dict[str, Any] = copy.deepcopy(database)
+    talks = _object_collection(candidate, "talks", required=True)
+    active = _active_claim_filenames(talks)
+    if active:
+        raise TrackingDatabaseError(
+            "tracking database has active queue writers; recover or complete these "
+            f"claims before migration: {active}"
+        )
+
+    config = candidate.setdefault("config", {})
+    if not isinstance(config, dict):
+        raise TrackingDatabaseError("tracking database 'config' must be an object")
+    config_changed = "schema_version" not in config
+    config.setdefault("schema_version", CONFIG_RECORD_SCHEMA_VERSION)
+
+    counts = _empty_record_counts()
+    counts["config"] = int(config_changed)
+    for talk in talks:
+        prior_rejections = talk.get("source_rejections", [])
+        if isinstance(prior_rejections, list):
+            counts["source_rejections"] += sum(
+                isinstance(record, dict) and "schema_version" not in record
+                for record in prior_rejections
+            )
+        if _migrate_talk_record(talk):
+            counts["talks"] += 1
+
+    simple_collections = {
+        "pptx_catalog": PPTX_CATALOG_RECORD_SCHEMA_VERSION,
+        "qr_codes": QR_CODE_RECORD_SCHEMA_VERSION,
+        "resources": RESOURCE_RECORD_SCHEMA_VERSION,
+        "thumbnails": THUMBNAIL_RECORD_SCHEMA_VERSION,
+        "confirmed_intents": CONFIRMED_INTENT_RECORD_SCHEMA_VERSION,
+    }
+    for key, schema_version in simple_collections.items():
+        records = candidate.setdefault(key, [])
+        if not isinstance(records, list):
+            raise TrackingDatabaseError(f"tracking database {key!r} must be an array")
+        for record in records:
+            if not isinstance(record, dict):
+                raise TrackingDatabaseError(
+                    f"tracking database {key!r} has a non-object"
+                )
+            if "schema_version" not in record:
+                record["schema_version"] = schema_version
+                counts[key] += 1
+
+    goals = candidate.setdefault("improvement_goals", [])
+    if not isinstance(goals, list):
+        raise TrackingDatabaseError(
+            "tracking database 'improvement_goals' must be an array"
+        )
+    for index, goal in enumerate(goals):
+        if not isinstance(goal, dict):
+            raise TrackingDatabaseError("improvement_goals contains a non-object")
+        _record_version(
+            goal,
+            f"improvement_goals[{index}]",
+            missing_version=LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
+        )
+        if "schema_version" not in goal:
+            goal["schema_version"] = LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION
+            counts["improvement_goals"] += 1
+
+    candidate["schema_version"] = TRACKING_DATABASE_SCHEMA_VERSION
+    require_current_tracking_database(candidate)
+    return TrackingDatabaseMigration(
+        database=candidate,
+        changed=True,
+        from_schema_version=LEGACY_TRACKING_DATABASE_SCHEMA_VERSION,
+        to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+        record_counts=counts,
+    )

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass
+from decimal import Decimal, DecimalException
 import fcntl
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import secrets
@@ -26,6 +28,7 @@ from typing import Any, Iterator, NoReturn
 
 
 READ_CHUNK_SIZE = 1024 * 1024
+MAX_JSON_NESTING_DEPTH = 200
 
 
 class TrackingDatabaseIOError(ValueError):
@@ -250,13 +253,53 @@ def snapshot_tracking_database(
     )
 
 
+def _validate_decoded_json_tree(payload: object, *, subject: str) -> None:
+    """Reject unsafe depth and non-scalar Unicode without recursive walking."""
+    pending: list[tuple[object, int]] = [(payload, 0)]
+    deepest_container_visits: dict[int, int] = {}
+    while pending:
+        value, depth = pending.pop()
+        if isinstance(value, str):
+            if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+                raise TrackingDatabaseIOError(
+                    f"{subject} contains an unpaired UTF-16 surrogate in a "
+                    "JSON string"
+                )
+            continue
+        if isinstance(value, dict):
+            if depth > MAX_JSON_NESTING_DEPTH:
+                raise TrackingDatabaseIOError(
+                    f"{subject} exceeds maximum supported JSON nesting depth "
+                    f"{MAX_JSON_NESTING_DEPTH}"
+                )
+            previous_depth = deepest_container_visits.get(id(value))
+            if previous_depth is not None and previous_depth >= depth:
+                continue
+            deepest_container_visits[id(value)] = depth
+            for key, child in value.items():
+                pending.append((key, depth + 1))
+                pending.append((child, depth + 1))
+            continue
+        if isinstance(value, list):
+            if depth > MAX_JSON_NESTING_DEPTH:
+                raise TrackingDatabaseIOError(
+                    f"{subject} exceeds maximum supported JSON nesting depth "
+                    f"{MAX_JSON_NESTING_DEPTH}"
+                )
+            previous_depth = deepest_container_visits.get(id(value))
+            if previous_depth is not None and previous_depth >= depth:
+                continue
+            deepest_container_visits[id(value)] = depth
+            pending.extend((child, depth + 1) for child in value)
+
+
 def decode_json_object_bytes(
     raw: bytes,
     path: str | os.PathLike[str],
     *,
     label: str = "tracking database",
 ) -> dict[str, Any]:
-    """Decode strict UTF-8 JSON while rejecting duplicate keys and non-finite values."""
+    """Decode one bounded, Unicode-scalar, strict UTF-8 JSON object."""
     artifact_path = _absolute_path(path)
 
     def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -274,11 +317,42 @@ def decode_json_object_bytes(
             f"{label} {artifact_path} contains non-standard JSON number {value}"
         )
 
+    def non_roundtrippable_number(value: str) -> TrackingDatabaseIOError:
+        description = (
+            repr(value)
+            if len(value) <= 80
+            else f"with {len(value)} characters beginning {value[:32]!r}"
+        )
+        return TrackingDatabaseIOError(
+            f"{label} {artifact_path} contains JSON number {description} that "
+            "cannot round-trip losslessly through this toolkit; replace it "
+            "with a string or use a supported finite number"
+        )
+
+    def parse_lossless_int(value: str) -> int:
+        try:
+            return int(value)
+        except (ValueError, OverflowError) as exc:
+            raise non_roundtrippable_number(value) from exc
+
+    def parse_lossless_float(value: str) -> float:
+        """Reject numbers that cannot round-trip through the toolkit decoder."""
+        try:
+            exact = Decimal(value)
+            decoded = float(value)
+        except (DecimalException, ValueError, OverflowError) as exc:
+            raise non_roundtrippable_number(value) from exc
+        if not math.isfinite(decoded) or Decimal(repr(decoded)) != exact:
+            raise non_roundtrippable_number(value)
+        return decoded
+
     try:
         payload = json.loads(
             raw.decode("utf-8"),
             object_pairs_hook=reject_duplicate_keys,
             parse_constant=reject_non_finite,
+            parse_float=parse_lossless_float,
+            parse_int=parse_lossless_int,
         )
     except TrackingDatabaseIOError:
         raise
@@ -286,11 +360,20 @@ def decode_json_object_bytes(
         raise TrackingDatabaseIOError(
             f"{label} {artifact_path} is not valid UTF-8: {exc}"
         ) from exc
+    except RecursionError as exc:
+        raise TrackingDatabaseIOError(
+            f"{label} {artifact_path} exceeds maximum supported JSON nesting "
+            f"depth {MAX_JSON_NESTING_DEPTH}"
+        ) from exc
     except json.JSONDecodeError as exc:
         raise TrackingDatabaseIOError(
             f"{label} {artifact_path} is not valid JSON at line {exc.lineno}, "
             f"column {exc.colno}"
         ) from exc
+    _validate_decoded_json_tree(
+        payload,
+        subject=f"{label} {artifact_path}",
+    )
     if not isinstance(payload, dict):
         raise TrackingDatabaseIOError(
             f"{label} {artifact_path} root must be a JSON object"
@@ -309,6 +392,10 @@ def decode_json_object(
 
 def render_json_object(payload: dict[str, Any]) -> bytes:
     """Render the canonical human-readable tracking-database JSON form."""
+    _validate_decoded_json_tree(
+        payload,
+        subject="tracking-database candidate",
+    )
     try:
         rendered = json.dumps(
             payload,
@@ -316,11 +403,22 @@ def render_json_object(payload: dict[str, Any]) -> bytes:
             ensure_ascii=False,
             allow_nan=False,
         )
+    except RecursionError as exc:
+        raise TrackingDatabaseIOError(
+            "tracking-database candidate exceeds maximum supported JSON nesting "
+            f"depth {MAX_JSON_NESTING_DEPTH}"
+        ) from exc
     except (TypeError, ValueError) as exc:
         raise TrackingDatabaseIOError(
             f"tracking-database candidate is not strict JSON: {exc}"
         ) from exc
-    return rendered.encode("utf-8") + b"\n"
+    try:
+        return rendered.encode("utf-8") + b"\n"
+    except UnicodeEncodeError as exc:
+        raise TrackingDatabaseIOError(
+            "tracking-database candidate contains an unpaired UTF-16 surrogate "
+            "and is not valid Unicode scalar text"
+        ) from exc
 
 
 def _lock_identity(metadata: os.stat_result) -> tuple[int, int]:

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -66,6 +66,10 @@ import sys
 import tempfile
 import unicodedata
 
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
 from pattern_evidence import (
     LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION,
     PATTERN_EVIDENCE_SCHEMA_VERSION,
@@ -1017,13 +1021,29 @@ def load_tracking_database(path):
     """Load the owner artifact through its strict shared decoder."""
     try:
         snapshot = snapshot_tracking_database(path)
-        return decode_json_object(snapshot)
+        database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
         message = str(exc)
         if "root must be a JSON object" in message:
             message += "; expected an object with a `talks` array"
         print(f"ERROR: {message}", file=sys.stderr)
         sys.exit(1)
+    try:
+        assessment = assess_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        print(
+            f"ERROR: tracking database schema is invalid: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not assessment.usable:
+        print(
+            "ERROR: tracking database is not usable by this reader: "
+            + ", ".join(assessment.reason_codes),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return database
 
 
 def parse_args(argv):
@@ -1080,7 +1100,7 @@ def main():
         )
         sys.exit(1)
     db = load_tracking_database(talks_path)
-    if not isinstance(db, dict) or not isinstance(db.get("talks"), list):
+    if not isinstance(db.get("talks"), list):
         print(
             f"ERROR: {talks_path} is not a tracking database — expected a JSON "
             f"object with a `talks` array; pass the vault's "

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -110,6 +110,10 @@ Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/load-v
   never confers pattern-baseline eligibility.
 - Exit non-zero with stderr message if arguments, vault sources, catalog identity, or
   scoring-generation metadata are missing or malformed.
+- Legacy database schema 0 and current schema 1 are read-only inputs. An
+  unsupported future database or record schema exits non-zero as no usable prior
+  state. Compatibility stays internal and does not add fields to the payload.
+  This skill never migrates the database.
 
 If the script aborts on missing `rhetoric-style-summary.md`, run vault-ingress first. If `slide-design-spec.md` is missing, `design_spec` is `""` and the design-spec section of the profile remains empty — continue without aborting.
 

--- a/skills/vault-profile/references/schemas-config.md
+++ b/skills/vault-profile/references/schemas-config.md
@@ -3,7 +3,7 @@
 ## Config Fields — Clarification Session Questions
 
 Fields below `template_skip_patterns` are asked during vault-clarification
-Step 4 (first session only) when empty. The question column shows what to
+Step 5 (first session only) when empty. The question column shows what to
 ask the speaker.
 
 | Config field | Question |
@@ -30,6 +30,7 @@ ask the speaker.
 ```json
 {
   "config": {
+    "schema_version": 1,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
     "vault_storage_path": "/actual/path/if/custom (null when using default location)",
     "pptx_source_dir": "/path/to/Presentations",
@@ -151,9 +152,9 @@ them as follows:
 | `config.talks_source_dir` | `config.shownotes.source.path_or_url` + `talks_subdir` (split on the last path segment) |
 | `config.shownotes_url_pattern` (flat `{slug}`) | `config.shownotes.url.base` + `config.shownotes.url.template` (template defaults to `/{slug}/`) |
 
-If a vault presents only the legacy fields, readers should upgrade-on-read
-(build the shownotes block in memory) and vault-profile writes the new schema
-on next regeneration. Do not leave both shapes populated — one source of truth.
+If a vault presents only the legacy fields, readers build the shownotes block
+in memory. vault-ingress owns persistence of the current config shape. Do not
+leave both shapes populated — one source of truth.
 
 ## Confirmed Intents Schema
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -479,6 +479,15 @@ not a closed three-value enum. `deliberate`, `accidental`, and
 `context_dependent` are recommended defaults, while established labels such as
 `accepted_tradeoff`, `fact`, or `deliberate_signature` remain authoritative.
 
+The `confirmed_intents[].schema_version` shown in the profile is the independent
+public profile-domain intent schema, not the tracking-database record version.
+`load-vault.py` projects only `pattern`, `intent`, `rule`, and `note` from stored
+intent records; it strips database schema and capture provenance before profile
+generation. Storage-only fields such as `confirmed_date`, source-talk pointers,
+and `retrofit_targets` intentionally do not enter the semantic profile. The
+profile producer then emits the profile-domain schema-v1 intent object shown
+above.
+
 ### Pattern Cohort Provenance
 
 `pattern_profile.pattern_baseline` is copied unchanged from the loader's

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -21,7 +21,7 @@ Stdout (JSON):
     {
       "vault_root":        "<absolute path>",
       "config":            { ... }   # tracking-database.json `config` block
-      "confirmed_intents": [ ... ]   # tracking-database.json `confirmed_intents`
+      "confirmed_intents": [ ... ]   # projected semantic intent fields
       "talks":             [ ... ]   # all talks
       "processed_talks":   [ ... ]   # talks with status processed* only
       "baseline_talks":    [ ... ]   # exact active pattern-scoring generation
@@ -71,6 +71,10 @@ from return_validation import (  # noqa: E402
     ReturnValidationError,
     load_catalog,
 )
+from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
@@ -86,6 +90,7 @@ DEFAULT_VAULT = "~/.claude/rhetoric-knowledge-vault"
 # baseline eligibility is determined independently by exact catalog/scoring
 # identity through ``partition_pattern_scoring_cohort``.
 INSTRUMENTATION_EPOCH = "2026-07-26"
+_CONFIRMED_INTENT_PROFILE_FIELDS = ("pattern", "intent", "rule", "note")
 
 
 def partition_by_instrumentation(processed_talks, epoch=INSTRUMENTATION_EPOCH):
@@ -112,6 +117,18 @@ def default_as_of(now: datetime | None = None) -> str:
     if not isinstance(moment, datetime):
         raise AdherenceBaselineError("now must be a datetime")
     return normalize_as_of(moment.isoformat())
+
+
+def project_confirmed_intents(records):
+    """Remove tracking-storage metadata from the public profile projection."""
+    projected = []
+    for record in records:
+        projected.append({
+            field: record[field]
+            for field in _CONFIRMED_INTENT_PROFILE_FIELDS
+            if field in record
+        })
+    return projected
 
 
 def _parse_args(argv: list[str]) -> tuple[pathlib.Path, str | None]:
@@ -166,6 +183,20 @@ def main(argv: list[str]) -> int:
         db = decode_json_object(database_snapshot)
     except TrackingDatabaseIOError as exc:
         print(f"ERROR: tracking-database.json is malformed: {exc}", file=sys.stderr)
+        return 1
+    try:
+        database_assessment = assess_tracking_database(db)
+    except TrackingDatabaseError as exc:
+        print(
+            f"ERROR: tracking-database.json schema is invalid: {exc}", file=sys.stderr
+        )
+        return 1
+    if not database_assessment.usable:
+        print(
+            "ERROR: tracking-database.json is not usable by this reader: "
+            + ", ".join(database_assessment.reason_codes),
+            file=sys.stderr,
+        )
         return 1
 
     summary_path = vault_root / "rhetoric-style-summary.md"
@@ -232,7 +263,9 @@ def main(argv: list[str]) -> int:
     payload = {
         "vault_root": str(vault_root),
         "config": db.get("config", {}),
-        "confirmed_intents": db.get("confirmed_intents", []),
+        "confirmed_intents": project_confirmed_intents(
+            db.get("confirmed_intents", [])
+        ),
         "talks": talks,
         "processed_talks": processed_talks,
         "baseline_talks": baseline_talks,

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -71,6 +71,7 @@ from return_validation import (  # noqa: E402
     ReturnValidationError,
     load_catalog,
 )
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseError,
     assess_tracking_database,

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -57,6 +57,7 @@ from pattern_opportunities import PatternOpportunityError  # noqa: E402
 from return_validation import (  # noqa: E402
     ReturnValidationError,
 )
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseError,
     assess_tracking_database,

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -57,6 +57,10 @@ from pattern_opportunities import PatternOpportunityError  # noqa: E402
 from return_validation import (  # noqa: E402
     ReturnValidationError,
 )
+from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
@@ -575,14 +579,33 @@ def _load_json(path: Path) -> object:
         ) from exc
 
 
+def _require_usable_tracking_database(tracking_database: object) -> None:
+    """Reject malformed or unreadable owner generations before config semantics."""
+    if not isinstance(tracking_database, Mapping):
+        raise Section15PatternHistoryError("tracking database must be a JSON object")
+    try:
+        assessment = assess_tracking_database(tracking_database)
+    except TrackingDatabaseError as exc:
+        raise Section15PatternHistoryError(
+            f"tracking database schema is invalid: {exc}"
+        ) from exc
+    if not assessment.usable:
+        raise Section15PatternHistoryError(
+            "tracking database has no usable prior state for this reader: "
+            + ", ".join(assessment.reason_codes)
+        )
+
+
 def _load_tracking_database(path: Path) -> dict[str, Any]:
     try:
         snapshot = snapshot_tracking_database(path)
-        return decode_json_object(snapshot)
+        tracking_database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
         raise Section15PatternHistoryError(
             f"cannot load strict tracking database from {path}: {exc}"
         ) from exc
+    _require_usable_tracking_database(tracking_database)
+    return tracking_database
 
 
 def _pattern_profile_candidate(value: object) -> object:
@@ -598,8 +621,8 @@ def _validate_complete_tracking_cohort(
     evidence_freshness_assessor: EvidenceFreshnessAssessor,
 ) -> None:
     """Bind a write candidate to the complete live scoring cohort."""
-    if not isinstance(tracking_database, Mapping):
-        raise Section15PatternHistoryError("tracking database must be a JSON object")
+    _require_usable_tracking_database(tracking_database)
+    assert isinstance(tracking_database, Mapping)
     talks = tracking_database.get("talks")
     if not isinstance(talks, list):
         raise Section15PatternHistoryError(

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -53,6 +53,10 @@ from pattern_cohort_snapshot import (  # noqa: E402
     build_current_pattern_snapshot,
     configured_evidence_freshness_assessor,
 )
+from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
@@ -171,6 +175,15 @@ def _load_live_pattern_snapshot(
         database = decode_json_object(database_snapshot)
     except TrackingDatabaseIOError as exc:
         raise ValueError(f"tracking-database.json is invalid: {exc}") from exc
+    try:
+        assessment = assess_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        raise ValueError(f"tracking-database.json schema is invalid: {exc}") from exc
+    if not assessment.usable:
+        raise ValueError(
+            "tracking-database.json has no usable prior state for this reader: "
+            + ", ".join(assessment.reason_codes)
+        )
     talks = database.get("talks")
     if not isinstance(talks, list) or any(
         not isinstance(talk, Mapping) for talk in talks

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -53,6 +53,7 @@ from pattern_cohort_snapshot import (  # noqa: E402
     build_current_pattern_snapshot,
     configured_evidence_freshness_assessor,
 )
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseError,
     assess_tracking_database,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,21 @@ def scan_shownotes_module():
 
 
 @pytest.fixture(scope="session")
+def tracking_database():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "tracking_database.py"), "tracking_database"
+    )
+
+
+@pytest.fixture(scope="session")
+def migrate_tracking_database():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "migrate-tracking-database.py"),
+        "migrate_tracking_database",
+    )
+
+
+@pytest.fixture(scope="session")
 def return_validation():
     return _import_script(
         os.path.join(SCRIPTS_VI, "return_validation.py"), "return_validation")

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -13,14 +13,22 @@ def write_json(path, value):
 
 def base_database():
     return {
-        "config": {},
+        "schema_version": 1,
+        "config": {"schema_version": 1},
         "talks": [{
+            "schema_version": 5,
             "filename": "talk.md",
             "status": "processed",
             "video_url": "https://youtu.be/AbCdEfGhI_1",
             "youtube_id": "AbCdEfGhI_1",
             "transcript_source": "youtube_auto",
         }],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
     }
 
 
@@ -69,6 +77,55 @@ def test_dry_run_reports_changes_without_writing(
     assert report["database_written"] is False
     assert report["durability_state"] == "dry_run"
     assert report["warnings"] == []
+    assert database_path.read_bytes() == before
+
+
+def test_legacy_database_rejects_repair_dry_run_without_writing(
+    apply_source_repairs, tmp_path,
+):
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    database = base_database()
+    database.pop("schema_version")
+    database["config"].pop("schema_version")
+    database["talks"][0].pop("schema_version")
+    write_json(database_path, database)
+    write_json(plan_path, repair_plan())
+    before = database_path.read_bytes()
+
+    with pytest.raises(
+        apply_source_repairs.SourceRepairError,
+        match="migrate-tracking-database.py",
+    ):
+        apply_source_repairs.execute(database_path, plan_path, apply=False)
+
+    assert database_path.read_bytes() == before
+
+
+def test_repair_cannot_create_unversioned_source_rejection(
+    apply_source_repairs, tmp_path,
+):
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    write_json(database_path, base_database())
+    plan = repair_plan()
+    plan["repairs"][0]["expect"]["source_rejections"] = {"$missing": True}
+    plan["repairs"][0]["set"]["source_rejections"] = [{
+        "source_type": "video",
+        "url": "https://youtu.be/AbCdEfGhI_1",
+        "reason": "wrong_delivery",
+        "evidence": "provider metadata identifies another delivery",
+        "verified_at": "2026-08-01T12:00:00+00:00",
+    }]
+    write_json(plan_path, plan)
+    before = database_path.read_bytes()
+
+    with pytest.raises(
+        apply_source_repairs.SourceRepairError,
+        match="source_rejections_schema_version_missing",
+    ):
+        apply_source_repairs.execute(database_path, plan_path, apply=False)
+
     assert database_path.read_bytes() == before
 
 
@@ -220,7 +277,16 @@ def test_active_queue_claim_cannot_be_repaired(
     plan_path = tmp_path / "plan.json"
     database = base_database()
     database["talks"][0]["status"] = "reprocessing-inflight"
-    database["talks"][0]["_queue_claim"] = {"state": "claimed"}
+    database["talks"][0]["reprocess_generation"] = 1
+    database["talks"][0]["_queue_claim"] = {
+        "schema_version": 1,
+        "run_id": "repair-blocked",
+        "batch_id": "1",
+        "claimed_at": "2026-08-01T12:00:00+00:00",
+        "previous_status": "needs-reprocessing",
+        "reprocess_generation": 1,
+        "state": "claimed",
+    }
     write_json(database_path, database)
     write_json(plan_path, repair_plan())
 

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -401,6 +401,28 @@ def test_inactive_stored_id_is_not_fetched_or_resurrected(
     assert report["talks"] == []
 
 
+def test_future_tracking_database_is_not_fetched_or_rewritten(
+        audit_source_identities):
+    database = {
+        "schema_version": 99,
+        "future_inventory": {"records": "not-an-old-talks-array"},
+    }
+    before = json.dumps(database, sort_keys=True)
+    calls = []
+
+    report = audit_source_identities.audit_database(
+        database,
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=lambda video_id: calls.append(video_id),
+        captured_at=CAPTURED_AT,
+    )
+
+    assert calls == []
+    assert "tracking_database_schema_unsupported" in finding_codes(report)
+    assert "talks_shape_invalid" not in finding_codes(report)
+    assert json.dumps(database, sort_keys=True) == before
+
+
 def test_incomplete_provider_metadata_is_proposed_without_invented_values(
         audit_source_identities):
     report = audit_source_identities.audit_database(

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -2,13 +2,30 @@
 
 import json
 import os
+import sys
+from pathlib import Path
+
+import pytest
 
 from PIL import Image
 from pptx import Presentation
 from pptx.util import Inches
-import pytest
 
 from conftest import make_deck
+
+
+def _current_tracking_database():
+    return {
+        "schema_version": 1,
+        "config": {"schema_version": 1},
+        "talks": [],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
 
 
 def _square_png(tmp_path, name="sq.png"):
@@ -133,6 +150,7 @@ def test_tracking_db_crud_update(generate_qr):
     assert db["qr_codes"][0]["qr_png_rel_path"] == "new.png"
     # created_at preserved from original
     assert db["qr_codes"][0]["created_at"] == "2024-01-01"
+    assert db["qr_codes"][0]["schema_version"] == 1
 
 
 def test_tracking_db_semantic_noop_preserves_raw_bytes_and_inode(
@@ -140,14 +158,11 @@ def test_tracking_db_semantic_noop_preserves_raw_bytes_and_inode(
     tmp_path,
 ):
     path = tmp_path / "tracking-database.json"
-    raw = b'{"qr_codes":[],"config":{"enabled":true},"talks":[]}\n'
+    database = _current_tracking_database()
+    raw = (json.dumps(database, separators=(",", ":")) + "\n").encode()
     path.write_bytes(raw)
     snapshot = generate_qr.snapshot_tracking_database(path)
-    equivalent = {
-        "talks": [],
-        "config": {"enabled": True},
-        "qr_codes": [],
-    }
+    equivalent = {key: database[key] for key in reversed(database)}
 
     result = generate_qr.write_tracking_db(snapshot, equivalent)
 
@@ -284,7 +299,7 @@ def test_main_valid_snapshot_generates_png_and_persists_metadata(
     vault.mkdir()
     database_path = vault / "tracking-database.json"
     database_path.write_text(
-        json.dumps({"config": {}, "talks": []}) + "\n",
+        json.dumps(_current_tracking_database()) + "\n",
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -592,3 +607,116 @@ def test_slug_cache_entry_is_reused(generate_qr, monkeypatch):
     )
     assert short_url == "https://jbaru.ch/my-slug"
     assert meta["short_path"] == "my-slug"
+
+
+def test_main_dry_run_dual_reads_legacy_database_without_writing(
+        generate_qr, monkeypatch, tmp_path):
+    database = {"config": {}, "talks": [], "pptx_catalog": []}
+    path = tmp_path / "tracking-database.json"
+    path.write_text(json.dumps(database), encoding="utf-8")
+    before = path.read_bytes()
+    monkeypatch.setattr(sys, "argv", [
+        "generate-qr.py", "--png-only", "--talk-slug", "legacy",
+        "--short-url", "https://example.test/legacy", "--vault", str(tmp_path),
+        "--dry-run",
+    ])
+
+    generate_qr.main()
+
+    assert path.read_bytes() == before
+
+
+def test_main_rejects_legacy_database_before_qr_side_effect(
+        generate_qr, monkeypatch, tmp_path):
+    database = {"config": {}, "talks": [], "pptx_catalog": []}
+    path = tmp_path / "tracking-database.json"
+    path.write_text(json.dumps(database), encoding="utf-8")
+    before = path.read_bytes()
+    monkeypatch.setattr(
+        generate_qr,
+        "generate_qr_png",
+        lambda *_: pytest.fail("QR generation must not start on legacy state"),
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "generate-qr.py", "--png-only", "--talk-slug", "legacy",
+        "--short-url", "https://example.test/legacy", "--vault", str(tmp_path),
+    ])
+
+    with pytest.raises(SystemExit, match="current tracking schema"):
+        generate_qr.main()
+
+    assert path.read_bytes() == before
+
+
+def test_main_current_database_stamps_qr_record_and_writes_atomically(
+        generate_qr, monkeypatch, tmp_path):
+    database = _current_tracking_database()
+    path = tmp_path / "tracking-database.json"
+    path.write_text(json.dumps(database), encoding="utf-8")
+    output = tmp_path / "current.png"
+    monkeypatch.setattr(
+        generate_qr,
+        "generate_qr_png",
+        lambda _url, _fg, _bg, target: Path(target).write_bytes(b"qr"),
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "generate-qr.py", "--png-only", "--talk-slug", "current",
+        "--short-url", "https://example.test/current", "--vault", str(tmp_path),
+        "--output", str(output),
+    ])
+
+    generate_qr.main()
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written["schema_version"] == 1
+    assert written["qr_codes"] == [{
+        "schema_version": 1,
+        "talk_slug": "current",
+        "target_url": "https://example.test/current",
+        "shortener": "mcp_preresolved",
+        "short_path": None,
+        "short_url": "https://example.test/current",
+        "shortener_link_id": None,
+        "qr_png_rel_path": "current-qr.png",
+        "created_at": written["qr_codes"][0]["created_at"],
+        "updated_at": written["qr_codes"][0]["updated_at"],
+    }]
+
+
+def test_main_rejects_future_database_without_side_effect(
+        generate_qr, monkeypatch, tmp_path):
+    database = _current_tracking_database() | {"schema_version": 2}
+    path = tmp_path / "tracking-database.json"
+    path.write_text(json.dumps(database), encoding="utf-8")
+    before = path.read_bytes()
+    monkeypatch.setattr(
+        generate_qr,
+        "generate_qr_png",
+        lambda *_: pytest.fail("QR generation must not start on future state"),
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "generate-qr.py", "--png-only", "--talk-slug", "future",
+        "--short-url", "https://example.test/future", "--vault", str(tmp_path),
+        "--dry-run",
+    ])
+
+    with pytest.raises(SystemExit, match="no usable prior state"):
+        generate_qr.main()
+
+    assert path.read_bytes() == before
+
+
+def test_main_rejects_tracking_database_symlink_before_loading_config(
+        generate_qr, monkeypatch, tmp_path):
+    target = tmp_path / "target.json"
+    target.write_text(json.dumps(_current_tracking_database()), encoding="utf-8")
+    path = tmp_path / "tracking-database.json"
+    path.symlink_to(target.name)
+    monkeypatch.setattr(sys, "argv", [
+        "generate-qr.py", "--png-only", "--talk-slug", "link",
+        "--short-url", "https://example.test/link", "--vault", str(tmp_path),
+        "--dry-run",
+    ])
+
+    with pytest.raises(SystemExit, match="symbolic link"):
+        generate_qr.main()

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -18,8 +18,11 @@ def _write_json(path: Path, value: object) -> None:
 
 def _base_database() -> dict[str, object]:
     return {
-        "config": {},
-        "talks": [{"filename": "talk.md", "status": "processed"}],
+        "schema_version": 1,
+        "config": {"schema_version": 1},
+        "talks": [
+            {"schema_version": 5, "filename": "talk.md", "status": "processed"}
+        ],
         "pptx_catalog": [],
         "qr_codes": [],
         "resources": [],
@@ -212,7 +215,10 @@ def test_noop_plan_preserves_noncanonical_bytes_and_inode(
     tmp_path: Path,
 ) -> None:
     database_path = tmp_path / "tracking-database.json"
-    raw = b'{"config":{"speaker_name":"Ada"},"talks":[]}\n'
+    database = _base_database()
+    database["config"]["speaker_name"] = "Ada"
+    database["talks"] = []
+    raw = (json.dumps(database, separators=(",", ":")) + "\n").encode()
     database_path.write_bytes(raw)
     plan_path = tmp_path / "plan.json"
     _write_json(
@@ -394,6 +400,68 @@ def test_plan_strict_json_rejects_duplicate_keys(
         mutate_tracking_database.load_plan(plan_path)
 
 
+def test_plan_strict_json_rejects_non_roundtrippable_number(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        '{"schema_version":1,"mutations":[{"kind":"set_config",'
+        '"path":["ratio"],"expect":{"$missing":true},'
+        '"value":0.12345678901234567890123456789}]}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="cannot round-trip losslessly",
+    ):
+        mutate_tracking_database.load_plan(plan_path)
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        pytest.param(
+            b'{"schema_version":1,"mutations":' + b"[" * 500 + b"{}"
+            + b"]" * 500 + b"}\n",
+            "maximum supported JSON nesting depth 200",
+            id="decoded-depth-limit",
+        ),
+        pytest.param(
+            b'{"schema_version":1,"mutations":' + b"[" * 10_000 + b"{}"
+            + b"]" * 10_000 + b"}\n",
+            "maximum supported JSON nesting depth 200",
+            id="decoder-recursion-limit",
+        ),
+        pytest.param(
+            b'{"schema_version":1,"mutations":[{"kind":"set_config",'
+            b'"path":["value"],"expect":{"$missing":true},'
+            b'"value":"\\ud800"}]}\n',
+            "unpaired UTF-16 surrogate",
+            id="unpaired-surrogate",
+        ),
+    ],
+)
+def test_plan_strict_json_rejects_unsafe_tree(
+    mutate_tracking_database,
+    tmp_path: Path,
+    raw: bytes,
+    message: str,
+) -> None:
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_bytes(raw)
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match=message,
+    ) as stopped:
+        mutate_tracking_database.load_plan(plan_path)
+
+    assert len(str(stopped.value)) < 1000
+    assert plan_path.read_bytes() == raw
+
+
 def test_talk_clarification_operation_accepts_only_structured_exact_fields(
     mutate_tracking_database,
 ) -> None:
@@ -438,17 +506,155 @@ def test_talk_clarification_operation_accepts_only_structured_exact_fields(
         )
 
 
+@pytest.mark.parametrize("schema_version", [1, 2, 3, 4])
+@pytest.mark.parametrize(
+    ("kind", "field", "value"),
+    [
+        ("update_talk_publishing", "shownotes_published", True),
+        (
+            "update_talk_clarification",
+            "humor_postmortem",
+            ["legacy talk must first be promoted by its domain writer"],
+        ),
+    ],
+)
+def test_talk_metadata_mutations_require_exact_current_talk_schema(
+    mutate_tracking_database,
+    schema_version: int,
+    kind: str,
+    field: str,
+    value: object,
+) -> None:
+    database = _base_database()
+    database["talks"][0]["schema_version"] = schema_version
+    original = copy.deepcopy(database)
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="must be exact current talk schema 5",
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                {
+                    "kind": kind,
+                    "filename": "talk.md",
+                    "expect": {field: MISSING},
+                    "set": {field: value},
+                }
+            ],
+        )
+
+    assert database == original
+
+
+def _legacy_goal_for_mutation(kind: str) -> dict[str, object]:
+    goal = {
+        key: copy.deepcopy(value)
+        for key, value in _goal().items()
+        if key
+        not in {
+            "verification_state",
+            "verification_reasons",
+            "supersedes_goal_id",
+            "baseline_provenance",
+        }
+    }
+    goal["schema_version"] = 1
+    goal["kind"] = kind
+    goal["antipattern_id"] = "shortchanged" if kind == "antipattern" else None
+    return goal
+
+
+@pytest.mark.parametrize("kind", ["antipattern", "underuse"])
+def test_legacy_pattern_goals_are_report_only(
+    mutate_tracking_database,
+    kind: str,
+) -> None:
+    database = _base_database()
+    goal = _legacy_goal_for_mutation(kind)
+    database["improvement_goals"] = [goal]
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="historical schema-v1 .* skip and report",
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                {
+                    "kind": "patch_improvement_goal_verification",
+                    "id": goal["id"],
+                    "expect": {"status": "active"},
+                    "set": {"status": "stalled"},
+                }
+            ],
+        )
+
+
+@pytest.mark.parametrize("kind", ["pacing", "other"])
+def test_legacy_independent_goals_allow_only_legacy_verification_fields(
+    mutate_tracking_database,
+    kind: str,
+) -> None:
+    database = _base_database()
+    goal = _legacy_goal_for_mutation(kind)
+    database["improvement_goals"] = [goal]
+    mutation = {
+        "kind": "patch_improvement_goal_verification",
+        "id": goal["id"],
+        "expect": {
+            "status": "active",
+            "current_value": "",
+            "last_checked": None,
+            "checked_by": None,
+        },
+        "set": {
+            "status": "improving",
+            "current_value": "3",
+            "last_checked": "2026-08-01",
+            "checked_by": "vault-ingress",
+        },
+    }
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database,
+        [mutation],
+    )
+
+    updated = candidate["improvement_goals"][0]
+    assert updated["schema_version"] == 1
+    assert updated["status"] == "improving"
+    assert updated["current_value"] == "3"
+    assert "verification_state" not in updated
+    assert changes[0]["kind"] == "patch_improvement_goal_verification"
+
+    forbidden = copy.deepcopy(mutation)
+    forbidden["expect"] = {"verification_state": MISSING}
+    forbidden["set"] = {"verification_state": "current"}
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="unsupported fields.*verification_state",
+    ):
+        mutate_tracking_database.build_candidate(database, [forbidden])
+
+
 def test_legacy_goal_retirement_preserves_every_other_field(
     mutate_tracking_database,
 ) -> None:
     database = _base_database()
     legacy = {
-        "id": "legacy-goal",
-        "schema_version": 1,
-        "status": "active",
-        "legacy_note": {"must": "survive"},
-        "verification_reasons": ["historical"],
+        key: copy.deepcopy(value)
+        for key, value in _goal().items()
+        if key
+        not in {
+            "verification_state",
+            "verification_reasons",
+            "supersedes_goal_id",
+            "baseline_provenance",
+        }
     }
+    legacy.update({"id": "legacy-goal", "schema_version": 1})
     database["improvement_goals"] = [copy.deepcopy(legacy)]
 
     candidate, changes = mutate_tracking_database.build_candidate(
@@ -524,7 +730,7 @@ def test_json_preconditions_and_noops_are_type_sensitive(
     mutate_tracking_database,
 ) -> None:
     database = _base_database()
-    database["config"] = {"enabled": True}
+    database["config"] = {"schema_version": 1, "enabled": True}
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
         match="precondition failed",
@@ -594,7 +800,10 @@ def test_delete_missing_nested_config_does_not_materialize_parents(
         ],
     )
 
-    assert candidate["config"] == {"shownotes": {"enabled": True}}
+    assert candidate["config"] == {
+        "schema_version": 1,
+        "shownotes": {"enabled": True},
+    }
     assert len(changes) == 1
     assert changes[0]["identity"] == "shownotes.enabled"
 
@@ -619,7 +828,10 @@ def test_delete_missing_nested_config_preserves_exact_expectations(
         )
 
     database = _base_database()
-    database["config"] = {"shownotes": {"legacy": None}}
+    database["config"] = {
+        "schema_version": 1,
+        "shownotes": {"legacy": None},
+    }
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
         match=r"config\.shownotes\.legacy must be an object",

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -104,6 +104,7 @@ def _return(**overrides):
 
 def _talk(**overrides):
     talk = {
+        "schema_version": 5,
         "filename": "talk.md",
         "status": "reprocessing-inflight",
         "reprocess_generation": 1,
@@ -126,6 +127,21 @@ def _talk(**overrides):
     }
     talk.update(overrides)
     return talk
+
+
+def _db_json(database):
+    """Render a current tracking database around one test's talk fixtures."""
+    database["schema_version"] = 1
+    config = database.setdefault("config", {})
+    if isinstance(config, dict):
+        config["schema_version"] = 1
+    database.setdefault("pptx_catalog", [])
+    database.setdefault("qr_codes", [])
+    database.setdefault("resources", [])
+    database.setdefault("thumbnails", [])
+    database.setdefault("confirmed_intents", [])
+    database.setdefault("improvement_goals", [])
+    return json.dumps(database)
 
 
 def _adherence_baseline(persist_results, *, count=0, filenames=("talk.md",)):
@@ -536,7 +552,7 @@ def test_v2_atomic_snapshot_matches_rendered_analysis(
     ret["structured_data"]["typography_observations"] = {
         "current_marker": "current",
     }
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([ret]))
 
     persisted = subprocess.run(
@@ -837,9 +853,10 @@ def test_pattern_observations_normalized(persist_results):
 def test_transcript_quote_is_verified_and_locations_are_engine_owned(
         persist_results, return_validation, tmp_path):
     talk, ret = _v4_transcript_batch(return_validation, tmp_path)
+    talk["schema_version"] = persist_results.TALK_SCHEMA_VERSION
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([ret]))
 
     result = subprocess.run(
@@ -1030,7 +1047,7 @@ def test_not_evaluable_patterns_are_persisted_but_never_scored(
         "evidence_source": "static_slides",
         "reason": "No animation timing survives in the rendered pages.",
     }]
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1094,7 +1111,7 @@ def test_cli_run_date_pins_the_stamp(persist_results, tmp_path):
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     del ret["processed_date"]
-    db.write_text(json.dumps({"talks": [_talk(processed_date="2026-04-09")]}))
+    db.write_text(_db_json({"talks": [_talk(processed_date="2026-04-09")]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch),
@@ -1113,7 +1130,7 @@ def test_cli_batch_timestamp_overrides_date_only_return_stamp_everywhere(
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     authoritative = "2026-07-27T14:03:22+00:00"
-    db.write_text(json.dumps({"talks": [_talk(processed_date="2026-04-09")]}))
+    db.write_text(_db_json({"talks": [_talk(processed_date="2026-04-09")]}))
     batch.write_text(json.dumps([_return(processed_date="2026-07-27")]))
 
     result = subprocess.run(
@@ -1134,7 +1151,7 @@ def test_cli_rejects_conflicting_explicit_return_timestamp_before_write(
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk(processed_date="2026-04-09")]}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([
         _return(processed_date="2026-07-27T08:00:00+00:00")]))
 
@@ -1165,7 +1182,7 @@ def test_matching_explicit_return_timestamp_is_accepted_and_batch_stamped(
 def test_cli_rejects_malformed_run_date(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch),
@@ -1179,7 +1196,7 @@ def test_cli_rejects_malformed_run_date(persist_results, tmp_path):
 def test_cli_writes_db_and_reports(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     script = persist_results.__file__
     result = subprocess.run(
@@ -1199,7 +1216,7 @@ def test_cli_writes_db_and_reports(persist_results, tmp_path):
 def test_cli_fails_visibly_on_filename_mismatch(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk(filename="a.md")]}))
+    db.write_text(_db_json({"talks": [_talk(filename="a.md")]}))
     batch.write_text(json.dumps([_return(filename="missing.md")]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1239,7 +1256,7 @@ def test_cli_malformed_json_is_actionable(persist_results, tmp_path):
 def test_cli_non_array_batch_is_actionable(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps({"filename": "talk.md"}))  # object, not array
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1292,7 +1309,7 @@ def test_naive_timestamp_is_rejected_with_an_actionable_message(persist_results)
 def test_cli_rejects_a_naive_timestamp(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch),
@@ -1310,7 +1327,7 @@ def test_explicit_date_only_stamp_is_still_accepted(persist_results, tmp_path):
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     del ret["processed_date"]
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch),
@@ -1326,7 +1343,7 @@ def test_explicit_timestamp_is_accepted(persist_results, tmp_path):
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     del ret["processed_date"]
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch),
@@ -1349,7 +1366,7 @@ def test_bare_int_pattern_score_is_coerced_and_promoted(persist_results, tmp_pat
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret["pattern_observations"]["pattern_score"] = 1  # 2 patterns - 1 antipattern
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1367,7 +1384,7 @@ def test_dict_pattern_score_is_not_reported_as_coerced(persist_results, tmp_path
     """Guard the guard: the flag must distinguish the two shapes."""
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1389,7 +1406,7 @@ def test_bare_int_contradicting_the_arrays_fails_loudly(persist_results, tmp_pat
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret["pattern_observations"]["pattern_score"] = 42  # arrays say 2 - 1 = 1
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1414,7 +1431,7 @@ def test_non_numeric_pattern_score_never_reaches_the_db(persist_results, tmp_pat
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret["pattern_observations"]["pattern_score"] = bad
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1439,7 +1456,7 @@ def test_invalid_score_inside_the_declared_dict_is_rejected(
     ret = _return()
     ret["pattern_observations"]["pattern_score"] = {
         "patterns_used": 2, "antipatterns_detected": 1, "score": inner}
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1455,7 +1472,7 @@ def test_merge_stamps_the_talk_schema_version(persist_results, tmp_path):
     """stateful-artifacts requires a schema_version on every record."""
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1466,27 +1483,50 @@ def test_merge_stamps_the_talk_schema_version(persist_results, tmp_path):
     assert talk["schema_version"] == persist_results.TALK_SCHEMA_VERSION
 
 
-def test_schema_version_is_stamped_over_an_older_value(persist_results, tmp_path):
-    """A v1 record merged by this writer becomes v2 — that is the migration."""
+def test_persistence_accepts_historical_talk_under_current_root(
+        persist_results, tmp_path):
+    """Current roots may retain v1-v4 talks until that exact talk is persisted."""
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     old = _talk()
     old["schema_version"] = 1
-    db.write_text(json.dumps({"talks": [old]}))
+    db.write_text(_db_json({"talks": [old]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
         capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
-    assert (json.loads(db.read_text())["talks"][0]["schema_version"] ==
-            persist_results.TALK_SCHEMA_VERSION)
+    assert (
+        json.loads(db.read_text())["talks"][0]["schema_version"]
+        == persist_results.TALK_SCHEMA_VERSION
+    )
 
 
-def test_legacy_migration_marks_pattern_evidence_unlocated(persist_results):
+def test_persistence_refuses_legacy_database_without_rewriting(
+        persist_results, tmp_path):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    db.write_text(json.dumps({"talks": [_talk()]}))
+    batch.write_text(json.dumps([_return()]))
+    before = db.read_bytes()
+
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "migrate-tracking-database.py" in result.stderr
+    assert db.read_bytes() == before
+
+
+def test_root_migration_preserves_historical_pattern_evidence(tracking_database):
     talk = {
         "filename": "legacy.md",
         "schema_version": 2,
+        "status": "processed",
         "pattern_observations": {
             "patterns_detected": [{
                 "pattern_id": "narrative-arc",
@@ -1508,15 +1548,15 @@ def test_legacy_migration_marks_pattern_evidence_unlocated(persist_results):
     }
     database = {"talks": [talk]}
 
-    assert persist_results.migrate_records(database) == 1
-    observations = talk["pattern_observations"]
-    assert talk["schema_version"] == persist_results.TALK_SCHEMA_VERSION
-    assert observations["patterns_detected"][0]["evidence_citations"] == []
-    assert observations["antipatterns_detected"][0]["evidence_citations"] == []
-    assert "evidence_schema_version" not in observations
+    before = copy.deepcopy(talk)
+
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    assert migrated["talks"][0] == before
 
 
-def test_future_talk_schema_rejects_before_any_record_is_migrated(persist_results):
+def test_future_talk_schema_rejects_before_any_record_is_migrated(
+        persist_results, tracking_database):
     database = {
         "talks": [
             {"filename": "legacy.md", "schema_version": 1},
@@ -1528,8 +1568,11 @@ def test_future_talk_schema_rejects_before_any_record_is_migrated(persist_result
     }
     before = copy.deepcopy(database)
 
-    with pytest.raises(ValueError, match="will not downgrade"):
-        persist_results.migrate_records(database)
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="talks_schema_version_unsupported",
+    ):
+        tracking_database.migrate_tracking_database(database)
 
     assert database == before
 
@@ -1539,6 +1582,31 @@ def test_cli_rejects_future_talk_schema_without_rewriting(
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk(schema_version=99)]}
+    db.write_text(_db_json(original))
+    batch.write_text(json.dumps([_return()]))
+    before = db.read_bytes()
+
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "talks_schema_version_unsupported" in result.stderr
+    assert db.read_bytes() == before
+
+
+def test_cli_assesses_future_root_before_old_talks_shape(
+    persist_results,
+    tmp_path,
+):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    original = {
+        "schema_version": 99,
+        "future_inventory": {"records": "opaque"},
+    }
     db.write_text(json.dumps(original))
     batch.write_text(json.dumps([_return()]))
     before = db.read_bytes()
@@ -1550,8 +1618,8 @@ def test_cli_rejects_future_talk_schema_without_rewriting(
     )
 
     assert result.returncode == 1
-    assert "future talk schema_version 99" in result.stderr
-    assert "will not downgrade" in result.stderr
+    assert "tracking_database_schema_version_unsupported" in result.stderr
+    assert "expected a JSON object with a `talks` array" not in result.stderr
     assert db.read_bytes() == before
 
 
@@ -1559,7 +1627,7 @@ def test_non_object_talk_member_is_actionable_and_does_not_rewrite(
         persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk(), "not-a-talk"]}))
+    db.write_text(_db_json({"talks": [_talk(), "not-a-talk"]}))
     batch.write_text(json.dumps([_return()]))
     before = db.read_bytes()
 
@@ -1609,7 +1677,7 @@ def test_a_malformed_content_block_fails_loudly(persist_results, tmp_path, block
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret[block] = [{"slide_count": 60}]  # a list where an object is declared
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1632,7 +1700,7 @@ def test_malformed_detection_arrays_fail_loudly(persist_results, tmp_path, bad):
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret["pattern_observations"]["patterns_detected"] = bad
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1650,7 +1718,7 @@ def test_a_malformed_return_leaves_the_talk_untouched(persist_results, tmp_path)
     ret = _return()
     ret["pattern_observations"]["patterns_detected"] = ["narrative-arc"]
     original = _talk()
-    db.write_text(json.dumps({"talks": [original]}))
+    db.write_text(_db_json({"talks": [original]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1679,7 +1747,7 @@ def test_v2_destructive_empty_scalars_leave_database_byte_stable(
         transcript_source="manual",
     )]}
     ret = _return(**{field: value})
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     before = db.read_bytes()
     batch.write_text(json.dumps([ret]))
 
@@ -1710,7 +1778,7 @@ def test_malformed_per_slide_visual_leaves_database_untouched(
         }],
     })
     original = {"talks": [_talk()]}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     before = db.read_bytes()
     batch.write_text(json.dumps([ret]))
 
@@ -1739,7 +1807,7 @@ def test_effective_per_slide_dependencies_fail_before_database_write(
         "slide_count": 1,
         "per_slide_visual": [_visual_row()],
     })
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([ret]))
 
@@ -1773,7 +1841,7 @@ def test_late_effective_failure_keeps_complete_database_byte_stable(
         "slide_count": 1,
         "per_slide_visual": [_visual_row()],
     })
-    db.write_text(json.dumps({"talks": [first_talk, second_talk]}))
+    db.write_text(_db_json({"talks": [first_talk, second_talk]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([first_return, second_return]))
 
@@ -1792,7 +1860,7 @@ def test_malformed_stored_structured_container_keeps_database_byte_stable(
         persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk(structured_data=["legacy"])]}))
+    db.write_text(_db_json({"talks": [_talk(structured_data=["legacy"])]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([_return()]))
 
@@ -1815,7 +1883,7 @@ def test_undeclared_legacy_verbatim_lane_keeps_database_byte_stable(
         "jokes": ["legacy line"],
         "legacy_lane": ["undeclared"],
     })
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([_return(verbatim_examples={"jokes": []})]))
 
@@ -1840,7 +1908,7 @@ def test_missing_image_source_distribution_basis_leaves_database_untouched(
         "unknown": 2,
     }
     original = {"talks": [_talk()]}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     before = db.read_bytes()
     batch.write_text(json.dumps([ret]))
 
@@ -1862,7 +1930,7 @@ def test_v2_image_source_basis_without_map_leaves_database_untouched(
     ret = _return()
     ret["structured_data"]["image_source_distribution_basis"] = (
         "Unit: slide; unknown origins stay unknown.")
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([ret]))
 
@@ -1877,22 +1945,21 @@ def test_v2_image_source_basis_without_map_leaves_database_untouched(
     assert db.read_bytes() == before
 
 
-def test_migration_stamps_every_record_not_just_merged_ones(persist_results, tmp_path):
-    """Stamping only touched talks leaves the artifact permanently mixed-version,
-    so a reader cannot tell an unversioned record from an untouched one."""
+def test_persistence_reports_that_schema_migration_was_not_run(
+        persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     merged, untouched = _talk(), _talk()
     untouched["filename"] = "other-talk.md"
     untouched["_queue_claim"]["batch_id"] = "unrelated-batch"
-    db.write_text(json.dumps({"talks": [merged, untouched]}))
+    db.write_text(_db_json({"talks": [merged, untouched]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
         capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout)["migrated_records"] == 2
+    assert json.loads(result.stdout)["migrated_records"] == 0
     for talk in json.loads(db.read_text())["talks"]:
         assert talk["schema_version"] == persist_results.TALK_SCHEMA_VERSION
 
@@ -1905,7 +1972,7 @@ def test_score_object_without_a_score_key_fails_loudly(persist_results, tmp_path
     ret = _return()
     ret["pattern_observations"]["pattern_score"] = {
         "patterns_used": 2, "antipatterns_detected": 1}
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1935,7 +2002,7 @@ def test_clear_fields_removes_contaminated_values_and_promoted_scalars(
     ])
     del ret["structured_data"]["slide_count"]
     ret["verbatim_examples"]["jokes"] = []
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1965,7 +2032,7 @@ def test_pattern_score_clear_removes_both_nested_and_promoted_value(
     ret = _return(clear_fields=["pattern_observations.pattern_score"])
     # The valid replacement score is written after the clear; the important
     # invariant is that no old 99 survives on either surface.
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -1982,7 +2049,7 @@ def test_historical_return_is_marked_unbaselineable_and_claim_is_closed(
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talk = _talk(reprocess_reason="pattern_scoring_generation:legacy_generation")
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -2048,7 +2115,7 @@ def test_v3_member_baseline_mismatch_rejects_whole_batch_without_write(
         "average_pattern_score": 1.0,
     })
     original = {"talks": talks}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     before = db.read_bytes()
     batch.write_text(json.dumps(returns))
 
@@ -2096,7 +2163,7 @@ def test_post_batch_stdout_uses_complete_replacement_cohort_and_keeps_claim(
             persist_results.PATTERN_SCORING_SCHEMA_VERSION),
         "pattern_catalog_fingerprint": persist_results.load_catalog().fingerprint,
     })
-    db.write_text(json.dumps({"talks": [talk, prior]}))
+    db.write_text(_db_json({"talks": [talk, prior]}))
     batch.write_text(json.dumps([ret]))
 
     result = subprocess.run(
@@ -2133,7 +2200,7 @@ def test_missing_status_rejects_the_whole_batch_without_migrating_db(
     original = {"talks": [_talk()]}
     invalid = _return()
     del invalid["status"]
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([_return(filename="talk.md"), invalid]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -2148,14 +2215,14 @@ def test_duplicate_db_filenames_are_rejected_before_write(persist_results, tmp_p
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk(), _talk()]}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
         capture_output=True, text=True,
     )
     assert result.returncode == 1
-    assert "duplicate filenames" in result.stderr
+    assert "duplicate talk filename" in result.stderr
     assert json.loads(db.read_text()) == original
 
 
@@ -2166,7 +2233,7 @@ def test_partial_three_member_batch_is_rejected_before_any_db_write(
     talks = [_talk(filename=f"{name}.md") for name in ("a", "b", "c")]
     returns = [_return(filename=f"{name}.md") for name in ("a", "b")]
     original = {"talks": talks}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps(returns))
 
     result = subprocess.run(
@@ -2193,7 +2260,7 @@ def test_partially_closed_batch_cannot_be_finished_piecemeal(
             "result_status": "processed",
         })
     original = {"talks": talks}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([
         _return(filename=f"{name}.md") for name in ("a", "b", "c")]))
 
@@ -2214,7 +2281,7 @@ def test_stale_return_generation_cannot_roll_back_a_requeue(persist_results, tmp
     talk["_queue_claim"]["reprocess_generation"] = 2
     original = {"talks": [talk]}
     stale = _return()  # generation 1
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([stale]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -2230,7 +2297,7 @@ def test_claim_generation_cannot_lag_top_level_generation(persist_results, tmp_p
     batch = tmp_path / "batch-returns.json"
     talk = _talk(reprocess_generation=2)
     original = {"talks": [talk]}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([_return()]))
 
     result = subprocess.run(
@@ -2239,7 +2306,7 @@ def test_claim_generation_cannot_lag_top_level_generation(persist_results, tmp_p
     )
 
     assert result.returncode == 1
-    assert "active claim generation 1 disagrees with talk generation 2" in result.stderr
+    assert "current claim generation 1 disagrees with talk generation 2" in result.stderr
     assert json.loads(db.read_text()) == original
 
 
@@ -2250,7 +2317,7 @@ def test_active_claim_with_undeclared_fields_is_rejected_before_write(
     talk = _talk()
     talk["_queue_claim"]["released_at"] = None
     original = {"talks": [talk]}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([_return()]))
 
     result = subprocess.run(
@@ -2285,7 +2352,7 @@ def test_skipped_return_preserves_prior_analysis_and_persists_terminal_metadata(
         pptx_path=None,
         slides_url=None,
     )
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([_skipped_return()]))
 
     result = subprocess.run(
@@ -2353,7 +2420,7 @@ def test_skipped_no_sources_rejects_each_live_capability(
     talk = _talk(**{**base, **source_fields})
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([_skipped_return()]))
     before = db.read_bytes()
 
@@ -2408,7 +2475,7 @@ def test_invalid_source_cannot_hide_independent_terminal_capability(
     talk = _talk(**fields)
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([_skipped_return()]))
 
     result = subprocess.run(
@@ -2456,7 +2523,7 @@ def test_download_failure_rejects_when_a_local_artifact_remains(
     })
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([
         _skipped_return(status="skipped_download_failed")]))
     before = db.read_bytes()
@@ -2482,7 +2549,7 @@ def test_broken_local_reference_allows_no_sources_terminal(
     )
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([_skipped_return()]))
 
     result = subprocess.run(
@@ -2504,7 +2571,7 @@ def test_broken_local_reference_with_remote_allows_download_failed(
     )
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([
         _skipped_return(status="skipped_download_failed")]))
 
@@ -2529,7 +2596,7 @@ def test_download_failure_requires_a_remote_acquisition_path(
     )
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([
         _skipped_return(status="skipped_download_failed")]))
 
@@ -2557,7 +2624,7 @@ def test_malformed_remote_references_do_not_authorize_download_failed(
     )
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([
         _skipped_return(status="skipped_download_failed")]))
 
@@ -2576,7 +2643,7 @@ def test_duplicate_skip_requires_a_bound_canonical_talk(
     talk = _talk(video_url=None, pptx_path=None, slides_url=None)
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([_skipped_return(status="skipped_duplicate")]))
 
     result = subprocess.run(
@@ -2620,7 +2687,7 @@ def test_mechanically_bound_skip_status_can_close_claim(
     })
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [talk]}))
+    db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([_skipped_return(status=status)]))
 
     result = subprocess.run(
@@ -2642,7 +2709,7 @@ def test_skipped_return_with_analysis_fields_aborts_without_write(
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk(rhetoric_notes="trusted prior analysis")]}
     invalid = _skipped_return(rhetoric_notes="stale rejected analysis")
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([invalid]))
 
     result = subprocess.run(
@@ -2672,7 +2739,7 @@ def test_wrong_transcript_source_cannot_be_resurrected(
         "transcript", "static_slides"]
     _complete_unavailable_source_gates(return_validation, ret)
     original = {"talks": [talk]}
-    db.write_text(json.dumps(original))
+    db.write_text(_db_json(original))
     batch.write_text(json.dumps([ret]))
 
     result = subprocess.run(
@@ -2688,7 +2755,7 @@ def test_wrong_transcript_source_cannot_be_resurrected(
 def test_completed_generation_cannot_be_replayed(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    db.write_text(json.dumps({"talks": [_talk()]}))
+    db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     first = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -95,7 +95,7 @@ def source_identity(**updates):
     return evidence
 
 
-def write_database(fixture, talks, config=None):
+def write_database(fixture, talks, config=None, *, current=False):
     database = {
         "config": config or {
             "speaker_name": "Baruch Sadogursky",
@@ -103,6 +103,20 @@ def write_database(fixture, talks, config=None):
         },
         "talks": talks,
     }
+    if current:
+        database.update({
+            "schema_version": 1,
+            "pptx_catalog": [],
+            "qr_codes": [],
+            "resources": [],
+            "thumbnails": [],
+            "confirmed_intents": [],
+            "improvement_goals": [],
+        })
+        database["config"]["schema_version"] = 1
+        for talk in talks:
+            if isinstance(talk, dict):
+                talk["schema_version"] = 5
     fixture["database"].write_text(
         json.dumps(database, indent=2), encoding="utf-8"
     )
@@ -311,7 +325,7 @@ def test_legacy_quality_warning_allows_normalize_to_requeue(
 ):
     transcript = materialize_transcript(vault_fixture)
     transcript.with_suffix(".quality.json").unlink()
-    write_database(vault_fixture, [base_talk()])
+    write_database(vault_fixture, [base_talk()], current=True)
 
     report = preflight_vault.run_preflight(vault_fixture["root"])
     assert report["ok"] is True
@@ -1243,6 +1257,23 @@ def test_report_is_deterministic_and_preflight_is_read_only(
     second = preflight_vault.run_preflight(vault_fixture["root"])
 
     assert first == second
+    assert database.read_bytes() == before
+
+
+def test_future_tracking_database_is_blocking_no_usable_state(
+    preflight_vault, vault_fixture,
+):
+    database = write_database(vault_fixture, [base_talk()])
+    payload = json.loads(database.read_text(encoding="utf-8"))
+    payload["schema_version"] = 99
+    database.write_text(json.dumps(payload), encoding="utf-8")
+    before = database.read_bytes()
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert finding_codes(report, "blocking") == {
+        "tracking_database_schema_unsupported"
+    }
     assert database.read_bytes() == before
 
 

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -331,7 +331,7 @@ def test_current_profile_binds_every_pattern_denominator_to_one_cohort(
     }
 
 
-def test_live_validation_ignores_duplicate_filenames_in_ineligible_rows(
+def test_live_validation_rejects_duplicate_filenames_in_ineligible_rows(
     validate_profile,
     tmp_path,
     capsys,
@@ -350,8 +350,9 @@ def test_live_validation_ignores_duplicate_filenames_in_ineligible_rows(
         extra_talks=[pending_duplicate],
     )
 
-    assert return_code == 0, "\n".join(report["errors"])
-    assert report["valid"] is True
+    assert return_code == 1
+    assert report["valid"] is False
+    assert any("duplicate talk filename" in error for error in report["errors"])
 
 
 def test_reusable_assessment_distinguishes_current_empty_and_stale_history(

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -38,6 +38,7 @@ def _talk(
 ) -> dict[str, object]:
     filename = filename or f"playlist-{video_id}.md"
     return {
+        "schema_version": 5,
         "filename": filename,
         "title": filename,
         "status": status,
@@ -74,7 +75,7 @@ def _scored_talk(
     return talk
 
 
-def _write_db(tmp_path, talks, *, config=None):
+def _write_db(tmp_path, talks, *, config=None, current=True):
     transcripts = tmp_path / "transcripts"
     transcripts.mkdir(exist_ok=True)
     for talk in talks:
@@ -202,10 +203,23 @@ def _write_db(tmp_path, talks, *, config=None):
                 ).encode("utf-8")).hexdigest(),
             )
     path = tmp_path / "tracking-database.json"
-    path.write_text(
-        json.dumps({"config": config or {}, "talks": talks}, indent=2),
-        encoding="utf-8",
-    )
+    database = {
+        "config": {**(config or {})},
+        "talks": talks,
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+    if current:
+        database["schema_version"] = 1
+        database["config"]["schema_version"] = 1
+    else:
+        for talk in talks:
+            talk.pop("schema_version", None)
+    path.write_text(json.dumps(database, indent=2), encoding="utf-8")
     return path
 
 
@@ -1359,6 +1373,89 @@ def test_inspect_reconstructs_claims_after_stale_recovery(tmp_path):
     assert payload["claims"][0]["state"] == "stale_recovered"
 
 
+def test_legacy_database_inspect_is_read_only(tmp_path):
+    talk = _talk("eg6gqvUFh6Q", status="processed")
+    talk["reprocess_generation"] = 1
+    talk["_queue_claim"] = {
+        "schema_version": 1,
+        "run_id": "legacy-run",
+        "batch_id": "legacy-batch",
+        "claimed_at": "2026-07-31T17:00:00+00:00",
+        "previous_status": "needs-reprocessing",
+        "reprocess_generation": 1,
+        "state": "completed",
+        "released_at": "2026-07-31T17:30:00+00:00",
+        "release_reason": "return_persisted",
+        "result_status": "processed",
+    }
+    path = _write_db(tmp_path, [talk], current=False)
+    before = path.read_bytes()
+
+    result = _run(path, "inspect", "--run-id", "legacy-run")
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["claims"][0]["state"] == "completed"
+    assert path.read_bytes() == before
+
+
+def test_legacy_database_recover_closes_lease_without_migrating(tmp_path):
+    talk = _talk("eg6gqvUFh6Q", status="reprocessing-inflight")
+    talk["reprocess_generation"] = 1
+    talk["_queue_claim"] = {
+        "schema_version": 1,
+        "run_id": "legacy-run",
+        "batch_id": "legacy-batch",
+        "claimed_at": "2026-07-31T17:00:00+00:00",
+        "previous_status": "needs-reprocessing",
+        "reprocess_generation": 1,
+        "state": "claimed",
+    }
+    path = _write_db(tmp_path, [talk], current=False)
+
+    result = _run(
+        path,
+        "recover",
+        "--now",
+        "2026-07-31T18:00:00+00:00",
+        "--stale-after-seconds",
+        "3600",
+    )
+
+    assert result.returncode == 0, result.stderr
+    database = _read_db(path)
+    assert "schema_version" not in database
+    assert "schema_version" not in database["config"]
+    assert "schema_version" not in database["talks"][0]
+    assert database["talks"][0]["status"] == "needs-reprocessing"
+    assert database["talks"][0]["_queue_claim"]["schema_version"] == 2
+    assert database["talks"][0]["_queue_claim"]["state"] == "stale_recovered"
+
+
+@pytest.mark.parametrize("action", ["normalize", "claim"])
+def test_legacy_database_rejects_new_queue_mutations(tmp_path, action):
+    path = _write_db(tmp_path, [_talk("eg6gqvUFh6Q")], current=False)
+    before = path.read_bytes()
+    arguments = (
+        ("normalize",)
+        if action == "normalize"
+        else (
+            "claim",
+            "--run-id",
+            "new-run",
+            "--batch-id",
+            "1",
+            "--now",
+            NOW,
+        )
+    )
+
+    result = _run(path, *arguments)
+
+    assert result.returncode == 2
+    assert "migrate-tracking-database.py" in json.loads(result.stdout)["error"]
+    assert path.read_bytes() == before
+
+
 def test_inspect_accepts_a_completed_persistence_claim(tmp_path):
     talk = _talk("eg6gqvUFh6Q", status="processed")
     talk["reprocess_generation"] = 1
@@ -1430,7 +1527,10 @@ def test_unknown_future_claim_schema_fails_without_rewriting(tmp_path):
     result = _run(path, "inspect", "--run-id", "future-run")
 
     assert result.returncode == 2
-    assert "newer than supported" in json.loads(result.stdout)["error"]
+    assert (
+        "queue_claim_schema_version_unsupported"
+        in json.loads(result.stdout)["error"]
+    )
     assert path.read_bytes() == before
 
 

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -47,9 +47,32 @@ def _database_path(
     config: dict[str, object],
     *,
     talks: list[dict[str, object]] | None = None,
+    legacy: bool = False,
 ) -> Path:
     path = tmp_path / "tracking-database.json"
-    _write_json(path, {"config": config, "talks": talks or []})
+    if legacy:
+        database = {"config": config, "talks": talks or []}
+    else:
+        current_talks = []
+        for talk in talks or []:
+            current_talk = {**talk, "schema_version": 5}
+            current_talk["source_rejections"] = [
+                {**rejection, "schema_version": 1}
+                for rejection in current_talk.get("source_rejections", [])
+            ]
+            current_talks.append(current_talk)
+        database = {
+            "schema_version": 1,
+            "config": {"schema_version": 1, **config},
+            "talks": current_talks,
+            "pptx_catalog": [],
+            "qr_codes": [],
+            "resources": [],
+            "thumbnails": [],
+            "confirmed_intents": [],
+            "improvement_goals": [],
+        }
+    _write_json(path, database)
     return path
 
 
@@ -128,6 +151,26 @@ def test_dry_run_parses_jekyll_links_and_derives_exact_source_ids(
     assert database_path.read_bytes() == before
 
 
+def test_legacy_database_is_dry_run_only(tmp_path: Path) -> None:
+    site, _ = _shownotes_site(tmp_path)
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        legacy=True,
+    )
+    before = database_path.read_bytes()
+
+    scan_shownotes.execute(database_path, apply_requested=False)
+
+    assert database_path.read_bytes() == before
+    with pytest.raises(
+        scan_shownotes.ShownotesScanError,
+        match="migrate-tracking-database.py",
+    ):
+        scan_shownotes.execute(database_path, apply_requested=True)
+    assert database_path.read_bytes() == before
+
+
 def test_apply_adds_only_complete_proposal_and_preserves_file_mode(
     tmp_path: Path,
 ) -> None:
@@ -170,7 +213,7 @@ def test_exact_filename_update_fills_only_empty_fields(tmp_path: Path) -> None:
         "title": "Deterministic Ingress",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 4,
+        "schema_version": 5,
         "status": "processed",
     }
     database_path = _database_path(
@@ -184,7 +227,7 @@ def test_exact_filename_update_fills_only_empty_fields(tmp_path: Path) -> None:
     talk = json.loads(database_path.read_text(encoding="utf-8"))["talks"][0]
     assert talk["video_url"] == video_url
     assert talk["youtube_id"] == YOUTUBE_ID
-    assert talk["schema_version"] == 4
+    assert talk["schema_version"] == 5
     assert talk["status"] == "processed"
     assert report["entries"][0]["changes"] == {
         "video_url": video_url,
@@ -438,6 +481,24 @@ def test_database_symlink_is_rejected_before_read(tmp_path: Path) -> None:
         match="symbolic link",
     ):
         scan_shownotes.execute(link, apply_requested=False)
+
+
+def test_future_root_is_classified_before_old_shownotes_shapes(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "tracking-database.json"
+    raw = b'{"schema_version":99,"future_inventory":{"records":[]}}\n'
+    database_path.write_bytes(raw)
+
+    with pytest.raises(
+        scan_shownotes.ShownotesScanError,
+        match="tracking_database_schema_version_unsupported",
+    ) as stopped:
+        scan_shownotes.execute(database_path, apply_requested=False)
+
+    assert "config must be" not in str(stopped.value)
+    assert "talk records are invalid" not in str(stopped.value)
+    assert database_path.read_bytes() == raw
 
 
 def test_shownotes_directory_symlink_is_rejected_before_glob(

--- a/tests/test_schema5_pattern_outcomes.py
+++ b/tests/test_schema5_pattern_outcomes.py
@@ -792,12 +792,13 @@ def test_opportunity_identity_binds_scoring_generation_independently(
     assert return_validation.RETURN_SCHEMA_VERSION == 5
 
 
-def test_v4_source_locations_survive_talk_schema_migration_without_v5_outcomes(
-    persist_results,
+def test_v4_source_locations_survive_root_migration_without_v5_outcomes(
+    tracking_database,
 ):
     talk = {
         "schema_version": 4,
         "filename": "archive.md",
+        "status": "processed",
         "pattern_observations": {
             "evidence_schema_version": 1,
             "patterns_detected": [
@@ -812,8 +813,9 @@ def test_v4_source_locations_survive_talk_schema_migration_without_v5_outcomes(
     }
     database = {"talks": [talk]}
 
-    assert persist_results.migrate_records(database) == 1
-    assert talk["schema_version"] == 5
+    migrated = tracking_database.migrate_tracking_database(database).database
+    talk = migrated["talks"][0]
+    assert talk["schema_version"] == 4
     assert talk["pattern_observations"]["evidence_schema_version"] == 1
     assert talk["pattern_observations"]["patterns_detected"][0]["evidence_citations"]
     assert "pattern_outcomes" not in talk["pattern_observations"]

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -716,6 +716,58 @@ def test_section15_replace_cli_binds_real_vault_freshness(
     assert section15.BLOCK_START in summary_path.read_text(encoding="utf-8")
 
 
+def test_replace_cli_gates_future_database_before_config_path_semantics(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    profile = _pattern_profile()
+    summary_path = tmp_path / "rhetoric-style-summary.md"
+    summary_path.write_text(_summary(), encoding="utf-8")
+    original_summary = summary_path.read_bytes()
+    profile_path = tmp_path / "pattern-profile.json"
+    profile_path.write_text(json.dumps(profile), encoding="utf-8")
+    database_path = tmp_path / "tracking-database.json"
+    database_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 99,
+                "config": {"vault_storage_path": "\u0000"},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    original_database = database_path.read_bytes()
+
+    def forbidden_path_semantics(*_args, **_kwargs):
+        pytest.fail("configured path semantics ran before the owner schema gate")
+
+    monkeypatch.setattr(
+        section15,
+        "configured_evidence_freshness_assessor",
+        forbidden_path_semantics,
+    )
+
+    return_code = section15.main(
+        [
+            "replace",
+            str(summary_path),
+            str(profile_path),
+            str(database_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 1
+    assert captured.out == ""
+    assert "no usable prior state" in captured.err
+    assert "tracking_database_schema_version_unsupported" in captured.err
+    assert "Traceback" not in captured.err
+    assert summary_path.read_bytes() == original_summary
+    assert database_path.read_bytes() == original_database
+
+
 def test_atomic_helper_inserts_once_then_reports_noop(tmp_path):
     summary_path = tmp_path / "rhetoric-style-summary.md"
     summary_path.write_text(_summary(), encoding="utf-8")
@@ -774,7 +826,7 @@ def test_invalid_candidate_and_torn_summary_are_no_write_failures(tmp_path):
     assert summary_path.read_text(encoding="utf-8") == torn
 
 
-def test_replace_ignores_duplicate_filenames_in_ineligible_rows(tmp_path):
+def test_replace_rejects_duplicate_filenames_in_ineligible_rows(tmp_path):
     profile = _pattern_profile()
     database = _tracking_database(profile)
     database["talks"].append(
@@ -787,16 +839,40 @@ def test_replace_ignores_duplicate_filenames_in_ineligible_rows(tmp_path):
     summary_path = tmp_path / "rhetoric-style-summary.md"
     summary_path.write_text(_summary(), encoding="utf-8")
 
-    result = section15.replace_section15_current_block(
-        summary_path,
-        profile,
-        database,
-        evidence_freshness_assessor=_fresh_evidence,
-    )
+    before = summary_path.read_bytes()
+    with pytest.raises(
+        section15.Section15PatternHistoryError,
+        match="duplicate talk filename",
+    ):
+        section15.replace_section15_current_block(
+            summary_path,
+            profile,
+            database,
+            evidence_freshness_assessor=_fresh_evidence,
+        )
+    assert summary_path.read_bytes() == before
 
-    assert result.changed is True
-    assert result.eligible_talk_count == 2
-    assert section15.BLOCK_START in summary_path.read_text(encoding="utf-8")
+
+def test_replace_rejects_future_tracking_database_without_write(tmp_path):
+    profile = _pattern_profile()
+    database = _tracking_database(profile)
+    database["schema_version"] = 99
+    summary_path = tmp_path / "rhetoric-style-summary.md"
+    summary_path.write_text(_summary(), encoding="utf-8")
+    before = summary_path.read_bytes()
+
+    with pytest.raises(
+        section15.Section15PatternHistoryError,
+        match="no usable prior state",
+    ):
+        section15.replace_section15_current_block(
+            summary_path,
+            profile,
+            database,
+            evidence_freshness_assessor=_fresh_evidence,
+        )
+
+    assert summary_path.read_bytes() == before
 
 
 def test_failed_atomic_swap_leaves_original_and_no_temp_file(

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -51,6 +51,118 @@ def test_strict_decoder_rejects_ambiguous_json_without_changing_bytes(
     assert path.read_bytes() == raw
 
 
+@pytest.mark.parametrize(
+    "token",
+    [
+        "0.12345678901234567890123456789",
+        "1e400",
+        pytest.param(
+            "1e" + "9" * 30,
+            id="extreme-exponent",
+        ),
+        pytest.param(
+            "7" * 5000,
+            id="huge-integer",
+        ),
+    ],
+)
+def test_strict_decoder_rejects_numbers_that_cannot_round_trip(
+    tracking_database_io,
+    tmp_path: Path,
+    token: str,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    raw = f'{{"talks":[],"value":{token}}}\n'.encode()
+    path.write_bytes(raw)
+
+    snapshot = tracking_database_io.snapshot_tracking_database(path)
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="cannot round-trip losslessly",
+    ) as stopped:
+        tracking_database_io.decode_json_object(snapshot)
+
+    assert len(str(stopped.value)) < 1000
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        pytest.param(
+            b'{"config":{"value":' + b"[" * 500 + b"0" + b"]" * 500
+            + b'},"talks":[]}\n',
+            "maximum supported JSON nesting depth 200",
+            id="decoded-depth-limit",
+        ),
+        pytest.param(
+            b'{"config":{"value":' + b"[" * 10_000 + b"0" + b"]" * 10_000
+            + b'},"talks":[]}\n',
+            "maximum supported JSON nesting depth 200",
+            id="decoder-recursion-limit",
+        ),
+        pytest.param(
+            b'{"config":{"value":"\\ud800"},"talks":[]}\n',
+            "unpaired UTF-16 surrogate",
+            id="unpaired-surrogate",
+        ),
+    ],
+)
+def test_strict_decoder_rejects_unsafe_tree_before_consumers(
+    tracking_database_io,
+    tmp_path: Path,
+    raw: bytes,
+    message: str,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    path.write_bytes(raw)
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match=message,
+    ) as stopped:
+        tracking_database_io.decode_json_object(
+            tracking_database_io.snapshot_tracking_database(path)
+        )
+
+    assert len(str(stopped.value)) < 1000
+    assert path.read_bytes() == raw
+
+
+def test_strict_decoder_accepts_valid_escaped_surrogate_pair(
+    tracking_database_io,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    raw = b'{"config":{"value":"\\ud83d\\ude00"},"talks":[]}\n'
+    path.write_bytes(raw)
+
+    decoded = tracking_database_io.decode_json_object(
+        tracking_database_io.snapshot_tracking_database(path)
+    )
+
+    assert decoded["config"]["value"] == "😀"
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.parametrize("token", ["0.1", "0.10", "1e0", "-0.0"])
+def test_strict_decoder_accepts_lossless_numeric_lexical_variants(
+    tracking_database_io,
+    tmp_path: Path,
+    token: str,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    raw = f'{{"talks":[],"value":{token}}}\n'.encode()
+    path.write_bytes(raw)
+
+    decoded = tracking_database_io.decode_json_object(
+        tracking_database_io.snapshot_tracking_database(path)
+    )
+
+    assert decoded["value"] == float(token)
+    assert type(decoded["value"]) is float
+
+
 def test_snapshot_rejects_final_symlink(tracking_database_io, tmp_path: Path) -> None:
     target = tmp_path / "target.json"
     _write(target, {"talks": []})
@@ -70,6 +182,65 @@ def test_renderer_refuses_to_create_non_standard_json(tracking_database_io) -> N
         match="candidate is not strict JSON",
     ):
         tracking_database_io.render_json_object({"value": float("nan")})
+
+
+def test_renderer_rejects_unsafe_depth_with_bounded_domain_error(
+    tracking_database_io,
+) -> None:
+    nested: object = 0
+    for _ in range(tracking_database_io.MAX_JSON_NESTING_DEPTH + 1):
+        nested = [nested]
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="maximum supported JSON nesting depth 200",
+    ) as stopped:
+        tracking_database_io.render_json_object({"value": nested})
+
+    assert len(str(stopped.value)) < 1000
+
+
+def test_renderer_rejects_unpaired_surrogate_with_domain_error(
+    tracking_database_io,
+) -> None:
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="unpaired UTF-16 surrogate",
+    ):
+        tracking_database_io.render_json_object({"value": "\ud800"})
+
+
+def test_renderer_normalizes_recursion_error_backstop(
+    tracking_database_io,
+    monkeypatch,
+) -> None:
+    def fail_render(*_args, **_kwargs):
+        raise RecursionError("synthetic renderer recursion")
+
+    monkeypatch.setattr(tracking_database_io.json, "dumps", fail_render)
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="maximum supported JSON nesting depth 200",
+    ):
+        tracking_database_io.render_json_object({"value": "safe"})
+
+
+def test_renderer_normalizes_unicode_encode_error_backstop(
+    tracking_database_io,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        tracking_database_io.json,
+        "dumps",
+        lambda *_args, **_kwargs: "\ud800",
+    )
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="unpaired UTF-16 surrogate",
+    ):
+        tracking_database_io.render_json_object({"value": "safe"})
 
 
 def test_commit_refuses_an_invalid_candidate_before_locking(

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1,0 +1,1310 @@
+"""Tracking-database schema ownership and migration tests."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+
+import pytest
+
+
+def _legacy_goal(*, goal_id: str = "legacy") -> dict:
+    return {
+        "id": goal_id,
+        "issue": "Keep the final section unhurried",
+        "kind": "pacing",
+        "antipattern_id": None,
+        "metric": "minutes remaining at final section",
+        "baseline_value": "2 minutes",
+        "target": "at least 5 minutes",
+        "set_date": "2026-06-11",
+        "set_by": "vault-clarification",
+        "status": "active",
+        "current_value": "",
+        "last_checked": None,
+        "checked_by": None,
+    }
+
+
+def _current_goal(*, goal_id: str = "current") -> dict:
+    return {
+        **_legacy_goal(goal_id=goal_id),
+        "schema_version": 2,
+        "kind": "other",
+        "metric": "audience questions answered",
+        "baseline_value": "3",
+        "target": "5",
+        "verification_state": "pending",
+        "verification_reasons": [],
+        "supersedes_goal_id": None,
+        "baseline_provenance": {"lane": "independent"},
+    }
+
+
+def _legacy_talk(*, filename: str = "one.md") -> dict:
+    return {
+        "filename": filename,
+        "status": "processed",
+        "pattern_observations": {
+            "source_inspection": {"transcript": "legacy-unverified"},
+            "patterns_detected": [
+                {
+                    "pattern_id": "hook",
+                    "evidence_citations": [{"source": "transcript"}],
+                }
+            ],
+        },
+        "source_rejections": [
+            {
+                "source_type": "video",
+                "url": "https://example.test/wrong",
+                "reason": "wrong delivery",
+                "evidence": "title and event do not match",
+                "verified_at": "2026-07-31T14:00:00-05:00",
+            }
+        ],
+    }
+
+
+def _baseline_for_claim(version: int, *, filename: str = "one.md") -> dict:
+    baseline = {
+        "schema_version": 2 if version == 5 else 1,
+        "as_of": "2026-07-31T12:00:00+00:00",
+        "scope": "global",
+        "active_batch_excluded": True,
+        "excluded_filenames": [filename],
+        "eligible_statuses": ["processed", "processed_partial"],
+        "pattern_scoring_generation_status": "current",
+        "pattern_scoring_generation_reasons": [],
+        "pattern_catalog_fingerprint": "a" * 64,
+        "pattern_scoring_schema_version": 5 if version == 5 else 4,
+        "scored_talk_count": 0,
+        "pattern_score_sum": 0,
+        "average_pattern_score": None,
+    }
+    if version == 5:
+        baseline.update(
+            {
+                "eligible_talk_count": 0,
+                "opportunity_coverage_identity": None,
+                "raw_score_comparison_status": "unavailable",
+                "raw_score_comparison_reason": "empty_current_cohort",
+            }
+        )
+    return baseline
+
+
+def _claim_for_version(
+    version: int,
+    *,
+    generation: int,
+    state: str,
+    batch_id: str,
+    filename: str = "one.md",
+) -> dict:
+    claim = {
+        "schema_version": version,
+        "run_id": "schema-test",
+        "batch_id": batch_id,
+        "claimed_at": "2026-07-31T12:00:00+00:00",
+        "previous_status": "needs-reprocessing",
+        "reprocess_generation": generation,
+        "state": state,
+    }
+    if version >= 3:
+        claim.update(
+            {
+                "required_return_schema_version": version,
+                "adherence_baseline": _baseline_for_claim(
+                    version,
+                    filename=filename,
+                ),
+            }
+        )
+    if state != "claimed":
+        claim.update(
+            {
+                "released_at": "2026-07-31T13:00:00+00:00",
+                "release_reason": "schema_test_closed",
+            }
+        )
+    return claim
+
+
+def _legacy_database() -> dict:
+    return {
+        "config": {"python_path": "/opt/python"},
+        "talks": [_legacy_talk()],
+        "pptx_catalog": [
+            {
+                "pptx_path": "decks/one.pptx",
+                "talk_filename": "one.md",
+                "matched": True,
+                "slide_count": 42,
+                "visual_extracted": False,
+            }
+        ],
+        "qr_codes": [
+            {
+                "talk_slug": "one",
+                "target_url": "https://example.test/one",
+                "shortener": "none",
+                "short_path": None,
+                "short_url": "https://example.test/one",
+                "shortener_link_id": None,
+                "qr_png_rel_path": "illustrations/one-qr.png",
+                "created_at": "2026-07-01",
+                "updated_at": "2026-07-01",
+            }
+        ],
+        "resources": [
+            {
+                "talk_slug": "one",
+                "item_count": 3,
+                "category_breakdown": {"url": 3},
+            }
+        ],
+        "thumbnails": [
+            {
+                "talk_slug": "one",
+                "youtube_url": "https://youtube.test/watch?v=abcdefghijk",
+                "source_slide_num": 7,
+                "speaker_photo_used": "photos/speaker.png",
+                "thumbnail_path": "illustrations/thumbnail.png",
+                "shownotes_thumbnail_path": "assets/one-thumbnail.png",
+                "dimensions": "1280x720",
+                "file_size_kb": 512,
+                "created_at": "2026-07-02",
+                "approved": True,
+            }
+        ],
+        "confirmed_intents": [
+            {
+                "pattern": "hook",
+                "intent": "deliberate",
+                "rule": "Open with the result",
+                "note": "",
+                "confirmed_date": "2026-07-03",
+                "source_talks": ["one.md"],
+            }
+        ],
+        "improvement_goals": [_legacy_goal(), _current_goal()],
+    }
+
+
+def _expected_migration(database: dict) -> dict:
+    expected = copy.deepcopy(database)
+    expected["schema_version"] = 1
+    expected["config"]["schema_version"] = 1
+    for talk in expected["talks"]:
+        talk.setdefault("schema_version", 1)
+        for rejection in talk.get("source_rejections", []):
+            rejection.setdefault("schema_version", 1)
+    for collection in (
+        "pptx_catalog",
+        "qr_codes",
+        "resources",
+        "thumbnails",
+        "confirmed_intents",
+    ):
+        for record in expected.setdefault(collection, []):
+            record.setdefault("schema_version", 1)
+    for goal in expected.setdefault("improvement_goals", []):
+        goal.setdefault("schema_version", 1)
+    for collection in (
+        "talks",
+        "pptx_catalog",
+        "qr_codes",
+        "resources",
+        "thumbnails",
+        "confirmed_intents",
+        "improvement_goals",
+    ):
+        expected.setdefault(collection, [])
+    return expected
+
+
+def test_legacy_reader_accepts_without_mutating(tracking_database):
+    database = _legacy_database()
+    original = copy.deepcopy(database)
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.as_dict() == {
+        "usable": True,
+        "state": "legacy",
+        "schema_version": 0,
+        "accepted_schema_versions": [0, 1],
+        "reason_codes": [],
+    }
+    assert database == original
+
+
+def test_future_root_is_no_usable_prior_state(tracking_database):
+    assessment = tracking_database.assess_tracking_database(
+        _legacy_database() | {"schema_version": 2}
+    )
+
+    assert assessment.usable is False
+    assert assessment.state == "unsupported"
+    assert assessment.reason_codes == (
+        "tracking_database_schema_version_unsupported",
+    )
+
+
+def test_explicit_root_zero_is_not_implicit_legacy_state(tracking_database):
+    database = _legacy_database() | {"schema_version": 0}
+    original = copy.deepcopy(database)
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        "tracking_database_schema_version_unsupported",
+    )
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.migrate_tracking_database(database)
+    assert database == original
+
+
+@pytest.mark.parametrize(
+    ("collection", "record"),
+    [
+        (
+            "talks",
+            {
+                "schema_version": 6,
+                "talk_id": "future-talk",
+                "pattern_observations": ["future-shape"],
+            },
+        ),
+        (
+            "pptx_catalog",
+            {"schema_version": 2, "path": "future/deck.pptx"},
+        ),
+    ],
+)
+def test_future_owner_shape_is_classified_before_legacy_identity_validation(
+    tracking_database,
+    collection,
+    record,
+):
+    database = _legacy_database()
+    database[collection] = [record]
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        f"{collection}_schema_version_unsupported",
+    )
+
+
+@pytest.mark.parametrize(
+    ("record_class", "reason_code"),
+    [
+        ("config", "config_schema_version_unsupported"),
+        ("talks", "talks_schema_version_unsupported"),
+        ("pptx_catalog", "pptx_catalog_schema_version_unsupported"),
+        ("qr_codes", "qr_codes_schema_version_unsupported"),
+        ("resources", "resources_schema_version_unsupported"),
+        ("thumbnails", "thumbnails_schema_version_unsupported"),
+        ("confirmed_intents", "confirmed_intents_schema_version_unsupported"),
+        ("improvement_goals", "improvement_goals_schema_version_unsupported"),
+        ("source_rejections", "source_rejections_schema_version_unsupported"),
+    ],
+)
+@pytest.mark.parametrize("unsupported_version", [0, 99])
+def test_explicit_sentinel_or_future_record_is_not_migrated(
+    tracking_database,
+    record_class,
+    reason_code,
+    unsupported_version,
+):
+    database = _legacy_database()
+    if record_class == "config":
+        database["config"]["schema_version"] = unsupported_version
+    elif record_class == "source_rejections":
+        database["talks"][0]["source_rejections"][0][
+            "schema_version"
+        ] = unsupported_version
+    else:
+        database[record_class][0]["schema_version"] = unsupported_version
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (reason_code,)
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.migrate_tracking_database(database)
+
+
+def test_future_pattern_evidence_is_no_usable_prior_state_without_mutation(
+    tracking_database,
+):
+    database = _legacy_database()
+    database["talks"][0]["pattern_observations"]["evidence_schema_version"] = 99
+    before = copy.deepcopy(database)
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        "pattern_evidence_schema_version_unsupported",
+    )
+    assert database == before
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        (lambda value: value.update(config=[]), "'config' must be an object"),
+        (lambda value: value.update(talks={}), "'talks' must be an array"),
+        (
+            lambda value: value["talks"].append(_legacy_talk()),
+            "duplicate talk filename",
+        ),
+        (
+            lambda value: value["pptx_catalog"][0].update(matched=False),
+            "matched must equal",
+        ),
+        (
+            lambda value: value["resources"][0].update(item_count=2),
+            "category_breakdown total",
+        ),
+        (
+            lambda value: value["thumbnails"][0].update(speaker_photo_used=True),
+            "speaker_photo_used must be a non-empty",
+        ),
+        (
+            lambda value: value["confirmed_intents"][0].update(
+                source_talk="one.md"
+            ),
+            "may use only one",
+        ),
+        (
+            lambda value: value["improvement_goals"][0].pop("target"),
+            "missing fields",
+        ),
+        (
+            lambda value: value["talks"][0]["source_rejections"][0].update(
+                verified_at="2026-07-31"
+            ),
+            "timezone-aware",
+        ),
+    ],
+)
+def test_malformed_legacy_shape_fails_before_migration(
+    tracking_database,
+    change,
+    message,
+):
+    database = _legacy_database()
+    change(database)
+
+    with pytest.raises(tracking_database.TrackingDatabaseError, match=message):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize(
+    ("collection", "identity"),
+    [
+        ("talks", "filename"),
+        ("pptx_catalog", "pptx_path"),
+        ("qr_codes", "talk_slug"),
+        ("resources", "talk_slug"),
+        ("thumbnails", "talk_slug"),
+        ("confirmed_intents", "pattern"),
+        ("improvement_goals", "id"),
+    ],
+)
+def test_duplicate_owner_identity_is_rejected(
+    tracking_database,
+    collection,
+    identity,
+):
+    database = _legacy_database()
+    database[collection].append(copy.deepcopy(database[collection][0]))
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match=f"duplicate .*{identity}",
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_owner_migration_only_adds_owned_version_keys(tracking_database):
+    database = _legacy_database()
+    original = copy.deepcopy(database)
+
+    result = tracking_database.migrate_tracking_database(database)
+
+    assert result.changed is True
+    assert result.from_schema_version == 0
+    assert result.to_schema_version == 1
+    assert database == original
+    assert result.database == _expected_migration(original)
+    assert result.database["talks"][0]["schema_version"] == 1
+    assert (
+        result.database["talks"][0]["pattern_observations"]
+        == original["talks"][0]["pattern_observations"]
+    )
+    assert result.record_counts == {
+        "config": 1,
+        "talks": 1,
+        "pptx_catalog": 1,
+        "qr_codes": 1,
+        "resources": 1,
+        "thumbnails": 1,
+        "confirmed_intents": 1,
+        "improvement_goals": 1,
+        "source_rejections": 1,
+    }
+    assert tracking_database.assess_tracking_database(result.database).state == "current"
+
+
+def test_talk_count_excludes_nested_source_rejection_stamp(tracking_database):
+    database = _legacy_database()
+    database["talks"][0]["schema_version"] = 1
+
+    result = tracking_database.migrate_tracking_database(database)
+
+    assert result.record_counts["talks"] == 0
+    assert result.record_counts["source_rejections"] == 1
+
+
+@pytest.mark.parametrize("evidence_version", [1, 2])
+def test_owner_migration_preserves_supported_pattern_evidence_exactly(
+    tracking_database,
+    evidence_version,
+):
+    database = _legacy_database()
+    observations = database["talks"][0]["pattern_observations"]
+    observations["evidence_schema_version"] = evidence_version
+    observations["antipatterns_detected"] = [
+        {
+            "pattern_id": "wall-of-text",
+            "evidence_citations": [{"source": "slides", "slide_numbers": [3]}],
+        }
+    ]
+    before = copy.deepcopy(observations)
+
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    assert migrated["talks"][0]["pattern_observations"] == before
+
+
+@pytest.mark.parametrize(
+    "legacy_observations",
+    [
+        None,
+        [],
+        [
+            {"pattern": "hook", "evidence": "opening line"},
+            {"pattern": "callback", "evidence": "closing line"},
+        ],
+    ],
+)
+def test_implicit_v1_migration_preserves_legacy_observation_shapes(
+    tracking_database,
+    legacy_observations,
+):
+    database = _legacy_database()
+    database["talks"][0]["pattern_observations"] = copy.deepcopy(
+        legacy_observations
+    )
+
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    assert migrated["talks"][0]["pattern_observations"] == legacy_observations
+    assert migrated["talks"][0]["schema_version"] == 1
+
+
+def test_future_source_identity_receipt_does_not_poison_root_migration(
+    tracking_database,
+):
+    database = _legacy_database()
+    database["talks"][0]["source_identity"] = {
+        "schema_version": 99,
+        "provider": "future-provider",
+        "future_receipt": {"preserve": True},
+    }
+    before = copy.deepcopy(database["talks"][0]["source_identity"])
+
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    assert migrated["talks"][0]["source_identity"] == before
+
+
+@pytest.mark.parametrize("current_root", [False, True])
+@pytest.mark.parametrize("claim_version", [1, 2, 3, 4, 5])
+def test_legacy_and_current_roots_accept_supported_claim_version_boundaries(
+    tracking_database,
+    current_root,
+    claim_version,
+):
+    database = _legacy_database()
+    if current_root:
+        database = tracking_database.migrate_tracking_database(database).database
+    database["talks"][0]["status"] = "reprocessing-inflight"
+    database["talks"][0]["reprocess_generation"] = 2
+    database["talks"][0]["_queue_claim"] = _claim_for_version(
+        claim_version,
+        generation=2,
+        state="claimed",
+        batch_id="current",
+    )
+    database["talks"][0]["_queue_claim_history"] = [
+        _claim_for_version(
+            claim_version,
+            generation=1,
+            state="stale_recovered",
+            batch_id="history",
+        )
+    ]
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.usable is True
+    assert assessment.state == ("current" if current_root else "legacy")
+
+
+@pytest.mark.parametrize("current_root", [False, True])
+@pytest.mark.parametrize("claim_location", ["current", "history"])
+@pytest.mark.parametrize(
+    "malformed_claim",
+    [
+        {},
+        {"schema_version": 0},
+        {"schema_version": 3, "required_return_schema_version": 3},
+        {
+            "schema_version": 3,
+            "required_return_schema_version": 3,
+            "adherence_baseline": {},
+        },
+        {
+            "schema_version": 4,
+            "required_return_schema_version": 4,
+            "adherence_baseline": {"schema_version": 2},
+        },
+        {
+            "schema_version": 5,
+            "required_return_schema_version": 5,
+            "adherence_baseline": {"schema_version": 1},
+        },
+    ],
+)
+def test_legacy_and_current_roots_reject_malformed_claim_versions(
+    tracking_database,
+    current_root,
+    claim_location,
+    malformed_claim,
+):
+    database = _legacy_database()
+    if current_root:
+        database = tracking_database.migrate_tracking_database(database).database
+    if claim_location == "current":
+        database["talks"][0]["_queue_claim"] = copy.deepcopy(malformed_claim)
+    else:
+        database["talks"][0]["_queue_claim_history"] = [
+            copy.deepcopy(malformed_claim)
+        ]
+
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("current_root", [False, True])
+@pytest.mark.parametrize("claim_location", ["current", "history"])
+def test_future_claim_is_no_usable_state_before_old_nested_validation(
+    tracking_database,
+    current_root,
+    claim_location,
+):
+    database = _legacy_database()
+    if current_root:
+        database = tracking_database.migrate_tracking_database(database).database
+    database["talks"][0]["schema_version"] = 5
+    database["talks"][0]["pattern_observations"] = ["future-owned-shape"]
+    future_claim = {
+        "schema_version": 6,
+        "future_identity": "not-an-old-run-id",
+        "state": {"future": True},
+    }
+    if claim_location == "current":
+        database["talks"][0]["_queue_claim"] = future_claim
+        database["talks"][0]["_queue_claim_history"] = {
+            "future_history_shape": True
+        }
+    else:
+        database["talks"][0]["_queue_claim_history"] = [future_claim]
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        "queue_claim_schema_version_unsupported",
+    )
+
+
+def test_future_claim_baseline_is_classified_before_known_baseline_shape(
+    tracking_database,
+):
+    database = _legacy_database()
+    database["talks"][0]["_queue_claim"] = {
+        "schema_version": 5,
+        "adherence_baseline": {
+            "schema_version": 99,
+            "future_snapshot": {"shape": "opaque"},
+        },
+    }
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        "adherence_baseline_schema_version_unsupported",
+    )
+
+
+@pytest.mark.parametrize("current_root", [False, True])
+def test_legacy_and_current_roots_reject_malformed_claim_history(
+    tracking_database,
+    current_root,
+):
+    database = _legacy_database()
+    if current_root:
+        database = tracking_database.migrate_tracking_database(database).database
+    database["talks"][0]["_queue_claim_history"] = {}
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="_queue_claim_history must be an array",
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_migration_rejects_queue_invalid_open_history_record(
+    tracking_database,
+):
+    database = _legacy_database()
+    database["talks"][0]["_queue_claim_history"] = [
+        _claim_for_version(
+            1,
+            generation=1,
+            state="claimed",
+            batch_id="invalid-history",
+        )
+    ]
+    original = copy.deepcopy(database)
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="historical claims must be closed",
+    ):
+        tracking_database.migrate_tracking_database(database)
+
+    assert database == original
+
+
+def test_owner_migration_adds_absent_owned_collections(tracking_database):
+    database = {"config": {}, "talks": []}
+
+    result = tracking_database.migrate_tracking_database(database)
+
+    for collection in (
+        "pptx_catalog",
+        "qr_codes",
+        "resources",
+        "thumbnails",
+        "confirmed_intents",
+        "improvement_goals",
+    ):
+        assert result.database[collection] == []
+    assert result.database["schema_version"] == 1
+
+
+def test_owner_migration_preserves_mixed_historical_talk_versions(
+    tracking_database,
+):
+    database = _legacy_database()
+    database["talks"] = []
+    for version in (1, 4, 5):
+        talk = _legacy_talk(filename=f"v{version}.md")
+        talk["schema_version"] = version
+        database["talks"].append(talk)
+    database["talks"].append(_legacy_talk(filename="implicit-v1.md"))
+
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    assert [talk["schema_version"] for talk in migrated["talks"]] == [1, 4, 5, 1]
+
+
+@pytest.mark.parametrize(
+    "active_talk",
+    [
+        {
+            **_legacy_talk(),
+            "status": "reprocessing-inflight",
+            "reprocess_generation": 1,
+            "_queue_claim": _claim_for_version(
+                1,
+                generation=1,
+                state="claimed",
+                batch_id="active",
+            ),
+        },
+        {
+            **_legacy_talk(),
+            "status": "needs-reprocessing",
+            "reprocess_generation": 1,
+            "_queue_claim": _claim_for_version(
+                1,
+                generation=1,
+                state="claimed",
+                batch_id="drifted",
+            ),
+        },
+    ],
+)
+def test_owner_migration_rejects_active_writers(tracking_database, active_talk):
+    database = _legacy_database()
+    database["talks"] = [active_talk]
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="active queue writers",
+    ):
+        tracking_database.migrate_tracking_database(database)
+
+
+def test_current_migration_is_idempotent_with_stable_counts(tracking_database):
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+
+    second = tracking_database.migrate_tracking_database(current)
+
+    assert second.changed is False
+    assert second.database == current
+    assert second.database is not current
+    assert second.record_counts == {
+        "config": 0,
+        "talks": 0,
+        "pptx_catalog": 0,
+        "qr_codes": 0,
+        "resources": 0,
+        "thumbnails": 0,
+        "confirmed_intents": 0,
+        "improvement_goals": 0,
+        "source_rejections": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "collection",
+    [
+        "talks",
+        "pptx_catalog",
+        "qr_codes",
+        "resources",
+        "thumbnails",
+        "confirmed_intents",
+        "improvement_goals",
+    ],
+)
+def test_current_root_requires_every_owned_collection(
+    tracking_database,
+    collection,
+):
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current.pop(collection)
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match=f"requires a '{collection}' array",
+    ):
+        tracking_database.assess_tracking_database(current)
+
+
+def test_current_root_requires_explicit_child_versions(tracking_database):
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current["talks"][0].pop("schema_version")
+    current["talks"][0]["source_rejections"][0].pop("schema_version")
+    current["qr_codes"][0].pop("schema_version")
+
+    assessment = tracking_database.assess_tracking_database(current)
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        "qr_codes_schema_version_missing",
+        "talks_schema_version_missing",
+    )
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="migration will refuse",
+    ):
+        tracking_database.require_current_tracking_database(current)
+
+
+def test_require_current_routes_legacy_state_to_owner_migration(tracking_database):
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="migrate-tracking-database.py",
+    ):
+        tracking_database.require_current_tracking_database(_legacy_database())
+
+
+def _write_database(path, database: dict) -> bytes:
+    raw = (json.dumps(database, indent=2) + "\n").encode()
+    path.write_bytes(raw)
+    os.chmod(path, 0o600)
+    return raw
+
+
+def test_migration_dry_run_is_side_effect_free(
+    migrate_tracking_database,
+    tmp_path,
+):
+    path = tmp_path / "tracking-database.json"
+    raw = _write_database(path, _legacy_database())
+
+    report = migrate_tracking_database.execute(
+        path,
+        apply=False,
+        expected_sha256=None,
+    )
+
+    assert path.read_bytes() == raw
+    assert report["mode"] == "dry-run"
+    assert report["changed"] is True
+    assert report["database_written"] is False
+    assert report["input_sha256"] == hashlib.sha256(raw).hexdigest()
+    assert not (tmp_path / ".backups").exists()
+
+
+@pytest.mark.parametrize("apply", [False, True])
+def test_explicit_root_zero_cli_refuses_before_write_or_backup(
+    migrate_tracking_database,
+    tmp_path,
+    apply,
+):
+    path = tmp_path / "tracking-database.json"
+    raw = _write_database(path, _legacy_database() | {"schema_version": 0})
+
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="tracking_database_schema_version_unsupported",
+    ):
+        migrate_tracking_database.execute(
+            path,
+            apply=apply,
+            expected_sha256=(hashlib.sha256(raw).hexdigest() if apply else None),
+        )
+
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+
+def test_apply_writes_exact_backup_through_shared_transaction(
+    migrate_tracking_database,
+    tracking_database,
+    tmp_path,
+):
+    path = tmp_path / "tracking-database.json"
+    raw = _write_database(path, _legacy_database())
+    digest = hashlib.sha256(raw).hexdigest()
+
+    report = migrate_tracking_database.execute(
+        path,
+        apply=True,
+        expected_sha256=digest,
+    )
+
+    backup = tmp_path / ".backups" / f"{path.name}.schema-v0-{digest}.bak"
+    assert backup.read_bytes() == raw
+    assert report["backup"] == str(backup)
+    assert report["database_written"] is True
+    assert report["durability_state"] == "durable"
+    assert report["warnings"] == []
+    current = json.loads(path.read_text())
+    assert tracking_database.assess_tracking_database(current).state == "current"
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_apply_current_database_is_exact_noop_without_backup(
+    migrate_tracking_database,
+    tracking_database,
+    tmp_path,
+):
+    path = tmp_path / "tracking-database.json"
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    raw = _write_database(path, current)
+    inode = path.stat().st_ino
+
+    report = migrate_tracking_database.execute(
+        path,
+        apply=True,
+        expected_sha256=hashlib.sha256(raw).hexdigest(),
+    )
+
+    assert report["changed"] is False
+    assert report["database_written"] is False
+    assert report["backup"] is None
+    assert path.read_bytes() == raw
+    assert path.stat().st_ino == inode
+
+
+def test_apply_requires_matching_dry_run_hash(
+    migrate_tracking_database,
+    tmp_path,
+):
+    path = tmp_path / "tracking-database.json"
+    _write_database(path, _legacy_database())
+
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="--expected-sha256",
+    ):
+        migrate_tracking_database.execute(path, apply=True, expected_sha256=None)
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="sha256 precondition failed",
+    ):
+        migrate_tracking_database.execute(
+            path,
+            apply=True,
+            expected_sha256="0" * 64,
+        )
+
+
+def test_shared_cas_rejects_change_before_commit(
+    migrate_tracking_database,
+    monkeypatch,
+    tmp_path,
+):
+    path = tmp_path / "tracking-database.json"
+    raw = _write_database(path, _legacy_database())
+    digest = hashlib.sha256(raw).hexdigest()
+    concurrent = b'{"concurrent":true}\n'
+    original_commit = migrate_tracking_database.commit_tracking_database
+
+    def racing_commit(expected, candidate, *, backup=None):
+        path.write_bytes(concurrent)
+        return original_commit(expected, candidate, backup=backup)
+
+    monkeypatch.setattr(
+        migrate_tracking_database,
+        "commit_tracking_database",
+        racing_commit,
+    )
+
+    with pytest.raises(migrate_tracking_database.TrackingDatabaseMigrationError):
+        migrate_tracking_database.execute(
+            path,
+            apply=True,
+            expected_sha256=digest,
+        )
+
+    assert path.read_bytes() == concurrent
+    assert not (tmp_path / ".backups").exists()
+
+
+@pytest.mark.parametrize("apply", [False, True])
+def test_malformed_or_active_state_blocks_before_backup(
+    migrate_tracking_database,
+    tmp_path,
+    apply,
+):
+    path = tmp_path / "tracking-database.json"
+    database = _legacy_database()
+    database["talks"][0].update(
+        {
+            "status": "reprocessing-inflight",
+            "reprocess_generation": 1,
+            "_queue_claim": _claim_for_version(
+                1,
+                generation=1,
+                state="claimed",
+                batch_id="blocking",
+            ),
+        }
+    )
+    raw = _write_database(path, database)
+
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="active queue writers",
+    ):
+        migrate_tracking_database.execute(
+            path,
+            apply=apply,
+            expected_sha256=(hashlib.sha256(raw).hexdigest() if apply else None),
+        )
+
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+
+def test_legacy_queue_recovery_unblocks_migration_without_schema_stamping(
+    migrate_tracking_database,
+    queue_state,
+    tmp_path,
+    capsys,
+):
+    path = tmp_path / "tracking-database.json"
+    database = _legacy_database()
+    database["talks"] = [
+        {
+            **_legacy_talk(),
+            "status": "reprocessing-inflight",
+            "reprocess_generation": 1,
+            "_queue_claim": {
+                "schema_version": 1,
+                "run_id": "legacy-run",
+                "batch_id": "1",
+                "claimed_at": "2026-07-31T12:00:00+00:00",
+                "previous_status": "needs-reprocessing",
+                "reprocess_generation": 1,
+                "state": "claimed",
+            },
+        }
+    ]
+    raw = _write_database(path, database)
+
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="active queue writers",
+    ):
+        migrate_tracking_database.execute(
+            path,
+            apply=False,
+            expected_sha256=None,
+        )
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+    assert queue_state.main(
+        [str(path), "inspect", "--run-id", "legacy-run"]
+    ) == 0
+    capsys.readouterr()
+    assert path.read_bytes() == raw
+
+    assert queue_state.main(
+        [
+            str(path),
+            "recover",
+            "--now",
+            "2026-08-01T12:00:00+00:00",
+            "--stale-after-seconds",
+            "1",
+            "--run-id",
+            "legacy-run",
+        ]
+    ) == 0
+    capsys.readouterr()
+    recovered = json.loads(path.read_text())
+    assert "schema_version" not in recovered
+    assert "schema_version" not in recovered["talks"][0]
+    assert recovered["talks"][0]["status"] == "needs-reprocessing"
+    claim = recovered["talks"][0]["_queue_claim"]
+    assert claim["schema_version"] == 2
+    assert claim["state"] == "stale_recovered"
+    assert claim["release_reason"] == "lease_expired"
+
+    report = migrate_tracking_database.execute(
+        path,
+        apply=False,
+        expected_sha256=None,
+    )
+    assert report["changed"] is True
+    assert report["from_schema_version"] == 0
+    assert report["to_schema_version"] == 1
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        (
+            b'{"config":{"python_path":"a","python_path":"b"},"talks":[]}\n',
+            "duplicate object key 'python_path'",
+        ),
+        (b'{"config":{"value":NaN},"talks":[]}\n', "JSON number NaN"),
+    ],
+)
+def test_strict_json_failure_has_no_write_or_backup(
+    migrate_tracking_database,
+    tmp_path,
+    raw,
+    message,
+):
+    path = tmp_path / "tracking-database.json"
+    path.write_bytes(raw)
+
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match=message,
+    ):
+        migrate_tracking_database.execute(
+            path,
+            apply=True,
+            expected_sha256=hashlib.sha256(raw).hexdigest(),
+        )
+
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+
+@pytest.mark.parametrize("apply", [False, True])
+def test_non_roundtrippable_number_blocks_migration_before_backup(
+    migrate_tracking_database,
+    tmp_path,
+    apply,
+):
+    path = tmp_path / "tracking-database.json"
+    database = _legacy_database()
+    database["config"]["precision_marker"] = "NUMBER_TOKEN"
+    raw = (json.dumps(database, indent=2) + "\n").encode().replace(
+        b'"NUMBER_TOKEN"',
+        b"0.12345678901234567890123456789",
+    )
+    path.write_bytes(raw)
+
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="cannot round-trip losslessly",
+    ):
+        migrate_tracking_database.execute(
+            path,
+            apply=apply,
+            expected_sha256=(hashlib.sha256(raw).hexdigest() if apply else None),
+        )
+
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+
+@pytest.mark.parametrize(
+    "number_token",
+    [
+        pytest.param("1e" + "9" * 30, id="extreme-exponent"),
+        pytest.param("7" * 5000, id="huge-integer"),
+    ],
+)
+def test_cli_reports_extreme_number_as_json_without_write_or_backup(
+    migrate_tracking_database,
+    tmp_path,
+    capsys,
+    number_token,
+):
+    path = tmp_path / "tracking-database.json"
+    database = _legacy_database()
+    database["config"]["precision_marker"] = "NUMBER_TOKEN"
+    raw = (json.dumps(database, indent=2) + "\n").encode().replace(
+        b'"NUMBER_TOKEN"',
+        number_token.encode(),
+    )
+    path.write_bytes(raw)
+
+    result = migrate_tracking_database.main(
+        [
+            str(path),
+            "--apply",
+            "--expected-sha256",
+            hashlib.sha256(raw).hexdigest(),
+        ]
+    )
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+
+    assert result == 2
+    assert report["ok"] is False
+    assert "cannot round-trip losslessly" in report["error"]
+    assert len(report["error"]) < 1000
+    assert "Traceback" not in captured.err
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        pytest.param(
+            b'{"config":{"value":' + b"[" * 500 + b"0" + b"]" * 500
+            + b'},"talks":[]}\n',
+            "maximum supported JSON nesting depth 200",
+            id="decoded-depth-limit",
+        ),
+        pytest.param(
+            b'{"config":{"value":' + b"[" * 10_000 + b"0" + b"]" * 10_000
+            + b'},"talks":[]}\n',
+            "maximum supported JSON nesting depth 200",
+            id="decoder-recursion-limit",
+        ),
+        pytest.param(
+            b'{"config":{"value":"\\ud800"},"talks":[]}\n',
+            "unpaired UTF-16 surrogate",
+            id="unpaired-surrogate",
+        ),
+    ],
+)
+def test_cli_reports_unsafe_json_tree_without_write_or_backup(
+    migrate_tracking_database,
+    tmp_path,
+    capsys,
+    raw,
+    message,
+):
+    path = tmp_path / "tracking-database.json"
+    path.write_bytes(raw)
+
+    result = migrate_tracking_database.main(
+        [
+            str(path),
+            "--apply",
+            "--expected-sha256",
+            hashlib.sha256(raw).hexdigest(),
+        ]
+    )
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+
+    assert result == 2
+    assert report["ok"] is False
+    assert message in report["error"]
+    assert len(report["error"]) < 1000
+    assert "Traceback" not in captured.err
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+
+def test_cli_errors_follow_json_contract(
+    migrate_tracking_database,
+    tmp_path,
+    capsys,
+):
+    path = tmp_path / "tracking-database.json"
+    raw = b'{"config":{},"talks":[],"talks":[{"filename":"hidden.md"}]}\n'
+    path.write_bytes(raw)
+
+    result = migrate_tracking_database.main(
+        [
+            str(path),
+            "--apply",
+            "--expected-sha256",
+            hashlib.sha256(raw).hexdigest(),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert json.loads(captured.out)["ok"] is False
+    assert "duplicate object key 'talks'" in captured.err
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+    result = migrate_tracking_database.main([])
+    captured = capsys.readouterr()
+    assert result == 2
+    assert json.loads(captured.out)["ok"] is False
+    assert "invalid arguments" in captured.err

--- a/tests/test_tracking_database_strict_readers.py
+++ b/tests/test_tracking_database_strict_readers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 import pytest
 
@@ -51,6 +52,63 @@ def _database(tmp_path: Path, raw: bytes) -> Path:
     path = tmp_path / "tracking-database.json"
     path.write_bytes(raw)
     return path
+
+
+def test_owner_reader_accepts_implicit_legacy_after_schema_assessment(
+    read_tracking_database,
+    tmp_path: Path,
+) -> None:
+    raw = b'{"config":{},"talks":[]}\n'
+    database = _database(tmp_path, raw)
+
+    report = read_tracking_database.execute(database)
+
+    assert report["ok"] is True
+    assert report["database"] == {"config": {}, "talks": []}
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "schema_version": 2,
+            "future_config": ["no old config/talks shape"],
+        },
+        {
+            "config": {},
+            "talks": [
+                {
+                    "schema_version": 6,
+                    "talk_id": "future-talk",
+                }
+            ],
+        },
+    ],
+)
+def test_owner_reader_rejects_no_usable_owner_state_without_database_output(
+    read_tracking_database,
+    tracking_database_io,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    payload: dict[str, object],
+) -> None:
+    raw = (json.dumps(payload) + "\n").encode()
+    database = _database(tmp_path, raw)
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError,
+        match="no usable legacy/current owner state",
+    ):
+        read_tracking_database.execute(database)
+
+    result = read_tracking_database.main([str(database)])
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert result == 2
+    assert output["ok"] is False
+    assert "database" not in output
+    assert database.read_bytes() == raw
 
 
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -17,6 +17,20 @@ def _write(path: Path, value: object) -> bytes:
     return raw
 
 
+def _current_database() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "config": {"schema_version": 1},
+        "talks": [],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+
+
 def _inject_final_window_replacement(
     tracking_database_io,
     monkeypatch: pytest.MonkeyPatch,
@@ -150,7 +164,8 @@ def test_qr_writer_preserves_final_window_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = tmp_path / "tracking-database.json"
-    _write(path, {"config": {}, "talks": [], "qr_codes": []})
+    database = _current_database()
+    _write(path, database)
     expected = tracking_database_io.snapshot_tracking_database(path)
     concurrent = _inject_final_window_replacement(
         tracking_database_io,
@@ -161,7 +176,7 @@ def test_qr_writer_preserves_final_window_generation(
     with pytest.raises(ValueError, match="generation changed"):
         generate_qr.write_tracking_db(
             expected,
-            {"config": {}, "talks": [], "qr_codes": [], "writer": "qr"},
+            database | {"writer": "qr"},
         )
 
     assert path.read_bytes() == concurrent
@@ -174,7 +189,7 @@ def test_owner_mutation_cli_preserves_final_window_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = tmp_path / "tracking-database.json"
-    _write(path, {"config": {}, "talks": []})
+    _write(path, _current_database())
     plan = tmp_path / "plan.json"
     _write(
         plan,

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -166,9 +166,11 @@ def _minimal_profile(validate_profile):
     return profile
 
 
-def _run(validate_profile, profile, tmp_path):
+def _run(validate_profile, profile, tmp_path, *, database=None):
     (tmp_path / "tracking-database.json").write_text(
-        json.dumps({"config": {}, "talks": []}),
+        json.dumps(
+            {"config": {}, "talks": []} if database is None else database
+        ),
         encoding="utf-8",
     )
     path = tmp_path / "profile.json"
@@ -189,6 +191,25 @@ def test_profile_without_engines_still_validates(validate_profile, tmp_path, cap
     assert rc == 0
     assert out["valid"] is True
     assert out["missing_keys"] == []
+
+
+def test_validate_profile_rejects_future_tracking_database(
+    validate_profile, tmp_path, capsys
+):
+    profile = _minimal_profile(validate_profile)
+
+    rc = _run(
+        validate_profile,
+        profile,
+        tmp_path,
+        database={"schema_version": 99, "config": {}, "talks": []},
+    )
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert rc == 1
+    assert out["valid"] is False
+    assert "no usable prior state" in captured.err
 
 
 def test_profile_with_engines_validates(validate_profile, tmp_path, capsys):
@@ -501,7 +522,7 @@ def test_load_vault_separates_pattern_generation_from_instrumentation(
     )
     missing_generation.pop("pattern_scoring_generation_status")
     pending_duplicate = _scored_talk(
-        "current-old-date.md",
+        "pending-ineligible.md",
         60,
         status="pending",
         generation_status="future",
@@ -572,6 +593,75 @@ def test_load_vault_separates_pattern_generation_from_instrumentation(
     assert "snapshot observation time" in payload["baseline_note"]
     assert "processed_date" in payload["baseline_note"]
     assert "does not confer pattern-scoring" in payload["instrumentation_note"]
+
+
+def test_load_vault_rejects_future_tracking_database(
+    load_vault,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _write_vault(tmp_path, [])
+    database_path = tmp_path / "tracking-database.json"
+    database = json.loads(database_path.read_text(encoding="utf-8"))
+    database["schema_version"] = 99
+    database_path.write_text(json.dumps(database), encoding="utf-8")
+    before = database_path.read_bytes()
+
+    rc, payload, error = _run_load_vault(load_vault, tmp_path, monkeypatch, capsys)
+
+    assert rc == 1
+    assert payload is None
+    assert "not usable by this reader" in error
+    assert database_path.read_bytes() == before
+
+
+def test_load_vault_projects_confirmed_intents_without_storage_metadata(
+    load_vault,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _write_vault(tmp_path, [])
+    database_path = tmp_path / "tracking-database.json"
+    database = {
+        "schema_version": 1,
+        "config": {"schema_version": 1, "synthetic": True},
+        "talks": [],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [{
+            "schema_version": 1,
+            "pattern": "delayed_self_introduction",
+            "intent": "deliberate",
+            "rule": "Use the two-phase introduction",
+            "note": "Speaker-confirmed",
+            "confirmed_date": "2026-08-01",
+            "source_talk": "example.md",
+        }],
+        "improvement_goals": [],
+    }
+    raw = (json.dumps(database, indent=2) + "\n").encode()
+    database_path.write_bytes(raw)
+
+    rc, payload, error = _run_load_vault(
+        load_vault, tmp_path, monkeypatch, capsys
+    )
+
+    assert rc == 0
+    assert error == ""
+    assert payload["confirmed_intents"] == [{
+        "pattern": "delayed_self_introduction",
+        "intent": "deliberate",
+        "rule": "Use the two-phase introduction",
+        "note": "Speaker-confirmed",
+    }]
+    assert list(payload["confirmed_intents"][0]) == [
+        "pattern", "intent", "rule", "note",
+    ]
+    assert database_path.read_bytes() == raw
 
 
 @pytest.mark.parametrize(

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -237,7 +237,7 @@ def _write_tracking_db(
         talk = {
             "filename": ret["filename"],
             "title": title,
-            "schema_version": 3,
+            "schema_version": 5,
             "status": ret["status"],
             "processed_date": (
                 persisted_date or ret.get("processed_date") or "2026-07-26"
@@ -323,7 +323,17 @@ def _write_tracking_db(
             talk["pattern_score"] = score
         talks.append(talk)
     path = tmp_path / name
-    path.write_text(json.dumps({"talks": talks}))
+    path.write_text(json.dumps({
+        "schema_version": 1,
+        "config": {"schema_version": 1},
+        "talks": talks,
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }))
     return path
 
 
@@ -1399,9 +1409,10 @@ def test_cli_does_not_write_outside_the_output_dir(write_analysis, tmp_path):
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 1
+    assert "filename must be a non-empty basename" in result.stderr
     assert victim.read_text() == '{"talks": []}', "the sibling file was overwritten"
-    assert (out / "tracking-database.json.md").exists()
+    assert not out.exists()
 
 
 def test_cli_rejects_filename_that_names_no_file(write_analysis, tmp_path):
@@ -1422,7 +1433,7 @@ def test_cli_rejects_filename_that_names_no_file(write_analysis, tmp_path):
         text=True,
     )
     assert result.returncode != 0
-    assert "does not name a file" in result.stderr
+    assert "filename must be a non-empty basename" in result.stderr
 
 
 def test_cli_rejects_malformed_tracking_db(write_analysis, tmp_path):
@@ -1630,7 +1641,7 @@ def test_top_level_generation_mismatch_cannot_overwrite_analysis(
     )
 
     assert result.returncode == 1
-    assert "active claim generation 1 disagrees with talk generation 2" in result.stderr
+    assert "current claim generation 1 disagrees with talk generation 2" in result.stderr
     assert target.read_text() == "# current generation\n"
 
 
@@ -2123,8 +2134,72 @@ def test_future_talk_schema_cannot_authorize_analysis_write(write_analysis, tmp_
     )
 
     assert result.returncode == 1
-    assert "future talk schema_version 99" in result.stderr
+    assert "talks_schema_version_unsupported" in result.stderr
     assert not out.exists()
+
+
+def test_future_root_is_assessed_before_old_talks_shape(write_analysis, tmp_path):
+    batch = tmp_path / "batch-returns.json"
+    batch.write_text(json.dumps([_return()]))
+    db = tmp_path / "tracking-database.json"
+    original = {
+        "schema_version": 99,
+        "future_inventory": {"records": "opaque"},
+    }
+    db.write_text(json.dumps(original))
+    before = db.read_bytes()
+    out = tmp_path / "analyses"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "tracking_database_schema_version_unsupported" in result.stderr
+    assert "expected a JSON object with a `talks` array" not in result.stderr
+    assert db.read_bytes() == before
+    assert not out.exists()
+
+
+def test_legacy_database_can_render_analysis_without_database_write(
+    write_analysis, tmp_path
+):
+    ret = _return()
+    batch = tmp_path / "batch-returns.json"
+    batch.write_text(json.dumps([ret]))
+    db = _write_tracking_db(tmp_path, [ret])
+    payload = json.loads(db.read_text())
+    payload.pop("schema_version")
+    payload["config"].pop("schema_version")
+    db.write_text(json.dumps(payload))
+    before = db.read_bytes()
+    out = tmp_path / "analyses"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out / "talk.md").is_file()
+    assert db.read_bytes() == before
 
 
 def test_tracking_database_symlink_is_rejected_before_analysis_write(
@@ -2256,11 +2331,11 @@ def test_cli_rejects_normalized_target_collision_before_any_write(
     batch = tmp_path / "batch-returns.json"
     out = tmp_path / "analyses"
     out.mkdir()
-    existing = out / "TALK.MD"
+    existing = out / "CAFÉ.md"
     existing.write_text("# existing analysis\n")
     returns = [
-        _return(filename="first/TALK.MD"),
-        _return(filename="second/talk.md"),
+        _return(filename="Cafe\N{COMBINING ACUTE ACCENT}.md"),
+        _return(filename="Caf\N{LATIN SMALL LETTER E WITH ACUTE}.md"),
     ]
     batch.write_text(json.dumps(returns))
     db = _write_tracking_db(tmp_path, returns)
@@ -2281,7 +2356,7 @@ def test_cli_rejects_normalized_target_collision_before_any_write(
     assert result.returncode == 1
     assert "resolve to the same analysis target" in result.stderr
     assert existing.read_text() == "# existing analysis\n"
-    assert [path.name for path in out.iterdir()] == ["TALK.MD"]
+    assert [path.name for path in out.iterdir()] == ["CAFÉ.md"]
 
 
 def test_existing_casefold_target_collision_rejects_before_any_write(


### PR DESCRIPTION
Closes #147.

## What changed

- Gives vault-ingress explicit ownership of tracking-database root and record schemas.
- Adds a deterministic schema-0 to schema-1 migration with exact-byte backup, SHA-256 apply precondition, active-writer refusal, and idempotent current-state no-op.
- Preserves historical talk/evidence generations instead of fabricating current evidence during migration.
- Keeps legacy queue inspection and stale-lease recovery available before migration while all other writers require current owner state.
- Shares one complete queue claim/history/batch contract between migration assessment and queue operations.
- Makes schema assessment the first semantic operation for every tracking-database consumer.
- Rejects unsupported future generations before interpreting their legacy identities or shapes.
- Rejects JSON values that cannot round-trip safely, excessive nesting, and unpaired surrogates through bounded domain errors before backup or write.
- Aligns publishing, clarification, profile projection, and improvement-goal mutation contracts with the owned schemas.

## Verification

- Full pytest suite: 3,280 passed, 3 skipped.
- Independent rollout review: 922 targeted tests, all clear.
- Independent adversarial schema/migration review: 705 targeted tests plus exact repro matrix, all clear.
- Ruff and Pyright clean.
- Pre-publish pin and package-content checks pass.
- Plugin lint passes with only the two existing skill-length advisories.
- Exact-byte cutover rehearsal verified active-lease refusal, recovery compatibility, deterministic migration, exact backup, preservation after removing inserted schema markers, and byte/inode-preserving repeat apply.

## Rollout

Installing the plugin does not mutate a vault. Migration remains an explicit dry-run/apply operation; apply requires the dry-run input digest and refuses active queue claims. Legacy inspect/recover remains available to close old leases before migration.
