### PR TITLE
fix(vault-ingress): isolate native module probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### fix(vault-ingress) — contain native dependency probe crashes
+
+Runtime module imports now run in bounded child processes launched by the exact
+configured interpreter. A missing dependency, Python initializer exception,
+native crash, timeout, or malformed child result degrades only an optional lane
+and blocks that lane when required. The parent retains its one-JSON stdout
+contract, reports a machine-readable failure reason per module, and emits an
+actionable recovery step without forwarding native crash output.
+
 ## 0.20.1 — 2026-08-01
 
 ### fix(vault-ingress) — give the tracking database one versioned owner

--- a/README.md
+++ b/README.md
@@ -367,7 +367,8 @@ vault-ingress skill are the runtime authority. After `python_path` is
 bootstrapped, run its stdlib-only `check-runtime.py` probe. Optional lane
 dependency absence is isolated: missing pypdf cannot erase transcript/PPTX
 capability, and missing python-pptx cannot erase transcript/PDF capability.
-Unexpected dependency initializer faults stop the probe visibly.
+Dependency initializer exceptions, native crashes, timeouts, and invalid child
+results remain lane-local and carry machine-readable failure reasons.
 
 ## Generation & Publishing Skills Details
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -181,9 +181,11 @@ inspection needs `pdftoppm`; video extraction needs Pillow, `imagehash`,
 Inspect those with the checker's `google-drive`, `captions`,
 `youtube-download`, `pdf-render`, `video`, and `whisper` lanes as selected talks
 require. Each lane is independent: a failed optional import/tool disables only
-that lane when the checker recognizes dependency absence or incompatibility.
-An unexpected initializer fault stops the probe with one JSON error and a
-recovery instruction.
+that lane. Import failure details appear under the lane's `module_failures`;
+dependency absence, initializer exceptions, native crashes, timeouts, and
+invalid child results degrade an optional lane or block a required lane without
+breaking the one-JSON contract. The checker writes a recovery instruction to
+stderr whenever a lane is unavailable.
 
 **Scan for new talks:** run the deterministic scanner in its default read-only
 mode:

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -5,20 +5,30 @@ The installed plugin does not ship ``pyproject.toml``. This stdlib-only probe is
 the executable dependency contract for the interpreter recorded in
 ``config.python_path``. Core failures block ingress. Recognized missing or
 incompatible optional dependencies are reported as degradation unless the
-caller explicitly requires that lane. Unexpected probe faults fail visibly.
+caller explicitly requires that lane. Isolated import faults remain lane-local.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib
 import json
+import os
+import signal
 import shutil
+import subprocess
 import sys
-from typing import Any
+import tempfile
+from pathlib import Path
+from typing import Any, BinaryIO, Callable, TypedDict
 
 
 REPORT_SCHEMA_VERSION = 1
+MODULE_PROBE_SCHEMA_VERSION = 1
+MODULE_PROBE_TIMEOUT_SECONDS = 30
+MODULE_PROBE_MAX_OUTPUT_BYTES = 4096
+MODULE_PROBE_CHILD_FLAG = "--module-probe-child"
 MINIMUM_PYTHON = (3, 10)
 LANE_REQUIREMENTS: dict[str, dict[str, dict[str, str]]] = {
     "core": {
@@ -64,12 +74,207 @@ DEFAULT_LANES = ("core", "pdf", "pptx")
 DEFAULT_REQUIRED_LANES = ("core",)
 
 
-def _module_available(import_name: str) -> bool:
+class ModuleProbeResult(TypedDict):
+    """Parent-side result for one isolated dependency import."""
+
+    available: bool
+    failure: dict[str, object] | None
+
+
+def _failed_module_probe(reason: str, **details: object) -> ModuleProbeResult:
+    failure: dict[str, object] = {"reason": reason}
+    failure.update(details)
+    return {"available": False, "failure": failure}
+
+
+def _write_module_probe_result(
+    result_file: BinaryIO,
+    payload: dict[str, object],
+) -> None:
+    """Replace the pre-created child result through its retained descriptor."""
+    rendered = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+    result_file.seek(0)
+    result_file.truncate()
+    remaining = memoryview(rendered)
+    while remaining:
+        written = result_file.write(remaining)
+        if written is None or written <= 0:
+            raise OSError("module probe result write made no progress")
+        remaining = remaining[written:]
+    result_file.flush()
+
+
+def _module_probe_child(import_name: str) -> dict[str, object]:
+    """Import one module and return the private child-process payload."""
     try:
         importlib.import_module(import_name)
-    except (ImportError, OSError, RuntimeError):
-        return False
-    return True
+    except ImportError as exc:
+        return {
+            "schema_version": MODULE_PROBE_SCHEMA_VERSION,
+            "available": False,
+            "failure_reason": "unavailable_import",
+            "exception_type": type(exc).__name__,
+        }
+    return {
+        "schema_version": MODULE_PROBE_SCHEMA_VERSION,
+        "available": True,
+    }
+
+
+def _malformed_child_output(malformation: str) -> ModuleProbeResult:
+    return _failed_module_probe(
+        "malformed_child_output",
+        malformation=malformation,
+    )
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON object key")
+        result[key] = value
+    return result
+
+
+def _reject_nonstandard_json_constant(_value: str) -> object:
+    raise ValueError("non-standard JSON number")
+
+
+def _decode_module_probe_child(raw: bytes) -> ModuleProbeResult:
+    if len(raw) > MODULE_PROBE_MAX_OUTPUT_BYTES:
+        return _malformed_child_output("oversized")
+    if not raw.strip():
+        return _malformed_child_output("empty")
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return _malformed_child_output("invalid_utf8")
+    lines = decoded.splitlines()
+    if len(lines) != 1:
+        return _malformed_child_output("multiple_lines")
+    try:
+        payload = json.loads(
+            lines[0],
+            object_pairs_hook=_unique_json_object,
+            parse_constant=_reject_nonstandard_json_constant,
+        )
+    except (json.JSONDecodeError, RecursionError, ValueError):
+        return _malformed_child_output("invalid_json")
+    if not isinstance(payload, dict):
+        return _malformed_child_output("invalid_payload")
+    schema_version = payload.get("schema_version")
+    if (
+        type(schema_version) is not int
+        or schema_version != MODULE_PROBE_SCHEMA_VERSION
+    ):
+        return _malformed_child_output("invalid_payload")
+    available = payload.get("available")
+    if available is True and set(payload) == {"schema_version", "available"}:
+        return {"available": True, "failure": None}
+    expected_failure_keys = {
+        "schema_version",
+        "available",
+        "failure_reason",
+        "exception_type",
+    }
+    failure_reason = payload.get("failure_reason")
+    exception_type = payload.get("exception_type")
+    if (
+        available is False
+        and set(payload) == expected_failure_keys
+        and isinstance(failure_reason, str)
+        and failure_reason in {"unavailable_import", "initializer_exception"}
+        and isinstance(exception_type, str)
+        and bool(exception_type)
+    ):
+        return _failed_module_probe(
+            str(failure_reason),
+            exception_type=exception_type,
+        )
+    return _malformed_child_output("invalid_payload")
+
+
+def _read_module_probe_child_result(result_file: BinaryIO) -> ModuleProbeResult:
+    """Read one bounded result through the parent's retained descriptor."""
+    try:
+        result_file.seek(0)
+        remaining = MODULE_PROBE_MAX_OUTPUT_BYTES + 1
+        chunks: list[bytes] = []
+        while remaining:
+            chunk = result_file.read(remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+    except OSError:
+        return _malformed_child_output("unreadable")
+    return _decode_module_probe_child(raw)
+
+
+def _signal_name(signal_number: int) -> str:
+    try:
+        return signal.Signals(signal_number).name
+    except ValueError:
+        return f"SIG{signal_number}"
+
+
+def _probe_module(
+    import_name: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[object]] | None = None,
+) -> ModuleProbeResult:
+    """Probe one import in a bounded child of this exact interpreter."""
+    run = subprocess.run if runner is None else runner
+    with tempfile.TemporaryDirectory(prefix="speaker-toolkit-module-probe-") as temp:
+        result_path = Path(temp) / "result.json"
+        with result_path.open("x+b", buffering=0) as result_file:
+            command = [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                MODULE_PROBE_CHILD_FLAG,
+                import_name,
+                str(result_path),
+            ]
+            try:
+                completed = run(
+                    command,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    timeout=MODULE_PROBE_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired:
+                return _failed_module_probe(
+                    "timeout",
+                    timeout_seconds=MODULE_PROBE_TIMEOUT_SECONDS,
+                )
+            except OSError as exc:
+                return _failed_module_probe(
+                    "probe_start_failure",
+                    exception_type=type(exc).__name__,
+                )
+            if completed.returncode != 0:
+                if completed.returncode < 0:
+                    signal_number = -completed.returncode
+                    return _failed_module_probe(
+                        "native_crash",
+                        termination="signal",
+                        signal_number=signal_number,
+                        signal_name=_signal_name(signal_number),
+                    )
+                return _failed_module_probe(
+                    "native_crash",
+                    termination="exit",
+                    exit_code=completed.returncode,
+                )
+            return _read_module_probe_child_result(result_file)
+
+
+def _module_available(import_name: str) -> bool:
+    """Return the legacy boolean view of an isolated module probe."""
+    return _probe_module(import_name)["available"]
 
 
 def _command_available(command: str) -> bool:
@@ -101,9 +306,18 @@ def build_report(
     lane_reports: dict[str, dict[str, Any]] = {}
     for lane in selected:
         requirements = LANE_REQUIREMENTS[lane]
-        modules = {
-            distribution: _module_available(import_name)
+        module_probes = {
+            distribution: _probe_module(import_name)
             for distribution, import_name in requirements["modules"].items()
+        }
+        modules = {
+            distribution: probe["available"]
+            for distribution, probe in module_probes.items()
+        }
+        module_failures = {
+            distribution: probe["failure"]
+            for distribution, probe in module_probes.items()
+            if probe["failure"] is not None
         }
         commands = {
             label: _command_available(command)
@@ -122,6 +336,7 @@ def build_report(
             "available": available,
             "required": lane in required,
             "modules": modules,
+            "module_failures": module_failures,
             "commands": commands,
             "missing_modules": missing_modules,
             "missing_commands": missing_commands,
@@ -169,19 +384,52 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "vault-ingress runtime is unavailable for required lanes "
             f"{blocking}; use Python {MINIMUM_PYTHON[0]}.{MINIMUM_PYTHON[1]}+ "
-            f"and install the missing modules or commands listed in the JSON "
-            f"into {sys.executable}, then rerun this check",
+            "and install the missing modules or commands, or repair failed "
+            f"dependency initialization, listed in the JSON in {sys.executable}, "
+            "then rerun this check",
+            file=sys.stderr,
+        )
+    elif report["degraded_lanes"]:
+        degraded = ", ".join(report["degraded_lanes"])
+        print(
+            "vault-ingress runtime is degraded for optional lanes "
+            f"{degraded}; install the missing modules or commands, or repair "
+            "failed dependency initialization, listed in the JSON in "
+            f"{sys.executable}, then rerun this check",
             file=sys.stderr,
         )
     return 0 if report["ok"] else 1
 
 
 if __name__ == "__main__":
+    child_probe = len(sys.argv) == 4 and sys.argv[1] == MODULE_PROBE_CHILD_FLAG
+    if child_probe:
+        with Path(sys.argv[3]).open("r+b", buffering=0) as child_result_file:
+            with (
+                open(os.devnull, "w", encoding="utf-8") as dependency_output,
+                contextlib.redirect_stdout(dependency_output),
+                contextlib.redirect_stderr(dependency_output),
+            ):
+                try:
+                    child_payload = _module_probe_child(sys.argv[2])
+                # The parent silently collapses a non-zero exit without a result into
+                # native_crash; emit initializer_exception because propagation would
+                # erase the actionable Python initializer-failure classification.
+                except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+                    child_payload = {
+                        "schema_version": MODULE_PROBE_SCHEMA_VERSION,
+                        "available": False,
+                        "failure_reason": "initializer_exception",
+                        "exception_type": type(exc).__name__,
+                    }
+            _write_module_probe_result(child_result_file, child_payload)
+        raise SystemExit(0)
     try:
         raise SystemExit(main())
-    # outer-boundary-process-contract: callers treat missing JSON as a silent
-    # probe failure; emit one failure object and recovery step before exiting.
-    except Exception as exc:  # noqa: BLE001
+    # Callers treat a non-zero exit without report JSON as a silent precheck
+    # failure; emit one failure report and recovery step because propagation
+    # would suppress the machine-readable diagnostic contract.
+    except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
         print(
             json.dumps(
                 {

--- a/tests/test_check_runtime.py
+++ b/tests/test_check_runtime.py
@@ -11,7 +11,6 @@ import runpy
 import signal
 import subprocess
 import sys
-import time
 
 import pytest
 
@@ -650,15 +649,12 @@ def test_module_probe_bounds_a_blocked_child_process(
         timeout_seconds,
     )
 
-    started_at = time.monotonic()
     result = check_runtime._probe_module(module_name)
-    elapsed = time.monotonic() - started_at
 
     assert result == _failed_probe(
         "timeout",
         timeout_seconds=timeout_seconds,
     )
-    assert elapsed < 3
 
 
 def test_module_probe_start_failure_is_lane_local() -> None:

--- a/tests/test_check_runtime.py
+++ b/tests/test_check_runtime.py
@@ -628,35 +628,6 @@ def test_module_probe_timeout_is_a_bounded_failure() -> None:
     _assert_probe_result_removed(observed_result_paths[0])
 
 
-def test_module_probe_bounds_a_blocked_child_process(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    module_name = "speaker_toolkit_test_blocked_initializer"
-    (tmp_path / f"{module_name}.py").write_text(
-        "import time\n"
-        "time.sleep(10)\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv(
-        "PYTHONPATH",
-        _child_probe_environment(tmp_path)["PYTHONPATH"],
-    )
-    timeout_seconds = 0.1
-    monkeypatch.setattr(
-        check_runtime,
-        "MODULE_PROBE_TIMEOUT_SECONDS",
-        timeout_seconds,
-    )
-
-    result = check_runtime._probe_module(module_name)
-
-    assert result == _failed_probe(
-        "timeout",
-        timeout_seconds=timeout_seconds,
-    )
-
-
 def test_module_probe_start_failure_is_lane_local() -> None:
     def runner(
         _command: list[str], **_kwargs: object

--- a/tests/test_check_runtime.py
+++ b/tests/test_check_runtime.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 from pathlib import Path
 import runpy
+import signal
+import subprocess
 import sys
+import time
 
 import pytest
 
@@ -25,12 +29,86 @@ check_runtime = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(check_runtime)
 
 
-def test_optional_lane_failure_degrades_without_blocking_core(monkeypatch) -> None:
-    monkeypatch.setattr(
-        check_runtime,
-        "_module_available",
-        lambda name: name != "pptx",
+def _available_probe() -> dict[str, object]:
+    return {"available": True, "failure": None}
+
+
+def _failed_probe(reason: str, **details: object) -> dict[str, object]:
+    failure: dict[str, object] = {"reason": reason}
+    failure.update(details)
+    return {"available": False, "failure": failure}
+
+
+def _completed_probe(
+    command: list[str],
+    payload: dict[str, object] | str | bytes | None,
+    *,
+    returncode: int = 0,
+) -> subprocess.CompletedProcess[object]:
+    if payload is not None:
+        if isinstance(payload, dict):
+            raw = (json.dumps(payload) + "\n").encode("utf-8")
+        elif isinstance(payload, str):
+            raw = payload.encode("utf-8")
+        else:
+            raw = payload
+        Path(command[-1]).write_bytes(raw)
+    return subprocess.CompletedProcess(
+        args=command,
+        returncode=returncode,
     )
+
+
+def _assert_probe_result_removed(result_path: Path) -> None:
+    assert not result_path.exists()
+    assert not result_path.parent.exists()
+
+
+def _child_probe_environment(module_directory: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{module_directory}{os.pathsep}{existing_pythonpath}"
+        if existing_pythonpath
+        else str(module_directory)
+    )
+    return env
+
+
+def _run_child_probe(
+    module_name: str,
+    result_path: Path,
+    *,
+    module_directory: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = (
+        _child_probe_environment(module_directory)
+        if module_directory is not None
+        else None
+    )
+    with result_path.open("x+b", buffering=0):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                check_runtime.MODULE_PROBE_CHILD_FLAG,
+                module_name,
+                str(result_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+
+def test_optional_lane_failure_degrades_without_blocking_core(monkeypatch) -> None:
+    def probe(name: str) -> dict[str, object]:
+        if name == "pptx":
+            return _failed_probe("unavailable_import")
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
     monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
 
     report = check_runtime.build_report(
@@ -42,14 +120,18 @@ def test_optional_lane_failure_degrades_without_blocking_core(monkeypatch) -> No
     assert report["blocking_lanes"] == []
     assert report["degraded_lanes"] == ["pptx"]
     assert report["lanes"]["pptx"]["missing_modules"] == ["python-pptx"]
+    assert report["lanes"]["pptx"]["module_failures"] == {
+        "python-pptx": {"reason": "unavailable_import"}
+    }
 
 
 def test_explicitly_required_lane_failure_is_blocking(monkeypatch) -> None:
-    monkeypatch.setattr(
-        check_runtime,
-        "_module_available",
-        lambda name: name != "pypdf",
-    )
+    def probe(name: str) -> dict[str, object]:
+        if name == "pypdf":
+            return _failed_probe("unavailable_import")
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
     monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
 
     report = check_runtime.build_report(
@@ -63,11 +145,12 @@ def test_explicitly_required_lane_failure_is_blocking(monkeypatch) -> None:
 
 
 def test_core_is_always_selected_and_required(monkeypatch) -> None:
-    monkeypatch.setattr(
-        check_runtime,
-        "_module_available",
-        lambda name: name != "yaml",
-    )
+    def probe(name: str) -> dict[str, object]:
+        if name == "yaml":
+            return _failed_probe("unavailable_import")
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
     monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
 
     report = check_runtime.build_report(("pptx",), ())
@@ -87,27 +170,726 @@ def test_lane_parser_gives_recovery_for_empty_names() -> None:
         check_runtime._parse_lanes("")
 
 
-def test_module_probe_contains_expected_import_failures(monkeypatch) -> None:
+def test_module_probe_child_contains_expected_import_failures(
+    monkeypatch,
+) -> None:
     def unavailable(_name: str) -> None:
         raise ImportError("dependency is not installed")
 
     monkeypatch.setattr(check_runtime.importlib, "import_module", unavailable)
 
-    assert check_runtime._module_available("missing") is False
+    assert check_runtime._module_probe_child("missing") == {
+        "available": False,
+        "exception_type": "ImportError",
+        "failure_reason": "unavailable_import",
+        "schema_version": 1,
+    }
 
 
-def test_module_probe_does_not_hide_unexpected_failures(monkeypatch) -> None:
+def test_module_probe_child_quarantines_dependency_output(
+    tmp_path: Path,
+) -> None:
+    module_name = "speaker_toolkit_test_noisy_initializer"
+    (tmp_path / f"{module_name}.py").write_text(
+        'print("dependency stdout")\n'
+        "import sys\n"
+        'print("dependency stderr", file=sys.stderr)\n',
+        encoding="utf-8",
+    )
+    result_path = tmp_path / "result.json"
+
+    completed = _run_child_probe(
+        module_name,
+        result_path,
+        module_directory=tmp_path,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    assert completed.stdout == ""
+    assert json.loads(result_path.read_text(encoding="utf-8")) == {
+        "available": True,
+        "schema_version": 1,
+    }
+
+
+def test_child_result_protocol_supports_paths_with_spaces(tmp_path: Path) -> None:
+    result_directory = tmp_path / "result directory with spaces"
+    result_directory.mkdir()
+    result_path = result_directory / "probe result with spaces.json"
+
+    completed = _run_child_probe("json", result_path)
+
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    assert completed.stdout == ""
+    assert json.loads(result_path.read_text(encoding="utf-8")) == {
+        "available": True,
+        "schema_version": 1,
+    }
+
+
+def test_child_path_replacement_cannot_redirect_retained_descriptors(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module_name = "speaker_toolkit_test_result_path_replacement"
+    decoy_payload = (
+        b'{"available": false, "exception_type": "Redirected", '
+        b'"failure_reason": "initializer_exception", "schema_version": 1}\n'
+    )
+    (tmp_path / f"{module_name}.py").write_text(
+        "from pathlib import Path\n"
+        "import sys\n"
+        "result_path = Path(sys.argv[3])\n"
+        "try:\n"
+        "    result_path.unlink()\n"
+        f"    result_path.write_bytes({decoy_payload!r})\n"
+        "except OSError:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        _child_probe_environment(tmp_path)["PYTHONPATH"],
+    )
+
+    result = check_runtime._probe_module(module_name)
+
+    assert result == _available_probe()
+
+
+@pytest.mark.parametrize("exception_class", [RuntimeError, OSError])
+def test_module_probe_child_propagates_initializer_exceptions(
+    exception_class: type[Exception],
+    monkeypatch,
+) -> None:
     def broken(_name: str) -> None:
-        raise ValueError("dependency initialization is corrupt")
+        raise exception_class("initializer failed")
 
     monkeypatch.setattr(check_runtime.importlib, "import_module", broken)
 
-    with pytest.raises(ValueError, match="initialization is corrupt"):
-        check_runtime._module_available("broken")
+    with pytest.raises(exception_class, match="initializer failed"):
+        check_runtime._module_probe_child("broken")
+
+
+def test_module_probe_uses_exact_interpreter_and_bounded_timeout(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+    configured_interpreter = "/configured/vault/.venv/bin/python3"
+    monkeypatch.setattr(check_runtime.sys, "executable", configured_interpreter)
+
+    def runner(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        observed["command"] = command
+        observed["kwargs"] = kwargs
+        result_path = Path(command[-1])
+        assert result_path.parent.is_dir()
+        completed = _completed_probe(
+            command,
+            {"schema_version": 1, "available": True},
+        )
+        assert result_path.is_file()
+        return completed
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _available_probe()
+    command = observed["command"]
+    assert isinstance(command, list)
+    assert command[:4] == [
+        configured_interpreter,
+        str(SCRIPT.resolve()),
+        check_runtime.MODULE_PROBE_CHILD_FLAG,
+        "mlx_whisper",
+    ]
+    assert len(command) == 5
+    result_path = Path(command[4])
+    assert result_path.name == "result.json"
+    _assert_probe_result_removed(result_path)
+    assert observed["kwargs"] == {
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "check": False,
+        "timeout": check_runtime.MODULE_PROBE_TIMEOUT_SECONDS,
+    }
+
+
+@pytest.mark.parametrize(
+    ("failure_reason", "exception_type"),
+    [
+        ("unavailable_import", "ModuleNotFoundError"),
+        ("initializer_exception", "ValueError"),
+    ],
+)
+def test_module_probe_preserves_child_failure_reason(
+    failure_reason: str,
+    exception_type: str,
+) -> None:
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        return _completed_probe(
+            command,
+            {
+                "schema_version": 1,
+                "available": False,
+                "failure_reason": failure_reason,
+                "exception_type": exception_type,
+            }
+        )
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        failure_reason,
+        exception_type=exception_type,
+    )
+
+
+def test_module_probe_classifies_sigabrt_as_native_crash() -> None:
+    observed_result_paths: list[Path] = []
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        result_path = Path(command[-1])
+        observed_result_paths.append(result_path)
+        assert result_path.parent.is_dir()
+        completed = _completed_probe(
+            command,
+            b"partial result",
+            returncode=-signal.SIGABRT,
+        )
+        assert result_path.is_file()
+        return completed
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "native_crash",
+        termination="signal",
+        signal_number=signal.SIGABRT,
+        signal_name="SIGABRT",
+    )
+    assert len(observed_result_paths) == 1
+    _assert_probe_result_removed(observed_result_paths[0])
+
+
+def test_module_probe_classifies_nonzero_native_style_exit() -> None:
+    observed_result_paths: list[Path] = []
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        result_path = Path(command[-1])
+        observed_result_paths.append(result_path)
+        assert result_path.parent.is_dir()
+        completed = _completed_probe(
+            command,
+            b"partial result",
+            returncode=134,
+        )
+        assert result_path.is_file()
+        return completed
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "native_crash",
+        termination="exit",
+        exit_code=134,
+    )
+    assert len(observed_result_paths) == 1
+    _assert_probe_result_removed(observed_result_paths[0])
+
+
+@pytest.mark.parametrize(
+    ("payload", "malformation"),
+    [
+        (None, "empty"),
+        ("", "empty"),
+        (b"\xff", "invalid_utf8"),
+        ("not-json\n", "invalid_json"),
+        (
+            '{"available": true, "available": false, "schema_version": 1}\n',
+            "invalid_json",
+        ),
+        ('{"available": NaN, "schema_version": 1}\n', "invalid_json"),
+        ('{"available": true}\n', "invalid_payload"),
+        (
+            '{"available": false, "exception_type": "ValueError", '
+            '"failure_reason": [], "schema_version": 1}\n',
+            "invalid_payload",
+        ),
+        ('{"available": true, "schema_version": 1}\nextra\n', "multiple_lines"),
+    ],
+)
+def test_module_probe_rejects_empty_or_malformed_child_output(
+    payload: str | bytes | None,
+    malformation: str,
+) -> None:
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        return _completed_probe(command, payload)
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "malformed_child_output",
+        malformation=malformation,
+    )
+
+
+def test_module_probe_rejects_oversized_child_output() -> None:
+    oversized = b"x" * (check_runtime.MODULE_PROBE_MAX_OUTPUT_BYTES + 1)
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        return _completed_probe(command, oversized)
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "malformed_child_output",
+        malformation="oversized",
+    )
+
+
+def test_module_probe_has_no_posix_open_flag_dependency(monkeypatch) -> None:
+    class OsWithoutPosixOpenFlags:
+        def __getattr__(self, name: str) -> object:
+            if name in {"O_NONBLOCK", "O_NOFOLLOW"}:
+                raise AssertionError(f"unexpected POSIX-only flag access: {name}")
+            return getattr(os, name)
+
+    monkeypatch.setattr(check_runtime, "os", OsWithoutPosixOpenFlags())
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        return _completed_probe(
+            command,
+            {"schema_version": 1, "available": True},
+        )
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _available_probe()
+
+
+def test_module_probe_bounds_retained_descriptor_read(monkeypatch) -> None:
+    observed_payload_lengths: list[int] = []
+    decode = check_runtime._decode_module_probe_child
+
+    def recording_decode(raw: bytes) -> dict[str, object]:
+        observed_payload_lengths.append(len(raw))
+        return decode(raw)
+
+    monkeypatch.setattr(
+        check_runtime,
+        "_decode_module_probe_child",
+        recording_decode,
+    )
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        return _completed_probe(command, b"x" * 1_000_000)
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "malformed_child_output",
+        malformation="oversized",
+    )
+    assert observed_payload_lengths == [
+        check_runtime.MODULE_PROBE_MAX_OUTPUT_BYTES + 1
+    ]
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "mkfifo"),
+    reason="requires POSIX FIFOs",
+)
+def test_module_probe_reads_retained_descriptor_after_fifo_replacement() -> None:
+    observed_result_paths: list[Path] = []
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        result_path = Path(command[-1])
+        observed_result_paths.append(result_path)
+        assert result_path.is_file()
+        result_path.unlink()
+        os.mkfifo(result_path)
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "malformed_child_output",
+        malformation="empty",
+    )
+    assert len(observed_result_paths) == 1
+    _assert_probe_result_removed(observed_result_paths[0])
+
+
+def test_module_probe_reads_retained_descriptor_after_symlink_replacement(
+    tmp_path: Path,
+) -> None:
+    target_path = tmp_path / "valid-target.json"
+    target_payload = b'{"available": true, "schema_version": 1}\n'
+    target_path.write_bytes(target_payload)
+    observed_result_paths: list[Path] = []
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        result_path = Path(command[-1])
+        observed_result_paths.append(result_path)
+        assert result_path.is_file()
+        try:
+            result_path.unlink()
+            result_path.symlink_to(target_path)
+        except OSError as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "malformed_child_output",
+        malformation="empty",
+    )
+    assert target_path.read_bytes() == target_payload
+    assert len(observed_result_paths) == 1
+    _assert_probe_result_removed(observed_result_paths[0])
+
+
+@pytest.mark.parametrize("schema_version", [True, 1.0])
+def test_module_probe_requires_exact_integer_schema_version(
+    schema_version: object,
+) -> None:
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        return _completed_probe(
+            command,
+            {"schema_version": schema_version, "available": True},
+        )
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "malformed_child_output",
+        malformation="invalid_payload",
+    )
+
+
+def test_module_probe_contains_recursive_json_decoder_failure(monkeypatch) -> None:
+    def recursive_json(*_args: object, **_kwargs: object) -> object:
+        raise RecursionError("child JSON is too deeply nested")
+
+    monkeypatch.setattr(check_runtime.json, "loads", recursive_json)
+
+    result = check_runtime._decode_module_probe_child(b"{}")
+
+    assert result == _failed_probe(
+        "malformed_child_output",
+        malformation="invalid_json",
+    )
+
+
+def test_module_probe_timeout_is_a_bounded_failure() -> None:
+    observed_result_paths: list[Path] = []
+
+    def runner(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        result_path = Path(command[-1])
+        observed_result_paths.append(result_path)
+        assert result_path.parent.is_dir()
+        result_path.write_bytes(b"partial result")
+        assert result_path.is_file()
+        raise subprocess.TimeoutExpired(
+            cmd="module-probe",
+            timeout=check_runtime.MODULE_PROBE_TIMEOUT_SECONDS,
+        )
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "timeout",
+        timeout_seconds=check_runtime.MODULE_PROBE_TIMEOUT_SECONDS,
+    )
+    assert len(observed_result_paths) == 1
+    _assert_probe_result_removed(observed_result_paths[0])
+
+
+def test_module_probe_bounds_a_blocked_child_process(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module_name = "speaker_toolkit_test_blocked_initializer"
+    (tmp_path / f"{module_name}.py").write_text(
+        "import time\n"
+        "time.sleep(10)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        _child_probe_environment(tmp_path)["PYTHONPATH"],
+    )
+    timeout_seconds = 0.1
+    monkeypatch.setattr(
+        check_runtime,
+        "MODULE_PROBE_TIMEOUT_SECONDS",
+        timeout_seconds,
+    )
+
+    started_at = time.monotonic()
+    result = check_runtime._probe_module(module_name)
+    elapsed = time.monotonic() - started_at
+
+    assert result == _failed_probe(
+        "timeout",
+        timeout_seconds=timeout_seconds,
+    )
+    assert elapsed < 3
+
+
+def test_module_probe_start_failure_is_lane_local() -> None:
+    def runner(
+        _command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[object]:
+        raise FileNotFoundError("configured interpreter disappeared")
+
+    result = check_runtime._probe_module("mlx_whisper", runner=runner)
+
+    assert result == _failed_probe(
+        "probe_start_failure",
+        exception_type="FileNotFoundError",
+    )
+
+
+@pytest.mark.parametrize("exception_type", ["ValueError", "RuntimeError", "OSError"])
+def test_child_outer_boundary_reports_python_initializer_exception(
+    tmp_path: Path,
+    exception_type: str,
+) -> None:
+    module_name = f"speaker_toolkit_test_{exception_type.lower()}_initializer"
+    (tmp_path / f"{module_name}.py").write_text(
+        f'raise {exception_type}("initializer is corrupt")\n',
+        encoding="utf-8",
+    )
+    result_path = tmp_path / "result.json"
+
+    completed = _run_child_probe(
+        module_name,
+        result_path,
+        module_directory=tmp_path,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    assert completed.stdout == ""
+    assert json.loads(result_path.read_text(encoding="utf-8")) == {
+        "available": False,
+        "exception_type": exception_type,
+        "failure_reason": "initializer_exception",
+        "schema_version": 1,
+    }
+
+
+def test_child_outer_boundary_does_not_reclassify_result_write_fault(
+    tmp_path: Path,
+) -> None:
+    module_name = "speaker_toolkit_test_result_write_fault"
+    (tmp_path / f"{module_name}.py").write_text(
+        "import sys\n"
+        "def fail_result_write(*_args, **_kwargs):\n"
+        '    raise OSError("result write failed")\n'
+        'sys.modules["__main__"]._write_module_probe_result = fail_result_write\n',
+        encoding="utf-8",
+    )
+    result_path = tmp_path / "result.json"
+
+    completed = _run_child_probe(
+        module_name,
+        result_path,
+        module_directory=tmp_path,
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+    assert "OSError: result write failed" in completed.stderr
+    assert result_path.read_bytes() == b""
+
+
+def test_child_outer_boundary_does_not_reclassify_output_setup_fault(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    result_path = tmp_path / "result.json"
+
+    def fail_output_setup(*_args: object, **_kwargs: object) -> None:
+        raise OSError("dependency-output setup failed")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            check_runtime.MODULE_PROBE_CHILD_FLAG,
+            "json",
+            str(result_path),
+        ],
+    )
+
+    with result_path.open("x+b", buffering=0):
+        with pytest.raises(OSError, match="dependency-output setup failed"):
+            runpy.run_path(
+                str(SCRIPT),
+                init_globals={"open": fail_output_setup},
+                run_name="__main__",
+            )
+
+    assert result_path.read_bytes() == b""
+
+
+def test_child_outer_boundary_does_not_reclassify_output_teardown_fault(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    result_path = tmp_path / "result.json"
+
+    class FailingTeardown:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *_args: object) -> None:
+            raise OSError("dependency-output teardown failed")
+
+    monkeypatch.setattr(
+        check_runtime.contextlib,
+        "redirect_stderr",
+        lambda _target: FailingTeardown(),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            check_runtime.MODULE_PROBE_CHILD_FLAG,
+            "json",
+            str(result_path),
+        ],
+    )
+
+    with result_path.open("x+b", buffering=0):
+        with pytest.raises(OSError, match="dependency-output teardown failed"):
+            runpy.run_path(str(SCRIPT), run_name="__main__")
+
+    assert result_path.read_bytes() == b""
+
+
+def test_module_probe_discards_large_process_fd_output(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module_name = "speaker_toolkit_test_large_fd_output"
+    (tmp_path / f"{module_name}.py").write_text(
+        "import os\n"
+        'os.write(1, b"x" * 1_000_000)\n'
+        'os.write(2, b"y" * 1_000_000)\n',
+        encoding="utf-8",
+    )
+    existing_pythonpath = os.environ.get("PYTHONPATH")
+    pythonpath = (
+        f"{tmp_path}{os.pathsep}{existing_pythonpath}"
+        if existing_pythonpath
+        else str(tmp_path)
+    )
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
+
+    result = check_runtime._probe_module(module_name)
+
+    assert result == _available_probe()
+
+
+def test_native_whisper_failure_degrades_when_only_core_is_required(
+    monkeypatch,
+) -> None:
+    def probe(name: str) -> dict[str, object]:
+        if name == "mlx_whisper":
+            return _failed_probe(
+                "native_crash",
+                termination="signal",
+                signal_number=signal.SIGABRT,
+                signal_name="SIGABRT",
+            )
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    report = check_runtime.build_report(("whisper",), ("core",))
+
+    assert report["ok"] is True
+    assert report["degraded_lanes"] == ["whisper"]
+    assert report["blocking_lanes"] == []
+    assert report["lanes"]["whisper"]["module_failures"]["mlx-whisper"] == {
+        "reason": "native_crash",
+        "termination": "signal",
+        "signal_number": signal.SIGABRT,
+        "signal_name": "SIGABRT",
+    }
+
+
+def test_native_whisper_failure_blocks_when_whisper_is_required(
+    monkeypatch, capsys
+) -> None:
+    def probe(name: str) -> dict[str, object]:
+        if name == "mlx_whisper":
+            return _failed_probe(
+                "native_crash",
+                termination="exit",
+                exit_code=134,
+            )
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    exit_code = check_runtime.main(
+        ["--lanes", "whisper", "--require-lanes", "core,whisper"]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert len(captured.out.splitlines()) == 1
+    payload = json.loads(captured.out)
+    assert payload["ok"] is False
+    assert payload["blocking_lanes"] == ["whisper"]
+    assert payload["degraded_lanes"] == []
+    assert payload["lanes"]["whisper"]["module_failures"]["mlx-whisper"] == {
+        "reason": "native_crash",
+        "termination": "exit",
+        "exit_code": 134,
+    }
+    assert "unavailable for required lanes whisper" in captured.err
+    assert "then rerun this check" in captured.err
 
 
 def test_main_reports_blocking_lanes_with_recovery_step(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(check_runtime, "_module_available", lambda _name: False)
+    monkeypatch.setattr(
+        check_runtime,
+        "_probe_module",
+        lambda _name: _failed_probe("unavailable_import"),
+    )
     monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
 
     assert check_runtime.main(["--lanes", "core"]) == 1
@@ -120,13 +902,46 @@ def test_main_reports_blocking_lanes_with_recovery_step(monkeypatch, capsys) -> 
     assert "then rerun this check" in captured.err
 
 
+def test_main_reports_degraded_lane_with_one_json_and_recovery(
+    monkeypatch, capsys
+) -> None:
+    def probe(name: str) -> dict[str, object]:
+        if name == "mlx_whisper":
+            return _failed_probe(
+                "native_crash",
+                termination="signal",
+                signal_number=signal.SIGABRT,
+                signal_name="SIGABRT",
+            )
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    assert check_runtime.main(["--lanes", "whisper", "--require-lanes", "core"]) == 0
+
+    captured = capsys.readouterr()
+    assert len(captured.out.splitlines()) == 1
+    payload = json.loads(captured.out)
+    assert payload["ok"] is True
+    assert payload["degraded_lanes"] == ["whisper"]
+    assert payload["lanes"]["whisper"]["module_failures"]["mlx-whisper"] == {
+        "reason": "native_crash",
+        "termination": "signal",
+        "signal_number": signal.SIGABRT,
+        "signal_name": "SIGABRT",
+    }
+    assert "degraded for optional lanes whisper" in captured.err
+    assert "then rerun this check" in captured.err
+
+
 def test_outer_boundary_emits_one_json_failure_for_unexpected_probe_fault(
     monkeypatch, capsys
 ) -> None:
-    def broken(_name: str) -> None:
+    def broken(*_args: object, **_kwargs: object) -> None:
         raise ValueError("dependency initialization is corrupt")
 
-    monkeypatch.setattr("importlib.import_module", broken)
+    monkeypatch.setattr("subprocess.run", broken)
     monkeypatch.setattr(sys, "argv", [str(SCRIPT)])
 
     with pytest.raises(SystemExit) as raised:


### PR DESCRIPTION
## Summary

- run dependency imports in bounded child processes under the exact configured interpreter
- keep probe results on a private parent-owned descriptor with bounded reads, bounded execution, and discarded child output
- classify import absence, initializer exceptions, native crashes, timeouts, and malformed results per lane while preserving the one-JSON parent contract
- keep optional lanes degradable and required lanes blocking

## Validation

- full suite: 3319 passed, 3 skipped
- focused and adjacent: 232 passed
- Ruff and Pyright clean
- real SIGABRT smoke: optional Whisper degrades; required Whisper blocks
- adversarial result-path replacement, large output, timeout, cleanup, descriptor-leak, path-with-spaces, and no-POSIX-flags checks passed
- two independent final reviews found no blockers or advisories

Closes #173