### PR TITLE
fix(vault-ingress): ignore presentation-only shownotes drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### fix(vault-ingress) — suppress presentation-only shownotes conflicts
+
+Shownotes title comparison now treats straight and curly single/double quote
+glyphs as equivalent after Unicode NFC normalization. Conference comparison
+uses NFC plus case folding only. These transforms never rewrite stored or
+reported values, while substantive wording, punctuation, whitespace, source,
+and identity differences continue to require review.
+
 ## 0.20.2 — 2026-08-01
 
 ### fix(vault-ingress) — contain native dependency probe crashes

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -199,8 +199,13 @@ Read the structured report before any mutation. `add` and `update` entries are
 safe deterministic proposals; `review_required` entries need a human decision.
 The scanner uses exact filename identity, derives supported YouTube and Google
 Drive IDs, and keeps every matching `source_rejections` identity inactive.
-Incomplete metadata, conflicts, and normalized filename collisions remain
-proposals. Disabled, `remote_url`, and `none` sources return a structured no-op.
+For comparison only, title equality applies Unicode NFC and maps straight/curly
+single and double quote glyphs to the same narrow equivalents; it preserves
+case, other punctuation, and wording. Conference equality applies NFC plus
+casefold only and preserves whitespace. The scanner never writes these
+comparison transforms back to the database or report. Incomplete metadata,
+substantive conflicts, and normalized filename collisions remain proposals.
+Disabled, `remote_url`, and `none` sources return a structured no-op.
 
 Apply the reviewed deterministic proposals with the same command plus
 `--apply`. Only `add` and `update` entries mutate the tracking database. New

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -105,6 +105,18 @@ RAW_URL_RE = re.compile(r"https?://[^\s<>]+")
 DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 FileGeneration = tuple[int, int, int, int, int]
 
+# These transforms are deliberately narrower than general punctuation folding.
+# They exist only for comparison: reports and stored values keep their original
+# typography and capitalization.
+_TITLE_QUOTE_EQUIVALENTS = str.maketrans(
+    {
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+    }
+)
+
 
 class ShownotesScanError(ValueError):
     """Input or state prevents a deterministic shownotes scan."""
@@ -133,6 +145,31 @@ def _nonempty(value: object) -> str | None:
 
 def _normalized_filename(value: str) -> str:
     return unicodedata.normalize("NFC", value).casefold()
+
+
+def _normalized_title_for_comparison(value: str) -> str:
+    """Normalize title presentation glyphs without changing title wording/case."""
+    return unicodedata.normalize("NFC", value).translate(_TITLE_QUOTE_EQUIVALENTS)
+
+
+def _normalized_conference_for_comparison(value: str) -> str:
+    """Normalize conference Unicode and case only; whitespace stays significant."""
+    return unicodedata.normalize("NFC", value).casefold()
+
+
+def _same_presentation_value(field: str, left: object, right: object) -> bool:
+    """Return whether a title/conference pair differs only in presentation."""
+    if not isinstance(left, str) or not isinstance(right, str):
+        return False
+    if field == "title":
+        return _normalized_title_for_comparison(
+            left
+        ) == _normalized_title_for_comparison(right)
+    if field == "conference":
+        return _normalized_conference_for_comparison(
+            left
+        ) == _normalized_conference_for_comparison(right)
+    return False
 
 
 def _reject_symlink_components(path: Path, *, subject: str) -> None:
@@ -754,6 +791,8 @@ def _existing_entry(
             patch[field] = candidate
             continue
         if current == candidate:
+            continue
+        if _same_presentation_value(field, current, candidate):
             continue
         if (
             field in {"video_url", "slides_url"}

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -266,6 +266,149 @@ def test_existing_metadata_conflict_stays_a_non_mutating_review_proposal(
 
 
 @pytest.mark.parametrize(
+    ("field", "stored_value", "shownotes_value"),
+    [
+        ("title", "Kahneman\u2019s Shortcut", "Kahneman's Shortcut"),
+        (
+            "title",
+            'The "DevOps engineer" Test',
+            "The \u201cDevOps engineer\u201d Test",
+        ),
+        ("conference", "TESTCONF", "testconf"),
+        ("title", "Caf\u00e9", "Cafe\u0301"),
+        ("conference", "Caf\u00e9Conf", "Cafe\u0301Conf"),
+    ],
+)
+def test_presentation_only_metadata_differences_are_comparison_only(
+    tmp_path: Path,
+    field: str,
+    stored_value: str,
+    shownotes_value: str,
+) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    shownotes_arguments = {field: shownotes_value}
+    _write_jekyll_talk(talks_directory, **shownotes_arguments)
+    existing = {
+        "filename": "2026-08-01-deterministic-ingress.md",
+        "title": "Deterministic Ingress",
+        "conference": "TestConf",
+        "date": "2026-08-01",
+        "schema_version": 5,
+        "status": "processed",
+    }
+    existing[field] = stored_value
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+    before = database_path.read_bytes()
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    entry = report["entries"][0]
+    assert entry["disposition"] == "unchanged"
+    assert entry["proposal"][field] == shownotes_value
+    assert entry["changes"] == {}
+    assert entry["issues"] == []
+    assert report["counts"] == {
+        "add": 0,
+        "update": 0,
+        "unchanged": 1,
+        "review_required": 0,
+    }
+    assert report["database_written"] is False
+    assert database_path.read_bytes() == before
+    assert json.loads(before)["talks"][0][field] == stored_value
+
+
+def test_comparison_equivalence_does_not_rewrite_during_an_unrelated_update(
+    tmp_path: Path,
+) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    video_url = f"https://youtu.be/{YOUTUBE_ID}"
+    stored_title = "Kahneman\u2019s Shortcut"
+    _write_jekyll_talk(
+        talks_directory,
+        title="Kahneman's Shortcut",
+        video_url=video_url,
+    )
+    existing = {
+        "filename": "2026-08-01-deterministic-ingress.md",
+        "title": stored_title,
+        "conference": "TestConf",
+        "date": "2026-08-01",
+        "schema_version": 5,
+        "status": "processed",
+    }
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    talk = json.loads(database_path.read_text(encoding="utf-8"))["talks"][0]
+    assert report["entries"][0]["disposition"] == "update"
+    assert report["entries"][0]["changes"] == {
+        "video_url": video_url,
+        "youtube_id": YOUTUBE_ID,
+    }
+    assert talk["title"] == stored_title
+    assert talk["video_url"] == video_url
+
+
+def test_conference_added_word_remains_a_conflict(tmp_path: Path) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    _write_jekyll_talk(talks_directory, conference="TESTCONF Global")
+    existing = {
+        "filename": "2026-08-01-deterministic-ingress.md",
+        "title": "Deterministic Ingress",
+        "conference": "testconf",
+        "date": "2026-08-01",
+        "schema_version": 5,
+        "status": "processed",
+    }
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+    before = database_path.read_bytes()
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    entry = report["entries"][0]
+    assert entry["disposition"] == "review_required"
+    assert entry["changes"] == {}
+    assert entry["issues"][0]["code"] == "existing_conference_conflict"
+    assert report["database_written"] is False
+    assert database_path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    ("field", "stored_value", "shownotes_value"),
+    [
+        ("title", "Case Matters", "case matters"),
+        ("title", "Quoted: Title", "Quoted Title"),
+        ("conference", "Test Conf", "Test  Conf"),
+        ("conference", "TestConf", "TestConf Global"),
+    ],
+)
+def test_presentation_comparison_stays_narrow(
+    field: str,
+    stored_value: str,
+    shownotes_value: str,
+) -> None:
+    assert not scan_shownotes._same_presentation_value(
+        field,
+        stored_value,
+        shownotes_value,
+    )
+
+
+@pytest.mark.parametrize(
     ("source_type", "field", "rejected_url", "proposed_url"),
     [
         (

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -359,17 +359,33 @@ def test_comparison_equivalence_does_not_rewrite_during_an_unrelated_update(
     assert talk["video_url"] == video_url
 
 
-def test_conference_added_word_remains_a_conflict(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("field", "stored_value", "shownotes_value"),
+    [
+        ("title", "Case Matters", "case matters"),
+        ("title", "Quoted: Title", "Quoted Title"),
+        ("conference", "Test Conf", "Test  Conf"),
+        ("conference", "TestConf", "TestConf Global"),
+    ],
+)
+def test_presentation_comparison_stays_narrow(
+    tmp_path: Path,
+    field: str,
+    stored_value: str,
+    shownotes_value: str,
+) -> None:
     site, talks_directory = _shownotes_site(tmp_path)
-    _write_jekyll_talk(talks_directory, conference="TESTCONF Global")
+    shownotes_arguments = {field: shownotes_value}
+    _write_jekyll_talk(talks_directory, **shownotes_arguments)
     existing = {
         "filename": "2026-08-01-deterministic-ingress.md",
         "title": "Deterministic Ingress",
-        "conference": "testconf",
+        "conference": "TestConf",
         "date": "2026-08-01",
         "schema_version": 5,
         "status": "processed",
     }
+    existing[field] = stored_value
     database_path = _database_path(
         tmp_path,
         _local_config(site),
@@ -382,30 +398,18 @@ def test_conference_added_word_remains_a_conflict(tmp_path: Path) -> None:
     entry = report["entries"][0]
     assert entry["disposition"] == "review_required"
     assert entry["changes"] == {}
-    assert entry["issues"][0]["code"] == "existing_conference_conflict"
+    assert entry["issues"] == [
+        {
+            "code": f"existing_{field}_conflict",
+            "field": field,
+            "message": (
+                f"tracking DB {field} {stored_value!r} conflicts with shownotes "
+                f"{shownotes_value!r}; choose the authoritative value"
+            ),
+        }
+    ]
     assert report["database_written"] is False
     assert database_path.read_bytes() == before
-
-
-@pytest.mark.parametrize(
-    ("field", "stored_value", "shownotes_value"),
-    [
-        ("title", "Case Matters", "case matters"),
-        ("title", "Quoted: Title", "Quoted Title"),
-        ("conference", "Test Conf", "Test  Conf"),
-        ("conference", "TestConf", "TestConf Global"),
-    ],
-)
-def test_presentation_comparison_stays_narrow(
-    field: str,
-    stored_value: str,
-    shownotes_value: str,
-) -> None:
-    assert not scan_shownotes._same_presentation_value(
-        field,
-        stored_value,
-        shownotes_value,
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- compare shownotes titles through NFC plus only straight/curly quote-glyph equivalence
- compare conference names through NFC plus casefold, without whitespace or fuzzy normalization
- preserve stored and displayed values byte-for-byte while classifying presentation-only drift as unchanged
- keep substantive wording, source, rejection, URL, and identity conflicts blocking

## Validation

- full suite: 3328 passed, 3 skipped
- focused scanner suite: 32 passed
- Ruff and Pyright clean
- live read-only scan: review entries 28 -> 16, title conflicts 15 -> 2, conference conflicts 3 -> 2
- entry ordering and source/rejection conflicts unchanged
- live tracking database remained unchanged
- independent final review found no blockers or advisories

Closes #174