### PR TITLE
fix(vault-ingress): preserve damaged PPTX evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+### fix(vault-ingress) — make damaged native-deck evidence fail closed (#151)
+
+PPTX extraction schema v3 validates every archive member and reports bad-CRC
+embedded media through a closed `archive_recovery` record. Recovery replaces
+only the damaged media in memory so healthy structure remains inspectable;
+malformed containers and damaged XML, relationships, or other structural parts
+remain unavailable with an actionable error. The source deck is never rewritten.
+
+The shared capability probe now uses the same recovery contract as extraction,
+so offline preflight reports `slide_pptx_artifact_degraded` or
+`slide_pptx_artifact_unreadable` instead of leaking `BadZipFile`. A required
+`pptx`/`both` source with placeholder recovery cannot receive a fresh claim or
+persist current analysis. An unused optional degraded deck beside an independent
+source remains diagnostic.
+
+Each extraction also emits a closed `native_deck_audit` bound to the exact PPTX
+bytes, extractor generation, slide count, and derived render requirements. The
+optional rendered-page receipt binds an equal-page-count PDF and the exact pages
+inspected. Return validation and owner-side canonicalization require complete,
+identity-matched rendered inspection for native-deck design findings that need a
+rendered page. Single-file extractor failures now return one concise diagnostic
+without a parser traceback.
+
+Grouped shapes and tables are walked recursively, while SmartArt, graphic
+frames, unreadable pictures, and other unsupported visual containers remain
+explicit render requirements. Picture/background OCR emits one bounded receipt
+per exact asset, including engine/result confidence and trustworthy-text status,
+so a missing engine or corrupt image cannot masquerade as a wordless slide or
+abort the whole deck. Raw native timing stays split into animation behaviors,
+visibility actions, transitions, media timing, and build-list entries; every
+lane records package structure only and explicitly declines to claim observed
+playback.
+
 ## 0.20.3 — 2026-08-01
 
 ### fix(vault-ingress) — suppress presentation-only shownotes conflicts

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -221,10 +221,14 @@ fuzzy-match to `talks[]` entries. Report counts, then persist each reviewed resu
 the talk's exact prior `pptx_path` expectation. See [references/schemas-db.md](references/schemas-db.md)
 for the PPTX extraction output schema (per-slide visual data, shape types, global design stats).
 Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py"` for extraction.
-Consume current schema v2 for timing/build evidence. A v0/v1 record has unknown
-timing, not zero timing, and must be regenerated; an unknown future schema is
-unusable until this reader is updated. The vault-profile layout-only consumer is
-the documented v1/v2 exception for the unchanged `template_layouts` field.
+Consume current schema v3. A v0/v1 record has unknown timing, not zero timing;
+v2 has the pre-build timing lanes but lacks raw build-list evidence,
+archive-recovery, and exact native/render audit receipts. Regenerate v0-v2
+output for current analysis. An unknown future
+schema is unusable until this reader is updated. The vault-profile layout-only
+consumer is the documented v1/v2/v3 exception for the unchanged
+`template_layouts` field. Non-empty `archive_recovery` is degraded evidence:
+restore or re-export a required native deck before claiming or returning it.
 
 **Pattern taxonomy recovery:** See [references/processing-rules.md](references/processing-rules.md) for the queue-owned
 contract. Step 2 normalization deterministically routes processed results outside
@@ -641,8 +645,12 @@ Process PPTX files not yet extracted during Step 3: unmatched catalog entries, t
 that used PDF as primary but have a PPTX available, or entries with
 `pptx_visual_status: "pending"`. Skip if already `"extracted"`.
 Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py" <path.pptx>` for each file.
-Require schema v2 before using native timing fields. Regenerate v0/v1 output and
-stop on an unknown future schema rather than interpreting missing fields as zero.
+Require schema v3 for current analysis. Regenerate v0-v2 output and stop on an
+unknown future schema rather than interpreting missing fields as zero. When
+rendered pages were inspected, rerun with `--rendered-pdf <path.pdf>` and one or
+more `--inspected-pages <PAGE|START-END>` arguments so the extraction receipt
+binds the exact artifacts and covered pages. A non-empty `archive_recovery`
+blocks a required native-deck claim until the source is restored or re-exported.
 
 **PPTX matching rules:** The .pptx files are in `Conference/Year/TalkName.pptx` and
 shownotes entries have `conference` and `title` fields. Fuzzy-match by: normalize

--- a/skills/vault-ingress/references/known-issues.md
+++ b/skills/vault-ingress/references/known-issues.md
@@ -21,9 +21,11 @@ one produces code that runs clean against data nothing consumes.
 
 ## Native Timing Metadata Is Not Playback Evidence
 
-PPTX schema v2 exposes timing containers, exact animation behavior elements,
-visibility set actions, transitions, and audio/video timing nodes directly from
-slide-part XML. The lanes are separate because `<p:timing>` can contain media
+PPTX schema v3 extends the schema-v2 timing model with a distinct raw build-list
+lane. Timing containers, exact animation behavior elements, visibility set
+actions, transitions, audio/video timing nodes, and build entries come directly
+from slide-part XML. The lanes are
+separate because `<p:timing>` can contain media
 playback or other time nodes without any shape motion, and a stored behavior can
 exist without executing in the delivered talk.
 
@@ -60,10 +62,14 @@ scored as wordless backdrops (#116).
   background-image blobs, the same script emits provenance-bearing
   `picture_ocr` / `background_image_ocr` channels, aggregates their text into
   `ocr_text`, and sets `text_extraction_method` to `shapes+ocr` (or
-  `shapes+ocr_unavailable` if tesseract is missing). Use `text_channels` for
-  source/confidence and `ocr_text` for a combined word list. Empty
+  `shapes+ocr_unavailable` if tesseract is missing). OCR channels record whether
+  an attempt occurred, engine/version, numeric result confidence, and one
+  package-part/SHA-bound receipt per readable asset. `--no-ocr`, missing blobs,
+  unavailable engines, genuine empty results, and failures are distinct. Use
+  only `trustworthy_text: true` receipts as affirmative evidence; preserved
+  low-confidence text is review inventory, not a native-text claim. Empty
   `text_content_preview` still means *native channels could not read it*, not
-  *the slide is blank*.
+  *the slide is blank*, and empty/failed/unavailable OCR remains render-required.
 - **Read the confidence, never `image_area_ratio`.** The two are independent: a
   slide can be `"low"` with a ratio of `0.0`. Deriving your own trigger from the
   ratio reproduces the bug this entry exists to prevent.
@@ -83,8 +89,10 @@ scored as wordless backdrops (#116).
   rendered-page or specialized-parser pass.
 - Bad-CRC members under `ppt/media/` are replaced in memory with a transparent
   placeholder so healthy slides and text survive extraction. Read
-  `corrupt_assets` and `render_required_reasons`; the source PPTX is never
-  rewritten, and corrupt structural members remain hard errors.
+  `archive_recovery`, the compatibility `corrupt_assets` projection, and
+  `render_required_reasons`; the source PPTX is never rewritten, and corrupt
+  structural members remain hard errors. Placeholder recovery is degraded
+  evidence and blocks a fresh claim/return when the native deck is required.
 - `has_text_frame_shapes` (formerly `has_text_placeholder`) names what it
   measures: shapes with text frames. It is not a claim about on-screen text.
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1400,7 +1400,7 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
 | 10. Color Sequencing | Full sequence of hex values | `color_sequence` |
 | Text-channel provenance | Recursive shape text, table cells, picture OCR, background OCR | `text_channels[]` |
 | Unsupported visual containers | SmartArt, charts, OLE/media, unknown graphic frames, damaged assets | `unsupported_content[]`, `render_required_reasons[]` |
-| Native timing structure | Raw timing containers, behavior elements, visibility sets, transitions, and media timing | `native_timing`, `native_timing_summary` |
+| Native timing/build structure | Raw timing containers, behavior elements, visibility sets, transitions, media timing, and build-list entries | `native_timing`, `native_timing_summary` |
 
 ### What the Script Does NOT Extract (still needs PDF visual analysis)
 
@@ -1421,8 +1421,8 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
 
 ```json
 {
-  "schema_version": 2,
-  "pipeline_version": "1.1.0",
+  "schema_version": 3,
+  "pipeline_version": "1.2.0",
   "input_fingerprint": {
     "algorithm": "sha256",
     "digest": "64 lowercase hex characters",
@@ -1438,6 +1438,17 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
       "part_name": "ppt/media/image7.png",
       "error_type": "crc_mismatch",
       "status": "recovered_with_placeholder"
+    }
+  ],
+  "archive_recovery": [
+    {
+      "schema_version": 1,
+      "part_name": "ppt/media/image7.png",
+      "member_kind": "embedded_media",
+      "error_type": "crc_mismatch",
+      "status": "recovered_with_placeholder_asset",
+      "content_replaced": true,
+      "replacement_sha256": "64 lowercase hex characters"
     }
   ],
   "per_slide_visual": [
@@ -1461,11 +1472,41 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
           "channel": "shape_text|table_cell_text|picture_ocr|background_image_ocr|<unsupported-kind>_text|group_container_text",
           "text": "Talk Title",
           "confidence": "high|medium|low",
-          "status": "extracted|empty|skipped|unavailable|unsupported|requires_render",
+          "status": "extracted|empty|partial|failed|skipped|unavailable|unsupported|requires_render",
           "provenance": {
             "source": "pptx_shape_text_frame",
             "shape_path": ["Group 1", "Title 2"]
           }
+        },
+        {
+          "channel": "picture_ocr",
+          "text": "Recovered label",
+          "confidence": "low",
+          "result_confidence": 91.25,
+          "status": "extracted",
+          "attempted": true,
+          "engine": "tesseract",
+          "engine_version": "5.5.1",
+          "reason": null,
+          "provenance": {
+            "source": "embedded_picture_blobs",
+            "shape_paths": [["Picture 3"]]
+          },
+          "ocr_receipts": [
+            {
+              "attempted": true,
+              "engine": "tesseract",
+              "engine_version": "5.5.1",
+              "result_status": "text_recovered|low_confidence_text|genuine_empty|failed|unavailable|skipped",
+              "result_confidence": 91.25,
+              "error": null,
+              "part_name": "ppt/media/image3.png",
+              "asset_sha256": "64 lowercase hex characters",
+              "shape_path": ["Picture 3"],
+              "recovered_text": "Recovered label",
+              "trustworthy_text": true
+            }
+          ]
         }
       ],
       "unsupported_content": [
@@ -1499,8 +1540,18 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
           "total": 6
         },
         "media_timing_counts": {"audio": 1, "video": 0, "total": 1},
+        "build_list_present": true,
+        "build_list_count": 1,
+        "build_entry_counts": {
+          "paragraph": 1,
+          "diagram": 1,
+          "ole_chart": 0,
+          "graphic": 0,
+          "total": 2
+        },
         "has_animation_behaviors": true,
         "has_media_timing": true,
+        "has_build_entries": true,
         "provenance": {
           "source": "pptx_package_xml",
           "measurement": "raw_ooxml_element_counts",
@@ -1519,10 +1570,13 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
     "slides_with_transitions": 40,
     "slides_with_animation_behaviors": 10,
     "slides_with_media_timing": 2,
+    "slides_with_build_lists": 1,
+    "slides_with_build_entries": 1,
     "timing_element_count": 12,
     "transition_count": 40,
     "set_action_count": 18,
     "visibility_set_action_count": 9,
+    "build_list_count": 1,
     "animation_behavior_counts": {
       "general": 7,
       "color": 3,
@@ -1533,10 +1587,39 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
       "total": 36
     },
     "media_timing_counts": {"audio": 2, "video": 1, "total": 3},
+    "build_entry_counts": {
+      "paragraph": 1,
+      "diagram": 1,
+      "ole_chart": 0,
+      "graphic": 0,
+      "total": 2
+    },
     "provenance": {
       "source": "pptx_package_xml",
       "measurement": "raw_ooxml_element_counts",
       "observed_playback": false
+    }
+  },
+  "native_deck_audit": {
+    "schema_version": 1,
+    "extraction_schema_version": 3,
+    "extraction_pipeline_version": "1.2.0",
+    "source_pptx_sha256": "64 lowercase hex characters",
+    "source_pptx_size_bytes": 123456,
+    "slide_count": 60,
+    "render_required_slide_numbers": [1],
+    "render_required_reasons": {"1": ["smartart"]},
+    "extraction_receipt_sha256": "64 lowercase hex characters",
+    "rendered_page_inspection": {
+      "schema_version": 1,
+      "source_pptx_sha256": "64 lowercase hex characters",
+      "rendered_pdf_sha256": "64 lowercase hex characters",
+      "rendered_pdf_size_bytes": 98765,
+      "rendered_page_count": 60,
+      "inspected_page_ranges": [[1, 60]],
+      "inspected_required_slide_numbers": [1],
+      "complete": true,
+      "binding_sha256": "64 lowercase hex characters"
     }
   },
   "global_design": {
@@ -1549,26 +1632,38 @@ Produced by `skills/vault-ingress/scripts/pptx-extraction.py`.
 ```
 
 `schema_version` tracks this JSON field shape. Missing means legacy shape `0`;
-v1 added the version/fingerprint and current v2 adds `native_timing` to every
-slide plus `native_timing_summary`. `pipeline_version` tracks extraction behavior
-and changes when the walk, classification, confidence, OCR, recovery, or timing
-behavior changes; current is `1.1.0`.
+v1 added the version/fingerprint, v2 added `native_timing` to every slide plus
+`native_timing_summary`, and current v3 adds the raw build-list timing lane plus
+closed `archive_recovery` and `native_deck_audit` records. `pipeline_version`
+tracks extraction behavior and
+changes when the walk, classification, confidence, OCR, recovery, timing, or
+receipt behavior changes; current is `1.2.0`.
+
+Extractor schema v3 is independent of persisted pattern-evidence schema v2,
+return schema v5, queue-claim schema v5, and tracking-database schema v1. Those
+downstream generations do not advance here; their current readers bind or
+validate the new nested records inside their existing contracts.
 
 These records are transient per-invocation output, not a persisted artifact with
 an in-place migration. Regenerate old output with the current extractor. A timing
-reader must treat v0/v1 as **timing unknown**, never as all-zero, and rerun; an
-unknown future schema version is no usable prior output. The vault-profile layout
-reader may dual-read v1/v2 because `template_layouts` is unchanged, but it also
+reader must treat v0/v1 as **timing unknown**, never as all-zero. Schema v2 has
+the pre-build timing shape but lacks raw build-list evidence and cannot satisfy
+archive-recovery or audit-receipt requirements, so current analysis reruns it
+too. An unknown future schema version
+is no usable prior output. The vault-profile layout reader may read v1/v2/v3
+because `template_layouts` is unchanged, but it also
 rejects missing/unknown versions and reruns instead of guessing. This is the only
 declared cross-pipeline compatibility exception.
 `input_fingerprint` hashes the exact source PPTX bytes before any in-memory
 media recovery; identical bytes have the same fingerprint regardless of path.
 
-`corrupt_assets` is empty on a healthy package. A bad-CRC member under
+`archive_recovery` is empty on a healthy package. A bad-CRC member under
 `ppt/media/` is replaced only in an in-memory package with a transparent
-placeholder, allowing healthy text and slides to survive. Structural members
-(XML, relationships, content types) are never discarded; their corruption is
-a hard extraction error.
+placeholder, allowing healthy text and slides to survive while recording the
+lost part and exact replacement digest. `corrupt_assets` remains the legacy
+three-field projection. Structural members (XML, relationships, content types,
+layouts, masters, and presentation topology) are never discarded; their
+corruption makes the deck unavailable. The source file is never rewritten.
 
 `native_timing` inventories exact PresentationML element names under each slide's
 `<p:timing>` tree. `general` means the exact `<p:anim>` behavior, not a total;
@@ -1577,11 +1672,16 @@ specific behavior elements. `visibility_set_action_count` is the subset of
 `<p:set>` actions whose attribute name is `visibility` or ends in
 `.visibility`. Audio/video time nodes have a separate `media_timing_counts` lane,
 and slide transitions are counted separately whether or not a timing tree exists.
+The build lane counts only exact `p:bldP`, `p:bldDgm`, `p:bldOleChart`, and
+`p:bldGraphic` entries beneath `p:bldLst`, with fixed zero-valued keys and an
+explicit `build_list_present` flag. A build entry is raw package structure: it
+does not prove reveal order, visible state, execution, or delivered playback,
+and it is never merged into visibility-set counts.
 
 All counts are raw OOXML structure. Markup Compatibility `Choice` and `Fallback`
 branches are both present in the package and both counted. The provenance field's
 `observed_playback: false` is load-bearing: timing-container presence, media timing,
-or a motion behavior element does not prove execution, concurrency, smoothness,
+or a motion/build element does not prove execution, concurrency, smoothness,
 the perceived target, or delivered audience behavior. Adjacent static duplicate
 slides can still be progressive-reveal evidence after rendered-state inspection;
 they correctly carry zero native timing when the author implemented the build as
@@ -1598,8 +1698,20 @@ containers can remain invisible. On a `"low"` slide:
   channels*, never wordless
 - `ocr_text` holds the backward-compatible aggregate of picture and background
   image OCR channels when the engine ran (`text_extraction_method:
-  "shapes+ocr"`). Use it for cites,
-  transcript cross-checks, language policy on slide text, and pattern evidence
+  "shapes+ocr"`). Use only receipt records with `trustworthy_text: true` for
+  affirmative cites, transcript cross-checks, language policy on slide text,
+  and pattern evidence; lower-confidence recovered text remains available for
+  spelling review but is not trustworthy evidence
+- OCR channels add `attempted`, configured engine/version, aggregate numeric
+  `result_confidence` (finite 0..100 or null), a closed reason, and
+  `ocr_receipts[]`. Each per-asset receipt binds the exact package `part_name`,
+  asset SHA-256, and shape path to one result. `recovered_text` is capped at
+  8,000 characters per receipt. With no readable blob the channel has
+  `attempted: false`, `status: "unavailable"`, reason `no_readable_asset`, and
+  an empty receipt array. With `--no-ocr`, every readable asset gets an explicit
+  `attempted: false` / `result_status: "skipped"` receipt and reason
+  `ocr_disabled`. A missing engine records `ocr_engine_unavailable`; processing
+  failures record `ocr_failed` or `partial_ocr_results`
 - `text_extraction_method` is `"shapes"` when OCR was not attempted (high
   confidence, `--no-ocr`, or no usable image blob), `"shapes+ocr"` when it ran,
   `"shapes+ocr_unavailable"` when the engine was missing
@@ -1618,6 +1730,20 @@ SmartArt, charts, OLE/media objects, unknown graphic frames, unreadable images,
 and recovered corrupt assets are listed in `unsupported_content`. Never infer
 completeness when `render_required` is true; use
 `render_required_reasons` to choose the fallback.
+
+`native_deck_audit` binds the exact PPTX digest and size, extractor schema and
+pipeline, slide count, and every derived render-required slide/reason. Its
+optional `rendered_page_inspection` binds an equal-page-count PDF plus the exact
+inspected ranges. Hash, byte size, and page count come from one stable copied PDF
+generation; persistence snapshots the current canonical PDF again and compares
+all three, so a same-size replacement cannot inherit an old receipt. Every
+current return that declares, inspects, or cites `native_deck` must carry the
+current audit even when it reports zero findings. Native citations—including
+applicability citations—need rendered evidence only when their cited slide
+numbers overlap the audit's render-required slides; explicit authored visual
+summary fields require complete coverage of every render-required slide.
+Persistence recomputes the audit in a bounded worker and matches the receipt to
+owner-canonical native-deck and static-slide identities.
 
 `image_area_ratio` is the **largest** PICTURE shape's area as a fraction of the
 slide, rounded to 3 decimals; always present. `0.0` means no picture, unreadable

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -237,13 +237,15 @@ Checks apply to a record with a declared transcript, slide, or video capability
   provenance is blocking for completed records and a warning for requeued/pending
   work.
 
-The seven stable slide-contract fault classes are:
+The nine stable slide-contract fault classes are:
 
 | Code | Meaning |
 |---|---|
 | `slide_source_unsupported` | Explicit source is outside the enum |
 | `slide_pptx_reference_missing` | `pptx`/`both` has no `pptx_path` |
 | `slide_pptx_artifact_missing` | Resolved PPTX does not exist |
+| `slide_pptx_artifact_unreadable` | Resolved PPTX exists but its container or structural members cannot be parsed safely |
+| `slide_pptx_artifact_degraded` | Resolved PPTX required loss-reporting placeholder recovery for damaged media |
 | `slide_pdf_reference_missing` | `pdf`/`both` has no Drive ID |
 | `slide_pdf_artifact_missing` | Drive-ID PDF does not exist |
 | `slide_video_reference_missing` | Video extraction has no valid YouTube identity |
@@ -258,8 +260,8 @@ A claimed source missing from a completed record is blocking, except for a valid
 manifest-backed unpromoted `processed_partial` video result. The same absence on
 a pending/processable record is a warning because acquisition has not yet run.
 
-The preflight checks only artifact identity and existence. It never opens a PDF,
-never counts PDF pages, and never derives or validates authored `slide_count`
+The preflight opens declared PPTX artifacts through the shared loss-reporting
+probe; it never opens a PDF, never counts PDF pages, and never derives or validates authored `slide_count`
 from `structured_data.video_extraction.unique_slides_count`. A video extraction
 can produce multiple captured states for one authored slide; those are different
 measurements by contract.

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -136,9 +136,13 @@ explicitly authorizes full transcript/receipt replacement.
 
 - **`pptx` / `both`** — run
   `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py" <path.pptx>`.
-  Require extraction schema v2 before using native timing/build evidence. A
-  missing/v0/v1 schema means timing is unknown and the deck must be re-extracted;
-  an unknown future version is unusable until the reader contract is updated.
+  Require extraction schema v3 for current analysis. Missing/v0/v1 output has
+  unknown timing; v2 has the pre-build timing lanes but lacks raw build-list
+  evidence, archive-recovery, and native/render audit receipts. Re-extract
+  v0-v2; an unknown future version
+  is unusable until the reader contract is updated. A non-empty
+  `archive_recovery` is degraded input, not permission to score the surviving
+  slides: restore or re-export a required native deck before returning evidence.
 - **`pdf`** — download via gdown (pass the bare Google Drive file id; gdown
   accepts a `url_or_id` argument, so no full download URL is needed):
   ```bash
@@ -265,9 +269,14 @@ When any slide in a deck reports `text_extraction_confidence: "low"`:
 1. Read `text_channels`, `unsupported_content`, and
    `render_required_reasons` from the extraction JSON first. Each channel names
    its source, confidence, and status. `ocr_text` remains a convenient combined
-   inventory. `shapes+ocr_unavailable` means install tesseract next time; an
-   `unsupported` or `unavailable` channel needs rendering or a specialized
-   parser. Do not invent words.
+   inventory. For OCR channels, read channel-level `attempted`, engine/version,
+   result confidence, reason, and every `ocr_receipts[]` record: each receipt
+   binds one exact package `part_name` and asset SHA-256 to its outcome.
+   `trustworthy_text: false`, `failed`, `unavailable`, or `genuine_empty` never
+   proves visible-text absence. `--no-ocr` and missing blobs are explicit
+   `attempted: false` outcomes. `shapes+ocr_unavailable` means install tesseract
+   next time; an `unsupported` or `unavailable` channel needs rendering or a
+   specialized parser. Do not invent words.
 
 2. Get a PDF to render for design judgment. Which one depends on `slide_source`
    — the `pptx` path never downloads one, so it has to be produced:
@@ -295,16 +304,39 @@ When any slide in a deck reports `text_extraction_confidence: "low"`:
    resolver will then retain both the distinct `native_deck` and `static_slides`
    identities; it never aliases the PPTX itself to static pages.
 
-   If the export fails and no PDF exists for the talk, say so in the analysis
-   and mark Dimensions 8 and 13 design fields low-confidence rather than
-   judging layout from shape JSON alone — an unreadable deck is not a wordless
-   one. Still use any `ocr_text` that the extractor produced from picture blobs.
+   If the export fails and no PDF exists for the talk, say so in the analysis,
+   omit render-dependent Dimensions 8 and 13 structured fields/detections, and
+   return the affected catalog outcomes as `not_evaluable` with missing source
+   coverage. There is no confidence carrier for those structured fields, so do
+   not put a guessed "low-confidence" value into them. Preserve only structural
+   observations that the native audit actually supports. Still use any
+   trustworthy, receipt-bearing `ocr_text` inventory that the extractor
+   produced from healthy picture blobs; low-confidence, failed, unavailable, or
+   empty OCR is not affirmative text evidence.
 
 3. Render the pages and read them for design:
 
    ```bash
    pdftoppm -png -r 100 -f <first> -l <last> "{pdf_path}" "{tmp}/slide"
    ```
+
+   Bind the rendered artifact and exact pages inspected by rerunning extraction:
+
+   ```bash
+   "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py" \
+     "{pptx_path}" --rendered-pdf "{pdf_path}" \
+     --inspected-pages <PAGE|START-END>
+   ```
+
+   Every current return that declares, inspects, or cites `native_deck` must
+   carry the current `native_deck_audit`, even when it reports zero findings.
+   `native_deck_audit.rendered_page_inspection.complete` must be true for
+   explicit authored visual summary fields. A native citation needs rendered
+   coverage only when its cited slide overlaps the audit's render-required
+   pages; an unrelated clean-slide citation remains usable. The owner
+   re-extracts the exact PPTX and matches the receipt to canonical
+   `native_deck` and `static_slides` identities. If extraction reports
+   `archive_recovery`, stop and repair/re-export the required deck.
 
 4. Judge **Dimension 8** structure (dense vs minimal, room vs reward layer) and
    **Dimension 13** (Slide Design) from the rendered images. Cross-check the
@@ -319,9 +351,11 @@ Structural fields stay authoritative for what they actually measure —
 
 ### Native timing is structure, not observed playback
 
-Schema-v2 PPTX extraction keeps four evidence lanes distinct on every slide:
+Schema-v3 PPTX extraction extends the schema-v2 timing model with a fifth raw
+build-list lane and keeps all five evidence lanes distinct on every slide:
 exact animation behavior elements, visibility-targeting `<p:set>` actions,
-slide transitions, and audio/video timing nodes. Read the per-slide
+slide transitions, audio/video timing nodes, and raw `<p:bldLst>` build entries.
+Read the per-slide
 `native_timing` record and the fixed-key `native_timing_summary`; do not derive
 an `animated` verdict merely from `<p:timing>` presence.
 
@@ -331,8 +365,11 @@ executed, looked smooth, or targeted the perceived object. Audio/video timing is
 not shape motion. Raw counts also do not establish concurrency or effect order,
 so multiple effect/scale/rotation elements alone cannot score
 `composite-animation`; inspect target/timing relationships or delivery video.
-Markup-compatibility Choice/Fallback branches are counted as stored, not resolved
-for the presenter that delivered the talk.
+Build-list records establish only that PowerPoint stored paragraph, diagram,
+OLE-chart, or graphic build metadata; they do not establish reveal order or a
+visible state and are never merged into visibility actions. Markup-compatibility
+Choice/Fallback branches are counted as stored, not resolved for the presenter
+that delivered the talk.
 
 Conversely, zero native timing does not rule out progressive builds implemented
 as adjacent duplicate slides. Ordered rendered states with controlled cumulative

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -34,6 +34,15 @@ from transcript_timing import (
     resolve_quote,
     sidecar_path,
 )
+from pptx_evidence import (
+    PPTX_EXTRACTION_PIPELINE_VERSION,
+    PPTX_EXTRACTION_SCHEMA_VERSION,
+    PptxEvidenceError,
+    probe_pptx_artifact,
+    recompute_native_deck_audit,
+    snapshot_rendered_pdf,
+    validate_native_deck_audit,
+)
 
 
 LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION = 1
@@ -376,12 +385,20 @@ def _resolve_preclaim_artifact(
             configured_root = Path(configured).expanduser().resolve()
             root_kind = "pptx_source"
     if supplied.is_absolute():
+        lexical_supplied = Path(os.path.abspath(supplied))
+        resolved_supplied = supplied.resolve(strict=False)
+        if lexical_supplied != resolved_supplied:
+            raise PatternEvidenceError(
+                f"{field} must not traverse a symbolic link: {value!r}"
+            )
         try:
-            supplied.resolve(strict=False).relative_to(vault)
+            candidate = resolved_supplied.relative_to(vault).as_posix()
         except ValueError:
             if configured_root is not None:
                 try:
-                    supplied.resolve(strict=False).relative_to(configured_root)
+                    candidate = resolved_supplied.relative_to(
+                        configured_root
+                    ).as_posix()
                 except ValueError:
                     root = supplied.parent.resolve()
                     root_kind = f"preclaim:{field}"
@@ -389,7 +406,6 @@ def _resolve_preclaim_artifact(
                 else:
                     root = configured_root
                     root_kind = "pptx_source"
-                    candidate = supplied
             else:
                 # An exact absolute path in the preclaim is trusted as an
                 # immutable source reference. Its parent becomes a field-specific
@@ -400,7 +416,6 @@ def _resolve_preclaim_artifact(
         else:
             root = vault
             root_kind = "vault"
-            candidate = supplied
     elif configured_root is not None:
         root = configured_root
         candidate = value
@@ -413,19 +428,9 @@ def _resolve_preclaim_artifact(
 
 def _pptx_locator_count(path: Path) -> int:
     try:
-        from pptx import Presentation
-        from pptx.exc import PackageNotFoundError
-    except ImportError as exc:  # pragma: no cover - packaging owns installation
-        raise PatternEvidenceError(
-            "PPTX evidence requires the declared python-pptx runtime dependency; "
-            "install the speaker-toolkit project dependencies"
-        ) from exc
-    try:
-        count = len(Presentation(str(path)).slides)
-    except (OSError, ValueError, KeyError, PackageNotFoundError) as exc:
+        count = probe_pptx_artifact(path).slide_count
+    except PptxEvidenceError as exc:
         raise PatternEvidenceError(f"cannot read PPTX artifact {path}: {exc}") from exc
-    if count < 1:
-        raise PatternEvidenceError(f"PPTX artifact has no slides: {path}")
     return count
 
 
@@ -1241,7 +1246,10 @@ def build_evidence_context(
     slide_counts: dict[str, int] = {}
     slide_artifact_paths: dict[str, Path] = {}
     slide_artifact_roots: dict[str, tuple[Path, str]] = {}
+    slide_artifact_sha256s: dict[str, str] = {}
     source_reasons: dict[str, str] = {}
+    source_degradations: dict[str, dict[str, object]] = {}
+    source_unavailable: dict[str, dict[str, object]] = {}
     pptx_count: int | None = None
     pdf_count: int | None = None
     pptx_path: Path | None = None
@@ -1260,11 +1268,50 @@ def build_evidence_context(
                 suffix=".pptx",
                 source_roots=source_roots,
             )
-            pptx_count = _pptx_locator_count(pptx_path)
-            slide_counts["native_deck"] = pptx_count
-            slide_artifact_paths["native_deck"] = pptx_path
-            slide_artifact_roots["native_deck"] = (pptx_root, pptx_root_kind)
-            source_reasons["native_deck"] = f"read local PPTX {pptx_path}"
+            pptx_probe = probe_pptx_artifact(pptx_path)
+            pptx_count = pptx_probe.slide_count
+            if pptx_probe.archive_recovery:
+                recovered_parts = sorted(
+                    str(item.get("part_name", "<unknown>"))
+                    for item in pptx_probe.archive_recovery
+                )
+                source_reasons["native_deck"] = (
+                    f"read degraded local PPTX {pptx_path}; recovery "
+                    f"placeholders used for {', '.join(recovered_parts)}"
+                )
+                source_degradations["native_deck"] = {
+                    "schema_version": 1,
+                    "status": "degraded_recoverable",
+                    "reason_code": "pptx_archive_recovery_required",
+                    "source_artifact_sha256": pptx_probe.source_sha256,
+                    "source_artifact_size_bytes": pptx_probe.source_size_bytes,
+                    "extraction_schema_version": PPTX_EXTRACTION_SCHEMA_VERSION,
+                    "extraction_pipeline_version": PPTX_EXTRACTION_PIPELINE_VERSION,
+                    "archive_recovery": [
+                        copy.deepcopy(item) for item in pptx_probe.archive_recovery
+                    ],
+                }
+            else:
+                slide_counts["native_deck"] = pptx_count
+                slide_artifact_paths["native_deck"] = pptx_path
+                slide_artifact_roots["native_deck"] = (
+                    pptx_root,
+                    pptx_root_kind,
+                )
+                slide_artifact_sha256s["native_deck"] = (
+                    pptx_probe.source_sha256
+                )
+                source_reasons["native_deck"] = f"read local PPTX {pptx_path}"
+        except PptxEvidenceError as exc:
+            source_reasons["native_deck"] = str(exc)
+            source_unavailable["native_deck"] = {
+                "schema_version": 1,
+                "status": "unavailable",
+                "reason_code": exc.reason_code,
+                "reason": str(exc),
+                "details": copy.deepcopy(exc.details),
+                "artifact_path": str(pptx_path) if pptx_path is not None else None,
+            }
         except PatternEvidenceError as exc:
             source_reasons["native_deck"] = str(exc)
     else:
@@ -1281,27 +1328,49 @@ def build_evidence_context(
                 suffix=".pdf",
                 source_roots=source_roots,
             )
-            pdf_count = _pdf_locator_count(pdf_path)
+            pdf_sha256, _pdf_size, pdf_count = snapshot_rendered_pdf(pdf_path)
+            slide_artifact_sha256s["static_slides"] = pdf_sha256
             source_reasons["static_slides"] = f"read local PDF {pdf_path}"
-        except PatternEvidenceError as exc:
+        except (PatternEvidenceError, PptxEvidenceError) as exc:
             source_reasons["static_slides"] = str(exc)
 
     slide_source = talk.get("slide_source")
     if slide_source == "video_extracted":
+        # A predeclared PDF is not interchangeable with the manifest-selected
+        # video extraction. Bind path/count/digest together below, or leave the
+        # static-slide lane unavailable without disturbing independent sources.
+        slide_artifact_sha256s.pop("static_slides", None)
         youtube_id = talk.get("youtube_id")
         if isinstance(youtube_id, str) and _YOUTUBE_ID.fullmatch(youtube_id):
             video_slide_count, video_slide_reason, video_slide_path = (
                 _trusted_video_slide_count(vault_root, talk, youtube_id)
             )
-            if video_slide_count is not None:
-                slide_counts["static_slides"] = video_slide_count
-                if video_slide_path is not None:
-                    slide_artifact_paths["static_slides"] = video_slide_path
-                    slide_artifact_roots["static_slides"] = (
-                        Path(vault_root).resolve(),
-                        "vault",
-                    )
             source_reasons["static_slides"] = video_slide_reason
+            if video_slide_count is not None and video_slide_path is not None:
+                try:
+                    video_slide_sha256, _video_pdf_size, snapshot_count = (
+                        snapshot_rendered_pdf(video_slide_path)
+                    )
+                except PptxEvidenceError as exc:
+                    source_reasons["static_slides"] = (
+                        f"cannot snapshot trusted video slides: {exc}"
+                    )
+                else:
+                    if snapshot_count != video_slide_count:
+                        source_reasons["static_slides"] = (
+                            "trusted video slide PDF changed while its identity "
+                            "was bound"
+                        )
+                    else:
+                        slide_counts["static_slides"] = snapshot_count
+                        slide_artifact_paths["static_slides"] = video_slide_path
+                        slide_artifact_roots["static_slides"] = (
+                            Path(vault_root).resolve(),
+                            "vault",
+                        )
+                        slide_artifact_sha256s["static_slides"] = (
+                            video_slide_sha256
+                        )
             static_slides_absence_complete = False
         else:
             source_reasons["static_slides"] = (
@@ -1363,15 +1432,31 @@ def build_evidence_context(
         )
         returned_source = ret.get("slide_source")
         if returned_count is not None:
-            static_slides_absence_complete = returned_source in {"pdf", "both"}
-            slide_counts["static_slides"] = returned_count
-            source_reasons["static_slides"] = returned_reason
-            if returned_slide_path is not None:
-                slide_artifact_paths["static_slides"] = returned_slide_path
-                slide_artifact_roots["static_slides"] = (
-                    Path(vault_root).resolve(),
-                    "vault",
+            if returned_slide_path is None:
+                raise PatternEvidenceError(
+                    "returned static-slide count has no identity-bound PDF path"
                 )
+            try:
+                returned_sha256, _returned_size, snapshot_count = (
+                    snapshot_rendered_pdf(returned_slide_path)
+                )
+            except PptxEvidenceError as exc:
+                raise PatternEvidenceError(
+                    f"cannot snapshot returned static slides: {exc}"
+                ) from exc
+            if snapshot_count != returned_count:
+                raise PatternEvidenceError(
+                    "returned static-slide PDF changed while its identity was bound"
+                )
+            static_slides_absence_complete = returned_source in {"pdf", "both"}
+            slide_counts["static_slides"] = snapshot_count
+            source_reasons["static_slides"] = returned_reason
+            slide_artifact_paths["static_slides"] = returned_slide_path
+            slide_artifact_roots["static_slides"] = (
+                Path(vault_root).resolve(),
+                "vault",
+            )
+            slide_artifact_sha256s["static_slides"] = returned_sha256
         elif returned_source in {"pdf", "both", "video_extracted"}:
             # No explicit current-run artifact assertion: retain any verified
             # preclaim artifact instead of silently deleting its capability.
@@ -1488,7 +1573,10 @@ def build_evidence_context(
             source, (Path(vault_root).resolve(), "vault")
         )
         slide_artifact_identities[source] = _artifact_identity(
-            root, path, root_kind=root_kind
+            root,
+            path,
+            root_kind=root_kind,
+            artifact_sha256=slide_artifact_sha256s.get(source),
         )
     video_artifact_identity: dict[str, str] = {}
     if (
@@ -1551,6 +1639,8 @@ def build_evidence_context(
         "absence_complete_evidence_sources": absence_complete_sources,
         "absence_capability_reasons": absence_capability_reasons,
         "source_reasons": source_reasons,
+        "degraded_evidence_sources": source_degradations,
+        "unavailable_evidence_sources": source_unavailable,
         "metadata": metadata,
         "delivery_language": delivery_language,
     }
@@ -1663,13 +1753,78 @@ def assess_talk_artifact_capabilities(
     youtube_id = talk.get("youtube_id")
     if isinstance(youtube_id, str) and _YOUTUBE_ID.fullmatch(youtube_id):
         acquisitions.add("transcript")
+    raw_degradations = (
+        context.get("degraded_evidence_sources")
+        if isinstance(context, Mapping)
+        else None
+    )
+    degraded_sources = (
+        {
+            str(source): copy.deepcopy(dict(details))
+            for source, details in raw_degradations.items()
+            if isinstance(details, Mapping)
+        }
+        if isinstance(raw_degradations, Mapping)
+        else {}
+    )
+    raw_unavailable = (
+        context.get("unavailable_evidence_sources")
+        if isinstance(context, Mapping)
+        else None
+    )
+    unavailable_sources = (
+        {
+            str(source): copy.deepcopy(dict(details))
+            for source, details in raw_unavailable.items()
+            if isinstance(details, Mapping)
+        }
+        if isinstance(raw_unavailable, Mapping)
+        else {}
+    )
     return {
         "verified_capabilities": tuple(sorted(verified_capabilities)),
         "verified_evidence_sources": tuple(sorted(verified_sources)),
         "acquisition_capabilities": tuple(sorted(acquisitions)),
         "repair_capabilities": tuple(sorted(repairs)),
         "source_reasons": source_reasons,
+        "degraded_evidence_sources": degraded_sources,
+        "unavailable_evidence_sources": unavailable_sources,
     }
+
+
+def required_pptx_evidence_blocking_reason(
+    talk: Mapping[str, object],
+    assessment: Mapping[str, object],
+    *,
+    native_deck_used: bool = False,
+) -> str | None:
+    """Explain why degraded mandatory native evidence blocks current work."""
+    if talk.get("slide_source") not in {"pptx", "both"} and not native_deck_used:
+        return None
+    raw_degradations = assessment.get("degraded_evidence_sources")
+    native = (
+        raw_degradations.get("native_deck")
+        if isinstance(raw_degradations, Mapping)
+        else None
+    )
+    if not isinstance(native, Mapping):
+        return None
+    raw_recovery = native.get("archive_recovery")
+    parts = (
+        sorted(
+            str(item.get("part_name", "<unknown>"))
+            for item in raw_recovery
+            if isinstance(item, Mapping)
+        )
+        if isinstance(raw_recovery, list)
+        else []
+    )
+    suffix = f"; damaged members: {', '.join(parts)}" if parts else ""
+    return (
+        "native_deck is degraded by placeholder archive recovery and cannot "
+        f"authorize a current claim or analysis{suffix}; restore or re-export "
+        "the PPTX first"
+    )
 
 
 def assess_batch_artifact_capabilities(
@@ -2553,6 +2708,142 @@ def canonicalize_detection_citations(
     return canonical
 
 
+def _live_native_deck_audit(pptx_path: Path) -> dict[str, object]:
+    """Recompute the audit in a bounded worker from the exact owner deck."""
+    try:
+        return recompute_native_deck_audit(pptx_path)
+    except PptxEvidenceError as exc:
+        raise PatternEvidenceError(
+            f"cannot recompute native-deck audit for {pptx_path}: {exc}"
+        ) from exc
+
+
+def _canonicalize_native_deck_audit(
+    structured: dict[str, object],
+    context: Mapping[str, object],
+    canonical_inspection: list[dict[str, object]],
+) -> None:
+    """Bind a render receipt to fresh extraction and canonical source identities."""
+    raw_audit = structured.get("native_deck_audit")
+    if raw_audit is None:
+        return
+    slide_count = structured.get("slide_count")
+    expected_count = (
+        slide_count
+        if isinstance(slide_count, int) and not isinstance(slide_count, bool)
+        else None
+    )
+    try:
+        audit = validate_native_deck_audit(raw_audit, slide_count=expected_count)
+    except PptxEvidenceError as exc:
+        raise PatternEvidenceError(f"native_deck_audit is invalid: {exc}") from exc
+
+    slide_paths = context.get("slide_artifact_paths")
+    native_path = (
+        slide_paths.get("native_deck")
+        if isinstance(slide_paths, Mapping)
+        else None
+    )
+    if not isinstance(native_path, Path):
+        raise PatternEvidenceError(
+            "native_deck_audit has no canonical native_deck source artifact"
+        )
+    live = _live_native_deck_audit(native_path)
+    immutable_fields = {
+        "schema_version",
+        "extraction_schema_version",
+        "extraction_pipeline_version",
+        "source_pptx_sha256",
+        "source_pptx_size_bytes",
+        "slide_count",
+        "render_required_slide_numbers",
+        "render_required_reasons",
+        "extraction_receipt_sha256",
+    }
+    drift = sorted(
+        field for field in immutable_fields if audit.get(field) != live.get(field)
+    )
+    if drift:
+        raise PatternEvidenceError(
+            "native_deck_audit disagrees with a fresh extraction of the exact "
+            f"source PPTX: {drift}"
+        )
+
+    receipt = audit.get("rendered_page_inspection")
+    if receipt is None:
+        structured["native_deck_audit"] = audit
+        return
+    if not isinstance(receipt, Mapping):
+        raise PatternEvidenceError("rendered_page_inspection must be an object")
+    by_source = {
+        record.get("source"): record
+        for record in canonical_inspection
+        if isinstance(record, Mapping)
+    }
+    native_inspection = by_source.get("native_deck")
+    static_inspection = by_source.get("static_slides")
+    if not isinstance(native_inspection, Mapping):
+        raise PatternEvidenceError(
+            "native_deck_audit requires receipt-bound native_deck source_inspection"
+        )
+    if not isinstance(static_inspection, Mapping):
+        raise PatternEvidenceError(
+            "rendered_page_inspection requires receipt-bound static_slides inspection"
+        )
+    if native_inspection.get("artifact_sha256") != audit["source_pptx_sha256"]:
+        raise PatternEvidenceError(
+            "native_deck_audit source digest does not match canonical native_deck"
+        )
+    expected_static = {
+        "rendered_pdf_sha256": static_inspection.get("artifact_sha256"),
+        "rendered_page_count": static_inspection.get("page_count"),
+        "inspected_page_ranges": static_inspection.get("page_ranges"),
+    }
+    mismatches = sorted(
+        field
+        for field, expected in expected_static.items()
+        if receipt.get(field) != expected
+    )
+    if mismatches:
+        raise PatternEvidenceError(
+            "rendered_page_inspection is not bound to the canonical static_slides "
+            f"artifact and inspected ranges: {mismatches}"
+        )
+    static_path = (
+        slide_paths.get("static_slides")
+        if isinstance(slide_paths, Mapping)
+        else None
+    )
+    if not isinstance(static_path, Path):
+        raise PatternEvidenceError(
+            "rendered_page_inspection has no canonical static_slides artifact"
+        )
+    try:
+        current_sha, current_size, current_page_count = snapshot_rendered_pdf(
+            static_path
+        )
+    except PptxEvidenceError as exc:
+        raise PatternEvidenceError(
+            f"cannot snapshot canonical rendered PDF {static_path}: {exc}"
+        ) from exc
+    current_identity = {
+        "rendered_pdf_sha256": current_sha,
+        "rendered_pdf_size_bytes": current_size,
+        "rendered_page_count": current_page_count,
+    }
+    current_mismatches = sorted(
+        field
+        for field, expected in current_identity.items()
+        if receipt.get(field) != expected
+    )
+    if current_mismatches:
+        raise PatternEvidenceError(
+            "rendered_page_inspection PDF generation does not match current "
+            f"canonical static_slides: {current_mismatches}"
+        )
+    structured["native_deck_audit"] = audit
+
+
 def canonicalize_return_evidence(
     ret: Mapping[str, object],
     talk: Mapping[str, object],
@@ -2655,10 +2946,16 @@ def canonicalize_return_evidence(
                         f"the canonical 1..{selected_slide_count} artifact bound"
                     )
             structured["slide_count"] = selected_slide_count
-    elif canonical.get("status") == "processed":
-        raise PatternEvidenceError(
-            "status processed requires a readable canonical authored-slide artifact"
-        )
+    else:
+        if isinstance(structured, Mapping) and "slide_count" in structured:
+            raise PatternEvidenceError(
+                "structured_data.slide_count has no verified selected slide artifact"
+            )
+        if canonical.get("status") == "processed":
+            raise PatternEvidenceError(
+                "status processed requires a readable canonical authored-slide "
+                "artifact"
+            )
     raw_metadata = context.get("metadata")
     post_return_metadata: dict[str, object] = (
         copy.deepcopy(dict(raw_metadata)) if isinstance(raw_metadata, Mapping) else {}
@@ -2694,6 +2991,12 @@ def canonicalize_return_evidence(
             "processed_partial when no authored slide artifact was inspected"
         )
     observations["source_inspection"] = canonical_inspection
+    if isinstance(structured, dict):
+        _canonicalize_native_deck_audit(
+            structured,
+            context,
+            canonical_inspection,
+        )
     detected_ids: set[str] = set()
     for field in ("patterns_detected", "antipatterns_detected"):
         detections = observations.get(field)
@@ -3136,12 +3439,12 @@ def assess_persisted_pattern_evidence_freshness(
         reasons.update(_v5_projection_freshness_reasons(talk, observations))
     vault = Path(vault_root).resolve()
     current_context: Mapping[str, object] = {}
-    if evidence_schema_version == PATTERN_EVIDENCE_SCHEMA_VERSION:
-        try:
-            current_context = build_evidence_context(
-                vault_root, talk, source_roots=source_roots
-            )
-        except PatternEvidenceError:
+    try:
+        current_context = build_evidence_context(
+            vault_root, talk, source_roots=source_roots
+        )
+    except PatternEvidenceError:
+        if evidence_schema_version == PATTERN_EVIDENCE_SCHEMA_VERSION:
             reasons.add("source_role_context_unavailable")
 
     def identity_root(kind: object, label: str) -> Path | None:
@@ -3173,6 +3476,8 @@ def assess_persisted_pattern_evidence_freshness(
         *,
         timing: bool = False,
         quality: bool = False,
+        bounded_current_digest: str | None = None,
+        require_bounded_digest: bool = False,
     ) -> Path | None:
         if timing and quality:  # pragma: no cover - internal API guard
             raise ValueError("an identity cannot be both timing and quality")
@@ -3211,14 +3516,53 @@ def assess_persisted_pattern_evidence_freshness(
         if not resolved.is_file():
             reasons.add(f"{label}:{prefix}_missing")
             return None
-        try:
-            current_digest = _sha256_file(resolved)
-        except PatternEvidenceError:
-            reasons.add(f"{label}:{prefix}_unreadable")
-            return None
+        if bounded_current_digest is not None:
+            current_digest = bounded_current_digest
+        elif require_bounded_digest:
+            reasons.add(f"{label}:{prefix}_bounded_digest_unavailable")
+            return resolved
+        else:
+            try:
+                current_digest = _sha256_file(resolved)
+            except PatternEvidenceError:
+                reasons.add(f"{label}:{prefix}_unreadable")
+                return None
         if current_digest != digest:
             reasons.add(f"{label}:{prefix}_digest_mismatch")
         return resolved
+
+    slide_identities = current_context.get("slide_artifact_identities")
+    current_native_identity = (
+        slide_identities.get("native_deck")
+        if isinstance(slide_identities, Mapping)
+        else None
+    )
+    candidate_native_digest = (
+        current_native_identity.get("artifact_sha256")
+        if isinstance(current_native_identity, Mapping)
+        else None
+    )
+    bounded_native_digest = (
+        candidate_native_digest
+        if isinstance(candidate_native_digest, str)
+        and re.fullmatch(r"[0-9a-f]{64}", candidate_native_digest) is not None
+        else None
+    )
+
+    def check_source_identity(
+        owner: Mapping[str, object],
+        label: str,
+        source: object,
+    ) -> Path | None:
+        """Check one source identity without parent-process PPTX reads."""
+        return check_identity(
+            owner,
+            label,
+            bounded_current_digest=(
+                bounded_native_digest if source == "native_deck" else None
+            ),
+            require_bounded_digest=source == "native_deck",
+        )
 
     def owner_candidates(source: str) -> list[Path]:
         values: list[tuple[str | None, object]] = []
@@ -3295,7 +3639,7 @@ def assess_persisted_pattern_evidence_freshness(
             reasons.add(f"{label}:source_invalid_or_duplicate")
             continue
         underlying[source] = record
-        path = check_identity(record, label)
+        path = check_source_identity(record, label, source)
         if "timing_artifact_path" in record or "timing_artifact_sha256" in record:
             check_identity(record, label, timing=True)
         if source == "transcript":
@@ -3484,7 +3828,7 @@ def assess_persisted_pattern_evidence_freshness(
             actual = {key: identity.get(key) for key in expected}
             if actual != expected:
                 reasons.add(f"{label}:{source}:artifact_identity_mismatch")
-            check_identity(identity, f"{label}:{source}")
+            check_source_identity(identity, f"{label}:{source}", source)
             if "timing_artifact_path" in identity:
                 check_identity(identity, f"{label}:{source}", timing=True)
             if "quality_artifact_path" in identity:
@@ -3565,7 +3909,7 @@ def assess_persisted_pattern_evidence_freshness(
                         field
                     ) != expected_record.get(field):
                         reasons.add(f"{citation_label}:{field}_mismatch")
-                check_identity(citation, citation_label)
+                check_source_identity(citation, citation_label, source)
                 if "timing_artifact_path" in citation:
                     check_identity(citation, citation_label, timing=True)
                 if "quality_artifact_path" in citation:

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -17,6 +17,7 @@ about observed motion, concurrency, or delivered behavior.
 
 Usage:
     pptx-extraction.py <path> [--skip template] [--no-ocr]
+        [--rendered-pdf <path>] [--inspected-pages <PAGE|START-END>]
     pptx-extraction.py --version
 
     <path>       Path to a single .pptx file or a directory to scan recursively
@@ -29,7 +30,6 @@ Examples:
 """
 
 import argparse
-import base64
 import glob
 import hashlib
 import io
@@ -37,23 +37,30 @@ import json
 import os
 import re
 import sys
-import zipfile
 from collections import Counter
 from math import gcd
-from pathlib import Path
-from zlib import error as ZlibError
-
-from pptx import Presentation
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.oxml.ns import qn
 
+from pptx_evidence import (
+    PPTX_EXTRACTION_PIPELINE_VERSION,
+    PPTX_EXTRACTION_SCHEMA_VERSION,
+    PptxEvidenceError,
+    build_native_deck_audit,
+    build_rendered_page_inspection,
+    finite_confidence,
+    parse_page_range_arguments,
+    presentation_with_media_recovery,
+    sha256_bytes,
+    snapshot_regular_file,
+)
+
 # Field-shape and behavior versions are deliberately separate. A missing
 # schema_version/pipeline_version identifies the legacy extractor output.
-# v2 adds the fixed-shape native_timing record on every slide plus stable deck
-# totals. The additive shape does not change v1 fields, but a v1 record cannot
-# answer timing questions and must not turn missing metadata into a zero count.
-SCHEMA_VERSION = 2
-PIPELINE_VERSION = "1.1.0"
+# v2 added fixed-shape native timing. V3 adds a raw build-list lane, a closed
+# native-deck audit, and an exact rendered-page inspection receipt.
+SCHEMA_VERSION = PPTX_EXTRACTION_SCHEMA_VERSION
+PIPELINE_VERSION = PPTX_EXTRACTION_PIPELINE_VERSION
 
 # PresentationML timing elements are counted by exact qualified name and kept
 # in separate semantic lanes. In particular, a <p:timing> container or a media
@@ -69,6 +76,12 @@ _ANIMATION_BEHAVIOR_ELEMENTS = {
 _MEDIA_TIMING_ELEMENTS = {
     "audio": "p:audio",
     "video": "p:video",
+}
+_BUILD_ENTRY_ELEMENTS = {
+    "paragraph": "p:bldP",
+    "diagram": "p:bldDgm",
+    "ole_chart": "p:bldOleChart",
+    "graphic": "p:bldGraphic",
 }
 _TIMING_PROVENANCE = {
     "source": "pptx_package_xml",
@@ -89,14 +102,6 @@ _GRAPHIC_DATA_URI_OLE = (
     "http://schemas.openxmlformats.org/presentationml/2006/ole"
 )
 
-# A valid, transparent one-pixel PNG. When a ZIP member under ppt/media has a
-# bad CRC, the extractor substitutes this blob in an in-memory copy of the
-# package. That preserves every healthy slide/shape while making the lost asset
-# explicit in corrupt_assets; the source file is never rewritten.
-_RECOVERY_IMAGE_BYTES = base64.b64decode(
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
-)
-
 # A picture covering at least this fraction of the slide is large enough to be
 # carrying rendered text — AI-generated illustration decks bake titles, callout
 # labels, and annotations into the image, where python-pptx cannot see them.
@@ -111,6 +116,11 @@ _TEXT_BEARING_IMAGE_AREA_RATIO = 0.5
 # cites and transcript cross-checks, not a full document dump.
 _OCR_TEXT_MAX_CHARS = 8000
 
+# Mean Tesseract token confidence uses the engine's documented 0..100 scale.
+# Text below this floor remains visible for spelling review but is not marked
+# trustworthy evidence.
+_OCR_TRUST_CONFIDENCE = 50.0
+
 # One stderr warning per process when the OCR engine is missing — not once
 # per slide on a 100-slide deck.
 _ocr_unavailable_warned = False
@@ -118,18 +128,22 @@ _ocr_unavailable_warned = False
 # Cached tesseract availability for this process: None = not checked yet.
 _tesseract_available = None
 
+# Populated by the same availability probe, then repeated on every asset
+# receipt so an OCR result is reproducible and distinguishable from a skip.
+_tesseract_version = None
+
 
 class OcrUnavailableError(Exception):
     """Tesseract (or its Python binding) is not available on this machine."""
 
 
-def _count_in_timing(timing_elements, qualified_name):
-    """Count exact descendants across presentation timing containers."""
+def _count_in_containers(containers, qualified_name):
+    """Count exact descendants across selected PresentationML containers."""
     tag = qn(qualified_name)
     return sum(
         1
-        for timing in timing_elements
-        for _element in timing.iter(tag)
+        for container in containers
+        for _element in container.iter(tag)
     )
 
 
@@ -151,21 +165,27 @@ def extract_native_timing(slide):
     """
     root = slide.element
     timing_elements = list(root.iter(qn("p:timing")))
+    build_lists = list(root.iter(qn("p:bldLst")))
     set_actions = [
         element
         for timing in timing_elements
         for element in timing.iter(qn("p:set"))
     ]
     animation_counts = {
-        name: _count_in_timing(timing_elements, qualified_name)
+        name: _count_in_containers(timing_elements, qualified_name)
         for name, qualified_name in _ANIMATION_BEHAVIOR_ELEMENTS.items()
     }
     animation_counts["total"] = sum(animation_counts.values())
     media_counts = {
-        name: _count_in_timing(timing_elements, qualified_name)
+        name: _count_in_containers(timing_elements, qualified_name)
         for name, qualified_name in _MEDIA_TIMING_ELEMENTS.items()
     }
     media_counts["total"] = sum(media_counts.values())
+    build_counts = {
+        name: _count_in_containers(build_lists, qualified_name)
+        for name, qualified_name in _BUILD_ENTRY_ELEMENTS.items()
+    }
+    build_counts["total"] = sum(build_counts.values())
     part_name = str(slide.part.partname).lstrip("/")
     return {
         "timing_element_present": bool(timing_elements),
@@ -177,8 +197,12 @@ def extract_native_timing(slide):
         ),
         "animation_behavior_counts": animation_counts,
         "media_timing_counts": media_counts,
+        "build_list_present": bool(build_lists),
+        "build_list_count": len(build_lists),
+        "build_entry_counts": build_counts,
         "has_animation_behaviors": animation_counts["total"] > 0,
         "has_media_timing": media_counts["total"] > 0,
+        "has_build_entries": build_counts["total"] > 0,
         "provenance": {
             **_TIMING_PROVENANCE,
             "part_name": part_name,
@@ -192,15 +216,19 @@ def summarize_native_timing(per_slide_visual):
         name: 0 for name in _ANIMATION_BEHAVIOR_ELEMENTS
     }
     media_counts = {name: 0 for name in _MEDIA_TIMING_ELEMENTS}
+    build_counts = {name: 0 for name in _BUILD_ENTRY_ELEMENTS}
     summary = {
         "slides_with_timing_elements": 0,
         "slides_with_transitions": 0,
         "slides_with_animation_behaviors": 0,
         "slides_with_media_timing": 0,
+        "slides_with_build_lists": 0,
+        "slides_with_build_entries": 0,
         "timing_element_count": 0,
         "transition_count": 0,
         "set_action_count": 0,
         "visibility_set_action_count": 0,
+        "build_list_count": 0,
     }
     for slide_data in per_slide_visual:
         timing = slide_data["native_timing"]
@@ -212,23 +240,32 @@ def summarize_native_timing(per_slide_visual):
             timing["has_animation_behaviors"])
         summary["slides_with_media_timing"] += int(
             timing["has_media_timing"])
+        summary["slides_with_build_lists"] += int(
+            timing["build_list_present"])
+        summary["slides_with_build_entries"] += int(
+            timing["has_build_entries"])
         for field in (
             "timing_element_count",
             "transition_count",
             "set_action_count",
             "visibility_set_action_count",
+            "build_list_count",
         ):
             summary[field] += timing[field]
         for name in animation_counts:
             animation_counts[name] += timing["animation_behavior_counts"][name]
         for name in media_counts:
             media_counts[name] += timing["media_timing_counts"][name]
+        for name in build_counts:
+            build_counts[name] += timing["build_entry_counts"][name]
     animation_counts["total"] = sum(animation_counts.values())
     media_counts["total"] = sum(media_counts.values())
+    build_counts["total"] = sum(build_counts.values())
     return {
         **summary,
         "animation_behavior_counts": animation_counts,
         "media_timing_counts": media_counts,
+        "build_entry_counts": build_counts,
         "provenance": dict(_TIMING_PROVENANCE),
     }
 
@@ -240,74 +277,6 @@ def _input_fingerprint(blob):
         "digest": hashlib.sha256(blob).hexdigest(),
         "size_bytes": len(blob),
     }
-
-
-def _is_embedded_media_member(member_name):
-    """Return whether a ZIP member is an independently recoverable asset."""
-    normalized = member_name.replace("\\", "/").lstrip("/")
-    return normalized.startswith("ppt/media/") and not normalized.endswith("/")
-
-
-def _validate_zip_members(package_blob):
-    """Return corrupt ZIP member names, validating every member's CRC."""
-    corrupt = []
-    try:
-        with zipfile.ZipFile(io.BytesIO(package_blob)) as archive:
-            for member in archive.infolist():
-                try:
-                    with archive.open(member) as stream:
-                        while stream.read(1024 * 1024):
-                            pass
-                except (zipfile.BadZipFile, ZlibError):
-                    corrupt.append(member.filename)
-    except zipfile.BadZipFile as e:
-        raise ValueError("invalid PPTX ZIP container") from e
-    return corrupt
-
-
-def _presentation_with_media_recovery(package_blob):
-    """Load a presentation, substituting only corrupt embedded media.
-
-    XML, relationships, and other structural package parts are not safe to
-    discard. A corrupt non-media member therefore remains a hard error, while
-    corrupt assets under ppt/media are replaced in an in-memory copy so the
-    rest of the deck can still be cataloged.
-    """
-    corrupt_names = _validate_zip_members(package_blob)
-    if not corrupt_names:
-        return Presentation(io.BytesIO(package_blob)), []
-
-    unsafe = [name for name in corrupt_names if not _is_embedded_media_member(name)]
-    if unsafe:
-        joined = ", ".join(sorted(unsafe))
-        raise ValueError(f"corrupt structural PPTX member(s): {joined}")
-
-    recovered_package = io.BytesIO()
-    corrupt_set = set(corrupt_names)
-    try:
-        with (
-            zipfile.ZipFile(io.BytesIO(package_blob)) as source,
-            zipfile.ZipFile(recovered_package, "w") as destination,
-        ):
-            for member in source.infolist():
-                if member.filename in corrupt_set:
-                    payload = _RECOVERY_IMAGE_BYTES
-                else:
-                    payload = source.read(member)
-                destination.writestr(member, payload)
-    except (zipfile.BadZipFile, ZlibError) as e:
-        raise ValueError("could not recover corrupt PPTX media") from e
-
-    recovered_package.seek(0)
-    assets = [
-        {
-            "part_name": name,
-            "error_type": "crc_mismatch",
-            "status": "recovered_with_placeholder",
-        }
-        for name in sorted(corrupt_names)
-    ]
-    return Presentation(recovered_package), assets
 
 
 def picture_area_ratio(shape, prs):
@@ -331,15 +300,42 @@ def normalize_ocr_text(text):
     return re.sub(r"\s+", " ", text).strip()
 
 
+def _ocr_text_and_confidence(data):
+    """Pair each retained Tesseract token with only its own confidence."""
+    tokens = []
+    confidences = []
+    for token, raw_confidence in zip(
+        data.get("text", []), data.get("conf", [])
+    ):
+        normalized = normalize_ocr_text(token)
+        if not normalized:
+            continue
+        tokens.append(normalized)
+        try:
+            confidence = float(raw_confidence)
+        except (TypeError, ValueError):
+            continue
+        normalized_confidence = finite_confidence(confidence)
+        if normalized_confidence is not None:
+            confidences.append(normalized_confidence)
+    text = normalize_ocr_text(" ".join(tokens))[:_OCR_TEXT_MAX_CHARS]
+    confidence = (
+        round(sum(confidences) / len(confidences), 3)
+        if confidences
+        else None
+    )
+    return text, confidence
+
+
 def _require_tesseract():
     """Ensure tesseract + bindings are available; cache the result per process.
 
     Raises OcrUnavailableError when missing. Subsequent calls in the same
     process do not re-spawn the version check.
     """
-    global _tesseract_available
+    global _tesseract_available, _tesseract_version
     if _tesseract_available is True:
-        return
+        return _tesseract_version
     if _tesseract_available is False:
         raise OcrUnavailableError(
             "tesseract binary not found; install tesseract-ocr (apt) or "
@@ -355,7 +351,7 @@ def _require_tesseract():
         ) from e
 
     try:
-        pytesseract.get_tesseract_version()
+        version = pytesseract.get_tesseract_version()
     except pytesseract.TesseractNotFoundError as e:
         _tesseract_available = False
         raise OcrUnavailableError(
@@ -364,48 +360,109 @@ def _require_tesseract():
         ) from e
 
     _tesseract_available = True
+    _tesseract_version = str(version)[:128]
+    return _tesseract_version
 
 
-def ocr_image_bytes(blob):
-    """OCR a single image blob. Returns normalized text (maybe empty).
-
-    Raises OcrUnavailableError when the engine or its binding is missing.
-    Unreadable blobs and per-image OCR failures return "" so one bad picture
-    does not abort the deck.
-    """
+def _ocr_image_result(blob):
+    """OCR one image and return an outcome distinct from asset provenance."""
     global _tesseract_available
-    _require_tesseract()
+    engine_version = _require_tesseract()
 
     try:
         import pytesseract
-        from PIL import Image
+        from PIL import Image, UnidentifiedImageError
     except ImportError as e:
         raise OcrUnavailableError(
             "OCR requires Pillow and pytesseract; install project dependencies"
         ) from e
+    pillow_errors = (
+        UnidentifiedImageError,
+        Image.DecompressionBombError,
+        OSError,
+    )
 
     try:
         img = Image.open(io.BytesIO(blob))
-    except OSError as e:
-        sys.stderr.write(f"WARN: OCR skipped unreadable image blob: {e}\n")
-        return ""
-
-    if img.mode not in ("RGB", "L"):
-        img = img.convert("RGB")
+    except pillow_errors as e:
+        error_code = f"image_decode_error:{type(e).__name__}"[:512]
+        sys.stderr.write(f"WARN: OCR skipped image blob ({error_code})\n")
+        return {
+            "attempted": True,
+            "engine": "tesseract",
+            "engine_version": engine_version,
+            "result_status": "failed",
+            "result_confidence": None,
+            "error": error_code,
+            "recovered_text": "",
+            "trustworthy_text": False,
+        }
 
     try:
-        raw = pytesseract.image_to_string(img)
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+        data = pytesseract.image_to_data(
+            img,
+            output_type=pytesseract.Output.DICT,
+        )
     except pytesseract.TesseractNotFoundError as e:
         _tesseract_available = False
         raise OcrUnavailableError(
             "tesseract binary not found; install tesseract-ocr (apt) or "
             "tesseract (brew)"
         ) from e
+    except pillow_errors as e:
+        error_code = f"image_decode_error:{type(e).__name__}"[:512]
+        sys.stderr.write(f"WARN: OCR failed on image blob ({error_code})\n")
+        return {
+            "attempted": True,
+            "engine": "tesseract",
+            "engine_version": engine_version,
+            "result_status": "failed",
+            "result_confidence": None,
+            "error": error_code,
+            "recovered_text": "",
+            "trustworthy_text": False,
+        }
     except pytesseract.TesseractError as e:
-        sys.stderr.write(f"WARN: OCR failed on image blob: {e}\n")
-        return ""
+        error_code = f"engine_error:{type(e).__name__}"[:512]
+        sys.stderr.write(f"WARN: OCR failed on image blob ({error_code})\n")
+        return {
+            "attempted": True,
+            "engine": "tesseract",
+            "engine_version": engine_version,
+            "result_status": "failed",
+            "result_confidence": None,
+            "error": error_code,
+            "recovered_text": "",
+            "trustworthy_text": False,
+        }
 
-    return normalize_ocr_text(raw)
+    text, confidence = _ocr_text_and_confidence(data)
+    trustworthy = bool(
+        text and confidence is not None and confidence >= _OCR_TRUST_CONFIDENCE
+    )
+    if not text:
+        status = "genuine_empty"
+    elif trustworthy:
+        status = "text_recovered"
+    else:
+        status = "low_confidence_text"
+    return {
+        "attempted": True,
+        "engine": "tesseract",
+        "engine_version": engine_version,
+        "result_status": status,
+        "result_confidence": confidence,
+        "error": None,
+        "recovered_text": text,
+        "trustworthy_text": trustworthy,
+    }
+
+
+def ocr_image_bytes(blob):
+    """OCR one image and return recovered text for legacy callers."""
+    return _ocr_image_result(blob)["recovered_text"]
 
 
 def ocr_picture_blobs(blobs):
@@ -435,45 +492,201 @@ def _append_ocr_text(slide_data, text):
 
 
 def _run_ocr_channel(
-    slide_data, blobs, *, channel, provenance, ocr=True, ocr_fn=None,
+    slide_data, assets, *, channel, provenance, ocr=True, ocr_fn=None,
 ):
-    """OCR one image source and emit channel-level provenance/confidence."""
+    """OCR image assets and emit one outcome receipt for every exact blob."""
     record = {
         "channel": channel,
         "text": "",
         "confidence": "low",
-        "status": "unavailable" if not blobs else "pending",
+        "result_confidence": None,
+        "status": "unavailable" if not assets else "pending",
+        "attempted": False,
+        "engine": "tesseract",
+        "engine_version": None,
+        "reason": "no_readable_asset" if not assets else None,
         "provenance": provenance,
+        "ocr_receipts": [],
     }
     slide_data["text_channels"].append(record)
 
-    if not blobs:
+    if not assets:
         return
     if not ocr:
         record["status"] = "skipped"
+        record["reason"] = "ocr_disabled"
+        for asset in assets:
+            record["ocr_receipts"].append({
+                "attempted": False,
+                "engine": "tesseract",
+                "engine_version": None,
+                "result_status": "skipped",
+                "result_confidence": None,
+                "error": "ocr_disabled",
+                "part_name": asset.get("part_name"),
+                "asset_sha256": sha256_bytes(asset["blob"]),
+                "shape_path": list(asset.get("shape_path") or []),
+                "recovered_text": "",
+                "trustworthy_text": False,
+            })
         return
 
-    run_ocr = ocr_fn if ocr_fn is not None else ocr_picture_blobs
     global _ocr_unavailable_warned
-    try:
-        text = normalize_ocr_text(run_ocr(blobs))
-        record["text"] = text
-        record["status"] = "extracted" if text else "empty"
-        _append_ocr_text(slide_data, text)
-        slide_data["text_extraction_method"] = "shapes+ocr"
-    except OcrUnavailableError as e:
+    for asset in assets:
+        blob = asset["blob"]
+        try:
+            if ocr_fn is None:
+                outcome = _ocr_image_result(blob)
+            else:
+                injected = ocr_fn([blob])
+                if isinstance(injected, dict):
+                    recovered_text = normalize_ocr_text(
+                        injected.get("recovered_text", "")
+                    )[:_OCR_TEXT_MAX_CHARS]
+                    injected_engine = injected.get("engine", "injected")
+                    injected_version = injected.get("engine_version")
+                    injected_error = injected.get("error")
+                    outcome = {
+                        "attempted": injected.get("attempted", True) is True,
+                        "engine": (
+                            injected_engine[:128]
+                            if isinstance(injected_engine, str)
+                            else "injected"
+                        ),
+                        "engine_version": (
+                            injected_version[:128]
+                            if isinstance(injected_version, str)
+                            else None
+                        ),
+                        "result_status": injected.get("result_status") or (
+                            "text_recovered" if recovered_text else "genuine_empty"
+                        ),
+                        "result_confidence": finite_confidence(
+                            injected.get("result_confidence")
+                        ),
+                        "error": (
+                            injected_error[:512]
+                            if isinstance(injected_error, str)
+                            else None
+                        ),
+                        "recovered_text": recovered_text,
+                        "trustworthy_text": (
+                            injected.get("trustworthy_text", bool(recovered_text))
+                            is True
+                        ),
+                    }
+                else:
+                    text = normalize_ocr_text(injected)[:_OCR_TEXT_MAX_CHARS]
+                    outcome = {
+                        "attempted": True,
+                        "engine": "injected",
+                        "engine_version": None,
+                        "result_status": (
+                            "text_recovered" if text else "genuine_empty"
+                        ),
+                        "result_confidence": None,
+                        "error": None,
+                        "recovered_text": text,
+                        "trustworthy_text": bool(text),
+                    }
+        except OcrUnavailableError as e:
+            outcome = {
+                "attempted": False,
+                "engine": "tesseract",
+                "engine_version": None,
+                "result_status": "unavailable",
+                "result_confidence": None,
+                "error": str(e)[:512],
+                "recovered_text": "",
+                "trustworthy_text": False,
+            }
+            if not _ocr_unavailable_warned:
+                sys.stderr.write(
+                    f"WARN: OCR unavailable ({e}); low-confidence slides will "
+                    "retain per-asset unavailable receipts. Install tesseract "
+                    "to enable OCR.\n"
+                )
+                _ocr_unavailable_warned = True
+        record["ocr_receipts"].append({
+            **outcome,
+            "part_name": asset.get("part_name"),
+            "asset_sha256": sha256_bytes(blob),
+            "shape_path": list(asset.get("shape_path") or []),
+        })
+
+    recovered = [
+        receipt["recovered_text"]
+        for receipt in record["ocr_receipts"]
+        if receipt["recovered_text"]
+    ]
+    text = normalize_ocr_text(" | ".join(recovered))[:_OCR_TEXT_MAX_CHARS]
+    record["text"] = text
+    confidences = [
+        receipt["result_confidence"]
+        for receipt in record["ocr_receipts"]
+        if receipt["result_confidence"] is not None
+    ]
+    if confidences:
+        record["result_confidence"] = round(
+            sum(confidences) / len(confidences), 3
+        )
+    statuses = {
+        receipt["result_status"] for receipt in record["ocr_receipts"]
+    }
+    record["attempted"] = any(
+        receipt["attempted"] for receipt in record["ocr_receipts"]
+    )
+    engines = {
+        receipt["engine"]
+        for receipt in record["ocr_receipts"]
+        if isinstance(receipt.get("engine"), str) and receipt["engine"]
+    }
+    record["engine"] = next(iter(engines)) if len(engines) == 1 else None
+    versions = {
+        receipt["engine_version"]
+        for receipt in record["ocr_receipts"]
+        if isinstance(receipt.get("engine_version"), str)
+        and receipt["engine_version"]
+    }
+    record["engine_version"] = (
+        next(iter(versions)) if len(versions) == 1 else None
+    )
+    all_recovered_text_trustworthy = all(
+        receipt["trustworthy_text"] is True
+        for receipt in record["ocr_receipts"]
+        if receipt["recovered_text"]
+    )
+    if (
+        text
+        and statuses == {"text_recovered"}
+        and all_recovered_text_trustworthy
+    ):
+        record["status"] = "extracted"
+    elif text:
+        record["status"] = "partial"
+    elif statuses == {"genuine_empty"}:
+        record["status"] = "empty"
+    elif "failed" in statuses:
+        record["status"] = "failed"
+    elif statuses == {"unavailable"}:
         record["status"] = "unavailable"
+        record["reason"] = "ocr_engine_unavailable"
+    else:
+        record["status"] = "partial"
+    if record["status"] == "failed":
+        record["reason"] = "ocr_failed"
+    elif record["status"] == "partial":
+        record["reason"] = "partial_ocr_results"
+    _append_ocr_text(slide_data, text)
+    if any(receipt["attempted"] for receipt in record["ocr_receipts"]):
+        slide_data["text_extraction_method"] = "shapes+ocr"
+    elif statuses == {"unavailable"}:
         slide_data["text_extraction_method"] = "shapes+ocr_unavailable"
-        if not _ocr_unavailable_warned:
-            sys.stderr.write(
-                f"WARN: OCR unavailable ({e}); low-confidence slides will "
-                f"have empty OCR channels. Install tesseract to enable.\n"
-            )
-            _ocr_unavailable_warned = True
 
 
 def apply_ocr_to_slide(
     slide_data, picture_blobs, *, ocr=True, ocr_fn=None, shape_paths=None,
+    part_names=None,
 ):
     """Fill picture OCR fields on a per-slide dict.
 
@@ -481,17 +694,35 @@ def apply_ocr_to_slide(
     available. Image-background slides with no PICTURE shapes have no blob to
     OCR here (rendering the page is out of this script's scope).
 
-    ocr_fn is injectable for tests (signature: list[bytes] -> str). Default
-    is ocr_picture_blobs.
+    ocr_fn is injectable for tests (signature: list[bytes] -> str|dict). The
+    production path runs Tesseract independently for each asset.
     """
     if slide_data.get("text_extraction_confidence") != "low":
         return slide_data
     if not picture_blobs:
+        if slide_data.get("has_image") is True:
+            _run_ocr_channel(
+                slide_data,
+                [],
+                channel="picture_ocr",
+                provenance={
+                    "source": "embedded_picture_blobs",
+                    "shape_paths": shape_paths or [],
+                },
+                ocr=ocr,
+                ocr_fn=ocr_fn,
+            )
         return slide_data
 
+    paths = shape_paths or [[] for _blob in picture_blobs]
+    names = part_names or [None for _blob in picture_blobs]
+    assets = [
+        {"blob": blob, "shape_path": path, "part_name": part_name}
+        for blob, path, part_name in zip(picture_blobs, paths, names)
+    ]
     _run_ocr_channel(
         slide_data,
-        picture_blobs,
+        assets,
         channel="picture_ocr",
         provenance={
             "source": "embedded_picture_blobs",
@@ -512,11 +743,16 @@ def apply_background_ocr(slide_data, background_image, *, ocr=True, ocr_fn=None)
             "provenance": {"source": "pptx_background_image"},
         }
     blob = background_image.get("blob")
+    provenance = background_image["provenance"]
     _run_ocr_channel(
         slide_data,
-        [blob] if blob else [],
+        ([{
+            "blob": blob,
+            "shape_path": [],
+            "part_name": provenance.get("part_name"),
+        }] if blob else []),
         channel="background_image_ocr",
-        provenance=background_image["provenance"],
+        provenance=provenance,
         ocr=ocr,
         ocr_fn=ocr_fn,
     )
@@ -902,16 +1138,26 @@ def extract_template_layouts(prs):
     return layouts
 
 
-def extract_pptx(pptx_path, *, ocr=True, ocr_fn=None):
+def extract_pptx(
+    pptx_path,
+    *,
+    ocr=True,
+    ocr_fn=None,
+    rendered_pdf_path=None,
+    inspected_page_ranges=None,
+):
     """Main extraction function.
 
     ocr: when True (default), low-confidence image channels get an OCR
          inventory in ocr_text and text_channels.
     ocr_fn: optional callable(list[bytes]) -> str for tests; default uses
             tesseract via ocr_picture_blobs.
+    rendered_pdf_path/inspected_page_ranges: optional exact rendered artifact
+            plus the page ranges actually inspected for the native-deck audit.
     """
-    package_blob = Path(pptx_path).read_bytes()
-    prs, corrupt_assets = _presentation_with_media_recovery(package_blob)
+    package_blob = snapshot_regular_file(pptx_path, label="PPTX artifact")
+    source_fingerprint = _input_fingerprint(package_blob)
+    prs, archive_recovery = presentation_with_media_recovery(package_blob)
     slide_width = prs.slide_width
     slide_height = prs.slide_height
     if slide_width is None or slide_height is None:
@@ -921,11 +1167,13 @@ def extract_pptx(pptx_path, *, ocr=True, ocr_fn=None):
     if slide_width_value <= 0 or slide_height_value <= 0:
         raise ValueError("PPTX presentation has invalid slide dimensions")
     ratio_divisor = gcd(slide_width_value, slide_height_value)
-    corrupt_part_names = {asset["part_name"] for asset in corrupt_assets}
+    corrupt_part_names = {
+        str(record["part_name"]) for record in archive_recovery
+    }
     result = {
         "schema_version": SCHEMA_VERSION,
         "pipeline_version": PIPELINE_VERSION,
-        "input_fingerprint": _input_fingerprint(package_blob),
+        "input_fingerprint": source_fingerprint,
         "pptx_path": os.fspath(pptx_path),
         "slide_count": len(prs.slides),
         "slide_width_inches": round(slide_width_value / 914400, 2),
@@ -934,7 +1182,15 @@ def extract_pptx(pptx_path, *, ocr=True, ocr_fn=None):
             f"{slide_width_value // ratio_divisor}:"
             f"{slide_height_value // ratio_divisor}"
         ),
-        "corrupt_assets": corrupt_assets,
+        "corrupt_assets": [
+            {
+                "part_name": record["part_name"],
+                "error_type": record["error_type"],
+                "status": "recovered_with_placeholder",
+            }
+            for record in archive_recovery
+        ],
+        "archive_recovery": archive_recovery,
         "template_layouts": extract_template_layouts(prs),
         "per_slide_visual": [],
         "global_design": {
@@ -1125,12 +1381,14 @@ def extract_pptx(pptx_path, *, ocr=True, ocr_fn=None):
         picture_entries.sort(key=lambda item: item[0], reverse=True)
         picture_blobs = [entry[1] for entry in picture_entries]
         picture_paths = [entry[2] for entry in picture_entries]
+        picture_part_names = [entry[3] for entry in picture_entries]
         apply_ocr_to_slide(
             slide_data,
             picture_blobs,
             ocr=ocr,
             ocr_fn=ocr_fn,
             shape_paths=picture_paths,
+            part_names=picture_part_names,
         )
 
         if bg_type == "image":
@@ -1173,7 +1431,35 @@ def extract_pptx(pptx_path, *, ocr=True, ocr_fn=None):
             result["global_design"]["background_colors"][bg_hex] += 1
         result["global_design"]["color_sequence"].append(bg_hex or "unknown")
 
+        slide_data["render_required_reasons"].sort()
         result["per_slide_visual"].append(slide_data)
+
+    required_reasons = {
+        slide_data["slide_number"]: slide_data["render_required_reasons"]
+        for slide_data in result["per_slide_visual"]
+        if slide_data["render_required"]
+    }
+    if inspected_page_ranges and rendered_pdf_path is None:
+        raise PptxEvidenceError(
+            "inspected_page_ranges requires rendered_pdf_path so the assertion "
+            "can be identity-bound"
+        )
+    render_receipt = None
+    if rendered_pdf_path is not None:
+        render_receipt = build_rendered_page_inspection(
+            source_pptx_sha256=source_fingerprint["digest"],
+            rendered_pdf_path=rendered_pdf_path,
+            inspected_page_ranges=inspected_page_ranges or [],
+            required_slide_numbers=sorted(required_reasons),
+            slide_count=len(prs.slides),
+        )
+    result["native_deck_audit"] = build_native_deck_audit(
+        source_pptx_sha256=source_fingerprint["digest"],
+        source_pptx_size_bytes=source_fingerprint["size_bytes"],
+        slide_count=len(prs.slides),
+        render_required_reasons=required_reasons,
+        rendered_page_inspection=render_receipt,
+    )
 
     # Convert Counters to dicts for JSON serialization
     result["global_design"]["fonts_used"] = dict(result["global_design"]["fonts_used"])
@@ -1218,9 +1504,9 @@ def batch_extract(directory, skip_patterns, *, ocr=True):
             data = extract_pptx(pptx_path, ocr=ocr)
             results.append(data)
             print(f"OK:   {pptx_path} ({data['slide_count']} slides)", file=sys.stderr)
-        except Exception as e:
-            skipped.append({"path": pptx_path, "reason": f"error: {e}"})
-            print(f"FAIL: {pptx_path}: {e}", file=sys.stderr)
+        except (PptxEvidenceError, OSError, ValueError, KeyError, AttributeError) as exc:
+            skipped.append({"path": pptx_path, "reason": f"error: {exc}"})
+            print(f"FAIL: {pptx_path}: {exc}", file=sys.stderr)
 
     return results, skipped
 
@@ -1242,6 +1528,17 @@ def main(argv=None):
         help="Skip OCR on low-confidence slides (shape walk only)",
     )
     parser.add_argument(
+        "--rendered-pdf",
+        help="PDF rendered from the exact input PPTX for identity-bound review",
+    )
+    parser.add_argument(
+        "--inspected-pages",
+        action="append",
+        default=[],
+        metavar="PAGE|START-END",
+        help="Rendered pages actually inspected; repeat or comma-separate values",
+    )
+    parser.add_argument(
         "--version",
         action="store_true",
         help="Print extractor schema and pipeline versions as JSON",
@@ -1256,18 +1553,39 @@ def main(argv=None):
     if args.path is None:
         parser.error("path is required unless --version is used")
     ocr = not args.no_ocr
+    try:
+        inspected_page_ranges = parse_page_range_arguments(args.inspected_pages)
+    except PptxEvidenceError as exc:
+        parser.error(str(exc))
 
     if os.path.isfile(args.path):
-        result = extract_pptx(args.path, ocr=ocr)
+        try:
+            result = extract_pptx(
+                args.path,
+                ocr=ocr,
+                rendered_pdf_path=args.rendered_pdf,
+                inspected_page_ranges=inspected_page_ranges,
+            )
+        # The preflight caller treats an invalid/nonzero process result as the
+        # silent-failure shape; emit one concise diagnostic so propagation does
+        # not replace the contract with an unstructured traceback.
+        except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+            print(f"ERROR: cannot extract PPTX {args.path}: {exc}", file=sys.stderr)
+            return 1
         print(json.dumps(result, indent=2))
     elif os.path.isdir(args.path):
+        if args.rendered_pdf or inspected_page_ranges:
+            parser.error(
+                "--rendered-pdf/--inspected-pages require a single PPTX input"
+            )
         results, skipped = batch_extract(args.path, args.skip, ocr=ocr)
         output = {"results": results, "skipped": skipped}
         print(json.dumps(output, indent=2))
     else:
         print(f"Error: {args.path} is not a file or directory", file=sys.stderr)
-        sys.exit(1)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/skills/vault-ingress/scripts/pptx_evidence.py
+++ b/skills/vault-ingress/scripts/pptx_evidence.py
@@ -1,0 +1,1659 @@
+#!/usr/bin/env python3
+"""Shared native-deck recovery and exact render-inspection receipts."""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import copy
+import hashlib
+import importlib.util
+import io
+import json
+import math
+import os
+import re
+import signal
+import stat as stat_module
+import subprocess
+import sys
+import tempfile
+import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, Callable
+from zlib import error as ZlibError
+
+
+PPTX_EXTRACTION_SCHEMA_VERSION = 3
+PPTX_EXTRACTION_PIPELINE_VERSION = "1.2.0"
+ARCHIVE_RECOVERY_SCHEMA_VERSION = 1
+NATIVE_DECK_AUDIT_SCHEMA_VERSION = 1
+RENDER_INSPECTION_SCHEMA_VERSION = 1
+PPTX_ARTIFACT_PROBE_SCHEMA_VERSION = 1
+PPTX_ARTIFACT_PROBE_TIMEOUT_SECONDS = 10
+PPTX_ARTIFACT_PROBE_MAX_RESULT_BYTES = 64 * 1024
+PPTX_ARTIFACT_PROBE_MAX_RECOVERY_RECORDS = 64
+PPTX_ARTIFACT_PROBE_CHILD_FLAG = "--artifact-probe-child"
+PPTX_NATIVE_AUDIT_CHILD_FLAG = "--native-audit-child"
+PPTX_MACOS_DATALESS_FLAG = int(
+    getattr(
+        stat_module,
+        "SF_DATALESS",
+        0x40000000 if sys.platform == "darwin" else 0,
+    )
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_AUDIT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "extraction_schema_version",
+        "extraction_pipeline_version",
+        "source_pptx_sha256",
+        "source_pptx_size_bytes",
+        "slide_count",
+        "render_required_slide_numbers",
+        "render_required_reasons",
+        "extraction_receipt_sha256",
+        "rendered_page_inspection",
+    }
+)
+_RENDER_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "source_pptx_sha256",
+        "rendered_pdf_sha256",
+        "rendered_pdf_size_bytes",
+        "rendered_page_count",
+        "inspected_page_ranges",
+        "inspected_required_slide_numbers",
+        "complete",
+        "binding_sha256",
+    }
+)
+_RECOVERY_IMAGE_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+class PptxEvidenceError(ValueError):
+    """A PPTX artifact or evidence receipt violates its closed contract."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str = "pptx_evidence_invalid",
+        details: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.details = dict(details or {})
+
+
+@dataclass(frozen=True)
+class PptxArtifactProbe:
+    """One exact readable deck generation plus any loss-recovery records."""
+
+    slide_count: int
+    source_sha256: str
+    source_size_bytes: int
+    archive_recovery: tuple[dict[str, object], ...]
+
+
+_PPTX_ARTIFACT_PROBE_CACHE: dict[
+    tuple[str, int, int, int, int, int, int],
+    PptxArtifactProbe | tuple[str, str, dict[str, object]],
+] = {}
+_PPTX_NATIVE_AUDIT_CACHE: dict[
+    tuple[str, int, int, int, int, int, int],
+    dict[str, object] | tuple[str, str, dict[str, object]],
+] = {}
+
+
+def sha256_bytes(blob: bytes) -> str:
+    """Return the lowercase SHA-256 digest for exact bytes."""
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _canonical_sha256(value: Mapping[str, object]) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return sha256_bytes(payload)
+
+
+def _require_sha256(value: object, label: str) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise PptxEvidenceError(
+            f"{label} must be a lowercase 64-character SHA-256 digest"
+        )
+    return value
+
+
+def _file_generation(
+    stat_result: os.stat_result,
+) -> tuple[int, int, int, int, int, int]:
+    """Return fields that identify one stable regular-file generation."""
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+        int(getattr(stat_result, "st_flags", 0)),
+    )
+
+
+def snapshot_regular_file(path: str | Path, *, label: str) -> bytes:
+    """Read one exact non-symlink regular-file generation into memory."""
+    artifact = Path(path)
+    try:
+        initial = artifact.lstat()
+    except OSError as exc:
+        raise PptxEvidenceError(
+            f"{label} is unavailable at {artifact}: {exc}",
+            reason_code="pptx_artifact_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    if stat_module.S_ISLNK(initial.st_mode) or not stat_module.S_ISREG(
+        initial.st_mode
+    ):
+        raise PptxEvidenceError(
+            f"{label} must be a non-symlink regular file: {artifact}",
+            reason_code="pptx_artifact_unavailable",
+        )
+    generation = _file_generation(initial)
+    try:
+        with artifact.open("rb") as stream:
+            opened = os.fstat(stream.fileno())
+            if _file_generation(opened) != generation:
+                raise PptxEvidenceError(
+                    f"{label} changed while opening: {artifact}",
+                    reason_code="pptx_artifact_changed",
+                )
+            blob = stream.read()
+            after_read = os.fstat(stream.fileno())
+    except PptxEvidenceError:
+        raise
+    except OSError as exc:
+        raise PptxEvidenceError(
+            f"cannot read {label} at {artifact}: {exc}",
+            reason_code="pptx_artifact_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    try:
+        current = artifact.lstat()
+    except OSError as exc:
+        raise PptxEvidenceError(
+            f"{label} changed while it was read at {artifact}: {exc}",
+            reason_code="pptx_artifact_changed",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    if (
+        _file_generation(after_read) != generation
+        or _file_generation(current) != generation
+        or len(blob) != initial.st_size
+    ):
+        raise PptxEvidenceError(
+            f"{label} changed while reading: {artifact}",
+            reason_code="pptx_artifact_changed",
+        )
+    return blob
+
+
+def _is_embedded_media_member(member_name: str) -> bool:
+    normalized = member_name.replace("\\", "/").lstrip("/")
+    return normalized.startswith("ppt/media/") and not normalized.endswith("/")
+
+
+def _corrupt_zip_members(package_blob: bytes) -> list[str]:
+    """Validate every ZIP member and return those whose payload is corrupt."""
+    corrupt: list[str] = []
+    try:
+        with zipfile.ZipFile(io.BytesIO(package_blob)) as archive:
+            for member in archive.infolist():
+                try:
+                    with archive.open(member) as stream:
+                        while stream.read(1024 * 1024):
+                            pass
+                except (zipfile.BadZipFile, ZlibError):
+                    corrupt.append(member.filename)
+                    if (
+                        len(corrupt)
+                        > PPTX_ARTIFACT_PROBE_MAX_RECOVERY_RECORDS
+                    ):
+                        raise PptxEvidenceError(
+                            "PPTX archive has more corrupt members than the "
+                            "bounded recovery contract permits",
+                            reason_code="pptx_probe_result_oversized",
+                        )
+    except zipfile.BadZipFile as exc:
+        raise PptxEvidenceError(
+            "invalid PPTX ZIP container; restore or re-export the source deck",
+            reason_code="pptx_invalid_container",
+        ) from exc
+    return corrupt
+
+
+def _parse_presentation(package_blob: bytes, *, recovered: bool) -> Any:
+    try:
+        from lxml.etree import XMLSyntaxError
+        from pptx import Presentation
+        from pptx.exc import PackageNotFoundError
+    except ImportError as exc:
+        raise PptxEvidenceError(
+            "PPTX evidence requires the declared python-pptx and lxml runtime "
+            "dependencies; install the speaker-toolkit project dependencies",
+            reason_code="pptx_dependency_unavailable",
+        ) from exc
+    try:
+        return Presentation(io.BytesIO(package_blob))
+    except (
+        zipfile.BadZipFile,
+        ZlibError,
+        PackageNotFoundError,
+        XMLSyntaxError,
+        OSError,
+        ValueError,
+        KeyError,
+    ) as exc:
+        prefix = "recovered PPTX package" if recovered else "PPTX package"
+        raise PptxEvidenceError(
+            f"{prefix} cannot be parsed; restore or re-export the source deck: {exc}",
+            reason_code="pptx_parse_failure",
+        ) from exc
+
+
+def presentation_with_media_recovery(
+    package_blob: bytes,
+) -> tuple[Any, list[dict[str, object]]]:
+    """Open a deck, replacing only CRC-damaged embedded media in memory."""
+    corrupt_names = _corrupt_zip_members(package_blob)
+    if not corrupt_names:
+        return _parse_presentation(package_blob, recovered=False), []
+
+    structural = [
+        name for name in corrupt_names if not _is_embedded_media_member(name)
+    ]
+    if structural:
+        raise PptxEvidenceError(
+            "corrupt structural PPTX member(s) are not recoverable: "
+            f"{', '.join(sorted(structural))}; restore or re-export the source deck",
+            reason_code="pptx_structural_damage",
+            details={"part_names": sorted(structural)},
+        )
+
+    recovered_package = io.BytesIO()
+    corrupt_set = set(corrupt_names)
+    try:
+        with (
+            zipfile.ZipFile(io.BytesIO(package_blob)) as source,
+            zipfile.ZipFile(recovered_package, "w") as destination,
+        ):
+            for member in source.infolist():
+                payload = (
+                    _RECOVERY_IMAGE_BYTES
+                    if member.filename in corrupt_set
+                    else source.read(member)
+                )
+                destination.writestr(member, payload)
+    except (zipfile.BadZipFile, ZlibError, OSError) as exc:
+        raise PptxEvidenceError(
+            "could not recover corrupt PPTX media; restore or re-export the source deck",
+            reason_code="pptx_recovery_failure",
+        ) from exc
+
+    recovery = [
+        {
+            "schema_version": ARCHIVE_RECOVERY_SCHEMA_VERSION,
+            "part_name": name,
+            "member_kind": "embedded_media",
+            "error_type": "crc_mismatch",
+            "status": "recovered_with_placeholder_asset",
+            "content_replaced": True,
+            "replacement_sha256": sha256_bytes(_RECOVERY_IMAGE_BYTES),
+        }
+        for name in sorted(corrupt_names)
+    ]
+    return _parse_presentation(recovered_package.getvalue(), recovered=True), recovery
+
+
+def _probe_pptx_artifact_in_process(path: str | Path) -> PptxArtifactProbe:
+    """Perform the expensive deck probe inside the bounded worker only."""
+    package_blob = snapshot_regular_file(path, label="PPTX artifact")
+    presentation, recovery = presentation_with_media_recovery(package_blob)
+    slide_count = len(presentation.slides)
+    if slide_count < 1:
+        raise PptxEvidenceError(
+            f"PPTX artifact has no slides: {path}",
+            reason_code="pptx_no_slides",
+        )
+    return PptxArtifactProbe(
+        slide_count=slide_count,
+        source_sha256=sha256_bytes(package_blob),
+        source_size_bytes=len(package_blob),
+        archive_recovery=tuple(dict(item) for item in recovery),
+    )
+
+
+_CHILD_PROBE_REASON_CODES = frozenset(
+    {
+        "pptx_artifact_changed",
+        "pptx_artifact_unavailable",
+        "pptx_archive_recovery_required",
+        "pptx_dependency_unavailable",
+        "pptx_evidence_invalid",
+        "pptx_invalid_container",
+        "pptx_no_slides",
+        "pptx_parse_failure",
+        "pptx_probe_exception",
+        "pptx_probe_resource_unavailable",
+        "pptx_probe_result_oversized",
+        "pptx_recovery_failure",
+        "pptx_structural_damage",
+    }
+)
+
+_ARCHIVE_INTEGRITY_CONFIRMATION_REASON_CODES = frozenset(
+    {
+        "pptx_artifact_unavailable",
+        "pptx_archive_recovery_required",
+        "pptx_invalid_container",
+        "pptx_parse_failure",
+        "pptx_probe_result_oversized",
+        "pptx_recovery_failure",
+        "pptx_structural_damage",
+    }
+)
+
+
+def _probe_failure(
+    reason_code: str,
+    *,
+    details: Mapping[str, object] | None = None,
+) -> PptxEvidenceError:
+    """Create one bounded, actionable parent-side probe error."""
+    normalized = dict(details or {})
+    part_names = normalized.get("part_names")
+    joined_parts = (
+        ", ".join(str(name) for name in part_names)
+        if isinstance(part_names, list)
+        else ""
+    )
+    messages = {
+        "pptx_artifact_unavailable": (
+            "PPTX artifact is unavailable; restore the file and retry"
+        ),
+        "pptx_archive_recovery_required": (
+            "PPTX artifact required placeholder archive recovery and cannot "
+            "authorize a fresh native-deck audit"
+            + (f": {joined_parts}" if joined_parts else "")
+            + "; restore or re-export the source deck"
+        ),
+        "pptx_dependency_unavailable": (
+            "PPTX evidence requires the declared python-pptx and lxml runtime "
+            "dependencies; install the speaker-toolkit project dependencies"
+        ),
+        "pptx_evidence_invalid": (
+            "PPTX artifact violates the evidence contract; restore or re-export "
+            "the source deck"
+        ),
+        "pptx_invalid_container": (
+            "invalid PPTX ZIP container; restore or re-export the source deck"
+        ),
+        "pptx_no_slides": "PPTX artifact has no slides; re-export the source deck",
+        "pptx_parse_failure": (
+            "PPTX package cannot be parsed; restore or re-export the source deck"
+        ),
+        "pptx_probe_exception": (
+            "PPTX artifact probe failed unexpectedly inside its bounded worker"
+        ),
+        "pptx_probe_resource_unavailable": (
+            "PPTX artifact probe exhausted worker resources"
+        ),
+        "pptx_probe_result_oversized": (
+            "PPTX artifact probe produced more recovery metadata than the bounded "
+            "result contract permits"
+        ),
+        "pptx_recovery_failure": (
+            "could not recover corrupt PPTX media; restore or re-export the source deck"
+        ),
+        "pptx_structural_damage": (
+            "corrupt structural PPTX member(s) are not recoverable"
+            + (f": {joined_parts}" if joined_parts else "")
+            + "; restore or re-export the source deck"
+        ),
+        "pptx_probe_timeout": (
+            "PPTX artifact probe timed out after "
+            f"{PPTX_ARTIFACT_PROBE_TIMEOUT_SECONDS} seconds; use an independent "
+            "healthy evidence lane or repair/re-export the deck"
+        ),
+        "pptx_probe_start_failure": "could not start the bounded PPTX artifact probe",
+        "pptx_probe_crash": (
+            "PPTX artifact probe terminated inside its bounded worker"
+        ),
+        "pptx_probe_malformed_result": (
+            "PPTX artifact probe returned an invalid bounded result"
+        ),
+        "pptx_probe_materialization_changed": (
+            "PPTX artifact produced inconsistent bounded reads while cloud "
+            "materialization was changing; retry after the file is fully local"
+        ),
+        "pptx_artifact_changed": "PPTX artifact changed while it was being probed",
+        "pptx_cloud_placeholder_unavailable": (
+            "PPTX artifact is a macOS dataless cloud placeholder; download the "
+            "file locally before using native-deck evidence"
+        ),
+    }
+    return PptxEvidenceError(
+        messages.get(reason_code, "PPTX artifact is unavailable"),
+        reason_code=reason_code,
+        details=normalized,
+    )
+
+
+def _probe_child_failure_details(exc: PptxEvidenceError) -> dict[str, object]:
+    """Copy only closed, bounded diagnostic fields into the child result."""
+    details: dict[str, object] = {}
+    raw_names = exc.details.get("part_names")
+    if isinstance(raw_names, list):
+        names = [
+            name
+            for name in raw_names
+            if isinstance(name, str) and 0 < len(name) <= 2048
+        ]
+        if len(names) == len(raw_names) and len(names) <= 64:
+            details["part_names"] = names
+    exception_type = exc.details.get("exception_type")
+    if (
+        isinstance(exception_type, str)
+        and exception_type
+        and len(exception_type) <= 128
+    ):
+        details["exception_type"] = exception_type
+    return details
+
+
+def _pptx_probe_child(path: str | Path) -> dict[str, object]:
+    """Return the closed payload written by the isolated probe worker."""
+    try:
+        probe = _probe_pptx_artifact_in_process(path)
+    except MemoryError:
+        return {
+            "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+            "status": "unavailable",
+            "reason_code": "pptx_probe_resource_unavailable",
+            "details": {},
+        }
+    except PptxEvidenceError as exc:
+        reason_code = (
+            exc.reason_code
+            if exc.reason_code in _CHILD_PROBE_REASON_CODES
+            else "pptx_evidence_invalid"
+        )
+        return {
+            "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+            "status": "unavailable",
+            "reason_code": reason_code,
+            "details": _probe_child_failure_details(exc),
+        }
+    return {
+        "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+        "status": "available",
+        "slide_count": probe.slide_count,
+        "source_sha256": probe.source_sha256,
+        "source_size_bytes": probe.source_size_bytes,
+        "archive_recovery": [dict(item) for item in probe.archive_recovery],
+    }
+
+
+def _write_pptx_probe_result(
+    result_file: BinaryIO,
+    payload: Mapping[str, object],
+) -> None:
+    """Replace the private result through the child's retained descriptor."""
+    rendered = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+    if len(rendered) > PPTX_ARTIFACT_PROBE_MAX_RESULT_BYTES:
+        rendered = (
+            json.dumps(
+                {
+                    "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+                    "status": "unavailable",
+                    "reason_code": "pptx_probe_result_oversized",
+                    "details": {},
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("utf-8")
+    result_file.seek(0)
+    result_file.truncate()
+    remaining = memoryview(rendered)
+    while remaining:
+        written = result_file.write(remaining)
+        if written is None or written <= 0:
+            raise OSError("PPTX probe result write made no progress")
+        remaining = remaining[written:]
+    result_file.flush()
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON object key")
+        result[key] = value
+    return result
+
+
+def _reject_nonstandard_json_constant(_value: str) -> object:
+    raise ValueError("non-standard JSON number")
+
+
+def _validated_recovery_records(value: object) -> tuple[dict[str, object], ...]:
+    if (
+        not isinstance(value, list)
+        or len(value) > PPTX_ARTIFACT_PROBE_MAX_RECOVERY_RECORDS
+    ):
+        raise _probe_failure("pptx_probe_malformed_result")
+    expected_fields = {
+        "schema_version",
+        "part_name",
+        "member_kind",
+        "error_type",
+        "status",
+        "content_replaced",
+        "replacement_sha256",
+    }
+    records: list[dict[str, object]] = []
+    for raw_record in value:
+        if not isinstance(raw_record, dict) or set(raw_record) != expected_fields:
+            raise _probe_failure("pptx_probe_malformed_result")
+        part_name = raw_record.get("part_name")
+        if (
+            raw_record.get("schema_version") != ARCHIVE_RECOVERY_SCHEMA_VERSION
+            or not isinstance(part_name, str)
+            or not _is_embedded_media_member(part_name)
+            or len(part_name) > 2048
+            or raw_record.get("member_kind") != "embedded_media"
+            or raw_record.get("error_type") != "crc_mismatch"
+            or raw_record.get("status") != "recovered_with_placeholder_asset"
+            or raw_record.get("content_replaced") is not True
+            or raw_record.get("replacement_sha256")
+            != sha256_bytes(_RECOVERY_IMAGE_BYTES)
+        ):
+            raise _probe_failure("pptx_probe_malformed_result")
+        records.append(dict(raw_record))
+    part_names = [str(record["part_name"]) for record in records]
+    if part_names != sorted(set(part_names)):
+        raise _probe_failure("pptx_probe_malformed_result")
+    return tuple(records)
+
+
+def _decode_pptx_probe_result(raw: bytes) -> PptxArtifactProbe:
+    if len(raw) > PPTX_ARTIFACT_PROBE_MAX_RESULT_BYTES or not raw.strip():
+        raise _probe_failure("pptx_probe_malformed_result")
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _probe_failure("pptx_probe_malformed_result") from exc
+    if len(decoded.splitlines()) != 1:
+        raise _probe_failure("pptx_probe_malformed_result")
+    try:
+        payload = json.loads(
+            decoded,
+            object_pairs_hook=_unique_json_object,
+            parse_constant=_reject_nonstandard_json_constant,
+        )
+    except (json.JSONDecodeError, RecursionError, ValueError) as exc:
+        raise _probe_failure("pptx_probe_malformed_result") from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != PPTX_ARTIFACT_PROBE_SCHEMA_VERSION
+    ):
+        raise _probe_failure("pptx_probe_malformed_result")
+    if payload.get("status") == "unavailable":
+        if set(payload) != {"schema_version", "status", "reason_code", "details"}:
+            raise _probe_failure("pptx_probe_malformed_result")
+        reason_code = payload.get("reason_code")
+        details = payload.get("details")
+        if reason_code not in _CHILD_PROBE_REASON_CODES or not isinstance(details, dict):
+            raise _probe_failure("pptx_probe_malformed_result")
+        if set(details) - {"part_names", "exception_type"}:
+            raise _probe_failure("pptx_probe_malformed_result")
+        raw_names = details.get("part_names")
+        if raw_names is not None and (
+            not isinstance(raw_names, list)
+            or len(raw_names) > 64
+            or any(
+                not isinstance(name, str) or not name or len(name) > 2048
+                for name in raw_names
+            )
+        ):
+            raise _probe_failure("pptx_probe_malformed_result")
+        exception_type = details.get("exception_type")
+        if exception_type is not None and (
+            not isinstance(exception_type, str)
+            or not exception_type
+            or len(exception_type) > 128
+        ):
+            raise _probe_failure("pptx_probe_malformed_result")
+        raise _probe_failure(str(reason_code), details=details)
+    expected_fields = {
+        "schema_version",
+        "status",
+        "slide_count",
+        "source_sha256",
+        "source_size_bytes",
+        "archive_recovery",
+    }
+    slide_count = payload.get("slide_count")
+    source_size = payload.get("source_size_bytes")
+    source_sha = payload.get("source_sha256")
+    if (
+        payload.get("status") != "available"
+        or set(payload) != expected_fields
+        or isinstance(slide_count, bool)
+        or not isinstance(slide_count, int)
+        or slide_count < 1
+        or isinstance(source_size, bool)
+        or not isinstance(source_size, int)
+        or source_size < 1
+        or not isinstance(source_sha, str)
+        or _SHA256_RE.fullmatch(source_sha) is None
+    ):
+        raise _probe_failure("pptx_probe_malformed_result")
+    return PptxArtifactProbe(
+        slide_count=slide_count,
+        source_sha256=source_sha,
+        source_size_bytes=source_size,
+        archive_recovery=_validated_recovery_records(
+            payload.get("archive_recovery")
+        ),
+    )
+
+
+def _read_pptx_probe_result(result_file: BinaryIO) -> PptxArtifactProbe:
+    try:
+        result_file.seek(0)
+        raw = result_file.read(PPTX_ARTIFACT_PROBE_MAX_RESULT_BYTES + 1)
+    except OSError as exc:
+        raise _probe_failure("pptx_probe_malformed_result") from exc
+    return _decode_pptx_probe_result(raw)
+
+
+def _signal_name(signal_number: int) -> str:
+    try:
+        return signal.Signals(signal_number).name
+    except ValueError:
+        return f"SIG{signal_number}"
+
+
+def _run_bounded_private_worker(
+    path: Path,
+    *,
+    child_flag: str,
+    decoder: Callable[[bytes], Any],
+) -> Any:
+    """Run one output-silent worker and decode its private bounded result."""
+    with tempfile.TemporaryDirectory(prefix="speaker-toolkit-pptx-probe-") as temp:
+        result_path = Path(temp) / "result.json"
+        with result_path.open("x+b", buffering=0) as result_file:
+            command = [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                child_flag,
+                os.fspath(path),
+                os.fspath(result_path),
+            ]
+            try:
+                completed = subprocess.run(
+                    command,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    timeout=PPTX_ARTIFACT_PROBE_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise _probe_failure(
+                    "pptx_probe_timeout",
+                    details={
+                        "timeout_seconds": PPTX_ARTIFACT_PROBE_TIMEOUT_SECONDS
+                    },
+                ) from exc
+            except OSError as exc:
+                raise _probe_failure(
+                    "pptx_probe_start_failure",
+                    details={"exception_type": type(exc).__name__},
+                ) from exc
+            if completed.returncode != 0:
+                if completed.returncode < 0:
+                    signal_number = -completed.returncode
+                    details: dict[str, object] = {
+                        "termination": "signal",
+                        "signal_number": signal_number,
+                        "signal_name": _signal_name(signal_number),
+                    }
+                else:
+                    details = {
+                        "termination": "exit",
+                        "exit_code": completed.returncode,
+                    }
+                raise _probe_failure("pptx_probe_crash", details=details)
+            try:
+                result_file.seek(0)
+                raw = result_file.read(PPTX_ARTIFACT_PROBE_MAX_RESULT_BYTES + 1)
+            except OSError as exc:
+                raise _probe_failure("pptx_probe_malformed_result") from exc
+            return decoder(raw)
+
+
+def _confirm_archive_integrity_failure(
+    artifact: Path,
+    key: tuple[str, int, int, int, int, int, int],
+    first_error: PptxEvidenceError,
+    *,
+    child_flag: str,
+    decoder: Callable[[bytes], Any],
+) -> None:
+    """Require two identical bounded failures before treating damage as stable."""
+    try:
+        _run_bounded_private_worker(
+            artifact,
+            child_flag=child_flag,
+            decoder=decoder,
+        )
+    except PptxEvidenceError as confirmation_error:
+        _confirmed_path, confirmed_key = _probe_file_identity(artifact)
+        if confirmed_key != key:
+            raise _probe_failure("pptx_artifact_changed") from confirmation_error
+        if (
+            confirmation_error.reason_code == first_error.reason_code
+            and confirmation_error.details == first_error.details
+        ):
+            return
+        raise _probe_failure(
+            "pptx_probe_materialization_changed"
+        ) from confirmation_error
+    raise _probe_failure("pptx_probe_materialization_changed") from first_error
+
+
+def _run_bounded_pptx_probe(path: Path) -> PptxArtifactProbe:
+    """Probe one deck in an output-silent, time-bounded worker."""
+    result = _run_bounded_private_worker(
+        path,
+        child_flag=PPTX_ARTIFACT_PROBE_CHILD_FLAG,
+        decoder=_decode_pptx_probe_result,
+    )
+    if not isinstance(result, PptxArtifactProbe):
+        raise _probe_failure("pptx_probe_malformed_result")
+    return result
+
+
+def _probe_file_identity(
+    path: str | Path,
+) -> tuple[Path, tuple[str, int, int, int, int, int, int]]:
+    artifact = Path(path)
+    try:
+        initial = artifact.lstat()
+    except OSError as exc:
+        raise _probe_failure(
+            "pptx_artifact_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    if stat_module.S_ISLNK(initial.st_mode) or not stat_module.S_ISREG(
+        initial.st_mode
+    ):
+        raise _probe_failure("pptx_artifact_unavailable")
+    canonical = artifact.resolve(strict=False)
+    generation = _file_generation(initial)
+    return canonical, (os.fspath(canonical), *generation)
+
+
+def _copy_probe(probe: PptxArtifactProbe) -> PptxArtifactProbe:
+    return PptxArtifactProbe(
+        slide_count=probe.slide_count,
+        source_sha256=probe.source_sha256,
+        source_size_bytes=probe.source_size_bytes,
+        archive_recovery=tuple(dict(item) for item in probe.archive_recovery),
+    )
+
+
+def _cache_probe_result(
+    key: tuple[str, int, int, int, int, int, int],
+    value: PptxArtifactProbe | tuple[str, str, dict[str, object]],
+) -> None:
+    for stale_key in [candidate for candidate in _PPTX_ARTIFACT_PROBE_CACHE if candidate[0] == key[0] and candidate != key]:
+        _PPTX_ARTIFACT_PROBE_CACHE.pop(stale_key, None)
+    _PPTX_ARTIFACT_PROBE_CACHE[key] = value
+
+
+def clear_pptx_artifact_probe_cache() -> None:
+    """Clear process-local probe memoization for tests and explicit refreshes."""
+    _PPTX_ARTIFACT_PROBE_CACHE.clear()
+    _PPTX_NATIVE_AUDIT_CACHE.clear()
+
+
+def probe_pptx_artifact(path: str | Path) -> PptxArtifactProbe:
+    """Return exact deck evidence through a bounded, generation-cached worker."""
+    artifact, key = _probe_file_identity(path)
+    cached = _PPTX_ARTIFACT_PROBE_CACHE.get(key)
+    if isinstance(cached, PptxArtifactProbe):
+        return _copy_probe(cached)
+    if isinstance(cached, tuple):
+        message, reason_code, details = cached
+        raise PptxEvidenceError(
+            message,
+            reason_code=reason_code,
+            details=details,
+        )
+    dataless_flag = PPTX_MACOS_DATALESS_FLAG
+    if dataless_flag and key[-1] & dataless_flag:
+        error = _probe_failure(
+            "pptx_cloud_placeholder_unavailable",
+            details={"st_flags": key[-1]},
+        )
+        cached_error = (str(error), error.reason_code, dict(error.details))
+        _cache_probe_result(key, cached_error)
+        raise error
+    try:
+        probe = _run_bounded_pptx_probe(artifact)
+    except PptxEvidenceError as exc:
+        try:
+            _current_path, current_key = _probe_file_identity(artifact)
+        except PptxEvidenceError:
+            raise _probe_failure("pptx_artifact_changed") from exc
+        if current_key != key:
+            raise _probe_failure("pptx_artifact_changed") from exc
+        if exc.reason_code in {
+            "pptx_artifact_changed",
+            "pptx_probe_materialization_changed",
+        }:
+            raise _probe_failure("pptx_probe_materialization_changed") from exc
+        if exc.reason_code in _ARCHIVE_INTEGRITY_CONFIRMATION_REASON_CODES:
+            _confirm_archive_integrity_failure(
+                artifact,
+                key,
+                exc,
+                child_flag=PPTX_ARTIFACT_PROBE_CHILD_FLAG,
+                decoder=_decode_pptx_probe_result,
+            )
+        cached_error = (str(exc), exc.reason_code, dict(exc.details))
+        _cache_probe_result(key, cached_error)
+        raise PptxEvidenceError(
+            cached_error[0],
+            reason_code=cached_error[1],
+            details=cached_error[2],
+        ) from exc
+    _between_path, between_key = _probe_file_identity(artifact)
+    if between_key != key:
+        raise _probe_failure("pptx_artifact_changed")
+    if probe.archive_recovery:
+        try:
+            confirmation = _run_bounded_pptx_probe(artifact)
+        except PptxEvidenceError as exc:
+            raise _probe_failure("pptx_probe_materialization_changed") from exc
+        _confirmed_path, confirmed_key = _probe_file_identity(artifact)
+        if confirmed_key != key:
+            raise _probe_failure("pptx_artifact_changed")
+        if confirmation != probe:
+            raise _probe_failure("pptx_probe_materialization_changed")
+    _current_path, current_key = _probe_file_identity(artifact)
+    if current_key != key or probe.source_size_bytes != key[3]:
+        raise _probe_failure("pptx_artifact_changed")
+    cached_probe = _copy_probe(probe)
+    _cache_probe_result(key, cached_probe)
+    return _copy_probe(cached_probe)
+
+
+def normalize_page_ranges(
+    ranges: object,
+    *,
+    page_count: int,
+    allow_empty: bool,
+    label: str = "inspected_page_ranges",
+) -> list[list[int]]:
+    """Validate inclusive page ranges and return a normalized copy."""
+    if not isinstance(ranges, list) or (not ranges and not allow_empty):
+        qualifier = "an array" if allow_empty else "a non-empty array"
+        raise PptxEvidenceError(f"{label} must be {qualifier}")
+    normalized: list[list[int]] = []
+    prior_end = 0
+    for index, raw_range in enumerate(ranges):
+        range_label = f"{label}[{index}]"
+        if not isinstance(raw_range, list) or len(raw_range) != 2:
+            raise PptxEvidenceError(
+                f"{range_label} must be a two-item [start, end] array"
+            )
+        start, end = raw_range
+        if (
+            isinstance(start, bool)
+            or isinstance(end, bool)
+            or not isinstance(start, int)
+            or not isinstance(end, int)
+            or start < 1
+            or end < start
+            or end > page_count
+            or start <= prior_end
+        ):
+            raise PptxEvidenceError(
+                f"{range_label} must be ascending, non-overlapping, and inside "
+                f"the verified 1..{page_count} page bound"
+            )
+        normalized.append([start, end])
+        prior_end = end
+    return normalized
+
+
+def pages_covered(ranges: list[list[int]]) -> set[int]:
+    return {page for start, end in ranges for page in range(start, end + 1)}
+
+
+def _normalize_required_slides(value: object, *, slide_count: int) -> list[int]:
+    if not isinstance(value, list):
+        raise PptxEvidenceError("render_required_slide_numbers must be an array")
+    if any(
+        isinstance(number, bool)
+        or not isinstance(number, int)
+        or number < 1
+        or number > slide_count
+        for number in value
+    ):
+        raise PptxEvidenceError(
+            "render_required_slide_numbers must contain integers inside the "
+            f"verified 1..{slide_count} slide bound"
+        )
+    if value != sorted(set(value)):
+        raise PptxEvidenceError(
+            "render_required_slide_numbers must be sorted and duplicate-free"
+        )
+    return list(value)
+
+
+def build_native_deck_audit(
+    *,
+    source_pptx_sha256: str,
+    source_pptx_size_bytes: int,
+    slide_count: int,
+    render_required_reasons: Mapping[int, list[str]],
+    rendered_page_inspection: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build the deterministic native-deck audit emitted by the extractor."""
+    _require_sha256(source_pptx_sha256, "source_pptx_sha256")
+    if (
+        isinstance(source_pptx_size_bytes, bool)
+        or not isinstance(source_pptx_size_bytes, int)
+        or source_pptx_size_bytes < 1
+    ):
+        raise PptxEvidenceError("source_pptx_size_bytes must be positive")
+    if (
+        isinstance(slide_count, bool)
+        or not isinstance(slide_count, int)
+        or slide_count < 1
+    ):
+        raise PptxEvidenceError("slide_count must be positive")
+    normalized_reasons: dict[str, list[str]] = {}
+    for slide_number in sorted(render_required_reasons):
+        reasons = render_required_reasons[slide_number]
+        if (
+            isinstance(slide_number, bool)
+            or not isinstance(slide_number, int)
+            or slide_number < 1
+            or slide_number > slide_count
+            or not isinstance(reasons, list)
+            or not reasons
+            or any(not isinstance(reason, str) or not reason for reason in reasons)
+            or reasons != sorted(set(reasons))
+        ):
+            raise PptxEvidenceError(
+                "render_required_reasons must map valid slide numbers to sorted, "
+                "duplicate-free non-empty reason arrays"
+            )
+        normalized_reasons[str(slide_number)] = list(reasons)
+    required = [int(number) for number in normalized_reasons]
+    identity: dict[str, object] = {
+        "schema_version": NATIVE_DECK_AUDIT_SCHEMA_VERSION,
+        "extraction_schema_version": PPTX_EXTRACTION_SCHEMA_VERSION,
+        "extraction_pipeline_version": PPTX_EXTRACTION_PIPELINE_VERSION,
+        "source_pptx_sha256": source_pptx_sha256,
+        "source_pptx_size_bytes": source_pptx_size_bytes,
+        "slide_count": slide_count,
+        "render_required_slide_numbers": required,
+        "render_required_reasons": normalized_reasons,
+    }
+    return {
+        **identity,
+        "extraction_receipt_sha256": _canonical_sha256(identity),
+        "rendered_page_inspection": (
+            dict(rendered_page_inspection)
+            if rendered_page_inspection is not None
+            else None
+        ),
+    }
+
+
+def _pdf_page_count(path: Path) -> int:
+    pdf_read_error: type[Exception] = ValueError
+    try:
+        from pypdf import PdfReader
+        from pypdf.errors import PdfReadError as ImportedPdfReadError
+
+        pdf_read_error = ImportedPdfReadError
+
+        count = len(PdfReader(os.fspath(path), strict=True).pages)
+    except ImportError as exc:
+        raise PptxEvidenceError(
+            "render receipt validation requires the declared pypdf dependency; "
+            "install the speaker-toolkit project dependencies"
+        ) from exc
+    except (pdf_read_error, OSError, ValueError, KeyError, EOFError) as exc:
+        raise PptxEvidenceError(
+            f"rendered PDF is unreadable at {path}: {type(exc).__name__}"
+        ) from exc
+    if count < 1:
+        raise PptxEvidenceError(f"rendered PDF has no pages at {path}")
+    return count
+
+
+def snapshot_rendered_pdf(path: str | Path) -> tuple[str, int, int]:
+    """Copy, hash, and page-count one exact rendered-PDF generation."""
+    artifact = Path(path)
+    try:
+        initial = artifact.lstat()
+    except OSError as exc:
+        raise PptxEvidenceError(
+            f"rendered PDF is unavailable at {artifact}: {exc}"
+        ) from exc
+    if stat_module.S_ISLNK(initial.st_mode) or not stat_module.S_ISREG(
+        initial.st_mode
+    ):
+        raise PptxEvidenceError(
+            f"rendered PDF must be a non-symlink regular file: {artifact}"
+        )
+    generation = _file_generation(initial)
+    digest = hashlib.sha256()
+    copied_size = 0
+    with tempfile.TemporaryDirectory(prefix="speaker-toolkit-render-") as temp_dir:
+        snapshot = Path(temp_dir) / "rendered.pdf"
+        try:
+            with artifact.open("rb") as source, snapshot.open("xb") as target:
+                opened = os.fstat(source.fileno())
+                if _file_generation(opened) != generation:
+                    raise PptxEvidenceError(
+                        f"rendered PDF changed while opening: {artifact}"
+                    )
+                while True:
+                    chunk = source.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    target.write(chunk)
+                    copied_size += len(chunk)
+                after_read = os.fstat(source.fileno())
+        except PptxEvidenceError:
+            raise
+        except OSError as exc:
+            raise PptxEvidenceError(
+                f"cannot snapshot rendered PDF at {artifact}: {exc}"
+            ) from exc
+        try:
+            current = artifact.lstat()
+        except OSError as exc:
+            raise PptxEvidenceError(
+                f"rendered PDF changed while it was read at {artifact}: {exc}"
+            ) from exc
+        if (
+            _file_generation(after_read) != generation
+            or _file_generation(current) != generation
+            or copied_size != initial.st_size
+        ):
+            raise PptxEvidenceError(
+                f"rendered PDF changed while reading: {artifact}"
+            )
+        page_count = _pdf_page_count(snapshot)
+    return digest.hexdigest(), copied_size, page_count
+
+
+def build_rendered_page_inspection(
+    *,
+    source_pptx_sha256: str,
+    rendered_pdf_path: str | Path,
+    inspected_page_ranges: object,
+    required_slide_numbers: list[int],
+    slide_count: int,
+) -> dict[str, object]:
+    """Bind asserted page inspection to exact PPTX and rendered-PDF identities."""
+    _require_sha256(source_pptx_sha256, "source_pptx_sha256")
+    if (
+        isinstance(slide_count, bool)
+        or not isinstance(slide_count, int)
+        or slide_count < 1
+    ):
+        raise PptxEvidenceError("slide_count must be a positive integer")
+    required = _normalize_required_slides(
+        required_slide_numbers, slide_count=slide_count
+    )
+    pdf_sha256, pdf_size, page_count = snapshot_rendered_pdf(
+        Path(rendered_pdf_path)
+    )
+    if page_count != slide_count:
+        raise PptxEvidenceError(
+            "rendered PDF page count must equal the source deck slide count; "
+            f"expected {slide_count}, got {page_count}"
+        )
+    ranges = normalize_page_ranges(
+        inspected_page_ranges,
+        page_count=page_count,
+        allow_empty=True,
+    )
+    covered = pages_covered(ranges)
+    inspected_required = [number for number in required if number in covered]
+    identity: dict[str, object] = {
+        "schema_version": RENDER_INSPECTION_SCHEMA_VERSION,
+        "source_pptx_sha256": source_pptx_sha256,
+        "rendered_pdf_sha256": pdf_sha256,
+        "rendered_pdf_size_bytes": pdf_size,
+        "rendered_page_count": page_count,
+        "inspected_page_ranges": ranges,
+        "inspected_required_slide_numbers": inspected_required,
+        "complete": inspected_required == required,
+    }
+    return {**identity, "binding_sha256": _canonical_sha256(identity)}
+
+
+def validate_native_deck_audit(
+    value: object,
+    *,
+    slide_count: int | None = None,
+) -> dict[str, object]:
+    """Validate a closed native-deck audit and its optional render receipt."""
+    if not isinstance(value, Mapping):
+        raise PptxEvidenceError("native_deck_audit must be an object")
+    unknown = sorted(set(value) - _AUDIT_FIELDS)
+    missing = sorted(_AUDIT_FIELDS - set(value))
+    if unknown or missing:
+        raise PptxEvidenceError(
+            "native_deck_audit must contain exactly the schema fields; "
+            f"missing={missing}, unknown={unknown}"
+        )
+    if value.get("schema_version") != NATIVE_DECK_AUDIT_SCHEMA_VERSION:
+        raise PptxEvidenceError(
+            "native_deck_audit.schema_version must be "
+            f"{NATIVE_DECK_AUDIT_SCHEMA_VERSION}"
+        )
+    if value.get("extraction_schema_version") != PPTX_EXTRACTION_SCHEMA_VERSION:
+        raise PptxEvidenceError(
+            "native_deck_audit.extraction_schema_version must match the current "
+            f"extractor schema {PPTX_EXTRACTION_SCHEMA_VERSION}"
+        )
+    if value.get("extraction_pipeline_version") != PPTX_EXTRACTION_PIPELINE_VERSION:
+        raise PptxEvidenceError(
+            "native_deck_audit.extraction_pipeline_version must match the current "
+            f"extractor pipeline {PPTX_EXTRACTION_PIPELINE_VERSION}"
+        )
+    source_sha = _require_sha256(
+        value.get("source_pptx_sha256"),
+        "native_deck_audit.source_pptx_sha256",
+    )
+    size = value.get("source_pptx_size_bytes")
+    if isinstance(size, bool) or not isinstance(size, int) or size < 1:
+        raise PptxEvidenceError(
+            "native_deck_audit.source_pptx_size_bytes must be a positive integer"
+        )
+    recorded_slide_count = value.get("slide_count")
+    if (
+        isinstance(recorded_slide_count, bool)
+        or not isinstance(recorded_slide_count, int)
+        or recorded_slide_count < 1
+    ):
+        raise PptxEvidenceError(
+            "native_deck_audit.slide_count must be a positive integer"
+        )
+    if slide_count is not None and recorded_slide_count != slide_count:
+        raise PptxEvidenceError(
+            "native_deck_audit.slide_count must equal structured_data.slide_count"
+        )
+    required = _normalize_required_slides(
+        value.get("render_required_slide_numbers"),
+        slide_count=recorded_slide_count,
+    )
+    reasons = value.get("render_required_reasons")
+    if not isinstance(reasons, Mapping):
+        raise PptxEvidenceError(
+            "native_deck_audit.render_required_reasons must be an object"
+        )
+    normalized_reasons: dict[str, list[str]] = {}
+    for raw_slide, raw_reasons in reasons.items():
+        if not isinstance(raw_slide, str) or not raw_slide.isdigit():
+            raise PptxEvidenceError(
+                "native_deck_audit.render_required_reasons keys must be decimal "
+                "slide-number strings"
+            )
+        slide_number = int(raw_slide)
+        if slide_number not in required:
+            raise PptxEvidenceError(
+                "native_deck_audit.render_required_reasons keys must exactly "
+                "match render_required_slide_numbers"
+            )
+        if (
+            not isinstance(raw_reasons, list)
+            or not raw_reasons
+            or any(not isinstance(reason, str) or not reason for reason in raw_reasons)
+            or raw_reasons != sorted(set(raw_reasons))
+        ):
+            raise PptxEvidenceError(
+                "native_deck_audit.render_required_reasons values must be sorted, "
+                "duplicate-free non-empty string arrays"
+            )
+        normalized_reasons[raw_slide] = list(raw_reasons)
+    if sorted(int(number) for number in normalized_reasons) != required:
+        raise PptxEvidenceError(
+            "native_deck_audit.render_required_reasons keys must exactly match "
+            "render_required_slide_numbers"
+        )
+    identity: dict[str, object] = {
+        "schema_version": NATIVE_DECK_AUDIT_SCHEMA_VERSION,
+        "extraction_schema_version": PPTX_EXTRACTION_SCHEMA_VERSION,
+        "extraction_pipeline_version": PPTX_EXTRACTION_PIPELINE_VERSION,
+        "source_pptx_sha256": source_sha,
+        "source_pptx_size_bytes": size,
+        "slide_count": recorded_slide_count,
+        "render_required_slide_numbers": required,
+        "render_required_reasons": normalized_reasons,
+    }
+    if value.get("extraction_receipt_sha256") != _canonical_sha256(identity):
+        raise PptxEvidenceError(
+            "native_deck_audit.extraction_receipt_sha256 does not bind the "
+            "declared extraction identity and render requirements"
+        )
+    raw_receipt = value.get("rendered_page_inspection")
+    receipt = (
+        validate_rendered_page_inspection(
+            raw_receipt,
+            required_slide_numbers=required,
+            slide_count=recorded_slide_count,
+        )
+        if raw_receipt is not None
+        else None
+    )
+    if receipt is not None and receipt["source_pptx_sha256"] != source_sha:
+        raise PptxEvidenceError(
+            "rendered_page_inspection.source_pptx_sha256 must match the "
+            "native-deck audit source identity"
+        )
+    return {
+        **identity,
+        "extraction_receipt_sha256": value["extraction_receipt_sha256"],
+        "rendered_page_inspection": receipt,
+    }
+
+
+def validate_rendered_page_inspection(
+    value: object,
+    *,
+    required_slide_numbers: list[int],
+    slide_count: int,
+) -> dict[str, object]:
+    """Validate a closed rendered-page receipt and recompute its binding."""
+    if not isinstance(value, Mapping):
+        raise PptxEvidenceError("rendered_page_inspection must be an object")
+    unknown = sorted(set(value) - _RENDER_RECEIPT_FIELDS)
+    missing = sorted(_RENDER_RECEIPT_FIELDS - set(value))
+    if unknown or missing:
+        raise PptxEvidenceError(
+            "rendered_page_inspection must contain exactly the schema fields; "
+            f"missing={missing}, unknown={unknown}"
+        )
+    if value.get("schema_version") != RENDER_INSPECTION_SCHEMA_VERSION:
+        raise PptxEvidenceError(
+            "rendered_page_inspection.schema_version must be "
+            f"{RENDER_INSPECTION_SCHEMA_VERSION}"
+        )
+    source_sha = _require_sha256(
+        value.get("source_pptx_sha256"),
+        "rendered_page_inspection.source_pptx_sha256",
+    )
+    pdf_sha = _require_sha256(
+        value.get("rendered_pdf_sha256"),
+        "rendered_page_inspection.rendered_pdf_sha256",
+    )
+    pdf_size = value.get("rendered_pdf_size_bytes")
+    page_count = value.get("rendered_page_count")
+    if isinstance(pdf_size, bool) or not isinstance(pdf_size, int) or pdf_size < 1:
+        raise PptxEvidenceError(
+            "rendered_page_inspection.rendered_pdf_size_bytes must be positive"
+        )
+    if (
+        isinstance(page_count, bool)
+        or not isinstance(page_count, int)
+        or page_count != slide_count
+    ):
+        raise PptxEvidenceError(
+            "rendered_page_inspection.rendered_page_count must equal the source "
+            f"deck slide count {slide_count}"
+        )
+    ranges = normalize_page_ranges(
+        value.get("inspected_page_ranges"),
+        page_count=page_count,
+        allow_empty=True,
+    )
+    required = _normalize_required_slides(
+        required_slide_numbers, slide_count=slide_count
+    )
+    inspected_required = [
+        number for number in required if number in pages_covered(ranges)
+    ]
+    if value.get("inspected_required_slide_numbers") != inspected_required:
+        raise PptxEvidenceError(
+            "rendered_page_inspection.inspected_required_slide_numbers must be "
+            "derived from inspected_page_ranges"
+        )
+    complete = inspected_required == required
+    if value.get("complete") is not complete:
+        raise PptxEvidenceError(
+            "rendered_page_inspection.complete must reflect coverage of every "
+            "render-required slide"
+        )
+    identity: dict[str, object] = {
+        "schema_version": RENDER_INSPECTION_SCHEMA_VERSION,
+        "source_pptx_sha256": source_sha,
+        "rendered_pdf_sha256": pdf_sha,
+        "rendered_pdf_size_bytes": pdf_size,
+        "rendered_page_count": page_count,
+        "inspected_page_ranges": ranges,
+        "inspected_required_slide_numbers": inspected_required,
+        "complete": complete,
+    }
+    if value.get("binding_sha256") != _canonical_sha256(identity):
+        raise PptxEvidenceError(
+            "rendered_page_inspection.binding_sha256 does not bind the exact "
+            "source, render, and inspected ranges"
+        )
+    return {**identity, "binding_sha256": value["binding_sha256"]}
+
+
+def _extract_native_deck_audit_in_process(path: Path) -> dict[str, object]:
+    """Recompute one audit inside the bounded native-audit worker."""
+    sys.modules.setdefault("pptx_evidence", sys.modules[__name__])
+    extractor_path = Path(__file__).with_name("pptx-extraction.py")
+    spec = importlib.util.spec_from_file_location(
+        "_speaker_toolkit_bounded_pptx_extraction",
+        extractor_path,
+    )
+    if spec is None or spec.loader is None:
+        raise PptxEvidenceError(
+            "cannot load the current PPTX extractor",
+            reason_code="pptx_dependency_unavailable",
+        )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    extract = getattr(module, "extract_pptx", None)
+    if not callable(extract):
+        raise PptxEvidenceError(
+            "current PPTX extractor has no extraction entrypoint",
+            reason_code="pptx_dependency_unavailable",
+        )
+    payload = extract(path, ocr=False)
+    if not isinstance(payload, Mapping):
+        raise PptxEvidenceError(
+            "current PPTX extractor returned a non-object",
+            reason_code="pptx_evidence_invalid",
+        )
+    raw_recovery = payload.get("archive_recovery")
+    if isinstance(raw_recovery, list) and raw_recovery:
+        part_names = sorted(
+            str(item.get("part_name", "<unknown>"))
+            for item in raw_recovery
+            if isinstance(item, Mapping)
+        )
+        raise PptxEvidenceError(
+            "PPTX extraction required placeholder archive recovery",
+            reason_code="pptx_archive_recovery_required",
+            details={"part_names": part_names},
+        )
+    return validate_native_deck_audit(payload.get("native_deck_audit"))
+
+
+def _native_audit_child(path: str | Path) -> dict[str, object]:
+    """Return a closed native-audit payload from the isolated worker."""
+    try:
+        audit = _extract_native_deck_audit_in_process(Path(path))
+    except MemoryError:
+        return {
+            "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+            "status": "unavailable",
+            "reason_code": "pptx_probe_resource_unavailable",
+            "details": {},
+        }
+    except PptxEvidenceError as exc:
+        reason_code = (
+            exc.reason_code
+            if exc.reason_code in _CHILD_PROBE_REASON_CODES
+            else "pptx_evidence_invalid"
+        )
+        return {
+            "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+            "status": "unavailable",
+            "reason_code": reason_code,
+            "details": _probe_child_failure_details(exc),
+        }
+    return {
+        "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+        "status": "available",
+        "native_deck_audit": audit,
+    }
+
+
+def _decode_native_audit_result(raw: bytes) -> dict[str, object]:
+    if len(raw) > PPTX_ARTIFACT_PROBE_MAX_RESULT_BYTES or not raw.strip():
+        raise _probe_failure("pptx_probe_malformed_result")
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _probe_failure("pptx_probe_malformed_result") from exc
+    if len(decoded.splitlines()) != 1:
+        raise _probe_failure("pptx_probe_malformed_result")
+    try:
+        payload = json.loads(
+            decoded,
+            object_pairs_hook=_unique_json_object,
+            parse_constant=_reject_nonstandard_json_constant,
+        )
+    except (json.JSONDecodeError, RecursionError, ValueError) as exc:
+        raise _probe_failure("pptx_probe_malformed_result") from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != PPTX_ARTIFACT_PROBE_SCHEMA_VERSION
+    ):
+        raise _probe_failure("pptx_probe_malformed_result")
+    if payload.get("status") == "unavailable":
+        if set(payload) != {"schema_version", "status", "reason_code", "details"}:
+            raise _probe_failure("pptx_probe_malformed_result")
+        reason_code = payload.get("reason_code")
+        details = payload.get("details")
+        if reason_code not in _CHILD_PROBE_REASON_CODES or not isinstance(details, dict):
+            raise _probe_failure("pptx_probe_malformed_result")
+        if set(details) - {"part_names", "exception_type"}:
+            raise _probe_failure("pptx_probe_malformed_result")
+        part_names = details.get("part_names")
+        if part_names is not None and (
+            not isinstance(part_names, list)
+            or len(part_names) > 64
+            or any(
+                not isinstance(name, str) or not name or len(name) > 2048
+                for name in part_names
+            )
+        ):
+            raise _probe_failure("pptx_probe_malformed_result")
+        exception_type = details.get("exception_type")
+        if exception_type is not None and (
+            not isinstance(exception_type, str)
+            or not exception_type
+            or len(exception_type) > 128
+        ):
+            raise _probe_failure("pptx_probe_malformed_result")
+        raise _probe_failure(str(reason_code), details=details)
+    if set(payload) != {"schema_version", "status", "native_deck_audit"} or payload.get(
+        "status"
+    ) != "available":
+        raise _probe_failure("pptx_probe_malformed_result")
+    try:
+        return validate_native_deck_audit(payload.get("native_deck_audit"))
+    except PptxEvidenceError as exc:
+        raise _probe_failure("pptx_probe_malformed_result") from exc
+
+
+def _cache_native_audit(
+    key: tuple[str, int, int, int, int, int, int],
+    value: dict[str, object] | tuple[str, str, dict[str, object]],
+) -> None:
+    stale = [
+        candidate
+        for candidate in _PPTX_NATIVE_AUDIT_CACHE
+        if candidate[0] == key[0] and candidate != key
+    ]
+    for stale_key in stale:
+        _PPTX_NATIVE_AUDIT_CACHE.pop(stale_key, None)
+    _PPTX_NATIVE_AUDIT_CACHE[key] = value
+
+
+def recompute_native_deck_audit(path: str | Path) -> dict[str, object]:
+    """Recompute an exact audit through a bounded, generation-cached worker."""
+    artifact, key = _probe_file_identity(path)
+    cached = _PPTX_NATIVE_AUDIT_CACHE.get(key)
+    if isinstance(cached, dict):
+        return copy.deepcopy(cached)
+    if isinstance(cached, tuple):
+        message, reason_code, details = cached
+        raise PptxEvidenceError(
+            message,
+            reason_code=reason_code,
+            details=details,
+        )
+    dataless_flag = PPTX_MACOS_DATALESS_FLAG
+    if dataless_flag and key[-1] & dataless_flag:
+        error = _probe_failure(
+            "pptx_cloud_placeholder_unavailable",
+            details={"st_flags": key[-1]},
+        )
+        _cache_native_audit(
+            key,
+            (str(error), error.reason_code, dict(error.details)),
+        )
+        raise error
+    try:
+        result = _run_bounded_private_worker(
+            artifact,
+            child_flag=PPTX_NATIVE_AUDIT_CHILD_FLAG,
+            decoder=_decode_native_audit_result,
+        )
+    except PptxEvidenceError as exc:
+        _current_path, current_key = _probe_file_identity(artifact)
+        if current_key != key:
+            raise _probe_failure("pptx_artifact_changed") from exc
+        if exc.reason_code in {
+            "pptx_artifact_changed",
+            "pptx_probe_materialization_changed",
+        }:
+            raise _probe_failure("pptx_probe_materialization_changed") from exc
+        if exc.reason_code in _ARCHIVE_INTEGRITY_CONFIRMATION_REASON_CODES:
+            _confirm_archive_integrity_failure(
+                artifact,
+                key,
+                exc,
+                child_flag=PPTX_NATIVE_AUDIT_CHILD_FLAG,
+                decoder=_decode_native_audit_result,
+            )
+        cached_error = (str(exc), exc.reason_code, dict(exc.details))
+        _cache_native_audit(key, cached_error)
+        raise PptxEvidenceError(
+            cached_error[0],
+            reason_code=cached_error[1],
+            details=cached_error[2],
+        ) from exc
+    if not isinstance(result, dict):
+        raise _probe_failure("pptx_probe_malformed_result")
+    _current_path, current_key = _probe_file_identity(artifact)
+    if current_key != key or result.get("source_pptx_size_bytes") != key[3]:
+        raise _probe_failure("pptx_artifact_changed")
+    cached_result = copy.deepcopy(result)
+    _cache_native_audit(key, cached_result)
+    return copy.deepcopy(cached_result)
+
+
+def parse_page_range_arguments(values: list[str] | None) -> list[list[int]]:
+    """Parse repeated CLI PAGE or START-END values."""
+    if not values:
+        return []
+    parsed: list[list[int]] = []
+    for value in values:
+        for token in value.split(","):
+            candidate = token.strip()
+            match = re.fullmatch(r"(\d+)(?:-(\d+))?", candidate)
+            if match is None:
+                raise PptxEvidenceError(
+                    "--inspected-pages values must be PAGE or START-END, "
+                    f"got {candidate!r}"
+                )
+            start = int(match.group(1))
+            end = int(match.group(2) or match.group(1))
+            parsed.append([start, end])
+    return parsed
+
+
+def ranges_cover_pages(ranges: object, pages: list[int], *, page_count: int) -> bool:
+    normalized = normalize_page_ranges(
+        ranges, page_count=page_count, allow_empty=True
+    )
+    return set(pages).issubset(pages_covered(normalized))
+
+
+def finite_confidence(value: object) -> float | None:
+    """Normalize an OCR confidence to a finite 0..100 float or ``None``."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0 or numeric > 100:
+        return None
+    return round(numeric, 3)
+
+
+if __name__ == "__main__":
+    child_mode = (
+        sys.argv[1]
+        if len(sys.argv) == 4
+        and sys.argv[1]
+        in {PPTX_ARTIFACT_PROBE_CHILD_FLAG, PPTX_NATIVE_AUDIT_CHILD_FLAG}
+        else None
+    )
+    if child_mode is not None:
+        with Path(sys.argv[3]).open("r+b", buffering=0) as child_result_file:
+            with (
+                open(os.devnull, "w", encoding="utf-8") as child_output,
+                contextlib.redirect_stdout(child_output),
+                contextlib.redirect_stderr(child_output),
+            ):
+                try:
+                    child_result = (
+                        _pptx_probe_child(sys.argv[2])
+                        if child_mode == PPTX_ARTIFACT_PROBE_CHILD_FLAG
+                        else _native_audit_child(sys.argv[2])
+                    )
+                # The parent classifies only a closed private result; collapse an
+                # unexpected worker fault without exposing parser output.
+                except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+                    child_result = {
+                        "schema_version": PPTX_ARTIFACT_PROBE_SCHEMA_VERSION,
+                        "status": "unavailable",
+                        "reason_code": "pptx_probe_exception",
+                        "details": {"exception_type": type(exc).__name__},
+                    }
+            _write_pptx_probe_result(child_result_file, child_result)
+        raise SystemExit(0)
+    raise SystemExit("pptx_evidence.py is a library; run pptx-extraction.py")

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -75,6 +75,8 @@ SLIDE_CONTRACT_CODES = frozenset({
     "slide_source_unsupported",
     "slide_pptx_reference_missing",
     "slide_pptx_artifact_missing",
+    "slide_pptx_artifact_unreadable",
+    "slide_pptx_artifact_degraded",
     "slide_pdf_reference_missing",
     "slide_pdf_artifact_missing",
     "slide_video_reference_missing",
@@ -598,6 +600,59 @@ class VaultPreflight:
                     field="pptx_path", actual=talk.get("pptx_path"),
                     artifact_path=pptx_path,
                 )
+            else:
+                capabilities = self._capabilities(index)
+                raw_degradations = capabilities.get("degraded_evidence_sources")
+                degradation = (
+                    raw_degradations.get("native_deck")
+                    if isinstance(raw_degradations, dict)
+                    else None
+                )
+                raw_verified = capabilities.get("verified_evidence_sources")
+                native_verified = isinstance(
+                    raw_verified, (tuple, list, set, frozenset)
+                ) and "native_deck" in raw_verified
+                if isinstance(degradation, dict):
+                    self.talk_add(
+                        index,
+                        severity,
+                        "slide_pptx_artifact_degraded",
+                        "declared PPTX required loss-reporting media recovery; "
+                        "restore or re-export the deck before current analysis",
+                        field="pptx_path",
+                        actual=degradation,
+                        artifact_path=pptx_path,
+                        capability_fact=capabilities,
+                    )
+                elif not native_verified:
+                    raw_unavailable = capabilities.get(
+                        "unavailable_evidence_sources"
+                    )
+                    unavailable = (
+                        raw_unavailable.get("native_deck")
+                        if isinstance(raw_unavailable, dict)
+                        else None
+                    )
+                    raw_reasons = capabilities.get("source_reasons")
+                    reason = (
+                        unavailable
+                        if isinstance(unavailable, dict)
+                        else (
+                            raw_reasons.get("native_deck")
+                            if isinstance(raw_reasons, dict)
+                            else "PPTX parser returned no native-deck capability"
+                        )
+                    )
+                    self.talk_add(
+                        index,
+                        severity,
+                        "slide_pptx_artifact_unreadable",
+                        "declared PPTX exists but cannot be parsed or safely recovered",
+                        field="pptx_path",
+                        actual=reason,
+                        artifact_path=pptx_path,
+                        capability_fact=capabilities,
+                    )
 
         if slide_source in {"pdf", "both"}:
             explicit_pdf = self._slide_pdf_path(talk)

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -100,6 +100,7 @@ from adherence_baseline import (
 )
 from pattern_evidence import (
     assess_talk_artifact_capabilities,
+    required_pptx_evidence_blocking_reason,
 )
 from return_validation import (
     PATTERN_SCORING_SCHEMA_VERSION,
@@ -244,19 +245,20 @@ def evidence_freshness_assessor(database, path):
 
 
 def artifact_capability_assessor(database, path):
-    """Bind and memoize root-aware local/acquisition capability checks."""
+    """Bind root-aware local/acquisition capability checks.
+
+    The bounded PPTX probe owns generation-aware memoization.  Keeping a
+    second filename-only cache here could authorize a claim after its deck had
+    changed between eligibility selection and the final claim boundary.
+    """
     vault_root, source_roots = evidence_roots(database, path)
-    cache = {}
 
     def assess(talk):
-        filename = talk.get("filename")
-        if filename not in cache:
-            cache[filename] = assess_talk_artifact_capabilities(
-                talk,
-                vault_root=vault_root,
-                source_roots=source_roots,
-            )
-        return cache[filename]
+        return assess_talk_artifact_capabilities(
+            talk,
+            vault_root=vault_root,
+            source_roots=source_roots,
+        )
 
     return assess
 
@@ -296,6 +298,34 @@ def has_processable_source(talk, *, capability_assessor):
             talk,
             capability_assessor=capability_assessor,
         )
+    )
+
+
+def claim_blocking_artifact_reason(talk, *, capability_assessor):
+    """Return a live artifact reason that forbids a fresh current claim."""
+    assessment = capability_assessor(talk)
+    if not isinstance(assessment, dict):
+        raise QueueStateError(
+            f"{talk.get('filename')}: artifact capability assessor returned "
+            "a non-object result"
+        )
+    return required_pptx_evidence_blocking_reason(talk, assessment)
+
+
+def has_claimable_source(talk, *, capability_assessor):
+    """Require a processable lane and no mandatory degraded native deck."""
+    assessment = capability_assessor(talk)
+
+    def provisional_assessor(_talk):
+        return assessment
+
+    return (
+        has_processable_source(talk, capability_assessor=provisional_assessor)
+        and claim_blocking_artifact_reason(
+            talk,
+            capability_assessor=provisional_assessor,
+        )
+        is None
     )
 
 
@@ -583,9 +613,22 @@ def claim_talk(
         raise QueueStateError(
             f"{talk['filename']}: cannot transition {previous!r} to {INFLIGHT_STATUS}"
         )
+    # Reassess exactly once at the mutation boundary.  Selection is only a
+    # provisional filter: a deck may have changed after it was found eligible.
+    final_assessment = capability_assessor(talk)
+
+    def final_capability_assessor(_talk):
+        return final_assessment
+
+    blocking_reason = claim_blocking_artifact_reason(
+        talk,
+        capability_assessor=final_capability_assessor,
+    )
+    if blocking_reason is not None:
+        raise QueueStateError(f"{talk['filename']}: cannot claim: {blocking_reason}")
     if not has_processable_source(
         talk,
-        capability_assessor=capability_assessor,
+        capability_assessor=final_capability_assessor,
     ):
         raise QueueStateError(
             f"{talk['filename']}: cannot claim a talk without a usable transcript, "
@@ -722,9 +765,22 @@ def command_claim(database, path, args, *, expected_snapshot):
                 raise QueueStateError(
                     f"{talk['filename']}: cannot claim status {talk['status']!r}"
                 )
+            provisional_assessment = capability_assessor(talk)
+
+            def provisional_assessor(_talk):
+                return provisional_assessment
+
+            blocking_reason = claim_blocking_artifact_reason(
+                talk,
+                capability_assessor=provisional_assessor,
+            )
+            if blocking_reason is not None:
+                raise QueueStateError(
+                    f"{talk['filename']}: cannot claim: {blocking_reason}"
+                )
             if not has_processable_source(
                 talk,
-                capability_assessor=capability_assessor,
+                capability_assessor=provisional_assessor,
             ):
                 raise QueueStateError(
                     f"{talk['filename']}: cannot claim a talk without a usable "
@@ -734,7 +790,7 @@ def command_claim(database, path, args, *, expected_snapshot):
         eligible = [
             talk for talk in candidate["talks"]
             if talk["status"] in CLAIMABLE_STATUSES
-            and has_processable_source(
+            and has_claimable_source(
                 talk,
                 capability_assessor=capability_assessor,
             )
@@ -771,7 +827,7 @@ def command_claim(database, path, args, *, expected_snapshot):
     ]
     remaining = sum(
         talk["status"] in CLAIMABLE_STATUSES
-        and has_processable_source(
+        and has_claimable_source(
             talk,
             capability_assessor=capability_assessor,
         )

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -64,7 +64,13 @@ from pattern_evidence import (
     TALK_METADATA_FIELDS,
     assess_persisted_pattern_evidence_freshness as assess_artifact_freshness,
     opportunity_coverage_identity,
+    required_pptx_evidence_blocking_reason,
     validate_transcript_path,
+)
+from pptx_evidence import (
+    PptxEvidenceError,
+    ranges_cover_pages,
+    validate_native_deck_audit,
 )
 
 
@@ -331,6 +337,7 @@ AUTHORED_SLIDE_FIELDS = frozenset({
     "footer_observations",
     "shape_observations",
 })
+PPTX_RENDER_DEPENDENT_FIELDS = AUTHORED_SLIDE_FIELDS - {"slide_count"}
 PER_SLIDE_VISUAL_FIELDS = frozenset({
     "slide_number",
     "background_color_name",
@@ -1096,6 +1103,25 @@ def _validate_video_return(ret: dict, structured: dict,
                 "context-only video extraction cannot return authored-slide evidence "
                 f"in structured_data: {contaminated}")
     return state.trusted_slide_region
+
+
+def validate_authored_slide_fields_against_source(
+    structured: Mapping[str, object],
+    slide_source: str,
+) -> None:
+    """Reject model-authored slide evidence when no slide lane was used."""
+    if slide_source != "none":
+        return
+    contaminated = sorted(
+        field
+        for field in AUTHORED_SLIDE_FIELDS
+        if _is_nonempty(structured.get(field))
+    )
+    if contaminated:
+        raise ReturnValidationError(
+            "slide_source none cannot return authored-slide evidence in "
+            f"structured_data: {contaminated}"
+        )
 
 
 def canonical_evidence_source_group(group: frozenset[str]) -> list[str]:
@@ -2556,6 +2582,169 @@ def validate_structured_data(
             "and image_source_distribution_basis to be supplied together")
 
 
+def _native_deck_cited_slide_numbers(
+    detections: list[dict],
+) -> set[int]:
+    """Return exact native-deck slides cited by validated detections."""
+    cited: set[int] = set()
+    for detection in detections:
+        citations = detection.get("evidence_citations")
+        if not isinstance(citations, list):
+            continue
+        for citation in citations:
+            if not isinstance(citation, Mapping):
+                continue
+            if citation.get("source") != "native_deck":
+                continue
+            slide_numbers = citation.get("slide_numbers")
+            if not isinstance(slide_numbers, list):
+                continue
+            cited.update(
+                number
+                for number in slide_numbers
+                if isinstance(number, int) and not isinstance(number, bool)
+            )
+    return cited
+
+
+def _native_deck_findings_present(
+    structured: Mapping[str, object],
+    detections: list[dict],
+) -> bool:
+    """Return whether a PPTX return carries audit-bound native findings."""
+    if any(field in structured for field in PPTX_RENDER_DEPENDENT_FIELDS):
+        return True
+    return bool(_native_deck_cited_slide_numbers(detections))
+
+
+def validate_native_deck_design_receipt(
+    *,
+    structured: dict,
+    observations: dict,
+    slide_source: str,
+    detections: list[dict],
+) -> None:
+    """Require a current native audit and any claim-dependent render evidence."""
+    raw_audit = structured.get("native_deck_audit")
+    if raw_audit is not None and slide_source not in {"pptx", "both"}:
+        raise ReturnValidationError(
+            "structured_data.native_deck_audit requires slide_source pptx or both"
+        )
+    evidence_sources = observations.get("evidence_sources")
+    source_inspection = observations.get("source_inspection")
+    native_declared = (
+        slide_source in {"pptx", "both"}
+        or (
+            isinstance(evidence_sources, list)
+            and "native_deck" in evidence_sources
+        )
+        or (
+            isinstance(source_inspection, list)
+            and any(
+                isinstance(item, Mapping)
+                and item.get("source") == "native_deck"
+                for item in source_inspection
+            )
+        )
+        or bool(_native_deck_cited_slide_numbers(detections))
+    )
+    design_findings = (
+        native_declared
+        and _native_deck_findings_present(structured, detections)
+    )
+    if raw_audit is None:
+        if native_declared:
+            raise ReturnValidationError(
+                "declared, inspected, or cited native-deck evidence requires the current "
+                "structured_data.native_deck_audit from pptx-extraction.py"
+            )
+        return
+    slide_count = structured.get("slide_count")
+    expected_count = (
+        slide_count
+        if isinstance(slide_count, int) and not isinstance(slide_count, bool)
+        else None
+    )
+    try:
+        audit = validate_native_deck_audit(
+            raw_audit,
+            slide_count=expected_count,
+        )
+    except PptxEvidenceError as exc:
+        raise ReturnValidationError(
+            f"structured_data.native_deck_audit is invalid: {exc}"
+        ) from exc
+    if not design_findings or not audit["render_required_slide_numbers"]:
+        return
+    render_required = set(cast(list[int], audit["render_required_slide_numbers"]))
+    structured_visual_findings = any(
+        field in structured for field in PPTX_RENDER_DEPENDENT_FIELDS
+    )
+    cited_required = _native_deck_cited_slide_numbers(detections).intersection(
+        render_required
+    )
+    pages_requiring_render = (
+        render_required if structured_visual_findings else cited_required
+    )
+    if not pages_requiring_render:
+        return
+    receipt = audit["rendered_page_inspection"]
+    if not isinstance(receipt, Mapping):
+        raise ReturnValidationError(
+            "render-required native-deck findings need an "
+            "identity-bound rendered_page_inspection receipt"
+        )
+    inspected_required = receipt.get("inspected_required_slide_numbers")
+    if (
+        not isinstance(inspected_required, list)
+        or not pages_requiring_render.issubset(set(inspected_required))
+        or (structured_visual_findings and receipt.get("complete") is not True)
+    ):
+        raise ReturnValidationError(
+            "identity-bound rendered_page_inspection does not cover every "
+            "render-required slide used by the native-deck findings"
+        )
+    if not isinstance(evidence_sources, list) or "static_slides" not in evidence_sources:
+        raise ReturnValidationError(
+            "render-required native-deck design findings must list the exact "
+            "rendered PDF as inspected static_slides evidence"
+        )
+    static_receipt = (
+        next(
+            (
+                item
+                for item in source_inspection
+                if isinstance(item, Mapping)
+                and item.get("source") == "static_slides"
+            ),
+            None,
+        )
+        if isinstance(source_inspection, list)
+        else None
+    )
+    if static_receipt is None:
+        raise ReturnValidationError(
+            "render-required native-deck design findings need a static_slides "
+            "source_inspection record"
+        )
+    try:
+        audited_slide_count = cast(int, audit["slide_count"])
+        covered = ranges_cover_pages(
+            static_receipt.get("page_ranges"),
+            sorted(pages_requiring_render),
+            page_count=audited_slide_count,
+        )
+    except PptxEvidenceError as exc:
+        raise ReturnValidationError(
+            f"static_slides render inspection is invalid: {exc}"
+        ) from exc
+    if not covered:
+        raise ReturnValidationError(
+            "static_slides source_inspection must cover every render-required "
+            "native-deck page"
+        )
+
+
 def validate_structured_policy_value(field, value, policy) -> None:
     """Validate one declared v2 field against its persistence policy shape."""
     if policy in {ATOMIC_MAP, ADDITIVE_MAP} and not isinstance(value, dict):
@@ -3325,6 +3514,38 @@ def validate_claim_against_talk(
             raise ReturnValidationError(
                 "structured_data.video_extraction.source_video_id "
                 f"{returned_id!r} does not match talk youtube_id {expected_id!r}")
+    if (
+        ret.get("status") in ANALYSIS_STATUSES
+        and return_schema_version == RETURN_SCHEMA_VERSION
+        and artifact_capabilities is not None
+    ):
+        observations = ret.get("pattern_observations")
+        evidence_sources = (
+            observations.get("evidence_sources")
+            if isinstance(observations, dict)
+            else None
+        )
+        structured = ret.get("structured_data")
+        native_deck_used = (
+            ret.get("slide_source") in {"pptx", "both"}
+            or (
+                isinstance(evidence_sources, list)
+                and "native_deck" in evidence_sources
+            )
+            or (
+                isinstance(structured, dict)
+                and "native_deck_audit" in structured
+            )
+        )
+        blocking_reason = required_pptx_evidence_blocking_reason(
+            talk,
+            artifact_capabilities,
+            native_deck_used=native_deck_used,
+        )
+        if blocking_reason is not None:
+            raise ReturnValidationError(
+                f"{filename} cannot persist current analysis: {blocking_reason}"
+            )
     _validate_terminal_status_against_talk(
         talk, ret, artifact_capabilities=artifact_capabilities)
     _validate_return_sources_against_talk(talk, ret)
@@ -3691,6 +3912,7 @@ def validate_return(ret, catalog: PatternCatalog | None = None) -> None:
     if not isinstance(structured, dict):
         raise ReturnValidationError("structured_data is required and must be an object")
     validate_structured_data(structured)
+    validate_authored_slide_fields_against_source(structured, slide_source)
     video_static_slides_available = False
     if slide_source == "video_extracted":
         video_static_slides_available = _validate_video_return(
@@ -3733,20 +3955,27 @@ def validate_return(ret, catalog: PatternCatalog | None = None) -> None:
     antipatterns = _validate_detection_list(
         observations, "antipatterns_detected", "antipattern", resolved_catalog,
         available_sources, return_schema_version)
-    not_evaluable = _validate_not_evaluable(
-        observations, resolved_catalog, available_sources,
-        return_schema_version)
     detected_ids = (
-        {item["pattern_id"] for item in patterns} |
-        {item["pattern_id"] for item in antipatterns}
+        {item["pattern_id"] for item in patterns}
+        | {item["pattern_id"] for item in antipatterns}
     )
-    _validate_applicability_assessments(
+    applicability = _validate_applicability_assessments(
         observations,
         resolved_catalog,
         available_sources,
         detected_ids,
         return_schema_version,
     )
+    if return_schema_version == RETURN_SCHEMA_VERSION:
+        validate_native_deck_design_receipt(
+            structured=structured,
+            observations=observations,
+            slide_source=slide_source,
+            detections=[*patterns, *antipatterns, *applicability],
+        )
+    not_evaluable = _validate_not_evaluable(
+        observations, resolved_catalog, available_sources,
+        return_schema_version)
     _validate_unavailable_catalog_gates(
         resolved_catalog, available_sources, not_evaluable, detected_ids,
         return_schema_version)

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -159,7 +159,7 @@ this extraction but must not be replaced with another interpreter:
 - Exit non-zero with stderr message if the file is missing, unreadable, or not a valid `.pptx`.
 
 Check the extraction root's `schema_version` before reading layouts. This
-layout-only consumer accepts v1 and v2 for `template_layouts` only.
+layout-only consumer accepts v1, v2, and v3 for `template_layouts` only.
 Missing/legacy v0 or an unknown future version is not
 usable prior output: rerun the current extractor and read that result. Do not
 interpret a v1 record as carrying zero timing; it carries no timing contract.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,11 @@ def pptx_extraction():
 
 
 @pytest.fixture(scope="session")
+def pptx_evidence():
+    return _import_script(os.path.join(SCRIPTS_VI, "pptx_evidence.py"), "pptx_evidence")
+
+
+@pytest.fixture(scope="session")
 def vtt_cleanup():
     return _import_script(os.path.join(SCRIPTS_VI, "vtt-cleanup.py"), "vtt_cleanup")
 

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -6,14 +6,19 @@ import builtins
 import copy
 import hashlib
 import importlib
+import json
+import struct
 import sys
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from PIL import Image
 from pypdf import PdfWriter
 from pptx import Presentation
+from pptx.util import Inches
 
 
 SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
@@ -21,6 +26,7 @@ if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 pattern_evidence = importlib.import_module("pattern_evidence")
+pptx_evidence = importlib.import_module("pptx_evidence")
 return_validation = importlib.import_module("return_validation")
 transcript_timing = importlib.import_module("transcript_timing")
 SYNTHETIC_VIDEO_ID = "abcdefghijk"
@@ -51,6 +57,31 @@ def _write_pptx(path: Path, slide_count: int = 2) -> None:
     for _ in range(slide_count):
         deck.slides.add_slide(layout)
     deck.save(str(path))
+
+
+def _write_crc_damaged_media_pptx(path: Path) -> str:
+    """Create a deck whose embedded image follows the live BadZipFile path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image_path = path.with_suffix(".png")
+    Image.new("RGB", (64, 64), "navy").save(image_path)
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[6])
+    slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
+    deck.save(str(path))
+    with zipfile.ZipFile(path) as archive:
+        member = next(
+            item
+            for item in archive.infolist()
+            if item.filename.startswith("ppt/media/") and item.file_size
+        )
+    package = bytearray(path.read_bytes())
+    name_size, extra_size = struct.unpack_from(
+        "<HH", package, member.header_offset + 26
+    )
+    payload_offset = member.header_offset + 30 + name_size + extra_size
+    package[payload_offset + (member.compress_size // 2)] ^= 0xFF
+    path.write_bytes(package)
+    return member.filename
 
 
 def _transcript_lines() -> list[str]:
@@ -237,6 +268,18 @@ def test_artifact_root_kinds_are_canonical_and_owner_bound(tmp_path: Path) -> No
         == "pptx_source"
     )
 
+    configured_absolute = pattern_evidence.build_evidence_context(
+        vault,
+        {"pptx_path": str(configured_deck), "slide_source": "pptx"},
+        source_roots={"pptx_source_dir": str(source_root)},
+    )
+    assert configured_absolute["slide_counts"] == {"native_deck": 2}
+    assert (
+        configured_absolute["slide_artifact_identities"]["native_deck"]
+        ["artifact_path"]
+        == "configured.pptx"
+    )
+
     absolute = pattern_evidence.build_evidence_context(
         vault,
         {"pptx_path": str(absolute_deck), "slide_source": "pptx"},
@@ -284,6 +327,14 @@ def test_traversal_and_symlinked_artifacts_never_become_sources(
     )
     assert "native_deck" not in linked["verified_evidence_sources"]
     assert "symbolic link" in linked["source_reasons"]["native_deck"]
+
+    absolute_linked = pattern_evidence.build_evidence_context(
+        vault,
+        {"pptx_path": str(link), "slide_source": "pptx"},
+        source_roots={"pptx_source_dir": str(source_root)},
+    )
+    assert "native_deck" not in absolute_linked["verified_evidence_sources"]
+    assert "symbolic link" in absolute_linked["source_reasons"]["native_deck"]
 
 
 @pytest.mark.parametrize(
@@ -362,6 +413,97 @@ def test_video_extracted_static_pages_support_positive_inspection_not_absence() 
     assert records[0]["absence_capability_complete"] is False
     assert records[0]["absence_capability_reason"] == ("nonexhaustive_video_extraction")
     assert "static_slides" not in complete_sources
+
+
+def test_video_extracted_pdf_path_and_digest_replace_predeclared_pdf_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    declared = vault / "slides" / "declared.pdf"
+    extracted = vault / "slides-rebuild" / "video.pdf"
+    _write_pdf(declared, page_count=2)
+    _write_pdf(extracted, page_count=2)
+    extracted_bytes = extracted.read_bytes()
+    assert b"pypdf" in extracted_bytes
+    extracted.write_bytes(extracted_bytes.replace(b"pypdf", b"qypdf", 1))
+    assert declared.read_bytes() != extracted.read_bytes()
+    monkeypatch.setattr(
+        pattern_evidence,
+        "_trusted_video_slide_count",
+        lambda *_args, **_kwargs: (2, "trusted extracted PDF", extracted),
+    )
+    talk = {
+        "filename": "video-talk.md",
+        "youtube_id": SYNTHETIC_VIDEO_ID,
+        "slides_pdf_path": declared.relative_to(vault).as_posix(),
+        "slide_source": "video_extracted",
+    }
+
+    context = pattern_evidence.build_evidence_context(vault, talk)
+    identity = context["slide_artifact_identities"]["static_slides"]
+
+    assert identity["artifact_path"] == extracted.relative_to(vault).as_posix()
+    assert identity["artifact_sha256"] == hashlib.sha256(
+        extracted.read_bytes()
+    ).hexdigest()
+    assert identity["artifact_sha256"] != hashlib.sha256(
+        declared.read_bytes()
+    ).hexdigest()
+
+
+def test_unreadable_video_extracted_pdf_does_not_hide_independent_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    transcript, _ = _write_transcript(vault, name=SYNTHETIC_VIDEO_ID)
+    deck = vault / "decks" / "talk.pptx"
+    extracted = vault / "slides-rebuild" / "video.pdf"
+    _write_pptx(deck, slide_count=2)
+    _write_pdf(extracted, page_count=2)
+    monkeypatch.setattr(
+        pattern_evidence,
+        "_trusted_video_slide_count",
+        lambda *_args, **_kwargs: (2, "trusted extracted PDF", extracted),
+    )
+    original_snapshot = pattern_evidence.snapshot_rendered_pdf
+
+    def fail_video_snapshot(path: str | Path):
+        if Path(path) == extracted:
+            raise pptx_evidence.PptxEvidenceError(
+                "synthetic video PDF generation changed"
+            )
+        return original_snapshot(path)
+
+    monkeypatch.setattr(
+        pattern_evidence,
+        "snapshot_rendered_pdf",
+        fail_video_snapshot,
+    )
+    talk = {
+        "filename": "video-talk.md",
+        "youtube_id": SYNTHETIC_VIDEO_ID,
+        "transcript_path": transcript.relative_to(vault).as_posix(),
+        "transcript_source": "manual",
+        "pptx_path": deck.relative_to(vault).as_posix(),
+        "slide_source": "video_extracted",
+    }
+
+    assessment = pattern_evidence.assess_talk_artifact_capabilities(
+        talk,
+        vault_root=vault,
+    )
+
+    assert assessment["verified_capabilities"] == ("slides", "transcript")
+    assert assessment["verified_evidence_sources"] == (
+        "native_deck",
+        "transcript",
+    )
+    assert "static_slides" not in assessment["verified_evidence_sources"]
+    assert "cannot snapshot trusted video slides" in (
+        assessment["source_reasons"]["static_slides"]
+    )
 
 
 def test_pptx_preserves_a_separately_declared_rendered_pdf(
@@ -524,6 +666,7 @@ def test_non_english_transcript_citations_require_an_english_translation(
 
 def test_relative_pptx_native_deck_evidence_is_immediately_fresh(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vault = tmp_path / "vault"
     source_root = tmp_path / "pptx-source"
@@ -570,6 +713,14 @@ def test_relative_pptx_native_deck_evidence_is_immediately_fresh(
         channels=frozenset({"slides"}),
     )
     roots = {"pptx_source_dir": str(source_root)}
+    original_hash = pattern_evidence._sha256_file
+
+    def no_parent_pptx_hash(path: Path) -> str:
+        if path.suffix.casefold() == ".pptx":
+            raise AssertionError("native PPTX bytes were hashed in the parent")
+        return original_hash(path)
+
+    monkeypatch.setattr(pattern_evidence, "_sha256_file", no_parent_pptx_hash)
     canonical = pattern_evidence.canonicalize_return_evidence(
         raw, talk, vault, _catalog(entry), source_roots=roots
     )
@@ -584,6 +735,34 @@ def test_relative_pptx_native_deck_evidence_is_immediately_fresh(
             source_roots=roots,
         )
         == ()
+    )
+
+    _write_crc_damaged_media_pptx(deck)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    degraded_reasons = (
+        pattern_evidence.assess_persisted_pattern_evidence_freshness(
+            persisted,
+            vault_root=vault,
+            source_roots=roots,
+        )
+    )
+    assert any(
+        reason.endswith(":artifact_bounded_digest_unavailable")
+        for reason in degraded_reasons
+    )
+
+    deck.write_bytes(b"not a PPTX")
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    unavailable_reasons = (
+        pattern_evidence.assess_persisted_pattern_evidence_freshness(
+            persisted,
+            vault_root=vault,
+            source_roots=roots,
+        )
+    )
+    assert any(
+        reason.endswith(":artifact_bounded_digest_unavailable")
+        for reason in unavailable_reasons
     )
 
 
@@ -1385,6 +1564,224 @@ def test_invalid_utf8_transcript_cannot_hide_an_independent_valid_deck(
     assert "not valid UTF-8" in assessment["source_reasons"]["transcript"]
 
 
+def test_crc_damaged_pptx_is_a_structured_degraded_capability(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    deck = vault / "decks" / "talk.pptx"
+    damaged_part = _write_crc_damaged_media_pptx(deck)
+
+    assessment = pattern_evidence.assess_talk_artifact_capabilities(
+        {
+            "filename": "talk.md",
+            "pptx_path": deck.relative_to(vault).as_posix(),
+            "slide_source": "pptx",
+        },
+        vault_root=vault,
+    )
+
+    assert assessment["verified_capabilities"] == ()
+    assert assessment["verified_evidence_sources"] == ()
+    degradation = assessment["degraded_evidence_sources"]["native_deck"]
+    assert degradation["schema_version"] == 1
+    assert degradation["status"] == "degraded_recoverable"
+    assert degradation["reason_code"] == "pptx_archive_recovery_required"
+    assert degradation["archive_recovery"][0]["part_name"] == damaged_part
+    assert "read degraded local PPTX" in assessment["source_reasons"]["native_deck"]
+    json.dumps(assessment)
+
+
+@pytest.mark.parametrize("slide_source", [None, "none"])
+def test_degraded_deck_is_not_native_evidence_when_slide_source_is_absent(
+    tmp_path: Path,
+    slide_source: str | None,
+) -> None:
+    vault = tmp_path / "vault"
+    deck = vault / "decks" / "talk.pptx"
+    _write_crc_damaged_media_pptx(deck)
+    talk: dict[str, object] = {
+        "filename": "talk.md",
+        "pptx_path": deck.relative_to(vault).as_posix(),
+    }
+    if slide_source is not None:
+        talk["slide_source"] = slide_source
+
+    context = pattern_evidence.build_evidence_context(vault, talk)
+    assessment = pattern_evidence.assess_talk_artifact_capabilities(
+        talk,
+        vault_root=vault,
+    )
+
+    assert "native_deck" not in context["slide_counts"]
+    assert "native_deck" not in context["slide_artifact_identities"]
+    assert assessment["verified_capabilities"] == ()
+    assert assessment["verified_evidence_sources"] == ()
+    assert "native_deck" in assessment["degraded_evidence_sources"]
+
+
+def test_optional_degraded_deck_keeps_independent_static_slides(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    deck = vault / "decks" / "talk.pptx"
+    slides = vault / "slides" / "talk.pdf"
+    _write_crc_damaged_media_pptx(deck)
+    _write_pdf(slides)
+
+    assessment = pattern_evidence.assess_talk_artifact_capabilities(
+        {
+            "filename": "talk.md",
+            "pptx_path": deck.relative_to(vault).as_posix(),
+            "slides_local_path": slides.relative_to(vault).as_posix(),
+            "slide_source": "pdf",
+        },
+        vault_root=vault,
+    )
+
+    assert assessment["verified_capabilities"] == ("slides",)
+    assert assessment["verified_evidence_sources"] == ("static_slides",)
+    assert "native_deck" in assessment["degraded_evidence_sources"]
+
+
+def test_structural_pptx_damage_is_unavailable_without_erasing_transcript(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    transcript, _lines = _write_transcript(vault, timed=False)
+    deck = vault / "decks" / "talk.pptx"
+    _write_pptx(deck, slide_count=1)
+    with zipfile.ZipFile(deck) as archive:
+        member = archive.getinfo("ppt/slides/slide1.xml")
+    package = bytearray(deck.read_bytes())
+    name_size, extra_size = struct.unpack_from(
+        "<HH", package, member.header_offset + 26
+    )
+    payload_offset = member.header_offset + 30 + name_size + extra_size
+    package[payload_offset + (member.compress_size // 2)] ^= 0xFF
+    deck.write_bytes(package)
+
+    assessment = pattern_evidence.assess_talk_artifact_capabilities(
+        {
+            "filename": "talk.md",
+            "transcript_path": transcript.relative_to(vault).as_posix(),
+            "transcript_source": "manual",
+            "pptx_path": deck.relative_to(vault).as_posix(),
+            "slide_source": "pptx",
+        },
+        vault_root=vault,
+    )
+
+    assert assessment["verified_capabilities"] == ("transcript",)
+    assert assessment["verified_evidence_sources"] == ("transcript",)
+    assert "structural PPTX member" in assessment["source_reasons"]["native_deck"]
+    assert assessment["degraded_evidence_sources"] == {}
+
+
+def test_native_deck_audit_is_recomputed_and_bound_to_canonical_render(
+    pptx_extraction,
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    deck = vault / "decks" / "talk.pptx"
+    image_path = vault / "decks" / "full-bleed.png"
+    deck.parent.mkdir(parents=True)
+    Image.new("RGB", (640, 480), "navy").save(image_path)
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    slide.shapes.add_picture(
+        str(image_path),
+        0,
+        0,
+        width=presentation.slide_width,
+        height=presentation.slide_height,
+    )
+    presentation.save(str(deck))
+    rendered = vault / "slides" / "talk.pdf"
+    _write_pdf(rendered, page_count=1)
+    extraction = pptx_extraction.extract_pptx(
+        deck,
+        ocr=False,
+        rendered_pdf_path=rendered,
+        inspected_page_ranges=[[1, 1]],
+    )
+    talk = {
+        "filename": "talk.md",
+        "pptx_path": deck.relative_to(vault).as_posix(),
+        "slides_local_path": rendered.relative_to(vault).as_posix(),
+        "slide_source": "both",
+    }
+    raw = {
+        "filename": "talk.md",
+        "return_schema_version": 4,
+        "status": "processed_partial",
+        "slide_source": "both",
+        "transcript_source": "none",
+        "structured_data": {
+            "slide_count": 1,
+            "native_deck_audit": extraction["native_deck_audit"],
+        },
+        "pattern_observations": {
+            "evidence_sources": ["native_deck", "static_slides"],
+            "source_inspection": [
+                {"source": "native_deck", "page_ranges": [[1, 1]]},
+                {"source": "static_slides", "page_ranges": [[1, 1]]},
+            ],
+            "patterns_detected": [],
+            "antipatterns_detected": [],
+            "not_evaluable": [],
+            "pattern_score": 0,
+        },
+    }
+    original = copy.deepcopy(raw)
+    canonical = pattern_evidence.canonicalize_return_evidence(
+        raw,
+        talk,
+        vault,
+        _catalog(),
+    )
+    assert raw == original
+    assert canonical["structured_data"]["native_deck_audit"] == (
+        extraction["native_deck_audit"]
+    )
+
+    forged = copy.deepcopy(raw)
+    forged["structured_data"]["native_deck_audit"] = (
+        pptx_evidence.build_native_deck_audit(
+            source_pptx_sha256=extraction["input_fingerprint"]["digest"],
+            source_pptx_size_bytes=extraction["input_fingerprint"]["size_bytes"],
+            slide_count=1,
+            render_required_reasons={},
+        )
+    )
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match="disagrees with a fresh extraction",
+    ):
+        pattern_evidence.canonicalize_return_evidence(
+            forged,
+            talk,
+            vault,
+            _catalog(),
+        )
+
+    original_render = rendered.read_bytes()
+    assert b"pypdf" in original_render
+    changed_render = original_render.replace(b"pypdf", b"qypdf", 1)
+    assert len(changed_render) == len(original_render)
+    rendered.write_bytes(changed_render)
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match="rendered_page_inspection.*(canonical static_slides|PDF generation)",
+    ):
+        pattern_evidence.canonicalize_return_evidence(
+            raw,
+            talk,
+            vault,
+            _catalog(),
+        )
+
+
 def test_invalid_deck_cannot_hide_an_independent_valid_transcript(
     tmp_path: Path,
 ) -> None:
@@ -1547,14 +1944,17 @@ def test_missing_python_pptx_dependency_is_local_to_the_pptx_lane(
     slides = vault / "slides" / "talk.pdf"
     _write_pptx(deck)
     _write_pdf(slides)
-    original_import = builtins.__import__
+    def unavailable_pptx(_path: Path) -> Any:
+        raise pattern_evidence.PptxEvidenceError(
+            "PPTX evidence requires the declared python-pptx runtime dependency",
+            reason_code="pptx_dependency_unavailable",
+        )
 
-    def without_pptx(name: str, *args: Any, **kwargs: Any) -> Any:
-        if name == "pptx" or name.startswith("pptx."):
-            raise ImportError("synthetic missing python-pptx")
-        return original_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", without_pptx)
+    monkeypatch.setattr(
+        pattern_evidence,
+        "probe_pptx_artifact",
+        unavailable_pptx,
+    )
     assessment = pattern_evidence.assess_talk_artifact_capabilities(
         {
             "filename": "talk.md",

--- a/tests/test_pptx_evidence_recovery.py
+++ b/tests/test_pptx_evidence_recovery.py
@@ -1,0 +1,779 @@
+"""Focused regressions for PPTX recovery and exact audit receipts."""
+
+from __future__ import annotations
+
+import ast
+import json
+import struct
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+from pptx import Presentation
+from pptx.util import Inches
+from pypdf import PdfWriter
+
+
+def _write_deck(path: Path, *, with_image: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[6])
+    if with_image:
+        image_path = path.with_suffix(".png")
+        Image.new("RGB", (64, 64), "navy").save(image_path)
+        slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
+    deck.save(path)
+
+
+def _damage_member(path: Path, predicate) -> str:
+    with zipfile.ZipFile(path) as archive:
+        member = next(
+            item for item in archive.infolist() if predicate(item.filename)
+        )
+    package = bytearray(path.read_bytes())
+    name_size, extra_size = struct.unpack_from(
+        "<HH", package, member.header_offset + 26
+    )
+    payload_offset = member.header_offset + 30 + name_size + extra_size
+    package[payload_offset + max(member.compress_size // 2, 0)] ^= 0xFF
+    path.write_bytes(package)
+    return member.filename
+
+
+def _damage_member_crc(path: Path, predicate) -> str:
+    """Alter only the central-directory CRC so reading raises BadZipFile."""
+    with zipfile.ZipFile(path) as archive:
+        member = next(
+            item for item in archive.infolist() if predicate(item.filename)
+        )
+    package = bytearray(path.read_bytes())
+    cursor = 0
+    while True:
+        header = package.find(b"PK\x01\x02", cursor)
+        if header < 0:
+            raise AssertionError(f"central directory entry not found: {member.filename}")
+        name_size, extra_size, comment_size = struct.unpack_from(
+            "<HHH", package, header + 28
+        )
+        name_start = header + 46
+        name_end = name_start + name_size
+        if package[name_start:name_end].decode("utf-8") == member.filename:
+            recorded_crc = struct.unpack_from("<I", package, header + 16)[0]
+            struct.pack_into("<I", package, header + 16, recorded_crc ^ 0xFFFFFFFF)
+            path.write_bytes(package)
+            return member.filename
+        cursor = name_end + extra_size + comment_size
+
+
+def _write_pdf(path: Path, *, page_count: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    writer = PdfWriter()
+    for _index in range(page_count):
+        writer.add_blank_page(width=640, height=480)
+    with path.open("wb") as stream:
+        writer.write(stream)
+
+
+def test_live_badzipfile_media_path_recovers_with_structured_loss(
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "damaged-media.pptx"
+    _write_deck(deck, with_image=True)
+    damaged_part = _damage_member_crc(
+        deck, lambda name: name.startswith("ppt/media/")
+    )
+
+    with pytest.raises(zipfile.BadZipFile):
+        Presentation(deck)
+
+    probe = pptx_evidence.probe_pptx_artifact(deck)
+
+    assert probe.slide_count == 1
+    assert len(probe.source_sha256) == 64
+    assert probe.archive_recovery == (
+        {
+            "schema_version": 1,
+            "part_name": damaged_part,
+            "member_kind": "embedded_media",
+            "error_type": "crc_mismatch",
+            "status": "recovered_with_placeholder_asset",
+            "content_replaced": True,
+            "replacement_sha256": (
+                "431ced6916a2a21a156e38701afe55bbd7f88969fbbfc56d7fe099d47f265460"
+            ),
+        },
+    )
+
+
+def test_bounded_probe_timeout_is_structured_and_cached(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "slow.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    calls = 0
+
+    def timeout_runner(command, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise subprocess.TimeoutExpired(
+            command,
+            pptx_evidence.PPTX_ARTIFACT_PROBE_TIMEOUT_SECONDS,
+        )
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", timeout_runner)
+    for _index in range(2):
+        with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+            pptx_evidence.probe_pptx_artifact(deck)
+        assert caught.value.reason_code == "pptx_probe_timeout"
+    assert calls == 1
+
+
+def test_bounded_probe_resource_failure_is_structured(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "memory-heavy.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+
+    def resource_runner(command, **_kwargs):
+        Path(command[-1]).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "unavailable",
+                    "reason_code": "pptx_probe_resource_unavailable",
+                    "details": {},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", resource_runner)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.probe_pptx_artifact(deck)
+    assert caught.value.reason_code == "pptx_probe_resource_unavailable"
+
+
+def test_successful_probe_is_cached_by_exact_file_generation(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "cached.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    calls = 0
+
+    def successful_runner(command, **_kwargs):
+        nonlocal calls
+        calls += 1
+        Path(command[-1]).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "available",
+                    "slide_count": 1,
+                    "source_sha256": "a" * 64,
+                    "source_size_bytes": deck.stat().st_size,
+                    "archive_recovery": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", successful_runner)
+    assert pptx_evidence.probe_pptx_artifact(deck).slide_count == 1
+    assert pptx_evidence.probe_pptx_artifact(deck).source_sha256 == "a" * 64
+    assert calls == 1
+
+
+def test_single_recovery_read_is_transient_and_not_cached(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "materializing.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    calls = 0
+    recovery = [{
+        "schema_version": 1,
+        "part_name": "ppt/media/image1.png",
+        "member_kind": "embedded_media",
+        "error_type": "crc_mismatch",
+        "status": "recovered_with_placeholder_asset",
+        "content_replaced": True,
+        "replacement_sha256": (
+            "431ced6916a2a21a156e38701afe55bbd7f88969fbbfc56d7fe099d47f265460"
+        ),
+    }]
+
+    def materializing_runner(command, **_kwargs):
+        nonlocal calls
+        calls += 1
+        Path(command[-1]).write_text(
+            json.dumps({
+                "schema_version": 1,
+                "status": "available",
+                "slide_count": 1,
+                "source_sha256": "a" * 64,
+                "source_size_bytes": deck.stat().st_size,
+                "archive_recovery": recovery if calls == 1 else [],
+            })
+            + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", materializing_runner)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.probe_pptx_artifact(deck)
+    assert caught.value.reason_code == "pptx_probe_materialization_changed"
+    assert calls == 2
+
+    assert pptx_evidence.probe_pptx_artifact(deck).archive_recovery == ()
+    assert calls == 3
+
+
+def test_single_structural_crc_failure_is_not_cached_when_confirmation_is_clean(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "materializing-structure.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    calls = 0
+
+    def materializing_runner(command, **_kwargs):
+        nonlocal calls
+        calls += 1
+        payload = (
+            {
+                "schema_version": 1,
+                "status": "unavailable",
+                "reason_code": "pptx_structural_damage",
+                "details": {"part_names": ["ppt/slides/slide1.xml"]},
+            }
+            if calls == 1
+            else {
+                "schema_version": 1,
+                "status": "available",
+                "slide_count": 1,
+                "source_sha256": "a" * 64,
+                "source_size_bytes": deck.stat().st_size,
+                "archive_recovery": [],
+            }
+        )
+        Path(command[-1]).write_text(
+            json.dumps(payload) + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", materializing_runner)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.probe_pptx_artifact(deck)
+    assert caught.value.reason_code == "pptx_probe_materialization_changed"
+    assert calls == 2
+
+    assert pptx_evidence.probe_pptx_artifact(deck).slide_count == 1
+    assert calls == 3
+
+
+def test_single_child_io_failure_is_not_cached_when_confirmation_is_clean(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "hydrating.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    calls = 0
+
+    def hydrating_runner(command, **_kwargs):
+        nonlocal calls
+        calls += 1
+        payload = (
+            {
+                "schema_version": 1,
+                "status": "unavailable",
+                "reason_code": "pptx_artifact_unavailable",
+                "details": {"exception_type": "OSError"},
+            }
+            if calls == 1
+            else {
+                "schema_version": 1,
+                "status": "available",
+                "slide_count": 1,
+                "source_sha256": "a" * 64,
+                "source_size_bytes": deck.stat().st_size,
+                "archive_recovery": [],
+            }
+        )
+        Path(command[-1]).write_text(
+            json.dumps(payload) + "\n", encoding="utf-8"
+        )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", hydrating_runner)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.probe_pptx_artifact(deck)
+    assert caught.value.reason_code == "pptx_probe_materialization_changed"
+    assert calls == 2
+
+    assert pptx_evidence.probe_pptx_artifact(deck).slide_count == 1
+    assert calls == 3
+
+
+def test_snapshot_open_io_failure_has_portable_unavailable_code(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "open-failure.pptx"
+    _write_deck(deck, with_image=False)
+    original_open = Path.open
+
+    def failing_open(path: Path, *args, **kwargs):
+        if path == deck:
+            raise OSError("synthetic hydration failure")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", failing_open)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence._probe_pptx_artifact_in_process(deck)
+    assert caught.value.reason_code == "pptx_artifact_unavailable"
+    assert caught.value.details == {"exception_type": "OSError"}
+
+
+def test_snapshot_generation_change_has_nonsticky_changed_code(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "generation-change.pptx"
+    _write_deck(deck, with_image=False)
+    actual = deck.lstat()
+    original_lstat = Path.lstat
+    calls = 0
+
+    def changing_lstat(path: Path):
+        nonlocal calls
+        if path != deck:
+            return original_lstat(path)
+        calls += 1
+        if calls == 1:
+            return actual
+        return SimpleNamespace(
+            st_mode=actual.st_mode,
+            st_dev=actual.st_dev,
+            st_ino=actual.st_ino,
+            st_size=actual.st_size,
+            st_mtime_ns=actual.st_mtime_ns + 1,
+            st_ctime_ns=actual.st_ctime_ns,
+            st_flags=getattr(actual, "st_flags", 0),
+        )
+
+    monkeypatch.setattr(Path, "lstat", changing_lstat)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.snapshot_regular_file(deck, label="PPTX artifact")
+    assert caught.value.reason_code == "pptx_artifact_changed"
+
+
+def test_rendered_pdf_same_size_generation_replacement_fails_closed(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    rendered = tmp_path / "rendered.pdf"
+    _write_pdf(rendered, page_count=1)
+    actual = rendered.lstat()
+    original_lstat = Path.lstat
+    calls = 0
+
+    def replaced_lstat(path: Path):
+        nonlocal calls
+        if path != rendered:
+            return original_lstat(path)
+        calls += 1
+        if calls == 1:
+            return actual
+        return SimpleNamespace(
+            st_mode=actual.st_mode,
+            st_dev=actual.st_dev,
+            st_ino=actual.st_ino,
+            st_size=actual.st_size,
+            st_mtime_ns=actual.st_mtime_ns + 1,
+            st_ctime_ns=actual.st_ctime_ns,
+            st_flags=getattr(actual, "st_flags", 0),
+        )
+
+    monkeypatch.setattr(Path, "lstat", replaced_lstat)
+    with pytest.raises(pptx_evidence.PptxEvidenceError, match="changed"):
+        pptx_evidence.snapshot_rendered_pdf(rendered)
+
+
+def test_native_audit_recomputation_timeout_is_structured(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "slow-audit.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+
+    def timeout_runner(command, **_kwargs):
+        raise subprocess.TimeoutExpired(
+            command,
+            pptx_evidence.PPTX_ARTIFACT_PROBE_TIMEOUT_SECONDS,
+        )
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", timeout_runner)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.recompute_native_deck_audit(deck)
+    assert caught.value.reason_code == "pptx_probe_timeout"
+
+
+def test_native_audit_recovery_is_not_sticky_when_confirmation_is_clean(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "materializing-audit.pptx"
+    _write_deck(deck, with_image=False)
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+    audit = pptx_evidence.build_native_deck_audit(
+        source_pptx_sha256="a" * 64,
+        source_pptx_size_bytes=deck.stat().st_size,
+        slide_count=1,
+        render_required_reasons={},
+    )
+    calls = 0
+
+    def materializing_runner(command, **_kwargs):
+        nonlocal calls
+        calls += 1
+        payload = (
+            {
+                "schema_version": 1,
+                "status": "unavailable",
+                "reason_code": "pptx_archive_recovery_required",
+                "details": {"part_names": ["ppt/media/image1.png"]},
+            }
+            if calls == 1
+            else {
+                "schema_version": 1,
+                "status": "available",
+                "native_deck_audit": audit,
+            }
+        )
+        Path(command[-1]).write_text(
+            json.dumps(payload) + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(pptx_evidence.subprocess, "run", materializing_runner)
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.recompute_native_deck_audit(deck)
+    assert caught.value.reason_code == "pptx_probe_materialization_changed"
+    assert calls == 2
+    assert pptx_evidence.recompute_native_deck_audit(deck) == audit
+    assert calls == 3
+
+
+def test_dataless_cloud_placeholder_never_starts_worker_io(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "cloud-placeholder.pptx"
+    _write_deck(deck, with_image=False)
+    actual = deck.lstat()
+    dataless_flag = pptx_evidence.PPTX_MACOS_DATALESS_FLAG or 0x40000000
+    original_lstat = Path.lstat
+
+    def dataless_lstat(path: Path):
+        if path == deck:
+            return SimpleNamespace(
+                st_mode=actual.st_mode,
+                st_dev=actual.st_dev,
+                st_ino=actual.st_ino,
+                st_size=actual.st_size,
+                st_mtime_ns=actual.st_mtime_ns,
+                st_ctime_ns=actual.st_ctime_ns,
+                st_flags=dataless_flag,
+            )
+        return original_lstat(path)
+
+    if pptx_evidence.PPTX_MACOS_DATALESS_FLAG == 0:
+        monkeypatch.setattr(
+            pptx_evidence,
+            "PPTX_MACOS_DATALESS_FLAG",
+            dataless_flag,
+        )
+    monkeypatch.setattr(Path, "lstat", dataless_lstat)
+    monkeypatch.setattr(
+        pptx_evidence.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("dataless deck started worker I/O"),
+    )
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.probe_pptx_artifact(deck)
+    assert caught.value.reason_code == "pptx_cloud_placeholder_unavailable"
+
+
+def test_dataless_flag_uses_explicit_darwin_fallback(pptx_evidence) -> None:
+    expected = int(
+        getattr(
+            pptx_evidence.stat_module,
+            "SF_DATALESS",
+            0x40000000 if sys.platform == "darwin" else 0,
+        )
+    )
+    assert pptx_evidence.PPTX_MACOS_DATALESS_FLAG == expected
+    if sys.platform == "darwin":
+        assert expected == 0x40000000
+
+
+def test_structural_crc_damage_is_unavailable_not_placeholder_recovered(
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "damaged-slide.pptx"
+    _write_deck(deck, with_image=False)
+    damaged_part = _damage_member(
+        deck, lambda name: name == "ppt/slides/slide1.xml"
+    )
+
+    with pytest.raises(
+        pptx_evidence.PptxEvidenceError,
+        match=f"structural PPTX member.*{damaged_part}",
+    ):
+        pptx_evidence.probe_pptx_artifact(deck)
+
+
+def test_corrupt_member_scan_enforces_recovery_record_cap(
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    package_path = tmp_path / "many-corrupt.zip"
+    with zipfile.ZipFile(package_path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for index in range(
+            pptx_evidence.PPTX_ARTIFACT_PROBE_MAX_RECOVERY_RECORDS + 1
+        ):
+            archive.writestr(f"ppt/media/image{index}.bin", b"asset")
+    package = bytearray(package_path.read_bytes())
+    cursor = 0
+    while True:
+        header = package.find(b"PK\x01\x02", cursor)
+        if header < 0:
+            break
+        recorded_crc = struct.unpack_from("<I", package, header + 16)[0]
+        struct.pack_into("<I", package, header + 16, recorded_crc ^ 0xFFFFFFFF)
+        name_size, extra_size, comment_size = struct.unpack_from(
+            "<HHH", package, header + 28
+        )
+        cursor = header + 46 + name_size + extra_size + comment_size
+
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence._corrupt_zip_members(bytes(package))
+    assert caught.value.reason_code == "pptx_probe_result_oversized"
+
+
+def test_malformed_container_is_structured_unavailable(
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "not-a-deck.pptx"
+    deck.write_bytes(b"not an OOXML ZIP package")
+
+    with pytest.raises(
+        pptx_evidence.PptxEvidenceError,
+        match="invalid PPTX ZIP container",
+    ):
+        pptx_evidence.probe_pptx_artifact(deck)
+
+
+def test_extractor_reports_recovered_media_and_keeps_schema_versions_distinct(
+    pptx_extraction,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "damaged-media.pptx"
+    _write_deck(deck, with_image=True)
+    damaged_part = _damage_member(
+        deck, lambda name: name.startswith("ppt/media/")
+    )
+
+    result = pptx_extraction.extract_pptx(deck, ocr=False)
+
+    assert result["schema_version"] == 3
+    assert result["pipeline_version"] == "1.2.0"
+    assert result["archive_recovery"][0]["part_name"] == damaged_part
+    assert result["corrupt_assets"] == [
+        {
+            "part_name": damaged_part,
+            "error_type": "crc_mismatch",
+            "status": "recovered_with_placeholder",
+        }
+    ]
+    assert result["native_deck_audit"]["schema_version"] == 1
+    assert result["native_deck_audit"]["extraction_schema_version"] == 3
+
+
+def test_render_receipt_binds_exact_source_render_and_ranges(
+    pptx_extraction,
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "render-required.pptx"
+    deck.parent.mkdir(parents=True, exist_ok=True)
+    image_path = tmp_path / "full-bleed.png"
+    Image.new("RGB", (640, 480), "navy").save(image_path)
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    slide.shapes.add_picture(
+        str(image_path),
+        0,
+        0,
+        width=presentation.slide_width,
+        height=presentation.slide_height,
+    )
+    presentation.save(deck)
+    rendered = tmp_path / "rendered.pdf"
+    _write_pdf(rendered, page_count=1)
+
+    result = pptx_extraction.extract_pptx(
+        deck,
+        ocr=False,
+        rendered_pdf_path=rendered,
+        inspected_page_ranges=[[1, 1]],
+    )
+    audit = pptx_evidence.validate_native_deck_audit(
+        result["native_deck_audit"], slide_count=1
+    )
+
+    assert audit["render_required_slide_numbers"] == [1]
+    receipt = audit["rendered_page_inspection"]
+    assert receipt["inspected_page_ranges"] == [[1, 1]]
+    assert receipt["complete"] is True
+    tampered = json.loads(json.dumps(audit))
+    tampered["rendered_page_inspection"]["inspected_page_ranges"] = []
+    with pytest.raises(
+        pptx_evidence.PptxEvidenceError,
+        match="inspected_required_slide_numbers",
+    ):
+        pptx_evidence.validate_native_deck_audit(tampered, slide_count=1)
+
+
+@pytest.mark.parametrize(
+    ("size_bytes", "slide_count"),
+    [(True, 1), (1, True), (0, 1), (1, 0)],
+)
+def test_native_audit_builder_rejects_nonpositive_and_boolean_integers(
+    pptx_evidence,
+    size_bytes,
+    slide_count,
+) -> None:
+    with pytest.raises(pptx_evidence.PptxEvidenceError):
+        pptx_evidence.build_native_deck_audit(
+            source_pptx_sha256="a" * 64,
+            source_pptx_size_bytes=size_bytes,
+            slide_count=slide_count,
+            render_required_reasons={},
+        )
+
+
+def test_render_builder_rejects_boolean_slide_count_before_file_io(
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(pptx_evidence.PptxEvidenceError, match="positive integer"):
+        pptx_evidence.build_rendered_page_inspection(
+            source_pptx_sha256="a" * 64,
+            rendered_pdf_path=tmp_path / "missing.pdf",
+            inspected_page_ranges=[],
+            required_slide_numbers=[],
+            slide_count=True,
+        )
+
+
+def test_native_audit_rejects_future_or_extra_fields(
+    pptx_evidence,
+) -> None:
+    audit = pptx_evidence.build_native_deck_audit(
+        source_pptx_sha256="a" * 64,
+        source_pptx_size_bytes=1,
+        slide_count=1,
+        render_required_reasons={},
+    )
+    future = dict(audit, schema_version=2)
+    with pytest.raises(pptx_evidence.PptxEvidenceError, match="schema_version"):
+        pptx_evidence.validate_native_deck_audit(future)
+    extra = dict(audit, unexpected=True)
+    with pytest.raises(pptx_evidence.PptxEvidenceError, match="unknown"):
+        pptx_evidence.validate_native_deck_audit(extra)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -1.0, 101.0, True])
+def test_finite_confidence_rejects_nonfinite_or_out_of_domain(
+    pptx_evidence,
+    value,
+) -> None:
+    assert pptx_evidence.finite_confidence(value) is None
+
+
+def test_extractor_has_no_inner_broad_exception_handler(
+    pptx_extraction,
+) -> None:
+    tree = ast.parse(Path(pptx_extraction.__file__).read_text(encoding="utf-8"))
+    broad_handlers: list[tuple[str, int]] = []
+    for function in (
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    ):
+        for node in ast.walk(function):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            if isinstance(node.type, ast.Name) and node.type.id == "Exception":
+                broad_handlers.append((function.name, node.lineno))
+
+    assert len(broad_handlers) == 1
+    assert broad_handlers[0][0] == "main"
+
+
+def test_single_file_cli_reports_parser_failure_without_traceback(
+    pptx_extraction,
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "broken.pptx"
+    deck.write_bytes(b"not an OOXML ZIP package")
+
+    completed = subprocess.run(
+        [sys.executable, pptx_extraction.__file__, str(deck), "--no-ocr"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == 1
+    assert completed.stdout == ""
+    assert "invalid PPTX ZIP container" in completed.stderr
+    assert "Traceback" not in completed.stderr

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -1,10 +1,12 @@
 """Tests for pptx-extraction.py — PPTX visual data extraction."""
 
+import io
 import json
 import struct
 import subprocess
 import sys
 import zipfile
+from types import SimpleNamespace
 
 import pytest
 from pptx import Presentation
@@ -390,6 +392,15 @@ def test_normalize_ocr_text(pptx_extraction):
     assert pptx_extraction.normalize_ocr_text(None) == ""
 
 
+def test_ocr_confidence_is_paired_only_with_retained_token(pptx_extraction):
+    text, confidence = pptx_extraction._ocr_text_and_confidence({
+        "text": ["", "VISIBLE"],
+        "conf": [99.0, 12.0],
+    })
+    assert text == "VISIBLE"
+    assert confidence == 12.0
+
+
 def test_high_confidence_slide_method_is_shapes_only(pptx_extraction, tmp_path):
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
@@ -423,6 +434,211 @@ def test_full_bleed_runs_ocr_fn_and_records_inventory(
     assert data["text_extraction_method"] == "shapes+ocr"
 
 
+def test_multi_image_ocr_emits_one_identity_and_outcome_receipt_per_asset(
+    pptx_extraction, tmp_path,
+):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_picture(
+        _png_with_text(tmp_path / "left.png", text="LEFT LABEL"),
+        0,
+        0,
+        width=int(prs.slide_width / 2),
+        height=prs.slide_height,
+    )
+    slide.shapes.add_picture(
+        _png_with_text(tmp_path / "right.png", text="RIGHT LABEL"),
+        int(prs.slide_width / 2),
+        0,
+        width=int(prs.slide_width / 2),
+        height=prs.slide_height,
+    )
+    path = tmp_path / "multi-image.pptx"
+    prs.save(path)
+    outcomes = iter([
+        {
+            "engine": "fixture-ocr",
+            "engine_version": "1.0",
+            "result_status": "text_recovered",
+            "result_confidence": 94.5,
+            "recovered_text": "LEFT LABEL",
+            "trustworthy_text": True,
+            "error": None,
+        },
+        {
+            "engine": "fixture-ocr",
+            "engine_version": "1.0",
+            "result_status": "low_confidence_text",
+            "result_confidence": 31.0,
+            "recovered_text": "RIGHT LAB3L",
+            "trustworthy_text": False,
+            "error": None,
+        },
+    ])
+
+    data = pptx_extraction.extract_pptx(
+        str(path), ocr_fn=lambda _blobs: next(outcomes),
+    )["per_slide_visual"][0]
+    channel = next(
+        item
+        for item in data["text_channels"]
+        if item["channel"] == "picture_ocr"
+    )
+
+    assert channel["status"] == "partial"
+    assert channel["reason"] == "partial_ocr_results"
+    assert channel["text"] == "LEFT LABEL | RIGHT LAB3L"
+    assert channel["result_confidence"] == pytest.approx(62.75)
+    receipts = channel["ocr_receipts"]
+    assert len(receipts) == 2
+    assert [receipt["result_status"] for receipt in receipts] == [
+        "text_recovered",
+        "low_confidence_text",
+    ]
+    assert [receipt["part_name"] for receipt in receipts] == [
+        "ppt/media/image1.png",
+        "ppt/media/image2.png",
+    ]
+    assert all(len(receipt["asset_sha256"]) == 64 for receipt in receipts)
+    assert receipts[0]["asset_sha256"] != receipts[1]["asset_sha256"]
+    assert all(receipt["shape_path"] for receipt in receipts)
+    assert receipts[1]["recovered_text"] == "RIGHT LAB3L"
+    assert receipts[1]["trustworthy_text"] is False
+
+
+def test_genuine_empty_ocr_is_distinct_from_asset_failure(
+    pptx_extraction, tmp_path,
+):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    for index in range(2):
+        slide.shapes.add_picture(
+            _png(tmp_path / f"asset-{index}.png", w=16 + index),
+            int(prs.slide_width * index / 2),
+            0,
+            width=int(prs.slide_width / 2),
+            height=prs.slide_height,
+        )
+    path = tmp_path / "empty-vs-failure.pptx"
+    prs.save(path)
+    outcomes = iter([
+        {
+            "engine": "fixture-ocr",
+            "engine_version": "1.0",
+            "result_status": "genuine_empty",
+            "result_confidence": None,
+            "recovered_text": "",
+            "trustworthy_text": False,
+            "error": None,
+        },
+        {
+            "engine": "fixture-ocr",
+            "engine_version": "1.0",
+            "result_status": "failed",
+            "result_confidence": None,
+            "recovered_text": "",
+            "trustworthy_text": False,
+            "error": "engine_error: synthetic failure",
+        },
+    ])
+
+    data = pptx_extraction.extract_pptx(
+        str(path), ocr_fn=lambda _blobs: next(outcomes),
+    )["per_slide_visual"][0]
+    channel = next(
+        item
+        for item in data["text_channels"]
+        if item["channel"] == "picture_ocr"
+    )
+
+    assert channel["text"] == ""
+    assert channel["status"] == "failed"
+    assert [item["result_status"] for item in channel["ocr_receipts"]] == [
+        "genuine_empty",
+        "failed",
+    ]
+    assert channel["ocr_receipts"][0]["error"] is None
+    assert "synthetic failure" in channel["ocr_receipts"][1]["error"]
+
+
+def test_truncated_picture_is_one_failed_receipt_not_a_deck_abort(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_picture(
+        _png(tmp_path / "healthy.png", w=64),
+        0,
+        0,
+        width=int(prs.slide_width / 2),
+        height=prs.slide_height,
+    )
+    slide.shapes.add_picture(
+        _png(tmp_path / "truncated.png", w=65),
+        int(prs.slide_width / 2),
+        0,
+        width=int(prs.slide_width / 2),
+        height=prs.slide_height,
+    )
+    path = tmp_path / "mixed-assets.pptx"
+    prs.save(path)
+    source = io.BytesIO(path.read_bytes())
+    rewritten = io.BytesIO()
+    with (
+        zipfile.ZipFile(source) as archive,
+        zipfile.ZipFile(rewritten, "w") as destination,
+    ):
+        for member in archive.infolist():
+            payload = archive.read(member)
+            if member.filename == "ppt/media/image2.png":
+                payload = payload[:40]
+            destination.writestr(member, payload)
+    path.write_bytes(rewritten.getvalue())
+
+    class FakeTesseractError(Exception):
+        pass
+
+    def image_to_data(image, *, output_type):
+        assert output_type == "DICT"
+        image.load()
+        return {"text": ["HEALTHY"], "conf": ["93"]}
+
+    fake_pytesseract = SimpleNamespace(
+        Output=SimpleNamespace(DICT="DICT"),
+        TesseractNotFoundError=FakeTesseractError,
+        TesseractError=FakeTesseractError,
+        image_to_data=image_to_data,
+    )
+    monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
+    monkeypatch.setattr(pptx_extraction, "_tesseract_available", True)
+    monkeypatch.setattr(pptx_extraction, "_tesseract_version", "fixture-1")
+
+    data = pptx_extraction.extract_pptx(path)["per_slide_visual"][0]
+    channel = next(
+        item
+        for item in data["text_channels"]
+        if item["channel"] == "picture_ocr"
+    )
+
+    assert channel["status"] == "partial"
+    assert channel["text"] == "HEALTHY"
+    assert [item["result_status"] for item in channel["ocr_receipts"]] == [
+        "text_recovered",
+        "failed",
+    ]
+    assert [item["part_name"] for item in channel["ocr_receipts"]] == [
+        "ppt/media/image1.png",
+        "ppt/media/image2.png",
+    ]
+    failed = channel["ocr_receipts"][1]
+    assert failed["attempted"] is True
+    assert failed["trustworthy_text"] is False
+    assert failed["error"].startswith("image_decode_error:")
+    assert "/" not in failed["error"]
+
+
 def test_no_ocr_flag_skips_inventory(pptx_extraction, tmp_path):
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[6])
@@ -447,6 +663,15 @@ def test_no_ocr_flag_skips_inventory(pptx_extraction, tmp_path):
     assert data["ocr_text"] == ""
     assert data["text_extraction_method"] == "shapes"
     assert data["text_extraction_confidence"] == "low"
+    channel = next(
+        item
+        for item in data["text_channels"]
+        if item["channel"] == "picture_ocr"
+    )
+    assert channel["status"] == "skipped"
+    assert channel["ocr_receipts"][0]["attempted"] is False
+    assert channel["ocr_receipts"][0]["result_status"] == "skipped"
+    assert channel["ocr_receipts"][0]["part_name"] == "ppt/media/image1.png"
 
 
 def test_small_decorative_image_does_not_ocr(pptx_extraction, tmp_path):
@@ -489,6 +714,17 @@ def test_ocr_unavailable_records_method_not_crash(pptx_extraction, tmp_path):
     assert data["ocr_text"] == ""
     assert data["text_extraction_method"] == "shapes+ocr_unavailable"
     assert data["text_extraction_confidence"] == "low"
+    channel = next(
+        item
+        for item in data["text_channels"]
+        if item["channel"] == "picture_ocr"
+    )
+    assert channel["attempted"] is False
+    assert channel["engine"] == "tesseract"
+    assert channel["engine_version"] is None
+    assert channel["status"] == "unavailable"
+    assert channel["reason"] == "ocr_engine_unavailable"
+    assert channel["ocr_receipts"][0]["attempted"] is False
 
 
 def test_reported_image_background_without_blob_does_not_claim_ocr(
@@ -512,6 +748,18 @@ def test_reported_image_background_without_blob_does_not_claim_ocr(
     assert called == []
     assert data["ocr_text"] == ""
     assert data["text_extraction_method"] == "shapes"
+    channel = next(
+        item
+        for item in data["text_channels"]
+        if item["channel"] == "background_image_ocr"
+    )
+    assert channel["attempted"] is False
+    assert channel["engine"] == "tesseract"
+    assert channel["engine_version"] is None
+    assert channel["status"] == "unavailable"
+    assert channel["reason"] == "no_readable_asset"
+    assert channel["ocr_receipts"] == []
+    assert data["render_required"] is True
 
 
 def test_ocr_text_capped(pptx_extraction, monkeypatch):
@@ -520,6 +768,74 @@ def test_ocr_text_capped(pptx_extraction, monkeypatch):
     )
     out = pptx_extraction.ocr_picture_blobs([b"x"])
     assert len(out) == pptx_extraction._OCR_TEXT_MAX_CHARS
+
+
+@pytest.mark.parametrize(
+    "injected",
+    [
+        "A" * 9000,
+        {
+            "engine": "fixture",
+            "engine_version": "1",
+            "result_status": "text_recovered",
+            "result_confidence": 90.0,
+            "recovered_text": "A" * 9000,
+            "trustworthy_text": True,
+            "error": None,
+        },
+    ],
+)
+def test_each_ocr_receipt_text_is_capped(pptx_extraction, injected):
+    slide_data = {
+        "text_channels": [],
+        "ocr_text": "",
+        "text_extraction_method": "shapes",
+    }
+    pptx_extraction._run_ocr_channel(
+        slide_data,
+        [{
+            "blob": b"exact-asset",
+            "shape_path": ["Picture 1"],
+            "part_name": "ppt/media/image1.png",
+        }],
+        channel="picture_ocr",
+        provenance={"source": "embedded_picture_blobs"},
+        ocr_fn=lambda _blobs: injected,
+    )
+    receipt = slide_data["text_channels"][0]["ocr_receipts"][0]
+    assert len(receipt["recovered_text"]) == pptx_extraction._OCR_TEXT_MAX_CHARS
+    assert len(slide_data["ocr_text"]) == pptx_extraction._OCR_TEXT_MAX_CHARS
+
+
+def test_untrustworthy_recovered_receipt_keeps_channel_partial(pptx_extraction):
+    slide_data = {
+        "text_channels": [],
+        "ocr_text": "",
+        "text_extraction_method": "shapes",
+    }
+    pptx_extraction._run_ocr_channel(
+        slide_data,
+        [{
+            "blob": b"exact-asset",
+            "shape_path": ["Picture 1"],
+            "part_name": "ppt/media/image1.png",
+        }],
+        channel="picture_ocr",
+        provenance={"source": "embedded_picture_blobs"},
+        ocr_fn=lambda _blobs: {
+            "engine": "fixture",
+            "engine_version": "1",
+            "result_status": "text_recovered",
+            "result_confidence": 10.0,
+            "recovered_text": "UNCERTAIN",
+            "trustworthy_text": False,
+            "error": None,
+        },
+    )
+    channel = slide_data["text_channels"][0]
+    assert channel["text"] == "UNCERTAIN"
+    assert channel["status"] == "partial"
+    assert channel["reason"] == "partial_ocr_results"
 
 
 def test_ocr_image_bytes_reads_clear_text(pptx_extraction, tmp_path):
@@ -809,6 +1125,16 @@ def test_bad_crc_media_is_recovered_without_losing_the_deck(
         item["content_type"] == "corrupt_embedded_asset"
         for item in data["unsupported_content"]
     )
+    channel = next(
+        item
+        for item in data["text_channels"]
+        if item["channel"] == "picture_ocr"
+    )
+    assert channel["attempted"] is False
+    assert channel["status"] == "unavailable"
+    assert channel["reason"] == "no_readable_asset"
+    assert channel["ocr_receipts"] == []
+    assert data["render_required"] is True
 
 
 # ── native timing/build structure (issue #151) ──────────────────────
@@ -832,6 +1158,19 @@ def _append_transition_xml(slide):
     ))
 
 
+def _append_build_list_xml(slide):
+    """Append real PresentationML build entries without inferring playback."""
+    timing = slide.element.xpath("./p:timing")[0]
+    timing.append(parse_xml(
+        f'<p:bldLst {nsdecls("p")}>'
+        '<p:bldP spid="2" grpId="0"/>'
+        '<p:bldDgm spid="3" grpId="1"/>'
+        '<p:bldOleChart spid="4" grpId="2"/>'
+        '<p:bldGraphic spid="5" grpId="3"/>'
+        '</p:bldLst>'
+    ))
+
+
 def test_native_timing_categories_and_deck_totals_stay_distinct(
         pptx_extraction, tmp_path):
     prs = Presentation()
@@ -849,6 +1188,7 @@ def test_native_timing_categories_and_deck_totals_stay_distinct(
         '<p:audio><p:cMediaNode><p:cTn id="4"/></p:cMediaNode></p:audio>'
         '<p:video><p:cMediaNode><p:cTn id="5"/></p:cMediaNode></p:video>'
     ))
+    _append_build_list_xml(animated)
 
     media_only = prs.slides.add_slide(prs.slide_layouts[6])
     _append_timing_xml(media_only, (
@@ -880,6 +1220,16 @@ def test_native_timing_categories_and_deck_totals_stay_distinct(
     }
     assert first["media_timing_counts"] == {
         "audio": 1, "video": 1, "total": 2}
+    assert first["build_list_present"] is True
+    assert first["build_list_count"] == 1
+    assert first["build_entry_counts"] == {
+        "paragraph": 1,
+        "diagram": 1,
+        "ole_chart": 1,
+        "graphic": 1,
+        "total": 4,
+    }
+    assert first["has_build_entries"] is True
     assert first["has_animation_behaviors"] is True
     assert first["has_media_timing"] is True
     assert first["provenance"] == {
@@ -899,6 +1249,16 @@ def test_native_timing_categories_and_deck_totals_stay_distinct(
     assert second["has_media_timing"] is True
     assert second["media_timing_counts"] == {
         "audio": 1, "video": 0, "total": 1}
+    assert second["build_list_present"] is False
+    assert second["build_list_count"] == 0
+    assert second["build_entry_counts"] == {
+        "paragraph": 0,
+        "diagram": 0,
+        "ole_chart": 0,
+        "graphic": 0,
+        "total": 0,
+    }
+    assert second["has_build_entries"] is False
 
     third = slides[2]["native_timing"]
     assert third["timing_element_present"] is False
@@ -911,10 +1271,13 @@ def test_native_timing_categories_and_deck_totals_stay_distinct(
         "slides_with_transitions": 2,
         "slides_with_animation_behaviors": 1,
         "slides_with_media_timing": 2,
+        "slides_with_build_lists": 1,
+        "slides_with_build_entries": 1,
         "timing_element_count": 2,
         "transition_count": 2,
         "set_action_count": 2,
         "visibility_set_action_count": 1,
+        "build_list_count": 1,
         "animation_behavior_counts": {
             "general": 1,
             "color": 1,
@@ -925,6 +1288,13 @@ def test_native_timing_categories_and_deck_totals_stay_distinct(
             "total": 7,
         },
         "media_timing_counts": {"audio": 2, "video": 1, "total": 3},
+        "build_entry_counts": {
+            "paragraph": 1,
+            "diagram": 1,
+            "ole_chart": 1,
+            "graphic": 1,
+            "total": 4,
+        },
         "provenance": {
             "source": "pptx_package_xml",
             "measurement": "raw_ooxml_element_counts",
@@ -959,6 +1329,12 @@ def test_adjacent_static_progressive_builds_do_not_invent_native_timing(
     )
     assert result["native_timing_summary"]["animation_behavior_counts"]["total"] == 0
     assert result["native_timing_summary"]["media_timing_counts"]["total"] == 0
+    assert all(
+        slide["native_timing"]["build_list_present"] is False
+        and slide["native_timing"]["build_entry_counts"]["total"] == 0
+        for slide in result["per_slide_visual"]
+    )
+    assert result["native_timing_summary"]["build_entry_counts"]["total"] == 0
 
 
 def test_versions_and_input_fingerprint_are_stable_and_content_addressed(
@@ -977,8 +1353,8 @@ def test_versions_and_input_fingerprint_are_stable_and_content_addressed(
     copied = pptx_extraction.extract_pptx(str(copy), ocr=False)
     changed = pptx_extraction.extract_pptx(str(modified), ocr=False)
 
-    assert pptx_extraction.SCHEMA_VERSION == 2
-    assert pptx_extraction.PIPELINE_VERSION == "1.1.0"
+    assert pptx_extraction.SCHEMA_VERSION == 3
+    assert pptx_extraction.PIPELINE_VERSION == "1.2.0"
     assert first["schema_version"] == pptx_extraction.SCHEMA_VERSION
     assert first["pipeline_version"] == pptx_extraction.PIPELINE_VERSION
     assert first["input_fingerprint"] == second["input_fingerprint"]

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4,11 +4,16 @@ from copy import deepcopy
 import importlib
 import json
 from pathlib import Path
+import struct
 import subprocess
 import sys
 from typing import Any
+import zipfile
 
 import pytest
+from PIL import Image
+from pptx import Presentation
+from pptx.util import Inches
 
 
 VIDEO_ID = "AbCdEfGhI_1"
@@ -140,6 +145,59 @@ def materialize_transcript(fixture, video_id=VIDEO_ID):
     return path
 
 
+def materialize_crc_damaged_pptx(fixture):
+    """Create a deck with one CRC-damaged media member under the source root."""
+    image_path = fixture["pptx_source"] / "asset.png"
+    Image.new("RGB", (64, 64), "navy").save(image_path)
+    path = fixture["pptx_source"] / "damaged.pptx"
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[6])
+    slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
+    deck.save(str(path))
+    with zipfile.ZipFile(path) as archive:
+        member = next(
+            item
+            for item in archive.infolist()
+            if item.filename.startswith("ppt/media/") and item.file_size
+        )
+    package = bytearray(path.read_bytes())
+    name_size, extra_size = struct.unpack_from(
+        "<HH", package, member.header_offset + 26
+    )
+    payload_offset = member.header_offset + 30 + name_size + extra_size
+    package[payload_offset + (member.compress_size // 2)] ^= 0xFF
+    path.write_bytes(package)
+    return path, member.filename
+
+
+def materialize_shared_crc_damaged_tiff_pptx(fixture, *, slide_count=73):
+    """Model the stable multi-owner vault deck without retaining private bytes."""
+    image_path = fixture["pptx_source"] / "shared-asset.tiff"
+    Image.new("RGB", (64, 64), "navy").save(image_path, format="TIFF")
+    path = fixture["pptx_source"] / "shared-damaged-73-slides.pptx"
+    deck = Presentation()
+    for index in range(slide_count):
+        slide = deck.slides.add_slide(deck.slide_layouts[6])
+        if index == 0:
+            slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
+    deck.save(str(path))
+    with zipfile.ZipFile(path) as archive:
+        member = next(
+            item
+            for item in archive.infolist()
+            if item.filename.startswith("ppt/media/") and item.file_size
+        )
+    assert member.filename.endswith(".tiff")
+    package = bytearray(path.read_bytes())
+    name_size, extra_size = struct.unpack_from(
+        "<HH", package, member.header_offset + 26
+    )
+    payload_offset = member.header_offset + 30 + name_size + extra_size
+    package[payload_offset + (member.compress_size // 2)] ^= 0xFF
+    path.write_bytes(package)
+    return path, member.filename
+
+
 def trusted_video_manifest(fixture, page_count=1):
     rebuild = fixture["root"] / "slides-rebuild" / VIDEO_ID
     rebuild.mkdir(parents=True, exist_ok=True)
@@ -245,7 +303,9 @@ def test_clean_record_has_no_findings(preflight_vault, vault_fixture):
     (vault_fixture["slides"] / f"{DRIVE_ID}.pdf").write_bytes(b"%PDF fixture")
     pptx = vault_fixture["pptx_source"] / "Conf" / "Perfect.pptx"
     pptx.parent.mkdir()
-    pptx.write_bytes(b"PPTX fixture")
+    deck = Presentation()
+    deck.slides.add_slide(deck.slide_layouts[6])
+    deck.save(str(pptx))
     talk = base_talk(
         slide_source="both",
         google_drive_id=DRIVE_ID,
@@ -343,6 +403,7 @@ def test_legacy_quality_warning_allows_normalize_to_requeue(
         text=True,
         capture_output=True,
         check=False,
+        timeout=30,
     )
 
     assert completed.returncode == 0, completed.stderr
@@ -724,6 +785,134 @@ def test_legacy_missing_remote_pdf_is_a_reacquisition_warning(
     )
     assert finding["severity"] == "warning"
     assert finding["capability_fact"]["acquisition_capabilities"] == ["slides"]
+
+
+def test_crc_damaged_pptx_preflight_is_structured_and_severity_is_current_aware(
+    preflight_vault,
+    vault_fixture,
+):
+    materialize_transcript(vault_fixture)
+    deck, damaged_part = materialize_crc_damaged_pptx(vault_fixture)
+    legacy = base_talk(
+        slide_source="pptx",
+        pptx_path=deck.name,
+    )
+    write_database(vault_fixture, [legacy])
+
+    warning_report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    warning = next(
+        item
+        for item in warning_report["findings"]
+        if item["code"] == "slide_pptx_artifact_degraded"
+    )
+    assert warning["severity"] == "warning"
+    assert warning["actual"]["archive_recovery"][0]["part_name"] == damaged_part
+
+    current = current_v5_talk(
+        preflight_vault,
+        slide_source="pptx",
+        pptx_path=deck.name,
+    )
+    write_database(vault_fixture, [current])
+    cli_run = subprocess.run(
+        [sys.executable, preflight_vault.__file__, str(vault_fixture["root"])],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    blocking_report = json.loads(cli_run.stdout)
+    blocking = next(
+        item
+        for item in blocking_report["findings"]
+        if item["code"] == "slide_pptx_artifact_degraded"
+    )
+    assert cli_run.returncode == 1
+    assert "Traceback" not in cli_run.stderr
+    assert blocking["severity"] == "blocking"
+    assert blocking["actual"]["status"] == "degraded_recoverable"
+
+
+def test_shared_73_slide_damaged_tiff_deck_reports_both_owners_without_promotion(
+    preflight_vault,
+    vault_fixture,
+):
+    deck, damaged_part = materialize_shared_crc_damaged_tiff_pptx(vault_fixture)
+    talks = []
+    for filename, video_id in (
+        ("2018-01-01-shared-deck-a.md", VIDEO_ID),
+        ("2018-01-02-shared-deck-b.md", OTHER_VIDEO_ID),
+    ):
+        talks.append(base_talk(
+            filename=filename,
+            title=f"Shared damaged deck {filename[-4]}",
+            video_url=f"https://www.youtube.com/watch?v={video_id}",
+            youtube_id=video_id,
+            transcript_source="none",
+            slide_source="pptx",
+            pptx_path=deck.name,
+        ))
+    write_database(vault_fixture, talks)
+
+    cli_run = subprocess.run(
+        [sys.executable, preflight_vault.__file__, str(vault_fixture["root"])],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    report = json.loads(cli_run.stdout)
+    findings = [
+        item
+        for item in report["findings"]
+        if item["code"] == "slide_pptx_artifact_degraded"
+    ]
+    assert cli_run.returncode == 0
+    assert "Traceback" not in cli_run.stderr
+    assert [item["filename"] for item in findings] == [
+        "2018-01-01-shared-deck-a.md",
+        "2018-01-02-shared-deck-b.md",
+    ]
+    assert all(item["severity"] == "warning" for item in findings)
+    assert all(
+        item["actual"]["archive_recovery"][0]["part_name"] == damaged_part
+        for item in findings
+    )
+    assert all(
+        "native_deck"
+        not in item["capability_fact"]["verified_evidence_sources"]
+        for item in findings
+    )
+
+
+def test_unrecoverable_pptx_preflight_is_a_structured_unavailable_finding(
+    preflight_vault,
+    vault_fixture,
+):
+    materialize_transcript(vault_fixture)
+    deck = vault_fixture["pptx_source"] / "unrecoverable.pptx"
+    deck.write_bytes(b"not an OOXML ZIP package")
+    write_database(
+        vault_fixture,
+        [base_talk(slide_source="pptx", pptx_path=deck.name)],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "slide_pptx_artifact_unreadable"
+    )
+    assert finding["severity"] == "warning"
+    assert finding["actual"]["reason_code"] == "pptx_invalid_container"
+    assert "invalid PPTX ZIP container" in finding["actual"]["reason"]
+    assert "native_deck" not in finding["capability_fact"][
+        "verified_evidence_sources"
+    ]
 
 
 def test_transcript_only_partial_record_can_repair_a_missing_slide_lane(
@@ -1287,6 +1476,7 @@ def test_cli_emits_json_and_only_blocks_on_integrity_errors(
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
     warning_report = json.loads(warning_run.stdout)
     assert warning_run.returncode == 0
@@ -1299,6 +1489,7 @@ def test_cli_emits_json_and_only_blocks_on_integrity_errors(
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
     blocking_report = json.loads(blocking_run.stdout)
     assert blocking_run.returncode == 1

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -9,12 +9,16 @@ import hashlib
 import json
 import os
 import shutil
+import struct
 import subprocess
 import sys
 from pathlib import Path
+import zipfile
 
 import pytest
+from PIL import Image
 from pptx import Presentation
+from pptx.util import Inches
 from pypdf import PdfWriter
 
 
@@ -243,6 +247,31 @@ def _write_verified_transcript(tmp_path, name="talk"):
         encoding="utf-8",
     )
     return transcript
+
+
+def _write_crc_damaged_media_pptx(path):
+    """Create a deck whose media needs loss-reporting placeholder recovery."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image_path = path.with_suffix(".png")
+    Image.new("RGB", (64, 64), "navy").save(image_path)
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
+    presentation.save(path)
+    with zipfile.ZipFile(path) as archive:
+        member = next(
+            item
+            for item in archive.infolist()
+            if item.filename.startswith("ppt/media/") and item.file_size
+        )
+    package = bytearray(path.read_bytes())
+    name_size, extra_size = struct.unpack_from(
+        "<HH", package, member.header_offset + 26
+    )
+    payload_offset = member.header_offset + 30 + name_size + extra_size
+    package[payload_offset + (member.compress_size // 2)] ^= 0xFF
+    path.write_bytes(package)
+    return member.filename
 
 
 def _read_db(path):
@@ -636,6 +665,161 @@ def test_retry_status_with_only_a_missing_local_artifact_is_not_claimed(tmp_path
     assert payload["claimed"] == []
     assert payload["remaining_eligible"] == 0
     assert _read_db(path)["talks"][0]["status"] == "skipped_download_failed"
+
+
+def test_required_degraded_pptx_cannot_create_a_fresh_current_claim(tmp_path):
+    deck = tmp_path / "decks" / "damaged.pptx"
+    damaged_part = _write_crc_damaged_media_pptx(deck)
+    talk = _talk(
+        "abcdefghijk",
+        filename="required-damaged-deck.md",
+    )
+    talk.update({
+        "pptx_path": "decks/damaged.pptx",
+        "slide_source": "pptx",
+    })
+    path = _write_db(tmp_path, [talk])
+    before = path.read_bytes()
+
+    result = _claim(path, filenames=(str(talk["filename"]),))
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert "placeholder archive recovery" in payload["error"]
+    assert damaged_part in payload["error"]
+    assert "restore or re-export" in payload["error"]
+    assert path.read_bytes() == before
+    persisted = _read_db(path)["talks"][0]
+    assert persisted["status"] == "pending"
+    assert "_queue_claim" not in persisted
+
+
+def test_claim_reassesses_after_eligibility_and_refuses_mutated_deck(
+    queue_state,
+):
+    talk = _talk("abcdefghijk", filename="changed-after-selection.md")
+    talk.update({"pptx_path": "decks/talk.pptx", "slide_source": "pptx"})
+    clean = {
+        "verified_capabilities": ("slides",),
+        "verified_evidence_sources": ("native_deck",),
+        "acquisition_capabilities": (),
+        "repair_capabilities": (),
+        "degraded_evidence_sources": {},
+    }
+    degraded = {
+        "verified_capabilities": (),
+        "verified_evidence_sources": (),
+        "acquisition_capabilities": (),
+        "repair_capabilities": (),
+        "degraded_evidence_sources": {
+            "native_deck": {
+                "reason_code": "pptx_archive_recovery_required",
+                "archive_recovery": [
+                    {
+                        "part_name": "ppt/media/image1.png",
+                        "status": "recovered_with_placeholder_asset",
+                    }
+                ],
+            }
+        },
+    }
+    assessments = iter([clean, degraded])
+
+    def assessor(_talk):
+        return next(assessments)
+
+    assert queue_state.has_claimable_source(
+        talk, capability_assessor=assessor
+    ) is True
+    before = copy.deepcopy(talk)
+    with pytest.raises(queue_state.QueueStateError, match="cannot claim"):
+        queue_state.claim_talk(
+            talk,
+            "run",
+            "batch",
+            NOW,
+            {},
+            capability_assessor=assessor,
+        )
+    assert talk == before
+
+
+def test_unused_optional_degraded_pptx_does_not_block_independent_source(
+    tmp_path,
+):
+    deck = tmp_path / "decks" / "optional-damaged.pptx"
+    _write_crc_damaged_media_pptx(deck)
+    talk = _talk(
+        "abcdefghijk",
+        filename="optional-damaged-deck.md",
+    )
+    talk.update({
+        "pptx_path": "decks/optional-damaged.pptx",
+        "slide_source": "pdf",
+    })
+    path = _write_db(tmp_path, [talk])
+
+    result = _claim(path, filenames=(str(talk["filename"]),))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert [item["filename"] for item in payload["claimed"]] == [
+        "optional-damaged-deck.md"
+    ]
+
+
+@pytest.mark.parametrize("slide_source", [None, "none"])
+def test_degraded_deck_without_declared_or_independent_lane_is_not_claimed(
+    tmp_path,
+    slide_source,
+):
+    deck = tmp_path / "decks" / "undeclared-damaged.pptx"
+    _write_crc_damaged_media_pptx(deck)
+    talk = _talk(
+        "abcdefghijk",
+        filename="undeclared-damaged-deck.md",
+        video=False,
+        youtube_identity=False,
+    )
+    talk["pptx_path"] = "decks/undeclared-damaged.pptx"
+    if slide_source is not None:
+        talk["slide_source"] = slide_source
+    path = _write_db(tmp_path, [talk])
+    before = path.read_bytes()
+
+    result = _claim(path)
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["claimed"] == []
+    assert path.read_bytes() == before
+
+
+def test_optional_degraded_deck_allows_an_independent_healthy_transcript(
+    tmp_path,
+):
+    deck = tmp_path / "decks" / "optional-damaged.pptx"
+    _write_crc_damaged_media_pptx(deck)
+    transcript = _write_verified_transcript(tmp_path, "independent")
+    talk = _talk(
+        "abcdefghijk",
+        filename="independent-transcript.md",
+        video=False,
+        youtube_identity=False,
+    )
+    talk.update({
+        "pptx_path": "decks/optional-damaged.pptx",
+        "slide_source": "none",
+        "transcript_path": transcript.relative_to(tmp_path).as_posix(),
+        "transcript_source": "manual",
+    })
+    path = _write_db(tmp_path, [talk])
+
+    result = _claim(path, filenames=(str(talk["filename"]),))
+
+    assert result.returncode == 0, result.stderr
+    assert [item["filename"] for item in json.loads(result.stdout)["claimed"]] == [
+        "independent-transcript.md"
+    ]
 
 
 def test_manual_provenance_label_without_artifact_is_not_a_capability(tmp_path):

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 
 import pytest
+from pypdf import PdfWriter
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -99,6 +100,30 @@ def _canonical_visual_rows():
             "has_footer": False,
         },
     ]
+
+
+def _native_deck_audit_fixture(pptx_evidence, tmp_path, *, inspected=True):
+    rendered = tmp_path / "rendered.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=96, height=54)
+    writer.add_blank_page(width=96, height=54)
+    with rendered.open("wb") as stream:
+        writer.write(stream)
+    source_sha = "a" * 64
+    receipt = pptx_evidence.build_rendered_page_inspection(
+        source_pptx_sha256=source_sha,
+        rendered_pdf_path=rendered,
+        inspected_page_ranges=[[1, 1]] if inspected else [],
+        required_slide_numbers=[1],
+        slide_count=2,
+    )
+    return pptx_evidence.build_native_deck_audit(
+        source_pptx_sha256=source_sha,
+        source_pptx_size_bytes=1234,
+        slide_count=2,
+        render_required_reasons={1: ["large_picture"]},
+        rendered_page_inspection=receipt,
+    )
 
 
 def _return_with_canonical_visuals():
@@ -274,6 +299,29 @@ def _claimed_talk(ret, **overrides):
     return talk
 
 
+def _degraded_native_capabilities():
+    return {
+        "verified_capabilities": ("slides",),
+        "verified_evidence_sources": ("native_deck",),
+        "acquisition_capabilities": (),
+        "repair_capabilities": (),
+        "source_reasons": {"native_deck": "read degraded local PPTX"},
+        "degraded_evidence_sources": {
+            "native_deck": {
+                "schema_version": 1,
+                "status": "degraded_recoverable",
+                "reason_code": "pptx_archive_recovery_required",
+                "archive_recovery": [
+                    {
+                        "part_name": "ppt/media/image1.png",
+                        "status": "recovered_with_placeholder_asset",
+                    }
+                ],
+            },
+        },
+    }
+
+
 def _adherence_baseline(return_validation, *, count, filenames=("talk.md",)):
     return {
         "schema_version": 1,
@@ -303,6 +351,28 @@ def _v3_claimed_talk(return_validation, ret, *, baseline_count):
             count=baseline_count,
             filenames=(ret["filename"],),
         ),
+    })
+    return talk
+
+
+def _current_claimed_talk(return_validation, ret, **overrides):
+    import adherence_baseline
+
+    talk = _claimed_talk(ret, **overrides)
+    baseline = adherence_baseline.build_adherence_baseline(
+        [],
+        selected_filenames=[ret["filename"]],
+        as_of=talk["_queue_claim"]["claimed_at"],
+        pattern_catalog_fingerprint=return_validation.load_catalog().fingerprint,
+        pattern_scoring_schema_version=(
+            return_validation.PATTERN_SCORING_SCHEMA_VERSION
+        ),
+        evidence_freshness_assessor=lambda _talk: (),
+    )
+    talk["_queue_claim"].update({
+        "schema_version": return_validation.QUEUE_CLAIM_SCHEMA_VERSION,
+        "required_return_schema_version": return_validation.RETURN_SCHEMA_VERSION,
+        "adherence_baseline": baseline,
     })
     return talk
 
@@ -520,6 +590,53 @@ def test_completed_receiptless_v1_claim_cannot_authorize_analysis_replay(
             match="predates the return-payload receipt"):
         return_validation.validate_claim_against_talk(
             talk, ret, require_completed=True)
+
+
+def test_required_degraded_pptx_cannot_persist_current_analysis(
+    return_validation,
+):
+    ret = _return(return_schema_version=return_validation.RETURN_SCHEMA_VERSION)
+    talk = _current_claimed_talk(
+        return_validation,
+        ret,
+        slide_source="pptx",
+    )
+
+    with pytest.raises(
+        return_validation.ReturnValidationError,
+        match="cannot persist current analysis.*placeholder archive recovery",
+    ):
+        return_validation.validate_claim_against_talk(
+            talk,
+            ret,
+            artifact_capabilities=_degraded_native_capabilities(),
+        )
+
+
+def test_unused_optional_degraded_pptx_does_not_block_pdf_analysis(
+    return_validation,
+):
+    ret = _return(
+        return_schema_version=return_validation.RETURN_SCHEMA_VERSION,
+        slide_source="pdf",
+    )
+    ret["pattern_observations"]["evidence_sources"] = [
+        source
+        for source in ret["pattern_observations"]["evidence_sources"]
+        if source != "native_deck"
+    ]
+    talk = _current_claimed_talk(
+        return_validation,
+        ret,
+        slide_source="pdf",
+        slides_local_path="Conference/Talk.pdf",
+    )
+
+    return_validation.validate_claim_against_talk(
+        talk,
+        ret,
+        artifact_capabilities=_degraded_native_capabilities(),
+    )
 
 
 def test_trusted_video_return_requires_complete_manifest_and_promoted_path(
@@ -1590,6 +1707,280 @@ def test_delivery_language_requires_a_code(return_validation):
     value = _return()
     value["structured_data"]["delivery_language"] = "English"
     assert "lowercase language code" in _error(return_validation, value)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("slide_count", 2),
+        ("per_slide_visual", _canonical_visual_rows()),
+        ("slide_design_style", "mixed"),
+    ],
+)
+def test_slide_source_none_rejects_authored_slide_fields(
+    return_validation,
+    field,
+    value,
+):
+    ret = _return(status="processed_partial", slide_source="none")
+    ret["structured_data"][field] = value
+    if field == "per_slide_visual":
+        ret["structured_data"]["slide_count"] = 2
+    assert "cannot return authored-slide evidence" in _error(
+        return_validation, ret
+    )
+
+
+def test_transcript_only_partial_remains_valid_without_slide_fields(
+    return_validation,
+):
+    return_validation.validate_authored_slide_fields_against_source(
+        {"delivery_language": "en", "co_presenter": False},
+        "none",
+    )
+
+
+def test_native_deck_design_findings_fail_closed_without_current_audit(
+    return_validation,
+):
+    structured = {"slide_count": 2, "slide_design_style": "mixed"}
+    observations = {
+        "evidence_sources": ["native_deck"],
+        "source_inspection": [
+            {"source": "native_deck", "page_ranges": [[1, 2]]},
+        ],
+    }
+
+    with pytest.raises(
+        return_validation.ReturnValidationError,
+        match="requires the current.*native_deck_audit",
+    ):
+        return_validation.validate_native_deck_design_receipt(
+            structured=structured,
+            observations=observations,
+            slide_source="pptx",
+            detections=[],
+        )
+
+
+def test_native_deck_use_requires_current_audit_even_without_findings(
+    return_validation,
+):
+    with pytest.raises(
+        return_validation.ReturnValidationError,
+        match="requires the current.*native_deck_audit",
+    ):
+        return_validation.validate_native_deck_design_receipt(
+            structured={"slide_count": 2},
+            observations={
+                "evidence_sources": ["native_deck"],
+                "source_inspection": [
+                    {"source": "native_deck", "page_ranges": [[1, 2]]},
+                ],
+            },
+            slide_source="pptx",
+            detections=[],
+        )
+
+
+def test_native_deck_design_findings_require_complete_render_receipt(
+    return_validation,
+    pptx_evidence,
+    tmp_path,
+):
+    audit = _native_deck_audit_fixture(
+        pptx_evidence,
+        tmp_path,
+        inspected=False,
+    )
+    structured = {
+        "slide_count": 2,
+        "slide_design_style": "mixed",
+        "native_deck_audit": audit,
+    }
+    observations = {
+        "evidence_sources": ["native_deck", "static_slides"],
+        "source_inspection": [
+            {"source": "native_deck", "page_ranges": [[1, 2]]},
+            {"source": "static_slides", "page_ranges": [[1, 2]]},
+        ],
+    }
+
+    with pytest.raises(
+        return_validation.ReturnValidationError,
+        match="does not cover every render-required slide",
+    ):
+        return_validation.validate_native_deck_design_receipt(
+            structured=structured,
+            observations=observations,
+            slide_source="pptx",
+            detections=[],
+        )
+
+
+def test_native_deck_design_receipt_requires_matching_static_page_coverage(
+    return_validation,
+    pptx_evidence,
+    tmp_path,
+):
+    audit = _native_deck_audit_fixture(pptx_evidence, tmp_path)
+    structured = {
+        "slide_count": 2,
+        "slide_design_style": "mixed",
+        "native_deck_audit": audit,
+    }
+    observations = {
+        "evidence_sources": ["native_deck", "static_slides"],
+        "source_inspection": [
+            {"source": "native_deck", "page_ranges": [[1, 2]]},
+            {"source": "static_slides", "page_ranges": [[2, 2]]},
+        ],
+    }
+
+    with pytest.raises(
+        return_validation.ReturnValidationError,
+        match="cover every render-required",
+    ):
+        return_validation.validate_native_deck_design_receipt(
+            structured=structured,
+            observations=observations,
+            slide_source="pptx",
+            detections=[],
+        )
+
+    observations["source_inspection"][1]["page_ranges"] = [[1, 1]]
+    return_validation.validate_native_deck_design_receipt(
+        structured=structured,
+        observations=observations,
+        slide_source="pptx",
+        detections=[],
+    )
+
+
+def test_clean_native_citation_does_not_require_unrelated_render_page(
+    return_validation,
+    pptx_evidence,
+    tmp_path,
+):
+    audit = _native_deck_audit_fixture(
+        pptx_evidence,
+        tmp_path,
+        inspected=False,
+    )
+    return_validation.validate_native_deck_design_receipt(
+        structured={"slide_count": 2, "native_deck_audit": audit},
+        observations={
+            "evidence_sources": ["native_deck"],
+            "source_inspection": [
+                {"source": "native_deck", "page_ranges": [[2, 2]]},
+            ],
+        },
+        slide_source="pptx",
+        detections=[{
+            "evidence_citations": [{
+                "source": "native_deck",
+                "channel": "slide_sequence",
+                "slide_numbers": [2],
+            }],
+        }],
+    )
+
+
+def test_render_required_native_citation_requires_that_rendered_page(
+    return_validation,
+    pptx_evidence,
+    tmp_path,
+):
+    audit = _native_deck_audit_fixture(
+        pptx_evidence,
+        tmp_path,
+        inspected=False,
+    )
+    with pytest.raises(
+        return_validation.ReturnValidationError,
+        match="does not cover every render-required slide",
+    ):
+        return_validation.validate_native_deck_design_receipt(
+            structured={"slide_count": 2, "native_deck_audit": audit},
+            observations={
+                "evidence_sources": ["native_deck"],
+                "source_inspection": [
+                    {"source": "native_deck", "page_ranges": [[1, 1]]},
+                ],
+            },
+            slide_source="pptx",
+            detections=[{
+                "evidence_citations": [{
+                    "source": "native_deck",
+                    "channel": "slide_sequence",
+                    "slide_numbers": [1],
+                }],
+            }],
+        )
+
+
+def test_render_required_applicability_citation_is_included_in_render_gate(
+    return_validation,
+    pptx_evidence,
+    monkeypatch,
+):
+    audit = pptx_evidence.build_native_deck_audit(
+        source_pptx_sha256="a" * 64,
+        source_pptx_size_bytes=1234,
+        slide_count=2,
+        render_required_reasons={1: ["large_picture"]},
+    )
+    ret = _return(
+        return_schema_version=return_validation.RETURN_SCHEMA_VERSION,
+        slide_source="pptx",
+    )
+    ret["structured_data"].update({
+        "slide_count": 2,
+        "native_deck_audit": audit,
+    })
+    ret["pattern_observations"].update({
+        "evidence_sources": ["native_deck"],
+        "source_inspection": [
+            {"source": "native_deck", "page_ranges": [[1, 2]]},
+        ],
+        "applicability_assessments": [],
+    })
+    applicability = [{
+        "evidence_citations": [{
+            "source": "native_deck",
+            "channel": "slide_sequence",
+            "slide_numbers": [1],
+        }],
+    }]
+    monkeypatch.setattr(
+        return_validation,
+        "_validate_available_sources",
+        lambda *_args, **_kwargs: {"native_deck"},
+    )
+    monkeypatch.setattr(
+        return_validation,
+        "_validate_source_inspection",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        return_validation,
+        "_validate_detection_list",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        return_validation,
+        "_validate_applicability_assessments",
+        lambda *_args, **_kwargs: applicability,
+    )
+
+    with pytest.raises(
+        return_validation.ReturnValidationError,
+        match="identity-bound rendered_page_inspection receipt",
+    ):
+        return_validation.validate_return(
+            ret,
+            return_validation.load_catalog(),
+        )
 
 
 @pytest.mark.parametrize("field", [

--- a/tests/test_schema5_pattern_outcomes.py
+++ b/tests/test_schema5_pattern_outcomes.py
@@ -596,6 +596,7 @@ def test_bare_native_deck_is_fail_closed_for_applicability_and_fresh_with_root(
     tmp_path,
 ):
     import pattern_evidence
+    import pptx_evidence
 
     condition = return_validation.NotApplicableCondition(
         "no-opportunity", "No relevant opportunity occurs."
@@ -639,6 +640,12 @@ def test_bare_native_deck_is_fail_closed_for_applicability_and_fresh_with_root(
         ]
     )
     raw["slide_source"] = "pptx"
+    raw["structured_data"] = {
+        "slide_count": 1,
+        "native_deck_audit": pptx_evidence.recompute_native_deck_audit(
+            deck_path
+        ),
+    }
     raw["pattern_observations"].update(
         {
             "evidence_sources": ["native_deck"],


### PR DESCRIPTION
Closes #151

## Summary

- recover CRC-damaged embedded media in memory while failing closed on structural package damage
- recursively inventory grouped shapes, tables, unsupported visual containers, per-asset picture/background OCR receipts, and raw timing/build-list metadata
- bind extraction schema v3 to exact PPTX identity and require an identity-bound rendered-page receipt for render-dependent native-deck findings
- keep degraded or unavailable native decks out of verified capabilities, queue claims, current returns, and persistence while preserving independent healthy evidence lanes
- classify cloud placeholders and parser failures as structured preflight findings without tracebacks

## Verification

- `3397 passed, 3 skipped` after rebasing onto `main` / toolkit 0.20.3
- Ruff: clean
- Pyright: 0 errors
- pre-publish dependency/package gates: clean (258 declared content files)
- `tessl plugin lint`: valid
- generated 73-slide, shared-two-record, damaged-TIFF end-to-end regression passes
- read-only live preflight reproduces the two expected degraded-owner findings and leaves the tracking database and vault file manifest unchanged

## Release gate

This PR is issue-complete but intentionally draft. Do not merge or release it alone: #182 must add hard cross-platform PPTX worker/process supervision, and #183 must add the equivalent bounded PDF identity/diagnostic boundary. The follow-up #182 PR will be stacked on this branch so both can be reviewed before one release.