### PR TITLE
test(vault-ingress): isolate cached catalog overrides

### DIFF
--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -1849,16 +1849,25 @@ def test_ungated_pattern_cannot_be_recorded_as_not_evaluable(return_validation):
             "reason": "No reason can override available transcript evidence.",
         }
     ]
-    catalog = return_validation.load_catalog()
-    catalog.entries["narrative-arc"] = replace(
-        catalog.entries["narrative-arc"],
+    bundled = return_validation.load_catalog()
+    original_entry = bundled.entries["narrative-arc"]
+    entries = dict(bundled.entries)
+    entries["narrative-arc"] = replace(
+        original_entry,
         evaluable_from=None,
         strong_evaluable_from=None,
         absence_evaluable_from=None,
     )
+    catalog = return_validation.PatternCatalog(
+        entries=entries,
+        fingerprint=bundled.fingerprint,
+    )
     with pytest.raises(return_validation.ReturnValidationError) as excinfo:
         return_validation.validate_batch([value], catalog)
     assert "has no source-aware evidence gate" in str(excinfo.value)
+    # Persistence derives outcomes from this session cache before its subprocess
+    # reloads the bundled catalog, so the two views must stay aligned.
+    assert return_validation.load_catalog().entries["narrative-arc"] == original_entry
 
 
 def test_detected_pattern_cannot_also_be_not_evaluable(return_validation):


### PR DESCRIPTION
## Summary

- construct the synthetic ungated catalog test from a copied entries mapping
  instead of mutating the session-cached bundled `PatternCatalog`
- preserve the original catalog fingerprint and every immutable entry field
- assert the cached bundled entry remains unchanged after the override test,
  preventing parent/subprocess catalog-gate disagreement in later persistence
  tests

This is test-isolation only; production catalog loading and vault data are
unchanged. No plugin version bump is required.

Closes #189.

## Validation

- exact head: `8e2dd4a779b52dec5ff7522ab7a34998f6e8c45e`
- exact order-sensitive two-test reproduction: **2 passed**
- ordered return-validation → queue-state → persistence suites: **480 passed**
- complete repository suite: **3,937 passed, 3 skipped**
- Ruff lint/format and diff hygiene: clean
- pre-publish checks: all 261 declared plugin files packaged

The live rhetoric vault was not mutated.
