### PR TITLE
Make ingress artifact and video boundaries deterministic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,7 @@ jobs:
       - run: pip install ".[test]"
       - run: >-
           pytest -v --tb=short
+          tests/test_artifact_locator.py
           tests/test_artifact_supervisor.py
           tests/test_artifact_metadata.py
           tests/test_pdf_evidence.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,5 +107,5 @@ jobs:
           tests/test_artifact_supervisor.py
           tests/test_artifact_metadata.py
           tests/test_pdf_evidence.py
-          tests/test_pattern_evidence.py::test_forward_slash_root_uses_native_absolute_path_semantics
+          tests/test_pattern_evidence.py::test_forward_slash_root_is_classified_without_host_reinterpretation
           tests/test_check_runtime.py::test_psutil_version_authorities_are_synchronized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+### fix(vault-ingress) — make artifact locators host-deterministic (#210)
+
+Ingress now classifies raw artifact locators before `Path`, `abspath`,
+`expanduser`, symlink resolution, metadata inspection, cache lookup, or worker
+launch. Canonical trusted-root-relative locators use `/`; raw dot segments,
+home-relative forms, backslash/mixed relative syntax, Windows ambient-drive and
+device forms, dual-flavor `//` paths, foreign absolute flavors, and relative
+components that Win32 would trim or reinterpret as alternate streams or device
+names fail closed with stable path-neutral reasons. Native POSIX, Windows
+drive-absolute, and backslash-UNC locators remain available on their matching
+host.
+
+The same stdlib-only contract now governs PPTX/PDF/video context admission,
+preflight, return-manifest validation, freshness reconstruction, configured
+PPTX roots, and the direct metadata/probe/extraction/directory worker
+boundaries. A present `pptx_source_dir` must be native absolute; an invalid
+setting can no longer become a cwd-relative root or silently fall back. Worker
+payloads receive only already-materialized native absolute paths, with the same
+checks repeated at child boundaries. Foreign or legacy noncanonical locators
+require explicit owner repair and reprocessing; no database, return, evidence,
+or extraction schema is bumped and no stored locator is silently rewritten.
+
 ## 0.20.6 — 2026-08-03
 
 ### fix(vault-ingress) — supervise exact-generation PDF evidence (#183)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### fix(vault-ingress) — validate video owner identity before output derivation (#214)
+
+Video slide extraction now admits only the shared canonical 11-character
+YouTube-ID grammar before path resolution, directory creation, ffmpeg, or
+artifact writes. Frame workspace and PDF paths are derived only from that
+validated identity and must remain below the canonical caller-authorized output
+root, including when a pre-existing symlink would redirect a derived path.
+Traversal, separator, drive/device, whitespace, NUL, Unicode-lookalike, and
+wrong-length identities fail with one closed reason. Manifest ownership and
+artifact filenames retain the same admitted ID; invalid legacy identities
+require repair and re-extraction rather than normalization.
+
+### fix(vault-ingress) — keep ffmpeg artifact paths out of the shell (#211)
+
+Frame extraction now invokes ffmpeg with an explicit argv vector and
+`shell=False`. Spaces, quotes, semicolons, substitutions, and redirection
+characters in otherwise valid native paths remain data, while failures report
+only the process exit status rather than an interpolated command. The remaining
+vault-ingress Python scripts contain no `os.system` or `shell=True` artifact
+boundary. The extractor pipeline advances to `0.11.0`; its schema remains v3.
+
 ### fix(vault-ingress) — make artifact locators host-deterministic (#210)
 
 Ingress now classifies raw artifact locators before `Path`, `abspath`,

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -89,7 +89,7 @@ persists that exact talk.
     "schema_version": 1,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
     "vault_storage_path": "/actual/path/if/custom (null when using default location)",
-    "pptx_source_dir": "/path/to/Presentations",
+    "pptx_source_dir": "/native/absolute/path/to/Presentations (optional; null/absent falls back to the vault root)",
     "python_path": "/path/to/python3",
     "template_skip_patterns": ["template"],
     "shownotes": {
@@ -1351,9 +1351,15 @@ applied from whether `slide_region` is present, and verified `false`; re-extract
 is still required before treating an old crop as verified.
 
 Version 3 separates derived artifacts by provenance and scope. `artifacts[].path` and
-`source_video_path` are absolute, symlink-resolved paths at extraction time.
-They must remain within the configured vault storage root, contain no NUL or raw
-dot segments, and name non-symlink descendants. Before a current return is
+`source_video_path` are native absolute, symlink-resolved paths at extraction
+time. They must remain within the configured vault storage root, contain no NUL,
+raw dot segments, `~`, device/current-drive syntax, foreign absolute flavor, or
+dual-flavor `//` form, and name non-symlink descendants. Persisted relative
+artifact locators elsewhere in the database use canonical `/` separators and
+exclude Win32-trimmed components, alternate-stream syntax, and reserved DOS
+device basenames. They are joined as logical root-relative components, never
+reinterpreted through the host's alternate separator or namespace rules. Before
+a current return is
 persisted, every manifest PDF—not only the trusted `slide_region`—must pass the
 bounded exact-generation PDF probe and match its recorded page count. A
 configured canonical vault symlink is admitted as the trusted root locator and

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1281,9 +1281,9 @@ Stored in `structured_data.video_extraction` on the talk entry:
 {
   "slide_source": "video_extracted",
   "schema_version": 3,
-  "pipeline_version": "0.10.0",
-  "source_video_id": "aBcDeFg",
-  "source_video_path": "/vault/slides-rebuild/aBcDeFg/aBcDeFg.mp4",
+  "pipeline_version": "0.11.0",
+  "source_video_id": "AbCdEfGhI_1",
+  "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
   "total_frames_extracted": 1500,
   "unique_frame_count": 85,
   "authored_slide_count": null,
@@ -1300,21 +1300,21 @@ Stored in `structured_data.video_extraction` on the talk entry:
   ],
   "artifacts": [
     {
-      "path": "/vault/slides-rebuild/aBcDeFg/aBcDeFg.slide-region.pdf",
+      "path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.slide-region.pdf",
       "artifact_scope": "slide_region",
       "page_count": 85,
-      "source_video_id": "aBcDeFg",
-      "source_video_path": "/vault/slides-rebuild/aBcDeFg/aBcDeFg.mp4",
+      "source_video_id": "AbCdEfGhI_1",
+      "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
       "crop_method": "manual",
       "crop_verified": true,
       "trusted_for_authored_slide_analysis": true
     },
     {
-      "path": "/vault/slides-rebuild/aBcDeFg/aBcDeFg.context.pdf",
+      "path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.context.pdf",
       "artifact_scope": "full_frame_context",
       "page_count": 85,
-      "source_video_id": "aBcDeFg",
-      "source_video_path": "/vault/slides-rebuild/aBcDeFg/aBcDeFg.mp4",
+      "source_video_id": "AbCdEfGhI_1",
+      "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
       "crop_method": "none",
       "crop_verified": false,
       "trusted_for_authored_slide_analysis": false

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -211,12 +211,20 @@ Checks apply to a record with a declared transcript, slide, or video capability
   `transcript_path` is resolved from the vault root.
 - Slide source enum: `pptx`, `pdf`, `both`, `video_extracted`, `none`.
   `transcript_only` is unsupported; represent that state as `none`.
+- Persisted local-artifact locators are classified before host path
+  normalization. Relative locators use canonical `/` separators beneath their
+  documented trusted root; raw dot segments, `~`, backslash/mixed relative
+  syntax, Windows current-drive/per-drive-relative forms, device namespaces,
+  dual-flavor `//` paths, Win32-trimmed components, alternate-stream syntax,
+  and reserved DOS device basenames fail closed.
+- A native absolute locator is valid only on its matching host. Windows UNC
+  locators use their backslash form. Foreign absolute locators are never
+  translated or rebased beneath a trusted root; repair the owner locator and
+  reprocess its evidence after moving a vault between operating systems.
 - Relative `pptx_path` is resolved from `config.pptx_source_dir`, falling back
-  to the vault root.
-- PPTX locators reject raw dot segments, Windows current-drive/per-drive-relative
-  forms, and Windows device namespaces before host path normalization. Use a
-  trusted-root-relative locator or, on Windows, an ordinary fully qualified
-  drive/UNC path.
+  to the vault root only when that setting is absent or null. A present source
+  root must be a native absolute path; an invalid/relative/foreign root is a
+  blocking configuration error, not a request to fall back.
 - A recorded local PDF path is authoritative only after its exact generation
   passes the bounded metadata, copy/hash, strict container, and complete page-tree
   probe.

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -94,6 +94,15 @@ device/current-drive, foreign absolute, raw-dot-segment, and dual-flavor `//`
 forms fail closed; paths are never translated between operating-system
 grammars.
 
+`youtube_id` must match the shared ingress grammar exactly:
+`[A-Za-z0-9_-]{11}`. It is validated before any filesystem or process boundary,
+is never normalized, and is the only component used to derive the frame
+workspace, PDF filenames, and manifest ownership. Every derived path must stay
+under the canonical authorized output root; an existing redirecting symlink is
+rejected. The script passes video/output paths to ffmpeg as argv data with no
+shell interpolation, so shell metacharacters in valid native POSIX filenames do
+not become commands.
+
 ```bash
 # Download video at 720p
 yt-dlp -f "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720]" \

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -87,6 +87,13 @@ manual crop; it never deletes the source video.
 
 Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/video-slide-extraction.py"` for each video after downloading it:
 
+The source-video and output-directory arguments must be native absolute paths.
+The producer validates their raw flavor before creating directories, resolving
+symlinks, invoking ffmpeg, or writing artifacts. Relative, `~`-expanded,
+device/current-drive, foreign absolute, raw-dot-segment, and dual-flavor `//`
+forms fail closed; paths are never translated between operating-system
+grammars.
+
 ```bash
 # Download video at 720p
 yt-dlp -f "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720]" \

--- a/skills/vault-ingress/scripts/artifact_locator.py
+++ b/skills/vault-ingress/scripts/artifact_locator.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Host-deterministic lexical materialization for persisted artifact locators.
+
+Classification deliberately happens before constructing a host-native
+``pathlib.Path``.  The functions in this module perform no filesystem access and
+never expand a home directory or process-relative path.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path, PurePosixPath
+from typing import Literal, NamedTuple, NoReturn
+
+
+ArtifactLocatorKind = Literal[
+    "relative",
+    "posix_absolute",
+    "windows_drive_absolute",
+    "windows_unc_absolute",
+]
+
+_REASON_CODES = frozenset(
+    {
+        "artifact_locator_not_text",
+        "artifact_locator_empty_or_whitespace",
+        "artifact_locator_nul_byte",
+        "artifact_locator_home_expansion_unsupported",
+        "artifact_locator_dot_segment",
+        "artifact_locator_windows_device_namespace",
+        "artifact_locator_windows_drive_relative",
+        "artifact_locator_windows_current_drive_rooted",
+        "artifact_locator_ambiguous_double_slash",
+        "artifact_locator_malformed_unc",
+        "artifact_locator_windows_reserved_character",
+        "artifact_locator_windows_trimmed_component",
+        "artifact_locator_windows_reserved_name",
+        "artifact_locator_noncanonical_relative",
+        "artifact_locator_foreign_absolute",
+        "artifact_locator_trusted_root_required",
+        "artifact_root_not_native_absolute",
+    }
+)
+_WINDOWS_DEVICE_PREFIXES = ("\\\\?\\", "\\\\.\\", "\\??\\", "\\\\??\\")
+_WINDOWS_DRIVE_PREFIX = re.compile(r"^[A-Za-z]:")
+_WINDOWS_RESERVED_CHARACTERS = frozenset('<>:"|?*')
+_WINDOWS_RESERVED_BASENAME = re.compile(
+    r"^(?:CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|COM[1-9\u00b9\u00b2\u00b3]|LPT[1-9\u00b9\u00b2\u00b3])$",
+    re.IGNORECASE,
+)
+
+
+class ArtifactLocatorError(ValueError):
+    """A closed, path-neutral artifact locator rejection."""
+
+    def __init__(self, reason_code: str) -> None:
+        if reason_code not in _REASON_CODES:
+            raise ValueError("invalid artifact locator reason code")
+        self.reason_code = reason_code
+        super().__init__(reason_code)
+
+
+class _ClassifiedLocator(NamedTuple):
+    kind: ArtifactLocatorKind
+    text: str
+    relative_parts: tuple[str, ...]
+
+
+def _reject(reason_code: str) -> NoReturn:
+    raise ArtifactLocatorError(reason_code)
+
+
+def _locator_text(raw: object) -> str:
+    if not isinstance(raw, (str, os.PathLike)):
+        _reject("artifact_locator_not_text")
+    try:
+        value = os.fspath(raw)
+    except TypeError:
+        _reject("artifact_locator_not_text")
+    if not isinstance(value, str):
+        _reject("artifact_locator_not_text")
+    if not value or not value.strip():
+        _reject("artifact_locator_empty_or_whitespace")
+    if "\x00" in value:
+        _reject("artifact_locator_nul_byte")
+    if value.startswith("~"):
+        _reject("artifact_locator_home_expansion_unsupported")
+    return value
+
+
+def _contains_dot_segment(value: str) -> bool:
+    return any(
+        segment in {".", ".."}
+        for slash_segment in value.split("/")
+        for segment in slash_segment.split("\\")
+    )
+
+
+def _validate_windows_file_components(
+    components: tuple[str, ...],
+    *,
+    reject_reserved_names: bool = True,
+) -> None:
+    """Reject Win32 aliases and namespaces before a locator reaches ``Path``."""
+    for component in components:
+        if any(
+            character in _WINDOWS_RESERVED_CHARACTERS or ord(character) < 32
+            for character in component
+        ):
+            _reject("artifact_locator_windows_reserved_character")
+        if component.endswith((".", " ")):
+            _reject("artifact_locator_windows_trimmed_component")
+        basename = component.split(".", 1)[0].rstrip(" ")
+        if (
+            reject_reserved_names
+            and _WINDOWS_RESERVED_BASENAME.fullmatch(basename) is not None
+        ):
+            _reject("artifact_locator_windows_reserved_name")
+
+
+def _validate_unc(value: str) -> None:
+    windows_value = value.replace("/", "\\")
+    if not windows_value.startswith("\\\\") or windows_value.startswith("\\\\\\"):
+        _reject("artifact_locator_malformed_unc")
+    components = windows_value[2:].split("\\")
+    if components and components[-1] == "":
+        components = components[:-1]
+    if (
+        len(components) < 2
+        or any(not component for component in components)
+        or ":" in components[0]
+        or ":" in components[1]
+    ):
+        _reject("artifact_locator_malformed_unc")
+
+
+def _classify_artifact_locator(raw: object) -> _ClassifiedLocator:
+    value = _locator_text(raw)
+    windows_value = value.replace("/", "\\")
+
+    if windows_value.startswith(_WINDOWS_DEVICE_PREFIXES):
+        _reject("artifact_locator_windows_device_namespace")
+
+    drive_match = _WINDOWS_DRIVE_PREFIX.match(value)
+    if drive_match is not None:
+        drive_tail = value[2:]
+        if not drive_tail.startswith(("/", "\\")):
+            _reject("artifact_locator_windows_drive_relative")
+        if _contains_dot_segment(value):
+            _reject("artifact_locator_dot_segment")
+        windows_parts = tuple(
+            component
+            for component in drive_tail.replace("/", "\\").split("\\")
+            if component
+        )
+        _validate_windows_file_components(windows_parts)
+        return _ClassifiedLocator("windows_drive_absolute", value, ())
+
+    if value.startswith("//"):
+        _reject("artifact_locator_ambiguous_double_slash")
+
+    if value.startswith("\\\\"):
+        _validate_unc(value)
+        if _contains_dot_segment(value):
+            _reject("artifact_locator_dot_segment")
+        unc_parts = tuple(
+            component
+            for component in value.replace("/", "\\")[2:].split("\\")
+            if component
+        )
+        _validate_windows_file_components(
+            unc_parts[:2],
+            reject_reserved_names=False,
+        )
+        _validate_windows_file_components(unc_parts[2:])
+        return _ClassifiedLocator("windows_unc_absolute", value, ())
+
+    if value.startswith("\\"):
+        _reject("artifact_locator_windows_current_drive_rooted")
+
+    if value.startswith("/"):
+        if _contains_dot_segment(value):
+            _reject("artifact_locator_dot_segment")
+        return _ClassifiedLocator("posix_absolute", value, ())
+
+    if value != value.strip():
+        _reject("artifact_locator_empty_or_whitespace")
+
+    if _contains_dot_segment(value):
+        _reject("artifact_locator_dot_segment")
+    if "\\" in value:
+        _reject("artifact_locator_noncanonical_relative")
+
+    relative = PurePosixPath(value)
+    parts = relative.parts
+    if not parts or relative.is_absolute() or relative.as_posix() != value:
+        _reject("artifact_locator_noncanonical_relative")
+    if any(_WINDOWS_DRIVE_PREFIX.match(part) is not None for part in parts):
+        _reject("artifact_locator_windows_drive_relative")
+    _validate_windows_file_components(parts)
+    return _ClassifiedLocator("relative", value, parts)
+
+
+def classify_artifact_locator(raw: object) -> ArtifactLocatorKind:
+    """Return the locator's lexical flavor without consulting the host or disk."""
+    return _classify_artifact_locator(raw).kind
+
+
+def _is_native_absolute(kind: ArtifactLocatorKind) -> bool:
+    if os.name == "nt":
+        return kind in {"windows_drive_absolute", "windows_unc_absolute"}
+    return kind == "posix_absolute"
+
+
+def materialize_native_root(raw: object) -> Path:
+    """Materialize a native absolute trusted root without normalization or I/O."""
+    classified = _classify_artifact_locator(raw)
+    if classified.kind == "relative":
+        _reject("artifact_root_not_native_absolute")
+    if not _is_native_absolute(classified.kind):
+        _reject("artifact_locator_foreign_absolute")
+    return Path(classified.text)
+
+
+def materialize_artifact_locator(
+    raw: object,
+    trusted_root: object | None = None,
+) -> Path:
+    """Materialize one native absolute or canonical root-relative locator.
+
+    A supplied trusted root is validated even when ``raw`` is already absolute,
+    but this lexical helper does not impose containment on absolute locators.
+    Callers that require containment retain ownership of that policy.
+    """
+    classified = _classify_artifact_locator(raw)
+    if classified.kind == "relative":
+        if trusted_root is None:
+            _reject("artifact_locator_trusted_root_required")
+        root = materialize_native_root(trusted_root)
+        return root.joinpath(*classified.relative_parts)
+
+    if not _is_native_absolute(classified.kind):
+        _reject("artifact_locator_foreign_absolute")
+    if trusted_root is not None:
+        materialize_native_root(trusted_root)
+    return Path(classified.text)
+
+
+__all__ = [
+    "ArtifactLocatorError",
+    "ArtifactLocatorKind",
+    "classify_artifact_locator",
+    "materialize_artifact_locator",
+    "materialize_native_root",
+]

--- a/skills/vault-ingress/scripts/artifact_metadata.py
+++ b/skills/vault-ingress/scripts/artifact_metadata.py
@@ -9,6 +9,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from artifact_locator import (
+    ArtifactLocatorError,
+    materialize_artifact_locator,
+    materialize_native_root,
+)
 from artifact_supervisor import FileGeneration
 
 
@@ -40,6 +45,15 @@ METADATA_FAILURE_KINDS = frozenset(
 class ArtifactMetadataMalformed(ValueError):
     """A worker metadata request is structurally invalid before artifact I/O."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        locator_failure: str | None = None,
+    ) -> None:
+        self.locator_failure = locator_failure
+        super().__init__(message)
+
 
 class ArtifactMetadataUnavailable(OSError):
     """A stable, path-free artifact metadata failure."""
@@ -58,8 +72,8 @@ class ArtifactMetadataUnavailable(OSError):
 
 
 def canonicalize_trusted_artifact_locator(
-    path: Path,
-    trusted_root: Path | None,
+    path: object,
+    trusted_root: object | None,
 ) -> tuple[Path, Path | None]:
     """Admit a configured symlink root without resolving the artifact leaf.
 
@@ -67,16 +81,26 @@ def canonicalize_trusted_artifact_locator(
     Descendants remain lexical and are still checked component-by-component by
     the metadata worker after the root locator is mapped to its storage target.
     """
-    if trusted_root is None:
-        return path, None
     try:
-        canonical_root = trusted_root.resolve(strict=True)
+        root = (
+            materialize_native_root(trusted_root) if trusted_root is not None else None
+        )
+        artifact = materialize_artifact_locator(path, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise ArtifactMetadataMalformed(
+            "artifact locator is invalid",
+            locator_failure=exc.reason_code,
+        ) from exc
+    if root is None:
+        return artifact, None
+    try:
+        canonical_root = root.resolve(strict=True)
     except (OSError, RuntimeError):
-        return path, trusted_root
+        return artifact, root
     try:
-        relative = path.relative_to(trusted_root)
+        relative = artifact.relative_to(root)
     except ValueError:
-        return path, canonical_root
+        return artifact, canonical_root
     return canonical_root / relative, canonical_root
 
 
@@ -187,27 +211,30 @@ def _failure(
 
 
 def inspect_metadata_generation(
-    path: Path,
+    path: object,
     *,
-    trusted_root: Path | None,
+    trusted_root: object | None,
     reparse_point_attribute: int = WINDOWS_REPARSE_POINT_ATTRIBUTE,
     cloud_reparse_tags: frozenset[int] = WINDOWS_CLOUD_REPARSE_TAGS,
 ) -> ArtifactMetadataReceipt:
     """Inspect one file without following links, for bounded-worker use only."""
-    if not path.is_absolute() or Path(os.path.abspath(path)) != path:
-        raise ArtifactMetadataMalformed("artifact path must be lexical absolute")
+    try:
+        root = (
+            materialize_native_root(trusted_root) if trusted_root is not None else None
+        )
+        artifact = materialize_artifact_locator(path, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise ArtifactMetadataMalformed(
+            "artifact locator is invalid",
+            locator_failure=exc.reason_code,
+        ) from exc
 
-    target = path
+    target = artifact
     snapshot: os.stat_result | None = None
     root_generation: FileGeneration | None = None
-    if trusted_root is not None:
-        if (
-            not trusted_root.is_absolute()
-            or Path(os.path.abspath(trusted_root)) != trusted_root
-        ):
-            raise ArtifactMetadataMalformed("trusted root must be lexical absolute")
+    if root is not None:
         try:
-            relative = path.relative_to(trusted_root)
+            relative = artifact.relative_to(root)
         except ValueError as exc:
             raise _failure("root_escape") from exc
         if not relative.parts or any(
@@ -215,7 +242,7 @@ def inspect_metadata_generation(
         ):
             raise _failure("root_escape")
         try:
-            root_snapshot = trusted_root.lstat()
+            root_snapshot = root.lstat()
         except FileNotFoundError as exc:
             raise _failure("missing", exc) from exc
         except (OSError, RuntimeError) as exc:
@@ -232,7 +259,7 @@ def inspect_metadata_generation(
         ):
             raise _failure("root_escape")
         root_generation = FileGeneration.from_directory_identity(root_snapshot)
-        target = trusted_root
+        target = root
         for index, component in enumerate(relative.parts):
             target = target / component
             try:

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -914,6 +914,10 @@ def _returned_slide_artifact(
         declared_pdf = _declared_pdf_path(talk)
         if declared_pdf is not None and declared_pdf[0] != "google_drive_id":
             field, expected = declared_pdf
+            if returned_path != expected:
+                raise PatternEvidenceError(
+                    f"return PDF path must match the exact {field} preclaim"
+                )
             path, artifact_root, _root_kind = _resolve_preclaim_artifact(
                 vault_root,
                 talk,
@@ -921,10 +925,6 @@ def _returned_slide_artifact(
                 suffix=".pdf",
                 source_roots=None,
             )
-            if returned_path != expected:
-                raise PatternEvidenceError(
-                    f"return PDF path must match the exact {field} preclaim"
-                )
         else:
             drive_id = talk.get("google_drive_id")
             if not isinstance(drive_id, str) or not drive_id.strip():

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -1064,8 +1064,7 @@ def resolve_transcript_artifact(
             expected = PurePosixPath("transcripts") / f"{youtube_id}.txt"
             if relative != expected:
                 raise PatternEvidenceError(
-                    f"transcript_path {str(relative)!r} does not match the "
-                    f"claimed talk's youtube_id; expected {str(expected)!r}"
+                    "transcript_path does not match the claimed talk's youtube_id"
                 )
         resolved = bound(root.joinpath(*relative.parts))
         return resolved, f"resolved transcript_path {relative}"

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -13,8 +13,6 @@ import copy
 import hashlib
 import json
 import math
-import ntpath
-import os
 import re
 import subprocess
 from collections.abc import Collection, Iterable, Mapping
@@ -22,6 +20,12 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
+from artifact_locator import (
+    ArtifactLocatorError,
+    classify_artifact_locator,
+    materialize_artifact_locator,
+    materialize_native_root,
+)
 from ingress_contract import (
     has_remote_slide_acquisition,
     has_remote_video_acquisition,
@@ -242,36 +246,52 @@ def _resolve_local_artifact(
     if "\x00" in value:
         raise PatternEvidenceError(f"{label} must not contain a NUL byte")
     _reject_ambiguous_path_segments(value, label=label)
-    supplied = Path(value)
     suffixes = frozenset({suffix}) if isinstance(suffix, str) else suffix
-    if supplied.suffix.casefold() not in suffixes:
-        raise PatternEvidenceError(
-            f"{label} must use one of {sorted(suffixes)}, got {value!r}"
-        )
-    root = Path(vault_root).resolve()
-    candidate = supplied if supplied.is_absolute() else root / supplied
-    lexical = Path(os.path.abspath(candidate))
+    root = _native_artifact_root(vault_root, label="vault_root").resolve()
+    candidate = _materialize_artifact_locator(
+        value,
+        trusted_root=root,
+        label=label,
+    )
+    if candidate.suffix.casefold() not in suffixes:
+        raise PatternEvidenceError(f"{label} must use one of {sorted(suffixes)}")
+    lexical = candidate
     resolved = candidate.resolve(strict=False)
     try:
         resolved.relative_to(root)
     except ValueError as exc:
-        raise PatternEvidenceError(
-            f"{label} resolves outside the vault root: {value!r}"
-        ) from exc
+        raise PatternEvidenceError(f"{label} resolves outside the vault root") from exc
     if lexical != resolved:
-        raise PatternEvidenceError(
-            f"{label} must not traverse a symbolic link: {value!r}"
-        )
+        raise PatternEvidenceError(f"{label} must not traverse a symbolic link")
     if not resolved.is_file():
-        raise PatternEvidenceError(
-            f"{label} artifact is missing or unreadable: {resolved}"
-        )
+        raise PatternEvidenceError(f"{label} artifact is missing or unreadable")
     return resolved
 
 
 def _lexical_absolute(value: str | Path) -> Path:
     """Return an absolute locator without touching the filesystem."""
-    return Path(os.path.abspath(os.fspath(Path(value).expanduser())))
+    return _native_artifact_root(value, label="artifact root")
+
+
+def _materialize_artifact_locator(
+    value: object,
+    *,
+    trusted_root: object | None = None,
+    label: str,
+) -> Path:
+    """Translate the shared closed locator contract to evidence errors."""
+    try:
+        return materialize_artifact_locator(value, trusted_root=trusted_root)
+    except ArtifactLocatorError as exc:
+        raise PatternEvidenceError(f"{label}: {exc.reason_code}") from exc
+
+
+def _native_artifact_root(value: object, *, label: str) -> Path:
+    """Require a lexical native absolute root without cwd/home expansion."""
+    try:
+        return materialize_native_root(value)
+    except ArtifactLocatorError as exc:
+        raise PatternEvidenceError(f"{label}: {exc.reason_code}") from exc
 
 
 def _canonical_pdf_root(value: str | Path) -> Path:
@@ -285,47 +305,11 @@ def _canonical_pdf_root(value: str | Path) -> Path:
 
 
 def _reject_ambiguous_path_segments(value: str, *, label: str) -> None:
-    """Reject ambiguous Windows forms and dot segments before normalization."""
-
-    expanded = os.path.expanduser(value)
-    windows_normalized = expanded.replace("/", "\\")
-    if windows_normalized.startswith(("\\\\?\\", "\\\\.\\", "\\??\\", "\\\\??\\")):
-        raise PatternEvidenceError(
-            f"{label} uses an unsupported Windows device namespace; pass an "
-            "ordinary trusted-root-relative path or a fully qualified drive/UNC path"
-        )
-    windows_drive, windows_tail = ntpath.splitdrive(expanded)
-    drive_relative = re.fullmatch(
-        r"[A-Za-z]:", windows_drive
-    ) is not None and not windows_tail.startswith(("/", "\\"))
-    root_relative = (
-        windows_normalized.startswith("\\")
-        and not windows_normalized.startswith("\\\\")
-        and (expanded.startswith("\\") or os.name == "nt")
-    )
-    if drive_relative or root_relative:
-        raise PatternEvidenceError(
-            f"{label} is an ambiguous Windows path whose target depends on the "
-            "current drive or per-drive working directory; pass a "
-            "trusted-root-relative path or a fully qualified drive/UNC path"
-        )
-    separators: list[str] = []
-    for separator in (os.sep, os.altsep, "/", "\\"):
-        if separator is not None and separator not in separators:
-            separators.append(separator)
-    # Scan the full locator so ambiguous UNC share components cannot disappear
-    # into splitdrive(), and scan the tail as well so drive-relative C:.. forms
-    # expose the dot segment that is attached to the drive prefix.
-    segments = [expanded]
-    if windows_drive:
-        segments.append(windows_tail)
-    for separator in separators:
-        segments = [piece for segment in segments for piece in segment.split(separator)]
-    if any(segment in {".", ".."} for segment in segments):
-        raise PatternEvidenceError(
-            f"{label} contains an ambiguous '.' or '..' path segment; "
-            "pass a normalized path with all dot segments removed"
-        )
+    """Apply the shared host-independent lexical locator classifier."""
+    try:
+        classify_artifact_locator(value)
+    except ArtifactLocatorError as exc:
+        raise PatternEvidenceError(f"{label}: {exc.reason_code}") from exc
 
 
 def _resolve_local_bounded_artifact(
@@ -342,12 +326,12 @@ def _resolve_local_bounded_artifact(
     if "\x00" in value:
         raise PatternEvidenceError(f"{label} must not contain a NUL byte")
     _reject_ambiguous_path_segments(value, label=label)
-    root_locator = _lexical_absolute(trusted_root)
-    supplied = Path(value).expanduser()
-    if supplied.is_absolute():
-        candidate = _lexical_absolute(supplied)
-    else:
-        candidate = _lexical_absolute(root_locator / supplied)
+    root_locator = _native_artifact_root(trusted_root, label="trusted root")
+    candidate = _materialize_artifact_locator(
+        value,
+        trusted_root=root_locator,
+        label=label,
+    )
     canonical_root = root_locator
     if canonicalize_root:
         candidate, admitted_root = canonicalize_trusted_artifact_locator(
@@ -361,7 +345,7 @@ def _resolve_local_bounded_artifact(
         relative = candidate.relative_to(canonical_root)
     except ValueError as exc:
         raise PatternEvidenceError(
-            f"{label} resolves outside the trusted root: {value!r}"
+            f"{label} resolves outside the trusted root"
         ) from exc
     if not relative.parts or candidate.suffix.casefold() != suffix:
         raise PatternEvidenceError(f"{label} must use the {suffix} suffix")
@@ -512,85 +496,67 @@ def _resolve_preclaim_artifact(
     value = owner.get(field)
     if not isinstance(value, str) or not value.strip():
         raise PatternEvidenceError(f"{field} must be a non-empty path")
-    if suffix in {".pptx", ".pdf"}:
-        _reject_ambiguous_path_segments(value, label=field)
-        vault = _lexical_absolute(vault_root)
-        supplied = Path(value).expanduser()
-        configured_root: Path | None = None
-        if field == "pptx_path" and isinstance(source_roots, Mapping):
-            configured = source_roots.get("pptx_source_dir")
-            if isinstance(configured, str) and configured.strip():
-                configured_root = _lexical_absolute(configured)
-        resolver = (
-            _resolve_local_pptx_artifact
-            if suffix == ".pptx"
-            else _resolve_local_pdf_artifact
+    _reject_ambiguous_path_segments(value, label=field)
+    vault = _native_artifact_root(vault_root, label="vault_root")
+    configured_root: Path | None = None
+    if (
+        field == "pptx_path"
+        and isinstance(source_roots, Mapping)
+        and "pptx_source_dir" in source_roots
+        and source_roots.get("pptx_source_dir") is not None
+    ):
+        configured_root = _native_artifact_root(
+            source_roots.get("pptx_source_dir"),
+            label="pptx_source_dir",
         )
-        if supplied.is_absolute():
-            absolute = _lexical_absolute(supplied)
-            for root, root_kind in (
-                (vault, "vault"),
-                (configured_root, "pptx_source"),
-            ):
-                if root is None:
-                    continue
-                try:
-                    candidate = absolute.relative_to(root).as_posix()
-                except ValueError:
-                    continue
-                admitted_root = _canonical_pdf_root(root) if suffix == ".pdf" else root
-                return (
-                    resolver(
-                        root,
-                        candidate,
-                        label=field,
-                    ),
-                    admitted_root,
-                    root_kind,
-                )
-            root = _lexical_absolute(supplied.parent)
-            admitted_root = _canonical_pdf_root(root) if suffix == ".pdf" else root
-            return (
-                resolver(root, supplied.name, label=field),
-                admitted_root,
-                f"preclaim:{field}",
-            )
+    try:
+        locator_kind = classify_artifact_locator(value)
+    except ArtifactLocatorError as exc:
+        raise PatternEvidenceError(f"{field}: {exc.reason_code}") from exc
+    resolver = (
+        _resolve_local_pptx_artifact
+        if suffix == ".pptx"
+        else _resolve_local_pdf_artifact
+        if suffix == ".pdf"
+        else None
+    )
+    if locator_kind == "relative":
         root = configured_root or vault
         root_kind = "pptx_source" if configured_root is not None else "vault"
-        admitted_root = _canonical_pdf_root(root) if suffix == ".pdf" else root
-        return (
-            resolver(root, value, label=field),
-            admitted_root,
-            root_kind,
-        )
-
-    vault = Path(vault_root).resolve()
-    supplied = Path(value).expanduser()
-    root_kind = "vault"
-    if supplied.is_absolute():
-        lexical_supplied = Path(os.path.abspath(supplied))
-        resolved_supplied = supplied.resolve(strict=False)
-        if lexical_supplied != resolved_supplied:
-            raise PatternEvidenceError(
-                f"{field} must not traverse a symbolic link: {value!r}"
-            )
-        try:
-            candidate = resolved_supplied.relative_to(vault).as_posix()
-        except ValueError:
-            # An exact absolute path in the preclaim is trusted as an
-            # immutable source reference. Its parent becomes a field-specific
-            # root; workers cannot introduce or redirect this path.
-            root = supplied.parent.resolve()
-            root_kind = f"preclaim:{field}"
-            candidate = supplied.name
+        if resolver is None:
+            path = _resolve_local_artifact(root, value, suffix=suffix, label=field)
         else:
-            root = vault
-            root_kind = "vault"
-    else:
-        root = vault
-        candidate = value
-    path = _resolve_local_artifact(root, candidate, suffix=suffix, label=field)
-    return path, root, root_kind
+            path = resolver(root, value, label=field)
+        admitted_root = _canonical_pdf_root(root) if suffix == ".pdf" else root
+        return path, admitted_root, root_kind
+
+    absolute = _materialize_artifact_locator(value, label=field)
+    for root, root_kind in (
+        (vault, "vault"),
+        (configured_root, "pptx_source"),
+    ):
+        if root is None:
+            continue
+        try:
+            candidate = absolute.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        admitted_root = _canonical_pdf_root(root) if suffix == ".pdf" else root
+        path = (
+            _resolve_local_artifact(root, candidate, suffix=suffix, label=field)
+            if resolver is None
+            else resolver(root, candidate, label=field)
+        )
+        return path, admitted_root, root_kind
+
+    root = _native_artifact_root(absolute.parent, label=f"{field} parent")
+    admitted_root = _canonical_pdf_root(root) if suffix == ".pdf" else root
+    path = (
+        _resolve_local_artifact(root, absolute.name, suffix=suffix, label=field)
+        if resolver is None
+        else resolver(root, absolute.name, label=field)
+    )
+    return path, admitted_root, f"preclaim:{field}"
 
 
 def _pptx_locator_count(
@@ -948,11 +914,6 @@ def _returned_slide_artifact(
         declared_pdf = _declared_pdf_path(talk)
         if declared_pdf is not None and declared_pdf[0] != "google_drive_id":
             field, expected = declared_pdf
-            if returned_path != expected:
-                raise PatternEvidenceError(
-                    f"return PDF path must match the exact {field} preclaim "
-                    f"{expected!r}"
-                )
             path, artifact_root, _root_kind = _resolve_preclaim_artifact(
                 vault_root,
                 talk,
@@ -960,6 +921,10 @@ def _returned_slide_artifact(
                 suffix=".pdf",
                 source_roots=None,
             )
+            if returned_path != expected:
+                raise PatternEvidenceError(
+                    f"return PDF path must match the exact {field} preclaim"
+                )
         else:
             drive_id = talk.get("google_drive_id")
             if not isinstance(drive_id, str) or not drive_id.strip():
@@ -1071,10 +1036,13 @@ def resolve_transcript_artifact(
     v3 citation implementation.  It is deliberately ignored: a return must not
     redirect evidence resolution to another talk's transcript.
     """
-    root = Path(vault_root).resolve()
+    root = _native_artifact_root(vault_root, label="vault_root").resolve()
 
     def bound(candidate: Path) -> Path:
-        lexical = Path(os.path.abspath(candidate))
+        lexical = _materialize_artifact_locator(
+            candidate,
+            label="transcript artifact",
+        )
         resolved = candidate.resolve(strict=False)
         try:
             resolved.relative_to(root)
@@ -1936,7 +1904,8 @@ def build_evidence_context(
     slide_artifact_identities = {}
     for source, path in slide_artifact_paths.items():
         root, root_kind = slide_artifact_roots.get(
-            source, (Path(vault_root).resolve(), "vault")
+            source,
+            (_native_artifact_root(vault_root, label="vault_root"), "vault"),
         )
         slide_artifact_identities[source] = _artifact_identity(
             root,
@@ -1953,13 +1922,16 @@ def build_evidence_context(
     ):
         try:
             local_video_path.resolve(strict=False).relative_to(
-                Path(vault_root).resolve()
+                _native_artifact_root(vault_root, label="vault_root")
             )
         except ValueError:
-            video_root = local_video_path.parent.resolve()
+            video_root = _native_artifact_root(
+                local_video_path.parent,
+                label="video artifact parent",
+            )
             video_root_kind = "preclaim:video_local_path"
         else:
-            video_root = Path(vault_root).resolve()
+            video_root = _native_artifact_root(vault_root, label="vault_root")
             video_root_kind = "vault"
         try:
             video_artifact_identity.update(
@@ -3870,33 +3842,46 @@ def assess_persisted_pattern_evidence_freshness(
                 return bounded_vault
             if bounded_suffix == ".pptx":
                 return vault
-            return Path(vault_root).resolve()
+            return vault
         if kind == "pptx_source":
             configured = (
                 source_roots.get("pptx_source_dir")
                 if isinstance(source_roots, Mapping)
                 else None
             )
-            if isinstance(configured, str) and configured.strip():
-                return (
-                    _lexical_absolute(configured)
-                    if bounded_suffix is not None
-                    else Path(configured).expanduser().resolve()
-                )
-            reasons.add(f"{label}:artifact_root_unconfigured")
-            return None
+            if configured is None:
+                reasons.add(f"{label}:artifact_root_unconfigured")
+                return None
+            try:
+                configured_root = materialize_native_root(configured)
+            except ArtifactLocatorError as exc:
+                reasons.add(f"{label}:artifact_root_invalid:{exc.reason_code}")
+                return None
+            return (
+                _canonical_pdf_root(configured_root)
+                if bounded_suffix == ".pdf"
+                else configured_root
+            )
         if isinstance(kind, str) and kind.startswith("preclaim:"):
             field = kind.removeprefix("preclaim:")
             declared = talk.get(field)
-            if isinstance(declared, str) and Path(declared).expanduser().is_absolute():
-                parent = Path(declared).expanduser().parent
-                if bounded_suffix == ".pdf":
-                    return _canonical_pdf_root(parent)
-                if bounded_suffix == ".pptx":
-                    return _lexical_absolute(parent)
-                return parent.resolve()
-            reasons.add(f"{label}:artifact_root_preclaim_missing")
-            return None
+            try:
+                locator_kind = classify_artifact_locator(declared)
+            except ArtifactLocatorError as exc:
+                reasons.add(f"{label}:artifact_root_preclaim_invalid:{exc.reason_code}")
+                return None
+            if locator_kind == "relative":
+                reasons.add(f"{label}:artifact_root_preclaim_missing")
+                return None
+            try:
+                absolute = materialize_artifact_locator(declared)
+            except ArtifactLocatorError as exc:
+                reasons.add(f"{label}:artifact_root_preclaim_invalid:{exc.reason_code}")
+                return None
+            parent = absolute.parent
+            if bounded_suffix == ".pdf":
+                return _canonical_pdf_root(parent)
+            return parent
         reasons.add(f"{label}:artifact_root_invalid")
         return None
 
@@ -3943,7 +3928,11 @@ def assess_persisted_pattern_evidence_freshness(
         if quality and not raw_path.endswith(".quality.json"):
             reasons.add(f"{label}:{prefix}_path_invalid")
             return None
-        lexical = Path(os.path.abspath(root.joinpath(*PurePosixPath(raw_path).parts)))
+        try:
+            lexical = materialize_artifact_locator(raw_path, trusted_root=root)
+        except ArtifactLocatorError:
+            reasons.add(f"{label}:{prefix}_path_invalid")
+            return None
         if bounded_suffix is not None:
             try:
                 resolved = _resolve_local_bounded_artifact(
@@ -4124,40 +4113,37 @@ def assess_persisted_pattern_evidence_freshness(
                 if isinstance(current_path, Path)
                 else []
             )
-        values: list[tuple[str | None, object]] = []
+        values: list[object] = []
         if source == "transcript":
             explicit = talk.get("transcript_path")
             if _nonempty(explicit):
-                values.append(("transcript_path", explicit))
+                values.append(explicit)
             else:
                 youtube_id = talk.get("youtube_id")
                 if isinstance(youtube_id, str) and _YOUTUBE_ID.fullmatch(youtube_id):
-                    values.append(("transcript_path", f"transcripts/{youtube_id}.txt"))
+                    values.append(f"transcripts/{youtube_id}.txt")
         elif source == "delivery_video":
             for field in ("video_local_path", "video_path"):
                 if _nonempty(talk.get(field)):
-                    values.append((field, talk[field]))
+                    values.append(talk[field])
             manifest_path = _dig(
                 talk, "structured_data.video_extraction.source_video_path"
             )
             if _nonempty(manifest_path):
-                values.append((None, manifest_path))
+                values.append(manifest_path)
         candidates: list[Path] = []
         allowed_suffixes = (
             frozenset({".txt"})
             if source == "transcript"
             else frozenset({".mp4", ".webm", ".mkv", ".mov"})
         )
-        for field, value in values:
-            if not isinstance(value, str):
+        for value in values:
+            try:
+                supplied = materialize_artifact_locator(value, trusted_root=vault)
+            except ArtifactLocatorError:
                 continue
-            supplied = Path(value).expanduser()
-            if supplied.suffix.casefold() not in allowed_suffixes:
-                continue
-            if supplied.is_absolute():
+            if supplied.suffix.casefold() in allowed_suffixes:
                 candidates.append(supplied.resolve(strict=False))
-            else:
-                candidates.append((vault / supplied).resolve(strict=False))
         return candidates
 
     inspection = observations.get("source_inspection")

--- a/skills/vault-ingress/scripts/pdf_evidence.py
+++ b/skills/vault-ingress/scripts/pdf_evidence.py
@@ -32,6 +32,11 @@ from artifact_metadata import (
     decode_artifact_metadata_payload,
     inspect_metadata_generation,
 )
+from artifact_locator import (
+    ArtifactLocatorError,
+    materialize_artifact_locator,
+    materialize_native_root,
+)
 from artifact_supervisor import (
     DiagnosticReceipt,
     FileGeneration,
@@ -255,23 +260,40 @@ def _failure(
     )
 
 
-def _lexical_absolute(value: str | os.PathLike[str]) -> Path:
+def _materialize_public_locator(
+    value: object,
+    *,
+    trusted_root: object | None,
+) -> tuple[Path, Path | None]:
     try:
-        rendered = os.fspath(value)
-    except TypeError as exc:
-        raise _failure("pdf_evidence_invalid") from exc
-    if not isinstance(rendered, str) or not rendered or "\x00" in rendered:
-        raise _failure("pdf_evidence_invalid")
-    return Path(os.path.abspath(rendered))
+        root = (
+            materialize_native_root(trusted_root) if trusted_root is not None else None
+        )
+        artifact = materialize_artifact_locator(value, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise _failure(
+            "pdf_evidence_invalid",
+            details={"locator_failure": exc.reason_code},
+        ) from exc
+    return artifact, root
 
 
-def _worker_bound_path(value: object) -> Path:
-    if not isinstance(value, str) or not value or "\x00" in value:
-        raise SupervisorError("invalid_worker_request")
-    path = Path(value)
-    if not path.is_absolute() or Path(os.path.abspath(value)) != path:
-        raise SupervisorError("invalid_worker_request")
-    return path
+def _worker_bound_paths(
+    artifact_value: object,
+    root_value: object | None,
+) -> tuple[Path, Path | None]:
+    try:
+        root = materialize_native_root(root_value) if root_value is not None else None
+        artifact = materialize_artifact_locator(
+            artifact_value,
+            trusted_root=root,
+        )
+    except ArtifactLocatorError as exc:
+        raise SupervisorError(
+            "invalid_worker_request",
+            {"locator_failure": exc.reason_code},
+        ) from exc
+    return artifact, root
 
 
 def _metadata_failure_payload(exc: ArtifactMetadataUnavailable) -> dict[str, object]:
@@ -289,11 +311,13 @@ def _metadata_failure_payload(exc: ArtifactMetadataUnavailable) -> dict[str, obj
 def _metadata_child(payload: Mapping[str, object]) -> dict[str, object]:
     if set(payload) != {"pdf_path", "trusted_root"}:
         raise SupervisorError("invalid_worker_request")
-    artifact = _worker_bound_path(payload.get("pdf_path"))
     root_value = payload.get("trusted_root")
     if root_value is not None and not isinstance(root_value, str):
         raise SupervisorError("invalid_worker_request")
-    trusted_root = _worker_bound_path(root_value) if root_value is not None else None
+    artifact, trusted_root = _worker_bound_paths(
+        payload.get("pdf_path"),
+        root_value,
+    )
     try:
         receipt = inspect_metadata_generation(
             artifact,
@@ -1173,11 +1197,13 @@ def _probe_payload_values(
         "max_pages",
     }:
         raise SupervisorError("invalid_worker_request")
-    artifact = _worker_bound_path(payload.get("pdf_path"))
     root_value = payload.get("trusted_root")
     if root_value is not None and not isinstance(root_value, str):
         raise SupervisorError("invalid_worker_request")
-    trusted_root = _worker_bound_path(root_value) if root_value is not None else None
+    artifact, trusted_root = _worker_bound_paths(
+        payload.get("pdf_path"),
+        root_value,
+    )
     max_input_bytes = payload.get("max_input_bytes")
     max_pages = payload.get("max_pages")
     if max_input_bytes != PDF_MAX_INPUT_BYTES or max_pages != PDF_MAX_PAGES:
@@ -1680,9 +1706,16 @@ def probe_pdf_artifact(
     deadline_monotonic: float | None = None,
 ) -> PdfArtifactProbe:
     """Return exact PDF evidence without whole-file work in the parent process."""
-    artifact = _lexical_absolute(path)
-    root = _lexical_absolute(trusted_root) if trusted_root is not None else None
-    artifact, root = canonicalize_trusted_artifact_locator(artifact, root)
+    artifact, root = _materialize_public_locator(path, trusted_root=trusted_root)
+    try:
+        artifact, root = canonicalize_trusted_artifact_locator(artifact, root)
+    except ArtifactMetadataMalformed as exc:
+        raise _failure(
+            "pdf_evidence_invalid",
+            details={
+                "locator_failure": exc.locator_failure or "artifact_locator_invalid"
+            },
+        ) from exc
     try:
         receipt = _run_bounded_metadata_worker(
             artifact,

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -48,6 +48,7 @@ from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.oxml.ns import qn
 
 import artifact_metadata
+from artifact_locator import ArtifactLocatorError, materialize_native_root
 from artifact_supervisor import (
     SupervisorError,
     SupervisorLimits,
@@ -1833,7 +1834,7 @@ def _usable_directory_identity(stat_result):
 
 def _discover_pptx_files(directory, skip_patterns):
     """Discover a deterministic, bounded set inside the contained worker."""
-    root = Path(directory)
+    root = Path(_validated_directory_root(directory))
     try:
         root_stat = root.lstat()
     except OSError as exc:
@@ -2009,19 +2010,22 @@ def _discover_pptx_files(directory, skip_patterns):
 
 
 def _validated_directory_root(value):
-    if (
-        not isinstance(value, str)
-        or not value
-        or "\x00" in value
-        or len(value) > _BATCH_MAX_ROOT_PATH_CHARS
-        or not os.path.isabs(value)
-        or os.path.abspath(value) != value
-    ):
+    try:
+        root = materialize_native_root(value)
+    except ArtifactLocatorError as exc:
         raise PptxEvidenceError(
-            "directory root must be a bounded path string",
+            "directory root must be a bounded native absolute path",
             reason_code="pptx_batch_root_invalid",
+            details={"locator_failure": exc.reason_code},
+        ) from exc
+    rendered = os.fspath(root)
+    if len(rendered) > _BATCH_MAX_ROOT_PATH_CHARS:
+        raise PptxEvidenceError(
+            "directory root must be a bounded native absolute path",
+            reason_code="pptx_batch_root_invalid",
+            details={"locator_failure": "directory_root_path_limit"},
         )
-    return value
+    return rendered
 
 
 def _validated_skip_patterns(value):
@@ -2188,7 +2192,7 @@ def _directory_limits_before_deadline(deadline_monotonic):
 
 def _run_supervised_directory_discovery(directory, skip_patterns, *, deadline):
     """Resolve one directory only through the authenticated bounded worker."""
-    root = _validated_directory_root(os.path.abspath(os.fspath(directory)))
+    root = _validated_directory_root(directory)
     patterns = _validated_skip_patterns(skip_patterns)
     limits, deadline_limited = _directory_limits_before_deadline(deadline)
     command = [sys.executable, os.path.abspath(__file__), _DIRECTORY_WORKER_FLAG]
@@ -2245,7 +2249,13 @@ def _dispatch_directory_worker(request: WorkerRequest):
         patterns = _validated_skip_patterns(request.payload.get("skip_patterns"))
         discovered, skipped, _started = _discover_pptx_files(root, patterns)
     except PptxEvidenceError as exc:
-        raise SupervisorError(exc.reason_code) from exc
+        locator_failure = exc.details.get("locator_failure")
+        details = (
+            {"locator_failure": locator_failure}
+            if isinstance(locator_failure, str)
+            else {}
+        )
+        raise SupervisorError(exc.reason_code, details) from exc
     return {
         "schema_version": _DIRECTORY_MANIFEST_SCHEMA_VERSION,
         "kind": "directory",
@@ -2317,7 +2327,7 @@ def batch_extract(directory, skip_patterns, *, ocr=True):
     results = []
     started = time.monotonic()
     deadline = started + _BATCH_MAX_WALL_SECONDS
-    root = Path(_validated_directory_root(os.path.abspath(os.fspath(directory))))
+    root = Path(_validated_directory_root(directory))
     try:
         relative_files, skipped = _run_supervised_directory_discovery(
             root,

--- a/skills/vault-ingress/scripts/pptx_evidence.py
+++ b/skills/vault-ingress/scripts/pptx_evidence.py
@@ -26,6 +26,11 @@ from pathlib import Path
 from typing import Any, BinaryIO, Callable, cast
 from zlib import error as ZlibError
 
+from artifact_locator import (
+    ArtifactLocatorError,
+    materialize_artifact_locator,
+    materialize_native_root,
+)
 from artifact_supervisor import (
     FileGeneration,
     JsonValue,
@@ -1110,6 +1115,44 @@ def _probe_failure(
     )
 
 
+def _materialize_public_input(
+    path: object,
+    *,
+    trusted_root: object | None,
+) -> tuple[Path, Path | None]:
+    """Materialize one host-stable locator before metadata or worker activity."""
+    try:
+        root = (
+            materialize_native_root(trusted_root) if trusted_root is not None else None
+        )
+        artifact = materialize_artifact_locator(path, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise _probe_failure(
+            "pptx_evidence_invalid",
+            details={"locator_failure": exc.reason_code},
+        ) from exc
+    return artifact, root
+
+
+def _materialize_worker_input(
+    path: object,
+    *,
+    trusted_root: object | None,
+) -> tuple[Path, Path | None]:
+    """Repeat locator validation inside the authenticated worker boundary."""
+    try:
+        root = (
+            materialize_native_root(trusted_root) if trusted_root is not None else None
+        )
+        artifact = materialize_artifact_locator(path, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise SupervisorError(
+            "invalid_worker_request",
+            {"locator_failure": exc.reason_code},
+        ) from exc
+    return artifact, root
+
+
 def _probe_child_failure_details(exc: PptxEvidenceError) -> dict[str, object]:
     """Copy only closed, bounded diagnostic fields into the child result."""
     if exc.reason_code in _CONTAINED_RENDERED_PDF_FAILURE_REASON_CODES:
@@ -1396,7 +1439,10 @@ def _metadata_generation_in_worker(
             cloud_reparse_tags=PPTX_WINDOWS_CLOUD_REPARSE_TAGS,
         )
     except ArtifactMetadataMalformed as exc:
-        raise SupervisorError("invalid_worker_request") from exc
+        details: dict[str, JsonValue] = {}
+        if exc.locator_failure is not None:
+            details["locator_failure"] = exc.locator_failure
+        raise SupervisorError("invalid_worker_request", details) from exc
     except ArtifactMetadataUnavailable as exc:
         raise _metadata_failure(
             exc.failure_kind,
@@ -1408,11 +1454,13 @@ def _metadata_generation_in_worker(
 def _metadata_child(payload: Mapping[str, object]) -> dict[str, object]:
     if set(payload) != {"pptx_path", "trusted_root"}:
         raise SupervisorError("invalid_worker_request")
-    path = _worker_bound_path(payload.get("pptx_path"))
     root_value = payload.get("trusted_root")
     if root_value is not None and not isinstance(root_value, str):
         raise SupervisorError("invalid_worker_request")
-    trusted_root = _worker_bound_path(root_value) if root_value is not None else None
+    path, trusted_root = _materialize_worker_input(
+        payload.get("pptx_path"),
+        trusted_root=root_value,
+    )
     try:
         generation, root_generation, reparse_tag = _metadata_generation_in_worker(
             path,
@@ -1504,12 +1552,7 @@ def _run_bounded_metadata_worker(
 ) -> _MetadataReceipt:
     if artifact_kind not in _ADMISSION_KINDS:
         raise _probe_failure("pptx_probe_malformed_result")
-    artifact = Path(os.path.abspath(os.fspath(path)))
-    root = (
-        Path(os.path.abspath(os.fspath(trusted_root)))
-        if trusted_root is not None
-        else None
-    )
+    artifact, root = _materialize_public_input(path, trusted_root=trusted_root)
     command = [
         sys.executable,
         os.fspath(Path(__file__).absolute()),
@@ -1843,12 +1886,7 @@ def _probe_file_identity(
     # Keep the lexical absolute path. Resolving here would follow a path that
     # was swapped to a symlink after lstat and could move worker I/O outside
     # the admitted artifact boundary.
-    canonical = Path(os.path.abspath(os.fspath(path)))
-    root = (
-        Path(os.path.abspath(os.fspath(trusted_root)))
-        if trusted_root is not None
-        else None
-    )
+    canonical, root = _materialize_public_input(path, trusted_root=trusted_root)
     generation = _supervised_file_generation(
         canonical,
         label="PPTX artifact",
@@ -1923,13 +1961,9 @@ def probe_pptx_artifact(
     deadline_monotonic: float | None = None,
 ) -> PptxArtifactProbe:
     """Return exact deck evidence through a bounded, generation-cached worker."""
-    root = (
-        Path(os.path.abspath(os.fspath(trusted_root)))
-        if trusted_root is not None
-        else None
-    )
+    artifact, root = _materialize_public_input(path, trusted_root=trusted_root)
     artifact, key = _probe_file_identity(
-        path,
+        artifact,
         trusted_root=root,
         deadline_monotonic=deadline_monotonic,
     )
@@ -2723,12 +2757,8 @@ def recompute_native_deck_audit(
     trusted_root: str | Path | None = None,
 ) -> dict[str, object]:
     """Recompute an exact audit through a bounded, generation-cached worker."""
-    root = (
-        Path(os.path.abspath(os.fspath(trusted_root)))
-        if trusted_root is not None
-        else None
-    )
-    artifact, key = _probe_file_identity(path, trusted_root=root)
+    artifact, root = _materialize_public_input(path, trusted_root=trusted_root)
+    artifact, key = _probe_file_identity(artifact, trusted_root=root)
     cached = _PPTX_NATIVE_AUDIT_CACHE.get(key)
     if isinstance(cached, dict):
         return copy.deepcopy(cached)
@@ -2820,12 +2850,7 @@ def _admit_supervised_input(
     del label  # Failure text is deliberately path- and artifact-label-free.
     if artifact_kind not in _ADMISSION_KINDS:
         raise _probe_failure("pptx_probe_malformed_result")
-    artifact = Path(os.path.abspath(os.fspath(path)))
-    root = (
-        Path(os.path.abspath(os.fspath(trusted_root)))
-        if trusted_root is not None
-        else None
-    )
+    artifact, root = _materialize_public_input(path, trusted_root=trusted_root)
     receipt = _run_bounded_metadata_worker(
         artifact,
         trusted_root=root,
@@ -4691,18 +4716,23 @@ def _run_supervised_pptx_extraction_impl(
     admitted_source_sizes: list[int],
 ) -> dict[str, object]:
     """Extract one deck only through the authenticated worker boundary."""
+    artifact, root = _materialize_public_input(
+        pptx_path,
+        trusted_root=trusted_root,
+    )
+    rendered_artifact: Path | None = None
+    if rendered_pdf_path is not None:
+        rendered_artifact, _rendered_root = _materialize_public_input(
+            rendered_pdf_path,
+            trusted_root=None,
+        )
     if type(ocr) is not bool:
         raise PptxEvidenceError(
             "ocr must be a boolean",
             reason_code="pptx_evidence_invalid",
         )
-    root = (
-        Path(os.path.abspath(os.fspath(trusted_root)))
-        if trusted_root is not None
-        else None
-    )
     artifact, generation, root_generation = _admit_supervised_input(
-        pptx_path,
+        artifact,
         label="PPTX artifact",
         trusted_root=root,
         deadline_monotonic=deadline_monotonic,
@@ -4729,12 +4759,11 @@ def _run_supervised_pptx_extraction_impl(
         if root_generation is None:
             raise _probe_failure("pptx_probe_malformed_result")
         expected["pptx_root"] = root_generation
-    rendered_artifact: Path | None = None
     rendered_generation: FileGeneration | None = None
-    if rendered_pdf_path is not None:
+    if rendered_artifact is not None:
         rendered_artifact, rendered_generation, rendered_root_generation = (
             _admit_supervised_input(
-                rendered_pdf_path,
+                rendered_artifact,
                 label="rendered PDF",
                 deadline_monotonic=deadline_monotonic,
                 artifact_kind=_RENDERED_PDF_ADMISSION_KIND,
@@ -4927,12 +4956,6 @@ def _worker_request_payload(request: WorkerRequest) -> dict[str, object]:
     return dict(request.payload)
 
 
-def _worker_bound_path(value: object) -> Path:
-    if not isinstance(value, str) or not value or "\x00" in value:
-        raise SupervisorError("invalid_worker_request")
-    return Path(value)
-
-
 def _worker_generation(
     path: Path,
     *,
@@ -5029,7 +5052,7 @@ def _load_pptx_extractor() -> Any:
 
 def _validated_extract_worker_payload(
     payload: Mapping[str, object],
-) -> tuple[Path, Path | None, str | None, list[list[int]]]:
+) -> tuple[Path, Path | None, Path | None, list[list[int]]]:
     """Validate the complete extraction request before any artifact I/O."""
     expected_fields = {
         "pptx_path",
@@ -5049,24 +5072,28 @@ def _validated_extract_worker_payload(
         != PPTX_EXTRACTION_PIPELINE_VERSION
     ):
         raise SupervisorError("invalid_worker_request")
-    pptx_path = _worker_bound_path(payload.get("pptx_path"))
     trusted_root_value = payload.get("trusted_root")
     if trusted_root_value is not None and not isinstance(trusted_root_value, str):
         raise SupervisorError("invalid_worker_request")
-    trusted_root = (
-        _worker_bound_path(trusted_root_value)
-        if trusted_root_value is not None
-        else None
+    pptx_path, trusted_root = _materialize_worker_input(
+        payload.get("pptx_path"),
+        trusted_root=trusted_root_value,
     )
     rendered_value = payload.get("rendered_pdf_path")
     if rendered_value is not None and not isinstance(rendered_value, str):
         raise SupervisorError("invalid_worker_request")
+    rendered_path = None
+    if rendered_value is not None:
+        rendered_path, _rendered_root = _materialize_worker_input(
+            rendered_value,
+            trusted_root=None,
+        )
     ranges = payload.get("inspected_page_ranges")
     try:
         ranges = _validated_requested_page_ranges(ranges)
     except PptxEvidenceError as exc:
         raise SupervisorError("invalid_worker_request") from exc
-    return pptx_path, trusted_root, rendered_value, ranges
+    return pptx_path, trusted_root, rendered_path, ranges
 
 
 def _extract_child(
@@ -5088,9 +5115,7 @@ def _extract_child(
         result = extract(
             pptx_path,
             ocr=payload["ocr"],
-            rendered_pdf_path=(
-                Path(rendered_value) if rendered_value is not None else None
-            ),
+            rendered_pdf_path=rendered_value,
             inspected_page_ranges=ranges,
             rendered_pdf_generation=rendered_pdf_generation,
         )
@@ -5138,6 +5163,7 @@ def _dispatch_supervised_worker(
     request: WorkerRequest,
 ) -> tuple[dict[str, object], dict[str, FileGeneration]]:
     payload = _worker_request_payload(request)
+    rendered_path: Path | None = None
     expected_profile = {
         PPTX_METADATA_OPERATION: PPTX_METADATA_LIMITS.profile_id,
         PPTX_PROBE_OPERATION: PPTX_PROBE_LIMITS.profile_id,
@@ -5161,28 +5187,24 @@ def _dispatch_supervised_worker(
         return _metadata_child(payload), {}
 
     if request.operation in {PPTX_PROBE_OPERATION, PPTX_NATIVE_AUDIT_OPERATION}:
-        pptx_path = _worker_bound_path(payload.get("pptx_path"))
-        trusted_root_value = payload.get("trusted_root")
         if set(payload) != {"pptx_path", "trusted_root"}:
             raise SupervisorError("invalid_worker_request")
+        trusted_root_value = payload.get("trusted_root")
         if trusted_root_value is not None and not isinstance(trusted_root_value, str):
             raise SupervisorError("invalid_worker_request")
-        trusted_root = (
-            _worker_bound_path(trusted_root_value)
-            if trusted_root_value is not None
-            else None
+        pptx_path, trusted_root = _materialize_worker_input(
+            payload.get("pptx_path"),
+            trusted_root=trusted_root_value,
         )
     elif request.operation == PPTX_EXTRACT_OPERATION:
-        pptx_path, trusted_root, _rendered_value, _ranges = (
+        pptx_path, trusted_root, rendered_path, _ranges = (
             _validated_extract_worker_payload(payload)
         )
     else:
         raise SupervisorError("invalid_worker_operation")
     paths: dict[str, tuple[Path, Path | None]] = {"pptx": (pptx_path, trusted_root)}
-    if request.operation == PPTX_EXTRACT_OPERATION:
-        rendered_value = payload.get("rendered_pdf_path")
-        if rendered_value is not None:
-            paths["rendered_pdf"] = (_worker_bound_path(rendered_value), None)
+    if request.operation == PPTX_EXTRACT_OPERATION and rendered_path is not None:
+        paths["rendered_pdf"] = (rendered_path, None)
     expected_names = set(paths)
     if trusted_root is not None:
         expected_names.add("pptx_root")

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1026,6 +1026,13 @@ class VaultPreflight:
         if explicit:
             try:
                 relative = validate_transcript_path(explicit)
+                youtube_id = _nonempty_string(talk.get("youtube_id"))
+                if (
+                    youtube_id
+                    and YOUTUBE_ID_RE.fullmatch(youtube_id)
+                    and relative.as_posix() != f"transcripts/{youtube_id}.txt"
+                ):
+                    return None
                 return materialize_artifact_locator(
                     relative.as_posix(),
                     trusted_root=self.vault_root,

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -26,6 +26,11 @@ import re
 import sys
 from typing import Any
 
+from artifact_locator import (
+    ArtifactLocatorError,
+    materialize_artifact_locator,
+    materialize_native_root,
+)
 from ingress_contract import (
     YOUTUBE_ID_RE,
     is_youtube_url,
@@ -45,6 +50,7 @@ from pattern_evidence import (
     PatternEvidenceError,
     assess_talk_artifact_capabilities,
     resolve_video_extraction_source,
+    validate_transcript_path,
     validate_transcript_quality_for_owner,
 )
 from pdf_evidence import PdfArtifactProbe, PdfEvidenceError, probe_pdf_artifact
@@ -97,8 +103,23 @@ SLIDE_CONTRACT_CODES = frozenset(
 WORD_RE = re.compile(r"[^\W_]+", re.UNICODE)
 
 
+def _reportable_artifact_path(value: Path | str | None) -> str | None:
+    """Return only a proved native absolute path; never cwd-rebase a locator."""
+    if value is None:
+        return None
+    try:
+        return os.fspath(materialize_artifact_locator(value))
+    except ArtifactLocatorError:
+        return None
+
+
 def _nonempty_string(value: Any) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _raw_locator_string(value: Any) -> str | None:
+    """Return a present locator unchanged so validation sees its raw grammar."""
+    return value if isinstance(value, str) and value else None
 
 
 def _is_timezone_aware_timestamp(value: Any) -> bool:
@@ -167,11 +188,7 @@ class VaultPreflight:
                 "message": message,
                 "expected": _json_value(expected),
                 "actual": _json_value(actual),
-                "artifact_path": (
-                    os.path.abspath(os.fspath(artifact_path))
-                    if artifact_path is not None
-                    else None
-                ),
+                "artifact_path": _reportable_artifact_path(artifact_path),
                 "capability_fact": _json_value(capability_fact),
             }
         )
@@ -241,6 +258,7 @@ class VaultPreflight:
         config = self.database.get("config", {})
         if isinstance(config, dict):
             self.config = config
+            self._validate_config_artifact_roots()
         else:
             self.add(
                 "warning",
@@ -291,6 +309,25 @@ class VaultPreflight:
         self._validate_relations()
         self._validate_duplicate_youtube_ids()
         return self.report(len(talks))
+
+    def _validate_config_artifact_roots(self) -> None:
+        """Report each invalid configured source root once, even without talks."""
+        if (
+            "pptx_source_dir" not in self.config
+            or self.config.get("pptx_source_dir") is None
+        ):
+            return
+        try:
+            materialize_native_root(self.config.get("pptx_source_dir"))
+        except ArtifactLocatorError as exc:
+            self.add(
+                "blocking",
+                "pptx_source_dir_invalid",
+                "configured PPTX source root must be a native absolute path",
+                field="config.pptx_source_dir",
+                expected="absent, null, or a native absolute path",
+                actual={"reason_code": exc.reason_code},
+            )
 
     def _validate_filenames(self) -> None:
         occurrences: defaultdict[str, list[int]] = defaultdict(list)
@@ -602,9 +639,11 @@ class VaultPreflight:
         cached = self.artifact_capabilities.get(index)
         if cached is not None:
             return cached
-        source_dir = _nonempty_string(self.config.get("pptx_source_dir"))
+        configured_source = self.config.get("pptx_source_dir")
         source_roots = (
-            {"pptx_source_dir": source_dir} if source_dir is not None else None
+            {"pptx_source_dir": configured_source}
+            if "pptx_source_dir" in self.config and configured_source is not None
+            else None
         )
         assessed = assess_talk_artifact_capabilities(
             self.talks[index],
@@ -692,7 +731,7 @@ class VaultPreflight:
             *,
             code_prefix: str,
             field: str,
-            artifact_path: Path,
+            artifact_path: Path | None,
         ) -> bool:
             capabilities = self._capabilities(index)
             raw_verified = capabilities.get("verified_evidence_sources")
@@ -757,7 +796,7 @@ class VaultPreflight:
 
         if slide_source in {"pptx", "both"}:
             pptx_path = self._pptx_path(talk)
-            if pptx_path is None:
+            if _raw_locator_string(talk.get("pptx_path")) is None:
                 self.talk_add(
                     index,
                     severity,
@@ -837,11 +876,13 @@ class VaultPreflight:
                     )
 
         if slide_source in {"pdf", "both"}:
+            explicit_field = self._slide_pdf_path_field(talk)
+            explicit_locator = _raw_locator_string(talk.get(explicit_field))
             explicit_pdf = self._slide_pdf_path(talk)
-            if explicit_pdf is not None:
+            if explicit_locator is not None:
                 require_static_pdf_capability(
                     code_prefix="slide_pdf",
-                    field=self._slide_pdf_path_field(talk),
+                    field=explicit_field,
                     artifact_path=explicit_pdf,
                 )
                 # An explicit local artifact is a complete offline reference.
@@ -869,12 +910,17 @@ class VaultPreflight:
                 )
 
         if slide_source == "video_extracted":
+            explicit_field = self._slide_pdf_path_field(talk)
+            explicit_locator = _raw_locator_string(talk.get(explicit_field))
             explicit_pdf = self._slide_pdf_path(talk)
-            if explicit_pdf is not None:
-                if require_static_pdf_capability(
-                    code_prefix="slide_video",
-                    field=self._slide_pdf_path_field(talk),
-                    artifact_path=explicit_pdf,
+            if explicit_locator is not None:
+                if (
+                    require_static_pdf_capability(
+                        code_prefix="slide_video",
+                        field=explicit_field,
+                        artifact_path=explicit_pdf,
+                    )
+                    and explicit_pdf is not None
                 ):
                     self._validate_video_extraction_provenance(
                         index,
@@ -976,10 +1022,16 @@ class VaultPreflight:
                     )
 
     def _transcript_path(self, talk: dict[str, Any]) -> Path | None:
-        explicit = _nonempty_string(talk.get("transcript_path"))
+        explicit = _raw_locator_string(talk.get("transcript_path"))
         if explicit:
-            path = Path(explicit).expanduser()
-            return path if path.is_absolute() else self.vault_root / path
+            try:
+                relative = validate_transcript_path(explicit)
+                return materialize_artifact_locator(
+                    relative.as_posix(),
+                    trusted_root=self.vault_root,
+                )
+            except (ArtifactLocatorError, PatternEvidenceError):
+                return None
         youtube_id = _nonempty_string(talk.get("youtube_id"))
         if youtube_id and YOUTUBE_ID_RE.fullmatch(youtube_id):
             return self.vault_root / "transcripts" / f"{youtube_id}.txt"
@@ -1050,22 +1102,25 @@ class VaultPreflight:
         )
 
     def _pptx_path(self, talk: dict[str, Any]) -> Path | None:
-        value = _nonempty_string(talk.get("pptx_path"))
+        value = _raw_locator_string(talk.get("pptx_path"))
         if value is None:
             return None
-        path = Path(value).expanduser()
-        if path.is_absolute():
-            return path
-        source_dir = _nonempty_string(self.config.get("pptx_source_dir"))
-        if source_dir:
-            return Path(source_dir).expanduser() / path
-        return self.vault_root / path
+        configured_source = self.config.get("pptx_source_dir")
+        try:
+            trusted_root = (
+                materialize_native_root(configured_source)
+                if "pptx_source_dir" in self.config and configured_source is not None
+                else self.vault_root
+            )
+            return materialize_artifact_locator(value, trusted_root=trusted_root)
+        except ArtifactLocatorError:
+            return None
 
     @staticmethod
     def _slide_pdf_path_field(talk: dict[str, Any]) -> str:
         """Return the first populated canonical-or-legacy local PDF field."""
         for field in ("slides_local_path", "slides_pdf_path", "pdf_path"):
-            if _nonempty_string(talk.get(field)):
+            if _raw_locator_string(talk.get(field)):
                 return field
         return "slides_local_path"
 
@@ -1078,11 +1133,16 @@ class VaultPreflight:
         no Google Drive identifier was ever recorded.
         """
         field = self._slide_pdf_path_field(talk)
-        value = _nonempty_string(talk.get(field))
+        value = _raw_locator_string(talk.get(field))
         if value is None:
             return None
-        path = Path(value).expanduser()
-        return path if path.is_absolute() else self.vault_root / path
+        try:
+            return materialize_artifact_locator(
+                value,
+                trusted_root=self.vault_root,
+            )
+        except ArtifactLocatorError:
+            return None
 
     def _validate_video_extraction_provenance(
         self,
@@ -1148,13 +1208,24 @@ class VaultPreflight:
         assert isinstance(artifacts, list)
         for artifact in artifacts:
             assert isinstance(artifact, dict)
-            artifact_path = _nonempty_string(artifact.get("path"))
+            artifact_path = _raw_locator_string(artifact.get("path"))
             if artifact_path is None:
                 errors.append("every artifact path must exist")
                 continue
             try:
+                materialized_artifact = materialize_artifact_locator(
+                    artifact_path,
+                    trusted_root=self.vault_root,
+                )
+            except ArtifactLocatorError:
+                errors.append(
+                    "every artifact path must be a native absolute or canonical "
+                    "vault-relative locator"
+                )
+                continue
+            try:
                 artifact_probe = probe_pdf_artifact(
-                    Path(artifact_path).expanduser(),
+                    materialized_artifact,
                     trusted_root=self.vault_root,
                 )
             except PdfEvidenceError as exc:

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -22,6 +22,10 @@ from typing import Mapping, NoReturn, cast
 
 from yaml import YAMLError
 
+from artifact_locator import (
+    ArtifactLocatorError,
+    materialize_native_root,
+)
 from adherence_baseline import (
     ADHERENCE_BASELINE_SCHEMA_VERSION,
     AdherenceBaselineError,
@@ -932,15 +936,20 @@ def _manifest_nonnegative_int(manifest: dict, field: str, *, positive=False) -> 
 
 def _validate_absolute_manifest_path(value, field: str) -> str:
     if not isinstance(value, str) or not value.strip() or value != value.strip():
-        _manifest_error(field, f"must be a non-empty absolute path, got {value!r}")
-    if "\x00" in value:
-        _manifest_error(field, "must not contain a NUL byte")
-    if any(segment in {".", ".."} for segment in re.split(r"[\\/]", value)):
-        _manifest_error(field, "must not contain ambiguous dot segments")
-    path = Path(value)
-    if not path.is_absolute():
+        _manifest_error(field, "must be a non-empty native absolute path")
+    try:
+        materialize_native_root(value)
+    except ArtifactLocatorError as exc:
+        reason_message = {
+            "artifact_locator_nul_byte": "must not contain a NUL byte",
+            "artifact_locator_dot_segment": ("must not contain ambiguous dot segments"),
+        }.get(
+            exc.reason_code,
+            "must be a native absolute path without ambiguous syntax",
+        )
         _manifest_error(
-            field, f"must be an absolute path without traversal, got {value!r}"
+            field,
+            f"{reason_message} ({exc.reason_code})",
         )
     return value
 

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -26,8 +26,8 @@ Usage:
                   crop; review-required runs always preserve context
 
 Examples:
-    video-slide-extraction.py video.mp4 output/ aBcDeFg
-    video-slide-extraction.py video.mp4 output/ aBcDeFg --fps 0.5 --threshold 12
+    video-slide-extraction.py /vault/video.mp4 /vault/output aBcDeFg
+    video-slide-extraction.py /vault/video.mp4 /vault/output aBcDeFg --fps 0.5 --threshold 12
 """
 
 import argparse
@@ -35,6 +35,8 @@ import glob
 import json
 import os
 import sys
+
+from artifact_locator import ArtifactLocatorError, materialize_native_root
 
 # Pipeline version — stamped into every video-extracted vault entry (DB row +
 # PDF metadata) so artifacts record which extraction iteration produced them.
@@ -122,6 +124,8 @@ def parse_slide_region(value: str) -> str | NormalizedSlideRegion:
 
 def extract_frames(video_path, frames_dir, fps=0.5):
     """Extract frames from video at specified fps."""
+    video_path = canonical_path(video_path)
+    frames_dir = canonical_path(frames_dir)
     os.makedirs(frames_dir, exist_ok=True)
     cmd = (
         f'ffmpeg -i "{video_path}" -vf "fps={fps}" -q:v 2 '
@@ -329,8 +333,14 @@ def crop_frame(img, region):
 
 
 def canonical_path(path):
-    """Return an absolute, symlink-resolved path for durable provenance."""
-    return os.path.realpath(os.path.abspath(os.fspath(path)))
+    """Return a native absolute, symlink-resolved path for durable provenance."""
+    try:
+        native = materialize_native_root(path)
+    except ArtifactLocatorError as exc:
+        raise ValueError(
+            f"artifact path must be native absolute ({exc.reason_code})"
+        ) from None
+    return os.path.realpath(os.fspath(native))
 
 
 def deduplicate_frames(frames, slide_region=None, hash_threshold=8):
@@ -597,7 +607,7 @@ def extract_slides_from_video(
     print(f"Extracting video artifacts from {youtube_id}...", file=sys.stderr)
 
     # Step 2: Extract frames
-    frames = extract_frames(video_path, frames_dir, fps=fps)
+    frames = extract_frames(source_video_path, frames_dir, fps=fps)
     if not frames:
         return {
             "slide_source": "video_extracted",
@@ -781,7 +791,6 @@ def main():
         )
         sys.exit(1)
 
-    os.makedirs(args.outdir, exist_ok=True)
     result = extract_slides_from_video(
         args.video,
         args.outdir,

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -26,17 +26,19 @@ Usage:
                   crop; review-required runs always preserve context
 
 Examples:
-    video-slide-extraction.py /vault/video.mp4 /vault/output aBcDeFg
-    video-slide-extraction.py /vault/video.mp4 /vault/output aBcDeFg --fps 0.5 --threshold 12
+    video-slide-extraction.py /vault/video.mp4 /vault/output AbCdEfGhI_1
+    video-slide-extraction.py /vault/video.mp4 /vault/output AbCdEfGhI_1 --fps 0.5 --threshold 12
 """
 
 import argparse
 import glob
 import json
 import os
+import subprocess
 import sys
 
 from artifact_locator import ArtifactLocatorError, materialize_native_root
+from ingress_contract import YOUTUBE_ID_RE
 
 # Pipeline version — stamped into every video-extracted vault entry (DB row +
 # PDF metadata) so artifacts record which extraction iteration produced them.
@@ -44,7 +46,7 @@ from artifact_locator import ArtifactLocatorError, materialize_native_root
 # the download tier, region-detection logic, dedup hashing, or PDF assembly.
 # See skills/vault-ingress/references/video-slide-extraction.md ("Pipeline
 # Versioning") for the policy.
-PIPELINE_VERSION = "0.10.0"
+PIPELINE_VERSION = "0.11.0"
 
 # Shape version of the structured_data.video_extraction record (distinct from
 # PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
@@ -69,6 +71,25 @@ except ImportError as exc:
 
 
 NormalizedSlideRegion = tuple[float, float, float, float]
+
+
+def validate_youtube_id(value: object) -> str:
+    """Return one canonical ingress YouTube ID or fail with a closed reason."""
+    if not isinstance(value, str) or YOUTUBE_ID_RE.fullmatch(value) is None:
+        raise ValueError("youtube_id_invalid")
+    return value
+
+
+def _confined_output_path(output_root: str, filename: str) -> str:
+    """Return a derived output that remains under the canonical authorized root."""
+    candidate = os.path.realpath(os.path.join(output_root, filename))
+    try:
+        common = os.path.commonpath((output_root, candidate))
+    except ValueError:
+        common = ""
+    if os.path.normcase(common) != os.path.normcase(output_root):
+        raise ValueError("video_output_path_escape")
+    return candidate
 
 
 def _require_image_dependencies():
@@ -127,14 +148,27 @@ def extract_frames(video_path, frames_dir, fps=0.5):
     video_path = canonical_path(video_path)
     frames_dir = canonical_path(frames_dir)
     os.makedirs(frames_dir, exist_ok=True)
-    cmd = (
-        f'ffmpeg -i "{video_path}" -vf "fps={fps}" -q:v 2 '
-        f'"{frames_dir}/frame_%05d.jpg" -y -loglevel warning'
+    output_pattern = os.path.join(frames_dir, "frame_%05d.jpg")
+    completed = subprocess.run(
+        [
+            "ffmpeg",
+            "-i",
+            video_path,
+            "-vf",
+            f"fps={fps}",
+            "-q:v",
+            "2",
+            output_pattern,
+            "-y",
+            "-loglevel",
+            "warning",
+        ],
+        check=False,
+        shell=False,
     )
-    ret = os.system(cmd)
-    if ret != 0:
-        raise RuntimeError(f"ffmpeg failed with code {ret}")
-    frames = sorted(glob.glob(f"{frames_dir}/frame_*.jpg"))
+    if completed.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed with exit status {completed.returncode}")
+    frames = sorted(glob.glob(os.path.join(frames_dir, "frame_*.jpg")))
     print(f"  Extracted {len(frames)} frames", file=sys.stderr)
     return frames
 
@@ -471,6 +505,8 @@ def combine_to_pdf(
         raise ValueError("slide_region artifacts require a physical crop")
     if artifact_scope == "full_frame_context" and slide_region is not None:
         raise ValueError("full_frame_context artifacts must preserve the full frame")
+    if source_video_id is not None:
+        source_video_id = validate_youtube_id(source_video_id)
 
     images = []
     if not unique_frames:
@@ -553,6 +589,7 @@ def artifact_record(
         crop_method == "manual" and crop_verified
     ):
         raise ValueError("authored-slide trust requires a verified manual crop")
+    source_video_id = validate_youtube_id(source_video_id)
     return {
         "path": canonical_path(path),
         "artifact_scope": artifact_scope,
@@ -596,13 +633,17 @@ def extract_slides_from_video(
     Returns:
         dict with extraction results for structured_data
     """
+    youtube_id = validate_youtube_id(youtube_id)
     if fps <= 0:
         raise ValueError("fps must be greater than zero")
     output_dir = canonical_path(output_dir)
     source_video_path = canonical_path(video_path)
-    frames_dir = os.path.join(output_dir, "frames")
-    slide_pdf = os.path.join(output_dir, f"{youtube_id}.slide-region.pdf")
-    context_pdf = os.path.join(output_dir, f"{youtube_id}.context.pdf")
+    frames_dir = _confined_output_path(output_dir, "frames")
+    slide_pdf = _confined_output_path(
+        output_dir,
+        f"{youtube_id}.slide-region.pdf",
+    )
+    context_pdf = _confined_output_path(output_dir, f"{youtube_id}.context.pdf")
 
     print(f"Extracting video artifacts from {youtube_id}...", file=sys.stderr)
 
@@ -783,6 +824,10 @@ def main():
         parser.error(
             "--region-verified requires manual LEFT,TOP,RIGHT,BOTTOM coordinates"
         )
+    try:
+        youtube_id = validate_youtube_id(args.youtube_id)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     if _DEPS_ERROR is not None:
         print(
@@ -794,7 +839,7 @@ def main():
     result = extract_slides_from_video(
         args.video,
         args.outdir,
-        args.youtube_id,
+        youtube_id,
         fps=args.fps,
         hash_threshold=args.threshold,
         slide_region=args.region,

--- a/tests/test_artifact_locator.py
+++ b/tests/test_artifact_locator.py
@@ -1,0 +1,407 @@
+"""Host-independent and native-host tests for artifact locator materialization."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+import pytest
+
+
+SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+artifact_locator = importlib.import_module("artifact_locator")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("talk.pptx", "relative"),
+        ("conference/talk.pptx", "relative"),
+        ("conference/name with spaces.pptx", "relative"),
+        ("conférence/talk.pptx", "relative"),
+        (".hidden/talk.pptx", "relative"),
+        (PurePosixPath("conference/talk.pptx"), "relative"),
+        ("/talk.pptx", "posix_absolute"),
+        ("/Volumes/Talks/talk.pptx", "posix_absolute"),
+        ("/Volumes/Talks/talk.pptx ", "posix_absolute"),
+        ("/", "posix_absolute"),
+        (PurePosixPath("/srv/talk.pptx"), "posix_absolute"),
+        (r"C:\talk.pptx", "windows_drive_absolute"),
+        ("c:/conference/talk.pptx", "windows_drive_absolute"),
+        ("Z:\\", "windows_drive_absolute"),
+        (r"C:\conference/mixed\talk.pptx", "windows_drive_absolute"),
+        (PureWindowsPath(r"D:\Talks\talk.pptx"), "windows_drive_absolute"),
+        (r"\\server\share\talk.pptx", "windows_unc_absolute"),
+        (r"\\server/share\folder/talk.pptx", "windows_unc_absolute"),
+        (r"\\server\share", "windows_unc_absolute"),
+        ("\\\\server\\share\\", "windows_unc_absolute"),
+        (PureWindowsPath(r"\\server\share\talk.pptx"), "windows_unc_absolute"),
+    ],
+)
+def test_classifier_recognizes_closed_locator_flavors(
+    raw: object,
+    expected: str,
+) -> None:
+    assert artifact_locator.classify_artifact_locator(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason_code"),
+    [
+        (None, "artifact_locator_not_text"),
+        (7, "artifact_locator_not_text"),
+        (b"talk.pptx", "artifact_locator_not_text"),
+        ("", "artifact_locator_empty_or_whitespace"),
+        (" ", "artifact_locator_empty_or_whitespace"),
+        ("\ttalk.pptx", "artifact_locator_empty_or_whitespace"),
+        ("talk.pptx\n", "artifact_locator_empty_or_whitespace"),
+        (" talk.pptx", "artifact_locator_empty_or_whitespace"),
+        ("talk.pptx ", "artifact_locator_empty_or_whitespace"),
+        ("talk\x00.pptx", "artifact_locator_nul_byte"),
+        ("~", "artifact_locator_home_expansion_unsupported"),
+        ("~/talk.pptx", "artifact_locator_home_expansion_unsupported"),
+        ("~speaker/talk.pptx", "artifact_locator_home_expansion_unsupported"),
+        (r"~\talk.pptx", "artifact_locator_home_expansion_unsupported"),
+        (r"\\?\C:\talk.pptx", "artifact_locator_windows_device_namespace"),
+        (r"\\.\C:\talk.pptx", "artifact_locator_windows_device_namespace"),
+        (r"\??\C:\talk.pptx", "artifact_locator_windows_device_namespace"),
+        (r"\\??\C:\talk.pptx", "artifact_locator_windows_device_namespace"),
+        (r"//?/C:/talk.pptx", "artifact_locator_windows_device_namespace"),
+        (r"//./C:/talk.pptx", "artifact_locator_windows_device_namespace"),
+        (r"/??/C:/talk.pptx", "artifact_locator_windows_device_namespace"),
+        (r"//??/C:/talk.pptx", "artifact_locator_windows_device_namespace"),
+        ("C:", "artifact_locator_windows_drive_relative"),
+        ("C:talk.pptx", "artifact_locator_windows_drive_relative"),
+        ("c:folder/talk.pptx", "artifact_locator_windows_drive_relative"),
+        ("conference/C:talk.pptx", "artifact_locator_windows_drive_relative"),
+        ("conference/C:/talk.pptx", "artifact_locator_windows_drive_relative"),
+        (r"\talk.pptx", "artifact_locator_windows_current_drive_rooted"),
+        (r"\folder\talk.pptx", "artifact_locator_windows_current_drive_rooted"),
+        ("//server/share/talk.pptx", "artifact_locator_ambiguous_double_slash"),
+        ("///srv/talk.pptx", "artifact_locator_ambiguous_double_slash"),
+        ("//", "artifact_locator_ambiguous_double_slash"),
+        ("\\\\", "artifact_locator_malformed_unc"),
+        (r"\\server", "artifact_locator_malformed_unc"),
+        ("\\\\server\\", "artifact_locator_malformed_unc"),
+        (r"\\server\\share", "artifact_locator_malformed_unc"),
+        (r"\\\server\share", "artifact_locator_malformed_unc"),
+        (r"\\\\server\share", "artifact_locator_malformed_unc"),
+        (r"\\server\share\\folder", "artifact_locator_malformed_unc"),
+        (r"\\server//share/folder", "artifact_locator_malformed_unc"),
+        (r"\\server:\share\talk.pptx", "artifact_locator_malformed_unc"),
+        (r"\\server\share:\talk.pptx", "artifact_locator_malformed_unc"),
+        (".", "artifact_locator_dot_segment"),
+        ("..", "artifact_locator_dot_segment"),
+        ("./talk.pptx", "artifact_locator_dot_segment"),
+        ("conference/../talk.pptx", "artifact_locator_dot_segment"),
+        ("conference/./talk.pptx", "artifact_locator_dot_segment"),
+        (r"conference\..\talk.pptx", "artifact_locator_dot_segment"),
+        ("/srv/../talk.pptx", "artifact_locator_dot_segment"),
+        (r"C:\Talks\..\talk.pptx", "artifact_locator_dot_segment"),
+        (r"\\server\share\..\talk.pptx", "artifact_locator_dot_segment"),
+        (r"conference\talk.pptx", "artifact_locator_noncanonical_relative"),
+        (r"conference/talk\deck.pptx", "artifact_locator_noncanonical_relative"),
+        ("conference//talk.pptx", "artifact_locator_noncanonical_relative"),
+        ("conference///talk.pptx", "artifact_locator_noncanonical_relative"),
+        ("conference/talk.pptx/", "artifact_locator_noncanonical_relative"),
+        ("conference/.../talk.pptx", "artifact_locator_windows_trimmed_component"),
+        ("conference./talk.pptx", "artifact_locator_windows_trimmed_component"),
+        ("conference /talk.pptx", "artifact_locator_windows_trimmed_component"),
+        ("conference/deck:stream.pptx", "artifact_locator_windows_reserved_character"),
+        ("conference/deck?.pptx", "artifact_locator_windows_reserved_character"),
+        ("conference/deck\x1f.pptx", "artifact_locator_windows_reserved_character"),
+        ("CON/talk.pptx", "artifact_locator_windows_reserved_name"),
+        ("con.pptx", "artifact_locator_windows_reserved_name"),
+        ("con .pptx", "artifact_locator_windows_reserved_name"),
+        ("aux.notes/talk.pptx", "artifact_locator_windows_reserved_name"),
+        ("COM1/talk.pptx", "artifact_locator_windows_reserved_name"),
+        ("lpt\u00b9.txt", "artifact_locator_windows_reserved_name"),
+        ("CONIN$/talk.pptx", "artifact_locator_windows_reserved_name"),
+        (r"C:\conference.\talk.pptx", "artifact_locator_windows_trimmed_component"),
+        (
+            r"C:\conference\deck:stream.pptx",
+            "artifact_locator_windows_reserved_character",
+        ),
+        (r"C:\CON\talk.pptx", "artifact_locator_windows_reserved_name"),
+        (
+            r"\\server\share\conference.\talk.pptx",
+            "artifact_locator_windows_trimmed_component",
+        ),
+        (
+            r"\\server\share\deck:stream.pptx",
+            "artifact_locator_windows_reserved_character",
+        ),
+        (r"\\server\share\NUL.pptx", "artifact_locator_windows_reserved_name"),
+        (
+            r"\\server.\share\talk.pptx",
+            "artifact_locator_windows_trimmed_component",
+        ),
+        (
+            "\\\\server\\share \\talk.pptx",
+            "artifact_locator_windows_trimmed_component",
+        ),
+        (
+            r"\\server?\share\talk.pptx",
+            "artifact_locator_windows_reserved_character",
+        ),
+        (
+            "\\\\server\\sha\x1fre\\talk.pptx",
+            "artifact_locator_windows_reserved_character",
+        ),
+    ],
+)
+def test_classifier_rejects_ambiguous_or_noncanonical_forms(
+    raw: object,
+    reason_code: str,
+) -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.classify_artifact_locator(raw)
+
+    assert caught.value.reason_code == reason_code
+    assert caught.value.args == (reason_code,)
+    assert str(caught.value) == reason_code
+
+
+@pytest.mark.parametrize("character", tuple('<>:"|?*'))
+def test_portable_relative_components_reject_every_win32_reserved_character(
+    character: str,
+) -> None:
+    locator = f"conference/deck{character}variant.pptx"
+
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.classify_artifact_locator(locator)
+
+    assert caught.value.reason_code == "artifact_locator_windows_reserved_character"
+
+
+@pytest.mark.parametrize("control", ("\x01", "\x1f"))
+def test_portable_relative_components_reject_win32_control_characters(
+    control: str,
+) -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.classify_artifact_locator(f"conference/deck{control}.pptx")
+
+    assert caught.value.reason_code == "artifact_locator_windows_reserved_character"
+
+
+@pytest.mark.parametrize(
+    "basename",
+    (
+        "CON",
+        "PRN.txt",
+        "AUX.notes",
+        "NUL",
+        "CONIN$",
+        "CONOUT$.txt",
+        "COM1",
+        "COM9.txt",
+        "COM\u00b9",
+        "COM\u00b2.txt",
+        "COM\u00b3",
+        "LPT1",
+        "LPT9.txt",
+        "LPT\u00b9",
+        "LPT\u00b2.txt",
+        "LPT\u00b3",
+        "CON .pptx",
+    ),
+)
+def test_portable_relative_components_reject_win32_device_basenames(
+    basename: str,
+) -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.classify_artifact_locator(f"conference/{basename}")
+
+    assert caught.value.reason_code == "artifact_locator_windows_reserved_name"
+
+
+@pytest.mark.parametrize(
+    "basename",
+    ("COM0", "COM10", "LPT0", "LPT10", "CLOCK$", "DEL\x7f"),
+)
+def test_portable_relative_components_keep_nonreserved_near_misses(
+    basename: str,
+) -> None:
+    assert (
+        artifact_locator.classify_artifact_locator(f"conference/{basename}.pptx")
+        == "relative"
+    )
+
+
+class _BytesPath:
+    def __fspath__(self) -> bytes:
+        return b"hidden-locator.pptx"
+
+
+def test_non_text_pathlike_is_rejected_without_exposing_its_value() -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.classify_artifact_locator(_BytesPath())
+
+    assert caught.value.reason_code == "artifact_locator_not_text"
+    assert "hidden-locator" not in str(caught.value)
+
+
+def test_error_instances_contain_only_a_closed_reason_code() -> None:
+    secret_locator = "/private/credential-bearing/talk.pptx"
+    error = artifact_locator.ArtifactLocatorError("artifact_locator_foreign_absolute")
+
+    assert isinstance(error, ValueError)
+    assert error.__dict__ == {"reason_code": "artifact_locator_foreign_absolute"}
+    assert secret_locator not in str(error)
+    assert secret_locator not in repr(error)
+
+    with pytest.raises(ValueError, match="^invalid artifact locator reason code$"):
+        artifact_locator.ArtifactLocatorError(secret_locator)
+
+
+def _native_root() -> Path:
+    return (
+        Path(r"C:\trusted\artifacts") if os.name == "nt" else Path("/trusted/artifacts")
+    )
+
+
+def _native_absolute() -> str:
+    return (
+        r"C:\trusted\artifacts\talk.pptx"
+        if os.name == "nt"
+        else "/trusted/artifacts/talk.pptx"
+    )
+
+
+def _foreign_absolutes() -> tuple[str, str] | tuple[str]:
+    if os.name == "nt":
+        return ("/srv/talk.pptx",)
+    return (r"C:\Talks\talk.pptx", r"\\server\share\talk.pptx")
+
+
+def test_canonical_relative_locator_is_joined_from_pure_posix_parts() -> None:
+    root = _native_root()
+
+    materialized = artifact_locator.materialize_artifact_locator(
+        PurePosixPath("conference/talk.pptx"),
+        trusted_root=root,
+    )
+
+    assert materialized == root / "conference" / "talk.pptx"
+
+
+def test_native_absolute_locator_and_root_materialize_lexically() -> None:
+    root = _native_root()
+    locator = _native_absolute()
+
+    assert artifact_locator.materialize_native_root(root) == root
+    assert artifact_locator.materialize_artifact_locator(locator) == Path(locator)
+    assert artifact_locator.materialize_artifact_locator(
+        locator,
+        trusted_root=root,
+    ) == Path(locator)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-native filename semantics")
+def test_native_posix_absolute_preserves_a_component_ending_in_space() -> None:
+    locator = "/trusted/artifacts/talk.pptx "
+
+    assert artifact_locator.materialize_artifact_locator(locator) == Path(locator)
+
+
+def test_native_windows_unc_materializes_on_windows_only() -> None:
+    locator = r"\\server\share\talk.pptx"
+
+    if os.name == "nt":
+        assert artifact_locator.materialize_artifact_locator(locator) == Path(locator)
+        assert artifact_locator.materialize_native_root(r"\\server\share") == Path(
+            r"\\server\share"
+        )
+    else:
+        with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+            artifact_locator.materialize_artifact_locator(locator)
+        assert caught.value.reason_code == "artifact_locator_foreign_absolute"
+
+
+@pytest.mark.parametrize("locator", _foreign_absolutes())
+def test_foreign_absolute_never_materializes(locator: str) -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as artifact_error:
+        artifact_locator.materialize_artifact_locator(locator, _native_root())
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as root_error:
+        artifact_locator.materialize_native_root(locator)
+
+    assert artifact_error.value.reason_code == "artifact_locator_foreign_absolute"
+    assert root_error.value.reason_code == "artifact_locator_foreign_absolute"
+    assert locator not in str(artifact_error.value)
+    assert locator not in str(root_error.value)
+
+
+def test_relative_locator_requires_a_trusted_root() -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.materialize_artifact_locator("conference/talk.pptx")
+
+    assert caught.value.reason_code == "artifact_locator_trusted_root_required"
+
+
+@pytest.mark.parametrize("root", ["trusted/root", PurePosixPath("trusted/root")])
+def test_relative_root_is_never_rebased_from_the_process_cwd(root: object) -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.materialize_native_root(root)
+
+    assert caught.value.reason_code == "artifact_root_not_native_absolute"
+
+
+def test_absolute_locator_still_validates_a_supplied_root() -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.materialize_artifact_locator(
+            _native_absolute(),
+            trusted_root="relative/root",
+        )
+
+    assert caught.value.reason_code == "artifact_root_not_native_absolute"
+
+
+@pytest.mark.parametrize(
+    ("root", "reason_code"),
+    [
+        ("~/artifacts", "artifact_locator_home_expansion_unsupported"),
+        (r"\artifacts", "artifact_locator_windows_current_drive_rooted"),
+        (r"C:artifacts", "artifact_locator_windows_drive_relative"),
+        ("artifacts/../other", "artifact_locator_dot_segment"),
+    ],
+)
+def test_root_lexical_failures_preserve_closed_reasons(
+    root: object,
+    reason_code: str,
+) -> None:
+    with pytest.raises(artifact_locator.ArtifactLocatorError) as caught:
+        artifact_locator.materialize_native_root(root)
+
+    assert caught.value.reason_code == reason_code
+
+
+def test_materialization_does_not_call_filesystem_or_expansion_apis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_call(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("materialization performed filesystem normalization")
+
+    monkeypatch.setattr(Path, "resolve", unexpected_call)
+    monkeypatch.setattr(Path, "absolute", unexpected_call)
+    monkeypatch.setattr(Path, "expanduser", unexpected_call)
+    monkeypatch.setattr(Path, "cwd", unexpected_call)
+    monkeypatch.setattr(Path, "exists", unexpected_call)
+    monkeypatch.setattr(Path, "is_file", unexpected_call)
+    monkeypatch.setattr(os.path, "abspath", unexpected_call)
+    monkeypatch.setattr(os.path, "expanduser", unexpected_call)
+    monkeypatch.setattr(os, "getcwd", unexpected_call)
+
+    root = _native_root()
+    assert (
+        artifact_locator.materialize_artifact_locator(
+            "conference/talk.pptx",
+            root,
+        )
+        == root / "conference" / "talk.pptx"
+    )
+    assert artifact_locator.materialize_native_root(root) == root

--- a/tests/test_artifact_metadata.py
+++ b/tests/test_artifact_metadata.py
@@ -252,6 +252,76 @@ def test_inspection_binds_exact_leaf_and_stable_root_identity(
     assert receipt.reparse_tag is None
 
 
+def test_metadata_relative_locator_is_materialized_beneath_native_root(
+    artifact_metadata,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    deck = root / "nested" / "deck.pptx"
+    deck.parent.mkdir(parents=True)
+    deck.write_bytes(b"deck")
+
+    receipt = artifact_metadata.inspect_metadata_generation(
+        "nested/deck.pptx",
+        trusted_root=root,
+    )
+
+    assert receipt.generation == artifact_metadata.FileGeneration.from_stat(
+        deck.lstat()
+    )
+    assert receipt.root_generation == (
+        artifact_metadata.FileGeneration.from_directory_identity(root.lstat())
+    )
+
+
+def test_metadata_invalid_locators_fail_before_filesystem_inspection(
+    artifact_metadata,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    foreign_locators = (
+        ["/foreign/deck.pptx"]
+        if os.name == "nt"
+        else [r"C:\conference\deck.pptx", r"\\server\share\deck.pptx"]
+    )
+    cases = [
+        ("deck.pptx", None, "artifact_locator_trusted_root_required"),
+        (
+            "~/deck.pptx",
+            None,
+            "artifact_locator_home_expansion_unsupported",
+        ),
+        (
+            r"conference\deck.pptx",
+            tmp_path,
+            "artifact_locator_noncanonical_relative",
+        ),
+        (
+            tmp_path / "deck.pptx",
+            "relative-root",
+            "artifact_root_not_native_absolute",
+        ),
+        *[
+            (foreign, None, "artifact_locator_foreign_absolute")
+            for foreign in foreign_locators
+        ],
+    ]
+    monkeypatch.setattr(
+        Path,
+        "lstat",
+        lambda *_args, **_kwargs: pytest.fail("invalid locator reached lstat"),
+    )
+
+    for locator, root, expected_failure in cases:
+        with pytest.raises(artifact_metadata.ArtifactMetadataMalformed) as caught:
+            artifact_metadata.inspect_metadata_generation(
+                locator,
+                trusted_root=root,
+            )
+        assert caught.value.locator_failure == expected_failure
+        assert os.fspath(locator) not in str(caught.value)
+
+
 def test_directory_identity_excludes_mutable_child_metadata(
     artifact_metadata,
 ) -> None:

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -398,22 +398,33 @@ def test_return_pdf_mismatch_never_leaks_or_probes_an_invalid_preclaim(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    secret = _foreign_absolute_locator("credential-bearing-secret.pdf")
+    secret_preclaim = _foreign_absolute_locator("credential-bearing-secret.pdf")
+    secret_return = "slides/other-private-artifact.pdf"
+    preclaim_resolutions: list[object] = []
+
+    def reject_preclaim_resolution(*args, **kwargs):
+        preclaim_resolutions.append((args, kwargs))
+        pytest.fail("mismatched return reached preclaim artifact resolution")
+
     monkeypatch.setattr(
         pattern_evidence,
-        "probe_pdf_artifact",
-        lambda *_args, **_kwargs: pytest.fail("invalid preclaim reached PDF probe"),
+        "_resolve_preclaim_artifact",
+        reject_preclaim_resolution,
     )
 
     with pytest.raises(pattern_evidence.PatternEvidenceError) as caught:
         pattern_evidence.admit_return_artifacts(
             tmp_path / "vault",
-            {"slides_local_path": secret, "slide_source": "pdf"},
-            {"slides_local_path": "slides/other.pdf", "slide_source": "pdf"},
+            {"slides_local_path": secret_preclaim, "slide_source": "pdf"},
+            {"slides_local_path": secret_return, "slide_source": "pdf"},
         )
 
-    assert "artifact_locator_foreign_absolute" in str(caught.value)
-    assert secret not in str(caught.value)
+    assert str(caught.value) == (
+        "return PDF path must match the exact slides_local_path preclaim"
+    )
+    assert preclaim_resolutions == []
+    assert secret_preclaim not in str(caught.value)
+    assert secret_return not in str(caught.value)
 
 
 def test_pptx_preclaim_is_lexical_until_bounded_probe(

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -34,6 +34,12 @@ SYNTHETIC_VIDEO_ID = "abcdefghijk"
 SYNTHETIC_DURATION = 600.0
 
 
+def _foreign_absolute_locator(name: str) -> str:
+    if os.name == "nt":
+        return f"/foreign/{name}"
+    return rf"C:\foreign\{name}"
+
+
 def _identity(name: str) -> dict[str, str]:
     return {
         "artifact_root": "vault",
@@ -388,6 +394,28 @@ def test_return_pdf_admission_accepts_only_the_exact_local_preclaim(
         pattern_evidence.admit_return_artifacts(vault, talk, redirected)
 
 
+def test_return_pdf_mismatch_never_leaks_or_probes_an_invalid_preclaim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = _foreign_absolute_locator("credential-bearing-secret.pdf")
+    monkeypatch.setattr(
+        pattern_evidence,
+        "probe_pdf_artifact",
+        lambda *_args, **_kwargs: pytest.fail("invalid preclaim reached PDF probe"),
+    )
+
+    with pytest.raises(pattern_evidence.PatternEvidenceError) as caught:
+        pattern_evidence.admit_return_artifacts(
+            tmp_path / "vault",
+            {"slides_local_path": secret, "slide_source": "pdf"},
+            {"slides_local_path": "slides/other.pdf", "slide_source": "pdf"},
+        )
+
+    assert "artifact_locator_foreign_absolute" in str(caught.value)
+    assert secret not in str(caught.value)
+
+
 def test_pptx_preclaim_is_lexical_until_bounded_probe(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -480,8 +508,9 @@ def test_pptx_preclaim_rejects_raw_dot_segments_before_normalization(
         )
 
         assert "native_deck" not in context["verified_evidence_sources"]
-        assert "ambiguous" in context["source_reasons"]["native_deck"]
-        assert "path segment" in context["source_reasons"]["native_deck"]
+        assert context["source_reasons"]["native_deck"].endswith(
+            "artifact_locator_dot_segment"
+        )
 
 
 @pytest.mark.parametrize(
@@ -501,7 +530,13 @@ def test_pptx_preclaim_rejects_raw_dot_segments_before_normalization(
     ],
 )
 def test_pptx_dot_segment_guard_is_platform_independent(locator: str) -> None:
-    with pytest.raises(pattern_evidence.PatternEvidenceError, match="ambiguous"):
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match=(
+            r"artifact_locator_(dot_segment|windows_drive_relative|"
+            r"ambiguous_double_slash)"
+        ),
+    ):
         pattern_evidence._reject_ambiguous_path_segments(
             locator,
             label="pptx_path",
@@ -524,7 +559,7 @@ def test_pptx_windows_cwd_dependent_guard_is_platform_independent(
 ) -> None:
     with pytest.raises(
         pattern_evidence.PatternEvidenceError,
-        match="ambiguous Windows path",
+        match=r"artifact_locator_windows_(drive_relative|current_drive_rooted)",
     ) as caught:
         pattern_evidence._reject_ambiguous_path_segments(
             locator,
@@ -549,7 +584,7 @@ def test_pptx_windows_device_namespace_guard_is_platform_independent(
 ) -> None:
     with pytest.raises(
         pattern_evidence.PatternEvidenceError,
-        match="device namespace",
+        match=(r"artifact_locator_(windows_device_namespace|ambiguous_double_slash)"),
     ) as caught:
         pattern_evidence._reject_ambiguous_path_segments(
             locator,
@@ -562,37 +597,56 @@ def test_pptx_windows_device_namespace_guard_is_platform_independent(
 @pytest.mark.parametrize(
     "locator",
     [
-        r"conference\track\talk.pptx",
         "conference/track/talk.pptx",
-        r"conference\track/mixed/talk.pptx",
         r"C:\conference\talk.pptx",
         "C:/conference/talk.pptx",
         r"C:\conference/mixed\talk.pptx",
         r"\\server\share\conference\talk.pptx",
-        "//server/share/conference/talk.pptx",
         r"\\server\share/conference\talk.pptx",
     ],
 )
-def test_pptx_dot_segment_guard_accepts_clean_mixed_separators(locator: str) -> None:
+def test_pptx_locator_guard_accepts_canonical_relative_or_absolute_flavors(
+    locator: str,
+) -> None:
     pattern_evidence._reject_ambiguous_path_segments(locator, label="pptx_path")
 
 
-def test_forward_slash_root_uses_native_absolute_path_semantics() -> None:
-    locator = "/conference/talk.pptx"
-    if os.name == "nt":
-        with pytest.raises(
-            pattern_evidence.PatternEvidenceError,
-            match="ambiguous Windows path",
-        ):
-            pattern_evidence._reject_ambiguous_path_segments(
-                locator,
-                label="pptx_path",
-            )
-    else:
+@pytest.mark.parametrize(
+    "locator,reason_code",
+    [
+        (r"conference\track\talk.pptx", "artifact_locator_noncanonical_relative"),
+        (
+            r"conference\track/mixed/talk.pptx",
+            "artifact_locator_noncanonical_relative",
+        ),
+        (
+            "//server/share/conference/talk.pptx",
+            "artifact_locator_ambiguous_double_slash",
+        ),
+        ("conference./talk.pptx", "artifact_locator_windows_trimmed_component"),
+        (
+            "conference/deck:stream.pptx",
+            "artifact_locator_windows_reserved_character",
+        ),
+        ("CON/talk.pptx", "artifact_locator_windows_reserved_name"),
+    ],
+)
+def test_pptx_locator_guard_rejects_cross_host_relative_or_dual_flavors(
+    locator: str,
+    reason_code: str,
+) -> None:
+    with pytest.raises(pattern_evidence.PatternEvidenceError, match=reason_code):
         pattern_evidence._reject_ambiguous_path_segments(
             locator,
             label="pptx_path",
         )
+
+
+def test_forward_slash_root_is_classified_without_host_reinterpretation() -> None:
+    pattern_evidence._reject_ambiguous_path_segments(
+        "/conference/talk.pptx",
+        label="pptx_path",
+    )
 
 
 @pytest.mark.parametrize(
@@ -620,12 +674,202 @@ def test_pptx_cwd_dependent_preclaim_never_reaches_bounded_probe(
 
     assert "native_deck" not in context["verified_evidence_sources"]
     reason = context["source_reasons"]["native_deck"]
-    assert reason == (
-        "pptx_path is an ambiguous Windows path whose target depends on the "
-        "current drive or per-drive working directory; pass a "
-        "trusted-root-relative path or a fully qualified drive/UNC path"
+    expected_code = (
+        "artifact_locator_windows_drive_relative"
+        if locator.startswith("C:")
+        else "artifact_locator_windows_current_drive_rooted"
     )
+    assert reason == f"pptx_path: {expected_code}"
     assert locator not in reason
+
+
+@pytest.mark.parametrize(
+    "locator,reason_code",
+    [
+        ("~/conference/talk.pptx", "artifact_locator_home_expansion_unsupported"),
+        (
+            r"conference\track\talk.pptx",
+            "artifact_locator_noncanonical_relative",
+        ),
+        (
+            "//server/share/conference/talk.pptx",
+            "artifact_locator_ambiguous_double_slash",
+        ),
+        (
+            _foreign_absolute_locator("talk.pptx"),
+            "artifact_locator_foreign_absolute",
+        ),
+        ("conference./talk.pptx", "artifact_locator_windows_trimmed_component"),
+        (
+            "conference/deck:stream.pptx",
+            "artifact_locator_windows_reserved_character",
+        ),
+        ("CON/talk.pptx", "artifact_locator_windows_reserved_name"),
+    ],
+)
+def test_rejected_pptx_locator_never_selects_a_shadow_file_or_reaches_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    locator: str,
+    reason_code: str,
+) -> None:
+    vault = tmp_path / "vault"
+    source_root = tmp_path / "pptx-source"
+    if os.name != "nt" and not locator.startswith("//"):
+        _write_pptx(source_root / locator)
+    monkeypatch.setattr(
+        pattern_evidence,
+        "probe_pptx_artifact",
+        lambda *_args, **_kwargs: pytest.fail("rejected locator reached probe"),
+    )
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {"pptx_path": locator, "slide_source": "pptx"},
+        source_roots={"pptx_source_dir": str(source_root)},
+    )
+
+    assert "native_deck" not in context["verified_evidence_sources"]
+    reason = context["source_reasons"]["native_deck"]
+    assert reason == f"pptx_path: {reason_code}"
+    assert locator not in reason
+
+
+@pytest.mark.parametrize(
+    "configured_root,reason_code",
+    [
+        ("", "artifact_locator_empty_or_whitespace"),
+        ("relative-presentations", "artifact_root_not_native_absolute"),
+        ("~/presentations", "artifact_locator_home_expansion_unsupported"),
+        (
+            _foreign_absolute_locator("presentations"),
+            "artifact_locator_foreign_absolute",
+        ),
+    ],
+)
+def test_invalid_configured_pptx_root_fails_closed_without_vault_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    configured_root: str,
+    reason_code: str,
+) -> None:
+    vault = tmp_path / "vault"
+    _write_pptx(vault / "deck.pptx")
+    monkeypatch.setattr(
+        pattern_evidence,
+        "probe_pptx_artifact",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid configured root fell back to the vault"
+        ),
+    )
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {"pptx_path": "deck.pptx", "slide_source": "pptx"},
+        source_roots={"pptx_source_dir": configured_root},
+    )
+
+    assert "native_deck" not in context["verified_evidence_sources"]
+    assert context["source_reasons"]["native_deck"] == (
+        f"pptx_source_dir: {reason_code}"
+    )
+
+
+def test_null_configured_pptx_root_retains_vault_fallback(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    deck = vault / "deck.pptx"
+    _write_pptx(deck)
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {"pptx_path": deck.name, "slide_source": "pptx"},
+        source_roots={"pptx_source_dir": None},
+    )
+
+    assert context["slide_counts"] == {"native_deck": 2}
+    assert context["slide_artifact_identities"]["native_deck"]["artifact_root"] == (
+        "vault"
+    )
+
+
+def test_foreign_pdf_and_video_locators_fail_only_their_independent_lanes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    transcript, _ = _write_transcript(
+        vault,
+        name=SYNTHETIC_VIDEO_ID,
+        timed=False,
+    )
+    foreign_pdf = _foreign_absolute_locator("slides.pdf")
+    foreign_video = _foreign_absolute_locator(f"{SYNTHETIC_VIDEO_ID}.mp4")
+    monkeypatch.setattr(
+        pattern_evidence,
+        "probe_pdf_artifact",
+        lambda *_args, **_kwargs: pytest.fail("foreign PDF reached probe"),
+    )
+    monkeypatch.setattr(
+        pattern_evidence,
+        "_verified_video_snapshot",
+        lambda *_args, **_kwargs: pytest.fail("foreign video reached probe"),
+    )
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {
+            "filename": "talk.md",
+            "transcript_path": transcript.relative_to(vault).as_posix(),
+            "transcript_source": "manual",
+            "slides_local_path": foreign_pdf,
+            "slide_source": "pdf",
+            "video_local_path": foreign_video,
+            "youtube_id": SYNTHETIC_VIDEO_ID,
+        },
+    )
+
+    assert context["verified_evidence_sources"] == {"transcript"}
+    assert context["source_reasons"]["static_slides"] == (
+        "slides_local_path: artifact_locator_foreign_absolute"
+    )
+    assert context["source_reasons"]["delivery_video"] == (
+        "video_local_path: artifact_locator_foreign_absolute"
+    )
+
+
+def test_foreign_video_manifest_pdf_never_reaches_current_context_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    foreign_pdf = _foreign_absolute_locator(f"{SYNTHETIC_VIDEO_ID}.slide-region.pdf")
+    monkeypatch.setattr(
+        pattern_evidence,
+        "probe_pdf_artifact",
+        lambda *_args, **_kwargs: pytest.fail("foreign manifest PDF reached probe"),
+    )
+    manifest = {
+        "unique_frame_count": 1,
+        "artifacts": [
+            {
+                "artifact_scope": "slide_region",
+                "source_video_id": SYNTHETIC_VIDEO_ID,
+                "page_count": 1,
+                "path": foreign_pdf,
+            }
+        ],
+    }
+
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match="artifact_locator_foreign_absolute",
+    ) as caught:
+        pattern_evidence._probe_video_manifest_artifacts(
+            tmp_path / "vault",
+            manifest,
+            SYNTHETIC_VIDEO_ID,
+        )
+
+    assert foreign_pdf not in str(caught.value)
 
 
 def test_traversal_and_symlinked_artifacts_never_become_sources(
@@ -648,7 +892,9 @@ def test_traversal_and_symlinked_artifacts_never_become_sources(
         source_roots={"pptx_source_dir": str(source_root)},
     )
     assert "native_deck" not in traversal["verified_evidence_sources"]
-    assert "ambiguous" in traversal["source_reasons"]["native_deck"]
+    assert traversal["source_reasons"]["native_deck"].endswith(
+        "artifact_locator_dot_segment"
+    )
 
     source_root.mkdir(parents=True, exist_ok=True)
     real = source_root / "real.pptx"
@@ -1297,6 +1543,27 @@ def test_relative_pptx_native_deck_evidence_is_immediately_fresh(
             source_roots=roots,
         )
         == ()
+    )
+
+    foreign_owner = copy.deepcopy(persisted)
+    foreign_owner["pptx_path"] = _foreign_absolute_locator("deck.pptx")
+    foreign_reasons = pattern_evidence.assess_persisted_pattern_evidence_freshness(
+        foreign_owner,
+        vault_root=vault,
+        source_roots=roots,
+    )
+    assert any(
+        reason.endswith(":artifact_owner_path_drift") for reason in foreign_reasons
+    )
+
+    invalid_root_reasons = pattern_evidence.assess_persisted_pattern_evidence_freshness(
+        persisted,
+        vault_root=vault,
+        source_roots={"pptx_source_dir": "relative-presentations"},
+    )
+    assert any(
+        reason.endswith(":artifact_root_invalid:artifact_root_not_native_absolute")
+        for reason in invalid_root_reasons
     )
 
     missing_audit = copy.deepcopy(persisted)
@@ -2579,7 +2846,9 @@ def test_invalid_deck_cannot_hide_an_independent_valid_transcript(
     assert assessment["verified_capabilities"] == ("transcript",)
     assert assessment["verified_evidence_sources"] == ("transcript",)
     assert assessment["repair_capabilities"] == ()
-    assert "ambiguous" in assessment["source_reasons"]["native_deck"]
+    assert assessment["source_reasons"]["native_deck"].endswith(
+        "artifact_locator_dot_segment"
+    )
 
 
 def test_unprobeable_video_is_not_hashed_or_allowed_to_hide_other_lanes(

--- a/tests/test_pdf_evidence.py
+++ b/tests/test_pdf_evidence.py
@@ -127,6 +127,72 @@ def test_limits_use_dedicated_profiles_and_documented_ceilings() -> None:
     assert pdf_evidence.PDF_PROBE_LIMITS.max_processes == 1
 
 
+def test_public_pdf_locators_fail_before_metadata_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign_locators = (
+        ["/foreign/talk.pdf"]
+        if os.name == "nt"
+        else [r"C:\conference\talk.pdf", r"\\server\share\talk.pdf"]
+    )
+    cases = [
+        ("talk.pdf", None, "artifact_locator_trusted_root_required"),
+        ("~/talk.pdf", None, "artifact_locator_home_expansion_unsupported"),
+        (
+            r"conference\talk.pdf",
+            tmp_path,
+            "artifact_locator_noncanonical_relative",
+        ),
+        (
+            tmp_path / "talk.pdf",
+            "relative-root",
+            "artifact_root_not_native_absolute",
+        ),
+        (
+            r"\\server.\share\talk.pdf",
+            None,
+            "artifact_locator_windows_trimmed_component",
+        ),
+        *[
+            (foreign, None, "artifact_locator_foreign_absolute")
+            for foreign in foreign_locators
+        ],
+    ]
+    monkeypatch.setattr(
+        pdf_evidence,
+        "_invoke_metadata_worker",
+        lambda *_args, **_kwargs: pytest.fail("invalid locator started metadata"),
+    )
+
+    for locator, root, expected_failure in cases:
+        with pytest.raises(pdf_evidence.PdfEvidenceError) as caught:
+            pdf_evidence.probe_pdf_artifact(locator, trusted_root=root)
+        assert caught.value.reason_code == "pdf_evidence_invalid"
+        assert caught.value.details == {"locator_failure": expected_failure}
+        assert os.fspath(locator) not in str(caught.value)
+        assert os.fspath(locator) not in repr(caught.value.details)
+
+
+def test_pdf_metadata_worker_revalidates_locator_before_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign = "/foreign/talk.pdf" if os.name == "nt" else r"C:\conference\talk.pdf"
+    monkeypatch.setattr(
+        pdf_evidence,
+        "inspect_metadata_generation",
+        lambda *_args, **_kwargs: pytest.fail("invalid locator reached metadata"),
+    )
+
+    with pytest.raises(pdf_evidence.SupervisorError) as caught:
+        pdf_evidence._metadata_child({"pdf_path": foreign, "trusted_root": None})
+
+    assert caught.value.reason_code == "invalid_worker_request"
+    assert caught.value.details == {
+        "locator_failure": "artifact_locator_foreign_absolute"
+    }
+
+
 def test_real_worker_probes_synthetic_pdf_and_reuses_exact_cache(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -135,7 +201,7 @@ def test_real_worker_probes_synthetic_pdf_and_reuses_exact_cache(
     source = _synthetic_pdf(2)
     artifact.write_bytes(source)
 
-    first = pdf_evidence.probe_pdf_artifact(artifact, trusted_root=tmp_path)
+    first = pdf_evidence.probe_pdf_artifact("talk.pdf", trusted_root=tmp_path)
 
     assert first.page_count == 2
     assert first.source_sha256 == hashlib.sha256(source).hexdigest()

--- a/tests/test_pptx_evidence_recovery.py
+++ b/tests/test_pptx_evidence_recovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import importlib
 import json
+import os
 import struct
 import subprocess
 import sys
@@ -190,6 +191,165 @@ def test_metadata_generation_never_calls_owner_lstat(
     command_text = "\n".join(str(part) for part in captured["command"])
     assert str(deck) not in command_text
     assert captured["sensitive_values"] == (deck,)
+
+
+def test_public_pptx_locators_fail_before_metadata_or_cache(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    foreign_locators = (
+        ["/foreign/deck.pptx"]
+        if os.name == "nt"
+        else [r"C:\conference\deck.pptx", r"\\server\share\deck.pptx"]
+    )
+    cases = [
+        ("deck.pptx", None, "artifact_locator_trusted_root_required"),
+        (
+            "~/deck.pptx",
+            None,
+            "artifact_locator_home_expansion_unsupported",
+        ),
+        (
+            r"conference\deck.pptx",
+            tmp_path,
+            "artifact_locator_noncanonical_relative",
+        ),
+        (
+            tmp_path / "deck.pptx",
+            "relative-root",
+            "artifact_root_not_native_absolute",
+        ),
+        (
+            r"\\server.\share\deck.pptx",
+            None,
+            "artifact_locator_windows_trimmed_component",
+        ),
+        *[
+            (foreign, None, "artifact_locator_foreign_absolute")
+            for foreign in foreign_locators
+        ],
+    ]
+    monkeypatch.setattr(
+        pptx_evidence,
+        "_invoke_metadata_worker",
+        lambda *_args, **_kwargs: pytest.fail("invalid locator started metadata"),
+    )
+    pptx_evidence.clear_pptx_artifact_probe_cache()
+
+    for locator, root, expected_failure in cases:
+        callers = (
+            lambda: pptx_evidence.probe_pptx_artifact(
+                locator,
+                trusted_root=root,
+            ),
+            lambda: pptx_evidence.recompute_native_deck_audit(
+                locator,
+                trusted_root=root,
+            ),
+            lambda: pptx_evidence.run_supervised_pptx_extraction(
+                locator,
+                trusted_root=root,
+                ocr=False,
+            ),
+        )
+        for call in callers:
+            with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+                call()
+            assert caught.value.reason_code == "pptx_evidence_invalid"
+            assert caught.value.details == {"locator_failure": expected_failure}
+            assert os.fspath(locator) not in str(caught.value)
+            assert os.fspath(locator) not in repr(caught.value.details)
+        assert pptx_evidence._PPTX_ARTIFACT_PROBE_CACHE == {}
+        assert pptx_evidence._PPTX_NATIVE_AUDIT_CACHE == {}
+
+
+def test_invalid_rendered_pdf_locator_fails_before_deck_metadata(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        pptx_evidence,
+        "_invoke_metadata_worker",
+        lambda *_args, **_kwargs: pytest.fail("invalid render started metadata"),
+    )
+
+    with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
+        pptx_evidence.run_supervised_pptx_extraction(
+            tmp_path / "deck.pptx",
+            rendered_pdf_path="rendered.pdf",
+            ocr=False,
+        )
+
+    assert caught.value.reason_code == "pptx_evidence_invalid"
+    assert caught.value.details == {
+        "locator_failure": "artifact_locator_trusted_root_required"
+    }
+
+
+def test_pptx_metadata_worker_revalidates_locator_before_inspection(
+    pptx_evidence,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    foreign = "/foreign/deck.pptx" if os.name == "nt" else r"C:\conference\deck.pptx"
+    monkeypatch.setattr(
+        pptx_evidence,
+        "_metadata_generation_in_worker",
+        lambda *_args, **_kwargs: pytest.fail("invalid locator reached metadata"),
+    )
+
+    with pytest.raises(pptx_evidence.SupervisorError) as caught:
+        pptx_evidence._metadata_child({"pptx_path": foreign, "trusted_root": None})
+
+    assert caught.value.reason_code == "invalid_worker_request"
+    assert caught.value.details == {
+        "locator_failure": "artifact_locator_foreign_absolute"
+    }
+
+    with pytest.raises(pptx_evidence.SupervisorError) as caught:
+        pptx_evidence._validated_extract_worker_payload(
+            {
+                "pptx_path": os.fspath(tmp_path / "deck.pptx"),
+                "trusted_root": None,
+                "ocr": False,
+                "rendered_pdf_path": foreign.replace(".pptx", ".pdf"),
+                "inspected_page_ranges": [],
+                "extraction_schema_version": (
+                    pptx_evidence.PPTX_EXTRACTION_SCHEMA_VERSION
+                ),
+                "extraction_pipeline_version": (
+                    pptx_evidence.PPTX_EXTRACTION_PIPELINE_VERSION
+                ),
+            }
+        )
+
+    assert caught.value.reason_code == "invalid_worker_request"
+    assert caught.value.details == {
+        "locator_failure": "artifact_locator_foreign_absolute"
+    }
+
+
+def test_relative_pptx_locator_is_materialized_beneath_native_root(
+    pptx_evidence,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "decks"
+    deck = root / "nested" / "deck.pptx"
+    _write_deck(deck, with_image=False)
+
+    artifact, generation, root_generation = pptx_evidence._admit_supervised_input(
+        "nested/deck.pptx",
+        label="PPTX artifact",
+        trusted_root=root,
+    )
+
+    assert artifact == deck
+    assert generation == pptx_evidence.FileGeneration.from_stat(deck.lstat())
+    assert root_generation == pptx_evidence.FileGeneration.from_directory_identity(
+        root.lstat()
+    )
 
 
 def test_unhashable_worker_reason_enums_fail_as_malformed_results(
@@ -3739,12 +3899,16 @@ def test_public_extractor_runs_healthy_deck_through_real_worker(
     deck = tmp_path / "healthy-worker.pptx"
     _write_deck(deck, with_image=False)
 
-    result = pptx_extraction.extract_pptx(deck, ocr=False)
+    result = pptx_extraction.extract_pptx(
+        deck.name,
+        trusted_root=tmp_path,
+        ocr=False,
+    )
 
     assert result["schema_version"] == 4
     assert result["pipeline_version"] == "1.5.0"
     assert result["slide_count"] == 1
-    assert result["pptx_path"] == str(deck)
+    assert result["pptx_path"] == deck.name
 
 
 def test_full_extraction_rejects_render_generation_change(

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -7,6 +7,7 @@ import struct
 import subprocess
 import sys
 import zipfile
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -635,47 +636,116 @@ def test_directory_cli_passes_only_the_exact_configured_skip_patterns(
     }
 
 
-def test_directory_relative_root_is_lexically_absolutized_before_supervision(
+def test_directory_relative_root_is_rejected_before_supervision(
+    pptx_extraction,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        pptx_extraction,
+        "run_authenticated_worker",
+        lambda *_args, **_kwargs: pytest.fail("relative root started worker"),
+    )
+
+    with pytest.raises(pptx_extraction.PptxEvidenceError) as caught:
+        pptx_extraction._run_supervised_directory_discovery(
+            ".",
+            [],
+            deadline=pptx_extraction.time.monotonic() + 30,
+        )
+
+    assert caught.value.reason_code == "pptx_batch_root_invalid"
+    assert caught.value.details == {"locator_failure": "artifact_locator_dot_segment"}
+
+
+def test_directory_foreign_home_and_noncanonical_roots_never_launch_worker(
+    pptx_extraction,
+    monkeypatch,
+):
+    foreign_roots = (
+        ["/foreign/decks"]
+        if pptx_extraction.os.name == "nt"
+        else [r"C:\conference\decks", r"\\server\share\decks"]
+    )
+    cases = [
+        ("decks", "artifact_root_not_native_absolute"),
+        ("~/decks", "artifact_locator_home_expansion_unsupported"),
+        (r"conference\decks", "artifact_locator_noncanonical_relative"),
+        *[(foreign, "artifact_locator_foreign_absolute") for foreign in foreign_roots],
+    ]
+    monkeypatch.setattr(
+        pptx_extraction,
+        "run_authenticated_worker",
+        lambda *_args, **_kwargs: pytest.fail("invalid root started worker"),
+    )
+
+    for locator, expected_failure in cases:
+        with pytest.raises(pptx_extraction.PptxEvidenceError) as caught:
+            pptx_extraction._run_supervised_directory_discovery(
+                locator,
+                [],
+                deadline=pptx_extraction.time.monotonic() + 30,
+            )
+        assert caught.value.reason_code == "pptx_batch_root_invalid"
+        assert caught.value.details == {"locator_failure": expected_failure}
+        assert locator not in str(caught.value)
+        assert locator not in repr(caught.value.details)
+
+
+def test_directory_worker_revalidates_root_before_discovery(
     pptx_extraction,
     monkeypatch,
     tmp_path,
 ):
-    monkeypatch.chdir(tmp_path)
-    captured = {}
-
-    def authenticated_worker(
-        _command, _operation, _generations, payload, _limits, **kwargs
-    ):
-        captured["payload"] = payload
-        captured["sensitive_values"] = kwargs["sensitive_values"]
-        return SimpleNamespace(
-            payload={
-                "schema_version": 1,
-                "kind": "directory",
-                "files": [],
-                "skipped": [],
-            }
-        )
-
+    request = pptx_extraction.WorkerRequest(
+        request_id="a" * 64,
+        operation=pptx_extraction._DIRECTORY_OPERATION,
+        request_sha256="b" * 64,
+        limit_profile_id=pptx_extraction._DIRECTORY_LIMITS.profile_id,
+        schema_generation=pptx_extraction.SCHEMA_VERSION,
+        pipeline_generation=pptx_extraction.PIPELINE_VERSION,
+        expected_generations={},
+        payload={"root_path": "relative", "skip_patterns": []},
+        key=b"k" * 32,
+    )
     monkeypatch.setattr(
         pptx_extraction,
-        "run_authenticated_worker",
-        authenticated_worker,
+        "_discover_pptx_files",
+        lambda *_args, **_kwargs: pytest.fail("invalid root reached discovery"),
     )
 
-    files, skipped = pptx_extraction._run_supervised_directory_discovery(
-        ".",
-        [],
-        deadline=pptx_extraction.time.monotonic() + 30,
+    with pytest.raises(pptx_extraction.SupervisorError) as caught:
+        pptx_extraction._dispatch_directory_worker(request)
+
+    assert caught.value.reason_code == "pptx_batch_root_invalid"
+    assert caught.value.details == {
+        "locator_failure": "artifact_root_not_native_absolute"
+    }
+
+    observed = {}
+
+    def discover(root, patterns):
+        observed["root"] = root
+        observed["patterns"] = patterns
+        return [], [], 0.0
+
+    monkeypatch.setattr(pptx_extraction, "_discover_pptx_files", discover)
+    payload = pptx_extraction._dispatch_directory_worker(
+        replace(
+            request,
+            payload={"root_path": str(tmp_path), "skip_patterns": []},
+        )
     )
 
-    assert files == []
-    assert skipped == []
-    assert captured["payload"]["root_path"] == str(tmp_path)
-    assert captured["sensitive_values"] == (str(tmp_path),)
+    assert observed == {"root": str(tmp_path), "patterns": []}
+    assert payload == {
+        "schema_version": 1,
+        "kind": "directory",
+        "files": [],
+        "skipped": [],
+    }
 
 
-def test_batch_reuses_canonical_root_if_working_directory_changes(
+def test_batch_reuses_native_absolute_root_if_working_directory_changes(
     pptx_extraction,
     monkeypatch,
     tmp_path,
@@ -710,7 +780,7 @@ def test_batch_reuses_canonical_root_if_working_directory_changes(
     )
     monkeypatch.setattr(pptx_extraction, "extract_pptx", extract)
 
-    results, skipped = pptx_extraction.batch_extract("decks", [], ocr=False)
+    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
 
     assert skipped == []
     assert observed == [root / "deck.pptx"]

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 import importlib
 import json
+import os
 from pathlib import Path
 import struct
 import subprocess
@@ -27,6 +28,12 @@ QUEUE_STATE_SCRIPT = (
     / "scripts"
     / "queue-state.py"
 )
+
+
+def foreign_absolute_locator(name: str) -> str:
+    if os.name == "nt":
+        return f"/foreign/{name}"
+    return rf"C:\foreign\{name}"
 
 
 @pytest.fixture
@@ -1200,6 +1207,315 @@ def test_all_seven_slide_contract_fault_classes_are_reported(
 
     assert fault_code in finding_codes(report, severity)
     assert fault_code in preflight_vault.SLIDE_CONTRACT_CODES
+
+
+@pytest.mark.parametrize(
+    "source_fields,expected_code,expected_reason",
+    [
+        (
+            {
+                "slide_source": "pptx",
+                "pptx_path": foreign_absolute_locator("talk.pptx"),
+            },
+            "slide_pptx_artifact_unreadable",
+            "pptx_path: artifact_locator_foreign_absolute",
+        ),
+        (
+            {
+                "slide_source": "pptx",
+                "pptx_path": r"conference\talk.pptx",
+            },
+            "slide_pptx_artifact_unreadable",
+            "pptx_path: artifact_locator_noncanonical_relative",
+        ),
+        (
+            {
+                "slide_source": "pptx",
+                "pptx_path": "//server/share/talk.pptx",
+            },
+            "slide_pptx_artifact_unreadable",
+            "pptx_path: artifact_locator_ambiguous_double_slash",
+        ),
+        (
+            {
+                "slide_source": "pdf",
+                "slides_local_path": "~/slides/talk.pdf",
+            },
+            "slide_pdf_artifact_unreadable",
+            "slides_local_path: artifact_locator_home_expansion_unsupported",
+        ),
+        (
+            {
+                "slide_source": "pptx",
+                "pptx_path": " deck.pptx ",
+            },
+            "slide_pptx_artifact_unreadable",
+            "pptx_path: artifact_locator_empty_or_whitespace",
+        ),
+        (
+            {
+                "slide_source": "pdf",
+                "slides_local_path": " slides/talk.pdf ",
+            },
+            "slide_pdf_artifact_unreadable",
+            "slides_local_path: artifact_locator_empty_or_whitespace",
+        ),
+    ],
+)
+def test_preflight_uses_context_locator_contract_without_rebased_artifact_path(
+    preflight_vault,
+    vault_fixture,
+    source_fields,
+    expected_code,
+    expected_reason,
+) -> None:
+    talk = base_talk(
+        status="pending",
+        transcript_source="none",
+        video_url=None,
+        youtube_id=None,
+        **source_fields,
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(item for item in report["findings"] if item["code"] == expected_code)
+    assert finding["artifact_path"] is None
+    capability = finding["capability_fact"]
+    lane = "native_deck" if source_fields["slide_source"] == "pptx" else "static_slides"
+    assert capability["source_reasons"][lane] == expected_reason
+    raw_locator = next(
+        source_fields[field]
+        for field in ("pptx_path", "slides_local_path")
+        if field in source_fields
+    )
+    assert raw_locator not in json.dumps(finding, sort_keys=True)
+
+
+def test_preflight_rejects_invalid_configured_pptx_root_without_vault_fallback(
+    preflight_vault,
+    vault_fixture,
+) -> None:
+    deck = Presentation()
+    deck.slides.add_slide(deck.slide_layouts[6])
+    deck.save(str(vault_fixture["root"] / "shadow.pptx"))
+    talk = base_talk(
+        status="pending",
+        transcript_source="none",
+        video_url=None,
+        youtube_id=None,
+        slide_source="pptx",
+        pptx_path="shadow.pptx",
+    )
+    write_database(
+        vault_fixture,
+        [talk],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "pptx_source_dir": "relative-presentations",
+        },
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "slide_pptx_artifact_unreadable"
+    )
+    assert finding["artifact_path"] is None
+    assert finding["capability_fact"]["source_reasons"]["native_deck"] == (
+        "pptx_source_dir: artifact_root_not_native_absolute"
+    )
+
+
+@pytest.mark.parametrize(
+    "configured_root,reason_code",
+    [
+        ("", "artifact_locator_empty_or_whitespace"),
+        ("relative-presentations", "artifact_root_not_native_absolute"),
+        ("~/presentations", "artifact_locator_home_expansion_unsupported"),
+        (
+            foreign_absolute_locator("presentations"),
+            "artifact_locator_foreign_absolute",
+        ),
+        (r"\\?\C:\presentations", "artifact_locator_windows_device_namespace"),
+    ],
+)
+def test_preflight_reports_invalid_configured_pptx_root_without_talks(
+    preflight_vault,
+    vault_fixture,
+    configured_root,
+    reason_code,
+) -> None:
+    write_database(
+        vault_fixture,
+        [],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "pptx_source_dir": configured_root,
+        },
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    findings = [
+        item for item in report["findings"] if item["code"] == "pptx_source_dir_invalid"
+    ]
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["severity"] == "blocking"
+    assert finding["actual"] == {"reason_code": reason_code}
+    assert finding["artifact_path"] is None
+    if configured_root:
+        assert configured_root not in json.dumps(finding, sort_keys=True)
+
+
+def test_preflight_null_configured_pptx_root_uses_vault_fallback(
+    preflight_vault,
+    vault_fixture,
+) -> None:
+    deck = Presentation()
+    deck.slides.add_slide(deck.slide_layouts[6])
+    deck.save(str(vault_fixture["root"] / "deck.pptx"))
+    talk = base_talk(
+        status="pending",
+        transcript_source="none",
+        video_url=None,
+        youtube_id=None,
+        slide_source="pptx",
+        pptx_path="deck.pptx",
+    )
+    write_database(
+        vault_fixture,
+        [talk],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "pptx_source_dir": None,
+        },
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "pptx_source_dir_invalid" not in finding_codes(report)
+    assert not any(
+        code.startswith("slide_pptx_artifact_") for code in finding_codes(report)
+    )
+
+
+def test_preflight_absolute_transcript_locator_cannot_select_existing_bytes(
+    preflight_vault,
+    vault_fixture,
+) -> None:
+    external = vault_fixture["root"].parent / "external.txt"
+    external.write_text("substantive transcript evidence " * 600, encoding="utf-8")
+    talk = base_talk(
+        status="pending",
+        transcript_source="manual",
+        transcript_path=str(external),
+        video_url=None,
+        youtube_id=None,
+        slide_source="none",
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "transcript_reference_missing"
+    )
+    assert finding["artifact_path"] is None
+    assert str(external) not in json.dumps(finding, sort_keys=True)
+
+
+def test_preflight_never_strips_a_transcript_locator_before_artifact_io(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch,
+) -> None:
+    transcript = vault_fixture["transcripts"] / "manual.txt"
+    transcript.write_text("substantive transcript evidence " * 600, encoding="utf-8")
+    raw_locator = " transcripts/manual.txt "
+    talk = base_talk(
+        status="pending",
+        transcript_source="manual",
+        transcript_path=raw_locator,
+        video_url=None,
+        youtube_id=None,
+        slide_source="none",
+    )
+    write_database(vault_fixture, [talk])
+    original_is_file = Path.is_file
+    original_read_text = Path.read_text
+
+    def guarded_is_file(path: Path) -> bool:
+        if path == transcript:
+            pytest.fail("stripped transcript locator reached is_file")
+        return original_is_file(path)
+
+    def guarded_read_text(path: Path, *args, **kwargs) -> str:
+        if path == transcript:
+            pytest.fail("stripped transcript locator reached read_text")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "is_file", guarded_is_file)
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "transcript_reference_missing"
+    )
+    assert finding["artifact_path"] is None
+    assert raw_locator not in json.dumps(finding, sort_keys=True)
+
+
+def test_preflight_path_helpers_never_strip_raw_locator_grammar(
+    preflight_vault,
+    vault_fixture,
+) -> None:
+    validator = preflight_vault.VaultPreflight(
+        {},
+        vault_fixture["root"],
+        vault_fixture["database"],
+    )
+
+    assert validator._pptx_path({"pptx_path": " deck.pptx "}) is None
+    assert validator._slide_pdf_path({"slides_local_path": " slides/deck.pdf "}) is None
+
+
+def test_preflight_foreign_video_manifest_locator_is_path_neutral(
+    preflight_vault,
+    vault_fixture,
+) -> None:
+    manifest = context_video_manifest(vault_fixture)
+    foreign_video = foreign_absolute_locator(f"{VIDEO_ID}.mp4")
+    manifest["source_video_path"] = foreign_video
+    for artifact in manifest["artifacts"]:
+        artifact["source_video_path"] = foreign_video
+    talk = base_talk(
+        status="processed_partial",
+        transcript_source="none",
+        slide_source="video_extracted",
+        structured_data={"video_extraction": manifest},
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "video_extraction_provenance_invalid"
+    )
+    assert finding["artifact_path"] is None
+    assert "artifact_locator_foreign_absolute" in finding["actual"]
+    assert foreign_video not in json.dumps(finding, sort_keys=True)
 
 
 def test_pending_artifact_gaps_are_warnings_not_blockers(

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -1475,6 +1475,48 @@ def test_preflight_never_strips_a_transcript_locator_before_artifact_io(
     assert raw_locator not in json.dumps(finding, sort_keys=True)
 
 
+def test_preflight_never_reads_a_transcript_owned_by_another_youtube_id(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch,
+) -> None:
+    transcript = vault_fixture["transcripts"] / "other-owner.txt"
+    transcript.write_text("substantive transcript evidence " * 600, encoding="utf-8")
+    raw_locator = "transcripts/other-owner.txt"
+    talk = base_talk(
+        status="pending",
+        transcript_source="manual",
+        transcript_path=raw_locator,
+        slide_source="none",
+    )
+    write_database(vault_fixture, [talk])
+    original_is_file = Path.is_file
+    original_read_text = Path.read_text
+
+    def guarded_is_file(path: Path) -> bool:
+        if path == transcript:
+            pytest.fail("mismatched transcript owner reached is_file")
+        return original_is_file(path)
+
+    def guarded_read_text(path: Path, *args, **kwargs) -> str:
+        if path == transcript:
+            pytest.fail("mismatched transcript owner reached read_text")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "is_file", guarded_is_file)
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "transcript_reference_missing"
+    )
+    assert finding["artifact_path"] is None
+    assert raw_locator not in json.dumps(finding, sort_keys=True)
+
+
 def test_preflight_path_helpers_never_strip_raw_locator_grammar(
     preflight_vault,
     vault_fixture,

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -17,6 +17,12 @@ VALIDATE_SCRIPT = os.path.join(
 )
 
 
+def _foreign_absolute_locator(name):
+    if os.name == "nt":
+        return f"/foreign/{name}"
+    return rf"C:\foreign\{name}"
+
+
 def _return(**overrides):
     value = {
         "filename": "talk.md",
@@ -949,6 +955,67 @@ def test_video_manifest_rejects_spoofed_or_inconsistent_provenance(
     value = _video_return(trusted=False, promoted=False)
     mutation(value["structured_data"]["video_extraction"])
     assert expected in _error(return_validation, value)
+
+
+@pytest.mark.parametrize(
+    "locator,reason_code",
+    [
+        (
+            "~/abcDEF12345.mp4",
+            "artifact_locator_home_expansion_unsupported",
+        ),
+        (
+            r"videos\abcDEF12345.mp4",
+            "artifact_locator_noncanonical_relative",
+        ),
+        (
+            "//server/share/abcDEF12345.mp4",
+            "artifact_locator_ambiguous_double_slash",
+        ),
+        (
+            _foreign_absolute_locator("abcDEF12345.mp4"),
+            "artifact_locator_foreign_absolute",
+        ),
+    ],
+)
+def test_video_manifest_absolute_paths_use_shared_locator_classifier(
+    return_validation,
+    locator,
+    reason_code,
+):
+    value = _video_return(trusted=False, promoted=False)
+    value["structured_data"]["video_extraction"]["source_video_path"] = locator
+
+    error = _error(return_validation, value)
+
+    assert reason_code in error
+    assert locator not in error
+
+
+def test_video_manifest_artifact_path_rejects_foreign_absolute_flavor(
+    return_validation,
+):
+    locator = _foreign_absolute_locator("abcDEF12345.context.pdf")
+    value = _video_return(trusted=False, promoted=False)
+    value["structured_data"]["video_extraction"]["artifacts"][0]["path"] = locator
+
+    error = _error(return_validation, value)
+
+    assert "artifact_locator_foreign_absolute" in error
+    assert locator not in error
+
+
+def test_video_manifest_relative_path_uses_native_root_failure_reason(
+    return_validation,
+):
+    value = _video_return(trusted=False, promoted=False)
+    value["structured_data"]["video_extraction"]["source_video_path"] = (
+        "videos/abcDEF12345.mp4"
+    )
+
+    error = _error(return_validation, value)
+
+    assert "artifact_root_not_native_absolute" in error
 
 
 def test_video_manifest_accepts_extractor_timestamp_rounding(return_validation):

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -26,6 +26,7 @@ SCHEMA_PATH = os.path.join(
     "references",
     "schemas-db.md",
 )
+YOUTUBE_ID = "AbCdEfGhI_1"
 
 
 def _artifact(result, scope):
@@ -159,6 +160,186 @@ def test_extract_frames_rejects_foreign_source_before_creating_frame_directory(
         )
 
 
+@pytest.mark.skipif(os.name == "nt", reason="characters are not valid Win32 names")
+@pytest.mark.parametrize(
+    "component",
+    [
+        "path with spaces",
+        'path-with-"quote',
+        "path;with;semicolons",
+        "path-$(command-substitution)",
+        "path>with-redirection",
+    ],
+)
+def test_extract_frames_passes_adversarial_paths_as_argv_data(
+    video_slide_extraction,
+    monkeypatch,
+    tmp_path,
+    component,
+):
+    video = os.path.realpath(tmp_path / f"{component}.mp4")
+    frames_dir = os.path.realpath(tmp_path / f"frames-{component}")
+    calls = []
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(video_slide_extraction.subprocess, "run", run)
+    monkeypatch.setattr(video_slide_extraction.os, "makedirs", lambda *_a, **_k: None)
+    monkeypatch.setattr(video_slide_extraction.glob, "glob", lambda _pattern: [])
+
+    assert video_slide_extraction.extract_frames(video, frames_dir, fps=0.25) == []
+
+    assert calls == [
+        (
+            [
+                "ffmpeg",
+                "-i",
+                video,
+                "-vf",
+                "fps=0.25",
+                "-q:v",
+                "2",
+                os.path.join(frames_dir, "frame_%05d.jpg"),
+                "-y",
+                "-loglevel",
+                "warning",
+            ],
+            {"check": False, "shell": False},
+        )
+    ]
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="shell quoting regression is POSIX-specific"
+)
+def test_extract_frames_cannot_create_a_shell_side_effect_sentinel(
+    video_slide_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.chdir(tmp_path)
+    sentinel = tmp_path / "shell-side-effect"
+    video = tmp_path / 'source"; touch shell-side-effect; #.mp4'
+    frames_dir = tmp_path / "frames"
+
+    monkeypatch.setattr(
+        video_slide_extraction.subprocess,
+        "run",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0),
+    )
+    monkeypatch.setattr(video_slide_extraction.glob, "glob", lambda _pattern: [])
+
+    video_slide_extraction.extract_frames(str(video), str(frames_dir))
+
+    assert not sentinel.exists()
+
+
+def test_extract_frames_reports_closed_process_exit_status(
+    video_slide_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    video = tmp_path / "private-source.mp4"
+    frames_dir = tmp_path / "frames"
+    monkeypatch.setattr(
+        video_slide_extraction.subprocess,
+        "run",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 17),
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        video_slide_extraction.extract_frames(str(video), str(frames_dir))
+
+    assert str(caught.value) == "ffmpeg failed with exit status 17"
+    assert str(video) not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "youtube_id",
+    [
+        None,
+        "",
+        " ",
+        "../escape-id",
+        "abc/defghij",
+        r"abc\defghij",
+        "/absolute-id",
+        r"C:\escape-id",
+        r"\\?\C:\escape",
+        "short-id",
+        "twelve_chars",
+        YOUTUBE_ID + "\x00",
+        "ＡbCdEfGhI_1",
+    ],
+)
+def test_video_pipeline_rejects_noncanonical_youtube_id_before_io(
+    video_slide_extraction,
+    monkeypatch,
+    tmp_path,
+    youtube_id,
+):
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "canonical_path",
+        lambda *_args, **_kwargs: pytest.fail("invalid ID reached path resolution"),
+    )
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_frames",
+        lambda *_args, **_kwargs: pytest.fail("invalid ID reached ffmpeg"),
+    )
+
+    with pytest.raises(ValueError) as caught:
+        video_slide_extraction.extract_slides_from_video(
+            tmp_path / "source.mp4",
+            tmp_path / "output",
+            youtube_id,
+        )
+
+    assert str(caught.value) == "youtube_id_invalid"
+    if isinstance(youtube_id, str) and youtube_id:
+        assert youtube_id not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "derived_name",
+    [
+        "frames",
+        f"{YOUTUBE_ID}.slide-region.pdf",
+        f"{YOUTUBE_ID}.context.pdf",
+    ],
+)
+def test_video_pipeline_rejects_existing_output_symlink_escape_before_ffmpeg(
+    video_slide_extraction,
+    monkeypatch,
+    tmp_path,
+    derived_name,
+):
+    output = tmp_path / "output"
+    output.mkdir()
+    target = tmp_path / "outside"
+    try:
+        (output / derived_name).symlink_to(
+            target, target_is_directory=derived_name == "frames"
+        )
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not available to this test process")
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_frames",
+        lambda *_args, **_kwargs: pytest.fail("escaping output reached ffmpeg"),
+    )
+
+    with pytest.raises(ValueError, match="video_output_path_escape"):
+        video_slide_extraction.extract_slides_from_video(
+            tmp_path / "source.mp4",
+            output,
+            YOUTUBE_ID,
+        )
+
+
 def test_deduplicate_identical_frames(video_slide_extraction, tmp_path):
     """Identical frames should collapse to one."""
     frames = []
@@ -251,7 +432,7 @@ def test_combine_to_pdf_applies_crop_to_saved_pages(video_slide_extraction, tmp_
         str(output),
         slide_region=(0.25, 0.25, 0.75, 0.75),
         artifact_scope="slide_region",
-        source_video_id="video-id",
+        source_video_id=YOUTUBE_ID,
         crop_method="manual",
         crop_verified=True,
     )
@@ -291,7 +472,7 @@ def test_artifact_manifest_rejects_unverified_authored_slide_trust(
             tmp_path / "candidate.pdf",
             "slide_region",
             1,
-            "video-id",
+            YOUTUBE_ID,
             tmp_path / "source.mp4",
             crop_method="auto",
             crop_verified=False,
@@ -354,7 +535,7 @@ def test_success_cli_emits_only_result_json_on_stdout(
             video_slide_extraction.__file__,
             str(video),
             str(outdir),
-            "video-id",
+            YOUTUBE_ID,
             "--region",
             "none",
         ],
@@ -364,12 +545,58 @@ def test_success_cli_emits_only_result_json_on_stdout(
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
-    assert payload["source_video_id"] == "video-id"
+    assert payload["source_video_id"] == YOUTUBE_ID
     assert payload["artifacts"][0]["artifact_scope"] == "full_frame_context"
     assert "Extracting video artifacts" in captured.err
     assert "Deduplicated: 1 frames -> 1 unique frames" in captured.err
     assert "Saved full_frame_context PDF" in captured.err
     assert "Done: 1 unique frames retained" in captured.err
+
+
+@pytest.mark.parametrize(
+    "youtube_id",
+    ["../escape-id", r"abc\defghij", YOUTUBE_ID + "\x00"],
+)
+def test_cli_rejects_noncanonical_youtube_id_before_pipeline_io(
+    video_slide_extraction,
+    monkeypatch,
+    capsys,
+    youtube_id,
+):
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_slides_from_video",
+        lambda *_args, **_kwargs: pytest.fail("invalid CLI ID reached the pipeline"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            video_slide_extraction.__file__,
+            "/native/source.mp4",
+            "/native/output",
+            youtube_id,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        video_slide_extraction.main()
+
+    assert caught.value.code == 2
+    captured = capsys.readouterr()
+    assert "youtube_id_invalid" in captured.err
+    assert youtube_id not in captured.err
+
+
+def test_ingress_scripts_have_no_shell_artifact_process_boundary():
+    scripts = os.path.dirname(SCRIPT_PATH)
+    for name in os.listdir(scripts):
+        if not name.endswith(".py"):
+            continue
+        with open(os.path.join(scripts, name), encoding="utf-8") as source_file:
+            source = source_file.read()
+        assert "os.system(" not in source, name
+        assert "shell=True" not in source.replace(" ", ""), name
 
 
 def test_combine_to_pdf_stamps_version_metadata(video_slide_extraction, tmp_path):
@@ -460,7 +687,7 @@ def test_full_pipeline(video_slide_extraction, tmp_path, capsys):
 
     outdir = str(tmp_path / "output")
     result = video_slide_extraction.extract_slides_from_video(
-        video, outdir, "test_id", fps=1, hash_threshold=8
+        video, outdir, YOUTUBE_ID, fps=1, hash_threshold=8
     )
     captured = capsys.readouterr()
     assert captured.out == ""
@@ -485,7 +712,7 @@ def test_full_pipeline(video_slide_extraction, tmp_path, capsys):
     context = _artifact(result, "full_frame_context")
     assert context["trusted_for_authored_slide_analysis"] is False
     assert os.path.isfile(context["path"])
-    assert context["path"].endswith("test_id.context.pdf")
+    assert context["path"].endswith(f"{YOUTUBE_ID}.context.pdf")
     assert result["source_video_path"] == os.path.realpath(video)
     assert os.path.isfile(video), "the extractor must preserve its source video"
 
@@ -507,7 +734,7 @@ def test_no_region_emits_context_only_even_when_extra_context_is_disabled(
     result = video_slide_extraction.extract_slides_from_video(
         str(video),
         str(outdir),
-        "no_region",
+        YOUTUBE_ID,
         slide_region="none",
         include_context_pdf=False,
     )
@@ -516,9 +743,9 @@ def test_no_region_emits_context_only_even_when_extra_context_is_disabled(
     assert result["artifacts"] == [_artifact(result, "full_frame_context")]
     context = result["artifacts"][0]
     assert context["path"] == os.path.realpath(
-        tmp_path / "output" / "no_region.context.pdf"
+        tmp_path / "output" / f"{YOUTUBE_ID}.context.pdf"
     )
-    assert context["source_video_id"] == "no_region"
+    assert context["source_video_id"] == YOUTUBE_ID
     assert context["source_video_path"] == os.path.realpath(video)
     assert context["crop_method"] == "none"
     assert context["crop_verified"] is False
@@ -549,7 +776,7 @@ def test_unverified_auto_crop_is_a_review_required_candidate(
     result = video_slide_extraction.extract_slides_from_video(
         str(video),
         str(outdir),
-        "auto_id",
+        YOUTUBE_ID,
         fps=0.5,
         include_context_pdf=False,
     )
@@ -562,8 +789,8 @@ def test_unverified_auto_crop_is_a_review_required_candidate(
     assert slide["crop_verified"] is False
     assert slide["trusted_for_authored_slide_analysis"] is False
     assert context["trusted_for_authored_slide_analysis"] is False
-    assert slide["path"] == os.path.realpath(outdir / "auto_id.slide-region.pdf")
-    assert context["path"] == os.path.realpath(outdir / "auto_id.context.pdf")
+    assert slide["path"] == os.path.realpath(outdir / f"{YOUTUBE_ID}.slide-region.pdf")
+    assert context["path"] == os.path.realpath(outdir / f"{YOUTUBE_ID}.context.pdf")
     with open(slide["path"], "rb") as slide_file:
         assert b"/MediaBox [ 0 0 500.0 250.0 ]" in slide_file.read()
     assert result["retained_frames"] == [
@@ -596,7 +823,7 @@ def test_manual_region_bypasses_detection_and_records_verified_provenance(
     result = video_slide_extraction.extract_slides_from_video(
         str(video),
         str(outdir),
-        "manual_id",
+        YOUTUBE_ID,
         slide_region=region,
         slide_region_verified=True,
     )
@@ -635,7 +862,7 @@ def test_verified_crop_can_omit_extra_context_without_deleting_source(
     result = video_slide_extraction.extract_slides_from_video(
         str(video),
         str(outdir),
-        "manual_no_context",
+        YOUTUBE_ID,
         slide_region=(0.2, 0.1, 0.9, 0.8),
         slide_region_verified=True,
         include_context_pdf=False,
@@ -646,9 +873,9 @@ def test_verified_crop_can_omit_extra_context_without_deleting_source(
         "slide_region"
     ]
     assert _artifact(result, "slide_region")["path"].endswith(
-        "manual_no_context.slide-region.pdf"
+        f"{YOUTUBE_ID}.slide-region.pdf"
     )
-    assert not (outdir / "manual_no_context.context.pdf").exists()
+    assert not (outdir / f"{YOUTUBE_ID}.context.pdf").exists()
     assert video.exists()
 
 

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -84,6 +84,81 @@ def test_region_argument_rejects_invalid_geometry(video_slide_extraction, value)
         video_slide_extraction.parse_slide_region(value)
 
 
+@pytest.mark.parametrize(
+    ("locator", "reason_code"),
+    [
+        ("relative/video.mp4", "artifact_root_not_native_absolute"),
+        ("~/video.mp4", "artifact_locator_home_expansion_unsupported"),
+        (r"C:video.mp4", "artifact_locator_windows_drive_relative"),
+        (r"\video.mp4", "artifact_locator_windows_current_drive_rooted"),
+        (r"\\?\C:\video.mp4", "artifact_locator_windows_device_namespace"),
+        ("//server/share/video.mp4", "artifact_locator_ambiguous_double_slash"),
+        ("/vault/../video.mp4", "artifact_locator_dot_segment"),
+        (r"relative\video.mp4", "artifact_locator_noncanonical_relative"),
+    ],
+)
+def test_canonical_path_rejects_ambient_or_noncanonical_locators_before_realpath(
+    video_slide_extraction,
+    monkeypatch,
+    locator,
+    reason_code,
+):
+    monkeypatch.setattr(
+        video_slide_extraction.os.path,
+        "realpath",
+        lambda *_args, **_kwargs: pytest.fail("invalid locator reached realpath"),
+    )
+
+    with pytest.raises(ValueError, match=reason_code) as caught:
+        video_slide_extraction.canonical_path(locator)
+
+    assert locator not in str(caught.value)
+
+
+def test_video_pipeline_rejects_relative_output_before_filesystem_or_ffmpeg(
+    video_slide_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    video = tmp_path / "source.mp4"
+    monkeypatch.setattr(
+        video_slide_extraction.os,
+        "makedirs",
+        lambda *_args, **_kwargs: pytest.fail("invalid output reached filesystem"),
+    )
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_frames",
+        lambda *_args, **_kwargs: pytest.fail("invalid output reached ffmpeg"),
+    )
+
+    with pytest.raises(ValueError, match="artifact_root_not_native_absolute"):
+        video_slide_extraction.extract_slides_from_video(
+            str(video),
+            "relative-output",
+            "abcdefghijk",
+        )
+
+
+def test_extract_frames_rejects_foreign_source_before_creating_frame_directory(
+    video_slide_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    foreign = "/vault/source.mp4" if os.name == "nt" else r"C:\vault\source.mp4"
+    monkeypatch.setattr(
+        video_slide_extraction.os,
+        "makedirs",
+        lambda *_args, **_kwargs: pytest.fail("foreign source reached filesystem"),
+    )
+
+    with pytest.raises(ValueError, match="artifact_locator_foreign_absolute"):
+        video_slide_extraction.extract_frames(
+            foreign,
+            str(tmp_path / "frames"),
+        )
+
+
 def test_deduplicate_identical_frames(video_slide_extraction, tmp_path):
     """Identical frames should collapse to one."""
     frames = []
@@ -422,7 +497,7 @@ def test_no_region_emits_context_only_even_when_extra_context_is_disabled(
     Image.new("RGB", (320, 180), (80, 40, 20)).save(frame)
     video = tmp_path / "source.mp4"
     video.write_bytes(b"source-video")
-    outdir = tmp_path / "output" / ".." / "output"
+    outdir = tmp_path / "output"
     monkeypatch.setattr(
         video_slide_extraction,
         "extract_frames",
@@ -502,6 +577,7 @@ def test_manual_region_bypasses_detection_and_records_verified_provenance(
 ):
     frame = tmp_path / "manual-region-frame.png"
     Image.new("RGB", (320, 180), (80, 40, 20)).save(frame)
+    video = tmp_path / "source.mp4"
     outdir = tmp_path / "output"
     outdir.mkdir()
 
@@ -518,7 +594,7 @@ def test_manual_region_bypasses_detection_and_records_verified_provenance(
 
     region = (0.2, 0.1, 0.9, 0.8)
     result = video_slide_extraction.extract_slides_from_video(
-        "video.mp4",
+        str(video),
         str(outdir),
         "manual_id",
         slide_region=region,


### PR DESCRIPTION
## Summary

- classify artifact locator flavor lexically before Path normalization, filesystem access, cache lookup, or worker launch
- enforce canonical trusted-root-relative syntax and reject foreign absolutes, home expansion, dot traversal, Windows ambient/device forms, UNC ambiguity, Win32 trimming aliases, alternate streams, and reserved device names
- apply the same path-neutral contract to metadata, PDF/PPTX/video admission, preflight, return manifests, freshness, extraction, directory discovery, and authenticated child requests
- require a present pptx_source_dir to be native absolute while retaining absent/null vault fallback
- validate video owner IDs against the shared 11-character grammar before deriving any path, and keep every frame/PDF output beneath the authorized root
- pass ffmpeg paths as argv data with shell disabled; report only the closed exit status
- add native macOS/Windows coverage plus adversarial shadow, worker, cache, freshness, identity, confinement, shell-side-effect, and leak regressions

## Validation

- full exact-head suite: 4175 passed, 3 skipped
- video extraction suite: 74 passed
- pattern evidence suite: 135 passed
- Ruff lint and format: clean
- Pyright: 0 findings
- actionlint: clean
- pre-publish pin/package checks: clean; all 262 declared files packaged
- Tessl plugin lint: valid; only the pre-existing skill-length advisories tracked by #163

## Compatibility and follow-ups

No database, return, evidence, or extraction schema is bumped and no locator or owner identity is silently rewritten. Foreign or legacy noncanonical owner locators require explicit repair and reprocessing. Video extraction behavior advances to pipeline 0.11.0 while retaining manifest schema v3.

Trusted vault-root authority remains intentionally separate in #212.

Closes #210
Closes #211
Closes #214
