### PR TITLE
Unify trusted vault-root authority across ingress and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,7 @@ jobs:
       - run: >-
           pytest -v --tb=short
           tests/test_artifact_locator.py
+          tests/test_vault_root_authority.py
           tests/test_artifact_supervisor.py
           tests/test_artifact_metadata.py
           tests/test_pdf_evidence.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+### fix(vault-ingress) — unify trusted vault-root authority (#212)
+
+Queue selection, persistence, analysis rendering, preflight, and profile cohort
+freshness now use one stdlib-only vault-root authority resolver. The native
+absolute parent of `tracking-database.json` is primary; a supplied CLI vault
+root and a present `config.vault_storage_path` must be lexically equal to it.
+An absent or null configured root falls back to the database parent. Empty,
+relative, home-expanded, foreign, device, and ambient-drive forms fail closed
+before artifact assessment, freshness caching, persistence, rendering, or
+preflight artifact I/O.
+
+The resolver performs no `expanduser`, cwd rebasing, symlink resolution, stat,
+or equivalence-by-filesystem lookup. It reports only closed, path-neutral
+database/CLI/config authority reasons. Existing mismatched or noncanonical
+configuration requires explicit operator repair; no database migration or
+stored-root rewrite is performed. The ingress references now document the
+expectation-bound `set_config` dry-run/apply/re-read/preflight sequence for
+removing or replacing an invalid stored assertion.
+
 ## 0.20.7 — 2026-08-03
 
 ### fix(vault-ingress) — validate video owner identity before output derivation (#214)

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -82,13 +82,24 @@ needed for current pattern-goal verification. Talks v1-v5 remain readable under
 the current root and are promoted only when the talk-domain writer legitimately
 persists that exact talk.
 
+`config.vault_storage_path` is a root assertion, not a redirect. When present
+and non-null it must be a native absolute locator lexically equal to the parent
+of `tracking-database.json`; absent/null uses that database parent. Readers do
+not expand `~`, rebase relative values, translate foreign path flavors, resolve
+symlinks to establish equivalence, or silently repair a mismatch. Empty/blank,
+drive-relative forms such as `C:vault`, current-drive-rooted forms such as
+`\vault`, dot-segment roots, device namespaces, and every other non-native or
+non-absolute value fail closed. Repair an invalid stored assertion with the
+expectation-bound `set_config` dry-run/apply/re-read/preflight sequence in
+[source-identity-preflight.md](source-identity-preflight.md#repair-a-stored-root-assertion).
+
 ```json
 {
   "schema_version": 1,
   "config": {
     "schema_version": 1,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
-    "vault_storage_path": "/actual/path/if/custom (null when using default location)",
+    "vault_storage_path": "/native/absolute/vault/root (optional; must match the tracking-database parent; null/absent uses that parent)",
     "pptx_source_dir": "/native/absolute/path/to/Presentations (optional; null/absent falls back to the vault root)",
     "python_path": "/path/to/python3",
     "template_skip_patterns": ["template"],

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -2,7 +2,8 @@
 
 `skills/vault-ingress/scripts/preflight-vault.py` is the read-only integrity
 gate before ingress selection or re-analysis. It accepts either the vault root
-or `tracking-database.json`, performs no network access and makes no writes:
+or `tracking-database.json` as a native absolute locator, performs no network
+access and makes no writes:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/preflight-vault.py" \
@@ -14,6 +15,82 @@ report may contain warnings); exit `1` means at least one integrity finding is
 blocking. Invocation errors use argparse's exit `2` and still emit a blocking
 JSON report. A missing, unreadable, malformed, or structurally invalid tracking
 database is itself a blocking integrity finding.
+
+## Trusted vault-root authority
+
+Every ingress reader derives the same artifact root before it assesses,
+caches, persists, or renders evidence. The native absolute parent of
+`tracking-database.json` is the primary authority. When preflight is invoked
+with a vault root, that CLI root must be lexically equal to the database parent.
+`config.vault_storage_path` may be absent or null, in which case the database
+parent is used; every other present value must be a native absolute root and
+must be lexically equal to that parent.
+
+Preflight labels a raw input by its final basename before any `Path`
+materialization or filesystem access. A case-insensitive exact
+`tracking-database.json` basename is a `database_path` authority; every other
+input is a `cli_root` authority. The same lexical decision controls how the
+validated native absolute path is interpreted, so a relative direct database
+locator fails as `vault_root_database_path_invalid` rather than being relabeled
+as a vault directory.
+
+Root comparison is lexical and host-native. It does not expand `~`, rebase a
+relative value from the process cwd, translate a foreign absolute flavor,
+resolve symlinks, stat the filesystem, or infer that two different locators
+reach the same storage. Invalid database, CLI, and config authorities fail with
+closed path-neutral reasons; a disagreement names only the authority pair.
+Repair the invocation/config explicitly before reprocessing. No reader silently
+migrates or rewrites a stored root.
+
+### Repair a stored root assertion
+
+Read the database through its owner command before constructing a repair. For
+example, if that read reports the exact stored value `"C:vault"`, remove the
+invalid assertion and let the database parent remain authoritative with this
+expectation-bound mutation plan:
+
+```json
+{
+  "schema_version": 1,
+  "mutations": [{
+    "kind": "set_config",
+    "path": ["vault_storage_path"],
+    "expect": "C:vault",
+    "delete": true
+  }]
+}
+```
+
+Use the exact decoded value from the owner read in `expect`; JSON null and an
+absent key are different expectations. If the assertion should remain explicit,
+replace `"delete": true` with `"value": "<native-absolute-database-parent>"`.
+That value must be the lexical native parent of `tracking-database.json`, not a
+symlink-resolved alias.
+
+Run the plan as a dry run, review its `changes`, then bind apply to the dry
+run's exact `input_sha256`:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py" \
+  "{vault_root}/tracking-database.json"
+
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/mutate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" vault-root-repair-plan.json
+
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/mutate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" vault-root-repair-plan.json \
+  --apply --expected-sha256 "<input_sha256-from-dry-run>"
+
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py" \
+  "{vault_root}/tracking-database.json"
+
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/preflight-vault.py" \
+  "{vault_root}"
+```
+
+The second owner read must show the applied generation. Preflight must then
+report no trusted-root blocking finding before queue normalization, claiming,
+persistence, analysis rendering, or profile generation resumes.
 
 Use `scripts/apply-source-repairs.py` for catalog metadata fixes. Its plan
 requires an exact `expect` map for every record, permits only source/queue
@@ -81,6 +158,28 @@ All finding keys are always present. Findings and `summary.by_code` are sorted,
 so the same filesystem state produces byte-for-byte equivalent decoded data.
 Paths are absolute. Consumers route on `severity` and `code`, never on message
 text.
+
+`database` and `vault_root` are nullable authority fields. When raw database or
+CLI input is rejected before admission, both are null, `talk_count` is zero,
+and the report contains one path-neutral blocking finding. Once the direct
+input is admitted, they remain its lexical native absolute database/root paths,
+including when a later configured-root mismatch blocks the run.
+
+Trusted-root findings use this closed reason family:
+
+| Code | Field | Safe `actual` detail |
+|---|---|---|
+| `vault_root_database_path_invalid` | `database.path` | `reason_code` plus closed `locator_reason_code` |
+| `vault_root_cli_invalid` | `cli.vault_root` | `reason_code` plus closed `locator_reason_code` |
+| `vault_root_config_invalid` | `config.vault_storage_path` | `reason_code` plus closed `locator_reason_code` |
+| `vault_root_authority_mismatch` | disagreeing CLI/config field | `reason_code` plus `authorities` (`database_path` and `cli_root` or `config_root`) |
+
+These findings never echo a rejected locator. Empty/blank, relative,
+drive-relative (`C:vault`), current-drive-rooted (`\vault`), dot-segment,
+home-relative, foreign-absolute, and device-namespace config values all route
+through the config-invalid family. Lexically different symlink aliases remain
+different authorities even when the filesystem would resolve them to one
+directory.
 
 ## Recorded source identity (v1)
 

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -77,7 +77,6 @@ Example:
 
 import copy
 import json
-import os
 import sys
 from datetime import datetime, timezone
 
@@ -134,6 +133,11 @@ from tracking_database_io import (
     decode_json_object,
     snapshot_tracking_database,
     write_json_object,
+)
+from vault_root_authority import (
+    VaultRootAuthorityError,
+    materialize_native_authority,
+    resolve_vault_root_authority,
 )
 
 
@@ -842,23 +846,34 @@ def parse_args(argv):
 def main():
     db_path, batch_path, run_date = parse_args(sys.argv[1:])
 
+    try:
+        db_path = str(
+            materialize_native_authority(
+                db_path,
+                authority="database_path",
+            )
+        )
+    except VaultRootAuthorityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
     db, database_snapshot = load_tracking_database(db_path)
+    raw_config = db.get("config")
+    source_roots: dict[str, object] = (
+        copy.deepcopy(raw_config) if isinstance(raw_config, dict) else {})
+    try:
+        vault_root = resolve_vault_root_authority(
+            database_path=db_path,
+            config=source_roots,
+        )
+    except VaultRootAuthorityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
     returns = load_json(batch_path, "batch-returns")
     try:
         catalog = validate_batch(returns)
     except ReturnValidationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
-
-    raw_config = db.get("config")
-    source_roots: dict[str, object] = (
-        copy.deepcopy(raw_config) if isinstance(raw_config, dict) else {})
-    configured_vault = source_roots.get("vault_storage_path")
-    vault_root = (
-        os.path.abspath(os.path.expanduser(configured_vault))
-        if isinstance(configured_vault, str) and configured_vault.strip()
-        else os.path.dirname(os.path.abspath(db_path))
-    )
     artifact_capabilities_by_filename = assess_batch_artifact_capabilities(
         db["talks"],
         {

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -69,6 +69,11 @@ from tracking_database_io import (
     decode_json_object,
     snapshot_tracking_database,
 )
+from vault_root_authority import (
+    VaultRootAuthorityError,
+    materialize_native_authority,
+    resolve_vault_root_authority,
+)
 
 
 REPORT_SCHEMA_VERSION = 1
@@ -101,6 +106,42 @@ SLIDE_CONTRACT_CODES = frozenset(
 )
 
 WORD_RE = re.compile(r"[^\W_]+", re.UNICODE)
+
+
+def _vault_root_authority_finding(
+    error: VaultRootAuthorityError,
+) -> dict[str, Any]:
+    """Build one closed, path-neutral authority finding."""
+    actual: dict[str, object] = {"reason_code": error.reason_code}
+    if error.locator_reason_code is not None:
+        actual["locator_reason_code"] = error.locator_reason_code
+    authorities = getattr(error, "authorities", ())
+    if authorities:
+        actual["authorities"] = list(authorities)
+    if error.reason_code == "vault_root_authority_mismatch":
+        field = (
+            "cli.vault_root"
+            if authorities == ("database_path", "cli_root")
+            else "config.vault_storage_path"
+        )
+    else:
+        field = {
+            "vault_root_cli_invalid": "cli.vault_root",
+            "vault_root_database_path_invalid": "database.path",
+            "vault_root_config_invalid": "config.vault_storage_path",
+        }[error.reason_code]
+    return {
+        "severity": "blocking",
+        "code": error.reason_code,
+        "talk_index": None,
+        "filename": None,
+        "field": field,
+        "message": str(error),
+        "expected": "one lexically identical native absolute vault root",
+        "actual": actual,
+        "artifact_path": None,
+        "capability_fact": None,
+    }
 
 
 def _reportable_artifact_path(value: Path | str | None) -> str | None:
@@ -152,8 +193,8 @@ class VaultPreflight:
 
     def __init__(self, database: Any, vault_root: Path, database_path: Path):
         self.database = database
-        self.vault_root = Path(os.path.abspath(os.fspath(vault_root)))
-        self.database_path = Path(os.path.abspath(os.fspath(database_path)))
+        self.vault_root = Path(vault_root)
+        self.database_path = Path(database_path)
         self.findings: list[dict[str, Any]] = []
         self.talks: list[dict[str, Any]] = []
         self.source_indexes: list[int] = []
@@ -256,6 +297,16 @@ class VaultPreflight:
                 return self.report(0)
 
         config = self.database.get("config", {})
+        try:
+            self.vault_root = resolve_vault_root_authority(
+                database_path=self.database_path,
+                config=config,
+                cli_vault_root=self.vault_root,
+            )
+        except VaultRootAuthorityError as exc:
+            self._add_vault_root_authority_error(exc)
+            return self.report(0)
+
         if isinstance(config, dict):
             self.config = config
             self._validate_config_artifact_roots()
@@ -309,6 +360,13 @@ class VaultPreflight:
         self._validate_relations()
         self._validate_duplicate_youtube_ids()
         return self.report(len(talks))
+
+    def _add_vault_root_authority_error(
+        self,
+        error: VaultRootAuthorityError,
+    ) -> None:
+        """Record one path-neutral authority failure before artifact checks."""
+        self.findings.append(_vault_root_authority_finding(error))
 
     def _validate_config_artifact_roots(self) -> None:
         """Report each invalid configured source root once, even without talks."""
@@ -1943,14 +2001,32 @@ def relation_from(talk: dict[str, Any]) -> tuple[Any, Any] | None:
     return None
 
 
+def _is_direct_database_locator(value: object) -> bool:
+    """Recognize the raw final basename without materializing or probing it."""
+    if not isinstance(value, (str, os.PathLike)):
+        return False
+    try:
+        raw = os.fspath(value)
+    except TypeError:
+        return False
+    if not isinstance(raw, str):
+        return False
+    final_separator = max(raw.rfind("/"), raw.rfind("\\"))
+    return raw[final_separator + 1 :].casefold() == "tracking-database.json"
+
+
 def resolve_input(value: str | Path) -> tuple[Path, Path]:
     """Bind a vault root to its canonical database without filesystem probes.
 
     Only a case-insensitive ``tracking-database.json`` basename is a direct
     database locator; every other value is the vault root.
     """
-    path = Path(value).expanduser()
-    if path.name.casefold() != "tracking-database.json":
+    is_database = _is_direct_database_locator(value)
+    path = materialize_native_authority(
+        value,
+        authority="database_path" if is_database else "cli_root",
+    )
+    if not is_database:
         return path, path / "tracking-database.json"
     return path.parent, path
 
@@ -1963,9 +2039,33 @@ def error_report(
     return validator.report(0)
 
 
+def vault_root_authority_error_report(
+    error: VaultRootAuthorityError,
+) -> dict[str, Any]:
+    """Return one path-neutral report when no input root was admitted."""
+    finding = _vault_root_authority_finding(error)
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "ok": False,
+        "database": None,
+        "vault_root": None,
+        "talk_count": 0,
+        "blocking_count": 1,
+        "warning_count": 0,
+        "summary": {
+            "by_severity": {"blocking": 1, "warning": 0},
+            "by_code": {error.reason_code: 1},
+        },
+        "findings": [finding],
+    }
+
+
 def run_preflight(value: str | Path) -> dict[str, Any]:
     """Load and validate a vault, returning a report without mutating it."""
-    vault_root, database_path = resolve_input(value)
+    try:
+        vault_root, database_path = resolve_input(value)
+    except VaultRootAuthorityError as exc:
+        return vault_root_authority_error_report(exc)
     try:
         snapshot = snapshot_tracking_database(database_path)
         database = decode_json_object(snapshot)

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -61,11 +61,9 @@ without deleting the generation record.
 import argparse
 import copy
 import json
-import os
 import re
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
@@ -118,6 +116,11 @@ from tracking_database_io import (
     snapshot_tracking_database,
     unchanged_write_result,
     write_json_object,
+)
+from vault_root_authority import (
+    VaultRootAuthorityError,
+    materialize_native_authority,
+    resolve_vault_root_authority,
 )
 
 
@@ -217,11 +220,9 @@ def evidence_roots(database, path):
         if isinstance(database.get("config"), dict)
         else {}
     )
-    configured_vault = source_roots.get("vault_storage_path")
-    vault_root = (
-        Path(configured_vault).expanduser().resolve()
-        if isinstance(configured_vault, str) and configured_vault.strip()
-        else path.parent.resolve()
+    vault_root = resolve_vault_root_authority(
+        database_path=path,
+        config=database.get("config"),
     )
     return vault_root, source_roots
 
@@ -977,11 +978,18 @@ def main(argv=None):
     parser = build_parser()
     try:
         args = parser.parse_args(argv)
-        path = Path(os.path.abspath(Path(args.database).expanduser()))
+        path = materialize_native_authority(
+            args.database,
+            authority="database_path",
+        )
         database, snapshot = load_database_snapshot(
             path,
             allow_claim_status_drift=args.action == "recover",
             require_current=args.action not in {"inspect", "recover"},
+        )
+        resolve_vault_root_authority(
+            database_path=path,
+            config=database.get("config"),
         )
         commands = {
             "normalize": command_normalize,
@@ -995,7 +1003,7 @@ def main(argv=None):
             args,
             expected_snapshot=snapshot,
         )
-    except QueueStateError as exc:
+    except (QueueStateError, VaultRootAuthorityError) as exc:
         payload = {"ok": False, "error": str(exc)}
         print(str(exc), file=sys.stderr)
         print(json.dumps(payload, ensure_ascii=False))

--- a/skills/vault-ingress/scripts/vault_root_authority.py
+++ b/skills/vault-ingress/scripts/vault_root_authority.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Resolve one lexical, host-native authority for a rhetoric vault root.
+
+The tracking-database location is the primary authority.  An explicit CLI
+vault root and ``config.vault_storage_path`` are constraints on that authority,
+not aliases that may be resolved through the filesystem.  Every raw value is
+therefore classified before ``pathlib.Path`` materialization, and agreement is
+lexical: native ``Path`` equality only, with no home expansion, absolutization,
+filesystem resolution, or stat call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Literal, NoReturn
+
+from artifact_locator import ArtifactLocatorError, materialize_native_root
+
+
+VaultAuthority = Literal["database_path", "cli_root", "config_root"]
+VaultAuthorityPair = tuple[Literal["database_path"], Literal["cli_root", "config_root"]]
+
+_AUTHORITY_ERROR_CODES: dict[VaultAuthority, str] = {
+    "database_path": "vault_root_database_path_invalid",
+    "cli_root": "vault_root_cli_invalid",
+    "config_root": "vault_root_config_invalid",
+}
+_REASON_CODES = frozenset(
+    {
+        *_AUTHORITY_ERROR_CODES.values(),
+        "vault_root_authority_mismatch",
+    }
+)
+_AUTHORITY_PAIRS: frozenset[VaultAuthorityPair] = frozenset(
+    {
+        ("database_path", "cli_root"),
+        ("database_path", "config_root"),
+    }
+)
+
+
+class VaultRootAuthorityError(ValueError):
+    """A closed, path-neutral trusted-root authority rejection."""
+
+    def __init__(
+        self,
+        reason_code: str,
+        *,
+        locator_reason_code: str | None = None,
+        authorities: VaultAuthorityPair | None = None,
+    ) -> None:
+        if reason_code not in _REASON_CODES:
+            raise ValueError("invalid vault-root authority reason code")
+        if locator_reason_code is not None:
+            try:
+                ArtifactLocatorError(locator_reason_code)
+            except ValueError as exc:
+                raise ValueError("invalid artifact locator reason code") from exc
+        if authorities is not None and reason_code != "vault_root_authority_mismatch":
+            raise ValueError("authority pair is valid only for a root mismatch")
+        if reason_code == "vault_root_authority_mismatch" and authorities is None:
+            raise ValueError("root mismatch requires an authority pair")
+        if authorities is not None and authorities not in _AUTHORITY_PAIRS:
+            raise ValueError("invalid vault-root authority pair")
+        self.reason_code = reason_code
+        self.locator_reason_code = locator_reason_code
+        self.authorities = authorities
+        message = reason_code
+        if locator_reason_code is not None:
+            message = f"{message}:{locator_reason_code}"
+        if authorities is not None:
+            message = f"{message}:{authorities[0]}:{authorities[1]}"
+        super().__init__(message)
+
+
+def _reject(
+    reason_code: str,
+    *,
+    authorities: VaultAuthorityPair | None = None,
+) -> NoReturn:
+    raise VaultRootAuthorityError(reason_code, authorities=authorities)
+
+
+def materialize_native_authority(
+    raw: object,
+    *,
+    authority: VaultAuthority,
+) -> Path:
+    """Materialize one native absolute authority after lexical classification.
+
+    ``database_path`` identifies the tracking-database file. ``cli_root`` and
+    ``config_root`` identify the vault directory.  The distinction selects only
+    a stable diagnostic family; this function performs no filesystem access.
+    """
+    if authority not in _AUTHORITY_ERROR_CODES:
+        raise ValueError("invalid vault-root authority kind")
+    try:
+        return materialize_native_root(raw)
+    except ArtifactLocatorError as exc:
+        raise VaultRootAuthorityError(
+            _AUTHORITY_ERROR_CODES[authority],
+            locator_reason_code=exc.reason_code,
+        ) from exc
+
+
+def resolve_vault_root_authority(
+    *,
+    database_path: object,
+    config: object,
+    cli_vault_root: object | None = None,
+) -> Path:
+    """Return the database-bound vault root after all authorities agree.
+
+    A missing config object, an absent ``vault_storage_path`` key, and an
+    explicit JSON null all fall back to the database parent.  Every other
+    configured value is an asserted authority: invalid or lexically different
+    values fail closed.
+    """
+    cli_root = None
+    if cli_vault_root is not None:
+        cli_root = materialize_native_authority(
+            cli_vault_root,
+            authority="cli_root",
+        )
+
+    native_database_path = materialize_native_authority(
+        database_path,
+        authority="database_path",
+    )
+    database_root = native_database_path.parent
+
+    if cli_root is not None and cli_root != database_root:
+        _reject(
+            "vault_root_authority_mismatch",
+            authorities=("database_path", "cli_root"),
+        )
+
+    if config is None:
+        return database_root
+    if not isinstance(config, Mapping):
+        _reject("vault_root_config_invalid")
+    if "vault_storage_path" not in config:
+        return database_root
+
+    configured_raw = config["vault_storage_path"]
+    if configured_raw is None:
+        return database_root
+    configured_root = materialize_native_authority(
+        configured_raw,
+        authority="config_root",
+    )
+    if configured_root != database_root:
+        _reject(
+            "vault_root_authority_mismatch",
+            authorities=("database_path", "config_root"),
+        )
+    return database_root
+
+
+__all__ = [
+    "VaultAuthority",
+    "VaultAuthorityPair",
+    "VaultRootAuthorityError",
+    "materialize_native_authority",
+    "resolve_vault_root_authority",
+]

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -97,6 +97,11 @@ from tracking_database_io import (
     decode_json_object,
     snapshot_tracking_database,
 )
+from vault_root_authority import (
+    VaultRootAuthorityError,
+    materialize_native_authority,
+    resolve_vault_root_authority,
+)
 
 # structured_data keys rendered as their own table rather than inline, because
 # they are per-slide row collections and read as noise in a bullet list.
@@ -1085,13 +1090,6 @@ def parse_args(argv):
 def main():
     batch_path, out_dir, run_date, talks_path = parse_args(sys.argv[1:])
 
-    returns = load_json(batch_path, "batch-returns")
-    try:
-        catalog = validate_batch(returns)
-    except ReturnValidationError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        sys.exit(1)
-
     if not talks_path:
         print(
             "ERROR: --talks <tracking-database.json> is required so queue "
@@ -1099,6 +1097,17 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
+    try:
+        talks_path = str(
+            materialize_native_authority(
+                talks_path,
+                authority="database_path",
+            )
+        )
+    except VaultRootAuthorityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     db = load_tracking_database(talks_path)
     if not isinstance(db.get("talks"), list):
         print(
@@ -1112,12 +1121,20 @@ def main():
     source_roots: dict[str, object] = (
         copy.deepcopy(raw_config) if isinstance(raw_config, dict) else {}
     )
-    configured_vault = source_roots.get("vault_storage_path")
-    vault_root = (
-        os.path.abspath(os.path.expanduser(configured_vault))
-        if isinstance(configured_vault, str) and configured_vault.strip()
-        else os.path.dirname(os.path.abspath(talks_path))
-    )
+    try:
+        vault_root = resolve_vault_root_authority(
+            database_path=talks_path,
+            config=source_roots,
+        )
+    except VaultRootAuthorityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    returns = load_json(batch_path, "batch-returns")
+    try:
+        catalog = validate_batch(returns)
+    except ReturnValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
     artifact_capabilities_by_filename = assess_batch_artifact_capabilities(
         db["talks"],
         {

--- a/skills/vault-profile/references/schemas-config.md
+++ b/skills/vault-profile/references/schemas-config.md
@@ -32,7 +32,7 @@ ask the speaker.
   "config": {
     "schema_version": 1,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
-    "vault_storage_path": "/actual/path/if/custom (null when using default location)",
+    "vault_storage_path": "/native/absolute/database-parent (optional; null/absent uses that parent)",
     "pptx_source_dir": "/path/to/Presentations",
     "python_path": "/path/to/python3",
     "template_skip_patterns": ["template"],
@@ -65,6 +65,22 @@ ask the speaker.
   }
 }
 ```
+
+### Trusted vault storage root
+
+`vault_storage_path` is an optional assertion about the vault that contains
+`tracking-database.json`; it is not a redirect. Absent or JSON null uses the
+database parent. Every other present value must be a host-native absolute path
+lexically equal to that parent. Readers do not expand `~`, rebase relative,
+drive-relative (`C:vault`), or current-drive-rooted (`\vault`) values, translate
+foreign path flavors, collapse dot segments, or resolve symlinks to manufacture
+equality. Empty/blank and invalid locator forms fail closed before evidence
+freshness or profile cohort construction.
+
+Profile readers never repair this field. Use vault-ingress's expectation-bound
+owner mutation and rerun preflight before regenerating a profile; the concrete
+dry-run/apply/re-read sequence is documented in
+[source-identity-preflight.md](../../vault-ingress/references/source-identity-preflight.md#repair-a-stored-root-assertion).
 
 ## Shownotes Config — Field Reference
 

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -82,9 +82,14 @@ from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissin
     decode_json_object,
     snapshot_tracking_database,
 )
+from vault_root_authority import (  # noqa: E402
+    VaultRootAuthorityError,
+    materialize_native_authority,
+    resolve_vault_root_authority,
+)
 
 
-DEFAULT_VAULT = "~/.claude/rhetoric-knowledge-vault"
+DEFAULT_VAULT = pathlib.Path.home() / ".claude" / "rhetoric-knowledge-vault"
 
 # Talks processed on or after this date used the current extractor generation.
 # This partition supports extractor- and pacing-sensitive analysis only. Pattern
@@ -153,8 +158,11 @@ def _parse_args(argv: list[str]) -> tuple[pathlib.Path, str | None]:
             raise ValueError(f"unexpected extra argument {arg!r}")
         index += 1
 
+    raw_vault_root: object = (
+        DEFAULT_VAULT if vault_root_arg is None else vault_root_arg
+    )
     return (
-        pathlib.Path(vault_root_arg or DEFAULT_VAULT).expanduser().resolve(),
+        materialize_native_authority(raw_vault_root, authority="cli_root"),
         as_of,
     )
 
@@ -198,6 +206,15 @@ def main(argv: list[str]) -> int:
             + ", ".join(database_assessment.reason_codes),
             file=sys.stderr,
         )
+        return 1
+    try:
+        vault_root = resolve_vault_root_authority(
+            database_path=db_path,
+            config=db.get("config"),
+            cli_vault_root=vault_root,
+        )
+    except VaultRootAuthorityError as exc:
+        print(f"ERROR: trusted vault root is invalid: {exc}", file=sys.stderr)
         return 1
 
     summary_path = vault_root / "rhetoric-style-summary.md"

--- a/skills/vault-profile/scripts/pattern_cohort_snapshot.py
+++ b/skills/vault-profile/scripts/pattern_cohort_snapshot.py
@@ -37,6 +37,10 @@ from return_validation import (  # noqa: E402
     assess_current_persisted_pattern_evidence_freshness,
     load_catalog,
 )
+from vault_root_authority import (  # noqa: E402
+    VaultRootAuthorityError,
+    resolve_vault_root_authority,
+)
 
 
 class PatternCohortSnapshotError(ValueError):
@@ -62,12 +66,14 @@ def configured_evidence_freshness_assessor(
 ) -> EvidenceFreshnessAssessor:
     """Bind the shared evidence-freshness check to trusted live source roots."""
     source_roots = dict(config) if isinstance(config, Mapping) else {}
-    configured_vault = source_roots.get("vault_storage_path")
-    evidence_vault_root = (
-        pathlib.Path(configured_vault).expanduser().resolve()
-        if isinstance(configured_vault, str) and configured_vault.strip()
-        else vault_root.resolve()
-    )
+    try:
+        evidence_vault_root = resolve_vault_root_authority(
+            database_path=vault_root / "tracking-database.json",
+            config=config,
+            cli_vault_root=vault_root,
+        )
+    except VaultRootAuthorityError as exc:
+        raise PatternCohortSnapshotError(str(exc)) from exc
     freshness_cache: dict[int, tuple[str, ...]] = {}
 
     def assess(talk: Mapping[str, object]) -> tuple[str, ...]:

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -68,6 +68,11 @@ from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissin
     decode_json_object,
     snapshot_tracking_database,
 )
+from vault_root_authority import (  # noqa: E402
+    VaultRootAuthorityError,
+    materialize_native_authority,
+    resolve_vault_root_authority,
+)
 
 
 BLOCK_SCHEMA_VERSION = 2
@@ -694,7 +699,7 @@ def _parser() -> argparse.ArgumentParser:
     replace_parser = subparsers.add_parser("replace")
     replace_parser.add_argument("summary", type=Path)
     replace_parser.add_argument("pattern_profile", type=Path)
-    replace_parser.add_argument("tracking_database", type=Path)
+    replace_parser.add_argument("tracking_database")
     return parser
 
 
@@ -708,24 +713,34 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(assessment.as_status_dict(), sort_keys=True))
             return 0 if assessment.current_contract else 1
 
+        tracking_database_path = materialize_native_authority(
+            args.tracking_database,
+            authority="database_path",
+        )
+        tracking_database = _load_tracking_database(tracking_database_path)
+        vault_root = resolve_vault_root_authority(
+            database_path=tracking_database_path,
+            config=tracking_database.get("config"),
+        )
         candidate = _pattern_profile_candidate(_load_json(args.pattern_profile))
-        tracking_database = _load_tracking_database(args.tracking_database)
         result = replace_section15_current_block(
             args.summary,
             candidate,
             tracking_database,
             evidence_freshness_assessor=configured_evidence_freshness_assessor(
-                args.tracking_database.expanduser().resolve().parent,
-                (
-                    tracking_database.get("config")
-                    if isinstance(tracking_database, Mapping)
-                    else None
-                ),
+                vault_root,
+                tracking_database.get("config"),
             ),
         )
         print(json.dumps(result.as_dict(), sort_keys=True))
         return 0
-    except (OSError, UnicodeDecodeError, Section15PatternHistoryError) as exc:
+    except (
+        OSError,
+        UnicodeDecodeError,
+        PatternCohortSnapshotError,
+        Section15PatternHistoryError,
+        VaultRootAuthorityError,
+    ) as exc:
         print(str(exc), file=sys.stderr)
         return 1
 

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -50,6 +50,7 @@ from profile_pattern_provenance import (  # noqa: E402
 )
 from pattern_cohort_snapshot import (  # noqa: E402
     PatternCohortSnapshot,
+    PatternCohortSnapshotError,
     build_current_pattern_snapshot,
     configured_evidence_freshness_assessor,
 )
@@ -63,6 +64,10 @@ from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissin
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
+)
+from vault_root_authority import (  # noqa: E402
+    materialize_native_authority,
+    resolve_vault_root_authority,
 )
 
 
@@ -148,7 +153,10 @@ def _parse_args(argv: list[str]) -> tuple[pathlib.Path | None, pathlib.Path | No
             index += 1
             if index >= len(argv):
                 raise ValueError("--vault-root requires a path")
-            vault_root = pathlib.Path(argv[index]).expanduser().resolve()
+            vault_root = materialize_native_authority(
+                argv[index],
+                authority="cli_root",
+            )
         elif arg.startswith("-"):
             raise ValueError(f"unknown option {arg!r}")
         elif profile_path is None:
@@ -185,6 +193,11 @@ def _load_live_pattern_snapshot(
             "tracking-database.json has no usable prior state for this reader: "
             + ", ".join(assessment.reason_codes)
         )
+    vault_root = resolve_vault_root_authority(
+        database_path=database_path,
+        config=database.get("config"),
+        cli_vault_root=vault_root,
+    )
     talks = database.get("talks")
     if not isinstance(talks, list) or any(
         not isinstance(talk, Mapping) for talk in talks
@@ -399,10 +412,10 @@ def main(argv: list[str]) -> int:
     if vault_root is not None and isinstance(profile, Mapping):
         try:
             live_snapshot = _load_live_pattern_snapshot(vault_root, profile)
+        except PatternCohortSnapshotError as exc:
+            live_error = f"could not recompute the live pattern cohort: {exc}"
         except (json.JSONDecodeError, OSError, ValueError) as exc:
-            live_error = (
-                f"could not recompute the live pattern cohort from {vault_root}: {exc}"
-            )
+            live_error = f"could not recompute the live pattern cohort: {exc}"
 
     missing, errors, schema_version = validate_profile(
         profile,

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -1388,6 +1388,243 @@ def test_cli_writes_db_and_reports(persist_results, tmp_path):
     assert "slide_count" in report["talks"][0]["promoted"]
 
 
+@pytest.mark.parametrize("config_mode", ["absent", "null", "exact"])
+def test_cli_accepts_database_bound_vault_root_authority(
+    persist_results,
+    tmp_path,
+    config_mode,
+):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    database = {"talks": [_talk()]}
+    _db_json(database)
+    if config_mode == "null":
+        database["config"]["vault_storage_path"] = None
+    elif config_mode == "exact":
+        database["config"]["vault_storage_path"] = str(tmp_path)
+    db.write_text(json.dumps(database), encoding="utf-8")
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(db.read_text(encoding="utf-8"))["talks"][0]["status"] == (
+        "processed"
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="directory symlink setup is privileged",
+)
+@pytest.mark.parametrize("configured_identity", ["alias", "physical"])
+def test_cli_compares_symlinked_vault_roots_by_lexical_identity_before_persistence(
+    persist_results,
+    tmp_path,
+    configured_identity,
+):
+    physical_root = tmp_path / "physical-vault"
+    physical_root.mkdir()
+    alias_root = tmp_path / "alias-vault"
+    alias_root.symlink_to(physical_root, target_is_directory=True)
+    db = physical_root / "tracking-database.json"
+    alias_db = alias_root / db.name
+    batch = tmp_path / "batch-returns.json"
+    database = {"talks": [_talk()]}
+    _db_json(database)
+    configured_root = (
+        alias_root if configured_identity == "alias" else physical_root
+    )
+    database["config"]["vault_storage_path"] = str(configured_root)
+    db.write_text(json.dumps(database), encoding="utf-8")
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+    before = db.read_bytes()
+
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(alias_db), str(batch)],
+        capture_output=True,
+        text=True,
+    )
+
+    if configured_identity == "alias":
+        assert result.returncode == 0, result.stderr
+        assert json.loads(db.read_text(encoding="utf-8"))["talks"][0][
+            "status"
+        ] == "processed"
+    else:
+        assert result.returncode == 1
+        assert result.stderr == (
+            "ERROR: vault_root_authority_mismatch:database_path:config_root\n"
+        )
+        assert db.read_bytes() == before
+
+
+FOREIGN_ABSOLUTE_VAULT_ROOT = (
+    "/foreign/vault" if sys.platform == "win32" else r"C:\foreign\vault"
+)
+NATIVE_DOT_VAULT_ROOT = (
+    r"C:\trusted\other\..\vault"
+    if sys.platform == "win32"
+    else "/trusted/other/../vault"
+)
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "locator_reason"),
+    [
+        ("", "artifact_locator_empty_or_whitespace"),
+        (" ", "artifact_locator_empty_or_whitespace"),
+        ("relative/vault", "artifact_root_not_native_absolute"),
+        ("C:vault", "artifact_locator_windows_drive_relative"),
+        (r"\vault", "artifact_locator_windows_current_drive_rooted"),
+        (NATIVE_DOT_VAULT_ROOT, "artifact_locator_dot_segment"),
+        ("~/private-vault", "artifact_locator_home_expansion_unsupported"),
+        (FOREIGN_ABSOLUTE_VAULT_ROOT, "artifact_locator_foreign_absolute"),
+        (r"\\?\C:\private-vault", "artifact_locator_windows_device_namespace"),
+    ],
+)
+def test_cli_rejects_invalid_configured_vault_root_before_persistence(
+    persist_results,
+    tmp_path,
+    configured_root,
+    locator_reason,
+):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    database = {"talks": [_talk()]}
+    _db_json(database)
+    database["config"]["vault_storage_path"] = configured_root
+    original = json.dumps(database)
+    db.write_text(original, encoding="utf-8")
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == (
+        f"ERROR: vault_root_config_invalid:{locator_reason}\n"
+    )
+    assert "Traceback" not in result.stderr
+    if configured_root.strip():
+        assert configured_root not in result.stderr
+    assert db.read_text(encoding="utf-8") == original
+
+
+def test_cli_rejects_configured_vault_root_authority_mismatch(
+    persist_results,
+    tmp_path,
+):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    database = {"talks": [_talk()]}
+    _db_json(database)
+    mismatched_root = tmp_path / "other-vault"
+    database["config"]["vault_storage_path"] = str(mismatched_root)
+    original = json.dumps(database)
+    db.write_text(original, encoding="utf-8")
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, str(db), str(batch)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == (
+        "ERROR: vault_root_authority_mismatch:database_path:config_root\n"
+    )
+    assert str(mismatched_root) not in result.stderr
+    assert db.read_text(encoding="utf-8") == original
+
+
+def test_cli_rejects_relative_database_authority_before_open(
+    persist_results,
+    tmp_path,
+):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    database = {"talks": [_talk()]}
+    original = _db_json(database)
+    db.write_text(original, encoding="utf-8")
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, persist_results.__file__, db.name, str(batch)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == (
+        "ERROR: vault_root_database_path_invalid:"
+        "artifact_root_not_native_absolute\n"
+    )
+    assert db.name not in result.stderr
+    assert db.read_text(encoding="utf-8") == original
+
+
+def test_root_authority_rejection_precedes_every_artifact_and_write_boundary(
+    persist_results,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    db = tmp_path / "tracking-database.json"
+    batch = tmp_path / "batch-returns.json"
+    database = {"talks": [_talk()]}
+    _db_json(database)
+    database["config"]["vault_storage_path"] = "~/private-vault"
+    original = json.dumps(database)
+    db.write_text(original, encoding="utf-8")
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+    called = []
+
+    def forbidden(name):
+        def invoke(*_args, **_kwargs):
+            called.append(name)
+            raise AssertionError(f"{name} ran after root-authority rejection")
+
+        return invoke
+
+    for name in (
+        "load_json",
+        "validate_batch",
+        "assess_batch_artifact_capabilities",
+        "validate_batch_claims_against_talks",
+        "admit_return_artifacts",
+        "canonicalize_return_evidence",
+        "assess_current_persisted_pattern_evidence_freshness",
+        "atomic_write_json",
+    ):
+        monkeypatch.setattr(persist_results, name, forbidden(name))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [persist_results.__file__, str(db), str(batch)],
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        persist_results.main()
+
+    assert caught.value.code == 1
+    assert called == []
+    assert capsys.readouterr().err == (
+        "ERROR: vault_root_config_invalid:"
+        "artifact_locator_home_expansion_unsupported\n"
+    )
+    assert db.read_text(encoding="utf-8") == original
+
+
 def test_cli_fails_visibly_on_filename_mismatch(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -381,6 +381,296 @@ def test_preflight_input_and_finding_paths_are_lexical(
     assert validator.findings[0]["artifact_path"] == str(vault / "slides" / "talk.pptx")
 
 
+@pytest.mark.parametrize(
+    ("raw_root", "locator_reason_code"),
+    [
+        ("relative-vault", "artifact_root_not_native_absolute"),
+        ("~/vault", "artifact_locator_home_expansion_unsupported"),
+        (
+            foreign_absolute_locator("vault"),
+            "artifact_locator_foreign_absolute",
+        ),
+        (r"\\?\C:\vault", "artifact_locator_windows_device_namespace"),
+    ],
+)
+def test_preflight_rejects_direct_root_before_database_snapshot(
+    preflight_vault,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_root: str,
+    locator_reason_code: str,
+) -> None:
+    monkeypatch.setattr(
+        preflight_vault,
+        "snapshot_tracking_database",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid direct root reached the database snapshot boundary"
+        ),
+    )
+
+    report = preflight_vault.run_preflight(raw_root)
+
+    assert report["database"] is None
+    assert report["vault_root"] is None
+    assert report["blocking_count"] == 1
+    finding = report["findings"][0]
+    assert finding["code"] == "vault_root_cli_invalid"
+    assert finding["field"] == "cli.vault_root"
+    assert finding["actual"] == {
+        "reason_code": "vault_root_cli_invalid",
+        "locator_reason_code": locator_reason_code,
+    }
+    assert raw_root not in json.dumps(report, sort_keys=True)
+
+
+def test_preflight_labels_relative_direct_database_before_snapshot(
+    preflight_vault,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_database = "private-vault/tracking-database.json"
+    monkeypatch.setattr(
+        preflight_vault,
+        "snapshot_tracking_database",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid direct database reached the snapshot boundary"
+        ),
+    )
+
+    report = preflight_vault.run_preflight(raw_database)
+
+    assert report["database"] is None
+    assert report["vault_root"] is None
+    assert report["blocking_count"] == 1
+    finding = report["findings"][0]
+    assert finding["code"] == "vault_root_database_path_invalid"
+    assert finding["field"] == "database.path"
+    assert finding["actual"] == {
+        "reason_code": "vault_root_database_path_invalid",
+        "locator_reason_code": "artifact_root_not_native_absolute",
+    }
+    assert raw_database not in json.dumps(report, sort_keys=True)
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "expected_code", "expected_locator_reason"),
+    [
+        (
+            "",
+            "vault_root_config_invalid",
+            "artifact_locator_empty_or_whitespace",
+        ),
+        (
+            " ",
+            "vault_root_config_invalid",
+            "artifact_locator_empty_or_whitespace",
+        ),
+        (
+            "relative-vault",
+            "vault_root_config_invalid",
+            "artifact_root_not_native_absolute",
+        ),
+        (
+            "C:vault",
+            "vault_root_config_invalid",
+            "artifact_locator_windows_drive_relative",
+        ),
+        (
+            r"\vault",
+            "vault_root_config_invalid",
+            "artifact_locator_windows_current_drive_rooted",
+        ),
+        (
+            r"C:\trusted\other\..\vault"
+            if os.name == "nt"
+            else "/trusted/other/../vault",
+            "vault_root_config_invalid",
+            "artifact_locator_dot_segment",
+        ),
+        (
+            "~/vault",
+            "vault_root_config_invalid",
+            "artifact_locator_home_expansion_unsupported",
+        ),
+        (
+            foreign_absolute_locator("vault"),
+            "vault_root_config_invalid",
+            "artifact_locator_foreign_absolute",
+        ),
+        (
+            r"\\?\C:\vault",
+            "vault_root_config_invalid",
+            "artifact_locator_windows_device_namespace",
+        ),
+    ],
+)
+def test_preflight_rejects_invalid_configured_vault_root_before_catalog_checks(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch: pytest.MonkeyPatch,
+    configured_root: str,
+    expected_code: str,
+    expected_locator_reason: str,
+) -> None:
+    write_database(
+        vault_fixture,
+        [],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "vault_storage_path": configured_root,
+        },
+    )
+    monkeypatch.setattr(
+        preflight_vault.VaultPreflight,
+        "_validate_filenames",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid configured vault root reached catalog checks"
+        ),
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["blocking_count"] == 1
+    finding = report["findings"][0]
+    assert finding["code"] == expected_code
+    assert finding["field"] == "config.vault_storage_path"
+    assert finding["actual"] == {
+        "reason_code": expected_code,
+        "locator_reason_code": expected_locator_reason,
+    }
+    if configured_root.strip():
+        assert configured_root not in json.dumps(finding, sort_keys=True)
+
+
+def test_preflight_rejects_configured_vault_authority_mismatch_before_catalog_checks(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured_root = vault_fixture["root"].parent / "different-vault"
+    write_database(
+        vault_fixture,
+        [],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "vault_storage_path": str(configured_root),
+        },
+    )
+    monkeypatch.setattr(
+        preflight_vault.VaultPreflight,
+        "_validate_filenames",
+        lambda *_args, **_kwargs: pytest.fail(
+            "mismatched vault root reached catalog checks"
+        ),
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["blocking_count"] == 1
+    finding = report["findings"][0]
+    assert finding["code"] == "vault_root_authority_mismatch"
+    assert finding["field"] == "config.vault_storage_path"
+    assert finding["actual"] == {
+        "reason_code": "vault_root_authority_mismatch",
+        "authorities": ["database_path", "config_root"],
+    }
+    assert str(configured_root) not in json.dumps(finding, sort_keys=True)
+
+
+def test_preflight_names_cli_authority_when_database_parent_disagrees(
+    preflight_vault,
+    tmp_path: Path,
+) -> None:
+    cli_root = tmp_path / "cli-vault"
+    database_path = tmp_path / "database-vault" / "tracking-database.json"
+    validator = preflight_vault.VaultPreflight(
+        {"config": {}, "talks": []},
+        cli_root,
+        database_path,
+    )
+
+    report = validator.run()
+
+    assert report["blocking_count"] == 1
+    finding = report["findings"][0]
+    assert finding["code"] == "vault_root_authority_mismatch"
+    assert finding["field"] == "cli.vault_root"
+    assert finding["actual"] == {
+        "reason_code": "vault_root_authority_mismatch",
+        "authorities": ["database_path", "cli_root"],
+    }
+    diagnostic = json.dumps(finding, sort_keys=True)
+    assert str(cli_root) not in diagnostic
+    assert str(database_path) not in diagnostic
+
+
+@pytest.mark.parametrize("configured", [None, "same"])
+def test_preflight_accepts_null_or_matching_configured_vault_authority(
+    preflight_vault,
+    vault_fixture,
+    configured: str | None,
+) -> None:
+    configured_value = str(vault_fixture["root"]) if configured == "same" else None
+    write_database(
+        vault_fixture,
+        [],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "vault_storage_path": configured_value,
+        },
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["blocking_count"] == 0
+    assert not any(
+        finding["code"].startswith("vault_root_") for finding in report["findings"]
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="directory symlink setup is privileged",
+)
+@pytest.mark.parametrize("configured_identity", ["alias", "physical"])
+def test_preflight_compares_symlinked_vault_roots_by_lexical_identity(
+    preflight_vault,
+    vault_fixture,
+    tmp_path: Path,
+    configured_identity: str,
+) -> None:
+    physical_root = vault_fixture["root"]
+    alias_root = tmp_path / "alias-vault"
+    alias_root.symlink_to(physical_root, target_is_directory=True)
+    configured_root = (
+        alias_root if configured_identity == "alias" else physical_root
+    )
+    write_database(
+        vault_fixture,
+        [],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "vault_storage_path": str(configured_root),
+        },
+    )
+
+    report = preflight_vault.run_preflight(alias_root)
+
+    if configured_identity == "alias":
+        assert report["blocking_count"] == 0
+        assert report["vault_root"] == str(alias_root)
+        assert report["database"] == str(alias_root / "tracking-database.json")
+    else:
+        assert report["blocking_count"] == 1
+        finding = report["findings"][0]
+        assert finding["code"] == "vault_root_authority_mismatch"
+        assert finding["actual"] == {
+            "reason_code": "vault_root_authority_mismatch",
+            "authorities": ["database_path", "config_root"],
+        }
+        diagnostic = json.dumps(finding, sort_keys=True)
+        assert str(alias_root) not in diagnostic
+        assert str(physical_root) not in diagnostic
+
+
 def test_pptx_artifact_validation_never_calls_parent_is_file(
     preflight_vault,
     vault_fixture,

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -302,6 +302,206 @@ def _claim(path, *, run_id="run-1", batch_id="batch-1", limit=5, filenames=()):
     return _run(path, *arguments)
 
 
+@pytest.mark.parametrize(
+    "configured_root",
+    (None, "matching"),
+)
+def test_queue_uses_database_parent_as_the_single_vault_authority(
+    tmp_path,
+    configured_root,
+):
+    config = (
+        {"vault_storage_path": str(tmp_path)}
+        if configured_root == "matching"
+        else {"vault_storage_path": None}
+    )
+    path = _write_db(tmp_path, [], config=config)
+
+    result = _run(path, "normalize")
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["normalizations"] == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="directory symlink setup is privileged")
+@pytest.mark.parametrize("configured_identity", ["alias", "physical"])
+def test_queue_compares_symlinked_vault_roots_by_lexical_identity(
+    tmp_path,
+    configured_identity,
+):
+    physical_root = tmp_path / "physical-vault"
+    physical_root.mkdir()
+    alias_root = tmp_path / "alias-vault"
+    alias_root.symlink_to(physical_root, target_is_directory=True)
+    configured_root = (
+        alias_root if configured_identity == "alias" else physical_root
+    )
+    database = _write_db(
+        physical_root,
+        [],
+        config={"vault_storage_path": str(configured_root)},
+    )
+    alias_database = alias_root / database.name
+    before = database.read_bytes()
+
+    result = _run(alias_database, "normalize")
+
+    if configured_identity == "alias":
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)["normalizations"] == []
+    else:
+        assert result.returncode == 2
+        assert json.loads(result.stdout)["error"] == (
+            "vault_root_authority_mismatch:database_path:config_root"
+        )
+        assert database.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "locator_reason"),
+    (
+        ("", "artifact_locator_empty_or_whitespace"),
+        (" ", "artifact_locator_empty_or_whitespace"),
+        ("relative/credential-bearing-vault", "artifact_root_not_native_absolute"),
+        ("C:vault", "artifact_locator_windows_drive_relative"),
+        (r"\vault", "artifact_locator_windows_current_drive_rooted"),
+        (
+            r"C:\trusted\other\..\vault"
+            if os.name == "nt"
+            else "/trusted/other/../vault",
+            "artifact_locator_dot_segment",
+        ),
+        ("~/credential-bearing-vault", "artifact_locator_home_expansion_unsupported"),
+        (
+            r"\\?\C:\credential-bearing\vault",
+            "artifact_locator_windows_device_namespace",
+        ),
+    ),
+)
+def test_queue_rejects_invalid_configured_root_without_mutation_or_path_leak(
+    tmp_path,
+    configured_root,
+    locator_reason,
+):
+    path = _write_db(
+        tmp_path,
+        [],
+        config={"vault_storage_path": configured_root},
+    )
+    before = path.read_bytes()
+
+    result = _run(path, "normalize")
+
+    assert result.returncode == 2
+    expected = f"vault_root_config_invalid:{locator_reason}"
+    assert json.loads(result.stdout) == {"ok": False, "error": expected}
+    assert result.stderr.strip() == expected
+    assert "credential-bearing" not in result.stdout
+    assert "credential-bearing" not in result.stderr
+    assert path.read_bytes() == before
+
+
+def test_queue_rejects_foreign_configured_root_without_mutation(tmp_path):
+    configured_root = (
+        "/foreign/credential-bearing-vault"
+        if os.name == "nt"
+        else r"C:\foreign\credential-bearing-vault"
+    )
+    path = _write_db(
+        tmp_path,
+        [],
+        config={"vault_storage_path": configured_root},
+    )
+    before = path.read_bytes()
+
+    result = _run(path, "normalize")
+
+    assert result.returncode == 2
+    expected = "vault_root_config_invalid:artifact_locator_foreign_absolute"
+    assert json.loads(result.stdout) == {"ok": False, "error": expected}
+    assert configured_root not in result.stdout
+    assert configured_root not in result.stderr
+    assert path.read_bytes() == before
+
+
+def test_queue_rejects_lexically_different_configured_root(tmp_path):
+    other_root = tmp_path / "other-credential-bearing-vault"
+    path = _write_db(
+        tmp_path,
+        [],
+        config={"vault_storage_path": str(other_root)},
+    )
+    before = path.read_bytes()
+
+    result = _run(path, "normalize")
+
+    assert result.returncode == 2
+    expected = "vault_root_authority_mismatch:database_path:config_root"
+    assert json.loads(result.stdout) == {"ok": False, "error": expected}
+    assert result.stderr.strip() == expected
+    assert str(other_root) not in result.stdout
+    assert str(other_root) not in result.stderr
+    assert path.read_bytes() == before
+
+
+def test_queue_classifies_database_path_before_snapshot(
+    queue_state,
+    monkeypatch,
+    capsys,
+):
+    def forbidden_snapshot(*_args, **_kwargs):
+        raise AssertionError("snapshot must not run for an invalid database authority")
+
+    monkeypatch.setattr(queue_state, "load_database_snapshot", forbidden_snapshot)
+
+    result = queue_state.main(
+        [
+            "relative/credential-bearing/tracking-database.json",
+            "inspect",
+            "--run-id",
+            "run-1",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    expected = "vault_root_database_path_invalid:artifact_root_not_native_absolute"
+    assert result == 2
+    assert json.loads(captured.out) == {"ok": False, "error": expected}
+    assert captured.err.strip() == expected
+    assert "credential-bearing" not in captured.out
+    assert "credential-bearing" not in captured.err
+
+
+def test_invalid_root_stops_before_queue_assessors(
+    tmp_path,
+    queue_state,
+    monkeypatch,
+    capsys,
+):
+    path = _write_db(
+        tmp_path,
+        [],
+        config={"vault_storage_path": "relative/vault"},
+    )
+
+    def forbidden_assessor(*_args, **_kwargs):
+        raise AssertionError("artifact assessor must not run for an invalid root")
+
+    monkeypatch.setattr(
+        queue_state,
+        "artifact_capability_assessor",
+        forbidden_assessor,
+    )
+
+    result = queue_state.main([str(path), "normalize"])
+
+    captured = capsys.readouterr()
+    expected = "vault_root_config_invalid:artifact_root_not_native_absolute"
+    assert result == 2
+    assert json.loads(captured.out) == {"ok": False, "error": expected}
+    assert captured.err.strip() == expected
+
+
 def test_claim_recovers_the_two_stranded_transcript_statuses(tmp_path):
     """The two real vault rows with videos must re-enter the processable queue."""
     talks = [

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -30,6 +30,28 @@ adherence_baseline = importlib.import_module("adherence_baseline")
 transcript_timing = importlib.import_module("transcript_timing")
 
 
+def _foreign_absolute_vault_root() -> str:
+    return "/foreign/vault" if sys.platform == "win32" else r"C:\foreign\vault"
+
+
+DOT_SEGMENT_VAULT_ROOT = (
+    r"C:\trusted\other\..\vault"
+    if sys.platform == "win32"
+    else "/trusted/other/../vault"
+)
+INVALID_VAULT_ROOT_LOCATORS = (
+    ("", "artifact_locator_empty_or_whitespace"),
+    ("   ", "artifact_locator_empty_or_whitespace"),
+    ("relative-vault", "artifact_root_not_native_absolute"),
+    ("C:vault", "artifact_locator_windows_drive_relative"),
+    ("~/vault", "artifact_locator_home_expansion_unsupported"),
+    (_foreign_absolute_vault_root(), "artifact_locator_foreign_absolute"),
+    (r"\\?\C:\vault", "artifact_locator_windows_device_namespace"),
+    (r"\vault", "artifact_locator_windows_current_drive_rooted"),
+    (DOT_SEGMENT_VAULT_ROOT, "artifact_locator_dot_segment"),
+)
+
+
 def _fresh_evidence(_talk: object) -> tuple[str, ...]:
     return ()
 
@@ -714,6 +736,261 @@ def test_section15_replace_cli_binds_real_vault_freshness(
     assert return_code == 0
     assert payload["changed"] is True
     assert section15.BLOCK_START in summary_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("database_locator", "locator_reason"),
+    INVALID_VAULT_ROOT_LOCATORS,
+)
+def test_replace_cli_rejects_invalid_database_locator_before_any_input_io(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    database_locator,
+    locator_reason,
+):
+    input_calls = []
+
+    def forbidden_input(*_args, **_kwargs):
+        input_calls.append("input_io")
+        pytest.fail("invalid tracking-database locator reached input I/O")
+
+    monkeypatch.setattr(section15, "_load_json", forbidden_input)
+    monkeypatch.setattr(section15, "_load_tracking_database", forbidden_input)
+
+    return_code = section15.main(
+        [
+            "replace",
+            str(tmp_path / "missing-summary.md"),
+            str(tmp_path / "missing-profile.json"),
+            database_locator,
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 1
+    assert captured.out == ""
+    assert input_calls == []
+    assert (
+        f"vault_root_database_path_invalid:{locator_reason}" in captured.err
+    )
+    if database_locator.strip():
+        assert database_locator not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "locator_reason"),
+    INVALID_VAULT_ROOT_LOCATORS,
+)
+def test_replace_cli_rejects_invalid_config_before_freshness_or_summary_io(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    configured_root,
+    locator_reason,
+):
+    profile_path = tmp_path / "pattern-profile.json"
+    profile_path.write_text(json.dumps(_pattern_profile()), encoding="utf-8")
+    database_path = tmp_path / "tracking-database.json"
+    database_path.write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": configured_root},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    summary_path = tmp_path / "missing-summary.md"
+    monkeypatch.setattr(
+        section15,
+        "_load_json",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid configured root reached profile input I/O"
+        ),
+    )
+    monkeypatch.setattr(
+        section15,
+        "configured_evidence_freshness_assessor",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid configured root reached freshness assessment"
+        ),
+    )
+
+    return_code = section15.main(
+        [
+            "replace",
+            str(summary_path),
+            str(profile_path),
+            str(database_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 1
+    assert captured.out == ""
+    assert not summary_path.exists()
+    assert f"vault_root_config_invalid:{locator_reason}" in captured.err
+    if configured_root.strip():
+        assert configured_root not in captured.err
+
+
+def _section15_directory_symlink(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory policy does not permit symlink creation")
+
+
+def test_replace_cli_accepts_matching_symlink_lexical_authority(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    locator = tmp_path / "vault-alias"
+    _section15_directory_symlink(locator, storage)
+    profile_path = tmp_path / "pattern-profile.json"
+    profile_path.write_text("{}", encoding="utf-8")
+    database_path = storage / "tracking-database.json"
+    database_path.write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": str(locator)},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    observed = {}
+
+    def capture_freshness(vault_root, config):
+        observed.update(vault_root=vault_root, config=config)
+        return _fresh_evidence
+
+    monkeypatch.setattr(
+        section15,
+        "configured_evidence_freshness_assessor",
+        capture_freshness,
+    )
+    monkeypatch.setattr(
+        section15,
+        "replace_section15_current_block",
+        lambda summary, *_args, **_kwargs: section15.Section15WriteResult(
+            path=str(summary),
+            changed=False,
+            scored_talk_count=0,
+            eligible_talk_count=0,
+            catalog_fields_available=True,
+        ),
+    )
+
+    return_code = section15.main(
+        [
+            "replace",
+            str(tmp_path / "unused-summary.md"),
+            str(profile_path),
+            str(locator / "tracking-database.json"),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 0, captured.err
+    assert observed == {
+        "vault_root": locator,
+        "config": {"vault_storage_path": str(locator)},
+    }
+
+
+def test_replace_cli_rejects_symlink_target_locator_mismatch_without_paths(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    storage = tmp_path / "credential-bearing-storage"
+    storage.mkdir()
+    locator = tmp_path / "credential-bearing-alias"
+    _section15_directory_symlink(locator, storage)
+    profile_path = tmp_path / "pattern-profile.json"
+    profile_path.write_text("{}", encoding="utf-8")
+    database_path = storage / "tracking-database.json"
+    database_path.write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": str(storage)},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        section15,
+        "configured_evidence_freshness_assessor",
+        lambda *_args, **_kwargs: pytest.fail(
+            "mismatched root reached freshness assessment"
+        ),
+    )
+
+    return_code = section15.main(
+        [
+            "replace",
+            str(tmp_path / "missing-summary.md"),
+            str(profile_path),
+            str(locator / "tracking-database.json"),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 1
+    assert captured.out == ""
+    assert (
+        "vault_root_authority_mismatch:database_path:config_root"
+        in captured.err
+    )
+    assert str(storage) not in captured.err
+    assert str(locator) not in captured.err
+
+
+def test_replace_cli_catches_freshness_authority_error_without_traceback(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    profile_path = tmp_path / "pattern-profile.json"
+    profile_path.write_text("{}", encoding="utf-8")
+    database_path = tmp_path / "tracking-database.json"
+    database_path.write_text(
+        json.dumps({"config": {}, "talks": []}),
+        encoding="utf-8",
+    )
+
+    def fail_freshness(*_args, **_kwargs):
+        raise section15.PatternCohortSnapshotError(
+            "vault_root_config_invalid:artifact_locator_dot_segment"
+        )
+
+    monkeypatch.setattr(
+        section15,
+        "configured_evidence_freshness_assessor",
+        fail_freshness,
+    )
+
+    return_code = section15.main(
+        [
+            "replace",
+            str(tmp_path / "missing-summary.md"),
+            str(profile_path),
+            str(database_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert return_code == 1
+    assert captured.out == ""
+    assert "vault_root_config_invalid:artifact_locator_dot_segment" in captured.err
+    assert str(tmp_path) not in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_replace_cli_gates_future_database_before_config_path_semantics(

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -8,6 +8,7 @@ optional/additive and not part of REQUIRED_KEYS.
 import hashlib
 import importlib
 import json
+import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -18,6 +19,30 @@ from pptx import Presentation
 CATALOG = "c" * 64
 OTHER_CATALOG = "d" * 64
 AS_OF = "2026-07-31T13:30:45.987654-05:00"
+
+
+def foreign_absolute_locator(name: str) -> str:
+    if os.name == "nt":
+        return f"/foreign/{name}"
+    return rf"C:\foreign\{name}"
+
+
+DOT_SEGMENT_VAULT_ROOT = (
+    r"C:\trusted\other\..\vault"
+    if os.name == "nt"
+    else "/trusted/other/../vault"
+)
+INVALID_VAULT_ROOT_LOCATORS = (
+    ("", "artifact_locator_empty_or_whitespace"),
+    ("   ", "artifact_locator_empty_or_whitespace"),
+    ("relative-vault", "artifact_root_not_native_absolute"),
+    ("C:vault", "artifact_locator_windows_drive_relative"),
+    ("~/vault", "artifact_locator_home_expansion_unsupported"),
+    (foreign_absolute_locator("vault"), "artifact_locator_foreign_absolute"),
+    (r"\\?\C:\vault", "artifact_locator_windows_device_namespace"),
+    (r"\vault", "artifact_locator_windows_current_drive_rooted"),
+    (DOT_SEGMENT_VAULT_ROOT, "artifact_locator_dot_segment"),
+)
 
 
 def _catalog_projection(source: str | None = "transcript"):
@@ -833,7 +858,7 @@ def test_load_vault_passes_configured_source_roots_to_freshness_assessor(
     assert payload["pattern_scoring_exclusions"] == []
 
 
-def test_load_vault_uses_configured_vault_storage_root_for_freshness(
+def test_load_vault_rejects_mismatched_vault_storage_root_before_freshness(
     load_vault,
     tmp_path,
     monkeypatch,
@@ -900,14 +925,446 @@ def test_load_vault_uses_configured_vault_storage_root_for_freshness(
         [talk],
         config={"vault_storage_path": str(evidence_root)},
     )
+    cohort_snapshot = importlib.import_module("pattern_cohort_snapshot")
+    monkeypatch.setattr(
+        cohort_snapshot,
+        "assess_current_persisted_pattern_evidence_freshness",
+        lambda *_args, **_kwargs: pytest.fail(
+            "mismatched root reached the evidence freshness assessor"
+        ),
+    )
 
     rc, payload, error = _run_load_vault(load_vault, database_root, monkeypatch, capsys)
 
-    assert rc == 0
-    assert error == ""
-    assert [talk["filename"] for talk in payload["baseline_talks"]] == [
-        "configured-vault.md"
-    ], json.dumps(payload["pattern_scoring_exclusions"], indent=2)
+    assert rc == 1
+    assert payload is None
+    assert "vault_root_authority_mismatch:database_path:config_root" in error
+    assert str(evidence_root) not in error
+
+
+def test_load_vault_default_is_an_already_native_absolute_path(load_vault):
+    vault_root, as_of = load_vault._parse_args(["load-vault.py"])
+
+    assert as_of is None
+    assert vault_root == load_vault.DEFAULT_VAULT
+    assert vault_root.is_absolute()
+    assert "~" not in str(vault_root)
+
+
+@pytest.mark.parametrize(
+    ("cli_root", "locator_reason"),
+    INVALID_VAULT_ROOT_LOCATORS,
+)
+def test_load_vault_rejects_invalid_explicit_root_before_any_vault_io(
+    load_vault,
+    monkeypatch,
+    capsys,
+    cli_root,
+    locator_reason,
+):
+    io_calls = []
+
+    def forbidden_io(*_args, **_kwargs):
+        io_calls.append("vault_io")
+        pytest.fail("invalid CLI root reached vault I/O")
+
+    monkeypatch.setattr(load_vault.pathlib.Path, "exists", forbidden_io)
+    monkeypatch.setattr(load_vault, "snapshot_tracking_database", forbidden_io)
+
+    rc = load_vault.main(["load-vault.py", cli_root])
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert captured.out == ""
+    assert (
+        f"vault_root_cli_invalid:{locator_reason}" in captured.err
+    )
+    assert io_calls == []
+    if cli_root.strip():
+        assert cli_root not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "locator_reason"),
+    INVALID_VAULT_ROOT_LOCATORS,
+)
+def test_load_vault_rejects_invalid_config_before_summary_or_freshness_io(
+    load_vault,
+    tmp_path,
+    monkeypatch,
+    capsys,
+    configured_root,
+    locator_reason,
+):
+    (tmp_path / "tracking-database.json").write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": configured_root},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        load_vault,
+        "configured_evidence_freshness_assessor",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid configured root reached freshness assessment"
+        ),
+    )
+
+    rc = load_vault.main(["load-vault.py", str(tmp_path), "--as-of", AS_OF])
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert captured.out == ""
+    assert not (tmp_path / "rhetoric-style-summary.md").exists()
+    assert (
+        f"vault_root_config_invalid:{locator_reason}" in captured.err
+    )
+    if configured_root.strip():
+        assert configured_root not in captured.err
+
+
+def _directory_symlink(link, target):
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory policy does not permit symlink creation")
+
+
+def test_load_vault_accepts_one_matching_lexical_symlink_authority(
+    load_vault,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    locator = tmp_path / "vault-alias"
+    _directory_symlink(locator, storage)
+    _write_vault(storage, [], config={"vault_storage_path": str(locator)})
+
+    rc, payload, error = _run_load_vault(
+        load_vault,
+        locator,
+        monkeypatch,
+        capsys,
+    )
+
+    assert rc == 0, error
+    assert payload["vault_root"] == str(locator)
+
+
+def test_load_vault_rejects_symlink_target_and_locator_authority_mismatch(
+    load_vault,
+    tmp_path,
+    capsys,
+):
+    storage = tmp_path / "credential-bearing-storage"
+    storage.mkdir()
+    locator = tmp_path / "credential-bearing-alias"
+    _directory_symlink(locator, storage)
+    (storage / "tracking-database.json").write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": str(storage)},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = load_vault.main(["load-vault.py", str(locator), "--as-of", AS_OF])
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert captured.out == ""
+    assert (
+        "vault_root_authority_mismatch:database_path:config_root"
+        in captured.err
+    )
+    assert str(storage) not in captured.err
+    assert str(locator) not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "locator_reason"),
+    INVALID_VAULT_ROOT_LOCATORS,
+)
+def test_profile_cohort_rejects_invalid_configured_vault_before_freshness(
+    validate_profile,
+    tmp_path,
+    monkeypatch,
+    configured_root,
+    locator_reason,
+):
+    del validate_profile
+    cohort_snapshot = importlib.import_module("pattern_cohort_snapshot")
+    monkeypatch.setattr(
+        cohort_snapshot,
+        "assess_current_persisted_pattern_evidence_freshness",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid root reached the evidence freshness assessor"
+        ),
+    )
+
+    with pytest.raises(cohort_snapshot.PatternCohortSnapshotError) as caught:
+        cohort_snapshot.configured_evidence_freshness_assessor(
+            tmp_path,
+            {"vault_storage_path": configured_root},
+        )
+
+    assert str(caught.value) == f"vault_root_config_invalid:{locator_reason}"
+    if configured_root.strip():
+        assert configured_root not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "config_factory",
+    [
+        lambda _root: {},
+        lambda _root: {"vault_storage_path": None},
+        lambda root: {"vault_storage_path": str(root)},
+    ],
+    ids=["absent", "null", "matching"],
+)
+def test_profile_cohort_uses_database_root_for_every_valid_authority_form(
+    validate_profile,
+    tmp_path,
+    monkeypatch,
+    config_factory,
+):
+    del validate_profile
+    cohort_snapshot = importlib.import_module("pattern_cohort_snapshot")
+    observed = []
+
+    def assess(_talk, **kwargs):
+        observed.append(kwargs)
+        return ()
+
+    monkeypatch.setattr(
+        cohort_snapshot,
+        "assess_current_persisted_pattern_evidence_freshness",
+        assess,
+    )
+    config = config_factory(tmp_path)
+
+    assessor = cohort_snapshot.configured_evidence_freshness_assessor(
+        tmp_path,
+        config,
+    )
+
+    assert assessor({}) == ()
+    assert observed == [
+        {
+            "vault_root": tmp_path,
+            "source_roots": config,
+            "catalog": None,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("cli_root", "locator_reason"),
+    INVALID_VAULT_ROOT_LOCATORS,
+)
+def test_validate_profile_rejects_invalid_cli_root_before_profile_or_database_io(
+    validate_profile,
+    monkeypatch,
+    capsys,
+    cli_root,
+    locator_reason,
+):
+    io_calls = []
+
+    def forbidden_io(*_args, **_kwargs):
+        io_calls.append("profile_or_database_io")
+        pytest.fail("invalid CLI root reached profile or database I/O")
+
+    monkeypatch.setattr(validate_profile, "_load_input", forbidden_io)
+    monkeypatch.setattr(validate_profile, "snapshot_tracking_database", forbidden_io)
+
+    rc = validate_profile.main(
+        ["validate-profile.py", "--vault-root", cli_root]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert io_calls == []
+    assert f"vault_root_cli_invalid:{locator_reason}" in captured.err
+    if cli_root.strip():
+        assert cli_root not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "locator_reason"),
+    INVALID_VAULT_ROOT_LOCATORS,
+)
+def test_validate_profile_rejects_invalid_config_before_freshness(
+    validate_profile,
+    tmp_path,
+    monkeypatch,
+    capsys,
+    configured_root,
+    locator_reason,
+):
+    profile = _minimal_profile(validate_profile)
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text(json.dumps(profile), encoding="utf-8")
+    (tmp_path / "tracking-database.json").write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": configured_root},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        validate_profile,
+        "configured_evidence_freshness_assessor",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid configured root reached freshness assessment"
+        ),
+    )
+
+    rc = validate_profile.main(
+        [
+            "validate-profile.py",
+            str(profile_path),
+            "--vault-root",
+            str(tmp_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert f"vault_root_config_invalid:{locator_reason}" in captured.err
+    if configured_root.strip():
+        assert configured_root not in captured.err
+
+
+def test_validate_profile_accepts_matching_symlink_lexical_authority(
+    validate_profile,
+    tmp_path,
+    capsys,
+):
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    locator = tmp_path / "vault-alias"
+    _directory_symlink(locator, storage)
+    profile = _minimal_profile(validate_profile)
+    profile_path = storage / "profile.json"
+    profile_path.write_text(json.dumps(profile), encoding="utf-8")
+    (storage / "tracking-database.json").write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": str(locator)},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = validate_profile.main(
+        [
+            "validate-profile.py",
+            str(profile_path),
+            "--vault-root",
+            str(locator),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0, captured.err
+    assert json.loads(captured.out)["valid"] is True
+
+
+def test_validate_profile_rejects_symlink_target_locator_mismatch_without_paths(
+    validate_profile,
+    tmp_path,
+    capsys,
+):
+    storage = tmp_path / "credential-bearing-storage"
+    storage.mkdir()
+    locator = tmp_path / "credential-bearing-alias"
+    _directory_symlink(locator, storage)
+    profile_path = storage / "profile.json"
+    profile_path.write_text(
+        json.dumps(_minimal_profile(validate_profile)),
+        encoding="utf-8",
+    )
+    (storage / "tracking-database.json").write_text(
+        json.dumps(
+            {
+                "config": {"vault_storage_path": str(storage)},
+                "talks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = validate_profile.main(
+        [
+            "validate-profile.py",
+            str(profile_path),
+            "--vault-root",
+            str(locator),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert (
+        "vault_root_authority_mismatch:database_path:config_root"
+        in captured.err
+    )
+    assert str(storage) not in captured.err
+    assert str(locator) not in captured.err
+
+
+def test_validate_profile_catches_cohort_authority_error_without_raw_root_prefix(
+    validate_profile,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text(
+        json.dumps(_minimal_profile(validate_profile)),
+        encoding="utf-8",
+    )
+    (tmp_path / "tracking-database.json").write_text(
+        json.dumps({"config": {}, "talks": []}),
+        encoding="utf-8",
+    )
+
+    def fail_cohort(*_args, **_kwargs):
+        raise validate_profile.PatternCohortSnapshotError(
+            "vault_root_config_invalid:artifact_locator_dot_segment"
+        )
+
+    monkeypatch.setattr(
+        validate_profile,
+        "configured_evidence_freshness_assessor",
+        fail_cohort,
+    )
+
+    rc = validate_profile.main(
+        [
+            "validate-profile.py",
+            str(profile_path),
+            "--vault-root",
+            str(tmp_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "vault_root_config_invalid:artifact_locator_dot_segment" in captured.err
+    assert str(tmp_path) not in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_default_as_of_uses_injected_time_and_canonical_whole_seconds(load_vault):

--- a/tests/test_vault_root_authority.py
+++ b/tests/test_vault_root_authority.py
@@ -1,0 +1,221 @@
+"""Lexical trusted-vault-root authority contract tests."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+vault_root_authority = importlib.import_module("vault_root_authority")
+
+
+def _native_root_text(name: str = "vault") -> str:
+    if os.name == "nt":
+        return rf"C:\trusted\{name}"
+    return f"/trusted/{name}"
+
+
+def _native_database_text(name: str = "vault") -> str:
+    return str(Path(_native_root_text(name)) / "tracking-database.json")
+
+
+def _foreign_root_text() -> str:
+    return "/foreign/vault" if os.name == "nt" else r"C:\foreign\vault"
+
+
+def _native_dot_root_text() -> str:
+    return r"C:\trusted\other\..\vault" if os.name == "nt" else "/trusted/other/../vault"
+
+
+@pytest.mark.parametrize(
+    "config",
+    (
+        None,
+        {},
+        {"schema_version": 1},
+        {"vault_storage_path": None},
+    ),
+)
+def test_absent_or_null_configured_root_falls_back_to_database_parent(
+    config: object,
+) -> None:
+    resolved = vault_root_authority.resolve_vault_root_authority(
+        database_path=_native_database_text(),
+        config=config,
+    )
+
+    assert resolved == Path(_native_root_text())
+
+
+def test_matching_cli_and_config_roots_preserve_native_absolute_authority() -> None:
+    root = _native_root_text()
+    trailing_separator = "\\" if os.name == "nt" else "/"
+
+    resolved = vault_root_authority.resolve_vault_root_authority(
+        database_path=_native_database_text(),
+        config={"vault_storage_path": root + trailing_separator},
+        cli_vault_root=root,
+    )
+
+    assert resolved == Path(root)
+    assert resolved.is_absolute()
+
+
+@pytest.mark.parametrize(
+    ("raw", "locator_reason"),
+    (
+        ("", "artifact_locator_empty_or_whitespace"),
+        (" ", "artifact_locator_empty_or_whitespace"),
+        ("relative/vault", "artifact_root_not_native_absolute"),
+        ("C:vault", "artifact_locator_windows_drive_relative"),
+        (r"\vault", "artifact_locator_windows_current_drive_rooted"),
+        (_native_dot_root_text(), "artifact_locator_dot_segment"),
+        ("~/vault", "artifact_locator_home_expansion_unsupported"),
+        (
+            r"\\?\C:\credential-bearing\vault",
+            "artifact_locator_windows_device_namespace",
+        ),
+    ),
+)
+def test_present_invalid_configured_root_fails_closed(
+    raw: object,
+    locator_reason: str,
+) -> None:
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path=_native_database_text(),
+            config={"vault_storage_path": raw},
+        )
+
+    assert caught.value.reason_code == "vault_root_config_invalid"
+    assert caught.value.locator_reason_code == locator_reason
+    assert caught.value.authorities is None
+    assert str(caught.value) == f"vault_root_config_invalid:{locator_reason}"
+    assert "credential-bearing" not in str(caught.value)
+    assert "credential-bearing" not in repr(caught.value)
+
+
+def test_foreign_configured_root_fails_closed() -> None:
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path=_native_database_text(),
+            config={"vault_storage_path": _foreign_root_text()},
+        )
+
+    assert caught.value.reason_code == "vault_root_config_invalid"
+    assert caught.value.locator_reason_code == "artifact_locator_foreign_absolute"
+
+
+def test_dot_segment_configured_root_fails_before_lexical_comparison() -> None:
+    raw = r"C:\trusted\other\..\vault" if os.name == "nt" else "/trusted/other/../vault"
+
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path=_native_database_text(),
+            config={"vault_storage_path": raw},
+        )
+
+    assert caught.value.reason_code == "vault_root_config_invalid"
+    assert caught.value.locator_reason_code == "artifact_locator_dot_segment"
+
+
+@pytest.mark.parametrize("config", ("/trusted/vault", [], 7, True))
+def test_non_object_config_fails_closed(config: object) -> None:
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path=_native_database_text(),
+            config=config,
+        )
+
+    assert caught.value.reason_code == "vault_root_config_invalid"
+    assert caught.value.locator_reason_code is None
+    assert str(caught.value) == "vault_root_config_invalid"
+
+
+def test_configured_root_mismatch_names_only_the_closed_authorities() -> None:
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path=_native_database_text(),
+            config={"vault_storage_path": _native_root_text("other")},
+        )
+
+    assert caught.value.reason_code == "vault_root_authority_mismatch"
+    assert caught.value.locator_reason_code is None
+    assert caught.value.authorities == ("database_path", "config_root")
+    assert str(caught.value) == (
+        "vault_root_authority_mismatch:database_path:config_root"
+    )
+    assert "trusted" not in str(caught.value)
+
+
+def test_cli_root_mismatch_names_only_the_closed_authorities() -> None:
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path=_native_database_text(),
+            config=None,
+            cli_vault_root=_native_root_text("other"),
+        )
+
+    assert caught.value.reason_code == "vault_root_authority_mismatch"
+    assert caught.value.authorities == ("database_path", "cli_root")
+    assert str(caught.value) == ("vault_root_authority_mismatch:database_path:cli_root")
+
+
+def test_invalid_cli_root_is_classified_before_database_authority() -> None:
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path="also/relative.json",
+            config=None,
+            cli_vault_root="relative/vault",
+        )
+
+    assert caught.value.reason_code == "vault_root_cli_invalid"
+    assert caught.value.locator_reason_code == "artifact_root_not_native_absolute"
+
+
+def test_invalid_database_path_is_path_neutral() -> None:
+    secret = "credential-bearing/tracking-database.json"
+
+    with pytest.raises(vault_root_authority.VaultRootAuthorityError) as caught:
+        vault_root_authority.resolve_vault_root_authority(
+            database_path=secret,
+            config=None,
+        )
+
+    assert caught.value.reason_code == "vault_root_database_path_invalid"
+    assert caught.value.locator_reason_code == "artifact_root_not_native_absolute"
+    assert secret not in str(caught.value)
+    assert secret not in repr(caught.value)
+
+
+def test_error_constructor_rejects_open_diagnostics() -> None:
+    with pytest.raises(ValueError, match="invalid vault-root authority reason code"):
+        vault_root_authority.VaultRootAuthorityError("/secret/root")
+    with pytest.raises(ValueError, match="invalid artifact locator reason code"):
+        vault_root_authority.VaultRootAuthorityError(
+            "vault_root_config_invalid",
+            locator_reason_code="/secret/root",
+        )
+    with pytest.raises(ValueError, match="root mismatch requires an authority pair"):
+        vault_root_authority.VaultRootAuthorityError("vault_root_authority_mismatch")
+    with pytest.raises(ValueError, match="invalid vault-root authority pair"):
+        vault_root_authority.VaultRootAuthorityError(
+            "vault_root_authority_mismatch",
+            authorities=("database_path", "database_path"),
+        )
+
+
+def test_invalid_authority_selector_is_a_programming_error() -> None:
+    with pytest.raises(ValueError, match="invalid vault-root authority kind"):
+        vault_root_authority.materialize_native_authority(
+            _native_root_text(),
+            authority="untrusted",
+        )

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -924,6 +924,292 @@ def test_cli_uses_persisted_stamp_when_return_omits_processed_date(
     assert "**Processed:** 2026-07-27T14:03:22+00:00" in (out / "talk.md").read_text()
 
 
+@pytest.mark.parametrize("config_mode", ["absent", "null", "exact"])
+def test_cli_accepts_database_bound_vault_root_authority(
+    write_analysis,
+    tmp_path,
+    config_mode,
+):
+    batch = tmp_path / "batch-returns.json"
+    out = tmp_path / "analyses"
+    ret = _return()
+    batch.write_text(json.dumps([ret]), encoding="utf-8")
+    db = _write_tracking_db(tmp_path, [ret])
+    database = json.loads(db.read_text(encoding="utf-8"))
+    if config_mode == "null":
+        database["config"]["vault_storage_path"] = None
+    elif config_mode == "exact":
+        database["config"]["vault_storage_path"] = str(tmp_path)
+    db.write_text(json.dumps(database), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out / "talk.md").is_file()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="directory symlink setup is privileged",
+)
+@pytest.mark.parametrize("configured_identity", ["alias", "physical"])
+def test_cli_compares_symlinked_vault_roots_by_lexical_identity_before_write(
+    write_analysis,
+    tmp_path,
+    configured_identity,
+):
+    physical_root = tmp_path / "physical-vault"
+    physical_root.mkdir()
+    alias_root = tmp_path / "alias-vault"
+    alias_root.symlink_to(physical_root, target_is_directory=True)
+    batch = tmp_path / "batch-returns.json"
+    out = tmp_path / "analyses"
+    ret = _return()
+    batch.write_text(json.dumps([ret]), encoding="utf-8")
+    db = _write_tracking_db(
+        physical_root,
+        [ret],
+        name="tracking-database.json",
+    )
+    alias_db = alias_root / db.name
+    database = json.loads(db.read_text(encoding="utf-8"))
+    configured_root = (
+        alias_root if configured_identity == "alias" else physical_root
+    )
+    database["config"]["vault_storage_path"] = str(configured_root)
+    db.write_text(json.dumps(database), encoding="utf-8")
+    before = db.read_bytes()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(alias_db),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if configured_identity == "alias":
+        assert result.returncode == 0, result.stderr
+        assert (out / "talk.md").is_file()
+    else:
+        assert result.returncode == 1
+        assert result.stderr == (
+            "ERROR: vault_root_authority_mismatch:database_path:config_root\n"
+        )
+        assert db.read_bytes() == before
+        assert not out.exists()
+
+
+FOREIGN_ABSOLUTE_VAULT_ROOT = (
+    "/foreign/vault" if sys.platform == "win32" else r"C:\foreign\vault"
+)
+NATIVE_DOT_VAULT_ROOT = (
+    r"C:\trusted\other\..\vault"
+    if sys.platform == "win32"
+    else "/trusted/other/../vault"
+)
+
+
+@pytest.mark.parametrize(
+    ("configured_root", "locator_reason"),
+    [
+        ("", "artifact_locator_empty_or_whitespace"),
+        (" ", "artifact_locator_empty_or_whitespace"),
+        ("relative/vault", "artifact_root_not_native_absolute"),
+        ("C:vault", "artifact_locator_windows_drive_relative"),
+        (r"\vault", "artifact_locator_windows_current_drive_rooted"),
+        (NATIVE_DOT_VAULT_ROOT, "artifact_locator_dot_segment"),
+        ("~/private-vault", "artifact_locator_home_expansion_unsupported"),
+        (FOREIGN_ABSOLUTE_VAULT_ROOT, "artifact_locator_foreign_absolute"),
+        (r"\\?\C:\private-vault", "artifact_locator_windows_device_namespace"),
+    ],
+)
+def test_cli_rejects_invalid_configured_vault_root_before_analysis_write(
+    write_analysis,
+    tmp_path,
+    configured_root,
+    locator_reason,
+):
+    batch = tmp_path / "batch-returns.json"
+    out = tmp_path / "analyses"
+    ret = _return()
+    batch.write_text(json.dumps([ret]), encoding="utf-8")
+    db = _write_tracking_db(tmp_path, [ret])
+    database = json.loads(db.read_text(encoding="utf-8"))
+    database["config"]["vault_storage_path"] = configured_root
+    original = json.dumps(database)
+    db.write_text(original, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == (
+        f"ERROR: vault_root_config_invalid:{locator_reason}\n"
+    )
+    assert "Traceback" not in result.stderr
+    if configured_root.strip():
+        assert configured_root not in result.stderr
+    assert db.read_text(encoding="utf-8") == original
+    assert not out.exists()
+
+
+def test_cli_rejects_configured_vault_root_authority_mismatch_before_write(
+    write_analysis,
+    tmp_path,
+):
+    batch = tmp_path / "batch-returns.json"
+    out = tmp_path / "analyses"
+    ret = _return()
+    batch.write_text(json.dumps([ret]), encoding="utf-8")
+    db = _write_tracking_db(tmp_path, [ret])
+    database = json.loads(db.read_text(encoding="utf-8"))
+    mismatched_root = tmp_path / "other-vault"
+    database["config"]["vault_storage_path"] = str(mismatched_root)
+    original = json.dumps(database)
+    db.write_text(original, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == (
+        "ERROR: vault_root_authority_mismatch:database_path:config_root\n"
+    )
+    assert str(mismatched_root) not in result.stderr
+    assert db.read_text(encoding="utf-8") == original
+    assert not out.exists()
+
+
+def test_cli_rejects_relative_database_authority_before_open_or_write(
+    write_analysis,
+    tmp_path,
+):
+    batch = tmp_path / "batch-returns.json"
+    out = tmp_path / "analyses"
+    ret = _return()
+    batch.write_text(json.dumps([ret]), encoding="utf-8")
+    db = _write_tracking_db(tmp_path, [ret])
+    original = db.read_text(encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            db.name,
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == (
+        "ERROR: vault_root_database_path_invalid:"
+        "artifact_root_not_native_absolute\n"
+    )
+    assert db.name not in result.stderr
+    assert db.read_text(encoding="utf-8") == original
+    assert not out.exists()
+
+
+def test_root_authority_rejection_precedes_artifact_and_analysis_boundaries(
+    write_analysis,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    batch = tmp_path / "batch-returns.json"
+    out = tmp_path / "analyses"
+    ret = _return()
+    batch.write_text(json.dumps([ret]), encoding="utf-8")
+    db = _write_tracking_db(tmp_path, [ret])
+    database = json.loads(db.read_text(encoding="utf-8"))
+    database["config"]["vault_storage_path"] = "~/private-vault"
+    original = json.dumps(database)
+    db.write_text(original, encoding="utf-8")
+    called = []
+
+    def forbidden(name):
+        def invoke(*_args, **_kwargs):
+            called.append(name)
+            raise AssertionError(f"{name} ran after root-authority rejection")
+
+        return invoke
+
+    for name in (
+        "load_json",
+        "validate_batch",
+        "assess_batch_artifact_capabilities",
+        "validate_batch_claims_against_talks",
+        "assess_current_persisted_pattern_evidence_freshness",
+        "atomic_write_batch",
+    ):
+        monkeypatch.setattr(write_analysis, name, forbidden(name))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        write_analysis.main()
+
+    assert caught.value.code == 1
+    assert called == []
+    assert capsys.readouterr().err == (
+        "ERROR: vault_root_config_invalid:"
+        "artifact_locator_home_expansion_unsupported\n"
+    )
+    assert db.read_text(encoding="utf-8") == original
+    assert not out.exists()
+
+
 def test_cli_rejects_noncanonical_persisted_stamp_before_write(
     write_analysis, tmp_path
 ):
@@ -1353,11 +1639,19 @@ def test_cli_uses_titles_from_tracking_db(write_analysis, tmp_path):
 
 def test_cli_fails_visibly_on_return_without_filename(write_analysis, tmp_path):
     batch = tmp_path / "batch-returns.json"
+    db = _write_tracking_db(tmp_path, [_return()])
     ret = _return()
     del ret["filename"]
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
-        [sys.executable, write_analysis.__file__, str(batch), str(tmp_path / "a")],
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(tmp_path / "a"),
+            "--talks",
+            str(db),
+        ],
         capture_output=True,
         text=True,
     )
@@ -1367,9 +1661,17 @@ def test_cli_fails_visibly_on_return_without_filename(write_analysis, tmp_path):
 
 def test_cli_non_array_batch_is_actionable(write_analysis, tmp_path):
     batch = tmp_path / "batch-returns.json"
+    db = _write_tracking_db(tmp_path, [_return()])
     batch.write_text(json.dumps({"filename": "talk.md"}))
     result = subprocess.run(
-        [sys.executable, write_analysis.__file__, str(batch), str(tmp_path / "a")],
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(tmp_path / "a"),
+            "--talks",
+            str(db),
+        ],
         capture_output=True,
         text=True,
     )
@@ -1486,9 +1788,17 @@ def test_cli_non_object_return_entry_is_actionable(write_analysis, tmp_path):
     """An array of filenames is the plausible operator mistake — it passes the
     is-a-list check and then dies on .get()."""
     batch = tmp_path / "batch-returns.json"
+    db = _write_tracking_db(tmp_path, [_return()])
     batch.write_text(json.dumps(["talk.md", "other.md"]))
     result = subprocess.run(
-        [sys.executable, write_analysis.__file__, str(batch), str(tmp_path / "a")],
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(tmp_path / "a"),
+            "--talks",
+            str(db),
+        ],
         capture_output=True,
         text=True,
     )
@@ -1558,9 +1868,17 @@ def test_return_without_status_is_rejected_before_writing(write_analysis, tmp_pa
     del ret["status"]
     batch = tmp_path / "batch-returns.json"
     out = tmp_path / "analyses"
+    db = _write_tracking_db(tmp_path, [_return()])
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
-        [sys.executable, write_analysis.__file__, str(batch), str(out)],
+        [
+            sys.executable,
+            write_analysis.__file__,
+            str(batch),
+            str(out),
+            "--talks",
+            str(db),
+        ],
         capture_output=True,
         text=True,
     )
@@ -2568,12 +2886,15 @@ def test_none_valued_structured_fields_are_omitted(write_analysis):
 
 
 def test_cli_missing_input_file_is_actionable(write_analysis, tmp_path):
+    db = _write_tracking_db(tmp_path, [_return()])
     result = subprocess.run(
         [
             sys.executable,
             write_analysis.__file__,
             str(tmp_path / "nope.json"),
             str(tmp_path / "a"),
+            "--talks",
+            str(db),
         ],
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

- define one stdlib-only vault-root authority shared by queue selection, persistence, analysis rendering, preflight, profile loading/validation, Section 15 replacement, and evidence freshness
- make the native absolute tracking-database parent primary; CLI and configured roots are lexical assertions that must agree with it
- reject empty, blank, relative, home, foreign, device, drive-relative, current-drive-rooted, and dot-segment forms with closed path-neutral reasons before downstream I/O
- preserve canonical symlink locators lexically instead of resolving them to storage targets, while rejecting alias/target disagreement
- validate database/config authority before unrelated batch/profile reads, artifact assessment, freshness, rendering, or writes
- run the shared authority contract in native macOS/Windows CI and add cross-entrypoint adversarial/symlink regressions
- document an expectation-bound owner read, set_config dry-run/apply, re-read, and preflight repair transaction

## Validation

- full exact-head suite: 4345 passed, 3 skipped
- cross-entrypoint authority suite: 696 passed
- Ruff: clean on all changed Python files
- Pyright: 0 findings on all changed production modules
- actionlint and pre-publish pin/package checks: clean
- package contents: all 263 declared plugin files included
- Tessl plugin lint: valid; only the pre-existing skill-length advisories tracked by #163

## Compatibility

No database or evidence schema is bumped and no stored root is silently rewritten. An absent or null vault_storage_path continues to use the database parent. Invalid or lexically mismatched stored assertions require the documented expectation-bound repair before reprocessing.

Closes #212
