### PR TITLE
fix(vault-ingress): supervise source video evidence in platform CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,7 @@ jobs:
           tests/test_artifact_supervisor.py
           tests/test_artifact_metadata.py
           tests/test_pdf_evidence.py
+          tests/test_video_evidence.py
           tests/test_video_slide_extraction.py
           tests/test_pattern_evidence.py::test_forward_slash_root_is_classified_without_host_reinterpretation
           tests/test_check_runtime.py::test_psutil_version_authorities_are_synchronized

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,9 @@ jobs:
       - name: Install system dependencies (ffmpeg, libreoffice-impress, tesseract)
         # ffmpeg drives the video-slide-extraction tests; libreoffice-impress
         # drives the PPTX->PDF export tests; tesseract drives OCR of baked-in
-        # picture text in pptx-extraction. Video/PDF groups skipif their binary
-        # is absent; OCR unit tests inject a fake engine, integration tests
-        # skipif tesseract is missing — install hiccup degrades coverage
-        # rather than red-failing the suite.
+        # picture text in pptx-extraction. Source-video evidence tests require
+        # ffmpeg/ffprobe and fail if either is absent. OCR unit tests inject a
+        # fake engine; integration tests skipif tesseract is missing.
         #
         # Why this is verbose instead of a plain `apt-get install`: the plain
         # form intermittently wedged for the full 6h job limit (the identical
@@ -99,6 +98,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install Windows media evidence dependencies
+        if: runner.os == 'Windows'
+        # Chocolatey package pin. No Dependabot ecosystem for Chocolatey;
+        # renew quarterly or when the approved package advances.
+        run: choco install ffmpeg --version=8.1.2 --no-progress -y
       - run: pip install ".[test]"
       - run: >-
           pytest -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,17 +92,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-26-intel, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install macOS media evidence dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        # Immutable FFmpeg 8.1.2 Intel archives. Renew the URLs and checksums
+        # quarterly, or when the approved media-tool version advances.
+        env:
+          FFMPEG_URL: https://evermeet.cx/ffmpeg/ffmpeg-8.1.2.zip
+          FFMPEG_SHA256: e91df72a1ee7c26606f90dd2dd4dcccc6a75140ff9ea6fdd50faae828b82ba69
+          FFPROBE_URL: https://evermeet.cx/ffmpeg/ffprobe-8.1.2.zip
+          FFPROBE_SHA256: 399b93f0b9862f69767afa343e90c2f48d7e7958cadbb6deb76a012d0e3b7ce3
+        run: |
+          set -euo pipefail
+          media_dir="$RUNNER_TEMP/speaker-toolkit-ffmpeg-8.1.2"
+          mkdir -p "$media_dir/bin"
+          curl -fL --retry 3 --output "$media_dir/ffmpeg.zip" "$FFMPEG_URL"
+          curl -fL --retry 3 --output "$media_dir/ffprobe.zip" "$FFPROBE_URL"
+          printf '%s  %s\n' "$FFMPEG_SHA256" "$media_dir/ffmpeg.zip" \
+            | shasum -a 256 -c -
+          printf '%s  %s\n' "$FFPROBE_SHA256" "$media_dir/ffprobe.zip" \
+            | shasum -a 256 -c -
+          unzip -q "$media_dir/ffmpeg.zip" -d "$media_dir/bin"
+          unzip -q "$media_dir/ffprobe.zip" -d "$media_dir/bin"
+          chmod +x "$media_dir/bin/ffmpeg" "$media_dir/bin/ffprobe"
+          printf '%s\n' "$media_dir/bin" >> "$GITHUB_PATH"
       - name: Install Windows media evidence dependencies
         if: runner.os == 'Windows'
+        shell: pwsh
         # Chocolatey package pin. No Dependabot ecosystem for Chocolatey;
-        # renew quarterly or when the approved package advances.
-        run: choco install ffmpeg --version=8.1.2 --no-progress -y
+        # renew quarterly or when the approved package advances. Put the real
+        # binaries ahead of Chocolatey's process-spawning shims: the supervised
+        # worker intentionally permits only itself plus one ffprobe child.
+        run: |
+          choco install ffmpeg --version=8.1.2 --no-progress -y
+          $ffmpegBin = 'C:\ProgramData\chocolatey\lib\ffmpeg\tools\ffmpeg\bin'
+          if (-not (Test-Path "$ffmpegBin\ffprobe.exe" -PathType Leaf)) {
+            throw "Chocolatey ffprobe binary was not installed at the pinned path"
+          }
+          $ffmpegBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - run: pip install ".[test]"
       - run: >-
           pytest -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## 0.20.11 — 2026-08-04
-
 ### fix(vault-ingress) — supervise preserved source-video evidence (#190)
 
 Preserved source recordings now pass one bounded metadata/media/digest probe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.20.11 — 2026-08-04
+
+### fix(vault-ingress) — supervise preserved source-video evidence (#190)
+
+Preserved source recordings now pass one bounded metadata/media/digest probe
+before they can contribute local-media digest or duration evidence to transcript
+validation, authorize delivery-video citations, support video-derived slide
+provenance, or participate in persisted freshness. The probe accepts the
+declared MP4/MOV/WebM/Matroska container families, requires a usable video
+stream and positive duration, limits input size and stream count, and binds the
+result to one unchanged local-file generation. Media parsing and SHA-256 use one
+private snapshot copied from a verified no-follow descriptor, so a sync-time
+path replacement cannot combine facts from two files. Corrupt or incomplete
+media, cloud placeholders, parser diagnostics, sync-time replacement, missing
+`ffprobe`, and worker/resource failures remain structured, operation-local
+outcomes; a caller's transient deadline is never published to unrelated
+operations. These failures disable only the video lane and do not erase an
+independent transcript, PDF, or PPTX.
+
+Schema-v3 extraction manifests now own their exact `<youtube_id>.mp4` source
+even when a conflicting legacy top-level video path is present. Preflight
+separates a missing source (`source_video_artifact_missing`), an unhydrated
+placeholder (`source_video_artifact_unavailable`), and unreadable media
+(`source_video_artifact_unreadable`) from locator/ownership faults. Persistence,
+analysis rendering, queue normalization/claiming, preflight, and profile
+freshness share one assessment per top-level operation, so one transient result
+cannot be silently contradicted by a later nested retry. A returned recording
+may support current delivery evidence but cannot retroactively authorize the
+pre-return transcript. No tracking, return, evidence, scoring, or extraction
+schema changes, and existing records do not require reprocessing solely for
+this release.
+
+Ingress and direct profile workflows now require the narrow `source-video`
+runtime lane before an operation inspects a preserved recording. The executable
+skill workflows remain concise while their bootstrap, queue, persistence,
+profile-construction, PPTX follow-up, and clarification contracts live in named
+references. This keeps the operational order visible without weakening any
+validation or evidence rule.
+
 ## 0.20.10 — 2026-08-04
 
 ### fix(vault-ingress) — isolate video frame workspaces from stale evidence (#213)

--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ notes which named patterns and antipatterns are detected per talk.
   capabilities instead of aliasing one format to another. Every manifest PDF
   is generation-bound before persistence, including context-only artifacts,
   and a configured symlinked vault root does not weaken descendant path checks
+- Preserved source recordings are inspected through a bounded, exact-generation
+  probe before they contribute local-media digest or duration evidence to
+  transcript validation, authorize delivery-video citations, support
+  video-derived slide provenance, or participate in freshness checks. If a
+  recording cannot be verified, only source-video capability is removed;
+  independently verified transcript, PDF, and PPTX evidence remains
 - Each talk is scored against the taxonomy's 81 observable entries (62 patterns + 19 antipatterns),
   with source-located evidence restricted to the artifact channels each entry permits
 - Each batch updates the summary, per-talk analysis files, and triggers profile regeneration
@@ -358,7 +364,8 @@ notes which named patterns and antipatterns are detected per talk.
 - Python 3.10+ at the vault's configured `python_path`, with core `PyYAML`;
   `pypdf` + exactly `psutil==7.2.2` for supervised PDF evidence; and
   `python-pptx` + the same exact psutil version for resource-supervised
-  native-deck evidence
+  native-deck evidence. Preserved source-video evidence uses the separate
+  `source-video` runtime lane with exactly `psutil==7.2.2` plus `ffprobe`
 - Lane-specific runtime: importable `gdown` for Google Drive acquisition,
   `youtube-transcript-api` for captions, `yt-dlp` for provider probing/audio
   download, `pdftoppm` for rendered-PDF inspection, Pillow + `imagehash` +
@@ -522,15 +529,26 @@ speaker-toolkit/
     |   +-- scripts/
     |   |   +-- artifact_metadata.py          # shared bounded metadata + cloud/reparse policy
     |   |   +-- pdf_evidence.py               # supervised exact-generation PDF evidence
+    |   |   +-- video_evidence.py             # supervised exact-generation source-video evidence
     |   |   +-- pptx-extraction.py            # supervised PPTX extraction + bounded discovery
     |   |   +-- video-slide-extraction.py     # Video-to-slides via ffmpeg + perceptual dedup
     |   |   +-- vtt-cleanup.py                # WebVTT to plain text
     |   |   +-- batch-download-videos.sh      # Parallel video download for batch processing
     |   +-- references/
+    |       +-- bootstrap-and-preflight.md     # Runtime, discovery, migration, and preflight contract
+    |       +-- queue-selection.md             # Deterministic selection, claim, and lease contract
+    |       +-- batch-persistence.md           # Batch validation, atomic persistence, and rendering order
+    |       +-- pptx-followup.md               # Native-deck extraction and catalog follow-up
+    |       +-- clarification-handoff.md       # Post-processing clarification handoff
+    |       +-- source-identity-preflight.md   # Source ownership, artifact authority, and repair routing
     |       +-- rhetoric-dimensions.md        # 14 analysis dimensions + pattern cross-refs
     |       +-- schemas-db.md                 # DB, subagent, and extraction output schemas
     |       +-- video-slide-extraction.md     # Layout heuristics, tuning tables, limitations
     |       +-- processing-rules.md           # Language policy, pattern migration logic
+    +-- vault-profile/
+    |   +-- SKILL.md                          # Machine-readable speaker profile workflow
+    |   +-- references/
+    |       +-- profile-construction-rules.md  # Cohort, merge, trend, and diff authority
     +-- presentation-creator/
     |   +-- SKILL.md                          # Main creator workflow (7 phases)
     |   +-- scripts/

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -217,7 +217,8 @@ Proceed to Step 9.
 If no talk was processed, finish. Otherwise compute candidate topics and follow
 [Clarification Handoff](references/clarification-handoff.md).
 
-- **≤7 days:** offer to run `vault-clarification` inline and invoke it on acceptance.
+- **≤7 days:** offer to run `Skill(skill: "vault-clarification")` inline; on
+  acceptance, invoke it with the candidate topics as handoff context.
 - **7–30 days:** recommend the full session with topics; do not auto-invoke.
 - **30+ days:** recommend the compressed session; do not auto-invoke.
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -9,7 +9,7 @@ description: >
   Triggers: "parse my talks", "run the rhetoric analyzer", "analyze my presentation style",
   "how many talks have been processed", "update the rhetoric knowledge base",
   "check rhetoric vault status", "process remaining talks for style patterns".
-user_invocable: true
+user-invocable: true
 ---
 
 # Vault Ingress — Incremental Talk Parser
@@ -27,6 +27,20 @@ processes **unprocessed** talks, extracts rhetoric/style observations, and updat
 running summary. The vault lives at `~/.claude/rhetoric-knowledge-vault/` (may be a
 symlink to a custom location). All paths are relative to this **vault root**.
 
+## Quick Reference
+
+| Step | Required outcome |
+|---:|---|
+| 1 | Bootstrap/migrate, discover sources, and clear catalog/source preflight gates |
+| 2 | Normalize the queue and claim one exact versioned batch |
+| 3 | Run up to five per-talk workers in parallel |
+| 4 | Validate, persist, render, and aggregate feedback transactionally |
+| 5 | Apply speaker-approved narrative updates and rebuild Section 15 |
+| 6 | Finish pending PPTX visual evidence |
+| 7 | Regenerate an existing speaker profile |
+| 8 | Verify active improvement goals against current provenance |
+| 9 | Hand fresh findings to clarification using the delivery-recency policy |
+
 ## Key Files & References
 
 | File / Reference | Purpose |
@@ -34,13 +48,12 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | `tracking-database.json` | Source of truth — talks, status, config, confirmed intents |
 | `rhetoric-style-summary.md` | Running rhetoric & style narrative |
 | `slide-design-spec.md` | Visual design rules from PDF + PPTX analysis |
-| `speaker-profile.json` | Machine-readable bridge to presentation-creator |
-| `analyses/{talk_filename}.md` | Per-talk rhetoric analysis (one file per processed talk) |
-| `transcripts/{transcript_id}.txt` | Downloaded/cleaned transcripts (`youtube_id` for YouTube talks) |
-| `transcripts/{transcript_id}.segments.json` | Hash-bound acquisition source and optional timing for the matching transcript |
-| `transcripts/{transcript_id}.quality.json` | Hash-bound exact quality policy and source-owned duration provenance |
-| `slides/{id}.pdf` | Slide PDFs (from Google Drive, PPTX export, or video extraction) |
 | [references/schemas-db.md](references/schemas-db.md) | DB + subagent schemas; extraction output schemas |
+| [references/bootstrap-and-preflight.md](references/bootstrap-and-preflight.md) | Step 1 vault bootstrap, runtime, discovery, and preflight workflow |
+| [references/batch-persistence.md](references/batch-persistence.md) | Step 4 validation, persistence, rendering, and feedback sequence |
+| [references/queue-selection.md](references/queue-selection.md) | Step 2 normalization, claims, freshness, replay, and recovery contract |
+| [references/pptx-followup.md](references/pptx-followup.md) | Step 6 bounded PPTX follow-up and visual-evidence contract |
+| [references/clarification-handoff.md](references/clarification-handoff.md) | Step 9 topic selection and recency-bucket handoff contract |
 | [references/rhetoric-dimensions.md](references/rhetoric-dimensions.md) | 14 analysis dimensions |
 | [references/subagent-instructions.md](references/subagent-instructions.md) | Step 3 per-talk procedure — transcript download, slide acquisition, fallback chains, return-JSON shape |
 | [references/video-slide-extraction.md](references/video-slide-extraction.md) | Video-to-slides pipeline — layout heuristics, tuning, limitations |
@@ -50,26 +63,6 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/pattern-catalog-contract.md](references/pattern-catalog-contract.md) | Read-only catalog graph, polarity, source-gate, and semantic-debt contract |
 | [references/processing-rules.md](references/processing-rules.md) | Language policy, pattern migration logic, structured field rules |
 | [references/known-issues.md](references/known-issues.md) | Edge cases — wide-angle recordings, Whisper hallucination, non-speaker talks |
-| `skills/vault-ingress/scripts/persist-results.py` | Deterministically merge batch subagent returns into the tracking DB (Step 4) |
-| `skills/vault-ingress/scripts/migrate-tracking-database.py` | Owner-only tracking schema migration with hash precondition, backup, and atomic replacement (Step 1) |
-| `skills/vault-ingress/scripts/check-runtime.py` | Stdlib-only configured-interpreter and lane dependency probe |
-| `skills/vault-ingress/scripts/write-analysis.py` | Render per-talk `analyses/*.md` from persisted effective state authorized by the same batch returns (Step 4) |
-| `skills/vault-ingress/scripts/validate-returns.py` | Reject malformed schemas, statuses, scores, and catalog observations before either Step 4 writer runs |
-| `skills/vault-ingress/scripts/queue-state.py` | Normalize legacy statuses; claim versioned batches; inspect or recover queue leases without replaying returns |
-| `skills/vault-ingress/scripts/pptx-extraction.py` | Extract visual design data from .pptx files |
-| `skills/vault-ingress/scripts/video-slide-extraction.py` | Extract slides from video via ffmpeg + perceptual dedup |
-| `skills/vault-ingress/scripts/batch-download-videos.sh` | Parallel video download for batch processing |
-| `skills/vault-ingress/scripts/vtt-cleanup.py` | Clean VTT subtitles into plain transcript text |
-| `skills/vault-ingress/scripts/fetch-transcript.py` | Fetch a transcript, validate it, write only if real (captions → local Whisper) |
-| `skills/vault-ingress/scripts/transcript_timing.py` | Own independent timing/quality receipts, validation, and quote resolution |
-| `skills/vault-ingress/scripts/preflight-vault.py` | Read-only source/identity integrity gate before selection or re-analysis |
-| `skills/vault-ingress/scripts/scan-shownotes.py` | Deterministic shownotes discovery and guarded tracking-DB import |
-| `skills/vault-ingress/scripts/audit-source-identities.py` | Read-only `yt-dlp` evidence capture, deduplicated by active YouTube ID |
-| `skills/vault-ingress/scripts/audit-pattern-catalog.py` | Read-only pattern catalog graph and contract gate before analysis |
-| `skills/vault-ingress/scripts/apply-source-repairs.py` | Guarded dry-run/apply workflow for evidence-backed source metadata repairs |
-| `skills/vault-ingress/scripts/aggregate-catalog-feedback.py` | Validate and aggregate return feedback without editing the pattern catalog |
-| `skills/vault-ingress/scripts/read-tracking-database.py` | Strict, hash-reporting owner read for agent workflows |
-| `skills/vault-ingress/scripts/mutate-tracking-database.py` | Typed, expectation-bound owner mutations for config and catalog metadata |
 
 Every agent-driven read of `tracking-database.json` must go through
 `read-tracking-database.py`. Every agent-driven write not already owned by a
@@ -92,617 +85,104 @@ files to shownotes entries.
 
 ## Step 1 — Bootstrap Vault State
 
-**Vault discovery** — canonical path is always `~/.claude/rhetoric-knowledge-vault/`.
-
-1. **Path exists** — use as `vault_root`, then load the database with the strict
-   owner read command in
-   [references/schemas-db.md](references/schemas-db.md#owner-read-and-mutation-contract).
-2. **Path missing** — first-time setup: ask preferred location via `AskUserQuestion`,
-   create the directory (and symlink if a custom path was chosen), then use a sole
-   `initialize_database` mutation. Include database `schema_version: 1`, config
-   `schema_version: 1`, and empty `talks`, `pptx_catalog`, `qr_codes`, `resources`,
-   `thumbnails`, `confirmed_intents`, and `improvement_goals` arrays. Review the
-   dry-run and apply it with `--expected-sha256 missing`; never create the JSON
-   file directly.
-
-**Schema gate** — vault-ingress owns the tracking database shape and migrations.
-The stdlib-only strict reader may use the host interpreter for the initial
-bootstrap read only. Read `config.python_path` from an existing database, or ask
-for the interpreter path without writing the database when that field is absent.
-Immediately re-read the same canonical path with that configured interpreter and
-require the same SHA-256; restart discovery if the generation changed. Use the
-configured interpreter for migration, queue commands, and every later toolkit
-command. Run the owner migration before any other database mutation:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
-  "{vault_root}/tracking-database.json"
-```
-
-Exit 0 writes one dry-run JSON report with `input_sha256`, source and target
-schema versions, `output_sha256`, `record_counts`, `changed`,
-`database_written: false`, `warnings`, and the deterministic backup path. A
-changed report authorizes this exact apply command:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
-  "{vault_root}/tracking-database.json" --apply --expected-sha256 "{input_sha256}"
-```
-
-Exit 0 from apply writes one JSON report with `database_written: true`, preserves
-the complete original bytes under `{vault_root}/.backups/`, and atomically
-installs database schema v1. A non-empty `warnings` array means replacement
-completed with a durability warning and must not be reported as a failed/no-write
-run. Exit 2 writes one error object to stdout plus a diagnostic to stderr and
-leaves the database unchanged. Recover or
-complete every active queue claim named by the diagnostic. For an unversioned
-database, use `queue-state.py ... inspect` to identify the lease and
-`queue-state.py ... recover` to close it. Those two commands accept schema 0;
-recovery changes only queue-lease/status state and does not stamp or migrate the
-database or talk record. The existing queue transition may advance a recovered
-legacy claim receipt from schema v1 to v2 while adding its release fields. Rerun
-migration dry-run, then apply its new exact digest. Do not copy a digest across
-runs. `queue-state.py ... normalize` and `queue-state.py ... claim` require
-database schema 1.
-
-**Config bootstrapping** — ask once per missing field and persist to the tracking
-database with expectation-bound `set_config` mutations. Re-read after every
-successful apply and use the new hash for the next plan. Core fields: `shownotes` (enabled, source.type, source.path_or_url,
-source.talks_subdir, url.base, url.template, thumbnail_path_template,
-slug_convention), `pptx_source_dir`, `python_path`, `template_skip_patterns`.
-See [references/schemas-db.md](references/schemas-db.md) for the full schema
-and [../vault-profile/references/schemas-config.md](../vault-profile/references/schemas-config.md)
-for field-by-field semantics and migration notes.
-
-`python_path` is the interpreter authority for every operational command below;
-never fall back to whichever `python3` happens to be on `PATH`. Installed plugin
-bundles do not include `pyproject.toml`, so immediately probe the configured
-runtime with the shipped stdlib-only checker:
+Execute [Bootstrap and Preflight](references/bootstrap-and-preflight.md) in full.
+Do not select work until migration succeeds, the catalog is structurally valid,
+and offline preflight has no blocking finding. Before preflight may inspect any
+preserved local recording declared by
+`structured_data.video_extraction.source_video_path`, `video_local_path`, or
+`video_path`, require:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
-  --lanes core,pdf,pptx
+  --lanes core,source-video --require-lanes core,source-video
 ```
 
-All owner-authored tracking writes below require database schema 1 after this
-gate. Preserve every independent record version and validate the complete
-candidate before installing it. Only `migrate-tracking-database.py` may move
-schema 0 to schema 1; its hash precondition binds replacement to the exact input
-bytes as documented above.
+Never pre-open, hash, hydrate, or call `ffprobe` directly. Video failure disables
+only video evidence; retain independent transcript/PDF/PPTX evidence. Then read
+the summary/spec and report processed, remaining, cataloged, matched, and
+extracted counts.
 
-Core requires Python 3.10+ and PyYAML and is blocking. The PDF lane requires
-pypdf plus exactly `psutil==7.2.2`; the PPTX lane requires python-pptx plus the
-same exact psutil version. Both parser lanes run behind bounded worker
-supervision. The canonical vault locator may be the configured symlink; the PDF
-boundary maps that trusted root to storage while still rejecting every
-descendant symlink/reparse redirect. Trusted-root bindings retain the directory
-object's stable identity and policy attributes, not mutable child-content size or
-timestamps; PDF and PPTX leaf generations remain exact. The checker emits report
-schema v2 and records exact pins under
-each lane's `required_module_versions`; a mismatched version is unavailable. A
-missing optional lane is reported as degraded and must not erase a healthy
-transcript or alternate slide lane.
-Require a lane before using it, for example `--require-lanes core,pdf`. Remote
-Drive acquisition additionally needs the `gdown` module; captions need
-`youtube-transcript-api`; audio download fallback needs `yt-dlp`; rendered PDF
-inspection needs `pdftoppm`; video extraction needs exactly `Pillow==12.3.0`,
-`ImageHash==4.3.2`, `numpy==2.2.6`, and `filelock==3.32.2`, plus `ffmpeg` and
-`ffprobe`; local Whisper needs `mlx-whisper` and `ffprobe`.
-Inspect those with the checker's `google-drive`, `captions`,
-`youtube-download`, `pdf-render`, `video`, and `whisper` lanes as selected talks
-require. Each lane is independent: a failed optional import/tool disables only
-that lane. Import failure details appear under the lane's `module_failures`;
-dependency absence, initializer exceptions, native crashes, timeouts, and
-invalid child results degrade an optional lane or block a required lane without
-breaking the one-JSON contract. The checker writes a recovery instruction to
-stderr whenever a lane is unavailable.
+## Step 2 — Select Talks to Process
 
-**Scan for new talks:** run the deterministic scanner in its default read-only
-mode:
+Follow [Queue Selection](references/queue-selection.md) in full. Normalize once:
 
 ```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/scan-shownotes.py" \
-  "{vault_root}/tracking-database.json"
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/queue-state.py" \
+  "{vault_root}/tracking-database.json" normalize
 ```
 
-Read the structured report before any mutation. `add` and `update` entries are
-safe deterministic proposals; `review_required` entries need a human decision.
-The scanner uses exact filename identity, derives supported YouTube and Google
-Drive IDs, and keeps every matching `source_rejections` identity inactive.
-For comparison only, title equality applies Unicode NFC and maps straight/curly
-single and double quote glyphs to the same narrow equivalents; it preserves
-case, other punctuation, and wording. Conference equality applies NFC plus
-casefold only and preserves whitespace. The scanner never writes these
-comparison transforms back to the database or report. Incomplete metadata,
-substantive conflicts, and normalized filename collisions remain proposals.
-Disabled, `remote_url`, and `none` sources return a structured no-op.
+Then claim each exact batch:
 
-Apply the reviewed deterministic proposals with the same command plus
-`--apply`. Only `add` and `update` entries mutate the tracking database. New
-records receive current `schema_version` and status `"pending"`; exact-filename
-updates fill empty fields without overwriting established values. The write is
-atomic and rejects a tracking-database symlink. See
-[references/schemas-db.md](references/schemas-db.md#shownotes-scanimport-report)
-for the complete report and mutation contract.
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/queue-state.py" \
+  "{vault_root}/tracking-database.json" claim --run-id <stable-run> \
+  --batch-id <stable-batch> --now <timezone-aware-ISO>
+```
 
-**Scan for .pptx files:** Do not recursively glob the source tree. Run one bounded
-directory extraction, which owns deterministic discovery, symlink/reparse-point
-rejection, and aggregate file/input/output/wall budgets:
+Fresh claims are schema v5 and require return v5. Use the stored claim on replay;
+recover a stranded lease and issue a new generation. Set the best verified slide
+source, use `skipped_no_sources` only when every source is unavailable, and honor
+an explicit filename/title argument as a one-talk selection.
 
-Read the exact `config.template_skip_patterns` array from the strict owner-read
-result. Set `{template_skip_arguments}` to one separately shell-quoted
-`--skip=<exact-value>` argument per array entry, preserving its order. An empty
-array produces zero arguments; never add an implicit default.
+## Step 3 — Process Talks via Parallel Subagents (Batches of 5)
+
+Launch up to five claimed talks in parallel, then complete Steps 4 and 5 before
+the next batch. Each worker must execute
+[Per-Talk Subagent Instructions](references/subagent-instructions.md), A → B →
+B2 → C, against its claim and current summary.
+
+The claim fixes the return schema and immutable numeric baseline. Workers must
+not parse Section 15 for numeric adherence or return engine-owned enrichment;
+they return only observed analysis, raw inspection coverage, and citations.
+
+## Step 4 — Persist Subagent Results
+
+If any batch return declares a preserved local recording through
+`structured_data.video_extraction.source_video_path`, `video_local_path`, or
+`video_path`, first require the same `core,source-video` runtime gate from Step
+1. One successful check gates validation, persistence, and analysis rendering
+for that exact batch.
+
+Then execute [Batch Persistence](references/batch-persistence.md) in order:
+
+1. Validate the complete claimed batch.
+2. Persist it atomically; never hand-map fields.
+3. Render analyses from the same returns and persisted effective state.
+4. After the final batch, aggregate catalog feedback without editing the catalog.
+
+Any failure stops the sequence. A successful merge closes the lease and emits
+the complete post-batch baseline. Proceed immediately to Step 5.
+
+## Step 5 — Update Rhetoric Summary
+
+Present `summary_updates` and `new_patterns` as a section-by-section diff and
+apply only speaker-approved changes (unless this batch was pre-authorized).
+Follow the [Rhetoric Summary contract](references/processing-rules.md): rebuild
+Section 15 only after the complete batch persists, never from a date cohort or
+partial merge, and recount the database rather than incrementing totals.
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py" replace \
+  {vault_root}/rhetoric-style-summary.md pattern-profile-candidate.json \
+  {vault_root}/tracking-database.json
+```
+
+A stale candidate or nonzero exit makes no write. Report the batch outcome, then
+continue the loop or proceed to Step 6.
+
+## Step 6 — Extract Remaining PPTX Visual Data
+
+Follow [PPTX Follow-up](references/pptx-followup.md). Run one bounded directory
+extraction and select only unmatched entries, PDF-primary talks with a PPTX, or
+`pptx_visual_status: "pending"`; skip already extracted entries.
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py" \
   --directory "{pptx_source_dir}" {template_skip_arguments}
 ```
 
-Use root-relative `results[].pptx_path` identities to fuzzy-match `talks[]` entries
-and retain every `skipped[]` receipt. `pptx_batch_office_lock_file` is an explicit
-exclusion: never catalog or extract an Office temporary file whose basename starts
-with `~$`. Directory intent must remain explicit: do not omit `--directory` or
-pre-probe the root with `find`, a recursive glob, or a per-file loop. The bounded
-authenticated discovery worker owns root validation and enumeration. Report counts,
-then persist each reviewed result with a `record_pptx`
-mutation and `schema_version: 1`, including the exact prior catalog record and, for
-a match, the talk's exact prior `pptx_path` expectation. See
-[references/schemas-db.md](references/schemas-db.md) for the PPTX extraction output
-schema (per-slide visual data, shape types, global design stats).
-Consume current schema v4. A v0/v1 record has unknown timing, not zero timing;
-v2 has the pre-build timing lanes but lacks raw build-list evidence,
-archive-recovery, and exact native/render audit receipts; v3 lacks required
-shape/image capability bindings. Regenerate v0-v3
-output for current analysis. An unknown future
-schema is unusable until this reader is updated. The vault-profile layout-only
-consumer is the documented v1/v2/v3/v4 exception for the unchanged
-`template_layouts` field. Non-empty `archive_recovery` is degraded evidence:
-restore or re-export a required native deck before claiming or returning it.
-
-**Pattern taxonomy recovery:** See [references/processing-rules.md](references/processing-rules.md) for the queue-owned
-contract. Step 2 normalization deterministically routes processed results outside
-the active pattern-scoring generation back to `needs-reprocessing`; do not infer
-generation currency from processing date or hand-edit those statuses.
-
-**Pattern catalog preflight:** Before source selection or re-analysis, run:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-pattern-catalog.py"
-```
-
-Stdout is stable JSON. Exit 1 means structural catalog errors: stop before
-scoring. Exit 0 may include `semantic_debts`; present those for human review and
-do not auto-edit names, aliases, definitions, or graph relationships. The input,
-report, and no-write contracts are defined in
-[references/pattern-catalog-contract.md](references/pattern-catalog-contract.md).
-
-**Source/identity preflight:** After bootstrapping and scanning, and before talk
-selection or re-analysis, run the read-only offline gate:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/preflight-vault.py" {vault_root}
-```
-
-Exit 1 means one or more blocking integrity errors (identity disagreement,
-unqualified duplicate recording, invalid source claim, or a claimed completed
-artifact that is missing): stop and repair those records/artifacts before
-processing. Exit 0 may still carry warnings for legacy evidence gaps or pending
-artifacts; report them, but they do not make the vault unusable. The stable JSON
-report and evidence shape are defined in
-[references/source-identity-preflight.md](references/source-identity-preflight.md).
-
-After the offline gate, capture and compare live YouTube provider evidence:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-source-identities.py" {vault_root}
-```
-
-This networked audit invokes `yt-dlp` once per distinct active YouTube ID and
-prints deterministic JSON without changing the vault. Review every proposed
-`source_identity` block and finding, especially `likely_non_delivery_clip` and
-`same_id_cross_talk_collision`. Provider uploader is not speaker evidence,
-upload date is not recorded date, and the provider webpage URL must never be
-auto-applied as an active source. See
-[references/source-identity-audit.md](references/source-identity-audit.md).
-
-Only after that human review, write a source-repair plan containing supported
-facts and exact old-value preconditions, then dry-run it before applying:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/apply-source-repairs.py" \
-  {vault_root}/tracking-database.json source-repair-plan.json
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/apply-source-repairs.py" \
-  {vault_root}/tracking-database.json source-repair-plan.json --apply
-```
-
-The apply command validates the whole plan before mutation, refuses active queue
-claims, writes a byte-for-byte backup under `{vault_root}/.backups/`, and replaces
-the DB atomically. Re-run the preflight after applying; do not claim work until
-blocking findings reach zero.
-
-Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
-"X processed, Y remaining. PPTX: A cataloged, B matched, C extracted."
-
-## Step 2 — Select Talks to Process
-
-Fresh queue work uses claim schema v5. Before changing any talk status,
-`queue-state.py claim` snapshots one immutable `adherence_baseline` for the
-entire selected batch, stamps `required_return_schema_version: 5`, and copies
-that exact snapshot into every member claim. The snapshot uses the current
-catalog fingerprint and pattern-scoring schema, includes only current
-`processed`/`processed_partial` talks, and excludes every active-batch filename
-before inspecting its prior score. Its `as_of` equals the claim's canonical
-`claimed_at`; do not edit or recompute it after the claim is written.
-
-- Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/queue-state.py"
-  {vault_root}/tracking-database.json normalize` once. This one copy-on-write
-  command migrates legacy
-  `skipped_no_video`/`skipped_no_transcript` states from the talk's usable source
-  capabilities. The shared root-aware assessor must actually read and validate a
-  local transcript/deck/PDF before it counts; a non-empty or missing path is not a
-  capability. Declared remote video/slide acquisition remains eligible for a
-  claim-time download. A `transcript_source` provenance label alone
-  is not capability. Only a record with no verified local source or remote
-  acquisition path becomes `skipped_no_sources`. The same command uses the shared
-  exact-generation selector to requeue valid `processed`/`processed_partial`
-  results that cannot enter the active pattern cohort. For scoring v5, exact
-  generation identity is necessary but insufficient: the shared freshness assessor
-  also re-hashes every persisted source-located artifact against the database's
-  vault and configured source roots. Missing, replaced, or otherwise drifted
-  evidence is excluded and requeued. Transcript freshness also revalidates the
-  hash-bound quality policy against current owner/provider duration; source-
-  identity drift cannot leave a previously accepted partial transcript in the
-  cohort. Its `normalizations` report carries ordered
-  reason codes, deterministic freshness details where applicable, and the stored
-  `reprocess_reason` for each changed row. Malformed current-generation identity or
-  score lanes reject the complete command without writing; inflight, pending,
-  already-queued, and skipped records are not generation-normalized. A repeated
-  successful normalization with no new drift leaves the DB bytes unchanged.
-  Completed claims remain immutable evidence on the requeued talk and move to
-  history normally when a later claim is created.
-- Claim each exact batch through `queue-state.py ... claim --run-id <stable-run>
-  --batch-id <stable-batch> --now <timezone-aware-ISO>`. The command selects
-  `pending`, `needs-reprocessing`, and retryable download failures, writes an
-  atomic lease, increments `reprocess_generation`, and returns the claimed talk
-  list. Every fresh claim is schema v5 and requires return schema v5. Never
-  change a record to `reprocessing-inflight` by hand.
-- Before claiming a non-YouTube talk whose transcript will be used as evidence,
-  acquire the transcript and register its canonical vault-relative
-  `transcript_path` through the guarded source-repair workflow. A worker-returned
-  path cannot grant citation authority to that same return.
-- Repeating the same live/completed run and batch is an idempotent replay: use
-  the exact stored claims and baseline, and do not rewrite the DB. Recover an
-  expired or stranded lease with `queue-state.py ... recover`; recovery keeps
-  the saved snapshot in claim history. A later claim creates a new generation and
-  takes a fresh pre-mutation snapshot rather than editing or reusing the old
-  generation's baseline.
-- Set `slide_source` per the hierarchy above. Mark `"skipped_no_sources"` only if
-  preflight confirms that transcript, slide, and video sources are all unavailable.
-- If `$ARGUMENTS` specifies a talk filename or title, process ONLY that one.
-
-## Step 3 — Process Talks via Parallel Subagents (Batches of 5)
-
-Per batch: launch 5 subagents in parallel, wait, run Step 4 (Persist Subagent
-Results), then run Step 5 (Update Rhetoric Summary), then move to the next
-batch. When all batches have finished, proceed to Step 6.
-
-Each subagent receives the talk's DB entry and current
-`rhetoric-style-summary.md`, runs A → B → B2 → C, and returns a JSON payload.
-The summary supports qualitative rhetoric analysis, but the worker MUST NOT
-parse Section 15 for numeric adherence. The immutable
-`talk._queue_claim.adherence_baseline` is the sole numeric authority.
-
-The return version matches the active claim contract. A fresh schema-v5 claim
-with `required_return_schema_version: 5` requires return v5. Saved claim schemas
-v1–v4 authorize only their same-numbered return schemas and remain replayable
-archival artifacts; none can enter the current scoring cohort. Recover a live
-legacy lease and issue a fresh v5 generation instead of mutating its claim.
-A successfully persisted v5 return produces talk-record schema v5 and is the
-only return generation eligible for pattern-scoring schema v5. Valid v4
-source-located evidence remains intact with evidence-ledger schema v1, but it is
-requeued for v5 and never receives synthesized v5 outcomes.
-
-Return v5 uses the exact empty `adherence_assessment` sentinel and omits
-`adherence_comparison` unless an owner-side second-stage comparison can prove
-that the canonical talk and frozen baseline carry the same
-`opportunity_coverage_identity`. Persistence never guesses or normalizes across
-different identities. The schema-v2 baseline keeps `eligible_talk_count` for
-per-pattern history separately from the exact-identity `scored_talk_count`; a
-mixed opportunity cohort or a cohort with no evaluable pattern opportunities uses
-the explicit unavailable/null comparison sentinel.
-The return copies `run_id`, `batch_id`, and `reprocess_generation` from the
-talk's active `_queue_claim`; persistence rejects a stale, mismatched, or
-unclaimed return.
-Full procedure — slide acquisition per `slide_source`, rhetoric/style analysis,
-pattern-taxonomy tagging, and the return-JSON shape — lives in
-[references/subagent-instructions.md](references/subagent-instructions.md).
-
-Every v4/v5 worker also returns a closed `source_inspection` receipt. Transcript,
-static-slide/native-deck, and delivery-video records carry the exact line, page,
-or time ranges actually inspected. Distinct source comparisons each carry their
-exact underlying group and `comparison_scope`. Workers return only those raw
-ranges and citation claims; persistence derives artifact roots/paths/hashes,
-line and time matches, metadata values, coverage flags, and the evidence schema
-marker. Never copy engine-owned fields from an earlier analysis into a return.
-
-Transcripts come from `skills/vault-ingress/scripts/fetch-transcript.py`, never from inline fetch
-code. It tries the caption track, falls back to local Whisper, validates the
-result, and writes atomically only on success. A failed fetch never replaces the
-transcript with a crash report or partial speech:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/fetch-transcript.py" <video-id-or-url> \
-    --out {vault_root}/transcripts/<youtube_id>.txt \
-    --existing-source <youtube_auto|whisper|manual|unknown> \
-    [--duration-seconds N]
-```
-
-Exit 0 wrote (or kept) a valid transcript; exit 1 means no source produced one
-and the talk is `processed_partial` at best; exit 2 is an argument or tool-state
-error. Validation thresholds and failure signatures are the script's own — see
-its module docstring and `transcript_quality.py`. `--duration-seconds` is only an
-expected value and must match a source-owned provider or local-media probe; a
-worker return or unbound metadata never lowers the quality floor. Its JSON
-`quality_path` names the required hash-current quality receipt on every success.
-`timed_path` is non-null only when a separate schema- and hash-verified timing
-receipt has usable owner-bound segments. Current timing receipts are schema v2;
-v1/minimal sidecars are archival and cannot supply timing or provenance. Do not
-rewrite them in place: re-fetch/re-transcribe from the proved source, or import
-the original VTT artifact, so the current writer can bind owner and bounds.
-Missing or rejected timing does not invalidate ordinary
-transcript evidence, but missing quality does exclude it from current v5
-scoring; requeue legacy transcripts through the fetcher. Reparse runs must pass
-the talk's owner-recorded `transcript_source` (or `unknown` when absent), even
-when the transcript already exists. For `youtube_auto` only, a missing/stale
-timing receipt triggers non-destructive caption enrichment: fetched caption text
-must equal the existing text exactly except for whitespace layout before a
-caption timing receipt is written, and the transcript bytes are never replaced.
-Edited, manual, Whisper, unknown-provenance, or mismatching text remains
-timing-unavailable and is never relabeled as captions.
-
-Without `--force`, any existing transcript is validation-only: a stricter caller
-policy may reject it but cannot authorize replacement. Pass `--force` only after
-inspecting the named artifact and intentionally authorizing new source bytes.
-A failed fetch or caught bundle write restores the prior transcript, quality,
-and timing bytes. If fetched text is valid but optional segments are malformed,
-text-mismatched, or outside their source bound, the transaction writes text and
-quality, removes stale timing, and reports timing unavailable.
-
-For a supplied WebVTT artifact, choose the output identity explicitly; language
-suffixes must never collide implicitly:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/vtt-cleanup.py" \
-  {vault_root}/transcripts/<source>.vtt \
-  {vault_root}/transcripts/<transcript_id>.txt [--force]
-```
-
-The VTT must be a non-symlink regular file inside the transcript directory.
-Its schema-v2 receipt binds the safe relative path, exact VTT digest, and final
-cue extent. Replacement still requires explicit `--force`.
-
-## Step 4 — Persist Subagent Results
-
-Runs after each batch inside Step 3's loop (not as a separate post-loop
-phase). Mechanical persistence of the batch's subagent JSON returns:
-
-- **Validate the whole batch before any write.** Run
-  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/validate-returns.py" batch-returns.json`.
-  Stop on a non-zero exit and repair the named return. The validator enforces the
-  terminal status, return field types, catalog ID and polarity, observability,
-  confidence and evidence, score arithmetic, co-presenter shape, language code,
-  all catalog-feedback lanes, source-gated `not_evaluable` coverage, and the
-  schema-v3 video-artifact trust boundary. V4/v5 `not_evaluable` entries contain
-  only `pattern_id` plus the exact reason code derived by the contract. An
-  observable catalog entry still awaiting an owner-approved source gate fails
-  closed: it cannot be detected or silently counted as absent and must use
-  `source_gate_pending_owner_review`. For `video_extracted`, the enum alone
-  never creates `static_slides`: that source exists only when the complete manifest
-  proves a verified manual `slide_region`. `status: "processed"` additionally
-  requires its promoted `slides_local_path`. Both writers import this same validator,
-  so bypassing the standalone command cannot weaken the boundary.
-  For v5, an N/A-capable nondetected entry is assessed only after its complete
-  `applicability_evaluable_from` gate is proven. Complete coverage requires
-  exactly one source-located `applicability_assessments` row; incomplete
-  coverage forbids a row and yields `not_evaluable`. Catalog-authorized
-  `not_applicable`, applicable-then-undetected, positive-only absence, and
-  missing-coverage states remain distinct.
-  Range-complete does not mean modality-complete. Bare `native_deck`, bare
-  `delivery_video`, video-extracted static pages, and current source-comparison
-  receipts remain positive-only; they cannot authorize absence or force an
-  applicability assessment until a canonical modality/alignment receipt exists.
-  Canonical inspection rows expose this with engine-owned
-  `absence_capability_complete` and `absence_capability_reason` alongside the
-  independent `coverage_complete` locator receipt.
-  For newly emitted work, exit 0 is necessary but not sufficient: every
-  processed entry in `pattern_scoring_generations` must report
-  `status: current`. `legacy_unbaselineable` exists only so saved v1–v4 artifacts remain
-  replayable and must be repaired before accepting new analysis.
-  A v5 analysis additionally carries one sorted engine-owned `pattern_outcomes`
-  row per observable catalog entry plus `opportunity_coverage_identity`. Raw
-  returns cannot supply either field.
-- **Update tracking DB — deterministic merge, NOT hand-mapping.** Collect the
-  batch's subagent JSON returns into an array file (`batch-returns.json`) and run
-  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/persist-results.py" {vault_root}/tracking-database.json batch-returns.json`.
-  The script first requires the return filenames to equal every live member of one
-  run/batch claim; partial, extra, mixed-identity, duplicate, closed, or stranded
-  batches fail before merge. The script requires database schema v1 and current
-  independent record versions; Step 1 is the sole migration path. It then merges each return into its matching
-  talk entry, promotes the declared queryable scalars to the talk top level, and
-  rewrites the DB in place. Do NOT hand-copy fields one at a time — that is what
-  dropped structured data before (it was computed and reached the analysis files
-  but never landed in the DB).
-  Contract, the promoted-scalar allowlist, and merge semantics live in
-  `skills/vault-ingress/scripts/persist-results.py` (top-of-file docstring and the
-  `PROMOTE` list); the shared snapshot structured policy registry lives in
-  `skills/vault-ingress/scripts/return_validation.py` so standalone validation and
-  persistence enforce the same container shapes. To make
-  a new field queryable, extend the return schema and that list; never reintroduce
-  manual mapping.
-  The same script validates each new detection against catalog observability,
-  its `evidence_source` source/outcome gate, and its evidence-channel policy; it
-  resolves every `evidence_citations` source location and refuses the whole
-  batch when proof is absent or unverifiable. Comparison detections must locate
-  proof from every underlying member of `evidence_sources_used`.
-  Version-2 through version-5 returns snapshot-replace every supplied declared
-  field, including empty values where that field contract permits emptiness,
-  and complete structured maps; omission preserves a field. Saved returns with
-  missing/version-1 metadata retain their legacy
-  additive behavior. A corrective reparse that needs to delete a field rather
-  than replace it declares its analysis-owned dotted paths in `clear_fields`.
-  Any video return without a promoted artifact must clear
-  `slides_local_path`; an untrusted return is context-only and cannot carry
-  authored-slide evidence. The script
-  persists that path when a trusted artifact is promoted, replaces a complete
-  video-extraction manifest atomically, and clears matching promoted scalars.
-  Returns satisfying the current evidence contract receive the exact catalog
-  fingerprint and scoring-schema version 5. Replayable v1–v4 returns that cannot
-  prove it are retained with
-  `pattern_scoring_generation_status: legacy_unbaselineable`, exact machine reasons, and no current fingerprint or
-  scoring version. The DB write remains atomic.
-  Only after every member has merged successfully, stdout exposes
-  `current_adherence_baseline`: an all-inclusive post-batch snapshot with
-  `active_batch_excluded: false` and `excluded_filenames: []`. Downstream
-  Section 15/profile consumers use this complete-candidate payload; they never
-  recompute a cohort after an individual member merge or mutate the immutable
-  preclaim snapshot.
-  Its normalized `--run-date` (or generated UTC timestamp) is authoritative for
-  every processed member's `processed_date` and claim release; return-side dates
-  are legacy advisory metadata and cannot override it. A return-side full
-  timestamp is treated as an explicit identity assertion and must normalize to
-  the same batch stamp or the entire write fails.
-  A successful merge closes the matching queue lease as `completed`; it never
-  deletes claim history. Claims v2 through v5 close at their own versions, and
-  an active v1 lease upgrades to v2. Every completed v2–v5 claim stores a canonical
-  SHA-256 receipt of the exact return payload; a receiptless completed v1 claim
-  cannot authorize analysis replacement. Unknown future claim versions fail
-  closed. An
-  interrupted batch is recovered with
-  `queue-state.py ... recover --now <ISO> --stale-after-seconds <N>`, not by
-  replaying whichever old return files happen to exist.
-  Future talk-record schemas are rejected before merge so this writer never
-  stamps a newer record down to its current version. Pass the canonical tracking
-  DB path: queue and persistence tools reject a final-component symlink before
-  opening it, preventing atomic replacement from splitting the link and target.
-- **Write per-talk analysis files — run the script, do NOT hand-write them.** Run
-  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/write-analysis.py" batch-returns.json {vault_root}/analyses --talks {vault_root}/tracking-database.json`
-  over the SAME `batch-returns.json` the merge consumed, so the DB and the files
-  cannot diverge. The writer verifies each completed claim's payload receipt and
-  persisted catalog fingerprint/scoring version, requires exact membership
-  across the completed batch, validates the persisted effective snapshot analysis, and
-  renders analysis-owned fields from that canonical talk state. Fields
-  omitted and preserved during persistence remain in Markdown. Only the
-  receipt-bound, non-persisted catalog-feedback side channel comes from the
-  return. The writer also renders the persisted, writer-owned timestamp. It
-  checks return targets against both one
-  another and existing directory entries under normalized/case-folded identity,
-  rejects directory/special-file targets, stages every body, and commits with
-  reverse rollback so a late failure cannot leave a partial batch. An exact
-  analysis-target symlink is replaced as a directory entry; its external target
-  is never followed or modified.
-  It renders `{vault_root}/analyses/{talk_filename}.md` per effective talk —
-  14 dimensions, structured data, verbatim examples, "Presentation Patterns Scoring",
-  and catalog feedback — creates `analyses/` if missing, prints a JSON summary, and
-  exits non-zero on a return with no `filename`. Section list and field handling live
-  in `skills/vault-ingress/scripts/write-analysis.py` (top-of-file docstring).
-  Non-empty adherence prose from a legacy v1–v4 return is preserved only as
-  archival text under an unmistakable `legacy-unverified` label. It is never a
-  current numeric comparison, Section 15 aggregate, or profile input.
-- **Aggregate catalog feedback — after the final batch, do not hand-harvest or
-  auto-edit the catalog.** Run the read-only intake over every return file or
-  return directory:
-  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/aggregate-catalog-feedback.py" {return_paths}`.
-  Review the stable JSON's invalid entries, exact-ID recurrence, normalized
-  suggestions, and polarity warnings with the speaker. Recurrence is evidence
-  for review, never authorization to change a catalog file. The five lanes and
-  report contract live in
-  [references/catalog-feedback-intake.md](references/catalog-feedback-intake.md).
-
-Proceed immediately to Step 5.
-
-## Step 5 — Update Rhetoric Summary
-
-Still per-batch (continues Step 3's loop). The summary update requires a
-speaker-review gate and stays separate from Step 4 persistence. Unlike DB
-writes, edits to `rhetoric-style-summary.md` change the speaker's
-ground-truth narrative and must not be applied silently.
-
-1. **Speaker-review gate.** Present the subagent's proposed `summary_updates`
-   and `new_patterns` as a section-by-section diff and wait for explicit
-   speaker confirmation. Silent application erodes the speaker's sense of
-   ownership of their own style summary; pattern-taxonomy additions in
-   particular drift if applied unreviewed. Only bypass the gate if the
-   speaker pre-authorized this batch ("just apply everything, don't ask").
-2. **Apply approved changes.** Integrate confirmed `new_patterns` and
-   `summary_updates` into `rhetoric-style-summary.md`. Sections 1–14 map to
-   the 14 dimensions; Sections 15–16 are the cross-talk improvement & adherence
-   narrative and speaker-confirmed intent — structure defined in
-   [references/processing-rules.md](references/processing-rules.md) Rhetoric
-   Summary — Improvement & Adherence Sections. Rebuild Section 15 only after the
-   whole batch has persisted, using `persist-results.py` stdout's
-   `current_adherence_baseline` plus talks from the exact current catalog
-   fingerprint/scoring-schema cohort. Never use a processing-date cohort and
-   never rebuild after member 1 of a multi-member batch. Section 15 remains
-   human-readable narrative; workers do not parse it as numeric authority.
-   Render its sole machine-readable current block only from the complete
-   post-batch `pattern_profile` candidate and live tracking database:
-
-   ```bash
-   "{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py" replace \
-     {vault_root}/rhetoric-style-summary.md pattern-profile-candidate.json \
-     {vault_root}/tracking-database.json
-   ```
-
-   The helper rejects a stale same-generation cohort, validates through the
-   shared profile assessor, and atomically replaces only the delimited block.
-   `section15_pattern_history.py replace` is the sole supported current-block
-   replacement operation and always requires the live tracking database.
-   A nonzero exit guarantees no write; do not hand-edit or partially update the
-   block.
-   **Recount status from the DB every time** — never increment manually.
-3. **Report.** Output: talks processed, new patterns, current state, skipped
-   talks. Flag structural changes prominently (new presentation mode, new
-   workflow pattern).
-
-When Step 3's batch loop finishes, proceed to Step 6.
-
-## Step 6 — Extract Remaining PPTX Visual Data
-
-Runs once after all Step 3 batches have completed.
-
-Process PPTX files not yet extracted during Step 3: unmatched catalog entries, talks
-that used PDF as primary but have a PPTX available, or entries with
-`pptx_visual_status: "pending"`. Skip if already `"extracted"`. Use the bounded
-directory invocation from the scan step and select the root-relative results that
-remain pending; do not replace it with `**/*.pptx` or a shell/per-file extraction
-loop. Reuse the exact config-derived `{template_skip_arguments}` (including zero
-arguments for an empty array), keep the explicit `--directory` flag, preserve every
-bounded skip receipt, and never admit a `~$` Office lock file.
-Require schema v4 for current analysis. Regenerate v0-v3 output and stop on an
-unknown future schema rather than interpreting missing fields as zero. When
-rendered pages were inspected, rerun that selected deck as one supervised
-single-artifact invocation with `--rendered-pdf <path.pdf>` and one or more
-`--inspected-pages <PAGE|START-END>` arguments so the extraction receipt binds the
-exact artifacts and covered pages. A non-empty `archive_recovery`
-blocks a required native-deck claim until the source is restored or re-exported.
-For every catalog finding or citation, OCR is affirmative only at the individual
-receipt level: use `recovered_text` only when that same receipt has
-`trustworthy_text: true`. Never promote `ocr_text` or an OCR channel's aggregate
-`text` directly; both retain low-confidence text for review.
-
-**PPTX matching rules:** The .pptx files are in `Conference/Year/TalkName.pptx` and
-shownotes entries have `conference` and `title` fields. Fuzzy-match by: normalize
-conference names (strip year, "Days", "Conference"), match by date proximity and title
-substring. Skip Office locks beginning `~$`, files with "static" in name, conflict
-copies matching `(N).pptx`, and files matching `config.template_skip_patterns`.
-Some talks have multiple .pptx files
-(one per delivery) — match to the closest date.
-
-After 3+ extractions, populate `slide-design-spec.md`; after 5+, analyze cross-talk
-patterns (colors, fonts, footers).
-
-Proceed immediately to Step 7.
+Use only current schema-v4, artifact-bound evidence and the reference's matching,
+rendered-page, OCR, and cross-talk rules. Proceed to Step 7.
 
 ## Step 7 — Regenerate Speaker Profile
 
@@ -719,79 +199,27 @@ Proceed immediately to Step 8.
 
 ## Step 8 — Verify Improvement Goals
 
-If the tracking DB has no active `improvement_goals` (none whose `status` is
-outside `achieved`/`retired`), skip this step silently. Otherwise, with the
-post-batch full-cohort pattern baseline current, pass the complete active-goal
-array and that structured baseline to:
+Skip when no goal is active. Otherwise follow
+[Improvement Goal Verification](references/processing-rules.md#improvement-goal-verification)
+using every active goal and the current full-cohort baseline:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-clarification/scripts/goal_generation_provenance.py" \
   < goal-generation-input.json
 ```
 
-The input object contains `goals` and `current_pattern_baseline`; stdout is one
-schema-v1 assessment per goal. Exit 1 is a malformed owner record or baseline:
-stop before constructing a mutation plan and change no goal. Require exactly one
-assessment for every active goal before calculating or writing anything. Only a
-`comparable` assessment authorizes metric calculation.
-
-Apply the assessment according to the stored goal record schema; never restamp a
-legacy goal:
-
-- A schema-v1 `antipattern` or `underuse` goal is report-only
-  `unverifiable`. Preserve the complete record and create no mutation for it.
-- A schema-v1 `pacing` or `other` goal may be comparable through its independent
-  provenance lane. For a comparable goal, patch only `current_value`,
-  `last_checked`, `checked_by`, and `status`; never add `verification_state` or
-  `verification_reasons`. A non-comparable assessment is report-only.
-- A schema-v2 goal uses the full verification contract. Persist
-  `needs_rebaseline` or `unverifiable` in `verification_state` with the exact
-  assessment reasons while preserving `current_value` and `status`. For a
-  comparable goal, persist the calculated metric, check metadata, outcome status,
-  `verification_state: "current"`, and empty `verification_reasons`.
-
-For every mutation, `expect` must contain exactly the fields being set with the
-values from the latest strict read. If no assessment authorizes a write, do not
-invoke the mutator. Otherwise dry-run the complete multi-goal plan as one
-transaction, review it, apply it against the reported input SHA, then re-read the
-database; one failed assessment or mutation precondition must never leave a
-partial goal update. The full write rubric is in
-[references/processing-rules.md](references/processing-rules.md) Improvement
-Goal Verification. Report current comparable outcomes first, then every goal that
-needs rebaselining or is unverifiable.
-
-Proceed immediately to Step 9.
+Require one valid assessment per goal before one expectation-bound transaction,
+then re-read and report comparable, rebaseline, and unverifiable outcomes.
+Proceed to Step 9.
 
 ## Step 9 — Same-Week Clarification Trigger
 
-If no talks were newly processed in this run, finish here without further action.
+If no talk was processed, finish. Otherwise compute candidate topics and follow
+[Clarification Handoff](references/clarification-handoff.md).
 
-Otherwise, scan the newly-processed talks for delivery date and bucket each by how
-long ago it was delivered (`today − date`). The handoff strength is tiered by recency —
-clarification quality decays fast, so the freshest talks get an active handoff, not a
-footnote. For every bucket, first compute that talk's **candidate clarification topics**:
-- Each per-talk `areas_for_improvement` entry.
-- Any `pattern_observations` the subagent flagged as **unverifiable from transcript
-  alone** (low confidence, heavy reliance on visual cues, non-English dialogue without
-  captions).
-
-**≤7 days (same-week) — hand off inline, don't just recommend.** This is the
-freshest-possible clarification window: memory of the delivery is sharpest right after
-the talk, and verbal beats that didn't appear in auto-captions (bilingual jokes rendered
-in a non-primary language, improvised asides, fly-bys that weren't in the deck) are only
-recoverable now. Do NOT bury this as a closing recommendation. Use `AskUserQuestion` to
-**offer to run `vault-clarification` right now**, showing the candidate topics you
-computed so the speaker sees exactly what the session would cover. If they accept, invoke
-`Skill(skill: "vault-clarification")` immediately, carrying those candidate topics as the
-session's seed agenda. If they decline, note it and finish.
-
-**7–30 days — recommend the full session.** Recommend running
-`Skill(skill: "vault-clarification")`, listing the candidate topics, but note that some
-verbatim details may already be lost. Do not auto-invoke.
-
-**30+ days — recommend the compressed session.** Memory has decayed and detailed recall
-is unreliable; recommend the compressed clarification instead of the full one. Do not
-auto-invoke.
+- **≤7 days:** offer to run `vault-clarification` inline and invoke it on acceptance.
+- **7–30 days:** recommend the full session with topics; do not auto-invoke.
+- **30+ days:** recommend the compressed session; do not auto-invoke.
 
 ## Error Handling
 

--- a/skills/vault-ingress/references/batch-persistence.md
+++ b/skills/vault-ingress/references/batch-persistence.md
@@ -23,39 +23,18 @@ whether to run the gate.
 
 - **Validate the whole batch before any write.** Run
   `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/validate-returns.py" batch-returns.json`.
-  Stop on a non-zero exit and repair the named return. The validator enforces the
-  terminal status, return field types, catalog ID and polarity, observability,
-  confidence and evidence, score arithmetic, co-presenter shape, language code,
-  all catalog-feedback lanes, source-gated `not_evaluable` coverage, and the
-  schema-v3 video-artifact trust boundary. V4/v5 `not_evaluable` entries contain
-  only `pattern_id` plus the exact reason code derived by the contract. An
-  observable catalog entry still awaiting an owner-approved source gate fails
-  closed: it cannot be detected or silently counted as absent and must use
-  `source_gate_pending_owner_review`. For `video_extracted`, the enum alone
-  never creates `static_slides`: that source exists only when the complete manifest
-  proves a verified manual `slide_region`. `status: "processed"` additionally
-  requires its promoted `slides_local_path`. Both writers import this same validator,
-  so bypassing the standalone command cannot weaken the boundary.
-  For v5, an N/A-capable nondetected entry is assessed only after its complete
-  `applicability_evaluable_from` gate is proven. Complete coverage requires
-  exactly one source-located `applicability_assessments` row; incomplete
-  coverage forbids a row and yields `not_evaluable`. Catalog-authorized
-  `not_applicable`, applicable-then-undetected, positive-only absence, and
-  missing-coverage states remain distinct.
-  Range-complete does not mean modality-complete. Bare `native_deck`, bare
-  `delivery_video`, video-extracted static pages, and current source-comparison
-  receipts remain positive-only; they cannot authorize absence or force an
-  applicability assessment until a canonical modality/alignment receipt exists.
-  Canonical inspection rows expose this with engine-owned
-  `absence_capability_complete` and `absence_capability_reason` alongside the
-  independent `coverage_complete` locator receipt.
-  For newly emitted work, exit 0 is necessary but not sufficient: every
-  processed entry in `pattern_scoring_generations` must report
-  `status: current`. `legacy_unbaselineable` exists only so saved v1–v4 artifacts remain
-  replayable and must be repaired before accepting new analysis.
-  A v5 analysis additionally carries one sorted engine-owned `pattern_outcomes`
-  row per observable catalog entry plus `opportunity_coverage_identity`. Raw
-  returns cannot supply either field.
+  The command accepts one return object, an array, a directory of JSON returns,
+  or multiple such inputs. Exit 0 emits one structured JSON validation report on
+  stdout and authorizes the next step; exit 1 emits concise diagnostics on stderr,
+  authorizes no write, and requires repairing the named return before rerunning.
+  The complete field, catalog, source, evidence, scoring, and artifact predicates
+  are owned by `skills/vault-ingress/scripts/validate-returns.py` (top-of-file
+  input/output/exit contract) and
+  `skills/vault-ingress/scripts/return_validation.py` (shared validator). Both
+  persistence writers import that validator; do not restate, infer, or bypass its
+  internal predicates and allowlists here. Reports may surface stable machine
+  reason codes such as `source_gate_pending_owner_review`; their triggering
+  predicates remain script-owned.
 - **Update tracking DB — deterministic merge, NOT hand-mapping.** Collect the
   batch's subagent JSON returns into an array file (`batch-returns.json`) and run
   `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/persist-results.py" {vault_root}/tracking-database.json batch-returns.json`.

--- a/skills/vault-ingress/references/batch-persistence.md
+++ b/skills/vault-ingress/references/batch-persistence.md
@@ -1,0 +1,154 @@
+# Batch Persistence
+
+This is the complete normative Step 4 contract for `vault-ingress`. Run the
+validation, database merge, analysis rendering, and final feedback intake in the
+declared order. A failed operation never authorizes the next one.
+
+Runs after each batch inside Step 3's loop (not as a separate post-loop
+phase). Mechanical persistence of the batch's subagent JSON returns:
+
+Before validation, inspect only the return declarations. If any return declares
+a preserved local recording through
+`structured_data.video_extraction.source_video_path`, `video_local_path`, or
+`video_path`, require the configured runtime once for this exact batch:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
+  --lanes core,source-video --require-lanes core,source-video
+```
+
+That success gates validation, persistence, and analysis rendering for the
+batch. Do not pre-open, hash, hydrate, or invoke `ffprobe` directly to decide
+whether to run the gate.
+
+- **Validate the whole batch before any write.** Run
+  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/validate-returns.py" batch-returns.json`.
+  Stop on a non-zero exit and repair the named return. The validator enforces the
+  terminal status, return field types, catalog ID and polarity, observability,
+  confidence and evidence, score arithmetic, co-presenter shape, language code,
+  all catalog-feedback lanes, source-gated `not_evaluable` coverage, and the
+  schema-v3 video-artifact trust boundary. V4/v5 `not_evaluable` entries contain
+  only `pattern_id` plus the exact reason code derived by the contract. An
+  observable catalog entry still awaiting an owner-approved source gate fails
+  closed: it cannot be detected or silently counted as absent and must use
+  `source_gate_pending_owner_review`. For `video_extracted`, the enum alone
+  never creates `static_slides`: that source exists only when the complete manifest
+  proves a verified manual `slide_region`. `status: "processed"` additionally
+  requires its promoted `slides_local_path`. Both writers import this same validator,
+  so bypassing the standalone command cannot weaken the boundary.
+  For v5, an N/A-capable nondetected entry is assessed only after its complete
+  `applicability_evaluable_from` gate is proven. Complete coverage requires
+  exactly one source-located `applicability_assessments` row; incomplete
+  coverage forbids a row and yields `not_evaluable`. Catalog-authorized
+  `not_applicable`, applicable-then-undetected, positive-only absence, and
+  missing-coverage states remain distinct.
+  Range-complete does not mean modality-complete. Bare `native_deck`, bare
+  `delivery_video`, video-extracted static pages, and current source-comparison
+  receipts remain positive-only; they cannot authorize absence or force an
+  applicability assessment until a canonical modality/alignment receipt exists.
+  Canonical inspection rows expose this with engine-owned
+  `absence_capability_complete` and `absence_capability_reason` alongside the
+  independent `coverage_complete` locator receipt.
+  For newly emitted work, exit 0 is necessary but not sufficient: every
+  processed entry in `pattern_scoring_generations` must report
+  `status: current`. `legacy_unbaselineable` exists only so saved v1–v4 artifacts remain
+  replayable and must be repaired before accepting new analysis.
+  A v5 analysis additionally carries one sorted engine-owned `pattern_outcomes`
+  row per observable catalog entry plus `opportunity_coverage_identity`. Raw
+  returns cannot supply either field.
+- **Update tracking DB — deterministic merge, NOT hand-mapping.** Collect the
+  batch's subagent JSON returns into an array file (`batch-returns.json`) and run
+  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/persist-results.py" {vault_root}/tracking-database.json batch-returns.json`.
+  The script first requires the return filenames to equal every live member of one
+  run/batch claim; partial, extra, mixed-identity, duplicate, closed, or stranded
+  batches fail before merge. The script requires database schema v1 and current
+  independent record versions; Step 1 is the sole migration path. It then merges each return into its matching
+  talk entry, promotes the declared queryable scalars to the talk top level, and
+  rewrites the DB in place. Do NOT hand-copy fields one at a time — that is what
+  dropped structured data before (it was computed and reached the analysis files
+  but never landed in the DB).
+  Contract, the promoted-scalar allowlist, and merge semantics live in
+  `skills/vault-ingress/scripts/persist-results.py` (top-of-file docstring and the
+  `PROMOTE` list); the shared snapshot structured policy registry lives in
+  `skills/vault-ingress/scripts/return_validation.py` so standalone validation and
+  persistence enforce the same container shapes. To make
+  a new field queryable, extend the return schema and that list; never reintroduce
+  manual mapping.
+  The same script validates each new detection against catalog observability,
+  its `evidence_source` source/outcome gate, and its evidence-channel policy; it
+  resolves every `evidence_citations` source location and refuses the whole
+  batch when proof is absent or unverifiable. Comparison detections must locate
+  proof from every underlying member of `evidence_sources_used`.
+  Version-2 through version-5 returns snapshot-replace every supplied declared
+  field, including empty values where that field contract permits emptiness,
+  and complete structured maps; omission preserves a field. Saved returns with
+  missing/version-1 metadata retain their legacy
+  additive behavior. A corrective reparse that needs to delete a field rather
+  than replace it declares its analysis-owned dotted paths in `clear_fields`.
+  Any video return without a promoted artifact must clear
+  `slides_local_path`; an untrusted return is context-only and cannot carry
+  authored-slide evidence. The script
+  persists that path when a trusted artifact is promoted, replaces a complete
+  video-extraction manifest atomically, and clears matching promoted scalars.
+  Returns satisfying the current evidence contract receive the exact catalog
+  fingerprint and scoring-schema version 5. Replayable v1–v4 returns that cannot
+  prove it are retained with
+  `pattern_scoring_generation_status: legacy_unbaselineable`, exact machine reasons, and no current fingerprint or
+  scoring version. The DB write remains atomic.
+  Only after every member has merged successfully, stdout exposes
+  `current_adherence_baseline`: an all-inclusive post-batch snapshot with
+  `active_batch_excluded: false` and `excluded_filenames: []`. Downstream
+  Section 15/profile consumers use this complete-candidate payload; they never
+  recompute a cohort after an individual member merge or mutate the immutable
+  preclaim snapshot.
+  Its normalized `--run-date` (or generated UTC timestamp) is authoritative for
+  every processed member's `processed_date` and claim release; return-side dates
+  are legacy advisory metadata and cannot override it. A return-side full
+  timestamp is treated as an explicit identity assertion and must normalize to
+  the same batch stamp or the entire write fails.
+  A successful merge closes the matching queue lease as `completed`; it never
+  deletes claim history. Claims v2 through v5 close at their own versions, and
+  an active v1 lease upgrades to v2. Every completed v2–v5 claim stores a canonical
+  SHA-256 receipt of the exact return payload; a receiptless completed v1 claim
+  cannot authorize analysis replacement. Unknown future claim versions fail
+  closed. An
+  interrupted batch is recovered with
+  `queue-state.py ... recover --now <ISO> --stale-after-seconds <N>`, not by
+  replaying whichever old return files happen to exist.
+  Future talk-record schemas are rejected before merge so this writer never
+  stamps a newer record down to its current version. Pass the canonical tracking
+  DB path: queue and persistence tools reject a final-component symlink before
+  opening it, preventing atomic replacement from splitting the link and target.
+- **Write per-talk analysis files — run the script, do NOT hand-write them.** Run
+  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/write-analysis.py" batch-returns.json {vault_root}/analyses --talks {vault_root}/tracking-database.json`
+  over the SAME `batch-returns.json` the merge consumed, so the DB and the files
+  cannot diverge. The writer verifies each completed claim's payload receipt and
+  persisted catalog fingerprint/scoring version, requires exact membership
+  across the completed batch, validates the persisted effective snapshot analysis, and
+  renders analysis-owned fields from that canonical talk state. Fields
+  omitted and preserved during persistence remain in Markdown. Only the
+  receipt-bound, non-persisted catalog-feedback side channel comes from the
+  return. The writer also renders the persisted, writer-owned timestamp. It
+  checks return targets against both one
+  another and existing directory entries under normalized/case-folded identity,
+  rejects directory/special-file targets, stages every body, and commits with
+  reverse rollback so a late failure cannot leave a partial batch. An exact
+  analysis-target symlink is replaced as a directory entry; its external target
+  is never followed or modified.
+  It renders `{vault_root}/analyses/{talk_filename}.md` per effective talk —
+  14 dimensions, structured data, verbatim examples, "Presentation Patterns Scoring",
+  and catalog feedback — creates `analyses/` if missing, prints a JSON summary, and
+  exits non-zero on a return with no `filename`. Section list and field handling live
+  in `skills/vault-ingress/scripts/write-analysis.py` (top-of-file docstring).
+  Non-empty adherence prose from a legacy v1–v4 return is preserved only as
+  archival text under an unmistakable `legacy-unverified` label. It is never a
+  current numeric comparison, Section 15 aggregate, or profile input.
+- **Aggregate catalog feedback — after the final batch, do not hand-harvest or
+  auto-edit the catalog.** Run the read-only intake over every return file or
+  return directory:
+  `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/aggregate-catalog-feedback.py" {return_paths}`.
+  Review the stable JSON's invalid entries, exact-ID recurrence, normalized
+  suggestions, and polarity warnings with the speaker. Recurrence is evidence
+  for review, never authorization to change a catalog file. The five lanes and
+  report contract live in
+  [catalog-feedback-intake.md](catalog-feedback-intake.md).

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -1,0 +1,262 @@
+# Vault Bootstrap and Preflight
+
+This is the complete normative Step 1 contract for `vault-ingress`. Execute
+each section in order; later sections assume every earlier gate succeeded.
+
+**Vault discovery** — canonical path is always `~/.claude/rhetoric-knowledge-vault/`.
+
+1. **Path exists** — use as `vault_root`, then load the database with the strict
+   owner read command in
+   [schemas-db.md](schemas-db.md#owner-read-and-mutation-contract).
+2. **Path missing** — first-time setup: ask preferred location via `AskUserQuestion`,
+   create the directory (and symlink if a custom path was chosen), then use a sole
+   `initialize_database` mutation. Include database `schema_version: 1`, config
+   `schema_version: 1`, and empty `talks`, `pptx_catalog`, `qr_codes`, `resources`,
+   `thumbnails`, `confirmed_intents`, and `improvement_goals` arrays. Review the
+   dry-run and apply it with `--expected-sha256 missing`; never create the JSON
+   file directly.
+
+**Schema gate** — vault-ingress owns the tracking database shape and migrations.
+The stdlib-only strict reader may use the host interpreter for the initial
+bootstrap read only. Read `config.python_path` from an existing database, or ask
+for the interpreter path without writing the database when that field is absent.
+Immediately re-read the same canonical path with that configured interpreter and
+require the same SHA-256; restart discovery if the generation changed. Use the
+configured interpreter for migration, queue commands, and every later toolkit
+command. Run the owner migration before any other database mutation:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json"
+```
+
+Exit 0 writes one dry-run JSON report with `input_sha256`, source and target
+schema versions, `output_sha256`, `record_counts`, `changed`,
+`database_written: false`, `warnings`, and the deterministic backup path. A
+changed report authorizes this exact apply command:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" --apply --expected-sha256 "{input_sha256}"
+```
+
+Exit 0 from apply writes one JSON report with `database_written: true`, preserves
+the complete original bytes under `{vault_root}/.backups/`, and atomically
+installs database schema v1. A non-empty `warnings` array means replacement
+completed with a durability warning and must not be reported as a failed/no-write
+run. Exit 2 writes one error object to stdout plus a diagnostic to stderr and
+leaves the database unchanged. Recover or
+complete every active queue claim named by the diagnostic. For an unversioned
+database, use `queue-state.py ... inspect` to identify the lease and
+`queue-state.py ... recover` to close it. Those two commands accept schema 0;
+recovery changes only queue-lease/status state and does not stamp or migrate the
+database or talk record. The existing queue transition may advance a recovered
+legacy claim receipt from schema v1 to v2 while adding its release fields. Rerun
+migration dry-run, then apply its new exact digest. Do not copy a digest across
+runs. `queue-state.py ... normalize` and `queue-state.py ... claim` require
+database schema 1.
+
+**Config bootstrapping** — ask once per missing field and persist to the tracking
+database with expectation-bound `set_config` mutations. Re-read after every
+successful apply and use the new hash for the next plan. Core fields: `shownotes` (enabled, source.type, source.path_or_url,
+source.talks_subdir, url.base, url.template, thumbnail_path_template,
+slug_convention), `pptx_source_dir`, `python_path`, `template_skip_patterns`.
+See [schemas-db.md](schemas-db.md) for the full schema and
+[schemas-config.md](../../vault-profile/references/schemas-config.md) for
+field-by-field semantics and migration notes.
+
+`python_path` is the interpreter authority for every operational command below;
+never fall back to whichever `python3` happens to be on `PATH`. Installed plugin
+bundles do not include `pyproject.toml`, so immediately probe the configured
+runtime with the shipped stdlib-only checker:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
+  --lanes core,pdf,pptx
+```
+
+All owner-authored tracking writes below require database schema 1 after this
+gate. Preserve every independent record version and validate the complete
+candidate before installing it. Only `migrate-tracking-database.py` may move
+schema 0 to schema 1; its hash precondition binds replacement to the exact input
+bytes as documented above.
+
+Core requires Python 3.10+ and PyYAML and is blocking. The PDF lane requires
+pypdf plus exactly `psutil==7.2.2`; the PPTX lane requires python-pptx plus the
+same exact psutil version. Both parser lanes run behind bounded worker
+supervision. Preserved source-video evidence has its own narrow `source-video`
+lane requiring exactly `psutil==7.2.2` plus `ffprobe`; require that lane before
+preflight, persistence, queue, or profile work will inspect a local recording
+declared by `structured_data.video_extraction.source_video_path`,
+`video_local_path`, or `video_path`.
+The canonical vault locator may be the configured symlink; the PDF
+boundary maps that trusted root to storage while still rejecting every
+descendant symlink/reparse redirect. Trusted-root bindings retain the directory
+object's stable identity and policy attributes, not mutable child-content size or
+timestamps; PDF and PPTX leaf generations remain exact. The checker emits report
+schema v2 and records exact pins under
+each lane's `required_module_versions`; a mismatched version is unavailable. A
+missing optional lane is reported as degraded and must not erase a healthy
+transcript or alternate slide lane.
+Require a lane before using it, for example `--require-lanes core,pdf`. Remote
+Drive acquisition additionally needs the `gdown` module; captions need
+`youtube-transcript-api`; audio download fallback needs `yt-dlp`; rendered PDF
+inspection needs `pdftoppm`; video extraction needs exactly `Pillow==12.3.0`,
+`ImageHash==4.3.2`, `numpy==2.2.6`, and `filelock==3.32.2`, plus `ffmpeg` and
+`ffprobe`; local Whisper needs `mlx-whisper` and `ffprobe`.
+Inspect those with the checker's `google-drive`, `captions`,
+`youtube-download`, `pdf-render`, `video`, and `whisper` lanes as selected talks
+require; use `source-video` for evidence over an already-preserved recording and
+`video` for frame extraction. Each lane is independent: a failed optional
+import/tool disables only that lane. Import failure details appear under the
+lane's `module_failures`;
+dependency absence, initializer exceptions, native crashes, timeouts, and
+invalid child results degrade an optional lane or block a required lane without
+breaking the one-JSON contract. The checker writes a recovery instruction to
+stderr whenever a lane is unavailable.
+
+**Scan for new talks:** run the deterministic scanner in its default read-only
+mode:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/scan-shownotes.py" \
+  "{vault_root}/tracking-database.json"
+```
+
+Read the structured report before any mutation. `add` and `update` entries are
+safe deterministic proposals; `review_required` entries need a human decision.
+The scanner uses exact filename identity, derives supported YouTube and Google
+Drive IDs, and keeps every matching `source_rejections` identity inactive.
+For comparison only, title equality applies Unicode NFC and maps straight/curly
+single and double quote glyphs to the same narrow equivalents; it preserves
+case, other punctuation, and wording. Conference equality applies NFC plus
+casefold only and preserves whitespace. The scanner never writes these
+comparison transforms back to the database or report. Incomplete metadata,
+substantive conflicts, and normalized filename collisions remain proposals.
+Disabled, `remote_url`, and `none` sources return a structured no-op.
+
+Apply the reviewed deterministic proposals with the same command plus
+`--apply`. Only `add` and `update` entries mutate the tracking database. New
+records receive current `schema_version` and status `"pending"`; exact-filename
+updates fill empty fields without overwriting established values. The write is
+atomic and rejects a tracking-database symlink. See
+[schemas-db.md](schemas-db.md#shownotes-scanimport-report)
+for the complete report and mutation contract.
+
+**Scan for .pptx files:** Do not recursively glob the source tree. Run one bounded
+directory extraction, which owns deterministic discovery, symlink/reparse-point
+rejection, and aggregate file/input/output/wall budgets:
+
+Read the exact `config.template_skip_patterns` array from the strict owner-read
+result. Set `{template_skip_arguments}` to one separately shell-quoted
+`--skip=<exact-value>` argument per array entry, preserving its order. An empty
+array produces zero arguments; never add an implicit default.
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py" \
+  --directory "{pptx_source_dir}" {template_skip_arguments}
+```
+
+Use root-relative `results[].pptx_path` identities to fuzzy-match `talks[]` entries
+and retain every `skipped[]` receipt. `pptx_batch_office_lock_file` is an explicit
+exclusion: never catalog or extract an Office temporary file whose basename starts
+with `~$`. Directory intent must remain explicit: do not omit `--directory` or
+pre-probe the root with `find`, a recursive glob, or a per-file loop. The bounded
+authenticated discovery worker owns root validation and enumeration. Report counts,
+then persist each reviewed result with a `record_pptx`
+mutation and `schema_version: 1`, including the exact prior catalog record and, for
+a match, the talk's exact prior `pptx_path` expectation. See
+[schemas-db.md](schemas-db.md) for the PPTX extraction output
+schema (per-slide visual data, shape types, global design stats).
+Consume current schema v4. A v0/v1 record has unknown timing, not zero timing;
+v2 has the pre-build timing lanes but lacks raw build-list evidence,
+archive-recovery, and exact native/render audit receipts; v3 lacks required
+shape/image capability bindings. Regenerate v0-v3
+output for current analysis. An unknown future
+schema is unusable until this reader is updated. The vault-profile layout-only
+consumer is the documented v1/v2/v3/v4 exception for the unchanged
+`template_layouts` field. Non-empty `archive_recovery` is degraded evidence:
+restore or re-export a required native deck before claiming or returning it.
+
+**Pattern taxonomy recovery:** See [processing-rules.md](processing-rules.md) for the queue-owned
+contract. Step 2 normalization deterministically routes processed results outside
+the active pattern-scoring generation back to `needs-reprocessing`; do not infer
+generation currency from processing date or hand-edit those statuses.
+
+**Pattern catalog preflight:** Before source selection or re-analysis, run:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-pattern-catalog.py"
+```
+
+Stdout is stable JSON. Exit 1 means structural catalog errors: stop before
+scoring. Exit 0 may include `semantic_debts`; present those for human review and
+do not auto-edit names, aliases, definitions, or graph relationships. The input,
+report, and no-write contracts are defined in
+[pattern-catalog-contract.md](pattern-catalog-contract.md).
+
+**Conditional source-video runtime gate:** Use only the strict owner-read database
+payload to determine whether the upcoming source preflight may inspect any
+preserved local recording declared by
+`structured_data.video_extraction.source_video_path`, `video_local_path`, or
+`video_path`. When it may, require the configured runtime before invoking
+preflight:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
+  --lanes core,source-video --require-lanes core,source-video
+```
+
+Do not pre-open, hash, hydrate, or invoke `ffprobe` directly on the recording.
+The supervised source-video assessor owns availability, exact-generation hashing,
+media inspection, caching, and diagnostics. Repair a failed required lane before
+allowing preflight to inspect that recording. An unavailable or unreadable video
+disables only source-video evidence; it must not erase or invalidate independently
+verified transcript, rendered-PDF, or native-PPTX evidence.
+
+**Source/identity preflight:** After bootstrapping and scanning, and before talk
+selection or re-analysis, run the read-only offline gate:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/preflight-vault.py" {vault_root}
+```
+
+Exit 1 means one or more blocking integrity errors (identity disagreement,
+unqualified duplicate recording, invalid source claim, or a claimed completed
+artifact that is missing): stop and repair those records/artifacts before
+processing. Exit 0 may still carry warnings for legacy evidence gaps or pending
+artifacts; report them, but they do not make the vault unusable. The stable JSON
+report and evidence shape are defined in
+[source-identity-preflight.md](source-identity-preflight.md).
+
+After the offline gate, capture and compare live YouTube provider evidence:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-source-identities.py" {vault_root}
+```
+
+This networked audit invokes `yt-dlp` once per distinct active YouTube ID and
+prints deterministic JSON without changing the vault. Review every proposed
+`source_identity` block and finding, especially `likely_non_delivery_clip` and
+`same_id_cross_talk_collision`. Provider uploader is not speaker evidence,
+upload date is not recorded date, and the provider webpage URL must never be
+auto-applied as an active source. See
+[source-identity-audit.md](source-identity-audit.md).
+
+Only after that human review, write a source-repair plan containing supported
+facts and exact old-value preconditions, then dry-run it before applying:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/apply-source-repairs.py" \
+  {vault_root}/tracking-database.json source-repair-plan.json
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/apply-source-repairs.py" \
+  {vault_root}/tracking-database.json source-repair-plan.json --apply
+```
+
+The apply command validates the whole plan before mutation, refuses active queue
+claims, writes a byte-for-byte backup under `{vault_root}/.backups/`, and replaces
+the DB atomically. Re-run the preflight after applying; do not claim work until
+blocking findings reach zero.
+
+Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
+"X processed, Y remaining. PPTX: A cataloged, B matched, C extracted."

--- a/skills/vault-ingress/references/clarification-handoff.md
+++ b/skills/vault-ingress/references/clarification-handoff.md
@@ -1,0 +1,33 @@
+# Clarification Handoff by Delivery Recency
+
+This is the complete normative Step 9 contract for `vault-ingress`. Compute
+candidate topics first, then apply the exact recency bucket and interaction rule.
+
+If no talks were newly processed in this run, finish here without further action.
+
+Otherwise, scan the newly-processed talks for delivery date and bucket each by how
+long ago it was delivered (`today − date`). The handoff strength is tiered by recency —
+clarification quality decays fast, so the freshest talks get an active handoff, not a
+footnote. For every bucket, first compute that talk's **candidate clarification topics**:
+- Each per-talk `areas_for_improvement` entry.
+- Any `pattern_observations` the subagent flagged as **unverifiable from transcript
+  alone** (low confidence, heavy reliance on visual cues, non-English dialogue without
+  captions).
+
+**≤7 days (same-week) — hand off inline, don't just recommend.** This is the
+freshest-possible clarification window: memory of the delivery is sharpest right after
+the talk, and verbal beats that didn't appear in auto-captions (bilingual jokes rendered
+in a non-primary language, improvised asides, fly-bys that weren't in the deck) are only
+recoverable now. Do NOT bury this as a closing recommendation. Use `AskUserQuestion` to
+**offer to run `vault-clarification` right now**, showing the candidate topics you
+computed so the speaker sees exactly what the session would cover. If they accept, invoke
+`Skill(skill: "vault-clarification")` immediately, carrying those candidate topics as the
+session's seed agenda. If they decline, note it and finish.
+
+**7–30 days — recommend the full session.** Recommend running
+`Skill(skill: "vault-clarification")`, listing the candidate topics, but note that some
+verbatim details may already be lost. Do not auto-invoke.
+
+**30+ days — recommend the compressed session.** Memory has decayed and detailed recall
+is unreliable; recommend the compressed clarification instead of the full one. Do not
+auto-invoke.

--- a/skills/vault-ingress/references/clarification-handoff.md
+++ b/skills/vault-ingress/references/clarification-handoff.md
@@ -19,10 +19,10 @@ freshest-possible clarification window: memory of the delivery is sharpest right
 the talk, and verbal beats that didn't appear in auto-captions (bilingual jokes rendered
 in a non-primary language, improvised asides, fly-bys that weren't in the deck) are only
 recoverable now. Do NOT bury this as a closing recommendation. Use `AskUserQuestion` to
-**offer to run `vault-clarification` right now**, showing the candidate topics you
-computed so the speaker sees exactly what the session would cover. If they accept, invoke
-`Skill(skill: "vault-clarification")` immediately, carrying those candidate topics as the
-session's seed agenda. If they decline, note it and finish.
+offer an immediate session through `Skill(skill: "vault-clarification")`, showing the
+candidate topics you computed so the speaker sees exactly what the session would cover.
+If they accept, invoke that typed call immediately, carrying those candidate topics as
+the session's seed agenda. If they decline, note it and finish.
 
 **7–30 days — recommend the full session.** Recommend running
 `Skill(skill: "vault-clarification")`, listing the candidate topics, but note that some

--- a/skills/vault-ingress/references/pptx-followup.md
+++ b/skills/vault-ingress/references/pptx-followup.md
@@ -1,0 +1,38 @@
+# PPTX Follow-up and Visual Finalization
+
+This is the complete normative Step 6 contract for `vault-ingress`. It covers
+post-batch PPTX selection, bounded extraction, current-schema admission,
+rendered-page evidence, matching, and cross-talk visual updates.
+
+Runs once after all Step 3 batches have completed.
+
+Process PPTX files not yet extracted during Step 3: unmatched catalog entries, talks
+that used PDF as primary but have a PPTX available, or entries with
+`pptx_visual_status: "pending"`. Skip if already `"extracted"`. Use the bounded directory invocation from
+[bootstrap-and-preflight.md](bootstrap-and-preflight.md) and select the root-relative results that
+remain pending; do not replace it with `**/*.pptx` or a shell/per-file extraction
+loop. Reuse the exact config-derived `{template_skip_arguments}` (including zero
+arguments for an empty array), keep the explicit `--directory` flag, preserve every
+bounded skip receipt, and never admit a `~$` Office lock file.
+Require schema v4 for current analysis. Regenerate v0-v3 output and stop on an
+unknown future schema rather than interpreting missing fields as zero. When
+rendered pages were inspected, rerun that selected deck as one supervised
+single-artifact invocation with `--rendered-pdf <path.pdf>` and one or more
+`--inspected-pages <PAGE|START-END>` arguments so the extraction receipt binds the
+exact artifacts and covered pages. A non-empty `archive_recovery`
+blocks a required native-deck claim until the source is restored or re-exported.
+For every catalog finding or citation, OCR is affirmative only at the individual
+receipt level: use `recovered_text` only when that same receipt has
+`trustworthy_text: true`. Never promote `ocr_text` or an OCR channel's aggregate
+`text` directly; both retain low-confidence text for review.
+
+**PPTX matching rules:** The .pptx files are in `Conference/Year/TalkName.pptx` and
+shownotes entries have `conference` and `title` fields. Fuzzy-match by: normalize
+conference names (strip year, "Days", "Conference"), match by date proximity and title
+substring. Skip Office locks beginning `~$`, files with "static" in name, conflict
+copies matching `(N).pptx`, and files matching `config.template_skip_patterns`.
+Some talks have multiple .pptx files
+(one per delivery) — match to the closest date.
+
+After 3+ extractions, populate `slide-design-spec.md`; after 5+, analyze cross-talk
+patterns (colors, fonts, footers).

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -383,6 +383,8 @@ that block remains explicitly historical/non-baseline; ordinary Section 15 prose
 can never restore pattern-history authorization.
 `section15_pattern_history.py replace` is the only supported current-block
 replacement operation and must receive the live tracking database.
+Recount status from the tracking database every time; never increment it
+manually.
 
 ### Section 16 — Speaker-Confirmed Intent
 

--- a/skills/vault-ingress/references/queue-selection.md
+++ b/skills/vault-ingress/references/queue-selection.md
@@ -1,0 +1,60 @@
+# Queue Selection and Claim Lifecycle
+
+This is the complete normative Step 2 contract for `vault-ingress`. Execute
+normalization before claiming, and preserve every generation, freshness, replay,
+and recovery rule below.
+
+Fresh queue work uses claim schema v5. Before changing any talk status,
+`queue-state.py claim` snapshots one immutable `adherence_baseline` for the
+entire selected batch, stamps `required_return_schema_version: 5`, and copies
+that exact snapshot into every member claim. The snapshot uses the current
+catalog fingerprint and pattern-scoring schema, includes only current
+`processed`/`processed_partial` talks, and excludes every active-batch filename
+before inspecting its prior score. Its `as_of` equals the claim's canonical
+`claimed_at`; do not edit or recompute it after the claim is written.
+
+- Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/queue-state.py"
+  {vault_root}/tracking-database.json normalize` once. This one copy-on-write
+  command migrates legacy
+  `skipped_no_video`/`skipped_no_transcript` states from the talk's usable source
+  capabilities. The shared root-aware assessor must actually read and validate a
+  local transcript/deck/PDF before it counts; a non-empty or missing path is not a
+  capability. Declared remote video/slide acquisition remains eligible for a
+  claim-time download. A `transcript_source` provenance label alone
+  is not capability. Only a record with no verified local source or remote
+  acquisition path becomes `skipped_no_sources`. The same command uses the shared
+  exact-generation selector to requeue valid `processed`/`processed_partial`
+  results that cannot enter the active pattern cohort. For scoring v5, exact
+  generation identity is necessary but insufficient: the shared freshness assessor
+  also re-hashes every persisted source-located artifact against the database's
+  vault and configured source roots. Missing, replaced, or otherwise drifted
+  evidence is excluded and requeued. Transcript freshness also revalidates the
+  hash-bound quality policy against current owner/provider duration; source-
+  identity drift cannot leave a previously accepted partial transcript in the
+  cohort. Its `normalizations` report carries ordered
+  reason codes, deterministic freshness details where applicable, and the stored
+  `reprocess_reason` for each changed row. Malformed current-generation identity or
+  score lanes reject the complete command without writing; inflight, pending,
+  already-queued, and skipped records are not generation-normalized. A repeated
+  successful normalization with no new drift leaves the DB bytes unchanged.
+  Completed claims remain immutable evidence on the requeued talk and move to
+  history normally when a later claim is created.
+- Claim each exact batch through `queue-state.py ... claim --run-id <stable-run>
+  --batch-id <stable-batch> --now <timezone-aware-ISO>`. The command selects
+  `pending`, `needs-reprocessing`, and retryable download failures, writes an
+  atomic lease, increments `reprocess_generation`, and returns the claimed talk
+  list. Every fresh claim is schema v5 and requires return schema v5. Never
+  change a record to `reprocessing-inflight` by hand.
+- Before claiming a non-YouTube talk whose transcript will be used as evidence,
+  acquire the transcript and register its canonical vault-relative
+  `transcript_path` through the guarded source-repair workflow. A worker-returned
+  path cannot grant citation authority to that same return.
+- Repeating the same live/completed run and batch is an idempotent replay: use
+  the exact stored claims and baseline, and do not rewrite the DB. Recover an
+  expired or stranded lease with `queue-state.py ... recover`; recovery keeps
+  the saved snapshot in claim history. A later claim creates a new generation and
+  takes a fresh pre-mutation snapshot rather than editing or reusing the old
+  generation's baseline.
+- Set `slide_source` per the PPTX → PDF → video extraction → none hierarchy in `SKILL.md`. Mark `"skipped_no_sources"` only if
+  preflight confirms that transcript, slide, and video sources are all unavailable.
+- If `$ARGUMENTS` specifies a talk filename or title, process ONLY that one.

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -346,9 +346,11 @@ Checks apply to a record with a declared transcript, slide, or video capability
   before inspecting any of its paths. Every manifest PDF is independently
   probed and its bounded page count must match the manifest before either
   preflight or current-return persistence accepts the referential unit. Manifest
-  paths reject NUL/dot
-  ambiguity; the preserved source MP4 must be a root-confined regular file and
-  cannot be reached through a descendant symlink. A promoted PDF must have the
+  paths reject NUL/dot ambiguity. The schema-v3 source is exactly
+  `<youtube_id>.mp4`; it takes precedence over legacy top-level video path
+  fields and must pass the bounded `source-video` evidence probe as a
+  root-confined regular ISO-BMFF recording with a usable video stream and
+  positive duration. A promoted PDF must have the
   exact bounded SHA-256 digest of the manifest's trusted `slide_region` artifact
   and additionally requires `review_required: false` and
   a manually cropped, visually verified `slide_region` artifact marked
@@ -358,6 +360,25 @@ Checks apply to a record with a declared transcript, slide, or video capability
   authored-slide evidence. Missing, legacy, invalid, or falsely promoted
   provenance is blocking for completed records and a warning for requeued/pending
   work.
+
+Source-video artifact availability is reported separately from manifest
+ownership or locator faults:
+
+| Code | Meaning |
+|---|---|
+| `source_video_artifact_missing` | The exact manifest-owned source recording is absent |
+| `source_video_artifact_unavailable` | The recording exists as an offline cloud placeholder and must be hydrated locally |
+| `source_video_artifact_unreadable` | The recording could not complete bounded media inspection; the nested reason distinguishes container, stream, parser, dependency, generation-change, timeout, monitor, and resource causes |
+
+These outcomes disable only source-video evidence. They do not invalidate an
+independently verified transcript, rendered PDF, or native PPTX. A locator,
+root-containment, symlink/reparse, manifest-ID, or exact-basename mismatch
+remains `video_extraction_provenance_invalid`. For a completed record that
+claims the source, an unavailable source is blocking until repaired or the
+record is requeued; independent evidence remains valid. Introducing this probe
+does not itself change schema v3 or force a reparse. Requeue or reparse only when
+a current persisted claim depends on source-video evidence that can no longer be
+verified.
 
 The thirteen stable slide-contract fault classes are:
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -6,6 +6,9 @@ returns the JSON shape in [schemas-db.md](schemas-db.md). The summary supports
 qualitative rhetoric analysis, but Section 15 is human narrative and MUST NOT be
 parsed for numeric adherence. The active claim's immutable
 `adherence_baseline` is the sole numeric authority.
+A successfully persisted v5 return is the only return generation eligible for pattern-scoring schema v5;
+saved legacy claims remain replayable only with their
+same-numbered archival return generation.
 
 ## A. Acquire Transcript and Slides
 

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -73,6 +73,10 @@ LANE_REQUIREMENTS: dict[str, dict[str, dict[str, str]]] = {
         "modules": {"mlx-whisper": "mlx_whisper"},
         "commands": {"ffprobe": "ffprobe"},
     },
+    "source-video": {
+        "modules": {"psutil": "psutil"},
+        "commands": {"ffprobe": "ffprobe"},
+    },
     "video": {
         "modules": {
             "filelock": "filelock",

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -14,7 +14,6 @@ import hashlib
 import json
 import math
 import re
-import subprocess
 from collections.abc import Collection, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -49,6 +48,11 @@ from pptx_evidence import (
     probe_pptx_artifact,
     recompute_native_deck_audit,
     validate_native_deck_audit,
+)
+from video_evidence import (
+    VideoArtifactProbe,
+    VideoEvidenceAssessment,
+    VideoEvidenceError,
 )
 
 
@@ -150,18 +154,11 @@ TRANSCRIPT_BUNDLE_SNAPSHOT_ATTEMPTS = 3
 
 _WORD = re.compile(r"[^\W\d_]+", re.UNICODE)
 _YOUTUBE_ID = re.compile(r"[A-Za-z0-9_-]{11}")
+_VIDEO_SUFFIXES = frozenset({".mp4", ".webm", ".mkv", ".mov"})
 
 
 class PatternEvidenceError(ValueError):
     """A detection cannot be bound to the claimed talk's source artifacts."""
-
-
-@dataclass(frozen=True)
-class _VideoArtifactSnapshot:
-    """Duration and digest proven against one unchanged local-file generation."""
-
-    duration_seconds: float
-    artifact_sha256: str
 
 
 @dataclass(frozen=True)
@@ -304,6 +301,16 @@ def _canonical_pdf_root(value: str | Path) -> Path:
     return canonical_root or locator
 
 
+def _canonical_video_root(value: str | Path) -> Path:
+    """Map a trusted configured video root without resolving a video leaf."""
+    locator = _lexical_absolute(value)
+    _mapped_locator, canonical_root = canonicalize_trusted_artifact_locator(
+        locator,
+        locator,
+    )
+    return canonical_root or locator
+
+
 def _reject_ambiguous_path_segments(value: str, *, label: str) -> None:
     """Apply the shared host-independent lexical locator classifier."""
     try:
@@ -316,7 +323,7 @@ def _resolve_local_bounded_artifact(
     trusted_root: str | Path,
     value: object,
     *,
-    suffix: str,
+    suffix: str | frozenset[str],
     label: str,
     canonicalize_root: bool = False,
 ) -> Path:
@@ -347,8 +354,9 @@ def _resolve_local_bounded_artifact(
         raise PatternEvidenceError(
             f"{label} resolves outside the trusted root"
         ) from exc
-    if not relative.parts or candidate.suffix.casefold() != suffix:
-        raise PatternEvidenceError(f"{label} must use the {suffix} suffix")
+    suffixes = frozenset({suffix}) if isinstance(suffix, str) else suffix
+    if not relative.parts or candidate.suffix.casefold() not in suffixes:
+        raise PatternEvidenceError(f"{label} must use one of {sorted(suffixes)}")
     return candidate
 
 
@@ -381,6 +389,23 @@ def _resolve_local_pdf_artifact(
     )
 
 
+def _resolve_local_video_artifact(
+    trusted_root: str | Path,
+    value: object,
+    *,
+    label: str,
+    suffixes: frozenset[str] = _VIDEO_SUFFIXES,
+) -> Path:
+    """Resolve one video locator lexically; the bounded probe owns leaf I/O."""
+    return _resolve_local_bounded_artifact(
+        trusted_root,
+        value,
+        suffix=suffixes,
+        label=label,
+        canonicalize_root=True,
+    )
+
+
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     try:
@@ -390,51 +415,6 @@ def _sha256_file(path: Path) -> str:
     except OSError as exc:
         raise PatternEvidenceError(f"cannot hash artifact {path}: {exc}") from exc
     return digest.hexdigest()
-
-
-def _file_generation(path: Path) -> tuple[int, int, int, int, int]:
-    """Return fields that change when local file bytes or identity change."""
-
-    try:
-        status = path.stat()
-    except OSError as exc:
-        raise PatternEvidenceError(
-            f"cannot inspect artifact generation {path}: {exc}"
-        ) from exc
-    return (
-        status.st_dev,
-        status.st_ino,
-        status.st_size,
-        status.st_mtime_ns,
-        status.st_ctime_ns,
-    )
-
-
-def _verified_video_snapshot(path: Path) -> _VideoArtifactSnapshot:
-    """Bind ffprobe output and digest to one unchanged file generation.
-
-    Probe first so an unreadable video is never hashed. Generation checks before
-    and after both operations reject replacement, truncation, or in-place writes
-    instead of combining a duration from one generation with another's digest.
-    """
-
-    before_probe = _file_generation(path)
-    duration = _video_duration(path)
-    after_probe = _file_generation(path)
-    if after_probe != before_probe:
-        raise PatternEvidenceError(
-            f"local video artifact changed while ffprobe inspected it: {path}"
-        )
-    digest = _sha256_file(path)
-    after_digest = _file_generation(path)
-    if after_digest != before_probe:
-        raise PatternEvidenceError(
-            f"local video artifact changed while its digest was computed: {path}"
-        )
-    return _VideoArtifactSnapshot(
-        duration_seconds=duration,
-        artifact_sha256=digest,
-    )
 
 
 def _capture_transcript_bundle(path: Path) -> _TranscriptBundleSnapshot:
@@ -571,42 +551,6 @@ def _pptx_locator_count(
     return count
 
 
-def _video_duration(path: Path) -> float:
-    try:
-        completed = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "default=nw=1:nk=1",
-                str(path),
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise PatternEvidenceError(
-            f"cannot inspect video duration {path} with ffprobe: {exc}"
-        ) from exc
-    try:
-        duration = float(completed.stdout.strip())
-    except ValueError as exc:
-        raise PatternEvidenceError(
-            f"ffprobe returned no numeric duration for {path}"
-        ) from exc
-    if completed.returncode != 0 or not math.isfinite(duration) or duration <= 0:
-        raise PatternEvidenceError(
-            f"ffprobe rejected video artifact {path}: "
-            f"{completed.stderr.strip() or 'invalid duration'}"
-        )
-    return duration
-
-
 def _declared_pdf_path(talk: Mapping[str, object]) -> tuple[str, object] | None:
     for field in ("slides_local_path", "slides_pdf_path", "pdf_path"):
         if _nonempty(talk.get(field)):
@@ -647,19 +591,68 @@ def _catalog_duration(talk: Mapping[str, object]) -> float | None:
     return None
 
 
+def _selected_video_assessment(
+    assessment: VideoEvidenceAssessment | None,
+) -> VideoEvidenceAssessment:
+    """Resolve one operation-local assessment without hiding nested probes."""
+    return assessment if assessment is not None else VideoEvidenceAssessment()
+
+
+def _video_failure_reason(error: VideoEvidenceError) -> str:
+    return f"{error.reason_code}: {error}"
+
+
+def _video_unavailable_record(
+    error: VideoEvidenceError,
+    path: Path | None,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "status": "unavailable",
+        "reason_code": error.reason_code,
+        "reason": str(error),
+        "details": copy.deepcopy(error.details),
+        "artifact_path": str(path) if path is not None else None,
+    }
+
+
 def _local_video_binding(
     vault_root: str | Path,
     owner: Mapping[str, object],
     youtube_id: str | None,
 ) -> tuple[Path | None, str]:
+    structured = owner.get("structured_data")
+    manifest = (
+        structured.get("video_extraction") if isinstance(structured, Mapping) else None
+    )
+    if isinstance(manifest, Mapping):
+        if youtube_id is None:
+            return None, "video_extraction manifest has no claimed video id"
+        if (
+            manifest.get("schema_version") != 3
+            or manifest.get("source_video_id") != youtube_id
+        ):
+            return (
+                None,
+                "video_extraction manifest is not bound to the claimed video id",
+            )
+        try:
+            source_path = resolve_video_extraction_source(
+                vault_root,
+                manifest,
+                youtube_id,
+            )
+        except PatternEvidenceError as exc:
+            return None, str(exc)
+        return source_path, f"identity-bound local source video {source_path}"
+
     for field in ("video_local_path", "video_path"):
         if not _nonempty(owner.get(field)):
             continue
         try:
-            source_path = _resolve_local_artifact(
+            source_path = _resolve_local_video_artifact(
                 vault_root,
                 owner[field],
-                suffix=frozenset({".mp4", ".webm", ".mkv", ".mov"}),
                 label=field,
             )
         except PatternEvidenceError as exc:
@@ -667,27 +660,7 @@ def _local_video_binding(
         if youtube_id is not None and source_path.stem != youtube_id:
             return None, f"{field} filename is not bound to youtube_id"
         return source_path, f"pre-registered local source video {source_path}"
-
-    structured = owner.get("structured_data")
-    manifest = (
-        structured.get("video_extraction") if isinstance(structured, Mapping) else None
-    )
-    if not isinstance(manifest, Mapping) or youtube_id is None:
-        return None, "no predeclared local video artifact"
-    if (
-        manifest.get("schema_version") != 3
-        or manifest.get("source_video_id") != youtube_id
-    ):
-        return None, "video_extraction manifest is not bound to the claimed video id"
-    try:
-        source_path = resolve_video_extraction_source(
-            vault_root,
-            manifest,
-            youtube_id,
-        )
-    except PatternEvidenceError as exc:
-        return None, str(exc)
-    return source_path, f"identity-bound local source video {source_path}"
+    return None, "no predeclared local video artifact"
 
 
 def resolve_video_extraction_source(
@@ -695,14 +668,14 @@ def resolve_video_extraction_source(
     manifest: Mapping[str, object],
     youtube_id: str,
 ) -> Path:
-    """Resolve one manifest MP4 under the vault without following leaf links."""
-    source_path = _resolve_local_artifact(
+    """Resolve one manifest MP4 lexically; the bounded probe owns leaf I/O."""
+    source_path = _resolve_local_video_artifact(
         vault_root,
         manifest.get("source_video_path"),
-        suffix=".mp4",
         label="video_extraction.source_video_path",
+        suffixes=frozenset({".mp4"}),
     )
-    if source_path.stem != youtube_id:
+    if source_path.name != f"{youtube_id}.mp4":
         raise PatternEvidenceError(
             "local source-video filename is not bound to youtube_id"
         )
@@ -768,6 +741,8 @@ def _trusted_video_slide_probe(
     youtube_id: str,
     *,
     artifact_probes: Mapping[str, tuple[PdfArtifactProbe, Path]] | None = None,
+    source_video_probe: VideoArtifactProbe | None = None,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> tuple[PdfArtifactProbe | None, str, Path | None]:
     structured = owner.get("structured_data")
     manifest = (
@@ -807,6 +782,16 @@ def _trusted_video_slide_probe(
     local_path, local_reason = _local_video_binding(vault_root, owner, youtube_id)
     if local_path is None:
         return None, local_reason, None
+    if source_video_probe is None:
+        try:
+            source_video_probe = _selected_video_assessment(
+                video_evidence_assessment
+            ).probe(
+                local_path,
+                trusted_root=_canonical_video_root(vault_root),
+            )
+        except VideoEvidenceError as exc:
+            return None, _video_failure_reason(exc), None
     artifacts = manifest.get("artifacts")
     if not isinstance(artifacts, list):
         return None, "video_extraction artifacts must be an array", None
@@ -899,7 +884,15 @@ def _returned_slide_artifact(
     vault_root: str | Path,
     talk: Mapping[str, object],
     ret: Mapping[str, object],
-) -> tuple[PdfArtifactProbe | None, str, Path | None, Path | None]:
+    *,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
+) -> tuple[
+    PdfArtifactProbe | None,
+    str,
+    Path | None,
+    Path | None,
+    VideoArtifactProbe | None,
+]:
     """Admit only a current-run artifact at a path fixed by preclaim identity."""
     slide_source = ret.get("slide_source")
     returned_path = ret.get("slides_local_path")
@@ -908,6 +901,7 @@ def _returned_slide_artifact(
             return (
                 None,
                 "return makes no explicit current-run PDF artifact assertion",
+                None,
                 None,
                 None,
             )
@@ -948,6 +942,7 @@ def _returned_slide_artifact(
             f"read identity-bound PDF {path}",
             path,
             None,
+            None,
         )
     if slide_source == "video_extracted":
         youtube_id = talk.get("youtube_id")
@@ -970,6 +965,23 @@ def _returned_slide_artifact(
             raise PatternEvidenceError(
                 "return video slides have no video_extraction manifest"
             )
+        local_path, local_reason = _local_video_binding(vault_root, ret, youtube_id)
+        if local_path is None:
+            raise PatternEvidenceError(
+                "return video extraction source is unavailable: " + local_reason
+            )
+        try:
+            source_video_probe = _selected_video_assessment(
+                video_evidence_assessment
+            ).probe(
+                local_path,
+                trusted_root=_canonical_video_root(vault_root),
+            )
+        except VideoEvidenceError as exc:
+            raise PatternEvidenceError(
+                "return video extraction source is unavailable: "
+                + _video_failure_reason(exc)
+            ) from exc
         artifact_probes = _probe_video_manifest_artifacts(
             vault_root,
             manifest,
@@ -980,12 +992,9 @@ def _returned_slide_artifact(
             ret,
             youtube_id,
             artifact_probes=artifact_probes,
+            source_video_probe=source_video_probe,
+            video_evidence_assessment=video_evidence_assessment,
         )
-        local_path, local_reason = _local_video_binding(vault_root, ret, youtube_id)
-        if local_path is None:
-            raise PatternEvidenceError(
-                "return video extraction source is unavailable: " + local_reason
-            )
         observations = ret.get("pattern_observations")
         claimed_static = (
             "static_slides" in (observations.get("evidence_sources") or [])
@@ -995,15 +1004,23 @@ def _returned_slide_artifact(
         if probe is None or slide_path is None:
             if _nonempty(returned_path) or claimed_static:
                 raise PatternEvidenceError(reason)
-            return None, reason, None, local_path
-        return probe, reason, slide_path, local_path
-    return None, "return declares no deterministic local slide artifact", None, None
+            return None, reason, None, local_path, source_video_probe
+        return probe, reason, slide_path, local_path, source_video_probe
+    return (
+        None,
+        "return declares no deterministic local slide artifact",
+        None,
+        None,
+        None,
+    )
 
 
 def admit_return_artifacts(
     vault_root: str | Path,
     talk: Mapping[str, object],
     ret: Mapping[str, object],
+    *,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> None:
     """Bound current-return slide artifacts for every supported return schema."""
     structured = ret.get("structured_data")
@@ -1018,7 +1035,14 @@ def admit_return_artifacts(
     if ret.get("slide_source") not in {"pdf", "both", "video_extracted"}:
         return
     try:
-        _returned_slide_artifact(vault_root, talk, ret)
+        _returned_slide_artifact(
+            vault_root,
+            talk,
+            ret,
+            video_evidence_assessment=_selected_video_assessment(
+                video_evidence_assessment
+            ),
+        )
     except PdfEvidenceError as exc:
         raise PatternEvidenceError(
             f"cannot admit returned PDF artifact ({exc.reason_code}): {exc}"
@@ -1200,6 +1224,7 @@ def validate_transcript_quality_for_owner(
     talk: Mapping[str, object],
     *,
     vault_root: str | Path,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> tuple[bool, str, str, bool]:
     """Validate one transcript against its full receipt and current owner.
 
@@ -1221,12 +1246,17 @@ def validate_transcript_quality_for_owner(
     local_media_sha256: str | None = None
     if local_media_path is not None:
         try:
-            local_media_snapshot = _verified_video_snapshot(local_media_path)
-        except PatternEvidenceError:
+            local_media_probe = _selected_video_assessment(
+                video_evidence_assessment
+            ).probe(
+                local_media_path,
+                trusted_root=_canonical_video_root(vault_root),
+            )
+        except VideoEvidenceError:
             pass
         else:
-            local_media_duration = local_media_snapshot.duration_seconds
-            local_media_sha256 = local_media_snapshot.artifact_sha256
+            local_media_duration = local_media_probe.duration_seconds
+            local_media_sha256 = local_media_probe.source_sha256
     unstable_reason = (
         "transcript bundle changed during quality validation; retry after "
         "acquisition or cloud sync completes"
@@ -1280,7 +1310,7 @@ def _load_verified_transcript_snapshot(
     owner_video_id: str | None,
     owner_media_sha256: str | None,
     owner_duration_seconds: float | None,
-    local_media_snapshot: _VideoArtifactSnapshot | None,
+    local_media_probe: VideoArtifactProbe | None,
 ) -> _VerifiedTranscriptSnapshot:
     """Load text and both receipts from one stable bundle generation.
 
@@ -1351,13 +1381,13 @@ def _load_verified_transcript_snapshot(
             transcript_text,
             talk,
             trusted_fallback_duration=(
-                local_media_snapshot.duration_seconds
-                if local_media_snapshot is not None
+                local_media_probe.duration_seconds
+                if local_media_probe is not None
                 else None
             ),
             trusted_local_media_sha256=(
-                local_media_snapshot.artifact_sha256
-                if local_media_snapshot is not None
+                local_media_probe.source_sha256
+                if local_media_probe is not None
                 else None
             ),
         )
@@ -1427,8 +1457,11 @@ def build_evidence_context(
     talk: Mapping[str, object],
     ret: Mapping[str, object] | None = None,
     source_roots: Mapping[str, object] | None = None,
+    *,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> dict[str, object]:
     """Resolve preclaim sources plus identity-derived current-run artifacts."""
+    selected_video_assessment = _selected_video_assessment(video_evidence_assessment)
     raw_youtube_id = talk.get("youtube_id")
     bound_youtube_id = (
         raw_youtube_id
@@ -1439,16 +1472,19 @@ def build_evidence_context(
         vault_root, talk, bound_youtube_id
     )
     predeclared_video_duration: float | None = None
-    predeclared_video_snapshot: _VideoArtifactSnapshot | None = None
+    predeclared_video_probe: VideoArtifactProbe | None = None
+    predeclared_video_error: VideoEvidenceError | None = None
     if predeclared_video_path is not None:
         try:
-            predeclared_video_snapshot = _verified_video_snapshot(
-                predeclared_video_path
+            predeclared_video_probe = selected_video_assessment.probe(
+                predeclared_video_path,
+                trusted_root=_canonical_video_root(vault_root),
             )
-        except PatternEvidenceError as exc:
-            predeclared_video_reason = str(exc)
+        except VideoEvidenceError as exc:
+            predeclared_video_error = exc
+            predeclared_video_reason = _video_failure_reason(exc)
         else:
-            predeclared_video_duration = predeclared_video_snapshot.duration_seconds
+            predeclared_video_duration = predeclared_video_probe.duration_seconds
 
     transcript_text: str | None = None
     transcript_policy_bound = False
@@ -1461,8 +1497,8 @@ def build_evidence_context(
     if timing_owner_duration is None:
         timing_owner_duration = predeclared_video_duration
     timing_owner_media_sha256 = (
-        predeclared_video_snapshot.artifact_sha256
-        if predeclared_video_snapshot is not None
+        predeclared_video_probe.source_sha256
+        if predeclared_video_probe is not None
         else None
     )
     timed_segments: list[dict[str, object]] = []
@@ -1477,7 +1513,7 @@ def build_evidence_context(
             owner_video_id=bound_youtube_id,
             owner_media_sha256=timing_owner_media_sha256,
             owner_duration_seconds=timing_owner_duration,
-            local_media_snapshot=predeclared_video_snapshot,
+            local_media_probe=predeclared_video_probe,
         )
         transcript_text = verified_transcript.text
         transcript_reason = verified_transcript.transcript_reason
@@ -1544,6 +1580,11 @@ def build_evidence_context(
     source_reasons: dict[str, str] = {}
     source_degradations: dict[str, dict[str, object]] = {}
     source_unavailable: dict[str, dict[str, object]] = {}
+    if predeclared_video_error is not None:
+        source_unavailable["delivery_video"] = _video_unavailable_record(
+            predeclared_video_error,
+            predeclared_video_path,
+        )
     pptx_count: int | None = None
     pdf_count: int | None = None
     pptx_path: Path | None = None
@@ -1663,7 +1704,13 @@ def build_evidence_context(
             video_slide_path: Path | None = None
             try:
                 video_probe, video_slide_reason, video_slide_path = (
-                    _trusted_video_slide_probe(vault_root, talk, youtube_id)
+                    _trusted_video_slide_probe(
+                        vault_root,
+                        talk,
+                        youtube_id,
+                        source_video_probe=predeclared_video_probe,
+                        video_evidence_assessment=selected_video_assessment,
+                    )
                 )
             except PdfEvidenceError as exc:
                 source_reasons["static_slides"] = str(exc)
@@ -1764,10 +1811,20 @@ def build_evidence_context(
         )
 
     current_video_path: Path | None = None
+    current_video_probe: VideoArtifactProbe | None = None
     if isinstance(ret, Mapping):
         try:
-            returned_probe, returned_reason, returned_slide_path, current_video_path = (
-                _returned_slide_artifact(vault_root, talk, ret)
+            (
+                returned_probe,
+                returned_reason,
+                returned_slide_path,
+                current_video_path,
+                current_video_probe,
+            ) = _returned_slide_artifact(
+                vault_root,
+                talk,
+                ret,
+                video_evidence_assessment=selected_video_assessment,
             )
         except PdfEvidenceError as exc:
             raise PatternEvidenceError(
@@ -1819,21 +1876,17 @@ def build_evidence_context(
     video_artifact_bound = False
     video_timing_bound = False
     video_binding_reason = "no identity-bound timed video artifact"
-    local_video_path: Path | None = None
-    local_video_path = predeclared_video_path
-    local_video_reason = predeclared_video_reason
-    video_snapshot = predeclared_video_snapshot
+    local_video_path = current_video_path or predeclared_video_path
+    local_video_reason = (
+        f"identity-bound current-return source video {current_video_path}"
+        if current_video_path is not None
+        else predeclared_video_reason
+    )
+    video_probe = current_video_probe or predeclared_video_probe
     if local_video_path is not None or bound_youtube_id is not None:
-        if local_video_path is None and current_video_path is not None:
-            local_video_path = current_video_path
-            local_video_reason = f"identity-bound local source video {local_video_path}"
-            try:
-                video_snapshot = _verified_video_snapshot(local_video_path)
-            except PatternEvidenceError as exc:
-                video_binding_reason = str(exc)
         if local_video_path is not None:
-            if video_snapshot is not None:
-                probed_duration = video_snapshot.duration_seconds
+            if video_probe is not None:
+                probed_duration = video_probe.duration_seconds
                 identity_duration = (
                     _identity_duration(talk, bound_youtube_id)
                     if bound_youtube_id is not None
@@ -1857,6 +1910,7 @@ def build_evidence_context(
                     video_duration = probed_duration
                     video_artifact_bound = True
                     video_binding_reason = local_video_reason
+                    source_unavailable.pop("delivery_video", None)
             elif video_binding_reason == "no identity-bound timed video artifact":
                 video_binding_reason = local_video_reason
         elif local_video_reason:
@@ -1917,31 +1971,19 @@ def build_evidence_context(
     if (
         video_artifact_bound
         and local_video_path is not None
-        and video_snapshot is not None
+        and video_probe is not None
     ):
-        try:
-            local_video_path.resolve(strict=False).relative_to(
-                _native_artifact_root(vault_root, label="vault_root")
-            )
-        except ValueError:
-            video_root = _native_artifact_root(
-                local_video_path.parent,
-                label="video artifact parent",
-            )
-            video_root_kind = "preclaim:video_local_path"
-        else:
-            video_root = _native_artifact_root(vault_root, label="vault_root")
-            video_root_kind = "vault"
         try:
             video_artifact_identity.update(
                 _artifact_identity(
-                    video_root,
+                    _canonical_video_root(vault_root),
                     local_video_path,
-                    root_kind=video_root_kind,
-                    artifact_sha256=video_snapshot.artifact_sha256,
+                    root_kind="vault",
+                    artifact_sha256=video_probe.source_sha256,
+                    lexical=True,
                 )
             )
-        except (OSError, PatternEvidenceError) as exc:
+        except PatternEvidenceError as exc:
             # A video that cannot be identity-bound is unavailable video
             # evidence, not a reason to erase an independent transcript/deck.
             video_artifact_bound = False
@@ -1966,6 +2008,7 @@ def build_evidence_context(
             len(transcript_text.splitlines()) if transcript_text is not None else None
         ),
         "local_video_path": local_video_path,
+        "video_artifact_probe": video_probe,
         "transcript_artifact_identity": transcript_artifact_identity,
         "timing_artifact_identity": timing_artifact_identity,
         "quality_artifact_identity": quality_artifact_identity,
@@ -1991,6 +2034,7 @@ def assess_talk_artifact_capabilities(
     *,
     vault_root: str | Path,
     source_roots: Mapping[str, object] | None = None,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> dict[str, object]:
     """Return root-aware verified-local vs acquisition capabilities.
 
@@ -2000,8 +2044,14 @@ def assess_talk_artifact_capabilities(
     """
     context: dict[str, object] | None = None
     contract_error: str | None = None
+    selected_video_assessment = _selected_video_assessment(video_evidence_assessment)
     try:
-        context = build_evidence_context(vault_root, talk, source_roots=source_roots)
+        context = build_evidence_context(
+            vault_root,
+            talk,
+            source_roots=source_roots,
+            video_evidence_assessment=selected_video_assessment,
+        )
     except PatternEvidenceError as exc:
         # Transcript identity/path errors are intentionally fail-closed for the
         # transcript, but they must not erase an independent deck/video. Retry
@@ -2021,6 +2071,7 @@ def assess_talk_artifact_capabilities(
                 vault_root,
                 isolated_talk,
                 source_roots=source_roots,
+                video_evidence_assessment=selected_video_assessment,
             )
         except PatternEvidenceError as isolated_exc:
             verified_sources = set()
@@ -2173,8 +2224,10 @@ def assess_batch_artifact_capabilities(
     *,
     vault_root: str | Path,
     source_roots: Mapping[str, object] | None = None,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> dict[str, dict[str, object]]:
     """Assess only talks named by one supplied return batch."""
+    selected_video_assessment = _selected_video_assessment(video_evidence_assessment)
     requested = set(filenames)
     assessed: dict[str, dict[str, object]] = {}
     for talk in talks:
@@ -2187,6 +2240,7 @@ def assess_batch_artifact_capabilities(
             talk,
             vault_root=vault_root,
             source_roots=source_roots,
+            video_evidence_assessment=selected_video_assessment,
         )
     return assessed
 
@@ -3193,6 +3247,7 @@ def canonicalize_return_evidence(
     source_roots: Mapping[str, object] | None = None,
     *,
     pattern_scoring_schema_version: int = CURRENT_PATTERN_SCORING_SCHEMA_VERSION,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> dict[str, object]:
     """Return a v4/v5 payload with source claims canonically located."""
     canonical = copy.deepcopy(dict(ret))
@@ -3210,7 +3265,11 @@ def canonicalize_return_evidence(
             "pattern_observations is required for evidence canonicalization"
         )
     context = build_evidence_context(
-        vault_root, talk, canonical, source_roots=source_roots
+        vault_root,
+        talk,
+        canonical,
+        source_roots=source_roots,
+        video_evidence_assessment=_selected_video_assessment(video_evidence_assessment),
     )
     if context.get("transcript_text") is not None:
         canonical_transcript_source = context.get("canonical_transcript_source")
@@ -3800,6 +3859,7 @@ def assess_persisted_pattern_evidence_freshness(
     *,
     vault_root: str | Path,
     source_roots: Mapping[str, object] | None = None,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> tuple[str, ...]:
     """Return stable reason codes for any persisted evidence drift.
 
@@ -3821,10 +3881,15 @@ def assess_persisted_pattern_evidence_freshness(
         reasons.update(_v5_projection_freshness_reasons(talk, observations))
     vault = _lexical_absolute(vault_root)
     bounded_vault = _canonical_pdf_root(vault_root)
+    bounded_video_vault = _canonical_video_root(vault_root)
+    selected_video_assessment = _selected_video_assessment(video_evidence_assessment)
     current_context: Mapping[str, object] = {}
     try:
         current_context = build_evidence_context(
-            vault_root, talk, source_roots=source_roots
+            vault_root,
+            talk,
+            source_roots=source_roots,
+            video_evidence_assessment=selected_video_assessment,
         )
     except PatternEvidenceError:
         if evidence_schema_version == PATTERN_EVIDENCE_SCHEMA_VERSION:
@@ -3834,13 +3899,15 @@ def assess_persisted_pattern_evidence_freshness(
         kind: object,
         label: str,
         *,
-        bounded_suffix: str | None = None,
+        bounded_suffix: str | frozenset[str] | None = None,
     ) -> Path | None:
         if kind == "vault":
             if bounded_suffix == ".pdf":
                 return bounded_vault
             if bounded_suffix == ".pptx":
                 return vault
+            if bounded_suffix == _VIDEO_SUFFIXES:
+                return bounded_video_vault
             return vault
         if kind == "pptx_source":
             configured = (
@@ -3863,6 +3930,21 @@ def assess_persisted_pattern_evidence_freshness(
             )
         if isinstance(kind, str) and kind.startswith("preclaim:"):
             field = kind.removeprefix("preclaim:")
+            if field == "video_local_path" and bounded_suffix == _VIDEO_SUFFIXES:
+                raw_youtube_id = talk.get("youtube_id")
+                bound_youtube_id = (
+                    raw_youtube_id
+                    if isinstance(raw_youtube_id, str)
+                    and _YOUTUBE_ID.fullmatch(raw_youtube_id)
+                    else None
+                )
+                legacy_video_path, _reason = _local_video_binding(
+                    vault_root,
+                    talk,
+                    bound_youtube_id,
+                )
+                if legacy_video_path is not None:
+                    return legacy_video_path.parent
             declared = talk.get(field)
             try:
                 locator_kind = classify_artifact_locator(declared)
@@ -3891,7 +3973,7 @@ def assess_persisted_pattern_evidence_freshness(
         timing: bool = False,
         quality: bool = False,
         bounded_current_digest: str | None = None,
-        bounded_suffix: str | None = None,
+        bounded_suffix: str | frozenset[str] | None = None,
     ) -> Path | None:
         if timing and quality:  # pragma: no cover - internal API guard
             raise ValueError("an identity cannot be both timing and quality")
@@ -4009,6 +4091,12 @@ def assess_persisted_pattern_evidence_freshness(
         if isinstance(current_static_probe, PdfArtifactProbe)
         else None
     )
+    current_video_probe = current_context.get("video_artifact_probe")
+    bounded_video_digest = (
+        current_video_probe.source_sha256
+        if isinstance(current_video_probe, VideoArtifactProbe)
+        else None
+    )
     native_declared = _declares_persisted_native_deck(talk, observations)
     structured = talk.get("structured_data")
     raw_native_audit = (
@@ -4090,6 +4178,8 @@ def assess_persisted_pattern_evidence_freshness(
                 if source == "native_deck"
                 else bounded_static_digest
                 if source == "static_slides"
+                else bounded_video_digest
+                if source == "delivery_video"
                 else None
             ),
             bounded_suffix=(
@@ -4097,6 +4187,8 @@ def assess_persisted_pattern_evidence_freshness(
                 if source == "native_deck"
                 else ".pdf"
                 if source == "static_slides"
+                else _VIDEO_SUFFIXES
+                if source == "delivery_video"
                 else None
             ),
         )
@@ -4122,14 +4214,20 @@ def assess_persisted_pattern_evidence_freshness(
                 if isinstance(youtube_id, str) and _YOUTUBE_ID.fullmatch(youtube_id):
                     values.append(f"transcripts/{youtube_id}.txt")
         elif source == "delivery_video":
-            for field in ("video_local_path", "video_path"):
-                if _nonempty(talk.get(field)):
-                    values.append(talk[field])
-            manifest_path = _dig(
-                talk, "structured_data.video_extraction.source_video_path"
+            owner_youtube_id = talk.get("youtube_id")
+            bound_youtube_id = (
+                owner_youtube_id
+                if isinstance(owner_youtube_id, str)
+                and _YOUTUBE_ID.fullmatch(owner_youtube_id)
+                else None
             )
-            if _nonempty(manifest_path):
-                values.append(manifest_path)
+            bound_path, _reason = _local_video_binding(
+                vault_root,
+                talk,
+                bound_youtube_id,
+            )
+            if bound_path is not None:
+                return [_lexical_absolute(bound_path)]
         candidates: list[Path] = []
         allowed_suffixes = (
             frozenset({".txt"})
@@ -4142,7 +4240,7 @@ def assess_persisted_pattern_evidence_freshness(
             except ArtifactLocatorError:
                 continue
             if supplied.suffix.casefold() in allowed_suffixes:
-                candidates.append(supplied.resolve(strict=False))
+                candidates.append(_lexical_absolute(supplied))
         return candidates
 
     inspection = observations.get("source_inspection")
@@ -4192,7 +4290,7 @@ def assess_persisted_pattern_evidence_freshness(
                 expected_role_path = current_context.get("local_video_path")
             expected_role_identity = (
                 _lexical_absolute(expected_role_path)
-                if source in {"native_deck", "static_slides"}
+                if source in {"native_deck", "static_slides", "delivery_video"}
                 and isinstance(expected_role_path, Path)
                 else (
                     expected_role_path.resolve(strict=False)
@@ -4204,45 +4302,10 @@ def assess_persisted_pattern_evidence_freshness(
                 reasons.add(f"{label}:source_role_provenance_drift")
         coherent_transcript_text: str | None = None
         if source == "transcript":
-            owner_youtube_id = talk.get("youtube_id")
-            bound_youtube_id = (
-                owner_youtube_id
-                if isinstance(owner_youtube_id, str)
-                and _YOUTUBE_ID.fullmatch(owner_youtube_id)
-                else None
+            context_transcript = current_context.get("transcript_text")
+            coherent_transcript_text = (
+                context_transcript if isinstance(context_transcript, str) else None
             )
-            local_media_path, _ = _local_video_binding(
-                vault_root, talk, bound_youtube_id
-            )
-            local_media_snapshot: _VideoArtifactSnapshot | None = None
-            if local_media_path is not None:
-                try:
-                    local_media_snapshot = _verified_video_snapshot(local_media_path)
-                except PatternEvidenceError:
-                    pass
-            owner_duration = _catalog_duration(talk)
-            if owner_duration is None and local_media_snapshot is not None:
-                owner_duration = local_media_snapshot.duration_seconds
-            recorded_source = talk.get("transcript_source")
-            owner_source = (
-                cast(str, recorded_source)
-                if recorded_source in {"youtube_auto", "whisper", "manual"}
-                else "unknown"
-            )
-            verified_transcript = _load_verified_transcript_snapshot(
-                path,
-                talk,
-                owner_source=owner_source,
-                owner_video_id=bound_youtube_id,
-                owner_media_sha256=(
-                    local_media_snapshot.artifact_sha256
-                    if local_media_snapshot is not None
-                    else None
-                ),
-                owner_duration_seconds=owner_duration,
-                local_media_snapshot=local_media_snapshot,
-            )
-            coherent_transcript_text = verified_transcript.text
             if coherent_transcript_text is None:
                 reasons.add(f"{label}:transcript_quality_context_drift")
         current_candidates = owner_candidates(source)
@@ -4292,11 +4355,12 @@ def assess_persisted_pattern_evidence_freshness(
                 if record.get("page_count") != count:
                     reasons.add(f"{label}:page_count_drift")
             elif source == "delivery_video":
-                current_video_snapshot = _verified_video_snapshot(path)
-                duration = current_video_snapshot.duration_seconds
-                if current_video_snapshot.artifact_sha256 != record.get(
-                    "artifact_sha256"
-                ):
+                if not isinstance(current_video_probe, VideoArtifactProbe):
+                    raise PatternEvidenceError(
+                        "bounded current video receipt is unavailable"
+                    )
+                duration = current_video_probe.duration_seconds
+                if current_video_probe.source_sha256 != record.get("artifact_sha256"):
                     reasons.add(f"{label}:artifact_digest_mismatch")
                 _, complete = _validate_time_ranges(
                     record.get("time_ranges"), duration=duration
@@ -4539,10 +4603,17 @@ def assess_persisted_pattern_evidence_freshness(
 
 
 def assess_persisted_evidence_freshness(
-    talk: Mapping[str, object], vault_root: str | Path
+    talk: Mapping[str, object],
+    vault_root: str | Path,
+    *,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> tuple[str, ...]:
     """Compatibility wrapper for callers that have only a vault root."""
-    return assess_persisted_pattern_evidence_freshness(talk, vault_root=vault_root)
+    return assess_persisted_pattern_evidence_freshness(
+        talk,
+        vault_root=vault_root,
+        video_evidence_assessment=video_evidence_assessment,
+    )
 
 
 def return_evidence_claim(ret: Mapping[str, object]) -> dict[str, object]:

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -96,6 +96,7 @@ from pattern_evidence import (
     canonicalize_return_evidence,
     return_evidence_claim,
 )
+from video_evidence import VideoEvidenceAssessment
 from return_validation import (
     ADDITIVE_MAP,
     ANALYSIS_STATUSES,
@@ -868,6 +869,7 @@ def main():
     except VaultRootAuthorityError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
+    video_evidence_assessment = VideoEvidenceAssessment()
     returns = load_json(batch_path, "batch-returns")
     try:
         catalog = validate_batch(returns)
@@ -882,6 +884,7 @@ def main():
         },
         vault_root=vault_root,
         source_roots=source_roots,
+        video_evidence_assessment=video_evidence_assessment,
     )
     try:
         by_name = validate_batch_claims_against_talks(
@@ -900,7 +903,12 @@ def main():
         name = ret["filename"]
         try:
             if ret.get("status") in ANALYSIS_STATUSES:
-                admit_return_artifacts(vault_root, by_name[name], ret)
+                admit_return_artifacts(
+                    vault_root,
+                    by_name[name],
+                    ret,
+                    video_evidence_assessment=video_evidence_assessment,
+                )
             if (ret.get("status") in ANALYSIS_STATUSES and
                     resolve_return_schema_version(ret) in
                     SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS):
@@ -910,6 +918,7 @@ def main():
                     pattern_scoring_schema_version=(
                         PATTERN_SCORING_SCHEMA_VERSION
                     ),
+                    video_evidence_assessment=video_evidence_assessment,
                 )
             else:
                 canonical = copy.deepcopy(ret)
@@ -963,7 +972,8 @@ def main():
             pattern_scoring_schema_version=PATTERN_SCORING_SCHEMA_VERSION,
             evidence_freshness_assessor=lambda talk: (
                 assess_current_persisted_pattern_evidence_freshness(
-                    talk, vault_root=vault_root, source_roots=source_roots)
+                    talk, vault_root=vault_root, source_roots=source_roots,
+                    video_evidence_assessment=video_evidence_assessment)
             ),
         )
     except AdherenceBaselineError as exc:

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -31,6 +31,7 @@ from artifact_locator import (
     materialize_artifact_locator,
     materialize_native_root,
 )
+from artifact_metadata import canonicalize_trusted_artifact_locator
 from ingress_contract import (
     YOUTUBE_ID_RE,
     is_youtube_url,
@@ -54,6 +55,7 @@ from pattern_evidence import (
     validate_transcript_quality_for_owner,
 )
 from pdf_evidence import PdfArtifactProbe, PdfEvidenceError, probe_pdf_artifact
+from video_evidence import VideoEvidenceAssessment, VideoEvidenceError
 from source_identity_matching import (
     EventAlias,
     event_agreement,
@@ -103,6 +105,17 @@ SLIDE_CONTRACT_CODES = frozenset(
         "slide_video_artifact_unavailable",
         "slide_video_artifact_unreadable",
     }
+)
+SOURCE_VIDEO_CONTRACT_CODES = frozenset(
+    {
+        "source_video_artifact_missing",
+        "source_video_artifact_unavailable",
+        "source_video_artifact_unreadable",
+    }
+)
+
+_SOURCE_VIDEO_PROVENANCE_FAILURE_KINDS = frozenset(
+    {"not_regular", "root_escape", "symlink_or_reparse"}
 )
 
 WORD_RE = re.compile(r"[^\W_]+", re.UNICODE)
@@ -188,12 +201,31 @@ def _json_value(value: Any) -> Any:
     return repr(value)
 
 
+def _source_video_failure_code(error: VideoEvidenceError) -> str:
+    """Map bounded-video failures without conflating bytes with provenance."""
+    reason_code = error.reason_code
+    failure_kind = error.details.get("failure_kind")
+    if reason_code == "video_evidence_invalid" and isinstance(
+        error.details.get("locator_failure"), str
+    ):
+        return "video_extraction_provenance_invalid"
+    if reason_code == "video_artifact_unavailable":
+        if failure_kind == "missing":
+            return "source_video_artifact_missing"
+        if failure_kind in _SOURCE_VIDEO_PROVENANCE_FAILURE_KINDS:
+            return "video_extraction_provenance_invalid"
+    if reason_code == "video_cloud_placeholder_unavailable":
+        return "source_video_artifact_unavailable"
+    return "source_video_artifact_unreadable"
+
+
 class VaultPreflight:
     """Accumulate deterministic findings for one already-loaded database."""
 
     def __init__(self, database: Any, vault_root: Path, database_path: Path):
         self.database = database
         self.vault_root = Path(vault_root)
+        self._artifact_root: Path | None = None
         self.database_path = Path(database_path)
         self.findings: list[dict[str, Any]] = []
         self.talks: list[dict[str, Any]] = []
@@ -204,6 +236,18 @@ class VaultPreflight:
         self.valid_relations: dict[int, tuple[str, str]] = {}
         self.event_aliases: set[EventAlias] = set()
         self.artifact_capabilities: dict[int, dict[str, object]] = {}
+        self.video_evidence_assessment = VideoEvidenceAssessment()
+        self.reported_source_video_failures: set[int] = set()
+
+    def artifact_root(self) -> Path:
+        """Map the trusted configured root lazily, without probing CLI input."""
+        if self._artifact_root is None:
+            _artifact, admitted_root = canonicalize_trusted_artifact_locator(
+                self.vault_root,
+                self.vault_root,
+            )
+            self._artifact_root = admitted_root or self.vault_root
+        return self._artifact_root
 
     def add(
         self,
@@ -705,8 +749,9 @@ class VaultPreflight:
         )
         assessed = assess_talk_artifact_capabilities(
             self.talks[index],
-            vault_root=self.vault_root,
+            vault_root=self.artifact_root(),
             source_roots=source_roots,
+            video_evidence_assessment=self.video_evidence_assessment,
         )
         self.artifact_capabilities[index] = assessed
         return assessed
@@ -1126,7 +1171,8 @@ class VaultPreflight:
                 transcript_path,
                 text,
                 talk,
-                vault_root=self.vault_root,
+                vault_root=self.artifact_root(),
+                video_evidence_assessment=self.video_evidence_assessment,
             )
         )
         if valid:
@@ -1251,22 +1297,64 @@ class VaultPreflight:
             )
             return
 
-        errors: list[str] = []
+        errors: list[object] = []
         trusted_slide_region_probe: PdfArtifactProbe | None = None
         expected_id = self.youtube_ids.get(index)
         if state.source_video_id != expected_id:
             errors.append("source_video_id must match the talk's YouTube identity")
-        try:
-            resolve_video_extraction_source(
-                self.vault_root,
-                extraction,
-                state.source_video_id,
-            )
-        except PatternEvidenceError:
-            errors.append(
-                "source_video_path must name a root-confined, non-symlinked "
-                "preserved source video"
-            )
+        else:
+            try:
+                source_video_path = resolve_video_extraction_source(
+                    self.artifact_root(),
+                    extraction,
+                    state.source_video_id,
+                )
+            except PatternEvidenceError:
+                errors.append(
+                    "source_video_path must name a root-confined, non-symlinked "
+                    "preserved source video"
+                )
+            else:
+                try:
+                    self.video_evidence_assessment.probe(
+                        source_video_path,
+                        trusted_root=self.artifact_root(),
+                    )
+                except VideoEvidenceError as exc:
+                    finding_code = _source_video_failure_code(exc)
+                    failure = {
+                        "reason_code": exc.reason_code,
+                        "details": dict(exc.details),
+                    }
+                    if finding_code == "video_extraction_provenance_invalid":
+                        errors.append(failure)
+                    elif index not in self.reported_source_video_failures:
+                        self.reported_source_video_failures.add(index)
+                        message = {
+                            "source_video_artifact_missing": (
+                                "preserved source video artifact does not exist"
+                            ),
+                            "source_video_artifact_unavailable": (
+                                "preserved source video is not hydrated for local "
+                                "inspection"
+                            ),
+                            "source_video_artifact_unreadable": (
+                                "preserved source video could not complete bounded "
+                                "evidence inspection"
+                            ),
+                        }[finding_code]
+                        self.talk_add(
+                            index,
+                            severity,
+                            finding_code,
+                            message,
+                            field=(
+                                "structured_data.video_extraction.source_video_path"
+                            ),
+                            actual=failure,
+                            artifact_path=source_video_path,
+                            capability_fact=self._capabilities(index),
+                        )
 
         artifacts = extraction.get("artifacts")
         # Shared schema validation proved this is a list of artifact objects.

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1297,7 +1297,7 @@ class VaultPreflight:
             )
             return
 
-        errors: list[object] = []
+        errors: list[str] = []
         trusted_slide_region_probe: PdfArtifactProbe | None = None
         expected_id = self.youtube_ids.get(index)
         if state.source_video_id != expected_id:
@@ -1327,7 +1327,12 @@ class VaultPreflight:
                         "details": dict(exc.details),
                     }
                     if finding_code == "video_extraction_provenance_invalid":
-                        errors.append(failure)
+                        closed_reason = exc.details.get("locator_failure")
+                        if not isinstance(closed_reason, str):
+                            closed_reason = exc.details.get("failure_kind")
+                        if not isinstance(closed_reason, str):
+                            closed_reason = exc.reason_code
+                        errors.append(f"source_video_path: {closed_reason}")
                     elif index not in self.reported_source_video_failures:
                         self.reported_source_video_failures.add(index)
                         message = {

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -179,9 +179,13 @@ def timestamp_text(moment):
 
 def require_identifier(value, label):
     if not isinstance(value, str) or not value or value.strip() != value:
-        raise QueueStateError(f"{label} must be a non-empty string without edge whitespace")
+        raise QueueStateError(
+            f"{label} must be a non-empty string without edge whitespace"
+        )
     if any(char.isspace() for char in value):
-        raise QueueStateError(f"{label} {value!r} contains whitespace — use a stable token")
+        raise QueueStateError(
+            f"{label} {value!r} contains whitespace — use a stable token"
+        )
     return value
 
 
@@ -217,9 +221,7 @@ def has_video(talk):
 def evidence_roots(database, path):
     """Return the database-bound vault root and configured source roots."""
     source_roots = (
-        database.get("config")
-        if isinstance(database.get("config"), dict)
-        else {}
+        database.get("config") if isinstance(database.get("config"), dict) else {}
     )
     vault_root = resolve_vault_root_authority(
         database_path=path,
@@ -229,7 +231,8 @@ def evidence_roots(database, path):
 
 
 def evidence_freshness_assessor(
-        database, path, *, video_evidence_assessment: VideoEvidenceAssessment):
+    database, path, *, video_evidence_assessment: VideoEvidenceAssessment
+):
     """Bind the shared read-only assessor to this database's trusted roots."""
     vault_root, source_roots = evidence_roots(database, path)
     cache = {}
@@ -249,7 +252,8 @@ def evidence_freshness_assessor(
 
 
 def artifact_capability_assessor(
-        database, path, *, video_evidence_assessment: VideoEvidenceAssessment):
+    database, path, *, video_evidence_assessment: VideoEvidenceAssessment
+):
     """Bind root-aware local/acquisition capability checks.
 
     The bounded PPTX probe owns generation-aware memoization.  Keeping a
@@ -368,7 +372,9 @@ def validate_talk(talk, index, *, allow_claim_status_drift=False):
     if explicit_id in (None, ""):
         explicit_id = None
     elif not isinstance(explicit_id, str) or not YOUTUBE_ID.fullmatch(explicit_id):
-        raise QueueStateError(f"{filename}: youtube_id {explicit_id!r} is not 11 characters")
+        raise QueueStateError(
+            f"{filename}: youtube_id {explicit_id!r} is not 11 characters"
+        )
     url_id = youtube_id_from_url(talk.get("video_url"))
     if url_id and explicit_id is None:
         raise QueueStateError(
@@ -392,6 +398,7 @@ def validate_talk(talk, index, *, allow_claim_status_drift=False):
                 f"{filename}: filename id {filename_id} disagrees with "
                 f"youtube_id {explicit_id}"
             )
+
 
 def validate_database(database, *, allow_claim_status_drift=False):
     try:
@@ -506,19 +513,19 @@ def normalize_legacy_statuses(database, *, capability_assessor):
         )
         current = "pending" if capabilities else "skipped_no_sources"
         talk["status"] = current
-        changes.append({
-            "filename": talk["filename"],
-            "previous_status": previous,
-            "status": current,
-            "video_present": has_video(talk),
-            "source_capabilities": capabilities,
-        })
+        changes.append(
+            {
+                "filename": talk["filename"],
+                "previous_status": previous,
+                "status": current,
+                "video_present": has_video(talk),
+                "source_capabilities": capabilities,
+            }
+        )
     return changes
 
 
-def normalize_pattern_scoring_generations(
-    database, *, evidence_freshness_assessor
-):
+def normalize_pattern_scoring_generations(database, *, evidence_freshness_assessor):
     """Requeue every valid processed talk outside the active score generation."""
     try:
         catalog = load_catalog()
@@ -544,13 +551,15 @@ def normalize_pattern_scoring_generations(
         reprocess_reason = pattern_scoring_reprocess_reason(reason_codes)
         talk["status"] = "needs-reprocessing"
         talk["reprocess_reason"] = reprocess_reason
-        changes.append({
-            "filename": talk["filename"],
-            "previous_status": previous,
-            "status": talk["status"],
-            "reprocess_reason": reprocess_reason,
-            **detail,
-        })
+        changes.append(
+            {
+                "filename": talk["filename"],
+                "previous_status": previous,
+                "status": talk["status"],
+                "reprocess_reason": reprocess_reason,
+                **detail,
+            }
+        )
     return changes
 
 
@@ -574,9 +583,14 @@ def claims_for_run(database, run_id, batch_id=None):
             item["filename"] = talk["filename"]
             item["current_status"] = talk["status"]
             found.append(item)
-    return sorted(found, key=lambda item: (
-        item["batch_id"], item["filename"], item["reprocess_generation"]
-    ))
+    return sorted(
+        found,
+        key=lambda item: (
+            item["batch_id"],
+            item["filename"],
+            item["reprocess_generation"],
+        ),
+    )
 
 
 def reconstruct_run(database, run_id):
@@ -588,8 +602,12 @@ def reconstruct_run(database, run_id):
         {"batch_id": batch_id, "filenames": sorted(filenames)}
         for batch_id, filenames in sorted(grouped.items())
     ]
-    return {"run_id": run_id, "claim_count": len(claims),
-            "batches": batches, "claims": claims}
+    return {
+        "run_id": run_id,
+        "claim_count": len(claims),
+        "batches": batches,
+        "claims": claims,
+    }
 
 
 def archive_current_claim(talk, now_text):
@@ -663,12 +681,17 @@ def claim_talk(
 
 
 def command_normalize(
-        database, path, _args, *, expected_snapshot,
-        video_evidence_assessment: VideoEvidenceAssessment):
+    database,
+    path,
+    _args,
+    *,
+    expected_snapshot,
+    video_evidence_assessment: VideoEvidenceAssessment,
+):
     candidate = copy.deepcopy(database)
     capability_assessor = artifact_capability_assessor(
-        candidate, path,
-        video_evidence_assessment=video_evidence_assessment)
+        candidate, path, video_evidence_assessment=video_evidence_assessment
+    )
     normalizations = normalize_legacy_statuses(
         candidate,
         capability_assessor=capability_assessor,
@@ -677,7 +700,8 @@ def command_normalize(
         normalize_pattern_scoring_generations(
             candidate,
             evidence_freshness_assessor=evidence_freshness_assessor(
-                candidate, path,
+                candidate,
+                path,
                 video_evidence_assessment=video_evidence_assessment,
             ),
         )
@@ -702,8 +726,13 @@ def command_normalize(
 
 
 def command_claim(
-        database, path, args, *, expected_snapshot,
-        video_evidence_assessment: VideoEvidenceAssessment):
+    database,
+    path,
+    args,
+    *,
+    expected_snapshot,
+    video_evidence_assessment: VideoEvidenceAssessment,
+):
     run_id = require_identifier(args.run_id, "run_id")
     batch_id = require_identifier(args.batch_id, "batch_id")
     now_text = timestamp_text(parse_timestamp(args.now, "--now"))
@@ -716,11 +745,12 @@ def command_claim(
         for item in existing:
             filename = item["filename"]
             prior = latest_by_filename.get(filename)
-            if (prior is None or item["reprocess_generation"] >
-                    prior["reprocess_generation"]):
+            if (
+                prior is None
+                or item["reprocess_generation"] > prior["reprocess_generation"]
+            ):
                 latest_by_filename[filename] = item
-        latest = sorted(
-            latest_by_filename.values(), key=lambda item: item["filename"])
+        latest = sorted(latest_by_filename.values(), key=lambda item: item["filename"])
         existing_names = set(latest_by_filename)
         if requested and set(requested) != existing_names:
             raise QueueStateError(
@@ -748,9 +778,7 @@ def command_claim(
             # not replay a closed lease and leave the batch silently idle.
             requested = sorted(existing_names)
         else:
-            states_by_filename = {
-                item["filename"]: item["state"] for item in latest
-            }
+            states_by_filename = {item["filename"]: item["state"] for item in latest}
             raise QueueStateError(
                 f"run {run_id!r} batch {batch_id!r} has non-replayable mixed "
                 f"claim states {states_by_filename}; retry only recovered talks "
@@ -759,8 +787,8 @@ def command_claim(
 
     candidate = copy.deepcopy(database)
     capability_assessor = artifact_capability_assessor(
-        candidate, path,
-        video_evidence_assessment=video_evidence_assessment)
+        candidate, path, video_evidence_assessment=video_evidence_assessment
+    )
     normalizations = normalize_legacy_statuses(
         candidate,
         capability_assessor=capability_assessor,
@@ -769,7 +797,9 @@ def command_claim(
     if requested:
         missing = sorted(set(requested) - set(by_filename))
         if missing:
-            raise QueueStateError(f"requested filenames are not in the database: {missing}")
+            raise QueueStateError(
+                f"requested filenames are not in the database: {missing}"
+            )
         if len(requested) > args.limit:
             raise QueueStateError(
                 f"requested {len(requested)} filenames exceeds --limit {args.limit}"
@@ -803,14 +833,15 @@ def command_claim(
                 )
     else:
         eligible = [
-            talk for talk in candidate["talks"]
+            talk
+            for talk in candidate["talks"]
             if talk["status"] in CLAIMABLE_STATUSES
             and has_claimable_source(
                 talk,
                 capability_assessor=capability_assessor,
             )
         ]
-        selected = sorted(eligible, key=lambda talk: talk["filename"])[:args.limit]
+        selected = sorted(eligible, key=lambda talk: talk["filename"])[: args.limit]
 
     selected_filenames = [talk["filename"] for talk in selected]
     try:
@@ -822,7 +853,8 @@ def command_claim(
             pattern_catalog_fingerprint=catalog.fingerprint,
             pattern_scoring_schema_version=PATTERN_SCORING_SCHEMA_VERSION,
             evidence_freshness_assessor=evidence_freshness_assessor(
-                database, path,
+                database,
+                path,
                 video_evidence_assessment=video_evidence_assessment,
             ),
         )
@@ -912,10 +944,12 @@ def command_recover(database, path, args, *, expected_snapshot):
             "age_seconds": age_seconds,
         }
         if status_drift:
-            recovered_item.update({
-                "status_before": status_before,
-                "release_reason": "state_status_drift",
-            })
+            recovered_item.update(
+                {
+                    "status_before": status_before,
+                    "release_reason": "state_status_drift",
+                }
+            )
         recovered.append(recovered_item)
     if recovered:
         validate_database(database)
@@ -962,8 +996,9 @@ def positive_integer(value):
 def build_parser():
     parser = JsonArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument("database", help="tracking-database.json path")
-    actions = parser.add_subparsers(dest="action", required=True,
-                                    parser_class=JsonArgumentParser)
+    actions = parser.add_subparsers(
+        dest="action", required=True, parser_class=JsonArgumentParser
+    )
     actions.add_parser(
         "normalize",
         help="normalize legacy source statuses and stale scoring generations",
@@ -972,15 +1007,20 @@ def build_parser():
     claim = actions.add_parser("claim", help="claim a deterministic batch")
     claim.add_argument("--run-id", required=True)
     claim.add_argument("--batch-id", required=True)
-    claim.add_argument("--now", required=True,
-                       help="timezone-aware ISO-8601 claim time")
+    claim.add_argument(
+        "--now", required=True, help="timezone-aware ISO-8601 claim time"
+    )
     claim.add_argument("--limit", type=positive_integer, default=5)
-    claim.add_argument("--filename", action="append",
-                       help="claim this filename; repeat for an exact batch")
+    claim.add_argument(
+        "--filename",
+        action="append",
+        help="claim this filename; repeat for an exact batch",
+    )
 
     recover = actions.add_parser("recover", help="recover expired inflight leases")
-    recover.add_argument("--now", required=True,
-                         help="timezone-aware ISO-8601 reference time")
+    recover.add_argument(
+        "--now", required=True, help="timezone-aware ISO-8601 reference time"
+    )
     recover.add_argument("--stale-after-seconds", type=positive_integer, required=True)
     recover.add_argument("--run-id", help="recover only this run's expired claims")
 

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -100,6 +100,7 @@ from pattern_evidence import (
     assess_talk_artifact_capabilities,
     required_pptx_evidence_blocking_reason,
 )
+from video_evidence import VideoEvidenceAssessment
 from return_validation import (
     PATTERN_SCORING_SCHEMA_VERSION,
     QUEUE_CLAIM_SCHEMA_VERSION,
@@ -227,7 +228,8 @@ def evidence_roots(database, path):
     return vault_root, source_roots
 
 
-def evidence_freshness_assessor(database, path):
+def evidence_freshness_assessor(
+        database, path, *, video_evidence_assessment: VideoEvidenceAssessment):
     """Bind the shared read-only assessor to this database's trusted roots."""
     vault_root, source_roots = evidence_roots(database, path)
     cache = {}
@@ -239,13 +241,15 @@ def evidence_freshness_assessor(database, path):
                 talk,
                 vault_root=vault_root,
                 source_roots=source_roots,
+                video_evidence_assessment=video_evidence_assessment,
             )
         return cache[identity]
 
     return assess
 
 
-def artifact_capability_assessor(database, path):
+def artifact_capability_assessor(
+        database, path, *, video_evidence_assessment: VideoEvidenceAssessment):
     """Bind root-aware local/acquisition capability checks.
 
     The bounded PPTX probe owns generation-aware memoization.  Keeping a
@@ -259,6 +263,7 @@ def artifact_capability_assessor(database, path):
             talk,
             vault_root=vault_root,
             source_roots=source_roots,
+            video_evidence_assessment=video_evidence_assessment,
         )
 
     return assess
@@ -657,9 +662,13 @@ def claim_talk(
     return item
 
 
-def command_normalize(database, path, _args, *, expected_snapshot):
+def command_normalize(
+        database, path, _args, *, expected_snapshot,
+        video_evidence_assessment: VideoEvidenceAssessment):
     candidate = copy.deepcopy(database)
-    capability_assessor = artifact_capability_assessor(candidate, path)
+    capability_assessor = artifact_capability_assessor(
+        candidate, path,
+        video_evidence_assessment=video_evidence_assessment)
     normalizations = normalize_legacy_statuses(
         candidate,
         capability_assessor=capability_assessor,
@@ -668,7 +677,8 @@ def command_normalize(database, path, _args, *, expected_snapshot):
         normalize_pattern_scoring_generations(
             candidate,
             evidence_freshness_assessor=evidence_freshness_assessor(
-                candidate, path
+                candidate, path,
+                video_evidence_assessment=video_evidence_assessment,
             ),
         )
     )
@@ -691,7 +701,9 @@ def command_normalize(database, path, _args, *, expected_snapshot):
     }
 
 
-def command_claim(database, path, args, *, expected_snapshot):
+def command_claim(
+        database, path, args, *, expected_snapshot,
+        video_evidence_assessment: VideoEvidenceAssessment):
     run_id = require_identifier(args.run_id, "run_id")
     batch_id = require_identifier(args.batch_id, "batch_id")
     now_text = timestamp_text(parse_timestamp(args.now, "--now"))
@@ -746,7 +758,9 @@ def command_claim(database, path, args, *, expected_snapshot):
             )
 
     candidate = copy.deepcopy(database)
-    capability_assessor = artifact_capability_assessor(candidate, path)
+    capability_assessor = artifact_capability_assessor(
+        candidate, path,
+        video_evidence_assessment=video_evidence_assessment)
     normalizations = normalize_legacy_statuses(
         candidate,
         capability_assessor=capability_assessor,
@@ -808,7 +822,8 @@ def command_claim(database, path, args, *, expected_snapshot):
             pattern_catalog_fingerprint=catalog.fingerprint,
             pattern_scoring_schema_version=PATTERN_SCORING_SCHEMA_VERSION,
             evidence_freshness_assessor=evidence_freshness_assessor(
-                database, path
+                database, path,
+                video_evidence_assessment=video_evidence_assessment,
             ),
         )
     except (AdherenceBaselineError, ReturnValidationError, OSError) as exc:
@@ -997,12 +1012,22 @@ def main(argv=None):
             "recover": command_recover,
             "inspect": command_inspect,
         }
-        payload = commands[args.action](
-            database,
-            path,
-            args,
-            expected_snapshot=snapshot,
-        )
+        command = commands[args.action]
+        if args.action in {"normalize", "claim"}:
+            payload = command(
+                database,
+                path,
+                args,
+                expected_snapshot=snapshot,
+                video_evidence_assessment=VideoEvidenceAssessment(),
+            )
+        else:
+            payload = command(
+                database,
+                path,
+                args,
+                expected_snapshot=snapshot,
+            )
     except (QueueStateError, VaultRootAuthorityError) as exc:
         payload = {"ok": False, "error": str(exc)}
         print(str(exc), file=sys.stderr)

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -76,6 +76,7 @@ from pptx_evidence import (
     ranges_cover_pages,
     validate_native_deck_audit,
 )
+from video_evidence import VideoEvidenceAssessment
 
 
 ANALYSIS_STATUSES = frozenset({"processed", "processed_partial"})
@@ -1967,6 +1968,7 @@ def assess_current_persisted_pattern_evidence_freshness(
     vault_root: str | Path,
     source_roots: Mapping[str, object] | None = None,
     catalog: PatternCatalog | None = None,
+    video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> tuple[str, ...]:
     """Combine artifact freshness with active-catalog v5 projection replay."""
     reasons = set(
@@ -1974,6 +1976,7 @@ def assess_current_persisted_pattern_evidence_freshness(
             talk,
             vault_root=vault_root,
             source_roots=source_roots,
+            video_evidence_assessment=video_evidence_assessment,
         )
     )
     observations = talk.get("pattern_observations")

--- a/skills/vault-ingress/scripts/video_evidence.py
+++ b/skills/vault-ingress/scripts/video_evidence.py
@@ -1,0 +1,1958 @@
+#!/usr/bin/env python3
+"""Bounded, exact-generation evidence for local delivery-video artifacts."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, BinaryIO, Final, Iterator, Literal, NoReturn, cast
+
+from artifact_locator import (
+    ArtifactLocatorError,
+    materialize_artifact_locator,
+    materialize_native_root,
+)
+from artifact_metadata import (
+    ArtifactAvailability,
+    ArtifactMetadataMalformed,
+    ArtifactMetadataReceipt,
+    ArtifactMetadataUnavailable,
+    MACOS_DATALESS_FLAG,
+    METADATA_SCHEMA_VERSION,
+    WINDOWS_CLOUD_REPARSE_TAGS,
+    WINDOWS_REPARSE_POINT_ATTRIBUTE,
+    WINDOWS_UNAVAILABLE_CLOUD_ATTRIBUTES,
+    canonicalize_trusted_artifact_locator,
+    decode_artifact_metadata_payload,
+    inspect_metadata_generation,
+)
+from artifact_supervisor import (
+    DiagnosticReceipt,
+    FileGeneration,
+    JsonValue,
+    SupervisorError,
+    SupervisorLimits,
+    WorkerRequest,
+    WorkerResult,
+    _PipeDrainer,
+    isolate_protocol_output,
+    read_worker_request,
+    run_authenticated_worker,
+    write_worker_response,
+)
+
+
+VIDEO_PROBE_SCHEMA_VERSION: Final = 1
+VIDEO_PROBE_PIPELINE_VERSION: Final = "1.0.0"
+VIDEO_SUPERVISED_WORKER_FLAG: Final = "--supervised-worker"
+VIDEO_METADATA_OPERATION: Final = "video_metadata"
+VIDEO_PROBE_OPERATION: Final = "video_probe"
+
+VIDEO_MAX_INPUT_BYTES: Final = 8 * 1024**3
+VIDEO_MAX_STREAMS: Final = 64
+VIDEO_FFPROBE_STDOUT_BYTES: Final = 256 * 1024
+VIDEO_FFPROBE_STDERR_BYTES: Final = 64 * 1024
+VIDEO_DIGEST_CHUNK_BYTES: Final = 1024 * 1024
+
+VIDEO_MACOS_DATALESS_FLAG: Final = MACOS_DATALESS_FLAG
+VIDEO_WINDOWS_CLOUD_FILE_ATTRIBUTES: Final = WINDOWS_UNAVAILABLE_CLOUD_ATTRIBUTES
+VIDEO_WINDOWS_REPARSE_POINT_ATTRIBUTE: Final = WINDOWS_REPARSE_POINT_ATTRIBUTE
+VIDEO_WINDOWS_CLOUD_REPARSE_TAGS: Final = WINDOWS_CLOUD_REPARSE_TAGS
+
+VIDEO_METADATA_LIMITS = SupervisorLimits(
+    profile_id="video-metadata-v1",
+    wall_seconds=15,
+    max_memory_bytes=256 * 1024 * 1024,
+    max_input_bytes=64 * 1024,
+    max_output_bytes=64 * 1024,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=1,
+)
+VIDEO_PROBE_LIMITS = SupervisorLimits(
+    profile_id="video-probe-v1",
+    wall_seconds=300,
+    max_memory_bytes=512 * 1024 * 1024,
+    max_input_bytes=64 * 1024,
+    max_output_bytes=64 * 1024,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=2,
+)
+
+ContainerFamily = Literal["iso_bmff", "matroska_webm"]
+DurationSource = Literal["format", "stream"]
+
+_CONTAINER_FAMILY_BY_SUFFIX: Final[dict[str, ContainerFamily]] = {
+    ".mp4": "iso_bmff",
+    ".mov": "iso_bmff",
+    ".webm": "matroska_webm",
+    ".mkv": "matroska_webm",
+}
+_ISO_BMFF_FORMAT_NAMES: Final = frozenset({"mov", "mp4", "m4a", "3gp", "3g2", "mj2"})
+_MATROSKA_FORMAT_NAMES: Final = frozenset({"matroska", "webm"})
+_VIDEO_GENERATION_NAMES: Final = frozenset({"video", "video_root"})
+_SHA256_RE: Final = re.compile(r"^[0-9a-f]{64}$")
+_EXCEPTION_TYPE_RE: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+
+_CHILD_FAILURE_REASONS: Final = frozenset(
+    {
+        "video_artifact_unavailable",
+        "video_dependency_unavailable",
+        "video_duration_unavailable",
+        "video_invalid_container",
+        "video_no_video_stream",
+        "video_parser_rejected",
+        "video_parser_repair_required",
+        "video_probe_resource_unavailable",
+        "video_stream_limit",
+    }
+)
+_STABLE_GENERATION_FAILURES: Final = frozenset(
+    {
+        "video_artifact_too_large",
+        "video_cloud_placeholder_unavailable",
+        "video_duration_unavailable",
+        "video_invalid_container",
+        "video_no_video_stream",
+        "video_parser_rejected",
+        "video_parser_repair_required",
+        "video_stream_limit",
+    }
+)
+
+
+class VideoEvidenceError(ValueError):
+    """A path-neutral rejection from the closed video-evidence boundary."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str = "video_evidence_invalid",
+        details: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.details = dict(details or {})
+
+
+@dataclass(frozen=True)
+class VideoArtifactProbe:
+    """Immutable facts bound to one exact local video-file generation."""
+
+    generation: FileGeneration
+    root_generation: FileGeneration | None
+    availability: ArtifactAvailability
+    source_sha256: str
+    source_size_bytes: int
+    duration_seconds: float
+    duration_source: DurationSource
+    container_family: ContainerFamily
+    stream_count: int
+    video_stream_count: int
+    audio_stream_count: int
+    attached_picture_count: int
+    other_stream_count: int
+    parser_diagnostics: DiagnosticReceipt
+
+
+@dataclass(frozen=True)
+class _CachedFailure:
+    message: str
+    reason_code: str
+    details: Mapping[str, object]
+
+
+_Outcome = VideoArtifactProbe | _CachedFailure
+
+
+@dataclass(frozen=True)
+class _AssessmentRequestKey:
+    artifact_path: str
+    trusted_root: str | None
+    expected_container_family: ContainerFamily
+
+
+@dataclass(frozen=True)
+class _VideoCacheKey:
+    request: _AssessmentRequestKey
+    generation: FileGeneration
+    root_generation: FileGeneration | None
+    reparse_tag: int | None
+    availability_state: str
+    macos_dataless: bool
+    windows_offline: bool
+    windows_recall_on_open: bool
+    windows_recall_on_data_access: bool
+    metadata_profile_id: str
+    probe_profile_id: str
+    schema_generation: int
+    pipeline_generation: str
+    max_input_bytes: int
+    max_streams: int
+
+
+@dataclass
+class _AssessmentState:
+    lock: threading.RLock = field(default_factory=threading.RLock)
+    exact_outcomes: dict[_VideoCacheKey, _Outcome] = field(default_factory=dict)
+    transient_outcomes: dict[_AssessmentRequestKey, _CachedFailure] = field(
+        default_factory=dict
+    )
+
+
+class VideoEvidenceAssessment:
+    """One operation-local probe scope with externally immutable identity.
+
+    Successful and deterministic outcomes are revalidated against metadata on
+    every lookup, then reused only for the same exact generation. A transient
+    failure is retained for this path for the rest of the assessment, avoiding
+    a hidden confirmation probe inside one top-level operation.
+    """
+
+    __slots__ = ("_state",)
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "_state", _AssessmentState())
+
+    def __setattr__(self, _name: str, _value: object) -> NoReturn:
+        raise AttributeError("VideoEvidenceAssessment is immutable")
+
+    def probe(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        trusted_root: str | os.PathLike[str] | None = None,
+        deadline_monotonic: float | None = None,
+    ) -> VideoArtifactProbe:
+        artifact, root, expected_family = _materialize_public_request(
+            path,
+            trusted_root=trusted_root,
+        )
+        request_key = _request_key(artifact, root, expected_family)
+        with self._state.lock:
+            transient = self._state.transient_outcomes.get(request_key)
+        if transient is not None:
+            _raise_cached(transient)
+
+        try:
+            receipt = _run_bounded_metadata_worker(
+                artifact,
+                trusted_root=root,
+                deadline_monotonic=deadline_monotonic,
+            )
+        except VideoEvidenceError as exc:
+            cached = _cached_failure(exc)
+            with self._state.lock:
+                self._state.transient_outcomes.setdefault(request_key, cached)
+                selected = self._state.transient_outcomes[request_key]
+            _raise_cached(selected)
+
+        key = _cache_key(request_key, receipt)
+        with self._state.lock:
+            prior = self._state.exact_outcomes.get(key)
+        if prior is not None:
+            return _outcome_value(prior)
+
+        try:
+            outcome = _probe_generation_singleflight(
+                artifact,
+                trusted_root=root,
+                receipt=receipt,
+                key=key,
+                deadline_monotonic=deadline_monotonic,
+                assessment_state=self._state,
+            )
+        except VideoEvidenceError as exc:
+            cached = _cached_failure(exc)
+            with self._state.lock:
+                if exc.reason_code in _STABLE_GENERATION_FAILURES:
+                    self._state.exact_outcomes.setdefault(key, cached)
+                    selected = self._state.exact_outcomes[key]
+                else:
+                    self._state.transient_outcomes.setdefault(request_key, cached)
+                    selected = self._state.transient_outcomes[request_key]
+            return _outcome_value(selected)
+
+        with self._state.lock:
+            self._state.exact_outcomes.setdefault(key, outcome)
+            selected = self._state.exact_outcomes[key]
+        return _outcome_value(selected)
+
+
+@dataclass
+class _GlobalFlight:
+    leader_state: _AssessmentState
+    event: threading.Event = field(default_factory=threading.Event)
+    outcome: _Outcome | None = None
+    assessment_outcome: _Outcome | None = None
+
+
+@dataclass(frozen=True)
+class _PreparedVideoSource:
+    source_descriptor: int
+    probe_descriptor: int
+    probe_artifact: Path
+    probe_generation: FileGeneration
+
+
+_GLOBAL_CACHE_LOCK = threading.RLock()
+_GLOBAL_PROBE_CACHE: dict[_VideoCacheKey, _Outcome] = {}
+_GLOBAL_PROBE_FLIGHTS: dict[_VideoCacheKey, _GlobalFlight] = {}
+_GLOBAL_CACHE_EPOCH = 0
+
+
+def _failure(
+    reason_code: str,
+    *,
+    details: Mapping[str, object] | None = None,
+) -> VideoEvidenceError:
+    messages = {
+        "video_artifact_changed": "Video artifact changed during bounded inspection",
+        "video_artifact_too_large": "Video artifact exceeds the input-size ceiling",
+        "video_artifact_unavailable": "Video artifact is unavailable",
+        "video_batch_wall_limit": "Video evidence operation deadline expired",
+        "video_cloud_placeholder_unavailable": (
+            "Video artifact is an offline cloud placeholder; download it locally "
+            "before using video evidence"
+        ),
+        "video_dependency_unavailable": (
+            "Video evidence requires its declared runtime dependencies"
+        ),
+        "video_duration_unavailable": (
+            "Video artifact has no positive finite media duration"
+        ),
+        "video_evidence_invalid": "Video evidence request is invalid",
+        "video_invalid_container": "Video artifact has an invalid media container",
+        "video_no_video_stream": "Video artifact has no usable video stream",
+        "video_parser_rejected": "ffprobe rejected the video artifact",
+        "video_parser_repair_required": (
+            "ffprobe emitted diagnostics; repair or re-export the video artifact"
+        ),
+        "video_probe_containment_unavailable": (
+            "Bounded video worker process containment is unavailable"
+        ),
+        "video_probe_crash": "Bounded video evidence worker terminated unexpectedly",
+        "video_probe_malformed_result": (
+            "Bounded video evidence worker returned an invalid authenticated result"
+        ),
+        "video_probe_monitor_identity_changed": (
+            "Bounded video worker process identity changed during inspection"
+        ),
+        "video_probe_monitor_unavailable": (
+            "Bounded video worker process monitoring is unavailable"
+        ),
+        "video_probe_request_oversized": (
+            "Bounded video worker request exceeded its input contract"
+        ),
+        "video_probe_resource_unavailable": (
+            "Video evidence exceeded a configured worker resource limit"
+        ),
+        "video_probe_result_oversized": (
+            "Bounded video worker result exceeded its output contract"
+        ),
+        "video_probe_start_failure": "Could not start the bounded video worker",
+        "video_probe_timeout": "Bounded video evidence operation timed out",
+        "video_stream_limit": "Video artifact exceeds the stream-count ceiling",
+    }
+    return VideoEvidenceError(
+        messages.get(reason_code, "Video artifact is unavailable"),
+        reason_code=reason_code,
+        details=details,
+    )
+
+
+def _cached_failure(error: VideoEvidenceError) -> _CachedFailure:
+    return _CachedFailure(
+        message=str(error),
+        reason_code=error.reason_code,
+        details=copy.deepcopy(error.details),
+    )
+
+
+def _raise_cached(error: _CachedFailure) -> NoReturn:
+    raise VideoEvidenceError(
+        error.message,
+        reason_code=error.reason_code,
+        details=copy.deepcopy(error.details),
+    )
+
+
+def _outcome_value(outcome: _Outcome) -> VideoArtifactProbe:
+    if isinstance(outcome, _CachedFailure):
+        _raise_cached(outcome)
+    return outcome
+
+
+def _globally_shareable_outcome(outcome: _Outcome | None) -> _Outcome | None:
+    if isinstance(outcome, VideoArtifactProbe):
+        return outcome
+    if isinstance(outcome, _CachedFailure) and outcome.reason_code in (
+        _STABLE_GENERATION_FAILURES
+    ):
+        return outcome
+    return None
+
+
+def _materialize_public_request(
+    path: object,
+    *,
+    trusted_root: object | None,
+) -> tuple[Path, Path | None, ContainerFamily]:
+    try:
+        root = (
+            materialize_native_root(trusted_root) if trusted_root is not None else None
+        )
+        artifact = materialize_artifact_locator(path, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise _failure(
+            "video_evidence_invalid",
+            details={"locator_failure": exc.reason_code},
+        ) from exc
+    suffix = artifact.suffix.casefold()
+    expected_family = _CONTAINER_FAMILY_BY_SUFFIX.get(suffix)
+    if expected_family is None:
+        raise _failure(
+            "video_evidence_invalid",
+            details={"locator_failure": "video_suffix_unsupported"},
+        )
+    try:
+        artifact, root = canonicalize_trusted_artifact_locator(artifact, root)
+    except ArtifactMetadataMalformed as exc:
+        raise _failure(
+            "video_evidence_invalid",
+            details={
+                "locator_failure": exc.locator_failure or "artifact_locator_invalid"
+            },
+        ) from exc
+    return artifact, root, expected_family
+
+
+def _worker_bound_paths(
+    artifact_value: object,
+    root_value: object | None,
+) -> tuple[Path, Path | None]:
+    try:
+        root = materialize_native_root(root_value) if root_value is not None else None
+        artifact = materialize_artifact_locator(artifact_value, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise SupervisorError(
+            "invalid_worker_request",
+            {"locator_failure": exc.reason_code},
+        ) from exc
+    return artifact, root
+
+
+def _request_key(
+    artifact: Path,
+    trusted_root: Path | None,
+    expected_family: ContainerFamily,
+) -> _AssessmentRequestKey:
+    return _AssessmentRequestKey(
+        artifact_path=os.fspath(artifact),
+        trusted_root=(os.fspath(trusted_root) if trusted_root is not None else None),
+        expected_container_family=expected_family,
+    )
+
+
+def _availability(generation: FileGeneration) -> ArtifactAvailability:
+    return ArtifactAvailability.from_generation(
+        generation,
+        macos_dataless_flag=VIDEO_MACOS_DATALESS_FLAG,
+        windows_cloud_file_attributes=VIDEO_WINDOWS_CLOUD_FILE_ATTRIBUTES,
+    )
+
+
+def _cache_key(
+    request: _AssessmentRequestKey,
+    receipt: ArtifactMetadataReceipt,
+) -> _VideoCacheKey:
+    availability = _availability(receipt.generation)
+    return _VideoCacheKey(
+        request=request,
+        generation=receipt.generation,
+        root_generation=receipt.root_generation,
+        reparse_tag=receipt.reparse_tag,
+        availability_state=availability.state,
+        macos_dataless=availability.macos_dataless,
+        windows_offline=availability.windows_offline,
+        windows_recall_on_open=availability.windows_recall_on_open,
+        windows_recall_on_data_access=availability.windows_recall_on_data_access,
+        metadata_profile_id=VIDEO_METADATA_LIMITS.profile_id,
+        probe_profile_id=VIDEO_PROBE_LIMITS.profile_id,
+        schema_generation=VIDEO_PROBE_SCHEMA_VERSION,
+        pipeline_generation=VIDEO_PROBE_PIPELINE_VERSION,
+        max_input_bytes=VIDEO_MAX_INPUT_BYTES,
+        max_streams=VIDEO_MAX_STREAMS,
+    )
+
+
+def clear_video_artifact_probe_cache() -> None:
+    """Clear completed process-global results without cancelling live leaders."""
+    global _GLOBAL_CACHE_EPOCH
+    with _GLOBAL_CACHE_LOCK:
+        _GLOBAL_CACHE_EPOCH += 1
+        _GLOBAL_PROBE_CACHE.clear()
+
+
+def _metadata_failure_payload(exc: ArtifactMetadataUnavailable) -> dict[str, object]:
+    details: dict[str, object] = {"failure_kind": exc.failure_kind}
+    if exc.exception_type is not None:
+        details["exception_type"] = exc.exception_type
+    return {
+        "schema_version": METADATA_SCHEMA_VERSION,
+        "status": "unavailable",
+        "reason_code": "video_artifact_unavailable",
+        "details": details,
+    }
+
+
+def _metadata_child(payload: Mapping[str, object]) -> dict[str, object]:
+    if set(payload) != {"video_path", "trusted_root"}:
+        raise SupervisorError("invalid_worker_request")
+    root_value = payload.get("trusted_root")
+    if root_value is not None and not isinstance(root_value, str):
+        raise SupervisorError("invalid_worker_request")
+    artifact, trusted_root = _worker_bound_paths(payload.get("video_path"), root_value)
+    try:
+        receipt = inspect_metadata_generation(
+            artifact,
+            trusted_root=trusted_root,
+            reparse_point_attribute=VIDEO_WINDOWS_REPARSE_POINT_ATTRIBUTE,
+            cloud_reparse_tags=VIDEO_WINDOWS_CLOUD_REPARSE_TAGS,
+        )
+    except ArtifactMetadataUnavailable as exc:
+        return _metadata_failure_payload(exc)
+    except ArtifactMetadataMalformed as exc:
+        raise SupervisorError("invalid_worker_request") from exc
+    return {
+        "schema_version": METADATA_SCHEMA_VERSION,
+        "status": "available",
+        "generation": receipt.generation.to_dict(),
+        "root_generation": (
+            receipt.root_generation.to_dict()
+            if receipt.root_generation is not None
+            else None
+        ),
+        "reparse_tag": receipt.reparse_tag,
+    }
+
+
+def _decode_metadata_payload(payload: object) -> ArtifactMetadataReceipt:
+    try:
+        return decode_artifact_metadata_payload(
+            payload,
+            unavailable_reason_code="video_artifact_unavailable",
+            reparse_point_attribute=VIDEO_WINDOWS_REPARSE_POINT_ATTRIBUTE,
+            cloud_reparse_tags=VIDEO_WINDOWS_CLOUD_REPARSE_TAGS,
+        )
+    except ArtifactMetadataUnavailable as exc:
+        details: dict[str, object] = {"failure_kind": exc.failure_kind}
+        if exc.exception_type is not None:
+            details["exception_type"] = exc.exception_type
+        raise _failure("video_artifact_unavailable", details=details) from exc
+    except ArtifactMetadataMalformed as exc:
+        raise _failure("video_probe_malformed_result") from exc
+
+
+def _limits_before_deadline(
+    limits: SupervisorLimits,
+    deadline_monotonic: float | None,
+) -> SupervisorLimits:
+    if deadline_monotonic is None:
+        return limits
+    if (
+        isinstance(deadline_monotonic, bool)
+        or not isinstance(deadline_monotonic, (int, float))
+        or not math.isfinite(float(deadline_monotonic))
+    ):
+        raise _failure("video_evidence_invalid")
+    remaining = float(deadline_monotonic) - time.monotonic() - limits.cleanup_seconds
+    if remaining <= 0:
+        raise _failure("video_batch_wall_limit")
+    if remaining >= limits.wall_seconds:
+        return limits
+    return replace(limits, wall_seconds=remaining)
+
+
+def _wait_for_flight(
+    flight: _GlobalFlight,
+    deadline_monotonic: float | None,
+    assessment_state: _AssessmentState,
+) -> _Outcome | None:
+    if deadline_monotonic is None:
+        flight.event.wait()
+    else:
+        if (
+            isinstance(deadline_monotonic, bool)
+            or not isinstance(deadline_monotonic, (int, float))
+            or not math.isfinite(float(deadline_monotonic))
+        ):
+            raise _failure("video_evidence_invalid")
+        remaining = float(deadline_monotonic) - time.monotonic()
+        if remaining <= 0 or not flight.event.wait(timeout=remaining):
+            raise _failure("video_batch_wall_limit")
+    if flight.leader_state is assessment_state:
+        return flight.assessment_outcome
+    return flight.outcome
+
+
+def _worker_command() -> list[str]:
+    return [
+        sys.executable,
+        os.fspath(Path(__file__).absolute()),
+        VIDEO_SUPERVISED_WORKER_FLAG,
+    ]
+
+
+def _invoke_metadata_worker(
+    command: Sequence[str | os.PathLike[str]],
+    payload: dict[str, object],
+    sensitive_values: tuple[Path, ...],
+    limits: SupervisorLimits,
+) -> WorkerResult:
+    """Narrow injection seam for metadata protocol tests."""
+    return run_authenticated_worker(
+        command,
+        VIDEO_METADATA_OPERATION,
+        {},
+        cast(Any, payload),
+        limits,
+        sensitive_values=sensitive_values,
+        schema_generation=VIDEO_PROBE_SCHEMA_VERSION,
+        pipeline_generation=VIDEO_PROBE_PIPELINE_VERSION,
+    )
+
+
+def _run_bounded_metadata_worker(
+    artifact: Path,
+    *,
+    trusted_root: Path | None,
+    deadline_monotonic: float | None,
+) -> ArtifactMetadataReceipt:
+    payload: dict[str, object] = {
+        "video_path": os.fspath(artifact),
+        "trusted_root": (os.fspath(trusted_root) if trusted_root is not None else None),
+    }
+    sensitive = (artifact,) if trusted_root is None else (artifact, trusted_root)
+    limits = _limits_before_deadline(VIDEO_METADATA_LIMITS, deadline_monotonic)
+    deadline_limited = limits.wall_seconds < VIDEO_METADATA_LIMITS.wall_seconds
+    try:
+        result = _invoke_metadata_worker(_worker_command(), payload, sensitive, limits)
+    except SupervisorError as exc:
+        if deadline_limited and exc.reason_code == "worker_timeout":
+            raise _failure("video_batch_wall_limit") from exc
+        raise _supervisor_failure(
+            exc,
+            timeout_seconds=limits.wall_seconds,
+            max_diagnostic_bytes=limits.max_diagnostic_bytes,
+        ) from exc
+    diagnostics = _validated_diagnostic_receipt(
+        result.diagnostics,
+        max_diagnostic_bytes=limits.max_diagnostic_bytes,
+    )
+    if diagnostics.byte_count or diagnostics.truncated:
+        raise _failure(
+            "video_probe_malformed_result",
+            details=_diagnostic_details(diagnostics),
+        )
+    receipt = _decode_metadata_payload(result.payload)
+    if (trusted_root is None) != (receipt.root_generation is None):
+        raise _failure("video_probe_malformed_result")
+    return receipt
+
+
+def _probe_generation_singleflight(
+    artifact: Path,
+    *,
+    trusted_root: Path | None,
+    receipt: ArtifactMetadataReceipt,
+    key: _VideoCacheKey,
+    deadline_monotonic: float | None,
+    assessment_state: _AssessmentState,
+) -> VideoArtifactProbe:
+    flight: _GlobalFlight | None = None
+    leader = False
+    epoch = -1
+    while True:
+        local_transient: _CachedFailure | None = None
+        with _GLOBAL_CACHE_LOCK:
+            with assessment_state.lock:
+                local_transient = assessment_state.transient_outcomes.get(key.request)
+            if local_transient is None:
+                cached = _GLOBAL_PROBE_CACHE.get(key)
+                if cached is not None:
+                    return _outcome_value(cached)
+                flight = _GLOBAL_PROBE_FLIGHTS.get(key)
+                if flight is None:
+                    flight = _GlobalFlight(leader_state=assessment_state)
+                    _GLOBAL_PROBE_FLIGHTS[key] = flight
+                    leader = True
+                    epoch = _GLOBAL_CACHE_EPOCH
+                else:
+                    leader = False
+                    epoch = -1
+        if local_transient is not None:
+            _raise_cached(local_transient)
+        if flight is None:
+            raise _failure("video_probe_malformed_result")
+        if not leader:
+            outcome = _wait_for_flight(
+                flight,
+                deadline_monotonic,
+                assessment_state,
+            )
+            if outcome is None:
+                continue
+            return _outcome_value(outcome)
+        break
+    if flight is None:
+        raise _failure("video_probe_malformed_result")
+    leader_flight = flight
+
+    outcome: _Outcome | None = None
+    try:
+        try:
+            probe = _compute_generation_outcome(
+                artifact,
+                trusted_root=trusted_root,
+                receipt=receipt,
+                key=key,
+                deadline_monotonic=deadline_monotonic,
+            )
+        except VideoEvidenceError as exc:
+            outcome = _cached_failure(exc)
+        else:
+            outcome = probe
+        if isinstance(outcome, VideoArtifactProbe) or (
+            isinstance(outcome, _CachedFailure)
+            and outcome.reason_code in _STABLE_GENERATION_FAILURES
+        ):
+            with _GLOBAL_CACHE_LOCK:
+                if epoch == _GLOBAL_CACHE_EPOCH:
+                    stale_keys = [
+                        candidate
+                        for candidate in _GLOBAL_PROBE_CACHE
+                        if candidate.request == key.request and candidate != key
+                    ]
+                    for stale_key in stale_keys:
+                        _GLOBAL_PROBE_CACHE.pop(stale_key, None)
+                    _GLOBAL_PROBE_CACHE[key] = outcome
+        return _outcome_value(outcome)
+    finally:
+        with _GLOBAL_CACHE_LOCK:
+            current = _GLOBAL_PROBE_FLIGHTS.get(key)
+            if current is leader_flight:
+                # A transient result belongs to the leader's own assessment and
+                # deadline.  Wake waiters without publishing it so each waiter
+                # can retry under its own remaining budget.
+                shareable = _globally_shareable_outcome(outcome)
+                assessment_outcome = outcome
+                if isinstance(outcome, _CachedFailure) and shareable is None:
+                    with assessment_state.lock:
+                        assessment_state.transient_outcomes.setdefault(
+                            key.request,
+                            outcome,
+                        )
+                        assessment_outcome = assessment_state.transient_outcomes[
+                            key.request
+                        ]
+                leader_flight.assessment_outcome = assessment_outcome
+                leader_flight.outcome = shareable
+                _GLOBAL_PROBE_FLIGHTS.pop(key, None)
+                leader_flight.event.set()
+
+
+def _compute_generation_outcome(
+    artifact: Path,
+    *,
+    trusted_root: Path | None,
+    receipt: ArtifactMetadataReceipt,
+    key: _VideoCacheKey,
+    deadline_monotonic: float | None,
+) -> VideoArtifactProbe:
+    availability = _availability(receipt.generation)
+    if availability.state != "local":
+        raise _failure(
+            "video_cloud_placeholder_unavailable",
+            details={
+                "availability": availability.to_dict(),
+                "reparse_tag": receipt.reparse_tag,
+            },
+        )
+    if receipt.generation.size == 0:
+        raise _failure("video_invalid_container")
+    if receipt.generation.size > VIDEO_MAX_INPUT_BYTES:
+        raise _failure(
+            "video_artifact_too_large",
+            details={"limit_bytes": VIDEO_MAX_INPUT_BYTES},
+        )
+    return _run_bounded_video_probe(
+        artifact,
+        trusted_root=trusted_root,
+        receipt=receipt,
+        expected_container_family=key.request.expected_container_family,
+        deadline_monotonic=deadline_monotonic,
+    )
+
+
+def _invoke_probe_worker(
+    command: Sequence[str | os.PathLike[str]],
+    expected_generations: Mapping[str, FileGeneration],
+    payload: dict[str, object],
+    sensitive_values: tuple[Path, ...],
+    limits: SupervisorLimits,
+) -> WorkerResult:
+    """Narrow injection seam for authenticated probe protocol tests."""
+    return run_authenticated_worker(
+        command,
+        VIDEO_PROBE_OPERATION,
+        expected_generations,
+        cast(Any, payload),
+        limits,
+        sensitive_values=sensitive_values,
+        schema_generation=VIDEO_PROBE_SCHEMA_VERSION,
+        pipeline_generation=VIDEO_PROBE_PIPELINE_VERSION,
+    )
+
+
+def _run_bounded_video_probe(
+    artifact: Path,
+    *,
+    trusted_root: Path | None,
+    receipt: ArtifactMetadataReceipt,
+    expected_container_family: ContainerFamily,
+    deadline_monotonic: float | None,
+) -> VideoArtifactProbe:
+    expected_generations = {"video": receipt.generation}
+    if receipt.root_generation is not None:
+        expected_generations["video_root"] = receipt.root_generation
+    payload: dict[str, object] = {
+        "video_path": os.fspath(artifact),
+        "trusted_root": (os.fspath(trusted_root) if trusted_root is not None else None),
+        "expected_container_family": expected_container_family,
+        "max_input_bytes": VIDEO_MAX_INPUT_BYTES,
+        "max_streams": VIDEO_MAX_STREAMS,
+        "ffprobe_stdout_bytes": VIDEO_FFPROBE_STDOUT_BYTES,
+        "ffprobe_stderr_bytes": VIDEO_FFPROBE_STDERR_BYTES,
+        "digest_chunk_bytes": VIDEO_DIGEST_CHUNK_BYTES,
+    }
+    sensitive = (artifact,) if trusted_root is None else (artifact, trusted_root)
+    limits = _limits_before_deadline(VIDEO_PROBE_LIMITS, deadline_monotonic)
+    deadline_limited = limits.wall_seconds < VIDEO_PROBE_LIMITS.wall_seconds
+    try:
+        result = _invoke_probe_worker(
+            _worker_command(),
+            expected_generations,
+            payload,
+            sensitive,
+            limits,
+        )
+    except SupervisorError as exc:
+        if deadline_limited and exc.reason_code == "worker_timeout":
+            raise _failure("video_batch_wall_limit") from exc
+        raise _supervisor_failure(
+            exc,
+            timeout_seconds=limits.wall_seconds,
+            max_diagnostic_bytes=limits.max_diagnostic_bytes,
+        ) from exc
+    return _decode_probe_payload(
+        result.payload,
+        receipt=receipt,
+        diagnostics=result.diagnostics,
+        expected_container_family=expected_container_family,
+    )
+
+
+def _diagnostic_details(receipt: DiagnosticReceipt) -> dict[str, object]:
+    return {"diagnostic_receipt": receipt.to_dict()}
+
+
+def _validated_diagnostic_receipt(
+    value: object,
+    *,
+    max_diagnostic_bytes: int,
+) -> DiagnosticReceipt:
+    if not isinstance(value, DiagnosticReceipt):
+        raise _failure("video_probe_malformed_result")
+    if (
+        type(value.byte_count) is not int
+        or value.byte_count < 0
+        or not isinstance(value.sha256, str)
+        or _SHA256_RE.fullmatch(value.sha256) is None
+        or type(value.truncated) is not bool
+        or (not value.truncated and value.byte_count > max_diagnostic_bytes)
+    ):
+        raise _failure("video_probe_malformed_result")
+    return value
+
+
+def _closed_generation_names(details: Mapping[str, object]) -> list[str]:
+    raw = details.get("generation_names")
+    if not isinstance(raw, list):
+        return []
+    names = sorted(
+        {
+            name
+            for name in raw
+            if isinstance(name, str) and name in _VIDEO_GENERATION_NAMES
+        }
+    )
+    return names
+
+
+def _supervisor_failure(
+    exc: SupervisorError,
+    *,
+    timeout_seconds: float,
+    max_diagnostic_bytes: int,
+) -> VideoEvidenceError:
+    diagnostics = _validated_diagnostic_receipt(
+        exc.diagnostics,
+        max_diagnostic_bytes=max_diagnostic_bytes,
+    )
+
+    def details(**values: object) -> dict[str, object]:
+        closed = dict(values)
+        if diagnostics.byte_count or diagnostics.truncated:
+            closed.update(_diagnostic_details(diagnostics))
+        return closed
+
+    reason = exc.reason_code
+    if reason == "worker_generation_changed":
+        names = _closed_generation_names(exc.details)
+        return _failure(
+            "video_artifact_changed",
+            details=details(**({"generation_names": names} if names else {})),
+        )
+    if reason == "worker_timeout":
+        return _failure(
+            "video_probe_timeout",
+            details=details(timeout_seconds=timeout_seconds),
+        )
+    if reason == "worker_monitor_unavailable":
+        if exc.details.get("dependency") == "psutil":
+            return _failure(
+                "video_dependency_unavailable",
+                details=details(dependency="psutil"),
+            )
+        return _failure("video_probe_monitor_unavailable", details=details())
+    if reason == "worker_monitor_identity_changed":
+        return _failure(
+            "video_probe_monitor_identity_changed",
+            details=details(supervisor_reason_code=reason),
+        )
+    if reason in {
+        "worker_containment_unavailable",
+        "worker_process_tree_leak",
+        "worker_cleanup_failed",
+    }:
+        return _failure(
+            "video_probe_containment_unavailable",
+            details=details(supervisor_reason_code=reason),
+        )
+    if reason in {
+        "worker_memory_limit_exceeded",
+        "worker_process_limit_exceeded",
+        "worker_diagnostic_limit_exceeded",
+    }:
+        return _failure(
+            "video_probe_resource_unavailable",
+            details=details(supervisor_reason_code=reason),
+        )
+    if reason in {
+        "worker_start_failed",
+        "worker_pipe_setup_failed",
+        "worker_exit_before_barrier",
+        "worker_request_write_failed",
+        "invalid_worker_command",
+        "unsafe_worker_process_metadata",
+    }:
+        return _failure(
+            "video_probe_start_failure",
+            details=details(supervisor_reason_code=reason),
+        )
+    if reason == "worker_output_limit_exceeded":
+        return _failure(
+            "video_probe_result_oversized",
+            details=details(supervisor_reason_code=reason),
+        )
+    if reason == "worker_input_limit_exceeded":
+        return _failure(
+            "video_probe_request_oversized",
+            details=details(supervisor_reason_code=reason),
+        )
+    if reason in {
+        "worker_exit",
+        "worker_diagnostic_read_failed",
+        "worker_output_read_failed",
+    }:
+        return _failure(
+            "video_probe_crash",
+            details=details(supervisor_reason_code=reason),
+        )
+    return _failure(
+        "video_probe_malformed_result",
+        details=details(supervisor_reason_code=reason),
+    )
+
+
+def _diagnostic_from_mapping(value: object, *, limit: int) -> DiagnosticReceipt:
+    if not isinstance(value, Mapping) or set(value) != {
+        "byte_count",
+        "sha256",
+        "truncated",
+    }:
+        raise _failure("video_probe_malformed_result")
+    receipt = DiagnosticReceipt(
+        byte_count=cast(Any, value.get("byte_count")),
+        sha256=cast(Any, value.get("sha256")),
+        truncated=cast(Any, value.get("truncated")),
+    )
+    return _validated_diagnostic_receipt(
+        receipt,
+        max_diagnostic_bytes=limit,
+    )
+
+
+def _validated_child_failure_details(
+    reason_code: str,
+    raw: object,
+) -> dict[str, object]:
+    if not isinstance(raw, Mapping):
+        raise _failure("video_probe_malformed_result")
+    keys = set(raw)
+    details: dict[str, object] = {}
+    if reason_code == "video_dependency_unavailable":
+        if keys != {"dependency"} or raw.get("dependency") != "ffprobe":
+            raise _failure("video_probe_malformed_result")
+        return {"dependency": "ffprobe"}
+    if reason_code == "video_stream_limit":
+        if keys != {"max_streams"} or raw.get("max_streams") != VIDEO_MAX_STREAMS:
+            raise _failure("video_probe_malformed_result")
+        return {"max_streams": VIDEO_MAX_STREAMS}
+    if reason_code in {
+        "video_invalid_container",
+        "video_no_video_stream",
+        "video_duration_unavailable",
+    }:
+        if keys:
+            raise _failure("video_probe_malformed_result")
+        return {}
+    if reason_code == "video_artifact_unavailable":
+        if keys not in (set(), {"exception_type"}):
+            raise _failure("video_probe_malformed_result")
+    elif reason_code == "video_parser_repair_required":
+        if keys != {"diagnostic_receipt"}:
+            raise _failure("video_probe_malformed_result")
+    elif reason_code == "video_parser_rejected":
+        if keys not in (
+            set(),
+            {"exception_type"},
+            {"diagnostic_receipt"},
+        ):
+            raise _failure("video_probe_malformed_result")
+    elif reason_code == "video_probe_resource_unavailable":
+        if keys not in (
+            {"exception_type"},
+            {"limit_kind", "limit_bytes"},
+        ):
+            raise _failure("video_probe_malformed_result")
+    else:
+        raise _failure("video_probe_malformed_result")
+
+    exception_type = raw.get("exception_type")
+    if exception_type is not None:
+        if (
+            not isinstance(exception_type, str)
+            or _EXCEPTION_TYPE_RE.fullmatch(exception_type) is None
+        ):
+            raise _failure("video_probe_malformed_result")
+        details["exception_type"] = exception_type
+    diagnostic_value = raw.get("diagnostic_receipt")
+    if diagnostic_value is not None:
+        receipt = _diagnostic_from_mapping(
+            diagnostic_value,
+            limit=VIDEO_FFPROBE_STDERR_BYTES,
+        )
+        if receipt.byte_count == 0 or receipt.truncated:
+            raise _failure("video_probe_malformed_result")
+        details["diagnostic_receipt"] = receipt.to_dict()
+    limit_kind = raw.get("limit_kind")
+    limit_bytes = raw.get("limit_bytes")
+    if limit_kind is not None:
+        expected_limits = {
+            "ffprobe_stdout": VIDEO_FFPROBE_STDOUT_BYTES,
+            "ffprobe_stderr": VIDEO_FFPROBE_STDERR_BYTES,
+        }
+        if (
+            not isinstance(limit_kind, str)
+            or limit_kind not in expected_limits
+            or type(limit_bytes) is not int
+            or limit_bytes != expected_limits[limit_kind]
+        ):
+            raise _failure("video_probe_malformed_result")
+        details["limit_kind"] = limit_kind
+        details["limit_bytes"] = limit_bytes
+    return details
+
+
+def _decode_probe_payload(
+    payload: object,
+    *,
+    receipt: ArtifactMetadataReceipt,
+    diagnostics: DiagnosticReceipt,
+    expected_container_family: ContainerFamily,
+) -> VideoArtifactProbe:
+    diagnostics = _validated_diagnostic_receipt(
+        diagnostics,
+        max_diagnostic_bytes=VIDEO_PROBE_LIMITS.max_diagnostic_bytes,
+    )
+    if not isinstance(payload, Mapping):
+        raise _failure("video_probe_malformed_result")
+    if payload.get("schema_version") != VIDEO_PROBE_SCHEMA_VERSION:
+        raise _failure("video_probe_malformed_result")
+    if payload.get("status") == "unavailable":
+        if set(payload) != {"schema_version", "status", "reason_code", "details"}:
+            raise _failure("video_probe_malformed_result")
+        reason = payload.get("reason_code")
+        if not isinstance(reason, str) or reason not in _CHILD_FAILURE_REASONS:
+            raise _failure("video_probe_malformed_result")
+        details = _validated_child_failure_details(reason, payload.get("details"))
+        if diagnostics.byte_count or diagnostics.truncated:
+            details.update(_diagnostic_details(diagnostics))
+        raise _failure(reason, details=details)
+
+    expected_fields = {
+        "schema_version",
+        "status",
+        "source_sha256",
+        "source_size_bytes",
+        "duration_seconds",
+        "duration_source",
+        "container_family",
+        "stream_count",
+        "video_stream_count",
+        "audio_stream_count",
+        "attached_picture_count",
+        "other_stream_count",
+    }
+    if payload.get("status") != "available" or set(payload) != expected_fields:
+        raise _failure("video_probe_malformed_result")
+    source_sha256 = payload.get("source_sha256")
+    source_size = payload.get("source_size_bytes")
+    duration = payload.get("duration_seconds")
+    duration_source = payload.get("duration_source")
+    container_family = payload.get("container_family")
+    counts = [
+        payload.get("stream_count"),
+        payload.get("video_stream_count"),
+        payload.get("audio_stream_count"),
+        payload.get("attached_picture_count"),
+        payload.get("other_stream_count"),
+    ]
+    if (
+        not isinstance(source_sha256, str)
+        or _SHA256_RE.fullmatch(source_sha256) is None
+        or type(source_size) is not int
+        or source_size != receipt.generation.size
+        or not 1 <= source_size <= VIDEO_MAX_INPUT_BYTES
+        or isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(float(duration))
+        or float(duration) <= 0
+        or duration_source not in {"format", "stream"}
+        or container_family != expected_container_family
+        or any(type(count) is not int for count in counts)
+    ):
+        raise _failure("video_probe_malformed_result")
+    stream_count, video_count, audio_count, attached_count, other_count = cast(
+        list[int], counts
+    )
+    if (
+        not 1 <= stream_count <= VIDEO_MAX_STREAMS
+        or video_count < 1
+        or min(audio_count, attached_count, other_count) < 0
+        or video_count + audio_count + attached_count + other_count != stream_count
+    ):
+        raise _failure("video_probe_malformed_result")
+    if diagnostics.byte_count or diagnostics.truncated:
+        raise _failure(
+            "video_probe_malformed_result",
+            details=_diagnostic_details(diagnostics),
+        )
+    return VideoArtifactProbe(
+        generation=receipt.generation,
+        root_generation=receipt.root_generation,
+        availability=_availability(receipt.generation),
+        source_sha256=source_sha256,
+        source_size_bytes=source_size,
+        duration_seconds=float(duration),
+        duration_source=cast(DurationSource, duration_source),
+        container_family=cast(ContainerFamily, container_family),
+        stream_count=stream_count,
+        video_stream_count=video_count,
+        audio_stream_count=audio_count,
+        attached_picture_count=attached_count,
+        other_stream_count=other_count,
+        parser_diagnostics=diagnostics,
+    )
+
+
+def _worker_generation_change(*names: str) -> SupervisorError:
+    closed = sorted({name for name in names if name in _VIDEO_GENERATION_NAMES})
+    return SupervisorError(
+        "worker_generation_changed",
+        cast(Mapping[str, JsonValue], {"generation_names": closed}),
+    )
+
+
+def _metadata_receipt_in_probe_worker(
+    artifact: Path,
+    trusted_root: Path | None,
+) -> ArtifactMetadataReceipt:
+    try:
+        return inspect_metadata_generation(
+            artifact,
+            trusted_root=trusted_root,
+            reparse_point_attribute=VIDEO_WINDOWS_REPARSE_POINT_ATTRIBUTE,
+            cloud_reparse_tags=VIDEO_WINDOWS_CLOUD_REPARSE_TAGS,
+        )
+    except (ArtifactMetadataMalformed, ArtifactMetadataUnavailable) as exc:
+        names = ("video",) if trusted_root is None else ("video", "video_root")
+        raise _worker_generation_change(*names) from exc
+
+
+def _probe_payload_values(
+    payload: Mapping[str, object],
+) -> tuple[Path, Path | None, ContainerFamily]:
+    if set(payload) != {
+        "video_path",
+        "trusted_root",
+        "expected_container_family",
+        "max_input_bytes",
+        "max_streams",
+        "ffprobe_stdout_bytes",
+        "ffprobe_stderr_bytes",
+        "digest_chunk_bytes",
+    }:
+        raise SupervisorError("invalid_worker_request")
+    root_value = payload.get("trusted_root")
+    if root_value is not None and not isinstance(root_value, str):
+        raise SupervisorError("invalid_worker_request")
+    artifact, trusted_root = _worker_bound_paths(payload.get("video_path"), root_value)
+    expected_family = payload.get("expected_container_family")
+    if expected_family not in {"iso_bmff", "matroska_webm"}:
+        raise SupervisorError("invalid_worker_request")
+    expected_constants = {
+        "max_input_bytes": VIDEO_MAX_INPUT_BYTES,
+        "max_streams": VIDEO_MAX_STREAMS,
+        "ffprobe_stdout_bytes": VIDEO_FFPROBE_STDOUT_BYTES,
+        "ffprobe_stderr_bytes": VIDEO_FFPROBE_STDERR_BYTES,
+        "digest_chunk_bytes": VIDEO_DIGEST_CHUNK_BYTES,
+    }
+    if any(payload.get(name) != value for name, value in expected_constants.items()):
+        raise SupervisorError("invalid_worker_request")
+    return artifact, trusted_root, cast(ContainerFamily, expected_family)
+
+
+def _dispatch_supervised_worker(
+    request: WorkerRequest,
+) -> tuple[dict[str, object], dict[str, FileGeneration]]:
+    if request.schema_generation != VIDEO_PROBE_SCHEMA_VERSION:
+        raise SupervisorError("invalid_worker_request")
+    if request.pipeline_generation != VIDEO_PROBE_PIPELINE_VERSION:
+        raise SupervisorError("invalid_worker_request")
+    if not isinstance(request.payload, Mapping):
+        raise SupervisorError("invalid_worker_request")
+    if request.operation == VIDEO_METADATA_OPERATION:
+        if (
+            request.limit_profile_id != VIDEO_METADATA_LIMITS.profile_id
+            or request.expected_generations
+        ):
+            raise SupervisorError("invalid_worker_request")
+        return _metadata_child(request.payload), {}
+    if request.operation != VIDEO_PROBE_OPERATION:
+        raise SupervisorError("invalid_worker_operation")
+    if request.limit_profile_id != VIDEO_PROBE_LIMITS.profile_id:
+        raise SupervisorError("invalid_worker_request")
+
+    artifact, trusted_root, expected_family = _probe_payload_values(request.payload)
+    expected_names = {"video"}
+    if trusted_root is not None:
+        expected_names.add("video_root")
+    if set(request.expected_generations) != expected_names:
+        raise SupervisorError("invalid_worker_request")
+    before = _metadata_receipt_in_probe_worker(artifact, trusted_root)
+    observed: dict[str, FileGeneration] = {"video": before.generation}
+    if before.root_generation is not None:
+        observed["video_root"] = before.root_generation
+    changed_before = sorted(
+        name
+        for name in observed
+        if observed[name] != request.expected_generations[name]
+    )
+    if changed_before:
+        raise _worker_generation_change(*changed_before)
+    if _availability(before.generation).state != "local":
+        raise _worker_generation_change("video")
+    if before.generation.size <= 0 or before.generation.size > VIDEO_MAX_INPUT_BYTES:
+        raise _worker_generation_change("video")
+
+    media_facts: dict[str, object] | None = None
+    media_failure: VideoEvidenceError | None = None
+    digest: str | None = None
+    digest_failure: VideoEvidenceError | None = None
+    preparation_failure: VideoEvidenceError | None = None
+    try:
+        with _prepared_video_source(artifact, before.generation) as prepared:
+            try:
+                media_facts = _probe_media_with_ffprobe(
+                    prepared.probe_artifact,
+                    expected_container_family=expected_family,
+                )
+            except MemoryError:
+                media_failure = _failure(
+                    "video_probe_resource_unavailable",
+                    details={"exception_type": "MemoryError"},
+                )
+            except VideoEvidenceError as exc:
+                media_failure = exc
+
+            middle = _metadata_receipt_in_probe_worker(artifact, trusted_root)
+            _require_same_receipt(before, middle)
+            _require_descriptor_generation(
+                prepared.source_descriptor,
+                before.generation,
+            )
+            if media_failure is None:
+                try:
+                    digest = _digest_exact_generation(
+                        prepared.probe_artifact,
+                        prepared.probe_generation,
+                        source_descriptor=prepared.probe_descriptor,
+                    )
+                except MemoryError:
+                    digest_failure = _failure(
+                        "video_probe_resource_unavailable",
+                        details={"exception_type": "MemoryError"},
+                    )
+                except VideoEvidenceError as exc:
+                    digest_failure = exc
+            _require_descriptor_generation(
+                prepared.source_descriptor,
+                before.generation,
+            )
+    except MemoryError:
+        preparation_failure = _failure(
+            "video_probe_resource_unavailable",
+            details={"exception_type": "MemoryError"},
+        )
+    except VideoEvidenceError as exc:
+        preparation_failure = exc
+
+    after = _metadata_receipt_in_probe_worker(artifact, trusted_root)
+    _require_same_receipt(before, after)
+    failure = preparation_failure or media_failure or digest_failure
+    if failure is not None:
+        reason = (
+            failure.reason_code
+            if failure.reason_code in _CHILD_FAILURE_REASONS
+            else "video_parser_rejected"
+        )
+        return _unavailable_payload(reason, failure.details), observed
+    if media_facts is None or digest is None:
+        raise SupervisorError("invalid_worker_response")
+    payload = {
+        "schema_version": VIDEO_PROBE_SCHEMA_VERSION,
+        "status": "available",
+        "source_sha256": digest,
+        "source_size_bytes": before.generation.size,
+        **media_facts,
+    }
+    return payload, observed
+
+
+def _require_same_receipt(
+    expected: ArtifactMetadataReceipt,
+    observed: ArtifactMetadataReceipt,
+) -> None:
+    changed: list[str] = []
+    if observed.generation != expected.generation:
+        changed.append("video")
+    if observed.root_generation != expected.root_generation:
+        changed.append("video_root")
+    if observed.reparse_tag != expected.reparse_tag and "video" not in changed:
+        changed.append("video")
+    if changed:
+        raise _worker_generation_change(*changed)
+
+
+def _unavailable_payload(
+    reason_code: str,
+    details: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": VIDEO_PROBE_SCHEMA_VERSION,
+        "status": "unavailable",
+        "reason_code": reason_code,
+        "details": dict(details or {}),
+    }
+
+
+def _source_open_flags() -> int:
+    return (
+        os.O_RDONLY
+        | int(getattr(os, "O_BINARY", 0))
+        | int(getattr(os, "O_CLOEXEC", 0))
+        | int(getattr(os, "O_NOFOLLOW", 0))
+    )
+
+
+def _open_source_descriptor(
+    artifact: Path,
+    expected_generation: FileGeneration,
+) -> int:
+    try:
+        descriptor = os.open(artifact, _source_open_flags())
+    except OSError as exc:
+        raise _failure(
+            "video_artifact_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    try:
+        _require_descriptor_generation(descriptor, expected_generation)
+    except (SupervisorError, VideoEvidenceError):
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+    return descriptor
+
+
+def _require_descriptor_generation(
+    descriptor: int,
+    expected_generation: FileGeneration,
+) -> None:
+    try:
+        observed = FileGeneration.from_stat(os.fstat(descriptor))
+    except OSError as exc:
+        raise _failure(
+            "video_artifact_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    if observed != expected_generation:
+        raise _worker_generation_change("video")
+
+
+def _write_all(descriptor: int, data: bytes) -> None:
+    remaining = memoryview(data)
+    while remaining:
+        written = os.write(descriptor, remaining)
+        if written <= 0:
+            raise OSError("private video snapshot write made no progress")
+        remaining = remaining[written:]
+
+
+def _copy_source_snapshot(
+    source_descriptor: int,
+    snapshot_descriptor: int,
+    expected_generation: FileGeneration,
+) -> FileGeneration:
+    try:
+        os.lseek(source_descriptor, 0, os.SEEK_SET)
+        os.lseek(snapshot_descriptor, 0, os.SEEK_SET)
+    except OSError as exc:
+        raise _failure(
+            "video_artifact_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    total = 0
+    while True:
+        try:
+            chunk = os.read(source_descriptor, VIDEO_DIGEST_CHUNK_BYTES)
+        except OSError as exc:
+            raise _failure(
+                "video_artifact_unavailable",
+                details={"exception_type": type(exc).__name__},
+            ) from exc
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > expected_generation.size:
+            raise _worker_generation_change("video")
+        try:
+            _write_all(snapshot_descriptor, chunk)
+        except OSError as exc:
+            raise _failure(
+                "video_probe_resource_unavailable",
+                details={"exception_type": type(exc).__name__},
+            ) from exc
+    _require_descriptor_generation(source_descriptor, expected_generation)
+    if total != expected_generation.size:
+        raise _worker_generation_change("video")
+    try:
+        snapshot_generation = FileGeneration.from_stat(os.fstat(snapshot_descriptor))
+    except OSError as exc:
+        raise _failure(
+            "video_probe_resource_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    if snapshot_generation.size != expected_generation.size:
+        raise _failure("video_probe_resource_unavailable")
+    return snapshot_generation
+
+
+@contextmanager
+def _prepared_video_source(
+    artifact: Path,
+    expected_generation: FileGeneration,
+) -> Iterator[_PreparedVideoSource]:
+    source_descriptor = _open_source_descriptor(artifact, expected_generation)
+    probe_descriptor = source_descriptor
+    temporary_directory: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        try:
+            temporary_directory = tempfile.TemporaryDirectory(
+                prefix="speaker-toolkit-video-",
+                ignore_cleanup_errors=True,
+            )
+            snapshot = Path(temporary_directory.name) / f"source{artifact.suffix}"
+            probe_descriptor = os.open(
+                snapshot,
+                os.O_RDWR
+                | os.O_CREAT
+                | os.O_EXCL
+                | int(getattr(os, "O_BINARY", 0))
+                | int(getattr(os, "O_CLOEXEC", 0)),
+                0o600,
+            )
+        except OSError as exc:
+            raise _failure(
+                "video_probe_resource_unavailable",
+                details={"exception_type": type(exc).__name__},
+            ) from exc
+        snapshot_generation = _copy_source_snapshot(
+            source_descriptor,
+            probe_descriptor,
+            expected_generation,
+        )
+        prepared = _PreparedVideoSource(
+            source_descriptor=source_descriptor,
+            probe_descriptor=probe_descriptor,
+            probe_artifact=snapshot,
+            probe_generation=snapshot_generation,
+        )
+        yield prepared
+    finally:
+        for descriptor in {probe_descriptor, source_descriptor}:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if temporary_directory is not None:
+            temporary_directory.cleanup()
+
+
+def _digest_open_descriptor(
+    descriptor: int,
+    expected_generation: FileGeneration,
+) -> str:
+    _require_descriptor_generation(descriptor, expected_generation)
+    try:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+    except OSError as exc:
+        raise _failure(
+            "video_artifact_unavailable",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    digest = hashlib.sha256()
+    total = 0
+    while True:
+        try:
+            chunk = os.read(descriptor, VIDEO_DIGEST_CHUNK_BYTES)
+        except OSError as exc:
+            raise _failure(
+                "video_artifact_unavailable",
+                details={"exception_type": type(exc).__name__},
+            ) from exc
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > expected_generation.size:
+            raise _worker_generation_change("video")
+        digest.update(chunk)
+    _require_descriptor_generation(descriptor, expected_generation)
+    if total != expected_generation.size:
+        raise _worker_generation_change("video")
+    return digest.hexdigest()
+
+
+def _digest_exact_generation(
+    artifact: Path,
+    expected_generation: FileGeneration,
+    *,
+    source_descriptor: int | None = None,
+) -> str:
+    if source_descriptor is not None:
+        return _digest_open_descriptor(source_descriptor, expected_generation)
+    descriptor = _open_source_descriptor(artifact, expected_generation)
+    try:
+        return _digest_open_descriptor(descriptor, expected_generation)
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+
+
+def _ffprobe_command(executable: str, artifact: Path) -> list[str]:
+    return [
+        executable,
+        "-v",
+        "warning",
+        "-show_entries",
+        (
+            "format=format_name,duration:"
+            "stream=index,codec_type,duration:stream_disposition=attached_pic"
+        ),
+        "-of",
+        "json",
+        os.fspath(artifact),
+    ]
+
+
+def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+    except OSError:
+        return
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except OSError:
+            return
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            return
+
+
+def _run_ffprobe(artifact: Path) -> tuple[bytes, DiagnosticReceipt, int]:
+    executable = shutil.which("ffprobe")
+    if executable is None:
+        raise _failure(
+            "video_dependency_unavailable",
+            details={"dependency": "ffprobe"},
+        )
+    try:
+        process = subprocess.Popen(
+            _ffprobe_command(executable, artifact),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            close_fds=True,
+        )
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        raise _failure(
+            "video_dependency_unavailable",
+            details={"dependency": "ffprobe"},
+        ) from exc
+    if process.stdout is None or process.stderr is None:
+        _stop_process(process)
+        raise _failure(
+            "video_parser_rejected",
+            details={"exception_type": "PipeSetupError"},
+        )
+    stdout_reader = _PipeDrainer(
+        cast(BinaryIO, process.stdout), VIDEO_FFPROBE_STDOUT_BYTES
+    )
+    stderr_reader = _PipeDrainer(
+        cast(BinaryIO, process.stderr), VIDEO_FFPROBE_STDERR_BYTES
+    )
+    stdout_reader.start()
+    stderr_reader.start()
+    try:
+        while process.poll() is None:
+            if stdout_reader.overflowed or stderr_reader.overflowed:
+                _stop_process(process)
+                break
+            time.sleep(0.01)
+        exit_code = process.wait()
+        stdout_reader.join(1)
+        stderr_reader.join(1)
+        if stdout_reader.alive or stderr_reader.alive:
+            stdout_reader.close()
+            stderr_reader.close()
+            stdout_reader.join(1)
+            stderr_reader.join(1)
+        if stdout_reader.overflowed:
+            raise _failure(
+                "video_probe_resource_unavailable",
+                details={
+                    "limit_kind": "ffprobe_stdout",
+                    "limit_bytes": VIDEO_FFPROBE_STDOUT_BYTES,
+                },
+            )
+        if stderr_reader.overflowed:
+            raise _failure(
+                "video_probe_resource_unavailable",
+                details={
+                    "limit_kind": "ffprobe_stderr",
+                    "limit_bytes": VIDEO_FFPROBE_STDERR_BYTES,
+                },
+            )
+        if stdout_reader.failed or stderr_reader.failed:
+            raise _failure(
+                "video_parser_rejected",
+                details={"exception_type": "PipeReadError"},
+            )
+        return stdout_reader.data, stderr_reader.receipt, exit_code
+    finally:
+        _stop_process(process)
+        stdout_reader.close()
+        stderr_reader.close()
+
+
+def _reject_json_constant(_value: str) -> NoReturn:
+    raise ValueError("non-finite JSON number")
+
+
+def _decode_ffprobe_document(raw: bytes) -> Mapping[str, object]:
+    try:
+        document = json.loads(
+            raw.decode("utf-8"),
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError, RecursionError, ValueError) as exc:
+        raise _failure(
+            "video_parser_rejected",
+            details={"exception_type": type(exc).__name__},
+        ) from exc
+    if not isinstance(document, Mapping):
+        raise _failure("video_parser_rejected")
+    return document
+
+
+def _positive_finite_number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        return None
+    try:
+        parsed = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return parsed if parsed > 0 and math.isfinite(parsed) else None
+
+
+def _container_family(format_name: object) -> ContainerFamily | None:
+    if not isinstance(format_name, str) or not format_name:
+        return None
+    names = frozenset(part.strip().casefold() for part in format_name.split(","))
+    if names & _MATROSKA_FORMAT_NAMES:
+        return "matroska_webm"
+    if names & _ISO_BMFF_FORMAT_NAMES:
+        return "iso_bmff"
+    return None
+
+
+def _attached_picture(stream: Mapping[str, object]) -> bool:
+    disposition = stream.get("disposition")
+    if disposition is None:
+        return False
+    if not isinstance(disposition, Mapping):
+        raise _failure("video_parser_rejected")
+    value = disposition.get("attached_pic", 0)
+    if type(value) is not int or value not in {0, 1}:
+        raise _failure("video_parser_rejected")
+    return value == 1
+
+
+def _probe_media_with_ffprobe(
+    artifact: Path,
+    *,
+    expected_container_family: ContainerFamily,
+) -> dict[str, object]:
+    raw_stdout, stderr_receipt, exit_code = _run_ffprobe(artifact)
+    if exit_code != 0:
+        details = (
+            _diagnostic_details(stderr_receipt) if stderr_receipt.byte_count else {}
+        )
+        raise _failure("video_parser_rejected", details=details)
+    if stderr_receipt.byte_count:
+        raise _failure(
+            "video_parser_repair_required",
+            details=_diagnostic_details(stderr_receipt),
+        )
+    document = _decode_ffprobe_document(raw_stdout)
+    if set(document) - {"format", "streams", "programs", "stream_groups"}:
+        raise _failure("video_parser_rejected")
+    if document.get("programs", []) != [] or document.get("stream_groups", []) != []:
+        raise _failure("video_parser_rejected")
+    raw_format = document.get("format")
+    raw_streams = document.get("streams")
+    if not isinstance(raw_format, Mapping) or not isinstance(raw_streams, list):
+        raise _failure("video_invalid_container")
+    family = _container_family(raw_format.get("format_name"))
+    if family != expected_container_family:
+        raise _failure("video_invalid_container")
+    if len(raw_streams) > VIDEO_MAX_STREAMS:
+        raise _failure(
+            "video_stream_limit",
+            details={"max_streams": VIDEO_MAX_STREAMS},
+        )
+
+    video_count = 0
+    audio_count = 0
+    attached_count = 0
+    other_count = 0
+    stream_durations: list[float] = []
+    for stream in raw_streams:
+        if not isinstance(stream, Mapping):
+            raise _failure("video_parser_rejected")
+        codec_type = stream.get("codec_type")
+        if not isinstance(codec_type, str):
+            raise _failure("video_parser_rejected")
+        attached = codec_type == "video" and _attached_picture(stream)
+        if attached:
+            attached_count += 1
+        elif codec_type == "video":
+            video_count += 1
+        elif codec_type == "audio":
+            audio_count += 1
+        else:
+            other_count += 1
+        if codec_type == "audio" or (codec_type == "video" and not attached):
+            duration = _positive_finite_number(stream.get("duration"))
+            if duration is not None:
+                stream_durations.append(duration)
+    if video_count == 0:
+        raise _failure("video_no_video_stream")
+    format_duration = _positive_finite_number(raw_format.get("duration"))
+    if format_duration is not None:
+        duration_seconds = format_duration
+        duration_source: DurationSource = "format"
+    elif stream_durations:
+        duration_seconds = max(stream_durations)
+        duration_source = "stream"
+    else:
+        raise _failure("video_duration_unavailable")
+    return {
+        "duration_seconds": duration_seconds,
+        "duration_source": duration_source,
+        "container_family": family,
+        "stream_count": len(raw_streams),
+        "video_stream_count": video_count,
+        "audio_stream_count": audio_count,
+        "attached_picture_count": attached_count,
+        "other_stream_count": other_count,
+    }
+
+
+def probe_video_artifact(
+    path: str | os.PathLike[str],
+    *,
+    trusted_root: str | os.PathLike[str] | None = None,
+    deadline_monotonic: float | None = None,
+    assessment: VideoEvidenceAssessment | None = None,
+) -> VideoArtifactProbe:
+    """Return bounded video evidence, optionally shared within one operation."""
+    selected = assessment or VideoEvidenceAssessment()
+    if not isinstance(selected, VideoEvidenceAssessment):
+        raise _failure("video_evidence_invalid")
+    return selected.probe(
+        path,
+        trusted_root=trusted_root,
+        deadline_monotonic=deadline_monotonic,
+    )
+
+
+def _run_supervised_worker_child() -> int:
+    request = read_worker_request(max_input_bytes=VIDEO_METADATA_LIMITS.max_input_bytes)
+    protocol_output = isolate_protocol_output()
+    try:
+        try:
+            payload, observed = _dispatch_supervised_worker(request)
+            write_worker_response(
+                request,
+                payload=cast(JsonValue, payload),
+                observed_generations=observed,
+                stream=protocol_output,
+                max_output_bytes=VIDEO_PROBE_LIMITS.max_output_bytes,
+            )
+        except SupervisorError as exc:
+            write_worker_response(
+                request,
+                error=SupervisorError(exc.reason_code, exc.details),
+                observed_generations=request.expected_generations,
+                stream=protocol_output,
+                max_output_bytes=VIDEO_PROBE_LIMITS.max_output_bytes,
+            )
+    finally:
+        protocol_output.close()
+    return 0
+
+
+def _main() -> int:
+    if sys.argv[1:] != [VIDEO_SUPERVISED_WORKER_FLAG]:
+        raise SystemExit("video_evidence.py is a library")
+    try:
+        return _run_supervised_worker_child()
+    except SupervisorError as exc:
+        print(
+            f"video supervised worker failed: {exc.reason_code}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 2
+    # The supervisor owns this process boundary and converts a nonzero exit to
+    # one closed crash reason. No traceback, artifact path, or parser output may
+    # cross it. outer-boundary-process-contract.
+    except Exception:  # noqa: BLE001
+        print(
+            "video supervised worker failed: unexpected_error",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())
+
+
+__all__ = [
+    "VIDEO_DIGEST_CHUNK_BYTES",
+    "VIDEO_FFPROBE_STDERR_BYTES",
+    "VIDEO_FFPROBE_STDOUT_BYTES",
+    "VIDEO_MAX_INPUT_BYTES",
+    "VIDEO_MAX_STREAMS",
+    "VIDEO_METADATA_LIMITS",
+    "VIDEO_PROBE_LIMITS",
+    "VIDEO_PROBE_PIPELINE_VERSION",
+    "VIDEO_PROBE_SCHEMA_VERSION",
+    "VIDEO_SUPERVISED_WORKER_FLAG",
+    "VideoArtifactProbe",
+    "VideoEvidenceAssessment",
+    "VideoEvidenceError",
+    "clear_video_artifact_probe_cache",
+    "probe_video_artifact",
+]

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -77,6 +77,7 @@ from pattern_evidence import (
     assess_batch_artifact_capabilities,
     return_evidence_claim,
 )
+from video_evidence import VideoEvidenceAssessment
 from return_validation import (
     ANALYSIS_STATUSES,
     LEGACY_UNBASELINEABLE_SCORING_STATUS,
@@ -1129,6 +1130,7 @@ def main():
     except VaultRootAuthorityError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
+    video_evidence_assessment = VideoEvidenceAssessment()
     returns = load_json(batch_path, "batch-returns")
     try:
         catalog = validate_batch(returns)
@@ -1144,6 +1146,7 @@ def main():
         },
         vault_root=vault_root,
         source_roots=source_roots,
+        video_evidence_assessment=video_evidence_assessment,
     )
     try:
         talks_by_name = validate_batch_claims_against_talks(
@@ -1225,6 +1228,7 @@ def main():
                     talks_by_name[name],
                     vault_root=vault_root,
                     source_roots=source_roots,
+                    video_evidence_assessment=video_evidence_assessment,
                 )
                 if freshness_reasons:
                     raise PatternEvidenceError(

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -7,7 +7,7 @@ description: >
   speaker achievement badges.
   Triggers: "generate speaker profile", "update speaker profile",
   "regenerate speaker profile", "sync speaker profile".
-user_invocable: true
+user-invocable: true
 ---
 
 # Vault Profile — Speaker Profile Generator
@@ -53,22 +53,17 @@ configuration. Never fall back to whichever `python3` happens to be on `PATH`.
   --lanes core,pptx --require-lanes core
 ```
 
-## Key Files & References
+## Required References
 
-| File / Reference | Purpose |
-|------------------|---------|
-| `tracking-database.json` | Source of truth — talks, config, confirmed intents |
-| `rhetoric-style-summary.md` | Running rhetoric & style narrative |
-| `slide-design-spec.md` | Visual design rules from PDF + PPTX analysis |
-| `speaker-profile.json` | Output — machine-readable profile |
-| [references/speaker-profile-schema.md](references/speaker-profile-schema.md) | Profile JSON schema |
-| [references/schemas-config.md](references/schemas-config.md) | Config fields + confirmed intents schema |
-| `scripts/load-vault.py` | Read vault sources, emit JSON payload to stdout |
-| `scripts/validate-profile.py` | Validate profile v4 against the live vault cohort |
-| `scripts/pattern_cohort_snapshot.py` | Shared fresh-cohort selection used by loader and validator |
-| `scripts/pattern_opportunities.py` | Exact scoring-v5 opportunity-row aggregation and validation |
-| `scripts/profile_pattern_provenance.py` | Shared occurrence/classification availability contract for writers/readers |
-| `scripts/compute-pacing-adherence.py` | Compute `pacing.adherence` from scored talks + slide budgets |
+- Read [profile-construction-rules.md](references/profile-construction-rules.md)
+  before Steps 2, 4, and 6. It owns cohort use, merge rules, fail-closed edge cases,
+  and diff semantics.
+- Use [speaker-profile-schema.md](references/speaker-profile-schema.md) for the full
+  JSON shape and [schemas-config.md](references/schemas-config.md) for config and
+  confirmed intents.
+- Treat `tracking-database.json` as source of truth and `speaker-profile.json` as the
+  output. Toolkit scripts, not prose, own cohort, opportunity, pacing, and validation
+  arithmetic.
 
 ## Prerequisites
 
@@ -76,9 +71,28 @@ configuration. Never fall back to whichever `python3` happens to be on `PATH`.
 - Also runs on explicit request (overrides prerequisites).
 - Auto-triggered by vault-ingress Step 7 (Regenerate Speaker Profile) if profile already exists.
 
+If any talk declares a preserved local recording through
+`structured_data.video_extraction.source_video_path`, `video_local_path`, or
+`video_path`, first require the configured interpreter's source-video evidence
+lane:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
+  --lanes core,source-video --require-lanes core,source-video
+```
+
+This check gates the load and validation commands below, which may inspect that
+recording while assessing artifact freshness. Let the toolkit scripts perform
+the bounded, exact-generation probe; do not pre-open, hash, hydrate, or invoke
+`ffprobe` on a source recording directly. Use `source-video` for evidence over
+an existing recording and the separate `video` lane only for frame extraction.
+If a recording cannot be verified, only source-video capability is removed;
+independently verified transcript, PDF, and PPTX evidence remains valid.
+
 ## Step 1 — Load Vault Sources
 
-Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/load-vault.py"` to read `tracking-database.json`, `rhetoric-style-summary.md`, and `slide-design-spec.md` from the vault root. The script emits a single JSON payload on stdout.
+Load `tracking-database.json`, `rhetoric-style-summary.md`, and
+`slide-design-spec.md` into one payload:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/load-vault.py" \
@@ -86,6 +100,7 @@ Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/load-v
 ```
 
 **I/O contract:**
+
 - Args: optional vault-root path and optional timezone-aware `--as-of` timestamp;
   defaults are documented in the script's top-of-file contract.
 - Stdout (JSON): `{vault_root, config, confirmed_intents, talks, processed_talks,
@@ -93,55 +108,27 @@ Run `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/load-v
   pattern_baseline, pattern_opportunities, current_instrumentation_talks,
   stale_instrumentation_talks, baseline_note, instrumentation_note, summary,
   design_spec}`.
-- `baseline_talks` is the exact active Presentation Pattern scoring generation whose
-  persisted source-located artifacts still match their recorded identities. The
-  loader passes both the vault root and database-configured source roots to the
-  shared read-only freshness assessor. `pattern_baseline.eligible_talk_count` is the
-  occurrence cohort size. Its raw-score count and average are available only when all
-  eligible talks share one `opportunity_coverage_identity` and that identity contains
-  at least one evaluable opportunity; otherwise the baseline carries the explicit
-  mixed-coverage or no-evaluable-opportunities unavailable state. `pattern_opportunities`
-  contains the canonical exhaustive positive and negative rows. Copy those rows; do
-  not recalculate them in the model. `pattern_scoring_exclusions` explains every
-  eligible talk omitted from the cohort, including deterministic artifact-drift
-  details.
-- `current_instrumentation_talks` and `stale_instrumentation_talks` are a separate
-  extractor cohort used for pacing-sensitive analysis. Instrumentation membership
-  never confers pattern-baseline eligibility.
 - Exit non-zero with stderr message if arguments, vault sources, catalog identity, or
   scoring-generation metadata are missing or malformed.
-- Legacy database schema 0 and current schema 1 are read-only inputs. An
-  unsupported future database or record schema exits non-zero as no usable prior
-  state. Compatibility stays internal and does not add fields to the payload.
-  This skill never migrates the database.
 
-If the script aborts on missing `rhetoric-style-summary.md`, run vault-ingress first. If `slide-design-spec.md` is missing, `design_spec` is `""` and the design-spec section of the profile remains empty — continue without aborting.
+Apply the loader and missing-source rules in the construction reference.
 
 Proceed immediately to Step 2.
 
 ## Step 2 — Aggregate Structured Data
 
-Keep three explicitly named cohorts while aggregating:
-
-- `processed_talks` supplies `talks_analyzed` and non-catalog narrative/profile data.
-- `baseline_talks` supplies only source review; the deterministic
-  `pattern_opportunities` payload supplies catalog occurrence rows.
-- `current_instrumentation_talks` supplies the separately named pacing cohort.
-
-For non-catalog dimensions, skip processed talks with empty `structured_data` and use
-the matching prose in `summary` when necessary. If every processed talk lacks
-`structured_data`, warn the speaker and use prose only for those non-catalog fields.
-Never use prose, `processed_talks`, `excluded_pattern_scoring_talks`, either
-instrumentation cohort, or a prior profile to fill a missing pattern aggregate.
+Aggregate the three named cohorts exactly as defined in
+[profile-construction-rules.md](references/profile-construction-rules.md). Keep
+catalog, non-catalog, and pacing sources separate; never recalculate the deterministic
+`pattern_opportunities` payload.
 
 Proceed immediately to Step 3.
 
 ## Step 3 — Extract Template Layouts
 
-If `config.template_pptx_path` is set, call the vault-ingress PPTX extraction script:
-
-First require the configured interpreter's PPTX lane; an unavailable lane blocks
-this extraction but must not be replaced with another interpreter:
+If `config.template_pptx_path` is set, require the configured interpreter's PPTX lane,
+then extract layouts. An unavailable lane blocks extraction and must not be replaced
+with another interpreter:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
@@ -153,86 +140,27 @@ this extraction but must not be replaced with another interpreter:
   "$TEMPLATE_PPTX_PATH" > /tmp/template-layouts.json
 ```
 
-**I/O contract** (defined in vault-ingress; see `skills/vault-ingress/scripts/pptx-extraction.py`):
+**I/O contract:**
+
 - Args: path to a `.pptx` file.
-- Stdout (JSON): per-slide visual data, shape types, global design stats, and the master layouts list under the top-level `template_layouts` key. Each layout entry has `{index, master_index, name, placeholders: [{idx, type}]}`.
+- Stdout (JSON): per-slide visual data, shape types, global design stats, and
+  `template_layouts`; each layout has
+  `{index, master_index, name, placeholders: [{idx, type}]}`.
 - Exit non-zero with stderr message if the file is missing, unreadable, or not a valid `.pptx`.
 
-Check the extraction root's `schema_version` before reading layouts. This
-layout-only consumer accepts v1, v2, v3, and v4 for `template_layouts` only.
-Missing/legacy v0 or an unknown future version is not
-usable prior output: rerun the current extractor and read that result. Do not
-interpret a v1 record as carrying zero timing; it carries no timing contract.
-
-Merge the resulting layouts list into `infrastructure.template_layouts` in the profile being constructed. The script emits structural fields (`index`, `master_index`, `name`, `placeholders`); the `use_for` field is speaker-curated and is **not** emitted. When merging, key by the `(master_index, name)` pair — PowerPoint allows the same layout name to appear under different slide masters, so name alone is insufficient. For each fresh layout, copy any existing `use_for` value from the prior profile's matching `(master_index, name)` entry. Layouts present in the prior profile but absent from the fresh extraction are dropped — the script is the source of truth for layout existence. If `template_pptx_path` is not set, leave `template_layouts` as an empty list and continue.
+Apply the extraction-version and `(master_index, name)` merge rules in the
+construction reference. If no template path is configured, emit an empty layout list.
 
 Proceed immediately to Step 4.
 
 ## Step 4 — Construct the Profile
 
-Construct the `speaker-profile.json` dict per [references/speaker-profile-schema.md](references/speaker-profile-schema.md). Map vault sources to profile sections:
-
-| Profile section | Source |
-|---|---|
-| `speaker` / `infrastructure` | `config` (from Step 1 payload) |
-| `presentation_modes` / `instrument_catalog` | `summary` sections (from Step 1 payload) |
-| `rhetoric_defaults` | `confirmed_intents` (from Step 1 payload) |
-| `pacing` | `current_instrumentation_talks` only (separate non-pattern cohort) |
-| `guardrail_sources` | aggregated non-pattern data only; catalog history stays in `pattern_profile` |
-| `pattern_profile` | Step 1 `pattern_baseline` and deterministic `pattern_opportunities`; `baseline_talks` only for source review |
-| `visual_style_history` | dimension 13f observations from `summary` |
-
-Top-level keys (full nested schema in [references/speaker-profile-schema.md](references/speaker-profile-schema.md)):
-
-```
-schema_version, generated_date, talks_analyzed, speaker, infrastructure,
-presentation_modes, instrument_catalog, rhetoric_defaults, confirmed_intents,
-guardrail_sources, pacing, pattern_profile, visual_style_history,
-publishing_process, design_rules, badges
-```
-
-Copy Step 1 `pattern_baseline` unchanged into
-`pattern_profile.pattern_baseline`. Set
-`pattern_profile.baseline_talk_filenames` to the sorted, unique exact filenames from
-`baseline_talks`, and copy `pattern_baseline.eligible_talk_count` to
-`pattern_profile.eligible_talk_count`. Set `talks_scored` and
-`average_pattern_score` from the baseline's raw-score-comparison fields. They may be
-`0` and `null` while `eligible_talk_count` is non-zero when opportunity identities are
-mixed or no outcome is evaluable; never turn missing opportunity coverage into a zero
-average.
-
-Copy `pattern_opportunities.pattern_usage` and
-`pattern_opportunities.antipattern_frequency` unchanged into the matching profile
-fields. Their per-pattern denominators are not the global eligible count: the exact
-row contract belongs to `scripts/pattern_opportunities.py`. Keep the exhaustive rows
-even when the cohort is empty; their rates and coverage then use the script's null
-sentinels.
-The loader has already excluded scoring-v5 records whose persisted citation
-artifacts are missing, replaced, or inconsistent with their recorded root and digest;
-never restore them from another cohort or a prior profile.
-
-No speaker-owned versioned classification policy exists yet. Copy the exact
-owner-policy-unconfigured `classification_availability` sentinel from
-[references/speaker-profile-schema.md](references/speaker-profile-schema.md), and
-fail closed for every policy-derived claim: `score_trend`, breadth trend/average, and
-score-driver direction are unavailable; driver arrays, `never_used_patterns`, mastery
-tiers, signatures, strengths, underuse, and `by_mode` are empty. Zero detections do not
-mean never used, and a positive frequency does not mean recurring. `talks_analyzed`
-may remain the count of all `processed_talks`.
-
-Keep `pattern_profile` as the only catalog-history storage lane. Do not copy mastery,
-signatures, scores, usage, or other pattern aggregates into `rhetoric_defaults`. Do not
-materialize catalog-derived `guardrail_sources.recurring_issues` or `badges`; consumers
-derive those warnings and reinforcement directly from validated `pattern_profile`.
-Every top-level recurring issue or badge is non-pattern data and carries
-`source_lane: "non_pattern"`.
-
-If `baseline_talks` is empty, emit the explicit unavailable form from
-[references/speaker-profile-schema.md](references/speaker-profile-schema.md): retain
-the zero-count `pattern_baseline`, use empty filenames, preserve the exhaustive
-zero-opportunity rows, set both score and breadth averages to null, and use
-`unavailable` for the pattern trend/direction fields. Do not reuse pattern values from
-the prior profile or summary.
+Read [profile-construction-rules.md](references/profile-construction-rules.md) in full,
+then construct `speaker-profile.json` with the exact field ownership, cohort,
+classification, empty-cohort, and non-pattern provenance rules there. Use
+[speaker-profile-schema.md](references/speaker-profile-schema.md) for the complete
+schema. Copy deterministic baseline and opportunity data; do not infer or recalculate
+catalog history.
 
 Compute `pacing.adherence` by running `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/compute-pacing-adherence.py"`. The
 deterministic arithmetic — duration parsing, slides-per-minute, budget-band
@@ -255,14 +183,6 @@ echo "$PACING_INPUT" | "{python_path}" "{speaker_toolkit_root}/skills/vault-prof
   `current_instrumentation_talks`. The schema's `note` is optional descriptive text
   (as elsewhere in the schema) and is not emitted by the script.
 - Exit non-zero on malformed input.
-
-This is the quantitative counterpart to Dimension 14's transcript-evident "rushing"
-read. The duration estimate is approximate. Flag marginal overages softly.
-
-Cross-check Section 15 of `rhetoric-style-summary.md` only as a narrative consistency
-review. It cannot override or fill the current pattern cohort. See
-[references/speaker-profile-schema.md](references/speaker-profile-schema.md)
-`pattern_profile`.
 
 Set `schema_version` to `4` and `generated_date` to today's date in `YYYY-MM-DD` form.
 
@@ -294,24 +214,10 @@ Proceed immediately to Step 6.
 
 ## Step 6 — Diff Against Existing Profile
 
-If `{vault_root}/speaker-profile.json` already exists, compare
-`pattern_profile.pattern_baseline.pattern_catalog_fingerprint` and
-`pattern_profile.pattern_baseline.pattern_scoring_schema_version` first. If either identity differs, report a pattern
-generation reset and do not classify any catalog-derived score, trend, usage, mastery,
-or strength difference across that boundary as a regression.
-
-Within the same exact pattern generation, diff non-pattern profile data. Do not report
-raw-score movement across a changed or unavailable
-`pattern_baseline.opportunity_coverage_identity`, and do not infer policy-derived
-pattern changes while `classification_availability.status` is `unavailable`. Report to
-the speaker:
-- New instruments added to `instrument_catalog`
-- Revised thresholds in `guardrail_sources`
-- New non-pattern guardrails added to `recurring_issues`
-- A worsening `pacing.adherence.trend` or a rising `over_budget_rate` — the speaker is increasingly running long.
-- **New presentation modes** — flag prominently (the highest-signal field change for creator-skill behavior).
-
-If no prior profile exists, skip this step and proceed.
+If `{vault_root}/speaker-profile.json` exists, apply the generation-boundary and
+same-generation reporting rules in
+[profile-construction-rules.md](references/profile-construction-rules.md). If no prior
+profile exists, skip the diff.
 
 Proceed immediately to Step 7.
 
@@ -323,12 +229,8 @@ Proceed immediately to Step 8.
 
 ## Step 8 — Generate Achievement Badges
 
-Generate fun, self-deprecating non-pattern achievements grounded in pacing, visual,
-publishing, talk-count, or confirmed-intent data (for example, a visual-continuity or
-slide-budget badge). Do not generate a badge from catalog pattern usage, mastery,
-strength, antipattern, score, or absence; that reinforcement already lives in
-`pattern_profile`. Set `source_lane: "non_pattern"` on every badge. The tone should
-sound like the speaker's own voice, not corporate gamification. Append the array,
-rerun Step 5 validation on the final profile, then re-save only if it remains valid.
+Generate badges under the non-pattern provenance rules in the construction reference.
+Append the array, rerun Step 5 validation, and re-save only when the final profile is
+valid.
 
 Finish here.

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -1,0 +1,171 @@
+# Profile Construction Rules
+
+Read this reference before aggregating or constructing `speaker-profile.json`, and
+again before diffing an existing profile. The profile schema remains authoritative for
+the complete JSON shape; this file defines source ownership, merge behavior, and
+fail-closed edge cases used by the eight-step workflow in `../SKILL.md`.
+
+## Contents
+
+- [Loader and cohort semantics](#loader-and-cohort-semantics)
+- [Non-catalog aggregation](#non-catalog-aggregation)
+- [Template-layout merge](#template-layout-merge)
+- [Profile field ownership](#profile-field-ownership)
+- [Pattern-profile construction](#pattern-profile-construction)
+- [Empty-cohort behavior](#empty-cohort-behavior)
+- [Pacing and Section 15](#pacing-and-section-15)
+- [Existing-profile diff](#existing-profile-diff)
+- [Achievement badges](#achievement-badges)
+
+## Loader and Cohort Semantics
+
+`baseline_talks` is the exact active Presentation Pattern scoring generation whose
+persisted source-located artifacts still match their recorded identities. The loader
+passes the vault root and database-configured source roots to the shared read-only
+freshness assessor. The loader has already excluded scoring-v5 records whose persisted
+citation artifacts are missing, replaced, or inconsistent with their recorded root and
+digest; never restore them from another cohort or a prior profile.
+
+`pattern_baseline.eligible_talk_count` is the occurrence-cohort size. Its raw-score
+count and average are available only when every eligible talk shares one
+`opportunity_coverage_identity` containing at least one evaluable opportunity.
+Otherwise retain the explicit mixed-coverage or no-evaluable-opportunities unavailable
+state. `pattern_opportunities` contains the canonical exhaustive positive and negative
+rows; copy them rather than recalculating them. `pattern_scoring_exclusions` explains
+every otherwise eligible talk omitted from the cohort, including artifact drift.
+
+`current_instrumentation_talks` and `stale_instrumentation_talks` form a separate
+extractor cohort for pacing-sensitive analysis. Instrumentation membership never
+confers pattern-baseline eligibility.
+
+Legacy database schema 0 and current schema 1 are read-only inputs. An unsupported
+future database or record schema has no usable prior state. Compatibility stays
+internal, adds no payload fields, and never migrates the database.
+
+A missing `rhetoric-style-summary.md` blocks profile generation and requires
+vault-ingress. A missing `slide-design-spec.md` yields `design_spec: ""`; leave the
+design-spec section empty and continue.
+
+## Non-Catalog Aggregation
+
+Keep these cohorts distinct:
+
+- `processed_talks` supplies `talks_analyzed` and non-catalog narrative/profile data.
+- `baseline_talks` is available for source review only; deterministic
+  `pattern_opportunities` supplies catalog occurrence rows.
+- `current_instrumentation_talks` supplies pacing data only.
+
+For non-catalog dimensions, skip processed talks with empty `structured_data` and use
+matching `summary` prose when needed. If every processed talk lacks structured data,
+warn the speaker and use prose only for non-catalog fields. Never use prose,
+`processed_talks`, `excluded_pattern_scoring_talks`, either instrumentation cohort, or
+a prior profile to fill a missing pattern aggregate.
+
+## Template-Layout Merge
+
+Accept extraction schema v1, v2, v3, or v4 for `template_layouts` only. Missing or
+legacy v0 output and unknown future versions are unusable; obtain current extraction
+output. A v1 record has no timing contract and must not be interpreted as zero timing.
+
+Merge fresh layouts into `infrastructure.template_layouts`. Structural fields
+(`index`, `master_index`, `name`, and `placeholders`) come from extraction;
+speaker-curated `use_for` does not. Match prior `use_for` values by
+`(master_index, name)`, because layout names are not unique across masters. Drop prior
+layouts absent from fresh extraction. When `config.template_pptx_path` is unset, emit
+an empty layout list.
+
+## Profile Field Ownership
+
+| Profile section | Sole source |
+|---|---|
+| `speaker`, `infrastructure` | Step 1 `config` |
+| `presentation_modes`, `instrument_catalog` | Step 1 `summary` |
+| `rhetoric_defaults` | Step 1 `confirmed_intents` |
+| `pacing` | `current_instrumentation_talks` |
+| `guardrail_sources` | Aggregated non-pattern data |
+| `pattern_profile` | `pattern_baseline` and deterministic `pattern_opportunities` |
+| `visual_style_history` | Summary dimension 13f observations |
+
+Use every top-level key required by `speaker-profile-schema.md`. Set
+`schema_version` to `4`, `generated_date` to today's `YYYY-MM-DD` date, and
+`talks_analyzed` to the count of all `processed_talks`.
+
+The required top-level keys are `schema_version`, `generated_date`,
+`talks_analyzed`, `speaker`, `infrastructure`, `presentation_modes`,
+`instrument_catalog`, `rhetoric_defaults`, `confirmed_intents`,
+`guardrail_sources`, `pacing`, `pattern_profile`, `visual_style_history`,
+`publishing_process`, `design_rules`, and `badges`.
+
+Keep `pattern_profile` as the only catalog-history storage lane. Never copy mastery,
+signatures, scores, usage, or another pattern aggregate into `rhetoric_defaults`.
+Never materialize catalog-derived `guardrail_sources.recurring_issues` or `badges`;
+consumers derive those directly from validated `pattern_profile`. Every top-level
+recurring issue and badge is non-pattern data with `source_lane: "non_pattern"`.
+
+## Pattern-Profile Construction
+
+Copy `pattern_baseline` unchanged to `pattern_profile.pattern_baseline`. Set
+`baseline_talk_filenames` to the sorted unique exact filenames from `baseline_talks`,
+copy `pattern_baseline.eligible_talk_count` to `eligible_talk_count`, and take
+`talks_scored` plus `average_pattern_score` from the baseline's raw-score-comparison
+fields. A non-empty eligible cohort can validly have zero scored talks and a null
+average when opportunity identities are mixed or no outcome is evaluable. Never turn
+missing opportunity coverage into a zero average.
+
+Copy `pattern_opportunities.pattern_usage` and
+`pattern_opportunities.antipattern_frequency` unchanged. Their denominators are
+pattern-specific evaluable counts, not the global eligible count. Preserve exhaustive
+rows even for an empty cohort, including their canonical null rate and coverage
+sentinels.
+
+No versioned classification policy exists in schema v4. Copy the exact
+owner-policy-unconfigured `classification_availability` sentinel from
+`speaker-profile-schema.md`. Fail closed: score trend, breadth trend/average, and
+score-driver direction are unavailable; driver arrays, `never_used_patterns`, mastery
+tiers, signatures, strengths, underuse, and `by_mode` are empty. Zero detections never
+mean never used, and a positive frequency never means recurring.
+
+## Empty-Cohort Behavior
+
+When `baseline_talks` is empty, retain the zero-count baseline, empty filenames, and
+exhaustive zero-opportunity rows. Set score and breadth averages to null and pattern
+trend/direction fields to `unavailable`. Never borrow pattern values from a prior
+profile, summary prose, an excluded scoring generation, or an instrumentation cohort.
+
+## Pacing and Section 15
+
+Pacing is quantitative but approximate. Treat marginal slide-budget overages softly;
+the result complements, rather than replaces, Dimension 14's transcript-evident
+"rushing" assessment.
+
+Use Section 15 of `rhetoric-style-summary.md` only for narrative consistency review.
+It cannot override or fill the current pattern cohort.
+
+## Existing-Profile Diff
+
+If no prior profile exists, skip the diff.
+
+Otherwise compare `pattern_catalog_fingerprint` and
+`pattern_scoring_schema_version` first. A change in either is a pattern-generation
+reset: do not describe catalog-derived score, trend, usage, mastery, or strength
+differences across it as speaker improvement or regression.
+
+Within one exact generation, do not report raw-score movement across a changed or
+unavailable `opportunity_coverage_identity`. Do not infer policy-derived changes while
+`classification_availability.status` is `unavailable`.
+
+Report these same-generation non-pattern changes:
+
+- New `instrument_catalog` instruments.
+- Revised `guardrail_sources` thresholds.
+- New non-pattern `recurring_issues` guardrails.
+- Worsening `pacing.adherence.trend` or rising `over_budget_rate`.
+- New presentation modes, prominently; this is the highest-signal creator behavior
+  change.
+
+## Achievement Badges
+
+Generate fun, self-deprecating badges from pacing, visual, publishing, talk-count, or
+confirmed-intent data. Use the speaker's voice rather than corporate gamification.
+Never derive a badge from catalog pattern usage, mastery, strength, antipattern, score,
+or absence. Set `source_lane: "non_pattern"` on every badge.

--- a/skills/vault-profile/scripts/pattern_cohort_snapshot.py
+++ b/skills/vault-profile/scripts/pattern_cohort_snapshot.py
@@ -37,6 +37,7 @@ from return_validation import (  # noqa: E402
     assess_current_persisted_pattern_evidence_freshness,
     load_catalog,
 )
+from video_evidence import VideoEvidenceAssessment  # noqa: E402
 from vault_root_authority import (  # noqa: E402
     VaultRootAuthorityError,
     resolve_vault_root_authority,
@@ -74,6 +75,7 @@ def configured_evidence_freshness_assessor(
         )
     except VaultRootAuthorityError as exc:
         raise PatternCohortSnapshotError(str(exc)) from exc
+    video_evidence_assessment = VideoEvidenceAssessment()
     freshness_cache: dict[int, tuple[str, ...]] = {}
 
     def assess(talk: Mapping[str, object]) -> tuple[str, ...]:
@@ -85,6 +87,7 @@ def configured_evidence_freshness_assessor(
                     vault_root=evidence_vault_root,
                     source_roots=source_roots,
                     catalog=catalog,
+                    video_evidence_assessment=video_evidence_assessment,
                 )
             )
         return freshness_cache[identity]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,14 @@ def pdf_evidence():
 
 
 @pytest.fixture(scope="session")
+def video_evidence():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "video_evidence.py"),
+        "video_evidence",
+    )
+
+
+@pytest.fixture(scope="session")
 def vtt_cleanup():
     return _import_script(os.path.join(SCRIPTS_VI, "vtt-cleanup.py"), "vtt_cleanup")
 

--- a/tests/test_artifact_supervisor.py
+++ b/tests/test_artifact_supervisor.py
@@ -402,12 +402,15 @@ def test_artifact_consumers_reuse_one_supervisor_module_identity(
     artifact_metadata,
     pdf_evidence,
     pptx_evidence,
+    video_evidence,
 ) -> None:
     assert artifact_supervisor is sys.modules["artifact_supervisor"]
     assert artifact_metadata.FileGeneration is artifact_supervisor.FileGeneration
     assert pdf_evidence.FileGeneration is artifact_supervisor.FileGeneration
     assert pptx_evidence.FileGeneration is artifact_supervisor.FileGeneration
+    assert video_evidence.FileGeneration is artifact_supervisor.FileGeneration
     assert pdf_evidence.DiagnosticReceipt is artifact_supervisor.DiagnosticReceipt
+    assert video_evidence.DiagnosticReceipt is artifact_supervisor.DiagnosticReceipt
     assert pdf_evidence.SupervisorError is artifact_supervisor.SupervisorError
     assert pptx_evidence.SupervisorError is artifact_supervisor.SupervisorError
 
@@ -1584,7 +1587,12 @@ class BlockPsutil(importlib.abc.MetaPathFinder):
 sys.meta_path.insert(0, BlockPsutil())
 script_dir = Path({str(SCRIPT_DIR)!r})
 sys.path.insert(0, str(script_dir))
-for module_name in ("artifact_supervisor", "pptx_evidence", "pattern_evidence"):
+for module_name in (
+    "artifact_supervisor",
+    "pptx_evidence",
+    "video_evidence",
+    "pattern_evidence",
+):
     __import__(module_name)
 print("shared-pptx-imports-ok")
 """

--- a/tests/test_check_runtime.py
+++ b/tests/test_check_runtime.py
@@ -1093,6 +1093,10 @@ def test_lane_requirements_match_the_configured_interpreter_contract() -> None:
     assert requirements["google-drive"]["modules"] == {"gdown": "gdown"}
     assert requirements["captions"]["commands"] == {}
     assert requirements["youtube-download"]["commands"] == {"yt-dlp": "yt-dlp"}
+    assert requirements["source-video"] == {
+        "modules": {"psutil": "psutil"},
+        "commands": {"ffprobe": "ffprobe"},
+    }
     assert requirements["video"]["modules"] == {
         "filelock": "filelock",
         "imagehash": "imagehash",

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -685,8 +685,8 @@ def test_transcript_receipt_docs_keep_quality_separate_from_timing(
 ):
     repo = Path(fetch_transcript.__file__).resolve().parents[3]
     ingress = repo / "skills" / "vault-ingress"
+    skill = (ingress / "SKILL.md").read_text(encoding="utf-8")
     documents = {
-        "skill": (ingress / "SKILL.md").read_text(encoding="utf-8"),
         "processing": (ingress / "references" / "processing-rules.md").read_text(
             encoding="utf-8"
         ),
@@ -704,6 +704,7 @@ def test_transcript_receipt_docs_keep_quality_separate_from_timing(
     for text in documents.values():
         assert ".segments.json" in text
         assert ".quality.json" in text
+    assert "references/subagent-instructions.md" in skill
     assert "fixed_default" in documents["schemas"]
     assert "youtube_duration" in documents["schemas"]
     assert "local_media_duration" in documents["schemas"]

--- a/tests/test_goal_generation_docs.py
+++ b/tests/test_goal_generation_docs.py
@@ -37,7 +37,7 @@ def test_reader_runs_mechanical_gate_and_never_scores_mismatch():
     assert script in INGRESS
     assert '`"{python_path}"' in SKILL
     assert '"{python_path}"' in INGRESS
-    assert "needs_rebaseline" in INGRESS
+    assert "needs_rebaseline" in PROCESSING
     assert "must not set `status` to\n  `achieved`" in PROCESSING
 
 

--- a/tests/test_ingress_adherence_docs.py
+++ b/tests/test_ingress_adherence_docs.py
@@ -7,6 +7,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INGRESS = REPO_ROOT / "skills" / "vault-ingress"
 DOC_PATHS = {
     "skill": INGRESS / "SKILL.md",
+    "bootstrap": INGRESS / "references" / "bootstrap-and-preflight.md",
+    "persistence": INGRESS / "references" / "batch-persistence.md",
+    "selection": INGRESS / "references" / "queue-selection.md",
     "processing": INGRESS / "references" / "processing-rules.md",
     "schemas": INGRESS / "references" / "schemas-db.md",
     "worker": INGRESS / "references" / "subagent-instructions.md",
@@ -32,15 +35,57 @@ def test_claim_issuance_is_live_and_version_bound() -> None:
         "Saved claim schemas v1/v2 authorize only return schemas v1/v2"
         in docs["schemas"]
     )
-    assert "schema v3 authorizes only v3; schema v4 authorizes only archival v4" in docs[
-        "schemas"
-    ]
+    assert (
+        "schema v3 authorizes only v3; schema v4 authorizes only archival v4"
+        in docs["schemas"]
+    )
     assert "Recover a live legacy lease" in docs["worker"]
+
+
+def test_source_video_preflight_requires_the_supervised_runtime_lane() -> None:
+    docs = _docs()
+    bootstrap = docs["bootstrap"]
+
+    runtime_gate = "--lanes core,source-video --require-lanes core,source-video"
+    assert runtime_gate in bootstrap
+    assert bootstrap.index(runtime_gate) < bootstrap.index("scripts/preflight-vault.py")
+    assert "Do not pre-open, hash, hydrate, or invoke `ffprobe` directly" in bootstrap
+    assert "disables only source-video evidence" in bootstrap
+    for field in (
+        "structured_data.video_extraction.source_video_path",
+        "video_local_path",
+        "video_path",
+    ):
+        assert field in bootstrap
+        assert field in docs["skill"]
+    assert (
+        "independently\nverified transcript, rendered-PDF, or native-PPTX evidence"
+        in bootstrap
+    )
+    assert "references/bootstrap-and-preflight.md" in docs["skill"]
+
+
+def test_returned_source_video_requires_runtime_gate_before_persistence() -> None:
+    docs = _docs()
+    persistence = docs["persistence"]
+
+    runtime_gate = "--lanes core,source-video --require-lanes core,source-video"
+    assert runtime_gate in persistence
+    assert persistence.index(runtime_gate) < persistence.index("persist-results.py")
+    for field in (
+        "structured_data.video_extraction.source_video_path",
+        "video_local_path",
+        "video_path",
+    ):
+        assert field in persistence
+        assert field in docs["skill"]
+    assert "validation, persistence, and analysis rendering" in persistence
+    assert "references/batch-persistence.md" in docs["skill"]
 
 
 def test_workers_use_the_immutable_claim_baseline_not_section_15() -> None:
     docs = _docs()
-    assert "MUST NOT\nparse Section 15 for numeric adherence" in docs["skill"]
+    assert "references/subagent-instructions.md" in docs["skill"]
     assert "MUST NOT be\nparsed for numeric adherence" in docs["worker"]
     assert "the claim baseline remains immutable" in docs["processing"]
     assert "Workers MUST\nNOT parse Section 15" in docs["processing"]
@@ -53,9 +98,10 @@ def test_workers_use_the_immutable_claim_baseline_not_section_15() -> None:
 
 def test_threshold_and_structured_comparison_contract_is_documented() -> None:
     docs = _docs()
-    for name in ("skill", "processing", "schemas", "worker"):
+    for name in ("processing", "schemas", "worker"):
         assert "adherence_comparison" in docs[name]
         assert "legacy-unverified" in docs[name]
+    assert "references/processing-rules.md" in docs["skill"]
 
     assert "fewer than 10 `scored_talk_count`" in docs["processing"]
     assert "at least 10 scored talks" in docs["processing"]
@@ -76,14 +122,14 @@ def test_native_picture_render_threshold_is_script_owned() -> None:
 
 def test_post_batch_cohort_and_section_15_filter_are_explicit() -> None:
     docs = _docs()
-    for name in ("skill", "processing", "schemas"):
+    for name in ("persistence", "processing", "schemas"):
         assert "current_adherence_baseline" in docs[name]
         assert "active_batch_excluded: false" in docs[name]
 
     assert "only after every merge succeeds" in docs["processing"]
     assert "Never approximate this cohort by\n`processed_date`" in docs["processing"]
     assert "after the entire batch has persisted successfully" in docs["processing"]
-    assert "never rebuild after member 1" in docs["skill"]
+    assert "never update it after an\nindividual member merge" in docs["processing"]
     assert "must not recompute after member 1" in docs["schemas"]
 
 
@@ -94,11 +140,9 @@ def test_claim_replay_recovery_and_closure_matrix_are_documented() -> None:
         in docs["schemas"]
     )
     assert "Recovery never rewrites a claim snapshot" in docs["schemas"]
-    assert (
-        "closes v1 as v2 and closes v2–v5 at\ntheir own versions" in docs["schemas"]
-    )
-    assert "receiptless completed v1 claim" in docs["skill"]
-    assert "takes a fresh pre-mutation snapshot" in docs["skill"]
+    assert "closes v1 as v2 and closes v2–v5 at\ntheir own versions" in docs["schemas"]
+    assert "receiptless completed v1 claim" in docs["persistence"]
+    assert "takes a fresh pre-mutation snapshot" in docs["selection"]
 
 
 def test_archival_v4_and_current_v5_evidence_generations_are_distinct() -> None:
@@ -106,13 +150,12 @@ def test_archival_v4_and_current_v5_evidence_generations_are_distinct() -> None:
     assert "Two incompatible v3 lineages were emitted" in docs["schemas"]
     assert "v4 is their source-located union and remains archival" in docs["schemas"]
 
-
     assert '"pattern_scoring_schema_version": 5' in docs["schemas"]
     assert '"evidence_schema_version": 2' in docs["schemas"]
     assert "pattern_outcomes" in docs["worker"]
     assert "opportunity_coverage_identity" in docs["worker"]
 
-    for name in ("skill", "processing", "schemas", "worker"):
+    for name in ("persistence", "processing", "schemas", "worker"):
         assert "evidence_source" in docs[name]
         assert "evidence_citations" in docs[name]
 
@@ -145,16 +188,16 @@ def test_canonical_coverage_alone_never_authorizes_current_absence() -> None:
 
 def test_current_v5_cohort_requires_live_artifact_freshness() -> None:
     docs = _docs()
-    assert "shared freshness assessor" in docs["skill"]
-    assert "configured source roots" in docs["skill"]
+    assert "shared freshness assessor" in docs["selection"]
+    assert "configured source roots" in docs["selection"]
     assert "artifact freshness against the vault" in docs["processing"]
-    assert "shared root-aware assessor" in docs["skill"]
-    assert "remote video/slide acquisition remains eligible" in docs["skill"]
+    assert "shared root-aware assessor" in docs["selection"]
+    assert "remote video/slide acquisition remains eligible" in docs["selection"]
 
 
 def test_source_located_receipt_is_public_and_range_bound() -> None:
     docs = _docs()
-    for name in ("skill", "processing", "schemas", "worker"):
+    for name in ("processing", "schemas", "worker"):
         assert "source_inspection" in docs[name]
 
     for field in ("line_ranges", "page_ranges", "time_ranges"):
@@ -173,20 +216,27 @@ def test_source_located_worker_and_engine_evidence_ownership_is_explicit() -> No
     assert "Those are the complete worker-side shapes" in docs["schemas"]
     assert "must not copy `line_start`, `line_end`" in docs["schemas"]
     assert "metadata `value`/`owner_value_after_return`" in docs["worker"]
-    assert "persistence derives" in docs["skill"]
-    assert "artifact roots/paths/hashes" in docs["skill"]
-    assert "raw-return receipt remains the\nhash of exactly what the worker sent" in docs[
-        "schemas"
-    ]
+    assert "persistence derives" in docs["worker"]
+    assert "artifact root/path/hash fields" in docs["worker"]
+    assert (
+        "raw-return receipt remains the\nhash of exactly what the worker sent"
+        in docs["schemas"]
+    )
     assert "non-English `delivery_language`" in docs["worker"]
     assert "non-empty\nEnglish `translation` is required" in docs["schemas"]
 
-    schema_example = docs["schemas"].split(
-        "Each subagent returns this JSON after processing one talk:", 1
-    )[1].split("```json", 1)[1].split("```", 1)[0]
-    worker_example = docs["worker"].split(
-        "Minimal processed structure for a fresh v5 claim", 1
-    )[1].split("```json", 1)[1].split("```", 1)[0]
+    schema_example = (
+        docs["schemas"]
+        .split("Each subagent returns this JSON after processing one talk:", 1)[1]
+        .split("```json", 1)[1]
+        .split("```", 1)[0]
+    )
+    worker_example = (
+        docs["worker"]
+        .split("Minimal processed structure for a fresh v5 claim", 1)[1]
+        .split("```json", 1)[1]
+        .split("```", 1)[0]
+    )
     for raw_example in (schema_example, worker_example):
         for engine_field in (
             '"artifact_root"',
@@ -207,7 +257,7 @@ def test_source_located_worker_and_engine_evidence_ownership_is_explicit() -> No
 
 def test_source_located_not_evaluable_is_reason_code_only_and_fail_closed() -> None:
     docs = _docs()
-    for name in ("skill", "processing", "schemas", "worker"):
+    for name in ("persistence", "processing", "schemas", "worker"):
         assert "source_gate_pending_owner_review" in docs[name]
     for name in ("processing", "schemas", "worker"):
         assert "missing_required_source_coverage" in docs[name]
@@ -215,32 +265,32 @@ def test_source_located_not_evaluable_is_reason_code_only_and_fail_closed() -> N
     assert "fail-closed" in docs["schemas"]
     assert "fails closed" in docs["worker"]
 
-    assert "contains exactly `pattern_id` and `reason_code`" in docs[
-        "processing"
-    ]
+    assert "contains exactly `pattern_id` and `reason_code`" in docs["processing"]
     assert "prose-bearing" in docs["processing"]
 
 
 def test_claim_return_talk_and_scoring_axes_preserve_archival_v4() -> None:
     docs = _docs()
     assert "The four version axes are deliberately explicit" in docs["schemas"]
-    assert "| v4 | v4 only | archival source-located v4 | never current v5 |" in docs[
-        "schemas"
-    ]
-    assert "| v5 | v5 only | v5 | v5 when canonical evidence/outcomes are fresh |" in docs[
-        "schemas"
-    ]
-    assert "Saved claim schemas\nv1–v4 authorize only their same-numbered return schemas" in docs[
-        "skill"
-    ]
-    assert "only return generation eligible for pattern-scoring schema v5" in docs[
-        "skill"
-    ]
+    assert (
+        "| v4 | v4 only | archival source-located v4 | never current v5 |"
+        in docs["schemas"]
+    )
+    assert (
+        "| v5 | v5 only | v5 | v5 when canonical evidence/outcomes are fresh |"
+        in docs["schemas"]
+    )
+    assert "Fresh queue work uses claim schema v5" in docs["selection"]
+    assert (
+        "only return generation eligible for pattern-scoring schema v5"
+        in docs["worker"]
+    )
 
 
 def test_transcript_freshness_revalidates_quality_provenance() -> None:
     docs = _docs()
-    assert "hash-bound quality policy against current owner/provider duration" in docs[
-        "skill"
-    ]
+    assert (
+        "hash-bound quality policy against current owner/provider duration"
+        in docs["selection"]
+    )
     assert "transcript_quality_context_drift" in docs["schemas"]

--- a/tests/test_installed_plugin_paths.py
+++ b/tests/test_installed_plugin_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -227,6 +228,9 @@ def test_interpreter_bound_workflows_use_the_configured_interpreter() -> None:
 def test_profile_interpreter_authority_survives_the_ingress_handoff() -> None:
     profile = (SKILLS_ROOT / "vault-profile" / "SKILL.md").read_text(encoding="utf-8")
     ingress = (SKILLS_ROOT / "vault-ingress" / "SKILL.md").read_text(encoding="utf-8")
+    bootstrap = (
+        SKILLS_ROOT / "vault-ingress" / "references" / "bootstrap-and-preflight.md"
+    ).read_text(encoding="utf-8")
 
     assert "read `config.python_path` from that tracking\ndatabase" in profile
     assert "interpreter\nauthority for every operational command" in profile
@@ -240,5 +244,51 @@ def test_profile_interpreter_authority_survives_the_ingress_handoff() -> None:
     assert "rejects a missing or mismatched interpreter" in ingress
     assert (
         '"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/'
-        'scan-shownotes.py"' in ingress
+        'scan-shownotes.py"' in bootstrap
+    )
+
+
+def test_profile_requires_source_video_lane_before_freshness_work() -> None:
+    profile = (SKILLS_ROOT / "vault-profile" / "SKILL.md").read_text(encoding="utf-8")
+
+    runtime_gate = "--lanes core,source-video --require-lanes core,source-video"
+    assert runtime_gate in profile
+    assert profile.index(runtime_gate) < profile.index("## Step 1 — Load Vault Sources")
+    for field in (
+        "structured_data.video_extraction.source_video_path",
+        "video_local_path",
+        "video_path",
+    ):
+        assert field in profile
+    assert "do not pre-open, hash, hydrate, or invoke\n`ffprobe`" in profile
+    assert (
+        "independently verified transcript, PDF, and PPTX evidence remains valid"
+        in profile
+    )
+
+
+def test_profile_construction_rules_are_linked_and_shipped() -> None:
+    skill_path = SKILLS_ROOT / "vault-profile" / "SKILL.md"
+    reference = (
+        SKILLS_ROOT / "vault-profile" / "references" / "profile-construction-rules.md"
+    )
+    skill = skill_path.read_text(encoding="utf-8")
+    rules = reference.read_text(encoding="utf-8")
+
+    assert len(skill.splitlines()) <= 250
+    assert (
+        "[profile-construction-rules.md]"
+        "(references/profile-construction-rules.md)" in skill
+    )
+    assert "owner-policy-unconfigured" in rules
+    assert "pattern-generation\nreset" in rules
+
+    relative_reference = reference.relative_to(REPO_ROOT)
+    ignore_check = subprocess.run(
+        ["git", "check-ignore", "--no-index", "--quiet", "--", str(relative_reference)],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    assert ignore_check.returncode == 1, (
+        f"{relative_reference} is excluded from the published plugin"
     )

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -34,6 +34,73 @@ SYNTHETIC_VIDEO_ID = "abcdefghijk"
 SYNTHETIC_DURATION = 600.0
 
 
+def _video_probe(path: Path, *, duration: float = SYNTHETIC_DURATION) -> Any:
+    raw = path.read_bytes()
+    return pattern_evidence.VideoArtifactProbe(
+        generation=SimpleNamespace(),
+        root_generation=None,
+        availability=SimpleNamespace(state="local"),
+        source_sha256=hashlib.sha256(raw).hexdigest(),
+        source_size_bytes=len(raw),
+        duration_seconds=duration,
+        duration_source="format",
+        container_family="iso_bmff",
+        stream_count=1,
+        video_stream_count=1,
+        audio_stream_count=0,
+        attached_picture_count=0,
+        other_stream_count=0,
+        parser_diagnostics=SimpleNamespace(byte_count=0),
+    )
+
+
+class _TestVideoAssessment:
+    def __init__(
+        self,
+        *,
+        duration: float = SYNTHETIC_DURATION,
+        failure: Exception | None = None,
+    ) -> None:
+        self.duration = duration
+        self.failure = failure
+        self.calls: list[Path] = []
+
+    def probe(self, path: str | os.PathLike[str], **_kwargs: object) -> Any:
+        video_path = Path(os.fspath(path))
+        self.calls.append(video_path)
+        if self.failure is not None:
+            raise self.failure
+        return _video_probe(video_path, duration=self.duration)
+
+
+def _untrusted_video_manifest(vault: Path, source_video: Path) -> dict[str, Any]:
+    context_pdf = source_video.with_suffix(".context.pdf")
+    _write_pdf(context_pdf, page_count=1)
+    source_path = source_video.relative_to(vault).as_posix()
+    return {
+        "schema_version": 3,
+        "source_video_id": SYNTHETIC_VIDEO_ID,
+        "source_video_path": source_path,
+        "unique_frame_count": 1,
+        "slide_region_method": "none",
+        "slide_region_applied": False,
+        "slide_region_verified": False,
+        "review_required": True,
+        "review_reason": "context only",
+        "artifacts": [
+            {
+                "path": context_pdf.relative_to(vault).as_posix(),
+                "artifact_scope": "full_frame_context",
+                "page_count": 1,
+                "source_video_id": SYNTHETIC_VIDEO_ID,
+                "source_video_path": source_path,
+                "crop_verified": False,
+                "trusted_for_authored_slide_analysis": False,
+            }
+        ],
+    }
+
+
 def _foreign_absolute_locator(name: str) -> str:
     if os.name == "nt":
         return f"/foreign/{name}"
@@ -820,12 +887,6 @@ def test_foreign_pdf_and_video_locators_fail_only_their_independent_lanes(
         "probe_pdf_artifact",
         lambda *_args, **_kwargs: pytest.fail("foreign PDF reached probe"),
     )
-    monkeypatch.setattr(
-        pattern_evidence,
-        "_verified_video_snapshot",
-        lambda *_args, **_kwargs: pytest.fail("foreign video reached probe"),
-    )
-
     context = pattern_evidence.build_evidence_context(
         vault,
         {
@@ -881,6 +942,263 @@ def test_foreign_video_manifest_pdf_never_reaches_current_context_probe(
         )
 
     assert foreign_pdf not in str(caught.value)
+
+
+def test_schema_v3_manifest_source_takes_precedence_over_top_level_video_path(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    legacy_video = vault / "videos" / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    manifest_video = (
+        vault / "slides-rebuild" / SYNTHETIC_VIDEO_ID / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    )
+    legacy_video.parent.mkdir(parents=True)
+    manifest_video.parent.mkdir(parents=True)
+    legacy_video.write_bytes(b"legacy top-level bytes")
+    manifest_video.write_bytes(b"manifest-owned bytes")
+    assessment = _TestVideoAssessment()
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {
+            "youtube_id": SYNTHETIC_VIDEO_ID,
+            "video_local_path": legacy_video.relative_to(vault).as_posix(),
+            "structured_data": {
+                "video_extraction": {
+                    "schema_version": 3,
+                    "source_video_id": SYNTHETIC_VIDEO_ID,
+                    "source_video_path": manifest_video.relative_to(vault).as_posix(),
+                }
+            },
+        },
+        video_evidence_assessment=assessment,
+    )
+
+    assert context["local_video_path"] == manifest_video
+    assert (
+        context["video_artifact_identity"]["artifact_sha256"]
+        == hashlib.sha256(manifest_video.read_bytes()).hexdigest()
+    )
+    assert assessment.calls == [manifest_video]
+
+
+def test_schema_v3_video_identity_stays_fresh_through_a_symlinked_vault_root(
+    tmp_path: Path,
+) -> None:
+    storage = tmp_path / "vault-storage"
+    storage.mkdir()
+    vault = tmp_path / "vault"
+    try:
+        vault.symlink_to(storage, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - unusual restricted platform
+        pytest.skip(f"symlinks unavailable: {exc}")
+    source_video = (
+        storage / "slides-rebuild" / SYNTHETIC_VIDEO_ID / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    )
+    source_video.parent.mkdir(parents=True)
+    source_video.write_bytes(b"canonical storage video bytes")
+    manifest = {
+        "schema_version": 3,
+        "source_video_id": SYNTHETIC_VIDEO_ID,
+        "source_video_path": os.fspath(source_video),
+    }
+    assessment = _TestVideoAssessment()
+    talk: dict[str, Any] = {
+        "youtube_id": SYNTHETIC_VIDEO_ID,
+        "structured_data": {"video_extraction": manifest},
+    }
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        talk,
+        video_evidence_assessment=assessment,
+    )
+
+    assert context["local_video_path"] == source_video
+    assert context["video_artifact_identity"] == {
+        "artifact_root": "vault",
+        "artifact_path": (
+            f"slides-rebuild/{SYNTHETIC_VIDEO_ID}/{SYNTHETIC_VIDEO_ID}.mp4"
+        ),
+        "artifact_sha256": hashlib.sha256(source_video.read_bytes()).hexdigest(),
+    }
+    talk["pattern_observations"] = {
+        "evidence_schema_version": 1,
+        "evidence_sources": ["delivery_video"],
+        "source_inspection": [
+            {
+                "source": "delivery_video",
+                **context["video_artifact_identity"],
+                "time_ranges": [[0.0, SYNTHETIC_DURATION]],
+                "duration_seconds": SYNTHETIC_DURATION,
+                "coverage_complete": True,
+            }
+        ],
+        "patterns_detected": [],
+        "antipatterns_detected": [],
+    }
+    freshness_assessment = _TestVideoAssessment()
+
+    assert (
+        pattern_evidence.assess_persisted_pattern_evidence_freshness(
+            talk,
+            vault_root=vault,
+            video_evidence_assessment=freshness_assessment,
+        )
+        == ()
+    )
+    assert assessment.calls == [source_video]
+    assert freshness_assessment.calls == [source_video]
+
+    # Older canonicalization represented a video reached through a symlinked
+    # vault as a parent-rooted preclaim identity. Keep that exact persisted
+    # receipt readable so installing the bounded probe alone does not require
+    # reprocessing otherwise-current evidence.
+    legacy_record = talk["pattern_observations"]["source_inspection"][0]
+    legacy_record["artifact_root"] = "preclaim:video_local_path"
+    legacy_record["artifact_path"] = source_video.name
+    legacy_assessment = _TestVideoAssessment()
+    assert (
+        pattern_evidence.assess_persisted_pattern_evidence_freshness(
+            talk,
+            vault_root=vault,
+            video_evidence_assessment=legacy_assessment,
+        )
+        == ()
+    )
+    assert legacy_assessment.calls == [source_video]
+
+
+def test_current_return_video_does_not_retroactively_authorize_transcript(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    transcript, _ = _write_transcript(
+        vault,
+        name=SYNTHETIC_VIDEO_ID,
+        timed=False,
+    )
+    source_video = (
+        vault / "slides-rebuild" / SYNTHETIC_VIDEO_ID / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    )
+    source_video.parent.mkdir(parents=True)
+    source_video.write_bytes(b"current-return video bytes")
+    text = transcript.read_text(encoding="utf-8")
+    transcript_timing.write_quality_receipt(
+        transcript,
+        text,
+        transcript_timing.build_quality_policy(
+            400,
+            trusted_duration_seconds=SYNTHETIC_DURATION,
+        ),
+        {
+            "kind": "local_media_duration",
+            "media_sha256": hashlib.sha256(source_video.read_bytes()).hexdigest(),
+            "duration_seconds": SYNTHETIC_DURATION,
+        },
+    )
+    ret = {
+        "youtube_id": SYNTHETIC_VIDEO_ID,
+        "slide_source": "video_extracted",
+        "structured_data": {
+            "video_extraction": _untrusted_video_manifest(vault, source_video)
+        },
+    }
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {
+            "youtube_id": SYNTHETIC_VIDEO_ID,
+            "transcript_path": transcript.relative_to(vault).as_posix(),
+            "transcript_source": "manual",
+        },
+        ret,
+        video_evidence_assessment=_TestVideoAssessment(),
+    )
+
+    assert "transcript" not in context["verified_evidence_sources"]
+    assert "not bound to the claimed talk" in context["transcript_reason"]
+    assert "delivery_video" in context["verified_evidence_sources"]
+
+
+def test_current_return_video_receipt_is_preferred_for_delivery_evidence(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    preclaim_video = vault / "videos" / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    returned_video = (
+        vault / "slides-rebuild" / SYNTHETIC_VIDEO_ID / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    )
+    preclaim_video.parent.mkdir(parents=True)
+    returned_video.parent.mkdir(parents=True)
+    preclaim_video.write_bytes(b"preclaim video bytes")
+    returned_video.write_bytes(b"current-return video bytes")
+    assessment = _TestVideoAssessment()
+    ret = {
+        "youtube_id": SYNTHETIC_VIDEO_ID,
+        "slide_source": "video_extracted",
+        "structured_data": {
+            "video_extraction": _untrusted_video_manifest(vault, returned_video)
+        },
+    }
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {
+            "youtube_id": SYNTHETIC_VIDEO_ID,
+            "video_local_path": preclaim_video.relative_to(vault).as_posix(),
+        },
+        ret,
+        video_evidence_assessment=assessment,
+    )
+
+    assert context["local_video_path"] == returned_video
+    assert (
+        context["video_artifact_identity"]["artifact_sha256"]
+        == hashlib.sha256(returned_video.read_bytes()).hexdigest()
+    )
+    assert assessment.calls == [preclaim_video, returned_video]
+
+
+def test_video_freshness_reuses_the_context_receipt_without_a_second_probe(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    video = vault / "videos" / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    video.parent.mkdir(parents=True)
+    video.write_bytes(b"one exact persisted video generation")
+    digest = hashlib.sha256(video.read_bytes()).hexdigest()
+    assessment = _TestVideoAssessment()
+    talk = {
+        "youtube_id": SYNTHETIC_VIDEO_ID,
+        "video_local_path": video.relative_to(vault).as_posix(),
+        "pattern_observations": {
+            "evidence_schema_version": 1,
+            "evidence_sources": ["delivery_video"],
+            "source_inspection": [
+                {
+                    "source": "delivery_video",
+                    "artifact_root": "vault",
+                    "artifact_path": video.relative_to(vault).as_posix(),
+                    "artifact_sha256": digest,
+                    "time_ranges": [[0.0, SYNTHETIC_DURATION]],
+                    "duration_seconds": SYNTHETIC_DURATION,
+                    "coverage_complete": True,
+                }
+            ],
+            "patterns_detected": [],
+            "antipatterns_detected": [],
+        },
+    }
+
+    reasons = pattern_evidence.assess_persisted_pattern_evidence_freshness(
+        talk,
+        vault_root=vault,
+        video_evidence_assessment=assessment,
+    )
+
+    assert reasons == ()
+    assert assessment.calls == [video]
 
 
 def test_traversal_and_symlinked_artifacts_never_become_sources(
@@ -1159,6 +1477,7 @@ def test_current_video_manifest_bounds_bad_second_context_pdf_before_persistence
             vault,
             {"youtube_id": SYNTHETIC_VIDEO_ID},
             ret,
+            video_evidence_assessment=_TestVideoAssessment(),
         )
 
     assert caught.value.reason_code == "pdf_artifact_unavailable"
@@ -1220,6 +1539,7 @@ def test_promoted_video_pdf_must_match_trusted_slide_region_digest(
             vault,
             {"youtube_id": SYNTHETIC_VIDEO_ID},
             returned,
+            video_evidence_assessment=_TestVideoAssessment(),
         )
 
 
@@ -1871,7 +2191,6 @@ def test_fixed_default_receipt_is_valid_for_an_existing_youtube_artifact(
 
 
 def test_local_media_quality_provenance_binds_exact_video_bytes(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     vault = tmp_path / "vault"
@@ -1891,7 +2210,6 @@ def test_local_media_quality_provenance_binds_exact_video_bytes(
             "duration_seconds": duration,
         },
     )
-    monkeypatch.setattr(pattern_evidence, "_video_duration", lambda _: duration)
     talk = {
         "filename": "synthetic-talk.md",
         "title": "Synthetic Talk",
@@ -1901,14 +2219,22 @@ def test_local_media_quality_provenance_binds_exact_video_bytes(
         "video_local_path": video.relative_to(vault).as_posix(),
     }
 
-    context = pattern_evidence.build_evidence_context(vault, talk)
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        talk,
+        video_evidence_assessment=_TestVideoAssessment(duration=duration),
+    )
     assert "transcript" in context["verified_evidence_sources"]
     assert context["quality_artifact_identity"]["quality_artifact_path"] == (
         "transcripts/talk.quality.json"
     )
 
     video.write_bytes(b"different video bytes")
-    drifted = pattern_evidence.build_evidence_context(vault, talk)
+    drifted = pattern_evidence.build_evidence_context(
+        vault,
+        talk,
+        video_evidence_assessment=_TestVideoAssessment(duration=duration),
+    )
     assert "transcript" not in drifted["verified_evidence_sources"]
     assert "digest does not match" in str(drifted["transcript_reason"])
 
@@ -2487,8 +2813,9 @@ def test_batch_capability_preflight_does_not_touch_unrelated_talks(
         *,
         vault_root: str | Path,
         source_roots: dict[str, object] | None = None,
+        video_evidence_assessment: object | None = None,
     ) -> dict[str, object]:
-        del vault_root, source_roots
+        del vault_root, source_roots, video_evidence_assessment
         filename = str(talk["filename"])
         calls.append(filename)
         if filename == "unrelated.md":
@@ -2875,16 +3202,18 @@ def test_unprobeable_video_is_not_hashed_or_allowed_to_hide_other_lanes(
     video.write_bytes(b"not a probeable video")
     original_hash = pattern_evidence._sha256_file
 
-    def fail_video_probe(_path: Path) -> float:
-        raise pattern_evidence.PatternEvidenceError("synthetic ffprobe failure")
-
     def reject_video_hash(path: Path) -> str:
         if path == video:
             raise AssertionError("an unverified video must not be hashed")
         return original_hash(path)
 
-    monkeypatch.setattr(pattern_evidence, "_video_duration", fail_video_probe)
     monkeypatch.setattr(pattern_evidence, "_sha256_file", reject_video_hash)
+    video_assessment = _TestVideoAssessment(
+        failure=pattern_evidence.VideoEvidenceError(
+            "synthetic ffprobe failure",
+            reason_code="video_parser_rejected",
+        )
+    )
     assessment = pattern_evidence.assess_talk_artifact_capabilities(
         {
             "filename": "talk.md",
@@ -2895,15 +3224,23 @@ def test_unprobeable_video_is_not_hashed_or_allowed_to_hide_other_lanes(
             "video_local_path": video.relative_to(vault).as_posix(),
         },
         vault_root=vault,
+        video_evidence_assessment=video_assessment,
     )
 
     assert assessment["verified_capabilities"] == ("slides", "transcript")
     assert "delivery_video" not in assessment["verified_evidence_sources"]
     assert "synthetic ffprobe failure" in assessment["source_reasons"]["delivery_video"]
+    assert assessment["unavailable_evidence_sources"]["delivery_video"] == {
+        "schema_version": 1,
+        "status": "unavailable",
+        "reason_code": "video_parser_rejected",
+        "reason": "synthetic ffprobe failure",
+        "details": {},
+        "artifact_path": str(video),
+    }
 
 
 def test_video_mutation_between_probe_and_digest_rejects_only_video_lane(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     vault = tmp_path / "vault"
@@ -2913,20 +3250,11 @@ def test_video_mutation_between_probe_and_digest_rejects_only_video_lane(
     video = vault / "videos" / "talk.mp4"
     video.parent.mkdir(parents=True)
     video.write_bytes(b"first synthetic video generation")
-    original_hash = pattern_evidence._sha256_file
-
-    def mutate_during_digest(path: Path) -> str:
-        if path != video:
-            return original_hash(path)
-        replacement = b"second, longer synthetic video generation created after ffprobe"
-        path.write_bytes(replacement)
-        return hashlib.sha256(replacement).hexdigest()
-
-    monkeypatch.setattr(pattern_evidence, "_video_duration", lambda _: 60.0)
-    monkeypatch.setattr(
-        pattern_evidence,
-        "_sha256_file",
-        mutate_during_digest,
+    video_assessment = _TestVideoAssessment(
+        failure=pattern_evidence.VideoEvidenceError(
+            "synthetic video changed during supervised inspection",
+            reason_code="video_artifact_changed",
+        )
     )
 
     context = pattern_evidence.build_evidence_context(
@@ -2939,6 +3267,7 @@ def test_video_mutation_between_probe_and_digest_rejects_only_video_lane(
             "slide_source": "pptx",
             "video_local_path": video.relative_to(vault).as_posix(),
         },
+        video_evidence_assessment=video_assessment,
     )
 
     assert context["verified_evidence_sources"] == {
@@ -2947,7 +3276,7 @@ def test_video_mutation_between_probe_and_digest_rejects_only_video_lane(
     }
     assert context["video_artifact_identity"] == {}
     assert (
-        "changed while its digest was computed"
+        "changed during supervised inspection"
         in context["source_reasons"]["delivery_video"]
     )
 
@@ -2965,13 +3294,18 @@ def test_unhashable_video_cannot_hide_independent_transcript_and_deck(
     video.write_bytes(b"synthetic video bytes")
     original_hash = pattern_evidence._sha256_file
 
-    def fail_video_hash(path: Path) -> str:
+    def reject_video_hash(path: Path) -> str:
         if path == video:
-            raise pattern_evidence.PatternEvidenceError("synthetic video hash failure")
+            raise AssertionError("video digest must stay inside the bounded probe")
         return original_hash(path)
 
-    monkeypatch.setattr(pattern_evidence, "_video_duration", lambda _: 60.0)
-    monkeypatch.setattr(pattern_evidence, "_sha256_file", fail_video_hash)
+    monkeypatch.setattr(pattern_evidence, "_sha256_file", reject_video_hash)
+    video_assessment = _TestVideoAssessment(
+        failure=pattern_evidence.VideoEvidenceError(
+            "synthetic video digest worker failure",
+            reason_code="video_probe_resource_unavailable",
+        )
+    )
     assessment = pattern_evidence.assess_talk_artifact_capabilities(
         {
             "filename": "talk.md",
@@ -2982,12 +3316,13 @@ def test_unhashable_video_cannot_hide_independent_transcript_and_deck(
             "video_local_path": video.relative_to(vault).as_posix(),
         },
         vault_root=vault,
+        video_evidence_assessment=video_assessment,
     )
 
     assert assessment["verified_capabilities"] == ("slides", "transcript")
     assert "delivery_video" not in assessment["verified_evidence_sources"]
     assert assessment["source_reasons"]["delivery_video"].endswith(
-        "synthetic video hash failure"
+        "synthetic video digest worker failure"
     )
 
 

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -132,8 +132,10 @@ def _talk(**overrides):
 
 def _write_tiny_mp4(path):
     ffmpeg = shutil.which("ffmpeg")
-    if ffmpeg is None or shutil.which("ffprobe") is None:
-        pytest.skip("source-video persistence test requires ffmpeg and ffprobe")
+    assert ffmpeg is not None, "source-video persistence test requires ffmpeg"
+    assert shutil.which("ffprobe") is not None, (
+        "source-video persistence test requires ffprobe"
+    )
     created = subprocess.run(
         [
             ffmpeg,

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -7,6 +7,7 @@ the tracking DB, with the declared queryable scalars promoted to the talk top le
 import copy
 import importlib
 import json
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
@@ -127,6 +128,39 @@ def _talk(**overrides):
     }
     talk.update(overrides)
     return talk
+
+
+def _write_tiny_mp4(path):
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None or shutil.which("ffprobe") is None:
+        pytest.skip("source-video persistence test requires ffmpeg and ffprobe")
+    created = subprocess.run(
+        [
+            ffmpeg,
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x90:r=2",
+            "-t",
+            "0.25",
+            "-an",
+            "-c:v",
+            "mpeg4",
+            "-pix_fmt",
+            "yuv420p",
+            "-y",
+            str(path),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert created.returncode == 0, created.stderr.decode(
+        "utf-8", errors="replace"
+    )
 
 
 def _db_json(database):
@@ -527,7 +561,7 @@ def test_legacy_video_return_bounds_every_manifest_artifact_before_merge(
             tmp_path.parent / f"{tmp_path.name}-outside" / f"{video_id}.mp4"
         )
         source_video.parent.mkdir()
-    source_video.write_bytes(b"synthetic video")
+    _write_tiny_mp4(source_video)
     slide_region = rebuild / f"{video_id}.slide-region.pdf"
     promoted = tmp_path / "slides" / f"{video_id}.pdf"
     promoted.parent.mkdir()

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import os
 from pathlib import Path
+import shutil
 import struct
 import subprocess
 import sys
@@ -28,6 +29,7 @@ QUEUE_STATE_SCRIPT = (
     / "scripts"
     / "queue-state.py"
 )
+_TINY_VIDEO_BYTES: bytes | None = None
 
 
 def foreign_absolute_locator(name: str) -> str:
@@ -166,6 +168,50 @@ def write_pdf(path: Path, *, page_count: int = 1) -> Path:
     return path
 
 
+def write_tiny_video(path: Path) -> Path:
+    """Materialize one valid MP4 while keeping ffmpeg local to video tests."""
+    global _TINY_VIDEO_BYTES
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if _TINY_VIDEO_BYTES is not None:
+        path.write_bytes(_TINY_VIDEO_BYTES)
+        return path
+
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None or shutil.which("ffprobe") is None:
+        pytest.skip("source-video manifest tests require ffmpeg and ffprobe")
+    assert ffmpeg is not None
+    created = subprocess.run(
+        [
+            ffmpeg,
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x90:r=1",
+            "-t",
+            "1",
+            "-an",
+            "-c:v",
+            "mpeg4",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            "-y",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert created.returncode == 0, created.stderr
+    _TINY_VIDEO_BYTES = path.read_bytes()
+    return path
+
+
 def materialize_crc_damaged_pptx(fixture):
     """Create a deck with one CRC-damaged media member under the source root."""
     image_path = fixture["pptx_source"] / "asset.png"
@@ -223,7 +269,7 @@ def trusted_video_manifest(fixture, page_count=1):
     rebuild = fixture["root"] / "slides-rebuild" / VIDEO_ID
     rebuild.mkdir(parents=True, exist_ok=True)
     source_video = rebuild / f"{VIDEO_ID}.mp4"
-    source_video.write_bytes(b"video fixture")
+    write_tiny_video(source_video)
     candidate = rebuild / f"{VIDEO_ID}.slide-region.pdf"
     write_pdf(candidate, page_count=page_count)
     retained = [
@@ -640,9 +686,7 @@ def test_preflight_compares_symlinked_vault_roots_by_lexical_identity(
     physical_root = vault_fixture["root"]
     alias_root = tmp_path / "alias-vault"
     alias_root.symlink_to(physical_root, target_is_directory=True)
-    configured_root = (
-        alias_root if configured_identity == "alias" else physical_root
-    )
+    configured_root = alias_root if configured_identity == "alias" else physical_root
     write_database(
         vault_fixture,
         [],
@@ -963,17 +1007,18 @@ def test_missing_source_video_reports_closed_path_neutral_error(
     finding = next(
         item
         for item in report["findings"]
-        if item["code"] == "video_extraction_provenance_invalid"
+        if item["code"] == "source_video_artifact_missing"
     )
     diagnostic = json.dumps(
         {"message": finding["message"], "actual": finding["actual"]},
         sort_keys=True,
     )
     assert str(source) not in diagnostic
-    assert finding["actual"] == [
-        "source_video_path must name a root-confined, non-symlinked preserved "
-        "source video"
-    ]
+    assert finding["severity"] == "warning"
+    assert finding["field"] == ("structured_data.video_extraction.source_video_path")
+    assert finding["actual"]["reason_code"] == "video_artifact_unavailable"
+    assert finding["actual"]["details"]["failure_kind"] == "missing"
+    assert "video_extraction_provenance_invalid" not in finding_codes(report)
 
 
 def test_video_manifest_rejects_symlinked_source_video(
@@ -1036,6 +1081,185 @@ def test_slide_contract_taxonomy_includes_bounded_pdf_failures(
         "slide_video_artifact_unavailable",
         "slide_video_artifact_unreadable",
     } <= preflight_vault.SLIDE_CONTRACT_CODES
+
+
+def test_source_video_contract_taxonomy_is_separate_and_closed(
+    preflight_vault,
+) -> None:
+    assert preflight_vault.SOURCE_VIDEO_CONTRACT_CODES == {
+        "source_video_artifact_missing",
+        "source_video_artifact_unavailable",
+        "source_video_artifact_unreadable",
+    }
+    assert not (
+        preflight_vault.SOURCE_VIDEO_CONTRACT_CODES
+        & preflight_vault.SLIDE_CONTRACT_CODES
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason_code", "details", "expected_code"),
+    [
+        (
+            "video_artifact_unavailable",
+            {"failure_kind": "missing"},
+            "source_video_artifact_missing",
+        ),
+        (
+            "video_cloud_placeholder_unavailable",
+            {"availability": {"state": "offline"}},
+            "source_video_artifact_unavailable",
+        ),
+        *[
+            (reason, {}, "source_video_artifact_unreadable")
+            for reason in (
+                "video_artifact_changed",
+                "video_artifact_too_large",
+                "video_batch_wall_limit",
+                "video_dependency_unavailable",
+                "video_duration_unavailable",
+                "video_evidence_invalid",
+                "video_invalid_container",
+                "video_no_video_stream",
+                "video_parser_rejected",
+                "video_parser_repair_required",
+                "video_probe_containment_unavailable",
+                "video_probe_crash",
+                "video_probe_malformed_result",
+                "video_probe_monitor_identity_changed",
+                "video_probe_monitor_unavailable",
+                "video_probe_request_oversized",
+                "video_probe_resource_unavailable",
+                "video_probe_result_oversized",
+                "video_probe_start_failure",
+                "video_probe_timeout",
+                "video_stream_limit",
+            )
+        ],
+        (
+            "video_artifact_unavailable",
+            {"failure_kind": "io"},
+            "source_video_artifact_unreadable",
+        ),
+        (
+            "video_artifact_unavailable",
+            {},
+            "source_video_artifact_unreadable",
+        ),
+        *[
+            (
+                "video_artifact_unavailable",
+                {"failure_kind": failure_kind},
+                "video_extraction_provenance_invalid",
+            )
+            for failure_kind in (
+                "not_regular",
+                "root_escape",
+                "symlink_or_reparse",
+            )
+        ],
+        (
+            "video_evidence_invalid",
+            {"locator_failure": "artifact_locator_dot_segment"},
+            "video_extraction_provenance_invalid",
+        ),
+    ],
+)
+def test_source_video_failure_mapping_is_closed(
+    preflight_vault,
+    reason_code: str,
+    details: dict[str, object],
+    expected_code: str,
+) -> None:
+    video_evidence = importlib.import_module("video_evidence")
+    error = video_evidence.VideoEvidenceError(
+        "synthetic bounded video failure",
+        reason_code=reason_code,
+        details=details,
+    )
+
+    assert preflight_vault._source_video_failure_code(error) == expected_code
+
+
+@pytest.mark.parametrize(
+    ("reason_code", "details", "expected_code", "current", "severity"),
+    [
+        (
+            "video_artifact_unavailable",
+            {"failure_kind": "missing", "exception_type": "FileNotFoundError"},
+            "source_video_artifact_missing",
+            False,
+            "warning",
+        ),
+        (
+            "video_cloud_placeholder_unavailable",
+            {"availability": {"state": "offline"}, "reparse_tag": None},
+            "source_video_artifact_unavailable",
+            False,
+            "warning",
+        ),
+        (
+            "video_invalid_container",
+            {},
+            "source_video_artifact_unreadable",
+            False,
+            "warning",
+        ),
+        (
+            "video_invalid_container",
+            {},
+            "source_video_artifact_unreadable",
+            True,
+            "blocking",
+        ),
+    ],
+)
+def test_source_video_probe_failure_is_structured_current_aware_and_not_duplicated(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch: pytest.MonkeyPatch,
+    reason_code: str,
+    details: dict[str, object],
+    expected_code: str,
+    current: bool,
+    severity: str,
+) -> None:
+    video_evidence = importlib.import_module("video_evidence")
+    manifest = trusted_video_manifest(vault_fixture)
+
+    def fail_probe(*_args, **_kwargs):
+        raise video_evidence.VideoEvidenceError(
+            "synthetic bounded video failure",
+            reason_code=reason_code,
+            details=details,
+        )
+
+    monkeypatch.setattr(video_evidence.VideoEvidenceAssessment, "probe", fail_probe)
+    talk_updates = {
+        "status": "processed_partial",
+        "transcript_source": "none",
+        "slide_source": "video_extracted",
+        "structured_data": {"video_extraction": manifest},
+    }
+    talk = (
+        current_v5_talk(preflight_vault, **talk_updates)
+        if current
+        else base_talk(**talk_updates)
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    findings = [item for item in report["findings"] if item["code"] == expected_code]
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["severity"] == severity
+    assert finding["field"] == ("structured_data.video_extraction.source_video_path")
+    assert finding["actual"] == {
+        "reason_code": reason_code,
+        "details": details,
+    }
+    assert "video_extraction_provenance_invalid" not in finding_codes(report)
 
 
 def test_clean_record_has_no_findings(preflight_vault, vault_fixture):

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -177,9 +177,10 @@ def write_tiny_video(path: Path) -> Path:
         return path
 
     ffmpeg = shutil.which("ffmpeg")
-    if ffmpeg is None or shutil.which("ffprobe") is None:
-        pytest.skip("source-video manifest tests require ffmpeg and ffprobe")
-    assert ffmpeg is not None
+    assert ffmpeg is not None, "source-video manifest tests require ffmpeg"
+    assert shutil.which("ffprobe") is not None, (
+        "source-video manifest tests require ffprobe"
+    )
     created = subprocess.run(
         [
             ffmpeg,
@@ -1179,6 +1180,63 @@ def test_source_video_failure_mapping_is_closed(
     )
 
     assert preflight_vault._source_video_failure_code(error) == expected_code
+
+
+@pytest.mark.parametrize(
+    ("reason_code", "details", "expected_reason"),
+    [
+        (
+            "video_evidence_invalid",
+            {"locator_failure": "artifact_locator_dot_segment"},
+            "source_video_path: artifact_locator_dot_segment",
+        ),
+        (
+            "video_artifact_unavailable",
+            {"failure_kind": "root_escape"},
+            "source_video_path: root_escape",
+        ),
+    ],
+)
+def test_source_video_provenance_failures_keep_string_reason_list(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch: pytest.MonkeyPatch,
+    reason_code: str,
+    details: dict[str, object],
+    expected_reason: str,
+) -> None:
+    video_evidence = importlib.import_module("video_evidence")
+    manifest = trusted_video_manifest(vault_fixture)
+
+    def fail_probe(*_args, **_kwargs):
+        raise video_evidence.VideoEvidenceError(
+            "synthetic bounded video provenance failure",
+            reason_code=reason_code,
+            details=details,
+        )
+
+    monkeypatch.setattr(video_evidence.VideoEvidenceAssessment, "probe", fail_probe)
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                status="processed_partial",
+                transcript_source="none",
+                slide_source="video_extracted",
+                structured_data={"video_extraction": manifest},
+            )
+        ],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "video_extraction_provenance_invalid"
+    )
+    assert finding["actual"] == [expected_reason]
+    assert all(isinstance(reason, str) for reason in finding["actual"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -1348,7 +1348,10 @@ def test_ingress_docs_require_live_database_for_current_block_replace():
         encoding="utf-8"
     )
 
-    for text in (skill, processing):
-        assert "section15_pattern_history.py replace" in text
-        assert "tracking-database.json" in text
-        assert "stale" in text
+    assert "references/processing-rules.md" in skill
+    assert "section15_pattern_history.py" in skill
+    assert "tracking-database.json" in skill
+    assert "stale" in skill
+    assert "section15_pattern_history.py replace" in processing
+    assert "tracking-database.json" in processing
+    assert "stale" in processing

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -1108,6 +1108,11 @@ def test_profile_cohort_rejects_invalid_configured_vault_before_freshness(
             "invalid root reached the evidence freshness assessor"
         ),
     )
+    monkeypatch.setattr(
+        cohort_snapshot,
+        "VideoEvidenceAssessment",
+        lambda: pytest.fail("invalid root created a video evidence assessment"),
+    )
 
     with pytest.raises(cohort_snapshot.PatternCohortSnapshotError) as caught:
         cohort_snapshot.configured_evidence_freshness_assessor(
@@ -1138,6 +1143,12 @@ def test_profile_cohort_uses_database_root_for_every_valid_authority_form(
     del validate_profile
     cohort_snapshot = importlib.import_module("pattern_cohort_snapshot")
     observed = []
+    assessment = object()
+    created = []
+
+    def create_assessment():
+        created.append(assessment)
+        return assessment
 
     def assess(_talk, **kwargs):
         observed.append(kwargs)
@@ -1148,6 +1159,11 @@ def test_profile_cohort_uses_database_root_for_every_valid_authority_form(
         "assess_current_persisted_pattern_evidence_freshness",
         assess,
     )
+    monkeypatch.setattr(
+        cohort_snapshot,
+        "VideoEvidenceAssessment",
+        create_assessment,
+    )
     config = config_factory(tmp_path)
 
     assessor = cohort_snapshot.configured_evidence_freshness_assessor(
@@ -1155,13 +1171,24 @@ def test_profile_cohort_uses_database_root_for_every_valid_authority_form(
         config,
     )
 
-    assert assessor({}) == ()
+    first_talk = {}
+    second_talk = {"filename": "second.md"}
+    assert assessor(first_talk) == ()
+    assert assessor(second_talk) == ()
+    assert created == [assessment]
     assert observed == [
         {
             "vault_root": tmp_path,
             "source_roots": config,
             "catalog": None,
-        }
+            "video_evidence_assessment": assessment,
+        },
+        {
+            "vault_root": tmp_path,
+            "source_roots": config,
+            "catalog": None,
+            "video_evidence_assessment": assessment,
+        },
     ]
 
 

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -449,7 +449,14 @@ def test_stable_generation_failure_is_revalidated_then_reused_globally(
 @pytest.mark.parametrize(
     ("flags", "file_attributes"),
     [
-        (video_evidence.VIDEO_MACOS_DATALESS_FLAG, None),
+        pytest.param(
+            video_evidence.VIDEO_MACOS_DATALESS_FLAG,
+            None,
+            marks=pytest.mark.skipif(
+                video_evidence.VIDEO_MACOS_DATALESS_FLAG == 0,
+                reason="macOS dataless flag is unavailable on this platform",
+            ),
+        ),
         (None, artifact_metadata.WINDOWS_OFFLINE_ATTRIBUTE),
         (None, artifact_metadata.WINDOWS_RECALL_ON_OPEN_ATTRIBUTE),
         (None, artifact_metadata.WINDOWS_RECALL_ON_DATA_ACCESS_ATTRIBUTE),

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import importlib
 import os
-import shutil
 import subprocess
 import sys
 import threading
@@ -239,10 +238,6 @@ def test_metadata_child_closes_root_escape_symlink_and_nonregular_failures(
         assert os.fspath(artifact) not in repr(payload)
 
 
-@pytest.mark.skipif(
-    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
-    reason="real media probe requires ffmpeg and ffprobe",
-)
 def test_real_worker_probes_tiny_mp4_and_reuses_only_same_generation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -276,10 +271,6 @@ def test_real_worker_probes_tiny_mp4_and_reuses_only_same_generation(
     assert second == first
 
 
-@pytest.mark.skipif(
-    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
-    reason="real media probe requires ffmpeg and ffprobe",
-)
 @pytest.mark.parametrize(
     ("suffix", "codec", "expected_family"),
     [
@@ -319,11 +310,7 @@ def test_real_worker_accepts_each_declared_container_family(
         capture_output=True,
         check=False,
     )
-    if created.returncode != 0:
-        pytest.skip(
-            f"local ffmpeg does not provide the {codec} test encoder: "
-            + created.stderr.decode("utf-8", errors="replace")
-        )
+    assert created.returncode == 0, created.stderr.decode("utf-8", errors="replace")
 
     probe = video_evidence.VideoEvidenceAssessment().probe(
         artifact.name,
@@ -1327,10 +1314,6 @@ def test_transient_leader_failure_is_shared_with_waiter_in_same_assessment(
     assert probe_calls == 1
 
 
-@pytest.mark.skipif(
-    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
-    reason="real media rejection requires ffmpeg and ffprobe",
-)
 def test_real_worker_rejects_audio_only_wrong_container_and_corrupt_inputs(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -1,0 +1,1415 @@
+"""Bounded source-video evidence and operation-scope regression tests."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "vault-ingress"
+    / "scripts"
+    / "video_evidence.py"
+)
+SCRIPT_DIR = SCRIPT.parent
+if os.fspath(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, os.fspath(SCRIPT_DIR))
+video_evidence = importlib.import_module("video_evidence")
+artifact_supervisor = importlib.import_module("artifact_supervisor")
+artifact_metadata = importlib.import_module("artifact_metadata")
+
+
+def _generation(
+    *,
+    size: int = 1_024,
+    inode: int = 31,
+    flags: int | None = None,
+    file_attributes: int | None = None,
+) -> Any:
+    return video_evidence.FileGeneration(
+        size=size,
+        mtime_ns=11,
+        ctime_ns=12,
+        device=13,
+        inode=inode,
+        mode=0o100600,
+        flags=flags,
+        file_attributes=file_attributes,
+    )
+
+
+def _root_generation(*, inode: int = 41) -> Any:
+    return video_evidence.FileGeneration(
+        size=0,
+        mtime_ns=0,
+        ctime_ns=0,
+        device=13,
+        inode=inode,
+        mode=0o040700,
+        flags=None,
+        file_attributes=None,
+    )
+
+
+def _receipt(
+    generation: Any,
+    root_generation: Any | None = None,
+    *,
+    reparse_tag: int | None = None,
+) -> Any:
+    return video_evidence.ArtifactMetadataReceipt(
+        generation=generation,
+        root_generation=root_generation,
+        reparse_tag=reparse_tag,
+    )
+
+
+def _probe(
+    generation: Any,
+    *,
+    root_generation: Any | None = None,
+    digest: str = "a" * 64,
+) -> Any:
+    return video_evidence.VideoArtifactProbe(
+        generation=generation,
+        root_generation=root_generation,
+        availability=video_evidence.ArtifactAvailability.from_generation(generation),
+        source_sha256=digest,
+        source_size_bytes=generation.size,
+        duration_seconds=1.0,
+        duration_source="format",
+        container_family="iso_bmff",
+        stream_count=1,
+        video_stream_count=1,
+        audio_stream_count=0,
+        attached_picture_count=0,
+        other_stream_count=0,
+        parser_diagnostics=video_evidence.DiagnosticReceipt.empty(),
+    )
+
+
+def _worker_result(
+    generation: Any,
+    *,
+    payload: dict[str, object] | None = None,
+    diagnostics: Any | None = None,
+) -> Any:
+    selected_payload = payload or {
+        "schema_version": video_evidence.VIDEO_PROBE_SCHEMA_VERSION,
+        "status": "available",
+        "source_sha256": "a" * 64,
+        "source_size_bytes": generation.size,
+        "duration_seconds": 1.0,
+        "duration_source": "format",
+        "container_family": "iso_bmff",
+        "stream_count": 1,
+        "video_stream_count": 1,
+        "audio_stream_count": 0,
+        "attached_picture_count": 0,
+        "other_stream_count": 0,
+    }
+    return video_evidence.WorkerResult(
+        payload=selected_payload,
+        observed_generations={"video": generation},
+        diagnostics=diagnostics or video_evidence.DiagnosticReceipt.empty(),
+    )
+
+
+def _create_mp4(path: Path, *, duration: float = 1.0) -> bytes:
+    created = subprocess.run(
+        [
+            "ffmpeg",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x90:r=2",
+            "-t",
+            str(duration),
+            "-pix_fmt",
+            "yuv420p",
+            "-y",
+            os.fspath(path),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert created.returncode == 0, created.stderr.decode("utf-8", errors="replace")
+    return path.read_bytes()
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_cache() -> None:
+    video_evidence.clear_video_artifact_probe_cache()
+
+
+def test_declared_limits_and_public_receipts_are_immutable() -> None:
+    assert video_evidence.VIDEO_MAX_INPUT_BYTES == 8 * 1024**3
+    assert video_evidence.VIDEO_MAX_STREAMS == 64
+    assert video_evidence.VIDEO_FFPROBE_STDOUT_BYTES == 256 * 1024
+    assert video_evidence.VIDEO_FFPROBE_STDERR_BYTES == 64 * 1024
+    assert video_evidence.VIDEO_DIGEST_CHUNK_BYTES == 1024 * 1024
+    assert video_evidence.VIDEO_METADATA_LIMITS.wall_seconds == 15
+    assert video_evidence.VIDEO_METADATA_LIMITS.max_memory_bytes == 256 * 1024**2
+    assert video_evidence.VIDEO_METADATA_LIMITS.max_processes == 1
+    assert video_evidence.VIDEO_PROBE_LIMITS.wall_seconds == 300
+    assert video_evidence.VIDEO_PROBE_LIMITS.max_memory_bytes == 512 * 1024**2
+    assert video_evidence.VIDEO_PROBE_LIMITS.max_processes == 2
+
+    probe = _probe(_generation())
+    with pytest.raises(FrozenInstanceError):
+        probe.duration_seconds = 2.0
+    assessment = video_evidence.VideoEvidenceAssessment()
+    with pytest.raises(AttributeError, match="immutable"):
+        assessment.extra = True
+
+
+def test_invalid_public_locators_are_path_neutral_and_do_not_start_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign = "/foreign/talk.mp4" if os.name == "nt" else r"C:\talk.mp4"
+    cases = [
+        ("talk.mp4", None, "artifact_locator_trusted_root_required"),
+        ("../talk.mp4", tmp_path, "artifact_locator_dot_segment"),
+        ("bad\x00name.mp4", tmp_path, "artifact_locator_nul_byte"),
+        ("talk.avi", tmp_path, "video_suffix_unsupported"),
+        (foreign, None, "artifact_locator_foreign_absolute"),
+    ]
+    monkeypatch.setattr(
+        video_evidence,
+        "_invoke_metadata_worker",
+        lambda *_args, **_kwargs: pytest.fail("invalid locator started metadata"),
+    )
+
+    for locator, root, expected in cases:
+        with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+            video_evidence.probe_video_artifact(locator, trusted_root=root)
+        assert caught.value.reason_code == "video_evidence_invalid"
+        assert caught.value.details == {"locator_failure": expected}
+        assert str(locator) not in str(caught.value)
+        assert str(locator) not in repr(caught.value.details)
+
+
+def test_metadata_child_closes_root_escape_symlink_and_nonregular_failures(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.mp4"
+    outside.write_bytes(b"outside")
+    redirected = root / "redirected.mp4"
+    directory = root / "directory.mp4"
+    directory.mkdir()
+
+    cases = [
+        (outside, "root_escape"),
+        (directory, "not_regular"),
+    ]
+    try:
+        redirected.symlink_to(outside)
+    except OSError:
+        pass
+    else:
+        cases.append((redirected, "symlink_or_reparse"))
+    for artifact, failure_kind in cases:
+        payload = video_evidence._metadata_child(
+            {
+                "video_path": os.fspath(artifact),
+                "trusted_root": os.fspath(root),
+            }
+        )
+        assert payload["status"] == "unavailable"
+        assert payload["reason_code"] == "video_artifact_unavailable"
+        assert payload["details"]["failure_kind"] == failure_kind
+        assert os.fspath(artifact) not in repr(payload)
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="real media probe requires ffmpeg and ffprobe",
+)
+def test_real_worker_probes_tiny_mp4_and_reuses_only_same_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "talk.mp4"
+    source = _create_mp4(artifact)
+    assessment = video_evidence.VideoEvidenceAssessment()
+
+    first = assessment.probe("talk.mp4", trusted_root=tmp_path)
+
+    assert first.source_sha256 == hashlib.sha256(source).hexdigest()
+    assert first.source_size_bytes == len(source)
+    assert first.duration_seconds == pytest.approx(1.0, abs=0.05)
+    assert first.duration_source == "format"
+    assert first.container_family == "iso_bmff"
+    assert first.stream_count == 1
+    assert first.video_stream_count == 1
+    assert first.audio_stream_count == 0
+    assert first.attached_picture_count == 0
+    assert first.other_stream_count == 0
+    assert first.parser_diagnostics == video_evidence.DiagnosticReceipt.empty()
+
+    monkeypatch.setattr(
+        video_evidence,
+        "_invoke_probe_worker",
+        lambda *_args, **_kwargs: pytest.fail(
+            "same generation should reuse the immutable probe"
+        ),
+    )
+    second = assessment.probe(artifact, trusted_root=tmp_path)
+    assert second == first
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="real media probe requires ffmpeg and ffprobe",
+)
+@pytest.mark.parametrize(
+    ("suffix", "codec", "expected_family"),
+    [
+        (".mov", "mpeg4", "iso_bmff"),
+        (".webm", "libvpx-vp9", "matroska_webm"),
+        (".mkv", "ffv1", "matroska_webm"),
+    ],
+)
+def test_real_worker_accepts_each_declared_container_family(
+    tmp_path: Path,
+    suffix: str,
+    codec: str,
+    expected_family: str,
+) -> None:
+    artifact = tmp_path / f"talk{suffix}"
+    created = subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x90:r=2",
+            "-t",
+            "1",
+            "-an",
+            "-c:v",
+            codec,
+            "-pix_fmt",
+            "yuv420p",
+            "-y",
+            os.fspath(artifact),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    if created.returncode != 0:
+        pytest.skip(
+            f"local ffmpeg does not provide the {codec} test encoder: "
+            + created.stderr.decode("utf-8", errors="replace")
+        )
+
+    probe = video_evidence.VideoEvidenceAssessment().probe(
+        artifact.name,
+        trusted_root=tmp_path,
+    )
+
+    assert probe.container_family == expected_family
+    assert probe.video_stream_count == 1
+    assert probe.duration_seconds == pytest.approx(1.0, abs=0.1)
+
+
+def test_assessment_revalidates_success_and_reprobes_a_new_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_generation = _generation(inode=1)
+    second_generation = _generation(inode=2)
+    receipts = iter(
+        [
+            _receipt(first_generation, _root_generation()),
+            _receipt(second_generation, _root_generation()),
+        ]
+    )
+    probes: list[int] = []
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: next(receipts),
+    )
+
+    def run_probe(
+        _artifact: Path,
+        *,
+        receipt: Any,
+        **_kwargs: object,
+    ) -> Any:
+        probes.append(receipt.generation.inode)
+        return _probe(
+            receipt.generation,
+            root_generation=receipt.root_generation,
+            digest=("a" if receipt.generation.inode == 1 else "b") * 64,
+        )
+
+    monkeypatch.setattr(video_evidence, "_run_bounded_video_probe", run_probe)
+    assessment = video_evidence.VideoEvidenceAssessment()
+
+    first = assessment.probe("talk.mp4", trusted_root=tmp_path)
+    second = assessment.probe("talk.mp4", trusted_root=tmp_path)
+
+    assert probes == [1, 2]
+    assert first.source_sha256 != second.source_sha256
+
+
+def test_transient_failure_is_reused_in_one_assessment_but_not_globally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation()
+    metadata_calls = 0
+    probe_calls = 0
+
+    def metadata(*_args: object, **_kwargs: object) -> Any:
+        nonlocal metadata_calls
+        metadata_calls += 1
+        return _receipt(generation, _root_generation())
+
+    def probe(*_args: object, **_kwargs: object) -> Any:
+        nonlocal probe_calls
+        probe_calls += 1
+        if probe_calls == 1:
+            raise video_evidence._failure("video_probe_timeout")
+        return _probe(generation, root_generation=_root_generation())
+
+    monkeypatch.setattr(video_evidence, "_run_bounded_metadata_worker", metadata)
+    monkeypatch.setattr(video_evidence, "_run_bounded_video_probe", probe)
+    first_assessment = video_evidence.VideoEvidenceAssessment()
+
+    for _ in range(2):
+        with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+            first_assessment.probe("talk.mp4", trusted_root=tmp_path)
+        assert caught.value.reason_code == "video_probe_timeout"
+
+    result = video_evidence.VideoEvidenceAssessment().probe(
+        "talk.mp4", trusted_root=tmp_path
+    )
+    assert result.generation == generation
+    assert metadata_calls == 2
+    assert probe_calls == 2
+
+
+def test_stable_generation_failure_is_revalidated_then_reused_globally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation()
+    metadata_calls = 0
+    probe_calls = 0
+
+    def metadata(*_args: object, **_kwargs: object) -> Any:
+        nonlocal metadata_calls
+        metadata_calls += 1
+        return _receipt(generation, _root_generation())
+
+    def rejected(*_args: object, **_kwargs: object) -> Any:
+        nonlocal probe_calls
+        probe_calls += 1
+        raise video_evidence._failure("video_invalid_container")
+
+    monkeypatch.setattr(video_evidence, "_run_bounded_metadata_worker", metadata)
+    monkeypatch.setattr(video_evidence, "_run_bounded_video_probe", rejected)
+
+    for _ in range(2):
+        with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+            video_evidence.VideoEvidenceAssessment().probe(
+                "talk.mp4", trusted_root=tmp_path
+            )
+        assert caught.value.reason_code == "video_invalid_container"
+
+    assert metadata_calls == 2
+    assert probe_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("flags", "file_attributes"),
+    [
+        (video_evidence.VIDEO_MACOS_DATALESS_FLAG, None),
+        (None, artifact_metadata.WINDOWS_OFFLINE_ATTRIBUTE),
+        (None, artifact_metadata.WINDOWS_RECALL_ON_OPEN_ATTRIBUTE),
+        (None, artifact_metadata.WINDOWS_RECALL_ON_DATA_ACCESS_ATTRIBUTE),
+    ],
+)
+def test_placeholder_short_circuits_before_probe_or_digest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    flags: int | None,
+    file_attributes: int | None,
+) -> None:
+    generation = _generation(flags=flags, file_attributes=file_attributes)
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: _receipt(generation, _root_generation()),
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_video_probe",
+        lambda *_args, **_kwargs: pytest.fail("placeholder reached probe or digest"),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.probe_video_artifact("talk.mp4", trusted_root=tmp_path)
+
+    assert caught.value.reason_code == "video_cloud_placeholder_unavailable"
+    assert caught.value.details["availability"]["state"] == "unavailable"
+    assert caught.value.details["reparse_tag"] is None
+
+
+def test_windows_cloud_reparse_placeholder_stops_before_probe_or_digest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cloud_tag = min(video_evidence.VIDEO_WINDOWS_CLOUD_REPARSE_TAGS)
+    generation = _generation(
+        file_attributes=(
+            video_evidence.VIDEO_WINDOWS_REPARSE_POINT_ATTRIBUTE
+            | artifact_metadata.WINDOWS_OFFLINE_ATTRIBUTE
+        )
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: _receipt(
+            generation,
+            _root_generation(),
+            reparse_tag=cloud_tag,
+        ),
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_video_probe",
+        lambda *_args, **_kwargs: pytest.fail(
+            "cloud reparse placeholder reached ffprobe or digest"
+        ),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.probe_video_artifact("talk.mp4", trusted_root=tmp_path)
+
+    assert caught.value.reason_code == "video_cloud_placeholder_unavailable"
+    assert caught.value.details["availability"]["state"] == "unavailable"
+    assert caught.value.details["reparse_tag"] == cloud_tag
+
+
+def test_size_ceiling_short_circuits_before_probe_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation(size=video_evidence.VIDEO_MAX_INPUT_BYTES + 1)
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: _receipt(generation, _root_generation()),
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_invoke_probe_worker",
+        lambda *_args, **_kwargs: pytest.fail("oversized input started probe"),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.probe_video_artifact("large.mp4", trusted_root=tmp_path)
+
+    assert caught.value.reason_code == "video_artifact_too_large"
+    assert caught.value.details == {"limit_bytes": video_evidence.VIDEO_MAX_INPUT_BYTES}
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_lane"),
+    [
+        ("missing", "missing"),
+        ("io", "unavailable"),
+        ("not_regular", "unreadable"),
+        ("root_escape", "unreadable"),
+        ("symlink_or_reparse", "unreadable"),
+    ],
+)
+def test_metadata_failure_taxonomy_is_closed_for_preflight_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+    expected_lane: str,
+) -> None:
+    del expected_lane
+    error = video_evidence._failure(
+        "video_artifact_unavailable",
+        details={"failure_kind": failure_kind, "exception_type": "OSError"},
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(error),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.probe_video_artifact("talk.mp4", trusted_root=tmp_path)
+
+    assert caught.value.reason_code == "video_artifact_unavailable"
+    assert caught.value.details == {
+        "failure_kind": failure_kind,
+        "exception_type": "OSError",
+    }
+
+
+def test_ffprobe_success_diagnostics_require_repair_without_raw_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "private-speaker-name.mp4"
+    raw_diagnostic = b"private-speaker-name.mp4: non-fatal edit-list warning"
+    receipt = video_evidence.DiagnosticReceipt(
+        byte_count=len(raw_diagnostic),
+        sha256=hashlib.sha256(raw_diagnostic).hexdigest(),
+        truncated=False,
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_ffprobe",
+        lambda _artifact: (b"{}", receipt, 0),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence._probe_media_with_ffprobe(
+            artifact,
+            expected_container_family="iso_bmff",
+        )
+
+    assert caught.value.reason_code == "video_parser_repair_required"
+    assert caught.value.details == {"diagnostic_receipt": receipt.to_dict()}
+    assert "private-speaker-name" not in str(caught.value)
+    assert "private-speaker-name" not in repr(caught.value.details)
+    assert raw_diagnostic.decode() not in repr(caught.value.details)
+
+
+def test_missing_ffprobe_is_a_closed_dependency_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "private-name.mp4"
+    monkeypatch.setattr(video_evidence.shutil, "which", lambda _name: None)
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence._run_ffprobe(artifact)
+
+    assert caught.value.reason_code == "video_dependency_unavailable"
+    assert caught.value.details == {"dependency": "ffprobe"}
+    assert "private-name" not in str(caught.value)
+    assert "private-name" not in repr(caught.value.details)
+
+
+def test_duration_prefers_format_then_falls_back_to_usable_media_stream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "talk.mp4"
+
+    def run(document: bytes) -> dict[str, object]:
+        monkeypatch.setattr(
+            video_evidence,
+            "_run_ffprobe",
+            lambda _artifact: (
+                document,
+                video_evidence.DiagnosticReceipt.empty(),
+                0,
+            ),
+        )
+        return video_evidence._probe_media_with_ffprobe(
+            artifact,
+            expected_container_family="iso_bmff",
+        )
+
+    format_result = run(
+        b'{"format":{"format_name":"mov,mp4","duration":"3.5"},'
+        b'"streams":[{"codec_type":"video","duration":"2.0"}]}'
+    )
+    fallback_result = run(
+        b'{"format":{"format_name":"mov,mp4","duration":"N/A"},'
+        b'"streams":[{"codec_type":"video","duration":"2.0"},'
+        b'{"codec_type":"audio","duration":"2.5"}]}'
+    )
+
+    assert format_result["duration_seconds"] == 3.5
+    assert format_result["duration_source"] == "format"
+    assert fallback_result["duration_seconds"] == 2.5
+    assert fallback_result["duration_source"] == "stream"
+
+
+def test_attached_picture_is_not_a_usable_video_stream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    document = (
+        b'{"format":{"format_name":"mov,mp4","duration":"1"},'
+        b'"streams":[{"codec_type":"audio"},'
+        b'{"codec_type":"video","disposition":{"attached_pic":1}}]}'
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_ffprobe",
+        lambda _artifact: (
+            document,
+            video_evidence.DiagnosticReceipt.empty(),
+            0,
+        ),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence._probe_media_with_ffprobe(
+            tmp_path / "album-art.mp4",
+            expected_container_family="iso_bmff",
+        )
+
+    assert caught.value.reason_code == "video_no_video_stream"
+
+
+def test_wrong_container_and_stream_ceiling_are_closed_rejections(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "talk.mp4"
+    documents = iter(
+        [
+            b'{"format":{"format_name":"matroska,webm","duration":"1"},'
+            b'"streams":[{"codec_type":"video"}]}',
+            (
+                b'{"format":{"format_name":"mov,mp4","duration":"1"},'
+                b'"streams":['
+                + b",".join(b'{"codec_type":"video"}' for _ in range(65))
+                + b"]}"
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_ffprobe",
+        lambda _artifact: (
+            next(documents),
+            video_evidence.DiagnosticReceipt.empty(),
+            0,
+        ),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as wrong:
+        video_evidence._probe_media_with_ffprobe(
+            artifact, expected_container_family="iso_bmff"
+        )
+    with pytest.raises(video_evidence.VideoEvidenceError) as streams:
+        video_evidence._probe_media_with_ffprobe(
+            artifact, expected_container_family="iso_bmff"
+        )
+
+    assert wrong.value.reason_code == "video_invalid_container"
+    assert streams.value.reason_code == "video_stream_limit"
+    assert streams.value.details == {"max_streams": 64}
+
+
+@pytest.mark.parametrize(
+    ("supervisor_reason", "supervisor_details", "public_reason"),
+    [
+        ("worker_timeout", {}, "video_probe_timeout"),
+        ("worker_monitor_unavailable", {}, "video_probe_monitor_unavailable"),
+        (
+            "worker_monitor_unavailable",
+            {"dependency": "psutil"},
+            "video_dependency_unavailable",
+        ),
+        (
+            "worker_monitor_identity_changed",
+            {},
+            "video_probe_monitor_identity_changed",
+        ),
+        (
+            "worker_containment_unavailable",
+            {},
+            "video_probe_containment_unavailable",
+        ),
+        (
+            "worker_process_tree_leak",
+            {},
+            "video_probe_containment_unavailable",
+        ),
+        (
+            "worker_cleanup_failed",
+            {},
+            "video_probe_containment_unavailable",
+        ),
+        (
+            "worker_memory_limit_exceeded",
+            {},
+            "video_probe_resource_unavailable",
+        ),
+        (
+            "worker_process_limit_exceeded",
+            {},
+            "video_probe_resource_unavailable",
+        ),
+        (
+            "worker_diagnostic_limit_exceeded",
+            {},
+            "video_probe_resource_unavailable",
+        ),
+        ("worker_input_limit_exceeded", {}, "video_probe_request_oversized"),
+        ("worker_output_limit_exceeded", {}, "video_probe_result_oversized"),
+        ("worker_start_failed", {}, "video_probe_start_failure"),
+        ("worker_pipe_setup_failed", {}, "video_probe_start_failure"),
+        ("worker_exit_before_barrier", {}, "video_probe_start_failure"),
+        ("worker_request_write_failed", {}, "video_probe_start_failure"),
+        ("invalid_worker_command", {}, "video_probe_start_failure"),
+        ("unsafe_worker_process_metadata", {}, "video_probe_start_failure"),
+        ("worker_exit", {}, "video_probe_crash"),
+        ("worker_diagnostic_read_failed", {}, "video_probe_crash"),
+        ("worker_output_read_failed", {}, "video_probe_crash"),
+        (
+            "worker_response_authentication_failed",
+            {},
+            "video_probe_malformed_result",
+        ),
+        (
+            "worker_generation_changed",
+            {"generation_names": ["video", "private/path.mp4"]},
+            "video_artifact_changed",
+        ),
+    ],
+)
+def test_supervisor_failures_map_distinctly_without_raw_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    supervisor_reason: str,
+    supervisor_details: dict[str, object],
+    public_reason: str,
+) -> None:
+    generation = _generation()
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: _receipt(generation, _root_generation()),
+    )
+
+    def failed(*_args: object, **_kwargs: object) -> Any:
+        raise video_evidence.SupervisorError(
+            supervisor_reason,
+            cast_supervisor_details(supervisor_details),
+        )
+
+    monkeypatch.setattr(video_evidence, "_invoke_probe_worker", failed)
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.probe_video_artifact("talk.mp4", trusted_root=tmp_path)
+
+    assert caught.value.reason_code == public_reason
+    assert "private/path.mp4" not in repr(caught.value.details)
+    if public_reason == "video_artifact_changed":
+        assert caught.value.details == {"generation_names": ["video"]}
+
+
+def cast_supervisor_details(value: dict[str, object]) -> Any:
+    """Keep test-side construction explicit without weakening production types."""
+    return value
+
+
+def test_malformed_authenticated_success_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation()
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: _receipt(generation, _root_generation()),
+    )
+    malformed = _worker_result(
+        generation,
+        payload={
+            "schema_version": video_evidence.VIDEO_PROBE_SCHEMA_VERSION,
+            "status": "available",
+            "source_sha256": "not-a-digest",
+            "source_size_bytes": generation.size,
+            "duration_seconds": 1.0,
+            "duration_source": "format",
+            "container_family": "iso_bmff",
+            "stream_count": 1,
+            "video_stream_count": 1,
+            "audio_stream_count": 0,
+            "attached_picture_count": 0,
+            "other_stream_count": 0,
+        },
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_invoke_probe_worker",
+        lambda *_args, **_kwargs: malformed,
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.probe_video_artifact("talk.mp4", trusted_root=tmp_path)
+
+    assert caught.value.reason_code == "video_probe_malformed_result"
+
+
+def test_private_snapshot_is_distinct_and_digest_bound_to_source(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "talk.mp4"
+    original = b"platform-neutral-source-generation"
+    artifact.write_bytes(original)
+    generation = video_evidence.FileGeneration.from_stat(artifact.stat())
+
+    with video_evidence._prepared_video_source(artifact, generation) as prepared:
+        assert prepared.probe_artifact != artifact
+        assert prepared.probe_artifact.read_bytes() == original
+        digest = video_evidence._digest_exact_generation(
+            prepared.probe_artifact,
+            prepared.probe_generation,
+            source_descriptor=prepared.probe_descriptor,
+        )
+
+    assert digest == hashlib.sha256(original).hexdigest()
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="concrete directory-swap reproduction requires POSIX rename semantics",
+)
+def test_ffprobe_facts_and_digest_share_one_snapshot_during_path_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    current = root / "current"
+    alternate = root / "alternate"
+    saved = root / "saved"
+    current.mkdir(parents=True)
+    alternate.mkdir()
+    artifact = current / "talk.mp4"
+    original = b"original-generation-a"
+    replacement = b"replacement-generation-b"
+    artifact.write_bytes(original)
+    (alternate / artifact.name).write_bytes(replacement)
+    before = video_evidence.inspect_metadata_generation(
+        artifact,
+        trusted_root=root,
+        reparse_point_attribute=video_evidence.VIDEO_WINDOWS_REPARSE_POINT_ATTRIBUTE,
+        cloud_reparse_tags=video_evidence.VIDEO_WINDOWS_CLOUD_REPARSE_TAGS,
+    )
+    assert before.root_generation is not None
+
+    def parse_snapshot(
+        probe_artifact: Path,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        current.rename(saved)
+        alternate.rename(current)
+        try:
+            parsed = probe_artifact.read_bytes()
+        finally:
+            current.rename(alternate)
+            saved.rename(current)
+        return {
+            "duration_seconds": 1.0 if parsed == original else 999.0,
+            "duration_source": "format",
+            "container_family": "iso_bmff",
+            "stream_count": 1,
+            "video_stream_count": 1,
+            "audio_stream_count": 0,
+            "attached_picture_count": 0,
+            "other_stream_count": 0,
+        }
+
+    monkeypatch.setattr(
+        video_evidence,
+        "_probe_media_with_ffprobe",
+        parse_snapshot,
+    )
+    request = artifact_supervisor.build_worker_request(
+        video_evidence.VIDEO_PROBE_OPERATION,
+        {
+            "video": before.generation,
+            "video_root": before.root_generation,
+        },
+        {
+            "video_path": os.fspath(artifact),
+            "trusted_root": os.fspath(root),
+            "expected_container_family": "iso_bmff",
+            "max_input_bytes": video_evidence.VIDEO_MAX_INPUT_BYTES,
+            "max_streams": video_evidence.VIDEO_MAX_STREAMS,
+            "ffprobe_stdout_bytes": video_evidence.VIDEO_FFPROBE_STDOUT_BYTES,
+            "ffprobe_stderr_bytes": video_evidence.VIDEO_FFPROBE_STDERR_BYTES,
+            "digest_chunk_bytes": video_evidence.VIDEO_DIGEST_CHUNK_BYTES,
+        },
+        limit_profile_id=video_evidence.VIDEO_PROBE_LIMITS.profile_id,
+        schema_generation=video_evidence.VIDEO_PROBE_SCHEMA_VERSION,
+        pipeline_generation=video_evidence.VIDEO_PROBE_PIPELINE_VERSION,
+    )
+
+    payload, observed = video_evidence._dispatch_supervised_worker(request)
+    after = video_evidence.inspect_metadata_generation(
+        artifact,
+        trusted_root=root,
+        reparse_point_attribute=video_evidence.VIDEO_WINDOWS_REPARSE_POINT_ATTRIBUTE,
+        cloud_reparse_tags=video_evidence.VIDEO_WINDOWS_CLOUD_REPARSE_TAGS,
+    )
+
+    assert before == after
+    assert observed == {
+        "video": before.generation,
+        "video_root": before.root_generation,
+    }
+    assert payload["duration_seconds"] == 1.0
+    assert payload["source_sha256"] == hashlib.sha256(original).hexdigest()
+
+
+def test_generation_change_between_ffprobe_and_digest_is_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "talk.mp4"
+    artifact.write_bytes(b"source generation")
+    generation = video_evidence.FileGeneration.from_stat(artifact.stat())
+    changed = _generation(inode=2)
+    receipts = iter([_receipt(generation), _receipt(changed)])
+    monkeypatch.setattr(
+        video_evidence,
+        "_metadata_receipt_in_probe_worker",
+        lambda *_args, **_kwargs: next(receipts),
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_probe_media_with_ffprobe",
+        lambda *_args, **_kwargs: {
+            "duration_seconds": 1.0,
+            "duration_source": "format",
+            "container_family": "iso_bmff",
+            "stream_count": 1,
+            "video_stream_count": 1,
+            "audio_stream_count": 0,
+            "attached_picture_count": 0,
+            "other_stream_count": 0,
+        },
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_digest_exact_generation",
+        lambda *_args, **_kwargs: pytest.fail("changed generation reached digest"),
+    )
+    request = artifact_supervisor.build_worker_request(
+        video_evidence.VIDEO_PROBE_OPERATION,
+        {"video": generation},
+        {
+            "video_path": os.fspath(tmp_path / "talk.mp4"),
+            "trusted_root": None,
+            "expected_container_family": "iso_bmff",
+            "max_input_bytes": video_evidence.VIDEO_MAX_INPUT_BYTES,
+            "max_streams": video_evidence.VIDEO_MAX_STREAMS,
+            "ffprobe_stdout_bytes": video_evidence.VIDEO_FFPROBE_STDOUT_BYTES,
+            "ffprobe_stderr_bytes": video_evidence.VIDEO_FFPROBE_STDERR_BYTES,
+            "digest_chunk_bytes": video_evidence.VIDEO_DIGEST_CHUNK_BYTES,
+        },
+        limit_profile_id=video_evidence.VIDEO_PROBE_LIMITS.profile_id,
+        schema_generation=video_evidence.VIDEO_PROBE_SCHEMA_VERSION,
+        pipeline_generation=video_evidence.VIDEO_PROBE_PIPELINE_VERSION,
+    )
+
+    with pytest.raises(video_evidence.SupervisorError) as caught:
+        video_evidence._dispatch_supervised_worker(request)
+
+    assert caught.value.reason_code == "worker_generation_changed"
+    assert caught.value.details == {"generation_names": ["video"]}
+
+
+def test_generation_change_wins_over_stable_ffprobe_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "talk.mp4"
+    artifact.write_bytes(b"source generation")
+    generation = video_evidence.FileGeneration.from_stat(artifact.stat())
+    changed = _generation(inode=2)
+    receipts = iter([_receipt(generation), _receipt(changed)])
+    monkeypatch.setattr(
+        video_evidence,
+        "_metadata_receipt_in_probe_worker",
+        lambda *_args, **_kwargs: next(receipts),
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_probe_media_with_ffprobe",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            video_evidence._failure("video_invalid_container")
+        ),
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_digest_exact_generation",
+        lambda *_args, **_kwargs: pytest.fail("failed parser reached digest"),
+    )
+    request = artifact_supervisor.build_worker_request(
+        video_evidence.VIDEO_PROBE_OPERATION,
+        {"video": generation},
+        {
+            "video_path": os.fspath(tmp_path / "talk.mp4"),
+            "trusted_root": None,
+            "expected_container_family": "iso_bmff",
+            "max_input_bytes": video_evidence.VIDEO_MAX_INPUT_BYTES,
+            "max_streams": video_evidence.VIDEO_MAX_STREAMS,
+            "ffprobe_stdout_bytes": video_evidence.VIDEO_FFPROBE_STDOUT_BYTES,
+            "ffprobe_stderr_bytes": video_evidence.VIDEO_FFPROBE_STDERR_BYTES,
+            "digest_chunk_bytes": video_evidence.VIDEO_DIGEST_CHUNK_BYTES,
+        },
+        limit_profile_id=video_evidence.VIDEO_PROBE_LIMITS.profile_id,
+        schema_generation=video_evidence.VIDEO_PROBE_SCHEMA_VERSION,
+        pipeline_generation=video_evidence.VIDEO_PROBE_PIPELINE_VERSION,
+    )
+
+    with pytest.raises(video_evidence.SupervisorError) as caught:
+        video_evidence._dispatch_supervised_worker(request)
+
+    assert caught.value.reason_code == "worker_generation_changed"
+    assert caught.value.details == {"generation_names": ["video"]}
+
+
+def test_digest_growth_maps_to_generation_change_not_ffprobe_output_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "talk.mp4"
+    artifact.write_bytes(b"x")
+    expected = video_evidence.FileGeneration.from_stat(artifact.stat())
+    reads = iter([b"xx", b""])
+    monkeypatch.setattr(video_evidence.os, "read", lambda *_args: next(reads))
+
+    with pytest.raises(video_evidence.SupervisorError) as caught:
+        video_evidence._digest_exact_generation(artifact, expected)
+
+    assert caught.value.reason_code == "worker_generation_changed"
+    assert caught.value.details == {"generation_names": ["video"]}
+
+
+def test_singleflight_waiter_deadline_does_not_cancel_leader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation()
+    receipt = _receipt(generation, _root_generation())
+    leader_started = threading.Event()
+    release_leader = threading.Event()
+    probe_calls = 0
+    leader_results: list[Any] = []
+    leader_errors: list[Any] = []
+
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: receipt,
+    )
+
+    def slow_probe(*_args: object, **_kwargs: object) -> Any:
+        nonlocal probe_calls
+        probe_calls += 1
+        leader_started.set()
+        assert release_leader.wait(timeout=2)
+        return _probe(generation, root_generation=receipt.root_generation)
+
+    monkeypatch.setattr(video_evidence, "_run_bounded_video_probe", slow_probe)
+    leader_assessment = video_evidence.VideoEvidenceAssessment()
+    waiter_assessment = video_evidence.VideoEvidenceAssessment()
+
+    def lead() -> None:
+        try:
+            leader_results.append(
+                leader_assessment.probe("talk.mp4", trusted_root=tmp_path)
+            )
+        except video_evidence.VideoEvidenceError as exc:
+            leader_errors.append(exc)
+
+    thread = threading.Thread(target=lead)
+    thread.start()
+    assert leader_started.wait(timeout=1)
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        waiter_assessment.probe(
+            "talk.mp4",
+            trusted_root=tmp_path,
+            deadline_monotonic=time.monotonic() + 0.03,
+        )
+    assert caught.value.reason_code == "video_batch_wall_limit"
+    assert thread.is_alive()
+
+    release_leader.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert not leader_errors
+    assert len(leader_results) == 1
+    assert probe_calls == 1
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as repeated:
+        waiter_assessment.probe("talk.mp4", trusted_root=tmp_path)
+    assert repeated.value.reason_code == "video_batch_wall_limit"
+    assert probe_calls == 1
+
+
+def test_transient_short_deadline_leader_does_not_poison_unrelated_waiter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation()
+    receipt = _receipt(generation, _root_generation())
+    leader_started = threading.Event()
+    waiter_joined = threading.Event()
+    release_leader = threading.Event()
+    probe_calls = 0
+    leader_errors: list[str] = []
+    waiter_errors: list[str] = []
+    waiter_results: list[Any] = []
+
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: receipt,
+    )
+
+    def flaky_probe(*_args: object, **kwargs: object) -> Any:
+        nonlocal probe_calls
+        probe_calls += 1
+        if probe_calls == 1:
+            assert kwargs["deadline_monotonic"] is not None
+            leader_started.set()
+            assert release_leader.wait(timeout=2)
+            raise video_evidence._failure("video_batch_wall_limit")
+        assert kwargs["deadline_monotonic"] is None
+        return _probe(generation, root_generation=receipt.root_generation)
+
+    monkeypatch.setattr(video_evidence, "_run_bounded_video_probe", flaky_probe)
+    original_wait = video_evidence._wait_for_flight
+
+    def observed_wait(*args: object, **kwargs: object) -> Any:
+        waiter_joined.set()
+        return original_wait(*args, **kwargs)
+
+    monkeypatch.setattr(video_evidence, "_wait_for_flight", observed_wait)
+    leader_assessment = video_evidence.VideoEvidenceAssessment()
+    waiter_assessment = video_evidence.VideoEvidenceAssessment()
+
+    def lead() -> None:
+        try:
+            leader_assessment.probe(
+                "talk.mp4",
+                trusted_root=tmp_path,
+                deadline_monotonic=time.monotonic() + 0.1,
+            )
+        except video_evidence.VideoEvidenceError as exc:
+            leader_errors.append(exc.reason_code)
+
+    def wait() -> None:
+        try:
+            waiter_results.append(
+                waiter_assessment.probe("talk.mp4", trusted_root=tmp_path)
+            )
+        except video_evidence.VideoEvidenceError as exc:
+            waiter_errors.append(exc.reason_code)
+
+    leader_thread = threading.Thread(target=lead)
+    waiter_thread = threading.Thread(target=wait)
+    leader_thread.start()
+    assert leader_started.wait(timeout=1)
+    waiter_thread.start()
+    try:
+        assert waiter_joined.wait(timeout=1)
+    finally:
+        release_leader.set()
+    leader_thread.join(timeout=2)
+    waiter_thread.join(timeout=2)
+
+    assert not leader_thread.is_alive()
+    assert not waiter_thread.is_alive()
+    assert leader_errors == ["video_batch_wall_limit"]
+    assert not waiter_errors
+    assert len(waiter_results) == 1
+    assert probe_calls == 2
+    assert (
+        waiter_assessment.probe("talk.mp4", trusted_root=tmp_path) == waiter_results[0]
+    )
+    assert probe_calls == 2
+
+
+def test_transient_leader_failure_is_shared_with_waiter_in_same_assessment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation()
+    receipt = _receipt(generation, _root_generation())
+    leader_started = threading.Event()
+    waiter_joined = threading.Event()
+    release_leader = threading.Event()
+    probe_calls = 0
+    errors: list[str] = []
+
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: receipt,
+    )
+
+    def transient_probe(*_args: object, **_kwargs: object) -> Any:
+        nonlocal probe_calls
+        probe_calls += 1
+        leader_started.set()
+        assert release_leader.wait(timeout=2)
+        raise video_evidence._failure("video_probe_timeout")
+
+    monkeypatch.setattr(video_evidence, "_run_bounded_video_probe", transient_probe)
+    original_wait = video_evidence._wait_for_flight
+
+    def observed_wait(*args: object, **kwargs: object) -> Any:
+        waiter_joined.set()
+        return original_wait(*args, **kwargs)
+
+    monkeypatch.setattr(video_evidence, "_wait_for_flight", observed_wait)
+    assessment = video_evidence.VideoEvidenceAssessment()
+
+    def run() -> None:
+        try:
+            assessment.probe("talk.mp4", trusted_root=tmp_path)
+        except video_evidence.VideoEvidenceError as exc:
+            errors.append(exc.reason_code)
+
+    leader_thread = threading.Thread(target=run)
+    waiter_thread = threading.Thread(target=run)
+    leader_thread.start()
+    assert leader_started.wait(timeout=1)
+    waiter_thread.start()
+    try:
+        assert waiter_joined.wait(timeout=1)
+    finally:
+        release_leader.set()
+    leader_thread.join(timeout=2)
+    waiter_thread.join(timeout=2)
+
+    assert not leader_thread.is_alive()
+    assert not waiter_thread.is_alive()
+    assert errors == ["video_probe_timeout", "video_probe_timeout"]
+    assert probe_calls == 1
+    with pytest.raises(video_evidence.VideoEvidenceError) as repeated:
+        assessment.probe("talk.mp4", trusted_root=tmp_path)
+    assert repeated.value.reason_code == "video_probe_timeout"
+    assert probe_calls == 1
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="real media rejection requires ffmpeg and ffprobe",
+)
+def test_real_worker_rejects_audio_only_wrong_container_and_corrupt_inputs(
+    tmp_path: Path,
+) -> None:
+    audio_only = tmp_path / "audio.mp4"
+    created_audio = subprocess.run(
+        [
+            "ffmpeg",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=0.25",
+            "-vn",
+            "-c:a",
+            "aac",
+            "-y",
+            os.fspath(audio_only),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert created_audio.returncode == 0, created_audio.stderr
+
+    wrong_container = tmp_path / "renamed.mp4"
+    created_webm = subprocess.run(
+        [
+            "ffmpeg",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x90:r=1",
+            "-t",
+            "0.25",
+            "-c:v",
+            "ffv1",
+            "-f",
+            "matroska",
+            "-y",
+            os.fspath(wrong_container),
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert created_webm.returncode == 0, created_webm.stderr
+
+    corrupt = tmp_path / "corrupt.mp4"
+    corrupt.write_bytes(b"not a media container")
+    valid_for_truncation = tmp_path / "valid-for-truncation.mp4"
+    valid_source = _create_mp4(valid_for_truncation)
+    truncated = tmp_path / "truncated.mp4"
+    truncated.write_bytes(valid_source[: max(1, len(valid_source) // 4)])
+
+    expected = {
+        audio_only: "video_no_video_stream",
+        wrong_container: "video_invalid_container",
+        corrupt: "video_parser_rejected",
+        truncated: "video_parser_rejected",
+    }
+    for artifact, reason_code in expected.items():
+        with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+            video_evidence.probe_video_artifact(artifact, trusted_root=tmp_path)
+        assert caught.value.reason_code == reason_code
+        assert os.fspath(artifact) not in str(caught.value)
+        assert os.fspath(artifact) not in repr(caught.value.details)
+
+
+def test_empty_container_rejects_before_probe_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generation = _generation(size=0)
+    monkeypatch.setattr(
+        video_evidence,
+        "_run_bounded_metadata_worker",
+        lambda *_args, **_kwargs: _receipt(generation, _root_generation()),
+    )
+    monkeypatch.setattr(
+        video_evidence,
+        "_invoke_probe_worker",
+        lambda *_args, **_kwargs: pytest.fail("empty input started ffprobe worker"),
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.probe_video_artifact("empty.mp4", trusted_root=tmp_path)
+
+    assert caught.value.reason_code == "video_invalid_container"

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 import sys
 import threading
-import time
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from typing import Any
@@ -1132,6 +1131,9 @@ def test_singleflight_waiter_deadline_does_not_cancel_leader(
     monkeypatch.setattr(video_evidence, "_run_bounded_video_probe", slow_probe)
     leader_assessment = video_evidence.VideoEvidenceAssessment()
     waiter_assessment = video_evidence.VideoEvidenceAssessment()
+    clock = [100.0]
+    waiter_deadline = 100.1
+    monkeypatch.setattr(video_evidence.time, "monotonic", lambda: clock[0])
 
     def lead() -> None:
         try:
@@ -1145,11 +1147,12 @@ def test_singleflight_waiter_deadline_does_not_cancel_leader(
     thread.start()
     assert leader_started.wait(timeout=1)
 
+    clock[0] = waiter_deadline
     with pytest.raises(video_evidence.VideoEvidenceError) as caught:
         waiter_assessment.probe(
             "talk.mp4",
             trusted_root=tmp_path,
-            deadline_monotonic=time.monotonic() + 0.03,
+            deadline_monotonic=waiter_deadline,
         )
     assert caught.value.reason_code == "video_batch_wall_limit"
     assert thread.is_alive()
@@ -1191,10 +1194,14 @@ def test_transient_short_deadline_leader_does_not_poison_unrelated_waiter(
         nonlocal probe_calls
         probe_calls += 1
         if probe_calls == 1:
-            assert kwargs["deadline_monotonic"] is not None
+            assert kwargs["deadline_monotonic"] == leader_deadline
             leader_started.set()
             assert release_leader.wait(timeout=2)
-            raise video_evidence._failure("video_batch_wall_limit")
+            video_evidence._limits_before_deadline(
+                video_evidence.VIDEO_PROBE_LIMITS,
+                leader_deadline,
+            )
+            raise AssertionError("expired controlled deadline was accepted")
         assert kwargs["deadline_monotonic"] is None
         return _probe(generation, root_generation=receipt.root_generation)
 
@@ -1208,13 +1215,16 @@ def test_transient_short_deadline_leader_does_not_poison_unrelated_waiter(
     monkeypatch.setattr(video_evidence, "_wait_for_flight", observed_wait)
     leader_assessment = video_evidence.VideoEvidenceAssessment()
     waiter_assessment = video_evidence.VideoEvidenceAssessment()
+    clock = [100.0]
+    leader_deadline = clock[0] + video_evidence.VIDEO_PROBE_LIMITS.cleanup_seconds + 1.0
+    monkeypatch.setattr(video_evidence.time, "monotonic", lambda: clock[0])
 
     def lead() -> None:
         try:
             leader_assessment.probe(
                 "talk.mp4",
                 trusted_root=tmp_path,
-                deadline_monotonic=time.monotonic() + 0.1,
+                deadline_monotonic=leader_deadline,
             )
         except video_evidence.VideoEvidenceError as exc:
             leader_errors.append(exc.reason_code)
@@ -1234,6 +1244,7 @@ def test_transient_short_deadline_leader_does_not_poison_unrelated_waiter(
     waiter_thread.start()
     try:
         assert waiter_joined.wait(timeout=1)
+        clock[0] = leader_deadline
     finally:
         release_leader.set()
     leader_thread.join(timeout=2)

--- a/tests/test_video_evidence_operation_scope.py
+++ b/tests/test_video_evidence_operation_scope.py
@@ -1,0 +1,490 @@
+"""Operation-local source-video assessment wiring regressions."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_return_freshness_wrapper_forwards_the_supplied_assessment(
+    return_validation,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    assessment = object()
+    observed: list[object] = []
+
+    def assess_artifact(_talk, **kwargs):
+        observed.append(kwargs["video_evidence_assessment"])
+        return ()
+
+    monkeypatch.setattr(
+        return_validation,
+        "assess_artifact_freshness",
+        assess_artifact,
+    )
+
+    assert (
+        return_validation.assess_current_persisted_pattern_evidence_freshness(
+            {},
+            vault_root=tmp_path,
+            video_evidence_assessment=assessment,
+        )
+        == ()
+    )
+    assert observed == [assessment]
+
+
+def test_persist_operation_reuses_one_assessment_for_every_video_consumer(
+    persist_results,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    assessment = object()
+    created: list[object] = []
+    observed: list[tuple[str, object]] = []
+    talk = {"filename": "talk.md", "status": "processed"}
+    database = {"config": {}, "talks": [talk]}
+    returned = {
+        "filename": "talk.md",
+        "return_schema_version": 4,
+        "status": "processed",
+    }
+    snapshot = object()
+
+    def create_assessment():
+        created.append(assessment)
+        return assessment
+
+    def assess_batch(*_args, **kwargs):
+        observed.append(("capabilities", kwargs["video_evidence_assessment"]))
+        return {"talk.md": {}}
+
+    def admit(*_args, **kwargs):
+        observed.append(("admission", kwargs["video_evidence_assessment"]))
+
+    def canonicalize(ret, *_args, **kwargs):
+        observed.append(("canonicalization", kwargs["video_evidence_assessment"]))
+        return dict(ret)
+
+    def assess_freshness(_talk, **kwargs):
+        observed.append(("freshness", kwargs["video_evidence_assessment"]))
+        return ()
+
+    def build_baseline(talks, *, evidence_freshness_assessor, **_kwargs):
+        assert evidence_freshness_assessor(talks[0]) == ()
+        return {}
+
+    monkeypatch.setattr(persist_results, "VideoEvidenceAssessment", create_assessment)
+    monkeypatch.setattr(
+        persist_results,
+        "materialize_native_authority",
+        lambda *_args, **_kwargs: tmp_path / "tracking-database.json",
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "load_tracking_database",
+        lambda _path: (database, snapshot),
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "resolve_vault_root_authority",
+        lambda **_kwargs: tmp_path,
+    )
+    monkeypatch.setattr(persist_results, "load_json", lambda *_args: [returned])
+    monkeypatch.setattr(
+        persist_results,
+        "validate_batch",
+        lambda _returns: SimpleNamespace(fingerprint="f" * 64),
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "assess_batch_artifact_capabilities",
+        assess_batch,
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "validate_batch_claims_against_talks",
+        lambda *_args, **_kwargs: {"talk.md": talk},
+    )
+    monkeypatch.setattr(persist_results, "admit_return_artifacts", admit)
+    monkeypatch.setattr(
+        persist_results,
+        "canonicalize_return_evidence",
+        canonicalize,
+    )
+    monkeypatch.setattr(persist_results, "return_evidence_claim", lambda _value: {})
+    monkeypatch.setattr(
+        persist_results,
+        "merge_talk",
+        lambda *_args, **_kwargs: ([], True, False, []),
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "assess_current_persisted_pattern_evidence_freshness",
+        assess_freshness,
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "build_current_cohort_baseline",
+        build_baseline,
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "atomic_write_json",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            input_sha256="a" * 64,
+            output_sha256="b" * 64,
+            installed=True,
+            durability_state="durable",
+            warnings=(),
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "persist-results.py",
+            str(tmp_path / "tracking-database.json"),
+            str(tmp_path / "returns.json"),
+            "--run-date",
+            "2026-08-04T12:00:00+00:00",
+        ],
+    )
+
+    persist_results.main()
+
+    assert created == [assessment]
+    assert observed == [
+        ("capabilities", assessment),
+        ("admission", assessment),
+        ("canonicalization", assessment),
+        ("freshness", assessment),
+    ]
+
+
+def test_second_return_video_failure_blocks_the_whole_batch_before_merge(
+    persist_results,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    assessment = object()
+    talks = [
+        {"filename": "first.md", "status": "processed"},
+        {"filename": "second.md", "status": "processed"},
+    ]
+    database = {"config": {}, "talks": talks}
+    returns = [
+        {
+            "filename": talk["filename"],
+            "return_schema_version": 4,
+            "status": "processed",
+        }
+        for talk in talks
+    ]
+    admitted: list[str] = []
+
+    monkeypatch.setattr(
+        persist_results,
+        "VideoEvidenceAssessment",
+        lambda: assessment,
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "materialize_native_authority",
+        lambda *_args, **_kwargs: tmp_path / "tracking-database.json",
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "load_tracking_database",
+        lambda _path: (database, object()),
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "resolve_vault_root_authority",
+        lambda **_kwargs: tmp_path,
+    )
+    monkeypatch.setattr(persist_results, "load_json", lambda *_args: returns)
+    monkeypatch.setattr(
+        persist_results,
+        "validate_batch",
+        lambda _returns: SimpleNamespace(fingerprint="f" * 64),
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "assess_batch_artifact_capabilities",
+        lambda *_args, **_kwargs: {talk["filename"]: {} for talk in talks},
+    )
+    monkeypatch.setattr(
+        persist_results,
+        "validate_batch_claims_against_talks",
+        lambda *_args, **_kwargs: {talk["filename"]: talk for talk in talks},
+    )
+
+    def admit(_root, _talk, ret, **kwargs):
+        assert kwargs["video_evidence_assessment"] is assessment
+        admitted.append(ret["filename"])
+        if ret["filename"] == "second.md":
+            raise persist_results.PatternEvidenceError(
+                "second source video failed bounded inspection"
+            )
+
+    monkeypatch.setattr(persist_results, "admit_return_artifacts", admit)
+    monkeypatch.setattr(
+        persist_results,
+        "canonicalize_return_evidence",
+        lambda ret, *_args, **_kwargs: dict(ret),
+    )
+    monkeypatch.setattr(persist_results, "return_evidence_claim", lambda _value: {})
+    monkeypatch.setattr(
+        persist_results,
+        "merge_talk",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("batch merged before all source videos were admitted")
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "persist-results.py",
+            str(tmp_path / "tracking-database.json"),
+            str(tmp_path / "returns.json"),
+            "--run-date",
+            "2026-08-04T12:00:00+00:00",
+        ],
+    )
+
+    try:
+        persist_results.main()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:  # pragma: no cover - main must reject the batch
+        raise AssertionError("persist-results accepted a bad second source video")
+
+    assert admitted == ["first.md", "second.md"]
+
+
+def test_analysis_writer_reuses_one_assessment_for_capability_and_freshness(
+    write_analysis,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    assessment = object()
+    created: list[object] = []
+    observed: list[tuple[str, object]] = []
+    returned = {
+        "filename": "talk.md",
+        "return_schema_version": 4,
+        "status": "processed",
+        "pattern_observations": {},
+    }
+    persisted_observations = {
+        "evidence_schema_version": 2,
+        "source_inspection": [],
+        "patterns_detected": [],
+        "antipatterns_detected": [],
+        "not_evaluable": [],
+    }
+    talk = {
+        "filename": "talk.md",
+        "title": "Talk",
+        "status": "processed",
+        "processed_date": "2026-08-04T12:00:00+00:00",
+        "pattern_observations": persisted_observations,
+    }
+
+    def create_assessment():
+        created.append(assessment)
+        return assessment
+
+    def assess_batch(*_args, **kwargs):
+        observed.append(("capabilities", kwargs["video_evidence_assessment"]))
+        return {"talk.md": {}}
+
+    def assess_freshness(_talk, **kwargs):
+        observed.append(("freshness", kwargs["video_evidence_assessment"]))
+        return ()
+
+    monkeypatch.setattr(write_analysis, "VideoEvidenceAssessment", create_assessment)
+    monkeypatch.setattr(
+        write_analysis,
+        "materialize_native_authority",
+        lambda *_args, **_kwargs: tmp_path / "tracking-database.json",
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "load_tracking_database",
+        lambda _path: {"config": {}, "talks": [talk]},
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "resolve_vault_root_authority",
+        lambda **_kwargs: tmp_path,
+    )
+    monkeypatch.setattr(write_analysis, "load_json", lambda *_args: [returned])
+    monkeypatch.setattr(
+        write_analysis,
+        "validate_batch",
+        lambda _returns: SimpleNamespace(fingerprint="f" * 64),
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "assess_batch_artifact_capabilities",
+        assess_batch,
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "validate_batch_claims_against_talks",
+        lambda *_args, **_kwargs: {"talk.md": talk},
+    )
+    monkeypatch.setattr(write_analysis, "return_evidence_claim", lambda _value: {})
+    monkeypatch.setattr(
+        write_analysis,
+        "validate_persisted_catalog_generation",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "assess_current_persisted_pattern_evidence_freshness",
+        assess_freshness,
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "persisted_processed_stamp",
+        lambda *_args, **_kwargs: "2026-08-04T12:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "effective_render_payload",
+        lambda ret, _talk: ret,
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "render_analysis",
+        lambda *_args, **_kwargs: "analysis\n",
+    )
+    monkeypatch.setattr(
+        write_analysis,
+        "atomic_write_batch",
+        lambda _rendered: None,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "write-analysis.py",
+            str(tmp_path / "returns.json"),
+            str(tmp_path / "analyses"),
+            "--talks",
+            str(tmp_path / "tracking-database.json"),
+        ],
+    )
+
+    write_analysis.main()
+
+    assert created == [assessment]
+    assert observed == [
+        ("capabilities", assessment),
+        ("freshness", assessment),
+    ]
+
+
+def test_queue_operation_creates_one_assessment_after_root_authority(
+    queue_state,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    assessment = object()
+    events: list[object] = []
+    snapshot = object()
+
+    monkeypatch.setattr(
+        queue_state,
+        "materialize_native_authority",
+        lambda *_args, **_kwargs: Path(tmp_path / "tracking-database.json"),
+    )
+    monkeypatch.setattr(
+        queue_state,
+        "load_database_snapshot",
+        lambda *_args, **_kwargs: ({"config": {}, "talks": []}, snapshot),
+    )
+
+    def resolve_root(**_kwargs):
+        events.append("root")
+        return tmp_path
+
+    def create_assessment():
+        events.append(assessment)
+        return assessment
+
+    def normalize(*_args, **kwargs):
+        events.append(kwargs["video_evidence_assessment"])
+        return {"ok": True}
+
+    monkeypatch.setattr(queue_state, "resolve_vault_root_authority", resolve_root)
+    monkeypatch.setattr(queue_state, "VideoEvidenceAssessment", create_assessment)
+    monkeypatch.setattr(queue_state, "command_normalize", normalize)
+
+    assert (
+        queue_state.main([str(tmp_path / "tracking-database.json"), "normalize"]) == 0
+    )
+    assert events == ["root", assessment, assessment]
+
+
+def test_queue_capability_and_freshness_closures_share_the_operation_assessment(
+    queue_state,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    assessment = object()
+    observed: list[tuple[str, object]] = []
+    database = {"config": {}, "talks": []}
+    talk = {"filename": "talk.md"}
+
+    monkeypatch.setattr(
+        queue_state,
+        "evidence_roots",
+        lambda *_args: (tmp_path, {}),
+    )
+
+    def assess_capabilities(_talk, **kwargs):
+        observed.append(("capabilities", kwargs["video_evidence_assessment"]))
+        return {}
+
+    def assess_freshness(_talk, **kwargs):
+        observed.append(("freshness", kwargs["video_evidence_assessment"]))
+        return ()
+
+    monkeypatch.setattr(
+        queue_state,
+        "assess_talk_artifact_capabilities",
+        assess_capabilities,
+    )
+    monkeypatch.setattr(
+        queue_state,
+        "assess_current_persisted_pattern_evidence_freshness",
+        assess_freshness,
+    )
+
+    capability = queue_state.artifact_capability_assessor(
+        database,
+        tmp_path / "tracking-database.json",
+        video_evidence_assessment=assessment,
+    )
+    freshness = queue_state.evidence_freshness_assessor(
+        database,
+        tmp_path / "tracking-database.json",
+        video_evidence_assessment=assessment,
+    )
+
+    assert capability(talk) == {}
+    assert capability(talk) == {}
+    assert freshness(talk) == ()
+    assert freshness(talk) == ()
+    assert observed == [
+        ("capabilities", assessment),
+        ("capabilities", assessment),
+        ("freshness", assessment),
+    ]


### PR DESCRIPTION
## Summary
- Add bounded, authenticated, exact-generation source-video metadata, ffprobe, and digest assessment with lane-local failure reasons.
- Reuse one operation-scoped assessment across preflight, queue, persistence, rendering, freshness, provenance, and profile consumers.
- Intentionally add the complete source-video contract suite to the macOS and Windows artifact-platform CI job, covering platform metadata, every failure mapping, races, and batch atomicity.
- Split the ingress/profile workflow contracts into named references while preserving their required order.

## Test plan
- [x] Full pytest suite: 4,487 passed, 3 skipped
- [x] Focused post-cleanup suite: 458 passed
- [x] Windows CI matrix correction: video-evidence suite 60 passed locally; platform-unavailable macOS flag is conditionally skipped
- [x] Ruff and Pyright for every changed Python surface
- [x] Tessl skill reviews: vault-ingress 90, vault-profile 88 (threshold 85)
- [x] tessl plugin lint and pre-publish package checks

Closes #190