### PR TITLE
feat(vault-profile): classify patterns by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+### feat(vault-profile) — ship default pattern classification policy (#222)
+
+Speaker profiles now classify current scoring-v5 opportunity rows with the
+bundled, versioned `speaker-toolkit-default@1` policy instead of waiting for
+every speaker to invent thresholds. Schema-v5 profiles embed the exact policy,
+its canonical semantic SHA-256, exhaustive positive and antipattern
+classifications, combinations, trend evidence, and independent availability
+for each derived domain. A present `pattern-classification-policy.json` may
+override the default only when it passes the strict schema-v1 contract; an
+invalid override aborts rather than silently falling back.
+
+Section 15 writes the policy-bound v3 block while retaining read-only v2
+occurrence compatibility. Presentation creation consumes each available domain
+independently: New-to-You comes only from `never_tried`, recurring warnings come
+only from high/moderate derived antipattern classifications, and unsupported
+mode history remains unavailable. Raw opportunity rows stay unchanged, and the
+upgrade requires profile/summary regeneration but no talk reparse. Goal-setting
+accepts validated schema-v4 and schema-v5 raw baselines; it uses a v5 derived label
+only when that label's own classification domain is available.
+
 ## 0.20.11 — 2026-08-04
 
 ### fix(vault-ingress) — supervise preserved source-video evidence (#190)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ cohort by implication.
 declare explicit evidence gates, but only 16 permit an absence conclusion from a
 complete transcript or separately declared rendered PDF. Profile schema v5 preserves
 each pattern's exact denominator and automatically applies the bundled
-`speaker-toolkit-default@1` thresholds. A vault may provide a strict optional override;
-if that file is present but invalid, profile generation stops instead of silently
+`speaker-toolkit-default@1` thresholds. A vault may provide a strict optional override.
+If that file is present but invalid, profile generation stops instead of silently
 falling back. Mastery/novelty, antipattern recurrence, underuse, combinations, trends,
 and modes report availability independently. Section 15 readers still accept
 occurrence-only v2 blocks, while every replacement writes a policy-bound v3 block.
@@ -162,7 +162,7 @@ The toolkit is built on six skills connected by a shared **rhetoric vault** — 
 - **vault-profile** generates a schema-v5 speaker profile with source-exact opportunity rows, a self-contained policy stamp, and independently gated classifications after enough talks are analyzed.
 
 **Creator skills (generation):**
-- **presentation-creator** reads the vault at runtime and uses your documented rhetoric as a constitutional style guide to build new presentations. It follows a 7-phase process from intent distillation through slide generation, with a current-taxonomy Pattern Strategy and a go-live checklist before delivery. It uses each available profile domain independently—for example, mastery for the four history tiers and antipattern recurrence for recurring warnings—and falls back to a flat taxonomy when that domain is unavailable. Delegates the visual layer to the illustrations skill.
+- **presentation-creator** reads the vault at runtime and uses your documented rhetoric as a constitutional style guide to build new presentations. It follows a 7-phase process from intent distillation through slide generation, with a current-taxonomy Pattern Strategy and a go-live checklist before delivery. It uses each available profile domain independently. Mastery drives the four history tiers. Antipattern recurrence drives recurring warnings. When either domain is unavailable, the creator falls back to the corresponding current-taxonomy behavior. The skill delegates the visual layer to the illustrations skill.
 - **illustrations** owns the deck illustration strategy, generation, build chains, and YouTube thumbnails. Invoked by presentation-creator at the relevant phases (Phase 2 strategy, Phase 5 application, Phase 7 thumbnail).
 - **shownotes-publisher** writes talk pages into a Jekyll-based shownotes site (e.g., `speaking.jbaru.ch`). Encodes the custom parser's format contract so authored content actually renders: abstract is one paragraph, video field absent = "coming soon" badge, slides/video URLs must be markdown links, no frontmatter title, etc. Invoked after the talk is delivered (or pre-talk for slides-only publish).
 
@@ -253,7 +253,7 @@ rhetoric-knowledge-vault/
 
 **rhetoric-style-summary.md** is the constitution — rich prose covering presentation modes, opening patterns, humor techniques, audience interaction styles, closing patterns, verbal signatures, persuasion techniques, and more. It grows every time you parse new talks.
 
-**speaker-profile.json** is the specification — structured data that the creator reads at runtime: presentation modes with quantitative thresholds, instrument catalogs, guardrail rules, pacing data, design rules, the publishing workflow, and a `pattern_profile` with exact positive/negative occurrence rows, per-pattern denominators, source cohort provenance, exhaustive classifications, and independent availability by domain. Schema v5 uses the bundled `speaker-toolkit-default@1` policy automatically and embeds the full policy plus its semantic digest. An optional `pattern-classification-policy.json` overrides it only when the file passes strict validation; schema-v4 profiles remain readable as occurrence-only history.
+**speaker-profile.json** is the structured specification that the creator reads at runtime. It contains presentation modes with quantitative thresholds, instrument catalogs, guardrail rules, pacing data, design rules, the publishing workflow, and a `pattern_profile` with exact positive/negative occurrence rows, per-pattern denominators, source cohort provenance, exhaustive classifications, and independent availability by domain. Schema v5 uses the bundled `speaker-toolkit-default@1` policy automatically and embeds the full policy plus its semantic digest. An optional `pattern-classification-policy.json` overrides it only when the file passes strict validation. Schema-v4 profiles remain readable as occurrence-only history.
 
 **slide-design-spec.md** captures visual design rules extracted from both PDF inspection and programmatic .pptx analysis: background colors, typography, footer specs, shape vocabulary, and template layout catalog.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Older generations remain readable history but cannot enter the current scoring
 cohort by implication.
 
 **Defensible absence and ready-to-use classification** — all observable entries
-declare explicit evidence gates, but only 16 permit an absence conclusion from a
-complete transcript or separately declared rendered PDF. Profile schema v5 preserves
+declare explicit evidence gates, and the catalog keeps absence decisions source-bound.
+Profile schema v5 preserves
 each pattern's exact denominator and automatically applies the bundled
 `speaker-toolkit-default@1` thresholds. A vault may provide a strict optional override.
 If that file is present but invalid, profile generation stops instead of silently

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ catalog and to owner-validated transcript, slide, video, or metadata evidence.
 Older generations remain readable history but cannot enter the current scoring
 cohort by implication.
 
-**Defensible absence and opportunity-aware profiles** — all observable entries
+**Defensible absence and ready-to-use classification** — all observable entries
 declare explicit evidence gates, but only 16 permit an absence conclusion from a
-complete transcript or separately declared rendered PDF. Speaker profiles retain
-each pattern's exact evaluable denominator and fail closed on mastery, novelty,
-recurring severity, combinations, and trends until a speaker-owned classification
-policy exists.
+complete transcript or separately declared rendered PDF. Profile schema v5 preserves
+each pattern's exact denominator and automatically applies the bundled
+`speaker-toolkit-default@1` thresholds. A vault may provide a strict optional override;
+if that file is present but invalid, profile generation stops instead of silently
+falling back. Mastery/novelty, antipattern recurrence, underuse, combinations, trends,
+and modes report availability independently. Section 15 readers still accept
+occurrence-only v2 blocks, while every replacement writes a policy-bound v3 block.
 
 **Safer installed operation** — toolkit commands resolve from the installed
 plugin root and use the vault's configured Python interpreter. A stdlib-only
@@ -156,10 +159,10 @@ The toolkit is built on six skills connected by a shared **rhetoric vault** — 
 **Vault skills (analysis):**
 - **vault-ingress** parses recorded talks from transcripts, native decks, PDFs, or video and extracts rhetoric patterns across 14 dimensions — opening hooks, humor style, audience interaction, slide design, pacing, transitions, verbal signatures, and more. Before scoring, deterministic catalog and source-identity gates verify the evidence; video-derived slide claims require a provenance-bound, manually verified slide-region artifact. Recoverable queue leases and validated returns keep interrupted or stale batches from corrupting the vault.
 - **vault-clarification** runs interactive sessions to validate findings and capture deliberate intent.
-- **vault-profile** generates a structured speaker profile with source-exact per-pattern opportunity rows and explicit classification availability after enough talks are analyzed.
+- **vault-profile** generates a schema-v5 speaker profile with source-exact opportunity rows, a self-contained policy stamp, and independently gated classifications after enough talks are analyzed.
 
 **Creator skills (generation):**
-- **presentation-creator** reads the vault at runtime and uses your documented rhetoric as a constitutional style guide to build new presentations. It follows a 7-phase process from intent distillation through slide generation, with a current-taxonomy Pattern Strategy and a go-live checklist before delivery. The four historical tiers and recurring labels appear only when the profile explicitly authorizes classification fields; otherwise the creator stays on a flat taxonomy path. Delegates the visual layer to the illustrations skill.
+- **presentation-creator** reads the vault at runtime and uses your documented rhetoric as a constitutional style guide to build new presentations. It follows a 7-phase process from intent distillation through slide generation, with a current-taxonomy Pattern Strategy and a go-live checklist before delivery. It uses each available profile domain independently—for example, mastery for the four history tiers and antipattern recurrence for recurring warnings—and falls back to a flat taxonomy when that domain is unavailable. Delegates the visual layer to the illustrations skill.
 - **illustrations** owns the deck illustration strategy, generation, build chains, and YouTube thumbnails. Invoked by presentation-creator at the relevant phases (Phase 2 strategy, Phase 5 application, Phase 7 thumbnail).
 - **shownotes-publisher** writes talk pages into a Jekyll-based shownotes site (e.g., `speaking.jbaru.ch`). Encodes the custom parser's format contract so authored content actually renders: abstract is one paragraph, video field absent = "coming soon" badge, slides/video URLs must be markdown links, no frontmatter title, etc. Invoked after the talk is delivered (or pre-talk for slides-only publish).
 
@@ -199,7 +202,7 @@ The vault skill will:
    source-located, channel-permitted evidence
 6. Build a running narrative summary and slide design spec
 7. Run an interactive clarification session to validate findings and capture your intent
-8. Generate a structured speaker profile with auditable pattern opportunities and explicit classification availability (after 10+ talks)
+8. Generate a schema-v5 speaker profile with auditable opportunities and automatic, per-domain classification (after 10+ talks)
 
 ### Phase 2: Create Presentations
 
@@ -211,7 +214,7 @@ create a presentation about [topic] for [conference]
 The creator will:
 1. Load your vault (summary, design spec, profile) and the pattern taxonomy
 2. Walk you through intent distillation (purpose, audience, constraints)
-3. Jointly select rhetorical instruments, using a flat current-taxonomy Pattern Strategy unless validated classification history explicitly enables the four historical tiers
+3. Jointly select rhetorical instruments, using the available schema-v5 mastery history for the four tiers or a flat current-taxonomy strategy when that domain is unavailable
 4. Write a section-by-section outline with speaker notes in your voice
 5. Run guardrail checks (slide budget, Act 1 ratio, profanity, branding, pattern-based antipattern scan)
 6. Generate a .pptx deck from your template
@@ -250,7 +253,7 @@ rhetoric-knowledge-vault/
 
 **rhetoric-style-summary.md** is the constitution — rich prose covering presentation modes, opening patterns, humor techniques, audience interaction styles, closing patterns, verbal signatures, persuasion techniques, and more. It grows every time you parse new talks.
 
-**speaker-profile.json** is the specification — structured data that the creator reads at runtime: presentation modes with quantitative thresholds, instrument catalogs, guardrail rules, pacing data, design rules, the publishing workflow, and a `pattern_profile` with exact positive/negative occurrence rows, per-pattern opportunity denominators, source cohort provenance, and explicit classification availability. Current schema-v4 profiles fail closed on mastery, novelty, recurring severity, combinations, and trends until the speaker owns a versioned classification policy.
+**speaker-profile.json** is the specification — structured data that the creator reads at runtime: presentation modes with quantitative thresholds, instrument catalogs, guardrail rules, pacing data, design rules, the publishing workflow, and a `pattern_profile` with exact positive/negative occurrence rows, per-pattern denominators, source cohort provenance, exhaustive classifications, and independent availability by domain. Schema v5 uses the bundled `speaker-toolkit-default@1` policy automatically and embeds the full policy plus its semantic digest. An optional `pattern-classification-policy.json` overrides it only when the file passes strict validation; schema-v4 profiles remain readable as occurrence-only history.
 
 **slide-design-spec.md** captures visual design rules extracted from both PDF inspection and programmatic .pptx analysis: background colors, typography, footer specs, shape vocabulary, and template layout catalog.
 
@@ -430,7 +433,7 @@ two are invoked via typed `Skill(...)` handoffs.
 8. **Modular cut lines** — present for shorter/longer adaptation
 9. **Anti-pattern flags** — current-outline taxonomy findings plus independently sourced non-pattern guardrails
    - **9A:** Profile-based non-pattern recurring issues (`source_lane: "non_pattern"`)
-   - **9B:** Taxonomy-based antipattern scan — `[CONTEXTUAL]` always; `[RECURRING]` only when the shared profile gate explicitly authorizes classification history
+   - **9B:** Taxonomy-based antipattern scan — `[CONTEXTUAL]` always; `[RECURRING]` only when the profile's antipattern-recurrence domain is available
 10. **Illustration coverage** — format tags, EXCEPTION justifications, style anchor references, prompt quality (when illustration strategy is defined; `[SKIP]` otherwise)
 
 ### Presentation Patterns Taxonomy
@@ -467,10 +470,10 @@ remain outside absence denominators until versioned capability/alignment receipt
 | Integration point | Observable entries (81: 62 patterns + 19 antipatterns) | Unobservable entries (30: 21 patterns + 9 antipatterns) |
 |---|---|---|
 | **Vault scoring** (Step 3 B2) | Exhaustive per-talk outcomes aggregate into source-exact `pattern_profile` occurrence rows | Excluded from scoring |
-| **Creator Phase 2** | Flat current-taxonomy strategy by default; four historical tiers only when classification history is explicitly authorized | Included in recommendations |
-| **Creator Phase 4** | `[CONTEXTUAL]` flags always; `[RECURRING]` only from explicitly authorized classification history | Excluded from scan |
+| **Creator Phase 2** | Four history tiers from an available mastery/novelty domain; flat current taxonomy for an older, missing, or unavailable domain | Included in recommendations |
+| **Creator Phase 4** | `[CONTEXTUAL]` flags always; `[RECURRING]` only when the antipattern-recurrence domain is available | Excluded from scan |
 | **Creator Phase 6** | — | Go-live preparation checklist |
-| **Speaker profile** | `pattern_profile` with opportunity-aware occurrence rows and explicit classification availability | Not in profile |
+| **Speaker profile** | Schema-v5 `pattern_profile` with opportunity-aware occurrence rows, a self-contained policy stamp, exhaustive classifications, and per-domain availability | Not in profile |
 | **Summary-only mode** | Flat relevant-patterns list from reference files | Go-live checklist still applies |
 
 ### Special Workflows

--- a/evals/illustrated-outline-quality-audit/task.md
+++ b/evals/illustrated-outline-quality-audit/task.md
@@ -10,11 +10,17 @@ Produce the following file:
 
 1. **`guardrail-report.md`** — a Phase 4 audit report covering the outline and the speaker profile together. The report should be structured so the speaker can act on its findings.
 
+The old profile cannot authorize catalog-derived classifications. Still apply the
+`rushed_closing` guardrail at its declared severity because it is explicitly marked
+`source_lane: "non_pattern"`; keep that independent warning separate from taxonomy
+`[RECURRING]` labels, which require an available schema-v5 antipattern-recurrence domain
+and qualifying derived `antipattern_classifications` rows.
+
 ## Input Files
 
 =============== FILE: inputs/speaker-profile.json ===============
 {
-  "schema_version": 1,
+  "schema_version": 4,
   "speaker": {"name": "Pat Illustra", "handle": "@patillustra"},
   "rhetoric_defaults": {
     "default_duration_minutes": 45,
@@ -36,7 +42,7 @@ Produce the following file:
       {"duration_range": "45 min", "max_percent": 45}
     ],
     "recurring_issues": [
-      {"id": "rushed_closing", "description": "Rushes final section", "guardrail": "Closing must have at least 3 slides and 3 min", "severity": "warning"}
+      {"id": "rushed_closing", "source_lane": "non_pattern", "description": "Rushes final section", "guardrail": "Closing must have at least 3 slides and 3 min", "severity": "warning"}
     ]
   }
 }

--- a/evals/pattern-strategy-4-tier/criteria.json
+++ b/evals/pattern-strategy-4-tier/criteria.json
@@ -1,11 +1,11 @@
 {
-  "context": "Tests whether the agent fails closed on a deliberately legacy schema-v3/scoring-v4 profile, preserves the current taxonomy lane, and suppresses historical classifications.",
+  "context": "Tests whether the agent evaluates each schema-v5 classification domain independently, fails closed on a deliberately stale schema-v4/scoring-v4 pattern profile, preserves explicit non-pattern guardrails, and keeps the current taxonomy useful without inventing history.",
   "type": "weighted_checklist",
   "checklist": [
     {
       "name": "Legacy provenance fails closed",
-      "max_score": 15,
-      "description": "The report treats the supplied speaker-profile schema 3 / scoring schema 4 payload as history-disabled under the installed schema 4 / scoring schema 5 contract, regardless of its internally consistent legacy counts"
+      "max_score": 12,
+      "description": "The report treats the supplied speaker-profile schema 4 / scoring schema 4 pattern payload as history-disabled under the installed policy-bound schema 5 / scoring schema 5 contract, regardless of its internally consistent legacy counts; it does not mistake schema-v4 occurrence compatibility or its readable non-pattern lane for permission to use legacy derived pattern claims"
     },
     {
       "name": "No historical four-tier structure",
@@ -13,14 +13,14 @@
       "description": "The report uses one flat relevant-pattern list and does not emit Signature, Contextual History, New to You, or Shake It Up as speaker-history tiers"
     },
     {
-      "name": "Legacy classification claims suppressed",
-      "max_score": 15,
-      "description": "The report does not repeat usage rates, mastery levels, never-used/New-to-You claims, strengths, underuse, severity, or trend from the stale profile"
+      "name": "Per-domain classification claims suppressed",
+      "max_score": 13,
+      "description": "Because the legacy profile has no classification-availability-v2 domains or policy stamp, the report does not repeat usage rates, mastery, strengths, underuse, combinations, modes, severity, or trend from it. It emits no New-to-You/[NEW] claim: that tier is exactly an authorized never_tried classification, never not_yet_observed, a raw zero, or this stale never_used_patterns array"
     },
     {
-      "name": "No recurring labels",
-      "max_score": 15,
-      "description": "The report emits no [RECURRING] label and does not treat shortchanged or bullet-riddled-corpse as habitual based on the stale antipattern_frequency rows"
+      "name": "No catalog recurrence from raw rows",
+      "max_score": 13,
+      "description": "The report emits no catalog [RECURRING] label and does not treat shortchanged or bullet-riddled-corpse as habitual based on stale antipattern_frequency rows; recurrence requires an available antipattern_recurrence domain plus a derived antipattern_classifications row classified high_frequency or moderate_frequency"
     },
     {
       "name": "Current taxonomy remains useful",
@@ -29,13 +29,18 @@
     },
     {
       "name": "Contextual findings retained",
-      "max_score": 15,
+      "max_score": 12,
       "description": "At least one antipattern detection is labeled [CONTEXTUAL] — a current-outline risk found by the current taxonomy rather than a historical claim (e.g., the meme-heavy opening sequence)"
     },
     {
       "name": "Actionable recovery warning",
       "max_score": 10,
-      "description": "The report explains that pattern history is disabled and recommends regenerating/reprocessing with the current profile and scoring contract"
+      "description": "The report explains that the relevant classification domains are unavailable, recommends reprocessing the stale scoring generation as needed and regenerating schema v5, and says the bundled speaker-toolkit-default@1 policy applies automatically rather than asking Morgan to supply thresholds"
+    },
+    {
+      "name": "Explicit non-pattern recurring issue preserved",
+      "max_score": 10,
+      "description": "The report applies the long_context_ramp warning at its declared severity because it carries source_lane non_pattern, while keeping it separate from catalog-derived [RECURRING] labels and stale pattern history"
     },
     {
       "name": "Actionable recommendations",

--- a/evals/pattern-strategy-4-tier/criteria.json
+++ b/evals/pattern-strategy-4-tier/criteria.json
@@ -20,7 +20,7 @@
     {
       "name": "No catalog recurrence from raw rows",
       "max_score": 13,
-      "description": "The report emits no catalog [RECURRING] label and does not treat shortchanged or bullet-riddled-corpse as habitual based on stale antipattern_frequency rows; recurrence requires an available antipattern_recurrence domain plus a derived antipattern_classifications row classified high_frequency or moderate_frequency"
+      "description": "The report emits no catalog [RECURRING] label and does not treat shortchanged or bullet-riddled-corpse as habitual based on stale antipattern_frequency rows. Catalog recurrence labels relay guardrail-check.py recurring_antipatterns records, and this Phase 2 task has no such emitted record"
     },
     {
       "name": "Current taxonomy remains useful",

--- a/evals/pattern-strategy-4-tier/task.md
+++ b/evals/pattern-strategy-4-tier/task.md
@@ -31,11 +31,10 @@ Produce a pattern strategy report saved to `pattern-strategy.md` containing:
    authorized only by an available `mastery_and_novelty` domain and an exact
    `never_tried` classification—never by `not_yet_observed`, a raw zero, or the stale
    `never_used_patterns` array supplied here.
-3. Flag risks detected in the draft as `[CONTEXTUAL]`. A catalog `[RECURRING]` label
-   requires an available `antipattern_recurrence` domain and a derived
-   `antipattern_classifications` row classified `high_frequency` or
-   `moderate_frequency`; never derive it from the stale raw `antipattern_frequency`
-   rows.
+3. Flag risks detected in the draft as `[CONTEXTUAL]`. Do not emit a catalog
+   `[RECURRING]` label. Those labels relay `guardrail-check.py` `recurring_antipatterns`
+   records, and this Phase 2 task has no such emitted record. Never derive one from the
+   stale raw `antipattern_frequency` rows.
 4. Preserve the explicitly independent `long_context_ramp` guardrail because it carries
    `source_lane: "non_pattern"`. Report it at its declared severity, but do not present
    it as catalog-derived recurrence.

--- a/evals/pattern-strategy-4-tier/task.md
+++ b/evals/pattern-strategy-4-tier/task.md
@@ -2,13 +2,20 @@
 
 ## Background
 
-Morgan Lee is preparing a 45-minute talk for DevRelCon 2025 about "Developer Relations in the Age of AI Assistants." Morgan has a legacy profile containing historical pattern classifications, but it predates the current opportunity-aware contract and cannot authorize those claims.
+Morgan Lee is preparing a 45-minute talk for DevRelCon 2025 about "Developer
+Relations in the Age of AI Assistants." Morgan has a legacy profile containing
+historical pattern classifications, but it predates the current opportunity-aware
+contract and cannot authorize those claims.
 
 For this fixed synthetic case, the installed creator requires speaker-profile schema
-`4` and pattern-scoring schema `5`. The supplied profile is deliberately stale:
-speaker-profile schema `3` with pattern-scoring schema `4`. Its old mastery, novelty,
-frequency, severity, and trend fields must fail closed even though they are internally
-consistent.
+`5` and pattern-scoring schema `5` for policy-derived history. Schema v5 uses
+classification-availability v2 and the bundled `speaker-toolkit-default@1` policy when
+there is no strict vault override; schema v4 remains occurrence-only. The supplied
+profile uses the occurrence-compatible speaker-profile schema `4`, but its
+pattern-scoring schema is the stale schema `4`. It has neither a self-contained policy
+stamp nor independently authorized domains, so its old mastery, novelty, frequency,
+severity, and trend fields must fail closed even though they are internally
+consistent. Its explicitly non-pattern guardrail lane remains independently readable.
 
 Given Morgan's stale pattern profile and the draft outline below, produce a taxonomy-grounded pattern strategy for this talk without treating the legacy fields as speaker history.
 
@@ -16,10 +23,23 @@ Given Morgan's stale pattern profile and the draft outline below, produce a taxo
 
 Produce a pattern strategy report saved to `pattern-strategy.md` containing:
 
-1. Surface the pattern-history-disabled warning and recommend regenerating the profile.
-2. Present one flat relevant-pattern list from the current taxonomy. Do not emit the four historical tiers, usage/novelty/mastery/trend claims, or `[NEW]` labels.
-3. Flag risks detected in the draft as `[CONTEXTUAL]`. Do not emit `[RECURRING]` from the stale profile.
-4. Include specific recommendations for this talk.
+1. Surface the pattern-history-disabled warning and recommend reprocessing the stale
+   scoring generation as needed, then regenerating schema v5. The bundled policy applies
+   automatically; Morgan does not need to invent thresholds.
+2. Present one flat relevant-pattern list from the current taxonomy. Do not emit the
+   four historical tiers, usage/mastery/trend claims, or `[NEW]` labels. New-to-You is
+   authorized only by an available `mastery_and_novelty` domain and an exact
+   `never_tried` classification—never by `not_yet_observed`, a raw zero, or the stale
+   `never_used_patterns` array supplied here.
+3. Flag risks detected in the draft as `[CONTEXTUAL]`. A catalog `[RECURRING]` label
+   requires an available `antipattern_recurrence` domain and a derived
+   `antipattern_classifications` row classified `high_frequency` or
+   `moderate_frequency`; never derive it from the stale raw `antipattern_frequency`
+   rows.
+4. Preserve the explicitly independent `long_context_ramp` guardrail because it carries
+   `source_lane: "non_pattern"`. Report it at its declared severity, but do not present
+   it as catalog-derived recurrence.
+5. Include specific recommendations for this talk.
 
 Use the speaker profile and draft outline provided below.
 
@@ -29,11 +49,22 @@ The following files are provided as inputs. Extract them before beginning.
 
 =============== FILE: inputs/speaker-profile.json ===============
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "generated_date": "2025-02-15",
   "speaker": {
     "name": "Morgan Lee",
     "handle": "@mlee_devrel"
+  },
+  "guardrail_sources": {
+    "recurring_issues": [
+      {
+        "id": "long_context_ramp",
+        "source_lane": "non_pattern",
+        "description": "Delays the first concrete example with historical framing",
+        "guardrail": "Reach a concrete audience example within the first 10% of the talk",
+        "severity": "warning"
+      }
+    ]
   },
   "pattern_profile": {
     "pattern_baseline": {

--- a/evals/speaker-profile-from-vault/criteria.json
+++ b/evals/speaker-profile-from-vault/criteria.json
@@ -1,11 +1,11 @@
 {
-  "context": "Tests whether the agent generates a schema-v4 speaker profile while failing closed on legacy, non-source-located pattern rows and preserving independently grounded non-pattern profile data.",
+  "context": "Tests whether the agent generates a schema-v5 speaker profile with the bundled default policy while keeping legacy, non-source-located rows out of the current cohort and preserving independently grounded non-pattern profile data.",
   "type": "weighted_checklist",
   "checklist": [
     {
-      "name": "Schema-v4 top-level contract",
+      "name": "Schema-v5 top-level contract",
       "max_score": 10,
-      "description": "speaker-profile.json uses schema_version 4 and contains the required speaker, infrastructure, presentation_modes, rhetoric_defaults, instrument_catalog, guardrail_sources, pacing, pattern_profile, confirmed_intents, and badges lanes"
+      "description": "speaker-profile.json uses schema_version 5 and contains the required speaker, infrastructure, presentation_modes, rhetoric_defaults, instrument_catalog, guardrail_sources, pacing, pattern_profile, confirmed_intents, and badges lanes"
     },
     {
       "name": "Speaker fields from config",
@@ -18,14 +18,14 @@
       "description": "The top-level badges array contains independently grounded achievements and every entry declares source_lane 'non_pattern'; no badge is derived from pattern IDs, scores, mastery, absence, or frequency"
     },
     {
-      "name": "Legacy pattern cohort fails closed",
+      "name": "Legacy pattern cohort remains empty",
       "max_score": 18,
-      "description": "pattern_profile uses the current schema-v4 empty-cohort form because all supplied pattern observations lack scoring-v5 generation/evidence/outcome receipts: eligible_talk_count and talks_scored are 0, average_pattern_score is null, baseline filenames are empty, and exhaustive opportunity rows use zero/null sentinels"
+      "description": "pattern_profile uses the schema-v5 empty-current-cohort form because all supplied observations lack scoring-v5 generation/evidence/outcome receipts: eligible_talk_count and talks_scored are 0, average_pattern_score is null, baseline filenames are empty, and exhaustive raw opportunity rows use zero/null sentinels; legacy IDs, scores, and ordinary Section 15 prose are not imported"
     },
     {
-      "name": "Classification fields use exact unavailable sentinels",
+      "name": "Bundled policy and per-domain classification",
       "max_score": 15,
-      "description": "classification_availability reports owner_policy_unconfigured; mastery tiers, never_used_patterns, strengths, underuse, combinations, by-mode history, and driver arrays are empty, while trend/direction fields are unavailable and breadth average is null"
+      "description": "pattern_profile contains classification_schema_version 1; a complete classification_policy stamp for speaker-toolkit-default version 1 with source bundled_default, semantic policy, and matching digest; and classification_availability schema 2. Mastery/novelty, antipattern recurrence, underuse, and combinations are available domains with exhaustive unclassified zero-cohort rows, while trends is unavailable for insufficient dated sample and modes for unavailable assignments. Derived mastery, never-used/New-to-You, recurring, strengths, underuse, combinations, by-mode, and driver arrays remain empty; trend/direction fields are unavailable and breadth average is null"
     },
     {
       "name": "guardrail_sources.slide_budgets is array",

--- a/evals/speaker-profile-from-vault/criteria.json
+++ b/evals/speaker-profile-from-vault/criteria.json
@@ -1,5 +1,5 @@
 {
-  "context": "Tests whether the agent generates a schema-v5 speaker profile with the bundled default policy while keeping legacy, non-source-located rows out of the current cohort and preserving independently grounded non-pattern profile data.",
+  "context": "Tests whether the agent generates a schema-v5 speaker profile by preserving the profile loader's opaque catalog outputs, not importing legacy catalog rows, and retaining independently grounded non-pattern data.",
   "type": "weighted_checklist",
   "checklist": [
     {
@@ -18,14 +18,14 @@
       "description": "The top-level badges array contains independently grounded achievements and every entry declares source_lane 'non_pattern'; no badge is derived from pattern IDs, scores, mastery, absence, or frequency"
     },
     {
-      "name": "Legacy pattern cohort remains empty",
+      "name": "Loader-selected catalog cohort is copied",
       "max_score": 18,
-      "description": "pattern_profile uses the schema-v5 empty-current-cohort form because all supplied observations lack scoring-v5 generation/evidence/outcome receipts: eligible_talk_count and talks_scored are 0, average_pattern_score is null, baseline filenames are empty, and exhaustive raw opportunity rows use zero/null sentinels; legacy IDs, scores, and ordinary Section 15 prose are not imported"
+      "description": "pattern_profile copies the pattern_baseline and pattern_opportunities objects emitted by load-vault.py for the supplied fixture without changing counts, identities, rows, rates, or sentinels. Legacy IDs, scores, and ordinary Section 15 prose are not imported by hand"
     },
     {
-      "name": "Bundled policy and per-domain classification",
+      "name": "Classifier output is copied unchanged",
       "max_score": 15,
-      "description": "pattern_profile contains classification_schema_version 1; a complete classification_policy stamp for speaker-toolkit-default version 1 with source bundled_default, semantic policy, and matching digest; and classification_availability schema 2. Mastery/novelty, antipattern recurrence, underuse, and combinations are available domains with exhaustive unclassified zero-cohort rows, while trends is unavailable for insufficient dated sample and modes for unavailable assignments. Derived mastery, never-used/New-to-You, recurring, strengths, underuse, combinations, by-mode, and driver arrays remain empty; trend/direction fields are unavailable and breadth average is null"
+      "description": "pattern_profile contains every field of the pattern_classification object emitted by load-vault.py for the supplied fixture unchanged, including its policy stamp, semantic digest, availability, exhaustive classification rows, trend audit, and derived projections. No domain verdict, absence label, or projection is guessed from raw rows or prose"
     },
     {
       "name": "guardrail_sources.slide_budgets is array",
@@ -43,9 +43,9 @@
       "description": "rhetoric_defaults or a confirmed_intents key at the top level contains at least one confirmed intent from the tracking DB (specifically the 'delayed_intro' intent about not using a traditional opening bio)"
     },
     {
-      "name": "pacing data populated",
+      "name": "Pacing honors the instrumentation cohort",
       "max_score": 8,
-      "description": "The pacing object contains at least one field with a numeric value derived from the vault data — e.g., wpm_range, slides_per_minute, or average_duration_minutes — not empty or null"
+      "description": "The pacing object uses only current_instrumentation_talks emitted by load-vault.py. Because this fixture has no current instrumentation talks, it preserves the empty zero/null state and does not manufacture numeric pacing from stale talks or narrative prose"
     },
     {
       "name": "Catalog history stays in its sole lane",

--- a/evals/speaker-profile-from-vault/task.md
+++ b/evals/speaker-profile-from-vault/task.md
@@ -10,7 +10,24 @@ The vault is located at `./vault/` and all the data is provided below. Your job 
 
 Generate `vault/speaker-profile.json` — a complete speaker profile synthesizing all available vault data.
 
-The profile should capture Taylor's defaults and infrastructure in a structured form that another tool can consume programmatically. The supplied talk rows predate source-located scoring-v5 outcomes and therefore cannot authorize a current pattern cohort: emit the canonical schema-v4 empty-current-cohort pattern contract instead of migrating the legacy pattern IDs, scores, or Section 15 prose into mastery, novelty, recurring severity, trends, or badges. Include only non-pattern badges, each marked `source_lane: "non_pattern"`, grounded in independent talk-count, pacing, visual, publishing, or confirmed-intent data.
+The profile should capture Taylor's defaults and infrastructure in a structured form
+that another tool can consume programmatically. The supplied talk rows predate
+source-located scoring-v5 outcomes and therefore cannot authorize a current pattern
+cohort. Emit the canonical schema-v5 empty-current-cohort contract instead of migrating
+legacy IDs, scores, or Section 15 prose into classifications. Because no override file
+is supplied, stamp the self-contained bundled `speaker-toolkit-default@1` policy and use
+classification-availability schema v2. Keep each domain independent: the classifier's
+mastery/novelty, antipattern-recurrence, underuse, and combination domains remain
+available as contracts, but their exhaustive zero-cohort rows are unclassified and
+produce no mastery, New-to-You, recurring, strength, underuse, or combination claims;
+trends and modes remain explicitly unavailable for their own reasons.
+
+The supplied Section 15 is ordinary narrative, not a machine-readable current block,
+and cannot fill the empty cohort. Compatibility readers may inspect an actual v2 block
+as occurrence-only history, while the Section 15 writer emits only policy-bound v3;
+this task writes only `speaker-profile.json` and must not invent or edit either block.
+Include only non-pattern badges, each marked `source_lane: "non_pattern"`, grounded in
+independent talk-count, pacing, visual, publishing, or confirmed-intent data.
 
 ## Input Files
 

--- a/evals/speaker-profile-from-vault/task.md
+++ b/evals/speaker-profile-from-vault/task.md
@@ -11,23 +11,21 @@ The vault is located at `./vault/` and all the data is provided below. Your job 
 Generate `vault/speaker-profile.json` — a complete speaker profile synthesizing all available vault data.
 
 The profile should capture Taylor's defaults and infrastructure in a structured form
-that another tool can consume programmatically. The supplied talk rows predate
-source-located scoring-v5 outcomes and therefore cannot authorize a current pattern
-cohort. Emit the canonical schema-v5 empty-current-cohort contract instead of migrating
-legacy IDs, scores, or Section 15 prose into classifications. Because no override file
-is supplied, stamp the self-contained bundled `speaker-toolkit-default@1` policy and use
-classification-availability schema v2. Keep each domain independent: the classifier's
-mastery/novelty, antipattern-recurrence, underuse, and combination domains remain
-available as contracts, but their exhaustive zero-cohort rows are unclassified and
-produce no mastery, New-to-You, recurring, strength, underuse, or combination claims;
-trends and modes remain explicitly unavailable for their own reasons.
+that another tool can consume programmatically. After extracting the supplied files,
+run the installed vault-profile `scripts/load-vault.py` against `./vault/`. Treat its
+`pattern_baseline`, `pattern_opportunities`, and `pattern_classification` objects as an
+opaque fixture: copy them into `pattern_profile` according to the profile-construction
+contract without predicting or rewriting any policy stamp, domain status,
+classification, absence result, trend, or derived projection. A nonzero loader exit is
+a task failure, not permission to synthesize fallback catalog history.
 
-The supplied Section 15 is ordinary narrative, not a machine-readable current block,
-and cannot fill the empty cohort. Compatibility readers may inspect an actual v2 block
-as occurrence-only history, while the Section 15 writer emits only policy-bound v3;
-this task writes only `speaker-profile.json` and must not invent or edit either block.
-Include only non-pattern badges, each marked `source_lane: "non_pattern"`, grounded in
-independent talk-count, pacing, visual, publishing, or confirmed-intent data.
+The supplied legacy observations and ordinary Section 15 prose must not be imported by
+hand. This task writes only `speaker-profile.json`. Do not create or edit a Section 15
+current block. Include only non-pattern badges, each marked
+`source_lane: "non_pattern"`, grounded in independent talk-count, pacing, visual,
+publishing, or confirmed-intent data. Before saving, run the installed
+`scripts/validate-profile.py --vault-root ./vault`. Save only when it exits `0` and
+reports `valid: true`.
 
 ## Input Files
 

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -45,8 +45,8 @@ only from authorized `pattern_profile` history.
 Every antipattern flag MUST be tagged as one of:
 
 - `[RECURRING]`. Render one `guardrail-check.py` `recurring_antipatterns` record.
-  Preserve its `recurrence_classification`, `evidence`, and optional `trend` fields.
-  Do not reclassify the record.
+  - Preserve its `recurrence_classification`, `evidence`, and optional `trend` fields.
+  - Do not reclassify the record.
 - `[CONTEXTUAL]` — detected in the current outline but NOT in the speaker's
   authorized historical profile. It is a current-outline finding, not necessarily a
   first-time issue when history is unavailable.
@@ -62,10 +62,11 @@ recommendations into exactly four tiers:
 2. **Contextual history.** Use current-cohort regular/occasional patterns worth
    considering here.
 3. **New to You.** Use exactly `mastery_levels.never_tried` /
-   `never_used_patterns` entries that fit this talk. A first detection in the newest
-   talk or `not_yet_observed` never counts as New-to-You.
-4. **Shake It Up.** Use exactly 1-2 wild card patterns for experimentation. Never 0,
-   never 3+.
+   `never_used_patterns` entries that fit this talk.
+   - Do not treat a first detection in the newest talk or `not_yet_observed` as
+     New-to-You.
+4. **Shake It Up.** Use exactly 1-2 wild card patterns for experimentation.
+   - Do not use zero or three or more wild card patterns.
 
 When the mastery domain is unavailable, do not manufacture those tiers from legacy
 profiles or unprovenanced prose. Present a flat relevant-pattern list from the current

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -16,9 +16,9 @@ three-outcome PASS/WARN/FAIL logic:
 - `[PASS]` — value is under the limit by more than 5 percentage points
 
 The script checks pattern-history authorization, slide budget, Act 1 ratio, closing
-completeness, cut lines, data attribution, profanity, and branding. It emits historical
-recurring antipattern lines only when `antipattern_recurrence` appears in
-`available_classification_domains`. It adds movement only when `trends` also appears.
+completeness, cut lines, data attribution, profanity, and branding. Its
+`recurring_antipatterns` array is the complete catalog recurrence output. Render those
+records without re-filtering them or adding movement data.
 Add the remaining checks (time-sensitive, current-outline contextual antipatterns,
 illustration coverage, pattern strategy) to the report manually.
 
@@ -29,7 +29,8 @@ available, require the exact domain for each derived field:
 - Use `mastery_and_novelty` for tiers, strengths, and novelty.
 - Use `underuse` for underuse.
 - Use `signature_combinations` for combinations.
-- Use `antipattern_recurrence` for historical recurring labels.
+- Use the `antipattern_recurrence` domain only through the script's
+  `recurring_antipatterns` output.
 - Use `trends` for movements and score/breadth trend.
 - Use `modes` for by-mode history.
 - Always retain the current-taxonomy scan of the new outline.
@@ -43,12 +44,9 @@ only from authorized `pattern_profile` history.
 
 Every antipattern flag MUST be tagged as one of:
 
-- `[RECURRING]` — matches an authorized current-generation pattern in the speaker's
-  derived `antipattern_classifications` history. Use this label only when
-  `antipattern_recurrence` is available and the row is classified `high_frequency` or
-  `moderate_frequency`. These are frequency classes, not harm severities. Raw
-  `antipattern_frequency`, `occasional`, and pattern-derived top-level duplicates do
-  not authorize the tag. Add a movement only when `trends` is independently available.
+- `[RECURRING]`. Render one `guardrail-check.py` `recurring_antipatterns` record.
+  Preserve its `recurrence_classification`, `evidence`, and optional `trend` fields.
+  Do not reclassify the record.
 - `[CONTEXTUAL]` — detected in the current outline but NOT in the speaker's
   authorized historical profile. It is a current-outline finding, not necessarily a
   first-time issue when history is unavailable.

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -17,17 +17,20 @@ three-outcome PASS/WARN/FAIL logic:
 
 The script checks pattern-history authorization, slide budget, Act 1 ratio, closing
 completeness, cut lines, data attribution, profanity, and branding. It emits historical
-recurring antipattern lines only when the exact-generation authorization passes. Add
-the remaining checks (time-sensitive, current-outline contextual antipatterns,
+recurring antipattern lines only when `antipattern_recurrence` appears in
+`available_classification_domains`; it adds movement only when `trends` also appears.
+Add the remaining checks (time-sensitive, current-outline contextual antipatterns,
 illustration coverage, pattern strategy) to the report manually.
 
 A disabled pattern-history result affects only catalog-derived speaker history. Keep
-independent profile configuration and guardrails enabled. Suppress signature and
-contextual-history tiers, New-to-You claims, strengths, underuse, by-mode history,
-historical recurring labels, and pattern-derived recurring issues or badges. Always
-retain the current-taxonomy scan of the new outline.
+independent profile configuration and guardrails enabled. When history is partially
+available, require the exact domain for each derived field: `mastery_and_novelty` for
+tiers, strengths, and novelty; `underuse` for underuse; `signature_combinations` for
+combinations; `antipattern_recurrence` for historical recurring labels; `trends` for
+movements and score/breadth trend; and `modes` for by-mode history. Always retain the
+current-taxonomy scan of the new outline.
 
-Schema-v4 top-level `guardrail_sources.recurring_issues[]` and `badges[]` are usable
+Schema-v4/v5 top-level `guardrail_sources.recurring_issues[]` and `badges[]` are usable
 only when each consumed entry explicitly declares `source_lane: "non_pattern"`.
 Suppress legacy or ambiguous entries. Catalog-derived warnings and reinforcement come
 only from authorized `pattern_profile` history.
@@ -37,8 +40,11 @@ only from authorized `pattern_profile` history.
 Every antipattern flag MUST be tagged as one of:
 
 - `[RECURRING]` — matches an authorized current-generation pattern in the speaker's
-  `antipattern_frequency` or pattern-derived `recurring_issues` history. Use this label
-  only when `pattern_history_status.py` reports `history_enabled: true`.
+  derived `antipattern_classifications` history. Use this label only when
+  `antipattern_recurrence` is available and the row is classified `high_frequency` or
+  `moderate_frequency`. These are frequency classes, not harm severities. Raw
+  `antipattern_frequency`, `occasional`, and pattern-derived top-level duplicates do
+  not authorize the tag. Add a movement only when `trends` is independently available.
 - `[CONTEXTUAL]` — detected in the current outline but NOT in the speaker's
   authorized historical profile. It is a current-outline finding, not necessarily a
   first-time issue when history is unavailable.
@@ -47,21 +53,29 @@ Never use generic unlabeled antipattern warnings.
 
 ## 4-Tier Pattern Strategy
 
-When `pattern_history_status.py` reports `history_enabled: true`, organize
+When `pattern_history_status.py` reports the `mastery_and_novelty` domain, organize
 recommendations into exactly four tiers:
 
 1. **Signature** — current-cohort `mastery_levels.signature` patterns
-2. **Contextual history** — current-cohort regular/occasional patterns worth considering here
-3. **New to You** — current-cohort never-tried patterns that fit this talk
-4. **Shake It Up** — exactly 1-2 wild card patterns for experimentation. Never 0, never 3+.
+2. **Contextual history** — current-cohort regular/occasional patterns worth
+   considering here
+3. **New to You** — exactly `mastery_levels.never_tried` /
+   `never_used_patterns` entries that fit this talk. A first detection in the newest
+   talk or `not_yet_observed` never counts as New-to-You.
+4. **Shake It Up** — exactly 1-2 wild card patterns for experimentation. Never 0,
+   never 3+.
 
-When history is disabled, do not manufacture those tiers from legacy profiles or
-unprovenanced prose. Present a flat relevant-pattern list from the current taxonomy
-without usage or novelty claims. A catalog fingerprint or scoring-schema change is a
-generation reset, never evidence of improvement or regression.
+When the mastery domain is unavailable, do not manufacture those tiers from legacy
+profiles or unprovenanced prose. Present a flat relevant-pattern list from the current
+taxonomy without usage or novelty claims. A catalog fingerprint or scoring-schema
+change is a generation reset, never evidence of improvement or regression.
 
-`opportunity_rows_available: true` is an audit signal, not history authorization. Raw
-occurrence rows do not establish novelty, mastery, recurring severity, or trend. The
-four tiers and `[RECURRING]` labels also require
-`classification_fields_available: true`; current owner-policy-unconfigured schema-v4
-profiles stay on the flat taxonomy path.
+`history_enabled: true` means at least one policy-bound domain is available, not that
+all classification fields are authorized. `opportunity_rows_available: true` is an
+audit signal, not history authorization. Raw occurrence rows do not establish novelty,
+mastery, recurrence, or trend. Profile schema v4 and Section 15 v2 are occurrence-only;
+profile schema v5 and Section 15 v3 bind classifications to the versioned policy.
+
+A catalog/scoring identity change is a generation reset. Within one generation, a
+changed `policy_semantic_sha256` is a classification-comparison reset. Neither reset is
+ever evidence of speaker improvement or regression.

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -18,17 +18,21 @@ three-outcome PASS/WARN/FAIL logic:
 The script checks pattern-history authorization, slide budget, Act 1 ratio, closing
 completeness, cut lines, data attribution, profanity, and branding. It emits historical
 recurring antipattern lines only when `antipattern_recurrence` appears in
-`available_classification_domains`; it adds movement only when `trends` also appears.
+`available_classification_domains`. It adds movement only when `trends` also appears.
 Add the remaining checks (time-sensitive, current-outline contextual antipatterns,
 illustration coverage, pattern strategy) to the report manually.
 
 A disabled pattern-history result affects only catalog-derived speaker history. Keep
 independent profile configuration and guardrails enabled. When history is partially
-available, require the exact domain for each derived field: `mastery_and_novelty` for
-tiers, strengths, and novelty; `underuse` for underuse; `signature_combinations` for
-combinations; `antipattern_recurrence` for historical recurring labels; `trends` for
-movements and score/breadth trend; and `modes` for by-mode history. Always retain the
-current-taxonomy scan of the new outline.
+available, require the exact domain for each derived field:
+
+- Use `mastery_and_novelty` for tiers, strengths, and novelty.
+- Use `underuse` for underuse.
+- Use `signature_combinations` for combinations.
+- Use `antipattern_recurrence` for historical recurring labels.
+- Use `trends` for movements and score/breadth trend.
+- Use `modes` for by-mode history.
+- Always retain the current-taxonomy scan of the new outline.
 
 Schema-v4/v5 top-level `guardrail_sources.recurring_issues[]` and `badges[]` are usable
 only when each consumed entry explicitly declares `source_lane: "non_pattern"`.
@@ -56,13 +60,13 @@ Never use generic unlabeled antipattern warnings.
 When `pattern_history_status.py` reports the `mastery_and_novelty` domain, organize
 recommendations into exactly four tiers:
 
-1. **Signature** — current-cohort `mastery_levels.signature` patterns
-2. **Contextual history** — current-cohort regular/occasional patterns worth
-   considering here
-3. **New to You** — exactly `mastery_levels.never_tried` /
+1. **Signature.** Use current-cohort `mastery_levels.signature` patterns.
+2. **Contextual history.** Use current-cohort regular/occasional patterns worth
+   considering here.
+3. **New to You.** Use exactly `mastery_levels.never_tried` /
    `never_used_patterns` entries that fit this talk. A first detection in the newest
    talk or `not_yet_observed` never counts as New-to-You.
-4. **Shake It Up** — exactly 1-2 wild card patterns for experimentation. Never 0,
+4. **Shake It Up.** Use exactly 1-2 wild card patterns for experimentation. Never 0,
    never 3+.
 
 When the mastery domain is unavailable, do not manufacture those tiers from legacy

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -92,16 +92,15 @@ each use (Python consumers call `domain_available(domain)`). The domain contract
   newest talk or a `not_yet_observed` classification.
 - `underuse`: `underused_patterns`.
 - `signature_combinations`: `signature_combinations`.
-- `antipattern_recurrence`: `[RECURRING]` only for `antipattern_classifications`
-  rows classified `high_frequency` or `moderate_frequency`. These labels describe
-  recurrence frequency, not harm severity.
+- `antipattern_recurrence`: consume historical recurrence only through Phase 4's
+  emitted `recurring_antipatterns` output.
 - `trends`: pattern and antipattern movements, score/breadth trend, and score drivers.
   A recurrence claim may be available without a trend claim.
 - `modes`: `by_mode` history.
 
-A policy-bound profile with any available domain wins as the sole history source. The
-summary is considered only when profile history is disabled and is never merged with
-profile history. Surface a disabled result's `warning` verbatim and recommend profile
+A non-null `history_source` selects the sole catalog-history input. Use the emitted
+value without reproducing source-selection logic or merging inputs. Surface a disabled
+result's `warning` verbatim and recommend profile
 regeneration. Continue using independent non-pattern fields such as pacing, visual
 rules, presentation modes, infrastructure, publishing config, and confirmed intents.
 Exact occurrence rows may remain auditable when `opportunity_rows_available` is true,
@@ -435,11 +434,9 @@ per check.
 `guardrail-check.py` enforces **speaker-profile-aware rules** that depend on
 runtime profile data: pattern-history authorization, slide budget, Act 1 ratio
 limits, branding, profanity register, data attribution, closing completeness, and
-cut-line availability (conditional on `modular_design`). It emits historical
-`recurring_antipatterns` records only when the `antipattern_recurrence` domain is
-available, and adds a movement only when the independent `trends` domain is also
-available. Records come from derived `antipattern_classifications`, never raw
-occurrence frequency.
+cut-line availability (conditional on `modular_design`). Its report contains the
+resolved `pattern_history` contract and final `recurring_antipatterns` records. Render
+those records unchanged. Do not inspect profile rows to recreate them.
 
 `contextual_taxonomy_scan.enabled` remains true for the current outline. Illustration
 coverage and the contextual scan still live in `phase4-guardrails.md` as additional

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -83,7 +83,7 @@ Use `-` for the profile path in summary-only mode. The command emits
 eligible_talk_count, opportunity_rows_available,
 classification_fields_available, available_classification_domains,
 policy_semantic_sha256, reason_codes, reasons, warning}`. `history_enabled` means at
-least one policy-bound domain is available; it is not permission to consume every
+least one policy-bound domain is available. It is not permission to consume every
 derived field. In JSON, require membership in `available_classification_domains` for
 each use (Python consumers call `domain_available(domain)`). The domain contracts are:
 
@@ -93,32 +93,32 @@ each use (Python consumers call `domain_available(domain)`). The domain contract
 - `underuse`: `underused_patterns`.
 - `signature_combinations`: `signature_combinations`.
 - `antipattern_recurrence`: `[RECURRING]` only for `antipattern_classifications`
-  rows classified `high_frequency` or `moderate_frequency`; these labels describe
+  rows classified `high_frequency` or `moderate_frequency`. These labels describe
   recurrence frequency, not harm severity.
 - `trends`: pattern and antipattern movements, score/breadth trend, and score drivers.
   A recurrence claim may be available without a trend claim.
 - `modes`: `by_mode` history.
 
-A policy-bound profile with any available domain wins as the sole history source; the
+A policy-bound profile with any available domain wins as the sole history source. The
 summary is considered only when profile history is disabled and is never merged with
 profile history. Surface a disabled result's `warning` verbatim and recommend profile
-regeneration; continue using independent non-pattern fields such as pacing, visual
+regeneration. Continue using independent non-pattern fields such as pacing, visual
 rules, presentation modes, infrastructure, publishing config, and confirmed intents.
 Exact occurrence rows may remain auditable when `opportunity_rows_available` is true,
 but that status never authorizes a classification. Stored profile schemas v1/v2/v3
-remain readable for non-pattern fields only. Schema v4 is occurrence-only; schema v5
+remain readable for non-pattern fields only. Schema v4 is occurrence-only. Schema v5
 binds derived classifications to a versioned policy.
 
-Suppress each catalog-derived historical field when its required domain is absent;
-do not collapse the available domains behind the global history flag. Top-level
+Suppress each catalog-derived historical field when its required domain is absent.
+Do not collapse the available domains behind the global history flag. Top-level
 recurring issues and badges in schema-v4/v5 profiles remain usable only when their
-entries explicitly declare `source_lane: "non_pattern"`; legacy or ambiguous entries
+entries explicitly declare `source_lane: "non_pattern"`. Legacy or ambiguous entries
 do not authorize history. Current-taxonomy scans of the new outline remain enabled.
 If no profile exists, run in **summary-only mode**: use default guardrail thresholds (1.5
 slides/min, 45% Act 1 cap) and ask for template/publishing data interactively. Section
 15 v3 classifications are usable only when its uniquely delimited current block passes
 `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"`
-and the same strict pattern-profile assessment; require the relevant domain just as
+and the same strict pattern-profile assessment. Require the relevant domain just as
 for profile history.
 Section 15 v2 is occurrence-only. Ordinary, stale, or occurrence-only Section 15 data
 authorizes taxonomy-only recommendations, never speaker-history claims.

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -81,35 +81,55 @@ Then run:
 Use `-` for the profile path in summary-only mode. The command emits
 `{history_enabled, history_source, profile_schema_version, scored_talk_count,
 eligible_talk_count, opportunity_rows_available,
-classification_fields_available, reason_codes, reasons, warning}`. Historical
-classifications are authorized only when
-`history_enabled` is true. A valid profile always wins; the summary is considered
-only as fallback and is never merged with profile history. Otherwise surface
-`warning` verbatim and recommend profile regeneration; continue using independent
-non-pattern fields such as pacing, visual rules, presentation modes, infrastructure,
-publishing config, and confirmed intents. Exact occurrence rows may remain auditable
-when `opportunity_rows_available` is true, but that status never authorizes a
-classification. Stored profile schemas v1/v2/v3 remain
-readable for those non-pattern fields only.
+classification_fields_available, available_classification_domains,
+policy_semantic_sha256, reason_codes, reasons, warning}`. `history_enabled` means at
+least one policy-bound domain is available; it is not permission to consume every
+derived field. In JSON, require membership in `available_classification_domains` for
+each use (Python consumers call `domain_available(domain)`). The domain contracts are:
 
-When pattern history is disabled, suppress every catalog-derived historical claim:
-signature and contextual-history tiers, New-to-You claims, strengths, underuse,
-by-mode history, recurring antipattern labels, and pattern-derived recurring issues
-or badges. Schema-v4 top-level recurring issues and badges remain usable only when
-their entries explicitly declare `source_lane: "non_pattern"`; legacy or ambiguous
-entries do not authorize history. Current-taxonomy scans of the new outline remain enabled. If no profile
-exists, run in **summary-only mode**: use default guardrail thresholds (1.5
+- `mastery_and_novelty`: mastery tiers, strengths, and New-to-You. `[NEW]` is exactly
+  `mastery_levels.never_tried` / `never_used_patterns`, never first detection in the
+  newest talk or a `not_yet_observed` classification.
+- `underuse`: `underused_patterns`.
+- `signature_combinations`: `signature_combinations`.
+- `antipattern_recurrence`: `[RECURRING]` only for `antipattern_classifications`
+  rows classified `high_frequency` or `moderate_frequency`; these labels describe
+  recurrence frequency, not harm severity.
+- `trends`: pattern and antipattern movements, score/breadth trend, and score drivers.
+  A recurrence claim may be available without a trend claim.
+- `modes`: `by_mode` history.
+
+A policy-bound profile with any available domain wins as the sole history source; the
+summary is considered only when profile history is disabled and is never merged with
+profile history. Surface a disabled result's `warning` verbatim and recommend profile
+regeneration; continue using independent non-pattern fields such as pacing, visual
+rules, presentation modes, infrastructure, publishing config, and confirmed intents.
+Exact occurrence rows may remain auditable when `opportunity_rows_available` is true,
+but that status never authorizes a classification. Stored profile schemas v1/v2/v3
+remain readable for non-pattern fields only. Schema v4 is occurrence-only; schema v5
+binds derived classifications to a versioned policy.
+
+Suppress each catalog-derived historical field when its required domain is absent;
+do not collapse the available domains behind the global history flag. Top-level
+recurring issues and badges in schema-v4/v5 profiles remain usable only when their
+entries explicitly declare `source_lane: "non_pattern"`; legacy or ambiguous entries
+do not authorize history. Current-taxonomy scans of the new outline remain enabled.
+If no profile exists, run in **summary-only mode**: use default guardrail thresholds (1.5
 slides/min, 45% Act 1 cap) and ask for template/publishing data interactively. Section
-15 classifications are usable only when its uniquely delimited current block passes
-`"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"` and the same strict
-pattern-profile assessment with `classification_fields_available: true`; ordinary,
-stale, or occurrence-only Section 15 data authorizes taxonomy-only recommendations,
-never speaker-history claims.
+15 v3 classifications are usable only when its uniquely delimited current block passes
+`"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"`
+and the same strict pattern-profile assessment; require the relevant domain just as
+for profile history.
+Section 15 v2 is occurrence-only. Ordinary, stale, or occurrence-only Section 15 data
+authorizes taxonomy-only recommendations, never speaker-history claims.
 
 When comparing two profiles, compare their pattern catalog fingerprints and scoring
 schemas first. A mismatch is a generation reset; do not call cross-generation pattern
 differences improvements or regressions. Raw scores are also incomparable when the
 baseline reports an unavailable or changed `opportunity_coverage_identity`.
+Within one catalog/scoring generation, a changed `policy_semantic_sha256` is a
+classification-comparison reset: do not describe changed tiers, recurrence classes,
+combinations, or trends as speaker improvement or regression across that boundary.
 
 ## Workflow Overview
 
@@ -416,7 +436,11 @@ per check.
 runtime profile data: pattern-history authorization, slide budget, Act 1 ratio
 limits, branding, profanity register, data attribution, closing completeness, and
 cut-line availability (conditional on `modular_design`). It emits historical
-`recurring_antipatterns` records only when the exact-generation history gate passes.
+`recurring_antipatterns` records only when the `antipattern_recurrence` domain is
+available, and adds a movement only when the independent `trends` domain is also
+available. Records come from derived `antipattern_classifications`, never raw
+occurrence frequency.
+
 `contextual_taxonomy_scan.enabled` remains true for the current outline. Illustration
 coverage and the contextual scan still live in `phase4-guardrails.md` as additional
 manual checks the agent should surface alongside the script's output. See
@@ -437,7 +461,7 @@ Agent-added (not in script yet):
 - Current-taxonomy contextual antipattern scan of the new outline; this runs even when
   history is disabled and uses `[CONTEXTUAL]`, never `[RECURRING]`
 - Speaker-specific recurring issues from
-  `profile.guardrail_sources.recurring_issues[]` — schema-v4 entries with
+  `profile.guardrail_sources.recurring_issues[]` — schema-v4/v5 entries with
   `source_lane: "non_pattern"` remain usable independently; legacy or ambiguous
   entries are suppressed, while catalog warnings come from authorized
   `pattern_profile` history

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -29,12 +29,9 @@ combinatorics are needed.
    `not_evaluable` rather than guessing or treating it as absent. A polished outcome is
    not evidence that a named preparation process occurred.
 3. **During creator Phase 4 (Guardrails):** Read all antipatterns and compare against
-   the outline. Flag matches as `[RECURRING]` only from `high_frequency` or
-   `moderate_frequency` derived classifications while `pattern_history_status.py`
-   authorizes `antipattern_recurrence`; raw occurrence rows never suffice. Add a
-   movement only when `trends` is separately available. Use `[CONTEXTUAL]` for the
-   current-outline scan, which remains enabled without history. Skip unobservable
-   antipatterns.
+   the outline. Render `[RECURRING]` lines only from Phase 4's emitted
+   `recurring_antipatterns` records. Use `[CONTEXTUAL]` for the current-outline scan,
+   which remains enabled without history. Skip unobservable antipatterns.
 4. **During creator Phase 6 (Publishing / Go-Live):** Surface unobservable patterns as
    a go-live preparation checklist — these are actions to take before, during, and after
    delivery that the vault cannot score retroactively.
@@ -363,9 +360,7 @@ Build patterns — applied during outline writing.
 Antipatterns as warnings — scanned against the outline.
 
 **All 28 antipatterns**, with two flag types:
-- `[RECURRING]` — from authorized `pattern_profile.antipattern_classifications`
-  `high_frequency` / `moderate_frequency` rows only; omit when
-  `antipattern_recurrence` is unavailable
+- `[RECURRING]`. Emit one line per Phase 4 `recurring_antipatterns` record.
 - `[CONTEXTUAL]` — detected in the current outline; always enabled and not a claim that
   the issue is historically new
 

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -29,8 +29,10 @@ combinatorics are needed.
    `not_evaluable` rather than guessing or treating it as absent. A polished outcome is
    not evidence that a named preparation process occurred.
 3. **During creator Phase 4 (Guardrails):** Read all antipatterns and compare against
-   the outline. Flag matches as `[RECURRING]` only from an exact-generation speaker
-   history authorized by `pattern_history_status.py`; use `[CONTEXTUAL]` for the
+   the outline. Flag matches as `[RECURRING]` only from `high_frequency` or
+   `moderate_frequency` derived classifications while `pattern_history_status.py`
+   authorizes `antipattern_recurrence`; raw occurrence rows never suffice. Add a
+   movement only when `trends` is separately available. Use `[CONTEXTUAL]` for the
    current-outline scan, which remains enabled without history. Skip unobservable
    antipatterns.
 4. **During creator Phase 6 (Publishing / Go-Live):** Surface unobservable patterns as
@@ -322,14 +324,16 @@ Planning patterns — inform spec construction.
 ### Phase 2: Architecture
 All structural patterns — the main Pattern Strategy selection moment.
 
-**With authorized exact-generation `pattern_profile` history:**
+**With the `mastery_and_novelty` domain available:**
 - **Signature tier:** Current-cohort `mastery_levels.signature` patterns
 - **Contextual-history tier:** Current-cohort regular/occasional patterns matching context
-- **New to You tier:** Current-cohort never-tried patterns filtered by relevance
+- **New to You tier:** Exactly current-cohort `mastery_levels.never_tried` /
+  `never_used_patterns`, filtered by relevance; never `not_yet_observed` or a newest-talk
+  first detection
 - **Shake It Up tier:** Exactly 1–2 current-cohort never-tried provocations
 
-When history is disabled, suppress all four history-derived tiers and use a flat
-relevant list from this current taxonomy without usage or novelty claims.
+When that domain is unavailable, suppress all four history-derived tiers and use a
+flat relevant list from this current taxonomy without usage or novelty claims.
 
 Structural patterns relevant here:
 - narrative-arc, triad, talklet, expansion-joints, lightning-talk, takahashi, cave-painting
@@ -359,8 +363,9 @@ Build patterns — applied during outline writing.
 Antipatterns as warnings — scanned against the outline.
 
 **All 28 antipatterns**, with two flag types:
-- `[RECURRING]` — from authorized exact-generation
-  `pattern_profile.antipattern_frequency` only; omit when history is disabled
+- `[RECURRING]` — from authorized `pattern_profile.antipattern_classifications`
+  `high_frequency` / `moderate_frequency` rows only; omit when
+  `antipattern_recurrence` is unavailable
 - `[CONTEXTUAL]` — detected in the current outline; always enabled and not a claim that
   the issue is historically new
 

--- a/skills/presentation-creator/references/phase0-intake.md
+++ b/skills/presentation-creator/references/phase0-intake.md
@@ -44,18 +44,25 @@ require its name in `available_classification_domains` (Python consumers use
 `domain_available(domain)`). The domains are `mastery_and_novelty`, `underuse`,
 `signature_combinations`, `antipattern_recurrence`, `trends`, and `modes`.
 `opportunity_rows_available: true` means only that exact raw occurrence rows are
-auditable; it does not authorize history tiers or labels. A policy-bound profile with
-any available domain wins as the sole history source; otherwise the summary is a
-fallback and never merges with profile history. A disabled history lane does not
-invalidate the whole profile. Keep using independent pacing, visual, infrastructure,
-publishing, presentation-mode, instrument-catalog, and confirmed-intent fields.
+auditable. It does not authorize history tiers or labels. Treat the emitted
+`history_source` as the sole source selector. Read only the named source and never merge
+catalog history inputs. Source resolution is owned by
+`pattern_history_status.py` `resolve_creator_pattern_history()`. A disabled history
+lane does not invalidate the whole profile. Keep using independent pacing, visual,
+infrastructure, publishing, presentation-mode, instrument-catalog, and confirmed-intent
+fields.
 
-Gate each historical claim independently: mastery tiers, strengths, and exact
-never-tried New-to-You claims require `mastery_and_novelty`; underuse requires
-`underuse`; combinations require `signature_combinations`; `[RECURRING]` requires
-`antipattern_recurrence`; movements and score/breadth trend require `trends`; and
-`by_mode` requires `modes`. A recurrence claim does not imply a trend claim. The
-current pattern taxonomy remains available for analyzing the new outline. Profile
+Gate each historical claim independently:
+
+- Mastery tiers, strengths, and exact never-tried New-to-You claims require
+  `mastery_and_novelty`.
+- Underuse requires `underuse`.
+- Combinations require `signature_combinations`.
+- Movements and score/breadth trend require `trends`.
+- By-mode history requires `modes`.
+- Catalog recurrence comes only from Phase 4's emitted `recurring_antipatterns`.
+
+The current pattern taxonomy remains available for analyzing the new outline. Profile
 schemas v1/v2/v3 are non-pattern compatibility inputs; schema v4 has auditable
 occurrence rows only; schema v5 binds classifications to a versioned policy.
 Schema-v4/v5 top-level `guardrail_sources.recurring_issues[]` and `badges[]` are separate:

--- a/skills/presentation-creator/references/phase0-intake.md
+++ b/skills/presentation-creator/references/phase0-intake.md
@@ -34,22 +34,31 @@ counts, or rules — read the profile.
 > Run 'update speaker profile' to sync, or proceed with the current profile?"
 
 **Pattern-history authorization:** run
-`"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/pattern_history_status.py"` against the loaded
-profile and summary before reading any catalog-derived history. Use `-` as its profile
-argument when no profile exists. Its JSON `history_enabled` value is the sole creator
-classification gate; surface a disabled result's exact `warning`.
+`"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/pattern_history_status.py"`
+against the loaded profile and summary before reading any catalog-derived history. Use
+`-` as its profile argument when no profile exists. Surface a disabled result's exact
+`warning`.
+`history_enabled: true` says that at least one policy-bound classification domain is
+available, not that all derived fields are authorized. For every classification use,
+require its name in `available_classification_domains` (Python consumers use
+`domain_available(domain)`). The domains are `mastery_and_novelty`, `underuse`,
+`signature_combinations`, `antipattern_recurrence`, `trends`, and `modes`.
 `opportunity_rows_available: true` means only that exact raw occurrence rows are
-auditable; it does not authorize history tiers or labels. A valid profile source always wins;
-the summary is a fallback and never merges with it. A disabled history lane does not
+auditable; it does not authorize history tiers or labels. A policy-bound profile with
+any available domain wins as the sole history source; otherwise the summary is a
+fallback and never merges with profile history. A disabled history lane does not
 invalidate the whole profile. Keep using independent pacing, visual, infrastructure,
 publishing, presentation-mode, instrument-catalog, and confirmed-intent fields.
 
-Until history is enabled, do not read or repeat signature/contextual-history/
-New-to-You tiers, strengths, underuse, by-mode pattern history, recurring antipattern
-labels, or pattern-derived recurring issues and badges. The current pattern taxonomy
-remains available for analyzing the new outline. A profile schema v1/v2/v3 is therefore
-a non-pattern compatibility input, not evidence of speaker pattern history.
-Schema-v4 top-level `guardrail_sources.recurring_issues[]` and `badges[]` are separate:
+Gate each historical claim independently: mastery tiers, strengths, and exact
+never-tried New-to-You claims require `mastery_and_novelty`; underuse requires
+`underuse`; combinations require `signature_combinations`; `[RECURRING]` requires
+`antipattern_recurrence`; movements and score/breadth trend require `trends`; and
+`by_mode` requires `modes`. A recurrence claim does not imply a trend claim. The
+current pattern taxonomy remains available for analyzing the new outline. Profile
+schemas v1/v2/v3 are non-pattern compatibility inputs; schema v4 has auditable
+occurrence rows only; schema v5 binds classifications to a versioned policy.
+Schema-v4/v5 top-level `guardrail_sources.recurring_issues[]` and `badges[]` are separate:
 use an entry only when it explicitly carries `source_lane: "non_pattern"`. Catalog
 warnings and reinforcement come from authorized `pattern_profile` history, never from
 an unmarked duplicate in a top-level lane.
@@ -58,11 +67,11 @@ If the profile is absent, malformed, or history-disabled, Section 15 does not re
 history by implication. Use Section 15 history only when its current block carries
 explicit provenance matching the bundled catalog/scoring generation and a complete
 structured contract accepted by
-`"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"`. That parser delegates the
-payload to the shared profile provenance assessor, and classifications still require
-`classification_fields_available: true`. A date, a recent heading, an
-unlabeled count, or ordinary prose is insufficient; use taxonomy-only fallback when
-the proof is absent.
+`"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py"`.
+That parser delegates the payload to the shared profile provenance assessor. Section
+15 v2 is occurrence-only; Section 15 v3 is policy-bound, and every consumer must still
+require its relevant available domain. A date, a recent heading, an unlabeled count,
+or ordinary prose is insufficient; use taxonomy-only fallback when the proof is absent.
 
 When an older profile is available for comparison, compare catalog fingerprint and
 pattern-scoring schema before catalog-derived values. Different identities mean a
@@ -70,6 +79,10 @@ generation reset. Report the reset, but do not describe the score, frequency, ma
 strength, or underuse differences as improvement or regression. Even within one
 generation, raw-score comparisons are unavailable across a changed or null
 `opportunity_coverage_identity`.
+
+A changed `policy_semantic_sha256` within the same generation is a classification
+comparison reset. Do not describe tier, recurrence, combination, or trend changes
+across that policy boundary as speaker improvement or regression.
 
 ### Step 0.2: Gather User Context
 

--- a/skills/presentation-creator/references/phase2-architecture.md
+++ b/skills/presentation-creator/references/phase2-architecture.md
@@ -95,9 +95,9 @@ This is an architecture-phase concern (not a content-phase one) because the asks
 
 ### Decision #11: Pattern Strategy
 
-Read [patterns/_index.md](patterns/_index.md) for the current taxonomy. Read
-the resolved `pattern_profile` only when Phase 0's `pattern_history_status.py` result
-has `history_enabled: true`, then authorize each derived lane independently through
+Read [patterns/_index.md](patterns/_index.md) for the current taxonomy. Use only the
+catalog-history source selected by Phase 0's emitted `history_source`. When its status
+has `history_enabled: true`, authorize each derived lane independently through
 `available_classification_domains` / `domain_available(domain)`. Never infer a domain
 from profile recency, schema tolerance, Section 15 prose,
 `classification_fields_available: true`, or `opportunity_rows_available: true`.
@@ -127,8 +127,6 @@ SHAKE IT UP:
   ⚡ [WILD CARD] Cave Painting — one giant canvas instead of slides
 
 WARNINGS:
-  ⚠ [RECURRING] Going Meta (high frequency; D=12, A=24, E=24, U=0) — script
-      clean handoffs without preparation or equipment apologies
   ⚠ [CONTEXTUAL] Dual-Headed Monster — co-presented talk, define handoff points
 ===================================
 ```
@@ -150,16 +148,13 @@ Current-cohort `strengths` requires `mastery_and_novelty`;
 movements, score/breadth trend, and score drivers require `trends`. Never infer one
 domain from another.
 
-**Antipattern warnings** — merge speaker's recurring antipatterns (from
-`pattern_profile.antipattern_classifications`) + contextual warnings derived from the
-spec (co-presented → Dual-Headed Monster, dense content → Bullet-Riddled Corpse,
-new format → Shortchanged, etc.). Historical matches receive `[RECURRING]` only
-when `antipattern_recurrence` is available and the derived classification is
-`high_frequency` or `moderate_frequency`. Those classes describe frequency, not harm
-severity. Add movement only when `trends` is independently available. Raw
-`antipattern_frequency` never authorizes `[RECURRING]`. Current-outline detections
-always receive `[CONTEXTUAL]` and remain available without history. Explicit
-`source_lane: "non_pattern"` guardrails remain independent of this catalog lane.
+**Antipattern warnings.** Derive contextual warnings from the spec (co-presented →
+Dual-Headed Monster, dense content → Bullet-Riddled Corpse, new format → Shortchanged,
+etc.). Catalog recurrence filtering and `[RECURRING]` labels belong to Phase 4's
+emitted `recurring_antipatterns` output. Do not recreate them during
+architecture. Current-outline detections always receive `[CONTEXTUAL]` and remain
+available without history. Explicit `source_lane: "non_pattern"` guardrails remain
+independent of this catalog lane.
 
 **Mastery-domain-disabled / summary-only mode:** Pattern taxonomy still works —
 patterns come from the reference files alone. Present a flat relevant-patterns list

--- a/skills/presentation-creator/references/phase2-architecture.md
+++ b/skills/presentation-creator/references/phase2-architecture.md
@@ -80,7 +80,12 @@ For **informative talks**, present the existing narrative-arc templates (three-a
 
 The two patterns can coexist: an informative talk can have a small sparkline-shaped closing argument, and a persuasive talk can have informative sections inside its middle. But the choice of *top-level* structure matters because it shapes time allocation across the three sections — sparkline allocates ≤10% to "what is" baseline and most of the time to the persuasive middle; narrative-arc typically allocates ~25-50% to the middle, with longer setup and resolution.
 
-When the speaker profile shows historical preference (most past talks tagged narrative-arc or sparkline), surface that history but do not let it override the persuasive-vs-informative diagnostic. A speaker accustomed to narrative-arc tutorials switching to a sales pitch should switch to sparkline for that talk; the architecture should match the talk's purpose, not the speaker's habit.
+When the `mastery_and_novelty` domain is available and classifies narrative-arc or
+sparkline as `regular`/`signature`, surface that authorized preference but do not let
+it override the persuasive-vs-informative diagnostic. Never infer the preference from
+raw tags or occurrence rows. A speaker accustomed to narrative-arc tutorials switching
+to a sales pitch should switch to sparkline for that talk; the architecture should
+match the talk's purpose, not the speaker's habit.
 
 ### Action Typology — Pre-Plan the Call to Action
 
@@ -91,13 +96,15 @@ This is an architecture-phase concern (not a content-phase one) because the asks
 ### Decision #11: Pattern Strategy
 
 Read [patterns/_index.md](patterns/_index.md) for the current taxonomy. Read
-`profile → pattern_profile` only when Phase 0's
-`pattern_history_status.py` result has `history_enabled: true`. Never infer an
-enabled state from profile recency, schema tolerance, Section 15 prose, or
-`opportunity_rows_available: true`. Current schema-v4 profiles explicitly report
-classification policy unavailable, so use the flat taxonomy path below.
+the resolved `pattern_profile` only when Phase 0's `pattern_history_status.py` result
+has `history_enabled: true`, then authorize each derived lane independently through
+`available_classification_domains` / `domain_available(domain)`. Never infer a domain
+from profile recency, schema tolerance, Section 15 prose,
+`classification_fields_available: true`, or `opportunity_rows_available: true`.
+Profile schema v4 and Section 15 v2 are occurrence-only; profile schema v5 and
+Section 15 v3 are policy-bound.
 
-With authorized history, present patterns in **4 tiers:**
+When `mastery_and_novelty` is available, present patterns in **4 tiers:**
 
 ```
 PATTERN STRATEGY for "{talk title}"
@@ -120,8 +127,9 @@ SHAKE IT UP:
   ⚡ [WILD CARD] Cave Painting — one giant canvas instead of slides
 
 WARNINGS:
-  ⚠ Shortchanged (8/24 detections) — plan cut lines for the 20-min slot
-  ⚠ Dual-Headed Monster — co-presented talk, define handoff points
+  ⚠ [RECURRING] Going Meta (high frequency; D=12, A=24, E=24, U=0) — script
+      clean handoffs without preparation or equipment apologies
+  ⚠ [CONTEXTUAL] Dual-Headed Monster — co-presented talk, define handoff points
 ===================================
 ```
 
@@ -130,29 +138,42 @@ WARNINGS:
 2. **Contextual history** — current-cohort `mastery_levels.regular` or
    `mastery_levels.occasional` entries matching the talk context.
 3. **New to You** — current-cohort `never_used_patterns` /
-   `mastery_levels.never_tried`, filtered by relevance and marked `[NEW]`.
+   `mastery_levels.never_tried`, filtered by relevance and marked `[NEW]`. This set
+   is exact: never use first detection in the newest talk or `not_yet_observed` as
+   evidence of novelty.
 4. **Shake It Up** — exactly 1–2 current-cohort never-tried options used as
    provocations, not prescriptions.
 
-Current-cohort `strengths`, `underused_patterns`, and `by_mode` may refine the
-recommendation only under that same enabled status. They never independently authorize
-history and never cross a catalog/scoring generation boundary.
+Current-cohort `strengths` requires `mastery_and_novelty`;
+`underused_patterns` requires `underuse`; `signature_combinations` requires
+`signature_combinations`; and `by_mode` requires `modes`. Pattern or antipattern
+movements, score/breadth trend, and score drivers require `trends`. Never infer one
+domain from another.
 
 **Antipattern warnings** — merge speaker's recurring antipatterns (from
-`pattern_profile.antipattern_frequency`) + contextual warnings derived from the spec
-(co-presented → Dual-Headed Monster, dense content → Bullet-Riddled Corpse,
-new format → Shortchanged, etc.). Historical matches receive `[RECURRING]` only while
-history is enabled. Current-outline detections always receive `[CONTEXTUAL]` and remain
-available without history.
+`pattern_profile.antipattern_classifications`) + contextual warnings derived from the
+spec (co-presented → Dual-Headed Monster, dense content → Bullet-Riddled Corpse,
+new format → Shortchanged, etc.). Historical matches receive `[RECURRING]` only
+when `antipattern_recurrence` is available and the derived classification is
+`high_frequency` or `moderate_frequency`. Those classes describe frequency, not harm
+severity. Add movement only when `trends` is independently available. Raw
+`antipattern_frequency` never authorizes `[RECURRING]`. Current-outline detections
+always receive `[CONTEXTUAL]` and remain available without history. Explicit
+`source_lane: "non_pattern"` guardrails remain independent of this catalog lane.
 
-**History-disabled / summary-only mode:** Pattern taxonomy still works — patterns come
-from the reference files alone. Present a flat relevant-patterns list without the four
-history tiers, usage statistics, novelty claims, strengths, underuse, or by-mode
-claims. Do not call taxonomy entries "new to you" merely because history is
-unavailable. Contextual antipattern warnings still apply. Section 15 can restore the
-history view only when its current block carries a complete explicit provenance
-contract and the shared assessor reports `classification_fields_available: true`;
-an occurrence-only block is narrative/audit context, not tier authorization.
+**Mastery-domain-disabled / summary-only mode:** Pattern taxonomy still works —
+patterns come from the reference files alone. Present a flat relevant-patterns list
+without the four history tiers, usage statistics, novelty claims, or strengths. Do not
+call taxonomy entries "new to you" merely because mastery history is unavailable.
+Other policy-bound domains may still authorize their own narrow claims; contextual
+antipattern warnings always apply. Section 15 v3 can restore only the domains listed
+by its complete explicit provenance contract. Section 15 v2 is occurrence-only
+narrative/audit context, not tier authorization.
+
+Across profiles, a catalog/scoring generation change resets occurrence and
+classification comparison. Within one generation, a changed
+`policy_semantic_sha256` resets classification comparison. Neither boundary is
+speaker improvement or regression.
 
 Enhance decisions 3-10 with pattern cross-references as shared vocabulary: when recommending
 an opening pattern, reference the taxonomy ID; when selecting a narrative structure, note

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -8,13 +8,17 @@ Phase 4 runs two complementary checkers against `outline.yaml`:
 | `scripts/guardrail-check.py outline.yaml <speaker-profile.json\|-> [rhetoric-style-summary.md]` | Profile-aware rules — pattern-history authorization, slide budget, Act 1 ratio, branding, profanity, data attribution, closing completeness, cut-line availability (conditional on `modular_design`) | schema-v1 JSON on stdout |
 
 `guardrail-check.py` imports the vault-profile provenance assessor through
-`scripts/pattern_history_status.py`. A valid profile always wins. When its history is
-disabled, the optional summary path can authorize only the unique current block parsed
-by `skills/vault-profile/scripts/section15_pattern_history.py`; sources are never
-merged. The guardrail emits current-cohort recurring antipattern records only while
-`history_enabled` and `classification_fields_available` are both true. Exact raw
-occurrence rows alone never authorize recurring severity. Otherwise its
-`pattern_history.suppressed_fields` records the unavailable history-derived fields.
+`scripts/pattern_history_status.py`. A policy-bound profile with any available domain
+wins as the sole history source. Otherwise, the optional summary path can authorize
+only the unique current block parsed by
+`skills/vault-profile/scripts/section15_pattern_history.py`; sources are never merged.
+The guardrail emits current-cohort recurring antipattern records only while the
+`antipattern_recurrence` domain is available and only from derived
+`antipattern_classifications` rows classified `high_frequency` or
+`moderate_frequency`. Those classes describe recurrence frequency, not harm severity.
+A record carries movement only when the independent `trends` domain is available.
+Exact raw occurrence rows alone never authorize recurrence.
+`pattern_history.suppressed_fields` records each unavailable history-derived field.
 Current-outline contextual taxonomy scanning and illustration coverage (checks 9B and
 10 below) remain agent-run checks alongside the script output.
 
@@ -42,9 +46,14 @@ how it's wired to schema fields, and how results are reported.
 If the speaker profile is not available, Section 16 remains usable for confirmed
 intent. Section 15 history is usable only when its current block carries an explicit
 provenance contract matching the bundled catalog/scoring generation and accepted by
-the shared assessor with `classification_fields_available: true`. Otherwise use
-Section 15 only as narrative/audit context and run the current taxonomy scan without
-historical labels.
+the shared assessor. Section 15 v3 is policy-bound, but each use still requires the
+matching entry in `available_classification_domains`; Section 15 v2 is occurrence-only.
+Otherwise use Section 15 only as narrative/audit context and run the current taxonomy
+scan without historical labels.
+
+If `policy_semantic_sha256` changes within one catalog/scoring generation, treat
+classification differences as a comparison reset, never as speaker improvement or
+regression.
 
 Run these checks after Phase 3 delivery and after each Phase 4 revision.
 
@@ -221,12 +230,12 @@ taxonomy-based antipattern scanning from the Presentation Patterns reference.
 Read `guardrail_sources.recurring_issues[]` from the speaker profile. Each entry
 describes a known weakness and its specific guardrail check.
 
-Schema-v4 top-level entries are an independent lane: use an entry only when it carries
-exact `source_lane: "non_pattern"`. Suppress a legacy or ambiguous entry instead of
-guessing its provenance. Catalog-derived recurring warnings live only in the guarded
-`pattern_profile.antipattern_frequency` lane below; do not duplicate them here. For
-each authorized non-pattern entry, run the check described in its `guardrail` field
-and report at the severity level in its `severity` field.
+Schema-v4/v5 top-level entries are an independent lane: use an entry only when it
+carries exact `source_lane: "non_pattern"`. Suppress a legacy or ambiguous entry
+instead of guessing its provenance. Catalog-derived recurring warnings live only in
+the guarded `pattern_profile.antipattern_classifications` lane below; do not duplicate
+them here. For each authorized non-pattern entry, run the check described in its
+`guardrail` field and report at the severity level in its `severity` field.
 
 Common anti-patterns (may or may not apply to a given speaker):
 - **Meme accretion**: If Act 1 has more than 60% meme/image-only slides, flag it
@@ -236,15 +245,18 @@ Common anti-patterns (may or may not apply to a given speaker):
 
 ### 9B. Presentation Patterns Taxonomy Scan
 
-Read [references/patterns/_index.md](patterns/_index.md) (Phase 4 section of the phase-grouped lookup table)
-and classification-derived profile history only when the Phase 0 pattern-history
-status is enabled.
+Read [references/patterns/_index.md](patterns/_index.md) (Phase 4 section of the
+phase-grouped lookup table) and classification-derived profile history only when the
+Phase 0 pattern-history status lists the domain required for that claim.
 
-**Speaker-specific antipatterns** — emit `[RECURRING]` only from a future
-classification-authorized payload accepted by the shared status gate. Never derive
-recurring severity or trend from raw `antipattern_frequency` occurrence rows. Current
-schema-v4 owner-policy-unconfigured profiles, plus missing, legacy, malformed,
-mismatched, or empty-current-cohort inputs, produce no `[RECURRING]` label.
+**Speaker-specific antipatterns** — emit `[RECURRING]` only when
+`antipattern_recurrence` is available and a derived
+`pattern_profile.antipattern_classifications` row is `high_frequency` or
+`moderate_frequency`. Do not treat `occasional` as recurring, and do not treat a
+frequency class as harm severity. Never derive recurrence or trend from raw
+`antipattern_frequency` occurrence rows. Append a movement only when `trends` is also
+available; recurrence remains usable without it. Missing, occurrence-only, malformed,
+mismatched, or empty-current-cohort inputs produce no `[RECURRING]` label.
 
 **Contextual antipatterns** — scan the outline against ALL antipatterns from the taxonomy.
 For each match, read the individual pattern file for detection heuristics and scoring
@@ -266,15 +278,15 @@ Contextual detection rules:
 
 Report format:
 ```
-[RECURRING] Shortchanged (8/24, decreasing) — plan cut lines for the 20-min slot
-[RECURRING] Meme accretion (5/24, stable) — Act 1 meme ratio at 55%
+[RECURRING] Going Meta (high frequency; D=12, A=24, E=24, U=0; decreasing) — remove preparation/equipment apologies
+[CONTEXTUAL] Meme accretion — Act 1 meme ratio at 55%
 [CONTEXTUAL] Bullet-Riddled Corpse — slides 14, 22 have 6+ bullet points
 [CONTEXTUAL] Dual-Headed Monster — co-presented talk, handoff points not defined
 ```
 
-When history is disabled, the report contains only contextual lines and the exact
-status warning. Do not relabel a contextual detection as recurring because Section 15
-mentions a similar phrase.
+When recurrence is unavailable, omit recurring lines and keep contextual lines. If all
+history is disabled, also include the exact status warning. Do not relabel a contextual
+detection as recurring because Section 15 mentions a similar phrase.
 
 ---
 
@@ -418,7 +430,7 @@ This template is not the script's stdout contract.
 ```
 GUARDRAIL CHECK — {talk title} — {date}
 ================================================
-[PASS/WARN] Pattern history: {enabled for exact generation / disabled with exact reasons}
+[PASS/WARN] Pattern history: {available domains / disabled with exact reasons}
 [PASS] Slide budget: {actual}/{max} for {duration}-min slot
 [PASS/WARN/FAIL] Act 1 ratio: {%} (limit: {max}%)
 [PASS/FAIL] Branding: {status}
@@ -428,7 +440,7 @@ GUARDRAIL CHECK — {talk title} — {date}
 [PASS/FAIL] Closing: summary={y/n} CTA={y/n} social={y/n}
 [PASS/FAIL] Cut lines: {present/missing}
 [INFO/SKIP] Historical anti-patterns: {authorized recurring issues or suppressed}
-[RECURRING] Presentation Patterns: {authorized historical flags; omit when disabled}
+[RECURRING] Presentation Patterns: {authorized recurrence flags; omit when recurrence domain unavailable}
 [CONTEXTUAL] Presentation Patterns: {current-outline taxonomy flags; always enabled}
 [PASS/FAIL/SKIP] Illustrations: {coverage ratio} | {format tags} | {prompt quality}
 [PASS/SKIP] Builds: {N} defined, {M} images generated

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -7,17 +7,10 @@ Phase 4 runs two complementary checkers against `outline.yaml`:
 | `scripts/check-rhetorical.py outline.yaml` | Closed pattern taxonomy — opening PUNCH, big-idea singleton, thesis preview/payoff, sparkline elements, register coverage or match, master-story threading, callback ledger, inoculation count, progressive-list contiguity, running gags, duration accounting | `rhetorical-review.md` |
 | `scripts/guardrail-check.py outline.yaml <speaker-profile.json\|-> [rhetoric-style-summary.md]` | Profile-aware rules — pattern-history authorization, slide budget, Act 1 ratio, branding, profanity, data attribution, closing completeness, cut-line availability (conditional on `modular_design`) | schema-v1 JSON on stdout |
 
-`guardrail-check.py` imports the vault-profile provenance assessor through
-`scripts/pattern_history_status.py`. A policy-bound profile with any available domain
-wins as the sole history source. Otherwise, the optional summary path can authorize
-only the unique current block parsed by
-`skills/vault-profile/scripts/section15_pattern_history.py`; sources are never merged.
-The guardrail emits current-cohort recurring antipattern records only while the
-`antipattern_recurrence` domain is available and only from derived
-`antipattern_classifications` rows classified `high_frequency` or
-`moderate_frequency`. Those classes describe recurrence frequency, not harm severity.
-A record carries movement only when the independent `trends` domain is available.
-Exact raw occurrence rows alone never authorize recurrence.
+Treat the emitted `pattern_history.history_source` as the sole selected source. Treat
+`recurring_antipatterns` as the final filtered catalog recurrence contract.
+`guardrail-check.py` `recurring_pattern_history_items()` owns recurrence selection and
+optional movement attachment. Do not reproduce either decision in prose.
 `pattern_history.suppressed_fields` records each unavailable history-derived field.
 Current-outline contextual taxonomy scanning and illustration coverage (checks 9B and
 10 below) remain agent-run checks alongside the script output.
@@ -44,12 +37,10 @@ how it's wired to schema fields, and how results are reported.
 - Confirmed intents → `speaker-profile.json` → `confirmed_intents[]`
 
 If the speaker profile is not available, Section 16 remains usable for confirmed
-intent. Section 15 history is usable only when its current block carries an explicit
-provenance contract matching the bundled catalog/scoring generation and accepted by
-the shared assessor. Section 15 v3 is policy-bound, but each use still requires the
-matching entry in `available_classification_domains`; Section 15 v2 is occurrence-only.
-Otherwise use Section 15 only as narrative/audit context and run the current taxonomy
-scan without historical labels.
+intent. Do not resolve Section 15 catalog history manually. Use the guardrail report's
+emitted `history_source`, `available_classification_domains`, and reasons. When the
+report selects no catalog-history source, use Section 15 only as narrative/audit
+context and run the current taxonomy scan without historical labels.
 
 If `policy_semantic_sha256` changes within one catalog/scoring generation, treat
 classification differences as a comparison reset, never as speaker improvement or
@@ -249,14 +240,11 @@ Read [references/patterns/_index.md](patterns/_index.md) (Phase 4 section of the
 phase-grouped lookup table) and classification-derived profile history only when the
 Phase 0 pattern-history status lists the domain required for that claim.
 
-**Speaker-specific antipatterns** — emit `[RECURRING]` only when
-`antipattern_recurrence` is available and a derived
-`pattern_profile.antipattern_classifications` row is `high_frequency` or
-`moderate_frequency`. Do not treat `occasional` as recurring, and do not treat a
-frequency class as harm severity. Never derive recurrence or trend from raw
-`antipattern_frequency` occurrence rows. Append a movement only when `trends` is also
-available; recurrence remains usable without it. Missing, occurrence-only, malformed,
-mismatched, or empty-current-cohort inputs produce no `[RECURRING]` label.
+**Speaker-specific antipatterns.** Emit one `[RECURRING]` line per
+`recurring_antipatterns` record in the guardrail report. Preserve each record's
+`pattern_id`, `recurrence_classification`, `evidence`, and optional `trend`. Do not
+re-open profile rows or re-filter the emitted records. An empty array produces no
+`[RECURRING]` line.
 
 **Contextual antipatterns** — scan the outline against ALL antipatterns from the taxonomy.
 For each match, read the individual pattern file for detection heuristics and scoring
@@ -278,14 +266,14 @@ Contextual detection rules:
 
 Report format:
 ```
-[RECURRING] Going Meta (high frequency; D=12, A=24, E=24, U=0; decreasing) — remove preparation/equipment apologies
+[RECURRING] {pattern_id} ({recurrence_classification} | {evidence} | {optional trend})
 [CONTEXTUAL] Meme accretion — Act 1 meme ratio at 55%
 [CONTEXTUAL] Bullet-Riddled Corpse — slides 14, 22 have 6+ bullet points
 [CONTEXTUAL] Dual-Headed Monster — co-presented talk, handoff points not defined
 ```
 
-When recurrence is unavailable, omit recurring lines and keep contextual lines. If all
-history is disabled, also include the exact status warning. Do not relabel a contextual
+When `recurring_antipatterns` is empty, omit recurring lines and keep contextual lines.
+If all history is disabled, also include the exact status warning. Do not relabel a contextual
 detection as recurring because Section 15 mentions a similar phrase.
 
 ---
@@ -440,7 +428,7 @@ GUARDRAIL CHECK — {talk title} — {date}
 [PASS/FAIL] Closing: summary={y/n} CTA={y/n} social={y/n}
 [PASS/FAIL] Cut lines: {present/missing}
 [INFO/SKIP] Historical anti-patterns: {authorized recurring issues or suppressed}
-[RECURRING] Presentation Patterns: {authorized recurrence flags; omit when recurrence domain unavailable}
+[RECURRING] Presentation Patterns: {recurring_antipatterns records | omit when empty}
 [CONTEXTUAL] Presentation Patterns: {current-outline taxonomy flags; always enabled}
 [PASS/FAIL/SKIP] Illustrations: {coverage ratio} | {format tags} | {prompt quality}
 [PASS/SKIP] Builds: {N} defined, {M} images generated

--- a/skills/presentation-creator/scripts/guardrail-check.py
+++ b/skills/presentation-creator/scripts/guardrail-check.py
@@ -406,10 +406,12 @@ def check_pattern_history(
 ) -> tuple[str, str]:
     """Report the independent authorization state for catalog history."""
     if status.history_enabled:
+        domains = ", ".join(status.available_classification_domains)
         return (
             "PASS",
-            "enabled for the exact current catalog/scoring generation "
-            f"({status.scored_talk_count} talks; source={status.history_source})",
+            "policy-bound domains enabled for the exact current catalog/scoring "
+            f"generation ({status.scored_talk_count} talks; "
+            f"source={status.history_source}; domains={domains})",
         )
     return "WARN", disabled_history_warning(status)
 
@@ -418,40 +420,77 @@ def recurring_pattern_history_items(
     pattern_profile: Mapping[str, object] | None,
     status: CreatorPatternHistoryStatus,
 ) -> list[dict[str, object]]:
-    """Return recurring records only from authorized current-generation history."""
-    if not status.history_enabled:
+    """Return high/moderate recurrence rows from the authorized derived lane."""
+    if not status.domain_available("antipattern_recurrence"):
         return []
 
     assert isinstance(pattern_profile, Mapping)  # shared assessment postcondition
-    raw_frequency = pattern_profile.get("antipattern_frequency")
-    assert isinstance(raw_frequency, list)  # shared assessment postcondition
+    classifications = pattern_profile.get("antipattern_classifications")
+    assert isinstance(classifications, list)  # shared assessment postcondition
+
+    trends: dict[str, str] = {}
+    if status.domain_available("trends"):
+        trend_analysis = pattern_profile.get("trend_analysis")
+        if isinstance(trend_analysis, Mapping):
+            movements = trend_analysis.get("antipattern_movements")
+            if isinstance(movements, list):
+                for movement in movements:
+                    if not isinstance(movement, Mapping):
+                        continue
+                    pattern_id = movement.get("pattern_id")
+                    direction = movement.get("movement")
+                    if isinstance(pattern_id, str) and direction in {
+                        "increasing",
+                        "decreasing",
+                        "stable",
+                        "indeterminate",
+                    }:
+                        trends[pattern_id] = str(direction)
 
     items: list[dict[str, object]] = []
-    for item in raw_frequency:
-        if not isinstance(item, Mapping) or item.get("severity") != "recurring":
+    for item in classifications:
+        if not isinstance(item, Mapping) or item.get("classification") not in {
+            "high_frequency",
+            "moderate_frequency",
+        }:
             continue
         pattern_id = item.get("pattern_id")
         if not isinstance(pattern_id, str) or not pattern_id:
             continue
-        count = item.get("times_detected")
-        out_of = item.get("out_of")
-        if (
-            not isinstance(count, int)
-            or isinstance(count, bool)
-            or not isinstance(out_of, int)
-            or isinstance(out_of, bool)
-        ):
+        evidence = item.get("evidence")
+        if not isinstance(evidence, Mapping):
             continue
-        trend = item.get("trend")
         record: dict[str, object] = {
             "pattern_id": pattern_id,
-            "times_detected": count,
-            "out_of": out_of,
+            "recurrence_classification": item["classification"],
+            "evidence": dict(evidence),
         }
-        if isinstance(trend, str) and trend:
-            record["trend"] = trend
+        if pattern_id in trends:
+            record["trend"] = trends[pattern_id]
         items.append(record)
     return items
+
+
+def suppressed_pattern_history_fields(
+    status: CreatorPatternHistoryStatus,
+) -> list[str]:
+    """List each unavailable derived field family without collapsing domains."""
+    suppressed = ["legacy_pattern_guardrails", "legacy_pattern_badges"]
+    if not status.domain_available("mastery_and_novelty"):
+        suppressed.extend(
+            ["mastery_levels", "never_used_patterns", "strengths", "new_to_you"]
+        )
+    if not status.domain_available("underuse"):
+        suppressed.append("underused_patterns")
+    if not status.domain_available("signature_combinations"):
+        suppressed.append("signature_combinations")
+    if not status.domain_available("antipattern_recurrence"):
+        suppressed.append("recurring_antipatterns")
+    if not status.domain_available("trends"):
+        suppressed.extend(["score_trend", "pattern_breadth.trend", "score_drivers"])
+    if not status.domain_available("modes"):
+        suppressed.append("by_mode")
+    return suppressed
 
 
 # ── Main ─────────────────────────────────────────────────────────────
@@ -517,17 +556,7 @@ def main(argv: list[str]) -> int:
         ("Cut lines", check_cut_lines(outline, profile)),
     ]
 
-    suppressed_fields = []
-    if not history_status.history_enabled:
-        suppressed_fields = [
-            "tiers",
-            "labels",
-            "strengths",
-            "underuse",
-            "by_mode",
-            "legacy_pattern_guardrails",
-            "legacy_pattern_badges",
-        ]
+    suppressed_fields = suppressed_pattern_history_fields(history_status)
     report = {
         "schema_version": 1,
         "talk_title": outline.talk.title,

--- a/skills/presentation-creator/scripts/pattern_history_status.py
+++ b/skills/presentation-creator/scripts/pattern_history_status.py
@@ -32,18 +32,23 @@ _PROFILE_SCRIPTS = Path(__file__).resolve().parents[2] / "vault-profile" / "scri
 if str(_PROFILE_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_PROFILE_SCRIPTS))
 
-from profile_pattern_provenance import (  # noqa: E402
+# Pyright cannot resolve these sibling skill modules added to sys.path at runtime.
+from profile_pattern_provenance import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     REASON_CLASSIFICATION_POLICY_UNAVAILABLE,
     REASON_EMPTY_CURRENT_COHORT,
     assess_pattern_profile,
 )
-from section15_pattern_history import (  # noqa: E402
+from section15_pattern_history import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     Section15PatternHistoryAssessment,
     assess_section15_pattern_history,
 )
 
 
-CURRENT_PROFILE_SCHEMA_VERSION = 4
+CURRENT_PROFILE_SCHEMA_VERSION = 5
+OCCURRENCE_ONLY_PROFILE_SCHEMA_VERSION = 4
+SUPPORTED_PROFILE_SCHEMA_VERSIONS = frozenset(
+    {OCCURRENCE_ONLY_PROFILE_SCHEMA_VERSION, CURRENT_PROFILE_SCHEMA_VERSION}
+)
 REASON_INVALID_PROFILE = "invalid_speaker_profile_contract"
 REASON_PROFILE_SCHEMA_MISMATCH = "profile_schema_version_mismatch"
 
@@ -61,10 +66,16 @@ class CreatorPatternHistoryStatus:
     eligible_talk_count: int | None = None
     opportunity_rows_available: bool = False
     classification_fields_available: bool = False
+    available_classification_domains: tuple[str, ...] = ()
+    policy_semantic_sha256: str | None = None
 
     def as_dict(self) -> dict[str, object]:
         """Return a stable JSON-serializable status payload."""
         return asdict(self)
+
+    def domain_available(self, domain: str) -> bool:
+        """Return whether this resolution authorizes one derived history domain."""
+        return self.history_enabled and domain in self.available_classification_domains
 
 
 @dataclass(frozen=True)
@@ -78,7 +89,7 @@ class CreatorPatternHistoryResolution:
 def _assess_profile_pattern_history(
     profile: object,
 ) -> CreatorPatternHistoryStatus:
-    """Authorize classifications only for a current schema-v4 profile and policy.
+    """Assess schema-v4 occurrence history or schema-v5 policy-bound history.
 
     The shared vault-profile assessor owns every pattern-specific invariant.  This
     wrapper adds only the outer profile-version gate required by the creator.
@@ -97,7 +108,7 @@ def _assess_profile_pattern_history(
     if (
         not isinstance(schema_version, int)
         or isinstance(schema_version, bool)
-        or schema_version != CURRENT_PROFILE_SCHEMA_VERSION
+        or schema_version not in SUPPORTED_PROFILE_SCHEMA_VERSIONS
     ):
         return CreatorPatternHistoryStatus(
             history_enabled=False,
@@ -108,11 +119,13 @@ def _assess_profile_pattern_history(
             reasons=(
                 "speaker profile schema_version "
                 f"{schema_version!r} does not authorize pattern history; "
-                f"expected {CURRENT_PROFILE_SCHEMA_VERSION}",
+                "expected supported occurrence-only v4 or policy-bound v5",
             ),
         )
 
-    assessment = assess_pattern_profile(profile.get("pattern_profile"))
+    assessment = assess_pattern_profile(
+        profile.get("pattern_profile"), expected_contract_version=schema_version
+    )
     reasons = list(assessment.errors)
     if REASON_EMPTY_CURRENT_COHORT in assessment.reason_codes:
         reasons.append(
@@ -120,34 +133,32 @@ def _assess_profile_pattern_history(
         )
     if REASON_CLASSIFICATION_POLICY_UNAVAILABLE in assessment.reason_codes:
         reasons.append(
-            "pattern occurrence rows are current, but owner thresholds for "
-            "never-used, mastery, recurring severity, and trends are not configured"
+            "schema-v4 pattern occurrence rows are current but occurrence-only; "
+            "regenerate schema v5 to apply the toolkit's versioned default policy"
         )
 
+    occurrence_rows_available = (
+        assessment.current_contract and assessment.catalog_fields_available
+    )
+    available_domains = (
+        tuple(sorted(assessment.available_classification_domains))
+        if occurrence_rows_available
+        else ()
+    )
+    classification_fields_available = bool(available_domains)
+
     return CreatorPatternHistoryStatus(
-        history_enabled=(
-            assessment.current_contract
-            and assessment.catalog_fields_available
-            and assessment.classification_fields_available
-        ),
-        history_source=(
-            "profile"
-            if assessment.current_contract
-            and assessment.catalog_fields_available
-            and assessment.classification_fields_available
-            else None
-        ),
+        history_enabled=classification_fields_available,
+        history_source=("profile" if classification_fields_available else None),
         profile_schema_version=schema_version,
         scored_talk_count=assessment.scored_talk_count,
         reason_codes=assessment.reason_codes,
         reasons=tuple(reasons),
         eligible_talk_count=assessment.eligible_talk_count,
-        opportunity_rows_available=(
-            assessment.current_contract and assessment.catalog_fields_available
-        ),
-        classification_fields_available=(
-            assessment.current_contract and assessment.classification_fields_available
-        ),
+        opportunity_rows_available=occurrence_rows_available,
+        classification_fields_available=classification_fields_available,
+        available_classification_domains=available_domains,
+        policy_semantic_sha256=assessment.policy_semantic_sha256,
     )
 
 
@@ -159,11 +170,16 @@ def _fallback_status(
     profile_status: CreatorPatternHistoryStatus,
     summary_assessment: Section15PatternHistoryAssessment,
 ) -> CreatorPatternHistoryStatus:
-    if (
+    summary_rows_available = (
         summary_assessment.current_contract
         and summary_assessment.catalog_fields_available
-        and summary_assessment.classification_fields_available
-    ):
+    )
+    available_domains = (
+        tuple(sorted(summary_assessment.available_classification_domains))
+        if summary_rows_available
+        else ()
+    )
+    if available_domains:
         return CreatorPatternHistoryStatus(
             history_enabled=True,
             history_source="section15_current_block",
@@ -174,6 +190,8 @@ def _fallback_status(
             eligible_talk_count=summary_assessment.eligible_talk_count,
             opportunity_rows_available=True,
             classification_fields_available=True,
+            available_classification_domains=available_domains,
+            policy_semantic_sha256=summary_assessment.policy_semantic_sha256,
         )
 
     reasons = list(summary_assessment.errors)
@@ -184,8 +202,8 @@ def _fallback_status(
         )
     if REASON_CLASSIFICATION_POLICY_UNAVAILABLE in (summary_assessment.reason_codes):
         reasons.append(
-            "Section 15 occurrence rows are current, but owner classification "
-            "thresholds are not configured"
+            "Section 15 v2 occurrence rows are current but occurrence-only; "
+            "regenerate Section 15 v3 to apply the toolkit's versioned default policy"
         )
     return CreatorPatternHistoryStatus(
         history_enabled=False,
@@ -197,11 +215,10 @@ def _fallback_status(
         ),
         reasons=_dedupe(profile_status.reasons + tuple(reasons)),
         eligible_talk_count=summary_assessment.eligible_talk_count,
-        opportunity_rows_available=(
-            summary_assessment.current_contract
-            and summary_assessment.catalog_fields_available
-        ),
+        opportunity_rows_available=summary_rows_available,
         classification_fields_available=False,
+        available_classification_domains=(),
+        policy_semantic_sha256=summary_assessment.policy_semantic_sha256,
     )
 
 
@@ -211,8 +228,9 @@ def resolve_creator_pattern_history(
 ) -> CreatorPatternHistoryResolution:
     """Resolve one authorized history payload without merging source lanes.
 
-    A valid current profile always wins. Section 15 is consulted only when the
-    profile lane is disabled and only its explicit current block is eligible.
+    A policy-bound profile with any available domain wins. Section 15 is consulted
+    only when the profile lane is disabled and only its explicit current block is
+    eligible.
     """
     profile_status = _assess_profile_pattern_history(profile)
     if profile_status.history_enabled:
@@ -260,8 +278,9 @@ def disabled_history_warning(status: CreatorPatternHistoryStatus) -> str:
             "Pattern classifications disabled "
             f"({', '.join(status.reason_codes)}): {details}. Current occurrence "
             "rows remain auditable, but do not emit signature, New-to-You, "
-            "underuse, recurring-severity, mastery, or trend claims until the "
-            "speaker owns a versioned classification policy."
+            "underuse, recurrence, mastery, or trend claims. Regenerate the profile "
+            "with the current vault-profile skill; the bundled default policy applies "
+            "automatically and requires no threshold setup."
         )
     else:
         warning = (

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -178,12 +178,14 @@ today, `set_by: "vault-clarification"`, `current_value: ""`, `last_checked: null
 `supersedes_goal_id: null`, and `schema_version: 2`.
 
 For speaker-chosen `antipattern` and `underuse` goals, the baseline is
-catalog-derived. Read the exact occurrence metric only from a validated schema-v4
-profile whose pattern provenance matches the active catalog and scoring-v5 contract,
-copy `pattern_profile.pattern_baseline` unchanged into
+catalog-derived. Read the exact occurrence metric only from a validated schema-v4 or
+schema-v5 profile whose pattern provenance matches the active catalog and scoring-v5
+contract, copy `pattern_profile.pattern_baseline` unchanged into
 `baseline_provenance.pattern_baseline`, and set the lane to `pattern_scoring`. Raw
 occurrence rows do not themselves classify a pattern as recurring, underused, or a
-signature; the speaker must explicitly choose the target without those labels. Never
+signature. A schema-v5 derived label may inform the choices only when its exact
+classification domain is `available`; schema v4 supplies no derived labels. The
+speaker must explicitly choose the target. Never
 parse the numeric baseline or generation identity from Section 15 prose. If no
 matching non-empty raw-score-comparable current pattern cohort exists, explain that
 the pattern goal has no verifiable baseline yet and do not create it. `pacing` uses the separate `pacing`

--- a/skills/vault-clarification/references/schemas-config.md
+++ b/skills/vault-clarification/references/schemas-config.md
@@ -87,8 +87,10 @@ recognize, vault-ingress treats it as read-only and skips verification.
 
 Schema v2 binds every catalog-derived goal to the exact pattern-scoring generation
 accepted by the speaker. The full baseline snapshot is copied from a validated
-schema-v4 `speaker-profile.json`; Section 15 is narrative context, never the machine
-source. The helper at `scripts/goal_generation_provenance.py` makes the mechanical
+schema-v4 or schema-v5 `speaker-profile.json`; Section 15 is narrative context, never
+the machine source. Schema-v5 derived labels may inform the offered goals only when
+their exact classification domain is available; schema v4 remains occurrence-only.
+The helper at `scripts/goal_generation_provenance.py` makes the mechanical
 comparability decision for both the owner and reader.
 
 ```json

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -35,7 +35,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | 2 | Normalize the queue and claim one exact versioned batch |
 | 3 | Run up to five per-talk workers in parallel |
 | 4 | Validate, persist, render, and aggregate feedback transactionally |
-| 5 | Apply speaker-approved narrative updates and rebuild Section 15 |
+| 5 | Apply speaker-approved narrative updates and write policy-bound Section 15 v3 |
 | 6 | Finish pending PPTX visual evidence |
 | 7 | Regenerate an existing speaker profile |
 | 8 | Verify active improvement goals against current provenance |
@@ -159,7 +159,9 @@ Present `summary_updates` and `new_patterns` as a section-by-section diff and
 apply only speaker-approved changes (unless this batch was pre-authorized).
 Follow the [Rhetoric Summary contract](references/processing-rules.md): rebuild
 Section 15 only after the complete batch persists, never from a date cohort or
-partial merge, and recount the database rather than incrementing totals.
+partial merge, and recount the database rather than incrementing totals. Its reader
+accepts legacy occurrence-only v2 blocks, but every replacement writes v3 with the
+schema-v5 profile's self-contained policy stamp and deterministic classifications.
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py" replace \
@@ -167,8 +169,11 @@ partial merge, and recount the database rather than incrementing totals.
   {vault_root}/tracking-database.json
 ```
 
-A stale candidate or nonzero exit makes no write. Report the batch outcome, then
-continue the loop or proceed to Step 6.
+A stale candidate, invalid optional policy override, or nonzero exit makes no write;
+absence of an override automatically selects bundled `speaker-toolkit-default@1`.
+This step re-analyzes persisted outcomes without reparsing talks or changing raw
+tracking/opportunity rows. Report the batch outcome, then continue the loop or proceed
+to Step 6.
 
 ## Step 6 — Extract Remaining PPTX Visual Data
 
@@ -190,8 +195,9 @@ If `{vault_root}/speaker-profile.json` exists, invoke `Skill(skill: "vault-profi
 with the updated tracking database plus the resolved `{vault_root}` and exact
 database-configured `{python_path}` as handoff context. The profile skill re-reads
 the database and rejects a missing or mismatched interpreter; never let the handoff
-fall back to `python3` on `PATH`. Report the diff of changes (added fields, changed
-values) so the speaker can verify.
+fall back to `python3` on `PATH`. It writes schema v5 by classifying the existing raw
+outcomes; this does not reparse talks. Report the diff of changes (added fields,
+changed values) so the speaker can verify.
 
 If the profile doesn't exist, skip this step silently.
 
@@ -249,6 +255,9 @@ artifact; stale or unreadable local declarations are not capabilities;
 - Raw-score, breadth, and adherence comparisons are permitted only across an
   exact matching `opportunity_coverage_identity`. A mismatched or mixed cohort
   uses the explicit unavailable/empty sentinel; never normalize denominators.
+- Classification availability is per domain. Use each domain and row's explicit
+  status/reasons; never let an unavailable trend or mode erase available mastery,
+  recurrence, underuse, or combination classifications.
 
 For input-quality edge cases that require non-default handling — wide-angle
 room recordings, Whisper hallucination on bad audio, non-speaker talks

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -329,12 +329,19 @@ individual member merge.
 Section 15 is a human-readable account of the verified current cohort, not the
 numeric authority for a worker. `persist-results.py` stdout supplies the
 post-batch `current_adherence_baseline` only after every merge succeeds. That
-schema-v2 payload is all-inclusive (`active_batch_excluded: false`,
+adherence-baseline schema-v2 payload is all-inclusive (`active_batch_excluded: false`,
 `excluded_filenames: []`). `eligible_talk_count` is the complete fresh-v5
 candidate. `scored_talk_count`, sum, and ROUND_HALF_EVEN average describe only
 one exact `opportunity_coverage_identity`; mixed identities make raw-score
 comparison unavailable with zero/null score aggregates while retaining the
 per-pattern opportunity cohort.
+
+The independently versioned Section 15 current block has read-v2/write-v3
+compatibility. A reader may validate an occurrence-only v2 block, but it must keep every
+classification-derived claim unavailable: v2 has no policy identity and the existence
+of a new default cannot retroactively classify it. Every replacement writes v3 and
+embeds the complete validated schema-v5 `pattern_profile`, including the normalized
+classification policy and its canonical semantic digest.
 
 For every Section 15 current-block count, read only talks with status
 `processed`/`processed_partial`, `pattern_scoring_generation_status: current`,
@@ -346,19 +353,24 @@ machine-readable block has three audit lanes:
 
 1. **Occurrence rows** — copy the exhaustive `pattern_usage` and
    `antipattern_frequency` rows generated from v5 outcomes. Each row retains its
-   own opportunity denominator, detection count, undetected count, coverage, and
-   null-rate sentinel. These are observations, not frequency classifications.
+   own opportunity denominator; detected, evaluable, unevaluable, and not-applicable
+   counts; coverage; and null-rate sentinel. The v3 writer copies these raw rows
+   unchanged.
 2. **Raw-score availability** — copy the global comparison status, exact
    opportunity identity, scored count, sum, and `average_pattern_score` from the
    post-batch baseline. Mixed identities or no evaluable opportunities keep this
    lane explicitly unavailable; do not calculate a trajectory or substitute the
    broader eligible count.
-3. **Classification availability** — copy the exact
-   `owner-policy-unconfigured` sentinel. Until the speaker owns a versioned
-   classification policy, score/breadth trends and driver direction are
-   `unavailable`; recurring/resolved severity, novelty, mastery, signatures,
-   strengths, underuse, combinations, and mode splits remain empty. A zero count
-   does not mean “never used,” and a positive rate does not mean “recurring.”
+3. **Policy-derived history** — copy the classifier's self-contained policy stamp,
+   per-domain availability, exhaustive positive and antipattern classification rows,
+   trend audit, and derived projections. With no vault override, use bundled
+   `speaker-toolkit-default@1` automatically; do not ask the speaker to choose
+   thresholds. If `{vault_root}/pattern-classification-policy.json` exists, validate it
+   strictly and abort on any error rather than falling back. Mastery/novelty,
+   antipattern recurrence, underuse, combinations, trends, and modes are independently
+   gated. Honor row-level bounds and absence capability: zero detections become
+   `never_tried` or `confirmed_none` only when the catalog and complete-evaluation gates
+   permit an absence conclusion.
 
 Old recurring/signature/underuse/resolved prose may remain outside the delimited
 block only when explicitly labeled historical or manually curated. It is
@@ -366,7 +378,7 @@ non-baseline narrative and must not be regenerated from occurrence rates or
 consumed as current catalog classification.
 
 Section 15 is the human-readable mirror of the profile's validated
-`pattern_profile` occurrence/audit lanes (see
+`pattern_profile` occurrence, policy, classification, and audit lanes (see
 [../../vault-profile/references/speaker-profile-schema.md](../../vault-profile/references/speaker-profile-schema.md));
 keep the two consistent when both update. Profile generation must independently
 apply the same exact current-generation filter; Section 15 prose and legacy
@@ -374,13 +386,14 @@ adherence text are not machine-readable numeric inputs.
 
 After the complete post-batch narrative and `pattern_profile` candidate are
 ready, run `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py" replace`
-with the summary, candidate, and live `tracking-database.json`. The helper
-recomputes the full current cohort from the database, rejects stale candidates,
-checks scoring-v5 artifact freshness against the vault and configured source
-roots, delegates the full payload to the shared profile provenance assessor, and
-atomically replaces only the uniquely delimited current block. All prose outside
-that block remains explicitly historical/non-baseline; ordinary Section 15 prose
-can never restore pattern-history authorization.
+with the summary, candidate, and live `tracking-database.json`. The helper reads v2 or
+v3, writes only v3, recomputes the full current cohort from the database, rejects stale
+or policy-mismatched candidates, checks scoring-v5 artifact freshness against the vault
+and configured source roots, and atomically replaces only the uniquely delimited
+current block. Classification is a re-analysis of persisted outcomes: no talk is
+reparsed, and neither tracking records nor raw opportunity rows are mutated. All prose
+outside that block remains explicitly historical/non-baseline; ordinary Section 15
+prose can never restore pattern-history authorization.
 `section15_pattern_history.py replace` is the only supported current-block
 replacement operation and must receive the live tracking database.
 Recount status from the tracking database every time; never increment it
@@ -429,10 +442,12 @@ Section 15 prose as its baseline.
 For each comparable goal with `status` not in (`achieved`, `retired`):
 - Compute `current_value` for the goal's `metric` from the current Section 15
   cohort data — and, for `pacing` and mode-specific goals, from the freshly regenerated
-  speaker profile (this step runs after Step 7, so `pacing.adherence` and
-  `pattern_profile.by_mode` are current). Examples by `kind`: `antipattern` → the
-  antipattern's frequency over recent talks; `underuse` → the pattern's recent usage
-  or distinct-pattern breadth; `pacing` → `pacing.adherence.over_budget_rate`.
+  speaker profile. Freshness alone is not availability: require the matching
+  `classification_availability` domain before using antipattern recurrence, underuse,
+  trends, or `by_mode`; an unavailable domain yields an unverifiable/report-only result,
+  not a zero. Examples by `kind`: `antipattern` → the antipattern's policy-classified
+  frequency; `underuse` → the pattern's classification or available breadth trend;
+  `pacing` → `pacing.adherence.over_budget_rate`.
   For schema v1, write only `current_value`, `last_checked` (today),
   `checked_by: "vault-ingress"`, and `status`. For schema v2, write those
   fields plus `verification_state: "current"` and empty

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -328,49 +328,27 @@ individual member merge.
 
 Section 15 is a human-readable account of the verified current cohort, not the
 numeric authority for a worker. `persist-results.py` stdout supplies the
-post-batch `current_adherence_baseline` only after every merge succeeds. That
-adherence-baseline schema-v2 payload is all-inclusive (`active_batch_excluded: false`,
-`excluded_filenames: []`). `eligible_talk_count` is the complete fresh-v5
-candidate. `scored_talk_count`, sum, and ROUND_HALF_EVEN average describe only
-one exact `opportunity_coverage_identity`; mixed identities make raw-score
-comparison unavailable with zero/null score aggregates while retaining the
-per-pattern opportunity cohort.
+post-batch `current_adherence_baseline` only after every merge succeeds. Treat that
+emitted object as the complete baseline contract. Do not reproduce its cohort
+selection, arithmetic, or unavailable-state rules in Section 15 prose.
 
-The independently versioned Section 15 current block has read-v2/write-v3
-compatibility. A reader may validate an occurrence-only v2 block, but it must keep every
-classification-derived claim unavailable: v2 has no policy identity and the existence
-of a new default cannot retroactively classify it. Every replacement writes v3 and
-embeds the complete validated schema-v5 `pattern_profile`, including the normalized
-classification policy and its canonical semantic digest.
+The Section 15 current block is owned by
+`skills/vault-profile/scripts/section15_pattern_history.py`. Do not reproduce its
+cohort filter, policy resolution, classification, availability, or compatibility
+rules in this reference. To inspect a summary, run:
 
-For every Section 15 current-block count, read only talks with status
-`processed`/`processed_partial`, `pattern_scoring_generation_status: current`,
-empty generation reasons, the exact current catalog fingerprint, and the exact
-current pattern-scoring schema version. Never approximate this cohort by
-`processed_date`. Exclude skipped, legacy-unbaselineable, stale-fingerprint,
-stale-schema, and archival `legacy-unverified` adherence prose. The current
-machine-readable block has three audit lanes:
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py" assess \
+  "{vault_root}/rhetoric-style-summary.md"
+```
 
-1. **Occurrence rows** — copy the exhaustive `pattern_usage` and
-   `antipattern_frequency` rows generated from v5 outcomes. Each row retains its
-   own opportunity denominator; detected, evaluable, unevaluable, and not-applicable
-   counts; coverage; and null-rate sentinel. The v3 writer copies these raw rows
-   unchanged.
-2. **Raw-score availability** — copy the global comparison status, exact
-   opportunity identity, scored count, sum, and `average_pattern_score` from the
-   post-batch baseline. Mixed identities or no evaluable opportunities keep this
-   lane explicitly unavailable; do not calculate a trajectory or substitute the
-   broader eligible count.
-3. **Policy-derived history** — copy the classifier's self-contained policy stamp,
-   per-domain availability, exhaustive positive and antipattern classification rows,
-   trend audit, and derived projections. With no vault override, use bundled
-   `speaker-toolkit-default@1` automatically; do not ask the speaker to choose
-   thresholds. If `{vault_root}/pattern-classification-policy.json` exists, validate it
-   strictly and abort on any error rather than falling back. Mastery/novelty,
-   antipattern recurrence, underuse, combinations, trends, and modes are independently
-   gated. Honor row-level bounds and absence capability: zero detections become
-   `never_tried` or `confirmed_none` only when the catalog and complete-evaluation gates
-   permit an absence conclusion.
+`assess` emits `{current_contract, catalog_fields_available,
+classification_fields_available, available_classification_domains,
+block_schema_version, policy_semantic_sha256, scored_talk_count,
+eligible_talk_count, reason_codes, errors}`. Exit `0` authorizes only the fields and
+domains named by that output. Exit `1` means the block cannot authorize current
+catalog history. Use it only as narrative context. Never derive a classification or
+availability decision from Section 15 prose or raw occurrence counts.
 
 Old recurring/signature/underuse/resolved prose may remain outside the delimited
 block only when explicitly labeled historical or manually curated. It is
@@ -379,25 +357,28 @@ consumed as current catalog classification.
 
 Section 15 is the human-readable mirror of the profile's validated
 `pattern_profile` occurrence, policy, classification, and audit lanes (see
-[../../vault-profile/references/speaker-profile-schema.md](../../vault-profile/references/speaker-profile-schema.md));
-keep the two consistent when both update. Profile generation must independently
-apply the same exact current-generation filter; Section 15 prose and legacy
-adherence text are not machine-readable numeric inputs.
+[../../vault-profile/references/speaker-profile-schema.md](../../vault-profile/references/speaker-profile-schema.md)).
+Keep the two consistent by passing the complete profile-pipeline candidate to the
+owner script. Section 15 prose and legacy adherence text are not machine-readable
+numeric inputs.
 
 After the complete post-batch narrative and `pattern_profile` candidate are
 ready, run `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py" replace`
-with the summary, candidate, and live `tracking-database.json`. The helper reads v2 or
-v3, writes only v3, recomputes the full current cohort from the database, rejects stale
-or policy-mismatched candidates, checks scoring-v5 artifact freshness against the vault
-and configured source roots, and atomically replaces only the uniquely delimited
-current block. Classification is a re-analysis of persisted outcomes: no talk is
-reparsed, and neither tracking records nor raw opportunity rows are mutated. All prose
-outside that block remains explicitly historical/non-baseline; ordinary Section 15
-prose can never restore pattern-history authorization.
-`section15_pattern_history.py replace` is the only supported current-block
-replacement operation and must receive the live tracking database.
-Recount status from the tracking database every time; never increment it
-manually.
+with the summary, candidate, and live `tracking-database.json`:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/section15_pattern_history.py" replace \
+  "{vault_root}/rhetoric-style-summary.md" pattern-profile-candidate.json \
+  "{vault_root}/tracking-database.json"
+```
+
+`replace` is the only supported current-block writer. On exit `0`, it emits
+`{path, changed, scored_talk_count, eligible_talk_count,
+catalog_fields_available}` and writes the validated block atomically when `changed` is
+true. On exit `1`, it emits a diagnostic to stderr and makes no write. Pass the complete
+candidate copied from the profile pipeline. Do not hand-filter, classify, or repair it.
+The command re-analyzes persisted data without reparsing talks or mutating tracking or
+raw opportunity rows. All prose outside the block remains historical/non-baseline.
 
 ### Section 16 — Speaker-Confirmed Intent
 
@@ -442,12 +423,11 @@ Section 15 prose as its baseline.
 For each comparable goal with `status` not in (`achieved`, `retired`):
 - Compute `current_value` for the goal's `metric` from the current Section 15
   cohort data — and, for `pacing` and mode-specific goals, from the freshly regenerated
-  speaker profile. Freshness alone is not availability: require the matching
-  `classification_availability` domain before using antipattern recurrence, underuse,
-  trends, or `by_mode`; an unavailable domain yields an unverifiable/report-only result,
-  not a zero. Examples by `kind`: `antipattern` → the antipattern's policy-classified
-  frequency; `underuse` → the pattern's classification or available breadth trend;
-  `pacing` → `pacing.adherence.over_budget_rate`.
+  speaker profile. For a policy-derived metric, consume only the projection and
+  availability state emitted by the validated classifier payload. Never reconstruct
+  either from raw rows. If that payload does not authorize the requested metric, the
+  result is unverifiable/report-only, not zero. Pacing reads
+  `pacing.adherence.over_budget_rate` from its independent lane.
   For schema v1, write only `current_value`, `last_checked` (today),
   `checked_by: "vault-ingress"`, and `status`. For schema v2, write those
   fields plus `verification_state: "current"` and empty

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -194,11 +194,9 @@ Proceed immediately to Step 5.
 
 Pipe the constructed profile dict through
 `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/validate-profile.py" --vault-root "$VAULT_ROOT"`.
-Schema-v5 owner validation rereads the live tracking database with the same shared
-cohort/classification builders as Step 1 and rejects any candidate baseline, filename
-set, opportunity row, policy stamp/digest, availability domain, or derived row that is
-not source-exact. This is database re-analysis, not talk reparsing; raw persisted talk
-rows remain unchanged.
+Treat `validate-profile.py` as the sole owner-validation contract. Do not reproduce or
+summarize its live-source checks in this skill. It reads existing persisted sources for
+validation. It does not reparse talks or mutate the tracking database.
 
 ```bash
 echo "$PROFILE_JSON" | "{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/validate-profile.py" --vault-root "$VAULT_ROOT"
@@ -211,8 +209,9 @@ echo "$PROFILE_JSON" | "{python_path}" "{speaker_toolkit_root}/skills/vault-prof
 - Stdout (JSON): `{valid, schema_version, missing_keys, errors}`.
 - Exit code: `0` on valid, `1` on invalid.
 
-If exit code is `1`, report every `missing_keys` and `errors` entry and abort without
-writing. Fix the offending fields in Step 4 and rerun this step.
+Write nothing unless the command exits `0` and stdout reports `valid: true`. On exit
+`1`, report every `missing_keys` and `errors` entry, fix the offending fields in Step 4,
+and rerun validation.
 
 Proceed immediately to Step 6.
 

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -62,8 +62,8 @@ configuration. Never fall back to whichever `python3` happens to be on `PATH`.
   JSON shape and [schemas-config.md](references/schemas-config.md) for config and
   confirmed intents.
 - Treat `tracking-database.json` as source of truth and `speaker-profile.json` as the
-  output. Toolkit scripts, not prose, own cohort, opportunity, pacing, and validation
-  arithmetic.
+  output. Toolkit scripts, not prose, own cohort, opportunity, classification, pacing,
+  and validation arithmetic.
 
 ## Prerequisites
 
@@ -105,11 +105,12 @@ Load `tracking-database.json`, `rhetoric-style-summary.md`, and
   defaults are documented in the script's top-of-file contract.
 - Stdout (JSON): `{vault_root, config, confirmed_intents, talks, processed_talks,
   baseline_talks, excluded_pattern_scoring_talks, pattern_scoring_exclusions,
-  pattern_baseline, pattern_opportunities, current_instrumentation_talks,
+  pattern_baseline, pattern_opportunities, pattern_classification,
+  current_instrumentation_talks,
   stale_instrumentation_talks, baseline_note, instrumentation_note, summary,
   design_spec}`.
-- Exit non-zero with stderr message if arguments, vault sources, catalog identity, or
-  scoring-generation metadata are missing or malformed.
+- Exit non-zero with stderr message if arguments, vault sources, catalog identity,
+  scoring-generation metadata, or a present classification-policy override is invalid.
 
 Apply the loader and missing-source rules in the construction reference.
 
@@ -119,8 +120,8 @@ Proceed immediately to Step 2.
 
 Aggregate the three named cohorts exactly as defined in
 [profile-construction-rules.md](references/profile-construction-rules.md). Keep
-catalog, non-catalog, and pacing sources separate; never recalculate the deterministic
-`pattern_opportunities` payload.
+catalog, non-catalog, and pacing sources separate. Copy the deterministic
+`pattern_opportunities` and `pattern_classification` payloads; never recalculate either.
 
 Proceed immediately to Step 3.
 
@@ -159,8 +160,9 @@ Read [profile-construction-rules.md](references/profile-construction-rules.md) i
 then construct `speaker-profile.json` with the exact field ownership, cohort,
 classification, empty-cohort, and non-pattern provenance rules there. Use
 [speaker-profile-schema.md](references/speaker-profile-schema.md) for the complete
-schema. Copy deterministic baseline and opportunity data; do not infer or recalculate
-catalog history.
+schema. Copy deterministic baseline, opportunity, policy stamp, availability, and
+derived classification data; do not infer or recalculate catalog history. Regenerating
+these profile fields reads existing tracking rows and does not reparse any talk.
 
 Compute `pacing.adherence` by running `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/compute-pacing-adherence.py"`. The
 deterministic arithmetic — duration parsing, slides-per-minute, budget-band
@@ -184,7 +186,7 @@ echo "$PACING_INPUT" | "{python_path}" "{speaker_toolkit_root}/skills/vault-prof
   (as elsewhere in the schema) and is not emitted by the script.
 - Exit non-zero on malformed input.
 
-Set `schema_version` to `4` and `generated_date` to today's date in `YYYY-MM-DD` form.
+Set `schema_version` to `5` and `generated_date` to today's date in `YYYY-MM-DD` form.
 
 Proceed immediately to Step 5.
 
@@ -192,9 +194,11 @@ Proceed immediately to Step 5.
 
 Pipe the constructed profile dict through
 `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/validate-profile.py" --vault-root "$VAULT_ROOT"`.
-Schema-v4 owner validation reparses the live tracking database with the same shared
-cohort builder as Step 1 and rejects any candidate baseline, filename set, eligible
-count, or opportunity row that is not source-exact.
+Schema-v5 owner validation rereads the live tracking database with the same shared
+cohort/classification builders as Step 1 and rejects any candidate baseline, filename
+set, opportunity row, policy stamp/digest, availability domain, or derived row that is
+not source-exact. This is database re-analysis, not talk reparsing; raw persisted talk
+rows remain unchanged.
 
 ```bash
 echo "$PROFILE_JSON" | "{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/validate-profile.py" --vault-root "$VAULT_ROOT"

--- a/skills/vault-profile/references/pattern-classification-policy-v1.json
+++ b/skills/vault-profile/references/pattern-classification-policy-v1.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "policy_id": "speaker-toolkit-default",
+  "policy_version": 1,
+  "positive_patterns": {
+    "signature": {
+      "minimum_applicable": 8,
+      "minimum_lower": 0.7
+    },
+    "regular": {
+      "minimum_evaluable": 8,
+      "minimum_applicable_coverage": 0.8,
+      "minimum_lower": 0.4,
+      "maximum_upper_exclusive": 0.7
+    },
+    "occasional": {
+      "minimum_evaluable": 8,
+      "minimum_applicable_coverage": 0.8,
+      "minimum_lower": 0.15,
+      "maximum_upper_exclusive": 0.4
+    },
+    "rare": {
+      "minimum_evaluable": 8,
+      "minimum_applicable_coverage": 0.8,
+      "minimum_detections": 1,
+      "maximum_upper_exclusive": 0.15
+    },
+    "never_tried": {
+      "minimum_applicable": 8,
+      "require_complete_evaluation": true,
+      "maximum_detections": 0
+    }
+  },
+  "antipattern_recurrence": {
+    "high_frequency": {
+      "minimum_applicable": 8,
+      "minimum_detections": 4,
+      "minimum_lower": 0.5
+    },
+    "moderate_frequency": {
+      "minimum_evaluable": 8,
+      "minimum_applicable_coverage": 0.8,
+      "minimum_detections": 3,
+      "minimum_lower": 0.25,
+      "maximum_upper_exclusive": 0.5
+    },
+    "occasional": {
+      "minimum_evaluable": 8,
+      "minimum_applicable_coverage": 0.8,
+      "minimum_detections": 1,
+      "maximum_upper_exclusive": 0.25
+    },
+    "confirmed_none": {
+      "minimum_applicable": 8,
+      "require_complete_evaluation": true,
+      "maximum_detections": 0
+    }
+  },
+  "signature_combinations": {
+    "eligible_member_classifications": [
+      "regular",
+      "signature"
+    ],
+    "member_counts": [
+      2,
+      3
+    ],
+    "minimum_applicable": 8,
+    "minimum_detections": 4,
+    "minimum_lower": 0.4,
+    "maximum_results": 10
+  },
+  "trends": {
+    "minimum_comparable_talks": 10,
+    "window_size": 5,
+    "score_delta": 0.5,
+    "breadth_delta": 0.5,
+    "pattern_movement_delta": 0.2
+  }
+}

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -136,23 +136,20 @@ derived projections. Those projections are `score_trend`, `pattern_breadth`,
 `underused_patterns`, `score_drivers`, `by_mode`, `strengths`, `strengths_note`,
 `never_used_patterns`, `signature_combinations`, and `mastery_levels`.
 
-Availability is per domain, never one global switch. Under the bundled policy,
-mastery/novelty, antipattern recurrence, underuse, and combinations are available from
-their exact opportunity bounds; trends remain unavailable until their comparable dated
-sample gate passes, including a shared non-null opportunity identity and at least one
-evaluable opportunity in the selected ten talks, and modes remain unavailable until
-talk-mode assignments exist.
+`skills/vault-profile/scripts/classify-pattern-profile.py` is the sole authority for
+domain availability, thresholds, and classification arithmetic. Copy its
+`classification_availability` output unchanged. Never reconstruct availability from
+raw rows or restate the classifier's predicates in profile-construction guidance.
 Consumers must honor each domain's own `{status, reason_codes}` and each row's evidence
 and reason codes. In particular, `not_yet_observed` is not `never_tried`, and an
 unclassified antipattern is not recurring or confirmed absent.
 
-The classifier is the sole owner of thresholds and arithmetic. Do not relabel rows,
-derive tiers from raw rates, truncate exhaustive classification arrays, or infer an
-absence where `absence_conclusion_capable` is false. Profile regeneration re-analyzes
-already persisted current-generation outcomes; it does not reparse talks and does not
-modify the raw `pattern_usage`, `antipattern_frequency`, or tracking-database rows. See
-the generated profile's embedded semantic policy when the applied values must be
-inspected.
+Do not relabel rows, derive tiers from raw rates, truncate exhaustive classification
+arrays, or infer an absence where `absence_conclusion_capable` is false. Profile
+regeneration re-analyzes already persisted current-generation outcomes. It does not
+reparse talks or modify the raw `pattern_usage`, `antipattern_frequency`, or
+tracking-database rows. See the generated profile's embedded semantic policy when the
+applied values must be inspected.
 
 ## Empty-Cohort Behavior
 

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -31,8 +31,18 @@ count and average are available only when every eligible talk shares one
 `opportunity_coverage_identity` containing at least one evaluable opportunity.
 Otherwise retain the explicit mixed-coverage or no-evaluable-opportunities unavailable
 state. `pattern_opportunities` contains the canonical exhaustive positive and negative
-rows; copy them rather than recalculating them. `pattern_scoring_exclusions` explains
-every otherwise eligible talk omitted from the cohort, including artifact drift.
+rows. `pattern_classification` contains the canonical policy stamp, per-domain
+availability, exhaustive classifications, trend audit, and derived projections. Copy
+both payloads rather than recalculating them. `pattern_scoring_exclusions` explains every
+otherwise eligible talk omitted from the cohort, including artifact drift.
+
+The loader selects the bundled `speaker-toolkit-default@1` policy automatically when
+`{vault_root}/pattern-classification-policy.json` is absent. A present override is
+optional but strict: it must be a regular, valid policy file, and any read, syntax,
+schema, size (maximum 64 KiB), or semantic error aborts loading instead of falling back
+to the default. The classification stamp embeds the normalized semantic policy and its
+canonical SHA-256, so a profile is self-contained and formatting-only policy edits keep
+the same digest.
 
 `current_instrumentation_talks` and `stale_instrumentation_talks` form a separate
 extractor cohort for pacing-sensitive analysis. Instrumentation membership never
@@ -52,7 +62,7 @@ Keep these cohorts distinct:
 
 - `processed_talks` supplies `talks_analyzed` and non-catalog narrative/profile data.
 - `baseline_talks` is available for source review only; deterministic
-  `pattern_opportunities` supplies catalog occurrence rows.
+  `pattern_opportunities` and `pattern_classification` supply catalog rows.
 - `current_instrumentation_talks` supplies pacing data only.
 
 For non-catalog dimensions, skip processed talks with empty `structured_data` and use
@@ -83,11 +93,11 @@ an empty layout list.
 | `rhetoric_defaults` | Step 1 `confirmed_intents` |
 | `pacing` | `current_instrumentation_talks` |
 | `guardrail_sources` | Aggregated non-pattern data |
-| `pattern_profile` | `pattern_baseline` and deterministic `pattern_opportunities` |
+| `pattern_profile` | `pattern_baseline`, `pattern_opportunities`, and `pattern_classification` |
 | `visual_style_history` | Summary dimension 13f observations |
 
 Use every top-level key required by `speaker-profile-schema.md`. Set
-`schema_version` to `4`, `generated_date` to today's `YYYY-MM-DD` date, and
+`schema_version` to `5`, `generated_date` to today's `YYYY-MM-DD` date, and
 `talks_analyzed` to the count of all `processed_talks`.
 
 The required top-level keys are `schema_version`, `generated_date`,
@@ -118,19 +128,40 @@ pattern-specific evaluable counts, not the global eligible count. Preserve exhau
 rows even for an empty cohort, including their canonical null rate and coverage
 sentinels.
 
-No versioned classification policy exists in schema v4. Copy the exact
-owner-policy-unconfigured `classification_availability` sentinel from
-`speaker-profile-schema.md`. Fail closed: score trend, breadth trend/average, and
-score-driver direction are unavailable; driver arrays, `never_used_patterns`, mastery
-tiers, signatures, strengths, underuse, and `by_mode` are empty. Zero detections never
-mean never used, and a positive frequency never means recurring.
+Copy every field of the loader's deterministic `pattern_classification` bundle into
+`pattern_profile` unchanged: `classification_schema_version`, the self-contained
+`classification_policy` stamp, `classification_availability`, exhaustive
+`pattern_classifications` and `antipattern_classifications`, `trend_analysis`, and all
+derived projections. Those projections are `score_trend`, `pattern_breadth`,
+`underused_patterns`, `score_drivers`, `by_mode`, `strengths`, `strengths_note`,
+`never_used_patterns`, `signature_combinations`, and `mastery_levels`.
+
+Availability is per domain, never one global switch. Under the bundled policy,
+mastery/novelty, antipattern recurrence, underuse, and combinations are available from
+their exact opportunity bounds; trends remain unavailable until their comparable dated
+sample gate passes, including a shared non-null opportunity identity and at least one
+evaluable opportunity in the selected ten talks, and modes remain unavailable until
+talk-mode assignments exist.
+Consumers must honor each domain's own `{status, reason_codes}` and each row's evidence
+and reason codes. In particular, `not_yet_observed` is not `never_tried`, and an
+unclassified antipattern is not recurring or confirmed absent.
+
+The classifier is the sole owner of thresholds and arithmetic. Do not relabel rows,
+derive tiers from raw rates, truncate exhaustive classification arrays, or infer an
+absence where `absence_conclusion_capable` is false. Profile regeneration re-analyzes
+already persisted current-generation outcomes; it does not reparse talks and does not
+modify the raw `pattern_usage`, `antipattern_frequency`, or tracking-database rows. See
+[Bundled Default Thresholds](speaker-profile-schema.md#bundled-default-thresholds) for a
+plain-language explanation of the default labels and gates.
 
 ## Empty-Cohort Behavior
 
 When `baseline_talks` is empty, retain the zero-count baseline, empty filenames, and
 exhaustive zero-opportunity rows. Set score and breadth averages to null and pattern
-trend/direction fields to `unavailable`. Never borrow pattern values from a prior
-profile, summary prose, an excluded scoring generation, or an instrumentation cohort.
+trend/direction fields to `unavailable`; classification rows remain exhaustive with
+their classifier-owned unavailable/unclassified states, while derived lists are empty.
+Never borrow pattern values from a prior profile, summary prose, an excluded scoring
+generation, or an instrumentation cohort.
 
 ## Pacing and Section 15
 
@@ -139,7 +170,10 @@ the result complements, rather than replaces, Dimension 14's transcript-evident
 "rushing" assessment.
 
 Use Section 15 of `rhetoric-style-summary.md` only for narrative consistency review.
-It cannot override or fill the current pattern cohort.
+It cannot override or fill the current pattern cohort. The Section 15 reader accepts
+the occurrence-only v2 current block for compatibility, but the writer always replaces
+it with a policy-bound v3 block copied from the validated schema-v5 `pattern_profile`.
+Regenerating that block needs no talk reparse and never changes persisted raw rows.
 
 ## Existing-Profile Diff
 
@@ -151,8 +185,13 @@ reset: do not describe catalog-derived score, trend, usage, mastery, or strength
 differences across it as speaker improvement or regression.
 
 Within one exact generation, do not report raw-score movement across a changed or
-unavailable `opportunity_coverage_identity`. Do not infer policy-derived changes while
-`classification_availability.status` is `unavailable`.
+unavailable `opportunity_coverage_identity`. Compare the classification policy's
+`semantic_sha256` next. A changed semantic digest is a derived-classification reset:
+raw occurrence rows remain comparable, but do not attribute tier, severity,
+combination, underuse, or trend changes to the speaker. A formatting-only override edit
+does not reset comparisons because its canonical semantic digest is unchanged. Within
+one policy digest, report a derived change only when its own availability domain is
+`available` in both profiles.
 
 Report these same-generation non-pattern changes:
 

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -36,13 +36,8 @@ availability, exhaustive classifications, trend audit, and derived projections. 
 both payloads rather than recalculating them. `pattern_scoring_exclusions` explains every
 otherwise eligible talk omitted from the cohort, including artifact drift.
 
-The loader selects the bundled `speaker-toolkit-default@1` policy automatically when
-`{vault_root}/pattern-classification-policy.json` is absent. A present override is
-optional but strict: it must be a regular, valid policy file, and any read, syntax,
-schema, size, or semantic error aborts loading instead of falling back
-to the default. The classification stamp embeds the normalized semantic policy and its
-canonical SHA-256, so a profile is self-contained and formatting-only policy edits keep
-the same digest.
+Copy the loader's complete `classification_policy` stamp unchanged. Do not construct or
+repair any field in that stamp during profile assembly.
 
 `current_instrumentation_talks` and `stale_instrumentation_talks` form a separate
 extractor cohort for pacing-sensitive analysis. Instrumentation membership never
@@ -182,13 +177,11 @@ reset: do not describe catalog-derived score, trend, usage, mastery, or strength
 differences across it as speaker improvement or regression.
 
 Within one exact generation, do not report raw-score movement across a changed or
-unavailable `opportunity_coverage_identity`. Compare the classification policy's
-`semantic_sha256` next. A changed semantic digest is a derived-classification reset:
-raw occurrence rows remain comparable, but do not attribute tier, severity,
-combination, underuse, or trend changes to the speaker. A formatting-only override edit
-does not reset comparisons because its canonical semantic digest is unchanged. Within
-one policy digest, report a derived change only when its own availability domain is
-`available` in both profiles.
+unavailable `opportunity_coverage_identity`. Compare the classifier-emitted
+`semantic_sha256` next. A changed digest is a derived-classification reset. Raw
+occurrence rows remain comparable, but do not attribute tier, severity, combination,
+underuse, or trend changes to the speaker. Within one unchanged policy identity, report
+a derived change only when its own availability domain is `available` in both profiles.
 
 Report these same-generation non-pattern changes:
 

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -39,7 +39,7 @@ otherwise eligible talk omitted from the cohort, including artifact drift.
 The loader selects the bundled `speaker-toolkit-default@1` policy automatically when
 `{vault_root}/pattern-classification-policy.json` is absent. A present override is
 optional but strict: it must be a regular, valid policy file, and any read, syntax,
-schema, size (maximum 64 KiB), or semantic error aborts loading instead of falling back
+schema, size, or semantic error aborts loading instead of falling back
 to the default. The classification stamp embeds the normalized semantic policy and its
 canonical SHA-256, so a profile is self-contained and formatting-only policy edits keep
 the same digest.
@@ -151,8 +151,8 @@ derive tiers from raw rates, truncate exhaustive classification arrays, or infer
 absence where `absence_conclusion_capable` is false. Profile regeneration re-analyzes
 already persisted current-generation outcomes; it does not reparse talks and does not
 modify the raw `pattern_usage`, `antipattern_frequency`, or tracking-database rows. See
-[Bundled Default Thresholds](speaker-profile-schema.md#bundled-default-thresholds) for a
-plain-language explanation of the default labels and gates.
+the generated profile's embedded semantic policy when the applied values must be
+inspected.
 
 ## Empty-Cohort Behavior
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -355,7 +355,7 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
       "direction": "improving",
       "antipattern_drivers": ["going-meta"],
       "pattern_drivers": [],
-      "note": "Drivers include only catalog IDs whose conservative 5+5 interval crossed the policy movement threshold."
+      "note": "Classifier-produced drivers for the available trend domain."
     },
     "by_mode": [],
     "strengths": ["narrative-arc"],
@@ -407,39 +407,9 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
       "policy_id": "speaker-toolkit-default",
       "policy_version": 1,
       "source": "bundled_default",
-      "semantic_sha256": "ab327a0418794df3905a31794c6e079f12dae3abda66dbcc58be9b55e28d1f77",
+      "semantic_sha256": "<classifier-produced 64-character lowercase hex digest>",
       "semantic_policy": {
-        "schema_version": 1,
-        "policy_id": "speaker-toolkit-default",
-        "policy_version": 1,
-        "positive_patterns": {
-          "signature": {"minimum_applicable": 8, "minimum_lower": 0.7},
-          "regular": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_lower": 0.4, "maximum_upper_exclusive": 0.7},
-          "occasional": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_lower": 0.15, "maximum_upper_exclusive": 0.4},
-          "rare": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_detections": 1, "maximum_upper_exclusive": 0.15},
-          "never_tried": {"minimum_applicable": 8, "require_complete_evaluation": true, "maximum_detections": 0}
-        },
-        "antipattern_recurrence": {
-          "high_frequency": {"minimum_applicable": 8, "minimum_detections": 4, "minimum_lower": 0.5},
-          "moderate_frequency": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_detections": 3, "minimum_lower": 0.25, "maximum_upper_exclusive": 0.5},
-          "occasional": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_detections": 1, "maximum_upper_exclusive": 0.25},
-          "confirmed_none": {"minimum_applicable": 8, "require_complete_evaluation": true, "maximum_detections": 0}
-        },
-        "signature_combinations": {
-          "eligible_member_classifications": ["regular", "signature"],
-          "member_counts": [2, 3],
-          "minimum_applicable": 8,
-          "minimum_detections": 4,
-          "minimum_lower": 0.4,
-          "maximum_results": 10
-        },
-        "trends": {
-          "minimum_comparable_talks": 10,
-          "window_size": 5,
-          "score_delta": 0.5,
-          "breadth_delta": 0.5,
-          "pattern_movement_delta": 0.2
-        }
+        // Complete classifier-produced object omitted from this illustrative profile.
       }
     },
     "classification_availability": {
@@ -489,14 +459,16 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
         "reason_codes": ["meets_moderate_frequency_thresholds"]
       }
     ],
+    // Angle-bracket values in trend_analysis document output shape only.
+    // Copy the classifier-produced values unchanged.
     "trend_analysis": {
       "status": "available",
       "reason_codes": [],
       "sample": {
-        "required_talk_count": 10,
-        "valid_date_talk_count": 24,
+        "required_talk_count": "<classifier-produced integer>",
+        "valid_date_talk_count": "<integer>",
         "invalid_date_filenames": [],
-        "selected_filenames": ["example-15.md", "example-16.md", "example-17.md", "example-18.md", "example-19.md", "example-20.md", "example-21.md", "example-22.md", "example-23.md", "example-24.md"],
+        "selected_filenames": ["<classifier-selected filename>", "..."],
         "opportunity_coverage_identity": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
       },
       "score": {"status": "improving", "prior_average": 6.0, "recent_average": 7.0, "delta": 1.0},
@@ -507,8 +479,8 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
         {
           "pattern_id": "narrative-arc",
           "movement": "indeterminate",
-          "prior_evidence": {"applicable_count": 5, "evaluable_count": 4, "detected_count": 4, "unevaluable_count": 1, "applicable_coverage": 0.8, "lower": 0.8, "upper": 1.0},
-          "recent_evidence": {"applicable_count": 5, "evaluable_count": 4, "detected_count": 4, "unevaluable_count": 1, "applicable_coverage": 0.8, "lower": 0.8, "upper": 1.0},
+          "prior_evidence": {"applicable_count": "<integer>", "evaluable_count": "<integer>", "detected_count": "<integer>", "unevaluable_count": "<integer>", "applicable_coverage": "<number or null>", "lower": "<number or null>", "upper": "<number or null>"},
+          "recent_evidence": {"applicable_count": "<integer>", "evaluable_count": "<integer>", "detected_count": "<integer>", "unevaluable_count": "<integer>", "applicable_coverage": "<number or null>", "lower": "<number or null>", "upper": "<number or null>"},
           "reason_codes": ["uncertainty_spans_movement_threshold"]
         }
       ],
@@ -516,8 +488,8 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
         {
           "pattern_id": "going-meta",
           "movement": "decreasing",
-          "prior_evidence": {"applicable_count": 5, "evaluable_count": 5, "detected_count": 3, "unevaluable_count": 0, "applicable_coverage": 1.0, "lower": 0.6, "upper": 0.6},
-          "recent_evidence": {"applicable_count": 5, "evaluable_count": 5, "detected_count": 1, "unevaluable_count": 0, "applicable_coverage": 1.0, "lower": 0.2, "upper": 0.2},
+          "prior_evidence": {"applicable_count": "<integer>", "evaluable_count": "<integer>", "detected_count": "<integer>", "unevaluable_count": "<integer>", "applicable_coverage": "<number or null>", "lower": "<number or null>", "upper": "<number or null>"},
+          "recent_evidence": {"applicable_count": "<integer>", "evaluable_count": "<integer>", "detected_count": "<integer>", "unevaluable_count": "<integer>", "applicable_coverage": "<number or null>", "lower": "<number or null>", "upper": "<number or null>"},
           "reason_codes": ["conservative_interval_decrease"]
         }
       ]
@@ -647,12 +619,10 @@ override is strict and fail-closed: an unreadable file, duplicate key, non-finit
 number, unknown/missing field, unsupported version, oversized file, or invalid
 threshold aborts profile generation rather than silently selecting the default.
 
-`classification_policy` is self-contained. `semantic_policy` is the complete normalized
-policy used for the run, and `semantic_sha256` is the SHA-256 of its canonical sorted
-JSON. `policy_id`, `policy_version`, and `source` identify it for humans, but the digest
-is the comparison identity; whitespace and object-key order do not change it. The
-bundled file is `references/pattern-classification-policy-v1.json`. A vault override
-uses the same closed schema and records `source: "vault_override"`.
+`classification_policy` is self-contained. Copy `semantic_policy` and
+`semantic_sha256` from classifier output unchanged. Treat the digest as an opaque
+comparison identity. `policy_id`, `policy_version`, and `source` identify the applied
+policy for humans.
 
 `pattern_classifications` and `antipattern_classifications` contain one sorted row for
 every observable catalog entry of the matching polarity. Each row preserves the exact
@@ -686,11 +656,9 @@ remains non-recurring unless the classifier says otherwise.
 
 `classification_availability` is schema v2 and independent per domain. Mastery/novelty,
 antipattern recurrence, underuse, combinations, trends, and modes each carry their own
-`{status, reason_codes}`. The default policy makes the first four domains evaluable from
-opportunity rows; the classifier determines trend availability from its policy and
-input evidence. Modes remain unavailable until talk-mode assignments exist. A consumer
-must gate only the requested domain and retain row-level unclassified results; one
-unavailable domain never erases another available one.
+`{status, reason_codes}`. The classifier output is the only authority for those values.
+A consumer must gate only the requested domain and retain row-level unclassified
+results. One unavailable domain never erases another available one.
 `trend_analysis` retains the complete selected sample, metric values, exhaustive
 pattern movements, and reasons behind those projections.
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -21,7 +21,7 @@ creation at runtime.
 
 ## Schema Versioning
 
-Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
+Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
 `CURRENT_SCHEMA_VERSION`) accepts only the current version.
 
 - **v1 → v2** adds the coaching-outcome fields, all additive: `pattern_profile.score_drivers`,
@@ -34,26 +34,33 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
 - **v3 → v4** binds occurrence history to scoring-v5's exhaustive per-talk outcomes.
   It separates `eligible_talk_count` from raw-score-comparable `talks_scored`, adds
   exact per-pattern opportunity denominators and coverage, and makes classification
-  availability explicit. Until a speaker-owned classification policy is versioned,
-  all novelty, mastery, recurring-severity, underuse, combination, and trend fields
-  use fail-closed sentinels.
-- **Generation:** vault-profile writes only v4. Stored v1/v2/v3 profiles are non-current and
-  `scripts/validate-profile.py` rejects them as generation output. Compatibility for
-  non-owner readers is a separate rollout concern; an old profile never authorizes the
-  writer to reuse legacy pattern aggregates.
+  availability explicit. Its derived fields remain fail-closed because v4 carries no
+  policy identity.
+- **v4 → v5** adds deterministic policy-derived history. It embeds the normalized
+  policy plus its canonical semantic digest, adds exhaustive positive and antipattern
+  classification rows, makes availability independent per derived domain, and retains
+  the complete trend audit used by projections.
+- **Generation:** vault-profile writes only v5. Stored v1/v2/v3/v4 profiles are
+  non-current and `scripts/validate-profile.py` rejects them as generation output. A
+  compatible reader may expose a validated v4 profile's occurrence rows only; every v4
+  mastery, novelty, severity, combination, underuse, and trend field remains
+  unavailable because v4 has no policy stamp.
 - **Migration:** vault-profile regenerates the profile wholesale each run. An older file is
-  replaced by a v4 file on the next run — no in-place migration step. The only value carried
+  replaced by a v5 file on the next run — no in-place migration step and no talk reparse.
+  Existing current-generation tracking rows are read without mutation. The only value carried
   across regenerations is `infrastructure.template_layouts[].use_for` (merged by the
   `(master_index, name)` pair, version-independent).
 - **Generation reset:** when either the catalog fingerprint or pattern-scoring schema
   changes, catalog-derived diffs across the boundary are a reset. Do not describe score,
   usage, mastery, or trend changes across those identities as speaker regressions.
+  Within one generation, a changed classification-policy semantic digest resets only
+  policy-derived comparisons; raw occurrence rows remain comparable.
 
 ## Schema
 
 ```json
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "generated_date": "2026-02-22",
   "talks_analyzed": 24,
 
@@ -337,22 +344,22 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
     "eligible_talk_count": 24,
     "talks_scored": 24,
     "average_pattern_score": 6.79,
-    "score_trend": "unavailable",
+    "score_trend": "improving",
     "pattern_breadth": {
-      "avg_distinct_patterns_per_talk": null,
-      "trend": "unavailable",
-      "note": "Unavailable until a speaker-owned coverage-comparable breadth policy is versioned."
+      "avg_distinct_patterns_per_talk": 6.3,
+      "trend": "widening",
+      "note": "Breadth is the mean count of detected positive catalog patterns per current-generation talk."
     },
     "underused_patterns": [],
     "score_drivers": {
-      "direction": "unavailable",
-      "antipattern_drivers": [],
+      "direction": "improving",
+      "antipattern_drivers": ["going-meta"],
       "pattern_drivers": [],
-      "note": "Unavailable until a speaker-owned trend policy is versioned."
+      "note": "Drivers include only catalog IDs whose conservative 5+5 interval crossed the policy movement threshold."
     },
     "by_mode": [],
-    "strengths": [],
-    "strengths_note": "Unavailable until a speaker-owned classification policy is versioned.",
+    "strengths": ["narrative-arc"],
+    "strengths_note": "Deterministic projection of regular and signature positive-pattern classifications.",
     "note": "Only observable patterns are included. Patterns marked observable: false in the taxonomy (pre-event logistics, hidden authoring/provenance processes, physical stage behaviors, post-event follow-up, and external systems the current artifacts cannot prove) are excluded from scoring and surfaced as a go-live checklist in creator Phase 6 instead.",
     // Opportunity arrays are abbreviated here for readability. Generated
     // profiles contain one sorted row for every observable catalog entry of
@@ -361,19 +368,19 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
       {
         "pattern_id": "narrative-arc",
         "detected_count": 22,
-        "evaluable_count": 24,
-        "unevaluable_count": 0,
+        "evaluable_count": 22,
+        "unevaluable_count": 2,
         "not_applicable_count": 0,
         "eligible_cohort_count": 24,
-        "coverage": 1.0,
+        "coverage": 0.9166666666666666,
         "times_used": 22,
-        "out_of": 24,
-        "usage_rate": 0.9166666666666666
+        "out_of": 22,
+        "usage_rate": 1.0
       }
     ],
     "antipattern_frequency": [
       {
-        "pattern_id": "shortchanged",
+        "pattern_id": "going-meta",
         "detected_count": 8,
         "evaluable_count": 24,
         "unevaluable_count": 0,
@@ -388,16 +395,132 @@ Current `schema_version`: **4**. The validator (`scripts/validate-profile.py`,
     "never_used_patterns": [],
     "signature_combinations": [],
     "mastery_levels": {
-      "signature": [],
+      "signature": ["narrative-arc"],
       "regular": [],
       "occasional": [],
       "rare": [],
       "never_tried": []
     },
-    "classification_availability": {
+    "classification_schema_version": 1,
+    "classification_policy": {
       "schema_version": 1,
-      "status": "unavailable",
-      "reason_codes": ["owner_policy_unconfigured"]
+      "policy_id": "speaker-toolkit-default",
+      "policy_version": 1,
+      "source": "bundled_default",
+      "semantic_sha256": "ab327a0418794df3905a31794c6e079f12dae3abda66dbcc58be9b55e28d1f77",
+      "semantic_policy": {
+        "schema_version": 1,
+        "policy_id": "speaker-toolkit-default",
+        "policy_version": 1,
+        "positive_patterns": {
+          "signature": {"minimum_applicable": 8, "minimum_lower": 0.7},
+          "regular": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_lower": 0.4, "maximum_upper_exclusive": 0.7},
+          "occasional": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_lower": 0.15, "maximum_upper_exclusive": 0.4},
+          "rare": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_detections": 1, "maximum_upper_exclusive": 0.15},
+          "never_tried": {"minimum_applicable": 8, "require_complete_evaluation": true, "maximum_detections": 0}
+        },
+        "antipattern_recurrence": {
+          "high_frequency": {"minimum_applicable": 8, "minimum_detections": 4, "minimum_lower": 0.5},
+          "moderate_frequency": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_detections": 3, "minimum_lower": 0.25, "maximum_upper_exclusive": 0.5},
+          "occasional": {"minimum_evaluable": 8, "minimum_applicable_coverage": 0.8, "minimum_detections": 1, "maximum_upper_exclusive": 0.25},
+          "confirmed_none": {"minimum_applicable": 8, "require_complete_evaluation": true, "maximum_detections": 0}
+        },
+        "signature_combinations": {
+          "eligible_member_classifications": ["regular", "signature"],
+          "member_counts": [2, 3],
+          "minimum_applicable": 8,
+          "minimum_detections": 4,
+          "minimum_lower": 0.4,
+          "maximum_results": 10
+        },
+        "trends": {
+          "minimum_comparable_talks": 10,
+          "window_size": 5,
+          "score_delta": 0.5,
+          "breadth_delta": 0.5,
+          "pattern_movement_delta": 0.2
+        }
+      }
+    },
+    "classification_availability": {
+      "schema_version": 2,
+      "mastery_and_novelty": {"status": "available", "reason_codes": []},
+      "antipattern_recurrence": {"status": "available", "reason_codes": []},
+      "underuse": {"status": "available", "reason_codes": []},
+      "signature_combinations": {"status": "available", "reason_codes": []},
+      "trends": {"status": "available", "reason_codes": []},
+      "modes": {"status": "unavailable", "reason_codes": ["talk_mode_assignments_unavailable"]}
+    },
+    // Both arrays below are exhaustive and catalog-sorted in generated profiles;
+    // one representative row from each polarity is shown here.
+    "pattern_classifications": [
+      {
+        "pattern_id": "narrative-arc",
+        "classification": "signature",
+        "observation_status": "observed",
+        "absence_conclusion_capable": false,
+        "evidence": {
+          "applicable_count": 24,
+          "evaluable_count": 22,
+          "detected_count": 22,
+          "unevaluable_count": 2,
+          "applicable_coverage": 0.9166666666666666,
+          "lower": 0.9166666666666666,
+          "upper": 1.0
+        },
+        "reason_codes": ["meets_signature_thresholds"]
+      }
+    ],
+    "antipattern_classifications": [
+      {
+        "pattern_id": "going-meta",
+        "classification": "moderate_frequency",
+        "observation_status": "observed",
+        "absence_conclusion_capable": true,
+        "evidence": {
+          "applicable_count": 24,
+          "evaluable_count": 24,
+          "detected_count": 8,
+          "unevaluable_count": 0,
+          "applicable_coverage": 1.0,
+          "lower": 0.3333333333333333,
+          "upper": 0.3333333333333333
+        },
+        "reason_codes": ["meets_moderate_frequency_thresholds"]
+      }
+    ],
+    "trend_analysis": {
+      "status": "available",
+      "reason_codes": [],
+      "sample": {
+        "required_talk_count": 10,
+        "valid_date_talk_count": 24,
+        "invalid_date_filenames": [],
+        "selected_filenames": ["example-15.md", "example-16.md", "example-17.md", "example-18.md", "example-19.md", "example-20.md", "example-21.md", "example-22.md", "example-23.md", "example-24.md"],
+        "opportunity_coverage_identity": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+      },
+      "score": {"status": "improving", "prior_average": 6.0, "recent_average": 7.0, "delta": 1.0},
+      "breadth": {"status": "widening", "prior_average": 5.0, "recent_average": 6.0, "delta": 1.0},
+      // Movement arrays are exhaustive when trends are available and empty when
+      // the trend domain is unavailable. One representative row is shown per lane.
+      "pattern_movements": [
+        {
+          "pattern_id": "narrative-arc",
+          "movement": "indeterminate",
+          "prior_evidence": {"applicable_count": 5, "evaluable_count": 4, "detected_count": 4, "unevaluable_count": 1, "applicable_coverage": 0.8, "lower": 0.8, "upper": 1.0},
+          "recent_evidence": {"applicable_count": 5, "evaluable_count": 4, "detected_count": 4, "unevaluable_count": 1, "applicable_coverage": 0.8, "lower": 0.8, "upper": 1.0},
+          "reason_codes": ["uncertainty_spans_movement_threshold"]
+        }
+      ],
+      "antipattern_movements": [
+        {
+          "pattern_id": "going-meta",
+          "movement": "decreasing",
+          "prior_evidence": {"applicable_count": 5, "evaluable_count": 5, "detected_count": 3, "unevaluable_count": 0, "applicable_coverage": 1.0, "lower": 0.6, "upper": 0.6},
+          "recent_evidence": {"applicable_count": 5, "evaluable_count": 5, "detected_count": 1, "unevaluable_count": 0, "applicable_coverage": 1.0, "lower": 0.2, "upper": 0.2},
+          "reason_codes": ["conservative_interval_decrease"]
+        }
+      ]
     }
   },
 
@@ -517,17 +640,117 @@ The respective stable reasons are `mixed_opportunity_coverage` and
 `no_evaluable_pattern_opportunities`; the per-pattern occurrence rows remain
 available.
 
-All `pattern_profile` fields in the schema are required in v4. The current
-`classification_availability` sentinel states that no speaker-owned versioned
-classification policy exists. Therefore zero detections cannot authorize
-`never_used_patterns`, and occurrence rates cannot authorize mastery, recurring
-severity, strengths, underuse, combinations, mode splits, or trends. Those fields use
-the exact empty/unavailable shapes in the example until the owner versions such a
-policy. `talks_analyzed` may still count every processed talk. Pacing uses the
-separately named `current_instrumentation_talks` cohort and never borrows the pattern
-denominator.
+All `pattern_profile` fields in the schema are required in v5. If the vault has no
+`pattern-classification-policy.json`, the loader automatically applies the bundled
+`speaker-toolkit-default@1` policy; users are not asked to invent thresholds. A present
+override is strict and fail-closed: an unreadable file, duplicate key, non-finite
+number, unknown/missing field, unsupported version, file over 64 KiB, or invalid
+threshold aborts profile generation rather than silently selecting the default.
 
-`pattern_profile` is the only v4 storage lane for catalog history.
+`classification_policy` is self-contained. `semantic_policy` is the complete normalized
+policy used for the run, and `semantic_sha256` is the SHA-256 of its canonical sorted
+JSON. `policy_id`, `policy_version`, and `source` identify it for humans, but the digest
+is the comparison identity; whitespace and object-key order do not change it. The
+bundled file is `references/pattern-classification-policy-v1.json`. A vault override
+uses the same closed schema and records `source: "vault_override"`.
+
+`pattern_classifications` and `antipattern_classifications` contain one sorted row for
+every observable catalog entry of the matching polarity. Each row preserves the exact
+evaluable denominator and also gives conservative opportunity bounds: for applicable
+count `A`, evaluable count `E`, detections `D`, and unevaluable count `U`, coverage is
+`E/A`, `lower` is `D/A`, and `upper` is `(D+U)/A`; all three ratios are null when
+`A == 0`. Positive classifications are `signature`, `regular`, `occasional`, `rare`,
+`never_tried`, `not_yet_observed`, or `unclassified`. Antipattern classifications are
+`high_frequency`, `moderate_frequency`, `occasional`, `confirmed_none`, or
+`unclassified`. The embedded semantic policy is authoritative; the bundled defaults
+are summarized below in plain language.
+
+#### Bundled Default Thresholds
+
+In the tables below, `A` is the number of applicable talks, `E` the number actually
+evaluable, `D` the number with a detection, and `U` the applicable talks left
+unevaluable. “Definitely detected” is the conservative lower bound `D/A`; the upper
+bound `(D+U)/A` shows how high the rate could be if every unknown became a detection.
+Coverage is `E/A`.
+
+For positive patterns, `speaker-toolkit-default@1` uses these labels:
+
+| Label | Plain-language gate |
+|---|---|
+| `signature` | At least 8 applicable talks, with definite detections in at least 70% (`A >= 8`, lower `>= 0.70`). |
+| `regular` | At least 8 evaluable talks and 80% coverage; definitely present in at least 40%, but below 70% even if every unknown were positive (`E >= 8`, coverage `>= 0.80`, lower `>= 0.40`, upper `< 0.70`). |
+| `occasional` | The same sample and coverage gates; definitely present in at least 15%, but below 40% even under the unknown-positive upper bound (lower `>= 0.15`, upper `< 0.40`). |
+| `rare` | The same sample and coverage gates, at least one detection, and below 15% even under the upper bound (`D >= 1`, upper `< 0.15`). |
+| `never_tried` | The catalog permits an absence conclusion, at least 8 talks are applicable, every one is evaluable, and none contains the pattern (`A >= 8`, `E == A`, `D == 0`). |
+
+`mastery_levels` mirrors those five named tiers. `strengths` is the sorted union of
+`signature` and `regular`; `underused_patterns` is the sorted union of `rare` and
+`never_tried`; `never_used_patterns` contains only evidence-backed `never_tried` IDs.
+
+For antipattern recurrence, the default uses:
+
+| Label | Plain-language gate |
+|---|---|
+| `high_frequency` | At least 8 applicable talks, at least 4 detections, and definite detections in at least half (`A >= 8`, `D >= 4`, lower `>= 0.50`). |
+| `moderate_frequency` | At least 8 evaluable talks and 80% coverage, at least 3 detections, a definite rate of at least 25%, and a rate below 50% even if every unknown were positive (lower `>= 0.25`, upper `< 0.50`). |
+| `occasional` | At least 8 evaluable talks and 80% coverage, at least one detection, and an upper bound below 25% (`D >= 1`, upper `< 0.25`). |
+| `confirmed_none` | The catalog permits an absence conclusion, at least 8 talks are applicable, every one is evaluable, and none contains the antipattern (`A >= 8`, `E == A`, `D == 0`). |
+
+Signature combinations and trends have separate gates:
+
+- A combination contains exactly two or three positive patterns already classified
+  `regular` or `signature`. All members must be detected together in at least 4 of at
+  least 8 applicable talks, with a conservative joint rate of at least 40%. At most 10
+  combinations are retained, ordered by stronger lower bound, more detections, then ID.
+- Trends require at least 10 talks with valid dates. The newest 10, ordered by date and
+  filename, must share one non-null `opportunity_coverage_identity` and contain at
+  least one evaluable (`detected` or `undetected`) opportunity; the older five are
+  compared with the newer five. Otherwise the entire trend domain is unavailable.
+- A score change of at least `+0.5` is `improving`; at most `-0.5` is `declining`;
+  anything between is `stable`. Breadth—the number of detected positive patterns per
+  talk—uses the same `0.5` threshold for `widening`, `narrowing`, or `stable`.
+- A catalog-entry movement is `increasing` or `decreasing` only when its conservative
+  five-talk intervals prove a change of at least `0.20`; all five talks in each window
+  must be applicable to that entry. It is `stable` when the whole possible change stays
+  inside that band, and `indeterminate` when uncertainty crosses a boundary.
+
+`never_tried` and `not_yet_observed` are deliberately not synonyms. `never_tried` is an
+evidence-backed absence: the catalog says the available artifact can prove absence, the
+sample has at least eight applicable talks, every applicable talk was evaluated, and
+all eight or more were negative. `not_yet_observed` says only that this corpus has no
+positive detection while absence itself is still unknown—for example, the catalog
+permits positive detection but not absence, or coverage is incomplete. A smaller but
+fully evaluated absence-capable sample is instead `unclassified` with observation
+status `confirmed_absent`: absence is known, but the sample is too small for the
+`never_tried` tier. Neither state may appear in `never_used_patterns` or be presented
+as a policy-backed fact that the speaker has never tried the technique. With no
+applicable talks at all, the row is `unclassified` with observation status
+`unavailable`. The antipattern equivalent is `confirmed_none`; a zero-detection
+antipattern without the same absence gates remains `unclassified`, not “resolved.”
+
+`classification_availability` is schema v2 and independent per domain. Mastery/novelty,
+antipattern recurrence, underuse, combinations, trends, and modes each carry their own
+`{status, reason_codes}`. The default policy makes the first four domains evaluable from
+opportunity rows; trends additionally require ten valid dated talks, two five-talk
+windows, one non-null shared opportunity identity, and at least one evaluable
+opportunity in the selected sample. Modes remain unavailable until talk-mode
+assignments exist. A consumer must gate only the requested domain and retain row-level
+unclassified results; one unavailable domain never erases another available one.
+`trend_analysis` retains the complete selected sample, metric values, exhaustive
+pattern movements, and reasons behind those projections.
+
+A validated schema-v4 profile remains compatible only as occurrence history:
+`pattern_baseline`, filenames, raw score availability, `pattern_usage`, and
+`antipattern_frequency` may be read under their v4 provenance contract. Because v4 has
+no policy stamp, readers must ignore its mastery, novelty, recurrence, strength,
+underuse, combination, mode, and trend projections. Regenerate to v5 from the tracking
+database to obtain those fields; this re-analysis does not reparse talks or modify raw
+talk/opportunity rows.
+
+`talks_analyzed` may count every processed talk. Pacing uses the separately named
+`current_instrumentation_talks` cohort and never borrows the pattern denominator.
+
+`pattern_profile` is the only v5 storage lane for catalog history.
 `rhetoric_defaults` must not duplicate mastery, signatures, usage, scores, or other
 pattern-history fields. `guardrail_sources.recurring_issues[]` and `badges[]` are
 non-pattern-only lanes: every entry carries `source_lane: "non_pattern"` and must not
@@ -536,26 +759,26 @@ denominator. Consumers derive catalog warnings and reinforcement directly from t
 validated `pattern_profile`; the writer never materializes duplicate catalog-derived
 recurring issues or badges.
 
-Writers and readers call
-`scripts/profile_pattern_provenance.py::assess_pattern_profile` for the same strict
-decision. `current_contract: true` means the v4 provenance is structurally canonical;
-`catalog_fields_available: true` additionally requires a non-empty eligible cohort.
-`classification_fields_available: false` suppresses every derived history tier even
-when exact occurrence rows are present. The owner additionally runs
+Writers and readers use the shared profile provenance/classification validator for the
+same strict decision. Current v5 catalog availability requires source-exact cohort and
+opportunity rows; each classification domain then follows its own availability object.
+The owner additionally runs
 `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/validate-profile.py" --vault-root <path>`;
 it recomputes the cohort from the
-live tracking database and rejects structurally valid but source-fabricated rows.
-A reader may continue using unrelated non-pattern fields from an older profile, but it
-must treat that profile's historical pattern fields as unavailable rather than migrate
-or infer provenance.
+live tracking database and rejects structurally valid but source-fabricated occurrence,
+policy, classification, availability, or projection rows.
+A reader may continue using unrelated non-pattern fields from an older profile and the
+explicitly supported v4 occurrence-only lane above, but it must treat all other legacy
+pattern history as unavailable rather than migrate or infer provenance.
 
 When the current pattern cohort is empty, preserve the canonical zero-count baseline,
 an empty `baseline_talk_filenames`, `eligible_talk_count: 0`, `talks_scored: 0`, and
 `average_pattern_score: null`. Keep the exhaustive positive and negative catalog rows
-with zero counts and null rates/coverage. Set `score_trend`, `pattern_breadth.trend`,
-and `score_drivers.direction` to `"unavailable"`; set the breadth average to `null`
-and every classification-derived array/mastery tier to `[]`. Never fall back to an
-older profile, the rhetoric summary, excluded scoring generations, or the
+with zero counts and null rates/coverage, plus exhaustive classification rows with
+their classifier-owned unavailable/unclassified evidence. Set `score_trend`,
+`pattern_breadth.trend`, and `score_drivers.direction` to `"unavailable"`; set the
+breadth average to `null` and derived list/mastery projections to `[]`. Never fall back
+to an older profile, the rhetoric summary, excluded scoring generations, or the
 instrumentation cohort.
 
 ## How the Presentation Creator Uses Each Section
@@ -576,7 +799,7 @@ automatically picks up changes when the profile is regenerated.
 | `guardrail_sources` | Phase 4 (guardrails) | All guardrail checks with thresholds |
 | `instrument_catalog` | Phase 2 (architecture) | Complete instrument menu by dimension |
 | `visual_style_history` | Phase 2 (architecture — illustration strategy) | Default aesthetic, mode-specific departures, style proposals |
-| `pattern_profile` | Phase 2 (architecture), Phase 4 (guardrails) | Auditable occurrence rows; 4-tier recommendations and recurring antipattern warnings only when the shared gate explicitly authorizes classification fields |
+| `pattern_profile` | Phase 2 (architecture), Phase 4 (guardrails) | Auditable occurrence and exhaustive classification rows; recommendations and warnings gated by the relevant availability domain and row evidence |
 | `badges` | Informational | Fun speaker achievements mined from vault data |
 | `infrastructure.template_layouts` | Phase 5 (slide generation) | Layout map and selection logic |
 | `infrastructure.font_pair` | Phase 5 (slide generation) | Font usage rules |

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -644,7 +644,7 @@ All `pattern_profile` fields in the schema are required in v5. If the vault has 
 `pattern-classification-policy.json`, the loader automatically applies the bundled
 `speaker-toolkit-default@1` policy; users are not asked to invent thresholds. A present
 override is strict and fail-closed: an unreadable file, duplicate key, non-finite
-number, unknown/missing field, unsupported version, file over 64 KiB, or invalid
+number, unknown/missing field, unsupported version, oversized file, or invalid
 threshold aborts profile generation rather than silently selecting the default.
 
 `classification_policy` is self-contained. `semantic_policy` is the complete normalized
@@ -656,86 +656,41 @@ uses the same closed schema and records `source: "vault_override"`.
 
 `pattern_classifications` and `antipattern_classifications` contain one sorted row for
 every observable catalog entry of the matching polarity. Each row preserves the exact
-evaluable denominator and also gives conservative opportunity bounds: for applicable
-count `A`, evaluable count `E`, detections `D`, and unevaluable count `U`, coverage is
-`E/A`, `lower` is `D/A`, and `upper` is `(D+U)/A`; all three ratios are null when
-`A == 0`. Positive classifications are `signature`, `regular`, `occasional`, `rare`,
-`never_tried`, `not_yet_observed`, or `unclassified`. Antipattern classifications are
-`high_frequency`, `moderate_frequency`, `occasional`, `confirmed_none`, or
-`unclassified`. The embedded semantic policy is authoritative; the bundled defaults
-are summarized below in plain language.
+evaluable denominator and exposes classifier-produced evidence counts, coverage, and
+conservative bounds. Positive and antipattern rows use the label vocabularies shown in
+the schema example; row-level `unclassified` results remain part of the exhaustive
+output.
 
-#### Bundled Default Thresholds
+#### Classifier-Owned Policy Semantics
 
-In the tables below, `A` is the number of applicable talks, `E` the number actually
-evaluable, `D` the number with a detection, and `U` the applicable talks left
-unevaluable. “Definitely detected” is the conservative lower bound `D/A`; the upper
-bound `(D+U)/A` shows how high the rate could be if every unknown became a detection.
-Coverage is `E/A`.
+Thresholds, formulas, tier predicates, combination selection, trend windows, and
+movement decisions are not restated in this reference. See
+`references/pattern-classification-policy-v1.json` for the complete bundled semantic
+policy and `scripts/classify-pattern-profile.py` — `validate_policy()` and
+`classify_pattern_profile()` — for its executable contract. Each generated profile
+embeds the normalized policy that was actually applied, plus its semantic digest.
+Consumers copy the classifier's rows and projections unchanged.
 
-For positive patterns, `speaker-toolkit-default@1` uses these labels:
+`mastery_levels`, `strengths`, `underused_patterns`, `never_used_patterns`, signature
+combinations, and trend analysis are deterministic classifier projections. Consumers
+must not reconstruct them from raw rates or from the prose summary.
 
-| Label | Plain-language gate |
-|---|---|
-| `signature` | At least 8 applicable talks, with definite detections in at least 70% (`A >= 8`, lower `>= 0.70`). |
-| `regular` | At least 8 evaluable talks and 80% coverage; definitely present in at least 40%, but below 70% even if every unknown were positive (`E >= 8`, coverage `>= 0.80`, lower `>= 0.40`, upper `< 0.70`). |
-| `occasional` | The same sample and coverage gates; definitely present in at least 15%, but below 40% even under the unknown-positive upper bound (lower `>= 0.15`, upper `< 0.40`). |
-| `rare` | The same sample and coverage gates, at least one detection, and below 15% even under the upper bound (`D >= 1`, upper `< 0.15`). |
-| `never_tried` | The catalog permits an absence conclusion, at least 8 talks are applicable, every one is evaluable, and none contains the pattern (`A >= 8`, `E == A`, `D == 0`). |
-
-`mastery_levels` mirrors those five named tiers. `strengths` is the sorted union of
-`signature` and `regular`; `underused_patterns` is the sorted union of `rare` and
-`never_tried`; `never_used_patterns` contains only evidence-backed `never_tried` IDs.
-
-For antipattern recurrence, the default uses:
-
-| Label | Plain-language gate |
-|---|---|
-| `high_frequency` | At least 8 applicable talks, at least 4 detections, and definite detections in at least half (`A >= 8`, `D >= 4`, lower `>= 0.50`). |
-| `moderate_frequency` | At least 8 evaluable talks and 80% coverage, at least 3 detections, a definite rate of at least 25%, and a rate below 50% even if every unknown were positive (lower `>= 0.25`, upper `< 0.50`). |
-| `occasional` | At least 8 evaluable talks and 80% coverage, at least one detection, and an upper bound below 25% (`D >= 1`, upper `< 0.25`). |
-| `confirmed_none` | The catalog permits an absence conclusion, at least 8 talks are applicable, every one is evaluable, and none contains the antipattern (`A >= 8`, `E == A`, `D == 0`). |
-
-Signature combinations and trends have separate gates:
-
-- A combination contains exactly two or three positive patterns already classified
-  `regular` or `signature`. All members must be detected together in at least 4 of at
-  least 8 applicable talks, with a conservative joint rate of at least 40%. At most 10
-  combinations are retained, ordered by stronger lower bound, more detections, then ID.
-- Trends require at least 10 talks with valid dates. The newest 10, ordered by date and
-  filename, must share one non-null `opportunity_coverage_identity` and contain at
-  least one evaluable (`detected` or `undetected`) opportunity; the older five are
-  compared with the newer five. Otherwise the entire trend domain is unavailable.
-- A score change of at least `+0.5` is `improving`; at most `-0.5` is `declining`;
-  anything between is `stable`. Breadth—the number of detected positive patterns per
-  talk—uses the same `0.5` threshold for `widening`, `narrowing`, or `stable`.
-- A catalog-entry movement is `increasing` or `decreasing` only when its conservative
-  five-talk intervals prove a change of at least `0.20`; all five talks in each window
-  must be applicable to that entry. It is `stable` when the whole possible change stays
-  inside that band, and `indeterminate` when uncertainty crosses a boundary.
-
-`never_tried` and `not_yet_observed` are deliberately not synonyms. `never_tried` is an
-evidence-backed absence: the catalog says the available artifact can prove absence, the
-sample has at least eight applicable talks, every applicable talk was evaluated, and
-all eight or more were negative. `not_yet_observed` says only that this corpus has no
-positive detection while absence itself is still unknown—for example, the catalog
-permits positive detection but not absence, or coverage is incomplete. A smaller but
-fully evaluated absence-capable sample is instead `unclassified` with observation
-status `confirmed_absent`: absence is known, but the sample is too small for the
-`never_tried` tier. Neither state may appear in `never_used_patterns` or be presented
-as a policy-backed fact that the speaker has never tried the technique. With no
-applicable talks at all, the row is `unclassified` with observation status
-`unavailable`. The antipattern equivalent is `confirmed_none`; a zero-detection
-antipattern without the same absence gates remains `unclassified`, not “resolved.”
+`never_tried` and `not_yet_observed` are deliberately not synonyms. `never_tried` is a
+policy-backed absence classification. `not_yet_observed` says that this corpus has no
+positive detection while absence remains unknown. A conclusive absence that does not
+reach a named tier remains `unclassified` with observation status `confirmed_absent`.
+Only classifier-emitted `never_tried` IDs enter `never_used_patterns`; no other zero
+state may be presented as proof that the speaker has never tried the technique. The
+antipattern equivalent is `confirmed_none`; every other zero-detection antipattern
+remains non-recurring unless the classifier says otherwise.
 
 `classification_availability` is schema v2 and independent per domain. Mastery/novelty,
 antipattern recurrence, underuse, combinations, trends, and modes each carry their own
 `{status, reason_codes}`. The default policy makes the first four domains evaluable from
-opportunity rows; trends additionally require ten valid dated talks, two five-talk
-windows, one non-null shared opportunity identity, and at least one evaluable
-opportunity in the selected sample. Modes remain unavailable until talk-mode
-assignments exist. A consumer must gate only the requested domain and retain row-level
-unclassified results; one unavailable domain never erases another available one.
+opportunity rows; the classifier determines trend availability from its policy and
+input evidence. Modes remain unavailable until talk-mode assignments exist. A consumer
+must gate only the requested domain and retain row-level unclassified results; one
+unavailable domain never erases another available one.
 `trend_analysis` retains the complete selected sample, metric values, exhaustive
 pattern movements, and reasons behind those projections.
 

--- a/skills/vault-profile/scripts/classify-pattern-profile.py
+++ b/skills/vault-profile/scripts/classify-pattern-profile.py
@@ -204,8 +204,10 @@ def _validate_threshold_rule(
 def validate_policy(value: object) -> dict[str, object]:
     """Return a normalized strict schema-v1 policy or raise."""
     policy = _exact_fields(value, _POLICY_TOP_LEVEL_FIELDS, path="policy")
-    if policy.get("schema_version") != POLICY_SCHEMA_VERSION or isinstance(
-        policy.get("schema_version"), bool
+    policy_schema_version = policy.get("schema_version")
+    if (
+        not _is_integer(policy_schema_version)
+        or policy_schema_version != POLICY_SCHEMA_VERSION
     ):
         raise PatternClassificationError(
             f"policy.schema_version must be {POLICY_SCHEMA_VERSION}"
@@ -363,9 +365,15 @@ def validate_policy(value: object) -> dict[str, object]:
             "policy.signature_combinations.eligible_member_classifications must "
             "equal ['regular', 'signature']"
         )
-    if combinations.get("member_counts") != [2, 3]:
+    member_counts = combinations.get("member_counts")
+    if (
+        not isinstance(member_counts, list)
+        or any(not _is_integer(item) for item in member_counts)
+        or member_counts != [2, 3]
+    ):
         raise PatternClassificationError(
-            "policy.signature_combinations.member_counts must equal [2, 3]"
+            "policy.signature_combinations.member_counts must equal the integer "
+            "list [2, 3]"
         )
     normalized_combinations: dict[str, object] = {
         "eligible_member_classifications": ["regular", "signature"],
@@ -567,8 +575,10 @@ def resolve_classification_policy(
 def validate_policy_stamp(value: object) -> dict[str, object]:
     """Validate a self-contained profile policy stamp and its semantic digest."""
     stamp = _exact_fields(value, _POLICY_STAMP_FIELDS, path="classification_policy")
-    if stamp.get("schema_version") != POLICY_STAMP_SCHEMA_VERSION or isinstance(
-        stamp.get("schema_version"), bool
+    stamp_schema_version = stamp.get("schema_version")
+    if (
+        not _is_integer(stamp_schema_version)
+        or stamp_schema_version != POLICY_STAMP_SCHEMA_VERSION
     ):
         raise PatternClassificationError(
             f"classification_policy.schema_version must be {POLICY_STAMP_SCHEMA_VERSION}"
@@ -583,7 +593,12 @@ def validate_policy_stamp(value: object) -> dict[str, object]:
         raise PatternClassificationError(
             "classification_policy.policy_id does not match semantic_policy"
         )
-    if stamp.get("policy_version") != policy["policy_version"]:
+    stamp_policy_version = stamp.get("policy_version")
+    if not _is_integer(stamp_policy_version) or stamp_policy_version < 1:
+        raise PatternClassificationError(
+            "classification_policy.policy_version must be a positive integer"
+        )
+    if stamp_policy_version != policy["policy_version"]:
         raise PatternClassificationError(
             "classification_policy.policy_version does not match semantic_policy"
         )

--- a/skills/vault-profile/scripts/classify-pattern-profile.py
+++ b/skills/vault-profile/scripts/classify-pattern-profile.py
@@ -996,13 +996,30 @@ def _combination_rows(
                         "reason_codes": ["meets_signature_combination_thresholds"],
                     }
                 )
-    candidates.sort(
-        key=lambda item: (
-            -float(item["evidence"]["lower"]),  # type: ignore[index]
-            -int(item["evidence"]["detected_count"]),  # type: ignore[index]
-            tuple(item["pattern_ids"]),  # type: ignore[arg-type]
-        )
-    )
+
+    def candidate_sort_key(
+        item: Mapping[str, object],
+    ) -> tuple[float, int, tuple[str, ...]]:
+        evidence = item.get("evidence")
+        pattern_ids = item.get("pattern_ids")
+        if not isinstance(evidence, Mapping) or not isinstance(pattern_ids, list):
+            raise PatternClassificationError(
+                "classifier produced an invalid signature-combination row"
+            )
+        lower = evidence.get("lower")
+        detected = evidence.get("detected_count")
+        if (
+            isinstance(lower, bool)
+            or not isinstance(lower, (int, float))
+            or not _is_integer(detected)
+            or any(not isinstance(pattern_id, str) for pattern_id in pattern_ids)
+        ):
+            raise PatternClassificationError(
+                "classifier produced invalid signature-combination evidence"
+            )
+        return -float(lower), -detected, tuple(pattern_ids)
+
+    candidates.sort(key=candidate_sort_key)
     return candidates[: int(combination_policy["maximum_results"])]
 
 

--- a/skills/vault-profile/scripts/classify-pattern-profile.py
+++ b/skills/vault-profile/scripts/classify-pattern-profile.py
@@ -54,6 +54,7 @@ from pattern_opportunities import (  # noqa: E402
     build_pattern_opportunity_rows,
     canonical_talk_outcomes,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     load_catalog,
@@ -721,8 +722,7 @@ def _classify_positive(
         reason_codes = ["no_applicable_talks"]
     elif (
         detected > 0
-        and
-        applicable >= int(signature["minimum_applicable"])
+        and applicable >= int(signature["minimum_applicable"])
         and isinstance(lower, (int, float))
         and lower >= float(signature["minimum_lower"])
     ):
@@ -730,8 +730,7 @@ def _classify_positive(
         reason_codes = ["meets_signature_thresholds"]
     elif (
         detected > 0
-        and
-        evaluable >= int(regular["minimum_evaluable"])
+        and evaluable >= int(regular["minimum_evaluable"])
         and isinstance(coverage, (int, float))
         and coverage >= float(regular["minimum_applicable_coverage"])
         and isinstance(lower, (int, float))
@@ -743,8 +742,7 @@ def _classify_positive(
         reason_codes = ["meets_regular_thresholds"]
     elif (
         detected > 0
-        and
-        evaluable >= int(occasional["minimum_evaluable"])
+        and evaluable >= int(occasional["minimum_evaluable"])
         and isinstance(coverage, (int, float))
         and coverage >= float(occasional["minimum_applicable_coverage"])
         and isinstance(lower, (int, float))

--- a/skills/vault-profile/scripts/classify-pattern-profile.py
+++ b/skills/vault-profile/scripts/classify-pattern-profile.py
@@ -1,0 +1,1508 @@
+#!/usr/bin/env python3
+"""Apply a versioned policy to persisted scoring-v5 pattern outcomes.
+
+This is the sole arithmetic owner for speaker-profile pattern classifications,
+combinations, and trends. Raw opportunity aggregation remains owned by
+``pattern_opportunities.py`` and is deliberately not changed here.
+
+CLI contract
+------------
+Args:
+    vault_root: vault whose optional ``pattern-classification-policy.json`` is
+                resolved. An absent override selects the bundled default.
+
+Stdin:
+    JSON object with one ``baseline_talks`` array.
+
+Stdout:
+    JSON classification bundle suitable for merging into ``pattern_profile``.
+
+Exit codes:
+    0   success
+    1   invalid arguments, policy, input JSON, or current-generation outcomes
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+import math
+import pathlib
+import re
+import stat
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from datetime import date
+from fractions import Fraction
+from typing import Any, NoReturn, TypeGuard, cast
+
+
+_SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+_INGRESS_SCRIPTS = (
+    pathlib.Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts"
+)
+if str(_INGRESS_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_INGRESS_SCRIPTS))
+
+from pattern_opportunities import (  # noqa: E402
+    PatternOpportunityError,
+    build_pattern_opportunity_rows,
+    canonical_talk_outcomes,
+)
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    load_catalog,
+)
+
+
+POLICY_SCHEMA_VERSION = 1
+POLICY_STAMP_SCHEMA_VERSION = 1
+CLASSIFICATION_SCHEMA_VERSION = 1
+CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 2
+DEFAULT_POLICY_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "references"
+    / "pattern-classification-policy-v1.json"
+)
+OVERRIDE_POLICY_FILENAME = "pattern-classification-policy.json"
+MAX_POLICY_BYTES = 64 * 1024
+_POLICY_ID_RE = re.compile(r"[a-z0-9][a-z0-9._-]{0,63}")
+_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+_HEX64_RE = re.compile(r"[0-9a-f]{64}")
+
+_POLICY_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "policy_id",
+        "policy_version",
+        "positive_patterns",
+        "antipattern_recurrence",
+        "signature_combinations",
+        "trends",
+    }
+)
+_POLICY_STAMP_FIELDS = frozenset(
+    {
+        "schema_version",
+        "policy_id",
+        "policy_version",
+        "source",
+        "semantic_sha256",
+        "semantic_policy",
+    }
+)
+_DOMAIN_NAMES = (
+    "mastery_and_novelty",
+    "antipattern_recurrence",
+    "underuse",
+    "signature_combinations",
+    "trends",
+    "modes",
+)
+
+
+class PatternClassificationError(ValueError):
+    """Policy or current-generation evidence cannot authorize classifications."""
+
+
+def _is_integer(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _fail_constant(value: str) -> NoReturn:
+    raise PatternClassificationError(f"non-finite JSON number {value!r} is forbidden")
+
+
+def _strict_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise PatternClassificationError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _exact_fields(
+    value: object, expected: frozenset[str], *, path: str
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise PatternClassificationError(f"{path} must be an object")
+    missing = sorted(expected - set(value))
+    unknown = sorted(set(value) - expected, key=str)
+    if missing or unknown:
+        raise PatternClassificationError(
+            f"{path} fields are noncanonical; missing={missing}, "
+            f"unknown={[str(item) for item in unknown]}"
+        )
+    return value
+
+
+def _positive_integer(value: object, *, path: str) -> int:
+    if not _is_integer(value) or value < 1:
+        raise PatternClassificationError(f"{path} must be a positive integer")
+    return value
+
+
+def _non_negative_integer(value: object, *, path: str) -> int:
+    if not _is_integer(value) or value < 0:
+        raise PatternClassificationError(f"{path} must be a non-negative integer")
+    return value
+
+
+def _unit_interval(value: object, *, path: str, positive: bool = False) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+        or value > 1
+        or (positive and value == 0)
+    ):
+        qualifier = "greater than zero and " if positive else ""
+        raise PatternClassificationError(
+            f"{path} must be a finite number {qualifier}between zero and one"
+        )
+    normalized = float(value)
+    return 0.0 if normalized == 0 else normalized
+
+
+def _validate_threshold_rule(
+    value: object,
+    fields: frozenset[str],
+    *,
+    path: str,
+) -> dict[str, object]:
+    rule = _exact_fields(value, fields, path=path)
+    normalized: dict[str, object] = {}
+    for field in sorted(fields):
+        raw = rule[field]
+        field_path = f"{path}.{field}"
+        if field == "minimum_detections":
+            normalized[field] = _positive_integer(raw, path=field_path)
+        elif field.startswith("minimum_") and field not in {
+            "minimum_lower",
+            "minimum_applicable_coverage",
+        }:
+            normalized[field] = _non_negative_integer(raw, path=field_path)
+        elif field == "maximum_detections":
+            normalized[field] = _non_negative_integer(raw, path=field_path)
+        elif field == "require_complete_evaluation":
+            if raw is not True:
+                raise PatternClassificationError(f"{field_path} must be true")
+            normalized[field] = True
+        else:
+            normalized[field] = _unit_interval(raw, path=field_path)
+    return normalized
+
+
+def validate_policy(value: object) -> dict[str, object]:
+    """Return a normalized strict schema-v1 policy or raise."""
+    policy = _exact_fields(value, _POLICY_TOP_LEVEL_FIELDS, path="policy")
+    if policy.get("schema_version") != POLICY_SCHEMA_VERSION or isinstance(
+        policy.get("schema_version"), bool
+    ):
+        raise PatternClassificationError(
+            f"policy.schema_version must be {POLICY_SCHEMA_VERSION}"
+        )
+    policy_id = policy.get("policy_id")
+    if not isinstance(policy_id, str) or _POLICY_ID_RE.fullmatch(policy_id) is None:
+        raise PatternClassificationError(
+            "policy.policy_id must match [a-z0-9][a-z0-9._-]{0,63}"
+        )
+    policy_version = _positive_integer(
+        policy.get("policy_version"), path="policy.policy_version"
+    )
+
+    positive = _exact_fields(
+        policy.get("positive_patterns"),
+        frozenset({"signature", "regular", "occasional", "rare", "never_tried"}),
+        path="policy.positive_patterns",
+    )
+    normalized_positive: dict[str, dict[str, Any]] = {
+        "signature": _validate_threshold_rule(
+            positive["signature"],
+            frozenset({"minimum_applicable", "minimum_lower"}),
+            path="policy.positive_patterns.signature",
+        ),
+        "regular": _validate_threshold_rule(
+            positive["regular"],
+            frozenset(
+                {
+                    "minimum_evaluable",
+                    "minimum_applicable_coverage",
+                    "minimum_lower",
+                    "maximum_upper_exclusive",
+                }
+            ),
+            path="policy.positive_patterns.regular",
+        ),
+        "occasional": _validate_threshold_rule(
+            positive["occasional"],
+            frozenset(
+                {
+                    "minimum_evaluable",
+                    "minimum_applicable_coverage",
+                    "minimum_lower",
+                    "maximum_upper_exclusive",
+                }
+            ),
+            path="policy.positive_patterns.occasional",
+        ),
+        "rare": _validate_threshold_rule(
+            positive["rare"],
+            frozenset(
+                {
+                    "minimum_evaluable",
+                    "minimum_applicable_coverage",
+                    "minimum_detections",
+                    "maximum_upper_exclusive",
+                }
+            ),
+            path="policy.positive_patterns.rare",
+        ),
+        "never_tried": _validate_threshold_rule(
+            positive["never_tried"],
+            frozenset(
+                {
+                    "minimum_applicable",
+                    "require_complete_evaluation",
+                    "maximum_detections",
+                }
+            ),
+            path="policy.positive_patterns.never_tried",
+        ),
+    }
+    if normalized_positive["never_tried"]["maximum_detections"] != 0:
+        raise PatternClassificationError(
+            "policy.positive_patterns.never_tried.maximum_detections must be 0"
+        )
+    for tier in ("signature", "regular", "occasional"):
+        if float(normalized_positive[tier]["minimum_lower"]) <= 0:
+            raise PatternClassificationError(
+                f"policy.positive_patterns.{tier}.minimum_lower must be greater "
+                "than zero"
+            )
+
+    recurrence = _exact_fields(
+        policy.get("antipattern_recurrence"),
+        frozenset(
+            {"high_frequency", "moderate_frequency", "occasional", "confirmed_none"}
+        ),
+        path="policy.antipattern_recurrence",
+    )
+    normalized_recurrence: dict[str, dict[str, Any]] = {
+        "high_frequency": _validate_threshold_rule(
+            recurrence["high_frequency"],
+            frozenset({"minimum_applicable", "minimum_detections", "minimum_lower"}),
+            path="policy.antipattern_recurrence.high_frequency",
+        ),
+        "moderate_frequency": _validate_threshold_rule(
+            recurrence["moderate_frequency"],
+            frozenset(
+                {
+                    "minimum_evaluable",
+                    "minimum_applicable_coverage",
+                    "minimum_detections",
+                    "minimum_lower",
+                    "maximum_upper_exclusive",
+                }
+            ),
+            path="policy.antipattern_recurrence.moderate_frequency",
+        ),
+        "occasional": _validate_threshold_rule(
+            recurrence["occasional"],
+            frozenset(
+                {
+                    "minimum_evaluable",
+                    "minimum_applicable_coverage",
+                    "minimum_detections",
+                    "maximum_upper_exclusive",
+                }
+            ),
+            path="policy.antipattern_recurrence.occasional",
+        ),
+        "confirmed_none": _validate_threshold_rule(
+            recurrence["confirmed_none"],
+            frozenset(
+                {
+                    "minimum_applicable",
+                    "require_complete_evaluation",
+                    "maximum_detections",
+                }
+            ),
+            path="policy.antipattern_recurrence.confirmed_none",
+        ),
+    }
+    if normalized_recurrence["confirmed_none"]["maximum_detections"] != 0:
+        raise PatternClassificationError(
+            "policy.antipattern_recurrence.confirmed_none.maximum_detections must be 0"
+        )
+
+    combinations = _exact_fields(
+        policy.get("signature_combinations"),
+        frozenset(
+            {
+                "eligible_member_classifications",
+                "member_counts",
+                "minimum_applicable",
+                "minimum_detections",
+                "minimum_lower",
+                "maximum_results",
+            }
+        ),
+        path="policy.signature_combinations",
+    )
+    if combinations.get("eligible_member_classifications") != ["regular", "signature"]:
+        raise PatternClassificationError(
+            "policy.signature_combinations.eligible_member_classifications must "
+            "equal ['regular', 'signature']"
+        )
+    if combinations.get("member_counts") != [2, 3]:
+        raise PatternClassificationError(
+            "policy.signature_combinations.member_counts must equal [2, 3]"
+        )
+    normalized_combinations: dict[str, object] = {
+        "eligible_member_classifications": ["regular", "signature"],
+        "member_counts": [2, 3],
+        "minimum_applicable": _positive_integer(
+            combinations.get("minimum_applicable"),
+            path="policy.signature_combinations.minimum_applicable",
+        ),
+        "minimum_detections": _positive_integer(
+            combinations.get("minimum_detections"),
+            path="policy.signature_combinations.minimum_detections",
+        ),
+        "minimum_lower": _unit_interval(
+            combinations.get("minimum_lower"),
+            path="policy.signature_combinations.minimum_lower",
+            positive=True,
+        ),
+        "maximum_results": _positive_integer(
+            combinations.get("maximum_results"),
+            path="policy.signature_combinations.maximum_results",
+        ),
+    }
+    if normalized_combinations["maximum_results"] != 10:
+        raise PatternClassificationError(
+            "schema-v1 signature combinations require maximum_results=10"
+        )
+
+    trends = _exact_fields(
+        policy.get("trends"),
+        frozenset(
+            {
+                "minimum_comparable_talks",
+                "window_size",
+                "score_delta",
+                "breadth_delta",
+                "pattern_movement_delta",
+            }
+        ),
+        path="policy.trends",
+    )
+    minimum_comparable = _positive_integer(
+        trends.get("minimum_comparable_talks"),
+        path="policy.trends.minimum_comparable_talks",
+    )
+    window_size = _positive_integer(
+        trends.get("window_size"), path="policy.trends.window_size"
+    )
+    if minimum_comparable != 10 or window_size != 5:
+        raise PatternClassificationError(
+            "schema-v1 trend windows require minimum_comparable_talks=10 and "
+            "window_size=5"
+        )
+    normalized_trends: dict[str, object] = {
+        "minimum_comparable_talks": minimum_comparable,
+        "window_size": window_size,
+        "score_delta": _unit_interval(
+            trends.get("score_delta"), path="policy.trends.score_delta", positive=True
+        ),
+        "breadth_delta": _unit_interval(
+            trends.get("breadth_delta"),
+            path="policy.trends.breadth_delta",
+            positive=True,
+        ),
+        "pattern_movement_delta": _unit_interval(
+            trends.get("pattern_movement_delta"),
+            path="policy.trends.pattern_movement_delta",
+            positive=True,
+        ),
+    }
+
+    rare_upper = float(normalized_positive["rare"]["maximum_upper_exclusive"])
+    occasional_lower = float(normalized_positive["occasional"]["minimum_lower"])
+    occasional_upper = float(
+        normalized_positive["occasional"]["maximum_upper_exclusive"]
+    )
+    regular_lower = float(normalized_positive["regular"]["minimum_lower"])
+    regular_upper = float(normalized_positive["regular"]["maximum_upper_exclusive"])
+    signature_lower = float(normalized_positive["signature"]["minimum_lower"])
+    if not (
+        rare_upper <= occasional_lower
+        and occasional_lower < occasional_upper <= regular_lower
+        and regular_lower < regular_upper <= signature_lower
+    ):
+        raise PatternClassificationError(
+            "policy.positive_patterns bands must be ordered without overlap"
+        )
+
+    occasional_recurrence_upper = float(
+        normalized_recurrence["occasional"]["maximum_upper_exclusive"]
+    )
+    moderate_lower = float(normalized_recurrence["moderate_frequency"]["minimum_lower"])
+    moderate_upper = float(
+        normalized_recurrence["moderate_frequency"]["maximum_upper_exclusive"]
+    )
+    high_lower = float(normalized_recurrence["high_frequency"]["minimum_lower"])
+    if not (
+        occasional_recurrence_upper <= moderate_lower
+        and moderate_lower < moderate_upper <= high_lower
+    ):
+        raise PatternClassificationError(
+            "policy.antipattern_recurrence bands must be ordered without overlap"
+        )
+
+    return {
+        "schema_version": POLICY_SCHEMA_VERSION,
+        "policy_id": policy_id,
+        "policy_version": policy_version,
+        "positive_patterns": normalized_positive,
+        "antipattern_recurrence": normalized_recurrence,
+        "signature_combinations": normalized_combinations,
+        "trends": normalized_trends,
+    }
+
+
+def _decode_policy_bytes(raw: bytes, *, path: pathlib.Path) -> dict[str, object]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PatternClassificationError(f"{path}: policy is not UTF-8: {exc}") from exc
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_strict_object,
+            parse_constant=_fail_constant,
+        )
+    except (json.JSONDecodeError, PatternClassificationError) as exc:
+        raise PatternClassificationError(f"{path}: invalid policy JSON: {exc}") from exc
+    return validate_policy(value)
+
+
+def _read_policy(path: pathlib.Path) -> dict[str, object]:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise PatternClassificationError(
+            f"cannot inspect policy {path}: {exc}"
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise PatternClassificationError(f"policy {path} must be a regular file")
+    if metadata.st_size > MAX_POLICY_BYTES:
+        raise PatternClassificationError(
+            f"policy {path} exceeds the {MAX_POLICY_BYTES}-byte limit"
+        )
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise PatternClassificationError(f"cannot read policy {path}: {exc}") from exc
+    if len(raw) > MAX_POLICY_BYTES:
+        raise PatternClassificationError(
+            f"policy {path} exceeds the {MAX_POLICY_BYTES}-byte limit"
+        )
+    return _decode_policy_bytes(raw, path=path)
+
+
+def canonical_policy_sha256(policy: object) -> str:
+    """Hash canonical semantic policy JSON, independent of source formatting."""
+    normalized = validate_policy(policy)
+    encoded = json.dumps(
+        normalized,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def resolve_classification_policy(
+    vault_root: pathlib.Path,
+    *,
+    bundled_policy_path: pathlib.Path = DEFAULT_POLICY_PATH,
+) -> dict[str, object]:
+    """Resolve a strict vault override or the bundled default without prompting."""
+    if not isinstance(vault_root, pathlib.Path):
+        raise PatternClassificationError("vault_root must be a pathlib.Path")
+    override_path = vault_root / OVERRIDE_POLICY_FILENAME
+    try:
+        override_exists = override_path.exists() or override_path.is_symlink()
+    except OSError as exc:
+        raise PatternClassificationError(
+            f"cannot inspect policy override {override_path}: {exc}"
+        ) from exc
+    if override_exists:
+        policy = _read_policy(override_path)
+        source = "vault_override"
+    else:
+        policy = _read_policy(bundled_policy_path)
+        source = "bundled_default"
+    return {
+        "schema_version": POLICY_STAMP_SCHEMA_VERSION,
+        "policy_id": policy["policy_id"],
+        "policy_version": policy["policy_version"],
+        "source": source,
+        "semantic_sha256": canonical_policy_sha256(policy),
+        "semantic_policy": policy,
+    }
+
+
+def validate_policy_stamp(value: object) -> dict[str, object]:
+    """Validate a self-contained profile policy stamp and its semantic digest."""
+    stamp = _exact_fields(value, _POLICY_STAMP_FIELDS, path="classification_policy")
+    if stamp.get("schema_version") != POLICY_STAMP_SCHEMA_VERSION or isinstance(
+        stamp.get("schema_version"), bool
+    ):
+        raise PatternClassificationError(
+            f"classification_policy.schema_version must be {POLICY_STAMP_SCHEMA_VERSION}"
+        )
+    source = stamp.get("source")
+    if source not in {"bundled_default", "vault_override"}:
+        raise PatternClassificationError(
+            "classification_policy.source must be bundled_default or vault_override"
+        )
+    policy = validate_policy(stamp.get("semantic_policy"))
+    if stamp.get("policy_id") != policy["policy_id"]:
+        raise PatternClassificationError(
+            "classification_policy.policy_id does not match semantic_policy"
+        )
+    if stamp.get("policy_version") != policy["policy_version"]:
+        raise PatternClassificationError(
+            "classification_policy.policy_version does not match semantic_policy"
+        )
+    digest = stamp.get("semantic_sha256")
+    if not isinstance(digest, str) or _HEX64_RE.fullmatch(digest) is None:
+        raise PatternClassificationError(
+            "classification_policy.semantic_sha256 must be lowercase SHA-256 hex"
+        )
+    expected_digest = canonical_policy_sha256(policy)
+    if digest != expected_digest:
+        raise PatternClassificationError(
+            "classification_policy.semantic_sha256 does not match semantic_policy"
+        )
+    return {
+        "schema_version": POLICY_STAMP_SCHEMA_VERSION,
+        "policy_id": policy["policy_id"],
+        "policy_version": policy["policy_version"],
+        "source": source,
+        "semantic_sha256": expected_digest,
+        "semantic_policy": policy,
+    }
+
+
+def _evidence_bounds(row: Mapping[str, object]) -> dict[str, Any]:
+    required = (
+        "eligible_cohort_count",
+        "not_applicable_count",
+        "evaluable_count",
+        "detected_count",
+        "unevaluable_count",
+    )
+    counts: dict[str, int] = {}
+    for field in required:
+        raw = row.get(field)
+        if not _is_integer(raw) or raw < 0:
+            raise PatternClassificationError(
+                f"opportunity row {row.get('pattern_id')!r}.{field} must be a "
+                "non-negative integer"
+            )
+        counts[field] = raw
+    applicable = counts["eligible_cohort_count"] - counts["not_applicable_count"]
+    evaluable = counts["evaluable_count"]
+    detected = counts["detected_count"]
+    unevaluable = counts["unevaluable_count"]
+    if applicable < 0 or evaluable + unevaluable != applicable or detected > evaluable:
+        raise PatternClassificationError(
+            f"opportunity row {row.get('pattern_id')!r} has inconsistent A/E/D/U counts"
+        )
+    if applicable == 0:
+        applicable_coverage = lower = upper = None
+    else:
+        applicable_coverage = evaluable / applicable
+        lower = detected / applicable
+        upper = (detected + unevaluable) / applicable
+    return {
+        "applicable_count": applicable,
+        "evaluable_count": evaluable,
+        "detected_count": detected,
+        "unevaluable_count": unevaluable,
+        "applicable_coverage": applicable_coverage,
+        "lower": lower,
+        "upper": upper,
+    }
+
+
+def _observation_status(
+    evidence: Mapping[str, Any], *, absence_conclusion_capable: bool
+) -> str:
+    applicable = int(evidence["applicable_count"])
+    detected = int(evidence["detected_count"])
+    evaluable = int(evidence["evaluable_count"])
+    if applicable == 0:
+        return "unavailable"
+    if detected > 0:
+        return "observed"
+    if absence_conclusion_capable and evaluable == applicable:
+        return "confirmed_absent"
+    return "not_yet_observed"
+
+
+def _insufficiency_reasons(
+    evidence: Mapping[str, Any],
+    *,
+    minimum_applicable: int,
+    minimum_evaluable: int,
+    minimum_coverage: float,
+) -> list[str]:
+    applicable = int(evidence["applicable_count"])
+    evaluable = int(evidence["evaluable_count"])
+    coverage = evidence["applicable_coverage"]
+    reasons: list[str] = []
+    if applicable == 0:
+        return ["no_applicable_talks"]
+    if applicable < minimum_applicable:
+        reasons.append("insufficient_applicable_sample")
+    if evaluable < minimum_evaluable:
+        reasons.append("insufficient_evaluable_sample")
+    if isinstance(coverage, (int, float)) and coverage < minimum_coverage:
+        reasons.append("insufficient_applicable_coverage")
+    return reasons
+
+
+def _classify_positive(
+    row: Mapping[str, object],
+    *,
+    absence_conclusion_capable: bool,
+    policy: Mapping[str, Any],
+) -> dict[str, object]:
+    evidence = _evidence_bounds(row)
+    pattern_id = row.get("pattern_id")
+    if not isinstance(pattern_id, str) or not pattern_id:
+        raise PatternClassificationError(
+            "positive opportunity row has invalid pattern_id"
+        )
+    rules = policy["positive_patterns"]
+    assert isinstance(rules, Mapping)
+    signature = rules["signature"]
+    regular = rules["regular"]
+    occasional = rules["occasional"]
+    rare = rules["rare"]
+    never_tried = rules["never_tried"]
+    assert all(
+        isinstance(rule, Mapping)
+        for rule in (signature, regular, occasional, rare, never_tried)
+    )
+    applicable = int(evidence["applicable_count"])
+    evaluable = int(evidence["evaluable_count"])
+    detected = int(evidence["detected_count"])
+    coverage = evidence["applicable_coverage"]
+    lower = evidence["lower"]
+    upper = evidence["upper"]
+    classification = "unclassified"
+    reason_codes: list[str] = []
+
+    if applicable == 0:
+        reason_codes = ["no_applicable_talks"]
+    elif (
+        detected > 0
+        and
+        applicable >= int(signature["minimum_applicable"])
+        and isinstance(lower, (int, float))
+        and lower >= float(signature["minimum_lower"])
+    ):
+        classification = "signature"
+        reason_codes = ["meets_signature_thresholds"]
+    elif (
+        detected > 0
+        and
+        evaluable >= int(regular["minimum_evaluable"])
+        and isinstance(coverage, (int, float))
+        and coverage >= float(regular["minimum_applicable_coverage"])
+        and isinstance(lower, (int, float))
+        and lower >= float(regular["minimum_lower"])
+        and isinstance(upper, (int, float))
+        and upper < float(regular["maximum_upper_exclusive"])
+    ):
+        classification = "regular"
+        reason_codes = ["meets_regular_thresholds"]
+    elif (
+        detected > 0
+        and
+        evaluable >= int(occasional["minimum_evaluable"])
+        and isinstance(coverage, (int, float))
+        and coverage >= float(occasional["minimum_applicable_coverage"])
+        and isinstance(lower, (int, float))
+        and lower >= float(occasional["minimum_lower"])
+        and isinstance(upper, (int, float))
+        and upper < float(occasional["maximum_upper_exclusive"])
+    ):
+        classification = "occasional"
+        reason_codes = ["meets_occasional_thresholds"]
+    elif (
+        evaluable >= int(rare["minimum_evaluable"])
+        and isinstance(coverage, (int, float))
+        and coverage >= float(rare["minimum_applicable_coverage"])
+        and detected >= int(rare["minimum_detections"])
+        and isinstance(upper, (int, float))
+        and upper < float(rare["maximum_upper_exclusive"])
+    ):
+        classification = "rare"
+        reason_codes = ["meets_rare_thresholds"]
+    elif (
+        absence_conclusion_capable
+        and applicable >= int(never_tried["minimum_applicable"])
+        and evaluable == applicable
+        and detected <= int(never_tried["maximum_detections"])
+    ):
+        classification = "never_tried"
+        reason_codes = ["complete_absence_meets_never_tried_thresholds"]
+    elif detected == 0 and not (absence_conclusion_capable and evaluable == applicable):
+        classification = "not_yet_observed"
+        reason_codes = _insufficiency_reasons(
+            evidence,
+            minimum_applicable=min(
+                int(signature["minimum_applicable"]),
+                int(never_tried["minimum_applicable"]),
+            ),
+            minimum_evaluable=min(
+                int(regular["minimum_evaluable"]),
+                int(occasional["minimum_evaluable"]),
+                int(rare["minimum_evaluable"]),
+            ),
+            minimum_coverage=min(
+                float(regular["minimum_applicable_coverage"]),
+                float(occasional["minimum_applicable_coverage"]),
+                float(rare["minimum_applicable_coverage"]),
+            ),
+        )
+        reason_codes.append(
+            "absence_not_supported_by_catalog"
+            if not absence_conclusion_capable
+            else "incomplete_absence_evidence"
+        )
+    else:
+        reason_codes = _insufficiency_reasons(
+            evidence,
+            minimum_applicable=int(signature["minimum_applicable"]),
+            minimum_evaluable=min(
+                int(regular["minimum_evaluable"]),
+                int(occasional["minimum_evaluable"]),
+                int(rare["minimum_evaluable"]),
+            ),
+            minimum_coverage=min(
+                float(regular["minimum_applicable_coverage"]),
+                float(occasional["minimum_applicable_coverage"]),
+                float(rare["minimum_applicable_coverage"]),
+            ),
+        )
+        if int(evidence["unevaluable_count"]) > 0:
+            reason_codes.append("uncertain_interval_crosses_thresholds")
+        if not reason_codes:
+            reason_codes.append("no_positive_tier_matched")
+
+    return {
+        "pattern_id": pattern_id,
+        "classification": classification,
+        "observation_status": _observation_status(
+            evidence, absence_conclusion_capable=absence_conclusion_capable
+        ),
+        "absence_conclusion_capable": absence_conclusion_capable,
+        "evidence": evidence,
+        "reason_codes": reason_codes,
+    }
+
+
+def _classify_antipattern(
+    row: Mapping[str, object],
+    *,
+    absence_conclusion_capable: bool,
+    policy: Mapping[str, Any],
+) -> dict[str, object]:
+    evidence = _evidence_bounds(row)
+    pattern_id = row.get("pattern_id")
+    if not isinstance(pattern_id, str) or not pattern_id:
+        raise PatternClassificationError(
+            "antipattern opportunity row has invalid pattern_id"
+        )
+    rules = policy["antipattern_recurrence"]
+    assert isinstance(rules, Mapping)
+    high = rules["high_frequency"]
+    moderate = rules["moderate_frequency"]
+    occasional = rules["occasional"]
+    confirmed_none = rules["confirmed_none"]
+    assert all(
+        isinstance(rule, Mapping)
+        for rule in (high, moderate, occasional, confirmed_none)
+    )
+    applicable = int(evidence["applicable_count"])
+    evaluable = int(evidence["evaluable_count"])
+    detected = int(evidence["detected_count"])
+    coverage = evidence["applicable_coverage"]
+    lower = evidence["lower"]
+    upper = evidence["upper"]
+    classification = "unclassified"
+    reason_codes: list[str] = []
+
+    if applicable == 0:
+        reason_codes = ["no_applicable_talks"]
+    elif (
+        applicable >= int(high["minimum_applicable"])
+        and detected >= int(high["minimum_detections"])
+        and isinstance(lower, (int, float))
+        and lower >= float(high["minimum_lower"])
+    ):
+        classification = "high_frequency"
+        reason_codes = ["meets_high_frequency_thresholds"]
+    elif (
+        evaluable >= int(moderate["minimum_evaluable"])
+        and isinstance(coverage, (int, float))
+        and coverage >= float(moderate["minimum_applicable_coverage"])
+        and detected >= int(moderate["minimum_detections"])
+        and isinstance(lower, (int, float))
+        and lower >= float(moderate["minimum_lower"])
+        and isinstance(upper, (int, float))
+        and upper < float(moderate["maximum_upper_exclusive"])
+    ):
+        classification = "moderate_frequency"
+        reason_codes = ["meets_moderate_frequency_thresholds"]
+    elif (
+        evaluable >= int(occasional["minimum_evaluable"])
+        and isinstance(coverage, (int, float))
+        and coverage >= float(occasional["minimum_applicable_coverage"])
+        and detected >= int(occasional["minimum_detections"])
+        and isinstance(upper, (int, float))
+        and upper < float(occasional["maximum_upper_exclusive"])
+    ):
+        classification = "occasional"
+        reason_codes = ["meets_occasional_frequency_thresholds"]
+    elif (
+        absence_conclusion_capable
+        and applicable >= int(confirmed_none["minimum_applicable"])
+        and evaluable == applicable
+        and detected <= int(confirmed_none["maximum_detections"])
+    ):
+        classification = "confirmed_none"
+        reason_codes = ["complete_absence_meets_confirmed_none_thresholds"]
+    else:
+        reason_codes = _insufficiency_reasons(
+            evidence,
+            minimum_applicable=min(
+                int(high["minimum_applicable"]),
+                int(confirmed_none["minimum_applicable"]),
+            ),
+            minimum_evaluable=min(
+                int(moderate["minimum_evaluable"]),
+                int(occasional["minimum_evaluable"]),
+            ),
+            minimum_coverage=min(
+                float(moderate["minimum_applicable_coverage"]),
+                float(occasional["minimum_applicable_coverage"]),
+            ),
+        )
+        if detected == 0 and not (
+            absence_conclusion_capable and evaluable == applicable
+        ):
+            reason_codes.append(
+                "absence_not_supported_by_catalog"
+                if not absence_conclusion_capable
+                else "incomplete_absence_evidence"
+            )
+        elif int(evidence["unevaluable_count"]) > 0:
+            reason_codes.append("uncertain_interval_crosses_thresholds")
+        if not reason_codes:
+            reason_codes.append("no_recurrence_tier_matched")
+
+    return {
+        "pattern_id": pattern_id,
+        "classification": classification,
+        "observation_status": _observation_status(
+            evidence, absence_conclusion_capable=absence_conclusion_capable
+        ),
+        "absence_conclusion_capable": absence_conclusion_capable,
+        "evidence": evidence,
+        "reason_codes": reason_codes,
+    }
+
+
+def _joint_outcome(member_outcomes: Sequence[str]) -> str:
+    if all(outcome == "detected" for outcome in member_outcomes):
+        return "detected"
+    if all(outcome in {"detected", "undetected"} for outcome in member_outcomes):
+        return "undetected"
+    if any(outcome == "not_applicable" for outcome in member_outcomes):
+        return "not_applicable"
+    return "not_evaluable"
+
+
+def _combination_rows(
+    talks: Sequence[Mapping[str, object]],
+    outcomes_by_talk: Sequence[Mapping[str, str]],
+    positive_classifications: Sequence[Mapping[str, object]],
+    *,
+    policy: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    combination_policy = policy["signature_combinations"]
+    assert isinstance(combination_policy, Mapping)
+    eligible_classes = set(combination_policy["eligible_member_classifications"])
+    member_ids = sorted(
+        str(item["pattern_id"])
+        for item in positive_classifications
+        if item.get("classification") in eligible_classes
+    )
+    candidates: list[dict[str, object]] = []
+    for member_count in combination_policy["member_counts"]:
+        assert isinstance(member_count, int)
+        for members in itertools.combinations(member_ids, member_count):
+            counts: Counter[str] = Counter()
+            for outcomes in outcomes_by_talk:
+                counts[_joint_outcome([outcomes[member] for member in members])] += 1
+            opportunity = {
+                "pattern_id": "+".join(members),
+                "eligible_cohort_count": len(talks),
+                "not_applicable_count": counts["not_applicable"],
+                "evaluable_count": counts["detected"] + counts["undetected"],
+                "detected_count": counts["detected"],
+                "unevaluable_count": counts["not_evaluable"],
+            }
+            evidence = _evidence_bounds(opportunity)
+            lower = evidence["lower"]
+            if (
+                int(evidence["applicable_count"])
+                >= int(combination_policy["minimum_applicable"])
+                and int(evidence["detected_count"])
+                >= int(combination_policy["minimum_detections"])
+                and isinstance(lower, (int, float))
+                and lower >= float(combination_policy["minimum_lower"])
+            ):
+                candidates.append(
+                    {
+                        "combination_id": "+".join(members),
+                        "pattern_ids": list(members),
+                        "evidence": evidence,
+                        "reason_codes": ["meets_signature_combination_thresholds"],
+                    }
+                )
+    candidates.sort(
+        key=lambda item: (
+            -float(item["evidence"]["lower"]),  # type: ignore[index]
+            -int(item["evidence"]["detected_count"]),  # type: ignore[index]
+            tuple(item["pattern_ids"]),  # type: ignore[arg-type]
+        )
+    )
+    return candidates[: int(combination_policy["maximum_results"])]
+
+
+def _valid_talk_date(talk: Mapping[str, object]) -> date | None:
+    raw = talk.get("date")
+    if not isinstance(raw, str) or _DATE_RE.fullmatch(raw) is None:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _talk_filename(talk: Mapping[str, object]) -> str:
+    filename = talk.get("filename")
+    if not isinstance(filename, str) or not filename:
+        raise PatternClassificationError("baseline talk has no filename")
+    return filename
+
+
+def _talk_score(talk: Mapping[str, object]) -> int:
+    score = talk.get("pattern_score")
+    observations = talk.get("pattern_observations")
+    observed_score = (
+        observations.get("pattern_score") if isinstance(observations, Mapping) else None
+    )
+    if not _is_integer(score):
+        raise PatternClassificationError(
+            f"{_talk_filename(talk)}: pattern_score must be an integer"
+        )
+    if not _is_integer(observed_score) or observed_score != score:
+        raise PatternClassificationError(
+            f"{_talk_filename(talk)}: flattened and observed pattern_score must match"
+        )
+    return score
+
+
+def _talk_identity(talk: Mapping[str, object]) -> str | None:
+    observations = talk.get("pattern_observations")
+    raw = (
+        observations.get("opportunity_coverage_identity")
+        if isinstance(observations, Mapping)
+        else None
+    )
+    return raw if isinstance(raw, str) and _HEX64_RE.fullmatch(raw) else None
+
+
+def _window_bounds(outcomes: Sequence[str]) -> dict[str, Any]:
+    counts = Counter(outcomes)
+    opportunity = {
+        "pattern_id": "trend-window",
+        "eligible_cohort_count": len(outcomes),
+        "not_applicable_count": counts["not_applicable"],
+        "evaluable_count": counts["detected"] + counts["undetected"],
+        "detected_count": counts["detected"],
+        "unevaluable_count": counts["not_evaluable"],
+    }
+    return _evidence_bounds(opportunity)
+
+
+def _movement(
+    prior: Mapping[str, Any],
+    recent: Mapping[str, Any],
+    *,
+    threshold: float,
+    expected_applicable: int = 5,
+) -> tuple[str, list[str]]:
+    if (
+        int(prior["applicable_count"]) != expected_applicable
+        or int(recent["applicable_count"]) != expected_applicable
+    ):
+        return "unavailable", ["incomplete_window_applicability"]
+    prior_lower = prior["lower"]
+    prior_upper = prior["upper"]
+    recent_lower = recent["lower"]
+    recent_upper = recent["upper"]
+    if not all(
+        isinstance(value, (int, float))
+        for value in (prior_lower, prior_upper, recent_lower, recent_upper)
+    ):
+        return "unavailable", ["window_bounds_unavailable"]
+    exact_threshold = Fraction(str(threshold))
+    minimum_delta = Fraction(str(recent_lower)) - Fraction(str(prior_upper))
+    maximum_delta = Fraction(str(recent_upper)) - Fraction(str(prior_lower))
+    if minimum_delta >= exact_threshold:
+        return "increasing", ["conservative_interval_increase"]
+    if maximum_delta <= -exact_threshold:
+        return "decreasing", ["conservative_interval_decrease"]
+    if maximum_delta < exact_threshold and minimum_delta > -exact_threshold:
+        return "stable", ["conservative_interval_stable"]
+    return "indeterminate", ["uncertainty_spans_movement_threshold"]
+
+
+def _trend_analysis(
+    talks: Sequence[Mapping[str, object]],
+    outcomes_by_talk: Sequence[Mapping[str, str]],
+    *,
+    pattern_ids: Sequence[str],
+    antipattern_ids: Sequence[str],
+    policy: Mapping[str, Any],
+) -> dict[str, object]:
+    trend_policy = policy["trends"]
+    assert isinstance(trend_policy, Mapping)
+    dated: list[tuple[date, str, Mapping[str, object], Mapping[str, str]]] = []
+    invalid_date_filenames: list[str] = []
+    for talk, outcomes in zip(talks, outcomes_by_talk, strict=True):
+        filename = _talk_filename(talk)
+        talk_date = _valid_talk_date(talk)
+        if talk_date is None:
+            invalid_date_filenames.append(filename)
+        else:
+            dated.append((talk_date, filename, talk, outcomes))
+    dated.sort(key=lambda item: (item[0], item[1]))
+    required = int(trend_policy["minimum_comparable_talks"])
+    sample: dict[str, object] = {
+        "required_talk_count": required,
+        "valid_date_talk_count": len(dated),
+        "invalid_date_filenames": sorted(invalid_date_filenames),
+        "selected_filenames": [],
+        "opportunity_coverage_identity": None,
+    }
+    if len(dated) < required:
+        return {
+            "status": "unavailable",
+            "reason_codes": ["insufficient_valid_date_sample"],
+            "sample": sample,
+            "score": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "breadth": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "pattern_movements": [],
+            "antipattern_movements": [],
+        }
+    selected = dated[-required:]
+    sample["selected_filenames"] = [item[1] for item in selected]
+    identities = {_talk_identity(item[2]) for item in selected}
+    if None in identities:
+        return {
+            "status": "unavailable",
+            "reason_codes": ["opportunity_identity_unavailable"],
+            "sample": sample,
+            "score": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "breadth": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "pattern_movements": [],
+            "antipattern_movements": [],
+        }
+    if len(identities) != 1:
+        return {
+            "status": "unavailable",
+            "reason_codes": ["incomparable_opportunity_identities"],
+            "sample": sample,
+            "score": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "breadth": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "pattern_movements": [],
+            "antipattern_movements": [],
+        }
+    identity = next(iter(identities))
+    assert isinstance(identity, str)
+    sample["opportunity_coverage_identity"] = identity
+    if not any(
+        outcome in {"detected", "undetected"}
+        for _, _, _, outcomes in selected
+        for outcome in outcomes.values()
+    ):
+        return {
+            "status": "unavailable",
+            "reason_codes": ["no_evaluable_pattern_opportunities"],
+            "sample": sample,
+            "score": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "breadth": {
+                "status": "unavailable",
+                "prior_average": None,
+                "recent_average": None,
+                "delta": None,
+            },
+            "pattern_movements": [],
+            "antipattern_movements": [],
+        }
+    window_size = int(trend_policy["window_size"])
+    prior = selected[:window_size]
+    recent = selected[window_size:]
+    prior_scores = [_talk_score(item[2]) for item in prior]
+    recent_scores = [_talk_score(item[2]) for item in recent]
+    prior_breadth = [
+        sum(item[3][pattern_id] == "detected" for pattern_id in pattern_ids)
+        for item in prior
+    ]
+    recent_breadth = [
+        sum(item[3][pattern_id] == "detected" for pattern_id in pattern_ids)
+        for item in recent
+    ]
+
+    def metric(
+        values_prior: Sequence[int],
+        values_recent: Sequence[int],
+        threshold: float,
+        improving: str,
+        declining: str,
+    ) -> dict[str, object]:
+        exact_prior = Fraction(sum(values_prior), len(values_prior))
+        exact_recent = Fraction(sum(values_recent), len(values_recent))
+        exact_delta = exact_recent - exact_prior
+        exact_threshold = Fraction(str(threshold))
+        prior_average = float(exact_prior)
+        recent_average = float(exact_recent)
+        delta = float(exact_delta)
+        status = (
+            improving
+            if exact_delta >= exact_threshold
+            else declining
+            if exact_delta <= -exact_threshold
+            else "stable"
+        )
+        return {
+            "status": status,
+            "prior_average": prior_average,
+            "recent_average": recent_average,
+            "delta": delta,
+        }
+
+    score = metric(
+        prior_scores,
+        recent_scores,
+        float(trend_policy["score_delta"]),
+        "improving",
+        "declining",
+    )
+    breadth = metric(
+        prior_breadth,
+        recent_breadth,
+        float(trend_policy["breadth_delta"]),
+        "widening",
+        "narrowing",
+    )
+    movement_threshold = float(trend_policy["pattern_movement_delta"])
+
+    def movements(ids: Sequence[str]) -> list[dict[str, object]]:
+        rows: list[dict[str, object]] = []
+        for pattern_id in ids:
+            prior_bounds = _window_bounds([item[3][pattern_id] for item in prior])
+            recent_bounds = _window_bounds([item[3][pattern_id] for item in recent])
+            movement, reasons = _movement(
+                prior_bounds,
+                recent_bounds,
+                threshold=movement_threshold,
+                expected_applicable=window_size,
+            )
+            rows.append(
+                {
+                    "pattern_id": pattern_id,
+                    "movement": movement,
+                    "prior_evidence": prior_bounds,
+                    "recent_evidence": recent_bounds,
+                    "reason_codes": reasons,
+                }
+            )
+        return rows
+
+    return {
+        "status": "available",
+        "reason_codes": [],
+        "sample": sample,
+        "score": score,
+        "breadth": breadth,
+        "pattern_movements": movements(pattern_ids),
+        "antipattern_movements": movements(antipattern_ids),
+    }
+
+
+def _domain(status: str, reason_codes: Sequence[str]) -> dict[str, object]:
+    return {"status": status, "reason_codes": list(reason_codes)}
+
+
+def classify_pattern_profile(
+    talks: object,
+    policy_stamp: object,
+    *,
+    catalog: Any | None = None,
+) -> dict[str, object]:
+    """Return all deterministic policy-derived profile fields."""
+    if isinstance(talks, (str, bytes, Mapping)) or not isinstance(talks, Sequence):
+        raise PatternClassificationError("baseline_talks must be an array")
+    canonical_talks: list[Mapping[str, object]] = []
+    for index, talk in enumerate(talks):
+        if not isinstance(talk, Mapping):
+            raise PatternClassificationError(
+                f"baseline_talks[{index}] must be an object"
+            )
+        canonical_talks.append(talk)
+    stamp = validate_policy_stamp(policy_stamp)
+    policy = cast(Mapping[str, Any], stamp["semantic_policy"])
+    resolved_catalog = catalog or load_catalog()
+    entries = getattr(resolved_catalog, "entries", None)
+    if not isinstance(entries, Mapping):
+        raise PatternClassificationError("active catalog has no entries mapping")
+    try:
+        opportunities = build_pattern_opportunity_rows(
+            canonical_talks, catalog=resolved_catalog
+        )
+        outcomes_by_talk = [
+            canonical_talk_outcomes(
+                cast(Mapping[object, object], talk), catalog=resolved_catalog
+            )
+            for talk in canonical_talks
+        ]
+    except PatternOpportunityError as exc:
+        raise PatternClassificationError(str(exc)) from exc
+    raw_positive = opportunities.get("pattern_usage")
+    raw_antipattern = opportunities.get("antipattern_frequency")
+    if not isinstance(raw_positive, list) or not isinstance(raw_antipattern, list):
+        raise PatternClassificationError(
+            "raw opportunity builder returned invalid lanes"
+        )
+
+    def absence_capable(pattern_id: str) -> bool:
+        entry = entries.get(pattern_id)
+        if entry is None:
+            raise PatternClassificationError(
+                f"active catalog is missing opportunity ID {pattern_id!r}"
+            )
+        return getattr(entry, "absence_evaluable_from", None) is not None
+
+    positive_classifications = [
+        _classify_positive(
+            row,
+            absence_conclusion_capable=absence_capable(str(row["pattern_id"])),
+            policy=policy,
+        )
+        for row in raw_positive
+    ]
+    antipattern_classifications = [
+        _classify_antipattern(
+            row,
+            absence_conclusion_capable=absence_capable(str(row["pattern_id"])),
+            policy=policy,
+        )
+        for row in raw_antipattern
+    ]
+    combinations = _combination_rows(
+        canonical_talks,
+        outcomes_by_talk,
+        positive_classifications,
+        policy=policy,
+    )
+    positive_ids = [str(row["pattern_id"]) for row in raw_positive]
+    antipattern_ids = [str(row["pattern_id"]) for row in raw_antipattern]
+    trend_analysis = _trend_analysis(
+        canonical_talks,
+        outcomes_by_talk,
+        pattern_ids=positive_ids,
+        antipattern_ids=antipattern_ids,
+        policy=policy,
+    )
+    trend_status = str(trend_analysis["status"])
+    trend_reasons = trend_analysis["reason_codes"]
+    assert isinstance(trend_reasons, list)
+    availability = {
+        "schema_version": CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION,
+        "mastery_and_novelty": _domain("available", []),
+        "antipattern_recurrence": _domain("available", []),
+        "underuse": _domain("available", []),
+        "signature_combinations": _domain("available", []),
+        "trends": _domain(trend_status, trend_reasons),
+        "modes": _domain("unavailable", ["talk_mode_assignments_unavailable"]),
+    }
+    mastery_levels = {
+        tier: [
+            str(row["pattern_id"])
+            for row in positive_classifications
+            if row["classification"] == tier
+        ]
+        for tier in ("signature", "regular", "occasional", "rare", "never_tried")
+    }
+    never_tried_ids = list(mastery_levels["never_tried"])
+    underused_ids = sorted(mastery_levels["rare"] + never_tried_ids)
+    strength_ids = sorted(mastery_levels["signature"] + mastery_levels["regular"])
+    all_positive_breadths = [
+        sum(outcomes[pattern_id] == "detected" for pattern_id in positive_ids)
+        for outcomes in outcomes_by_talk
+    ]
+    average_breadth = (
+        None
+        if not all_positive_breadths
+        else math.fsum(all_positive_breadths) / len(all_positive_breadths)
+    )
+    pattern_movements = trend_analysis.get("pattern_movements", [])
+    antipattern_movements = trend_analysis.get("antipattern_movements", [])
+    assert isinstance(pattern_movements, list) and isinstance(
+        antipattern_movements, list
+    )
+    pattern_drivers = sorted(
+        str(row["pattern_id"])
+        for row in pattern_movements
+        if isinstance(row, Mapping)
+        and row.get("movement") in {"increasing", "decreasing"}
+    )
+    antipattern_drivers = sorted(
+        str(row["pattern_id"])
+        for row in antipattern_movements
+        if isinstance(row, Mapping)
+        and row.get("movement") in {"increasing", "decreasing"}
+    )
+    score = trend_analysis["score"]
+    breadth = trend_analysis["breadth"]
+    assert isinstance(score, Mapping) and isinstance(breadth, Mapping)
+    return {
+        "classification_schema_version": CLASSIFICATION_SCHEMA_VERSION,
+        "classification_policy": stamp,
+        "classification_availability": availability,
+        "pattern_classifications": positive_classifications,
+        "antipattern_classifications": antipattern_classifications,
+        "trend_analysis": trend_analysis,
+        "score_trend": score["status"],
+        "pattern_breadth": {
+            "avg_distinct_patterns_per_talk": average_breadth,
+            "trend": breadth["status"],
+            "note": "Breadth is the mean count of detected positive catalog patterns per current-generation talk.",
+        },
+        "underused_patterns": underused_ids,
+        "score_drivers": {
+            "direction": score["status"],
+            "antipattern_drivers": antipattern_drivers,
+            "pattern_drivers": pattern_drivers,
+            "note": "Drivers include only catalog IDs whose conservative 5+5 interval crossed the policy movement threshold.",
+        },
+        "by_mode": [],
+        "strengths": strength_ids,
+        "strengths_note": "Deterministic projection of regular and signature positive-pattern classifications.",
+        "never_used_patterns": never_tried_ids,
+        "signature_combinations": combinations,
+        "mastery_levels": mastery_levels,
+    }
+
+
+def _decode_stdin() -> Mapping[str, object]:
+    try:
+        payload = json.load(
+            sys.stdin, object_pairs_hook=_strict_object, parse_constant=_fail_constant
+        )
+    except (json.JSONDecodeError, PatternClassificationError) as exc:
+        raise PatternClassificationError(f"invalid input JSON: {exc}") from exc
+    if not isinstance(payload, Mapping) or set(payload) != {"baseline_talks"}:
+        raise PatternClassificationError(
+            "stdin must be an object containing exactly baseline_talks"
+        )
+    return payload
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"Usage: {pathlib.Path(argv[0]).name} VAULT_ROOT", file=sys.stderr)
+        return 1
+    try:
+        vault_root = pathlib.Path(argv[1]).expanduser().resolve(strict=True)
+        if not vault_root.is_dir():
+            raise PatternClassificationError("vault_root must be a directory")
+        payload = _decode_stdin()
+        policy_stamp = resolve_classification_policy(vault_root)
+        result = classify_pattern_profile(payload["baseline_talks"], policy_stamp)
+    except (OSError, PatternClassificationError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, ensure_ascii=False, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -72,23 +72,27 @@ from pattern_classification_runtime import (  # noqa: E402
     classify_pattern_profile,
     resolve_classification_policy,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     PATTERN_SCORING_SCHEMA_VERSION,
     ReturnValidationError,
     load_catalog,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseError,
     assess_tracking_database,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from vault_root_authority import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     VaultRootAuthorityError,
@@ -137,11 +141,13 @@ def project_confirmed_intents(records):
     """Remove tracking-storage metadata from the public profile projection."""
     projected = []
     for record in records:
-        projected.append({
-            field: record[field]
-            for field in _CONFIRMED_INTENT_PROFILE_FIELDS
-            if field in record
-        })
+        projected.append(
+            {
+                field: record[field]
+                for field in _CONFIRMED_INTENT_PROFILE_FIELDS
+                if field in record
+            }
+        )
     return projected
 
 
@@ -166,9 +172,7 @@ def _parse_args(argv: list[str]) -> tuple[pathlib.Path, str | None]:
             raise ValueError(f"unexpected extra argument {arg!r}")
         index += 1
 
-    raw_vault_root: object = (
-        DEFAULT_VAULT if vault_root_arg is None else vault_root_arg
-    )
+    raw_vault_root: object = DEFAULT_VAULT if vault_root_arg is None else vault_root_arg
     return (
         materialize_native_authority(raw_vault_root, authority="cli_root"),
         as_of,
@@ -298,9 +302,7 @@ def main(argv: list[str]) -> int:
     payload = {
         "vault_root": str(vault_root),
         "config": db.get("config", {}),
-        "confirmed_intents": project_confirmed_intents(
-            db.get("confirmed_intents", [])
-        ),
+        "confirmed_intents": project_confirmed_intents(db.get("confirmed_intents", [])),
         "talks": talks,
         "processed_talks": processed_talks,
         "baseline_talks": baseline_talks,

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -29,6 +29,7 @@ Stdout (JSON):
       "pattern_scoring_exclusions": [ ... ] # deterministic per-talk reasons
       "pattern_baseline":  { ... }   # exact-cohort count/sum/average + provenance
       "pattern_opportunities": { ... } # deterministic exhaustive per-pattern rows
+      "pattern_classification": { ... } # policy-bound deterministic derived fields
       "current_instrumentation_talks": [ ... ]  # current extractor cohort
       "stale_instrumentation_talks": [ ... ]    # pre-epoch extractor cohort
       "baseline_note":     "...",    # exact pattern-cohort semantics
@@ -57,7 +58,8 @@ INGRESS_SCRIPTS = (
 if str(INGRESS_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(INGRESS_SCRIPTS))
 
-from adherence_baseline import (  # noqa: E402
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from adherence_baseline import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     AdherenceBaselineError,
     normalize_as_of,
 )
@@ -66,7 +68,12 @@ from pattern_cohort_snapshot import (  # noqa: E402
     build_current_pattern_snapshot,
     configured_evidence_freshness_assessor,
 )
-from return_validation import (  # noqa: E402
+from pattern_classification_runtime import (  # noqa: E402
+    classify_pattern_profile,
+    resolve_classification_policy,
+)
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     PATTERN_SCORING_SCHEMA_VERSION,
     ReturnValidationError,
     load_catalog,
@@ -82,7 +89,8 @@ from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissin
     decode_json_object,
     snapshot_tracking_database,
 )
-from vault_root_authority import (  # noqa: E402
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from vault_root_authority import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     VaultRootAuthorityError,
     materialize_native_authority,
     resolve_vault_root_authority,
@@ -267,13 +275,22 @@ def main(argv: list[str]) -> int:
         pattern_scoring_exclusions = snapshot["pattern_scoring_exclusions"]
         pattern_baseline = snapshot["pattern_baseline"]
         pattern_opportunities = snapshot["pattern_opportunities"]
+        policy_stamp = resolve_classification_policy(vault_root)
+        pattern_classification = classify_pattern_profile(
+            baseline_talks,
+            policy_stamp,
+            catalog=catalog,
+        )
     except (
         AdherenceBaselineError,
         PatternCohortSnapshotError,
         ReturnValidationError,
+        RuntimeError,
+        ValueError,
     ) as exc:
         print(
-            f"ERROR: cannot build current pattern-scoring cohort: {exc}",
+            "ERROR: cannot build current pattern-scoring/classification "
+            f"payload: {exc}",
             file=sys.stderr,
         )
         return 1
@@ -291,6 +308,7 @@ def main(argv: list[str]) -> int:
         "pattern_scoring_exclusions": pattern_scoring_exclusions,
         "pattern_baseline": pattern_baseline,
         "pattern_opportunities": pattern_opportunities,
+        "pattern_classification": pattern_classification,
         "current_instrumentation_talks": current_instrumentation,
         "stale_instrumentation_talks": stale_instrumentation,
         "baseline_note": (

--- a/skills/vault-profile/scripts/pattern_classification_runtime.py
+++ b/skills/vault-profile/scripts/pattern_classification_runtime.py
@@ -1,0 +1,65 @@
+"""Import bridge for the public hyphenated classification CLI.
+
+The arithmetic owner intentionally keeps the issue-specified executable name
+``classify-pattern-profile.py``. Python cannot import that filename normally,
+so sibling owner/validator scripts use this zero-arithmetic bridge.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import runpy
+from collections.abc import Callable
+from functools import lru_cache
+from typing import Any, cast
+
+
+_CLASSIFIER = pathlib.Path(__file__).resolve().with_name("classify-pattern-profile.py")
+
+
+@lru_cache(maxsize=1)
+def _exports() -> dict[str, Any]:
+    return runpy.run_path(str(_CLASSIFIER), run_name="_vault_profile_classifier")
+
+
+def _callable(name: str) -> Callable[..., Any]:
+    value = _exports().get(name)
+    if not callable(value):
+        raise RuntimeError(f"classification runtime export {name!r} is unavailable")
+    return cast(Callable[..., Any], value)
+
+
+def resolve_classification_policy(
+    vault_root: pathlib.Path,
+    *,
+    bundled_policy_path: pathlib.Path | None = None,
+) -> dict[str, object]:
+    kwargs = (
+        {}
+        if bundled_policy_path is None
+        else {"bundled_policy_path": bundled_policy_path}
+    )
+    return cast(
+        dict[str, object],
+        _callable("resolve_classification_policy")(vault_root, **kwargs),
+    )
+
+
+def classify_pattern_profile(
+    talks: object,
+    policy_stamp: object,
+    *,
+    catalog: Any | None = None,
+) -> dict[str, object]:
+    return cast(
+        dict[str, object],
+        _callable("classify_pattern_profile")(talks, policy_stamp, catalog=catalog),
+    )
+
+
+def validate_policy_stamp(value: object) -> dict[str, object]:
+    return cast(dict[str, object], _callable("validate_policy_stamp")(value))
+
+
+def validate_policy(value: object) -> dict[str, object]:
+    return cast(dict[str, object], _callable("validate_policy")(value))

--- a/skills/vault-profile/scripts/pattern_classification_runtime.py
+++ b/skills/vault-profile/scripts/pattern_classification_runtime.py
@@ -19,7 +19,10 @@ _CLASSIFIER = pathlib.Path(__file__).resolve().with_name("classify-pattern-profi
 
 @lru_cache(maxsize=1)
 def _exports() -> dict[str, Any]:
-    return runpy.run_path(str(_CLASSIFIER), run_name="_vault_profile_classifier")
+    try:
+        return runpy.run_path(str(_CLASSIFIER), run_name="_vault_profile_classifier")
+    except (OSError, SyntaxError, ImportError) as exc:
+        raise RuntimeError("classification runtime owner could not be loaded") from exc
 
 
 def _callable(name: str) -> Callable[..., Any]:

--- a/skills/vault-profile/scripts/pattern_opportunities.py
+++ b/skills/vault-profile/scripts/pattern_opportunities.py
@@ -27,7 +27,8 @@ _INGRESS_SCRIPTS = (
 if str(_INGRESS_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_INGRESS_SCRIPTS))
 
-from return_validation import (  # noqa: E402
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     load_catalog,
 )
 
@@ -236,6 +237,26 @@ def _opportunity_row(
         common["times_detected"] = detected_count
         common["frequency_rate"] = _rate(detected_count, evaluable_count)
     return common
+
+
+def canonical_talk_outcomes(
+    talk: Mapping[object, object],
+    *,
+    catalog: Any | None = None,
+) -> dict[str, str]:
+    """Return one talk's validated exhaustive outcomes keyed by catalog ID.
+
+    Profile classifiers need the per-talk states for combinations and trends.
+    This public accessor keeps the scoring-v5 consistency checks here with the
+    raw-opportunity owner instead of duplicating them in a derived consumer.
+    """
+    resolved_catalog = catalog or load_catalog()
+    pattern_ids, antipattern_ids, polarity = _catalog_lanes(resolved_catalog)
+    return _canonical_talk_outcomes(
+        talk,
+        expected_ids=sorted(pattern_ids + antipattern_ids),
+        polarity=polarity,
+    )
 
 
 def build_pattern_opportunity_rows(

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -554,12 +554,27 @@ def _validate_classification_lane(
                 f"{path}.absence_conclusion_capable must match active catalog metadata"
             )
         evidence = item.get("evidence")
+        applicable_count: object = None
+        detected_count: object = None
         if not isinstance(evidence, Mapping):
             errors.append(f"{path}.evidence must be an object")
         else:
             errors.extend(
                 _exact_fields(evidence, _EVIDENCE_FIELDS, path=f"{path}.evidence")
             )
+            for field in (
+                "applicable_count",
+                "evaluable_count",
+                "detected_count",
+                "unevaluable_count",
+            ):
+                count = evidence.get(field)
+                if not _is_integer(count) or count < 0:
+                    errors.append(
+                        f"{path}.evidence.{field} must be a non-negative integer"
+                    )
+            applicable_count = evidence.get("applicable_count")
+            detected_count = evidence.get("detected_count")
             raw = raw_by_id.get(pattern_id)
             expected_evidence = (
                 _expected_evidence(raw) if isinstance(raw, Mapping) else None
@@ -582,10 +597,10 @@ def _validate_classification_lane(
             )
         if (
             absence_capable is False
-            and isinstance(evidence, Mapping)
-            and isinstance(evidence.get("applicable_count"), int)
-            and evidence.get("applicable_count", 0) > 0
-            and evidence.get("detected_count") == 0
+            and _is_integer(applicable_count)
+            and applicable_count > 0
+            and _is_integer(detected_count)
+            and detected_count == 0
         ):
             required_classification = (
                 "not_yet_observed"

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -162,17 +162,14 @@ _CLASSIFICATION_ROW_FIELDS = frozenset(
         "reason_codes",
     }
 )
-_EVIDENCE_FIELDS = frozenset(
-    {
-        "applicable_count",
-        "evaluable_count",
-        "detected_count",
-        "unevaluable_count",
-        "applicable_coverage",
-        "lower",
-        "upper",
-    }
+_EVIDENCE_COUNT_FIELDS = (
+    "applicable_count",
+    "evaluable_count",
+    "detected_count",
+    "unevaluable_count",
 )
+_EVIDENCE_RATE_FIELDS = ("applicable_coverage", "lower", "upper")
+_EVIDENCE_FIELDS = frozenset((*_EVIDENCE_COUNT_FIELDS, *_EVIDENCE_RATE_FIELDS))
 _COMBINATION_FIELDS = frozenset(
     {"combination_id", "pattern_ids", "evidence", "reason_codes"}
 )
@@ -214,6 +211,15 @@ def unavailable_classification_availability() -> dict[str, object]:
 
 def _is_integer(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_optional_unit_interval(value: object) -> bool:
+    return value is None or (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and 0 <= value <= 1
+        and math.isfinite(value)
+    )
 
 
 def _append_reason(reason_codes: list[str], reason_code: str) -> None:
@@ -483,6 +489,8 @@ def _expected_evidence(raw: Mapping[str, object]) -> dict[str, object] | None:
     detected = counts["detected_count"]
     unevaluable = counts["unevaluable_count"]
     applicable = eligible - not_applicable
+    if applicable < 0 or evaluable + unevaluable != applicable or detected > evaluable:
+        return None
     if applicable == 0:
         coverage = lower = upper = None
     else:
@@ -498,6 +506,58 @@ def _expected_evidence(raw: Mapping[str, object]) -> dict[str, object] | None:
         "lower": lower,
         "upper": upper,
     }
+
+
+def _validate_evidence(value: Mapping[object, object], *, path: str) -> list[str]:
+    errors = _exact_fields(value, _EVIDENCE_FIELDS, path=path)
+    counts: dict[str, int] = {}
+    for field in _EVIDENCE_COUNT_FIELDS:
+        count = value.get(field)
+        if not _is_integer(count) or count < 0:
+            errors.append(f"{path}.{field} must be a non-negative integer")
+        else:
+            counts[field] = count
+
+    for field in _EVIDENCE_RATE_FIELDS:
+        if not _is_optional_unit_interval(value.get(field)):
+            errors.append(
+                f"{path}.{field} must be null or a finite number between zero and one"
+            )
+
+    if len(counts) != len(_EVIDENCE_COUNT_FIELDS):
+        return errors
+    applicable = counts["applicable_count"]
+    evaluable = counts["evaluable_count"]
+    detected = counts["detected_count"]
+    unevaluable = counts["unevaluable_count"]
+    if evaluable + unevaluable != applicable:
+        errors.append(f"{path} must satisfy applicable_count = E + U")
+        return errors
+    if detected > evaluable:
+        errors.append(f"{path}.detected_count cannot exceed evaluable_count")
+        return errors
+
+    expected_rates: dict[str, float | None]
+    if applicable == 0:
+        expected_rates = {
+            "applicable_coverage": None,
+            "lower": None,
+            "upper": None,
+        }
+    else:
+        expected_rates = {
+            "applicable_coverage": evaluable / applicable,
+            "lower": detected / applicable,
+            "upper": (detected + unevaluable) / applicable,
+        }
+    for field, expected in expected_rates.items():
+        actual = value.get(field)
+        if _is_optional_unit_interval(actual) and actual != expected:
+            errors.append(
+                f"{path}.{field} must equal the canonical ratio {expected!r}, "
+                f"got {actual!r}"
+            )
+    return errors
 
 
 def _validate_classification_lane(
@@ -559,20 +619,7 @@ def _validate_classification_lane(
         if not isinstance(evidence, Mapping):
             errors.append(f"{path}.evidence must be an object")
         else:
-            errors.extend(
-                _exact_fields(evidence, _EVIDENCE_FIELDS, path=f"{path}.evidence")
-            )
-            for field in (
-                "applicable_count",
-                "evaluable_count",
-                "detected_count",
-                "unevaluable_count",
-            ):
-                count = evidence.get(field)
-                if not _is_integer(count) or count < 0:
-                    errors.append(
-                        f"{path}.evidence.{field} must be a non-negative integer"
-                    )
+            errors.extend(_validate_evidence(evidence, path=f"{path}.evidence"))
             applicable_count = evidence.get("applicable_count")
             detected_count = evidence.get("detected_count")
             raw = raw_by_id.get(pattern_id)
@@ -624,7 +671,10 @@ def _validate_classification_lane(
 
 
 def _validate_combinations(
-    value: object, positive_rows: Sequence[Mapping[str, object]]
+    value: object,
+    positive_rows: Sequence[Mapping[str, object]],
+    *,
+    eligible_talk_count: int,
 ) -> list[str]:
     if not isinstance(value, list):
         return ["pattern_profile.signature_combinations must be an array"]
@@ -661,17 +711,23 @@ def _validate_combinations(
         if not isinstance(evidence, Mapping):
             errors.append(f"{path}.evidence must be an object")
             continue
-        errors.extend(
-            _exact_fields(evidence, _EVIDENCE_FIELDS, path=f"{path}.evidence")
-        )
+        evidence_errors = _validate_evidence(evidence, path=f"{path}.evidence")
+        errors.extend(evidence_errors)
         lower = evidence.get("lower")
         detected = evidence.get("detected_count")
+        applicable = evidence.get("applicable_count")
+        if evidence_errors:
+            continue
+        assert _is_integer(applicable)
+        if applicable > eligible_talk_count:
+            errors.append(
+                f"{path}.evidence.applicable_count cannot exceed the eligible "
+                f"talk count {eligible_talk_count}"
+            )
         if not isinstance(lower, (int, float)) or isinstance(lower, bool):
             errors.append(f"{path}.evidence.lower must be numeric")
             continue
-        if not _is_integer(detected):
-            errors.append(f"{path}.evidence.detected_count must be an integer")
-            continue
+        assert _is_integer(detected)
         sort_key = (-float(lower), -detected, tuple(str(member) for member in members))
         if previous_sort_key is not None and sort_key < previous_sort_key:
             errors.append(
@@ -693,7 +749,10 @@ def _validate_combinations(
 
 
 def _validate_v5_policy_fields(
-    pattern_profile: Mapping[str, object], active_catalog: object
+    pattern_profile: Mapping[str, object],
+    active_catalog: object,
+    *,
+    eligible_talk_count: int,
 ) -> tuple[frozenset[str], str | None, list[str]]:
     errors: list[str] = []
     if pattern_profile.get(
@@ -758,7 +817,9 @@ def _validate_v5_policy_fields(
         )
     errors.extend(
         _validate_combinations(
-            pattern_profile.get("signature_combinations"), positive_rows
+            pattern_profile.get("signature_combinations"),
+            positive_rows,
+            eligible_talk_count=eligible_talk_count,
         )
     )
     if pattern_profile.get("by_mode") != []:
@@ -985,7 +1046,9 @@ def assess_pattern_profile(
         errors.extend(_validate_v4_unavailable(pattern_profile))
     elif active_catalog is not None:
         domains, policy_digest, policy_errors = _validate_v5_policy_fields(
-            pattern_profile, active_catalog
+            pattern_profile,
+            active_catalog,
+            eligible_talk_count=eligible_count,
         )
         errors.extend(policy_errors)
         if policy_digest is None:

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -14,6 +14,7 @@ import pathlib
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from fractions import Fraction
 from typing import TypeGuard
 
 
@@ -173,6 +174,48 @@ _EVIDENCE_FIELDS = frozenset((*_EVIDENCE_COUNT_FIELDS, *_EVIDENCE_RATE_FIELDS))
 _COMBINATION_FIELDS = frozenset(
     {"combination_id", "pattern_ids", "evidence", "reason_codes"}
 )
+_TREND_ANALYSIS_FIELDS = frozenset(
+    {
+        "status",
+        "reason_codes",
+        "sample",
+        "score",
+        "breadth",
+        "pattern_movements",
+        "antipattern_movements",
+    }
+)
+_TREND_SAMPLE_FIELDS = frozenset(
+    {
+        "required_talk_count",
+        "valid_date_talk_count",
+        "invalid_date_filenames",
+        "selected_filenames",
+        "opportunity_coverage_identity",
+    }
+)
+_TREND_METRIC_FIELDS = frozenset({"status", "prior_average", "recent_average", "delta"})
+_TREND_MOVEMENT_FIELDS = frozenset(
+    {"pattern_id", "movement", "prior_evidence", "recent_evidence", "reason_codes"}
+)
+_TREND_UNAVAILABLE_REASONS = frozenset(
+    {
+        "insufficient_valid_date_sample",
+        "opportunity_identity_unavailable",
+        "incomparable_opportunity_identities",
+        "no_evaluable_pattern_opportunities",
+    }
+)
+_MOVEMENT_REASON_CODES = {
+    "increasing": ("conservative_interval_increase",),
+    "decreasing": ("conservative_interval_decrease",),
+    "stable": ("conservative_interval_stable",),
+    "indeterminate": ("uncertainty_spans_movement_threshold",),
+}
+_UNAVAILABLE_MOVEMENT_REASON_CODES = frozenset(
+    {"incomplete_window_applicability", "window_bounds_unavailable"}
+)
+_LOWER_HEX_CHARS = frozenset("0123456789abcdef")
 
 
 @dataclass(frozen=True)
@@ -220,6 +263,24 @@ def _is_optional_unit_interval(value: object) -> bool:
         and 0 <= value <= 1
         and math.isfinite(value)
     )
+
+
+def _is_finite_number(value: object) -> TypeGuard[int | float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return not isinstance(value, float) or math.isfinite(value)
+
+
+def _is_lower_hex64(value: object) -> TypeGuard[str]:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in _LOWER_HEX_CHARS for character in value)
+    )
+
+
+def _unit_ratio(numerator: int, denominator: int) -> float:
+    return float(Fraction(numerator, denominator))
 
 
 def _append_reason(reason_codes: list[str], reason_code: str) -> None:
@@ -480,7 +541,7 @@ def _expected_evidence(raw: Mapping[str, object]) -> dict[str, object] | None:
     counts: dict[str, int] = {}
     for field in fields:
         value = raw.get(field)
-        if not _is_integer(value):
+        if not _is_integer(value) or value < 0:
             return None
         counts[field] = value
     eligible = counts["eligible_cohort_count"]
@@ -494,9 +555,9 @@ def _expected_evidence(raw: Mapping[str, object]) -> dict[str, object] | None:
     if applicable == 0:
         coverage = lower = upper = None
     else:
-        coverage = evaluable / applicable
-        lower = detected / applicable
-        upper = (detected + unevaluable) / applicable
+        coverage = _unit_ratio(evaluable, applicable)
+        lower = _unit_ratio(detected, applicable)
+        upper = _unit_ratio(detected + unevaluable, applicable)
     return {
         "applicable_count": applicable,
         "evaluable_count": evaluable,
@@ -546,9 +607,9 @@ def _validate_evidence(value: Mapping[object, object], *, path: str) -> list[str
         }
     else:
         expected_rates = {
-            "applicable_coverage": evaluable / applicable,
-            "lower": detected / applicable,
-            "upper": (detected + unevaluable) / applicable,
+            "applicable_coverage": _unit_ratio(evaluable, applicable),
+            "lower": _unit_ratio(detected, applicable),
+            "upper": _unit_ratio(detected + unevaluable, applicable),
         }
     for field, expected in expected_rates.items():
         actual = value.get(field)
@@ -750,6 +811,458 @@ def _validate_combinations(
     return errors
 
 
+def _validate_trend_metric(
+    value: object,
+    *,
+    path: str,
+    available: bool,
+    allowed_statuses: frozenset[str],
+) -> tuple[object, list[str]]:
+    if not isinstance(value, Mapping):
+        return None, [f"{path} must be an object"]
+    errors = _exact_fields(value, _TREND_METRIC_FIELDS, path=path)
+    status = value.get("status")
+    if not available:
+        expected = {
+            "status": "unavailable",
+            "prior_average": None,
+            "recent_average": None,
+            "delta": None,
+        }
+        if dict(value) != expected:
+            errors.append(f"{path} must use the unavailable null sentinel")
+        return status, errors
+
+    if status not in allowed_statuses:
+        errors.append(f"{path}.status is invalid: {status!r}")
+    numbers: dict[str, int | float] = {}
+    for field in ("prior_average", "recent_average", "delta"):
+        raw = value.get(field)
+        if not _is_finite_number(raw):
+            errors.append(f"{path}.{field} must be a finite number")
+        else:
+            numbers[field] = raw
+    if len(numbers) == 3:
+        try:
+            delta_matches = math.isclose(
+                float(numbers["delta"]),
+                float(numbers["recent_average"]) - float(numbers["prior_average"]),
+                rel_tol=0.0,
+                abs_tol=1e-12,
+            )
+        except OverflowError:
+            delta_matches = False
+        if not delta_matches:
+            errors.append(f"{path}.delta must equal recent_average - prior_average")
+    return status, errors
+
+
+def _validate_trend_movement_lane(
+    value: object,
+    *,
+    path: str,
+    expected_ids: list[str],
+    window_size: int | None,
+) -> tuple[list[Mapping[str, object]], list[str]]:
+    if not isinstance(value, list):
+        return [], [f"{path} must be an array"]
+    rows: list[Mapping[str, object]] = []
+    observed_ids: list[str] = []
+    errors: list[str] = []
+    for index, item in enumerate(value):
+        row_path = f"{path}[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{row_path} must be an object")
+            continue
+        errors.extend(_exact_fields(item, _TREND_MOVEMENT_FIELDS, path=row_path))
+        pattern_id = item.get("pattern_id")
+        if not isinstance(pattern_id, str) or not pattern_id:
+            errors.append(f"{row_path}.pattern_id must be a non-empty string")
+        else:
+            observed_ids.append(pattern_id)
+            rows.append(item)
+
+        movement = item.get("movement")
+        reason_codes = item.get("reason_codes")
+        errors.extend(_string_array(reason_codes, path=f"{row_path}.reason_codes"))
+        normalized_reasons = (
+            tuple(reason_codes)
+            if isinstance(reason_codes, list)
+            and all(isinstance(reason, str) for reason in reason_codes)
+            else ()
+        )
+        if movement == "unavailable":
+            if (
+                len(normalized_reasons) != 1
+                or normalized_reasons[0] not in _UNAVAILABLE_MOVEMENT_REASON_CODES
+            ):
+                errors.append(
+                    f"{row_path}.reason_codes must explain unavailable movement"
+                )
+        elif movement in _MOVEMENT_REASON_CODES:
+            if normalized_reasons != _MOVEMENT_REASON_CODES[movement]:
+                errors.append(
+                    f"{row_path}.reason_codes must match movement {movement!r}"
+                )
+        else:
+            errors.append(f"{row_path}.movement is invalid: {movement!r}")
+
+        evidence_by_window: dict[str, Mapping[object, object]] = {}
+        evidence_errors_by_window: dict[str, list[str]] = {}
+        for field in ("prior_evidence", "recent_evidence"):
+            evidence = item.get(field)
+            evidence_path = f"{row_path}.{field}"
+            if not isinstance(evidence, Mapping):
+                errors.append(f"{evidence_path} must be an object")
+                continue
+            evidence_errors = _validate_evidence(evidence, path=evidence_path)
+            errors.extend(evidence_errors)
+            evidence_by_window[field] = evidence
+            evidence_errors_by_window[field] = evidence_errors
+
+        if window_size is not None and len(evidence_by_window) == 2:
+            applicable_counts = [
+                evidence_by_window[field].get("applicable_count")
+                for field in ("prior_evidence", "recent_evidence")
+            ]
+            for field, applicable in zip(
+                ("prior_evidence", "recent_evidence"),
+                applicable_counts,
+                strict=True,
+            ):
+                if _is_integer(applicable) and applicable > window_size:
+                    errors.append(
+                        f"{row_path}.{field}.applicable_count cannot exceed "
+                        f"trend window size {window_size}"
+                    )
+            complete_windows = all(
+                _is_integer(applicable) and applicable == window_size
+                for applicable in applicable_counts
+            )
+            if movement == "unavailable":
+                reason = normalized_reasons[0] if len(normalized_reasons) == 1 else None
+                if reason == "incomplete_window_applicability" and complete_windows:
+                    errors.append(
+                        f"{row_path}.movement cannot report incomplete applicability "
+                        "for complete windows"
+                    )
+                if reason == "window_bounds_unavailable" and not any(
+                    evidence_errors_by_window.values()
+                ):
+                    errors.append(
+                        f"{row_path}.movement cannot report unavailable bounds for "
+                        "valid evidence"
+                    )
+            elif movement in _MOVEMENT_REASON_CODES and not complete_windows:
+                errors.append(
+                    f"{row_path}.movement must be unavailable unless both windows "
+                    f"have {window_size} applicable talks"
+                )
+
+    if observed_ids != expected_ids:
+        errors.append(
+            f"{path} must be sorted and exhaustive; "
+            f"expected={expected_ids}, got={observed_ids}"
+        )
+    return rows, errors
+
+
+def _validate_trend_analysis(
+    pattern_profile: Mapping[str, object],
+    positive_rows: Sequence[Mapping[str, object]],
+    antipattern_rows: Sequence[Mapping[str, object]],
+    *,
+    eligible_talk_count: int,
+    required_talk_count: int | None,
+    window_size: int | None,
+) -> list[str]:
+    value = pattern_profile.get("trend_analysis")
+    if not isinstance(value, Mapping):
+        return ["pattern_profile.trend_analysis must be an object"]
+    path = "pattern_profile.trend_analysis"
+    errors = _exact_fields(value, _TREND_ANALYSIS_FIELDS, path=path)
+    status = value.get("status")
+    reason_codes = value.get("reason_codes")
+    errors.extend(_string_array(reason_codes, path=f"{path}.reason_codes"))
+    reasons = (
+        list(reason_codes)
+        if isinstance(reason_codes, list)
+        and all(isinstance(reason, str) for reason in reason_codes)
+        else []
+    )
+    available = status == "available"
+    unavailable_reason: str | None = None
+    if available:
+        if reasons != []:
+            errors.append(f"{path}.reason_codes must be [] when available")
+    elif status == "unavailable":
+        if len(reasons) != 1 or reasons[0] not in _TREND_UNAVAILABLE_REASONS:
+            errors.append(
+                f"{path}.reason_codes must contain one supported unavailability reason"
+            )
+        else:
+            unavailable_reason = reasons[0]
+    else:
+        errors.append(f"{path}.status must be available or unavailable")
+
+    availability = pattern_profile.get("classification_availability")
+    trend_availability = (
+        availability.get("trends") if isinstance(availability, Mapping) else None
+    )
+    expected_availability = {"status": status, "reason_codes": reasons}
+    if (
+        not isinstance(trend_availability, Mapping)
+        or dict(trend_availability) != expected_availability
+    ):
+        errors.append(
+            "pattern_profile.classification_availability.trends must exactly mirror "
+            "trend_analysis status and reasons"
+        )
+
+    baseline_value = pattern_profile.get("baseline_talk_filenames")
+    baseline_filenames = (
+        list(baseline_value)
+        if isinstance(baseline_value, list)
+        and all(isinstance(filename, str) for filename in baseline_value)
+        else []
+    )
+    baseline_set = set(baseline_filenames)
+    sample = value.get("sample")
+    sample_required: int | None = None
+    valid_date_count: int | None = None
+    invalid_filenames: list[str] | None = None
+    selected_filenames: list[str] | None = None
+    identity: object = None
+    if not isinstance(sample, Mapping):
+        errors.append(f"{path}.sample must be an object")
+    else:
+        sample_path = f"{path}.sample"
+        errors.extend(_exact_fields(sample, _TREND_SAMPLE_FIELDS, path=sample_path))
+        raw_required = sample.get("required_talk_count")
+        if not _is_integer(raw_required) or raw_required < 1:
+            errors.append(
+                f"{sample_path}.required_talk_count must be a positive integer"
+            )
+        else:
+            sample_required = raw_required
+            if (
+                required_talk_count is not None
+                and sample_required != required_talk_count
+            ):
+                errors.append(
+                    f"{sample_path}.required_talk_count must equal the applied policy "
+                    f"value {required_talk_count}"
+                )
+        raw_valid = sample.get("valid_date_talk_count")
+        if not _is_integer(raw_valid) or raw_valid < 0:
+            errors.append(
+                f"{sample_path}.valid_date_talk_count must be a non-negative integer"
+            )
+        else:
+            valid_date_count = raw_valid
+
+        raw_invalid = sample.get("invalid_date_filenames")
+        invalid_errors = _string_array(
+            raw_invalid,
+            path=f"{sample_path}.invalid_date_filenames",
+            sorted_required=True,
+        )
+        errors.extend(invalid_errors)
+        if not invalid_errors and isinstance(raw_invalid, list):
+            invalid_filenames = list(raw_invalid)
+        raw_selected = sample.get("selected_filenames")
+        selected_errors = _string_array(
+            raw_selected, path=f"{sample_path}.selected_filenames"
+        )
+        errors.extend(selected_errors)
+        if not selected_errors and isinstance(raw_selected, list):
+            selected_filenames = list(raw_selected)
+
+        for field, filenames in (
+            ("invalid_date_filenames", invalid_filenames),
+            ("selected_filenames", selected_filenames),
+        ):
+            if filenames is not None:
+                unknown = sorted(set(filenames) - baseline_set)
+                if unknown:
+                    errors.append(
+                        f"{sample_path}.{field} contains filenames outside the "
+                        f"baseline: {unknown}"
+                    )
+        if (
+            invalid_filenames is not None
+            and selected_filenames is not None
+            and set(invalid_filenames).intersection(selected_filenames)
+        ):
+            errors.append(
+                f"{sample_path}.selected_filenames cannot include invalid-date talks"
+            )
+        if valid_date_count is not None and invalid_filenames is not None:
+            if valid_date_count + len(invalid_filenames) != eligible_talk_count:
+                errors.append(
+                    f"{sample_path} valid and invalid date counts must equal the "
+                    f"eligible talk count {eligible_talk_count}"
+                )
+        identity = sample.get("opportunity_coverage_identity")
+
+    if available:
+        if (
+            sample_required is not None
+            and selected_filenames is not None
+            and len(selected_filenames) != sample_required
+        ):
+            errors.append(
+                f"{path}.sample.selected_filenames must contain exactly "
+                f"{sample_required} talks when trends are available"
+            )
+        if valid_date_count is not None and sample_required is not None:
+            if valid_date_count < sample_required:
+                errors.append(
+                    f"{path}.sample does not have enough valid dated talks for trends"
+                )
+        if not _is_lower_hex64(identity):
+            errors.append(
+                f"{path}.sample.opportunity_coverage_identity must be lowercase hex64 "
+                "when trends are available"
+            )
+    elif unavailable_reason == "insufficient_valid_date_sample":
+        if valid_date_count is not None and sample_required is not None:
+            if valid_date_count >= sample_required:
+                errors.append(
+                    f"{path}.sample must have fewer valid talks than required for "
+                    "insufficient_valid_date_sample"
+                )
+        if selected_filenames not in (None, []):
+            errors.append(
+                f"{path}.sample.selected_filenames must be [] for an insufficient sample"
+            )
+        if identity is not None:
+            errors.append(
+                f"{path}.sample.opportunity_coverage_identity must be null for an "
+                "insufficient sample"
+            )
+    elif unavailable_reason in {
+        "opportunity_identity_unavailable",
+        "incomparable_opportunity_identities",
+        "no_evaluable_pattern_opportunities",
+    }:
+        if (
+            sample_required is not None
+            and selected_filenames is not None
+            and len(selected_filenames) != sample_required
+        ):
+            errors.append(
+                f"{path}.sample.selected_filenames must contain exactly "
+                f"{sample_required} talks after sample selection"
+            )
+        if valid_date_count is not None and sample_required is not None:
+            if valid_date_count < sample_required:
+                errors.append(f"{path}.sample must have enough valid dated talks")
+        if unavailable_reason == "no_evaluable_pattern_opportunities":
+            if not _is_lower_hex64(identity):
+                errors.append(
+                    f"{path}.sample.opportunity_coverage_identity must be lowercase "
+                    "hex64 after identity resolution"
+                )
+        elif identity is not None:
+            errors.append(
+                f"{path}.sample.opportunity_coverage_identity must be null while "
+                "identity resolution is unavailable"
+            )
+
+    score_status, metric_errors = _validate_trend_metric(
+        value.get("score"),
+        path=f"{path}.score",
+        available=available,
+        allowed_statuses=frozenset({"improving", "declining", "stable"}),
+    )
+    errors.extend(metric_errors)
+    breadth_status, metric_errors = _validate_trend_metric(
+        value.get("breadth"),
+        path=f"{path}.breadth",
+        available=available,
+        allowed_statuses=frozenset({"widening", "narrowing", "stable"}),
+    )
+    errors.extend(metric_errors)
+
+    pattern_rows: list[Mapping[str, object]] = []
+    antipattern_movement_rows: list[Mapping[str, object]] = []
+    if available:
+        pattern_rows, movement_errors = _validate_trend_movement_lane(
+            value.get("pattern_movements"),
+            path=f"{path}.pattern_movements",
+            expected_ids=[
+                str(row["pattern_id"])
+                for row in positive_rows
+                if isinstance(row.get("pattern_id"), str)
+            ],
+            window_size=window_size,
+        )
+        errors.extend(movement_errors)
+        antipattern_movement_rows, movement_errors = _validate_trend_movement_lane(
+            value.get("antipattern_movements"),
+            path=f"{path}.antipattern_movements",
+            expected_ids=[
+                str(row["pattern_id"])
+                for row in antipattern_rows
+                if isinstance(row.get("pattern_id"), str)
+            ],
+            window_size=window_size,
+        )
+        errors.extend(movement_errors)
+    else:
+        for field in ("pattern_movements", "antipattern_movements"):
+            if value.get(field) != []:
+                errors.append(f"{path}.{field} must be [] when trends are unavailable")
+
+    if pattern_profile.get("score_trend") != score_status:
+        errors.append(
+            "pattern_profile.score_trend must project trend_analysis.score.status"
+        )
+    profile_breadth = pattern_profile.get("pattern_breadth")
+    if (
+        not isinstance(profile_breadth, Mapping)
+        or profile_breadth.get("trend") != breadth_status
+    ):
+        errors.append(
+            "pattern_profile.pattern_breadth.trend must project "
+            "trend_analysis.breadth.status"
+        )
+
+    expected_pattern_drivers = sorted(
+        str(row["pattern_id"])
+        for row in pattern_rows
+        if row.get("movement") in {"increasing", "decreasing"}
+        and isinstance(row.get("pattern_id"), str)
+    )
+    expected_antipattern_drivers = sorted(
+        str(row["pattern_id"])
+        for row in antipattern_movement_rows
+        if row.get("movement") in {"increasing", "decreasing"}
+        and isinstance(row.get("pattern_id"), str)
+    )
+    score_drivers = pattern_profile.get("score_drivers")
+    if not isinstance(score_drivers, Mapping):
+        errors.append("pattern_profile.score_drivers must be an object")
+    else:
+        if score_drivers.get("direction") != score_status:
+            errors.append(
+                "pattern_profile.score_drivers.direction must project "
+                "trend_analysis.score.status"
+            )
+        if score_drivers.get("pattern_drivers") != expected_pattern_drivers:
+            errors.append(
+                "pattern_profile.score_drivers.pattern_drivers must project "
+                "pattern trend movements"
+            )
+        if score_drivers.get("antipattern_drivers") != expected_antipattern_drivers:
+            errors.append(
+                "pattern_profile.score_drivers.antipattern_drivers must project "
+                "antipattern trend movements"
+            )
+    return errors
+
+
 def _validate_v5_policy_fields(
     pattern_profile: Mapping[str, object],
     active_catalog: object,
@@ -757,6 +1270,8 @@ def _validate_v5_policy_fields(
     eligible_talk_count: int,
 ) -> tuple[frozenset[str], str | None, list[str]]:
     errors: list[str] = []
+    required_talk_count: int | None = None
+    window_size: int | None = None
     classification_schema_version = pattern_profile.get("classification_schema_version")
     if (
         not _is_integer(classification_schema_version)
@@ -766,6 +1281,19 @@ def _validate_v5_policy_fields(
     try:
         stamp = validate_policy_stamp(pattern_profile.get("classification_policy"))
         digest = str(stamp["semantic_sha256"])
+        semantic_policy = stamp.get("semantic_policy")
+        trend_policy = (
+            semantic_policy.get("trends")
+            if isinstance(semantic_policy, Mapping)
+            else None
+        )
+        if isinstance(trend_policy, Mapping):
+            raw_required = trend_policy.get("minimum_comparable_talks")
+            raw_window = trend_policy.get("window_size")
+            if _is_integer(raw_required):
+                required_talk_count = raw_required
+            if _is_integer(raw_window):
+                window_size = raw_window
     except (RuntimeError, ValueError) as exc:
         errors.append(f"pattern_profile.classification_policy is invalid: {exc}")
         digest = None
@@ -829,33 +1357,16 @@ def _validate_v5_policy_fields(
             "pattern_profile.by_mode must be [] while talk mode assignments are unavailable"
         )
 
-    trend_analysis = pattern_profile.get("trend_analysis")
-    if not isinstance(trend_analysis, Mapping):
-        errors.append("pattern_profile.trend_analysis must be an object")
-    else:
-        score = trend_analysis.get("score")
-        breadth = trend_analysis.get("breadth")
-        if not isinstance(score, Mapping) or pattern_profile.get(
-            "score_trend"
-        ) != score.get("status"):
-            errors.append(
-                "pattern_profile.score_trend must project trend_analysis.score.status"
-            )
-        profile_breadth = pattern_profile.get("pattern_breadth")
-        if (
-            not isinstance(breadth, Mapping)
-            or not isinstance(profile_breadth, Mapping)
-            or profile_breadth.get("trend") != breadth.get("status")
-        ):
-            errors.append(
-                "pattern_profile.pattern_breadth.trend must project "
-                "trend_analysis.breadth.status"
-            )
-        trend_available = "trends" in domains
-        if trend_available != (trend_analysis.get("status") == "available"):
-            errors.append(
-                "pattern_profile trend availability must match trend_analysis.status"
-            )
+    errors.extend(
+        _validate_trend_analysis(
+            pattern_profile,
+            positive_rows,
+            antipattern_rows,
+            eligible_talk_count=eligible_talk_count,
+            required_talk_count=required_talk_count,
+            window_size=window_size,
+        )
+    )
     if "antipattern_recurrence" not in domains:
         actionable = {
             row.get("classification")

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -33,6 +33,7 @@ from pattern_opportunities import (  # noqa: E402
     PatternOpportunityError,
     validate_pattern_opportunity_rows,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     PATTERN_SCORING_SCHEMA_VERSION,
@@ -224,9 +225,7 @@ def _exact_fields(
     value: Mapping[object, object], expected: frozenset[str], *, path: str
 ) -> list[str]:
     missing = sorted(field for field in expected if field not in value)
-    unknown = sorted(
-        (field for field in value if field not in expected), key=str
-    )
+    unknown = sorted((field for field in value if field not in expected), key=str)
     if not missing and not unknown:
         return []
     return [

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -1,9 +1,10 @@
-"""Strict, reusable availability contract for profile pattern history.
+"""Strict reusable contract for profile pattern history.
 
-Owner and consumer skills share this module so a profile exposes auditable
-current-generation occurrence rows independently from policy-derived historical
-classifications. The module performs no writes and does not encode consumer-
-specific fallback policy.
+Schema-v4 pattern profiles remain readable as occurrence-only inputs with every
+classification domain disabled. Schema-v5 profiles add a self-contained,
+policy-bound classification contract with independent domain availability.
+This module validates provenance and projections; classification arithmetic is
+owned only by ``classify-pattern-profile.py``.
 """
 
 from __future__ import annotations
@@ -11,7 +12,7 @@ from __future__ import annotations
 import math
 import pathlib
 import sys
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TypeGuard
 
@@ -22,18 +23,21 @@ _INGRESS_SCRIPTS = (
 if str(_INGRESS_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_INGRESS_SCRIPTS))
 
-from adherence_baseline import (  # noqa: E402
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from adherence_baseline import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     AdherenceBaselineError,
     validate_adherence_baseline,
 )
-from return_validation import (  # noqa: E402
-    PATTERN_SCORING_SCHEMA_VERSION,
-    ReturnValidationError,
-    load_catalog,
-)
+from pattern_classification_runtime import validate_policy_stamp  # noqa: E402
 from pattern_opportunities import (  # noqa: E402
     PatternOpportunityError,
     validate_pattern_opportunity_rows,
+)
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    PATTERN_SCORING_SCHEMA_VERSION,
+    ReturnValidationError,
+    load_catalog,
 )
 
 
@@ -43,14 +47,26 @@ REASON_CATALOG_FINGERPRINT_MISMATCH = "pattern_catalog_fingerprint_mismatch"
 REASON_SCORING_SCHEMA_MISMATCH = "pattern_scoring_schema_mismatch"
 REASON_EMPTY_CURRENT_COHORT = "empty_current_pattern_cohort"
 REASON_CLASSIFICATION_POLICY_UNAVAILABLE = "pattern_classification_policy_unavailable"
+REASON_CLASSIFICATION_POLICY_INVALID = "pattern_classification_policy_invalid"
 
-CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 1
+LEGACY_CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 1
+CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 2
+CLASSIFICATION_SCHEMA_VERSION = 1
 CLASSIFICATION_POLICY_UNAVAILABLE_REASON = "owner_policy_unconfigured"
-_CLASSIFICATION_AVAILABILITY_FIELDS = frozenset(
-    {"schema_version", "status", "reason_codes"}
-)
 
-_REQUIRED_PATTERN_PROFILE_FIELDS = frozenset(
+_LEGACY_AVAILABILITY_FIELDS = frozenset({"schema_version", "status", "reason_codes"})
+CLASSIFICATION_DOMAINS = (
+    "mastery_and_novelty",
+    "antipattern_recurrence",
+    "underuse",
+    "signature_combinations",
+    "trends",
+    "modes",
+)
+_DOMAIN_STATUS_FIELDS = frozenset({"status", "reason_codes"})
+_AVAILABILITY_V2_FIELDS = frozenset({"schema_version", *CLASSIFICATION_DOMAINS})
+
+_COMMON_PATTERN_PROFILE_FIELDS = frozenset(
     {
         "pattern_baseline",
         "baseline_talk_filenames",
@@ -71,6 +87,16 @@ _REQUIRED_PATTERN_PROFILE_FIELDS = frozenset(
         "signature_combinations",
         "mastery_levels",
         "classification_availability",
+    }
+)
+_V4_PATTERN_PROFILE_FIELDS = _COMMON_PATTERN_PROFILE_FIELDS
+_V5_PATTERN_PROFILE_FIELDS = _COMMON_PATTERN_PROFILE_FIELDS | frozenset(
+    {
+        "classification_schema_version",
+        "classification_policy",
+        "pattern_classifications",
+        "antipattern_classifications",
+        "trend_analysis",
     }
 )
 _REQUIRED_PATTERN_BREADTH_FIELDS = frozenset(
@@ -102,11 +128,58 @@ _MASTERY_TIERS = (
     "rare",
     "never_tried",
 )
+_POSITIVE_CLASSIFICATIONS = frozenset(
+    {
+        "signature",
+        "regular",
+        "occasional",
+        "rare",
+        "never_tried",
+        "not_yet_observed",
+        "unclassified",
+    }
+)
+_ANTIPATTERN_CLASSIFICATIONS = frozenset(
+    {
+        "high_frequency",
+        "moderate_frequency",
+        "occasional",
+        "confirmed_none",
+        "unclassified",
+    }
+)
+_OBSERVATION_STATUSES = frozenset(
+    {"observed", "confirmed_absent", "not_yet_observed", "unavailable"}
+)
+_CLASSIFICATION_ROW_FIELDS = frozenset(
+    {
+        "pattern_id",
+        "classification",
+        "observation_status",
+        "absence_conclusion_capable",
+        "evidence",
+        "reason_codes",
+    }
+)
+_EVIDENCE_FIELDS = frozenset(
+    {
+        "applicable_count",
+        "evaluable_count",
+        "detected_count",
+        "unevaluable_count",
+        "applicable_coverage",
+        "lower",
+        "upper",
+    }
+)
+_COMBINATION_FIELDS = frozenset(
+    {"combination_id", "pattern_ids", "evidence", "reason_codes"}
+)
 
 
 @dataclass(frozen=True)
 class PatternProfileAssessment:
-    """Availability and diagnostics for one profile's pattern history."""
+    """Availability and diagnostics for one nested pattern profile."""
 
     current_contract: bool
     catalog_fields_available: bool
@@ -115,6 +188,13 @@ class PatternProfileAssessment:
     errors: tuple[str, ...]
     eligible_talk_count: int | None = None
     classification_fields_available: bool = False
+    available_classification_domains: frozenset[str] = frozenset()
+    contract_version: int | None = None
+    policy_semantic_sha256: str | None = None
+
+    def domain_available(self, domain: str) -> bool:
+        """Return whether one policy-derived domain is independently enabled."""
+        return domain in self.available_classification_domains
 
 
 def active_pattern_generation_identity() -> tuple[str, int]:
@@ -123,9 +203,9 @@ def active_pattern_generation_identity() -> tuple[str, int]:
 
 
 def unavailable_classification_availability() -> dict[str, object]:
-    """Return the sole schema-v4 classification state currently authorized."""
+    """Return the schema-v4 occurrence-only classification sentinel."""
     return {
-        "schema_version": CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION,
+        "schema_version": LEGACY_CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION,
         "status": "unavailable",
         "reason_codes": [CLASSIFICATION_POLICY_UNAVAILABLE_REASON],
     }
@@ -140,87 +220,169 @@ def _append_reason(reason_codes: list[str], reason_code: str) -> None:
         reason_codes.append(reason_code)
 
 
-def _canonical_cohort_filenames(
-    value: object,
-) -> tuple[list[str] | None, list[str]]:
-    if not isinstance(value, list):
-        return None, ["pattern_profile.baseline_talk_filenames must be an array"]
-
-    errors: list[str] = []
-    filenames: list[str] = []
-    for index, filename in enumerate(value):
-        if (
-            not isinstance(filename, str)
-            or not filename
-            or filename != filename.strip()
-        ):
-            errors.append(
-                "pattern_profile.baseline_talk_filenames"
-                f"[{index}] must be a non-empty string without edge whitespace"
-            )
-            continue
-        filenames.append(filename)
-
-    if len(filenames) != len(set(filenames)):
-        errors.append(
-            "pattern_profile.baseline_talk_filenames must not contain duplicates"
-        )
-    if filenames != sorted(filenames):
-        errors.append(
-            "pattern_profile.baseline_talk_filenames must be sorted in canonical "
-            "filename order"
-        )
-    return filenames, errors
-
-
-def _validate_unavailable_classifications(
-    pattern_profile: Mapping[str, object],
+def _exact_fields(
+    value: Mapping[object, object], expected: frozenset[str], *, path: str
 ) -> list[str]:
-    """Require fail-closed sentinels until an owner policy is versioned."""
+    missing = sorted(field for field in expected if field not in value)
+    unknown = sorted(
+        (field for field in value if field not in expected), key=str
+    )
+    if not missing and not unknown:
+        return []
+    return [
+        f"{path} fields are noncanonical; missing={missing}, "
+        f"unknown={[str(item) for item in unknown]}"
+    ]
+
+
+def _string_array(
+    value: object, *, path: str, sorted_required: bool = False
+) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{path} must be an array"]
+    errors: list[str] = []
+    strings: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item or item != item.strip():
+            errors.append(
+                f"{path}[{index}] must be a non-empty string without edge whitespace"
+            )
+        else:
+            strings.append(item)
+    if len(strings) != len(set(strings)):
+        errors.append(f"{path} must not contain duplicates")
+    if sorted_required and strings != sorted(strings):
+        errors.append(f"{path} must be sorted")
+    return errors
+
+
+def _canonical_cohort_filenames(value: object) -> tuple[list[str] | None, list[str]]:
+    errors = _string_array(
+        value, path="pattern_profile.baseline_talk_filenames", sorted_required=True
+    )
+    if errors or not isinstance(value, list):
+        return None, errors
+    return list(value), []
+
+
+def _validate_common_shape(pattern_profile: Mapping[str, object]) -> list[str]:
+    errors: list[str] = []
+    for field in _ARRAY_PATTERN_PROFILE_FIELDS:
+        if field in pattern_profile and not isinstance(pattern_profile[field], list):
+            errors.append(f"pattern_profile.{field} must be an array")
+    for field in ("strengths_note", "note"):
+        if field in pattern_profile and not isinstance(pattern_profile[field], str):
+            errors.append(f"pattern_profile.{field} must be a string")
+
+    breadth = pattern_profile.get("pattern_breadth")
+    if isinstance(breadth, Mapping):
+        missing_breadth = sorted(_REQUIRED_PATTERN_BREADTH_FIELDS - set(breadth))
+        unknown_breadth = sorted(
+            set(breadth) - _REQUIRED_PATTERN_BREADTH_FIELDS, key=str
+        )
+        if missing_breadth:
+            errors.append(
+                "pattern_profile.pattern_breadth is missing required fields: "
+                + ", ".join(missing_breadth)
+            )
+        if unknown_breadth:
+            errors.append(
+                "pattern_profile.pattern_breadth has unknown fields: "
+                + ", ".join(str(field) for field in unknown_breadth)
+            )
+        if "note" in breadth and not isinstance(breadth["note"], str):
+            errors.append("pattern_profile.pattern_breadth.note must be a string")
+    else:
+        errors.append("pattern_profile.pattern_breadth must be an object")
+
+    drivers = pattern_profile.get("score_drivers")
+    if isinstance(drivers, Mapping):
+        errors.extend(
+            _exact_fields(
+                drivers,
+                _REQUIRED_SCORE_DRIVER_FIELDS,
+                path="pattern_profile.score_drivers",
+            )
+        )
+        for field in ("antipattern_drivers", "pattern_drivers"):
+            if field in drivers:
+                errors.extend(
+                    _string_array(
+                        drivers[field],
+                        path=f"pattern_profile.score_drivers.{field}",
+                        sorted_required=True,
+                    )
+                )
+        if "note" in drivers and not isinstance(drivers["note"], str):
+            errors.append("pattern_profile.score_drivers.note must be a string")
+    else:
+        errors.append("pattern_profile.score_drivers must be an object")
+
+    mastery = pattern_profile.get("mastery_levels")
+    if isinstance(mastery, Mapping):
+        missing_tiers = sorted(set(_MASTERY_TIERS) - set(mastery))
+        unknown_tiers = sorted(set(mastery) - set(_MASTERY_TIERS), key=str)
+        if missing_tiers:
+            errors.append(
+                "pattern_profile.mastery_levels is missing required tiers: "
+                + ", ".join(missing_tiers)
+            )
+        if unknown_tiers:
+            errors.append(
+                "pattern_profile.mastery_levels has unknown tiers: "
+                + ", ".join(str(field) for field in unknown_tiers)
+            )
+        for tier in _MASTERY_TIERS:
+            if tier in mastery:
+                errors.extend(
+                    _string_array(
+                        mastery[tier],
+                        path=f"pattern_profile.mastery_levels.{tier}",
+                        sorted_required=True,
+                    )
+                )
+    else:
+        errors.append("pattern_profile.mastery_levels must be an object")
+    return errors
+
+
+def _validate_v4_unavailable(pattern_profile: Mapping[str, object]) -> list[str]:
+    """Require fail-closed schema-v4 derived sentinels."""
     errors: list[str] = []
     availability = pattern_profile.get("classification_availability")
-    expected_availability = unavailable_classification_availability()
+    expected = unavailable_classification_availability()
     if not isinstance(availability, Mapping):
         errors.append("pattern_profile.classification_availability must be an object")
     else:
-        missing = sorted(_CLASSIFICATION_AVAILABILITY_FIELDS - set(availability))
-        unknown = sorted(
-            set(availability) - _CLASSIFICATION_AVAILABILITY_FIELDS,
-            key=str,
-        )
-        if missing or unknown:
-            errors.append(
-                "pattern_profile.classification_availability fields are "
-                f"noncanonical; missing={missing}, "
-                f"unknown={[str(field) for field in unknown]}"
+        errors.extend(
+            _exact_fields(
+                availability,
+                _LEGACY_AVAILABILITY_FIELDS,
+                path="pattern_profile.classification_availability",
             )
-        if dict(availability) != expected_availability:
+        )
+        if dict(availability) != expected:
             errors.append(
                 "pattern_profile.classification_availability must use the "
-                "owner-policy-unconfigured sentinel until a versioned "
-                "classification policy exists"
+                "owner-policy-unconfigured schema-v4 sentinel"
             )
-
     if pattern_profile.get("score_trend") != "unavailable":
         errors.append(
             "pattern_profile.score_trend must be 'unavailable' while pattern "
             "classification policy is unavailable"
         )
-
     breadth = pattern_profile.get("pattern_breadth")
     if isinstance(breadth, Mapping):
         if breadth.get("avg_distinct_patterns_per_talk") is not None:
             errors.append(
                 "pattern_profile.pattern_breadth.avg_distinct_patterns_per_talk "
-                "must be null while coverage-comparable breadth policy is "
-                "unavailable"
+                "must be null while coverage-comparable breadth policy is unavailable"
             )
         if breadth.get("trend") != "unavailable":
             errors.append(
                 "pattern_profile.pattern_breadth.trend must be 'unavailable' when "
                 "pattern classification policy is unavailable"
             )
-
     drivers = pattern_profile.get("score_drivers")
     if isinstance(drivers, Mapping):
         if drivers.get("direction") != "unavailable":
@@ -234,14 +396,12 @@ def _validate_unavailable_classifications(
                     f"pattern_profile.score_drivers.{field} must be [] when the "
                     "pattern classification policy is unavailable"
                 )
-
     for field in _DERIVED_ARRAY_PATTERN_PROFILE_FIELDS:
         if pattern_profile.get(field) != []:
             errors.append(
-                f"pattern_profile.{field} must be [] while pattern "
-                "classification policy is unavailable"
+                f"pattern_profile.{field} must be [] while pattern classification "
+                "policy is unavailable"
             )
-
     mastery = pattern_profile.get("mastery_levels")
     if isinstance(mastery, Mapping):
         for tier in _MASTERY_TIERS:
@@ -253,14 +413,391 @@ def _validate_unavailable_classifications(
     return errors
 
 
-def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
-    """Assess strict current-generation pattern history without applying fallback.
+def _validate_availability_v2(
+    value: object,
+) -> tuple[frozenset[str], list[str]]:
+    if not isinstance(value, Mapping):
+        return frozenset(), [
+            "pattern_profile.classification_availability must be an object"
+        ]
+    errors = _exact_fields(
+        value,
+        _AVAILABILITY_V2_FIELDS,
+        path="pattern_profile.classification_availability",
+    )
+    if value.get(
+        "schema_version"
+    ) != CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION or isinstance(
+        value.get("schema_version"), bool
+    ):
+        errors.append(
+            "pattern_profile.classification_availability.schema_version must be 2"
+        )
+    available: set[str] = set()
+    for domain in CLASSIFICATION_DOMAINS:
+        item = value.get(domain)
+        path = f"pattern_profile.classification_availability.{domain}"
+        if not isinstance(item, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        errors.extend(_exact_fields(item, _DOMAIN_STATUS_FIELDS, path=path))
+        status = item.get("status")
+        if status not in {"available", "unavailable"}:
+            errors.append(f"{path}.status must be available or unavailable")
+        reason_codes = item.get("reason_codes")
+        errors.extend(_string_array(reason_codes, path=f"{path}.reason_codes"))
+        if status == "available":
+            available.add(domain)
+            if reason_codes != []:
+                errors.append(f"{path}.reason_codes must be [] when available")
+        elif status == "unavailable" and reason_codes == []:
+            errors.append(f"{path}.reason_codes must explain unavailability")
+    modes = value.get("modes")
+    if isinstance(modes, Mapping) and modes != {
+        "status": "unavailable",
+        "reason_codes": ["talk_mode_assignments_unavailable"],
+    }:
+        errors.append(
+            "pattern_profile.classification_availability.modes must fail closed "
+            "with talk_mode_assignments_unavailable"
+        )
+    return frozenset(available), errors
 
-    A valid zero-talk snapshot is a current contract but has unavailable catalog
-    history. Any malformed or stale identity fails closed. Consumers may still
-    use unrelated profile fields; this assessment speaks only for catalog-derived
-    pattern history.
-    """
+
+def _expected_evidence(raw: Mapping[str, object]) -> dict[str, object] | None:
+    fields = (
+        "eligible_cohort_count",
+        "not_applicable_count",
+        "evaluable_count",
+        "detected_count",
+        "unevaluable_count",
+    )
+    counts: dict[str, int] = {}
+    for field in fields:
+        value = raw.get(field)
+        if not _is_integer(value):
+            return None
+        counts[field] = value
+    eligible = counts["eligible_cohort_count"]
+    not_applicable = counts["not_applicable_count"]
+    evaluable = counts["evaluable_count"]
+    detected = counts["detected_count"]
+    unevaluable = counts["unevaluable_count"]
+    applicable = eligible - not_applicable
+    if applicable == 0:
+        coverage = lower = upper = None
+    else:
+        coverage = evaluable / applicable
+        lower = detected / applicable
+        upper = (detected + unevaluable) / applicable
+    return {
+        "applicable_count": applicable,
+        "evaluable_count": evaluable,
+        "detected_count": detected,
+        "unevaluable_count": unevaluable,
+        "applicable_coverage": coverage,
+        "lower": lower,
+        "upper": upper,
+    }
+
+
+def _validate_classification_lane(
+    value: object,
+    raw_rows: object,
+    *,
+    lane: str,
+    allowed_classifications: frozenset[str],
+    active_catalog: object,
+) -> tuple[list[Mapping[str, object]], list[str]]:
+    errors: list[str] = []
+    if not isinstance(value, list):
+        return [], [f"pattern_profile.{lane} must be an array"]
+    if not isinstance(raw_rows, list):
+        return [], [f"pattern_profile.{lane} cannot bind missing raw rows"]
+    raw_by_id = {
+        row.get("pattern_id"): row
+        for row in raw_rows
+        if isinstance(row, Mapping) and isinstance(row.get("pattern_id"), str)
+    }
+    expected_ids = list(raw_by_id)
+    observed_ids: list[str] = []
+    canonical: list[Mapping[str, object]] = []
+    entries = getattr(active_catalog, "entries", {})
+    for index, item in enumerate(value):
+        path = f"pattern_profile.{lane}[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        canonical.append(item)
+        errors.extend(_exact_fields(item, _CLASSIFICATION_ROW_FIELDS, path=path))
+        pattern_id = item.get("pattern_id")
+        if not isinstance(pattern_id, str) or not pattern_id:
+            errors.append(f"{path}.pattern_id must be a non-empty string")
+            continue
+        observed_ids.append(pattern_id)
+        classification = item.get("classification")
+        if classification not in allowed_classifications:
+            errors.append(f"{path}.classification is invalid: {classification!r}")
+        observation_status = item.get("observation_status")
+        if observation_status not in _OBSERVATION_STATUSES:
+            errors.append(
+                f"{path}.observation_status is invalid: {observation_status!r}"
+            )
+        absence_capable = item.get("absence_conclusion_capable")
+        entry = entries.get(pattern_id) if isinstance(entries, Mapping) else None
+        expected_absence = (
+            getattr(entry, "absence_evaluable_from", None) is not None
+            if entry is not None
+            else None
+        )
+        if not isinstance(absence_capable, bool) or absence_capable != expected_absence:
+            errors.append(
+                f"{path}.absence_conclusion_capable must match active catalog metadata"
+            )
+        evidence = item.get("evidence")
+        if not isinstance(evidence, Mapping):
+            errors.append(f"{path}.evidence must be an object")
+        else:
+            errors.extend(
+                _exact_fields(evidence, _EVIDENCE_FIELDS, path=f"{path}.evidence")
+            )
+            raw = raw_by_id.get(pattern_id)
+            expected_evidence = (
+                _expected_evidence(raw) if isinstance(raw, Mapping) else None
+            )
+            if expected_evidence is not None and dict(evidence) != expected_evidence:
+                errors.append(
+                    f"{path}.evidence does not match the exact raw A/E/D/U row"
+                )
+        errors.extend(
+            _string_array(item.get("reason_codes"), path=f"{path}.reason_codes")
+        )
+        if item.get("reason_codes") == []:
+            errors.append(f"{path}.reason_codes must not be empty")
+        if absence_capable is False and classification in {
+            "never_tried",
+            "confirmed_none",
+        }:
+            errors.append(
+                f"{path}.classification cannot conclude absence for a positive-only entry"
+            )
+        if (
+            absence_capable is False
+            and isinstance(evidence, Mapping)
+            and isinstance(evidence.get("applicable_count"), int)
+            and evidence.get("applicable_count", 0) > 0
+            and evidence.get("detected_count") == 0
+        ):
+            required_classification = (
+                "not_yet_observed"
+                if lane == "pattern_classifications"
+                else "unclassified"
+            )
+            if (
+                classification != required_classification
+                or observation_status != "not_yet_observed"
+            ):
+                errors.append(
+                    f"{path} positive-only zero detection must be "
+                    f"{required_classification}/not_yet_observed"
+                )
+    if observed_ids != expected_ids:
+        errors.append(
+            f"pattern_profile.{lane} must be sorted and exhaustive for its raw lane; "
+            f"expected={expected_ids}, got={observed_ids}"
+        )
+    return canonical, errors
+
+
+def _validate_combinations(
+    value: object, positive_rows: Sequence[Mapping[str, object]]
+) -> list[str]:
+    if not isinstance(value, list):
+        return ["pattern_profile.signature_combinations must be an array"]
+    errors: list[str] = []
+    eligible = {
+        row.get("pattern_id")
+        for row in positive_rows
+        if row.get("classification") in {"regular", "signature"}
+    }
+    ids: list[str] = []
+    previous_sort_key: tuple[float, int, tuple[str, ...]] | None = None
+    for index, item in enumerate(value):
+        path = f"pattern_profile.signature_combinations[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{path} must be an object")
+            continue
+        errors.extend(_exact_fields(item, _COMBINATION_FIELDS, path=path))
+        members = item.get("pattern_ids")
+        if not isinstance(members, list) or len(members) not in {2, 3}:
+            errors.append(f"{path}.pattern_ids must contain exactly two or three IDs")
+            continue
+        errors.extend(
+            _string_array(members, path=f"{path}.pattern_ids", sorted_required=True)
+        )
+        combination_id = item.get("combination_id")
+        expected_id = "+".join(str(member) for member in members)
+        if combination_id != expected_id:
+            errors.append(f"{path}.combination_id must equal {expected_id!r}")
+        elif isinstance(combination_id, str):
+            ids.append(combination_id)
+        if any(member not in eligible for member in members):
+            errors.append(f"{path} members must each be regular or signature")
+        evidence = item.get("evidence")
+        if not isinstance(evidence, Mapping):
+            errors.append(f"{path}.evidence must be an object")
+            continue
+        errors.extend(
+            _exact_fields(evidence, _EVIDENCE_FIELDS, path=f"{path}.evidence")
+        )
+        lower = evidence.get("lower")
+        detected = evidence.get("detected_count")
+        if not isinstance(lower, (int, float)) or isinstance(lower, bool):
+            errors.append(f"{path}.evidence.lower must be numeric")
+            continue
+        if not _is_integer(detected):
+            errors.append(f"{path}.evidence.detected_count must be an integer")
+            continue
+        sort_key = (-float(lower), -detected, tuple(str(member) for member in members))
+        if previous_sort_key is not None and sort_key < previous_sort_key:
+            errors.append(
+                "pattern_profile.signature_combinations must use canonical ranking"
+            )
+        previous_sort_key = sort_key
+        errors.extend(
+            _string_array(item.get("reason_codes"), path=f"{path}.reason_codes")
+        )
+    if len(ids) != len(set(ids)):
+        errors.append(
+            "pattern_profile.signature_combinations duplicates a canonical ID"
+        )
+    if len(value) > 10:
+        errors.append(
+            "pattern_profile.signature_combinations may contain at most 10 rows"
+        )
+    return errors
+
+
+def _validate_v5_policy_fields(
+    pattern_profile: Mapping[str, object], active_catalog: object
+) -> tuple[frozenset[str], str | None, list[str]]:
+    errors: list[str] = []
+    if pattern_profile.get(
+        "classification_schema_version"
+    ) != CLASSIFICATION_SCHEMA_VERSION or isinstance(
+        pattern_profile.get("classification_schema_version"), bool
+    ):
+        errors.append("pattern_profile.classification_schema_version must be 1")
+    try:
+        stamp = validate_policy_stamp(pattern_profile.get("classification_policy"))
+        digest = str(stamp["semantic_sha256"])
+    except (RuntimeError, ValueError) as exc:
+        errors.append(f"pattern_profile.classification_policy is invalid: {exc}")
+        digest = None
+    domains, availability_errors = _validate_availability_v2(
+        pattern_profile.get("classification_availability")
+    )
+    errors.extend(availability_errors)
+    positive_rows, lane_errors = _validate_classification_lane(
+        pattern_profile.get("pattern_classifications"),
+        pattern_profile.get("pattern_usage"),
+        lane="pattern_classifications",
+        allowed_classifications=_POSITIVE_CLASSIFICATIONS,
+        active_catalog=active_catalog,
+    )
+    errors.extend(lane_errors)
+    antipattern_rows, lane_errors = _validate_classification_lane(
+        pattern_profile.get("antipattern_classifications"),
+        pattern_profile.get("antipattern_frequency"),
+        lane="antipattern_classifications",
+        allowed_classifications=_ANTIPATTERN_CLASSIFICATIONS,
+        active_catalog=active_catalog,
+    )
+    errors.extend(lane_errors)
+
+    expected_mastery = {
+        tier: [
+            str(row["pattern_id"])
+            for row in positive_rows
+            if row.get("classification") == tier
+        ]
+        for tier in _MASTERY_TIERS
+    }
+    if pattern_profile.get("mastery_levels") != expected_mastery:
+        errors.append(
+            "pattern_profile.mastery_levels is not the deterministic projection"
+        )
+    never_tried = expected_mastery["never_tried"]
+    if pattern_profile.get("never_used_patterns") != never_tried:
+        errors.append(
+            "pattern_profile.never_used_patterns must equal confirmed never_tried IDs"
+        )
+    underused = sorted(expected_mastery["rare"] + never_tried)
+    if pattern_profile.get("underused_patterns") != underused:
+        errors.append(
+            "pattern_profile.underused_patterns must equal sorted rare + never_tried IDs"
+        )
+    strengths = sorted(expected_mastery["regular"] + expected_mastery["signature"])
+    if pattern_profile.get("strengths") != strengths:
+        errors.append(
+            "pattern_profile.strengths must equal sorted regular + signature IDs"
+        )
+    errors.extend(
+        _validate_combinations(
+            pattern_profile.get("signature_combinations"), positive_rows
+        )
+    )
+    if pattern_profile.get("by_mode") != []:
+        errors.append(
+            "pattern_profile.by_mode must be [] while talk mode assignments are unavailable"
+        )
+
+    trend_analysis = pattern_profile.get("trend_analysis")
+    if not isinstance(trend_analysis, Mapping):
+        errors.append("pattern_profile.trend_analysis must be an object")
+    else:
+        score = trend_analysis.get("score")
+        breadth = trend_analysis.get("breadth")
+        if not isinstance(score, Mapping) or pattern_profile.get(
+            "score_trend"
+        ) != score.get("status"):
+            errors.append(
+                "pattern_profile.score_trend must project trend_analysis.score.status"
+            )
+        profile_breadth = pattern_profile.get("pattern_breadth")
+        if (
+            not isinstance(breadth, Mapping)
+            or not isinstance(profile_breadth, Mapping)
+            or profile_breadth.get("trend") != breadth.get("status")
+        ):
+            errors.append(
+                "pattern_profile.pattern_breadth.trend must project "
+                "trend_analysis.breadth.status"
+            )
+        trend_available = "trends" in domains
+        if trend_available != (trend_analysis.get("status") == "available"):
+            errors.append(
+                "pattern_profile trend availability must match trend_analysis.status"
+            )
+    if "antipattern_recurrence" not in domains:
+        actionable = {
+            row.get("classification")
+            for row in antipattern_rows
+            if row.get("classification") in {"high_frequency", "moderate_frequency"}
+        }
+        if actionable:
+            errors.append(
+                "unavailable antipattern recurrence cannot expose actionable tiers"
+            )
+    return domains, digest, errors
+
+
+def assess_pattern_profile(
+    pattern_profile: object,
+    *,
+    expected_contract_version: int | None = None,
+) -> PatternProfileAssessment:
+    """Assess v4 occurrence-only or v5 policy-bound pattern history."""
     errors: list[str] = []
     reason_codes: list[str] = []
     if not isinstance(pattern_profile, Mapping):
@@ -270,101 +807,47 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
             scored_talk_count=None,
             reason_codes=(REASON_INVALID_CONTRACT,),
             errors=("pattern_profile must be an object",),
+            contract_version=expected_contract_version,
         )
 
-    missing_fields = sorted(_REQUIRED_PATTERN_PROFILE_FIELDS - set(pattern_profile))
+    inferred_version = (
+        5
+        if any(
+            field in pattern_profile
+            for field in _V5_PATTERN_PROFILE_FIELDS - _V4_PATTERN_PROFILE_FIELDS
+        )
+        else 4
+    )
+    contract_version = expected_contract_version or inferred_version
+    if contract_version not in {4, 5}:
+        return PatternProfileAssessment(
+            current_contract=False,
+            catalog_fields_available=False,
+            scored_talk_count=None,
+            reason_codes=(REASON_INVALID_CONTRACT,),
+            errors=(
+                f"unsupported pattern-profile contract version {contract_version!r}",
+            ),
+            contract_version=contract_version,
+        )
+    required_fields = (
+        _V5_PATTERN_PROFILE_FIELDS
+        if contract_version == 5
+        else _V4_PATTERN_PROFILE_FIELDS
+    )
+    missing_fields = sorted(required_fields - set(pattern_profile))
+    unknown_fields = sorted(set(pattern_profile) - required_fields, key=str)
     if missing_fields:
         errors.append(
-            "pattern_profile is missing required schema-v4 fields: "
+            f"pattern_profile is missing required schema-v{contract_version} fields: "
             f"{', '.join(missing_fields)}"
         )
-    unknown_fields = sorted(
-        set(pattern_profile) - _REQUIRED_PATTERN_PROFILE_FIELDS,
-        key=str,
-    )
     if unknown_fields:
         errors.append(
-            "pattern_profile has unknown schema-v4 fields: "
+            f"pattern_profile has unknown schema-v{contract_version} fields: "
             f"{', '.join(str(field) for field in unknown_fields)}"
         )
-
-    for field in _ARRAY_PATTERN_PROFILE_FIELDS:
-        if field in pattern_profile and not isinstance(pattern_profile[field], list):
-            errors.append(f"pattern_profile.{field} must be an array")
-
-    for field in ("strengths_note", "note"):
-        if field in pattern_profile and not isinstance(pattern_profile[field], str):
-            errors.append(f"pattern_profile.{field} must be a string")
-
-    breadth = pattern_profile.get("pattern_breadth")
-    if isinstance(breadth, Mapping):
-        missing_breadth = sorted(_REQUIRED_PATTERN_BREADTH_FIELDS - set(breadth))
-        if missing_breadth:
-            errors.append(
-                "pattern_profile.pattern_breadth is missing required fields: "
-                f"{', '.join(missing_breadth)}"
-            )
-        unknown_breadth = sorted(
-            set(breadth) - _REQUIRED_PATTERN_BREADTH_FIELDS,
-            key=str,
-        )
-        if unknown_breadth:
-            errors.append(
-                "pattern_profile.pattern_breadth has unknown fields: "
-                f"{', '.join(str(field) for field in unknown_breadth)}"
-            )
-        if "note" in breadth and not isinstance(breadth["note"], str):
-            errors.append("pattern_profile.pattern_breadth.note must be a string")
-    else:
-        errors.append("pattern_profile.pattern_breadth must be an object")
-
-    drivers = pattern_profile.get("score_drivers")
-    if isinstance(drivers, Mapping):
-        missing_drivers = sorted(_REQUIRED_SCORE_DRIVER_FIELDS - set(drivers))
-        if missing_drivers:
-            errors.append(
-                "pattern_profile.score_drivers is missing required fields: "
-                f"{', '.join(missing_drivers)}"
-            )
-        unknown_drivers = sorted(
-            set(drivers) - _REQUIRED_SCORE_DRIVER_FIELDS,
-            key=str,
-        )
-        if unknown_drivers:
-            errors.append(
-                "pattern_profile.score_drivers has unknown fields: "
-                f"{', '.join(str(field) for field in unknown_drivers)}"
-            )
-        for field in ("antipattern_drivers", "pattern_drivers"):
-            if field in drivers and not isinstance(drivers[field], list):
-                errors.append(f"pattern_profile.score_drivers.{field} must be an array")
-        if "note" in drivers and not isinstance(drivers["note"], str):
-            errors.append("pattern_profile.score_drivers.note must be a string")
-    else:
-        errors.append("pattern_profile.score_drivers must be an object")
-
-    mastery = pattern_profile.get("mastery_levels")
-    if isinstance(mastery, Mapping):
-        missing_tiers = sorted(set(_MASTERY_TIERS) - set(mastery))
-        if missing_tiers:
-            errors.append(
-                "pattern_profile.mastery_levels is missing required tiers: "
-                f"{', '.join(missing_tiers)}"
-            )
-        unknown_tiers = sorted(
-            set(mastery) - set(_MASTERY_TIERS),
-            key=str,
-        )
-        if unknown_tiers:
-            errors.append(
-                "pattern_profile.mastery_levels has unknown tiers: "
-                f"{', '.join(str(field) for field in unknown_tiers)}"
-            )
-        for tier in _MASTERY_TIERS:
-            if tier in mastery and not isinstance(mastery[tier], list):
-                errors.append(f"pattern_profile.mastery_levels.{tier} must be an array")
-    else:
-        errors.append("pattern_profile.mastery_levels must be an object")
+    errors.extend(_validate_common_shape(pattern_profile))
 
     try:
         baseline = validate_adherence_baseline(pattern_profile.get("pattern_baseline"))
@@ -377,10 +860,11 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
             scored_talk_count=None,
             reason_codes=tuple(reason_codes),
             errors=tuple(errors),
+            contract_version=contract_version,
         )
 
     score_comparable_count = baseline["scored_talk_count"]
-    assert isinstance(score_comparable_count, int)  # canonical baseline postcondition
+    assert isinstance(score_comparable_count, int)
     raw_eligible_count = baseline.get("eligible_talk_count")
     if not _is_integer(raw_eligible_count) or raw_eligible_count < 0:
         errors.append(
@@ -390,7 +874,6 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
         eligible_count = 0
     else:
         eligible_count = raw_eligible_count
-
     if baseline["active_batch_excluded"] is not False:
         errors.append(
             "pattern_profile.pattern_baseline must be a full-cohort snapshot with "
@@ -399,7 +882,6 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
     if baseline["excluded_filenames"] != []:
         errors.append("pattern_profile.pattern_baseline.excluded_filenames must be []")
 
-    active_scoring_schema = PATTERN_SCORING_SCHEMA_VERSION
     active_catalog = None
     try:
         active_catalog = load_catalog()
@@ -411,7 +893,6 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
         )
         _append_reason(reason_codes, REASON_ACTIVE_CATALOG_UNAVAILABLE)
         active_fingerprint = None
-
     if (
         active_fingerprint is not None
         and baseline["pattern_catalog_fingerprint"] != active_fingerprint
@@ -422,11 +903,11 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
             "new scoring generation"
         )
         _append_reason(reason_codes, REASON_CATALOG_FINGERPRINT_MISMATCH)
-    if baseline["pattern_scoring_schema_version"] != active_scoring_schema:
+    if baseline["pattern_scoring_schema_version"] != PATTERN_SCORING_SCHEMA_VERSION:
         errors.append(
             "pattern_profile.pattern_baseline.pattern_scoring_schema_version is "
             f"{baseline['pattern_scoring_schema_version']!r}; expected active schema "
-            f"{active_scoring_schema}"
+            f"{PATTERN_SCORING_SCHEMA_VERSION}"
         )
         _append_reason(reason_codes, REASON_SCORING_SCHEMA_MISMATCH)
 
@@ -437,10 +918,8 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
     if filenames is not None and len(filenames) != eligible_count:
         errors.append(
             "pattern_profile.baseline_talk_filenames length must equal "
-            f"pattern_baseline.eligible_talk_count {eligible_count}, got "
-            f"{len(filenames)}"
+            f"pattern_baseline.eligible_talk_count {eligible_count}, got {len(filenames)}"
         )
-
     profile_eligible_count = pattern_profile.get("eligible_talk_count")
     if (
         not _is_integer(profile_eligible_count)
@@ -451,16 +930,12 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
             f"pattern_baseline.eligible_talk_count {eligible_count}, got "
             f"{profile_eligible_count!r}"
         )
-
     talks_scored = pattern_profile.get("talks_scored")
     if not _is_integer(talks_scored) or talks_scored != score_comparable_count:
         errors.append(
-            "pattern_profile.talks_scored must equal "
-            "pattern_baseline.scored_talk_count "
-            f"{score_comparable_count}, got "
-            f"{talks_scored!r}"
+            "pattern_profile.talks_scored must equal pattern_baseline.scored_talk_count "
+            f"{score_comparable_count}, got {talks_scored!r}"
         )
-
     profile_average = pattern_profile.get("average_pattern_score")
     baseline_average = baseline["average_pattern_score"]
     if score_comparable_count == 0:
@@ -475,10 +950,8 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
     if not average_is_valid:
         errors.append(
             "pattern_profile.average_pattern_score must equal the canonical "
-            f"pattern baseline average {baseline_average!r}, got "
-            f"{profile_average!r}"
+            f"pattern baseline average {baseline_average!r}, got {profile_average!r}"
         )
-
     if active_catalog is not None:
         try:
             errors.extend(
@@ -491,7 +964,18 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
             )
         except PatternOpportunityError as exc:
             errors.append(f"pattern opportunity rows are invalid: {exc}")
-    errors.extend(_validate_unavailable_classifications(pattern_profile))
+
+    domains = frozenset()
+    policy_digest = None
+    if contract_version == 4:
+        errors.extend(_validate_v4_unavailable(pattern_profile))
+    elif active_catalog is not None:
+        domains, policy_digest, policy_errors = _validate_v5_policy_fields(
+            pattern_profile, active_catalog
+        )
+        errors.extend(policy_errors)
+        if policy_digest is None:
+            _append_reason(reason_codes, REASON_CLASSIFICATION_POLICY_INVALID)
 
     if errors:
         _append_reason(reason_codes, REASON_INVALID_CONTRACT)
@@ -502,25 +986,24 @@ def assess_pattern_profile(pattern_profile: object) -> PatternProfileAssessment:
             reason_codes=tuple(reason_codes),
             errors=tuple(errors),
             eligible_talk_count=eligible_count,
+            available_classification_domains=frozenset(),
+            contract_version=contract_version,
+            policy_semantic_sha256=policy_digest,
         )
 
     if eligible_count == 0:
-        return PatternProfileAssessment(
-            current_contract=True,
-            catalog_fields_available=False,
-            scored_talk_count=score_comparable_count,
-            reason_codes=(
-                REASON_EMPTY_CURRENT_COHORT,
-                REASON_CLASSIFICATION_POLICY_UNAVAILABLE,
-            ),
-            errors=(),
-            eligible_talk_count=0,
-        )
+        _append_reason(reason_codes, REASON_EMPTY_CURRENT_COHORT)
+    if contract_version == 4:
+        _append_reason(reason_codes, REASON_CLASSIFICATION_POLICY_UNAVAILABLE)
     return PatternProfileAssessment(
         current_contract=True,
-        catalog_fields_available=True,
+        catalog_fields_available=eligible_count > 0,
         scored_talk_count=score_comparable_count,
-        reason_codes=(REASON_CLASSIFICATION_POLICY_UNAVAILABLE,),
+        reason_codes=tuple(reason_codes),
         errors=(),
         eligible_talk_count=eligible_count,
+        classification_fields_available=bool(domains),
+        available_classification_domains=domains,
+        contract_version=contract_version,
+        policy_semantic_sha256=policy_digest,
     )

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -430,10 +430,10 @@ def _validate_availability_v2(
         _AVAILABILITY_V2_FIELDS,
         path="pattern_profile.classification_availability",
     )
-    if value.get(
-        "schema_version"
-    ) != CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION or isinstance(
-        value.get("schema_version"), bool
+    availability_schema_version = value.get("schema_version")
+    if (
+        not _is_integer(availability_schema_version)
+        or availability_schema_version != CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION
     ):
         errors.append(
             "pattern_profile.classification_availability.schema_version must be 2"
@@ -737,6 +737,8 @@ def _validate_combinations(
         errors.extend(
             _string_array(item.get("reason_codes"), path=f"{path}.reason_codes")
         )
+        if item.get("reason_codes") == []:
+            errors.append(f"{path}.reason_codes must not be empty")
     if len(ids) != len(set(ids)):
         errors.append(
             "pattern_profile.signature_combinations duplicates a canonical ID"
@@ -755,10 +757,10 @@ def _validate_v5_policy_fields(
     eligible_talk_count: int,
 ) -> tuple[frozenset[str], str | None, list[str]]:
     errors: list[str] = []
-    if pattern_profile.get(
-        "classification_schema_version"
-    ) != CLASSIFICATION_SCHEMA_VERSION or isinstance(
-        pattern_profile.get("classification_schema_version"), bool
+    classification_schema_version = pattern_profile.get("classification_schema_version")
+    if (
+        not _is_integer(classification_schema_version)
+        or classification_schema_version != CLASSIFICATION_SCHEMA_VERSION
     ):
         errors.append("pattern_profile.classification_schema_version must be 1")
     try:

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -527,12 +527,12 @@ def _validate_classification_lane(
         if not isinstance(item, Mapping):
             errors.append(f"{path} must be an object")
             continue
-        canonical.append(item)
         errors.extend(_exact_fields(item, _CLASSIFICATION_ROW_FIELDS, path=path))
         pattern_id = item.get("pattern_id")
         if not isinstance(pattern_id, str) or not pattern_id:
             errors.append(f"{path}.pattern_id must be a non-empty string")
             continue
+        canonical.append(item)
         observed_ids.append(pattern_id)
         classification = item.get("classification")
         if classification not in allowed_classifications:

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -2,8 +2,9 @@
 """Validate and atomically replace Section 15 pattern-history provenance.
 
 The human narrative in ``rhetoric-style-summary.md`` is never a machine
-baseline.  This module recognizes only one versioned, uniquely delimited JSON
-block inside Markdown Section 15.  The block carries a complete
+baseline. This module reads the occurrence-only v2 block and the policy-bound
+v3 block, while writing only v3. Exactly one uniquely delimited JSON block may
+exist inside Markdown Section 15. The block carries a complete
 ``pattern_profile`` plus redundant generation/cohort identity.  The shared
 ``profile_pattern_provenance`` assessor remains the authority for the payload.
 
@@ -44,7 +45,8 @@ from profile_pattern_provenance import (  # noqa: E402
     PatternProfileAssessment,
     assess_pattern_profile,
 )
-from adherence_baseline import (  # noqa: E402
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from adherence_baseline import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     AdherenceBaselineError,
     EvidenceFreshnessAssessor,
 )
@@ -54,30 +56,43 @@ from pattern_cohort_snapshot import (  # noqa: E402
     configured_evidence_freshness_assessor,
 )
 from pattern_opportunities import PatternOpportunityError  # noqa: E402
-from return_validation import (  # noqa: E402
+from pattern_classification_runtime import (  # noqa: E402
+    classify_pattern_profile,
+    resolve_classification_policy,
+    validate_policy_stamp,
+)
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     ReturnValidationError,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseError,
     assess_tracking_database,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
 )
-from vault_root_authority import (  # noqa: E402
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from vault_root_authority import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     VaultRootAuthorityError,
     materialize_native_authority,
     resolve_vault_root_authority,
 )
 
 
-BLOCK_SCHEMA_VERSION = 2
+LEGACY_BLOCK_SCHEMA_VERSION = 2
+BLOCK_SCHEMA_VERSION = 3
 BLOCK_SOURCE_LANE = "current_pattern_history"
-BLOCK_TOKEN = "speaker-toolkit:section15-current-pattern-history:v2"
+LEGACY_BLOCK_TOKEN = "speaker-toolkit:section15-current-pattern-history:v2"
+BLOCK_TOKEN = "speaker-toolkit:section15-current-pattern-history:v3"
+LEGACY_BLOCK_START = f"<!-- {LEGACY_BLOCK_TOKEN}:start -->"
+LEGACY_BLOCK_END = f"<!-- {LEGACY_BLOCK_TOKEN}:end -->"
 BLOCK_START = f"<!-- {BLOCK_TOKEN}:start -->"
 BLOCK_END = f"<!-- {BLOCK_TOKEN}:end -->"
 NON_BASELINE_NOTICE = (
@@ -94,14 +109,27 @@ _SECTION_15_HEADING = re.compile(
     re.MULTILINE,
 )
 _NEXT_H2_HEADING = re.compile(r"^##[ \t]+", re.MULTILINE)
-_BLOCK_BODY = re.compile(
-    re.escape(BLOCK_START)
-    + r"\n```json\n(?P<payload>.*?)\n```\n\n"
-    + re.escape(NON_BASELINE_NOTICE)
-    + r"\n"
-    + re.escape(BLOCK_END),
-    re.DOTALL,
-)
+_BLOCK_MARKERS = {
+    LEGACY_BLOCK_SCHEMA_VERSION: (
+        LEGACY_BLOCK_TOKEN,
+        LEGACY_BLOCK_START,
+        LEGACY_BLOCK_END,
+    ),
+    BLOCK_SCHEMA_VERSION: (BLOCK_TOKEN, BLOCK_START, BLOCK_END),
+}
+
+
+def _block_body_pattern(start: str, end: str) -> re.Pattern[str]:
+    return re.compile(
+        re.escape(start)
+        + r"\n```json\n(?P<payload>.*?)\n```\n\n"
+        + re.escape(NON_BASELINE_NOTICE)
+        + r"\n"
+        + re.escape(end),
+        re.DOTALL,
+    )
+
+
 _REQUIRED_BLOCK_FIELDS = frozenset(
     {
         "schema_version",
@@ -138,6 +166,9 @@ class Section15PatternHistoryAssessment:
     errors: tuple[str, ...]
     pattern_profile: dict[str, object] | None
     classification_fields_available: bool = False
+    available_classification_domains: frozenset[str] = frozenset()
+    block_schema_version: int | None = None
+    policy_semantic_sha256: str | None = None
 
     def as_status_dict(self) -> dict[str, object]:
         """Return status without echoing the potentially large history payload."""
@@ -145,6 +176,11 @@ class Section15PatternHistoryAssessment:
             "current_contract": self.current_contract,
             "catalog_fields_available": self.catalog_fields_available,
             "classification_fields_available": (self.classification_fields_available),
+            "available_classification_domains": sorted(
+                self.available_classification_domains
+            ),
+            "block_schema_version": self.block_schema_version,
+            "policy_semantic_sha256": self.policy_semantic_sha256,
             "scored_talk_count": self.scored_talk_count,
             "eligible_talk_count": self.eligible_talk_count,
             "reason_codes": self.reason_codes,
@@ -219,59 +255,94 @@ def _section_15_bounds(summary: str) -> tuple[re.Match[str], int] | None:
 
 def _extract_payload_text(
     summary: str,
-) -> tuple[str | None, Section15PatternHistoryAssessment | None]:
+) -> tuple[str | None, int | None, Section15PatternHistoryAssessment | None]:
     section = _section_15_bounds(summary)
     if section is None:
-        return None, _invalid_assessment(
-            REASON_BLOCK_INVALID,
-            "rhetoric summary must contain exactly one Markdown H2 Section 15",
+        return (
+            None,
+            None,
+            _invalid_assessment(
+                REASON_BLOCK_INVALID,
+                "rhetoric summary must contain exactly one Markdown H2 Section 15",
+            ),
         )
     heading, section_end = section
 
-    start_count = summary.count(BLOCK_START)
-    end_count = summary.count(BLOCK_END)
-    token_count = summary.count(BLOCK_TOKEN)
-    if start_count == 0 and end_count == 0:
-        if token_count:
-            return None, _invalid_assessment(
+    marker_counts = {
+        version: (
+            summary.count(token),
+            summary.count(start),
+            summary.count(end),
+        )
+        for version, (token, start, end) in _BLOCK_MARKERS.items()
+    }
+    if all(counts == (0, 0, 0) for counts in marker_counts.values()):
+        return (
+            None,
+            None,
+            _invalid_assessment(
+                REASON_BLOCK_MISSING,
+                "Section 15 has no machine-readable current pattern-history block",
+            ),
+        )
+    if (
+        sum(counts[1] for counts in marker_counts.values()) > 1
+        or sum(counts[2] for counts in marker_counts.values()) > 1
+    ):
+        return (
+            None,
+            None,
+            _invalid_assessment(
+                REASON_BLOCK_DUPLICATE,
+                "Section 15 must contain exactly one v2 or v3 current block",
+            ),
+        )
+    valid_versions = [
+        version for version, counts in marker_counts.items() if counts == (2, 1, 1)
+    ]
+    if len(valid_versions) != 1 or any(
+        counts != (0, 0, 0) and counts != (2, 1, 1) for counts in marker_counts.values()
+    ):
+        return (
+            None,
+            None,
+            _invalid_assessment(
                 REASON_BLOCK_INVALID,
-                "Section 15 current-block marker is torn or malformed",
-            )
-        return None, _invalid_assessment(
-            REASON_BLOCK_MISSING,
-            "Section 15 has no machine-readable current pattern-history block",
+                "Section 15 v2/v3 current-block markers are mixed, torn, or malformed",
+            ),
         )
-    if start_count > 1 or end_count > 1:
-        return None, _invalid_assessment(
-            REASON_BLOCK_DUPLICATE,
-            "Section 15 must contain exactly one current pattern-history block",
-        )
-    if start_count != 1 or end_count != 1 or token_count != 2:
-        return None, _invalid_assessment(
-            REASON_BLOCK_INVALID,
-            "Section 15 current-block markers are incomplete or malformed",
-        )
-
-    start = summary.index(BLOCK_START)
-    end_marker_start = summary.index(BLOCK_END)
-    end = end_marker_start + len(BLOCK_END)
+    block_version = valid_versions[0]
+    _, block_start, block_end = _BLOCK_MARKERS[block_version]
+    start = summary.index(block_start)
+    end_marker_start = summary.index(block_end)
+    end = end_marker_start + len(block_end)
     if start < heading.end() or end > section_end or end_marker_start <= start:
-        return None, _invalid_assessment(
-            REASON_BLOCK_INVALID,
-            "the current pattern-history block must be wholly inside Section 15",
+        return (
+            None,
+            None,
+            _invalid_assessment(
+                REASON_BLOCK_INVALID,
+                "the current pattern-history block must be wholly inside Section 15",
+            ),
         )
 
     block = summary[start:end].replace("\r\n", "\n")
-    match = _BLOCK_BODY.fullmatch(block)
+    match = _block_body_pattern(block_start, block_end).fullmatch(block)
     if match is None:
-        return None, _invalid_assessment(
-            REASON_BLOCK_INVALID,
-            "Section 15 current block has a torn fence, marker, or notice",
+        return (
+            None,
+            None,
+            _invalid_assessment(
+                REASON_BLOCK_INVALID,
+                "Section 15 current block has a torn fence, marker, or notice",
+            ),
         )
-    return match.group("payload"), None
+    return match.group("payload"), block_version, None
 
 
-def _assess_payload(payload: object) -> Section15PatternHistoryAssessment:
+def _assess_payload(
+    payload: object, *, block_schema_version: int
+) -> Section15PatternHistoryAssessment:
     if not isinstance(payload, Mapping):
         return _invalid_assessment(
             REASON_BLOCK_INVALID,
@@ -291,11 +362,12 @@ def _assess_payload(payload: object) -> Section15PatternHistoryAssessment:
             "Section 15 current block has unknown fields: "
             + ", ".join(str(field) for field in unknown)
         )
-    if payload.get("schema_version") != BLOCK_SCHEMA_VERSION or isinstance(
+    if payload.get("schema_version") != block_schema_version or isinstance(
         payload.get("schema_version"), bool
     ):
         errors.append(
-            f"Section 15 current block schema_version must be {BLOCK_SCHEMA_VERSION}"
+            "Section 15 current block schema_version must match its marker "
+            f"version {block_schema_version}"
         )
     if payload.get("source_lane") != BLOCK_SOURCE_LANE:
         errors.append(
@@ -304,7 +376,10 @@ def _assess_payload(payload: object) -> Section15PatternHistoryAssessment:
 
     raw_pattern_profile = payload.get("pattern_profile")
     profile_assessment: PatternProfileAssessment = assess_pattern_profile(
-        raw_pattern_profile
+        raw_pattern_profile,
+        expected_contract_version=(
+            4 if block_schema_version == LEGACY_BLOCK_SCHEMA_VERSION else 5
+        ),
     )
     errors.extend(profile_assessment.errors)
 
@@ -354,6 +429,7 @@ def _assess_payload(payload: object) -> Section15PatternHistoryAssessment:
             errors=_dedupe(errors),
             pattern_profile=None,
             classification_fields_available=False,
+            block_schema_version=block_schema_version,
         )
 
     assert isinstance(raw_pattern_profile, Mapping)
@@ -369,6 +445,11 @@ def _assess_payload(payload: object) -> Section15PatternHistoryAssessment:
         classification_fields_available=(
             profile_assessment.classification_fields_available
         ),
+        available_classification_domains=(
+            profile_assessment.available_classification_domains
+        ),
+        block_schema_version=block_schema_version,
+        policy_semantic_sha256=profile_assessment.policy_semantic_sha256,
     )
 
 
@@ -376,10 +457,13 @@ def assess_section15_pattern_history(
     summary: str,
 ) -> Section15PatternHistoryAssessment:
     """Assess only the uniquely delimited Section 15 current block."""
-    payload_text, structural_error = _extract_payload_text(summary)
+    payload_text, block_schema_version, structural_error = _extract_payload_text(
+        summary
+    )
     if structural_error is not None:
         return structural_error
     assert payload_text is not None
+    assert block_schema_version is not None
     try:
         payload = _strict_json_loads(payload_text)
     except (
@@ -391,12 +475,12 @@ def assess_section15_pattern_history(
             REASON_BLOCK_INVALID,
             f"Section 15 current-block JSON is invalid: {exc}",
         )
-    return _assess_payload(payload)
+    return _assess_payload(payload, block_schema_version=block_schema_version)
 
 
 def render_section15_current_block(pattern_profile: object) -> str:
     """Render a canonical block from a complete shared-assessor payload."""
-    assessment = assess_pattern_profile(pattern_profile)
+    assessment = assess_pattern_profile(pattern_profile, expected_contract_version=5)
     if not assessment.current_contract:
         details = "; ".join(assessment.errors or assessment.reason_codes)
         raise Section15PatternHistoryError(
@@ -443,10 +527,15 @@ def _replace_block_text(summary: str, rendered_block: str) -> str:
         )
     heading, section_end = section
 
-    start_count = summary.count(BLOCK_START)
-    end_count = summary.count(BLOCK_END)
-    token_count = summary.count(BLOCK_TOKEN)
-    if start_count == 0 and end_count == 0 and token_count == 0:
+    marker_counts = {
+        version: (
+            summary.count(token),
+            summary.count(start),
+            summary.count(end),
+        )
+        for version, (token, start, end) in _BLOCK_MARKERS.items()
+    }
+    if all(counts == (0, 0, 0) for counts in marker_counts.values()):
         newline = "\r\n" if "\r\n" in summary else "\n"
         rendered = rendered_block.replace("\n", newline)
         suffix = summary[heading.end() :]
@@ -459,20 +548,30 @@ def _replace_block_text(summary: str, rendered_block: str) -> str:
             + after_block
             + suffix
         )
-    if start_count > 1 or end_count > 1:
+    if (
+        sum(counts[1] for counts in marker_counts.values()) > 1
+        or sum(counts[2] for counts in marker_counts.values()) > 1
+    ):
         raise Section15PatternHistoryError(
-            "Section 15 has duplicate current-block markers; repair it before "
+            "Section 15 has duplicate v2/v3 current-block markers; repair it before "
             "replacement"
         )
-    if start_count != 1 or end_count != 1 or token_count != 2:
+    valid_versions = [
+        version for version, counts in marker_counts.items() if counts == (2, 1, 1)
+    ]
+    if len(valid_versions) != 1 or any(
+        counts != (0, 0, 0) and counts != (2, 1, 1) for counts in marker_counts.values()
+    ):
         raise Section15PatternHistoryError(
-            "Section 15 current-block markers are torn or malformed; repair them "
-            "before replacement"
+            "Section 15 v2/v3 current-block markers are mixed, torn, or malformed; "
+            "repair them before replacement"
         )
 
-    start = summary.index(BLOCK_START)
-    end_marker_start = summary.index(BLOCK_END)
-    end = end_marker_start + len(BLOCK_END)
+    existing_version = valid_versions[0]
+    _, existing_start, existing_end = _BLOCK_MARKERS[existing_version]
+    start = summary.index(existing_start)
+    end_marker_start = summary.index(existing_end)
+    end = end_marker_start + len(existing_end)
     if start < heading.end() or end > section_end or end_marker_start <= start:
         raise Section15PatternHistoryError(
             "the sole current-block markers must be ordered wholly inside Section 15"
@@ -488,6 +587,7 @@ def replace_section15_current_block(
     tracking_database: object,
     *,
     evidence_freshness_assessor: EvidenceFreshnessAssessor,
+    classification_policy_stamp: object | None = None,
 ) -> Section15WriteResult:
     """Validate a complete candidate, then atomically replace only its block."""
     if not isinstance(pattern_profile, Mapping):
@@ -498,6 +598,7 @@ def replace_section15_current_block(
         canonical_input,
         tracking_database,
         evidence_freshness_assessor=evidence_freshness_assessor,
+        classification_policy_stamp=classification_policy_stamp,
     )
     try:
         original_bytes = summary_path.read_bytes()
@@ -625,6 +726,7 @@ def _validate_complete_tracking_cohort(
     tracking_database: object,
     *,
     evidence_freshness_assessor: EvidenceFreshnessAssessor,
+    classification_policy_stamp: object | None = None,
 ) -> None:
     """Bind a write candidate to the complete live scoring cohort."""
     _require_usable_tracking_database(tracking_database)
@@ -689,6 +791,25 @@ def _validate_complete_tracking_cohort(
             "pattern_profile.antipattern_frequency does not equal deterministic "
             "rows recomputed from the complete tracking-database scoring cohort"
         )
+    try:
+        policy_stamp = (
+            validate_policy_stamp(pattern_profile.get("classification_policy"))
+            if classification_policy_stamp is None
+            else validate_policy_stamp(classification_policy_stamp)
+        )
+        expected_classification = classify_pattern_profile(
+            snapshot["baseline_talks"], policy_stamp
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise Section15PatternHistoryError(
+            f"cannot recompute policy-bound classifications: {exc}"
+        ) from exc
+    for field, expected in expected_classification.items():
+        if pattern_profile.get(field) != expected:
+            raise Section15PatternHistoryError(
+                f"pattern_profile.{field} does not equal deterministic "
+                "classifications recomputed from the complete tracking cohort"
+            )
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -731,6 +852,7 @@ def main(argv: list[str] | None = None) -> int:
                 vault_root,
                 tracking_database.get("config"),
             ),
+            classification_policy_stamp=resolve_classification_policy(vault_root),
         )
         print(json.dumps(result.as_dict(), sort_keys=True))
         return 0
@@ -740,6 +862,7 @@ def main(argv: list[str] | None = None) -> int:
         PatternCohortSnapshotError,
         Section15PatternHistoryError,
         VaultRootAuthorityError,
+        ValueError,
     ) as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -45,6 +45,7 @@ from profile_pattern_provenance import (  # noqa: E402
     PatternProfileAssessment,
     assess_pattern_profile,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from adherence_baseline import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     AdherenceBaselineError,
@@ -61,6 +62,7 @@ from pattern_classification_runtime import (  # noqa: E402
     resolve_classification_policy,
     validate_policy_stamp,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     ReturnValidationError,
@@ -78,6 +80,7 @@ from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissin
     decode_json_object,
     snapshot_tracking_database,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from vault_root_authority import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     VaultRootAuthorityError,

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Validate a current speaker-profile.json before the owner writes it.
 
-Schema version 4 binds every Presentation Pattern aggregate to one exact,
-current scoring generation and exact per-pattern opportunity denominators. The
-reusable strict nested contract lives in
+Schema version 5 binds every Presentation Pattern aggregate to one exact,
+current scoring generation, exact per-pattern opportunity denominators, and a
+versioned classification policy. The reusable strict nested contract lives in
 ``profile_pattern_provenance.py`` so non-owner readers make the same pattern-
 history availability decision as this writer.
 
@@ -11,8 +11,9 @@ Contract
 --------
 Input:
     A profile path (positional) or JSON on stdin, plus required
-    ``--vault-root <path>`` for schema-v4 owner validation. The live vault is
-    reparsed with the candidate baseline's ``as_of`` value before acceptance.
+    ``--vault-root <path>`` for schema-v5 owner validation. The live vault is
+    reloaded with the candidate baseline's ``as_of`` value before acceptance;
+    no talk is reparsed.
 
 Stdout (JSON):
     {
@@ -40,7 +41,9 @@ from typing import Any
 _PROFILE_SCRIPTS = pathlib.Path(__file__).resolve().parent
 if str(_PROFILE_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_PROFILE_SCRIPTS))
-_INGRESS_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts"
+_INGRESS_SCRIPTS = (
+    pathlib.Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts"
+)
 if str(_INGRESS_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_INGRESS_SCRIPTS))
 
@@ -49,29 +52,35 @@ from profile_pattern_provenance import (  # noqa: E402
     assess_pattern_profile,
 )
 from pattern_cohort_snapshot import (  # noqa: E402
-    PatternCohortSnapshot,
     PatternCohortSnapshotError,
     build_current_pattern_snapshot,
     configured_evidence_freshness_assessor,
 )
+from pattern_classification_runtime import (  # noqa: E402
+    classify_pattern_profile,
+    resolve_classification_policy,
+)
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseError,
     assess_tracking_database,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
 )
-from vault_root_authority import (  # noqa: E402
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from vault_root_authority import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     materialize_native_authority,
     resolve_vault_root_authority,
 )
 
 
-CURRENT_SCHEMA_VERSION = 4
+CURRENT_SCHEMA_VERSION = 5
 
 REQUIRED_KEYS = [
     "schema_version",
@@ -111,6 +120,11 @@ _PATTERN_HISTORY_KEYS = frozenset(
         "signature_combinations",
         "mastery_levels",
         "classification_availability",
+        "classification_schema_version",
+        "classification_policy",
+        "pattern_classifications",
+        "antipattern_classifications",
+        "trend_analysis",
     }
 )
 _FORBIDDEN_NON_PATTERN_ENTRY_FIELDS = frozenset(
@@ -132,6 +146,12 @@ _FORBIDDEN_NON_PATTERN_ENTRY_FIELDS = frozenset(
         "not_applicable_count",
         "eligible_cohort_count",
         "coverage",
+        "classification",
+        "observation_status",
+        "applicable_coverage",
+        "lower",
+        "upper",
+        "semantic_sha256",
     }
 )
 
@@ -176,7 +196,7 @@ def _load_input(profile_path: pathlib.Path | None) -> dict[str, Any]:
 def _load_live_pattern_snapshot(
     vault_root: pathlib.Path,
     profile: Mapping[str, object],
-) -> PatternCohortSnapshot:
+) -> dict[str, object]:
     """Recompute the source-exact payload used by ``load-vault.py``."""
     database_path = vault_root / "tracking-database.json"
     try:
@@ -210,7 +230,7 @@ def _load_live_pattern_snapshot(
         else None
     )
     as_of = baseline.get("as_of") if isinstance(baseline, Mapping) else None
-    return build_current_pattern_snapshot(
+    snapshot = build_current_pattern_snapshot(
         talks,
         as_of=as_of,
         evidence_freshness_assessor=configured_evidence_freshness_assessor(
@@ -218,6 +238,11 @@ def _load_live_pattern_snapshot(
             database.get("config"),
         ),
     )
+    classification = classify_pattern_profile(
+        snapshot["baseline_talks"],
+        resolve_classification_policy(vault_root),
+    )
+    return {**snapshot, "pattern_classification": classification}
 
 
 def _validate_live_pattern_source(
@@ -233,6 +258,9 @@ def _validate_live_pattern_source(
     opportunities = snapshot.get("pattern_opportunities")
     if not isinstance(opportunities, Mapping):
         return ["live pattern snapshot lacks pattern_opportunities"]
+    classification = snapshot.get("pattern_classification")
+    if not isinstance(classification, Mapping):
+        return ["live pattern snapshot lacks pattern_classification"]
 
     comparisons = (
         (
@@ -267,6 +295,13 @@ def _validate_live_pattern_source(
             errors.append(
                 f"pattern_profile.{field} does not equal the {description}; "
                 "regenerate it from the current load-vault.py payload"
+            )
+    for field, expected in classification.items():
+        if pattern_profile.get(field) != expected:
+            errors.append(
+                f"pattern_profile.{field} does not equal the live deterministic "
+                "classification output; regenerate it from the current "
+                "load-vault.py payload"
             )
     return errors
 
@@ -317,7 +352,7 @@ def _validate_catalog_history_storage(profile: Mapping[object, object]) -> list[
     if not isinstance(guardrail_sources, Mapping):
         errors.append("guardrail_sources must be an object")
     elif "recurring_issues" not in guardrail_sources:
-        errors.append("guardrail_sources.recurring_issues is required in schema v4")
+        errors.append("guardrail_sources.recurring_issues is required in schema v5")
     else:
         errors.extend(
             _validate_non_pattern_entries(
@@ -352,7 +387,9 @@ def validate_profile(
             f"schema_version is {schema_version!r} (expected {CURRENT_SCHEMA_VERSION})"
         )
     if not missing and schema_version == CURRENT_SCHEMA_VERSION:
-        assessment = assess_pattern_profile(profile["pattern_profile"])
+        assessment = assess_pattern_profile(
+            profile["pattern_profile"], expected_contract_version=5
+        )
         if not assessment.current_contract:
             errors.extend(assessment.errors)
         errors.extend(_validate_catalog_history_storage(profile))
@@ -360,8 +397,9 @@ def validate_profile(
             errors.extend(_validate_live_pattern_source(profile, live_pattern_snapshot))
         elif require_live_source:
             errors.append(
-                "schema-v4 owner validation requires --vault-root so occurrence "
-                "rows can be recomputed from the live tracking database"
+                "schema-v5 owner validation requires --vault-root so occurrence "
+                "rows and classifications can be recomputed from the live "
+                "tracking database"
             )
     return missing, errors, schema_version
 

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -239,10 +239,15 @@ def _load_live_pattern_snapshot(
             database.get("config"),
         ),
     )
-    classification = classify_pattern_profile(
-        snapshot["baseline_talks"],
-        resolve_classification_policy(vault_root),
-    )
+    try:
+        classification = classify_pattern_profile(
+            snapshot["baseline_talks"],
+            resolve_classification_policy(vault_root),
+        )
+    except RuntimeError as exc:
+        raise ValueError(
+            f"pattern classification runtime is unavailable: {exc}"
+        ) from exc
     return {**snapshot, "pattern_classification": classification}
 
 

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -388,11 +388,16 @@ def validate_profile(
     missing = [key for key in REQUIRED_KEYS if key not in profile]
     schema_version = profile.get("schema_version")
     errors: list[str] = []
-    if schema_version != CURRENT_SCHEMA_VERSION:
+    schema_is_current = (
+        isinstance(schema_version, int)
+        and not isinstance(schema_version, bool)
+        and schema_version == CURRENT_SCHEMA_VERSION
+    )
+    if not schema_is_current:
         errors.append(
             f"schema_version is {schema_version!r} (expected {CURRENT_SCHEMA_VERSION})"
         )
-    if not missing and schema_version == CURRENT_SCHEMA_VERSION:
+    if not missing and schema_is_current:
         assessment = assess_pattern_profile(
             profile["pattern_profile"], expected_contract_version=5
         )

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -73,6 +73,7 @@ from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissin
     decode_json_object,
     snapshot_tracking_database,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from vault_root_authority import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     materialize_native_authority,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,6 +324,14 @@ def validate_profile():
 
 
 @pytest.fixture(scope="session")
+def classify_pattern_profile():
+    return _import_script(
+        os.path.join(SCRIPTS_VP, "classify-pattern-profile.py"),
+        "classify_pattern_profile",
+    )
+
+
+@pytest.fixture(scope="session")
 def compute_pacing_adherence():
     return _import_script(
         os.path.join(SCRIPTS_VP, "compute-pacing-adherence.py"),

--- a/tests/test_classify_pattern_profile.py
+++ b/tests/test_classify_pattern_profile.py
@@ -1,0 +1,854 @@
+"""Boundary tests for the versioned speaker-pattern classification policy."""
+
+from __future__ import annotations
+
+import copy
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+def _policy(classifier, tmp_path):
+    return classifier.resolve_classification_policy(tmp_path)
+
+
+def _override_policy(classifier, tmp_path, mutate):
+    policy = copy.deepcopy(_policy(classifier, tmp_path)["semantic_policy"])
+    mutate(policy)
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(policy), encoding="utf-8"
+    )
+    return _policy(classifier, tmp_path)
+
+
+def _opportunity(pattern_id, *, applicable, evaluable, detected):
+    return {
+        "pattern_id": pattern_id,
+        "eligible_cohort_count": applicable,
+        "not_applicable_count": 0,
+        "evaluable_count": evaluable,
+        "detected_count": detected,
+        "unevaluable_count": applicable - evaluable,
+    }
+
+
+def _classify_positive(
+    classifier, policy_stamp, *, applicable, evaluable, detected, absence=True
+):
+    return classifier._classify_positive(
+        _opportunity(
+            "positive", applicable=applicable, evaluable=evaluable, detected=detected
+        ),
+        absence_conclusion_capable=absence,
+        policy=policy_stamp["semantic_policy"],
+    )
+
+
+def _classify_antipattern(
+    classifier, policy_stamp, *, applicable, evaluable, detected, absence=True
+):
+    return classifier._classify_antipattern(
+        _opportunity(
+            "negative", applicable=applicable, evaluable=evaluable, detected=detected
+        ),
+        absence_conclusion_capable=absence,
+        policy=policy_stamp["semantic_policy"],
+    )
+
+
+def test_absent_override_selects_bundled_default_without_prompt(
+    classify_pattern_profile, tmp_path
+):
+    stamp = _policy(classify_pattern_profile, tmp_path)
+
+    assert stamp["policy_id"] == "speaker-toolkit-default"
+    assert stamp["policy_version"] == 1
+    assert stamp["source"] == "bundled_default"
+    assert len(stamp["semantic_sha256"]) == 64
+    assert classify_pattern_profile.validate_policy_stamp(stamp) == stamp
+
+
+def test_override_digest_ignores_formatting_only_changes(
+    classify_pattern_profile, tmp_path
+):
+    default = _policy(classify_pattern_profile, tmp_path)
+    policy_path = tmp_path / "pattern-classification-policy.json"
+    policy_path.write_text(
+        json.dumps(default["semantic_policy"], separators=(",", ":")),
+        encoding="utf-8",
+    )
+    compact = _policy(classify_pattern_profile, tmp_path)
+    policy_path.write_text(
+        json.dumps(default["semantic_policy"], indent=4, sort_keys=True),
+        encoding="utf-8",
+    )
+    formatted = _policy(classify_pattern_profile, tmp_path)
+
+    assert compact["source"] == "vault_override"
+    assert compact["semantic_sha256"] == formatted["semantic_sha256"]
+    assert compact["semantic_sha256"] == default["semantic_sha256"]
+
+
+def test_policy_digest_normalizes_signed_numeric_zero(
+    classify_pattern_profile, tmp_path
+):
+    policy = copy.deepcopy(
+        _policy(classify_pattern_profile, tmp_path)["semantic_policy"]
+    )
+    policy["positive_patterns"]["rare"]["maximum_upper_exclusive"] = -0.0
+    negative_zero = classify_pattern_profile.canonical_policy_sha256(policy)
+    policy["positive_patterns"]["rare"]["maximum_upper_exclusive"] = 0.0
+    positive_zero = classify_pattern_profile.canonical_policy_sha256(policy)
+
+    assert negative_zero == positive_zero
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{}",
+        '{"schema_version":1,"schema_version":1}',
+        '{"schema_version": NaN}',
+    ],
+)
+def test_present_invalid_override_aborts_instead_of_falling_back(
+    classify_pattern_profile, tmp_path, payload
+):
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        payload, encoding="utf-8"
+    )
+
+    with pytest.raises(classify_pattern_profile.PatternClassificationError):
+        _policy(classify_pattern_profile, tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("applicable", "evaluable", "detected", "expected"),
+    [
+        (8, 6, 6, "signature"),
+        (10, 8, 4, "regular"),
+        (20, 16, 3, "occasional"),
+        (20, 19, 1, "rare"),
+        (8, 8, 0, "never_tried"),
+        (0, 0, 0, "unclassified"),
+    ],
+)
+def test_positive_default_threshold_boundaries(
+    classify_pattern_profile,
+    tmp_path,
+    applicable,
+    evaluable,
+    detected,
+    expected,
+):
+    row = _classify_positive(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=applicable,
+        evaluable=evaluable,
+        detected=detected,
+    )
+
+    assert row["classification"] == expected
+    assert row["evidence"] == {
+        "applicable_count": applicable,
+        "evaluable_count": evaluable,
+        "detected_count": detected,
+        "unevaluable_count": applicable - evaluable,
+        "applicable_coverage": None if applicable == 0 else evaluable / applicable,
+        "lower": None if applicable == 0 else detected / applicable,
+        "upper": None
+        if applicable == 0
+        else (detected + applicable - evaluable) / applicable,
+    }
+    assert row["reason_codes"]
+
+
+def test_exclusive_positive_upper_boundary_stays_unclassified(
+    classify_pattern_profile, tmp_path
+):
+    row = _classify_positive(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=10,
+        evaluable=8,
+        detected=5,
+    )
+
+    assert row["evidence"]["upper"] == 0.7
+    assert row["classification"] == "unclassified"
+
+
+@pytest.mark.parametrize(
+    ("applicable", "evaluable", "detected", "excluded_tier"),
+    [
+        (7, 7, 7, "signature"),
+        (10, 10, 6, "signature"),
+        (8, 7, 4, "regular"),
+        (100, 79, 45, "regular"),
+        (10, 10, 3, "regular"),
+        (7, 7, 2, "occasional"),
+        (100, 79, 15, "occasional"),
+        (100, 90, 14, "occasional"),
+        (20, 16, 4, "occasional"),
+        (7, 7, 1, "rare"),
+        (20, 20, 3, "rare"),
+    ],
+)
+def test_positive_default_threshold_fail_sides(
+    classify_pattern_profile,
+    tmp_path,
+    applicable,
+    evaluable,
+    detected,
+    excluded_tier,
+):
+    row = _classify_positive(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=applicable,
+        evaluable=evaluable,
+        detected=detected,
+    )
+
+    assert row["classification"] != excluded_tier
+
+
+def test_rare_coverage_threshold_is_inclusive_and_enforced(
+    classify_pattern_profile, tmp_path
+):
+    def widen_rare_band(policy):
+        policy["positive_patterns"]["rare"]["maximum_upper_exclusive"] = 0.4
+        policy["positive_patterns"]["occasional"]["minimum_lower"] = 0.4
+        policy["positive_patterns"]["occasional"][
+            "maximum_upper_exclusive"
+        ] = 0.5
+        policy["positive_patterns"]["regular"]["minimum_lower"] = 0.5
+
+    policy = _override_policy(
+        classify_pattern_profile, tmp_path, widen_rare_band
+    )
+    exact = _classify_positive(
+        classify_pattern_profile,
+        policy,
+        applicable=10,
+        evaluable=8,
+        detected=1,
+    )
+    below = _classify_positive(
+        classify_pattern_profile,
+        policy,
+        applicable=100,
+        evaluable=79,
+        detected=1,
+    )
+
+    assert exact["evidence"]["applicable_coverage"] == 0.8
+    assert exact["classification"] == "rare"
+    assert below["evidence"]["applicable_coverage"] == 0.79
+    assert below["classification"] != "rare"
+
+
+def test_positive_only_zero_is_not_yet_observed_never_never_tried(
+    classify_pattern_profile, tmp_path
+):
+    row = _classify_positive(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=20,
+        evaluable=20,
+        detected=0,
+        absence=False,
+    )
+
+    assert row["classification"] == "not_yet_observed"
+    assert row["observation_status"] == "not_yet_observed"
+    assert row["absence_conclusion_capable"] is False
+    assert "absence_not_supported_by_catalog" in row["reason_codes"]
+
+
+def test_conclusive_absence_below_sample_is_unclassified_not_not_yet_observed(
+    classify_pattern_profile, tmp_path
+):
+    row = _classify_positive(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=7,
+        evaluable=7,
+        detected=0,
+        absence=True,
+    )
+
+    assert row["classification"] == "unclassified"
+    assert row["observation_status"] == "confirmed_absent"
+    assert row["reason_codes"] == [
+        "insufficient_applicable_sample",
+        "insufficient_evaluable_sample",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("applicable", "evaluable", "detected", "expected"),
+    [
+        (8, 4, 4, "high_frequency"),
+        (12, 10, 3, "moderate_frequency"),
+        (20, 19, 1, "occasional"),
+        (8, 8, 0, "confirmed_none"),
+    ],
+)
+def test_antipattern_default_threshold_boundaries(
+    classify_pattern_profile,
+    tmp_path,
+    applicable,
+    evaluable,
+    detected,
+    expected,
+):
+    row = _classify_antipattern(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=applicable,
+        evaluable=evaluable,
+        detected=detected,
+    )
+
+    assert row["classification"] == expected
+    assert row["reason_codes"]
+
+
+@pytest.mark.parametrize(
+    ("applicable", "evaluable", "detected", "excluded_tier"),
+    [
+        (7, 7, 4, "high_frequency"),
+        (10, 10, 4, "high_frequency"),
+        (7, 7, 3, "moderate_frequency"),
+        (100, 79, 25, "moderate_frequency"),
+        (8, 8, 2, "moderate_frequency"),
+        (13, 13, 3, "moderate_frequency"),
+        (10, 8, 3, "moderate_frequency"),
+        (7, 7, 1, "occasional"),
+        (100, 79, 1, "occasional"),
+        (20, 16, 1, "occasional"),
+        (7, 7, 0, "confirmed_none"),
+    ],
+)
+def test_antipattern_default_threshold_fail_sides(
+    classify_pattern_profile,
+    tmp_path,
+    applicable,
+    evaluable,
+    detected,
+    excluded_tier,
+):
+    row = _classify_antipattern(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=applicable,
+        evaluable=evaluable,
+        detected=detected,
+    )
+
+    assert row["classification"] != excluded_tier
+
+
+def test_antipattern_coverage_thresholds_are_inclusive_and_enforced(
+    classify_pattern_profile, tmp_path
+):
+    policy = _policy(classify_pattern_profile, tmp_path)
+    moderate_exact = _classify_antipattern(
+        classify_pattern_profile,
+        policy,
+        applicable=20,
+        evaluable=16,
+        detected=5,
+    )
+    occasional_exact = _classify_antipattern(
+        classify_pattern_profile,
+        policy,
+        applicable=100,
+        evaluable=80,
+        detected=1,
+    )
+
+    assert moderate_exact["evidence"]["applicable_coverage"] == 0.8
+    assert moderate_exact["classification"] == "moderate_frequency"
+    assert occasional_exact["evidence"]["applicable_coverage"] == 0.8
+    assert occasional_exact["classification"] == "occasional"
+
+
+def test_positive_only_antipattern_zero_is_unclassified_with_orthogonal_status(
+    classify_pattern_profile, tmp_path
+):
+    row = _classify_antipattern(
+        classify_pattern_profile,
+        _policy(classify_pattern_profile, tmp_path),
+        applicable=20,
+        evaluable=20,
+        detected=0,
+        absence=False,
+    )
+
+    assert row["classification"] == "unclassified"
+    assert row["observation_status"] == "not_yet_observed"
+
+
+def _catalog(*, positive_only=False):
+    return SimpleNamespace(
+        entries={
+            "p1": SimpleNamespace(
+                observable=True,
+                entry_type="pattern",
+                absence_evaluable_from=None if positive_only else (("transcript",),),
+            ),
+            "p2": SimpleNamespace(
+                observable=True,
+                entry_type="pattern",
+                absence_evaluable_from=(("transcript",),),
+            ),
+        }
+    )
+
+
+def _talk(index, *, p1, p2="detected", identity="a" * 64, date_value=None):
+    outcomes = {"p1": p1, "p2": p2}
+    detections = [
+        {"pattern_id": pattern_id}
+        for pattern_id, outcome in outcomes.items()
+        if outcome == "detected"
+    ]
+    score = len(detections)
+    return {
+        "filename": f"talk-{index:02d}.md",
+        "date": date_value or f"2026-01-{index + 1:02d}",
+        "pattern_score": score,
+        "pattern_observations": {
+            "pattern_score": score,
+            "patterns_detected": detections,
+            "antipatterns_detected": [],
+            "pattern_outcomes": [
+                {"pattern_id": pattern_id, "outcome": outcomes[pattern_id]}
+                for pattern_id in sorted(outcomes)
+            ],
+            "opportunity_coverage_identity": identity,
+        },
+    }
+
+
+def test_joint_outcomes_and_five_plus_five_trends_are_deterministic(
+    classify_pattern_profile, tmp_path
+):
+    talks = [
+        *[_talk(index, p1="undetected") for index in range(5)],
+        *[_talk(index, p1="detected") for index in range(5, 10)],
+    ]
+    result = classify_pattern_profile.classify_pattern_profile(
+        talks,
+        _policy(classify_pattern_profile, tmp_path),
+        catalog=_catalog(),
+    )
+
+    p1 = next(
+        row for row in result["pattern_classifications"] if row["pattern_id"] == "p1"
+    )
+    assert p1["classification"] == "regular"
+    assert result["signature_combinations"] == [
+        {
+            "combination_id": "p1+p2",
+            "pattern_ids": ["p1", "p2"],
+            "evidence": {
+                "applicable_count": 10,
+                "evaluable_count": 10,
+                "detected_count": 5,
+                "unevaluable_count": 0,
+                "applicable_coverage": 1.0,
+                "lower": 0.5,
+                "upper": 0.5,
+            },
+            "reason_codes": ["meets_signature_combination_thresholds"],
+        }
+    ]
+    trend = result["trend_analysis"]
+    assert trend["status"] == "available"
+    assert trend["score"]["status"] == "improving"
+    assert trend["breadth"]["status"] == "widening"
+    p1_movement = next(
+        row for row in trend["pattern_movements"] if row["pattern_id"] == "p1"
+    )
+    assert p1_movement["movement"] == "increasing"
+    assert result["score_drivers"]["pattern_drivers"] == ["p1"]
+
+
+def test_joint_denominator_distinguishes_not_applicable_and_unevaluable(
+    classify_pattern_profile, tmp_path
+):
+    outcome_pairs = [
+        *[("detected", "detected")] * 5,
+        ("detected", "undetected"),
+        ("undetected", "undetected"),
+        ("not_applicable", "detected"),
+        ("not_evaluable", "detected"),
+        ("detected", "not_evaluable"),
+    ]
+    talks = [
+        _talk(index, p1=p1, p2=p2)
+        for index, (p1, p2) in enumerate(outcome_pairs)
+    ]
+
+    result = classify_pattern_profile.classify_pattern_profile(
+        talks,
+        _policy(classify_pattern_profile, tmp_path),
+        catalog=_catalog(),
+    )
+
+    assert result["signature_combinations"] == [
+        {
+            "combination_id": "p1+p2",
+            "pattern_ids": ["p1", "p2"],
+            "evidence": {
+                "applicable_count": 9,
+                "evaluable_count": 7,
+                "detected_count": 5,
+                "unevaluable_count": 2,
+                "applicable_coverage": 7 / 9,
+                "lower": 5 / 9,
+                "upper": 7 / 9,
+            },
+            "reason_codes": ["meets_signature_combination_thresholds"],
+        }
+    ]
+
+
+def test_combination_thresholds_cover_exact_and_fail_sides(
+    classify_pattern_profile, tmp_path
+):
+    policy = _policy(classify_pattern_profile, tmp_path)["semantic_policy"]
+    positive = [
+        {"pattern_id": "p1", "classification": "regular"},
+        {"pattern_id": "p2", "classification": "signature"},
+    ]
+
+    def rows(*, total, detected):
+        outcomes = [
+            *[{"p1": "detected", "p2": "detected"} for _ in range(detected)],
+            *[
+                {"p1": "undetected", "p2": "detected"}
+                for _ in range(total - detected)
+            ],
+        ]
+        return classify_pattern_profile._combination_rows(
+            [{} for _ in range(total)], outcomes, positive, policy=policy
+        )
+
+    exact_applicable = rows(total=8, detected=4)
+    exact_detection_and_lower = rows(total=10, detected=4)
+    below_applicable = rows(total=7, detected=4)
+    below_detection_and_lower = rows(total=10, detected=3)
+
+    assert exact_applicable[0]["evidence"]["applicable_count"] == 8
+    assert exact_detection_and_lower[0]["evidence"] == {
+        "applicable_count": 10,
+        "evaluable_count": 10,
+        "detected_count": 4,
+        "unevaluable_count": 0,
+        "applicable_coverage": 1.0,
+        "lower": 0.4,
+        "upper": 0.4,
+    }
+    assert below_applicable == []
+    assert below_detection_and_lower == []
+
+
+def test_trends_distinguish_stable_indeterminate_and_unavailable(
+    classify_pattern_profile, tmp_path
+):
+    stable, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.4, "upper": 0.4},
+        {"applicable_count": 5, "lower": 0.4, "upper": 0.4},
+        threshold=0.2,
+    )
+    indeterminate, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.2, "upper": 0.8},
+        {"applicable_count": 5, "lower": 0.2, "upper": 0.8},
+        threshold=0.2,
+    )
+    unavailable, _ = classify_pattern_profile._movement(
+        {"applicable_count": 4, "lower": 0.2, "upper": 0.8},
+        {"applicable_count": 5, "lower": 0.2, "upper": 0.8},
+        threshold=0.2,
+    )
+    unavailable_four_of_five, _ = classify_pattern_profile._movement(
+        {"applicable_count": 4, "lower": 0.0, "upper": 0.0},
+        {"applicable_count": 4, "lower": 1.0, "upper": 1.0},
+        threshold=0.2,
+    )
+
+    assert (stable, indeterminate, unavailable) == (
+        "stable",
+        "indeterminate",
+        "unavailable",
+    )
+    assert unavailable_four_of_five == "unavailable"
+
+
+def test_movement_threshold_boundaries_are_conservative(
+    classify_pattern_profile,
+):
+    increasing, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.0, "upper": 0.0},
+        {"applicable_count": 5, "lower": 0.2, "upper": 0.2},
+        threshold=0.2,
+    )
+    decreasing, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.2, "upper": 0.2},
+        {"applicable_count": 5, "lower": 0.0, "upper": 0.0},
+        threshold=0.2,
+    )
+    boundary_reachable, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.0, "upper": 0.0},
+        {"applicable_count": 5, "lower": 0.0, "upper": 0.2},
+        threshold=0.2,
+    )
+    fractional_increasing, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.4, "upper": 0.4},
+        {"applicable_count": 5, "lower": 0.6, "upper": 0.6},
+        threshold=0.2,
+    )
+    fractional_decreasing, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.6, "upper": 0.6},
+        {"applicable_count": 5, "lower": 0.4, "upper": 0.4},
+        threshold=0.2,
+    )
+    upper_boundary, _ = classify_pattern_profile._movement(
+        {"applicable_count": 5, "lower": 0.8, "upper": 0.8},
+        {"applicable_count": 5, "lower": 1.0, "upper": 1.0},
+        threshold=0.2,
+    )
+
+    assert increasing == "increasing"
+    assert decreasing == "decreasing"
+    assert boundary_reachable == "indeterminate"
+    assert fractional_increasing == "increasing"
+    assert fractional_decreasing == "decreasing"
+    assert upper_boundary == "increasing"
+
+
+def test_score_and_breadth_thresholds_bracket_and_include_the_boundary(
+    classify_pattern_profile, tmp_path
+):
+    def result(detected_recent, policy):
+        talks = [
+            *[_talk(index, p1="undetected") for index in range(5)],
+            *[
+                _talk(index, p1="detected" if index - 5 < detected_recent else "undetected")
+                for index in range(5, 10)
+            ],
+        ]
+        return classify_pattern_profile.classify_pattern_profile(
+            talks, policy, catalog=_catalog()
+        )["trend_analysis"]
+
+    default = _policy(classify_pattern_profile, tmp_path)
+    below = result(2, default)
+    above = result(3, default)
+
+    def reachable_boundary(policy):
+        policy["trends"]["score_delta"] = 0.4
+        policy["trends"]["breadth_delta"] = 0.4
+
+    exact_policy = _override_policy(
+        classify_pattern_profile, tmp_path, reachable_boundary
+    )
+    exact = result(2, exact_policy)
+
+    assert below["score"]["delta"] == pytest.approx(0.4)
+    assert below["score"]["status"] == "stable"
+    assert below["breadth"]["status"] == "stable"
+    assert above["score"]["delta"] == pytest.approx(0.6)
+    assert above["score"]["status"] == "improving"
+    assert above["breadth"]["status"] == "widening"
+    assert exact["score"]["status"] == "improving"
+    assert exact["breadth"]["status"] == "widening"
+
+
+def test_trends_require_at_least_one_evaluable_opportunity(
+    classify_pattern_profile, tmp_path
+):
+    talks = [
+        _talk(index, p1="not_evaluable", p2="not_evaluable")
+        for index in range(10)
+    ]
+
+    result = classify_pattern_profile.classify_pattern_profile(
+        talks,
+        _policy(classify_pattern_profile, tmp_path),
+        catalog=_catalog(),
+    )
+
+    assert result["trend_analysis"]["status"] == "unavailable"
+    assert result["trend_analysis"]["reason_codes"] == [
+        "no_evaluable_pattern_opportunities"
+    ]
+    assert result["classification_availability"]["trends"] == {
+        "status": "unavailable",
+        "reason_codes": ["no_evaluable_pattern_opportunities"],
+    }
+    assert result["score_trend"] == "unavailable"
+
+
+def test_trend_sample_reports_invalid_dates_and_selects_newest_ten(
+    classify_pattern_profile, tmp_path
+):
+    talks = [_talk(index, p1="detected") for index in range(11)]
+    invalid = _talk(11, p1="detected")
+    invalid.pop("date")
+    talks.append(invalid)
+
+    result = classify_pattern_profile.classify_pattern_profile(
+        talks,
+        _policy(classify_pattern_profile, tmp_path),
+        catalog=_catalog(),
+    )
+
+    sample = result["trend_analysis"]["sample"]
+    assert result["trend_analysis"]["status"] == "available"
+    assert sample["valid_date_talk_count"] == 11
+    assert sample["invalid_date_filenames"] == ["talk-11.md"]
+    assert sample["selected_filenames"] == [
+        f"talk-{index:02d}.md" for index in range(1, 11)
+    ]
+
+
+def test_incomparable_opportunity_identity_makes_trends_unavailable(
+    classify_pattern_profile, tmp_path
+):
+    talks = [_talk(index, p1="detected") for index in range(10)]
+    talks[-1] = _talk(9, p1="detected", identity="b" * 64)
+
+    result = classify_pattern_profile.classify_pattern_profile(
+        talks,
+        _policy(classify_pattern_profile, tmp_path),
+        catalog=_catalog(),
+    )
+
+    assert result["trend_analysis"]["status"] == "unavailable"
+    assert result["trend_analysis"]["reason_codes"] == [
+        "incomparable_opportunity_identities"
+    ]
+    assert result["classification_availability"]["trends"] == {
+        "status": "unavailable",
+        "reason_codes": ["incomparable_opportunity_identities"],
+    }
+
+
+def test_policy_digest_change_is_visible_as_comparison_reset_identity(
+    classify_pattern_profile, tmp_path
+):
+    default = _policy(classify_pattern_profile, tmp_path)
+    override_policy = copy.deepcopy(default["semantic_policy"])
+    override_policy["policy_id"] = "speaker-custom"
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(override_policy), encoding="utf-8"
+    )
+    override = _policy(classify_pattern_profile, tmp_path)
+
+    assert override["policy_id"] == "speaker-custom"
+    assert override["semantic_sha256"] != default["semantic_sha256"]
+
+
+@pytest.mark.parametrize(
+    "lane",
+    ["positive_patterns", "antipattern_recurrence"],
+)
+def test_override_cannot_redefine_confirmed_absence_as_nonzero_detection(
+    classify_pattern_profile, tmp_path, lane
+):
+    default = _policy(classify_pattern_profile, tmp_path)
+    override_policy = copy.deepcopy(default["semantic_policy"])
+    tier = "never_tried" if lane == "positive_patterns" else "confirmed_none"
+    override_policy[lane][tier]["maximum_detections"] = 1
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(override_policy), encoding="utf-8"
+    )
+
+    with pytest.raises(classify_pattern_profile.PatternClassificationError):
+        _policy(classify_pattern_profile, tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("lane", "tier"),
+    [
+        ("positive_patterns", "rare"),
+        ("antipattern_recurrence", "high_frequency"),
+        ("antipattern_recurrence", "moderate_frequency"),
+        ("antipattern_recurrence", "occasional"),
+    ],
+)
+def test_override_requires_usage_classifications_to_have_a_detection(
+    classify_pattern_profile, tmp_path, lane, tier
+):
+    policy = copy.deepcopy(
+        _policy(classify_pattern_profile, tmp_path)["semantic_policy"]
+    )
+    policy[lane][tier]["minimum_detections"] = 0
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(policy), encoding="utf-8"
+    )
+
+    with pytest.raises(
+        classify_pattern_profile.PatternClassificationError,
+        match="minimum_detections must be a positive integer",
+    ):
+        _policy(classify_pattern_profile, tmp_path)
+
+
+@pytest.mark.parametrize("tier", ["signature", "regular", "occasional"])
+def test_override_requires_positive_usage_lower_bounds(
+    classify_pattern_profile, tmp_path, tier
+):
+    policy = copy.deepcopy(
+        _policy(classify_pattern_profile, tmp_path)["semantic_policy"]
+    )
+    policy["positive_patterns"][tier]["minimum_lower"] = 0
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(policy), encoding="utf-8"
+    )
+
+    with pytest.raises(
+        classify_pattern_profile.PatternClassificationError,
+        match=rf"{tier}\.minimum_lower must be greater than zero",
+    ):
+        _policy(classify_pattern_profile, tmp_path)
+
+
+def test_schema_v1_override_cannot_change_combination_result_cap(
+    classify_pattern_profile, tmp_path
+):
+    policy = copy.deepcopy(
+        _policy(classify_pattern_profile, tmp_path)["semantic_policy"]
+    )
+    policy["signature_combinations"]["maximum_results"] = 11
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(policy), encoding="utf-8"
+    )
+
+    with pytest.raises(classify_pattern_profile.PatternClassificationError):
+        _policy(classify_pattern_profile, tmp_path)
+
+
+def test_override_rejects_unknown_semantic_fields(
+    classify_pattern_profile, tmp_path
+):
+    policy = copy.deepcopy(
+        _policy(classify_pattern_profile, tmp_path)["semantic_policy"]
+    )
+    policy["future_semantics"] = {"enabled": True}
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(policy), encoding="utf-8"
+    )
+
+    with pytest.raises(
+        classify_pattern_profile.PatternClassificationError,
+        match="fields are noncanonical",
+    ):
+        _policy(classify_pattern_profile, tmp_path)

--- a/tests/test_classify_pattern_profile.py
+++ b/tests/test_classify_pattern_profile.py
@@ -221,14 +221,10 @@ def test_rare_coverage_threshold_is_inclusive_and_enforced(
     def widen_rare_band(policy):
         policy["positive_patterns"]["rare"]["maximum_upper_exclusive"] = 0.4
         policy["positive_patterns"]["occasional"]["minimum_lower"] = 0.4
-        policy["positive_patterns"]["occasional"][
-            "maximum_upper_exclusive"
-        ] = 0.5
+        policy["positive_patterns"]["occasional"]["maximum_upper_exclusive"] = 0.5
         policy["positive_patterns"]["regular"]["minimum_lower"] = 0.5
 
-    policy = _override_policy(
-        classify_pattern_profile, tmp_path, widen_rare_band
-    )
+    policy = _override_policy(classify_pattern_profile, tmp_path, widen_rare_band)
     exact = _classify_positive(
         classify_pattern_profile,
         policy,
@@ -490,10 +486,7 @@ def test_joint_denominator_distinguishes_not_applicable_and_unevaluable(
         ("not_evaluable", "detected"),
         ("detected", "not_evaluable"),
     ]
-    talks = [
-        _talk(index, p1=p1, p2=p2)
-        for index, (p1, p2) in enumerate(outcome_pairs)
-    ]
+    talks = [_talk(index, p1=p1, p2=p2) for index, (p1, p2) in enumerate(outcome_pairs)]
 
     result = classify_pattern_profile.classify_pattern_profile(
         talks,
@@ -531,10 +524,7 @@ def test_combination_thresholds_cover_exact_and_fail_sides(
     def rows(*, total, detected):
         outcomes = [
             *[{"p1": "detected", "p2": "detected"} for _ in range(detected)],
-            *[
-                {"p1": "undetected", "p2": "detected"}
-                for _ in range(total - detected)
-            ],
+            *[{"p1": "undetected", "p2": "detected"} for _ in range(total - detected)],
         ]
         return classify_pattern_profile._combination_rows(
             [{} for _ in range(total)], outcomes, positive, policy=policy
@@ -640,7 +630,10 @@ def test_score_and_breadth_thresholds_bracket_and_include_the_boundary(
         talks = [
             *[_talk(index, p1="undetected") for index in range(5)],
             *[
-                _talk(index, p1="detected" if index - 5 < detected_recent else "undetected")
+                _talk(
+                    index,
+                    p1="detected" if index - 5 < detected_recent else "undetected",
+                )
                 for index in range(5, 10)
             ],
         ]
@@ -675,8 +668,7 @@ def test_trends_require_at_least_one_evaluable_opportunity(
     classify_pattern_profile, tmp_path
 ):
     talks = [
-        _talk(index, p1="not_evaluable", p2="not_evaluable")
-        for index in range(10)
+        _talk(index, p1="not_evaluable", p2="not_evaluable") for index in range(10)
     ]
 
     result = classify_pattern_profile.classify_pattern_profile(
@@ -836,9 +828,7 @@ def test_schema_v1_override_cannot_change_combination_result_cap(
         _policy(classify_pattern_profile, tmp_path)
 
 
-def test_override_rejects_unknown_semantic_fields(
-    classify_pattern_profile, tmp_path
-):
+def test_override_rejects_unknown_semantic_fields(classify_pattern_profile, tmp_path):
     policy = copy.deepcopy(
         _policy(classify_pattern_profile, tmp_path)["semantic_policy"]
     )

--- a/tests/test_goal_generation_docs.py
+++ b/tests/test_goal_generation_docs.py
@@ -23,6 +23,9 @@ def test_owner_creates_generation_bound_schema_v2_pattern_goals():
     assert '"lane": "pattern_scoring"' in SCHEMA
     assert '"pattern_scoring_schema_version": 5' in SCHEMA
     assert '"opportunity_coverage_identity"' in SCHEMA
+    assert "validated schema-v4 or\nschema-v5 profile" in SKILL
+    assert "schema-v4 or schema-v5 `speaker-profile.json`" in SCHEMA
+    assert "only when its exact\nclassification domain is `available`" in SKILL
 
 
 def test_owner_keeps_pacing_and_pattern_provenance_separate():

--- a/tests/test_guardrail_check.py
+++ b/tests/test_guardrail_check.py
@@ -85,6 +85,122 @@ def test_main_rejects_invalid_input_without_stdout(guardrail_check, tmp_path, ca
     assert f"failed to load {missing_outline}" in captured.err
 
 
+# ── Pattern-history domains ─────────────────────────────────
+
+
+def _history_status(guardrail_check, *domains):
+    return guardrail_check.CreatorPatternHistoryStatus(
+        history_enabled=bool(domains),
+        history_source="profile" if domains else None,
+        profile_schema_version=5,
+        scored_talk_count=12,
+        reason_codes=(),
+        reasons=(),
+        eligible_talk_count=12,
+        opportunity_rows_available=True,
+        classification_fields_available=bool(domains),
+        available_classification_domains=tuple(domains),
+        policy_semantic_sha256="a" * 64 if domains else None,
+    )
+
+
+def _classified_antipatterns():
+    def row(pattern_id, classification, detected_count):
+        return {
+            "pattern_id": pattern_id,
+            "classification": classification,
+            "evidence": {
+                "applicable_count": 12,
+                "evaluable_count": 12,
+                "detected_count": detected_count,
+            },
+        }
+
+    return {
+        "antipattern_frequency": [
+            {
+                "pattern_id": "raw-occurrence-must-not-leak",
+                "severity": "recurring",
+            }
+        ],
+        "antipattern_classifications": [
+            row("high", "high_frequency", 8),
+            row("moderate", "moderate_frequency", 4),
+            row("occasional", "occasional", 1),
+            row("none", "confirmed_none", 0),
+        ],
+        "trend_analysis": {
+            "antipattern_movements": [
+                {"pattern_id": "high", "movement": "increasing"},
+                {"pattern_id": "moderate", "movement": "stable"},
+                {"pattern_id": "occasional", "movement": "decreasing"},
+            ]
+        },
+    }
+
+
+def test_recurring_history_requires_recurrence_domain(guardrail_check):
+    status = _history_status(guardrail_check, "mastery_and_novelty")
+
+    items = guardrail_check.recurring_pattern_history_items(
+        _classified_antipatterns(), status
+    )
+
+    assert items == []
+
+
+def test_recurring_history_uses_only_high_and_moderate_classifications(
+    guardrail_check,
+):
+    status = _history_status(guardrail_check, "antipattern_recurrence")
+
+    items = guardrail_check.recurring_pattern_history_items(
+        _classified_antipatterns(), status
+    )
+
+    assert [item["pattern_id"] for item in items] == ["high", "moderate"]
+    assert "raw-occurrence-must-not-leak" not in {item["pattern_id"] for item in items}
+    assert [item["recurrence_classification"] for item in items] == [
+        "high_frequency",
+        "moderate_frequency",
+    ]
+    assert all("trend" not in item for item in items)
+
+
+def test_recurring_history_adds_trend_only_when_trend_domain_is_available(
+    guardrail_check,
+):
+    status = _history_status(guardrail_check, "antipattern_recurrence", "trends")
+
+    items = guardrail_check.recurring_pattern_history_items(
+        _classified_antipatterns(), status
+    )
+
+    assert [(item["pattern_id"], item["trend"]) for item in items] == [
+        ("high", "increasing"),
+        ("moderate", "stable"),
+    ]
+
+
+def test_suppressed_history_fields_follow_independent_domains(guardrail_check):
+    status = _history_status(
+        guardrail_check,
+        "mastery_and_novelty",
+        "underuse",
+        "antipattern_recurrence",
+    )
+
+    suppressed = guardrail_check.suppressed_pattern_history_fields(status)
+
+    assert "mastery_levels" not in suppressed
+    assert "never_used_patterns" not in suppressed
+    assert "underused_patterns" not in suppressed
+    assert "recurring_antipatterns" not in suppressed
+    assert "signature_combinations" in suppressed
+    assert "score_trend" in suppressed
+    assert "by_mode" in suppressed
+
+
 # ── Slide budget ─────────────────────────────────────────────────────
 
 

--- a/tests/test_ingress_adherence_docs.py
+++ b/tests/test_ingress_adherence_docs.py
@@ -120,14 +120,18 @@ def test_native_picture_render_threshold_is_script_owned() -> None:
     assert "image_area_ratio >= 0.5" not in schemas
 
 
-def test_post_batch_cohort_and_section_15_filter_are_explicit() -> None:
+def test_post_batch_contract_is_explicit_without_repeating_section15_filter() -> None:
     docs = _docs()
-    for name in ("persistence", "processing", "schemas"):
+    for name in ("persistence", "schemas"):
         assert "current_adherence_baseline" in docs[name]
         assert "active_batch_excluded: false" in docs[name]
 
+    assert "current_adherence_baseline" in docs["processing"]
     assert "only after every merge succeeds" in docs["processing"]
-    assert "Never approximate this cohort by\n`processed_date`" in docs["processing"]
+    assert "complete baseline contract" in docs["processing"]
+    assert "Do not reproduce its cohort\nselection" in docs["processing"]
+    assert "section15_pattern_history.py" in docs["processing"]
+    assert "active_batch_excluded: false" not in docs["processing"]
     assert "after the entire batch has persisted successfully" in docs["processing"]
     assert "never update it after an\nindividual member merge" in docs["processing"]
     assert "must not recompute after member 1" in docs["schemas"]
@@ -186,11 +190,13 @@ def test_canonical_coverage_alone_never_authorizes_current_absence() -> None:
     )
 
 
-def test_current_v5_cohort_requires_live_artifact_freshness() -> None:
+def test_current_v5_freshness_filter_is_owned_by_section15_helper() -> None:
     docs = _docs()
     assert "shared freshness assessor" in docs["selection"]
     assert "configured source roots" in docs["selection"]
-    assert "artifact freshness against the vault" in docs["processing"]
+    assert "section15_pattern_history.py" in docs["processing"]
+    assert "Do not reproduce its\ncohort filter" in docs["processing"]
+    assert "artifact freshness against the vault" not in docs["processing"]
     assert "shared root-aware assessor" in docs["selection"]
     assert "remote video/slide acquisition remains eligible" in docs["selection"]
 

--- a/tests/test_installed_plugin_paths.py
+++ b/tests/test_installed_plugin_paths.py
@@ -280,9 +280,9 @@ def test_profile_construction_rules_are_linked_and_shipped() -> None:
         "[profile-construction-rules.md]"
         "(references/profile-construction-rules.md)" in skill
     )
-    assert "speaker-toolkit-default@1" in rules
-    assert "pattern-classification-policy.json" in rules
-    assert "canonical SHA-256" in rules
+    assert "Copy the loader's complete `classification_policy` stamp unchanged" in rules
+    assert "policy-comparison identity" not in rules
+    assert "canonical SHA-256" not in rules
     assert "pattern-generation\nreset" in rules
 
     shipped = (
@@ -318,6 +318,32 @@ def test_profile_schema_delegates_policy_arithmetic_to_classifier() -> None:
     assert "Bundled Default Thresholds" not in schema
     assert "`E/A`" not in schema
     assert "`D/A`" not in schema
+    assert "5+5" not in schema
+    assert "canonical sorted" not in schema
+    assert (
+        '"semantic_sha256": "<classifier-produced 64-character lowercase hex digest>"'
+        in schema
+    )
+    assert (
+        '"semantic_sha256": '
+        '"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"'
+        not in schema
+    )
+    for classifier_owned_field in (
+        '"minimum_applicable"',
+        '"minimum_evaluable"',
+        '"minimum_lower"',
+        '"minimum_detections"',
+        '"maximum_upper_exclusive"',
+        '"member_counts"',
+        '"maximum_results"',
+        '"minimum_comparable_talks"',
+        '"window_size"',
+        '"score_delta"',
+        '"breadth_delta"',
+        '"pattern_movement_delta"',
+    ):
+        assert classifier_owned_field not in schema
 
 
 def test_profile_construction_rules_delegate_availability_to_classifier() -> None:

--- a/tests/test_installed_plugin_paths.py
+++ b/tests/test_installed_plugin_paths.py
@@ -318,3 +318,18 @@ def test_profile_schema_delegates_policy_arithmetic_to_classifier() -> None:
     assert "Bundled Default Thresholds" not in schema
     assert "`E/A`" not in schema
     assert "`D/A`" not in schema
+
+
+def test_profile_construction_rules_delegate_availability_to_classifier() -> None:
+    rules = (
+        SKILLS_ROOT / "vault-profile" / "references" / "profile-construction-rules.md"
+    ).read_text(encoding="utf-8")
+
+    assert "skills/vault-profile/scripts/classify-pattern-profile.py" in rules
+    assert "`classification_availability` output unchanged" in rules
+    for duplicated_predicate in (
+        "their exact opportunity bounds",
+        "shared non-null opportunity identity",
+        "selected ten talks",
+    ):
+        assert duplicated_predicate not in rules

--- a/tests/test_installed_plugin_paths.py
+++ b/tests/test_installed_plugin_paths.py
@@ -280,15 +280,34 @@ def test_profile_construction_rules_are_linked_and_shipped() -> None:
         "[profile-construction-rules.md]"
         "(references/profile-construction-rules.md)" in skill
     )
-    assert "owner-policy-unconfigured" in rules
+    assert "speaker-toolkit-default@1" in rules
+    assert "pattern-classification-policy.json" in rules
+    assert "canonical SHA-256" in rules
     assert "pattern-generation\nreset" in rules
 
-    relative_reference = reference.relative_to(REPO_ROOT)
-    ignore_check = subprocess.run(
-        ["git", "check-ignore", "--no-index", "--quiet", "--", str(relative_reference)],
-        cwd=REPO_ROOT,
-        check=False,
+    shipped = (
+        reference,
+        SKILLS_ROOT
+        / "vault-profile"
+        / "references"
+        / "pattern-classification-policy-v1.json",
+        SKILLS_ROOT
+        / "vault-profile"
+        / "scripts"
+        / "classify-pattern-profile.py",
+        SKILLS_ROOT
+        / "vault-profile"
+        / "scripts"
+        / "pattern_classification_runtime.py",
     )
-    assert ignore_check.returncode == 1, (
-        f"{relative_reference} is excluded from the published plugin"
-    )
+    for path in shipped:
+        assert path.is_file(), path
+        relative = path.relative_to(REPO_ROOT)
+        ignore_check = subprocess.run(
+            ["git", "check-ignore", "--no-index", "--quiet", "--", str(relative)],
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        assert ignore_check.returncode == 1, (
+            f"{relative} is excluded from the published plugin"
+        )

--- a/tests/test_installed_plugin_paths.py
+++ b/tests/test_installed_plugin_paths.py
@@ -291,14 +291,8 @@ def test_profile_construction_rules_are_linked_and_shipped() -> None:
         / "vault-profile"
         / "references"
         / "pattern-classification-policy-v1.json",
-        SKILLS_ROOT
-        / "vault-profile"
-        / "scripts"
-        / "classify-pattern-profile.py",
-        SKILLS_ROOT
-        / "vault-profile"
-        / "scripts"
-        / "pattern_classification_runtime.py",
+        SKILLS_ROOT / "vault-profile" / "scripts" / "classify-pattern-profile.py",
+        SKILLS_ROOT / "vault-profile" / "scripts" / "pattern_classification_runtime.py",
     )
     for path in shipped:
         assert path.is_file(), path

--- a/tests/test_installed_plugin_paths.py
+++ b/tests/test_installed_plugin_paths.py
@@ -305,3 +305,16 @@ def test_profile_construction_rules_are_linked_and_shipped() -> None:
         assert ignore_check.returncode == 1, (
             f"{relative} is excluded from the published plugin"
         )
+
+
+def test_profile_schema_delegates_policy_arithmetic_to_classifier() -> None:
+    schema = (
+        SKILLS_ROOT / "vault-profile" / "references" / "speaker-profile-schema.md"
+    ).read_text(encoding="utf-8")
+
+    assert "#### Classifier-Owned Policy Semantics" in schema
+    assert "references/pattern-classification-policy-v1.json" in schema
+    assert "scripts/classify-pattern-profile.py" in schema
+    assert "Bundled Default Thresholds" not in schema
+    assert "`E/A`" not in schema
+    assert "`D/A`" not in schema

--- a/tests/test_pattern_classification_runtime.py
+++ b/tests/test_pattern_classification_runtime.py
@@ -1,0 +1,40 @@
+"""Failure-boundary tests for the pattern-classification import bridge."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        FileNotFoundError("missing classifier"),
+        PermissionError("unreadable classifier"),
+        SyntaxError("invalid classifier"),
+        ImportError("classifier dependency unavailable"),
+    ],
+    ids=["missing", "unreadable", "syntax", "import"],
+)
+def test_runtime_load_failures_use_the_caller_contract(monkeypatch, failure):
+    scripts = (
+        Path(__file__).resolve().parents[1] / "skills" / "vault-profile" / "scripts"
+    )
+    monkeypatch.syspath_prepend(str(scripts))
+    runtime = importlib.import_module("pattern_classification_runtime")
+    runtime._exports.cache_clear()
+
+    def fail_to_load(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(runtime.runpy, "run_path", fail_to_load)
+
+    with pytest.raises(
+        RuntimeError, match="classification runtime owner could not be loaded"
+    ) as raised:
+        runtime.validate_policy({})
+
+    assert raised.value.__cause__ is failure
+    runtime._exports.cache_clear()

--- a/tests/test_pattern_opportunities.py
+++ b/tests/test_pattern_opportunities.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 import copy
 import importlib
+import sys
+from pathlib import Path
 
 import pytest
+
+
+PROFILE_SCRIPTS = (
+    Path(__file__).resolve().parents[1] / "skills" / "vault-profile" / "scripts"
+)
+if str(PROFILE_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(PROFILE_SCRIPTS))
 
 
 def _modules():

--- a/tests/test_policy_delegation_docs.py
+++ b/tests/test_policy_delegation_docs.py
@@ -1,0 +1,66 @@
+"""Regression guards for prose that delegates policy-owned decisions to scripts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_profile_skill_treats_owner_validator_as_black_box() -> None:
+    skill = _read("skills/vault-profile/SKILL.md")
+
+    assert "scripts/validate-profile.py" in skill
+    assert "sole owner-validation contract" in skill
+    assert "Write nothing unless the command exits `0`" in skill
+    for internal_narration in (
+        "same shared cohort/classification builders",
+        "rejects any candidate baseline",
+        "policy stamp/digest, availability domain, or derived row",
+    ):
+        assert internal_narration not in skill
+
+
+def test_ingress_delegates_section15_assessment_and_replacement() -> None:
+    rules = _read("skills/vault-ingress/references/processing-rules.md")
+
+    assert 'section15_pattern_history.py" assess' in rules
+    assert 'section15_pattern_history.py" replace' in rules
+    assert "On exit `1`, it emits a diagnostic to stderr and makes no write" in rules
+    for classifier_owned_predicate in (
+        "For every Section 15 current-block count",
+        "zero detections become",
+        "recomputes the full current cohort from the database",
+        "trends and modes are independently",
+        "mixed identities make raw-score",
+        "apply the same exact current-generation filter",
+    ):
+        assert classifier_owned_predicate not in rules
+
+
+def test_speaker_profile_eval_requires_opaque_loader_outputs() -> None:
+    task = _read("evals/speaker-profile-from-vault/task.md")
+    criteria = json.loads(_read("evals/speaker-profile-from-vault/criteria.json"))
+    descriptions = "\n".join(item["description"] for item in criteria["checklist"])
+
+    assert "scripts/load-vault.py" in task
+    assert "opaque fixture" in task
+    assert "pattern_classification object emitted by load-vault.py" in descriptions
+    assert (
+        "uses only current_instrumentation_talks emitted by load-vault.py"
+        in descriptions
+    )
+    assert "contains at least one field with a numeric value" not in descriptions
+    for hardcoded_verdict in (
+        "mastery/novelty, antipattern-recurrence",
+        "trends and modes remain explicitly unavailable",
+        "Mastery/novelty, antipattern recurrence, underuse, and combinations",
+    ):
+        assert hardcoded_verdict not in task
+        assert hardcoded_verdict not in descriptions

--- a/tests/test_presentation_pattern_history.py
+++ b/tests/test_presentation_pattern_history.py
@@ -639,18 +639,29 @@ def test_docs_suppress_history_tiers_and_cross_generation_diffs():
     assert "Neither reset is\never evidence" in docs["rules"]
 
 
-def test_docs_define_exact_novelty_and_recurrence_sources():
+def test_docs_define_exact_novelty_and_delegate_recurrence_filtering():
     docs = _creator_docs()
 
     for name in ("skill", "phase2", "rules", "index"):
         assert "never_tried" in docs[name]
         assert "not_yet_observed" in docs[name]
-        assert "antipattern_classifications" in docs[name]
-        assert "high_frequency" in docs[name]
-        assert "moderate_frequency" in docs[name]
-    assert "frequency, not harm severity" in _normalized_doc(docs["phase2"])
-    assert "Raw `antipattern_frequency` never authorizes" in _normalized_doc(
-        docs["phase2"]
+    for name in ("skill", "phase2", "phase4", "rules", "index"):
+        assert "recurring_antipatterns" in docs[name]
+        assert "high_frequency" not in docs[name]
+        assert "moderate_frequency" not in docs[name]
+    assert "recurring_pattern_history_items()" in docs["phase4"]
+    assert "{action}" not in docs["phase4"]
+
+
+def test_docs_delegate_history_source_precedence_once():
+    docs = _creator_docs()
+
+    for name in ("skill", "phase0", "phase2", "phase4"):
+        assert "history_source" in docs[name]
+    assert "resolve_creator_pattern_history()" in docs["phase0"]
+    assert (
+        sum(text.count("resolve_creator_pattern_history()") for text in docs.values())
+        == 1
     )
 
 

--- a/tests/test_presentation_pattern_history.py
+++ b/tests/test_presentation_pattern_history.py
@@ -35,8 +35,14 @@ def _pattern_profile(*, count: int = 2) -> dict[str, Any]:
     opportunities = importlib.import_module("pattern_opportunities")
     pattern_evidence = importlib.import_module("pattern_evidence")
     fingerprint, scoring_schema = provenance.active_pattern_generation_identity()
-    filenames = [] if count == 0 else ["example-a.md", "example-b.md"]
-    score_sum = 0 if count == 0 else 14
+    filenames = (
+        []
+        if count == 0
+        else ["example-a.md", "example-b.md"]
+        if count == 2
+        else [f"example-{index:02d}.md" for index in range(count)]
+    )
+    score_sum = count * 7
     average = None if count == 0 else 7.0
     catalog = opportunities.load_catalog()
     observable_ids = sorted(
@@ -136,6 +142,101 @@ def _profile(*, schema_version: int = 4, count: int = 2) -> dict[str, Any]:
     }
 
 
+def _v5_profile(*, recurring_detections: int = 4) -> tuple[dict[str, Any], str]:
+    opportunities = importlib.import_module("pattern_opportunities")
+    pattern_evidence = importlib.import_module("pattern_evidence")
+    provenance = importlib.import_module("profile_pattern_provenance")
+    classification_runtime = importlib.import_module("pattern_classification_runtime")
+    catalog = opportunities.load_catalog()
+    fingerprint, scoring_schema = provenance.active_pattern_generation_identity()
+    observable = sorted(
+        (pattern_id, entry)
+        for pattern_id, entry in catalog.entries.items()
+        if entry.observable
+    )
+    recurring_id = next(
+        pattern_id
+        for pattern_id, entry in observable
+        if entry.entry_type == "antipattern"
+    )
+    talks = []
+    for index in range(8):
+        outcomes = []
+        positive_detections = []
+        negative_detections = []
+        for pattern_id, entry in observable:
+            outcome = (
+                "undetected"
+                if entry.absence_evaluable_from is not None
+                else "not_evaluable"
+            )
+            if pattern_id == recurring_id and index < recurring_detections:
+                outcome = "detected"
+                negative_detections.append({"pattern_id": pattern_id})
+            outcomes.append({"pattern_id": pattern_id, "outcome": outcome})
+        identity = pattern_evidence.opportunity_coverage_identity(
+            outcomes,
+            pattern_catalog_fingerprint=fingerprint,
+            pattern_scoring_schema_version=scoring_schema,
+        )
+        talks.append(
+            {
+                "filename": f"example-{index:02d}.md",
+                "date": f"2025-01-{index + 1:02d}",
+                "pattern_score": 0,
+                "pattern_observations": {
+                    "pattern_score": 0,
+                    "patterns_detected": positive_detections,
+                    "antipatterns_detected": negative_detections,
+                    "pattern_outcomes": outcomes,
+                    "opportunity_coverage_identity": identity,
+                },
+            }
+        )
+    rows = opportunities.build_pattern_opportunity_rows(talks, catalog=catalog)
+    policy_stamp = classification_runtime.resolve_classification_policy(
+        ROOT / "tests" / "__no_pattern_policy_override__"
+    )
+    classification = classification_runtime.classify_pattern_profile(
+        talks, policy_stamp, catalog=catalog
+    )
+    profile = {
+        "schema_version": 5,
+        "pattern_profile": {
+            "pattern_baseline": {
+                "schema_version": 2,
+                "as_of": "2025-01-09T00:00:00+00:00",
+                "scope": "global",
+                "active_batch_excluded": False,
+                "excluded_filenames": [],
+                "eligible_statuses": ["processed", "processed_partial"],
+                "pattern_scoring_generation_status": "current",
+                "pattern_scoring_generation_reasons": [],
+                "pattern_catalog_fingerprint": fingerprint,
+                "pattern_scoring_schema_version": scoring_schema,
+                "scored_talk_count": 8,
+                "pattern_score_sum": 0,
+                "average_pattern_score": 0.0,
+                "eligible_talk_count": 8,
+                "opportunity_coverage_identity": talks[0]["pattern_observations"][
+                    "opportunity_coverage_identity"
+                ],
+                "raw_score_comparison_status": "available",
+                "raw_score_comparison_reason": None,
+            },
+            "baseline_talk_filenames": [talk["filename"] for talk in talks],
+            "eligible_talk_count": 8,
+            "talks_scored": 8,
+            "average_pattern_score": 0.0,
+            "note": "Observable catalog entries only.",
+            "pattern_usage": rows["pattern_usage"],
+            "antipattern_frequency": rows["antipattern_frequency"],
+            **classification,
+        },
+    }
+    return profile, recurring_id
+
+
 def test_matching_v4_rows_suppress_unconfigured_classifications(
     pattern_history_status,
 ):
@@ -147,7 +248,109 @@ def test_matching_v4_rows_suppress_unconfigured_classifications(
     assert status.scored_talk_count == 2
     assert status.eligible_talk_count == 2
     assert status.reason_codes == ("pattern_classification_policy_unavailable",)
-    assert "owner thresholds" in status.reasons[0]
+    assert "occurrence-only" in status.reasons[0]
+    assert status.available_classification_domains == ()
+    assert status.policy_semantic_sha256 is None
+
+
+def test_v5_enables_each_policy_domain_independently(pattern_history_status):
+    profile, _ = _v5_profile()
+
+    status = pattern_history_status.assess_creator_pattern_history(profile)
+
+    assert status.history_enabled is True
+    assert status.history_source == "profile"
+    assert status.opportunity_rows_available is True
+    assert status.classification_fields_available is True
+    assert status.available_classification_domains == (
+        "antipattern_recurrence",
+        "mastery_and_novelty",
+        "signature_combinations",
+        "underuse",
+    )
+    assert status.domain_available("mastery_and_novelty") is True
+    assert status.domain_available("antipattern_recurrence") is True
+    assert status.domain_available("trends") is False
+    assert status.domain_available("modes") is False
+    assert isinstance(status.policy_semantic_sha256, str)
+
+
+def test_v5_new_to_you_projection_contains_only_confirmed_never_tried(
+    pattern_history_status,
+):
+    profile, _ = _v5_profile()
+    resolution = pattern_history_status.resolve_creator_pattern_history(profile)
+
+    assert resolution.status.domain_available("mastery_and_novelty") is True
+    assert resolution.pattern_profile is not None
+    pattern_profile = resolution.pattern_profile
+    never_tried = pattern_profile["mastery_levels"]["never_tried"]
+    assert never_tried
+    assert pattern_profile["never_used_patterns"] == never_tried
+    classifications = {
+        row["pattern_id"]: row["classification"]
+        for row in pattern_profile["pattern_classifications"]
+    }
+    assert all(
+        classifications[pattern_id] == "never_tried" for pattern_id in never_tried
+    )
+    assert not any(
+        pattern_id in never_tried
+        for pattern_id, classification in classifications.items()
+        if classification == "not_yet_observed"
+    )
+
+
+def _section15_summary(pattern_profile: dict[str, Any], *, version: int) -> str:
+    section15 = importlib.import_module("section15_pattern_history")
+    if version == 3:
+        block = section15.render_section15_current_block(pattern_profile)
+    else:
+        baseline = pattern_profile["pattern_baseline"]
+        payload = {
+            "schema_version": 2,
+            "source_lane": section15.BLOCK_SOURCE_LANE,
+            "pattern_catalog_fingerprint": baseline["pattern_catalog_fingerprint"],
+            "pattern_scoring_schema_version": baseline[
+                "pattern_scoring_schema_version"
+            ],
+            "baseline_talk_filenames": pattern_profile["baseline_talk_filenames"],
+            "pattern_profile": pattern_profile,
+        }
+        encoded = json.dumps(payload, indent=2, sort_keys=True)
+        block = (
+            f"{section15.LEGACY_BLOCK_START}\n```json\n{encoded}\n```\n\n"
+            f"{section15.NON_BASELINE_NOTICE}\n{section15.LEGACY_BLOCK_END}"
+        )
+    return f"## 15. Presentation Pattern History\n\n{block}\n"
+
+
+def test_section15_v3_can_supply_policy_bound_fallback(pattern_history_status):
+    profile, _ = _v5_profile()
+    summary = _section15_summary(profile["pattern_profile"], version=3)
+
+    status = pattern_history_status.assess_creator_pattern_history(
+        _profile(schema_version=4), summary
+    )
+
+    assert status.history_enabled is True
+    assert status.history_source == "section15_current_block"
+    assert status.domain_available("mastery_and_novelty") is True
+    assert status.domain_available("trends") is False
+
+
+def test_section15_v2_remains_occurrence_only(pattern_history_status):
+    summary = _section15_summary(_pattern_profile(), version=2)
+
+    status = pattern_history_status.assess_creator_pattern_history(
+        {"schema_version": 3}, summary
+    )
+
+    assert status.history_enabled is False
+    assert status.opportunity_rows_available is True
+    assert status.classification_fields_available is False
+    assert status.available_classification_domains == ()
+    assert "pattern_classification_policy_unavailable" in status.reason_codes
 
 
 @pytest.mark.parametrize("schema_version", [1, 2, 3])
@@ -264,6 +467,32 @@ def test_status_cli_emits_machine_readable_disabled_state(
     assert "Regenerate speaker-profile.json" in payload["warning"]
 
 
+def test_status_cli_exposes_independent_policy_domains(
+    pattern_history_status,
+    tmp_path,
+    capsys,
+):
+    profile, _ = _v5_profile()
+    profile_path = tmp_path / "speaker-profile.json"
+    profile_path.write_text(json.dumps(profile), encoding="utf-8")
+
+    return_code = pattern_history_status.main(
+        ["pattern_history_status.py", str(profile_path)]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert return_code == 0
+    assert payload["history_enabled"] is True
+    assert payload["available_classification_domains"] == [
+        "antipattern_recurrence",
+        "mastery_and_novelty",
+        "signature_combinations",
+        "underuse",
+    ]
+    assert isinstance(payload["policy_semantic_sha256"], str)
+    assert payload["warning"] == ""
+
+
 def _guardrail_profile(*, current_history: bool) -> dict[str, Any]:
     profile = _profile(schema_version=4 if current_history else 2)
     source_lane = {"source_lane": "non_pattern"} if current_history else {}
@@ -321,7 +550,7 @@ def test_guardrail_keeps_nonpattern_checks_and_contextual_scan_when_history_disa
     assert "legacy-badge-sentinel" not in json.dumps(report)
 
 
-def test_guardrail_suppresses_recurring_labels_without_owner_policy(
+def test_guardrail_suppresses_recurring_labels_for_occurrence_only_v4(
     guardrail_check,
     tmp_path,
     capsys,
@@ -365,17 +594,26 @@ def _creator_docs() -> dict[str, str]:
             encoding="utf-8"
         ),
         "rules": (ROOT / "rules" / "guardrail-rules.md").read_text(encoding="utf-8"),
+        "index": (creator / "references" / "patterns" / "_index.md").read_text(
+            encoding="utf-8"
+        ),
     }
 
 
-def test_phase_instructions_share_the_fail_closed_history_gate():
+def _normalized_doc(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_phase_instructions_share_the_independent_domain_gate():
     docs = _creator_docs()
 
     assert "pattern_history_status.py" in docs["skill"]
     assert "pattern_history_status.py" in docs["phase0"]
-    assert "history_enabled: true" in docs["phase2"]
-    assert "history is disabled" in docs["phase4"]
-    assert "history_enabled: true" in docs["rules"]
+    assert "available_classification_domains" in docs["skill"]
+    assert "available_classification_domains" in docs["phase0"]
+    assert "available_classification_domains" in docs["phase2"]
+    assert "available_classification_domains" in docs["phase4"]
+    assert "at least one policy-bound domain" in docs["rules"]
 
 
 def test_docs_keep_nonpattern_and_contextual_lanes_enabled():
@@ -386,16 +624,45 @@ def test_docs_keep_nonpattern_and_contextual_lanes_enabled():
     assert 'source_lane: "non_pattern"' in docs["phase4"]
     assert "current-outline scan always runs" in docs["phase4"]
     assert "Current-taxonomy scans of the new outline remain enabled" in docs["skill"]
+    assert "current-outline scan" in docs["index"]
 
 
 def test_docs_suppress_history_tiers_and_cross_generation_diffs():
     docs = _creator_docs()
 
     assert "flat current-taxonomy menu" in docs["skill"]
-    assert "without the four\nhistory tiers" in docs["phase2"]
+    assert "flat relevant-patterns list" in docs["phase2"]
     assert "generation reset" in docs["skill"]
     assert "generation reset" in docs["phase0"]
-    assert "never evidence of improvement or regression" in docs["rules"]
+    assert "classification-comparison reset" in docs["skill"]
+    assert "classification comparison reset" in _normalized_doc(docs["phase0"])
+    assert "Neither reset is\never evidence" in docs["rules"]
+
+
+def test_docs_define_exact_novelty_and_recurrence_sources():
+    docs = _creator_docs()
+
+    for name in ("skill", "phase2", "rules", "index"):
+        assert "never_tried" in docs[name]
+        assert "not_yet_observed" in docs[name]
+        assert "antipattern_classifications" in docs[name]
+        assert "high_frequency" in docs[name]
+        assert "moderate_frequency" in docs[name]
+    assert "frequency, not harm severity" in _normalized_doc(docs["phase2"])
+    assert "Raw `antipattern_frequency` never authorizes" in _normalized_doc(
+        docs["phase2"]
+    )
+
+
+def test_docs_distinguish_occurrence_only_and_policy_bound_contracts():
+    docs = _creator_docs()
+
+    for name in ("skill", "phase0", "phase2", "rules"):
+        normalized = _normalized_doc(docs[name])
+        assert "schema v4" in normalized.lower()
+        assert "schema v5" in normalized.lower()
+        assert "Section 15 v2" in normalized
+        assert "Section 15 v3" in normalized
 
 
 def test_pattern_strategy_eval_fails_closed_on_deliberately_legacy_provenance():
@@ -408,14 +675,19 @@ def test_pattern_strategy_eval_fails_closed_on_deliberately_legacy_provenance():
         )
     )
 
-    assert "installed creator requires speaker-profile schema\n`4`" in task
+    assert "installed creator requires speaker-profile schema\n`5`" in task
     assert "pattern-scoring schema `5`" in task
-    assert '"schema_version": 3' in task
+    assert "schema v4 remains occurrence-only" in task
+    assert "speaker-toolkit-default@1" in task
+    assert '"schema_version": 4' in task
     assert '"pattern_scoring_schema_version": 4' in task
-    assert "deliberately stale" in task
+    assert "occurrence-compatible speaker-profile schema `4`" in task
     assert '"pattern_catalog_fingerprint": "' + ("a" * 64) + '"' in task
     assert '"baseline_talk_filenames"' in task
     assert sum(item["max_score"] for item in criteria["checklist"]) == 100
     assert criteria["checklist"][0]["name"] == "Legacy provenance fails closed"
     assert "history-disabled" in criteria["checklist"][0]["description"]
-    assert any(item["name"] == "No recurring labels" for item in criteria["checklist"])
+    assert any(
+        item["name"] == "No catalog recurrence from raw rows"
+        for item in criteria["checklist"]
+    )

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -192,6 +192,29 @@ def _v5_pattern_profile(validate_profile, *, count: int = 2) -> dict[str, Any]:
     return profile
 
 
+def _signature_combination_fixture() -> tuple[dict[str, Any], list[dict[str, str]]]:
+    return (
+        {
+            "combination_id": "p1+p2",
+            "pattern_ids": ["p1", "p2"],
+            "evidence": {
+                "applicable_count": 10,
+                "evaluable_count": 10,
+                "detected_count": 5,
+                "unevaluable_count": 0,
+                "applicable_coverage": 1.0,
+                "lower": 0.5,
+                "upper": 0.5,
+            },
+            "reason_codes": ["meets_signature_combination_thresholds"],
+        },
+        [
+            {"pattern_id": "p1", "classification": "regular"},
+            {"pattern_id": "p2", "classification": "signature"},
+        ],
+    )
+
+
 def _run(validate_profile, profile, tmp_path, capsys, *, extra_talks=None):
     fingerprint, scoring_schema = validate_profile.active_pattern_generation_identity()
     opportunities = importlib.import_module("pattern_opportunities")
@@ -528,6 +551,143 @@ def test_v5_classification_evidence_rejects_boolean_counts(
         f".evidence.{field} must be a non-negative integer" in error
         for error in assessment.errors
     )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("applicable_coverage", True),
+        ("applicable_coverage", False),
+        ("lower", True),
+        ("lower", False),
+        ("upper", True),
+        ("upper", False),
+    ],
+)
+def test_v5_classification_evidence_rejects_boolean_bounds(
+    validate_profile,
+    field,
+    value,
+):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+    row = pattern_profile["pattern_classifications"][0]
+    row["evidence"][field] = value
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is False
+    assert any(
+        f".evidence.{field} must be null or a finite number "
+        "between zero and one" in error
+        for error in assessment.errors
+    )
+
+
+@pytest.mark.parametrize("field", ["applicable_coverage", "lower", "upper"])
+@pytest.mark.parametrize(
+    "value",
+    [-0.01, 1.01, float("nan"), float("inf"), "0.5", 10**1000],
+)
+def test_v5_classification_evidence_rejects_invalid_bounds(
+    validate_profile,
+    field,
+    value,
+):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+    row = pattern_profile["pattern_classifications"][0]
+    row["evidence"][field] = value
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is False
+    assert any(
+        f".evidence.{field} must be null or a finite number "
+        "between zero and one" in error
+        for error in assessment.errors
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        ("applicable_count", True, "must be a non-negative integer"),
+        ("evaluable_count", "ten", "must be a non-negative integer"),
+        ("unevaluable_count", -1, "must be a non-negative integer"),
+        (
+            "applicable_coverage",
+            True,
+            "must be null or a finite number between zero and one",
+        ),
+        ("lower", float("inf"), "must be null or a finite number between zero and one"),
+        ("upper", "one", "must be null or a finite number between zero and one"),
+    ],
+)
+def test_signature_combination_rejects_malformed_evidence(
+    validate_profile,
+    field,
+    value,
+    expected_error,
+):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    row, positive_rows = _signature_combination_fixture()
+    row["evidence"][field] = value
+
+    errors = provenance._validate_combinations(
+        [row], positive_rows, eligible_talk_count=10
+    )
+
+    assert any(f".evidence.{field} {expected_error}" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        ("applicable_count", 9, "must satisfy applicable_count = E + U"),
+        ("applicable_count", 11, "cannot exceed the eligible talk count 10"),
+        ("detected_count", 11, "detected_count cannot exceed evaluable_count"),
+        ("lower", 0.4, "must equal the canonical ratio 0.5"),
+    ],
+)
+def test_signature_combination_rejects_inconsistent_evidence(
+    validate_profile,
+    field,
+    value,
+    expected_error,
+):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    row, positive_rows = _signature_combination_fixture()
+    row["evidence"][field] = value
+
+    if field == "applicable_count" and value == 11:
+        row["evidence"].update(
+            {
+                "evaluable_count": 11,
+                "applicable_coverage": 1.0,
+                "lower": 5 / 11,
+                "upper": 5 / 11,
+            }
+        )
+
+    errors = provenance._validate_combinations(
+        [row], positive_rows, eligible_talk_count=10
+    )
+
+    assert any(expected_error in error for error in errors)
+
+
+def test_signature_combination_accepts_canonical_evidence(validate_profile):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    row, positive_rows = _signature_combination_fixture()
+
+    errors = provenance._validate_combinations(
+        [row], positive_rows, eligible_talk_count=10
+    )
+
+    assert errors == []
 
 
 def test_mixed_opportunity_identity_keeps_occurrences_and_suppresses_raw_average(

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -475,6 +475,24 @@ def test_v5_assessment_rejects_policy_digest_tampering(validate_profile):
     assert any("semantic_sha256" in error for error in assessment.errors)
 
 
+def test_v5_assessment_rejects_missing_classification_id_without_crashing(
+    validate_profile,
+):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+    row = pattern_profile["pattern_classifications"][0]
+    row["classification"] = "signature"
+    del row["pattern_id"]
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is False
+    assert any(
+        "pattern_id must be a non-empty string" in error for error in assessment.errors
+    )
+
+
 def test_mixed_opportunity_identity_keeps_occurrences_and_suppresses_raw_average(
     validate_profile,
 ):

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -493,6 +493,43 @@ def test_v5_assessment_rejects_missing_classification_id_without_crashing(
     )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("applicable_count", True),
+        ("applicable_count", False),
+        ("evaluable_count", True),
+        ("evaluable_count", False),
+        ("detected_count", True),
+        ("detected_count", False),
+        ("unevaluable_count", True),
+        ("unevaluable_count", False),
+    ],
+)
+def test_v5_classification_evidence_rejects_boolean_counts(
+    validate_profile,
+    field,
+    value,
+):
+    pattern_profile = _v5_pattern_profile(validate_profile, count=0)
+    row = next(
+        item
+        for item in pattern_profile["pattern_classifications"]
+        if item["absence_conclusion_capable"] is False
+    )
+    row["evidence"][field] = value
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is False
+    assert any(
+        f".evidence.{field} must be a non-negative integer" in error
+        for error in assessment.errors
+    )
+
+
 def test_mixed_opportunity_identity_keeps_occurrences_and_suppresses_raw_average(
     validate_profile,
 ):

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import importlib
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -141,7 +142,7 @@ def _pattern_profile(validate_profile, *, count: int = 2) -> dict[str, Any]:
 
 def _profile(validate_profile, *, count: int = 2) -> dict[str, Any]:
     return {
-        "schema_version": 4,
+        "schema_version": 5,
         "generated_date": "2025-01-02",
         "talks_analyzed": 4,
         "speaker": {},
@@ -152,12 +153,43 @@ def _profile(validate_profile, *, count: int = 2) -> dict[str, Any]:
         "confirmed_intents": [],
         "guardrail_sources": {"recurring_issues": []},
         "pacing": {},
-        "pattern_profile": _pattern_profile(validate_profile, count=count),
+        "pattern_profile": _v5_pattern_profile(validate_profile, count=count),
         "visual_style_history": {},
         "publishing_process": {},
         "design_rules": {},
         "badges": [],
     }
+
+
+def _v5_pattern_profile(validate_profile, *, count: int = 2) -> dict[str, Any]:
+    profile = _pattern_profile(validate_profile, count=count)
+    filenames = profile["baseline_talk_filenames"]
+    catalog = importlib.import_module("pattern_opportunities").load_catalog()
+    pattern_outcomes, _, _ = _transcript_projection(catalog)
+    talks = [
+        {
+            "filename": filename,
+            "pattern_score": 0,
+            "pattern_observations": {
+                "pattern_score": 0,
+                "patterns_detected": [],
+                "antipatterns_detected": [],
+                "pattern_outcomes": copy.deepcopy(pattern_outcomes),
+            },
+        }
+        for filename in filenames
+    ]
+    runtime = importlib.import_module("pattern_classification_runtime")
+    profile.update(
+        runtime.classify_pattern_profile(
+            talks,
+            runtime.resolve_classification_policy(
+                Path(__file__).resolve().parent / "__no_policy_override__"
+            ),
+            catalog=catalog,
+        )
+    )
+    return profile
 
 
 def _run(validate_profile, profile, tmp_path, capsys, *, extra_talks=None):
@@ -325,7 +357,7 @@ def test_current_profile_binds_every_pattern_denominator_to_one_cohort(
     assert return_code == 0, "\n".join(report["errors"])
     assert report == {
         "valid": True,
-        "schema_version": 4,
+        "schema_version": 5,
         "missing_keys": [],
         "errors": [],
     }
@@ -395,6 +427,47 @@ def test_reusable_assessment_distinguishes_current_empty_and_stale_history(
         "pattern_catalog_fingerprint_mismatch",
         "invalid_pattern_profile_contract",
     )
+
+
+def test_v5_assessment_enables_independent_policy_domains(validate_profile):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is True
+    assert assessment.classification_fields_available is True
+    assert assessment.available_classification_domains == frozenset(
+        {
+            "mastery_and_novelty",
+            "antipattern_recurrence",
+            "underuse",
+            "signature_combinations",
+        }
+    )
+    assert assessment.domain_available("trends") is False
+    assert assessment.domain_available("modes") is False
+    assert assessment.policy_semantic_sha256 == pattern_profile[
+        "classification_policy"
+    ]["semantic_sha256"]
+
+
+def test_v5_assessment_rejects_policy_digest_tampering(validate_profile):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+    pattern_profile["classification_policy"]["semantic_sha256"] = "0" * 64
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    provenance_module = importlib.import_module("profile_pattern_provenance")
+    assert assessment.current_contract is False
+    assert (
+        provenance_module.REASON_CLASSIFICATION_POLICY_INVALID
+        in assessment.reason_codes
+    )
+    assert any("semantic_sha256" in error for error in assessment.errors)
 
 
 def test_mixed_opportunity_identity_keeps_occurrences_and_suppresses_raw_average(
@@ -492,7 +565,7 @@ def test_profile_v3_is_noncurrent_and_rejected(validate_profile, tmp_path, capsy
 
     assert return_code == 1
     assert report["valid"] is False
-    assert report["errors"] == ["schema_version is 3 (expected 4)"]
+    assert report["errors"] == ["schema_version is 3 (expected 5)"]
 
 
 def test_missing_pattern_baseline_is_rejected(validate_profile, tmp_path, capsys):
@@ -644,7 +717,7 @@ def test_nonempty_profile_requires_complete_nested_schema(
 
     assert return_code == 1
     assert any(
-        "missing required schema-v4 fields" in error for error in report["errors"]
+        "missing required schema-v5 fields" in error for error in report["errors"]
     )
     assert any(
         "pattern_breadth is missing required fields" in error
@@ -664,7 +737,7 @@ def test_current_profile_rejects_unknown_nested_shape(
     return_code, report = _run(validate_profile, profile, tmp_path, capsys)
 
     assert return_code == 1
-    assert any("unknown schema-v4 fields" in error for error in report["errors"])
+    assert any("unknown schema-v5 fields" in error for error in report["errors"])
     assert any("unknown tiers" in error for error in report["errors"])
 
 
@@ -681,7 +754,7 @@ def test_nonempty_cohort_rejects_unconfigured_trend_claim(
 
     assert return_code == 1
     assert any(
-        "score_trend must be 'unavailable'" in error for error in report["errors"]
+        "score_trend must project" in error for error in report["errors"]
     )
 
 
@@ -791,10 +864,11 @@ def test_empty_current_cohort_rejects_legacy_pattern_fallback(
 
     assert return_code == 1
     assert any(
-        "score_trend must be 'unavailable'" in error for error in report["errors"]
+        "score_trend must project" in error for error in report["errors"]
     )
     assert any(
-        "mastery_levels.signature must be []" in error for error in report["errors"]
+        "mastery_levels is not the deterministic projection" in error
+        for error in report["errors"]
     )
 
 

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -215,6 +215,131 @@ def _signature_combination_fixture() -> tuple[dict[str, Any], list[dict[str, str
     )
 
 
+def _window_evidence(*, detected: int) -> dict[str, Any]:
+    return {
+        "applicable_count": 5,
+        "evaluable_count": 5,
+        "detected_count": detected,
+        "unevaluable_count": 0,
+        "applicable_coverage": 1.0,
+        "lower": detected / 5,
+        "upper": detected / 5,
+    }
+
+
+def _trend_validation_fixture(
+    reason: str | None = None,
+) -> tuple[dict[str, Any], list[dict[str, str]], list[dict[str, str]]]:
+    filenames = [f"talk-{index:02d}.md" for index in range(10)]
+    positive_rows = [{"pattern_id": "p1"}]
+    antipattern_rows = [{"pattern_id": "a1"}]
+    if reason is None:
+        status = "available"
+        reasons: list[str] = []
+        score = {
+            "status": "improving",
+            "prior_average": 0.0,
+            "recent_average": 1.0,
+            "delta": 1.0,
+        }
+        breadth = {
+            "status": "widening",
+            "prior_average": 0.0,
+            "recent_average": 1.0,
+            "delta": 1.0,
+        }
+        pattern_movements = [
+            {
+                "pattern_id": "p1",
+                "movement": "increasing",
+                "prior_evidence": _window_evidence(detected=0),
+                "recent_evidence": _window_evidence(detected=1),
+                "reason_codes": ["conservative_interval_increase"],
+            }
+        ]
+        antipattern_movements = [
+            {
+                "pattern_id": "a1",
+                "movement": "decreasing",
+                "prior_evidence": _window_evidence(detected=1),
+                "recent_evidence": _window_evidence(detected=0),
+                "reason_codes": ["conservative_interval_decrease"],
+            }
+        ]
+        valid_date_count = 10
+        invalid_filenames: list[str] = []
+        selected_filenames = filenames
+        identity: str | None = "a" * 64
+        score_drivers = {
+            "direction": "improving",
+            "pattern_drivers": ["p1"],
+            "antipattern_drivers": ["a1"],
+        }
+    else:
+        status = "unavailable"
+        reasons = [reason]
+        score = {
+            "status": "unavailable",
+            "prior_average": None,
+            "recent_average": None,
+            "delta": None,
+        }
+        breadth = copy.deepcopy(score)
+        pattern_movements = []
+        antipattern_movements = []
+        insufficient = reason == "insufficient_valid_date_sample"
+        valid_date_count = 9 if insufficient else 10
+        invalid_filenames = [filenames[-1]] if insufficient else []
+        selected_filenames = [] if insufficient else filenames
+        identity = "a" * 64 if reason == "no_evaluable_pattern_opportunities" else None
+        score_drivers = {
+            "direction": "unavailable",
+            "pattern_drivers": [],
+            "antipattern_drivers": [],
+        }
+    profile = {
+        "baseline_talk_filenames": filenames,
+        "classification_availability": {
+            "trends": {"status": status, "reason_codes": reasons}
+        },
+        "trend_analysis": {
+            "status": status,
+            "reason_codes": reasons,
+            "sample": {
+                "required_talk_count": 10,
+                "valid_date_talk_count": valid_date_count,
+                "invalid_date_filenames": invalid_filenames,
+                "selected_filenames": selected_filenames,
+                "opportunity_coverage_identity": identity,
+            },
+            "score": score,
+            "breadth": breadth,
+            "pattern_movements": pattern_movements,
+            "antipattern_movements": antipattern_movements,
+        },
+        "score_trend": score["status"],
+        "pattern_breadth": {"trend": breadth["status"]},
+        "score_drivers": score_drivers,
+    }
+    return profile, positive_rows, antipattern_rows
+
+
+def _trend_validation_errors(
+    provenance,
+    profile: dict[str, Any],
+    positive_rows: list[dict[str, str]],
+    antipattern_rows: list[dict[str, str]],
+) -> list[str]:
+    return provenance._validate_trend_analysis(
+        profile,
+        positive_rows,
+        antipattern_rows,
+        eligible_talk_count=10,
+        required_talk_count=10,
+        window_size=5,
+    )
+
+
 def _run(validate_profile, profile, tmp_path, capsys, *, extra_talks=None):
     fingerprint, scoring_schema = validate_profile.active_pattern_generation_identity()
     opportunities = importlib.import_module("pattern_opportunities")
@@ -815,6 +940,252 @@ def test_signature_combination_requires_reason_codes(validate_profile):
     )
 
     assert any("reason_codes must not be empty" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        None,
+        "insufficient_valid_date_sample",
+        "opportunity_identity_unavailable",
+        "incomparable_opportunity_identities",
+        "no_evaluable_pattern_opportunities",
+    ],
+)
+def test_trend_validator_accepts_every_canonical_variant(validate_profile, reason):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    profile, positive_rows, antipattern_rows = _trend_validation_fixture(reason)
+
+    errors = _trend_validation_errors(
+        provenance, profile, positive_rows, antipattern_rows
+    )
+
+    assert errors == []
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "unknown_analysis_field",
+        "unknown_sample_field",
+        "unknown_metric_field",
+        "boolean_valid_date_count",
+        "duplicate_selected_filename",
+        "availability_reason_mismatch",
+        "uppercase_identity",
+    ],
+)
+def test_trend_validator_rejects_noncanonical_sample_and_availability(
+    validate_profile, case
+):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    profile, positive_rows, antipattern_rows = _trend_validation_fixture()
+    sample = profile["trend_analysis"]["sample"]
+    if case == "unknown_analysis_field":
+        profile["trend_analysis"]["unexpected"] = True
+    elif case == "unknown_sample_field":
+        sample["unexpected"] = True
+    elif case == "unknown_metric_field":
+        profile["trend_analysis"]["score"]["unexpected"] = True
+    elif case == "boolean_valid_date_count":
+        sample["valid_date_talk_count"] = True
+    elif case == "duplicate_selected_filename":
+        sample["selected_filenames"][-1] = sample["selected_filenames"][0]
+    elif case == "availability_reason_mismatch":
+        profile["classification_availability"]["trends"]["reason_codes"] = [
+            "insufficient_valid_date_sample"
+        ]
+    else:
+        sample["opportunity_coverage_identity"] = "A" * 64
+
+    errors = _trend_validation_errors(
+        provenance, profile, positive_rows, antipattern_rows
+    )
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "boolean_metric",
+        "nonfinite_metric",
+        "delta_mismatch",
+        "direction_projection",
+        "driver_projection",
+    ],
+)
+def test_trend_validator_rejects_invalid_metrics_and_projections(
+    validate_profile, case
+):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    profile, positive_rows, antipattern_rows = _trend_validation_fixture()
+    if case == "boolean_metric":
+        profile["trend_analysis"]["score"]["prior_average"] = True
+    elif case == "nonfinite_metric":
+        profile["trend_analysis"]["breadth"]["recent_average"] = float("inf")
+    elif case == "delta_mismatch":
+        profile["trend_analysis"]["score"]["delta"] = 0.5
+    elif case == "direction_projection":
+        profile["score_drivers"]["direction"] = "stable"
+    else:
+        profile["score_drivers"]["pattern_drivers"] = []
+
+    errors = _trend_validation_errors(
+        provenance, profile, positive_rows, antipattern_rows
+    )
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "boolean_evidence_bound",
+        "inconsistent_evidence_counts",
+        "incomplete_available_movement",
+        "wrong_reason",
+        "wrong_pattern_id",
+        "unknown_movement_field",
+    ],
+)
+def test_trend_validator_rejects_invalid_movement_rows(validate_profile, case):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    profile, positive_rows, antipattern_rows = _trend_validation_fixture()
+    movement = profile["trend_analysis"]["pattern_movements"][0]
+    prior = movement["prior_evidence"]
+    if case == "boolean_evidence_bound":
+        prior["lower"] = False
+    elif case == "inconsistent_evidence_counts":
+        prior["unevaluable_count"] = 1
+    elif case == "incomplete_available_movement":
+        prior.update(
+            {
+                "applicable_count": 4,
+                "evaluable_count": 4,
+                "detected_count": 0,
+                "unevaluable_count": 0,
+                "applicable_coverage": 1.0,
+                "lower": 0.0,
+                "upper": 0.0,
+            }
+        )
+    elif case == "wrong_reason":
+        movement["reason_codes"] = ["conservative_interval_stable"]
+    elif case == "wrong_pattern_id":
+        movement["pattern_id"] = "wrong"
+    else:
+        movement["unexpected"] = True
+
+    errors = _trend_validation_errors(
+        provenance, profile, positive_rows, antipattern_rows
+    )
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "insufficient_with_selection",
+        "resolved_sample_without_identity",
+        "non_null_metric",
+        "nonempty_movements",
+    ],
+)
+def test_trend_validator_enforces_unavailable_sentinels(validate_profile, case):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    reason = (
+        "insufficient_valid_date_sample"
+        if case == "insufficient_with_selection"
+        else "no_evaluable_pattern_opportunities"
+    )
+    profile, positive_rows, antipattern_rows = _trend_validation_fixture(reason)
+    trend = profile["trend_analysis"]
+    if case == "insufficient_with_selection":
+        trend["sample"]["selected_filenames"] = ["talk-00.md"]
+    elif case == "resolved_sample_without_identity":
+        trend["sample"]["opportunity_coverage_identity"] = None
+    elif case == "non_null_metric":
+        trend["score"]["prior_average"] = 0.0
+    else:
+        trend["pattern_movements"] = [
+            {
+                "pattern_id": "p1",
+                "movement": "stable",
+                "prior_evidence": _window_evidence(detected=0),
+                "recent_evidence": _window_evidence(detected=0),
+                "reason_codes": ["conservative_interval_stable"],
+            }
+        ]
+
+    errors = _trend_validation_errors(
+        provenance, profile, positive_rows, antipattern_rows
+    )
+
+    assert errors
+
+
+def test_v5_assessment_rejects_arbitrary_trend_sample_shape(validate_profile):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+    pattern_profile["trend_analysis"]["sample"] = {
+        "required_talk_count": True,
+        "unexpected": "previously accepted",
+    }
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is False
+    assert any("trend_analysis.sample" in error for error in assessment.errors)
+
+
+def test_v5_assessment_fails_closed_on_huge_self_consistent_counts(validate_profile):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+    classified = pattern_profile["pattern_classifications"][0]
+    huge = 10**1000
+    classified["evidence"] = {
+        "applicable_count": huge,
+        "evaluable_count": huge,
+        "detected_count": huge,
+        "unevaluable_count": 0,
+        "applicable_coverage": 1.0,
+        "lower": 1.0,
+        "upper": 1.0,
+    }
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is False
+    assert assessment.errors
+
+
+def test_expected_evidence_handles_huge_canonical_counts(validate_profile):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    huge = 10**1000
+
+    evidence = provenance._expected_evidence(
+        {
+            "eligible_cohort_count": huge,
+            "not_applicable_count": 0,
+            "evaluable_count": huge,
+            "detected_count": huge,
+            "unevaluable_count": 0,
+        }
+    )
+
+    assert evidence == {
+        "applicable_count": huge,
+        "evaluable_count": huge,
+        "detected_count": huge,
+        "unevaluable_count": 0,
+        "applicable_coverage": 1.0,
+        "lower": 1.0,
+        "upper": 1.0,
+    }
 
 
 def test_mixed_opportunity_identity_keeps_occurrences_and_suppresses_raw_average(

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -254,16 +254,20 @@ def _run(validate_profile, profile, tmp_path, capsys, *, extra_talks=None):
                 "timing_artifact_sha256": timing_digest,
             }
             if channel == "timed_transcript":
-                citation.update({
-                    "start_seconds": 0.0,
-                    "end_seconds": 10.0,
-                })
-            located_assessments.append({
-                **assessment,
-                "evidence_source": "transcript",
-                "evidence": "The complete transcript establishes applicability.",
-                "evidence_citations": [citation],
-            })
+                citation.update(
+                    {
+                        "start_seconds": 0.0,
+                        "end_seconds": 10.0,
+                    }
+                )
+            located_assessments.append(
+                {
+                    **assessment,
+                    "evidence_source": "transcript",
+                    "evidence": "The complete transcript establishes applicability.",
+                    "evidence_citations": [citation],
+                }
+            )
         talks.append(
             {
                 "filename": filename,
@@ -448,9 +452,10 @@ def test_v5_assessment_enables_independent_policy_domains(validate_profile):
     )
     assert assessment.domain_available("trends") is False
     assert assessment.domain_available("modes") is False
-    assert assessment.policy_semantic_sha256 == pattern_profile[
-        "classification_policy"
-    ]["semantic_sha256"]
+    assert (
+        assessment.policy_semantic_sha256
+        == pattern_profile["classification_policy"]["semantic_sha256"]
+    )
 
 
 def test_v5_assessment_rejects_policy_digest_tampering(validate_profile):
@@ -753,9 +758,7 @@ def test_nonempty_cohort_rejects_unconfigured_trend_claim(
     return_code, report = _run(validate_profile, profile, tmp_path, capsys)
 
     assert return_code == 1
-    assert any(
-        "score_trend must project" in error for error in report["errors"]
-    )
+    assert any("score_trend must project" in error for error in report["errors"])
 
 
 def test_nested_out_of_denominator_cannot_use_another_cohort(
@@ -863,9 +866,7 @@ def test_empty_current_cohort_rejects_legacy_pattern_fallback(
     return_code, report = _run(validate_profile, profile, tmp_path, capsys)
 
     assert return_code == 1
-    assert any(
-        "score_trend must project" in error for error in report["errors"]
-    )
+    assert any("score_trend must project" in error for error in report["errors"])
     assert any(
         "mastery_levels is not the deterministic projection" in error
         for error in report["errors"]

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -498,6 +498,121 @@ def test_v5_assessment_rejects_policy_digest_tampering(validate_profile):
     assert any("semantic_sha256" in error for error in assessment.errors)
 
 
+@pytest.mark.parametrize(
+    ("path", "value", "expected_error"),
+    [
+        (
+            ("classification_schema_version",),
+            True,
+            "pattern_profile.classification_schema_version must be 1",
+        ),
+        (
+            ("classification_schema_version",),
+            1.0,
+            "pattern_profile.classification_schema_version must be 1",
+        ),
+        (
+            ("classification_availability", "schema_version"),
+            True,
+            "pattern_profile.classification_availability.schema_version must be 2",
+        ),
+        (
+            ("classification_availability", "schema_version"),
+            2.0,
+            "pattern_profile.classification_availability.schema_version must be 2",
+        ),
+        (
+            ("classification_policy", "schema_version"),
+            True,
+            "classification_policy.schema_version must be 1",
+        ),
+        (
+            ("classification_policy", "schema_version"),
+            1.0,
+            "classification_policy.schema_version must be 1",
+        ),
+        (
+            ("classification_policy", "policy_version"),
+            True,
+            "classification_policy.policy_version must be a positive integer",
+        ),
+        (
+            ("classification_policy", "policy_version"),
+            1.0,
+            "classification_policy.policy_version must be a positive integer",
+        ),
+        (
+            ("classification_policy", "semantic_policy", "schema_version"),
+            True,
+            "policy.schema_version must be 1",
+        ),
+        (
+            ("classification_policy", "semantic_policy", "schema_version"),
+            1.0,
+            "policy.schema_version must be 1",
+        ),
+        (
+            (
+                "classification_policy",
+                "semantic_policy",
+                "signature_combinations",
+                "member_counts",
+            ),
+            [2.0, 3],
+            "policy.signature_combinations.member_counts must equal the integer list",
+        ),
+        (
+            (
+                "classification_policy",
+                "semantic_policy",
+                "signature_combinations",
+                "member_counts",
+            ),
+            [2, 3.0],
+            "policy.signature_combinations.member_counts must equal the integer list",
+        ),
+        (
+            (
+                "classification_policy",
+                "semantic_policy",
+                "signature_combinations",
+                "member_counts",
+            ),
+            [True, 3],
+            "policy.signature_combinations.member_counts must equal the integer list",
+        ),
+        (
+            (
+                "classification_policy",
+                "semantic_policy",
+                "signature_combinations",
+                "member_counts",
+            ),
+            [2, True],
+            "policy.signature_combinations.member_counts must equal the integer list",
+        ),
+    ],
+)
+def test_v5_assessment_rejects_type_confused_policy_integers(
+    validate_profile,
+    path,
+    value,
+    expected_error,
+):
+    pattern_profile = _v5_pattern_profile(validate_profile)
+    target = pattern_profile
+    for field in path[:-1]:
+        target = target[field]
+    target[path[-1]] = value
+
+    assessment = validate_profile.assess_pattern_profile(
+        pattern_profile, expected_contract_version=5
+    )
+
+    assert assessment.current_contract is False
+    assert any(expected_error in error for error in assessment.errors)
+
+
 def test_v5_assessment_rejects_missing_classification_id_without_crashing(
     validate_profile,
 ):
@@ -688,6 +803,18 @@ def test_signature_combination_accepts_canonical_evidence(validate_profile):
     )
 
     assert errors == []
+
+
+def test_signature_combination_requires_reason_codes(validate_profile):
+    provenance = importlib.import_module("profile_pattern_provenance")
+    row, positive_rows = _signature_combination_fixture()
+    row["reason_codes"] = []
+
+    errors = provenance._validate_combinations(
+        [row], positive_rows, eligible_talk_count=10
+    )
+
+    assert any("reason_codes must not be empty" in error for error in errors)
 
 
 def test_mixed_opportunity_identity_keeps_occurrences_and_suppresses_raw_average(

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -1477,7 +1477,7 @@ def test_guardrail_uses_policy_bound_section15_without_inventing_recurrence(
     assert report["recurring_antipatterns"] == []
 
 
-def test_creator_docs_route_summary_fallback_through_shared_parser():
+def test_creator_docs_delegate_history_source_resolution():
     creator = ROOT / "skills" / "presentation-creator"
     docs = {
         "skill": (creator / "SKILL.md").read_text(encoding="utf-8"),
@@ -1490,12 +1490,12 @@ def test_creator_docs_route_summary_fallback_through_shared_parser():
     }
 
     for text in docs.values():
-        assert "section15_pattern_history.py" in text
-    assert "profile with any available domain wins" in docs["skill"]
-    normalized_phase0 = " ".join(docs["phase0"].split())
-    assert "summary is a fallback and never merges" in normalized_phase0
-    normalized_phase4 = " ".join(docs["phase4"].split())
-    assert "sources are never merged" in normalized_phase4
+        assert "history_source" in text
+    assert "resolve_creator_pattern_history()" in docs["phase0"]
+    assert "section15_pattern_history.py" in docs["skill"]
+    assert "section15_pattern_history.py" in docs["phase0"]
+    assert "section15_pattern_history.py" not in docs["phase4"]
+    assert "recurring_pattern_history_items()" in docs["phase4"]
 
 
 def test_ingress_docs_require_live_database_for_current_block_replace():
@@ -1509,6 +1509,6 @@ def test_ingress_docs_require_live_database_for_current_block_replace():
     assert "section15_pattern_history.py" in skill
     assert "tracking-database.json" in skill
     assert "stale" in skill
-    assert "section15_pattern_history.py replace" in processing
+    assert 'section15_pattern_history.py" replace' in processing
     assert "tracking-database.json" in processing
     assert "stale" in processing

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -776,10 +776,10 @@ def test_status_cli_reports_current_rows_without_authorizing_classifications(
     profile_path = tmp_path / "speaker-profile.json"
     profile_path.write_text(
         json.dumps(
-                {
-                    "schema_version": 4,
-                    "pattern_profile": _legacy_pattern_profile(),
-                }
+            {
+                "schema_version": 4,
+                "pattern_profile": _legacy_pattern_profile(),
+            }
         ),
         encoding="utf-8",
     )
@@ -1470,8 +1470,9 @@ def test_guardrail_uses_policy_bound_section15_without_inventing_recurrence(
     assert return_code == 0
     assert "policy-bound domains enabled" in checks["Pattern history"]["detail"]
     assert report["pattern_history"]["history_source"] == "section15_current_block"
-    assert "antipattern_recurrence" in (
-        report["pattern_history"]["available_classification_domains"]
+    assert (
+        "antipattern_recurrence"
+        in (report["pattern_history"]["available_classification_domains"])
     )
     assert report["recurring_antipatterns"] == []
 

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -24,6 +24,7 @@ for script_directory in (PROFILE_SCRIPTS, CREATOR_SCRIPTS):
 section15 = importlib.import_module("section15_pattern_history")
 pattern_history_status = importlib.import_module("pattern_history_status")
 provenance = importlib.import_module("profile_pattern_provenance")
+classification_runtime = importlib.import_module("pattern_classification_runtime")
 opportunities = importlib.import_module("pattern_opportunities")
 pattern_evidence = importlib.import_module("pattern_evidence")
 adherence_baseline = importlib.import_module("adherence_baseline")
@@ -92,6 +93,12 @@ def _pattern_profile(*, note: str = "Current exact cohort.") -> dict[str, Any]:
     opportunity_identity = outcome_talks[0]["pattern_observations"][
         "opportunity_coverage_identity"
     ]
+    classification = classification_runtime.classify_pattern_profile(
+        outcome_talks,
+        classification_runtime.resolve_classification_policy(
+            Path(__file__).resolve().parent / "__no_policy_override__"
+        ),
+    )
     return {
         "pattern_baseline": {
             "schema_version": 2,
@@ -116,38 +123,57 @@ def _pattern_profile(*, note: str = "Current exact cohort.") -> dict[str, Any]:
         "eligible_talk_count": 2,
         "talks_scored": 2,
         "average_pattern_score": 0.0,
-        "score_trend": "unavailable",
-        "pattern_breadth": {
-            "avg_distinct_patterns_per_talk": None,
-            "trend": "unavailable",
-            "note": note,
-        },
-        "underused_patterns": [],
-        "score_drivers": {
-            "direction": "unavailable",
-            "antipattern_drivers": [],
-            "pattern_drivers": [],
-            "note": note,
-        },
-        "by_mode": [],
-        "strengths": [],
-        "strengths_note": note,
         "note": note,
         "pattern_usage": rows["pattern_usage"],
         "antipattern_frequency": rows["antipattern_frequency"],
-        "never_used_patterns": [],
-        "signature_combinations": [],
-        "mastery_levels": {
-            "signature": [],
-            "regular": [],
-            "occasional": [],
-            "rare": [],
-            "never_tried": [],
-        },
-        "classification_availability": (
-            provenance.unavailable_classification_availability()
-        ),
+        **classification,
     }
+
+
+def _legacy_pattern_profile() -> dict[str, Any]:
+    """Project a valid v5 fixture back to the readable occurrence-only v4 shape."""
+    profile = _pattern_profile(note="Legacy occurrence-only payload.")
+    for field in (
+        "classification_schema_version",
+        "classification_policy",
+        "pattern_classifications",
+        "antipattern_classifications",
+        "trend_analysis",
+    ):
+        profile.pop(field)
+    profile.update(
+        {
+            "score_trend": "unavailable",
+            "pattern_breadth": {
+                "avg_distinct_patterns_per_talk": None,
+                "trend": "unavailable",
+                "note": "Occurrence-only v4 compatibility.",
+            },
+            "underused_patterns": [],
+            "score_drivers": {
+                "direction": "unavailable",
+                "antipattern_drivers": [],
+                "pattern_drivers": [],
+                "note": "Occurrence-only v4 compatibility.",
+            },
+            "by_mode": [],
+            "strengths": [],
+            "strengths_note": "Occurrence-only v4 compatibility.",
+            "never_used_patterns": [],
+            "signature_combinations": [],
+            "mastery_levels": {
+                "signature": [],
+                "regular": [],
+                "occasional": [],
+                "rare": [],
+                "never_tried": [],
+            },
+            "classification_availability": (
+                provenance.unavailable_classification_availability()
+            ),
+        }
+    )
+    return profile
 
 
 def _outcome_talks(
@@ -246,6 +272,14 @@ def _all_unknown_pattern_profile() -> dict[str, Any]:
     profile["average_pattern_score"] = None
     profile["pattern_usage"] = rows["pattern_usage"]
     profile["antipattern_frequency"] = rows["antipattern_frequency"]
+    profile.update(
+        classification_runtime.classify_pattern_profile(
+            outcome_talks,
+            classification_runtime.resolve_classification_policy(
+                Path(__file__).resolve().parent / "__no_policy_override__"
+            ),
+        )
+    )
     return profile
 
 
@@ -390,6 +424,17 @@ def _block_from_json(payload_json: str) -> str:
     )
 
 
+def _legacy_block_from_json(payload_json: str) -> str:
+    return (
+        f"{section15.LEGACY_BLOCK_START}\n"
+        "```json\n"
+        f"{payload_json}\n"
+        "```\n\n"
+        f"{section15.NON_BASELINE_NOTICE}\n"
+        f"{section15.LEGACY_BLOCK_END}"
+    )
+
+
 def _summary(block: str = "") -> str:
     block_area = f"\n{block}\n" if block else "\n"
     return (
@@ -419,12 +464,96 @@ def test_exact_current_block_accepts_complete_scoring_v5_cohort():
     assert assessment.current_contract is True
     assert assessment.catalog_fields_available is True
     assert assessment.scored_talk_count == 2
+    assert assessment.reason_codes == ()
+    assert assessment.classification_fields_available is True
+    assert assessment.block_schema_version == 3
+    assert assessment.available_classification_domains == frozenset(
+        {
+            "mastery_and_novelty",
+            "antipattern_recurrence",
+            "underuse",
+            "signature_combinations",
+        }
+    )
+    assert assessment.pattern_profile == profile
+    assert profile["pattern_baseline"]["pattern_scoring_schema_version"] == 5
+
+
+def test_v2_block_remains_readable_as_occurrence_only():
+    profile = _legacy_pattern_profile()
+    baseline = profile["pattern_baseline"]
+    payload = {
+        "schema_version": 2,
+        "source_lane": section15.BLOCK_SOURCE_LANE,
+        "pattern_catalog_fingerprint": baseline["pattern_catalog_fingerprint"],
+        "pattern_scoring_schema_version": baseline["pattern_scoring_schema_version"],
+        "baseline_talk_filenames": profile["baseline_talk_filenames"],
+        "pattern_profile": profile,
+    }
+    block = _legacy_block_from_json(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False)
+    )
+
+    assessment = section15.assess_section15_pattern_history(_summary(block))
+
+    assert assessment.current_contract is True
+    assert assessment.block_schema_version == 2
+    assert assessment.classification_fields_available is False
+    assert assessment.available_classification_domains == frozenset()
     assert assessment.reason_codes == (
         provenance.REASON_CLASSIFICATION_POLICY_UNAVAILABLE,
     )
-    assert assessment.classification_fields_available is False
-    assert assessment.pattern_profile == profile
-    assert profile["pattern_baseline"]["pattern_scoring_schema_version"] == 5
+
+
+def test_writer_replaces_v2_in_place_with_one_v3_block():
+    legacy = _legacy_pattern_profile()
+    baseline = legacy["pattern_baseline"]
+    payload = {
+        "schema_version": 2,
+        "source_lane": section15.BLOCK_SOURCE_LANE,
+        "pattern_catalog_fingerprint": baseline["pattern_catalog_fingerprint"],
+        "pattern_scoring_schema_version": baseline["pattern_scoring_schema_version"],
+        "baseline_talk_filenames": legacy["baseline_talk_filenames"],
+        "pattern_profile": legacy,
+    }
+    original = _summary(
+        _legacy_block_from_json(
+            json.dumps(payload, indent=2, sort_keys=True, allow_nan=False)
+        )
+    )
+
+    candidate = section15._replace_block_text(
+        original,
+        section15.render_section15_current_block(_pattern_profile()),
+    )
+
+    assert section15.LEGACY_BLOCK_TOKEN not in candidate
+    assert candidate.count(section15.BLOCK_START) == 1
+    assert candidate.count(section15.BLOCK_END) == 1
+    assert (
+        section15.assess_section15_pattern_history(candidate).current_contract is True
+    )
+
+
+def test_mixed_v2_v3_markers_fail_closed():
+    profile = _legacy_pattern_profile()
+    baseline = profile["pattern_baseline"]
+    payload = {
+        "schema_version": 2,
+        "source_lane": section15.BLOCK_SOURCE_LANE,
+        "pattern_catalog_fingerprint": baseline["pattern_catalog_fingerprint"],
+        "pattern_scoring_schema_version": baseline["pattern_scoring_schema_version"],
+        "baseline_talk_filenames": profile["baseline_talk_filenames"],
+        "pattern_profile": profile,
+    }
+    block = _legacy_block_from_json(json.dumps(payload)).replace(
+        section15.LEGACY_BLOCK_END, section15.BLOCK_END
+    )
+
+    assessment = section15.assess_section15_pattern_history(_summary(block))
+
+    assert assessment.current_contract is False
+    assert assessment.reason_codes == (section15.REASON_BLOCK_INVALID,)
     assert profile["baseline_talk_filenames"] == sorted(
         profile["baseline_talk_filenames"]
     )
@@ -447,7 +576,7 @@ def test_all_unknown_cohort_stays_raw_score_unavailable_through_section15_and_cr
     summary = summary_path.read_text(encoding="utf-8")
     assessment = section15.assess_section15_pattern_history(summary)
     creator_status = pattern_history_status.assess_creator_pattern_history(
-        {"schema_version": 4, "pattern_profile": profile},
+        {"schema_version": 5, "pattern_profile": profile},
         summary,
     )
 
@@ -463,9 +592,11 @@ def test_all_unknown_cohort_stays_raw_score_unavailable_through_section15_and_cr
     assert baseline["raw_score_comparison_reason"] == (
         adherence_baseline.NO_EVALUABLE_PATTERN_OPPORTUNITIES_REASON
     )
-    assert creator_status.history_enabled is False
+    assert creator_status.history_enabled is True
+    assert creator_status.history_source == "profile"
     assert creator_status.opportunity_rows_available is True
-    assert creator_status.classification_fields_available is False
+    assert creator_status.classification_fields_available is True
+    assert "mastery_and_novelty" in creator_status.available_classification_domains
     assert creator_status.scored_talk_count == 0
 
 
@@ -511,7 +642,7 @@ def test_incomplete_pattern_history_payload_fails_shared_assessor():
     assert assessment.current_contract is False
     assert provenance.REASON_INVALID_CONTRACT in assessment.reason_codes
     assert any(
-        "missing required schema-v4 fields" in error for error in assessment.errors
+        "missing required schema-v5 fields" in error for error in assessment.errors
     )
 
 
@@ -572,10 +703,10 @@ def test_ordinary_section15_prose_never_restores_history():
     assert section15.REASON_BLOCK_MISSING in status.reason_codes
 
 
-def test_current_profile_rows_do_not_authorize_unconfigured_classifications():
+def test_policy_bound_profile_wins_without_merging_section15():
     profile_history = _pattern_profile(note="Profile payload wins.")
     summary_history = _pattern_profile(note="Summary payload must be ignored.")
-    profile = {"schema_version": 4, "pattern_profile": profile_history}
+    profile = {"schema_version": 5, "pattern_profile": profile_history}
     summary = _summary(section15.render_section15_current_block(summary_history))
 
     resolution = pattern_history_status.resolve_creator_pattern_history(
@@ -583,14 +714,15 @@ def test_current_profile_rows_do_not_authorize_unconfigured_classifications():
         summary,
     )
 
-    assert resolution.status.history_enabled is False
+    assert resolution.status.history_enabled is True
     assert resolution.status.opportunity_rows_available is True
-    assert resolution.status.classification_fields_available is False
-    assert resolution.status.history_source is None
-    assert resolution.pattern_profile is None
+    assert resolution.status.classification_fields_available is True
+    assert resolution.status.history_source == "profile"
+    assert resolution.pattern_profile is not None
+    assert resolution.pattern_profile["note"] == "Profile payload wins."
 
 
-def test_current_section15_rows_do_not_authorize_unconfigured_classifications():
+def test_policy_bound_section15_is_used_when_profile_history_is_unavailable():
     summary_history = _pattern_profile()
     summary = _summary(section15.render_section15_current_block(summary_history))
 
@@ -599,13 +731,12 @@ def test_current_section15_rows_do_not_authorize_unconfigured_classifications():
         summary,
     )
 
-    assert resolution.status.history_enabled is False
+    assert resolution.status.history_enabled is True
     assert resolution.status.opportunity_rows_available is True
-    assert resolution.status.history_source is None
-    assert provenance.REASON_CLASSIFICATION_POLICY_UNAVAILABLE in (
-        resolution.status.reason_codes
-    )
-    assert resolution.pattern_profile is None
+    assert resolution.status.classification_fields_available is True
+    assert resolution.status.history_source == "section15_current_block"
+    assert resolution.status.reason_codes == ()
+    assert resolution.pattern_profile == summary_history
 
 
 def test_status_cli_uses_valid_fallback_when_profile_file_is_malformed(
@@ -632,9 +763,10 @@ def test_status_cli_uses_valid_fallback_when_profile_file_is_malformed(
     payload = json.loads(captured.out)
 
     assert return_code == 0
-    assert payload["history_enabled"] is False
+    assert payload["history_enabled"] is True
     assert payload["opportunity_rows_available"] is True
-    assert payload["history_source"] is None
+    assert payload["classification_fields_available"] is True
+    assert payload["history_source"] == "section15_current_block"
 
 
 def test_status_cli_reports_current_rows_without_authorizing_classifications(
@@ -644,10 +776,10 @@ def test_status_cli_reports_current_rows_without_authorizing_classifications(
     profile_path = tmp_path / "speaker-profile.json"
     profile_path.write_text(
         json.dumps(
-            {
-                "schema_version": 4,
-                "pattern_profile": _pattern_profile(),
-            }
+                {
+                    "schema_version": 4,
+                    "pattern_profile": _legacy_pattern_profile(),
+                }
         ),
         encoding="utf-8",
     )
@@ -771,9 +903,7 @@ def test_replace_cli_rejects_invalid_database_locator_before_any_input_io(
     assert return_code == 1
     assert captured.out == ""
     assert input_calls == []
-    assert (
-        f"vault_root_database_path_invalid:{locator_reason}" in captured.err
-    )
+    assert f"vault_root_database_path_invalid:{locator_reason}" in captured.err
     if database_locator.strip():
         assert database_locator not in captured.err
 
@@ -944,10 +1074,7 @@ def test_replace_cli_rejects_symlink_target_locator_mismatch_without_paths(
 
     assert return_code == 1
     assert captured.out == ""
-    assert (
-        "vault_root_authority_mismatch:database_path:config_root"
-        in captured.err
-    )
+    assert "vault_root_authority_mismatch:database_path:config_root" in captured.err
     assert str(storage) not in captured.err
     assert str(locator) not in captured.err
 
@@ -1218,7 +1345,31 @@ def test_replace_rejects_self_consistent_rows_not_present_in_live_database(tmp_p
 
     with pytest.raises(
         section15.Section15PatternHistoryError,
-        match="deterministic rows recomputed",
+        match="exact raw A/E/D/U row",
+    ):
+        section15.replace_section15_current_block(
+            summary_path,
+            profile,
+            database,
+            evidence_freshness_assessor=_fresh_evidence,
+        )
+
+    assert summary_path.read_bytes() == original
+
+
+def test_replace_recomputes_policy_derived_rows_from_live_talks(tmp_path):
+    profile = _pattern_profile()
+    profile["pattern_classifications"][0]["reason_codes"] = [
+        "plausible_but_not_canonical"
+    ]
+    database = _tracking_database(_pattern_profile())
+    summary_path = tmp_path / "rhetoric-style-summary.md"
+    summary_path.write_text(_summary(), encoding="utf-8")
+    original = summary_path.read_bytes()
+
+    with pytest.raises(
+        section15.Section15PatternHistoryError,
+        match="deterministic classifications recomputed",
     ):
         section15.replace_section15_current_block(
             summary_path,
@@ -1294,7 +1445,7 @@ def test_replace_cli_reports_catalog_domain_failure_without_traceback(
     assert summary_path.read_bytes() == original
 
 
-def test_guardrail_suppresses_unconfigured_fallback_classifications(
+def test_guardrail_uses_policy_bound_section15_without_inventing_recurrence(
     guardrail_check,
     tmp_path,
     capsys,
@@ -1317,8 +1468,11 @@ def test_guardrail_suppresses_unconfigured_fallback_classifications(
     checks = {item["name"]: item for item in report["checks"]}
 
     assert return_code == 0
-    assert "Pattern classifications disabled" in checks["Pattern history"]["detail"]
-    assert report["pattern_history"]["history_source"] is None
+    assert "policy-bound domains enabled" in checks["Pattern history"]["detail"]
+    assert report["pattern_history"]["history_source"] == "section15_current_block"
+    assert "antipattern_recurrence" in (
+        report["pattern_history"]["available_classification_domains"]
+    )
     assert report["recurring_antipatterns"] == []
 
 
@@ -1336,9 +1490,11 @@ def test_creator_docs_route_summary_fallback_through_shared_parser():
 
     for text in docs.values():
         assert "section15_pattern_history.py" in text
-    assert "A valid profile always wins" in docs["skill"]
-    assert "summary is a fallback and never merges" in docs["phase0"]
-    assert "sources are never\nmerged" in docs["phase4"]
+    assert "profile with any available domain wins" in docs["skill"]
+    normalized_phase0 = " ".join(docs["phase0"].split())
+    assert "summary is a fallback and never merges" in normalized_phase0
+    normalized_phase4 = " ".join(docs["phase4"].split())
+    assert "sources are never merged" in normalized_phase4
 
 
 def test_ingress_docs_require_live_database_for_current_block_replace():

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -241,6 +241,30 @@ def test_present_invalid_classification_override_aborts_owner_validation(
     assert any("policy fields are noncanonical" in error for error in report["errors"])
 
 
+def test_owner_reports_classification_runtime_failure_as_structured_validation(
+    validate_profile, tmp_path, capsys, monkeypatch
+):
+    profile = _minimal_profile(validate_profile)
+
+    def unavailable_runtime(_vault_root):
+        raise RuntimeError("classification runtime export is unavailable")
+
+    monkeypatch.setattr(
+        validate_profile, "resolve_classification_policy", unavailable_runtime
+    )
+
+    rc = _run(validate_profile, profile, tmp_path)
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+
+    assert rc == 1
+    assert report["valid"] is False
+    assert any(
+        "pattern classification runtime is unavailable" in error
+        for error in report["errors"]
+    )
+
+
 def test_valid_override_is_stamped_and_recomputed_without_talk_reparse(
     validate_profile, tmp_path, capsys
 ):

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -9,6 +9,7 @@ import hashlib
 import importlib
 import json
 import os
+import pathlib
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -28,9 +29,7 @@ def foreign_absolute_locator(name: str) -> str:
 
 
 DOT_SEGMENT_VAULT_ROOT = (
-    r"C:\trusted\other\..\vault"
-    if os.name == "nt"
-    else "/trusted/other/../vault"
+    r"C:\trusted\other\..\vault" if os.name == "nt" else "/trusted/other/../vault"
 )
 INVALID_VAULT_ROOT_LOCATORS = (
     ("", "artifact_locator_empty_or_whitespace"),
@@ -49,9 +48,7 @@ def _catalog_projection(source: str | None = "transcript"):
     """Return exhaustive outcomes for one absence-capable singleton source."""
     catalog = importlib.import_module("pattern_opportunities").load_catalog()
     complete_source = (
-        frozenset({source})
-        if source in {"transcript", "static_slides"}
-        else None
+        frozenset({source}) if source in {"transcript", "static_slides"} else None
     )
     outcomes = []
     not_evaluable = []
@@ -84,20 +81,24 @@ def _catalog_projection(source: str | None = "transcript"):
 def _set_projection(talk, source: str | None) -> None:
     _, outcomes, not_evaluable, assessments = _catalog_projection(source)
     observations = talk["pattern_observations"]
-    observations.update({
-        "pattern_outcomes": outcomes,
-        "not_evaluable": not_evaluable,
-        "applicability_assessments": assessments,
-        "opportunity_coverage_identity": (
-            importlib.import_module("pattern_evidence").opportunity_coverage_identity(
-                outcomes,
-                pattern_catalog_fingerprint=talk["pattern_catalog_fingerprint"],
-                pattern_scoring_schema_version=talk[
-                    "pattern_scoring_schema_version"
-                ],
-            )
-        ),
-    })
+    observations.update(
+        {
+            "pattern_outcomes": outcomes,
+            "not_evaluable": not_evaluable,
+            "applicability_assessments": assessments,
+            "opportunity_coverage_identity": (
+                importlib.import_module(
+                    "pattern_evidence"
+                ).opportunity_coverage_identity(
+                    outcomes,
+                    pattern_catalog_fingerprint=talk["pattern_catalog_fingerprint"],
+                    pattern_scoring_schema_version=talk[
+                        "pattern_scoring_schema_version"
+                    ],
+                )
+            ),
+        }
+    )
 
 
 # Built programmatically per testing-standards (no fixture file). A current
@@ -108,8 +109,14 @@ def _minimal_profile(validate_profile):
         validate_profile.active_pattern_generation_identity()
     )
     opportunities = importlib.import_module("pattern_opportunities")
-    provenance = importlib.import_module("profile_pattern_provenance")
+    classification_runtime = importlib.import_module("pattern_classification_runtime")
     rows = opportunities.build_pattern_opportunity_rows([])
+    classification = classification_runtime.classify_pattern_profile(
+        [],
+        classification_runtime.resolve_classification_policy(
+            pathlib.Path(__file__).resolve().parent / "__no_policy_override__"
+        ),
+    )
     profile = {
         k: []
         for k in (
@@ -129,7 +136,7 @@ def _minimal_profile(validate_profile):
             "design_rules",
             "badges",
         )
-    } | {"schema_version": 4}
+    } | {"schema_version": 5}
     profile["pattern_profile"] = {
         "pattern_baseline": {
             "schema_version": 2,
@@ -154,37 +161,10 @@ def _minimal_profile(validate_profile):
         "eligible_talk_count": 0,
         "talks_scored": 0,
         "average_pattern_score": None,
-        "score_trend": "unavailable",
-        "pattern_breadth": {
-            "avg_distinct_patterns_per_talk": None,
-            "trend": "unavailable",
-            "note": "No current pattern cohort.",
-        },
-        "underused_patterns": [],
-        "score_drivers": {
-            "direction": "unavailable",
-            "antipattern_drivers": [],
-            "pattern_drivers": [],
-            "note": "No current pattern cohort.",
-        },
-        "by_mode": [],
-        "strengths": [],
-        "strengths_note": "No current pattern cohort.",
         "note": "Only current observable patterns are included.",
         "pattern_usage": rows["pattern_usage"],
         "antipattern_frequency": rows["antipattern_frequency"],
-        "never_used_patterns": [],
-        "signature_combinations": [],
-        "mastery_levels": {
-            "signature": [],
-            "regular": [],
-            "occasional": [],
-            "rare": [],
-            "never_tried": [],
-        },
-        "classification_availability": (
-            provenance.unavailable_classification_availability()
-        ),
+        **classification,
     }
     profile["rhetoric_defaults"] = {}
     profile["guardrail_sources"] = {"recurring_issues": []}
@@ -193,9 +173,7 @@ def _minimal_profile(validate_profile):
 
 def _run(validate_profile, profile, tmp_path, *, database=None):
     (tmp_path / "tracking-database.json").write_text(
-        json.dumps(
-            {"config": {}, "talks": []} if database is None else database
-        ),
+        json.dumps({"config": {}, "talks": []} if database is None else database),
         encoding="utf-8",
     )
     path = tmp_path / "profile.json"
@@ -246,6 +224,65 @@ def test_profile_with_engines_validates(validate_profile, tmp_path, capsys):
     out = json.loads(capsys.readouterr().out)
     assert rc == 0
     assert out["valid"] is True
+
+
+def test_present_invalid_classification_override_aborts_owner_validation(
+    validate_profile, tmp_path, capsys
+):
+    profile = _minimal_profile(validate_profile)
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        '{"schema_version": 1}', encoding="utf-8"
+    )
+
+    rc = _run(validate_profile, profile, tmp_path)
+    report = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert any("policy fields are noncanonical" in error for error in report["errors"])
+
+
+def test_valid_override_is_stamped_and_recomputed_without_talk_reparse(
+    validate_profile, tmp_path, capsys
+):
+    profile = _minimal_profile(validate_profile)
+    runtime = importlib.import_module("pattern_classification_runtime")
+    policy = profile["pattern_profile"]["classification_policy"]["semantic_policy"]
+    override = json.loads(json.dumps(policy))
+    override["policy_id"] = "speaker-custom"
+    (tmp_path / "pattern-classification-policy.json").write_text(
+        json.dumps(override), encoding="utf-8"
+    )
+    profile["pattern_profile"].update(
+        runtime.classify_pattern_profile(
+            [], runtime.resolve_classification_policy(tmp_path)
+        )
+    )
+
+    rc = _run(validate_profile, profile, tmp_path)
+    report = json.loads(capsys.readouterr().out)
+
+    assert rc == 0, report
+    assert profile["pattern_profile"]["classification_policy"]["source"] == (
+        "vault_override"
+    )
+
+
+def test_owner_recomputes_derived_fields_instead_of_trusting_self_consistency(
+    validate_profile, tmp_path, capsys
+):
+    profile = _minimal_profile(validate_profile)
+    profile["pattern_profile"]["pattern_classifications"][0]["reason_codes"] = [
+        "plausible_but_not_canonical"
+    ]
+
+    rc = _run(validate_profile, profile, tmp_path)
+    report = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert any(
+        "does not equal the live deterministic classification output" in error
+        for error in report["errors"]
+    )
 
 
 def test_profile_missing_required_key_is_invalid(validate_profile, tmp_path, capsys):
@@ -444,7 +481,9 @@ def _write_vault(vault_root, talks, *, config=None):
             )
             raw_assessments = observations.get("applicability_assessments")
             if record is not None and isinstance(raw_assessments, list):
-                catalog = importlib.import_module("pattern_opportunities").load_catalog()
+                catalog = importlib.import_module(
+                    "pattern_opportunities"
+                ).load_catalog()
                 located = []
                 for assessment in raw_assessments:
                     if not isinstance(assessment, dict):
@@ -463,26 +502,35 @@ def _write_vault(vault_root, talks, *, config=None):
                         "line_end": 1,
                     }
                     for identity_field in (
-                        "artifact_root", "artifact_path", "artifact_sha256",
-                        "timing_artifact_root", "timing_artifact_path",
-                        "timing_artifact_sha256", "quality_artifact_root",
-                        "quality_artifact_path", "quality_artifact_sha256",
+                        "artifact_root",
+                        "artifact_path",
+                        "artifact_sha256",
+                        "timing_artifact_root",
+                        "timing_artifact_path",
+                        "timing_artifact_sha256",
+                        "quality_artifact_root",
+                        "quality_artifact_path",
+                        "quality_artifact_sha256",
                     ):
                         if identity_field in record:
                             citation[identity_field] = record[identity_field]
                     if channel == "timed_transcript":
-                        citation.update({
-                            "start_seconds": 0.0,
-                            "end_seconds": 10.0,
-                        })
-                    located.append({
-                        **assessment,
-                        "evidence_source": "transcript",
-                        "evidence": (
-                            "The complete transcript establishes applicability."
-                        ),
-                        "evidence_citations": [citation],
-                    })
+                        citation.update(
+                            {
+                                "start_seconds": 0.0,
+                                "end_seconds": 10.0,
+                            }
+                        )
+                    located.append(
+                        {
+                            **assessment,
+                            "evidence_source": "transcript",
+                            "evidence": (
+                                "The complete transcript establishes applicability."
+                            ),
+                            "evidence_citations": [citation],
+                        }
+                    )
                 observations["applicability_assessments"] = located
     (vault_root / "tracking-database.json").write_text(
         json.dumps(
@@ -657,34 +705,39 @@ def test_load_vault_projects_confirmed_intents_without_storage_metadata(
         "qr_codes": [],
         "resources": [],
         "thumbnails": [],
-        "confirmed_intents": [{
-            "schema_version": 1,
-            "pattern": "delayed_self_introduction",
-            "intent": "deliberate",
-            "rule": "Use the two-phase introduction",
-            "note": "Speaker-confirmed",
-            "confirmed_date": "2026-08-01",
-            "source_talk": "example.md",
-        }],
+        "confirmed_intents": [
+            {
+                "schema_version": 1,
+                "pattern": "delayed_self_introduction",
+                "intent": "deliberate",
+                "rule": "Use the two-phase introduction",
+                "note": "Speaker-confirmed",
+                "confirmed_date": "2026-08-01",
+                "source_talk": "example.md",
+            }
+        ],
         "improvement_goals": [],
     }
     raw = (json.dumps(database, indent=2) + "\n").encode()
     database_path.write_bytes(raw)
 
-    rc, payload, error = _run_load_vault(
-        load_vault, tmp_path, monkeypatch, capsys
-    )
+    rc, payload, error = _run_load_vault(load_vault, tmp_path, monkeypatch, capsys)
 
     assert rc == 0
     assert error == ""
-    assert payload["confirmed_intents"] == [{
-        "pattern": "delayed_self_introduction",
-        "intent": "deliberate",
-        "rule": "Use the two-phase introduction",
-        "note": "Speaker-confirmed",
-    }]
+    assert payload["confirmed_intents"] == [
+        {
+            "pattern": "delayed_self_introduction",
+            "intent": "deliberate",
+            "rule": "Use the two-phase introduction",
+            "note": "Speaker-confirmed",
+        }
+    ]
     assert list(payload["confirmed_intents"][0]) == [
-        "pattern", "intent", "rule", "note",
+        "pattern",
+        "intent",
+        "rule",
+        "note",
     ]
     assert database_path.read_bytes() == raw
 
@@ -976,9 +1029,7 @@ def test_load_vault_rejects_invalid_explicit_root_before_any_vault_io(
 
     assert rc == 1
     assert captured.out == ""
-    assert (
-        f"vault_root_cli_invalid:{locator_reason}" in captured.err
-    )
+    assert f"vault_root_cli_invalid:{locator_reason}" in captured.err
     assert io_calls == []
     if cli_root.strip():
         assert cli_root not in captured.err
@@ -1019,9 +1070,7 @@ def test_load_vault_rejects_invalid_config_before_summary_or_freshness_io(
     assert rc == 1
     assert captured.out == ""
     assert not (tmp_path / "rhetoric-style-summary.md").exists()
-    assert (
-        f"vault_root_config_invalid:{locator_reason}" in captured.err
-    )
+    assert f"vault_root_config_invalid:{locator_reason}" in captured.err
     if configured_root.strip():
         assert configured_root not in captured.err
 
@@ -1080,10 +1129,7 @@ def test_load_vault_rejects_symlink_target_and_locator_authority_mismatch(
 
     assert rc == 1
     assert captured.out == ""
-    assert (
-        "vault_root_authority_mismatch:database_path:config_root"
-        in captured.err
-    )
+    assert "vault_root_authority_mismatch:database_path:config_root" in captured.err
     assert str(storage) not in captured.err
     assert str(locator) not in captured.err
 
@@ -1212,9 +1258,7 @@ def test_validate_profile_rejects_invalid_cli_root_before_profile_or_database_io
     monkeypatch.setattr(validate_profile, "_load_input", forbidden_io)
     monkeypatch.setattr(validate_profile, "snapshot_tracking_database", forbidden_io)
 
-    rc = validate_profile.main(
-        ["validate-profile.py", "--vault-root", cli_root]
-    )
+    rc = validate_profile.main(["validate-profile.py", "--vault-root", cli_root])
     captured = capsys.readouterr()
 
     assert rc == 1
@@ -1343,10 +1387,7 @@ def test_validate_profile_rejects_symlink_target_locator_mismatch_without_paths(
     captured = capsys.readouterr()
 
     assert rc == 1
-    assert (
-        "vault_root_authority_mismatch:database_path:config_root"
-        in captured.err
-    )
+    assert "vault_root_authority_mismatch:database_path:config_root" in captured.err
     assert str(storage) not in captured.err
     assert str(locator) not in captured.err
 

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -332,6 +332,22 @@ def test_profile_with_outdated_schema_version_is_invalid(
     assert out["schema_version"] == 1
 
 
+@pytest.mark.parametrize("schema_version", [True, 5.0])
+def test_profile_with_type_confused_current_schema_version_is_invalid(
+    validate_profile, schema_version
+):
+    profile = _minimal_profile(validate_profile)
+    profile["schema_version"] = schema_version
+
+    missing, errors, observed_schema_version = validate_profile.validate_profile(
+        profile
+    )
+
+    assert missing == []
+    assert errors == [f"schema_version is {schema_version!r} (expected 5)"]
+    assert observed_schema_version == schema_version
+
+
 # --- load-vault instrumentation partitioning -------------------------------
 
 


### PR DESCRIPTION
## Summary

- Apply the bundled, versioned default classification policy to current scoring-v5 opportunity evidence, with a strict optional vault override.
- Produce policy-bound profile schema v5 and Section 15 v3 data with exhaustive classifications, exact denominators, combinations, trends, and independent domain availability.
- Gate presentation, guardrail, and coaching consumers by the relevant classification domain while preserving raw opportunity rows and avoiding talk reparsing.

Closes #222

## Test plan

- [x] `.venv/bin/pytest -q` — 4574 passed, 3 skipped
- [x] Ruff check and format check on every changed Python file
- [x] Pyright on every changed runtime script — 0 errors
- [x] `tessl plugin lint` — plugin valid
