### PR TITLE
fix(vault-ingress): reserve missing config marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### fix(vault-ingress) — reserve missing config markers (#226)
+
+Typed config mutations now reject the reserved `{"$missing": true}` expectation
+sentinel as a literal value and direct callers to `delete: true`. Vaults that
+already contain the sentinel as a present config value can remove it through the
+normal expectation-bound deletion; its change receipt distinguishes presence
+from absence. The database schema is unchanged and talks do not need reparsing
+for this repair.
+
 ## 0.20.12 — 2026-08-05
 
 ### feat(vault-profile) — ship default pattern classification policy (#222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ### fix(vault-ingress) — reserve missing config markers (#226)
 
 Typed config mutations now reject the reserved `{"$missing": true}` expectation

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -70,6 +70,12 @@ never fall back to whichever `python3` happens to be on `PATH`. Installed plugin
 bundles do not include `pyproject.toml`, so immediately probe the configured
 runtime with the shipped stdlib-only checker:
 
+Remove obsolete config fields with `delete: true`; never pass the missing marker
+as a `value`. If the owner read exposes that marker as a present legacy value,
+use the expectation-bound deletion in
+[schemas-db.md](schemas-db.md#owner-read-and-mutation-contract), then re-read
+before another config write.
+
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
   --lanes core,pdf,pptx

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -313,10 +313,33 @@ Agent-owned config and catalog changes use a typed plan:
 }
 ```
 
+Delete a config field with `delete: true`; never pass the missing marker as a
+`value`:
+
+```json
+{
+  "schema_version": 1,
+  "mutations": [{
+    "kind": "set_config",
+    "path": ["talks_source_dir"],
+    "expect": "/prior/path",
+    "delete": true
+  }]
+}
+```
+
 Every plan is strict JSON with exactly `schema_version` and a non-empty
 `mutations` array. Every expectation is either the exact decoded value/record
 seen by the owner reader or the exact missing marker `{"$missing": true}`. JSON
 `null` is a present value and is never interchangeable with that marker.
+The exact missing marker is reserved and invalid as a `set_config` value. A
+legacy writer may already have persisted that marker literally. A deletion with
+the missing-marker expectation is idempotent across both recoverable states: an
+absent field stays unchanged, while the exact present marker is removed. Any
+other present value fails the precondition. A recovery change receipt adds
+`before_exists: true` and `after_exists: false` to distinguish the literal old
+marker from the absent `after` marker. Run the usual dry-run, hash-bound apply,
+and owner re-read sequence.
 The plan decoder applies the same finite-number round-trip, 200-container depth,
 and Unicode-scalar gates as the database decoder, so a reviewed value cannot
 silently change or fail later during rendering.

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -616,6 +616,11 @@ def _apply_set_config(
         raise TrackingDatabaseMutationError(
             f"mutations[{index}] must set exactly one of value or delete:true"
         )
+    if has_value and json_values_equal(mutation["value"], MISSING_MARKER):
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].value cannot equal the reserved missing marker; "
+            "use delete:true to remove a config field"
+        )
     path = mutation["path"]
     if (
         not isinstance(path, list)
@@ -652,7 +657,19 @@ def _apply_set_config(
     leaf = path[-1]
     exists = leaf in parent
     actual = parent.get(leaf)
-    _expect_value(exists=exists, actual=actual, expected=mutation["expect"], label=label)
+    recovering_reserved_marker = (
+        delete
+        and exists
+        and json_values_equal(actual, MISSING_MARKER)
+        and json_values_equal(mutation["expect"], MISSING_MARKER)
+    )
+    if not recovering_reserved_marker:
+        _expect_value(
+            exists=exists,
+            actual=actual,
+            expected=mutation["expect"],
+            label=label,
+        )
     before: object = actual if exists else MISSING_MARKER
     if delete:
         parent.pop(leaf, None)
@@ -660,6 +677,18 @@ def _apply_set_config(
     else:
         after = copy.deepcopy(mutation["value"])
         parent[leaf] = after
+    if recovering_reserved_marker:
+        changes.append(
+            {
+                "kind": "set_config",
+                "identity": ".".join(path),
+                "before": copy.deepcopy(before),
+                "after": copy.deepcopy(after),
+                "before_exists": True,
+                "after_exists": False,
+            }
+        )
+        return
     _record_change(
         changes,
         kind="set_config",

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -849,6 +849,122 @@ def test_delete_missing_nested_config_preserves_exact_expectations(
         )
 
 
+def test_set_config_rejects_reserved_missing_marker_value(
+    mutate_tracking_database,
+) -> None:
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="value cannot equal the reserved missing marker",
+    ):
+        mutate_tracking_database.build_candidate(
+            _base_database(),
+            [
+                {
+                    "kind": "set_config",
+                    "path": ["legacy"],
+                    "expect": MISSING,
+                    "value": MISSING,
+                }
+            ],
+        )
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        _base_database(),
+        [
+            {
+                "kind": "set_config",
+                "path": ["ordinary_object"],
+                "expect": MISSING,
+                "value": {"$missing": 1},
+            }
+        ],
+    )
+    assert candidate["config"]["ordinary_object"] == {"$missing": 1}
+
+
+def test_delete_recovers_persisted_reserved_missing_marker(
+    mutate_tracking_database,
+    tmp_path: Path,
+) -> None:
+    database = _base_database()
+    database["config"]["legacy"] = copy.deepcopy(MISSING)
+
+    database_path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    _write_json(database_path, database)
+    _write_json(
+        plan_path,
+        {
+            "schema_version": 1,
+            "mutations": [
+                {
+                    "kind": "set_config",
+                    "path": ["legacy"],
+                    "expect": MISSING,
+                    "delete": True,
+                }
+            ],
+        },
+    )
+    before = database_path.read_bytes()
+
+    dry_run = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=False,
+        expected_sha256=None,
+    )
+    assert dry_run["changed"] is True
+    assert dry_run["database_written"] is False
+    assert database_path.read_bytes() == before
+    assert dry_run["changes"] == [
+        {
+            "kind": "set_config",
+            "identity": "legacy",
+            "before": MISSING,
+            "after": MISSING,
+            "before_exists": True,
+            "after_exists": False,
+        }
+    ]
+
+    applied = mutate_tracking_database.execute(
+        database_path,
+        plan_path,
+        apply=True,
+        expected_sha256=dry_run["input_sha256"],
+    )
+    result = json.loads(database_path.read_text(encoding="utf-8"))
+    assert applied["database_written"] is True
+    assert applied["changes"] == dry_run["changes"]
+    assert "legacy" not in result["config"]
+
+
+@pytest.mark.parametrize("legacy_value", [None, {"$missing": 1}, "value"])
+def test_missing_expectation_recovery_rejects_other_present_values(
+    mutate_tracking_database,
+    legacy_value: object,
+) -> None:
+    database = _base_database()
+    database["config"]["legacy"] = legacy_value
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="expected a missing value",
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                {
+                    "kind": "set_config",
+                    "path": ["legacy"],
+                    "expect": MISSING,
+                    "delete": True,
+                }
+            ],
+        )
+
+
 def test_boolean_plan_and_record_schema_versions_are_rejected(
     mutate_tracking_database,
     tmp_path: Path,

--- a/tests/test_tracking_database_mutation_docs.py
+++ b/tests/test_tracking_database_mutation_docs.py
@@ -1,0 +1,23 @@
+"""Regression guards for the typed config-mutation contract."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_config_deletion_and_reserved_marker_recovery_are_documented() -> None:
+    schema = _read("skills/vault-ingress/references/schemas-db.md")
+    bootstrap = _read("skills/vault-ingress/references/bootstrap-and-preflight.md")
+    normalized_schema = " ".join(schema.split())
+    normalized_bootstrap = " ".join(bootstrap.split())
+
+    assert '"delete": true' in schema
+    assert "invalid as a `set_config` value" in normalized_schema
+    assert "Any other present value fails the precondition" in normalized_schema
+    assert "`before_exists: true` and `after_exists: false`" in schema
+    assert "never pass the missing marker as a `value`" in normalized_bootstrap


### PR DESCRIPTION
## Summary

- reject the reserved missing expectation marker as a literal set_config value
- recover an already-persisted marker through the normal expectation-bound deletion and emit an unambiguous presence receipt
- document deletion/recovery and add behavioral plus documentation regressions

Closes #226

## Test plan

- [x] .venv/bin/python -m pytest -q (4682 passed, 3 skipped)
- [x] focused mutation/docs tests (48 passed)
- [x] Ruff check and Pyright
- [x] tessl plugin lint