### PR TITLE
fix(vault-ingress): allow nested PPTX discovery runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### fix(vault-ingress) — allow nested PPTX discovery runtimes (#228)
+
+Bounded PPTX directory discovery now permits its exact configured Python and
+fixed worker entrypoint to live beneath the scanned presentation root while
+continuing to reject sensitive paths in mutable process arguments. A
+whole-root discovery failure emits a structured top-level error and exits
+nonzero instead of looking like a successful empty scan. Existing talk
+analysis is unchanged; rerun the PPTX catalog scan where discovery previously
+reported only a root failure.
+
 ## 0.20.13 — 2026-08-05
 
 ### fix(vault-ingress) — reserve missing config markers (#226)

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -163,6 +163,12 @@ array produces zero arguments; never add an implicit default.
   --directory "{pptx_source_dir}" {template_skip_arguments}
 ```
 
+Require exit status zero before consuming `results[]` or `skipped[]`. A
+whole-root discovery failure exits nonzero and emits a compact top-level
+`error` containing the public `reason_code` plus any closed
+`details.supervisor_reason_code`; report both and stop the PPTX scan. Never
+reinterpret that failure's root `skipped[]` receipt as a successful empty scan.
+
 Use root-relative `results[].pptx_path` identities to fuzzy-match `talks[]` entries
 and retain every `skipped[]` receipt. `pptx_batch_office_lock_file` is an explicit
 exclusion: never catalog or extract an Office temporary file whose basename starts

--- a/skills/vault-ingress/scripts/artifact_supervisor.py
+++ b/skills/vault-ingress/scripts/artifact_supervisor.py
@@ -437,6 +437,7 @@ def run_authenticated_worker(
     limits: SupervisorLimits,
     *,
     credentials: WorkerCredentials | None = None,
+    immutable_process_identity: Sequence[str | os.PathLike[str]] = (),
     sensitive_values: Sequence[str | os.PathLike[str]] = (),
     schema_generation: int = 1,
     pipeline_generation: str = PROTOCOL_VERSION,
@@ -454,9 +455,19 @@ def run_authenticated_worker(
     controls never learns an artifact path or authentication key.  POSIX process
     groups are cleanup boundaries for trusted worker code, not portable security
     sandboxes against a worker that deliberately creates another session.
+
+    ``immutable_process_identity`` may name the command's exact two-path
+    interpreter/entrypoint prefix. Those paths may sit strictly below a
+    sensitive directory root; every later argv element remains subject to the
+    normal process-metadata rejection, and all sensitive values remain active
+    for environment and diagnostic redaction.
     """
 
     command_parts = _validate_command(command)
+    identity_parts = _validate_immutable_process_identity(
+        command_parts,
+        immutable_process_identity,
+    )
     selected_credentials = credentials or WorkerCredentials.generate()
     pending = _prepare_request(
         operation,
@@ -471,7 +482,11 @@ def run_authenticated_worker(
     inferred_sensitive = _payload_sensitive_strings(pending.request.payload)
     declared_sensitive = tuple(str(value) for value in sensitive_values if str(value))
     redactions = tuple(dict.fromkeys((*declared_sensitive, *inferred_sensitive)))
-    _reject_sensitive_process_metadata(command_parts, redactions)
+    _reject_sensitive_process_metadata(
+        command_parts,
+        redactions,
+        immutable_process_identity=identity_parts,
+    )
     environment = _sanitized_environment(redactions)
     response_redactions = (
         *redactions,
@@ -2047,11 +2062,51 @@ def _payload_sensitive_strings(payload: JsonValue) -> tuple[str, ...]:
     return tuple(dict.fromkeys(found))
 
 
+def _validate_immutable_process_identity(
+    command: Sequence[str],
+    identity: Sequence[str | os.PathLike[str]],
+) -> tuple[str, ...]:
+    """Bind two absolute identity paths to the exact fixed command prefix."""
+    if not identity:
+        return ()
+    identity_parts = tuple(_validate_command(identity))
+    if (
+        len(identity_parts) != 2
+        or not all(os.path.isabs(part) for part in identity_parts)
+        or tuple(command[:2]) != identity_parts
+    ):
+        raise SupervisorError("invalid_worker_command")
+    return identity_parts
+
+
+def _is_strict_path_descendant(candidate: str, root: str) -> bool:
+    """Return lexical containment without resolving or touching either path."""
+    if not os.path.isabs(candidate) or not os.path.isabs(root):
+        return False
+    candidate_path = os.path.normcase(os.path.normpath(candidate))
+    root_path = os.path.normcase(os.path.normpath(root))
+    if candidate_path == root_path:
+        return False
+    try:
+        return os.path.commonpath((candidate_path, root_path)) == root_path
+    except ValueError:
+        return False
+
+
 def _reject_sensitive_process_metadata(
-    command: Sequence[str], values: Sequence[str]
+    command: Sequence[str],
+    values: Sequence[str],
+    *,
+    immutable_process_identity: Sequence[str] = (),
 ) -> None:
-    if any(value and value in part for value in values for part in command):
-        raise SupervisorError("unsafe_worker_process_metadata")
+    identity_length = len(immutable_process_identity)
+    for index, part in enumerate(command):
+        for value in values:
+            if not value or value not in part:
+                continue
+            if index < identity_length and _is_strict_path_descendant(part, value):
+                continue
+            raise SupervisorError("unsafe_worker_process_metadata")
 
 
 def _sanitized_environment(sensitive_values: Sequence[str]) -> dict[str, str]:

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -2203,6 +2203,7 @@ def _run_supervised_directory_discovery(directory, skip_patterns, *, deadline):
             {},
             {"root_path": root, "skip_patterns": patterns},
             limits,
+            immutable_process_identity=command[:2],
             sensitive_values=(root,),
             schema_generation=SCHEMA_VERSION,
             pipeline_generation=PIPELINE_VERSION,
@@ -2229,6 +2230,7 @@ def _run_supervised_directory_discovery(directory, skip_patterns, *, deadline):
         raise PptxEvidenceError(
             "bounded directory discovery failed",
             reason_code=reason,
+            details={"supervisor_reason_code": exc.reason_code},
         ) from exc
     return _decode_directory_manifest(result.payload)
 
@@ -2299,6 +2301,23 @@ def _encode_batch_output(results, skipped):
     ).encode("utf-8")
 
 
+def _encode_batch_failure(error):
+    """Encode one path-neutral whole-root failure for machine callers."""
+    details = {}
+    supervisor_reason = error.details.get("supervisor_reason_code")
+    if isinstance(supervisor_reason, str):
+        details["supervisor_reason_code"] = supervisor_reason
+    return json.dumps(
+        {
+            "results": [],
+            "skipped": [{"path": ".", "reason": error.reason_code}],
+            "error": {"reason_code": error.reason_code, "details": details},
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
 def _encoded_json_size(value):
     return len(
         json.dumps(
@@ -2328,16 +2347,11 @@ def batch_extract(directory, skip_patterns, *, ocr=True):
     started = time.monotonic()
     deadline = started + _BATCH_MAX_WALL_SECONDS
     root = Path(_validated_directory_root(directory))
-    try:
-        relative_files, skipped = _run_supervised_directory_discovery(
-            root,
-            skip_patterns,
-            deadline=deadline,
-        )
-    except PptxEvidenceError as exc:
-        if exc.reason_code in _DIRECTORY_BATCH_FAILURE_REASONS:
-            return [], [{"path": ".", "reason": exc.reason_code}]
-        raise
+    relative_files, skipped = _run_supervised_directory_discovery(
+        root,
+        skip_patterns,
+        deadline=deadline,
+    )
     discovered = [
         (root.joinpath(*relative.split("/")), relative) for relative in relative_files
     ]
@@ -2516,6 +2530,8 @@ def main(argv=None):
         try:
             results, skipped = batch_extract(args.path, args.skip or [], ocr=ocr)
         except PptxEvidenceError as exc:
+            if exc.reason_code in _DIRECTORY_BATCH_FAILURE_REASONS:
+                sys.stdout.write(_encode_batch_failure(exc).decode("utf-8") + "\n")
             print(f"ERROR: {exc.reason_code}", file=sys.stderr)
             return 1
         sys.stdout.write(_encode_batch_output(results, skipped).decode("utf-8") + "\n")

--- a/tests/test_artifact_supervisor.py
+++ b/tests/test_artifact_supervisor.py
@@ -1460,6 +1460,99 @@ def test_request_input_cap_and_sensitive_argv_fail_before_process_start(tmp_path
     assert unsafe.value.reason_code == "unsafe_worker_process_metadata"
 
 
+def test_immutable_worker_identity_may_be_nested_below_sensitive_root(tmp_path):
+    root = tmp_path / "Presentations"
+    command = [
+        str(root / ".venv" / "bin" / "python3"),
+        str(root / "vault" / "worker.py"),
+        "--worker",
+    ]
+    starts = []
+
+    def fail_after_metadata_check(parts, **_kwargs):
+        starts.append(parts)
+        raise OSError("fixture stops before process creation")
+
+    with pytest.raises(artifact_supervisor.SupervisorError) as caught:
+        artifact_supervisor.run_authenticated_worker(
+            command,
+            "probe",
+            {},
+            {"root_path": str(root)},
+            _limits(),
+            immutable_process_identity=command[:2],
+            sensitive_values=(root,),
+            process_backend=fail_after_metadata_check,
+        )
+
+    assert caught.value.reason_code == "worker_start_failed"
+    assert starts == [command]
+
+
+def test_immutable_worker_identity_never_exempts_sensitive_mutable_argv(tmp_path):
+    root = tmp_path / "Presentations"
+    command = [
+        str(root / ".venv" / "bin" / "python3"),
+        str(root / "vault" / "worker.py"),
+        "--root",
+        str(root),
+    ]
+    starts = []
+
+    with pytest.raises(artifact_supervisor.SupervisorError) as caught:
+        artifact_supervisor.run_authenticated_worker(
+            command,
+            "probe",
+            {},
+            {"root_path": str(root)},
+            _limits(),
+            immutable_process_identity=command[:2],
+            sensitive_values=(root,),
+            process_backend=lambda *args, **kwargs: starts.append((args, kwargs)),
+        )
+
+    assert caught.value.reason_code == "unsafe_worker_process_metadata"
+    assert starts == []
+
+
+@pytest.mark.parametrize(
+    "identity_kind",
+    ["short", "long", "relative", "different_prefix"],
+)
+def test_immutable_worker_identity_must_be_exact_two_absolute_prefix_paths(
+    tmp_path,
+    identity_kind,
+):
+    root = tmp_path / "Presentations"
+    command = [
+        str(root / ".venv" / "bin" / "python3"),
+        str(root / "vault" / "worker.py"),
+        "--worker",
+    ]
+    identities = {
+        "short": command[:1],
+        "long": command,
+        "relative": ["python3", command[1]],
+        "different_prefix": [command[0], str(root / "vault" / "other.py")],
+    }
+
+    with pytest.raises(artifact_supervisor.SupervisorError) as caught:
+        artifact_supervisor.run_authenticated_worker(
+            command,
+            "probe",
+            {},
+            {"root_path": str(root)},
+            _limits(),
+            immutable_process_identity=identities[identity_kind],
+            sensitive_values=(root,),
+            process_backend=lambda *_args, **_kwargs: pytest.fail(
+                "invalid identity reached process creation"
+            ),
+        )
+
+    assert caught.value.reason_code == "invalid_worker_command"
+
+
 def test_sensitive_payload_keys_and_environment_names_are_removed(monkeypatch):
     sensitive = "/private/vault/secret-deck.pptx"
     sensitive_name = f"PREFIX_{sensitive}_SUFFIX"

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -587,6 +587,7 @@ def test_directory_owner_never_touches_root_before_authenticated_manifest(
     assert limits.profile_id == "pptx-directory-discovery-v1"
     assert kwargs["schema_generation"] == pptx_extraction.SCHEMA_VERSION
     assert kwargs["pipeline_generation"] == pptx_extraction.PIPELINE_VERSION
+    assert kwargs["immutable_process_identity"] == command[:2]
 
 
 def test_directory_cli_passes_only_the_exact_configured_skip_patterns(
@@ -828,18 +829,18 @@ def test_directory_discovery_timeout_blocks_every_extraction(
         lambda *_args, **_kwargs: pytest.fail("timeout launched an extractor"),
     )
 
-    results, skipped = pptx_extraction.batch_extract(
-        "/blocked/discovery", [], ocr=False
-    )
+    with pytest.raises(pptx_extraction.PptxEvidenceError) as caught:
+        pptx_extraction.batch_extract("/blocked/discovery", [], ocr=False)
 
-    assert results == []
-    assert skipped == [{"path": ".", "reason": "pptx_batch_discovery_timeout"}]
+    assert caught.value.reason_code == "pptx_batch_discovery_timeout"
+    assert caught.value.details == {"supervisor_reason_code": "worker_timeout"}
 
 
 @pytest.mark.parametrize(
     ("supervisor_reason", "expected_reason"),
     [
         ("worker_memory_limit_exceeded", "pptx_batch_discovery_resource_unavailable"),
+        ("unsafe_worker_process_metadata", "pptx_batch_discovery_start_failure"),
         ("worker_start_failed", "pptx_batch_discovery_start_failure"),
         ("worker_exit", "pptx_batch_discovery_worker_failure"),
         (
@@ -862,14 +863,42 @@ def test_directory_supervisor_failures_keep_closed_reason_distinctions(
         ),
     )
 
-    results, skipped = pptx_extraction.batch_extract(
-        "/lexical/root",
-        [],
-        ocr=False,
+    with pytest.raises(pptx_extraction.PptxEvidenceError) as caught:
+        pptx_extraction.batch_extract(
+            "/lexical/root",
+            [],
+            ocr=False,
+        )
+
+    assert caught.value.reason_code == expected_reason
+    assert caught.value.details == {"supervisor_reason_code": supervisor_reason}
+
+
+def test_directory_cli_returns_nonzero_structured_discovery_failure(
+    pptx_extraction,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(
+        pptx_extraction,
+        "run_authenticated_worker",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            pptx_extraction.SupervisorError("unsafe_worker_process_metadata")
+        ),
     )
 
-    assert results == []
-    assert skipped == [{"path": ".", "reason": expected_reason}]
+    assert pptx_extraction.main(["--directory", "/lexical/root", "--no-ocr"]) == 1
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "results": [],
+        "skipped": [{"path": ".", "reason": "pptx_batch_discovery_start_failure"}],
+        "error": {
+            "reason_code": "pptx_batch_discovery_start_failure",
+            "details": {"supervisor_reason_code": "unsafe_worker_process_metadata"},
+        },
+    }
+    assert captured.err == "ERROR: pptx_batch_discovery_start_failure\n"
 
 
 def test_directory_identity_zero_is_reported_instead_of_silently_deduplicated(


### PR DESCRIPTION
## Summary

- allow the exact configured Python/worker identity to be nested beneath a sensitive PPTX scan root without exempting mutable argv
- preserve redaction and reject malformed or mismatched identity declarations before process start
- make whole-root PPTX discovery failures structured, nonzero CLI outcomes instead of successful empty scans
- document the exit-status contract and catalog rerun requirement

Closes #228.

## Verification

- `uv run --extra test pytest -q` — 4686 passed, 3 skipped
- focused supervisor/PPTX suite — 215 passed
- Ruff on all changed Python files — clean
- Pyright on changed production modules with the project venv — clean
- `tessl plugin lint` — valid
- configured nested-runtime discovery probe — successful
