### PR TITLE
fix(vault-ingress): make PPTX directory completeness explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### fix(vault-ingress) — make PPTX directory completeness explicit (#234)
+
+PPTX directory extraction now emits a strict schema-v1 batch envelope whose
+closed skip receipts determine `complete` and `incomplete_reason_codes`.
+Partial scans keep safe per-deck results and exit zero, while only a complete
+scan authorizes full-catalog or missing-deck conclusions; whole-root and
+protocol failures still exit nonzero. The private discovery manifest advances
+to v2 so its authenticated response carries the same recomputable decision.
+
+Config schema v2 adds bounded, case-insensitive exact-component
+`pptx_directory_exclusions` with narrow environment/cache defaults. The owner
+migration upgrades config v1 without changing root schema v1, preserves a
+valid custom list, and prunes each configured real directory with one explicit
+policy receipt after symlink/reparse checks. Exclusions use a separate bounded
+enumeration allowance so they cannot consume the eligible-entry budget, and the
+private response is bound back to the exact requested policy. Public whole-root
+errors reject per-deck reason promotion and arbitrary/path-bearing details.
+Per-deck PPTX extractor schema v4
+and pipeline 1.5.0 are unchanged; existing talk evidence does not require
+reparsing solely for this release.
+
 ## 0.20.15 — 2026-08-05
 
 ### fix(vault-ingress) — allow nested PPTX batch workers (#233)

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -76,14 +76,15 @@ state:
 
 Exit 0 writes one JSON object with `from_schema_version`,
 `to_schema_version`, `changed`, `database_written: false`, `input_sha256`, and
-`record_counts`. Continue only for `changed: false` at database schema v1. A
-legacy report requires the owner workflow; invoke `Skill(skill: "vault-ingress")`
+`record_counts`. Continue only for `changed: false` at database schema v1 with
+config schema v2. A legacy root or config report requires the owner workflow;
+invoke `Skill(skill: "vault-ingress")`
 with the migration report as handoff context, then finish this clarification run.
 Exit 2 writes one error object to stdout plus an `ERROR:` diagnostic to stderr;
 stop without changing session state.
 
 Every tracking write in Steps 2–8 is current-only. Preserve database schema 1,
-config schema 1, talk schema 5, and every unrelated record. Stamp confirmed
+config schema 2, talk schema 5, and every unrelated record. Stamp confirmed
 intents with schema 1 and new improvement goals with schema 2. Capture the exact
 input bytes immediately before each write, reject a changed generation, validate
 the complete current shape, and use a same-directory atomic replacement. Never
@@ -233,7 +234,7 @@ Using the latest strict read, persist
 `config.clarification_sessions_completed + 1` with `set_config`, expecting the
 exact prior integer. This counter gates profile generation (vault-profile skill
 requires >= 1).
-The owner mutation preserves `config.schema_version: 1` and every unrelated
+The owner mutation preserves `config.schema_version: 2` and every unrelated
 field.
 
 Finish here.

--- a/skills/vault-clarification/references/schemas-config.md
+++ b/skills/vault-clarification/references/schemas-config.md
@@ -34,8 +34,10 @@ only) when empty. The question column shows what to ask the speaker.
 
 See the canonical schema and field reference in
 [../../vault-profile/references/schemas-config.md](../../vault-profile/references/schemas-config.md).
-That file also documents the migration path for vaults created before the
-unified `shownotes` block.
+Current writes preserve config schema v2, including the owner-validated
+`pptx_directory_exclusions`; config v1 is owner-migration input, not writable
+session state. That file also documents the migration path for the exclusion
+field and for vaults created before the unified `shownotes` block.
 
 ## Confirmed Intents Schema
 

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -183,10 +183,14 @@ extraction and select only unmatched entries, PDF-primary talks with a PPTX, or
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py" \
-  --directory "{pptx_source_dir}" {template_skip_arguments}
+  --directory "{pptx_source_dir}" {template_skip_arguments} \
+  {directory_exclusion_arguments}
 ```
 
-Use only current schema-v4, artifact-bound evidence and the reference's matching,
+Reuse both exact config-derived argument sets from Step 1. Safely extracted deck
+results in a partial schema-v1 directory envelope remain usable, but only
+`complete: true` authorizes a full-catalog or missing-deck conclusion. Use only
+current schema-v4, artifact-bound deck evidence and the reference's matching,
 rendered-page, OCR, and cross-talk rules. Proceed to Step 7.
 
 ## Step 7 — Regenerate Speaker Profile

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -11,10 +11,13 @@ each section in order; later sections assume every earlier gate succeeded.
 2. **Path missing** — first-time setup: ask preferred location via `AskUserQuestion`,
    create the directory (and symlink if a custom path was chosen), then use a sole
    `initialize_database` mutation. Include database `schema_version: 1`, config
-   `schema_version: 1`, and empty `talks`, `pptx_catalog`, `qr_codes`, `resources`,
-   `thumbnails`, `confirmed_intents`, and `improvement_goals` arrays. Review the
-   dry-run and apply it with `--expected-sha256 missing`; never create the JSON
-   file directly.
+   `schema_version: 2`, and empty `talks`, `pptx_catalog`, `qr_codes`, `resources`,
+   `thumbnails`, `confirmed_intents`, and `improvement_goals` arrays. The plan may
+   omit `pptx_directory_exclusions`; the initializer supplies the canonical default
+   defined by the [PPTX scan contract](#scan-for-pptx-files). Include that field
+   only when the speaker explicitly requests a valid customization.
+   Review the dry-run and apply it with `--expected-sha256 missing`; never create
+   the JSON file directly.
 
 **Schema gate** — vault-ingress owns the tracking database shape and migrations.
 The stdlib-only strict reader may use the host interpreter for the initial
@@ -42,7 +45,10 @@ changed report authorizes this exact apply command:
 
 Exit 0 from apply writes one JSON report with `database_written: true`, preserves
 the complete original bytes under `{vault_root}/.backups/`, and atomically
-installs database schema v1. A non-empty `warnings` array means replacement
+installs database schema v1 with config schema v2. A current root with config
+schema v1 is also a migration: root `from_schema_version` and
+`to_schema_version` both remain `1`, while `record_counts.config` records the
+config upgrade. A non-empty `warnings` array means replacement
 completed with a durability warning and must not be reported as a failed/no-write
 run. Exit 2 writes one error object to stdout plus a diagnostic to stderr and
 leaves the database unchanged. Recover or
@@ -56,11 +62,15 @@ migration dry-run, then apply its new exact digest. Do not copy a digest across
 runs. `queue-state.py ... normalize` and `queue-state.py ... claim` require
 database schema 1.
 
-**Config bootstrapping** — ask once per missing field and persist to the tracking
+**Config bootstrapping** — ask once per missing user-owned field and persist to the tracking
 database with expectation-bound `set_config` mutations. Re-read after every
 successful apply and use the new hash for the next plan. Core fields: `shownotes` (enabled, source.type, source.path_or_url,
 source.talks_subdir, url.base, url.template, thumbnail_path_template,
-slug_convention), `pptx_source_dir`, `python_path`, `template_skip_patterns`.
+slug_convention), `pptx_source_dir`, `python_path`, `template_skip_patterns`,
+and `pptx_directory_exclusions`. The exclusion field is not a missing-field
+question: initialization supplies the canonical default, while migration supplies
+that default when absent or preserves an existing valid custom list. Ask about or
+change it only when the speaker explicitly wants to customize directory pruning.
 See [schemas-db.md](schemas-db.md) for the full schema and
 [schemas-config.md](../../vault-profile/references/schemas-config.md) for
 field-by-field semantics and migration notes.
@@ -81,7 +91,8 @@ before another config write.
   --lanes core,pdf,pptx
 ```
 
-All owner-authored tracking writes below require database schema 1 after this
+All owner-authored tracking writes below require database schema 1 and config
+schema 2 after this
 gate. Preserve every independent record version and validate the complete
 candidate before installing it. Only `migrate-tracking-database.py` may move
 schema 0 to schema 1; its hash precondition binds replacement to the exact input
@@ -153,26 +164,52 @@ for the complete report and mutation contract.
 directory extraction, which owns deterministic discovery, symlink/reparse-point
 rejection, and aggregate file/input/output/wall budgets:
 
-Read the exact `config.template_skip_patterns` array from the strict owner-read
-result. Set `{template_skip_arguments}` to one separately shell-quoted
+Read the exact `config.template_skip_patterns` and
+`config.pptx_directory_exclusions` arrays from the strict owner-read result.
+Set `{template_skip_arguments}` to one separately shell-quoted
 `--skip=<exact-value>` argument per array entry, preserving its order. An empty
 array produces zero arguments; never add an implicit default.
+Set `{directory_exclusion_arguments}` the same way, using one
+`--exclude-directory=<exact-component>` argument per exclusion. These are
+case-insensitive exact directory-name components at any descendant depth—not
+substrings, paths, globs, or regular expressions. The sole config-v2 owner-default
+source is
+`skills/vault-ingress/scripts/pptx_discovery_contract.py::DEFAULT_PPTX_DIRECTORY_EXCLUSIONS`;
+do not copy or reconstruct that list in workflow prose.
+Do not broaden that code-owned default to plausible authored-content directory
+names without an explicit speaker-specific customization.
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/pptx-extraction.py" \
-  --directory "{pptx_source_dir}" {template_skip_arguments}
+  --directory "{pptx_source_dir}" {template_skip_arguments} \
+  {directory_exclusion_arguments}
 ```
 
-Require exit status zero before consuming `results[]` or `skipped[]`. A
+Require exit status zero before consuming the public schema-v1
+`pptx_directory_batch` envelope's `results[]` or `skipped[]`. A
 whole-root discovery failure exits nonzero and emits a compact top-level
 `error` containing the public `reason_code` plus any closed
 `details.supervisor_reason_code`; report both and stop the PPTX scan. Never
 reinterpret that failure's root `skipped[]` receipt as a successful empty scan.
 
+On exit zero, `complete` is true exactly when `incomplete_reason_codes` is
+empty. A partial scan deliberately still exits zero so its safely extracted
+per-deck results can be reviewed and persisted. Preserve those results and all
+skip receipts, report the incomplete reasons, and rerun after remediation. Only
+`complete: true` proves that all eligible descendants were considered; without
+it, never claim full catalog coverage, infer that a missing deck does not exist,
+or convert an empty result into an absence conclusion. Legacy unversioned
+`{"results": ..., "skipped": ...}` output has unknown completeness and must be
+rerun before any coverage or absence claim.
+
 Use root-relative `results[].pptx_path` identities to fuzzy-match `talks[]` entries
-and retain every `skipped[]` receipt. `pptx_batch_office_lock_file` is an explicit
-exclusion: never catalog or extract an Office temporary file whose basename starts
-with `~$`. Directory intent must remain explicit: do not omit `--directory` or
+and retain every `skipped[]` receipt. Treat the envelope's `complete` and
+`incomplete_reason_codes` fields as authoritative; never reclassify receipts by
+reason string. Configured exclusion dirents use a separate bounded
+policy-enumeration allowance rather than the eligible-entry budget, so policy
+pruning cannot hide an authored sibling; exhausting that allowance fails closed.
+Directory intent must remain explicit:
+do not omit `--directory` or
 pre-probe the root with `find`, a recursive glob, or a per-file loop. The bounded
 authenticated discovery worker owns root validation and enumeration. Report counts,
 then persist each reviewed result with a `record_pptx`

--- a/skills/vault-ingress/references/pptx-followup.md
+++ b/skills/vault-ingress/references/pptx-followup.md
@@ -11,9 +11,15 @@ that used PDF as primary but have a PPTX available, or entries with
 `pptx_visual_status: "pending"`. Skip if already `"extracted"`. Use the bounded directory invocation from
 [bootstrap-and-preflight.md](bootstrap-and-preflight.md) and select the root-relative results that
 remain pending; do not replace it with `**/*.pptx` or a shell/per-file extraction
-loop. Reuse the exact config-derived `{template_skip_arguments}` (including zero
-arguments for an empty array), keep the explicit `--directory` flag, preserve every
-bounded skip receipt, and never admit a `~$` Office lock file.
+loop. Reuse the exact config-derived `{template_skip_arguments}` and
+`{directory_exclusion_arguments}` (including zero arguments for either empty
+array), keep the explicit `--directory` flag, preserve every bounded skip
+receipt, and never admit a `~$` Office lock file. Require the public schema-v1
+`pptx_directory_batch` envelope. Safely extracted results from a partial batch
+remain usable, but only `complete: true` authorizes a full-catalog conclusion,
+a claim that a missing deck does not exist, or absence inferred from an empty
+result. Legacy unversioned batch output has unknown completeness and must be
+rerun before any such claim.
 Require schema v4 for current analysis. Regenerate v0-v3 output and stop on an
 unknown future schema rather than interpreting missing fields as zero. When
 rendered pages were inspected, rerun that selected deck as one supervised
@@ -31,6 +37,10 @@ shownotes entries have `conference` and `title` fields. Fuzzy-match by: normaliz
 conference names (strip year, "Days", "Conference"), match by date proximity and title
 substring. Skip Office locks beginning `~$`, files with "static" in name, conflict
 copies matching `(N).pptx`, and files matching `config.template_skip_patterns`.
+Configured `pptx_directory_exclusions` prune a real directory only by
+case-insensitive exact component identity after symlink/reparse rejection; they
+do not match substrings or authored file names. Preserve the single
+`pptx_batch_directory_excluded` receipt and do not scan below it.
 Some talks have multiple .pptx files
 (one per delivery) — match to the closest date.
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1788,8 +1788,11 @@ protocol failures exit nonzero and add the existing top-level `error`, bound to
 one root receipt and no results. Whole-root-only reason codes are invalid as
 ordinary partial receipts, and per-deck failures cannot be promoted into the
 top-level error. Its `details` object is path-neutral and may contain only one
-optional closed `supervisor_reason_code`. A legacy unversioned `results`/`skipped` object
-has unknown completeness and must be rerun before a coverage or absence claim.
+optional closed `supervisor_reason_code`. Each public `skipped[].path` is either
+`.` or one bounded canonical root-relative path; absolute, drive-qualified,
+backslash, traversal, empty-component, and control/format-bearing paths are
+rejected during decode. A legacy unversioned `results`/`skipped` object has
+unknown completeness and must be rerun before a coverage or absence claim.
 
 The owner performs no root stat, type probe, or recursive enumeration: an
 authenticated worker with fixed input, output, memory, process, and wall limits

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -26,22 +26,27 @@ Current constants live in
 implicit unversioned corpus. Within that root, a missing talk version is the
 historical talk schema v1, not a request to synthesize v5 evidence; missing
 config, PPTX, QR, resource, thumbnail, confirmed-intent, source-rejection, and
-goal versions likewise map only to their validated historical v1 shapes. Run the
-owner migration in vault-ingress Step 1.
+goal versions likewise map only to their validated historical v1 shapes. Config
+v2 adds the owner-controlled `pptx_directory_exclusions` discovery boundary.
+Run the owner migration in vault-ingress Step 1.
 Dry-run emits the exact input SHA-256. Apply requires that digest, refuses active
 queue claims, stores the complete original bytes under `.backups/`, and replaces
 the verified generation atomically. Backup directory and file opens do not
 follow symbolic links. The writer repeats its byte-and-file-generation check
-after staging and immediately before replacement. A current schema-v1 database
-is an idempotent no-op. Before migration, queue `inspect` may read schema 0 and
+after staging and immediately before replacement. A schema-v1 database with
+config v2 is an idempotent no-op. A schema-v1 database with config v1 receives
+only the config-v2 migration; the root generation and every other record remain
+unchanged. Before migration, queue `inspect` may read schema 0 and
 queue `recover` may close an active schema-0 lease in place. Recovery changes
 only queue lease/status state and never stamps database or talk schema fields;
 the established queue transition may advance a recovered claim receipt from v1
 to v2 while adding its release fields.
 
-The schema-0 migration is a preservation migration. Its only allowed semantic
+The owner migration is a preservation migration. Its only allowed semantic
 changes are adding root schema v1, adding the validated historical version to an
-unversioned owner record, and creating absent owned arrays as empty arrays. It
+unversioned owner record, creating absent owned arrays as empty arrays, and
+upgrading config v1 to v2. A missing exclusion list receives the canonical
+defaults; a valid owner-supplied list is preserved exactly. It
 preserves every other JSON value and missing-vs-present distinction, including
 legacy-v1 `pattern_observations` objects, arrays, or nulls and every historical
 citation/source-inspection field. Explicit version 0 sentinels, future owner
@@ -52,7 +57,7 @@ no-op.
 | Independent record | Current schema |
 |---|---:|
 | database root | 1 |
-| config | 1 |
+| config | 2 (schema 1 remains readable owner-migration input) |
 | talk | 5 |
 | PPTX catalog | 1 |
 | QR code | 1 |
@@ -64,17 +69,18 @@ no-op.
 
 | Component | Access | Contract |
 |---|---|---|
-| vault-ingress migration | owner read/write | Accept schema 0 or 1; migrate 0 exactly once; never downgrade future state |
+| vault-ingress migration | owner read/write | Accept root schema 0/1 and config schema 1/2; migrate to root v1/config v2; never downgrade future state |
 | vault-ingress queue inspection/recovery | owner compatibility transition | Inspect schema 0/1; recover active leases in schema 0/1; never stamp artifact or talk schema versions |
-| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 1 plus supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
+| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 1, config schema 2, and supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
 | vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0 and 1; gate through existing finding/error channels; never rewrite |
-| vault-clarification | current read/write | Route schema migration to vault-ingress; stamp config v1, confirmed intent v1, improvement goal v2 |
+| vault-clarification | current read/write | Route schema migration to vault-ingress; preserve config v2 and stamp confirmed intent v1/improvement goal v2 |
 | presentation-creator QR writer | dual reader/current writer | Read schemas 0 and 1; require schema 1 before URL creation or QR metadata persistence; stamp QR v1 |
 | presentation-creator publishing/post-event | authorized current writer | Require schema 1 before tracking writes; stamp resource v1 and preserve talk v5 |
 | illustrations thumbnail workflow | authorized current writer | Require schema 1 before tracking writes; stamp thumbnail v1 and preserve talk v5 |
 | vault-profile | dual reader | Parse schemas 0 and 1; treat unsupported generations as unavailable; never migrate |
 
-Current database schema 1 requires all eight top-level state fields shown below.
+Current database schema 1 with config schema 2 requires all eight top-level
+state fields shown below.
 Missing legacy arrays become empty during owner migration. Current writers do
 not create them opportunistically. A schema-v1 improvement goal remains valid
 historical state; migration never fabricates the schema-v2 baseline provenance
@@ -93,16 +99,21 @@ non-absolute value fail closed. Repair an invalid stored assertion with the
 expectation-bound `set_config` dry-run/apply/re-read/preflight sequence in
 [source-identity-preflight.md](source-identity-preflight.md#repair-a-stored-root-assertion).
 
+The exclusion value in the structural example below is one illustrative valid
+customization, not the owner default. See the
+[config field semantics](../../vault-profile/references/schemas-config.md#pptx-directory-exclusions).
+
 ```json
 {
   "schema_version": 1,
   "config": {
-    "schema_version": 1,
+    "schema_version": 2,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
     "vault_storage_path": "/native/absolute/vault/root (optional; must match the tracking-database parent; null/absent uses that parent)",
     "pptx_source_dir": "/native/absolute/path/to/Presentations (optional; null/absent falls back to the vault root)",
     "python_path": "/path/to/python3",
     "template_skip_patterns": ["template"],
+    "pptx_directory_exclusions": ["example-tool-cache"],
     "shownotes": {
       "enabled": true,
       "source": {
@@ -379,8 +390,10 @@ review its `changes`, then bind apply to that report's exact input hash:
   --apply --expected-sha256 <input-sha256-from-dry-run>
 ```
 
-Initialization uses a sole `initialize_database` mutation, stamps database and
-config schema version 1, defaults to dry-run, and applies with the literal
+Initialization uses a sole `initialize_database` mutation, stamps database
+schema version 1 and config schema version 2, supplies the canonical
+`pptx_directory_exclusions` when the plan omits that field, defaults to dry-run,
+and applies with the literal
 `--expected-sha256 missing`. All other applies
 require the dry-run SHA. The complete plan is one transaction: one failed type,
 record, semantic expectation, or file-generation precondition installs nothing.
@@ -1750,19 +1763,62 @@ Raw worker diagnostics are discarded after producing a bounded count/hash/
 truncation receipt. Source-artifact and operation resource limits are script-owned;
 see `skills/vault-ingress/scripts/pptx_evidence.py` — `PPTX_MAX_INPUT_BYTES` and
 the top-level `SupervisorLimits` profiles. Exceeding a configured limit fails
-closed. Directory
-extraction is selected only with `--directory`. The owner performs no root stat,
-type probe, or recursive enumeration: an authenticated worker with fixed input,
-output, memory, process, and wall limits validates and scans the root, then returns
-a closed root-relative manifest. It rejects symlinks, directory reparse points,
-unusable or colliding directory identities, unknown redirecting Windows reparse
-tags, unavailable Cloud Files (offline/recall), and `~$` Office locks; supported
-hydrated Cloud Files leaves remain eligible. A root-level receipt marks a scan
-truncated by the file cap. Discovery and extraction share one enclosing deadline,
-and final compact-JSON accounting includes its wrapper and newline. Stronger
-root/leaf handle binding and handle-relative traversal remain tracked by #176;
-until then all recursive filesystem contact is at least confined to the
-termination-safe discovery worker rather than occurring in the owner.
+closed.
+
+Directory extraction is selected only with `--directory`. Its public result is
+the strict schema-v1 completeness envelope below; this generation is independent
+of the per-deck extractor schema v4 and pipeline 1.5.0:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "pptx_directory_batch",
+  "complete": false,
+  "incomplete_reason_codes": ["pptx_batch_file_limit"],
+  "results": [],
+  "skipped": [{"path": ".", "reason": "pptx_batch_file_limit"}]
+}
+```
+
+`complete` is true exactly when `incomplete_reason_codes` is empty, and both are
+recomputed from the closed `skipped[]` taxonomy. Exit zero admits either complete
+or partial output: safe per-deck results remain usable, but only `complete: true`
+authorizes full-catalog coverage or an absence conclusion. Whole-root and
+protocol failures exit nonzero and add the existing top-level `error`, bound to
+one root receipt and no results. Whole-root-only reason codes are invalid as
+ordinary partial receipts, and per-deck failures cannot be promoted into the
+top-level error. Its `details` object is path-neutral and may contain only one
+optional closed `supervisor_reason_code`. A legacy unversioned `results`/`skipped` object
+has unknown completeness and must be rerun before a coverage or absence claim.
+
+The owner performs no root stat, type probe, or recursive enumeration: an
+authenticated worker with fixed input, output, memory, process, and wall limits
+validates and scans the root, then returns a private schema-v2 root-relative
+manifest. Its authenticated request carries the validated exact-component
+directory-exclusion list; the response echoes that exact ordered list and
+carries `complete` and `incomplete_reason_codes`. The owner rejects a response
+whose policy differs, fabricates an exclusion receipt, returns evidence below
+an excluded component, or nests any skip below another non-root skip, then
+independently recomputes completeness from `skipped[]`. For every encountered real directory, symlink and
+reparse-point rejection runs before the case-insensitive exact-component
+exclusion check. An excluded directory produces one
+`pptx_batch_directory_excluded` receipt, consumes no descendant scan budget, and
+is not traversed. The excluded dirent is charged to a separate finite policy
+enumeration ceiling rather than the eligible-entry ceiling, so excluded
+environment/cache directories cannot starve authored siblings. Exhausting
+either ceiling emits `pptx_batch_entry_limit`; enumeration remains bounded.
+
+The envelope's `complete` and `incomplete_reason_codes` fields are the sole
+consumer authority; never recreate the per-receipt classification. Its closed
+taxonomy lives only in
+`skills/vault-ingress/scripts/pptx_discovery_contract.py::{PPTX_DIRECTORY_POLICY_SKIP_REASON_CODES,PPTX_DIRECTORY_INCOMPLETE_REASON_CODES}`.
+The worker rejects unusable or colliding directory identities and unknown
+redirecting Windows reparse tags; supported hydrated Cloud Files leaves remain
+eligible. Discovery and extraction share one enclosing deadline, and final
+compact-JSON accounting includes its wrapper and newline. Stronger root/leaf
+handle binding and handle-relative traversal remain tracked by #176; until then
+all recursive filesystem contact is at least confined to the termination-safe
+discovery worker rather than occurring in the owner.
 
 `archive_recovery` is empty on a healthy package. A bad-CRC member under
 `ppt/media/` is replaced only in an in-memory package with a transparent

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -159,6 +159,12 @@ so the same filesystem state produces byte-for-byte equivalent decoded data.
 Paths are absolute. Consumers route on `severity` and `code`, never on message
 text.
 
+An unusable owner-schema finding retains the assessment's closed
+`reason_codes` in structured `actual` detail. A config-version failure names
+`config.schema_version`, expects readable generations `[1, 2]`, and reports the
+stored config generation separately from those reasons; it is not mislabeled as
+a root-schema failure.
+
 `database` and `vault_root` are nullable authority fields. When raw database or
 CLI input is rejected before admission, both are null, `talk_count` is zero,
 and the report contains one path-neutral blocking finding. Once the direct
@@ -303,6 +309,21 @@ content, but it cannot waive a duplicate-ID fault.
 
 Checks apply to a record with a declared transcript, slide, or video capability
 (processable) or status `processed` / `processed_partial` (completed):
+
+Config schema v2 must contain a bounded unique
+`pptx_directory_exclusions` array of literal directory-name components. Missing
+or malformed current state is blocking as
+`pptx_directory_exclusions_invalid`; config v1 remains readable only so the
+owner migration can supply or preserve the field. This offline check validates
+the policy but does not scan the configured presentation root.
+
+A missing declared PPTX is evidence about that exact locator, not proof that no
+matching deck exists elsewhere. Only a strict schema-v1
+`pptx_directory_batch` result with `complete: true` authorizes a full-catalog or
+missing-deck conclusion. Partial results are usable for the decks they safely
+return, but budget, availability, change, placeholder, probe, or extraction
+reasons leave coverage incomplete. Legacy unversioned batch output has unknown
+completeness and must be rerun before an absence conclusion.
 
 - Transcript source enum: `youtube_auto`, `whisper`, `manual`, `none`. Absence
   remains valid “unknown provenance.” Unless the value is `none`, the expected

--- a/skills/vault-ingress/scripts/migrate-tracking-database.py
+++ b/skills/vault-ingress/scripts/migrate-tracking-database.py
@@ -39,7 +39,7 @@ class JsonArgumentParser(argparse.ArgumentParser):
 
 
 def _backup_path(path: Path, digest: str) -> Path:
-    return path.parent / ".backups" / f"{path.name}.schema-v0-{digest}.bak"
+    return path.parent / ".backups" / f"{path.name}.owner-migration-{digest}.bak"
 
 
 def _validate_expected_digest(value: str) -> None:

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -48,6 +48,11 @@ from tracking_database_io import (
     render_json_object,
     snapshot_tracking_database,
 )
+from pptx_discovery_contract import (
+    DEFAULT_PPTX_DIRECTORY_EXCLUSIONS,
+    PptxDiscoveryContractError,
+    validate_pptx_directory_exclusions,
+)
 
 
 PLAN_SCHEMA_VERSION = 1
@@ -1048,6 +1053,21 @@ def initial_database(mutation: dict[str, Any], *, index: int) -> dict[str, Any]:
             f"{CONFIG_RECORD_SCHEMA_VERSION}"
         )
     initial_config["schema_version"] = CONFIG_RECORD_SCHEMA_VERSION
+    initial_config.setdefault(
+        "pptx_directory_exclusions",
+        list(DEFAULT_PPTX_DIRECTORY_EXCLUSIONS),
+    )
+    try:
+        initial_config["pptx_directory_exclusions"] = (
+            validate_pptx_directory_exclusions(
+                initial_config["pptx_directory_exclusions"],
+                label=(
+                    f"mutations[{index}].config.pptx_directory_exclusions"
+                ),
+            )
+        )
+    except PptxDiscoveryContractError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
     return {
         "schema_version": TRACKING_DATABASE_SCHEMA_VERSION,
         "config": initial_config,

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -503,7 +503,7 @@ def _require_tesseract():
         )
 
     try:
-        import pytesseract  # pyright: ignore[reportMissingImports]
+        import pytesseract  # pyright: ignore[reportMissingImports] - optional OCR dependency checked at runtime
     except ImportError as e:
         _tesseract_available = False
         raise OcrUnavailableError(
@@ -530,7 +530,7 @@ def _ocr_image_result(blob):
     engine_version = _require_tesseract()
 
     try:
-        import pytesseract  # pyright: ignore[reportMissingImports]
+        import pytesseract  # pyright: ignore[reportMissingImports] - optional OCR dependency checked at runtime
         from PIL import Image, UnidentifiedImageError
     except ImportError as e:
         raise OcrUnavailableError(

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -18,7 +18,8 @@ about observed motion, concurrency, or delivered behavior.
 Usage:
     pptx-extraction.py <file.pptx> [--no-ocr]
         [--rendered-pdf <path>] [--inspected-pages <PAGE|START-END>]
-    pptx-extraction.py --directory <directory> [--skip pattern ...] [--no-ocr]
+    pptx-extraction.py --directory <directory> [--skip pattern ...]
+        [--exclude-directory component ...] [--no-ocr]
     pptx-extraction.py --version
 
     <path>       Path to one .pptx, or a root when --directory is explicit
@@ -44,12 +45,14 @@ from collections import Counter
 from dataclasses import replace
 from math import gcd
 from pathlib import Path
+from typing import cast
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.oxml.ns import qn
 
 import artifact_metadata
 from artifact_locator import ArtifactLocatorError, materialize_native_root
 from artifact_supervisor import (
+    JsonValue,
     SupervisorError,
     SupervisorLimits,
     WorkerRequest,
@@ -72,6 +75,18 @@ from pptx_evidence import (
     run_supervised_pptx_extraction,
     sha256_bytes,
     snapshot_regular_file,
+)
+from pptx_discovery_contract import (
+    PPTX_DIRECTORY_BATCH_KIND,
+    PPTX_DIRECTORY_BATCH_SCHEMA_VERSION,
+    PPTX_DIRECTORY_INCOMPLETE_REASON_CODES,
+    PPTX_DIRECTORY_MANIFEST_KIND,
+    PPTX_DIRECTORY_MANIFEST_SCHEMA_VERSION,
+    PptxDiscoveryContractError,
+    build_pptx_directory_batch,
+    directory_component_is_excluded,
+    directory_incomplete_reason_codes,
+    validate_pptx_directory_exclusions,
 )
 
 # Field-shape and behavior versions are deliberately separate. A missing
@@ -144,6 +159,7 @@ def _bounded_package_part_name(value):
 _BATCH_MAX_DEPTH = 32
 _BATCH_MAX_DIRECTORIES = 5_000
 _BATCH_MAX_ENTRIES = 50_000
+_BATCH_MAX_POLICY_EXCLUDED_ENTRIES = 5_000
 _BATCH_MAX_FILES = 256
 _BATCH_MAX_RELATIVE_PATH_CHARS = 4_096
 _BATCH_MAX_INPUT_BYTES = 16 * 1024 * 1024 * 1024
@@ -162,7 +178,7 @@ _WINDOWS_CLOUD_REPARSE_TAGS = artifact_metadata.WINDOWS_CLOUD_REPARSE_TAGS
 _BATCH_MAX_ROOT_PATH_CHARS = 4_096
 _BATCH_MAX_SKIP_PATTERNS = 64
 _BATCH_MAX_SKIP_PATTERN_CHARS = 256
-_DIRECTORY_MANIFEST_SCHEMA_VERSION = 1
+_DIRECTORY_MANIFEST_SCHEMA_VERSION = PPTX_DIRECTORY_MANIFEST_SCHEMA_VERSION
 _DIRECTORY_WORKER_FLAG = "--directory-worker"
 _DIRECTORY_OPERATION = "pptx_resolve_input"
 _DIRECTORY_MANIFEST_SKIP_REASONS = frozenset(
@@ -173,6 +189,7 @@ _DIRECTORY_MANIFEST_SKIP_REASONS = frozenset(
         "pptx_batch_directory_changed",
         "pptx_batch_directory_identity_collision",
         "pptx_batch_directory_identity_unavailable",
+        "pptx_batch_directory_excluded",
         "pptx_batch_directory_limit",
         "pptx_batch_directory_unavailable",
         "pptx_batch_entry_limit",
@@ -264,11 +281,12 @@ _DIRECTORY_BATCH_FAILURE_REASONS = frozenset(
         "pptx_batch_discovery_start_failure",
         "pptx_batch_discovery_timeout",
         "pptx_batch_discovery_worker_failure",
+        "pptx_batch_manifest_invalid",
         "pptx_batch_wall_limit",
     }
 )
 _DIRECTORY_LIMITS = SupervisorLimits(
-    profile_id="pptx-directory-discovery-v1",
+    profile_id="pptx-directory-discovery-v2",
     wall_seconds=60,
     max_memory_bytes=512 * 1024 * 1024,
     max_input_bytes=64 * 1024,
@@ -485,7 +503,7 @@ def _require_tesseract():
         )
 
     try:
-        import pytesseract
+        import pytesseract  # pyright: ignore[reportMissingImports]
     except ImportError as e:
         _tesseract_available = False
         raise OcrUnavailableError(
@@ -512,7 +530,7 @@ def _ocr_image_result(blob):
     engine_version = _require_tesseract()
 
     try:
-        import pytesseract
+        import pytesseract  # pyright: ignore[reportMissingImports]
         from PIL import Image, UnidentifiedImageError
     except ImportError as e:
         raise OcrUnavailableError(
@@ -1832,9 +1850,31 @@ def _usable_directory_identity(stat_result):
     return (device, inode)
 
 
-def _discover_pptx_files(directory, skip_patterns):
+def _entry_is_real_excluded_directory(entry, exclusions):
+    """Identify one policy-prunable dirent without trusting its name alone."""
+    if not directory_component_is_excluded(entry.name, exclusions):
+        return False
+    try:
+        entry_stat = entry.stat(follow_symlinks=False)
+        return bool(
+            entry.is_dir(follow_symlinks=False)
+            and not _is_windows_reparse_point(entry_stat)
+            and not entry.is_symlink()
+        )
+    except OSError:
+        return False
+
+
+def _discover_pptx_files(directory, skip_patterns, directory_exclusions=()):
     """Discover a deterministic, bounded set inside the contained worker."""
     root = Path(_validated_directory_root(directory))
+    try:
+        exclusions = validate_pptx_directory_exclusions(directory_exclusions)
+    except PptxDiscoveryContractError as exc:
+        raise PptxEvidenceError(
+            "PPTX directory exclusions are invalid",
+            reason_code="pptx_batch_request_invalid",
+        ) from exc
     try:
         root_stat = root.lstat()
     except OSError as exc:
@@ -1869,6 +1909,7 @@ def _discover_pptx_files(directory, skip_patterns):
     visited = set()
     directory_count = 0
     entry_count = 0
+    policy_excluded_entry_count = 0
 
     while stack:
         if time.monotonic() - started > _BATCH_MAX_WALL_SECONDS:
@@ -1916,6 +1957,16 @@ def _discover_pptx_files(directory, skip_patterns):
             entry_limit_hit = False
             with os.scandir(current) as iterator:
                 for entry in iterator:
+                    if _entry_is_real_excluded_directory(entry, exclusions):
+                        if (
+                            policy_excluded_entry_count
+                            >= _BATCH_MAX_POLICY_EXCLUDED_ENTRIES
+                        ):
+                            entry_limit_hit = True
+                            break
+                        entries.append(entry)
+                        policy_excluded_entry_count += 1
+                        continue
                     if entry_count >= _BATCH_MAX_ENTRIES:
                         entry_limit_hit = True
                         break
@@ -1969,7 +2020,9 @@ def _discover_pptx_files(directory, skip_patterns):
                     )
                     continue
                 if entry_is_directory:
-                    if depth >= _BATCH_MAX_DEPTH:
+                    if directory_component_is_excluded(entry.name, exclusions):
+                        record_skip(relative, "pptx_batch_directory_excluded")
+                    elif depth >= _BATCH_MAX_DEPTH:
                         record_skip(relative, "pptx_batch_depth_limit")
                     else:
                         child_directories.append(
@@ -2050,6 +2103,19 @@ def _validated_skip_patterns(value):
     return normalized
 
 
+def _validated_directory_exclusions(value):
+    try:
+        return validate_pptx_directory_exclusions(
+            value,
+            label="directory_exclusions",
+        )
+    except PptxDiscoveryContractError as exc:
+        raise PptxEvidenceError(
+            "directory exclusions exceed their bounded exact-component contract",
+            reason_code="pptx_batch_request_invalid",
+        ) from exc
+
+
 def _validated_relative_manifest_path(value, *, allow_root=False):
     if allow_root and value == ".":
         return value
@@ -2075,11 +2141,24 @@ def _validated_relative_manifest_path(value, *, allow_root=False):
     return value
 
 
-def _decode_directory_manifest(value):
+def _decode_directory_manifest(value, *, expected_directory_exclusions=()):
     """Decode only the closed, authenticated directory-worker body."""
+    try:
+        expected_exclusions = validate_pptx_directory_exclusions(
+            expected_directory_exclusions,
+            label="expected_directory_exclusions",
+        )
+    except PptxDiscoveryContractError as exc:
+        raise PptxEvidenceError(
+            "expected directory exclusions violate their contract",
+            reason_code="pptx_batch_manifest_invalid",
+        ) from exc
     if not isinstance(value, dict) or set(value) != {
         "schema_version",
         "kind",
+        "complete",
+        "directory_exclusions",
+        "incomplete_reason_codes",
         "files",
         "skipped",
     }:
@@ -2090,12 +2169,32 @@ def _decode_directory_manifest(value):
     if (
         type(value.get("schema_version")) is not int
         or value.get("schema_version") != _DIRECTORY_MANIFEST_SCHEMA_VERSION
-        or value.get("kind") != "directory"
+        or value.get("kind") != PPTX_DIRECTORY_MANIFEST_KIND
+        or type(value.get("complete")) is not bool
+        or not isinstance(value.get("incomplete_reason_codes"), list)
     ):
         raise PptxEvidenceError(
             "directory worker returned an unsupported manifest",
             reason_code="pptx_batch_manifest_invalid",
         )
+    try:
+        returned_exclusions = validate_pptx_directory_exclusions(
+            value.get("directory_exclusions"),
+            label="manifest.directory_exclusions",
+        )
+    except PptxDiscoveryContractError as exc:
+        raise PptxEvidenceError(
+            "directory worker returned invalid exclusion policy",
+            reason_code="pptx_batch_manifest_invalid",
+        ) from exc
+    if returned_exclusions != expected_exclusions:
+        raise PptxEvidenceError(
+            "directory worker exclusion policy does not match its request",
+            reason_code="pptx_batch_manifest_invalid",
+        )
+    exclusion_identities = {
+        component.casefold() for component in expected_exclusions
+    }
     raw_files = value.get("files")
     raw_skipped = value.get("skipped")
     if (
@@ -2164,7 +2263,59 @@ def _decode_directory_manifest(value):
         if path != ".":
             seen_nonroot_skip_paths.add(path)
         skipped.append({"path": path, "reason": reason})
-    return files, skipped
+    skipped_nonroot_paths = {
+        item["path"] for item in skipped if item["path"] != "."
+    }
+    for item in skipped:
+        path = item["path"]
+        if path == ".":
+            continue
+        components = path.split("/")
+        if any(
+            component.casefold() in exclusion_identities
+            for component in components[:-1]
+        ):
+            raise PptxEvidenceError(
+                "directory worker returned a skip beneath an excluded directory",
+                reason_code="pptx_batch_manifest_invalid",
+            )
+        if (
+            item["reason"] == "pptx_batch_directory_excluded"
+            and components[-1].casefold() not in exclusion_identities
+        ):
+            raise PptxEvidenceError(
+                "directory worker fabricated an exclusion receipt",
+                reason_code="pptx_batch_manifest_invalid",
+            )
+    for relative in files:
+        components = relative.split("/")
+        if any(
+            component.casefold() in exclusion_identities
+            for component in components[:-1]
+        ) or any(
+            relative.startswith(f"{skipped_path}/")
+            for skipped_path in skipped_nonroot_paths
+        ):
+            raise PptxEvidenceError(
+                "directory worker returned a file beneath a skipped directory",
+                reason_code="pptx_batch_manifest_invalid",
+            )
+    try:
+        incomplete_reason_codes = directory_incomplete_reason_codes(skipped)
+    except PptxDiscoveryContractError as exc:
+        raise PptxEvidenceError(
+            "directory worker completeness receipts are invalid",
+            reason_code="pptx_batch_manifest_invalid",
+        ) from exc
+    if (
+        value.get("complete") != (not incomplete_reason_codes)
+        or value.get("incomplete_reason_codes") != incomplete_reason_codes
+    ):
+        raise PptxEvidenceError(
+            "directory worker completeness does not match its skip receipts",
+            reason_code="pptx_batch_manifest_invalid",
+        )
+    return files, skipped, not incomplete_reason_codes, incomplete_reason_codes
 
 
 def _directory_limits_before_deadline(deadline_monotonic):
@@ -2190,18 +2341,30 @@ def _directory_limits_before_deadline(deadline_monotonic):
     return replace(_DIRECTORY_LIMITS, wall_seconds=remaining), True
 
 
-def _run_supervised_directory_discovery(directory, skip_patterns, *, deadline):
+def _run_supervised_directory_discovery(
+    directory,
+    skip_patterns,
+    directory_exclusions=(),
+    *,
+    deadline,
+):
     """Resolve one directory only through the authenticated bounded worker."""
     root = _validated_directory_root(directory)
     patterns = _validated_skip_patterns(skip_patterns)
+    exclusions = _validated_directory_exclusions(directory_exclusions)
     limits, deadline_limited = _directory_limits_before_deadline(deadline)
     command = [sys.executable, os.path.abspath(__file__), _DIRECTORY_WORKER_FLAG]
+    payload: dict[str, JsonValue] = {
+        "root_path": root,
+        "skip_patterns": cast(JsonValue, patterns),
+        "directory_exclusions": cast(JsonValue, exclusions),
+    }
     try:
         result = run_authenticated_worker(
             command,
             _DIRECTORY_OPERATION,
             {},
-            {"root_path": root, "skip_patterns": patterns},
+            payload,
             limits,
             immutable_process_identity=command[:2],
             sensitive_values=(root,),
@@ -2232,7 +2395,10 @@ def _run_supervised_directory_discovery(directory, skip_patterns, *, deadline):
             reason_code=reason,
             details={"supervisor_reason_code": exc.reason_code},
         ) from exc
-    return _decode_directory_manifest(result.payload)
+    return _decode_directory_manifest(
+        result.payload,
+        expected_directory_exclusions=exclusions,
+    )
 
 
 def _dispatch_directory_worker(request: WorkerRequest):
@@ -2243,13 +2409,21 @@ def _dispatch_directory_worker(request: WorkerRequest):
         or request.pipeline_generation != PIPELINE_VERSION
         or request.expected_generations
         or not isinstance(request.payload, dict)
-        or set(request.payload) != {"root_path", "skip_patterns"}
+        or set(request.payload)
+        != {"root_path", "skip_patterns", "directory_exclusions"}
     ):
         raise SupervisorError("invalid_worker_request")
     try:
         root = _validated_directory_root(request.payload.get("root_path"))
         patterns = _validated_skip_patterns(request.payload.get("skip_patterns"))
-        discovered, skipped, _started = _discover_pptx_files(root, patterns)
+        exclusions = _validated_directory_exclusions(
+            request.payload.get("directory_exclusions")
+        )
+        discovered, skipped, _started = _discover_pptx_files(
+            root,
+            patterns,
+            exclusions,
+        )
     except PptxEvidenceError as exc:
         locator_failure = exc.details.get("locator_failure")
         details = (
@@ -2258,9 +2432,13 @@ def _dispatch_directory_worker(request: WorkerRequest):
             else {}
         )
         raise SupervisorError(exc.reason_code, details) from exc
+    incomplete_reason_codes = directory_incomplete_reason_codes(skipped)
     return {
         "schema_version": _DIRECTORY_MANIFEST_SCHEMA_VERSION,
-        "kind": "directory",
+        "kind": PPTX_DIRECTORY_MANIFEST_KIND,
+        "complete": not incomplete_reason_codes,
+        "directory_exclusions": exclusions,
+        "incomplete_reason_codes": incomplete_reason_codes,
         "files": [{"path": relative} for _path, relative in discovered],
         "skipped": skipped,
     }
@@ -2292,10 +2470,21 @@ def _run_directory_worker_child():
     return 0
 
 
-def _encode_batch_output(results, skipped):
-    """Encode the exact compact JSON emitted by directory mode."""
+def _build_batch_output(results, skipped):
+    """Build the public completeness envelope from all retained receipts."""
+    try:
+        return build_pptx_directory_batch(results, skipped)
+    except PptxDiscoveryContractError as exc:
+        raise PptxEvidenceError(
+            "PPTX directory batch output violates its closed contract",
+            reason_code="pptx_batch_manifest_invalid",
+        ) from exc
+
+
+def _encode_batch_output(batch):
+    """Encode the exact compact public JSON emitted by directory mode."""
     return json.dumps(
-        {"results": results, "skipped": skipped},
+        batch,
         ensure_ascii=False,
         separators=(",", ":"),
     ).encode("utf-8")
@@ -2307,15 +2496,18 @@ def _encode_batch_failure(error):
     supervisor_reason = error.details.get("supervisor_reason_code")
     if isinstance(supervisor_reason, str):
         details["supervisor_reason_code"] = supervisor_reason
-    return json.dumps(
-        {
-            "results": [],
-            "skipped": [{"path": ".", "reason": error.reason_code}],
-            "error": {"reason_code": error.reason_code, "details": details},
-        },
-        ensure_ascii=False,
-        separators=(",", ":"),
-    ).encode("utf-8")
+    try:
+        batch = build_pptx_directory_batch(
+            [],
+            [{"path": ".", "reason": error.reason_code}],
+            error={"reason_code": error.reason_code, "details": details},
+        )
+    except PptxDiscoveryContractError as exc:
+        raise PptxEvidenceError(
+            "whole-root failure is outside the public batch contract",
+            reason_code="pptx_batch_manifest_invalid",
+        ) from exc
+    return _encode_batch_output(batch)
 
 
 def _encoded_json_size(value):
@@ -2328,28 +2520,47 @@ def _encoded_json_size(value):
     )
 
 
-def _batch_output_size(result_sizes, skip_sizes):
-    """Return exact compact wrapper size from pre-encoded element sizes."""
+def _batch_output_size(result_sizes, skip_sizes, incomplete_reason_codes):
+    """Return exact compact envelope size from pre-encoded element sizes."""
+    metadata = {
+        "schema_version": PPTX_DIRECTORY_BATCH_SCHEMA_VERSION,
+        "kind": PPTX_DIRECTORY_BATCH_KIND,
+        "complete": not incomplete_reason_codes,
+        "incomplete_reason_codes": list(incomplete_reason_codes),
+        "results": [],
+        "skipped": [],
+    }
+    empty_size = _encoded_json_size(metadata)
     return (
-        len(b'{"results":[')
+        empty_size
         + sum(result_sizes)
         + max(0, len(result_sizes) - 1)
-        + len(b'],"skipped":[')
         + sum(skip_sizes)
         + max(0, len(skip_sizes) - 1)
-        + len(b"]}")
     )
 
 
-def batch_extract(directory, skip_patterns, *, ocr=True):
+def batch_extract(
+    directory,
+    skip_patterns,
+    directory_exclusions=(),
+    *,
+    ocr=True,
+):
     """Extract a bounded deterministic directory batch through the supervisor."""
     results = []
     started = time.monotonic()
     deadline = started + _BATCH_MAX_WALL_SECONDS
     root = Path(_validated_directory_root(directory))
-    relative_files, skipped = _run_supervised_directory_discovery(
+    (
+        relative_files,
+        skipped,
+        _discovery_complete,
+        _discovery_incomplete_reasons,
+    ) = _run_supervised_directory_discovery(
         root,
         skip_patterns,
+        directory_exclusions,
         deadline=deadline,
     )
     discovered = [
@@ -2415,6 +2626,7 @@ def batch_extract(directory, skip_patterns, *, ocr=True):
                 _batch_output_size(
                     [*result_sizes, encoded_size],
                     [*skip_sizes, *future_skip_sizes],
+                    sorted(PPTX_DIRECTORY_INCOMPLETE_REASON_CODES),
                 )
                 + 1
                 > _BATCH_MAX_OUTPUT_BYTES
@@ -2450,15 +2662,27 @@ def batch_extract(directory, skip_patterns, *, ocr=True):
                 break
             append_skip(relative, reason)
             if (
-                _batch_output_size(result_sizes, skip_sizes) + 1
+                _batch_output_size(
+                    result_sizes,
+                    skip_sizes,
+                    sorted(PPTX_DIRECTORY_INCOMPLETE_REASON_CODES),
+                )
+                + 1
                 > _BATCH_MAX_OUTPUT_BYTES
             ):
-                return [], [{"path": ".", "reason": "pptx_batch_output_limit"}]
+                return _build_batch_output(
+                    results,
+                    [{"path": ".", "reason": "pptx_batch_output_limit"}],
+                )
 
-    encoded_batch = _encode_batch_output(results, skipped)
+    batch = _build_batch_output(results, skipped)
+    encoded_batch = _encode_batch_output(batch)
     if len(encoded_batch) + 1 > _BATCH_MAX_OUTPUT_BYTES:
-        return [], [{"path": ".", "reason": "pptx_batch_output_limit"}]
-    return results, skipped
+        return _build_batch_output(
+            results,
+            [{"path": ".", "reason": "pptx_batch_output_limit"}],
+        )
+    return batch
 
 
 def main(argv=None):
@@ -2482,6 +2706,16 @@ def main(argv=None):
         help=(
             "Configured skip pattern (case-insensitive); repeat for each pattern "
             "and omit all --skip flags for an empty set"
+        ),
+    )
+    parser.add_argument(
+        "--exclude-directory",
+        action="append",
+        default=None,
+        metavar="COMPONENT",
+        help=(
+            "Exact directory-name component to prune; repeat for each configured "
+            "exclusion and omit all flags for an empty set"
         ),
     )
     parser.add_argument(
@@ -2528,13 +2762,18 @@ def main(argv=None):
         if args.rendered_pdf or inspected_page_ranges:
             parser.error("--rendered-pdf/--inspected-pages require a single PPTX input")
         try:
-            results, skipped = batch_extract(args.path, args.skip or [], ocr=ocr)
+            batch = batch_extract(
+                args.path,
+                args.skip or [],
+                args.exclude_directory or [],
+                ocr=ocr,
+            )
         except PptxEvidenceError as exc:
             if exc.reason_code in _DIRECTORY_BATCH_FAILURE_REASONS:
                 sys.stdout.write(_encode_batch_failure(exc).decode("utf-8") + "\n")
             print(f"ERROR: {exc.reason_code}", file=sys.stderr)
             return 1
-        sys.stdout.write(_encode_batch_output(results, skipped).decode("utf-8") + "\n")
+        sys.stdout.write(_encode_batch_output(batch).decode("utf-8") + "\n")
     else:
         try:
             result = extract_pptx(

--- a/skills/vault-ingress/scripts/pptx_discovery_contract.py
+++ b/skills/vault-ingress/scripts/pptx_discovery_contract.py
@@ -7,6 +7,7 @@ contract without importing the PPTX extraction runtime.
 
 from __future__ import annotations
 
+import re
 import unicodedata
 from dataclasses import dataclass
 from typing import Mapping, Sequence, cast
@@ -19,6 +20,7 @@ PPTX_DIRECTORY_MANIFEST_KIND = "directory"
 
 PPTX_DIRECTORY_EXCLUSION_MAX_COUNT = 64
 PPTX_DIRECTORY_EXCLUSION_MAX_CHARS = 255
+PPTX_DIRECTORY_RELATIVE_PATH_MAX_CHARS = 4_096
 DEFAULT_PPTX_DIRECTORY_EXCLUSIONS = (
     ".venv",
     "venv",
@@ -252,6 +254,33 @@ def directory_component_is_excluded(
     return component.casefold() in {item.casefold() for item in exclusions}
 
 
+def _validate_relative_path(value: object, *, label: str) -> str:
+    """Return one canonical root-relative path, with dot reserved for root."""
+    if isinstance(value, str) and value == ".":
+        return value
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > PPTX_DIRECTORY_RELATIVE_PATH_MAX_CHARS
+        or value.startswith(("/", "\\"))
+        or "\\" in value
+        or re.match(r"^[A-Za-z]:", value)
+        or any(
+            unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+            for character in value
+        )
+    ):
+        raise PptxDiscoveryContractError(
+            f"{label} must be dot or a canonical root-relative path"
+        )
+    components = value.split("/")
+    if any(component in {"", ".", ".."} for component in components):
+        raise PptxDiscoveryContractError(
+            f"{label} must be dot or a canonical root-relative path"
+        )
+    return value
+
+
 def _validate_skipped(value: object) -> list[dict[str, str]]:
     if not isinstance(value, list):
         raise PptxDiscoveryContractError("skipped must be an array")
@@ -263,12 +292,11 @@ def _validate_skipped(value: object) -> list[dict[str, str]]:
             raise PptxDiscoveryContractError(
                 f"skipped[{index}] must contain only path and reason"
             )
-        path = item.get("path")
+        path = _validate_relative_path(
+            item.get("path"),
+            label=f"skipped[{index}].path",
+        )
         reason = item.get("reason")
-        if not isinstance(path, str) or not path:
-            raise PptxDiscoveryContractError(
-                f"skipped[{index}].path must be a nonempty string"
-            )
         if not isinstance(reason, str) or reason not in PPTX_DIRECTORY_SKIP_REASON_CODES:
             raise PptxDiscoveryContractError(
                 f"skipped[{index}].reason is outside the closed taxonomy"

--- a/skills/vault-ingress/scripts/pptx_discovery_contract.py
+++ b/skills/vault-ingress/scripts/pptx_discovery_contract.py
@@ -1,0 +1,443 @@
+"""Versioned policy for bounded PPTX directory discovery.
+
+This module is deliberately stdlib-only so database migration, preflight, and
+the contained directory worker share one exact exclusion and completeness
+contract without importing the PPTX extraction runtime.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from dataclasses import dataclass
+from typing import Mapping, Sequence, cast
+
+
+PPTX_DIRECTORY_BATCH_SCHEMA_VERSION = 1
+PPTX_DIRECTORY_BATCH_KIND = "pptx_directory_batch"
+PPTX_DIRECTORY_MANIFEST_SCHEMA_VERSION = 2
+PPTX_DIRECTORY_MANIFEST_KIND = "directory"
+
+PPTX_DIRECTORY_EXCLUSION_MAX_COUNT = 64
+PPTX_DIRECTORY_EXCLUSION_MAX_CHARS = 255
+DEFAULT_PPTX_DIRECTORY_EXCLUSIONS = (
+    ".venv",
+    "venv",
+    "node_modules",
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".nox",
+    ".tessl",
+)
+
+# These skips are deliberate policy boundaries. Encountering only these still
+# proves that every eligible directory and deck was considered.
+PPTX_DIRECTORY_POLICY_SKIP_REASON_CODES = frozenset(
+    {
+        "pptx_batch_conflict_copy",
+        "pptx_batch_directory_excluded",
+        "pptx_batch_office_lock_file",
+        "pptx_batch_reparse_point_rejected",
+        "pptx_batch_skip_pattern",
+        "pptx_batch_static_export",
+        "pptx_batch_symlink_rejected",
+    }
+)
+
+# Every other closed skip means an eligible subtree or deck was not proved.
+# Public and private envelopes derive completeness from this set; callers never
+# maintain a second taxonomy.
+PPTX_DIRECTORY_INCOMPLETE_REASON_CODES = frozenset(
+    {
+        "pptx_archive_recovery_required",
+        "pptx_artifact_changed",
+        "pptx_artifact_unavailable",
+        "pptx_batch_cloud_placeholder_unavailable",
+        "pptx_batch_depth_limit",
+        "pptx_batch_directory_changed",
+        "pptx_batch_directory_identity_collision",
+        "pptx_batch_directory_identity_unavailable",
+        "pptx_batch_directory_limit",
+        "pptx_batch_directory_unavailable",
+        "pptx_batch_discovery_output_limit",
+        "pptx_batch_discovery_protocol_invalid",
+        "pptx_batch_discovery_resource_unavailable",
+        "pptx_batch_discovery_start_failure",
+        "pptx_batch_discovery_timeout",
+        "pptx_batch_discovery_worker_failure",
+        "pptx_batch_entry_limit",
+        "pptx_batch_entry_unavailable",
+        "pptx_batch_file_limit",
+        "pptx_batch_input_limit",
+        "pptx_batch_manifest_invalid",
+        "pptx_batch_output_limit",
+        "pptx_batch_path_invalid",
+        "pptx_batch_path_limit",
+        "pptx_batch_request_invalid",
+        "pptx_batch_root_invalid",
+        "pptx_batch_root_unavailable",
+        "pptx_batch_scan_incomplete_file_limit",
+        "pptx_batch_wall_limit",
+        "pptx_cloud_placeholder_unavailable",
+        "pptx_dependency_unavailable",
+        "pptx_evidence_invalid",
+        "pptx_extraction_failed",
+        "pptx_invalid_container",
+        "pptx_no_slides",
+        "pptx_parse_failure",
+        "pptx_probe_containment_unavailable",
+        "pptx_probe_crash",
+        "pptx_probe_exception",
+        "pptx_probe_malformed_result",
+        "pptx_probe_materialization_changed",
+        "pptx_probe_monitor_identity_changed",
+        "pptx_probe_monitor_unavailable",
+        "pptx_probe_request_oversized",
+        "pptx_probe_resource_unavailable",
+        "pptx_probe_result_oversized",
+        "pptx_probe_start_failure",
+        "pptx_probe_timeout",
+        "pptx_recovery_failure",
+        "pptx_structural_damage",
+    }
+)
+PPTX_DIRECTORY_SKIP_REASON_CODES = frozenset(
+    {
+        *PPTX_DIRECTORY_POLICY_SKIP_REASON_CODES,
+        *PPTX_DIRECTORY_INCOMPLETE_REASON_CODES,
+    }
+)
+
+# These reasons describe failure of the directory operation itself, rather
+# than one eligible deck. They are valid only as the sole root receipt in a
+# top-level error envelope.
+PPTX_DIRECTORY_WHOLE_ROOT_REASON_CODES = frozenset(
+    {
+        "pptx_batch_discovery_output_limit",
+        "pptx_batch_discovery_protocol_invalid",
+        "pptx_batch_discovery_resource_unavailable",
+        "pptx_batch_discovery_start_failure",
+        "pptx_batch_discovery_timeout",
+        "pptx_batch_discovery_worker_failure",
+        "pptx_batch_manifest_invalid",
+        "pptx_batch_request_invalid",
+        "pptx_batch_root_invalid",
+        "pptx_batch_root_unavailable",
+    }
+)
+
+# A wall deadline can expire before discovery starts or after safe results have
+# accumulated. The former may use a top-level error; the latter remains an
+# ordinary partial envelope.
+PPTX_DIRECTORY_ERROR_REASON_CODES = frozenset(
+    {
+        *PPTX_DIRECTORY_WHOLE_ROOT_REASON_CODES,
+        "pptx_batch_wall_limit",
+    }
+)
+
+# Public diagnostics expose only one optional path-neutral supervisor code.
+# Keep the vocabulary closed so arbitrary worker strings, locators, and parser
+# details cannot cross the public boundary.
+PPTX_DIRECTORY_SUPERVISOR_REASON_CODES = frozenset(
+    {
+        "invalid_worker_command",
+        "invalid_worker_request",
+        "invalid_worker_response",
+        "invalid_worker_response_bindings",
+        "invalid_worker_response_body",
+        "protocol_isolation_failed",
+        "pptx_batch_request_invalid",
+        "pptx_batch_root_invalid",
+        "pptx_batch_root_unavailable",
+        "unsafe_worker_process_metadata",
+        "worker_cleanup_failed",
+        "worker_containment_unavailable",
+        "worker_diagnostic_limit_exceeded",
+        "worker_diagnostic_read_failed",
+        "worker_exit",
+        "worker_exit_before_barrier",
+        "worker_generation_binding_mismatch",
+        "worker_generation_changed",
+        "worker_input_limit_exceeded",
+        "worker_memory_limit_exceeded",
+        "worker_monitor_identity_changed",
+        "worker_monitor_unavailable",
+        "worker_output_limit_exceeded",
+        "worker_output_read_failed",
+        "worker_pipe_setup_failed",
+        "worker_process_limit_exceeded",
+        "worker_process_tree_leak",
+        "worker_request_write_failed",
+        "worker_response_authentication_failed",
+        "worker_response_binding_mismatch",
+        "worker_response_bindings_mismatch",
+        "worker_response_body_mismatch",
+        "worker_start_failed",
+        "worker_timeout",
+    }
+)
+
+_FORBIDDEN_PATTERN_CHARACTERS = frozenset("*?[]{}()|^$+")
+
+
+class PptxDiscoveryContractError(ValueError):
+    """PPTX directory discovery state violates its closed contract."""
+
+
+@dataclass(frozen=True)
+class PptxDirectoryBatchAssessment:
+    """Completeness decision for a public directory-batch value."""
+
+    state: str
+    schema_version: int
+    complete: bool | None
+    incomplete_reason_codes: tuple[str, ...]
+
+
+def validate_pptx_directory_exclusions(
+    value: object,
+    *,
+    label: str = "pptx_directory_exclusions",
+) -> list[str]:
+    """Return one bounded exact-component exclusion list or raise."""
+    if not isinstance(value, (list, tuple)) or len(value) > (
+        PPTX_DIRECTORY_EXCLUSION_MAX_COUNT
+    ):
+        raise PptxDiscoveryContractError(
+            f"{label} must be an array of at most "
+            f"{PPTX_DIRECTORY_EXCLUSION_MAX_COUNT} directory components"
+        )
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, component in enumerate(value):
+        item_label = f"{label}[{index}]"
+        if (
+            not isinstance(component, str)
+            or not component
+            or component != component.strip()
+            or len(component) > PPTX_DIRECTORY_EXCLUSION_MAX_CHARS
+            or component in {".", ".."}
+            or "/" in component
+            or "\\" in component
+            or any(
+                unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+                for character in component
+            )
+            or any(character in _FORBIDDEN_PATTERN_CHARACTERS for character in component)
+        ):
+            raise PptxDiscoveryContractError(
+                f"{item_label} must be one literal directory-name component"
+            )
+        identity = component.casefold()
+        if identity in seen:
+            raise PptxDiscoveryContractError(
+                f"{label} contains a case-insensitive duplicate {component!r}"
+            )
+        seen.add(identity)
+        normalized.append(component)
+    return normalized
+
+
+def directory_component_is_excluded(
+    component: str,
+    exclusions: Sequence[str],
+) -> bool:
+    """Match one directory name by exact case-folded component identity."""
+    return component.casefold() in {item.casefold() for item in exclusions}
+
+
+def _validate_skipped(value: object) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        raise PptxDiscoveryContractError("skipped must be an array")
+    skipped: list[dict[str, str]] = []
+    seen_receipts: set[tuple[str, str]] = set()
+    seen_nonroot_paths: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping) or set(item) != {"path", "reason"}:
+            raise PptxDiscoveryContractError(
+                f"skipped[{index}] must contain only path and reason"
+            )
+        path = item.get("path")
+        reason = item.get("reason")
+        if not isinstance(path, str) or not path:
+            raise PptxDiscoveryContractError(
+                f"skipped[{index}].path must be a nonempty string"
+            )
+        if not isinstance(reason, str) or reason not in PPTX_DIRECTORY_SKIP_REASON_CODES:
+            raise PptxDiscoveryContractError(
+                f"skipped[{index}].reason is outside the closed taxonomy"
+            )
+        receipt = (path, reason)
+        if receipt in seen_receipts or (path != "." and path in seen_nonroot_paths):
+            raise PptxDiscoveryContractError(
+                f"skipped[{index}] duplicates an existing path receipt"
+            )
+        seen_receipts.add(receipt)
+        if path != ".":
+            seen_nonroot_paths.add(path)
+        skipped.append({"path": path, "reason": reason})
+    for path in seen_nonroot_paths:
+        components = path.split("/")
+        for length in range(1, len(components)):
+            ancestor = "/".join(components[:length])
+            if ancestor in seen_nonroot_paths:
+                raise PptxDiscoveryContractError(
+                    "skipped contains a descendant of another skipped path"
+                )
+    return skipped
+
+
+def directory_incomplete_reason_codes(skipped: object) -> list[str]:
+    """Derive stable unique completeness failures from closed skip receipts."""
+    validated = _validate_skipped(skipped)
+    return sorted(
+        {
+            item["reason"]
+            for item in validated
+            if item["reason"] in PPTX_DIRECTORY_INCOMPLETE_REASON_CODES
+        }
+    )
+
+
+def build_pptx_directory_batch(
+    results: object,
+    skipped: object,
+    *,
+    error: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build the strict public v1 envelope from safe results and receipts."""
+    if not isinstance(results, list) or any(
+        not isinstance(result, Mapping) for result in results
+    ):
+        raise PptxDiscoveryContractError("results must be an array of objects")
+    validated_skipped = _validate_skipped(skipped)
+    reasons = directory_incomplete_reason_codes(validated_skipped)
+    whole_root_receipts = [
+        item
+        for item in validated_skipped
+        if item["reason"] in PPTX_DIRECTORY_WHOLE_ROOT_REASON_CODES
+    ]
+    if whole_root_receipts and error is None:
+        raise PptxDiscoveryContractError(
+            "whole-root receipts require a matching top-level error"
+        )
+    output: dict[str, object] = {
+        "schema_version": PPTX_DIRECTORY_BATCH_SCHEMA_VERSION,
+        "kind": PPTX_DIRECTORY_BATCH_KIND,
+        "complete": not reasons,
+        "incomplete_reason_codes": reasons,
+        "results": results,
+        "skipped": validated_skipped,
+    }
+    if error is not None:
+        if set(error) != {"reason_code", "details"}:
+            raise PptxDiscoveryContractError(
+                "error must contain only reason_code and details"
+            )
+        reason_code = error.get("reason_code")
+        details = error.get("details")
+        if (
+            not isinstance(reason_code, str)
+            or reason_code not in PPTX_DIRECTORY_ERROR_REASON_CODES
+            or not isinstance(details, Mapping)
+            or results
+            or validated_skipped != [{"path": ".", "reason": reason_code}]
+        ):
+            raise PptxDiscoveryContractError(
+                "whole-root error must bind one incomplete root receipt and no results"
+            )
+        if set(details) - {"supervisor_reason_code"}:
+            raise PptxDiscoveryContractError(
+                "error.details may contain only supervisor_reason_code"
+            )
+        supervisor_reason_code = details.get("supervisor_reason_code")
+        if (
+            "supervisor_reason_code" in details
+            and (
+                not isinstance(supervisor_reason_code, str)
+                or supervisor_reason_code
+                not in PPTX_DIRECTORY_SUPERVISOR_REASON_CODES
+            )
+        ):
+            raise PptxDiscoveryContractError(
+                "error.details supervisor_reason_code is outside the closed taxonomy"
+            )
+        public_details = (
+            {"supervisor_reason_code": supervisor_reason_code}
+            if "supervisor_reason_code" in details
+            else {}
+        )
+        output["error"] = {
+            "reason_code": reason_code,
+            "details": public_details,
+        }
+    return output
+
+
+def decode_pptx_directory_batch(value: object) -> dict[str, object]:
+    """Validate and copy one strict public v1 batch envelope."""
+    if not isinstance(value, Mapping):
+        raise PptxDiscoveryContractError("directory batch must be an object")
+    expected = {
+        "schema_version",
+        "kind",
+        "complete",
+        "incomplete_reason_codes",
+        "results",
+        "skipped",
+    }
+    has_error = "error" in value
+    if set(value) != expected | ({"error"} if has_error else set()):
+        raise PptxDiscoveryContractError("directory batch has an invalid shape")
+    if (
+        type(value.get("schema_version")) is not int
+        or value.get("schema_version") != PPTX_DIRECTORY_BATCH_SCHEMA_VERSION
+        or value.get("kind") != PPTX_DIRECTORY_BATCH_KIND
+        or type(value.get("complete")) is not bool
+        or not isinstance(value.get("incomplete_reason_codes"), list)
+    ):
+        raise PptxDiscoveryContractError("directory batch has an invalid generation")
+    error = value.get("error") if has_error else None
+    built = build_pptx_directory_batch(
+        value.get("results"),
+        value.get("skipped"),
+        error=error if isinstance(error, Mapping) else None,
+    )
+    if has_error and not isinstance(error, Mapping):
+        raise PptxDiscoveryContractError("directory batch error must be an object")
+    if value.get("complete") != built["complete"] or value.get(
+        "incomplete_reason_codes"
+    ) != built["incomplete_reason_codes"]:
+        raise PptxDiscoveryContractError(
+            "directory batch completeness does not match its skip receipts"
+        )
+    return built
+
+
+def assess_pptx_directory_batch(value: object) -> PptxDirectoryBatchAssessment:
+    """Classify v1 output; legacy unversioned output is completeness-unknown."""
+    if isinstance(value, Mapping) and set(value) == {"results", "skipped"}:
+        if not isinstance(value.get("results"), list) or not isinstance(
+            value.get("skipped"), list
+        ):
+            raise PptxDiscoveryContractError("legacy directory batch is malformed")
+        return PptxDirectoryBatchAssessment(
+            state="unknown_legacy",
+            schema_version=0,
+            complete=None,
+            incomplete_reason_codes=("pptx_directory_batch_completeness_unknown",),
+        )
+    decoded = decode_pptx_directory_batch(value)
+    reasons = tuple(cast(list[str], decoded["incomplete_reason_codes"]))
+    return PptxDirectoryBatchAssessment(
+        state="complete" if decoded["complete"] else "partial",
+        schema_version=PPTX_DIRECTORY_BATCH_SCHEMA_VERSION,
+        complete=bool(decoded["complete"]),
+        incomplete_reason_codes=reasons,
+    )

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -63,8 +63,15 @@ from source_identity_matching import (
     titles_agree,
 )
 from tracking_database import (
+    CONFIG_RECORD_SCHEMA_VERSION,
+    LEGACY_CONFIG_RECORD_SCHEMA_VERSION,
+    TrackingDatabaseConfigExclusionsError,
     TrackingDatabaseError,
     assess_tracking_database,
+)
+from pptx_discovery_contract import (
+    PptxDiscoveryContractError,
+    validate_pptx_directory_exclusions,
 )
 from tracking_database_io import (
     TrackingDatabaseIOError,
@@ -238,6 +245,7 @@ class VaultPreflight:
         self.artifact_capabilities: dict[int, dict[str, object]] = {}
         self.video_evidence_assessment = VideoEvidenceAssessment()
         self.reported_source_video_failures: set[int] = set()
+        self.reported_config_exclusions_invalid = False
 
     def artifact_root(self) -> Path:
         """Map the trusted configured root lazily, without probing CLI input."""
@@ -322,21 +330,53 @@ class VaultPreflight:
         try:
             assessment = assess_tracking_database(self.database)
         except TrackingDatabaseError as exc:
-            self.add(
-                "blocking",
-                "tracking_database_schema_invalid",
-                str(exc),
-                field="schema_version",
-            )
+            config = self.database.get("config")
+            if not (
+                isinstance(exc, TrackingDatabaseConfigExclusionsError)
+                and isinstance(config, dict)
+                and self._report_invalid_pptx_directory_exclusions(config)
+            ):
+                self.add(
+                    "blocking",
+                    "tracking_database_schema_invalid",
+                    str(exc),
+                    field="schema_version",
+                )
         else:
             if not assessment.usable:
+                reason_codes = list(assessment.reason_codes)
+                field = "schema_version"
+                expected: Any = assessment.as_dict()["accepted_schema_versions"]
+                actual: Any = {
+                    "root_schema_version": assessment.schema_version,
+                    "reason_codes": reason_codes,
+                }
+                if {
+                    "config_schema_version_missing",
+                    "config_schema_version_unsupported",
+                }.intersection(assessment.reason_codes):
+                    config = self.database.get("config")
+                    config_version = (
+                        config.get("schema_version")
+                        if isinstance(config, dict)
+                        else None
+                    )
+                    field = "config.schema_version"
+                    expected = [
+                        LEGACY_CONFIG_RECORD_SCHEMA_VERSION,
+                        CONFIG_RECORD_SCHEMA_VERSION,
+                    ]
+                    actual = {
+                        "schema_version": config_version,
+                        "reason_codes": reason_codes,
+                    }
                 self.add(
                     "blocking",
                     "tracking_database_schema_unsupported",
                     "tracking database is not usable by this reader",
-                    field="schema_version",
-                    expected=assessment.as_dict()["accepted_schema_versions"],
-                    actual=assessment.schema_version,
+                    field=field,
+                    expected=expected,
+                    actual=actual,
                 )
                 return self.report(0)
 
@@ -414,6 +454,7 @@ class VaultPreflight:
 
     def _validate_config_artifact_roots(self) -> None:
         """Report each invalid configured source root once, even without talks."""
+        self._report_invalid_pptx_directory_exclusions(self.config)
         if (
             "pptx_source_dir" not in self.config
             or self.config.get("pptx_source_dir") is None
@@ -430,6 +471,43 @@ class VaultPreflight:
                 expected="absent, null, or a native absolute path",
                 actual={"reason_code": exc.reason_code},
             )
+
+    def _report_invalid_pptx_directory_exclusions(
+        self,
+        config: dict[str, Any],
+    ) -> bool:
+        """Report one typed exclusion fault and suppress generic schema noise."""
+        message: str | None = None
+        actual: Any = config.get("pptx_directory_exclusions")
+        if (
+            config.get("schema_version") == CONFIG_RECORD_SCHEMA_VERSION
+            and "pptx_directory_exclusions" not in config
+        ):
+            message = (
+                "current config must declare exact-component PPTX directory exclusions"
+            )
+            actual = {"state": "missing"}
+        elif "pptx_directory_exclusions" in config:
+            try:
+                validate_pptx_directory_exclusions(
+                    actual,
+                    label="config.pptx_directory_exclusions",
+                )
+            except PptxDiscoveryContractError as exc:
+                message = str(exc)
+        if message is None:
+            return False
+        if not self.reported_config_exclusions_invalid:
+            self.add(
+                "blocking",
+                "pptx_directory_exclusions_invalid",
+                message,
+                field="config.pptx_directory_exclusions",
+                expected="bounded unique exact-component string array",
+                actual=actual,
+            )
+            self.reported_config_exclusions_invalid = True
+        return True
 
     def _validate_filenames(self) -> None:
         occurrences: defaultdict[str, list[int]] = defaultdict(list)

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -19,13 +19,19 @@ from queue_claim_contract import (
     classify_queue_claim_versions,
     validate_queue_claim_database,
 )
+from pptx_discovery_contract import (
+    DEFAULT_PPTX_DIRECTORY_EXCLUSIONS,
+    PptxDiscoveryContractError,
+    validate_pptx_directory_exclusions,
+)
 
 
 LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
 TRACKING_DATABASE_SCHEMA_VERSION = 1
 LEGACY_TALK_RECORD_SCHEMA_VERSION = 1
 TALK_RECORD_SCHEMA_VERSION = 5
-CONFIG_RECORD_SCHEMA_VERSION = 1
+LEGACY_CONFIG_RECORD_SCHEMA_VERSION = 1
+CONFIG_RECORD_SCHEMA_VERSION = 2
 PPTX_CATALOG_RECORD_SCHEMA_VERSION = 1
 QR_CODE_RECORD_SCHEMA_VERSION = 1
 RESOURCE_RECORD_SCHEMA_VERSION = 1
@@ -142,6 +148,10 @@ IMPROVEMENT_GOAL_REQUIRED_FIELDS = frozenset(
 
 class TrackingDatabaseError(ValueError):
     """The tracking database cannot be read or migrated safely."""
+
+
+class TrackingDatabaseConfigExclusionsError(TrackingDatabaseError):
+    """The config-owned PPTX directory-exclusion field is invalid."""
 
 
 @dataclass(frozen=True)
@@ -312,6 +322,30 @@ def _require_string_array(
         if item in seen:
             raise TrackingDatabaseError(f"{label} contains duplicate value {item!r}")
         seen.add(item)
+
+
+def _validate_config_record(
+    config: Mapping[str, object],
+    *,
+    version: int,
+) -> None:
+    """Validate the owner-versioned PPTX discovery configuration."""
+    if version == CONFIG_RECORD_SCHEMA_VERSION and (
+        "pptx_directory_exclusions" not in config
+    ):
+        raise TrackingDatabaseConfigExclusionsError(
+            "config schema v2 requires pptx_directory_exclusions"
+        )
+    exclusions = config.get("pptx_directory_exclusions")
+    if exclusions is None and "pptx_directory_exclusions" not in config:
+        return
+    try:
+        validate_pptx_directory_exclusions(
+            exclusions,
+            label="config.pptx_directory_exclusions",
+        )
+    except PptxDiscoveryContractError as exc:
+        raise TrackingDatabaseConfigExclusionsError(str(exc)) from exc
 
 
 def _validate_improvement_goal(
@@ -685,11 +719,15 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
     reasons: list[str] = []
     if current and "schema_version" not in config:
         reasons.append("config_schema_version_missing")
-    if _record_version(
+    config_version = _record_version(
         config,
         "config",
-        missing_version=CONFIG_RECORD_SCHEMA_VERSION,
-    ) != CONFIG_RECORD_SCHEMA_VERSION:
+        missing_version=LEGACY_CONFIG_RECORD_SCHEMA_VERSION,
+    )
+    if config_version not in {
+        LEGACY_CONFIG_RECORD_SCHEMA_VERSION,
+        CONFIG_RECORD_SCHEMA_VERSION,
+    }:
         reasons.append("config_schema_version_unsupported")
 
     accepted_versions_by_collection = {
@@ -738,6 +776,8 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
             schema_version=root_version,
             reason_codes=tuple(sorted(set(reasons))),
         )
+
+    _validate_config_record(config, version=config_version)
 
     accepted_rejection_versions = frozenset(
         {SOURCE_REJECTION_RECORD_SCHEMA_VERSION}
@@ -871,7 +911,11 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
 
     return TrackingDatabaseAssessment(
         usable=True,
-        state="current" if current else "legacy",
+        state=(
+            "current"
+            if current and config_version == CONFIG_RECORD_SCHEMA_VERSION
+            else "legacy"
+        ),
         schema_version=root_version,
         reason_codes=(),
     )
@@ -898,7 +942,7 @@ def require_current_tracking_database(database: object) -> dict[str, Any]:
         return database
     if assessment.usable and assessment.state == "legacy":
         raise TrackingDatabaseError(
-            "tracking database uses legacy schema 0; run "
+            "tracking database has owner-managed legacy state; run "
             "skills/vault-ingress/scripts/migrate-tracking-database.py first"
         )
     reasons = ", ".join(assessment.reason_codes) or "unsupported_owner_state"
@@ -939,7 +983,7 @@ def _migrate_talk_record(talk: dict[str, Any]) -> bool:
 
 
 def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
-    """Build the deterministic owner migration from legacy schema 0 to 1."""
+    """Build the deterministic owner migration to root v1/config v2."""
     assessment = assess_tracking_database(database)
     if not assessment.usable:
         raise TrackingDatabaseError(
@@ -959,6 +1003,7 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
         raise TrackingDatabaseError("tracking database root must be a JSON object")
 
     candidate: dict[str, Any] = copy.deepcopy(database)
+    root_version = tracking_database_schema_version(candidate)
     talks = _object_collection(candidate, "talks", required=True)
     active = _active_claim_filenames(talks)
     if active:
@@ -970,11 +1015,37 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
     config = candidate.setdefault("config", {})
     if not isinstance(config, dict):
         raise TrackingDatabaseError("tracking database 'config' must be an object")
-    config_changed = "schema_version" not in config
-    config.setdefault("schema_version", CONFIG_RECORD_SCHEMA_VERSION)
-
     counts = _empty_record_counts()
-    counts["config"] = int(config_changed)
+    config_version = _record_version(
+        config,
+        "config",
+        missing_version=LEGACY_CONFIG_RECORD_SCHEMA_VERSION,
+    )
+    if config_version == LEGACY_CONFIG_RECORD_SCHEMA_VERSION:
+        if "pptx_directory_exclusions" in config:
+            try:
+                exclusions = validate_pptx_directory_exclusions(
+                    config["pptx_directory_exclusions"],
+                    label="config.pptx_directory_exclusions",
+                )
+            except PptxDiscoveryContractError as exc:
+                raise TrackingDatabaseError(str(exc)) from exc
+        else:
+            exclusions = list(DEFAULT_PPTX_DIRECTORY_EXCLUSIONS)
+        config["pptx_directory_exclusions"] = exclusions
+        config["schema_version"] = CONFIG_RECORD_SCHEMA_VERSION
+        counts["config"] = 1
+
+    if root_version == TRACKING_DATABASE_SCHEMA_VERSION:
+        require_current_tracking_database(candidate)
+        return TrackingDatabaseMigration(
+            database=candidate,
+            changed=bool(counts["config"]),
+            from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+            to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+            record_counts=counts,
+        )
+
     for talk in talks:
         prior_rejections = talk.get("source_rejections", [])
         if isinstance(prior_rejections, list):

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1029,7 +1029,7 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
                     label="config.pptx_directory_exclusions",
                 )
             except PptxDiscoveryContractError as exc:
-                raise TrackingDatabaseError(str(exc)) from exc
+                raise TrackingDatabaseConfigExclusionsError(str(exc)) from exc
         else:
             exclusions = list(DEFAULT_PPTX_DIRECTORY_EXCLUSIONS)
         config["pptx_directory_exclusions"] = exclusions

--- a/skills/vault-profile/references/schemas-config.md
+++ b/skills/vault-profile/references/schemas-config.md
@@ -27,15 +27,19 @@ ask the speaker.
 
 ## Full Config Schema
 
+The exclusion value below is one illustrative valid customization, not the
+canonical owner default.
+
 ```json
 {
   "config": {
-    "schema_version": 1,
+    "schema_version": 2,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
     "vault_storage_path": "/native/absolute/database-parent (optional; null/absent uses that parent)",
     "pptx_source_dir": "/path/to/Presentations",
     "python_path": "/path/to/python3",
     "template_skip_patterns": ["template"],
+    "pptx_directory_exclusions": ["example-tool-cache"],
     "speaker_name": "",
     "speaker_handle": "",
     "speaker_website": "",
@@ -65,6 +69,29 @@ ask the speaker.
   }
 }
 ```
+
+### PPTX directory exclusions
+
+Config schema v2 requires `pptx_directory_exclusions`: a bounded, unique array
+of literal directory-name components. Matching is case-insensitive and exact at
+any descendant depth. Values are not paths, substrings, globs, or regular
+expressions; `/`, `\\`, control characters, pattern metacharacters,
+case-insensitive duplicates, `.` and `..` are invalid. The code-owned owner
+default is intentionally not reproduced here; use the
+[vault-ingress PPTX scan contract](../../vault-ingress/references/bootstrap-and-preflight.md#scan-for-pptx-files).
+Do not broaden the code-owned default to plausible authored-content directory
+names without an explicit speaker-specific customization.
+
+Dual readers accept config schema v1 only as read-only compatibility and
+owner-migration state; it is never current or writable. It cannot authorize PPTX
+catalog coverage or an absence conclusion because no current directory-exclusion
+policy is established until migration succeeds. The vault-ingress migration
+stamps schema v2 and supplies the canonical defaults when the list is absent. A
+valid custom list already present on a schema-v1 record is preserved exactly. A
+root-schema-v1/config-schema-v1 vault receives only this config upgrade; the root
+and every unrelated record remain unchanged. Future or malformed config
+generations fail closed. Consumers never synthesize defaults or rewrite config
+themselves.
 
 ### Trusted vault storage root
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,36 @@ import sys
 import pytest
 from pptx import Presentation
 
+
+DEFAULT_PPTX_DIRECTORY_EXCLUSIONS = [
+    ".venv",
+    "venv",
+    "node_modules",
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".nox",
+    ".tessl",
+]
+
+
+def current_tracking_config(**updates: object) -> dict[str, object]:
+    """Return the owner-current config generation for writer fixtures."""
+    config: dict[str, object] = {
+        "schema_version": 2,
+        "pptx_directory_exclusions": list(
+            DEFAULT_PPTX_DIRECTORY_EXCLUSIONS
+        ),
+    }
+    config.update(updates)
+    return config
+
+
 # ── Script import helper ──────────────────────────────────────────────
 
 SCRIPTS_PC = os.path.join(

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import current_tracking_config
+
 
 def write_json(path, value):
     path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
@@ -14,7 +16,7 @@ def write_json(path, value):
 def base_database():
     return {
         "schema_version": 1,
-        "config": {"schema_version": 1},
+        "config": current_tracking_config(),
         "talks": [{
             "schema_version": 5,
             "filename": "talk.md",

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -11,13 +11,13 @@ from PIL import Image
 from pptx import Presentation
 from pptx.util import Inches
 
-from conftest import make_deck
+from conftest import current_tracking_config, make_deck
 
 
 def _current_tracking_database():
     return {
         "schema_version": 1,
-        "config": {"schema_version": 1},
+        "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],
         "qr_codes": [],

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -10,6 +10,30 @@ import pytest
 
 
 MISSING = {"$missing": True}
+DEFAULT_DIRECTORY_EXCLUSIONS = [
+    ".venv",
+    "venv",
+    "node_modules",
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".nox",
+    ".tessl",
+]
+
+
+def _current_config(**updates: object) -> dict[str, object]:
+    config: dict[str, object] = {
+        "schema_version": 2,
+        "pptx_directory_exclusions": copy.deepcopy(DEFAULT_DIRECTORY_EXCLUSIONS),
+    }
+    config.update(updates)
+    return config
 
 
 def _write_json(path: Path, value: object) -> None:
@@ -19,7 +43,7 @@ def _write_json(path: Path, value: object) -> None:
 def _base_database() -> dict[str, object]:
     return {
         "schema_version": 1,
-        "config": {"schema_version": 1},
+        "config": _current_config(),
         "talks": [
             {"schema_version": 5, "filename": "talk.md", "status": "processed"}
         ],
@@ -347,7 +371,11 @@ def test_initialization_dry_run_and_missing_precondition(
     assert applied["database_written"] is True
     initialized = json.loads(database_path.read_text(encoding="utf-8"))
     assert initialized["schema_version"] == 1
-    assert initialized["config"]["schema_version"] == 1
+    assert initialized["config"]["schema_version"] == 2
+    assert (
+        initialized["config"]["pptx_directory_exclusions"]
+        == DEFAULT_DIRECTORY_EXCLUSIONS
+    )
     assert initialized["talks"] == []
 
 
@@ -379,8 +407,65 @@ def test_initialization_surfaces_owner_io_failure_as_mutation_error(
             apply=True,
             expected_sha256="missing",
         )
-
     assert not database_path.exists()
+
+
+def test_initialization_preserves_valid_custom_directory_exclusions(
+    mutate_tracking_database,
+) -> None:
+    initialized = mutate_tracking_database.initial_database(
+        {
+            "kind": "initialize_database",
+            "config": {
+                "pptx_directory_exclusions": ["generated", "VendorCache"],
+            },
+        },
+        index=0,
+    )
+
+    assert initialized["config"]["schema_version"] == 2
+    assert initialized["config"]["pptx_directory_exclusions"] == [
+        "generated",
+        "VendorCache",
+    ]
+
+
+def test_mutation_rejects_malformed_directory_exclusions(
+    mutate_tracking_database,
+) -> None:
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="case-insensitive duplicate",
+    ):
+        mutate_tracking_database.build_candidate(
+            _base_database(),
+            [
+                {
+                    "kind": "set_config",
+                    "path": ["pptx_directory_exclusions"],
+                    "expect": DEFAULT_DIRECTORY_EXCLUSIONS,
+                    "value": ["venv", "VENV"],
+                }
+            ],
+        )
+
+
+def test_initialization_rejects_malformed_directory_exclusions(
+    mutate_tracking_database,
+) -> None:
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="case-insensitive duplicate",
+    ):
+        mutate_tracking_database.initial_database(
+            {
+                "kind": "initialize_database",
+                "config": {
+                    "pptx_directory_exclusions": ["venv", "VENV"],
+                },
+            },
+            index=0,
+        )
 
 
 def test_plan_strict_json_rejects_duplicate_keys(
@@ -730,7 +815,7 @@ def test_json_preconditions_and_noops_are_type_sensitive(
     mutate_tracking_database,
 ) -> None:
     database = _base_database()
-    database["config"] = {"schema_version": 1, "enabled": True}
+    database["config"] = _current_config(enabled=True)
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
         match="precondition failed",
@@ -801,7 +886,8 @@ def test_delete_missing_nested_config_does_not_materialize_parents(
     )
 
     assert candidate["config"] == {
-        "schema_version": 1,
+        "schema_version": 2,
+        "pptx_directory_exclusions": DEFAULT_DIRECTORY_EXCLUSIONS,
         "shownotes": {"enabled": True},
     }
     assert len(changes) == 1
@@ -828,10 +914,7 @@ def test_delete_missing_nested_config_preserves_exact_expectations(
         )
 
     database = _base_database()
-    database["config"] = {
-        "schema_version": 1,
-        "shownotes": {"legacy": None},
-    }
+    database["config"] = _current_config(shownotes={"legacy": None})
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
         match=r"config\.shownotes\.legacy must be an object",
@@ -1001,17 +1084,19 @@ def test_versioned_owner_records_require_schema_version(
         mutate_tracking_database.build_candidate(_base_database(), [mutation])
 
 
-def test_initialization_rejects_noninteger_config_schema_version(
+@pytest.mark.parametrize("schema_version", [True, 1, 3])
+def test_initialization_rejects_noncurrent_config_schema_version(
     mutate_tracking_database,
+    schema_version,
 ) -> None:
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="config.schema_version must be exact integer 1",
+        match="config.schema_version must be exact integer 2",
     ):
         mutate_tracking_database.initial_database(
             {
                 "kind": "initialize_database",
-                "config": {"schema_version": True},
+                "config": {"schema_version": schema_version},
             },
             index=0,
         )

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -16,6 +16,8 @@ import pytest
 from pypdf import PdfWriter
 from pptx import Presentation
 
+from conftest import current_tracking_config
+
 
 def test_atomic_json_write_cleans_stage_and_propagates_interrupt(
     persist_results, tracking_database_io, tmp_path, monkeypatch,
@@ -170,7 +172,9 @@ def _db_json(database):
     database["schema_version"] = 1
     config = database.setdefault("config", {})
     if isinstance(config, dict):
-        config["schema_version"] = 1
+        existing = dict(config)
+        config.clear()
+        config.update(current_tracking_config(**existing))
     database.setdefault("pptx_catalog", [])
     database.setdefault("qr_codes", [])
     database.setdefault("resources", [])

--- a/tests/test_pptx_discovery_contract.py
+++ b/tests/test_pptx_discovery_contract.py
@@ -202,6 +202,50 @@ def test_public_batch_rejects_descendant_skip_receipts() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/absolute/deck.pptx",
+        "\\absolute\\deck.pptx",
+        "C:/absolute/deck.pptx",
+        "../escape.pptx",
+        "nested/../escape.pptx",
+        "./deck.pptx",
+        "nested//deck.pptx",
+        "nested/",
+        "nested\\deck.pptx",
+        "line\nbreak.pptx",
+        "zero\u200bwidth.pptx",
+    ],
+)
+def test_public_batch_rejects_noncanonical_skip_paths(path: str) -> None:
+    with pytest.raises(
+        contract.PptxDiscoveryContractError,
+        match="canonical root-relative path",
+    ):
+        contract.build_pptx_directory_batch(
+            [],
+            [{"path": path, "reason": "pptx_batch_skip_pattern"}],
+        )
+
+
+def test_public_batch_bounds_skip_path_length() -> None:
+    with pytest.raises(
+        contract.PptxDiscoveryContractError,
+        match="canonical root-relative path",
+    ):
+        contract.build_pptx_directory_batch(
+            [],
+            [
+                {
+                    "path": "x"
+                    * (contract.PPTX_DIRECTORY_RELATIVE_PATH_MAX_CHARS + 1),
+                    "reason": "pptx_batch_skip_pattern",
+                }
+            ],
+        )
+
+
 def test_whole_root_failure_is_bound_to_the_same_public_envelope() -> None:
     batch = contract.build_pptx_directory_batch(
         [],

--- a/tests/test_pptx_discovery_contract.py
+++ b/tests/test_pptx_discovery_contract.py
@@ -12,7 +12,7 @@ SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
-import pptx_discovery_contract as contract  # noqa: E402
+import pptx_discovery_contract as contract  # noqa: E402 - import follows script-path injection
 
 
 def test_canonical_directory_exclusions_are_narrow_and_stable() -> None:

--- a/tests/test_pptx_discovery_contract.py
+++ b/tests/test_pptx_discovery_contract.py
@@ -1,0 +1,371 @@
+"""Tests for versioned PPTX directory discovery policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import pptx_discovery_contract as contract  # noqa: E402
+
+
+def test_canonical_directory_exclusions_are_narrow_and_stable() -> None:
+    assert contract.DEFAULT_PPTX_DIRECTORY_EXCLUSIONS == (
+        ".venv",
+        "venv",
+        "node_modules",
+        ".git",
+        ".hg",
+        ".svn",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".tox",
+        ".nox",
+        ".tessl",
+    )
+    assert not {
+        "templates",
+        "slides",
+        "decks",
+        "build",
+        "dist",
+        "vendor",
+        "archive",
+    } & set(contract.DEFAULT_PPTX_DIRECTORY_EXCLUSIONS)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "venv",
+        [""],
+        ["   "],
+        ["."],
+        [".."],
+        ["nested/venv"],
+        [r"nested\venv"],
+        ["venv*"],
+        ["^venv$"],
+        ["venv[0-9]"],
+        ["venv\ncache"],
+        ["venv\x85cache"],
+        ["venv\u202ecache"],
+        ["venv", "VENV"],
+        ["x" * (contract.PPTX_DIRECTORY_EXCLUSION_MAX_CHARS + 1)],
+        ["x"] * (contract.PPTX_DIRECTORY_EXCLUSION_MAX_COUNT + 1),
+    ],
+)
+def test_directory_exclusion_validation_rejects_patterns_and_ambiguous_values(
+    value: object,
+) -> None:
+    with pytest.raises(contract.PptxDiscoveryContractError):
+        contract.validate_pptx_directory_exclusions(value)
+
+
+def test_directory_exclusion_caps_accept_exact_boundaries() -> None:
+    components = [
+        f"cache-{index}"
+        for index in range(contract.PPTX_DIRECTORY_EXCLUSION_MAX_COUNT - 1)
+    ]
+    components.append("x" * contract.PPTX_DIRECTORY_EXCLUSION_MAX_CHARS)
+
+    assert contract.validate_pptx_directory_exclusions(components) == components
+
+
+def test_directory_exclusions_use_exact_casefolded_component_matching() -> None:
+    exclusions = contract.validate_pptx_directory_exclusions(
+        [".VENV", "generated assets"]
+    )
+
+    assert contract.directory_component_is_excluded(".venv", exclusions) is True
+    assert (
+        contract.directory_component_is_excluded("generated assets", exclusions)
+        is True
+    )
+    assert contract.directory_component_is_excluded("my.venv", exclusions) is False
+    assert (
+        contract.directory_component_is_excluded("generated assets old", exclusions)
+        is False
+    )
+
+
+def test_policy_skips_do_not_make_a_complete_scan_partial() -> None:
+    skipped = [
+        {"path": f"safe-{index}", "reason": reason}
+        for index, reason in enumerate(
+            sorted(contract.PPTX_DIRECTORY_POLICY_SKIP_REASON_CODES)
+        )
+    ]
+
+    batch = contract.build_pptx_directory_batch([], skipped)
+
+    assert batch["complete"] is True
+    assert batch["incomplete_reason_codes"] == []
+
+
+@pytest.mark.parametrize(
+    "reason_code",
+    sorted(contract.PPTX_DIRECTORY_INCOMPLETE_REASON_CODES),
+)
+def test_every_incomplete_reason_fails_closed(reason_code: str) -> None:
+    error = (
+        {"reason_code": reason_code, "details": {}}
+        if reason_code in contract.PPTX_DIRECTORY_WHOLE_ROOT_REASON_CODES
+        else None
+    )
+    batch = contract.build_pptx_directory_batch(
+        [],
+        [{"path": ".", "reason": reason_code}],
+        error=error,
+    )
+
+    assert batch["complete"] is False
+    assert batch["incomplete_reason_codes"] == [reason_code]
+
+
+def test_public_batch_round_trip_is_strict_and_recomputes_completeness() -> None:
+    batch = contract.build_pptx_directory_batch(
+        [{"pptx_path": "talk.pptx"}],
+        [
+            {"path": ".venv", "reason": "pptx_batch_directory_excluded"},
+            {"path": "bad.pptx", "reason": "pptx_parse_failure"},
+        ],
+    )
+
+    assert batch == {
+        "schema_version": 1,
+        "kind": "pptx_directory_batch",
+        "complete": False,
+        "incomplete_reason_codes": ["pptx_parse_failure"],
+        "results": [{"pptx_path": "talk.pptx"}],
+        "skipped": [
+            {"path": ".venv", "reason": "pptx_batch_directory_excluded"},
+            {"path": "bad.pptx", "reason": "pptx_parse_failure"},
+        ],
+    }
+    assert contract.decode_pptx_directory_batch(batch) == batch
+    assert contract.assess_pptx_directory_batch(batch).state == "partial"
+
+    for field, false_value in (
+        ("complete", True),
+        ("incomplete_reason_codes", []),
+        ("schema_version", True),
+        ("kind", "directory"),
+    ):
+        malformed = {**batch, field: false_value}
+        with pytest.raises(contract.PptxDiscoveryContractError):
+            contract.decode_pptx_directory_batch(malformed)
+
+
+def test_public_batch_rejects_nonobjects_unknown_reasons_and_duplicate_receipts() -> None:
+    for results, skipped in (
+        (["not-an-object"], []),
+        ([], [{"path": ".", "reason": "typo"}]),
+        (
+            [],
+            [
+                {"path": "one.pptx", "reason": "pptx_parse_failure"},
+                {"path": "one.pptx", "reason": "pptx_probe_timeout"},
+            ],
+        ),
+    ):
+        with pytest.raises(contract.PptxDiscoveryContractError):
+            contract.build_pptx_directory_batch(results, skipped)
+
+
+def test_public_batch_rejects_descendant_skip_receipts() -> None:
+    with pytest.raises(
+        contract.PptxDiscoveryContractError,
+        match="descendant of another skipped path",
+    ):
+        contract.build_pptx_directory_batch(
+            [],
+            [
+                {
+                    "path": "unavailable",
+                    "reason": "pptx_batch_directory_unavailable",
+                },
+                {
+                    "path": "unavailable/deck.pptx",
+                    "reason": "pptx_batch_entry_unavailable",
+                },
+            ],
+        )
+
+
+def test_whole_root_failure_is_bound_to_the_same_public_envelope() -> None:
+    batch = contract.build_pptx_directory_batch(
+        [],
+        [{"path": ".", "reason": "pptx_batch_discovery_start_failure"}],
+        error={
+            "reason_code": "pptx_batch_discovery_start_failure",
+            "details": {"supervisor_reason_code": "worker_start_failed"},
+        },
+    )
+
+    assert batch["complete"] is False
+    assert batch["results"] == []
+    assert contract.decode_pptx_directory_batch(batch) == batch
+
+
+def test_whole_root_receipt_requires_error_and_zero_results() -> None:
+    receipt = [
+        {"path": ".", "reason": "pptx_batch_discovery_start_failure"}
+    ]
+    with pytest.raises(
+        contract.PptxDiscoveryContractError,
+        match="require a matching top-level error",
+    ):
+        contract.build_pptx_directory_batch([], receipt)
+
+    with pytest.raises(
+        contract.PptxDiscoveryContractError,
+        match="one incomplete root receipt and no results",
+    ):
+        contract.build_pptx_directory_batch(
+            [{"pptx_path": "safe.pptx"}],
+            receipt,
+            error={
+                "reason_code": "pptx_batch_discovery_start_failure",
+                "details": {},
+            },
+        )
+
+    with pytest.raises(
+        contract.PptxDiscoveryContractError,
+        match="one incomplete root receipt and no results",
+    ):
+        contract.build_pptx_directory_batch(
+            [],
+            receipt,
+            error={
+                "reason_code": "pptx_batch_discovery_timeout",
+                "details": {},
+            },
+        )
+
+
+def test_top_level_error_rejects_per_file_reason_promotion() -> None:
+    with pytest.raises(
+        contract.PptxDiscoveryContractError,
+        match="one incomplete root receipt and no results",
+    ):
+        contract.build_pptx_directory_batch(
+            [],
+            [{"path": ".", "reason": "pptx_parse_failure"}],
+            error={"reason_code": "pptx_parse_failure", "details": {}},
+        )
+
+
+@pytest.mark.parametrize(
+    "details",
+    [
+        {"path": "/private/decks"},
+        {"unexpected": "worker_start_failed"},
+        {"supervisor_reason_code": "arbitrary_future_or_injected_value"},
+        {"supervisor_reason_code": ["worker_start_failed"]},
+    ],
+)
+def test_top_level_error_details_are_closed_and_path_neutral(details: object) -> None:
+    with pytest.raises(contract.PptxDiscoveryContractError):
+        contract.build_pptx_directory_batch(
+            [],
+            [
+                {
+                    "path": ".",
+                    "reason": "pptx_batch_discovery_start_failure",
+                }
+            ],
+            error={
+                "reason_code": "pptx_batch_discovery_start_failure",
+                "details": details,
+            },
+        )
+
+
+def test_legacy_unversioned_batch_never_authorizes_absence() -> None:
+    assessment = contract.assess_pptx_directory_batch(
+        {"results": [], "skipped": []}
+    )
+
+    assert assessment.state == "unknown_legacy"
+    assert assessment.schema_version == 0
+    assert assessment.complete is None
+    assert assessment.incomplete_reason_codes == (
+        "pptx_directory_batch_completeness_unknown",
+    )
+
+
+def test_ingress_and_config_docs_bind_directory_completeness_and_migration() -> None:
+    root = Path(__file__).parents[1]
+    relative_paths = {
+        "skill": "skills/vault-ingress/SKILL.md",
+        "bootstrap": (
+            "skills/vault-ingress/references/bootstrap-and-preflight.md"
+        ),
+        "followup": "skills/vault-ingress/references/pptx-followup.md",
+        "schemas": "skills/vault-ingress/references/schemas-db.md",
+        "preflight": (
+            "skills/vault-ingress/references/source-identity-preflight.md"
+        ),
+        "profile_config": "skills/vault-profile/references/schemas-config.md",
+        "clarification": "skills/vault-clarification/SKILL.md",
+        "clarification_config": (
+            "skills/vault-clarification/references/schemas-config.md"
+        ),
+    }
+    docs = {
+        name: (root / relative).read_text(encoding="utf-8")
+        for name, relative in relative_paths.items()
+    }
+
+    for name in ("skill", "bootstrap", "followup"):
+        assert "{directory_exclusion_arguments}" in docs[name]
+    for name in ("bootstrap", "followup", "schemas", "preflight"):
+        assert "complete: true" in docs[name]
+        assert "legacy unversioned" in docs[name].lower()
+    for name in ("bootstrap", "schemas", "profile_config"):
+        assert "pptx_directory_exclusions" in docs[name]
+        assert (
+            '"schema_version": 2' in docs[name]
+            or "`schema_version: 2`" in docs[name]
+        )
+    assert "config schema 2" in docs["clarification"]
+    assert "config schema v2" in docs["clarification_config"]
+    assert "per-deck extractor schema v4" in docs["schemas"]
+    assert "separate finite policy\nenumeration ceiling" in docs["schemas"]
+    assert "response echoes that exact ordered list" in docs["schemas"]
+    assert "per-deck failures cannot be promoted" in docs["schemas"]
+    assert docs["bootstrap"].count("DEFAULT_PPTX_DIRECTORY_EXCLUSIONS") == 1
+    assert "DEFAULT_PPTX_DIRECTORY_EXCLUSIONS" not in docs["profile_config"]
+    assert "DEFAULT_PPTX_DIRECTORY_EXCLUSIONS" not in docs["schemas"]
+    assert '"pptx_directory_exclusions": ["example-tool-cache"]' in (
+        docs["profile_config"]
+    )
+    assert '"pptx_directory_exclusions": ["example-tool-cache"]' in docs["schemas"]
+    taxonomy_reference = (
+        "pptx_discovery_contract.py::{PPTX_DIRECTORY_POLICY_SKIP_REASON_CODES,"
+        "PPTX_DIRECTORY_INCOMPLETE_REASON_CODES}"
+    )
+    assert taxonomy_reference in docs["schemas"]
+    assert all(
+        taxonomy_reference not in document
+        for name, document in docs.items()
+        if name != "schemas"
+    )
+    assert "never reclassify receipts by\nreason string" in docs["bootstrap"]
+    assert "without an explicit speaker-specific customization" in (
+        docs["bootstrap"]
+    )
+    assert "without an explicit speaker-specific customization" in (
+        docs["profile_config"]
+    )

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -27,18 +27,53 @@ from conftest import make_deck
 def _use_in_process_directory_discovery(pptx_extraction, monkeypatch):
     """Keep batch unit tests fast while production discovery stays supervised."""
 
-    def discover(directory, patterns, *, deadline):
+    def discover(directory, patterns, directory_exclusions, *, deadline):
         assert deadline > 0
         files, skipped, _started = pptx_extraction._discover_pptx_files(
-            directory, patterns
+            directory,
+            patterns,
+            directory_exclusions,
         )
-        return [relative for _path, relative in files], skipped
+        reasons = pptx_extraction.directory_incomplete_reason_codes(skipped)
+        return [relative for _path, relative in files], skipped, not reasons, reasons
 
     monkeypatch.setattr(
         pptx_extraction,
         "_run_supervised_directory_discovery",
         discover,
     )
+
+
+def _directory_manifest(*, files=None, skipped=None, **updates):
+    skipped = [] if skipped is None else skipped
+    policy_skips = {
+        "pptx_batch_conflict_copy",
+        "pptx_batch_directory_excluded",
+        "pptx_batch_office_lock_file",
+        "pptx_batch_reparse_point_rejected",
+        "pptx_batch_skip_pattern",
+        "pptx_batch_static_export",
+        "pptx_batch_symlink_rejected",
+    }
+    reasons = sorted(
+        {
+            item["reason"]
+            for item in skipped
+            if isinstance(item.get("reason"), str)
+            and item["reason"] not in policy_skips
+        }
+    )
+    manifest = {
+        "schema_version": 2,
+        "kind": "directory",
+        "complete": not reasons,
+        "directory_exclusions": [],
+        "incomplete_reason_codes": reasons,
+        "files": [] if files is None else files,
+        "skipped": skipped,
+    }
+    manifest.update(updates)
+    return manifest
 
 
 def test_slide_count(pptx_extraction, tmp_path):
@@ -305,6 +340,210 @@ def test_bounded_discovery_rejects_symlinks_and_is_deterministic(
     )
 
 
+def test_directory_exclusion_prunes_before_scandir_and_keeps_authored_default_deck(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    dependency = root / ".venv" / "lib" / "site-packages" / "pptx" / "templates"
+    authored = root / "templates"
+    dependency.mkdir(parents=True)
+    authored.mkdir(parents=True)
+    (dependency / "default.pptx").write_bytes(b"dependency")
+    (authored / "default.pptx").write_bytes(b"authored")
+    original_scandir = pptx_extraction.os.scandir
+
+    def guarded_scandir(path):
+        assert Path(path) != root / ".venv", "excluded directory was inspected"
+        return original_scandir(path)
+
+    monkeypatch.setattr(pptx_extraction.os, "scandir", guarded_scandir)
+
+    discovered, skipped, _started = pptx_extraction._discover_pptx_files(
+        root,
+        [],
+        [".VENV"],
+    )
+
+    assert [relative for _path, relative in discovered] == [
+        "templates/default.pptx"
+    ]
+    assert skipped == [
+        {"path": ".venv", "reason": "pptx_batch_directory_excluded"}
+    ]
+    assert pptx_extraction.directory_incomplete_reason_codes(skipped) == []
+
+
+def test_excluded_directory_cannot_starve_authored_sibling_at_entry_cap(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    excluded = root / ".venv"
+    excluded.mkdir(parents=True)
+    (excluded / "dependency.pptx").write_bytes(b"dependency")
+    (root / "talk.pptx").write_bytes(b"authored")
+    monkeypatch.setattr(pptx_extraction, "_BATCH_MAX_ENTRIES", 1)
+
+    discovered, skipped, _started = pptx_extraction._discover_pptx_files(
+        root,
+        [],
+        [".venv"],
+    )
+
+    assert [relative for _path, relative in discovered] == ["talk.pptx"]
+    assert skipped == [
+        {"path": ".venv", "reason": "pptx_batch_directory_excluded"}
+    ]
+
+
+def test_policy_exclusion_enumeration_has_its_own_closed_cap(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    (root / ".venv").mkdir(parents=True)
+    (root / "talk.pptx").write_bytes(b"authored")
+    monkeypatch.setattr(
+        pptx_extraction,
+        "_BATCH_MAX_POLICY_EXCLUDED_ENTRIES",
+        0,
+    )
+
+    discovered, skipped, _started = pptx_extraction._discover_pptx_files(
+        root,
+        [],
+        [".venv"],
+    )
+
+    assert discovered == []
+    assert skipped == [{"path": ".", "reason": "pptx_batch_entry_limit"}]
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX symlink precedence is tested separately from Windows reparse points",
+)
+def test_named_exclusion_keeps_symlink_rejection_precedence(
+    pptx_extraction,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (root / ".venv").symlink_to(outside, target_is_directory=True)
+
+    discovered, skipped, _started = pptx_extraction._discover_pptx_files(
+        root,
+        [],
+        [".venv"],
+    )
+
+    assert discovered == []
+    assert skipped == [
+        {"path": ".venv", "reason": "pptx_batch_symlink_rejected"}
+    ]
+
+
+def test_named_exclusion_keeps_reparse_rejection_precedence(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    excluded = root / ".venv"
+    excluded.mkdir(parents=True)
+    excluded_inode = excluded.lstat().st_ino
+    monkeypatch.setattr(
+        pptx_extraction,
+        "_is_windows_reparse_point",
+        lambda value: value.st_ino == excluded_inode,
+    )
+
+    discovered, skipped, _started = pptx_extraction._discover_pptx_files(
+        root,
+        [],
+        [".venv"],
+    )
+
+    assert discovered == []
+    assert skipped == [
+        {"path": ".venv", "reason": "pptx_batch_reparse_point_rejected"}
+    ]
+
+
+def test_excluded_directories_do_not_consume_directory_budget(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    included = root / "included"
+    excluded = root / ".venv"
+    included.mkdir(parents=True)
+    excluded.mkdir()
+    monkeypatch.setattr(pptx_extraction, "_BATCH_MAX_DIRECTORIES", 2)
+
+    _files, exact_skipped, _started = pptx_extraction._discover_pptx_files(root, [])
+    assert exact_skipped == [
+        {"path": ".", "reason": "pptx_batch_directory_limit"}
+    ]
+
+    _files, excluded_skipped, _started = pptx_extraction._discover_pptx_files(
+        root,
+        [],
+        [".venv"],
+    )
+    assert excluded_skipped == [
+        {"path": ".venv", "reason": "pptx_batch_directory_excluded"}
+    ]
+    assert pptx_extraction.directory_incomplete_reason_codes(excluded_skipped) == []
+
+
+def test_exact_directory_budget_is_complete_but_one_more_directory_is_partial(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    first = root / "first"
+    first.mkdir(parents=True)
+    monkeypatch.setattr(pptx_extraction, "_BATCH_MAX_DIRECTORIES", 2)
+
+    _files, skipped, _started = pptx_extraction._discover_pptx_files(root, [])
+    assert skipped == []
+
+    (root / "second").mkdir()
+    _files, skipped, _started = pptx_extraction._discover_pptx_files(root, [])
+    assert skipped == [
+        {"path": ".", "reason": "pptx_batch_directory_limit"}
+    ]
+
+
+def test_depth_budget_marks_only_unvisited_descendants_partial(
+    pptx_extraction,
+    monkeypatch,
+    tmp_path,
+):
+    root = tmp_path / "decks"
+    child = root / "child"
+    child.mkdir(parents=True)
+    monkeypatch.setattr(pptx_extraction, "_BATCH_MAX_DEPTH", 1)
+
+    _files, skipped, _started = pptx_extraction._discover_pptx_files(root, [])
+    assert skipped == []
+
+    (child / "grandchild").mkdir()
+    _files, skipped, _started = pptx_extraction._discover_pptx_files(root, [])
+    assert skipped == [
+        {"path": "child/grandchild", "reason": "pptx_batch_depth_limit"}
+    ]
+
+
 def test_bounded_discovery_rejects_symlink_root(pptx_extraction, tmp_path):
     root = tmp_path / "decks"
     root.mkdir()
@@ -407,76 +646,31 @@ def test_windows_leaf_policy_accepts_only_hydrated_supported_cloud_tags(
 @pytest.mark.parametrize(
     "manifest",
     [
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [],
-            "skipped": [],
-            "unexpected": True,
-        },
-        {
-            "schema_version": True,
-            "kind": "directory",
-            "files": [],
-            "skipped": [],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [{"path": "deck.pptx"}, {"path": "deck.pptx"}],
-            "skipped": [],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [{"path": "../deck.pptx"}],
-            "skipped": [],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [{"path": "/outside/deck.pptx"}],
-            "skipped": [],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [{"path": "not-a-deck.txt"}],
-            "skipped": [],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [{"path": "~$locked.pptx"}],
-            "skipped": [],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [],
-            "skipped": [{"path": ".", "reason": "pptx_batch_unknown_typo"}],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [],
-            "skipped": [{"path": ".", "reason": []}],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [{"path": "deck.pptx"}],
-            "skipped": [{"path": "deck.pptx", "reason": "pptx_batch_skip_pattern"}],
-        },
-        {
-            "schema_version": 1,
-            "kind": "directory",
-            "files": [],
-            "skipped": [
+        _directory_manifest(unexpected=True),
+        _directory_manifest(schema_version=True),
+        _directory_manifest(
+            files=[{"path": "deck.pptx"}, {"path": "deck.pptx"}],
+        ),
+        _directory_manifest(files=[{"path": "../deck.pptx"}]),
+        _directory_manifest(files=[{"path": "/outside/deck.pptx"}]),
+        _directory_manifest(files=[{"path": "not-a-deck.txt"}]),
+        _directory_manifest(files=[{"path": "~$locked.pptx"}]),
+        _directory_manifest(
+            skipped=[{"path": ".", "reason": "pptx_batch_unknown_typo"}],
+        ),
+        _directory_manifest(skipped=[{"path": ".", "reason": []}]),
+        _directory_manifest(
+            files=[{"path": "deck.pptx"}],
+            skipped=[{"path": "deck.pptx", "reason": "pptx_batch_skip_pattern"}],
+        ),
+        _directory_manifest(
+            skipped=[
                 {"path": ".", "reason": "pptx_batch_wall_limit"},
                 {"path": ".", "reason": "pptx_batch_wall_limit"},
             ],
-        },
+        ),
+        _directory_manifest(complete=False),
+        _directory_manifest(incomplete_reason_codes=["pptx_batch_wall_limit"]),
     ],
 )
 def test_directory_manifest_rejects_malformed_duplicate_or_noncanonical_data(
@@ -490,20 +684,92 @@ def test_directory_manifest_rejects_malformed_duplicate_or_noncanonical_data(
 
 
 def test_directory_manifest_allows_distinct_root_findings(pptx_extraction):
-    manifest = {
-        "schema_version": 1,
-        "kind": "directory",
-        "files": [],
-        "skipped": [
+    manifest = _directory_manifest(
+        skipped=[
             {"path": ".", "reason": "pptx_batch_wall_limit"},
             {"path": ".", "reason": "pptx_batch_entry_limit"},
         ],
-    }
+    )
 
     assert pptx_extraction._decode_directory_manifest(manifest) == (
         [],
         manifest["skipped"],
+        False,
+        ["pptx_batch_entry_limit", "pptx_batch_wall_limit"],
     )
+
+
+@pytest.mark.parametrize(
+    ("manifest", "expected_exclusions"),
+    [
+        (
+            _directory_manifest(directory_exclusions=["templates"]),
+            [".venv"],
+        ),
+        (
+            _directory_manifest(
+                directory_exclusions=[".venv"],
+                skipped=[
+                    {
+                        "path": "templates",
+                        "reason": "pptx_batch_directory_excluded",
+                    }
+                ],
+            ),
+            [".venv"],
+        ),
+        (
+            _directory_manifest(
+                directory_exclusions=[".venv"],
+                files=[{"path": ".venv/lib/default.pptx"}],
+            ),
+            [".venv"],
+        ),
+        (
+            _directory_manifest(
+                directory_exclusions=[".venv"],
+                skipped=[
+                    {
+                        "path": ".venv",
+                        "reason": "pptx_batch_directory_excluded",
+                    },
+                    {
+                        "path": ".venv/lib",
+                        "reason": "pptx_batch_directory_unavailable",
+                    },
+                ],
+            ),
+            [".venv"],
+        ),
+        (
+            _directory_manifest(
+                skipped=[
+                    {
+                        "path": "unavailable",
+                        "reason": "pptx_batch_directory_unavailable",
+                    },
+                    {
+                        "path": "unavailable/deck.pptx",
+                        "reason": "pptx_batch_entry_unavailable",
+                    },
+                ],
+            ),
+            [],
+        ),
+    ],
+)
+def test_directory_manifest_binds_exclusions_and_rejects_descendant_claims(
+    pptx_extraction,
+    manifest,
+    expected_exclusions,
+):
+    with pytest.raises(pptx_extraction.PptxEvidenceError) as caught:
+        pptx_extraction._decode_directory_manifest(
+            manifest,
+            expected_directory_exclusions=expected_exclusions,
+        )
+
+    assert caught.value.reason_code == "pptx_batch_manifest_invalid"
 
 
 @pytest.mark.skipif(
@@ -520,16 +786,19 @@ def test_directory_discovery_deduplicates_collapsed_invalid_path_receipts(
     (root / "two\\bad.pptx").write_bytes(b"two")
 
     files, skipped, _started = pptx_extraction._discover_pptx_files(root, [])
-    manifest = {
-        "schema_version": 1,
-        "kind": "directory",
-        "files": [{"path": relative} for _path, relative in files],
-        "skipped": skipped,
-    }
+    manifest = _directory_manifest(
+        files=[{"path": relative} for _path, relative in files],
+        skipped=skipped,
+    )
 
     assert files == []
     assert skipped == [{"path": ".", "reason": "pptx_batch_path_invalid"}]
-    assert pptx_extraction._decode_directory_manifest(manifest) == ([], skipped)
+    assert pptx_extraction._decode_directory_manifest(manifest) == (
+        [],
+        skipped,
+        False,
+        ["pptx_batch_path_invalid"],
+    )
 
 
 def test_directory_owner_never_touches_root_before_authenticated_manifest(
@@ -553,12 +822,7 @@ def test_directory_owner_never_touches_root_before_authenticated_manifest(
     ):
         calls.append((command, operation, generations, payload, limits, kwargs))
         return SimpleNamespace(
-            payload={
-                "schema_version": 1,
-                "kind": "directory",
-                "files": [{"path": "nested/deck.pptx"}],
-                "skipped": [],
-            }
+            payload=_directory_manifest(files=[{"path": "nested/deck.pptx"}])
         )
 
     monkeypatch.setattr(
@@ -587,8 +851,12 @@ def test_directory_owner_never_touches_root_before_authenticated_manifest(
     ]
     assert operation == "pptx_resolve_input"
     assert generations == {}
-    assert payload == {"root_path": root, "skip_patterns": []}
-    assert limits.profile_id == "pptx-directory-discovery-v1"
+    assert payload == {
+        "root_path": root,
+        "skip_patterns": [],
+        "directory_exclusions": [],
+    }
+    assert limits.profile_id == "pptx-directory-discovery-v2"
     assert kwargs["schema_generation"] == pptx_extraction.SCHEMA_VERSION
     assert kwargs["pipeline_generation"] == pptx_extraction.PIPELINE_VERSION
     assert kwargs["immutable_process_identity"] == command[:2]
@@ -650,7 +918,9 @@ def test_nested_runtime_reaches_every_fixed_pptx_worker(
         str(worker_scripts / "pptx_evidence.py"),
     )
 
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
+    results = batch["results"]
+    skipped = batch["skipped"]
     batch_operations = set(operations)
     operation_count = len(operations)
     probe = pptx_evidence.probe_pptx_artifact(deck, trusted_root=root)
@@ -659,6 +929,10 @@ def test_nested_runtime_reaches_every_fixed_pptx_worker(
     audit = pptx_evidence.recompute_native_deck_audit(deck, trusted_root=root)
     audit_operations = set(operations[operation_count:])
 
+    assert batch["schema_version"] == 1
+    assert batch["kind"] == "pptx_directory_batch"
+    assert batch["complete"] is True
+    assert batch["incomplete_reason_codes"] == []
     assert skipped == []
     assert len(results) == 1
     assert results[0]["pptx_path"] == "Conference/deck.pptx"
@@ -692,12 +966,7 @@ def test_directory_cli_passes_only_the_exact_configured_skip_patterns(
     ):
         captured_payload.update(payload)
         return SimpleNamespace(
-            payload={
-                "schema_version": 1,
-                "kind": "directory",
-                "files": [],
-                "skipped": [],
-            }
+            payload=_directory_manifest(directory_exclusions=[".venv"])
         )
 
     monkeypatch.setattr(
@@ -711,6 +980,7 @@ def test_directory_cli_passes_only_the_exact_configured_skip_patterns(
                 root,
                 "--skip=draft",
                 "--skip=-speaker-master",
+                "--exclude-directory=.venv",
                 "--no-ocr",
             ]
         )
@@ -719,10 +989,18 @@ def test_directory_cli_passes_only_the_exact_configured_skip_patterns(
 
     captured = capsys.readouterr()
     assert captured.err == ""
-    assert json.loads(captured.out) == {"results": [], "skipped": []}
+    assert json.loads(captured.out) == {
+        "schema_version": 1,
+        "kind": "pptx_directory_batch",
+        "complete": True,
+        "incomplete_reason_codes": [],
+        "results": [],
+        "skipped": [],
+    }
     assert captured_payload == {
         "root_path": root,
         "skip_patterns": ["draft", "-speaker-master"],
+        "directory_exclusions": [".venv"],
     }
 
 
@@ -794,7 +1072,11 @@ def test_directory_worker_revalidates_root_before_discovery(
         schema_generation=pptx_extraction.SCHEMA_VERSION,
         pipeline_generation=pptx_extraction.PIPELINE_VERSION,
         expected_generations={},
-        payload={"root_path": "relative", "skip_patterns": []},
+        payload={
+            "root_path": "relative",
+            "skip_patterns": [],
+            "directory_exclusions": [],
+        },
         key=b"k" * 32,
     )
     monkeypatch.setattr(
@@ -813,26 +1095,30 @@ def test_directory_worker_revalidates_root_before_discovery(
 
     observed = {}
 
-    def discover(root, patterns):
+    def discover(root, patterns, exclusions):
         observed["root"] = root
         observed["patterns"] = patterns
+        observed["exclusions"] = exclusions
         return [], [], 0.0
 
     monkeypatch.setattr(pptx_extraction, "_discover_pptx_files", discover)
     payload = pptx_extraction._dispatch_directory_worker(
         replace(
             request,
-            payload={"root_path": str(tmp_path), "skip_patterns": []},
+            payload={
+                "root_path": str(tmp_path),
+                "skip_patterns": [],
+                "directory_exclusions": [".venv"],
+            },
         )
     )
 
-    assert observed == {"root": str(tmp_path), "patterns": []}
-    assert payload == {
-        "schema_version": 1,
-        "kind": "directory",
-        "files": [],
-        "skipped": [],
+    assert observed == {
+        "root": str(tmp_path),
+        "patterns": [],
+        "exclusions": [".venv"],
     }
+    assert payload == _directory_manifest(directory_exclusions=[".venv"])
 
 
 def test_batch_reuses_native_absolute_root_if_working_directory_changes(
@@ -847,11 +1133,11 @@ def test_batch_reuses_native_absolute_root_if_working_directory_changes(
     other.mkdir()
     monkeypatch.chdir(original)
 
-    def discover(directory, _patterns, *, deadline):
+    def discover(directory, _patterns, _exclusions, *, deadline):
         assert directory == root
         assert deadline > 0
         monkeypatch.chdir(other)
-        return ["deck.pptx"], []
+        return ["deck.pptx"], [], True, []
 
     observed = []
 
@@ -870,11 +1156,12 @@ def test_batch_reuses_native_absolute_root_if_working_directory_changes(
     )
     monkeypatch.setattr(pptx_extraction, "extract_pptx", extract)
 
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
 
-    assert skipped == []
+    assert batch["complete"] is True
+    assert batch["skipped"] == []
     assert observed == [root / "deck.pptx"]
-    assert results[0]["pptx_path"] == "deck.pptx"
+    assert batch["results"][0]["pptx_path"] == "deck.pptx"
 
 
 def test_directory_skip_pattern_iterators_are_rejected_without_consumption(
@@ -895,6 +1182,37 @@ def test_directory_skip_pattern_iterators_are_rejected_without_consumption(
         pptx_extraction._run_supervised_directory_discovery(
             "/lexical/root",
             ExplodingIterator(),
+            deadline=pptx_extraction.time.monotonic() + 30,
+        )
+
+    assert caught.value.reason_code == "pptx_batch_request_invalid"
+
+
+@pytest.mark.parametrize(
+    "exclusions",
+    [
+        ["nested/.venv"],
+        ["venv*"],
+        ["venv", "VENV"],
+        (item for item in [".venv"]),
+    ],
+)
+def test_directory_exclusions_are_rejected_before_worker_launch(
+    pptx_extraction,
+    monkeypatch,
+    exclusions,
+):
+    monkeypatch.setattr(
+        pptx_extraction,
+        "run_authenticated_worker",
+        lambda *_args, **_kwargs: pytest.fail("invalid request started worker"),
+    )
+
+    with pytest.raises(pptx_extraction.PptxEvidenceError) as caught:
+        pptx_extraction._run_supervised_directory_discovery(
+            "/lexical/root",
+            [],
+            exclusions,
             deadline=pptx_extraction.time.monotonic() + 30,
         )
 
@@ -980,6 +1298,10 @@ def test_directory_cli_returns_nonzero_structured_discovery_failure(
 
     captured = capsys.readouterr()
     assert json.loads(captured.out) == {
+        "schema_version": 1,
+        "kind": "pptx_directory_batch",
+        "complete": False,
+        "incomplete_reason_codes": ["pptx_batch_discovery_start_failure"],
         "results": [],
         "skipped": [{"path": ".", "reason": "pptx_batch_discovery_start_failure"}],
         "error": {
@@ -1080,22 +1402,24 @@ def test_batch_continues_after_one_supervised_failure_with_relative_paths(
         }
 
     monkeypatch.setattr(pptx_extraction, "extract_pptx", fake_extract)
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
 
-    assert results == [
+    assert batch["complete"] is False
+    assert batch["incomplete_reason_codes"] == ["pptx_probe_timeout"]
+    assert batch["results"] == [
         {
             "pptx_path": "b-good.pptx",
             "slide_count": 1,
             "input_fingerprint": {"size_bytes": 4},
         }
     ]
-    assert skipped == [
+    assert batch["skipped"] == [
         {
             "path": "a-bad.pptx",
             "reason": "pptx_probe_timeout",
         }
     ]
-    assert str(root) not in json.dumps({"results": results, "skipped": skipped})
+    assert str(root) not in json.dumps(batch)
 
 
 @pytest.mark.skipif(
@@ -1116,12 +1440,12 @@ def test_batch_rejects_intermediate_directory_swapped_after_discovery(
     make_deck(2).save(outside / "deck.pptx")
     parked = tmp_path / "original-nested"
 
-    def discover(directory, _patterns, *, deadline):
+    def discover(directory, _patterns, _exclusions, *, deadline):
         assert directory == root
         assert deadline > 0
         nested.rename(parked)
         nested.symlink_to(outside, target_is_directory=True)
-        return ["nested/deck.pptx"], []
+        return ["nested/deck.pptx"], [], True, []
 
     monkeypatch.setattr(
         pptx_extraction,
@@ -1129,10 +1453,11 @@ def test_batch_rejects_intermediate_directory_swapped_after_discovery(
         discover,
     )
 
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
 
-    assert results == []
-    assert skipped == [
+    assert batch["results"] == []
+    assert batch["complete"] is False
+    assert batch["skipped"] == [
         {
             "path": "nested/deck.pptx",
             "reason": "pptx_artifact_unavailable",
@@ -1170,11 +1495,16 @@ def test_batch_file_budget_stops_before_extra_worker(
         }
 
     monkeypatch.setattr(pptx_extraction, "extract_pptx", fake_extract)
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
 
     assert calls == ["a.pptx"]
-    assert results[0]["pptx_path"] == "a.pptx"
-    assert skipped == [
+    assert batch["results"][0]["pptx_path"] == "a.pptx"
+    assert batch["complete"] is False
+    assert batch["incomplete_reason_codes"] == [
+        "pptx_batch_file_limit",
+        "pptx_batch_scan_incomplete_file_limit",
+    ]
+    assert batch["skipped"] == [
         {
             "path": "b.pptx",
             "reason": "pptx_batch_file_limit",
@@ -1240,11 +1570,12 @@ def test_batch_input_budget_uses_launched_generation_not_discovery_size(
         )
 
     monkeypatch.setattr(pptx_extraction, "extract_pptx", fake_extract)
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
 
     assert calls == [("a.pptx", 5), ("b.pptx", 1)]
-    assert results[0]["input_fingerprint"]["size_bytes"] == 4
-    assert skipped == [
+    assert batch["results"][0]["input_fingerprint"]["size_bytes"] == 4
+    assert batch["complete"] is False
+    assert batch["skipped"] == [
         {"path": "b.pptx", "reason": "pptx_batch_input_limit"},
         {"path": "c.pptx", "reason": "pptx_batch_input_limit"},
     ]
@@ -1258,8 +1589,10 @@ def test_batch_charges_admitted_generation_reported_by_failed_launch(
     monkeypatch.setattr(
         pptx_extraction,
         "_run_supervised_directory_discovery",
-        lambda _root, _patterns, *, deadline: (
+        lambda _root, _patterns, _exclusions, *, deadline: (
             ["a.pptx", "b.pptx", "c.pptx"],
+            [],
+            True,
             [],
         ),
     )
@@ -1280,11 +1613,12 @@ def test_batch_charges_admitted_generation_reported_by_failed_launch(
 
     monkeypatch.setattr(pptx_extraction, "extract_pptx", fake_extract)
 
-    results, skipped = pptx_extraction.batch_extract("/lexical/root", [], ocr=False)
+    batch = pptx_extraction.batch_extract("/lexical/root", [], ocr=False)
 
-    assert results == []
+    assert batch["results"] == []
     assert calls == [("a.pptx", 5), ("b.pptx", 1)]
-    assert skipped == [
+    assert batch["complete"] is False
+    assert batch["skipped"] == [
         {"path": "a.pptx", "reason": "pptx_evidence_invalid"},
         {"path": "b.pptx", "reason": "pptx_batch_input_limit"},
         {"path": "c.pptx", "reason": "pptx_batch_input_limit"},
@@ -1305,9 +1639,9 @@ def test_batch_passes_one_absolute_deadline_and_stops_after_wall_exhaustion(
     monkeypatch.setattr(pptx_extraction, "_BATCH_MAX_WALL_SECONDS", 10)
     deadlines = []
 
-    def discover(_directory, _patterns, *, deadline):
+    def discover(_directory, _patterns, _exclusions, *, deadline):
         deadlines.append(deadline)
-        return ["a.pptx", "b.pptx"], []
+        return ["a.pptx", "b.pptx"], [], True, []
 
     monkeypatch.setattr(
         pptx_extraction, "_run_supervised_directory_discovery", discover
@@ -1323,12 +1657,13 @@ def test_batch_passes_one_absolute_deadline_and_stops_after_wall_exhaustion(
         )
 
     monkeypatch.setattr(pptx_extraction, "extract_pptx", fake_extract)
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
 
-    assert results == []
+    assert batch["results"] == []
     assert deadlines == [110.0]
     assert calls == [("a.pptx", 110.0)]
-    assert skipped == [
+    assert batch["complete"] is False
+    assert batch["skipped"] == [
         {"path": "a.pptx", "reason": "pptx_batch_wall_limit"},
         {"path": "b.pptx", "reason": "pptx_batch_wall_limit"},
     ]
@@ -1346,15 +1681,17 @@ def test_batch_compact_output_budget_includes_wrapper_and_skips(
     expected_skips = [
         {"path": "~$locked.pptx", "reason": "pptx_batch_office_lock_file"}
     ]
-    exact = pptx_extraction._encode_batch_output([], expected_skips) + b"\n"
+    expected_batch = pptx_extraction._build_batch_output([], expected_skips)
+    exact = pptx_extraction._encode_batch_output(expected_batch) + b"\n"
     monkeypatch.setattr(pptx_extraction, "_BATCH_MAX_OUTPUT_BYTES", len(exact))
     _use_in_process_directory_discovery(pptx_extraction, monkeypatch)
 
-    results, skipped = pptx_extraction.batch_extract(root, [], ocr=False)
+    batch = pptx_extraction.batch_extract(root, [], ocr=False)
 
-    assert results == []
-    assert skipped == expected_skips
-    assert len(pptx_extraction._encode_batch_output(results, skipped)) + 1 == len(exact)
+    assert batch["results"] == []
+    assert batch["complete"] is True
+    assert batch["skipped"] == expected_skips
+    assert len(pptx_extraction._encode_batch_output(batch)) + 1 == len(exact)
 
 
 def test_directory_cli_emits_the_same_compact_bytes_budgeted_by_batch(
@@ -1368,8 +1705,15 @@ def test_directory_cli_emits_the_same_compact_bytes_budgeted_by_batch(
     (root / "~$locked.pptx").write_bytes(b"lock")
     expected = (
         pptx_extraction._encode_batch_output(
-            [],
-            [{"path": "~$locked.pptx", "reason": "pptx_batch_office_lock_file"}],
+            pptx_extraction._build_batch_output(
+                [],
+                [
+                    {
+                        "path": "~$locked.pptx",
+                        "reason": "pptx_batch_office_lock_file",
+                    }
+                ],
+            )
         )
         + b"\n"
     )
@@ -1382,6 +1726,51 @@ def test_directory_cli_emits_the_same_compact_bytes_budgeted_by_batch(
     assert captured.err == ""
     assert captured.out.encode("utf-8") == expected
     assert len(captured.out.encode("utf-8")) <= pptx_extraction._BATCH_MAX_OUTPUT_BYTES
+
+
+def test_directory_cli_partial_batch_exits_zero_with_exact_public_envelope(
+    pptx_extraction,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(
+        pptx_extraction,
+        "_run_supervised_directory_discovery",
+        lambda _root, _patterns, _exclusions, *, deadline: (
+            ["broken.pptx"],
+            [],
+            True,
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        pptx_extraction,
+        "extract_pptx",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            pptx_extraction.PptxEvidenceError(
+                "fixture parse failure",
+                reason_code="pptx_parse_failure",
+            )
+        ),
+    )
+
+    exit_code = pptx_extraction.main(
+        ["--directory", "/lexical/root", "--no-ocr"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == {
+        "schema_version": 1,
+        "kind": "pptx_directory_batch",
+        "complete": False,
+        "incomplete_reason_codes": ["pptx_parse_failure"],
+        "results": [],
+        "skipped": [
+            {"path": "broken.pptx", "reason": "pptx_parse_failure"}
+        ],
+    }
 
 
 def test_per_slide_visual_count(pptx_extraction, tmp_path):

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -22,6 +22,21 @@ from pptx.util import Inches
 VIDEO_ID = "AbCdEfGhI_1"
 OTHER_VIDEO_ID = "ZyXwVuTsR_2"
 DRIVE_ID = "drive-file-123"
+DEFAULT_DIRECTORY_EXCLUSIONS = [
+    ".venv",
+    "venv",
+    "node_modules",
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".nox",
+    ".tessl",
+]
 QUEUE_STATE_SCRIPT = (
     Path(__file__).parents[1]
     / "skills"
@@ -133,7 +148,11 @@ def write_database(fixture, talks, config=None, *, current=False):
                 "improvement_goals": [],
             }
         )
-        database["config"]["schema_version"] = 1
+        database["config"]["schema_version"] = 2
+        database["config"].setdefault(
+            "pptx_directory_exclusions",
+            deepcopy(DEFAULT_DIRECTORY_EXCLUSIONS),
+        )
         for talk in talks:
             if isinstance(talk, dict):
                 talk["schema_version"] = 5
@@ -1942,6 +1961,136 @@ def test_preflight_reports_invalid_configured_pptx_root_without_talks(
     assert finding["artifact_path"] is None
     if configured_root:
         assert configured_root not in json.dumps(finding, sort_keys=True)
+
+
+def test_preflight_reports_malformed_pptx_directory_exclusions(
+    preflight_vault,
+    vault_fixture,
+):
+    write_database(
+        vault_fixture,
+        [],
+        config={
+            "speaker_name": "Baruch Sadogursky",
+            "pptx_source_dir": str(vault_fixture["pptx_source"]),
+            "pptx_directory_exclusions": ["venv", "VENV"],
+        },
+        current=True,
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["ok"] is False
+    findings = [
+        item
+        for item in report["findings"]
+        if item["code"] == "pptx_directory_exclusions_invalid"
+    ]
+    assert len(findings) == 1
+    assert findings[0]["field"] == "config.pptx_directory_exclusions"
+    assert findings[0]["actual"] == ["venv", "VENV"]
+    assert "tracking_database_schema_invalid" not in finding_codes(report)
+
+
+def test_preflight_reports_missing_current_pptx_directory_exclusions_once(
+    preflight_vault,
+    vault_fixture,
+):
+    write_database(vault_fixture, [], current=True)
+    database = json.loads(vault_fixture["database"].read_text(encoding="utf-8"))
+    database["config"].pop("pptx_directory_exclusions")
+    vault_fixture["database"].write_text(
+        json.dumps(database, indent=2),
+        encoding="utf-8",
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    findings = [
+        item
+        for item in report["findings"]
+        if item["code"] == "pptx_directory_exclusions_invalid"
+    ]
+    assert len(findings) == 1
+    assert findings[0]["field"] == "config.pptx_directory_exclusions"
+    assert findings[0]["actual"] == {"state": "missing"}
+    assert "tracking_database_schema_invalid" not in finding_codes(report)
+
+
+def test_preflight_preserves_unrelated_schema_fault_with_invalid_exclusions(
+    preflight_vault,
+    vault_fixture,
+):
+    write_database(vault_fixture, [], current=True)
+    database = json.loads(vault_fixture["database"].read_text(encoding="utf-8"))
+    database["config"]["pptx_directory_exclusions"] = ["venv", "VENV"]
+    database["pptx_catalog"] = {}
+    vault_fixture["database"].write_text(
+        json.dumps(database, indent=2),
+        encoding="utf-8",
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    blocking_codes = finding_codes(report, "blocking")
+    assert "pptx_directory_exclusions_invalid" in blocking_codes
+    assert "tracking_database_schema_invalid" in blocking_codes
+    assert sum(
+        finding["code"] == "pptx_directory_exclusions_invalid"
+        for finding in report["findings"]
+    ) == 1
+    assert sum(
+        finding["code"] == "tracking_database_schema_invalid"
+        for finding in report["findings"]
+    ) == 1
+
+
+def test_preflight_accepts_historical_config_v1_for_owner_migration(
+    preflight_vault,
+    vault_fixture,
+):
+    write_database(vault_fixture, [], current=True)
+    database = json.loads(vault_fixture["database"].read_text(encoding="utf-8"))
+    database["config"]["schema_version"] = 1
+    database["config"].pop("pptx_directory_exclusions")
+    vault_fixture["database"].write_text(
+        json.dumps(database, indent=2),
+        encoding="utf-8",
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "pptx_directory_exclusions_invalid" not in finding_codes(report)
+    assert "tracking_database_schema_unsupported" not in finding_codes(report)
+
+
+def test_preflight_fails_closed_on_future_config_generation(
+    preflight_vault,
+    vault_fixture,
+):
+    write_database(vault_fixture, [], current=True)
+    database = json.loads(vault_fixture["database"].read_text(encoding="utf-8"))
+    database["config"]["schema_version"] = 3
+    vault_fixture["database"].write_text(
+        json.dumps(database, indent=2),
+        encoding="utf-8",
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["ok"] is False
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "tracking_database_schema_unsupported"
+    )
+    assert finding["severity"] == "blocking"
+    assert finding["field"] == "config.schema_version"
+    assert finding["expected"] == [1, 2]
+    assert finding["actual"] == {
+        "schema_version": 3,
+        "reason_codes": ["config_schema_version_unsupported"],
+    }
 
 
 def test_preflight_null_configured_pptx_root_uses_vault_fallback(

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -21,6 +21,8 @@ from pptx import Presentation
 from pptx.util import Inches
 from pypdf import PdfWriter
 
+from conftest import current_tracking_config
+
 
 SCRIPT = (
     Path(__file__).parents[1]
@@ -219,7 +221,9 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
     }
     if current:
         database["schema_version"] = 1
-        database["config"]["schema_version"] = 1
+        database["config"] = current_tracking_config(
+            **database["config"]
+        )
     else:
         for talk in talks:
             talk.pop("schema_version", None)

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -11,6 +11,8 @@ import sys
 
 import pytest
 
+from conftest import current_tracking_config
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "skills" / "vault-ingress" / "scripts" / "scan-shownotes.py"
@@ -63,7 +65,7 @@ def _database_path(
             current_talks.append(current_talk)
         database = {
             "schema_version": 1,
-            "config": {"schema_version": 1, **config},
+            "config": current_tracking_config(**config),
             "talks": current_talks,
             "pptx_catalog": [],
             "qr_codes": [],

--- a/tests/test_tracking_database_mutation_docs.py
+++ b/tests/test_tracking_database_mutation_docs.py
@@ -21,3 +21,25 @@ def test_config_deletion_and_reserved_marker_recovery_are_documented() -> None:
     assert "Any other present value fails the precondition" in normalized_schema
     assert "`before_exists: true` and `after_exists: false`" in schema
     assert "never pass the missing marker as a `value`" in normalized_bootstrap
+
+
+def test_pptx_exclusion_bootstrap_uses_code_owned_defaults_without_prompting() -> None:
+    bootstrap = _read("skills/vault-ingress/references/bootstrap-and-preflight.md")
+    profile_schema = _read("skills/vault-profile/references/schemas-config.md")
+    normalized_bootstrap = " ".join(bootstrap.split())
+    normalized_profile = " ".join(profile_schema.split())
+
+    assert "pptx_discovery_contract.py::DEFAULT_PPTX_DIRECTORY_EXCLUSIONS" in (
+        bootstrap
+    )
+    assert "The exclusion field is not a missing-field question" in (
+        normalized_bootstrap
+    )
+    assert "only when the speaker explicitly wants to customize" in (
+        normalized_bootstrap
+    )
+    assert "read-only compatibility and owner-migration state" in normalized_profile
+    assert "never current or writable" in normalized_profile
+    assert "cannot authorize PPTX catalog coverage or an absence conclusion" in (
+        normalized_profile
+    )

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -10,6 +10,23 @@ import os
 import pytest
 
 
+DEFAULT_DIRECTORY_EXCLUSIONS = [
+    ".venv",
+    "venv",
+    "node_modules",
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".nox",
+    ".tessl",
+]
+
+
 def _legacy_goal(*, goal_id: str = "legacy") -> dict:
     return {
         "id": goal_id,
@@ -197,7 +214,8 @@ def _legacy_database() -> dict:
 def _expected_migration(database: dict) -> dict:
     expected = copy.deepcopy(database)
     expected["schema_version"] = 1
-    expected["config"]["schema_version"] = 1
+    expected["config"]["schema_version"] = 2
+    expected["config"]["pptx_directory_exclusions"] = DEFAULT_DIRECTORY_EXCLUSIONS
     for talk in expected["talks"]:
         talk.setdefault("schema_version", 1)
         for rejection in talk.get("source_rejections", []):
@@ -801,6 +819,107 @@ def test_current_migration_is_idempotent_with_stable_counts(tracking_database):
     }
 
 
+def test_current_root_config_v1_migrates_only_config(tracking_database):
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current["config"] = {
+        "schema_version": 1,
+        "python_path": "/opt/python",
+    }
+    untouched = {
+        key: copy.deepcopy(value)
+        for key, value in current.items()
+        if key != "config"
+    }
+
+    assessment = tracking_database.assess_tracking_database(current)
+    migration = tracking_database.migrate_tracking_database(current)
+
+    assert assessment.usable is True
+    assert assessment.state == "legacy"
+    assert migration.changed is True
+    assert migration.from_schema_version == 1
+    assert migration.to_schema_version == 1
+    assert migration.record_counts["config"] == 1
+    assert migration.database["config"] == {
+        "schema_version": 2,
+        "python_path": "/opt/python",
+        "pptx_directory_exclusions": DEFAULT_DIRECTORY_EXCLUSIONS,
+    }
+    assert {
+        key: value
+        for key, value in migration.database.items()
+        if key != "config"
+    } == untouched
+
+    second = tracking_database.migrate_tracking_database(migration.database)
+    assert second.changed is False
+    assert second.from_schema_version == 1
+    assert second.to_schema_version == 1
+    assert second.database == migration.database
+    assert all(count == 0 for count in second.record_counts.values())
+
+
+def test_config_v1_migration_preserves_valid_custom_exclusions(tracking_database):
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current["config"] = {
+        "schema_version": 1,
+        "pptx_directory_exclusions": ["generated", "VendorCache"],
+    }
+
+    migration = tracking_database.migrate_tracking_database(current)
+
+    assert migration.database["config"] == {
+        "schema_version": 2,
+        "pptx_directory_exclusions": ["generated", "VendorCache"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {"schema_version": 2},
+            "config schema v2 requires pptx_directory_exclusions",
+        ),
+        (
+            {
+                "schema_version": 2,
+                "pptx_directory_exclusions": ["venv", "VENV"],
+            },
+            "case-insensitive duplicate",
+        ),
+    ],
+)
+def test_current_config_v2_rejects_missing_or_malformed_exclusions(
+    tracking_database,
+    config,
+    expected,
+):
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current["config"] = config
+
+    with pytest.raises(tracking_database.TrackingDatabaseError, match=expected):
+        tracking_database.assess_tracking_database(current)
+
+
+def test_future_config_generation_fails_closed_without_poisoning_root_version(
+    tracking_database,
+):
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current["config"]["schema_version"] = 3
+
+    assessment = tracking_database.assess_tracking_database(current)
+
+    assert assessment.usable is False
+    assert assessment.schema_version == 1
+    assert assessment.reason_codes == ("config_schema_version_unsupported",)
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="config_schema_version_unsupported",
+    ):
+        tracking_database.migrate_tracking_database(current)
+
+
 @pytest.mark.parametrize(
     "collection",
     [
@@ -921,7 +1040,11 @@ def test_apply_writes_exact_backup_through_shared_transaction(
         expected_sha256=digest,
     )
 
-    backup = tmp_path / ".backups" / f"{path.name}.schema-v0-{digest}.bak"
+    backup = (
+        tmp_path
+        / ".backups"
+        / f"{path.name}.owner-migration-{digest}.bak"
+    )
     assert backup.read_bytes() == raw
     assert report["backup"] == str(backup)
     assert report["database_written"] is True
@@ -930,6 +1053,35 @@ def test_apply_writes_exact_backup_through_shared_transaction(
     current = json.loads(path.read_text())
     assert tracking_database.assess_tracking_database(current).state == "current"
     assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_config_only_migration_uses_generation_neutral_backup_name(
+    migrate_tracking_database,
+    tracking_database,
+    tmp_path,
+):
+    path = tmp_path / "tracking-database.json"
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current["config"] = {"schema_version": 1, "python_path": "/opt/python"}
+    raw = _write_database(path, current)
+    digest = hashlib.sha256(raw).hexdigest()
+
+    report = migrate_tracking_database.execute(
+        path,
+        apply=True,
+        expected_sha256=digest,
+    )
+
+    backup = (
+        tmp_path
+        / ".backups"
+        / f"{path.name}.owner-migration-{digest}.bak"
+    )
+    assert backup.read_bytes() == raw
+    assert report["backup"] == str(backup)
+    assert report["from_schema_version"] == 1
+    assert report["to_schema_version"] == 1
+    assert report["record_counts"]["config"] == 1
 
 
 def test_apply_current_database_is_exact_noop_without_backup(

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -10,6 +10,8 @@ import threading
 
 import pytest
 
+from conftest import current_tracking_config
+
 
 def _write(path: Path, value: object) -> bytes:
     raw = json.dumps(value, indent=2).encode("utf-8") + b"\n"
@@ -20,7 +22,7 @@ def _write(path: Path, value: object) -> bytes:
 def _current_database() -> dict[str, object]:
     return {
         "schema_version": 1,
-        "config": {"schema_version": 1},
+        "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],
         "qr_codes": [],

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import current_tracking_config
+
 
 def _catalog_fingerprint():
     root = (
@@ -325,7 +327,7 @@ def _write_tracking_db(
     path = tmp_path / name
     path.write_text(json.dumps({
         "schema_version": 1,
-        "config": {"schema_version": 1},
+        "config": current_tracking_config(),
         "talks": talks,
         "pptx_catalog": [],
         "qr_codes": [],


### PR DESCRIPTION
## Summary

- emit a strict versioned PPTX directory-batch envelope whose closed receipts recompute complete versus partial coverage
- add config schema v2 with bounded exact-component directory exclusions, deterministic defaults, and an idempotent owner migration from config v1
- bind the private discovery manifest to the exact requested exclusion policy and reject fabricated, nested, or contradictory receipts
- keep safe partial results reviewable while preventing partial or legacy scans from authorizing full-catalog and missing-deck conclusions
- report config-generation and exclusion faults precisely, including simultaneous unrelated schema faults

## Verification

- full suite after rebasing over 0.20.15: `4812 passed, 3 skipped`
- independently audited migration/completeness suite: `282 passed`
- changed-file Ruff: clean
- changed production-script Pyright: `0 errors`
- `tessl plugin lint`: valid (existing presentation-creator size warning only)
- `git diff --check`: clean

Closes #234.
