### PR TITLE
fix(vault-ingress): tolerate CloudStorage stage timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### fix(vault-ingress) — allow CloudStorage owner writes (#239)
+
+The shared tracking-database transaction now tolerates bounded timestamp-only
+settling on its unique staged file, including macOS Google Drive/File Provider
+behavior after fsync. Staged file type, link count, descriptor/name identity,
+size, exact bytes, and SHA-256 remain strict; failures report the named staged
+invariant and unstable timestamp fields. The target database keeps its exact
+byte-and-generation precondition. Pre-install invariant failures remove the
+still-owned staged name, while a substituted name remains untouched.
+Config-only owner migration remains hash-bound, backed up, and idempotent.
+Database schemas and talk evidence are unchanged; no talk reparse is required
+for this fix.
+
 ## 0.20.16 — 2026-08-05
 
 ### fix(vault-ingress) — make PPTX directory completeness explicit (#234)

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -40,8 +40,8 @@ size, exact bytes, and SHA-256 throughout verification. Staged `mtime_ns` and
 `ctime_ns` may rebaseline after fsync only when the descriptor view and name view
 are each stable across one byte-read window within the writer-owned bounded
 attempts. Exhaustion and every hard staged mismatch raise
-`StagedCandidateConflictError` with the failed invariant; see
-`{speaker_toolkit_root}/skills/vault-ingress/scripts/tracking_database_io.py`.
+`StagedCandidateConflictError` carrying the failed invariant. The class is
+defined in `skills/vault-ingress/scripts/tracking_database_io.py`.
 
 A schema-v1 database with config v2 is an idempotent no-op. A schema-v1 database
 with config v1 receives only the config-v2 migration; the root generation and

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -32,15 +32,24 @@ Run the owner migration in vault-ingress Step 1.
 Dry-run emits the exact input SHA-256. Apply requires that digest, refuses active
 queue claims, stores the complete original bytes under `.backups/`, and replaces
 the verified generation atomically. Backup directory and file opens do not
-follow symbolic links. The writer repeats its byte-and-file-generation check
-after staging and immediately before replacement. A schema-v1 database with
-config v2 is an idempotent no-op. A schema-v1 database with config v1 receives
-only the config-v2 migration; the root generation and every other record remain
-unchanged. Before migration, queue `inspect` may read schema 0 and
-queue `recover` may close an active schema-0 lease in place. Recovery changes
-only queue lease/status state and never stamps database or talk schema fields;
-the established queue transition may advance a recovered claim receipt from v1
-to v2 while adding its release fields.
+follow symbolic links. The target input comparison remains exact across bytes
+and every `FileGeneration` field, including `mtime_ns` and `ctime_ns`, after
+staging and immediately before replacement. The unique staged candidate keeps
+its original descriptor/name device and inode, regular-file type, single link,
+size, exact bytes, and SHA-256 throughout verification. Staged `mtime_ns` and
+`ctime_ns` may rebaseline after fsync only when the descriptor view and name view
+are each stable across one byte-read window within the writer-owned bounded
+attempts. Exhaustion and every hard staged mismatch raise
+`StagedCandidateConflictError` with the failed invariant; see
+`{speaker_toolkit_root}/skills/vault-ingress/scripts/tracking_database_io.py`.
+
+A schema-v1 database with config v2 is an idempotent no-op. A schema-v1 database
+with config v1 receives only the config-v2 migration; the root generation and
+every other record remain unchanged. Before migration, queue `inspect` may read
+schema 0 and queue `recover` may close an active schema-0 lease in place.
+Recovery changes only queue lease/status state and never stamps database or talk
+schema fields; the established queue transition may advance a recovered claim
+receipt from v1 to v2 while adding its release fields.
 
 The owner migration is a preservation migration. Its only allowed semantic
 changes are adding root schema v1, adding the validated historical version to an

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -29,6 +29,7 @@ from typing import Any, Iterator, NoReturn
 
 READ_CHUNK_SIZE = 1024 * 1024
 MAX_JSON_NESTING_DEPTH = 200
+STAGED_METADATA_STABILIZATION_ATTEMPTS = 4
 
 
 class TrackingDatabaseIOError(ValueError):
@@ -37,6 +38,19 @@ class TrackingDatabaseIOError(ValueError):
 
 class TrackingDatabaseConflictError(TrackingDatabaseIOError):
     """The expected database generation is no longer current."""
+
+
+class StagedCandidateConflictError(TrackingDatabaseConflictError):
+    """One named staged-candidate invariant failed before installation."""
+
+    def __init__(self, path: Path, invariant: str, detail: str) -> None:
+        self.path = path
+        self.invariant = invariant
+        self.detail = detail
+        super().__init__(
+            f"staged tracking-database candidate {path} changed before install: "
+            f"invariant={invariant}; {detail}"
+        )
 
 
 @dataclass(frozen=True)
@@ -123,6 +137,17 @@ class StagedCandidate:
     generation: FileGeneration
     sha256: str
     size: int
+
+
+@dataclass(frozen=True)
+class _StagedCandidateObservation:
+    """One descriptor/name observation around an exact staged-byte read."""
+
+    opened_before: os.stat_result
+    visible_before: os.stat_result
+    raw: bytes
+    opened_after: os.stat_result
+    visible_after: os.stat_result
 
 
 def unchanged_write_result(
@@ -818,7 +843,9 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
                 pass
 
 
-def _verify_staged_candidate(stage: StagedCandidate, candidate: bytes) -> None:
+def _observe_staged_candidate(
+    stage: StagedCandidate,
+) -> _StagedCandidateObservation:
     try:
         opened_before = os.fstat(stage.descriptor)
         visible_before = os.stat(
@@ -834,28 +861,117 @@ def _verify_staged_candidate(stage: StagedCandidate, candidate: bytes) -> None:
             follow_symlinks=False,
         )
     except OSError as exc:
-        raise TrackingDatabaseConflictError(
-            f"staged tracking-database candidate {stage.path} changed before install: {exc}"
+        raise StagedCandidateConflictError(
+            stage.path,
+            "metadata_read",
+            str(exc),
         ) from exc
-    expected_generation = stage.generation
-    if (
-        not stat.S_ISREG(opened_before.st_mode)
-        or opened_before.st_nlink != 1
-        or not stat.S_ISREG(visible_before.st_mode)
-        or visible_before.st_nlink != 1
-        or FileGeneration.from_stat(opened_before) != expected_generation
-        or FileGeneration.from_stat(visible_before) != expected_generation
-        or FileGeneration.from_stat(opened_after) != expected_generation
-        or FileGeneration.from_stat(visible_after) != expected_generation
-        or opened_after.st_nlink != 1
-        or visible_after.st_nlink != 1
-        or raw != candidate
-        or _sha256(raw) != stage.sha256
-    ):
-        raise TrackingDatabaseConflictError(
-            f"staged tracking-database candidate {stage.path} content or generation "
-            "changed before install"
+    return _StagedCandidateObservation(
+        opened_before=opened_before,
+        visible_before=visible_before,
+        raw=raw,
+        opened_after=opened_after,
+        visible_after=visible_after,
+    )
+
+
+def _staged_metadata_samples(
+    observation: _StagedCandidateObservation,
+) -> tuple[tuple[str, os.stat_result], ...]:
+    return (
+        ("descriptor_before", observation.opened_before),
+        ("name_before", observation.visible_before),
+        ("descriptor_after", observation.opened_after),
+        ("name_after", observation.visible_after),
+    )
+
+
+def _require_staged_candidate_invariants(
+    stage: StagedCandidate,
+    candidate: bytes,
+    observation: _StagedCandidateObservation,
+) -> None:
+    samples = _staged_metadata_samples(observation)
+    non_regular = [
+        label for label, metadata in samples if not stat.S_ISREG(metadata.st_mode)
+    ]
+    if non_regular:
+        raise StagedCandidateConflictError(
+            stage.path,
+            "regular_file",
+            f"non-regular observations={non_regular}",
         )
+    expected_identity = (stage.generation.device, stage.generation.inode)
+    identities = {label: _lock_identity(metadata) for label, metadata in samples}
+    if any(identity != expected_identity for identity in identities.values()):
+        raise StagedCandidateConflictError(
+            stage.path,
+            "descriptor_name_identity",
+            f"expected={expected_identity}; observed={identities}",
+        )
+    link_counts = {label: metadata.st_nlink for label, metadata in samples}
+    if any(link_count != 1 for link_count in link_counts.values()):
+        raise StagedCandidateConflictError(
+            stage.path,
+            "link_count",
+            f"expected one link; observed={link_counts}",
+        )
+    sizes = {label: metadata.st_size for label, metadata in samples}
+    if (
+        len(candidate) != stage.size
+        or len(observation.raw) != stage.size
+        or any(size != stage.size for size in sizes.values())
+    ):
+        raise StagedCandidateConflictError(
+            stage.path,
+            "size",
+            f"expected={stage.size}; candidate={len(candidate)}; "
+            f"read={len(observation.raw)}; observed={sizes}",
+        )
+    if observation.raw != candidate:
+        raise StagedCandidateConflictError(
+            stage.path,
+            "exact_bytes",
+            "descriptor bytes differ from the exact candidate",
+        )
+    candidate_sha256 = _sha256(candidate)
+    observed_sha256 = _sha256(observation.raw)
+    if stage.sha256 != candidate_sha256 or observed_sha256 != stage.sha256:
+        raise StagedCandidateConflictError(
+            stage.path,
+            "sha256",
+            f"expected={stage.sha256}; candidate={candidate_sha256}; "
+            f"observed={observed_sha256}",
+        )
+
+
+def _verify_staged_candidate(stage: StagedCandidate, candidate: bytes) -> None:
+    last_timestamps: dict[str, tuple[int, int]] = {}
+    last_unstable_fields: list[str] = []
+    for _ in range(STAGED_METADATA_STABILIZATION_ATTEMPTS):
+        observation = _observe_staged_candidate(stage)
+        _require_staged_candidate_invariants(stage, candidate, observation)
+        last_timestamps = {
+            label: (metadata.st_mtime_ns, metadata.st_ctime_ns)
+            for label, metadata in _staged_metadata_samples(observation)
+        }
+        last_unstable_fields = []
+        for view in ("descriptor", "name"):
+            before = last_timestamps[f"{view}_before"]
+            after = last_timestamps[f"{view}_after"]
+            if before[0] != after[0]:
+                last_unstable_fields.append(f"{view}.mtime_ns")
+            if before[1] != after[1]:
+                last_unstable_fields.append(f"{view}.ctime_ns")
+        if not last_unstable_fields:
+            return
+    raise StagedCandidateConflictError(
+        stage.path,
+        "timestamp_stability",
+        "staged mtime_ns/ctime_ns changed within every read window across "
+        f"{STAGED_METADATA_STABILIZATION_ATTEMPTS} bounded observations; "
+        f"unstable_fields={last_unstable_fields}; last_observed={last_timestamps}",
+    )
 
 
 def _replace_staged_candidate(stage: StagedCandidate, target: Path) -> None:

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import subprocess
 import sys
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,6 +18,24 @@ def _write(path: Path, value: object) -> bytes:
     raw = json.dumps(value, indent=2).encode("utf-8") + b"\n"
     path.write_bytes(raw)
     return raw
+
+
+def _metadata_view(
+    metadata: os.stat_result,
+    *,
+    inode: int | None = None,
+    modified_ns: int | None = None,
+    changed_ns: int | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        st_mode=metadata.st_mode,
+        st_nlink=metadata.st_nlink,
+        st_dev=metadata.st_dev,
+        st_ino=metadata.st_ino if inode is None else inode,
+        st_size=metadata.st_size,
+        st_mtime_ns=(metadata.st_mtime_ns if modified_ns is None else modified_ns),
+        st_ctime_ns=metadata.st_ctime_ns if changed_ns is None else changed_ns,
+    )
 
 
 @pytest.mark.parametrize(
@@ -500,6 +519,496 @@ def test_staging_interrupt_cleans_candidate_and_preserves_database(
     assert tracking_database_io.lock_path_for(path).is_file()
 
 
+def test_staged_timestamp_churn_retries_same_candidate_then_installs_once(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_observe = tracking_database_io._observe_staged_candidate
+    original_verify = tracking_database_io._verify_staged_candidate
+    original_replace = tracking_database_io._replace_staged_candidate
+    real_fstat = tracking_database_io.os.fstat
+    real_stat = tracking_database_io.os.stat
+    staged_descriptor: int | None = None
+    staged_name: str | None = None
+    staged_directory_descriptor: int | None = None
+    descriptor_observations = 0
+    name_observations = 0
+    verify_windows = 0
+    verification_calls = 0
+    replacements = 0
+
+    def churning_fstat(descriptor: int):
+        nonlocal descriptor_observations
+        metadata = real_fstat(descriptor)
+        if descriptor != staged_descriptor:
+            return metadata
+        descriptor_observations += 1
+        offset = (1, 2, 3, 3)[min(descriptor_observations - 1, 3)]
+        return _metadata_view(
+            metadata,
+            modified_ns=metadata.st_mtime_ns + offset,
+            changed_ns=metadata.st_ctime_ns + offset,
+        )
+
+    def churning_stat(
+        name: object,
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ):
+        nonlocal name_observations
+        metadata = real_stat(
+            name,
+            dir_fd=dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+        if name != staged_name or dir_fd != staged_directory_descriptor:
+            return metadata
+        name_observations += 1
+        offset = (10, 11, 12, 12)[min(name_observations - 1, 3)]
+        return _metadata_view(
+            metadata,
+            modified_ns=metadata.st_mtime_ns + offset,
+            changed_ns=metadata.st_ctime_ns + offset,
+        )
+
+    def counted_observe(stage):
+        nonlocal verify_windows
+        verify_windows += 1
+        return original_observe(stage)
+
+    def verify_with_initial_churn(stage, raw: bytes) -> None:
+        nonlocal staged_descriptor, staged_name, staged_directory_descriptor
+        nonlocal verification_calls
+        verification_calls += 1
+        if staged_descriptor is None:
+            metadata = real_fstat(stage.descriptor)
+            os.utime(
+                stage.path,
+                ns=(metadata.st_atime_ns, metadata.st_mtime_ns + 1_000_000),
+                follow_symlinks=False,
+            )
+            staged_descriptor = stage.descriptor
+            staged_name = stage.name
+            staged_directory_descriptor = stage.directory_descriptor
+            monkeypatch.setattr(tracking_database_io.os, "fstat", churning_fstat)
+            monkeypatch.setattr(tracking_database_io.os, "stat", churning_stat)
+        original_verify(stage, raw)
+
+    def counted_replace(stage, target: Path) -> None:
+        nonlocal replacements
+        replacements += 1
+        original_replace(stage, target)
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_observe_staged_candidate",
+        counted_observe,
+    )
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_verify_staged_candidate",
+        verify_with_initial_churn,
+    )
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_replace_staged_candidate",
+        counted_replace,
+    )
+
+    result = tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert result.installed is True
+    assert path.read_bytes() == candidate
+    assert verify_windows == 3
+    assert verification_calls == 2
+    assert replacements == 1
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
+def test_never_stable_staged_timestamps_fail_with_bounded_typed_diagnostic(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_observe = tracking_database_io._observe_staged_candidate
+    original_verify = tracking_database_io._verify_staged_candidate
+    real_fstat = tracking_database_io.os.fstat
+    real_stat = tracking_database_io.os.stat
+    staged_descriptor: int | None = None
+    staged_name: str | None = None
+    staged_directory_descriptor: int | None = None
+    metadata_sequence = 0
+    verify_windows = 0
+    backup = tmp_path / "backups" / "tracking-database.bak"
+    backup_request = tracking_database_io.BackupRequest(
+        path=backup,
+        input_sha256=expected.sha256,
+    )
+
+    def next_view(metadata: os.stat_result) -> SimpleNamespace:
+        nonlocal metadata_sequence
+        metadata_sequence += 1
+        return _metadata_view(
+            metadata,
+            modified_ns=metadata.st_mtime_ns + metadata_sequence,
+            changed_ns=metadata.st_ctime_ns + metadata_sequence,
+        )
+
+    def churning_fstat(descriptor: int):
+        metadata = real_fstat(descriptor)
+        return next_view(metadata) if descriptor == staged_descriptor else metadata
+
+    def churning_stat(
+        name: object,
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ):
+        metadata = real_stat(
+            name,
+            dir_fd=dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+        if name == staged_name and dir_fd == staged_directory_descriptor:
+            return next_view(metadata)
+        return metadata
+
+    def counted_observe(stage):
+        nonlocal verify_windows
+        verify_windows += 1
+        return original_observe(stage)
+
+    def verify_with_never_stable_metadata(stage, raw: bytes) -> None:
+        nonlocal staged_descriptor, staged_name, staged_directory_descriptor
+        staged_descriptor = stage.descriptor
+        staged_name = stage.name
+        staged_directory_descriptor = stage.directory_descriptor
+        monkeypatch.setattr(tracking_database_io.os, "fstat", churning_fstat)
+        monkeypatch.setattr(tracking_database_io.os, "stat", churning_stat)
+        original_verify(stage, raw)
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_observe_staged_candidate",
+        counted_observe,
+    )
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_verify_staged_candidate",
+        verify_with_never_stable_metadata,
+    )
+
+    with pytest.raises(
+        tracking_database_io.StagedCandidateConflictError,
+        match="invariant=timestamp_stability.*bounded observations",
+    ) as stopped:
+        tracking_database_io.commit_tracking_database(
+            expected,
+            candidate,
+            backup=backup_request,
+        )
+
+    assert stopped.value.invariant == "timestamp_stability"
+    assert verify_windows == tracking_database_io.STAGED_METADATA_STABILIZATION_ATTEMPTS
+    assert path.read_bytes() == original
+    assert not backup.exists()
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
+def test_staged_name_identity_change_fails_typed_and_cleans_owned_candidate(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_stage = tracking_database_io._stage_candidate
+    real_stat = tracking_database_io.os.stat
+    staged_name: str | None = None
+    staged_directory_descriptor: int | None = None
+    substituted = False
+
+    def changed_stat(
+        name: object,
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ):
+        nonlocal substituted
+        metadata = real_stat(
+            name,
+            dir_fd=dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+        if (
+            not substituted
+            and name == staged_name
+            and dir_fd == staged_directory_descriptor
+        ):
+            substituted = True
+            return _metadata_view(metadata, inode=metadata.st_ino + 1)
+        return metadata
+
+    def stage_then_change_identity(target: Path, raw: bytes, mode: int):
+        nonlocal staged_name, staged_directory_descriptor
+        stage = original_stage(target, raw, mode)
+        staged_name = stage.name
+        staged_directory_descriptor = stage.directory_descriptor
+        monkeypatch.setattr(tracking_database_io.os, "stat", changed_stat)
+        return stage
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_stage_candidate",
+        stage_then_change_identity,
+    )
+
+    with pytest.raises(
+        tracking_database_io.StagedCandidateConflictError,
+        match="invariant=descriptor_name_identity",
+    ) as stopped:
+        tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert stopped.value.invariant == "descriptor_name_identity"
+    assert path.read_bytes() == original
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
+def test_regular_staged_name_substitution_fails_typed_and_is_left_untouched(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_stage = tracking_database_io._stage_candidate
+    replacement_raw = b"foreign regular staged name\n"
+    substituted: list[Path] = []
+    backup = tmp_path / "backups" / "tracking-database.bak"
+    backup_request = tracking_database_io.BackupRequest(
+        path=backup,
+        input_sha256=expected.sha256,
+    )
+
+    def substitute_regular_name(target: Path, raw: bytes, mode: int):
+        stage = original_stage(target, raw, mode)
+        os.unlink(stage.name, dir_fd=stage.directory_descriptor)
+        replacement_descriptor = os.open(
+            stage.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=stage.directory_descriptor,
+        )
+        with os.fdopen(replacement_descriptor, "wb") as replacement:
+            replacement.write(replacement_raw)
+        substituted.append(stage.path)
+        return stage
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_stage_candidate",
+        substitute_regular_name,
+    )
+
+    with pytest.raises(
+        tracking_database_io.StagedCandidateConflictError,
+        match="invariant=descriptor_name_identity",
+    ) as stopped:
+        tracking_database_io.commit_tracking_database(
+            expected,
+            candidate,
+            backup=backup_request,
+        )
+
+    assert stopped.value.invariant == "descriptor_name_identity"
+    assert path.read_bytes() == original
+    assert not backup.exists()
+    assert substituted[0].is_file()
+    assert substituted[0].read_bytes() == replacement_raw
+    assert list(tmp_path.glob(".*.tracking-db.tmp")) == substituted
+
+
+def test_staged_hardlink_change_fails_typed_and_removes_owned_name(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_stage = tracking_database_io._stage_candidate
+    extra_link = tmp_path / "unexpected-candidate-link"
+
+    def stage_then_link(target: Path, raw: bytes, mode: int):
+        stage = original_stage(target, raw, mode)
+        os.link(stage.path, extra_link)
+        return stage
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", stage_then_link)
+
+    with pytest.raises(
+        tracking_database_io.StagedCandidateConflictError,
+        match="invariant=link_count",
+    ) as stopped:
+        tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert stopped.value.invariant == "link_count"
+    assert path.read_bytes() == original
+    assert extra_link.read_bytes() == candidate
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
+def test_staged_size_change_fails_typed_and_cleans_candidate(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_stage = tracking_database_io._stage_candidate
+
+    def stage_then_resize(target: Path, raw: bytes, mode: int):
+        stage = original_stage(target, raw, mode)
+        os.ftruncate(stage.descriptor, stage.size + 1)
+        return stage
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", stage_then_resize)
+
+    with pytest.raises(
+        tracking_database_io.StagedCandidateConflictError,
+        match="invariant=size",
+    ) as stopped:
+        tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert stopped.value.invariant == "size"
+    assert path.read_bytes() == original
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
+def test_staged_same_size_byte_change_fails_typed_and_cleans_candidate(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_stage = tracking_database_io._stage_candidate
+
+    def stage_then_change_bytes(target: Path, raw: bytes, mode: int):
+        stage = original_stage(target, raw, mode)
+        os.pwrite(stage.descriptor, b"X", 0)
+        return stage
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_stage_candidate",
+        stage_then_change_bytes,
+    )
+
+    with pytest.raises(
+        tracking_database_io.StagedCandidateConflictError,
+        match="invariant=exact_bytes",
+    ) as stopped:
+        tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert stopped.value.invariant == "exact_bytes"
+    assert path.read_bytes() == original
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
+def test_staged_digest_binding_change_fails_typed_and_cleans_candidate(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+    original_stage = tracking_database_io._stage_candidate
+
+    def stage_then_change_digest(target: Path, raw: bytes, mode: int):
+        stage = original_stage(target, raw, mode)
+        stage.sha256 = "0" * 64
+        return stage
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_stage_candidate",
+        stage_then_change_digest,
+    )
+
+    with pytest.raises(
+        tracking_database_io.StagedCandidateConflictError,
+        match="invariant=sha256",
+    ) as stopped:
+        tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert stopped.value.invariant == "sha256"
+    assert path.read_bytes() == original
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
+def test_target_timestamp_change_remains_an_exact_cas_conflict(
+    tracking_database_io,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "tracking-database.json"
+    original = _write(path, {"talks": []})
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    metadata = path.stat()
+    os.utime(
+        path,
+        ns=(metadata.st_atime_ns, metadata.st_mtime_ns + 1_000_000),
+        follow_symlinks=False,
+    )
+    backup = tmp_path / "backups" / "tracking-database.bak"
+    backup_request = tracking_database_io.BackupRequest(
+        path=backup,
+        input_sha256=expected.sha256,
+    )
+
+    def unexpected_stage(*_args, **_kwargs):
+        pytest.fail("target generation conflict must fail before staging")
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", unexpected_stage)
+
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseConflictError,
+        match="content or generation changed after validation",
+    ):
+        tracking_database_io.commit_tracking_database(
+            expected,
+            tracking_database_io.render_json_object({"talks": [], "config": {}}),
+            backup=backup_request,
+        )
+
+    assert path.read_bytes() == original
+    assert path.stat().st_ino == expected.generation.inode
+    assert not backup.exists()
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
 def test_commit_rejects_substituted_stage_without_unlinking_it(
     tracking_database_io,
     tmp_path: Path,
@@ -531,15 +1040,16 @@ def test_commit_rejects_substituted_stage_without_unlinking_it(
 
     monkeypatch.setattr(tracking_database_io, "_stage_candidate", substitute_stage)
     with pytest.raises(
-        tracking_database_io.TrackingDatabaseConflictError,
+        tracking_database_io.StagedCandidateConflictError,
         match="staged tracking-database candidate.*changed before install",
-    ):
+    ) as stopped:
         tracking_database_io.commit_tracking_database(
             expected,
             tracking_database_io.render_json_object({"talks": [], "config": {}}),
             backup=request,
         )
 
+    assert stopped.value.invariant == "regular_file"
     assert path.read_bytes() == original
     assert attacker.read_bytes() == attacker_raw
     assert substituted[0].is_symlink()
@@ -570,11 +1080,12 @@ def test_initialization_rejects_substituted_stage_without_unlinking_it(
 
     monkeypatch.setattr(tracking_database_io, "_stage_candidate", substitute_stage)
     with pytest.raises(
-        tracking_database_io.TrackingDatabaseConflictError,
+        tracking_database_io.StagedCandidateConflictError,
         match="staged tracking-database candidate.*changed before install",
-    ):
+    ) as stopped:
         tracking_database_io.initialize_tracking_database(path, {"talks": []})
 
+    assert stopped.value.invariant == "regular_file"
     assert not path.exists()
     assert attacker.read_bytes() == attacker_raw
     assert substituted[0].is_symlink()
@@ -598,7 +1109,10 @@ def test_directory_fsync_failure_reports_installed_generation(
 
     assert result.installed is True
     assert result.durability_state == "installed_directory_fsync_failed"
-    assert result.output_sha256 == tracking_database_io.snapshot_tracking_database(path).sha256
+    assert (
+        result.output_sha256
+        == tracking_database_io.snapshot_tracking_database(path).sha256
+    )
     assert path.read_bytes() == candidate
     assert "inspect the installed output SHA before retrying" in result.warnings[0]
 
@@ -643,8 +1157,13 @@ def test_directory_close_failure_is_an_installed_warning(
         result = tracking_database_io.write_json_object(expected, payload)
 
     assert result.installed is True
-    assert tracking_database_io.decode_json_object_bytes(path.read_bytes(), path) == payload
-    assert any("could not close tracking-database directory" in w for w in result.warnings)
+    assert (
+        tracking_database_io.decode_json_object_bytes(path.read_bytes(), path)
+        == payload
+    )
+    assert any(
+        "could not close tracking-database directory" in w for w in result.warnings
+    )
 
 
 @pytest.mark.parametrize("initialize", [False, True], ids=["commit", "initialize"])
@@ -676,7 +1195,10 @@ def test_lock_cleanup_failure_is_an_installed_warning(
         result = tracking_database_io.write_json_object(expected, payload)
 
     assert result.installed is True
-    assert tracking_database_io.decode_json_object_bytes(path.read_bytes(), path) == payload
+    assert (
+        tracking_database_io.decode_json_object_bytes(path.read_bytes(), path)
+        == payload
+    )
     assert any("could not unlock cooperative" in w for w in result.warnings)
 
 
@@ -722,7 +1244,10 @@ def test_lock_close_failure_is_an_installed_warning(
         result = tracking_database_io.write_json_object(expected, payload)
 
     assert result.installed is True
-    assert tracking_database_io.decode_json_object_bytes(path.read_bytes(), path) == payload
+    assert (
+        tracking_database_io.decode_json_object_bytes(path.read_bytes(), path)
+        == payload
+    )
     assert any("could not close cooperative" in w for w in result.warnings)
 
 
@@ -751,7 +1276,10 @@ def test_postinstall_verification_failure_reports_installed_unknown_state(
 
     assert result.installed is True
     assert result.durability_state == "installed_verification_failed"
-    assert result.output_sha256 != tracking_database_io.snapshot_tracking_database(path).sha256
+    assert (
+        result.output_sha256
+        != tracking_database_io.snapshot_tracking_database(path).sha256
+    )
     assert path.read_bytes() == concurrent
     assert any("no longer matches" in warning for warning in result.warnings)
 
@@ -784,7 +1312,10 @@ def test_initialization_postinstall_verification_failure_reports_installed_state
 
     assert result.installed is True
     assert result.durability_state == "installed_verification_failed"
-    assert result.output_sha256 != tracking_database_io.snapshot_tracking_database(path).sha256
+    assert (
+        result.output_sha256
+        != tracking_database_io.snapshot_tracking_database(path).sha256
+    )
     assert path.read_bytes() == concurrent
     assert any("no longer matches" in warning for warning in result.warnings)
 
@@ -905,9 +1436,12 @@ def test_initialization_is_exclusive_and_reports_missing_input(
 
     assert result.input_sha256 is None
     assert result.installed is True
-    assert tracking_database_io.decode_json_object(
-        tracking_database_io.snapshot_tracking_database(path)
-    ) == payload
+    assert (
+        tracking_database_io.decode_json_object(
+            tracking_database_io.snapshot_tracking_database(path)
+        )
+        == payload
+    )
     with pytest.raises(
         tracking_database_io.TrackingDatabaseConflictError,
         match="already exists",

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1084,6 +1084,82 @@ def test_config_only_migration_uses_generation_neutral_backup_name(
     assert report["record_counts"]["config"] == 1
 
 
+def test_config_only_migration_tolerates_cloud_stage_churn_and_is_idempotent(
+    migrate_tracking_database,
+    tracking_database,
+    tracking_database_io,
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "tracking-database.json"
+    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    current["config"] = {"schema_version": 1, "python_path": "/opt/python"}
+    raw = _write_database(path, current)
+    digest = hashlib.sha256(raw).hexdigest()
+    dry_run = migrate_tracking_database.execute(
+        path,
+        apply=False,
+        expected_sha256=None,
+    )
+    original_stage = tracking_database_io._stage_candidate
+    stage_calls = 0
+
+    def stage_then_change_timestamps(target, candidate, mode):
+        nonlocal stage_calls
+        stage_calls += 1
+        stage = original_stage(target, candidate, mode)
+        metadata = os.fstat(stage.descriptor)
+        os.utime(
+            stage.path,
+            ns=(metadata.st_atime_ns, metadata.st_mtime_ns + 1_000_000),
+            follow_symlinks=False,
+        )
+        return stage
+
+    monkeypatch.setattr(
+        tracking_database_io,
+        "_stage_candidate",
+        stage_then_change_timestamps,
+    )
+
+    applied = migrate_tracking_database.execute(
+        path,
+        apply=True,
+        expected_sha256=digest,
+    )
+    installed = path.read_bytes()
+    installed_inode = path.stat().st_ino
+    backup = tmp_path / ".backups" / f"{path.name}.owner-migration-{digest}.bak"
+
+    assert applied["database_written"] is True
+    assert applied["durability_state"] == "durable"
+    assert applied["warnings"] == []
+    assert applied["output_sha256"] == dry_run["output_sha256"]
+    assert hashlib.sha256(installed).hexdigest() == dry_run["output_sha256"]
+    assert backup.read_bytes() == raw
+    assert applied["backup"] == str(backup)
+    assert json.loads(installed)["config"] == {
+        "schema_version": 2,
+        "python_path": "/opt/python",
+        "pptx_directory_exclusions": DEFAULT_DIRECTORY_EXCLUSIONS,
+    }
+
+    replay = migrate_tracking_database.execute(
+        path,
+        apply=True,
+        expected_sha256=applied["output_sha256"],
+    )
+
+    assert replay["changed"] is False
+    assert replay["database_written"] is False
+    assert replay["backup"] is None
+    assert replay["output_sha256"] == applied["output_sha256"]
+    assert path.read_bytes() == installed
+    assert path.stat().st_ino == installed_inode
+    assert stage_calls == 1
+    assert not list(tmp_path.glob(".*.tracking-db.tmp"))
+
+
 def test_apply_current_database_is_exact_noop_without_backup(
     migrate_tracking_database,
     tracking_database,


### PR DESCRIPTION
## Summary

- keep the live tracking-database compare-and-swap exact while allowing bounded timestamp stabilization on the retained staged candidate
- fail immediately on staged type, identity, link-count, size, byte, or digest changes with a named invariant
- cover CloudStorage-style config migration, exact backup, cleanup, replay, and adversarial staged-file cases

Closes #239

## Test plan

- [x] `pytest -q` — 4,834 passed, 3 skipped
- [x] focused tracking-database transaction/schema/docs tests — 204 passed
- [x] scoped Ruff and Pyright checks
- [x] `tessl plugin lint`
- [x] package contents and Tessl pin checks
