### PR TITLE
fix(vault-ingress): reconcile event-qualified titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### fix(vault-ingress) — reconcile event-qualified shownotes titles (#237)
+
+Shownotes reconciliation now keeps an existing authored title when the
+publication title adds only an explicit `at <event>` qualifier whose event alias
+and year agree with the same talk's already-stored conference and date. The
+current shownotes document cannot corroborate its own suffix through newly
+proposed metadata. The shared matcher remains asymmetric and preserves the prior
+narrow presentation normalization. Generic event-type words remain
+identity-bearing, while the observed Voxxed `Days` presentation variant stays
+equivalent. Changed subtitles, unrelated events, wrong years, and short-prefix
+collisions stay review-required.
+
 ## 0.20.17 — 2026-08-05
 
 ### fix(vault-ingress) — allow CloudStorage owner writes (#239)

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -152,18 +152,11 @@ comparison transforms back to the database or report. Incomplete metadata,
 substantive conflicts, and normalized filename collisions remain proposals.
 Disabled, `remote_url`, and `none` sources return a structured no-op.
 
-An exact-filename match may also accept a shownotes title that preserves the
-complete authored title and appends one terminal `at <event>` qualifier. Require
-non-empty conference and date values from the existing talk record. Do not use
-metadata from the current shownotes proposal to corroborate its own title.
-Require the shownotes-specific event alias to equal the stored conference alias.
-Require every explicit qualifier or conference year to agree with the stored
-talk date.
-Keep generic event-type words significant. The closed presentation-equivalence
-policy lives in
-`skills/vault-ingress/scripts/source_identity_matching.py::shownotes_titles_agree`.
-Do not substitute the provider-oriented `event_alias()` comparator. Keep the
-authored title unchanged when this comparison succeeds.
+For an exact-filename match, pass the stored and proposed title plus stored
+conference/date context to the shared title-agreement contract documented in
+[schemas-db.md](schemas-db.md#shownotes-scanimport-report). Agreement keeps the
+authored title unchanged. Disagreement emits `existing_title_conflict` and
+leaves the entry `review_required`.
 
 Apply the reviewed deterministic proposals with the same command plus
 `--apply`. Only `add` and `update` entries mutate the tracking database. New

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -145,12 +145,25 @@ safe deterministic proposals; `review_required` entries need a human decision.
 The scanner uses exact filename identity, derives supported YouTube and Google
 Drive IDs, and keeps every matching `source_rejections` identity inactive.
 For comparison only, title equality applies Unicode NFC and maps straight/curly
-single and double quote glyphs to the same narrow equivalents; it preserves
+single and double quote glyphs to the same narrow equivalents. It preserves
 case, other punctuation, and wording. Conference equality applies NFC plus
 casefold only and preserves whitespace. The scanner never writes these
 comparison transforms back to the database or report. Incomplete metadata,
 substantive conflicts, and normalized filename collisions remain proposals.
 Disabled, `remote_url`, and `none` sources return a structured no-op.
+
+An exact-filename match may also accept a shownotes title that preserves the
+complete authored title and appends one terminal `at <event>` qualifier. Require
+non-empty conference and date values from the existing talk record. Do not use
+metadata from the current shownotes proposal to corroborate its own title.
+Require the shownotes-specific event alias to equal the stored conference alias.
+Require every explicit qualifier or conference year to agree with the stored
+talk date.
+Keep generic event-type words significant. The closed presentation-equivalence
+policy lives in
+`skills/vault-ingress/scripts/source_identity_matching.py::shownotes_titles_agree`.
+Do not substitute the provider-oriented `event_alias()` comparator. Keep the
+authored title unchanged when this comparison succeeds.
 
 Apply the reviewed deterministic proposals with the same command plus
 `--apply`. Only `add` and `update` entries mutate the tracking database. New

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -443,6 +443,21 @@ reads `config.shownotes.source` for local sources and resolves
 migration. `remote_url`, `none`, and disabled sources return a structured no-op
 without reading Markdown or writing the database.
 
+On an exact-filename match, title agreement is asymmetric and comparison-only.
+The shownotes title may append `at <event>` to the complete authored title when
+the shownotes-specific NFC event alias equals the talk conference and every
+explicit event or conference year agrees with the talk date. Both corroborating
+values must already be non-empty in the stored talk. The current shownotes
+proposal cannot supply either value for its own title comparison. Generic
+event-type words remain significant. Only the comparator's closed branded
+presentation variants and the validated year are removed from event comparison.
+Other numeric event tokens fail closed. The scanner keeps the authored title
+unchanged. Different wording, subtitles, event aliases, years, and shared
+prefixes remain `existing_title_conflict` review findings. Exact-title agreement
+still permits missing metadata fields to be proposed normally. Only NFC and
+Unicode quote presentation variants retain the pre-existing exact-title
+equivalence.
+
 The command emits report schema v2:
 
 ```json

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -443,20 +443,14 @@ reads `config.shownotes.source` for local sources and resolves
 migration. `remote_url`, `none`, and disabled sources return a structured no-op
 without reading Markdown or writing the database.
 
-On an exact-filename match, title agreement is asymmetric and comparison-only.
-The shownotes title may append `at <event>` to the complete authored title when
-the shownotes-specific NFC event alias equals the talk conference and every
-explicit event or conference year agrees with the talk date. Both corroborating
-values must already be non-empty in the stored talk. The current shownotes
-proposal cannot supply either value for its own title comparison. Generic
-event-type words remain significant. Only the comparator's closed branded
-presentation variants and the validated year are removed from event comparison.
-Other numeric event tokens fail closed. The scanner keeps the authored title
-unchanged. Different wording, subtitles, event aliases, years, and shared
-prefixes remain `existing_title_conflict` review findings. Exact-title agreement
-still permits missing metadata fields to be proposed normally. Only NFC and
-Unicode quote presentation variants retain the pre-existing exact-title
-equivalence.
+On an exact-filename match, the title-agreement call receives the stored title,
+the proposed shownotes title, the stored conference, and the stored date. Its
+closed boolean decision contract lives in
+`skills/vault-ingress/scripts/source_identity_matching.py::shownotes_titles_agree`.
+Agreement is comparison-only and keeps the stored title unchanged. Disagreement
+emits `existing_title_conflict` and leaves the entry `review_required`. An exact
+title can still fill empty non-title metadata through the existing update
+contract.
 
 The command emits report schema v2:
 

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -36,6 +36,7 @@ from ingress_contract import (
     parse_youtube_id,
     validate_talk_record_schemas,
 )
+from source_identity_matching import shownotes_titles_agree
 from tracking_database import (
     TrackingDatabaseError,
     assess_tracking_database,
@@ -105,19 +106,6 @@ RAW_URL_RE = re.compile(r"https?://[^\s<>]+")
 DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 FileGeneration = tuple[int, int, int, int, int]
 
-# These transforms are deliberately narrower than general punctuation folding.
-# They exist only for comparison: reports and stored values keep their original
-# typography and capitalization.
-_TITLE_QUOTE_EQUIVALENTS = str.maketrans(
-    {
-        "\u2018": "'",
-        "\u2019": "'",
-        "\u201c": '"',
-        "\u201d": '"',
-    }
-)
-
-
 class ShownotesScanError(ValueError):
     """Input or state prevents a deterministic shownotes scan."""
 
@@ -147,24 +135,29 @@ def _normalized_filename(value: str) -> str:
     return unicodedata.normalize("NFC", value).casefold()
 
 
-def _normalized_title_for_comparison(value: str) -> str:
-    """Normalize title presentation glyphs without changing title wording/case."""
-    return unicodedata.normalize("NFC", value).translate(_TITLE_QUOTE_EQUIVALENTS)
-
-
 def _normalized_conference_for_comparison(value: str) -> str:
     """Normalize conference Unicode and case only; whitespace stays significant."""
     return unicodedata.normalize("NFC", value).casefold()
 
 
-def _same_presentation_value(field: str, left: object, right: object) -> bool:
-    """Return whether a title/conference pair differs only in presentation."""
+def _catalog_values_agree(
+    field: str,
+    left: object,
+    right: object,
+    *,
+    conference: object,
+    talk_date: object,
+) -> bool:
+    """Return whether stored and shownotes metadata agree without rewriting."""
     if not isinstance(left, str) or not isinstance(right, str):
         return False
     if field == "title":
-        return _normalized_title_for_comparison(
-            left
-        ) == _normalized_title_for_comparison(right)
+        return shownotes_titles_agree(
+            left,
+            right,
+            conference=conference,
+            talk_date=talk_date,
+        )
     if field == "conference":
         return _normalized_conference_for_comparison(
             left
@@ -777,6 +770,8 @@ def _existing_entry(
 ) -> tuple[str, dict[str, Any], list[dict[str, str]]]:
     issues = list(parse_issues)
     patch: dict[str, Any] = {}
+    stored_conference = talk.get("conference")
+    stored_date = talk.get("date")
     for field in TRACKED_FIELDS:
         if field not in proposal:
             continue
@@ -792,7 +787,13 @@ def _existing_entry(
             continue
         if current == candidate:
             continue
-        if _same_presentation_value(field, current, candidate):
+        if _catalog_values_agree(
+            field,
+            current,
+            candidate,
+            conference=stored_conference,
+            talk_date=stored_date,
+        ):
             continue
         if (
             field in {"video_url", "slides_url"}

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -9,8 +9,10 @@ from the wrong delivery.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from datetime import date
 import re
 from typing import Any
+import unicodedata
 
 
 WORD_RE = re.compile(r"[^\W_]+", re.UNICODE)
@@ -18,6 +20,21 @@ TITLE_SUBTITLE_RE = re.compile(r":|\s[-\u2013\u2014]\s|\s\(")
 EVENT_CONTEXT_SEPARATOR_RE = re.compile(r"\s[-\u2013\u2014|]\s")
 AT_RE = re.compile(r"\bat\b", re.IGNORECASE)
 YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+EXPLICIT_YEAR_RE = re.compile(r"(?<!\d)\d{4}(?!\d)")
+ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+SHOWNOTES_EVENT_QUALIFIER_RE = re.compile(
+    r"\s+at\s+(?P<event>\S(?:.*\S)?)\Z",
+    re.IGNORECASE,
+)
+
+TITLE_QUOTE_EQUIVALENTS = str.maketrans(
+    {
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+    }
+)
 
 TITLE_STOP_WORDS = frozenset({
     "a", "an", "and", "at", "by", "conference", "for", "from", "in",
@@ -28,6 +45,8 @@ EVENT_STOP_WORDS = frozenset({
     "days", "edition", "event", "events", "meetup", "meetups", "of", "open",
     "summit", "the", "webinar", "webinars",
 })
+SHOWNOTES_EVENT_STOP_WORDS = frozenset({"a", "an", "at", "of", "the"})
+SHOWNOTES_OPTIONAL_EVENT_BIGRAMS = frozenset({("voxxed", "days")})
 AMBIGUOUS_EVENT_ALIASES = frozenset({"ai", "devops", "java", "spring"})
 EVENT_WORD_REPLACEMENTS = {
     "belgium": ("be",),
@@ -51,6 +70,10 @@ def _ordered_words(value: str, stop_words: frozenset[str]) -> list[str]:
 def normalized_words(value: str) -> set[str]:
     """Return significant title words for overlap and clip-marker checks."""
     return set(_ordered_words(value, TITLE_STOP_WORDS))
+
+
+def _normalized_title_presentation(value: str) -> str:
+    return unicodedata.normalize("NFC", value).translate(TITLE_QUOTE_EQUIVALENTS)
 
 
 def _contains_sequence(haystack: list[str] | EventAlias, needle: EventAlias) -> bool:
@@ -125,6 +148,96 @@ def event_alias(value: Any) -> EventAlias | None:
     if not words or (len(words) == 1 and len(words[0]) < 3):
         return None
     return words
+
+
+def _shownotes_event_alias(value: Any, *, expected_year: str) -> EventAlias | None:
+    """Return a conservative NFC alias for shownotes title comparison."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    words_list: list[str] = []
+    normalized = unicodedata.normalize("NFC", value).casefold()
+    raw_words = WORD_RE.findall(normalized)
+    for index, word in enumerate(raw_words):
+        if word in SHOWNOTES_EVENT_STOP_WORDS:
+            continue
+        if word.isdigit():
+            if word == expected_year:
+                continue
+            return None
+        if len(word) <= 1:
+            continue
+        if (
+            index > 0
+            and (raw_words[index - 1], word) in SHOWNOTES_OPTIONAL_EVENT_BIGRAMS
+        ):
+            continue
+        words_list.extend(EVENT_WORD_REPLACEMENTS.get(word, (word,)))
+    words = tuple(words_list)
+    if not words or (len(words) == 1 and len(words[0]) < 3):
+        return None
+    return words
+
+
+def shownotes_titles_agree(
+    authored_title: Any,
+    shownotes_title: Any,
+    *,
+    conference: Any,
+    talk_date: Any,
+) -> bool:
+    """Compare an authored title with a shownotes publication title.
+
+    Agreement is intentionally asymmetric. Shownotes may retain the complete
+    authored title and append ``at <event>`` only when that event alias equals
+    the talk conference and every explicit year agrees with the talk date.
+    Generic event-type words remain significant. Only the shownotes comparator's
+    closed branded presentation variants may be omitted.
+    The authored title itself receives only the scanner's historical NFC and
+    Unicode-quote normalization; case, punctuation, wording, and whitespace
+    remain meaningful.
+    """
+    if not isinstance(authored_title, str) or not isinstance(shownotes_title, str):
+        return False
+
+    authored = _normalized_title_presentation(authored_title)
+    shownotes = _normalized_title_presentation(shownotes_title)
+    if authored == shownotes:
+        return True
+    if not authored or not shownotes.startswith(authored):
+        return False
+
+    qualifier_match = SHOWNOTES_EVENT_QUALIFIER_RE.fullmatch(
+        shownotes[len(authored):]
+    )
+    if qualifier_match is None:
+        return False
+    qualifier = qualifier_match.group("event")
+
+    if not isinstance(talk_date, str) or ISO_DATE_RE.fullmatch(talk_date) is None:
+        return False
+    try:
+        expected_year = f"{date.fromisoformat(talk_date).year:04d}"
+    except ValueError:
+        return False
+
+    for value in (conference, qualifier):
+        if not isinstance(value, str):
+            return False
+        explicit_years = set(EXPLICIT_YEAR_RE.findall(value))
+        if explicit_years and explicit_years != {expected_year}:
+            return False
+
+    conference_alias = _shownotes_event_alias(
+        conference,
+        expected_year=expected_year,
+    )
+    qualifier_alias = _shownotes_event_alias(
+        qualifier,
+        expected_year=expected_year,
+    )
+    if conference_alias is None or qualifier_alias != conference_alias:
+        return False
+    return True
 
 
 def known_event_aliases(talks: Iterable[Any]) -> set[EventAlias]:

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -91,13 +91,14 @@ def _write_jekyll_talk(
     filename: str = "2026-08-01-deterministic-ingress.md",
     title: str = "Deterministic Ingress",
     conference: str | None = "TestConf",
+    date: str = "2026-08-01",
     video_url: str | None = None,
     slides_url: str | None = None,
 ) -> Path:
     lines = ["---", "layout: talk", "---", f"# {title}"]
     if conference is not None:
         lines.append(f"**Conference:** {conference}")
-    lines.append("**Date:** 2026-08-01")
+    lines.append(f"**Date:** {date}")
     if slides_url is not None:
         lines.append(f"**Slides:** [View Slides]({slides_url})")
     if video_url is not None:
@@ -263,6 +264,258 @@ def test_existing_metadata_conflict_stays_a_non_mutating_review_proposal(
     assert entry["disposition"] == "review_required"
     assert entry["changes"] == {}
     assert entry["issues"][0]["code"] == "existing_title_conflict"
+    assert report["database_written"] is False
+    assert database_path.read_bytes() == before
+
+
+def test_event_qualified_shownotes_title_preserves_authored_title(
+    tmp_path: Path,
+) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    filename = "voxxed-lu-2026-monkey.md"
+    authored_title = (
+        "Never Trust a Monkey: The Chasm, the Craft, and the Chain of "
+        "AI-Assisted Code"
+    )
+    conference = "Voxxed Days Luxembourg 2026"
+    talk_date = "2026-06-18"
+    _write_jekyll_talk(
+        talks_directory,
+        filename=filename,
+        title=f"{authored_title} at Voxxed Luxembourg 2026",
+        conference=conference,
+        date=talk_date,
+    )
+    existing = {
+        "filename": filename,
+        "title": authored_title,
+        "conference": conference,
+        "date": talk_date,
+        "schema_version": 5,
+        "status": "processed",
+    }
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+    before = database_path.read_bytes()
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    entry = report["entries"][0]
+    assert entry["disposition"] == "unchanged"
+    assert entry["changes"] == {}
+    assert entry["issues"] == []
+    assert report["database_written"] is False
+    assert database_path.read_bytes() == before
+    assert json.loads(before)["talks"][0]["title"] == authored_title
+
+
+@pytest.mark.parametrize(
+    "stored_context",
+    [
+        {},
+        {"date": "2026-06-18"},
+        {"conference": "Voxxed Days Luxembourg 2026"},
+    ],
+)
+def test_event_qualified_title_requires_stored_conference_and_date(
+    tmp_path: Path,
+    stored_context: dict[str, str],
+) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    filename = "voxxed-lu-2026-monkey.md"
+    authored_title = "Never Trust a Monkey"
+    conference = "Voxxed Days Luxembourg 2026"
+    talk_date = "2026-06-18"
+    _write_jekyll_talk(
+        talks_directory,
+        filename=filename,
+        title=f"{authored_title} at Voxxed Luxembourg 2026",
+        conference=conference,
+        date=talk_date,
+    )
+    existing = {
+        "filename": filename,
+        "title": authored_title,
+        "schema_version": 5,
+        "status": "processed",
+        **stored_context,
+    }
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+    before = database_path.read_bytes()
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    entry = report["entries"][0]
+    assert entry["disposition"] == "review_required"
+    assert entry["changes"] == {}
+    assert [issue["code"] for issue in entry["issues"]] == [
+        "existing_title_conflict"
+    ]
+    assert report["database_written"] is False
+    assert database_path.read_bytes() == before
+
+
+def test_exact_title_still_fills_missing_stored_conference_and_date(
+    tmp_path: Path,
+) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    filename = "voxxed-lu-2026-monkey.md"
+    authored_title = "Never Trust a Monkey"
+    conference = "Voxxed Days Luxembourg 2026"
+    talk_date = "2026-06-18"
+    _write_jekyll_talk(
+        talks_directory,
+        filename=filename,
+        title=authored_title,
+        conference=conference,
+        date=talk_date,
+    )
+    existing = {
+        "filename": filename,
+        "title": authored_title,
+        "schema_version": 5,
+        "status": "processed",
+    }
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    entry = report["entries"][0]
+    assert entry["disposition"] == "update"
+    assert entry["changes"] == {
+        "conference": conference,
+        "date": talk_date,
+    }
+    assert entry["issues"] == []
+    assert report["database_written"] is True
+    talk = json.loads(database_path.read_text(encoding="utf-8"))["talks"][0]
+    assert talk["title"] == authored_title
+    assert talk["conference"] == conference
+    assert talk["date"] == talk_date
+
+
+@pytest.mark.parametrize(
+    ("catalog_conference", "shownotes_qualifier"),
+    [
+        ("Java Conference 2026", "Java Meetup 2026"),
+        ("DevOps Days 2026", "DevOps Conference 2026"),
+        ("Open Source Summit 2026", "Source Conference 2026"),
+    ],
+)
+def test_event_qualified_title_preserves_event_type_identity(
+    tmp_path: Path,
+    catalog_conference: str,
+    shownotes_qualifier: str,
+) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    filename = "2026-06-18-event-identity.md"
+    authored_title = "Identity-Bound Title"
+    talk_date = "2026-06-18"
+    _write_jekyll_talk(
+        talks_directory,
+        filename=filename,
+        title=f"{authored_title} at {shownotes_qualifier}",
+        conference=catalog_conference,
+        date=talk_date,
+    )
+    existing = {
+        "filename": filename,
+        "title": authored_title,
+        "conference": catalog_conference,
+        "date": talk_date,
+        "schema_version": 5,
+        "status": "processed",
+    }
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+    before = database_path.read_bytes()
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    entry = report["entries"][0]
+    assert entry["disposition"] == "review_required"
+    assert entry["changes"] == {}
+    assert [issue["code"] for issue in entry["issues"]] == [
+        "existing_title_conflict"
+    ]
+    assert report["database_written"] is False
+    assert database_path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "shownotes_title",
+    [
+        (
+            "Never Trust a Monkey: The Chasm, the Craft, and the Chain of "
+            "AI-Assisted Code at Devoxx Belgium 2026"
+        ),
+        (
+            "Never Trust a Monkey: The Chasm, the Craft, and the Chain of "
+            "AI-Assisted Code at Voxxed Days Luxembourg 2025"
+        ),
+        (
+            "Never Trust a Monkey: A Different Subtitle at "
+            "Voxxed Days Luxembourg 2026"
+        ),
+        "Never Trust a Monkey Returns at Voxxed Days Luxembourg 2026",
+    ],
+)
+def test_event_qualified_title_rejects_wrong_identity_and_shared_prefixes(
+    tmp_path: Path,
+    shownotes_title: str,
+) -> None:
+    site, talks_directory = _shownotes_site(tmp_path)
+    filename = "voxxed-lu-2026-monkey.md"
+    authored_title = (
+        "Never Trust a Monkey: The Chasm, the Craft, and the Chain of "
+        "AI-Assisted Code"
+    )
+    conference = "Voxxed Days Luxembourg 2026"
+    talk_date = "2026-06-18"
+    _write_jekyll_talk(
+        talks_directory,
+        filename=filename,
+        title=shownotes_title,
+        conference=conference,
+        date=talk_date,
+    )
+    existing = {
+        "filename": filename,
+        "title": authored_title,
+        "conference": conference,
+        "date": talk_date,
+        "schema_version": 5,
+        "status": "processed",
+    }
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[existing],
+    )
+    before = database_path.read_bytes()
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    entry = report["entries"][0]
+    assert entry["disposition"] == "review_required"
+    assert entry["changes"] == {}
+    assert [issue["code"] for issue in entry["issues"]] == [
+        "existing_title_conflict"
+    ]
     assert report["database_written"] is False
     assert database_path.read_bytes() == before
 

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -1,0 +1,152 @@
+"""Focused tests for the shared source-identity matching contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    REPO_ROOT
+    / "skills"
+    / "vault-ingress"
+    / "scripts"
+    / "source_identity_matching.py"
+)
+SPEC = importlib.util.spec_from_file_location("source_identity_matching", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+source_identity_matching = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(source_identity_matching)
+
+
+@pytest.mark.parametrize(
+    ("authored_title", "shownotes_title", "expected"),
+    [
+        ("Kahneman\u2019s Shortcut", "Kahneman's Shortcut", True),
+        ("Case Matters", "case matters", False),
+        ("Quoted: Title", "Quoted Title", False),
+    ],
+)
+def test_shownotes_title_presentation_rules_remain_narrow(
+    authored_title: str,
+    shownotes_title: str,
+    expected: bool,
+) -> None:
+    assert source_identity_matching.shownotes_titles_agree(
+        authored_title,
+        shownotes_title,
+        conference=None,
+        talk_date=None,
+    ) is expected
+
+
+@pytest.mark.parametrize(
+    ("shownotes_title", "conference", "talk_date", "expected"),
+    [
+        (
+            "Never Trust a Monkey at Voxxed Luxembourg 2026",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            True,
+        ),
+        (
+            "Never Trust a Monkey at Voxxed Days Luxembourg",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            True,
+        ),
+        (
+            "Never Trust a Monkey at Java Meetup 2026",
+            "Java Conference 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at DevOps Conference 2026",
+            "DevOps Days 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Source Conference 2026",
+            "Open Source Summit 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Luxembourg 2026",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Voxxed Days Luxembourg 2025",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Voxxed Days Luxembourg 2026",
+            "Voxxed Days Luxembourg 2025",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Voxxed Days Luxembourg 2026",
+            "Voxxed Days Luxembourg 2026",
+            "20260618",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Voxxed Days Luxembourg 2",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Voxxed Days Luxembourg 99999",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey at Caf\u00e9Conf 2026",
+            "Cafe\u0301Conf 2026",
+            "2026-06-18",
+            True,
+        ),
+        (
+            "Never Trust a Monkey at Cafe\u0301Conf 2026",
+            "Caf\u00e9Conf 2026",
+            "2026-06-18",
+            True,
+        ),
+        (
+            "Never Trust a Monkey — Voxxed Days Luxembourg 2026",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            False,
+        ),
+        (
+            "Never Trust a Monkey Returns at Voxxed Days Luxembourg 2026",
+            "Voxxed Days Luxembourg 2026",
+            "2026-06-18",
+            False,
+        ),
+    ],
+)
+def test_shownotes_event_qualifier_requires_exact_base_event_and_year(
+    shownotes_title: str,
+    conference: str,
+    talk_date: str,
+    expected: bool,
+) -> None:
+    assert source_identity_matching.shownotes_titles_agree(
+        "Never Trust a Monkey",
+        shownotes_title,
+        conference=conference,
+        talk_date=talk_date,
+    ) is expected


### PR DESCRIPTION
## Summary

- preserve an authored catalog title when shownotes append only a corroborated `at <event>` delivery qualifier
- keep generic event types identity-bearing and allow only the observed closed Voxxed `Days` presentation variant
- require stored conference and stored date as independent corroboration, leaving all other differences review-required

Closes #237

## Test plan

- [x] full suite — 4,864 passed, 3 skipped
- [x] matcher and scanner adversarial reproductions
- [x] changed-file Ruff and Pyright checks
- [x] `git diff --check`
- [x] `tessl plugin lint`
