### PR TITLE
ci(review-trigger): skip dependabot pull requests

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,15 +1,15 @@
 name: Trigger fleet policy review
 
-# PR-time trigger for the central jbaruch/coding-policy fleet reviewer. On every
-# same-repo PR event this fires a single-PR review in coding-policy immediately,
-# so the policy verdict is available before merge (the coding-policy cron poll is
-# only a backstop). Fork PRs are skipped — they cannot read the dispatch secret.
+# On each pull request in this repo, starts a review of that PR against the
+# jbaruch/coding-policy coding rules, so the result is available before merge. The
+# jbaruch/coding-policy schedule reviews the same PRs as a backstop. Fork pull
+# requests are skipped (they cannot read the secret). Dependabot pull requests are
+# skipped too (the dependabot actor gets no secrets); the schedule covers them.
 #
 # Requires one repo secret (set it at
 # https://github.com/<owner>/<repo>/settings/secrets/actions for this repo):
-#   FLEET_DISPATCH_TOKEN — a fine-grained PAT scoped to ONLY jbaruch/coding-policy
-#     with `Actions: write` (nothing else). It can trigger the review workflow and
-#     nothing more. The Codex credential itself lives only in coding-policy.
+#   FLEET_DISPATCH_TOKEN — the token this workflow reads to start the review run in
+#     jbaruch/coding-policy. Create it with Actions: Read and write on jbaruch/coding-policy.
 
 on:
   pull_request:
@@ -24,7 +24,11 @@ concurrency:
 jobs:
   trigger:
     # Fork PRs cannot read secrets — skip them (adopt via the adopt-fork-pr skill).
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot's actor also gets no secrets, so its request can't authenticate —
+    # skip it too (the coding-policy cron poll reviews dependabot PRs instead).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch the single-PR review to coding-policy
@@ -36,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "error: FLEET_DISPATCH_TOKEN secret is empty — set a fine-grained PAT (Actions: write on jbaruch/coding-policy only); see this workflow's header" >&2
+            echo "error: FLEET_DISPATCH_TOKEN secret is empty — set a fine-grained token scoped to Actions: Read and write on jbaruch/coding-policy only; see this workflow's header" >&2
             exit 1
           fi
           gh workflow run fleet-review.yml \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### ci(review-trigger) — skip dependabot pull requests (#244)
+
+The fleet policy review trigger is synced to the current
+`jbaruch/coding-policy` `install-reviewer` template, which skips Dependabot
+pull requests alongside fork pull requests. GitHub populates the `secrets`
+context from the Dependabot store — not the Actions store — for any workflow a
+Dependabot event triggers, so `FLEET_DISPATCH_TOKEN` resolved empty and the
+workflow's own emptiness guard exited non-zero on every Dependabot PR. This
+turned the `trigger` check red on PRs #125, #128, and #131 while their test
+suites were green. `pull_request_target` is not an escape hatch; GitHub applies
+the same restriction to it for Dependabot-authored pull requests. The
+coding-policy schedule remains the review path for these PRs.
+
 ## 0.20.18 — 2026-08-05
 
 ### fix(vault-ingress) — reconcile event-qualified shownotes titles (#237)


### PR DESCRIPTION
## Scope

This PR is a CI configuration change. That is its stated and only scope.

## Problem

The `trigger` check (Trigger fleet policy review) fails on every Dependabot PR — currently #125, #128, and #131 — while their test suites pass.

Root cause: GitHub populates the `secrets` context from the **Dependabot** secret store, not the Actions store, for any workflow a Dependabot event triggers. `FLEET_DISPATCH_TOKEN` exists only as an Actions secret (`gh secret list --app dependabot` is empty), so it resolved empty and the workflow's own emptiness guard exited non-zero. All three failing runs show `actor=dependabot[bot]`.

> "For workflows initiated by Dependabot (`github.actor == 'dependabot[bot]'`) ... Secrets are populated from Dependabot secrets. Actions secrets are not available."
> — [Dependabot on GitHub Actions](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-on-actions#restrictions-when-dependabot-triggers-events)

`pull_request_target` is not an escape hatch — GitHub applies the same restriction to it for Dependabot-authored PRs.

## Fix

Sync `.github/workflows/review-trigger.yml` to the current `install-reviewer` template in `jbaruch/coding-policy`, which already skips Dependabot PRs alongside fork PRs. This repo's copy was scaffolded before that guard was added; the template is the owner of this file and needed no change.

The only functional delta is the job's `if:` condition. The rest is the template's updated header wording. The other scaffolded reviewer files (`.github/copilot-instructions.md`, `.github/fleet-review-enabled`) are already byte-identical to the template — no drift there.

## Alternative considered

Mirroring the PAT into the Dependabot secret store (`gh secret set FLEET_DISPATCH_TOKEN --app dependabot`) would keep policy review running on Dependabot PRs. Not taken here: it needs the token value, and the coding-policy schedule already reviews these PRs as a backstop. Say the word if you'd rather have that instead — the two are mutually exclusive.

## Verification

The three Dependabot PRs need `@dependabot rebase` after this merges to pick up the new base and clear their red checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRDaNt3A2Q6tbTpazs1ewN