### PR TITLE
chore(deps): pin the setuptools build requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### chore(deps) — pin the setuptools build requirement
+
+`[build-system] requires` now pins `setuptools==83.0.0` instead of declaring the
+open lower-bound range `setuptools>=68`, matching how every other renewed
+dependency in `pyproject.toml` is declared. The policy reviewer gated
+Dependabot's range bump (#131) on this: `dependency-management` requires a pin
+or a committed lock file, and the repo has no lock file, so widening the range
+could not satisfy it. Renewal continues through the weekly Dependabot pip lane
+that already covers the other pins. The remaining unpinned runtime
+dependencies (`python-pptx`, `lxml`, `qrcode`) stay tracked in #161.
+
 ## 0.20.19 — 2026-08-08
 
 ### ci(review-trigger) — skip dependabot pull requests (#244)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools>=68"]
+# Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+requires = ["setuptools==83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Supersedes #131.

## Problem

The policy reviewer posted `CHANGES_REQUESTED` on Dependabot's #131:

> `pyproject.toml:2` — **dependency-management** — The build dependency is still declared as an open lower-bound range (`setuptools>=83.0.0`) with no lock file in the repo. The Pinning clause requires dependencies to be pinned or covered by a committed lock file for reproducible builds.

Dependabot could not clear that finding on its own — its PR widens the range (`>=68` → `>=83.0.0`), and a wider range is still a range. The repo has no lock file, so only an exact pin satisfies the rule.

## Fix

Pin `setuptools==83.0.0` in `[build-system] requires`, with the same renewal comment every other pinned dependency in `pyproject.toml` carries. This lands the version Dependabot wanted and closes the finding in one change.

Renewal is unchanged: the weekly Dependabot pip lane in `.github/dependabot.yml` already covers `/` and will bump this pin the same way it bumps `psutil`, `pypdf`, `Pillow`, and the rest.

## Scope

Narrow, on purpose. `python-pptx`, `lxml`, and `qrcode` are still unpinned — that is the broader cleanup tracked in #161 and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)