### PR TITLE
fix(vault-ingress): typed preflight diagnostics instead of exception prose (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+### fix(vault-ingress) — route preflight diagnostics off typed reasons, not exception prose (#200)
+
+Three preflight paths published raw exception text across a public diagnostic
+boundary, and one chose the public finding code by substring-matching that text.
+
+`TrackingDatabaseIOError` and `ReturnValidationError` now carry a
+`reason_code`. The top-level database read routes its finding code from that
+code through a lookup table, so rewording an upstream message can no longer
+silently reclassify a failure — an unmapped reason falls back to
+`database_unreadable` rather than inventing a code.
+
+`transcript_artifact_unreadable` reports `not_utf8` or
+`unreadable:<ExceptionType>` instead of the raw `OSError`/`UnicodeError`
+string, which carried the host path and decoder byte offset. The video-manifest
+rejection reports the schema field path instead of the validator's message,
+which can quote the value it rejected; where a narrower classification already
+exists — an artifact-locator reason — that code survives to the diagnostic
+rather than being flattened to the field path.
+
+Two further leaks surfaced while testing: `pattern_evidence.py` embedded the
+decoder's message in `source_reasons`, which preflight publishes as a
+`capability_fact`. Both now state the condition without the offset or path.
+
+The documented structured `artifact_path` field is unchanged — it exposes
+absolute paths by design, and this issue never covered it.
+
+
 ### fix(vault-ingress) — close the deterministic diagnostics gap in two CLI entrypoints (#203)
 
 `persist-results.py` and `preflight-vault.py` had no process-wide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ database path, the offending duplicate key, and rejected numeric literals —
 never reaches the report. An unmapped reason falls back to
 `database_unreadable` rather than inventing a code.
 
+`_validate_decoded_json_tree` runs after a successful decode, so its
+deep-nesting and unpaired-surrogate rejections are typed too — without codes
+they degraded to the generic `database_unreadable` and defeated the routing. A
+test asserts every `reason_code` the decoder emits has a mapping, so a new
+reason cannot silently fall through.
+
 Three existing tests asserted the report echoed the offending key or literal.
 They now assert the message belongs to the closed set of seven constants, which
 is a stronger guard: a message drawn from fixed strings cannot carry input at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,17 @@ Three preflight paths published raw exception text across a public diagnostic
 boundary, and one chose the public finding code by substring-matching that text.
 
 `TrackingDatabaseIOError` and `ReturnValidationError` now carry a
-`reason_code`. The top-level database read routes its finding code from that
-code through a lookup table, so rewording an upstream message can no longer
-silently reclassify a failure — an unmapped reason falls back to
+`reason_code`. The top-level database read derives BOTH its finding code and
+its public message from that reason, so rewording an upstream message can no
+longer silently reclassify a failure, and the decoder's text — which embeds the
+database path, the offending duplicate key, and rejected numeric literals —
+never reaches the report. An unmapped reason falls back to
 `database_unreadable` rather than inventing a code.
+
+Three existing tests asserted the report echoed the offending key or literal.
+They now assert the message belongs to the closed set of seven constants, which
+is a stronger guard: a message drawn from fixed strings cannot carry input at
+all.
 
 `transcript_artifact_unreadable` reports `not_utf8` or
 `unreadable:<ExceptionType>` instead of the raw `OSError`/`UnicodeError`

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -1308,11 +1308,14 @@ def validate_transcript_quality_for_owner(
         else:
             try:
                 current_text = before.transcript_bytes.decode("utf-8")
-            except UnicodeDecodeError as exc:
+            except UnicodeDecodeError:
+                # These strings reach public preflight capability facts, so the
+                # decoder's message — which carries the offending byte offset —
+                # stays out of them.
                 result = (
                     False,
-                    f"transcript artifact is not valid UTF-8: {exc}",
-                    f"transcript artifact is not valid UTF-8: {exc}",
+                    "transcript artifact is not valid UTF-8",
+                    "transcript artifact is not valid UTF-8",
                     False,
                 )
             else:
@@ -1383,7 +1386,7 @@ def _load_verified_transcript_snapshot(
 
         try:
             transcript_text = transcript_bytes.decode("utf-8")
-        except UnicodeDecodeError as exc:
+        except UnicodeDecodeError:
             try:
                 after = _capture_transcript_bundle(transcript_path)
             except PatternEvidenceError as snapshot_exc:
@@ -1393,9 +1396,9 @@ def _load_verified_transcript_snapshot(
                 continue
             return _VerifiedTranscriptSnapshot(
                 text=None,
-                transcript_reason=(
-                    f"transcript file is not valid UTF-8: {transcript_path}: {exc}"
-                ),
+                # Reaches public preflight capability facts: no host path and
+                # no decoder byte offset.
+                transcript_reason="transcript file is not valid UTF-8",
                 policy_bound=False,
                 timed_segments=(),
                 timing_reason="timed transcript is unavailable",

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -124,6 +124,10 @@ _DATABASE_READ_DIAGNOSTICS = {
         "database_json_invalid",
         "tracking database exceeds the maximum supported JSON nesting depth",
     ),
+    "json_unpaired_surrogate": (
+        "database_json_invalid",
+        "tracking database contains an unpaired UTF-16 surrogate in a JSON string",
+    ),
 }
 _DATABASE_READ_FALLBACK = (
     "database_unreadable",

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -88,6 +88,19 @@ from vault_root_authority import (
 
 REPORT_SCHEMA_VERSION = 1
 
+# Public finding code per typed decoder reason. Routing on the reason keeps the
+# taxonomy stable when an upstream message is reworded; an unmapped reason falls
+# back to the generic unreadable code rather than inventing one.
+_DATABASE_READ_FINDING_CODES = {
+    "encoding_invalid": "database_encoding_invalid",
+    "json_invalid": "database_json_invalid",
+    "json_duplicate_key": "database_json_invalid",
+    "json_non_standard_number": "database_json_invalid",
+    "json_non_roundtrippable_number": "database_json_invalid",
+    "json_root_not_object": "database_json_invalid",
+    "json_nesting_too_deep": "database_json_invalid",
+}
+
 
 def _sanitized_frames(exc: BaseException) -> list[str]:
     """Code locations from a traceback, with no exception text or full paths.
@@ -1250,13 +1263,19 @@ class VaultPreflight:
         try:
             text = transcript_path.read_text(encoding="utf-8")
         except (OSError, UnicodeError) as exc:
+            # `actual` is a public diagnostic field. A raw OSError/UnicodeError
+            # string carries the host path and decoder offsets; the typed reason
+            # says which failure it was without them.
             self.talk_add(
                 index,
                 severity,
                 "transcript_artifact_unreadable",
                 "transcript artifact cannot be decoded as UTF-8 speech text",
                 artifact_path=transcript_path,
-                actual=str(exc),
+                actual=(
+                    "not_utf8" if isinstance(exc, UnicodeError)
+                    else f"unreadable:{type(exc).__name__}"
+                ),
             )
             return
         valid, reason, receipt_reason, receipt_bound = (
@@ -1385,7 +1404,9 @@ class VaultPreflight:
                 "video extraction manifest violates the schema-v3 artifact contract",
                 field="structured_data.video_extraction",
                 expected="complete, internally consistent schema-v3 manifest",
-                actual=str(exc),
+                # ReturnValidationError text can echo the malformed input value
+                # it rejected, so only its typed reason crosses the boundary.
+                actual=getattr(exc, "reason_code", None) or type(exc).__name__,
                 artifact_path=promoted_pdf,
             )
             return
@@ -2256,23 +2277,14 @@ def run_preflight(value: str | Path) -> dict[str, Any]:
         snapshot = snapshot_tracking_database(database_path)
         database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
-        message = str(exc)
-        if "not valid UTF-8" in message:
-            code = "database_encoding_invalid"
-        elif (
-            "not valid JSON" in message
-            or "duplicate object key" in message
-            or ("non-standard JSON number" in message)
-            or "root must be a JSON object" in message
-        ):
-            code = "database_json_invalid"
-        else:
-            code = "database_unreadable"
+        code = _DATABASE_READ_FINDING_CODES.get(
+            getattr(exc, "reason_code", None), "database_unreadable"
+        )
         return error_report(
             vault_root,
             database_path,
             code,
-            message,
+            str(exc),
         )
     return VaultPreflight(database, vault_root, database_path).run()
 

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -91,15 +91,44 @@ REPORT_SCHEMA_VERSION = 1
 # Public finding code per typed decoder reason. Routing on the reason keeps the
 # taxonomy stable when an upstream message is reworded; an unmapped reason falls
 # back to the generic unreadable code rather than inventing one.
-_DATABASE_READ_FINDING_CODES = {
-    "encoding_invalid": "database_encoding_invalid",
-    "json_invalid": "database_json_invalid",
-    "json_duplicate_key": "database_json_invalid",
-    "json_non_standard_number": "database_json_invalid",
-    "json_non_roundtrippable_number": "database_json_invalid",
-    "json_root_not_object": "database_json_invalid",
-    "json_nesting_too_deep": "database_json_invalid",
+# Public finding code and closed message per typed decoder reason. Both are
+# derived from the reason, never from the exception text: decoder messages embed
+# the database path, the offending duplicate key, and rejected numeric values.
+_DATABASE_READ_DIAGNOSTICS = {
+    "encoding_invalid": (
+        "database_encoding_invalid",
+        "tracking database is not valid UTF-8",
+    ),
+    "json_invalid": (
+        "database_json_invalid",
+        "tracking database is not valid JSON",
+    ),
+    "json_duplicate_key": (
+        "database_json_invalid",
+        "tracking database contains a duplicate object key",
+    ),
+    "json_non_standard_number": (
+        "database_json_invalid",
+        "tracking database contains a non-standard JSON number",
+    ),
+    "json_non_roundtrippable_number": (
+        "database_json_invalid",
+        "tracking database contains a JSON number that cannot round-trip "
+        "losslessly through this toolkit",
+    ),
+    "json_root_not_object": (
+        "database_json_invalid",
+        "tracking database root must be a JSON object",
+    ),
+    "json_nesting_too_deep": (
+        "database_json_invalid",
+        "tracking database exceeds the maximum supported JSON nesting depth",
+    ),
 }
+_DATABASE_READ_FALLBACK = (
+    "database_unreadable",
+    "tracking database could not be read",
+)
 
 
 def _sanitized_frames(exc: BaseException) -> list[str]:
@@ -2277,15 +2306,10 @@ def run_preflight(value: str | Path) -> dict[str, Any]:
         snapshot = snapshot_tracking_database(database_path)
         database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
-        code = _DATABASE_READ_FINDING_CODES.get(
-            getattr(exc, "reason_code", None), "database_unreadable"
+        code, message = _DATABASE_READ_DIAGNOSTICS.get(
+            getattr(exc, "reason_code", None), _DATABASE_READ_FALLBACK
         )
-        return error_report(
-            vault_root,
-            database_path,
-            code,
-            str(exc),
-        )
+        return error_report(vault_root, database_path, code, message)
     return VaultPreflight(database, vault_root, database_path).run()
 
 

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -433,7 +433,16 @@ MEME_CONTENT_TYPES = frozenset({"meme_only", "meme_with_text"})
 
 
 class ReturnValidationError(ValueError):
-    """A subagent return violates the shared ingress contract."""
+    """A subagent return violates the shared ingress contract.
+
+    ``reason_code`` is the stable, typed classification. Its message may quote
+    the rejected input value, so a consumer publishing a public diagnostic
+    routes on the reason and never forwards the text.
+    """
+
+    def __init__(self, message: str, *, reason_code: str | None = None) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
 
 
 def resolve_return_schema_version(ret: dict) -> int:
@@ -916,8 +925,18 @@ def _validate_slides_local_path(ret: dict) -> str | None:
     return value
 
 
-def _manifest_error(field: str, message: str) -> NoReturn:
-    raise ReturnValidationError(f"structured_data.video_extraction.{field} {message}")
+def _manifest_error(field: str, message: str, *, reason: str | None = None) -> NoReturn:
+    """Raise a manifest rejection carrying a typed, closed reason.
+
+    The reason defaults to the schema field path — closed, schema-derived, and
+    free of the rejected input value the message quotes. A caller that already
+    holds a narrower classification (an artifact-locator reason, say) passes it
+    as ``reason`` so the specific code survives to the public diagnostic.
+    """
+    raise ReturnValidationError(
+        f"structured_data.video_extraction.{field} {message}",
+        reason_code=reason or f"video_extraction.{field}",
+    )
 
 
 def _manifest_bool(manifest: dict, field: str) -> bool:
@@ -951,6 +970,7 @@ def _validate_absolute_manifest_path(value, field: str) -> str:
         _manifest_error(
             field,
             f"{reason_message} ({exc.reason_code})",
+            reason=exc.reason_code,
         )
     return value
 

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -298,14 +298,16 @@ def _validate_decoded_json_tree(payload: object, *, subject: str) -> None:
             if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
                 raise TrackingDatabaseIOError(
                     f"{subject} contains an unpaired UTF-16 surrogate in a "
-                    "JSON string"
+                    "JSON string",
+                    reason_code="json_unpaired_surrogate",
                 )
             continue
         if isinstance(value, dict):
             if depth > MAX_JSON_NESTING_DEPTH:
                 raise TrackingDatabaseIOError(
                     f"{subject} exceeds maximum supported JSON nesting depth "
-                    f"{MAX_JSON_NESTING_DEPTH}"
+                    f"{MAX_JSON_NESTING_DEPTH}",
+                    reason_code="json_nesting_too_deep",
                 )
             previous_depth = deepest_container_visits.get(id(value))
             if previous_depth is not None and previous_depth >= depth:
@@ -319,7 +321,8 @@ def _validate_decoded_json_tree(payload: object, *, subject: str) -> None:
             if depth > MAX_JSON_NESTING_DEPTH:
                 raise TrackingDatabaseIOError(
                     f"{subject} exceeds maximum supported JSON nesting depth "
-                    f"{MAX_JSON_NESTING_DEPTH}"
+                    f"{MAX_JSON_NESTING_DEPTH}",
+                    reason_code="json_nesting_too_deep",
                 )
             previous_depth = deepest_container_visits.get(id(value))
             if previous_depth is not None and previous_depth >= depth:

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -33,7 +33,17 @@ STAGED_METADATA_STABILIZATION_ATTEMPTS = 4
 
 
 class TrackingDatabaseIOError(ValueError):
-    """The tracking database could not be read or installed safely."""
+    """The tracking database could not be read or installed safely.
+
+    ``reason_code`` is the stable, typed classification. Consumers route on it;
+    the message is human prose and may be reworded without notice. Readers that
+    substring-match the message instead will silently misclassify on any
+    rewording.
+    """
+
+    def __init__(self, message: str, *, reason_code: str = "io_error") -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
 
 
 class TrackingDatabaseConflictError(TrackingDatabaseIOError):
@@ -332,14 +342,16 @@ def decode_json_object_bytes(
         for key, value in pairs:
             if key in result:
                 raise TrackingDatabaseIOError(
-                    f"{label} {artifact_path} contains duplicate object key {key!r}"
+                    f"{label} {artifact_path} contains duplicate object key {key!r}",
+                    reason_code="json_duplicate_key",
                 )
             result[key] = value
         return result
 
     def reject_non_finite(value: str) -> NoReturn:
         raise TrackingDatabaseIOError(
-            f"{label} {artifact_path} contains non-standard JSON number {value}"
+            f"{label} {artifact_path} contains non-standard JSON number {value}",
+            reason_code="json_non_standard_number",
         )
 
     def non_roundtrippable_number(value: str) -> TrackingDatabaseIOError:
@@ -351,7 +363,8 @@ def decode_json_object_bytes(
         return TrackingDatabaseIOError(
             f"{label} {artifact_path} contains JSON number {description} that "
             "cannot round-trip losslessly through this toolkit; replace it "
-            "with a string or use a supported finite number"
+            "with a string or use a supported finite number",
+            reason_code="json_non_roundtrippable_number",
         )
 
     def parse_lossless_int(value: str) -> int:
@@ -383,17 +396,20 @@ def decode_json_object_bytes(
         raise
     except UnicodeDecodeError as exc:
         raise TrackingDatabaseIOError(
-            f"{label} {artifact_path} is not valid UTF-8: {exc}"
+            f"{label} {artifact_path} is not valid UTF-8: {exc}",
+            reason_code="encoding_invalid",
         ) from exc
     except RecursionError as exc:
         raise TrackingDatabaseIOError(
             f"{label} {artifact_path} exceeds maximum supported JSON nesting "
-            f"depth {MAX_JSON_NESTING_DEPTH}"
+            f"depth {MAX_JSON_NESTING_DEPTH}",
+            reason_code="json_nesting_too_deep",
         ) from exc
     except json.JSONDecodeError as exc:
         raise TrackingDatabaseIOError(
             f"{label} {artifact_path} is not valid JSON at line {exc.lineno}, "
-            f"column {exc.colno}"
+            f"column {exc.colno}",
+            reason_code="json_invalid",
         ) from exc
     _validate_decoded_json_tree(
         payload,
@@ -401,7 +417,8 @@ def decode_json_object_bytes(
     )
     if not isinstance(payload, dict):
         raise TrackingDatabaseIOError(
-            f"{label} {artifact_path} root must be a JSON object"
+            f"{label} {artifact_path} root must be a JSON object",
+            reason_code="json_root_not_object",
         )
     return payload
 

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3103,7 +3103,11 @@ def test_identity_date_and_duration_types_are_validated(
     report = preflight_vault.run_preflight(vault_fixture["root"])
 
     assert finding_codes(report, "blocking") == {"database_json_invalid"}
-    assert "non-standard JSON number Infinity" in report["findings"][0]["message"]
+    # The public message no longer echoes the rejected literal (#200).
+    assert report["findings"][0]["message"] == (
+        "tracking database contains a non-standard JSON number"
+    )
+    assert "Infinity" not in json.dumps(report["findings"], sort_keys=True)
     # The report remains strict JSON even when Python's input decoder accepted
     # a non-standard Infinity token from a legacy artifact.
     json.dumps(report, allow_nan=False)
@@ -3445,7 +3449,8 @@ def test_database_read_finding_code_comes_from_the_typed_reason(
 
 def test_unmapped_decoder_reason_falls_back_to_unreadable(preflight_vault):
     """An unrecognised reason must not invent a code."""
-    assert preflight_vault._DATABASE_READ_FINDING_CODES.get("brand_new_reason") is None
+    assert preflight_vault._DATABASE_READ_DIAGNOSTICS.get("brand_new_reason") is None
+    assert preflight_vault._DATABASE_READ_FALLBACK[0] == "database_unreadable"
 
 
 def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
@@ -3517,3 +3522,36 @@ def test_manifest_rejection_reports_a_typed_reason_not_the_rejected_value(
     assert finding is not None, [f["code"] for f in report["findings"]]
     assert finding["actual"].startswith("video_extraction.")
     assert poisoned not in json.dumps(finding, sort_keys=True)
+
+
+@pytest.mark.parametrize("payload,leaked", [
+    (b'{"a": 1, "SENSITIVE_KEY_abc": 2, "SENSITIVE_KEY_abc": 3}', "SENSITIVE_KEY_abc"),
+    (b'{"a": 123456789012345678901234567890123456789.5}', "123456789012345678901234567890"),
+])
+def test_database_read_report_never_echoes_malformed_input(
+        preflight_vault, tmp_path, payload, leaked):
+    """Decoder messages embed the rejected key or value; the report must not."""
+    database = tmp_path / "tracking-database.json"
+    database.write_bytes(payload)
+
+    report = preflight_vault.run_preflight(database)
+    serialized = json.dumps(
+        {k: v for k, v in report.items() if k not in {"database", "vault_root"}},
+        sort_keys=True,
+    )
+    assert leaked not in serialized, serialized
+    assert "database_json_invalid" in serialized
+
+
+def test_database_read_report_never_echoes_the_host_path(
+        preflight_vault, tmp_path):
+    """The decoder message embeds the artifact path; findings must not."""
+    database = tmp_path / "secret-vault-name" / "tracking-database.json"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"\xff\xfe not utf-8")
+
+    report = preflight_vault.run_preflight(database)
+    # `database` and `vault_root` are documented structured fields.
+    findings = json.dumps(report["findings"], sort_keys=True)
+    assert "secret-vault-name" not in findings, findings
+    assert report["findings"][0]["code"] == "database_encoding_invalid"

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3421,3 +3421,99 @@ def test_failure_report_names_code_locations_without_exception_text(
         assert "/private/vault/creds.json" not in stream
         assert "Traceback" not in stream
     assert "code locations that failed" in captured.err
+
+
+# --- #200: public diagnostics route on typed reasons, not exception prose ---
+
+@pytest.mark.parametrize("payload,expected_code", [
+    (b"\xff\xfe not utf-8", "database_encoding_invalid"),
+    (b"{not json", "database_json_invalid"),
+    (b'{"a": 1, "a": 2}', "database_json_invalid"),
+    (b'{"a": NaN}', "database_json_invalid"),
+    (b'["not", "an", "object"]', "database_json_invalid"),
+])
+def test_database_read_finding_code_comes_from_the_typed_reason(
+        preflight_vault, tmp_path, payload, expected_code):
+    """The public taxonomy must not depend on upstream message wording."""
+    database = tmp_path / "tracking-database.json"
+    database.write_bytes(payload)
+
+    report = preflight_vault.run_preflight(database)
+    codes = [item["code"] for item in report["findings"]]
+    assert expected_code in codes, codes
+
+
+def test_unmapped_decoder_reason_falls_back_to_unreadable(preflight_vault):
+    """An unrecognised reason must not invent a code."""
+    assert preflight_vault._DATABASE_READ_FINDING_CODES.get("brand_new_reason") is None
+
+
+def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
+        preflight_vault, vault_fixture):
+    """`actual` is public: a raw OSError string carries the host path."""
+    # The transcript resolves from youtube_id, so the file must use that name.
+    transcript = vault_fixture["root"] / "transcripts" / f"{VIDEO_ID}.txt"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_bytes(b"\xff\xfe invalid utf-8 bytes")
+    write_database(vault_fixture, [base_talk(status="processed")], current=True)
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+    finding = next(
+        (f for f in report["findings"]
+         if f["code"] == "transcript_artifact_unreadable"), None)
+    assert finding is not None, [f["code"] for f in report["findings"]]
+    assert finding["actual"] == "not_utf8"
+    # `artifact_path` is a documented structured field and legitimately carries
+    # an absolute path (#200). Every OTHER field must stay free of raw decoder
+    # prose and host paths.
+    rest = {k: v for k, v in finding.items() if k != "artifact_path"}
+    serialized = json.dumps(rest, sort_keys=True)
+    assert "codec" not in serialized
+    assert "invalid start byte" not in serialized
+    assert str(vault_fixture["root"]) not in serialized
+
+
+def test_reworded_decoder_message_keeps_its_finding_code(
+        preflight_vault, tmp_path, monkeypatch):
+    """The taxonomy survives upstream rewording — that is the point of the fix.
+
+    Substring matching on the message would fall through to the generic
+    `database_unreadable` as soon as the wording changed.
+    """
+    io_module = importlib.import_module("tracking_database_io")
+    database = tmp_path / "tracking-database.json"
+    database.write_text("{}", encoding="utf-8")
+
+    def reworded(*_args, **_kwargs):
+        raise io_module.TrackingDatabaseIOError(
+            "the file could not be interpreted as text",   # no legacy substring
+            reason_code="encoding_invalid",
+        )
+
+    monkeypatch.setattr(preflight_vault, "decode_json_object", reworded)
+
+    report = preflight_vault.run_preflight(database)
+    codes = [item["code"] for item in report["findings"]]
+    assert "database_encoding_invalid" in codes, codes
+    assert "database_unreadable" not in codes
+
+
+def test_manifest_rejection_reports_a_typed_reason_not_the_rejected_value(
+        preflight_vault, vault_fixture):
+    """ReturnValidationError text can echo the malformed input it rejected."""
+    poisoned = "SENSITIVE_VALUE_abc123"
+    talk = base_talk(
+        status="processed_partial",
+        transcript_source="none",
+        slide_source="video_extracted",
+        structured_data={"video_extraction": {"schema_version": poisoned}},
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+    finding = next(
+        (f for f in report["findings"]
+         if f["code"] == "video_extraction_provenance_invalid"), None)
+    assert finding is not None, [f["code"] for f in report["findings"]]
+    assert finding["actual"].startswith("video_extraction.")
+    assert poisoned not in json.dumps(finding, sort_keys=True)

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import os
 from pathlib import Path
+import pathlib
 import shutil
 import struct
 import subprocess
@@ -3555,3 +3556,38 @@ def test_database_read_report_never_echoes_the_host_path(
     findings = json.dumps(report["findings"], sort_keys=True)
     assert "secret-vault-name" not in findings, findings
     assert report["findings"][0]["code"] == "database_encoding_invalid"
+
+
+@pytest.mark.parametrize("payload,expected_message", [
+    (
+        # MAX_JSON_NESTING_DEPTH is 200; go comfortably past it.
+        ('{"config": {}, "talks": [], "deep": '
+         + "[" * 260 + "]" * 260 + "}").encode(),
+        "tracking database exceeds the maximum supported JSON nesting depth",
+    ),
+    (
+        b'{"config": {}, "talks": [], "s": "\\ud800"}',
+        "tracking database contains an unpaired UTF-16 surrogate in a JSON string",
+    ),
+])
+def test_tree_validator_defects_route_to_their_specific_reason(
+        preflight_vault, tmp_path, payload, expected_message):
+    """These raise after a successful decode; untyped they fall back to generic."""
+    database = tmp_path / "tracking-database.json"
+    database.write_bytes(payload)
+
+    report = preflight_vault.run_preflight(database)
+    finding = report["findings"][0]
+    assert finding["code"] == "database_json_invalid", finding
+    assert finding["message"] == expected_message
+
+
+def test_every_emitted_decoder_reason_is_mapped(preflight_vault):
+    """A reason with no mapping silently degrades to the generic code."""
+    import re
+    io_source = pathlib.Path(
+        importlib.import_module("tracking_database_io").__file__
+    ).read_text(encoding="utf-8")
+    emitted = set(re.findall(r'reason_code="([a-z_]+)"', io_source))
+    mapped = set(preflight_vault._DATABASE_READ_DIAGNOSTICS)
+    assert emitted <= mapped, sorted(emitted - mapped)

--- a/tests/test_tracking_database_strict_readers.py
+++ b/tests/test_tracking_database_strict_readers.py
@@ -144,7 +144,16 @@ def test_preflight_blocks_every_strict_json_defect_without_rewrite(
         "database_encoding_invalid",
         "database_json_invalid",
     }
-    assert message in report["findings"][0]["message"]
+    # The public report's message is derived from the decoder's typed reason,
+    # never from its text: the decoder names the offending key or value, and
+    # those are input data (#200, no-secrets). The message must be one of the
+    # closed set, and must not echo the detail this case injected.
+    closed_messages = {
+        text for _code, text in preflight_vault._DATABASE_READ_DIAGNOSTICS.values()
+    } | {preflight_vault._DATABASE_READ_FALLBACK[1]}
+    # Membership in a fixed set is itself the leak guard: a message drawn from
+    # seven constants cannot carry the offending key or value.
+    assert report["findings"][0]["message"] in closed_messages
     assert database.read_bytes() == raw
 
 


### PR DESCRIPTION
All three sites #200 names are real — this one was not stale. Verified before changing anything.

## The worst of the three

`run_preflight` chose the **public finding code** by substring-matching exception prose:

```python
if "not valid UTF-8" in message:        code = "database_encoding_invalid"
elif "not valid JSON" in message or ... code = "database_json_invalid"
else:                                   code = "database_unreadable"
```

Rewording any upstream message silently reclassifies the failure. `TrackingDatabaseIOError` now carries `reason_code`, set at all seven raise sites in the decoder, and preflight routes through a lookup table. An unmapped reason falls back to `database_unreadable` rather than inventing a code.

`test_reworded_decoder_message_keeps_its_finding_code` proves the mechanism changed: it raises with `reason_code="encoding_invalid"` and a message containing none of the legacy substrings, then asserts the code is still `database_encoding_invalid`.

## The other two

- `transcript_artifact_unreadable` published `str(OSError|UnicodeError)` — host path plus decoder byte offset. Now `not_utf8` or `unreadable:<ExceptionType>`.
- The video-manifest rejection published the validator's message, which can quote the value it rejected. Now the schema field path, via a `reason` on the single `_manifest_error` funnel all 46 manifest rejections pass through.

Where a **narrower** classification already exists it survives rather than being flattened. `_validate_absolute_manifest_path` passes the artifact-locator's `reason_code` through, so `artifact_locator_foreign_absolute` still reaches the diagnostic — an existing test caught me flattening it.

## Two leaks the tests found

Writing the transcript test surfaced sites #200 does not name: `pattern_evidence.py` embedded the decoder's message in `source_reasons`, which preflight publishes as a `capability_fact`. Fixed both.

## What is deliberately untouched

`artifact_path`. #200 says so explicitly — *"The preflight schema intentionally exposes structured absolute `artifact_path` values. The problem is not that documented field."* My first draft asserted the vault root appeared nowhere in a finding, which would have forbidden it; the assertion now scopes to every other field.

## Verification

- Full suite: **4,958 passed, 3 skipped**
- 9 new tests; the 4 that prove behavior change fail against pre-fix code
- The 5 taxonomy cases pass either way by design — they guard the code mapping, and I have said so rather than implying they demonstrate the fix

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)