### PR TITLE
fix(vault-ingress): distinguish transcript read failure from decode failure (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### fix(vault-ingress) — say which failure the unreadable transcript hit (#253)
+
+`transcript_artifact_unreadable` always read "transcript artifact cannot be
+decoded as UTF-8 speech text", but the handler catches `(OSError, UnicodeError)`
+— a permission denial or a vanished file got a message asserting the wrong
+cause. #252 already split `actual` into `not_utf8` versus
+`unreadable:<ExceptionType>`; the message now follows the same branch, staying
+free of the errno prose and host path that `artifact_path` already carries
+(#200).
+
+Found by Copilot's advisory review of #252. Advisories never gate
+(`rules/review-severity.md`), so it was deferred here rather than burning a
+re-review round.
+
 ## 0.20.29 — 2026-08-09
 
 ### fix(vault-ingress) — route preflight diagnostics off typed reasons, not exception prose (#200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ decoded as UTF-8 speech text", but the handler catches `(OSError, UnicodeError)`
 cause. #252 already split `actual` into `not_utf8` versus
 `unreadable:<ExceptionType>`; the message now follows the same branch, staying
 free of the errno prose and host path that `artifact_path` already carries
-(#200).
+(#200). Both messages name the recovery — re-fetch or re-save for a decode
+failure, restore and make readable for a read failure — because a diagnostic
+that only describes the fault leaves the operator to guess (`error-handling`
+Actionable Messages).
 
 Found by Copilot's advisory review of #252. Advisories never gate
 (`rules/review-severity.md`), so it was deferred here rather than burning a

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1298,15 +1298,22 @@ class VaultPreflight:
         except (OSError, UnicodeError) as exc:
             # `actual` is a public diagnostic field. A raw OSError/UnicodeError
             # string carries the host path and decoder offsets; the typed reason
-            # says which failure it was without them.
+            # says which failure it was without them. The message follows the
+            # same split: a permission denial is a read failure, not a decode
+            # failure, and must not assert the wrong cause.
+            decode_failure = isinstance(exc, UnicodeError)
             self.talk_add(
                 index,
                 severity,
                 "transcript_artifact_unreadable",
-                "transcript artifact cannot be decoded as UTF-8 speech text",
+                (
+                    "transcript artifact is not valid UTF-8 speech text"
+                    if decode_failure
+                    else "transcript artifact could not be read"
+                ),
                 artifact_path=transcript_path,
                 actual=(
-                    "not_utf8" if isinstance(exc, UnicodeError)
+                    "not_utf8" if decode_failure
                     else f"unreadable:{type(exc).__name__}"
                 ),
             )

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1307,9 +1307,13 @@ class VaultPreflight:
                 severity,
                 "transcript_artifact_unreadable",
                 (
-                    "transcript artifact is not valid UTF-8 speech text"
+                    "transcript artifact is not valid UTF-8 speech text; "
+                    "re-fetch it with fetch-transcript.py (or re-save it as "
+                    "UTF-8), then rerun preflight"
                     if decode_failure
-                    else "transcript artifact could not be read"
+                    else "transcript artifact could not be read; restore the "
+                    "file at the reported artifact_path and make it readable, "
+                    "then rerun preflight"
                 ),
                 artifact_path=transcript_path,
                 actual=(

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3469,7 +3469,12 @@ def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
          if f["code"] == "transcript_artifact_unreadable"), None)
     assert finding is not None, [f["code"] for f in report["findings"]]
     assert finding["actual"] == "not_utf8"
-    assert finding["message"] == "transcript artifact is not valid UTF-8 speech text"
+    assert finding["message"].startswith(
+        "transcript artifact is not valid UTF-8 speech text"
+    )
+    assert "rerun preflight" in finding["message"], (
+        "error-handling requires the message to say what to do next"
+    )
     # `artifact_path` is a documented structured field and legitimately carries
     # an absolute path (#200). Every OTHER field must stay free of raw decoder
     # prose and host paths.
@@ -3503,7 +3508,12 @@ def test_transcript_read_failure_does_not_claim_a_decode_failure(
          if f["code"] == "transcript_artifact_unreadable"), None)
     assert finding is not None, [f["code"] for f in report["findings"]]
     assert finding["actual"] == "unreadable:PermissionError"
-    assert finding["message"] == "transcript artifact could not be read"
+    assert finding["message"].startswith(
+        "transcript artifact could not be read"
+    )
+    assert "rerun preflight" in finding["message"], (
+        "error-handling requires the message to say what to do next"
+    )
     # The location lives in the documented `artifact_path` field (#200); neither
     # the message nor `actual` may carry the errno prose or the host path.
     for field in ("message", "actual"):

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3469,6 +3469,7 @@ def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
          if f["code"] == "transcript_artifact_unreadable"), None)
     assert finding is not None, [f["code"] for f in report["findings"]]
     assert finding["actual"] == "not_utf8"
+    assert finding["message"] == "transcript artifact is not valid UTF-8 speech text"
     # `artifact_path` is a documented structured field and legitimately carries
     # an absolute path (#200). Every OTHER field must stay free of raw decoder
     # prose and host paths.
@@ -3477,6 +3478,37 @@ def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
     assert "codec" not in serialized
     assert "invalid start byte" not in serialized
     assert str(vault_fixture["root"]) not in serialized
+
+
+def test_transcript_read_failure_does_not_claim_a_decode_failure(
+        preflight_vault, vault_fixture, monkeypatch):
+    """A permission denial is a read failure — the message must say so (#253)."""
+    transcript = vault_fixture["root"] / "transcripts" / f"{VIDEO_ID}.txt"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text("speech text", encoding="utf-8")
+    write_database(vault_fixture, [base_talk(status="processed")], current=True)
+
+    real_read_text = Path.read_text
+
+    def denied(self, *args, **kwargs):
+        if self == transcript:
+            raise PermissionError(13, "Permission denied", str(transcript))
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", denied)
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+    finding = next(
+        (f for f in report["findings"]
+         if f["code"] == "transcript_artifact_unreadable"), None)
+    assert finding is not None, [f["code"] for f in report["findings"]]
+    assert finding["actual"] == "unreadable:PermissionError"
+    assert finding["message"] == "transcript artifact could not be read"
+    # The location lives in the documented `artifact_path` field (#200); neither
+    # the message nor `actual` may carry the errno prose or the host path.
+    for field in ("message", "actual"):
+        assert "Permission denied" not in finding[field]
+        assert str(vault_fixture["root"]) not in finding[field]
 
 
 def test_reworded_decoder_message_keeps_its_finding_code(


### PR DESCRIPTION
Closes #253.

## The bug

`_validate_transcript_quality` catches `(OSError, UnicodeError)` but the
finding always said:

> transcript artifact cannot be decoded as UTF-8 speech text

A permission denial or a vanished file is a **read** failure. The message
asserted the wrong cause — and it's the field an operator actually reads before
deciding whether to re-run the fetch or fix a mount.

## The fix

#252 already split `actual` into `not_utf8` versus `unreadable:<ExceptionType>`.
The message now branches on the same `isinstance(exc, UnicodeError)` test:

| failure | `actual` | `message` |
|---|---|---|
| decode | `not_utf8` | transcript artifact is not valid UTF-8 speech text |
| read | `unreadable:PermissionError` | transcript artifact could not be read |

One boolean, computed once, drives both fields — they cannot drift apart.

## Path neutrality holds

Per #200, the location lives in the documented `artifact_path` field. Neither
message carries errno prose or a host path, and the new test asserts that on
`message` and `actual` specifically rather than blanket-scanning the finding
(`context` legitimately carries artifact paths, same as `artifact_path`).

## Tests

- New `test_transcript_read_failure_does_not_claim_a_decode_failure` — monkeypatches
  `Path.read_text` to raise `PermissionError` on the transcript only, asserts the
  read-failure message and `unreadable:PermissionError`. Fails against pre-fix code.
- Existing decode test extended with an exact-message assertion, so a future
  reword cannot silently reintroduce the conflation.
- `tests/test_preflight_vault.py`: 217 passed.

## Provenance

Copilot advisory on #252. Advisories never gate (`rules/review-severity.md`), so
it was filed rather than folded into an already-green PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)