### PR TITLE
fix(vault-ingress): close the last four deterministic entrypoint boundaries (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ All four pre-render their reports with `json.dumps` before writing. A
 `json.dump` straight to stdout that fails partway leaves a truncated document a
 caller would try to parse.
 
-`scripts/failure_diagnostics.py` is the new home of the diagnostic shape, which
-`persist-results.py` and `preflight-vault.py` had each copied. A sixth
-entrypoint would have been a third copy.
+`skills/vault-ingress/scripts/failure_diagnostics.py` is the new home of the
+diagnostic shape, which `persist-results.py` and `preflight-vault.py` had each
+copied. A sixth entrypoint would have been a third copy. The document's
+identity fields are written after a caller's `state`, so an entrypoint cannot
+shadow its own `error` code and make consumers misclassify the failure —
+raising instead would produce the traceback the boundary exists to prevent.
 
 `references/entrypoint-failure-contracts.md` inventories every entrypoint's
 stdout, stderr, exit-code, and commit-position contract — #203's first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+### fix(vault-ingress) — close the last four deterministic entrypoint boundaries (#203)
+
+`write-analysis.py`, `validate-returns.py`, `audit-pattern-catalog.py`, and
+`aggregate-catalog-feedback.py` had no process-wide unexpected-failure boundary.
+An unexpected exception reached the caller as a traceback carrying return paths,
+catalog entry text, and vault locations — and for `write-analysis.py`, which
+installs files before emitting its receipt, with no way to tell whether the
+batch had committed.
+
+Each now runs behind a `run_cli()` that emits one closed, path-neutral JSON
+document on stderr and exits non-zero. `write-analysis.py` reports
+`analyses_written` the way `persist-results.py` reports `database_written`, so
+an operator can distinguish a rolled-back batch from a committed one whose
+receipt died. The two catalog gates exit 3 rather than 2 because argparse
+already owns 2 there; a caller can still tell a malformed invocation from a
+broken tool.
+
+All four pre-render their reports with `json.dumps` before writing. A
+`json.dump` straight to stdout that fails partway leaves a truncated document a
+caller would try to parse.
+
+`scripts/failure_diagnostics.py` is the new home of the diagnostic shape, which
+`persist-results.py` and `preflight-vault.py` had each copied. A sixth
+entrypoint would have been a third copy.
+
+`references/entrypoint-failure-contracts.md` inventories every entrypoint's
+stdout, stderr, exit-code, and commit-position contract — #203's first
+acceptance criterion, and previously nowhere written down. The exit-2 shapes
+#251 introduced were undocumented too; the reference and the four call sites in
+`batch-persistence.md`, `bootstrap-and-preflight.md`, and
+`pattern-catalog-contract.md` now name them.
+
+Closes the deterministic-entrypoint scope of #203. The earlier audit
+(PR #251) established the three PPTX sites were already compliant and that
+`check-runtime.py`'s traceback is a deliberate, tested contract.
+
 ## 0.20.29 — 2026-08-09
 
 ### fix(vault-ingress) — route preflight diagnostics off typed reasons, not exception prose (#200)

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -65,6 +65,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/pattern-catalog-contract.md](references/pattern-catalog-contract.md) | Read-only catalog graph, polarity, source-gate, and semantic-debt contract |
 | [references/processing-rules.md](references/processing-rules.md) | Language policy, pattern migration logic, structured field rules |
 | [references/known-issues.md](references/known-issues.md) | Edge cases — wide-angle recordings, Whisper hallucination, non-speaker talks |
+| [references/entrypoint-failure-contracts.md](references/entrypoint-failure-contracts.md) | Per-script stdout, stderr, exit-code, and commit-position contract on failure |
 
 Every agent-driven read of `tracking-database.json` must go through
 `read-tracking-database.py`. Every agent-driven write not already owned by a

--- a/skills/vault-ingress/references/batch-persistence.md
+++ b/skills/vault-ingress/references/batch-persistence.md
@@ -27,6 +27,9 @@ whether to run the gate.
   or multiple such inputs. Exit 0 emits one structured JSON validation report on
   stdout and authorizes the next step; exit 1 emits concise diagnostics on stderr,
   authorizes no write, and requires repairing the named return before rerunning.
+  Exit 2 means the validator itself failed and the batch is UNVALIDATED, not
+  invalid — see
+  [Entrypoint Failure Contracts](entrypoint-failure-contracts.md).
   The complete field, catalog, source, evidence, scoring, and artifact predicates
   are owned by `skills/vault-ingress/scripts/validate-returns.py` (top-of-file
   input/output/exit contract) and
@@ -94,6 +97,9 @@ whether to run the gate.
   interrupted batch is recovered with
   `queue-state.py ... recover --now <ISO> --stale-after-seconds <N>`, not by
   replaying whichever old return files happen to exist.
+  On exit 2 read the stderr document's `database_written` before retrying — it
+  states whether the atomic commit landed. See
+  [Entrypoint Failure Contracts](entrypoint-failure-contracts.md).
   Future talk-record schemas are rejected before merge so this writer never
   stamps a newer record down to its current version. Pass the canonical tracking
   DB path: queue and persistence tools reject a final-component symlink before
@@ -119,6 +125,9 @@ whether to run the gate.
   and catalog feedback — creates `analyses/` if missing, prints a JSON summary, and
   exits non-zero on a return with no `filename`. Section list and field handling live
   in `skills/vault-ingress/scripts/write-analysis.py` (top-of-file docstring).
+  On exit 2 read the stderr document's `analyses_written` before retrying — it
+  states whether the batch committed. See
+  [Entrypoint Failure Contracts](entrypoint-failure-contracts.md).
   Non-empty adherence prose from a legacy v1–v4 return is preserved only as
   archival text under an unmistakable `legacy-unverified` label. It is never a
   current numeric comparison, Section 15 aggregate, or profile input.
@@ -130,4 +139,6 @@ whether to run the gate.
   suggestions, and polarity warnings with the speaker. Recurrence is evidence
   for review, never authorization to change a catalog file. The five lanes and
   report contract live in
-  [catalog-feedback-intake.md](catalog-feedback-intake.md).
+  [catalog-feedback-intake.md](catalog-feedback-intake.md); exit 3 means the
+  aggregator failed and no feedback was harvested, per
+  [Entrypoint Failure Contracts](entrypoint-failure-contracts.md).

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -280,7 +280,10 @@ Exit 1 means one or more blocking integrity errors (identity disagreement,
 unqualified duplicate recording, invalid source claim, or a claimed completed
 artifact that is missing): stop and repair those records/artifacts before
 processing. Exit 0 may still carry warnings for legacy evidence gaps or pending
-artifacts; report them, but they do not make the vault unusable. The stable JSON
+artifacts; report them, but they do not make the vault unusable. Exit 2 carries
+a real report whose single blocking `preflight_unexpected_failure` finding means
+the gate never completed — treat the vault as unverified, not clean, per
+[Entrypoint Failure Contracts](entrypoint-failure-contracts.md). The stable JSON
 report and evidence shape are defined in
 [source-identity-preflight.md](source-identity-preflight.md).
 

--- a/skills/vault-ingress/references/entrypoint-failure-contracts.md
+++ b/skills/vault-ingress/references/entrypoint-failure-contracts.md
@@ -10,7 +10,8 @@ validation predicates stay in the script (`rules/script-as-black-box.md`).
 
 ## The Shared Diagnostic Shape
 
-`scripts/failure_diagnostics.py` owns the emitted document. On an unexpected
+`skills/vault-ingress/scripts/failure_diagnostics.py` owns the emitted
+document. On an unexpected
 failure the entrypoint writes to **stderr**, one JSON object on the first line:
 
 ```json
@@ -28,6 +29,8 @@ A human-readable recovery note follows on the next lines.
 - Mutating entrypoints add commit-position fields; see the table.
 
 ## CLI Contracts
+
+Every script named below lives in `skills/vault-ingress/scripts/`.
 
 | Script | stdout on success | Unexpected-failure exit | Failure identifier | Commit-position field |
 |---|---|---|---|---|
@@ -68,8 +71,8 @@ Never infer commit position from the exit code; read the field.
 
 ## Worker Protocol Boundaries
 
-`pptx_evidence.py`, `pptx-extraction.py`, and `pdf_evidence.py` run supervised
-worker children whose stdout is reserved for one authenticated frame. Their
-boundaries emit a path-neutral `<kind> worker failed: <reason>` line on stderr
-and exit 2; the supervisor reads a non-zero child without an authenticated
-response as a bounded crash.
+`pptx_evidence.py`, `pptx-extraction.py`, and `pdf_evidence.py` — same
+directory — run supervised worker children whose stdout is reserved for one
+authenticated frame. Their boundaries emit a path-neutral
+`<kind> worker failed: <reason>` line on stderr and exit 2; the supervisor
+reads a non-zero child without an authenticated response as a bounded crash.

--- a/skills/vault-ingress/references/entrypoint-failure-contracts.md
+++ b/skills/vault-ingress/references/entrypoint-failure-contracts.md
@@ -1,0 +1,75 @@
+# Entrypoint Failure Contracts
+
+Every deterministic vault-ingress entrypoint closes its outer failure boundary
+(#203). No unexpected exception reaches a caller as a traceback, and no
+machine-readable command leaves a truncated document on stdout.
+
+Read this when a script exits non-zero and you need to know what state it left
+behind. It inventories the boundary contract only — each script's normal
+validation predicates stay in the script (`rules/script-as-black-box.md`).
+
+## The Shared Diagnostic Shape
+
+`scripts/failure_diagnostics.py` owns the emitted document. On an unexpected
+failure the entrypoint writes to **stderr**, one JSON object on the first line:
+
+```json
+{"error": "<entrypoint>_unexpected_failure",
+ "error_type": "RuntimeError",
+ "origin": ["persist-results.py:412 in merge_return"]}
+```
+
+A human-readable recovery note follows on the next lines.
+
+- `error_type` is the exception CLASS. The exception MESSAGE never crosses the
+  boundary — `no-secrets` forbids it, and a `FileNotFoundError` message embeds
+  the path it could not find.
+- `origin` is `basename:line in function`, innermost last. Never a full path.
+- Mutating entrypoints add commit-position fields; see the table.
+
+## CLI Contracts
+
+| Script | stdout on success | Unexpected-failure exit | Failure identifier | Commit-position field |
+|---|---|---|---|---|
+| `persist-results.py` | one JSON receipt | 2 | `persist_results_unexpected_failure` | `database_written` |
+| `write-analysis.py` | one JSON receipt | 2 | `write_analysis_unexpected_failure` | `analyses_written` |
+| `preflight-vault.py` | one JSON report | 2 | `preflight_unexpected_failure` (a blocking finding in a real report, not a stderr document) | — read-only |
+| `validate-returns.py` | one JSON report | 2 | `validate_returns_unexpected_failure` | — read-only |
+| `audit-pattern-catalog.py` | one JSON report | 3 | `catalog_audit_unexpected_failure` | — read-only |
+| `aggregate-catalog-feedback.py` | one JSON report | 3 | `catalog_feedback_unexpected_failure` | — read-only |
+
+The two catalog gates use exit 3 because argparse already owns exit 2 there; a
+caller can still tell a malformed invocation from a broken tool.
+
+`preflight-vault.py` is the one entrypoint whose failure lands on **stdout**: a
+caller gates claiming on its report, and a missing report reads as "preflight
+never ran". It emits a real report — `ok: false`, one blocking finding whose
+keys match every other finding — so a consumer parses it normally.
+
+## What an Exit Code Does Not Mean
+
+- Exit 1 is the script's own verdict: a rejected batch, a structurally invalid
+  catalog. The tool worked.
+- Exit 2 (or 3) with the JSON document above means the tool FAILED. A read-only
+  command's inputs are unexamined, not clean. Never read it as a pass.
+- `SystemExit` from a documented error path is not caught by these boundaries —
+  those exit codes reach the caller unchanged.
+
+## Retrying a Mutating Script
+
+`database_written` and `analyses_written` state whether the atomic commit
+landed before the failure:
+
+- `true` — the write is durable. Re-running re-persists the batch. Re-read the
+  live state before deciding.
+- `false` — every target was rolled back. The batch can be retried as-is.
+
+Never infer commit position from the exit code; read the field.
+
+## Worker Protocol Boundaries
+
+`pptx_evidence.py`, `pptx-extraction.py`, and `pdf_evidence.py` run supervised
+worker children whose stdout is reserved for one authenticated frame. Their
+boundaries emit a path-neutral `<kind> worker failed: <reason>` line on stderr
+and exit 2; the supervisor reads a non-zero child without an authenticated
+response as a bounded crash.

--- a/skills/vault-ingress/references/pattern-catalog-contract.md
+++ b/skills/vault-ingress/references/pattern-catalog-contract.md
@@ -10,7 +10,9 @@ Pass `--catalog <patterns-directory>` to inspect another catalog. The command
 uses local Markdown and YAML only. It does not use the network or modify any
 file. Stdout is one deterministic JSON document. Exit `0` means no structural
 errors, exit `1` means the catalog contract is broken, and argument errors use
-exit `2`.
+exit `2`. Exit `3` means the auditor itself failed and the catalog is
+UNAUDITED, not clean — see
+[Entrypoint Failure Contracts](entrypoint-failure-contracts.md).
 
 ## Authority boundaries
 

--- a/skills/vault-ingress/scripts/aggregate-catalog-feedback.py
+++ b/skills/vault-ingress/scripts/aggregate-catalog-feedback.py
@@ -9,6 +9,12 @@ grouped separately with occurrence, talk, and source-return counts.
 
 The five-lane schema, polarity rules, classifications, and report shape are
 documented in ``references/catalog-feedback-intake.md``.
+
+Exit 0 is a clean harvest, exit 1 a report with ``ok: false``, and exit 2 an
+argparse rejection. An unexpected failure uses exit 3 and writes one
+``catalog_feedback_unexpected_failure`` JSON document to stderr, leaving stdout
+empty — argparse already owns 2, so the caller can still tell a malformed
+invocation from a broken aggregator.
 """
 
 from __future__ import annotations
@@ -24,6 +30,7 @@ import unicodedata
 
 from yaml import YAMLError
 
+from failure_diagnostics import emit_unexpected_failure
 from catalog_io import DuplicateYAMLKeyError, catalog_entry_paths, load_catalog_yaml
 from catalog_normalization import normalize_catalog_alias
 
@@ -1084,5 +1091,29 @@ def main(argv: list[str] | None = None) -> int:
     return 0 if report["ok"] else 1
 
 
+def run_cli(argv: list[str] | None = None) -> int:
+    """Run the CLI behind its failure boundary. Returns the process exit code.
+
+    Importable so the boundary's contract is testable without executing the
+    module as a script.
+    """
+    try:
+        return main(argv)
+    # Every documented outcome — including the invalid-arguments report — leaves
+    # one JSON document on stdout, so a traceback here would be the only shape a
+    # caller could not parse, and it would carry return paths and catalog entry
+    # text with it.
+    except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+        emit_unexpected_failure(
+            exc,
+            "catalog_feedback_unexpected_failure",
+            "Catalog feedback aggregation failed unexpectedly. This command is "
+            "read-only, so neither the catalog nor the returns were changed — "
+            "but no feedback was harvested and the report on stdout is absent, "
+            "not empty.",
+        )
+        return 3
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(run_cli())

--- a/skills/vault-ingress/scripts/audit-pattern-catalog.py
+++ b/skills/vault-ingress/scripts/audit-pattern-catalog.py
@@ -8,6 +8,9 @@ to stdout. It never edits entries or invents semantic relationships.
 Structural errors make the process exit 1. Differences that require a human to
 choose which prose or metadata is authoritative are emitted separately as
 ``semantic_debts`` and do not make the process fail. Argument errors use exit 2.
+An unexpected failure uses exit 3 and writes one ``catalog_audit_unexpected_failure``
+JSON document to stderr, leaving stdout empty — argparse already owns 2, so the
+caller can still tell a malformed invocation from a broken auditor.
 
 The machine-owned contract is expressed by the named constants below:
 
@@ -37,6 +40,8 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from failure_diagnostics import emit_unexpected_failure
 
 from yaml import YAMLError
 
@@ -1505,8 +1510,10 @@ def main(argv: list[str] | None = None) -> int:
     """Run the CLI and return its process status."""
     args = _parser().parse_args(argv)
     report = audit_catalog(args.catalog)
-    json.dump(report, sys.stdout, indent=2, sort_keys=True, ensure_ascii=False)
-    sys.stdout.write("\n")
+    # Serialize before writing: a `json.dump` straight to stdout that fails
+    # partway leaves a truncated document the caller would try to parse.
+    rendered = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False)
+    sys.stdout.write(rendered + "\n")
     if not report["valid"]:
         print(
             f"catalog audit found {report['summary']['errors']} structural error(s); "
@@ -1517,5 +1524,28 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def run_cli(argv: list[str] | None = None) -> int:
+    """Run the CLI behind its failure boundary. Returns the process exit code.
+
+    Importable so the boundary's contract is testable without executing the
+    module as a script.
+    """
+    try:
+        return main(argv)
+    # Ingress gates on this audit, so a non-zero exit without the stdout report
+    # must still say what happened; a traceback would leak catalog entry paths
+    # and read a malformed catalog file as a broken auditor.
+    except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+        emit_unexpected_failure(
+            exc,
+            "catalog_audit_unexpected_failure",
+            "The Presentation Patterns catalog audit failed unexpectedly. This "
+            "command is read-only, so the catalog is unchanged — but it is "
+            "UNAUDITED. Do not begin ingress or catalog edits until a clean run "
+            "reports on stdout.",
+        )
+        return 3
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(run_cli())

--- a/skills/vault-ingress/scripts/failure_diagnostics.py
+++ b/skills/vault-ingress/scripts/failure_diagnostics.py
@@ -28,6 +28,10 @@ import sys
 import traceback
 from typing import Any, TextIO
 
+# The document's identity. A caller's `state` may add fields beside these but
+# never replace them — see `unexpected_failure_document`.
+IDENTITY_FIELDS = frozenset({"error", "error_type", "origin"})
+
 
 def sanitized_frames(exc: BaseException) -> list[str]:
     """Code locations from a traceback, with no exception text or full paths.
@@ -51,14 +55,17 @@ def unexpected_failure_document(
     `error_code` is the entrypoint's documented failure identifier. `state`
     carries entrypoint-specific facts an operator needs before retrying —
     commit position for a mutating script, `None` for a read-only one.
+
+    A `state` key colliding with `IDENTITY_FIELDS` loses: the identity fields
+    are written last. An entrypoint that renamed its own failure code would
+    make every downstream consumer misclassify the failure, and this builder
+    runs inside the boundary itself — raising here would produce exactly the
+    traceback the boundary exists to prevent.
     """
-    document: dict[str, Any] = {
-        "error": error_code,
-        "error_type": type(exc).__name__,
-        "origin": sanitized_frames(exc),
-    }
-    if state:
-        document.update(state)
+    document: dict[str, Any] = dict(state or {})
+    document["error"] = error_code
+    document["error_type"] = type(exc).__name__
+    document["origin"] = sanitized_frames(exc)
     return document
 
 

--- a/skills/vault-ingress/scripts/failure_diagnostics.py
+++ b/skills/vault-ingress/scripts/failure_diagnostics.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Path-neutral outer-boundary diagnostics shared by vault-ingress entrypoints.
+
+Every deterministic entrypoint here has the same caller contract: a non-zero
+exit without the documented document is read as a silent failure, so an
+unhandled exception must not reach the caller as a traceback. Each entrypoint
+therefore closes its outer boundary and emits one diagnostic through this
+module (#203).
+
+Two constraints shape what crosses that boundary:
+
+  * `no-secrets` forbids exception messages, credentials, and host paths in any
+    diagnostic. The exception TYPE and the code locations survive; the message
+    does not. A `FileNotFoundError` message embeds the path it could not find,
+    and a decoder message embeds the bytes it rejected.
+  * A machine-readable command must leave stdout holding exactly one valid
+    document or nothing at all. The diagnostic goes to stderr, never appended
+    after a partial stdout write.
+
+Entrypoints that mutate durable state pass `state` naming whether their atomic
+commit landed, so an operator can tell a pre-commit abort from a post-commit
+reporting failure without replaying writes.
+"""
+
+import json
+import os
+import sys
+import traceback
+from typing import Any, TextIO
+
+
+def sanitized_frames(exc: BaseException) -> list[str]:
+    """Code locations from a traceback, with no exception text or full paths.
+
+    Only `basename:line in function` crosses the boundary. That still points an
+    operator at the failing code, which the exception type alone does not.
+    """
+    return [
+        f"{os.path.basename(frame.filename)}:{frame.lineno} in {frame.name}"
+        for frame in traceback.extract_tb(exc.__traceback__)
+    ]
+
+
+def unexpected_failure_document(
+    exc: BaseException,
+    error_code: str,
+    state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the closed failure document for an outer boundary.
+
+    `error_code` is the entrypoint's documented failure identifier. `state`
+    carries entrypoint-specific facts an operator needs before retrying —
+    commit position for a mutating script, `None` for a read-only one.
+    """
+    document: dict[str, Any] = {
+        "error": error_code,
+        "error_type": type(exc).__name__,
+        "origin": sanitized_frames(exc),
+    }
+    if state:
+        document.update(state)
+    return document
+
+
+def emit_unexpected_failure(
+    exc: BaseException,
+    error_code: str,
+    recovery: str,
+    state: dict[str, Any] | None = None,
+    stream: TextIO | None = None,
+) -> None:
+    """Write one closed failure document plus its recovery note to stderr.
+
+    `recovery` tells the operator what to do — `rules/error-handling.md`
+    requires an actionable message, and "it failed" is not one.
+    """
+    target = sys.stderr if stream is None else stream
+    print(
+        json.dumps(
+            unexpected_failure_document(exc, error_code, state), sort_keys=True
+        ),
+        file=target,
+    )
+    print(
+        f"{recovery}\n"
+        "\n  `origin` above lists the code locations that failed, "
+        "innermost last.",
+        file=target,
+    )

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -77,11 +77,10 @@ Example:
 
 import copy
 import json
-import os
 import sys
-import traceback
 from datetime import datetime, timezone
 
+from failure_diagnostics import emit_unexpected_failure
 from adherence_baseline import (
     AdherenceBaselineError,
     build_current_cohort_baseline,
@@ -851,20 +850,6 @@ def parse_args(argv):
 _COMMIT_STATE = {"database_written": False}
 
 
-def _sanitized_frames(exc: BaseException) -> list[str]:
-    """Code locations from a traceback, with no exception text or full paths.
-
-    `no-secrets` forbids exception messages and credentials from reaching any
-    diagnostic, so only `basename:line in function` crosses the boundary. That
-    still points an operator at the failing code, which the exception type
-    alone does not.
-    """
-    return [
-        f"{os.path.basename(frame.filename)}:{frame.lineno} in {frame.name}"
-        for frame in traceback.extract_tb(exc.__traceback__)
-    ]
-
-
 
 def main():
     # Reset per invocation: a stale True from an earlier run in the same process
@@ -1048,27 +1033,17 @@ def run_cli() -> int:
     # because propagation would leave the operator unable to tell a pre-commit
     # abort from a post-commit reporting failure, and could replay writes.
     except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
-        print(
-            json.dumps(
-                {
-                    "error": "persist_results_unexpected_failure",
-                    "error_type": type(exc).__name__,
-                    "origin": _sanitized_frames(exc),
-                    "database_written": _COMMIT_STATE["database_written"],
-                    "persisted": None,
-                },
-                sort_keys=True,
-            ),
-            file=sys.stderr,
-        )
-        print(
+        emit_unexpected_failure(
+            exc,
+            "persist_results_unexpected_failure",
             "vault-ingress persistence failed unexpectedly. `database_written` "
             "above states whether the atomic commit landed: when true the "
             "database holds this batch and re-running would re-persist it; when "
-            "false nothing was written and the batch can be retried.\n"
-            "\n  `origin` above lists the code locations that failed, "
-            "innermost last.",
-            file=sys.stderr,
+            "false nothing was written and the batch can be retried.",
+            state={
+                "database_written": _COMMIT_STATE["database_written"],
+                "persisted": None,
+            },
         )
         return 2
     return 0

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -24,9 +24,9 @@ import os
 from pathlib import Path
 import re
 import sys
-import traceback
 from typing import Any
 
+from failure_diagnostics import sanitized_frames
 from artifact_locator import (
     ArtifactLocatorError,
     materialize_artifact_locator,
@@ -135,18 +135,6 @@ _DATABASE_READ_FALLBACK = (
 )
 
 
-def _sanitized_frames(exc: BaseException) -> list[str]:
-    """Code locations from a traceback, with no exception text or full paths.
-
-    `no-secrets` forbids exception messages and credentials from reaching any
-    diagnostic, so only `basename:line in function` crosses the boundary. That
-    still points an operator at the failing code, which the exception type
-    alone does not.
-    """
-    return [
-        f"{os.path.basename(frame.filename)}:{frame.lineno} in {frame.name}"
-        for frame in traceback.extract_tb(exc.__traceback__)
-    ]
 SOURCE_IDENTITY_SCHEMA_VERSION = 1
 TRANSCRIPT_SOURCES = frozenset({"youtube_auto", "whisper", "manual", "none"})
 SLIDE_SOURCES = frozenset({"pptx", "pdf", "both", "video_extracted", "none"})
@@ -2385,7 +2373,7 @@ def run_cli() -> int:
                             ),
                             "expected": None,
                             "actual": type(exc).__name__,
-                            "origin": _sanitized_frames(exc),
+                            "origin": sanitized_frames(exc),
                             "artifact_path": None,
                             "capability_fact": None,
                         }

--- a/skills/vault-ingress/scripts/validate-returns.py
+++ b/skills/vault-ingress/scripts/validate-returns.py
@@ -18,6 +18,7 @@ import json
 import sys
 from pathlib import Path
 
+from failure_diagnostics import emit_unexpected_failure
 from return_validation import (
     ReturnValidationError,
     audit_batch,
@@ -86,9 +87,36 @@ def main():
         sys.exit(1)
     report = validation_report(returns, resolved_catalog)
     report["input_files"] = files
-    json.dump(report, sys.stdout, ensure_ascii=False)
-    sys.stdout.write("\n")
+    # Serialize before writing: a `json.dump` straight to stdout that fails
+    # partway leaves a truncated document the batch gate would try to parse.
+    sys.stdout.write(json.dumps(report, ensure_ascii=False) + "\n")
+
+
+def run_cli() -> int:
+    """Run the CLI behind its failure boundary. Returns the process exit code.
+
+    Importable so the boundary's contract is testable without executing the
+    module as a script.
+    """
+    try:
+        main()
+    # The batch gate runs this immediately after agents return and reads a
+    # non-zero exit as "the batch is not validated"; emit one closed stderr
+    # document because a traceback would leak return paths and rejected values
+    # into the gate's log, and the gate could not tell a failed validation from
+    # a failed validator.
+    except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+        emit_unexpected_failure(
+            exc,
+            "validate_returns_unexpected_failure",
+            "vault-ingress return validation failed unexpectedly. This script "
+            "writes no state, so nothing was changed — but the batch is "
+            "UNVALIDATED and must not be persisted until a clean run reports "
+            "on stdout.",
+        )
+        return 2
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(run_cli())

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -66,6 +66,7 @@ import sys
 import tempfile
 import unicodedata
 
+from failure_diagnostics import emit_unexpected_failure
 from tracking_database import (
     TrackingDatabaseError,
     assess_tracking_database,
@@ -1088,7 +1089,15 @@ def parse_args(argv):
     return args[0], args[1], run_date, talks_path
 
 
+# Whether the atomic analysis-batch commit landed. The outer boundary reports
+# this so an operator never has to guess whether a late failure replaced files.
+_COMMIT_STATE = {"analyses_written": False}
+
+
 def main():
+    # Reset per invocation: a stale True from an earlier run in the same process
+    # would make a pre-commit failure claim the analyses were replaced.
+    _COMMIT_STATE["analyses_written"] = False
     batch_path, out_dir, run_date, talks_path = parse_args(sys.argv[1:])
 
     if not talks_path:
@@ -1301,12 +1310,17 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
+    # `atomic_write_batch` installs every target or rolls all of them back, so
+    # reaching here with a non-empty batch means the analyses are on disk.
+    _COMMIT_STATE["analyses_written"] = bool(rendered)
 
     written = []
     for name, path, body in rendered:
         written.append({"filename": name, "path": path, "bytes": len(body.encode())})
 
-    json.dump(
+    # Serialize before writing: a `json.dump` straight to stdout that fails
+    # partway leaves a truncated document the caller would try to parse.
+    receipt = json.dumps(
         {
             "written": len(written),
             "dir": out_dir,
@@ -1314,11 +1328,39 @@ def main():
             "skipped": skipped,
             "pattern_catalog_fingerprint": catalog.fingerprint,
         },
-        sys.stdout,
         ensure_ascii=False,
     )
-    sys.stdout.write("\n")
+    sys.stdout.write(receipt + "\n")
+
+
+def run_cli() -> int:
+    """Run the CLI behind its failure boundary. Returns the process exit code.
+
+    Importable so the boundary's contract is testable without executing the
+    module as a script.
+    """
+    try:
+        main()
+    # Callers read a non-zero exit without the stdout receipt as "no analyses
+    # were written"; emit one closed document naming whether the atomic commit
+    # landed because propagation would leave the operator unable to tell a
+    # pre-commit abort from a post-commit reporting failure, and the DB half of
+    # Step 4 would then disagree with the analyses on disk.
+    except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+        emit_unexpected_failure(
+            exc,
+            "write_analysis_unexpected_failure",
+            "vault-ingress analysis writing failed unexpectedly. "
+            "`analyses_written` above states whether the atomic batch commit "
+            "landed: when true the analyses directory holds this batch and the "
+            "files on disk are current; when false every target was restored "
+            "and the batch can be retried. Re-read the directory before "
+            "retrying rather than assuming either state.",
+            state={"analyses_written": _COMMIT_STATE["analyses_written"]},
+        )
+        return 2
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(run_cli())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,6 +237,20 @@ def write_analysis():
 
 
 @pytest.fixture(scope="session")
+def validate_returns():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "validate-returns.py"), "validate_returns"
+    )
+
+
+@pytest.fixture(scope="session")
+def failure_diagnostics():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "failure_diagnostics.py"), "failure_diagnostics"
+    )
+
+
+@pytest.fixture(scope="session")
 def fetch_transcript():
     return _import_script(
         os.path.join(SCRIPTS_VI, "fetch-transcript.py"), "fetch_transcript"

--- a/tests/test_aggregate_catalog_feedback.py
+++ b/tests/test_aggregate_catalog_feedback.py
@@ -600,3 +600,58 @@ def test_cli_exits_nonzero_on_invalid_feedback(
 
     assert result.returncode == 1
     assert json.loads(result.stdout)["ok"] is False
+
+
+# --- #203: the CLI has a closed failure boundary ---
+
+def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
+        aggregate_catalog_feedback, capsys, monkeypatch):
+    """Every documented outcome is JSON; a traceback would be the one exception."""
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("injected failure at /private/vault/returns/a.json")
+
+    monkeypatch.setattr(aggregate_catalog_feedback, "aggregate_feedback", explode)
+
+    assert aggregate_catalog_feedback.run_cli(["some-return.json"]) == 3
+
+    captured = capsys.readouterr()
+    assert captured.out == ""                     # stdout stays clean
+    payload = json.loads(captured.err.splitlines()[0])
+    assert payload["error"] == "catalog_feedback_unexpected_failure"
+    assert payload["error_type"] == "RuntimeError"
+    assert payload["origin"], "the failing code location must be reported"
+    assert "injected failure" not in captured.err
+    assert "/private/vault/returns/a.json" not in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_unexpected_failure_exit_is_distinct_from_the_argparse_exit(
+        aggregate_catalog_feedback, capsys, monkeypatch):
+    """argparse already owns 2 — reusing it would conflate the two causes."""
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(aggregate_catalog_feedback, "aggregate_feedback", explode)
+    assert aggregate_catalog_feedback.run_cli(["some-return.json"]) == 3
+
+    capsys.readouterr()
+    with pytest.raises(SystemExit) as excinfo:
+        aggregate_catalog_feedback.run_cli([])
+    assert excinfo.value.code == 2
+
+
+def test_the_argument_error_report_still_reaches_stdout(
+        aggregate_catalog_feedback, capsys):
+    """The boundary must not swallow the documented invalid-arguments report."""
+    with pytest.raises(SystemExit):
+        aggregate_catalog_feedback.run_cli([])
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["error"]["code"] == "invalid_arguments"
+
+
+def test_outer_boundary_lets_the_documented_verdicts_through(
+        aggregate_catalog_feedback, monkeypatch):
+    """An `ok: false` report is exit 1, not an unexpected failure."""
+    monkeypatch.setattr(aggregate_catalog_feedback, "main", lambda *a, **k: 1)
+    assert aggregate_catalog_feedback.run_cli([]) == 1

--- a/tests/test_audit_pattern_catalog.py
+++ b/tests/test_audit_pattern_catalog.py
@@ -1174,3 +1174,75 @@ def test_cli_emits_stable_json_for_valid_catalog(tmp_path, audit_pattern_catalog
     assert first.stdout == second.stdout
     assert first.stderr == ""
     assert json.loads(first.stdout)["valid"] is True
+
+
+# --- #203: the CLI has a closed failure boundary ---
+
+def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
+        audit_pattern_catalog, capsys, monkeypatch):
+    """Ingress gates on this audit; a bare traceback is not a verdict."""
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("injected failure at /private/vault/patterns/x.md")
+
+    monkeypatch.setattr(audit_pattern_catalog, "audit_catalog", explode)
+
+    assert audit_pattern_catalog.run_cli([]) == 3
+
+    captured = capsys.readouterr()
+    assert captured.out == ""                     # stdout stays clean
+    payload = json.loads(captured.err.splitlines()[0])
+    assert payload["error"] == "catalog_audit_unexpected_failure"
+    assert payload["error_type"] == "RuntimeError"
+    assert payload["origin"], "the failing code location must be reported"
+    assert "injected failure" not in captured.err
+    assert "/private/vault/patterns/x.md" not in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_unexpected_failure_exit_is_distinct_from_the_argparse_exit(
+        audit_pattern_catalog, capsys, monkeypatch):
+    """argparse already owns 2 — reusing it would conflate the two causes."""
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(audit_pattern_catalog, "audit_catalog", explode)
+    assert audit_pattern_catalog.run_cli([]) == 3
+
+    capsys.readouterr()
+    with pytest.raises(SystemExit) as excinfo:
+        audit_pattern_catalog.run_cli(["--not-a-flag"])
+    assert excinfo.value.code == 2
+
+
+def test_outer_boundary_lets_the_documented_verdicts_through(
+        audit_pattern_catalog, monkeypatch):
+    """A structural-error verdict is exit 1, not an unexpected failure."""
+    monkeypatch.setattr(
+        audit_pattern_catalog, "main", lambda *a, **k: 1
+    )
+    assert audit_pattern_catalog.run_cli([]) == 1
+
+
+def test_a_failed_report_write_does_not_leave_partial_json_on_stdout(
+        audit_pattern_catalog, capsys, monkeypatch):
+    """The report is serialized before it is written, so it lands whole or not at all."""
+    monkeypatch.setattr(
+        audit_pattern_catalog,
+        "audit_catalog",
+        lambda *a, **k: {"valid": True, "summary": {"errors": 0}},
+    )
+    real_write = audit_pattern_catalog.sys.stdout.write
+
+    def refuse_report(text):
+        if text.startswith("{"):
+            raise OSError("stdout closed")
+        return real_write(text)
+
+    monkeypatch.setattr(audit_pattern_catalog.sys.stdout, "write", refuse_report)
+
+    assert audit_pattern_catalog.run_cli([]) == 3
+
+    captured = capsys.readouterr()
+    assert captured.out == "", "a truncated document is worse than none"
+    payload = json.loads(captured.err.splitlines()[0])
+    assert payload["error"] == "catalog_audit_unexpected_failure"

--- a/tests/test_failure_diagnostics.py
+++ b/tests/test_failure_diagnostics.py
@@ -64,8 +64,8 @@ def test_state_fields_merge_into_the_document(failure_diagnostics):
     assert document["database_written"] is True
 
 
-def test_state_never_overwrites_the_error_identity(failure_diagnostics):
-    """An entrypoint cannot accidentally rename its own failure code."""
+def test_state_adds_fields_beside_the_identity(failure_diagnostics):
+    """State extends the document; it does not reshape it."""
     caught = _raised(RuntimeError("boom"))
 
     document = failure_diagnostics.unexpected_failure_document(
@@ -76,6 +76,35 @@ def test_state_never_overwrites_the_error_identity(failure_diagnostics):
 
     assert set(document) == {
         "error", "error_type", "origin", "analyses_written"
+    }
+
+
+def test_state_cannot_overwrite_the_error_identity(failure_diagnostics):
+    """An entrypoint must not be able to rename its own failure.
+
+    A caller that shadowed `error` would make every downstream consumer
+    misclassify the failure — including the tests that gate each entrypoint on
+    its own code.
+    """
+    caught = _raised(RuntimeError("boom"))
+
+    document = failure_diagnostics.unexpected_failure_document(
+        caught,
+        "example_unexpected_failure",
+        state={
+            "error": "something_else",
+            "error_type": "NotThisOne",
+            "origin": ["forged.py:1 in nowhere"],
+            "database_written": True,
+        },
+    )
+
+    assert document["error"] == "example_unexpected_failure"
+    assert document["error_type"] == "RuntimeError"
+    assert document["origin"] != ["forged.py:1 in nowhere"]
+    assert document["database_written"] is True, "non-identity state survives"
+    assert failure_diagnostics.IDENTITY_FIELDS == {
+        "error", "error_type", "origin"
     }
 
 

--- a/tests/test_failure_diagnostics.py
+++ b/tests/test_failure_diagnostics.py
@@ -1,0 +1,115 @@
+"""The shared outer-boundary diagnostic contract (#203).
+
+Six vault-ingress entrypoints publish failures through this module. The
+path-neutrality guarantee is asserted once here rather than re-derived in each
+entrypoint's suite; each entrypoint's own tests assert its error code, its
+state fields, and that stdout stays clean.
+"""
+
+import io
+import json
+
+import pytest
+
+
+def _raised(exc):
+    """Raise `exc` so it carries a real traceback for the frame extractor.
+
+    `pytest.raises` gives the caught instance without a broad handler, which
+    `rules/error-handling.md` reserves for outer process boundaries.
+    """
+    with pytest.raises(type(exc)) as excinfo:
+        raise exc
+    return excinfo.value
+
+
+def test_sanitized_frames_report_location_without_paths_or_text(
+        failure_diagnostics):
+    """`no-secrets` forbids exception text; the frames replace it."""
+    caught = _raised(RuntimeError("token=SECRET at /private/vault/creds.json"))
+
+    frames = failure_diagnostics.sanitized_frames(caught)
+
+    assert frames, "the failing code location must be reported"
+    for frame in frames:
+        assert ":" in frame and " in " in frame
+        assert "/" not in frame          # basename only, never a host path
+        assert "SECRET" not in frame
+
+
+def test_failure_document_carries_the_type_but_never_the_message(
+        failure_diagnostics):
+    """The type says which failure it was; the message would say where."""
+    caught = _raised(FileNotFoundError(2, "No such file", "/private/vault/db.json"))
+
+    document = failure_diagnostics.unexpected_failure_document(
+        caught, "example_unexpected_failure"
+    )
+
+    assert document["error"] == "example_unexpected_failure"
+    assert document["error_type"] == "FileNotFoundError"
+    serialized = json.dumps(document)
+    assert "/private/vault/db.json" not in serialized
+    assert "No such file" not in serialized
+
+
+def test_state_fields_merge_into_the_document(failure_diagnostics):
+    """A mutating entrypoint reports commit position beside the failure."""
+    caught = _raised(RuntimeError("boom"))
+
+    document = failure_diagnostics.unexpected_failure_document(
+        caught, "example_unexpected_failure", state={"database_written": True}
+    )
+
+    assert document["database_written"] is True
+
+
+def test_state_never_overwrites_the_error_identity(failure_diagnostics):
+    """An entrypoint cannot accidentally rename its own failure code."""
+    caught = _raised(RuntimeError("boom"))
+
+    document = failure_diagnostics.unexpected_failure_document(
+        caught,
+        "example_unexpected_failure",
+        state={"analyses_written": False},
+    )
+
+    assert set(document) == {
+        "error", "error_type", "origin", "analyses_written"
+    }
+
+
+def test_emitted_failure_is_one_json_document_then_a_recovery_note(
+        failure_diagnostics):
+    """Callers parse line one; a human reads the rest."""
+    caught = _raised(RuntimeError("boom at /private/vault/db.json"))
+    stream = io.StringIO()
+
+    failure_diagnostics.emit_unexpected_failure(
+        caught,
+        "example_unexpected_failure",
+        "Nothing was written; retry the batch.",
+        stream=stream,
+    )
+
+    lines = stream.getvalue().splitlines()
+    payload = json.loads(lines[0])
+    assert payload["error"] == "example_unexpected_failure"
+    assert "Nothing was written; retry the batch." in stream.getvalue()
+    assert "innermost last" in stream.getvalue()
+    assert "Traceback" not in stream.getvalue()
+    assert "/private/vault/db.json" not in stream.getvalue()
+
+
+def test_emitted_document_is_key_ordered_for_stable_diffs(failure_diagnostics):
+    """Operators diff these across runs; key order must not float."""
+    caught = _raised(RuntimeError("boom"))
+    stream = io.StringIO()
+
+    failure_diagnostics.emit_unexpected_failure(
+        caught, "example_unexpected_failure", "retry", state={"z": 1, "a": 2},
+        stream=stream,
+    )
+
+    first_line = stream.getvalue().splitlines()[0]
+    assert first_line == json.dumps(json.loads(first_line), sort_keys=True)

--- a/tests/test_validate_returns.py
+++ b/tests/test_validate_returns.py
@@ -1,0 +1,132 @@
+"""Tests for validate-returns.py — the read-only batch gate run after agents return.
+
+`test_return_validation.py` covers the validation logic this script wraps. This
+module covers the process contract: what the gate sees on stdout, on stderr, and
+in the exit code (#203).
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+
+def _return():
+    """One minimally-valid return the batch gate accepts."""
+    return {
+        "filename": "2026-01-01-a-talk.md",
+        "queue_claim": {
+            "run_id": "reparse",
+            "batch_id": "25",
+            "reprocess_generation": 1,
+        },
+        "status": "skipped_no_sources",
+    }
+
+
+def test_a_clean_batch_leaves_one_json_document_on_stdout(
+        validate_returns, tmp_path):
+    batch = tmp_path / "batch.json"
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, validate_returns.__file__, str(batch)],
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["input_files"] == [str(batch)]
+
+
+def test_a_rejected_batch_exits_one_with_a_stderr_diagnostic(
+        validate_returns, tmp_path):
+    """Exit 1 is a failed validation — distinct from a failed validator."""
+    batch = tmp_path / "batch.json"
+    batch.write_text(json.dumps([{"filename": "x.md"}]), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, validate_returns.__file__, str(batch)],
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode == 1
+    assert "ERROR:" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+# --- #203: the CLI has a closed failure boundary ---
+
+def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
+        validate_returns, capsys, monkeypatch):
+    """The gate reads a non-zero exit; it must still say what happened."""
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("injected failure at /private/vault/returns/a.json")
+
+    monkeypatch.setattr(validate_returns, "main", explode)
+
+    assert validate_returns.run_cli() == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""                     # stdout stays clean
+    payload = json.loads(captured.err.splitlines()[0])
+    assert payload["error"] == "validate_returns_unexpected_failure"
+    assert payload["error_type"] == "RuntimeError"
+    assert payload["origin"], "the failing code location must be reported"
+    assert "injected failure" not in captured.err
+    assert "/private/vault/returns/a.json" not in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_failure_note_says_the_batch_is_unvalidated_not_invalid(
+        validate_returns, capsys, monkeypatch):
+    """A broken validator must never read as a clean batch."""
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(validate_returns, "main", explode)
+    validate_returns.run_cli()
+
+    assert "UNVALIDATED" in capsys.readouterr().err
+
+
+def test_outer_boundary_does_not_catch_sys_exit(validate_returns, monkeypatch):
+    """main()'s own documented sys.exit(1) validation failures keep exit 1."""
+    def bail(*_args, **_kwargs):
+        raise SystemExit(1)
+
+    monkeypatch.setattr(validate_returns, "main", bail)
+    with pytest.raises(SystemExit) as excinfo:
+        validate_returns.run_cli()
+    assert excinfo.value.code == 1
+
+
+def test_outer_boundary_lets_a_clean_run_report_success(
+        validate_returns, monkeypatch):
+    monkeypatch.setattr(validate_returns, "main", lambda *a, **k: None)
+    assert validate_returns.run_cli() == 0
+
+
+def test_a_failed_report_write_does_not_leave_partial_json_on_stdout(
+        validate_returns, tmp_path, capsys, monkeypatch):
+    """The report is serialized before it is written, so it lands whole or not at all."""
+    batch = tmp_path / "batch.json"
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+
+    real_write = validate_returns.sys.stdout.write
+
+    def refuse_report(text):
+        if text.startswith("{"):
+            raise OSError("stdout closed")
+        return real_write(text)
+
+    monkeypatch.setattr(validate_returns.sys.stdout, "write", refuse_report)
+    monkeypatch.setattr(sys, "argv", ["validate-returns.py", str(batch)])
+
+    assert validate_returns.run_cli() == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == "", "a truncated document is worse than none"
+    payload = json.loads(captured.err.splitlines()[0])
+    assert payload["error"] == "validate_returns_unexpected_failure"

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -2903,3 +2903,104 @@ def test_cli_missing_input_file_is_actionable(write_analysis, tmp_path):
     )
     assert result.returncode != 0
     assert "not found" in result.stderr
+
+
+# --- #203: the CLI has a closed failure boundary that names commit position ---
+
+@pytest.mark.parametrize("committed", [False, True])
+def test_outer_boundary_reports_whether_the_analyses_landed(
+        write_analysis, capsys, monkeypatch, committed):
+    """A late failure must say whether the atomic batch commit already happened.
+
+    The DB half of Step 4 and this half must agree. Without commit position an
+    operator cannot tell a pre-commit abort — where every target was rolled
+    back — from a post-commit reporting failure where the files are current.
+    """
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("injected failure at /private/vault/analyses/x.md")
+
+    monkeypatch.setattr(write_analysis, "main", explode)
+    monkeypatch.setitem(write_analysis._COMMIT_STATE, "analyses_written", committed)
+
+    assert write_analysis.run_cli() == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""                     # stdout stays clean
+    payload = json.loads(captured.err.splitlines()[0])
+    assert payload["error"] == "write_analysis_unexpected_failure"
+    assert payload["error_type"] == "RuntimeError"
+    assert payload["analyses_written"] is committed
+    assert "injected failure" not in captured.err
+    assert "/private/vault/analyses/x.md" not in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_commit_state_does_not_leak_between_runs(
+        write_analysis, capsys, monkeypatch):
+    """A stale True would make a pre-commit failure claim files were replaced."""
+    write_analysis._COMMIT_STATE["analyses_written"] = True
+
+    def fail_after_reset(*_args, **_kwargs):
+        raise RuntimeError("failed before the commit")
+
+    # parse_args is main()'s first call after the reset.
+    monkeypatch.setattr(write_analysis, "parse_args", fail_after_reset)
+    monkeypatch.setattr(sys, "argv", ["write-analysis.py", "b.json", "out"])
+
+    assert write_analysis.run_cli() == 2
+    payload = json.loads(capsys.readouterr().err.splitlines()[0])
+    assert payload["analyses_written"] is False
+    assert write_analysis._COMMIT_STATE["analyses_written"] is False
+
+
+def test_outer_boundary_does_not_catch_sys_exit(write_analysis, monkeypatch):
+    """main()'s own documented sys.exit paths keep their exit codes."""
+    def bail(*_args, **_kwargs):
+        raise SystemExit(1)
+
+    monkeypatch.setattr(write_analysis, "main", bail)
+    with pytest.raises(SystemExit) as excinfo:
+        write_analysis.run_cli()
+    assert excinfo.value.code == 1
+
+
+def test_outer_boundary_lets_a_clean_run_report_success(
+        write_analysis, monkeypatch):
+    """The boundary must not swallow or alter a normal run."""
+    monkeypatch.setattr(write_analysis, "main", lambda *a, **k: None)
+    assert write_analysis.run_cli() == 0
+
+
+def test_a_committed_batch_reports_written_when_the_receipt_fails(
+        write_analysis, tmp_path, capsys, monkeypatch):
+    """The real failure this guards: files installed, receipt write dies.
+
+    Exercises the whole CLI rather than a stubbed main(), so the commit flag is
+    set by the same code path production uses.
+    """
+    db = _write_tracking_db(tmp_path, [_return()])
+    batch = tmp_path / "batch.json"
+    batch.write_text(json.dumps([_return()]), encoding="utf-8")
+    out_dir = tmp_path / "analyses"
+
+    real_write = write_analysis.sys.stdout.write
+
+    def refuse_receipt(text):
+        if text.startswith("{"):
+            raise OSError("stdout closed")
+        return real_write(text)
+
+    monkeypatch.setattr(write_analysis.sys.stdout, "write", refuse_receipt)
+    monkeypatch.setattr(
+        sys, "argv",
+        ["write-analysis.py", str(batch), str(out_dir), "--talks", str(db)],
+    )
+
+    assert write_analysis.run_cli() == 2
+
+    payload = json.loads(capsys.readouterr().err.splitlines()[0])
+    assert payload["error"] == "write_analysis_unexpected_failure"
+    assert payload["analyses_written"] is True, (
+        "the analyses are on disk; claiming otherwise invites a wrong retry"
+    )
+    assert list(out_dir.glob("*.md")), "the batch really did commit"


### PR DESCRIPTION
Closes #203.

## What was still open

The [audit on #203](https://github.com/jbaruch/speaker-toolkit/issues/203#issuecomment-3506234854) settled the problem statement's five original sites — three already compliant, two fixed in #251, and `check-runtime.py`'s traceback established as a deliberate, tested contract. What remained was the scope the 2026-08-03 comment added:

| Script | Gap |
|---|---|
| `write-analysis.py` | installs files, then emits an unguarded receipt — no boundary at all |
| `validate-returns.py` | no process-wide boundary |
| `audit-pattern-catalog.py` | no process-wide boundary |
| `aggregate-catalog-feedback.py` | no process-wide boundary |

An unexpected exception in any of them reached the caller as a traceback carrying return paths, catalog entry text, and vault locations.

## The commit-position problem

`write-analysis.py` is the one mutating script here. `atomic_write_batch` installs every target or rolls all of them back — but the receipt is emitted *after*. A failure in that window left an operator unable to tell "nothing was written, retry" from "the files are current, a retry would rewrite them", while `persist-results.py` had already merged the same batch into the DB.

It now reports `analyses_written` the way `persist-results.py` reports `database_written`:

```json
{"error": "write_analysis_unexpected_failure", "error_type": "OSError",
 "origin": ["write-analysis.py:1310 in main"], "analyses_written": true}
```

`test_a_committed_batch_reports_written_when_the_receipt_fails` drives the real CLI, kills the receipt write, and asserts both the flag and the `.md` files on disk.

## Exit 3 for the two catalog gates

argparse already owns exit 2 in `audit-pattern-catalog.py` and `aggregate-catalog-feedback.py`. Reusing it would make a malformed invocation indistinguishable from a broken tool, so their boundaries exit 3. Both documented it in their module docstring; a test pins the distinction.

## Pre-rendered reports

All four built their report with `json.dump(..., sys.stdout)`. A write that fails partway leaves a truncated document a caller would try to parse. Each now serializes with `json.dumps` first and writes once — so the document lands whole or not at all, and the failure diagnostic goes to stderr with stdout still empty.

## One diagnostic shape, not six

`persist-results.py` and `preflight-vault.py` had each copied `_sanitized_frames`. A sixth entrypoint would have been a third copy, so it moved to `scripts/failure_diagnostics.py` along with the document builder and the emitter. `tests/test_failure_diagnostics.py` asserts path-neutrality once — exception type crosses, message never does, frames are `basename:line in function`.

## The inventory #203 asked for first

`references/entrypoint-failure-contracts.md` records every entrypoint's stdout, stderr, exit-code, and commit-position contract. The exit-2 shapes #251 introduced were undocumented too — the reference and four call sites in `batch-persistence.md`, `bootstrap-and-preflight.md`, and `pattern-catalog-contract.md` now name them, including that a read-only tool's failure means "unexamined", never "clean".

## Tests

26 new tests. Full suite: 4991 passed, 3 skipped. Ruff clean on every changed file.

Per-entrypoint: injected outer failure with a path-bearing exception, injected output-write failure, `SystemExit` passthrough (documented error paths keep their codes), and a clean run still reporting success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)