### PR TITLE
chore(deps): pin the last four Python requirements and gate the rule (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+### chore(deps) — pin the last four Python requirements and gate the rule (#161)
+
+`python-pptx`, `lxml`, `qrcode`, and `pytest` were still unpinned, so every
+clean install resolved whatever PyPI served that day. All four now pin exactly
+and ride the same weekly Dependabot pip lane as their already-pinned siblings.
+
+`tests/test_pyproject_pins.py` is the gate. `dependency-management` said "pin
+versions" and nothing checked it, which is how four requirements drifted past
+in the first place — a deterministic check nobody runs does not exist. The test
+walks every requirement group in the manifest, including optional extras, and
+fails on a bare name, a range, or a pin paired with a second specifier. It also
+asserts the pip ecosystem is still declared in `.github/dependabot.yml`,
+because a pin without a renewal mechanism rots quietly.
+
+`project.version = "0.0.0"` now says beside itself why it is a sentinel: the
+registry version lives in `.tessl-plugin/plugin.json` and is bumped by the
+publish workflow. This package is never uploaded to PyPI. A real number here
+would be a second versioning scheme with nothing keeping it in step with the
+one that ships.
+
+Verified by building a clean venv from the manifest alone and running the full
+suite on Python 3.11 and 3.13, bracketing CI's 3.12.
+
 ### fix(vault-ingress) — close the last four deterministic entrypoint boundaries (#203)
 
 `write-analysis.py`, `validate-returns.py`, `audit-pattern-catalog.py`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ and ride the same weekly Dependabot pip lane as their already-pinned siblings.
 versions" and nothing checked it, which is how four requirements drifted past
 in the first place — a deterministic check nobody runs does not exist. The test
 walks every requirement group in the manifest, including optional extras, and
-fails on a bare name, a range, or a pin paired with a second specifier. It also
-asserts the pip ecosystem is still declared in `.github/dependabot.yml`,
-because a pin without a renewal mechanism rots quietly.
+parses each entry as PEP 508 rather than pattern-matching its text: a substring
+search for `==` calls `pkg===1.0`, `pkg==1.*`, `pkg==1.0,>=0.9`, and
+`pkg @ https://host/a==b.whl` pinned. Fixed negative cases cover each. The
+Dependabot half is parsed too — it asserts one active pip entry on the
+manifest's directory with its weekly schedule, because a commented-out entry
+leaves the text present while no bump PR is ever opened again.
+
+`packaging` and (below Python 3.11) `tomli` join the test extra for that
+parsing. `tomllib` entered the stdlib in 3.11 and `requires-python` still
+admits 3.10.
 
 `project.version = "0.0.0"` now says beside itself why it is a sentinel: the
 registry version lives in `.tessl-plugin/plugin.json` and is bumped by the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ dependencies = [
 test = [
     # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
     "pytest==9.1.1",
+    # tests/test_pyproject_pins.py parses this manifest's own requirements as
+    # PEP 508 rather than pattern-matching their text.
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "packaging==26.3",
+    # `tomllib` entered the stdlib in 3.11; requires-python still admits 3.10.
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "tomli==2.4.1; python_version < '3.11'",
 ]
 # Local Whisper transcription, used by vault-ingress/scripts/fetch-transcript.py
 # when a video has no caption track. Optional and not in the base dependency set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,25 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speaker-toolkit"
+# Not a published version. The registry version lives in
+# `.tessl-plugin/plugin.json` and is bumped by the publish workflow
+# (`tesslio/patch-version-publish`). This package is never uploaded to PyPI —
+# `pyproject.toml` exists to declare dependencies and pytest config for a local
+# or CI checkout. A real number here would be a second versioning scheme with
+# nothing keeping it in step with the one that ships.
 version = "0.0.0"
 requires-python = ">=3.10"
 dependencies = [
-    "python-pptx",
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "python-pptx==1.0.2",
     # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
     "psutil==7.2.2",
     # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
     "pypdf==6.14.2",
-    "lxml",
-    "qrcode",
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "lxml==6.1.1",
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "qrcode==8.2",
     # Video/image dependency pins renew through the same weekly Dependabot lane.
     "Pillow==12.3.0",
     # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
@@ -36,7 +45,8 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest",
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "pytest==9.1.1",
 ]
 # Local Whisper transcription, used by vault-ingress/scripts/fetch-transcript.py
 # when a video has no caption track. Optional and not in the base dependency set

--- a/tests/test_pyproject_pins.py
+++ b/tests/test_pyproject_pins.py
@@ -5,20 +5,33 @@ dependency. A remembered intention is not a gate, so this test is the gate: a
 newly added unpinned requirement fails CI on the commit that introduces it,
 rather than surfacing months later as an unreproducible build.
 
+Both halves parse rather than pattern-match. A substring search for `==` calls
+`pkg===1.0`, `pkg==1.*`, and `pkg @ https://host/a==b.whl` pinned; a text search
+for the Dependabot ecosystem passes on a commented-out entry. Either would let
+the gate report green while the thing it guards is broken.
+
 The `tessl.json` floating carve-out is a separate runtime-managed manifest
 contract and is deliberately out of scope here.
 """
 
-import tomllib
+import sys
 from pathlib import Path
 
 import pytest
+import yaml
+from packaging.requirements import InvalidRequirement, Requirement
 
-PYPROJECT = Path(__file__).parents[1] / "pyproject.toml"
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # requires-python admits 3.10, where tomllib is not in the stdlib
+    import tomli as tomllib
 
-# `~=`, `>=`, and a bare name all let the resolver pick a version the repo never
-# tested. Only `==` names one.
-EXACT_PIN = "=="
+REPO_ROOT = Path(__file__).parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
+
+# The manifest's directory as Dependabot addresses it.
+MANIFEST_DIRECTORY = "/"
 
 
 def _manifest() -> dict:
@@ -40,6 +53,31 @@ def _requirement_groups() -> list[tuple[str, list[str]]]:
     return groups
 
 
+def pin_violation(raw: str) -> str | None:
+    """Why `raw` is not an exact pin, or None when it is one.
+
+    An exact pin is a PEP 508 requirement with no direct URL and exactly one
+    specifier, whose operator is `==` and whose version carries no wildcard.
+    Environment markers are permitted — they select WHETHER a requirement
+    applies, never which version.
+    """
+    try:
+        requirement = Requirement(raw)
+    except InvalidRequirement as exc:
+        return f"not a valid PEP 508 requirement ({exc})"
+    if requirement.url:
+        return "pins a direct URL, which no version resolver can reproduce"
+    specifiers = list(requirement.specifier)
+    if len(specifiers) != 1:
+        return f"has {len(specifiers)} specifiers; an exact pin has exactly one"
+    specifier = specifiers[0]
+    if specifier.operator != "==":
+        return f"uses operator {specifier.operator!r}, not '=='"
+    if "*" in specifier.version:
+        return f"pins the wildcard {specifier.version!r}, not one version"
+    return None
+
+
 def test_the_manifest_declares_every_group_this_test_checks():
     """A new group added to the manifest must not slip past unchecked."""
     manifest = _manifest()
@@ -54,32 +92,69 @@ def test_the_manifest_declares_every_group_this_test_checks():
 
 @pytest.mark.parametrize("label,requirements", _requirement_groups())
 def test_every_requirement_pins_an_exact_version(label, requirements):
-    unpinned = [item for item in requirements if EXACT_PIN not in item]
-    assert not unpinned, (
-        f"{label} has unpinned requirement(s): {unpinned}. "
+    violations = {
+        raw: reason
+        for raw in requirements
+        if (reason := pin_violation(raw)) is not None
+    }
+    assert not violations, (
+        f"{label} has requirement(s) that are not exact pins: {violations}. "
         f"Pin each with `==<version>` and confirm .github/dependabot.yml's pip "
         f"ecosystem covers it, per rules/dependency-management.md Pinning."
     )
 
 
-@pytest.mark.parametrize("label,requirements", _requirement_groups())
-def test_no_requirement_carries_a_range_alongside_its_pin(label, requirements):
-    """`foo==1.0,>=0.9` pins nothing — the range still admits other versions."""
-    for item in requirements:
-        specifier = item.split(EXACT_PIN, 1)[1] if EXACT_PIN in item else ""
-        assert "," not in specifier, (
-            f"{label} requirement {item!r} pairs its pin with another "
-            f"specifier; a pin must stand alone"
-        )
+@pytest.mark.parametrize("raw", [
+    "pytest",                              # bare name
+    "setuptools>=68",                      # range
+    "numpy>=2.0,<3.0",                     # two-sided range
+    "numpy==2.2.6,>=2.0",                  # pin plus a range that reopens it
+    "numpy===2.2.6",                       # arbitrary-equality, not exact
+    "numpy==2.2.*",                        # wildcard
+    "numpy~=2.2.6",                        # compatible-release
+    "lxml @ https://example.invalid/a==b.whl",   # URL containing '=='
+])
+def test_the_pin_check_rejects_specifiers_that_are_not_exact(raw):
+    """The last four beat a naive `'==' in raw` check; the first four do not.
+
+    Both halves matter: dropping the parser would reopen the first four, and
+    keeping only the obvious cases would have hidden the rest.
+    """
+    assert pin_violation(raw) is not None, raw
 
 
-def test_dependabot_covers_the_pip_ecosystem():
-    """A pin with no renewal mechanism rots silently."""
-    config = (
-        Path(__file__).parents[1] / ".github" / "dependabot.yml"
-    ).read_text(encoding="utf-8")
-    assert 'package-ecosystem: "pip"' in config, (
-        "every pinned requirement needs an automated renewal mechanism"
+@pytest.mark.parametrize("raw", [
+    "numpy==2.2.6",
+    "Pillow==12.3.0",
+    "python-pptx==1.0.2",
+    "tomli==2.4.1; python_version < '3.11'",     # a marker is not a version
+    "qrcode[pil]==8.2",                          # an extra is not a version
+])
+def test_the_pin_check_accepts_real_pins(raw):
+    assert pin_violation(raw) is None, pin_violation(raw)
+
+
+def test_dependabot_actively_covers_the_pip_ecosystem():
+    """A pin with no renewal mechanism rots silently.
+
+    Parsed, not grepped: a commented-out or misplaced entry leaves the text
+    present while Dependabot no longer opens a single bump PR.
+    """
+    config = yaml.safe_load(DEPENDABOT.read_text(encoding="utf-8"))
+    pip_updates = [
+        entry for entry in config["updates"]
+        if entry.get("package-ecosystem") == "pip"
+    ]
+    assert len(pip_updates) == 1, (
+        f"expected exactly one active pip update entry, got {len(pip_updates)}"
+    )
+    entry = pip_updates[0]
+    assert entry.get("directory") == MANIFEST_DIRECTORY, (
+        f"pip entry watches {entry.get('directory')!r}, not the directory "
+        f"holding pyproject.toml ({MANIFEST_DIRECTORY!r})"
+    )
+    assert entry.get("schedule", {}).get("interval") == "weekly", (
+        "the pip entry must keep its recurring weekly schedule"
     )
 
 

--- a/tests/test_pyproject_pins.py
+++ b/tests/test_pyproject_pins.py
@@ -1,0 +1,96 @@
+"""Every requirement in `pyproject.toml` pins an exact version (#161).
+
+`dependency-management` requires a pin plus a stated renewal mechanism for each
+dependency. A remembered intention is not a gate, so this test is the gate: a
+newly added unpinned requirement fails CI on the commit that introduces it,
+rather than surfacing months later as an unreproducible build.
+
+The `tessl.json` floating carve-out is a separate runtime-managed manifest
+contract and is deliberately out of scope here.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+PYPROJECT = Path(__file__).parents[1] / "pyproject.toml"
+
+# `~=`, `>=`, and a bare name all let the resolver pick a version the repo never
+# tested. Only `==` names one.
+EXACT_PIN = "=="
+
+
+def _manifest() -> dict:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _requirement_groups() -> list[tuple[str, list[str]]]:
+    """Every requirement list in the manifest, labeled by where it lives."""
+    manifest = _manifest()
+    groups = [
+        ("build-system.requires", manifest["build-system"]["requires"]),
+        ("project.dependencies", manifest["project"]["dependencies"]),
+    ]
+    optional = manifest["project"].get("optional-dependencies", {})
+    groups.extend(
+        (f"project.optional-dependencies.{extra}", requirements)
+        for extra, requirements in sorted(optional.items())
+    )
+    return groups
+
+
+def test_the_manifest_declares_every_group_this_test_checks():
+    """A new group added to the manifest must not slip past unchecked."""
+    manifest = _manifest()
+    assert "build-system" in manifest
+    assert manifest["project"]["optional-dependencies"], (
+        "optional groups exist; the collector must be reading them"
+    )
+    labels = [label for label, _ in _requirement_groups()]
+    assert "project.optional-dependencies.test" in labels
+    assert "project.optional-dependencies.whisper" in labels
+
+
+@pytest.mark.parametrize("label,requirements", _requirement_groups())
+def test_every_requirement_pins_an_exact_version(label, requirements):
+    unpinned = [item for item in requirements if EXACT_PIN not in item]
+    assert not unpinned, (
+        f"{label} has unpinned requirement(s): {unpinned}. "
+        f"Pin each with `==<version>` and confirm .github/dependabot.yml's pip "
+        f"ecosystem covers it, per rules/dependency-management.md Pinning."
+    )
+
+
+@pytest.mark.parametrize("label,requirements", _requirement_groups())
+def test_no_requirement_carries_a_range_alongside_its_pin(label, requirements):
+    """`foo==1.0,>=0.9` pins nothing — the range still admits other versions."""
+    for item in requirements:
+        specifier = item.split(EXACT_PIN, 1)[1] if EXACT_PIN in item else ""
+        assert "," not in specifier, (
+            f"{label} requirement {item!r} pairs its pin with another "
+            f"specifier; a pin must stand alone"
+        )
+
+
+def test_dependabot_covers_the_pip_ecosystem():
+    """A pin with no renewal mechanism rots silently."""
+    config = (
+        Path(__file__).parents[1] / ".github" / "dependabot.yml"
+    ).read_text(encoding="utf-8")
+    assert 'package-ecosystem: "pip"' in config, (
+        "every pinned requirement needs an automated renewal mechanism"
+    )
+
+
+def test_the_package_version_stays_the_non_published_sentinel():
+    """The shipped version lives in .tessl-plugin/plugin.json, not here.
+
+    Two version fields with no mechanism keeping them in step is how a
+    published artifact starts disagreeing with its own manifest.
+    """
+    assert _manifest()["project"]["version"] == "0.0.0"
+    source = PYPROJECT.read_text(encoding="utf-8")
+    assert ".tessl-plugin/plugin.json" in source, (
+        "the sentinel must name where the real version lives"
+    )


### PR DESCRIPTION
Closes #161.

## What was left

Of the eight requirements #161 named, four had already been pinned by later work (`setuptools`, `Pillow`, `ImageHash`, `numpy`). These four had not:

| Requirement | Now | Floor check |
|---|---|---|
| `python-pptx` | `==1.0.2` | `requires_python >=3.8` |
| `lxml` | `==6.1.1` | `>=3.8` |
| `qrcode` | `==8.2` | `<4.0,>=3.9` |
| `pytest` | `==9.1.1` | `>=3.10` |

All four clear the project's `requires-python = ">=3.10"`, and each carries the same `# Pin + Dependabot pip ecosystem` comment its already-pinned siblings do. The pip ecosystem in `.github/dependabot.yml` needed no change — it is directory-wide, so it already covers them.

## The gate is the point

`dependency-management` has said "pin versions" the whole time. Four requirements drifted past anyway, which is the failure mode `script-delegation` names: a check nobody runs does not exist.

`tests/test_pyproject_pins.py` parses the manifest and fails on:

- a bare name (`"pytest"`)
- a range (`"setuptools>=68"`)
- a pin paired with a second specifier (`"foo==1.0,>=0.9"` — the range still admits other versions)

It walks `build-system.requires`, `project.dependencies`, and **every** optional-dependency group by iteration, so a new extra is covered the moment it is added rather than when someone remembers to extend the test. A guard test asserts the collector really is seeing both current extras, so a refactor that silently stopped collecting them fails loudly instead of passing vacuously.

It also asserts `.github/dependabot.yml` still declares the pip ecosystem — a pin whose renewal mechanism disappeared is a pin that rots quietly.

## The `0.0.0` sentinel

Documented in place rather than replaced. The registry version lives in `.tessl-plugin/plugin.json` and is bumped by the publish workflow; this package is never uploaded to PyPI, and `pyproject.toml` exists to declare dependencies and pytest config for a checkout. A real number here would be a second versioning scheme with nothing keeping it in step with the one that ships — so the test pins it as a sentinel and requires the comment to name where the real version lives.

`tessl.json`'s floating carve-out is untouched; it is a separate runtime-managed manifest contract.

## Verification

Built a clean venv from the manifest alone (`pip install -e '.[test]'`, no other input) and ran the full suite on Python 3.11 and 3.13 — bracketing CI's 3.12. 5004 passed, 3 skipped. Ruff clean.

The `whisper` extra is not installed in that check: `mlx-whisper` is Apple-Silicon-only and documented as platform-bound in the manifest itself. It is pinned and covered by the pin test regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)