### PR TITLE
chore(ci): clear the Ruff lint baseline and configure the linter (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ First of the #162 adoption sequence. `language-diagnostics` Adopting on a Dirty
 Tree wants the config and the fixes landed before the gate, in their own PR —
 so this one turns nothing red in CI yet.
 
+Ruff is declared and pinned in a new `lint` optional group (`ruff==0.16.2`),
+on the same weekly Dependabot pip lane. Its own group because the test runner
+does not need it and a linter bump is its own change.
+
 `[tool.ruff]` now pins `line-length = 88` and `target-version = "py310"`
 explicitly, and `[tool.ruff.lint]` selects Ruff's default set plus `BLE`.
 E501 stays off on purpose: the formatter owns line width, and running both
@@ -27,7 +31,8 @@ The baseline this cleared:
   — vertical stripes, a diagonal sawtooth, concentric rings — with a second test
   asserting their pairwise phash distances (31, 31, 38) really do clear the
   threshold 8 the first test relies on. Solid fills would not work: phash reads
-  structure, so three flat colors hash alike.
+  structure, so three flat colors hash alike. The ring pattern derives its
+  center from the frame's own extent, so the distances hold at any size.
 - Nine mechanical findings in tests: three unused imports, one dead local whose
   stale comment went with it, one multi-import line, six semicolon statements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+### chore(ci) — clear the Ruff lint baseline and configure the linter (#162)
+
+First of the #162 adoption sequence. `language-diagnostics` Adopting on a Dirty
+Tree wants the config and the fixes landed before the gate, in their own PR —
+so this one turns nothing red in CI yet.
+
+`[tool.ruff]` now pins `line-length = 88` and `target-version = "py310"`
+explicitly, and `[tool.ruff.lint]` selects Ruff's default set plus `BLE`.
+E501 stays off on purpose: the formatter owns line width, and running both
+makes the linter argue with the formatter over lines the formatter cannot split.
+
+The baseline this cleared:
+
+- `generate-qr.py` caught bare `Exception` twice, both inner helpers, neither an
+  outer process boundary. `_two_color_metrics` now catches `(OSError, ValueError)`
+  — Pillow raises `UnidentifiedImageError` (an `OSError`) for a format it cannot
+  read and `ValueError` for an unsupported convert mode. `_picture_is_qr` catches
+  `(ValueError, KeyError)` — python-pptx raises the first for a picture with no
+  embedded image and the second for a missing relationship. Anything else was
+  a bug in the script being swallowed as "not a QR".
+- `test_video_slide_extraction.py` built its distinct-frame fixture with
+  `np.random.RandomState(42)`. Seeded is not the same as fixed, and
+  `testing-standards` Determinism's carve-out covers property-based generators,
+  not a numpy RNG shaping a fixture. Three index-arithmetic patterns replace it
+  — vertical stripes, a diagonal sawtooth, concentric rings — with a second test
+  asserting their pairwise phash distances (31, 31, 38) really do clear the
+  threshold 8 the first test relies on. Solid fills would not work: phash reads
+  structure, so three flat colors hash alike.
+- Nine mechanical findings in tests: three unused imports, one dead local whose
+  stale comment went with it, one multi-import line, six semicolon statements.
+
+Still open on #162: the `ruff format` baseline, the Pyright baseline, and
+wiring all three into pull-request CI.
+
 ### chore(deps) — pin the last four Python requirements and gate the rule (#161)
 
 `python-pptx`, `lxml`, `qrcode`, and `pytest` were still unpinned, so every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,5 +68,22 @@ whisper = [
 [tool.setuptools]
 py-modules = []
 
+[tool.ruff]
+# The repo's prevailing width. Kept explicit rather than inherited so a Ruff
+# default change cannot silently rewrap the tree.
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+# Ruff's default set (`E4`, `E7`, `E9`, `F`) plus BLE. `error-handling` forbids
+# bare catch-alls outside an outer process boundary, and BLE001 is the only rule
+# that sees them; the boundaries that legitimately need one carry an inline
+# `# noqa: BLE001` naming its cause, per that rule's Outer-Boundary carve-out.
+#
+# E501 (line-too-long) stays off deliberately: the formatter owns line width,
+# and running both makes the linter argue with the formatter over lines the
+# formatter cannot split (long URLs, literal error strings).
+select = ["E4", "E7", "E9", "F", "BLE"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,14 @@ test = [
     # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
     "tomli==2.4.1; python_version < '3.11'",
 ]
+# Lint and formatting, run by the #162 CI gate. Its own group because the test
+# runner does not need it and a lint bump should not rebuild a test image.
+# A formatter/linter bump is its own change, per
+# `rules/code-formatting.md` Separation of Concerns.
+lint = [
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "ruff==0.16.2",
+]
 # Local Whisper transcription, used by vault-ingress/scripts/fetch-transcript.py
 # when a video has no caption track. Optional and not in the base dependency set
 # because mlx-whisper requires Apple Silicon and cannot install on the Linux CI

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -973,7 +973,11 @@ def _two_color_metrics(blob):
     """
     try:
         im = Image.open(io.BytesIO(blob)).convert("RGB")
-    except Exception:
+    # Pillow raises UnidentifiedImageError (an OSError) for a format it cannot
+    # read and plain OSError for a truncated one; `convert` raises ValueError on
+    # an unsupported mode. An unreadable blob is simply not a QR — anything else
+    # is a bug in this script and must propagate.
+    except (OSError, ValueError):
         return 255.0, 0.0
     q = im.quantize(colors=2)
     means = ImageStat.Stat(ImageChops.difference(im, q.convert("RGB"))).mean
@@ -1003,7 +1007,10 @@ def _picture_is_qr(shape):
         return False
     try:
         blob = shape.image.blob
-    except Exception:
+    # python-pptx raises ValueError for a picture with no embedded image (a
+    # linked one) and KeyError when the relationship is missing, which it
+    # documents as a corrupted .pptx. Neither carries a QR to find.
+    except (ValueError, KeyError):
         return False
     err, minority = _two_color_metrics(blob)
     return err < QR_RECON_ERR_MAX and minority >= QR_MIN_MINORITY

--- a/tests/test_batch_download.py
+++ b/tests/test_batch_download.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import stat
 
-import pytest
 
 SCRIPT = os.path.join(
     os.path.dirname(__file__), os.pardir,

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -148,7 +148,6 @@ def test_slides_omits_speaker_dialogue(extract_slides, outline):
 def test_slides_omits_interludes(extract_slides, outline_schema):
     """The slides extractor walks slides[] only — interludes never appear in
     slides.md, even if the outline declares them."""
-    import copy
     import yaml as _yaml
 
     data = _yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
@@ -175,7 +174,6 @@ def test_slides_omits_interludes(extract_slides, outline_schema):
 def test_script_interleaves_interludes_after_anchor(extract_script, outline_schema):
     """Build a tiny outline with one interlude anchored after_slide=1, verify
     it appears between slide 1 and slide 2 in the rendered script."""
-    import copy
     import yaml
 
     data = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))

--- a/tests/test_generate_thumbnail.py
+++ b/tests/test_generate_thumbnail.py
@@ -358,14 +358,8 @@ def test_compose_thumbnail_two_pass_threads_stylized_portrait(
     calls = []
 
     def fake_call_gemini(parts, model, api_key):
-        # Record the second inlineData part's `data` value (the speaker photo
-        # in the composition call) so the assertion can confirm it's the
-        # stylized output, not the original.
-        photo_part = next(
-            (p for p in parts if "inlineData" in p and p["inlineData"]["data"] != "PHOTO_RAW_B64"),
-            None,
-        )
-        # The composition call will have BOTH images; record the photo data.
+        # The composition call will have BOTH images; record the photo data so
+        # the assertion can confirm it's the stylized output, not the original.
         composition_photo_data = None
         if len(parts) >= 2 and "inlineData" in parts[1]:
             composition_photo_data = parts[1]["inlineData"]["data"]
@@ -419,7 +413,8 @@ def test_compose_thumbnail_skips_pre_stylize_when_no_anchor(
 ):
     """Without --portrait-style, stylize_portrait must NOT be invoked; the
     original photo bytes go directly to composition."""
-    import argparse, base64
+    import argparse
+    import base64
 
     slide_path = tmp_path / "slide.png"
     speaker_path = tmp_path / "headshot.jpg"

--- a/tests/test_insert_qr_wrapper.py
+++ b/tests/test_insert_qr_wrapper.py
@@ -38,8 +38,10 @@ def _run(args, tmp_path):
 
 
 def test_success_emits_json_only_stdout(tmp_path):
-    base = tmp_path / "deck.pptx"; base.write_text("x")
-    png = tmp_path / "qr.png"; png.write_text("x")
+    base = tmp_path / "deck.pptx"
+    base.write_text("x")
+    png = tmp_path / "qr.png"
+    png.write_text("x")
     out = tmp_path / "out.pptx"
     _fake_osascript(tmp_path, succeed=True)
 
@@ -51,7 +53,8 @@ def test_success_emits_json_only_stdout(tmp_path):
 
 
 def test_missing_base_fails_with_actionable_error(tmp_path):
-    png = tmp_path / "qr.png"; png.write_text("x")
+    png = tmp_path / "qr.png"
+    png.write_text("x")
     _fake_osascript(tmp_path, succeed=True)
 
     r = _run([str(tmp_path / "nope.pptx"), str(tmp_path / "o.pptx"), str(png), "1"], tmp_path)
@@ -60,7 +63,8 @@ def test_missing_base_fails_with_actionable_error(tmp_path):
 
 
 def test_missing_png_fails(tmp_path):
-    base = tmp_path / "deck.pptx"; base.write_text("x")
+    base = tmp_path / "deck.pptx"
+    base.write_text("x")
     _fake_osascript(tmp_path, succeed=True)
 
     r = _run([str(base), str(tmp_path / "o.pptx"), str(tmp_path / "nope.png"), "1"], tmp_path)
@@ -69,8 +73,10 @@ def test_missing_png_fails(tmp_path):
 
 
 def test_macro_failure_path(tmp_path):
-    base = tmp_path / "deck.pptx"; base.write_text("x")
-    png = tmp_path / "qr.png"; png.write_text("x")
+    base = tmp_path / "deck.pptx"
+    base.write_text("x")
+    png = tmp_path / "qr.png"
+    png.write_text("x")
     out = tmp_path / "out.pptx"
     _fake_osascript(tmp_path, succeed=False)
 

--- a/tests/test_pyproject_pins.py
+++ b/tests/test_pyproject_pins.py
@@ -87,6 +87,7 @@ def test_the_manifest_declares_every_group_this_test_checks():
     )
     labels = [label for label, _ in _requirement_groups()]
     assert "project.optional-dependencies.test" in labels
+    assert "project.optional-dependencies.lint" in labels
     assert "project.optional-dependencies.whisper" in labels
 
 

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -712,9 +712,12 @@ DISTINCT_FRAME_PATTERNS = (
     lambda rows, cols: ((cols // 4) % 2) * 255,
     # diagonal sawtooth
     lambda rows, cols: ((rows + cols) % 64) * 4,
-    # concentric rings about the center
+    # concentric rings about the center, derived from the frame's own extent so
+    # the pattern stays centered at any size
     lambda rows, cols: (
-        ((rows - 90) ** 2 + (cols - 160) ** 2) // 400 % 2
+        (
+            (rows - rows.size // 2) ** 2 + (cols - cols.size // 2) ** 2
+        ) // 400 % 2
     ) * 255,
 )
 
@@ -744,7 +747,8 @@ def test_deduplicate_distinct_frames(video_slide_extraction, tmp_path):
 
 
 def test_the_distinct_frame_patterns_really_are_distinct(
-        video_slide_extraction, tmp_path):
+    video_slide_extraction, tmp_path
+):
     """Guard the fixture itself: solid or near-identical patterns would make
     `test_deduplicate_distinct_frames` pass for the wrong reason."""
     import imagehash

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -700,21 +700,65 @@ def test_deduplicate_identical_frames(video_slide_extraction, tmp_path):
     assert len(unique) == 1
 
 
-def test_deduplicate_distinct_frames(video_slide_extraction, tmp_path):
-    """Visually distinct frames should all be kept."""
+# Three patterns built from index arithmetic, not RNG. Their pairwise phash
+# distances are 31, 31, and 38 — comfortably past the threshold 8 the test uses,
+# so the assertion does not sit on the edge of the comparison. Solid colors
+# would not work: phash reads structure, and three flat fills hash alike.
+# `testing-standards` Determinism bans runtime randomness from shaping inputs,
+# and its seeded carve-out covers property-based generators, not a numpy RNG
+# building a fixture.
+DISTINCT_FRAME_PATTERNS = (
+    # vertical stripes, 4px period
+    lambda rows, cols: ((cols // 4) % 2) * 255,
+    # diagonal sawtooth
+    lambda rows, cols: ((rows + cols) % 64) * 4,
+    # concentric rings about the center
+    lambda rows, cols: (
+        ((rows - 90) ** 2 + (cols - 160) ** 2) // 400 % 2
+    ) * 255,
+)
+
+
+def _patterned_frame(pattern, height=180, width=320):
+    """One deterministic RGB frame from an index-arithmetic pattern."""
     import numpy as np
 
-    # Use patterned images (not solid) so JPEG compression preserves distinctness
-    rng = np.random.RandomState(42)
+    rows = np.arange(height).reshape(height, 1)
+    cols = np.arange(width).reshape(1, width)
+    plane = np.broadcast_to(pattern(rows, cols), (height, width))
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    frame[:, :, :] = plane.astype(np.uint8)[:, :, None]
+    return Image.fromarray(frame)
+
+
+def test_deduplicate_distinct_frames(video_slide_extraction, tmp_path):
+    """Visually distinct frames should all be kept."""
     frames = []
-    for i in range(3):
-        arr = rng.randint(0, 256, (180, 320, 3), dtype=np.uint8)
-        img = Image.fromarray(arr)
+    for i, pattern in enumerate(DISTINCT_FRAME_PATTERNS):
         path = str(tmp_path / f"frame_{i:05d}.png")
-        img.save(path)  # PNG to avoid JPEG lossy compression
+        # PNG, not JPEG: lossy compression would blur the patterns together.
+        _patterned_frame(pattern).save(path)
         frames.append(path)
     unique = video_slide_extraction.deduplicate_frames(frames, hash_threshold=8)
     assert len(unique) == 3
+
+
+def test_the_distinct_frame_patterns_really_are_distinct(
+        video_slide_extraction, tmp_path):
+    """Guard the fixture itself: solid or near-identical patterns would make
+    `test_deduplicate_distinct_frames` pass for the wrong reason."""
+    import imagehash
+
+    hashes = [
+        imagehash.phash(_patterned_frame(pattern), hash_size=8)
+        for pattern in DISTINCT_FRAME_PATTERNS
+    ]
+    distances = [
+        hashes[i] - hashes[j]
+        for i in range(len(hashes))
+        for j in range(i + 1, len(hashes))
+    ]
+    assert all(distance > 8 for distance in distances), distances
 
 
 def test_higher_hash_threshold_monotonically_keeps_fewer_variants(


### PR DESCRIPTION
Refs #162 — first of the adoption sequence, not the whole issue.

`language-diagnostics` Adopting on a Dirty Tree: land the config and the fixes first, wire the gate only once the tree reports zero. This PR turns nothing red in CI. The `ruff format` baseline (93 files), the Pyright baseline, and the CI gate follow as separate PRs.

## Config

```toml
[tool.ruff]
line-length = 88
target-version = "py310"

[tool.ruff.lint]
select = ["E4", "E7", "E9", "F", "BLE"]
```

Ruff's default set plus `BLE`. E501 stays off deliberately — the formatter owns line width, and running both makes the linter argue with the formatter over lines the formatter cannot split (long URLs, literal error strings). For scale: enabling E501 today would report 468 findings against 11 for everything else combined.

`line-length` and `target-version` are stated rather than inherited so a Ruff default change cannot silently rewrap the tree.

## The two policy-shaped findings #162 named

**Inner catch-alls.** The issue points at `pptx-extraction.py`; that one was fixed since the audit — its two `except Exception` handlers are now `_main`/`main` boundaries carrying `outer-boundary-process-contract`. `BLE` found the real remaining pair in `generate-qr.py`, both inner helpers:

| Site | Was | Now | Why those types |
|---|---|---|---|
| `_two_color_metrics` | `except Exception` | `except (OSError, ValueError)` | Pillow raises `UnidentifiedImageError` (an `OSError`) for a format it can't read, plain `OSError` for a truncated one; `.convert()` raises `ValueError` on an unsupported mode |
| `_picture_is_qr` | `except Exception` | `except (ValueError, KeyError)` | python-pptx raises `ValueError` for a picture with no embedded image (a linked one) and `KeyError` for a missing relationship, which it documents as a corrupted `.pptx` |

Both returned a "not a QR" sentinel, so anything else — an `AttributeError` from a refactor, a `MemoryError` — was a bug being silently reclassified as a negative detection.

**The RNG fixture.** `test_deduplicate_distinct_frames` built its three frames with `np.random.RandomState(42)`. Seeded is not fixed: `testing-standards` Determinism's carve-out covers property-based generators under a pinned seed, not a numpy RNG shaping ordinary fixture data.

Replaced with three index-arithmetic patterns — vertical stripes, a diagonal sawtooth, concentric rings. Solid fills are not an option: phash reads structure, so three flat colors hash alike (verified: two solid frames differ by 0).

A second test asserts the fixture itself. The pairwise phash distances are 31, 31, and 38 against the threshold 8 the first test uses — so if someone later swaps in patterns that happen to hash alike, `test_the_distinct_frame_patterns_really_are_distinct` fails loudly instead of `test_deduplicate_distinct_frames` passing for the wrong reason.

## The mechanical nine

Three unused imports, one dead local (`photo_part` in `test_generate_thumbnail.py`, computed and never read — its stale comment went with it), one multi-import line, six semicolon statements.

## Verification

`ruff check .` — All checks passed. Full suite: 5014 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)