### PR TITLE
style: clear the ruff format baseline (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+### chore(ci) — clear the `ruff format` baseline (#162)
+
+Second of the #162 adoption sequence. `ruff format` rewrites 94 of the repo's
+153 tracked Python files; landing that alongside anything else would bury the
+"anything else". This PR is the reformat and nothing but.
+
+`code-formatting` Separation of Concerns is enforced at the commit level here,
+not just the PR level. The reformat is one commit whose 94 files are each
+AST-identical to their prior form — `ast.dump(ast.parse(before)) ==
+ast.dump(ast.parse(after))`, checked file by file rather than asserted.
+
+One docstring needed a prior commit to make that hold. `""""Repair the
+condition..."""` opens with a quote character, so the formatter inserts a
+disambiguating space and changes the string's value. Rewording it first keeps
+the formatting commit provably mechanical instead of "mechanical except for
+one thing".
+
+Still open on #162: the Pyright baseline, and wiring Ruff check, Ruff format
+check, and Pyright into pull-request CI.
+
 ### chore(ci) — clear the Ruff lint baseline and configure the linter (#162)
 
 First of the #162 adoption sequence. `language-diagnostics` Adopting on a Dirty

--- a/skills/illustrations/scripts/apply-illustrations-to-deck.py
+++ b/skills/illustrations/scripts/apply-illustrations-to-deck.py
@@ -38,6 +38,7 @@ Usage:
         [--out OUT_DECK] [--image-ext jpg|jpeg|png] \\
         [--scrim-color RRGGBB] [--scrim-alpha 0-100000]
 """
+
 import argparse
 import json
 import shutil
@@ -55,8 +56,11 @@ from pptx.util import Inches
 sys.path.insert(
     0,
     str(
-        (Path(__file__).resolve().parent.parent.parent
-         / "presentation-creator" / "scripts")
+        (
+            Path(__file__).resolve().parent.parent.parent
+            / "presentation-creator"
+            / "scripts"
+        )
     ),
 )
 import outline_schema  # noqa: E402  (path appended above)
@@ -72,16 +76,41 @@ SLIDE_H_IN = 7.5
 TEXT_W_FULL_IN = 10.0
 TEXT_W_HALF_IN = 5.5
 HALF_MARGIN_IN = 0.4
-_BAND_H_IN = 1.9    # horizontal-band title height (title + subtitle)
-_HALF_H_IN = 4.5    # half-frame title column height
+_BAND_H_IN = 1.9  # horizontal-band title height (title + subtitle)
+_HALF_H_IN = 4.5  # half-frame title column height
 _HALF_TOP_IN = (SLIDE_H_IN - _HALF_H_IN) / 2
 
 ZONE_LAYOUT = {
-    "upper_third":  {"top_in": 0.4,         "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2,            "width_in": TEXT_W_FULL_IN, "height_in": _BAND_H_IN},
-    "middle_third": {"top_in": (SLIDE_H_IN - _BAND_H_IN) / 2, "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2, "width_in": TEXT_W_FULL_IN, "height_in": _BAND_H_IN},
-    "lower_third":  {"top_in": SLIDE_H_IN - _BAND_H_IN - 0.4, "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2, "width_in": TEXT_W_FULL_IN, "height_in": _BAND_H_IN},
-    "left_half":    {"top_in": _HALF_TOP_IN, "left_in": HALF_MARGIN_IN,                               "width_in": TEXT_W_HALF_IN, "height_in": _HALF_H_IN},
-    "right_half":   {"top_in": _HALF_TOP_IN, "left_in": SLIDE_W_IN - HALF_MARGIN_IN - TEXT_W_HALF_IN, "width_in": TEXT_W_HALF_IN, "height_in": _HALF_H_IN},
+    "upper_third": {
+        "top_in": 0.4,
+        "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2,
+        "width_in": TEXT_W_FULL_IN,
+        "height_in": _BAND_H_IN,
+    },
+    "middle_third": {
+        "top_in": (SLIDE_H_IN - _BAND_H_IN) / 2,
+        "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2,
+        "width_in": TEXT_W_FULL_IN,
+        "height_in": _BAND_H_IN,
+    },
+    "lower_third": {
+        "top_in": SLIDE_H_IN - _BAND_H_IN - 0.4,
+        "left_in": (SLIDE_W_IN - TEXT_W_FULL_IN) / 2,
+        "width_in": TEXT_W_FULL_IN,
+        "height_in": _BAND_H_IN,
+    },
+    "left_half": {
+        "top_in": _HALF_TOP_IN,
+        "left_in": HALF_MARGIN_IN,
+        "width_in": TEXT_W_HALF_IN,
+        "height_in": _HALF_H_IN,
+    },
+    "right_half": {
+        "top_in": _HALF_TOP_IN,
+        "left_in": SLIDE_W_IN - HALF_MARGIN_IN - TEXT_W_HALF_IN,
+        "width_in": TEXT_W_HALF_IN,
+        "height_in": _HALF_H_IN,
+    },
 }
 
 SUBTITLE_OFFSET_IN = 1.2
@@ -90,16 +119,16 @@ SUBTITLE_OFFSET_IN = 1.2
 # Numbers chosen to leave a 0.3" outer margin, 0.2" gutter, and 0.6" footer band.
 IMGTXT_IMG_LEFT_IN = 0.3
 IMGTXT_IMG_TOP_IN = 0.8
-IMGTXT_IMG_WIDTH_IN = 8.0       # ~60% of 13.333" slide width
-IMGTXT_IMG_HEIGHT_IN = 5.9      # leaves a 0.8" footer band below
-IMGTXT_TEXT_LEFT_IN = IMGTXT_IMG_LEFT_IN + IMGTXT_IMG_WIDTH_IN + 0.2   # 8.5
-IMGTXT_TEXT_WIDTH_IN = SLIDE_W_IN - IMGTXT_TEXT_LEFT_IN - 0.3          # 4.533
+IMGTXT_IMG_WIDTH_IN = 8.0  # ~60% of 13.333" slide width
+IMGTXT_IMG_HEIGHT_IN = 5.9  # leaves a 0.8" footer band below
+IMGTXT_TEXT_LEFT_IN = IMGTXT_IMG_LEFT_IN + IMGTXT_IMG_WIDTH_IN + 0.2  # 8.5
+IMGTXT_TEXT_WIDTH_IN = SLIDE_W_IN - IMGTXT_TEXT_LEFT_IN - 0.3  # 4.533
 IMGTXT_TITLE_TOP_IN = IMGTXT_IMG_TOP_IN
 IMGTXT_TITLE_HEIGHT_IN = 1.9
-IMGTXT_BODY_TOP_IN = IMGTXT_TITLE_TOP_IN + IMGTXT_TITLE_HEIGHT_IN + 0.1   # 2.8
+IMGTXT_BODY_TOP_IN = IMGTXT_TITLE_TOP_IN + IMGTXT_TITLE_HEIGHT_IN + 0.1  # 2.8
 IMGTXT_BODY_HEIGHT_IN = (
     IMGTXT_IMG_TOP_IN + IMGTXT_IMG_HEIGHT_IN - IMGTXT_BODY_TOP_IN
-)   # aligns body bottom with image bottom — 3.9
+)  # aligns body bottom with image bottom — 3.9
 
 # Default scrim: 45% black. Decks with a strong tonal style (warm sepia,
 # cool night, etc.) should pass a sampled color via --scrim-color.
@@ -194,8 +223,10 @@ def swap_or_insert_picture(slide, illust_path: Path):
         return bg
     return slide.shapes.add_picture(
         str(illust_path),
-        left=Inches(0), top=Inches(0),
-        width=Inches(SLIDE_W_IN), height=Inches(SLIDE_H_IN),
+        left=Inches(0),
+        top=Inches(0),
+        width=Inches(SLIDE_W_IN),
+        height=Inches(SLIDE_H_IN),
     )
 
 
@@ -212,8 +243,10 @@ def ensure_scrim(slide, zone: str, scrim_hex: str, scrim_alpha: int) -> int:
     layout = ZONE_LAYOUT[zone]
     shape = slide.shapes.add_shape(
         MSO_SHAPE.RECTANGLE,
-        left=Inches(layout["left_in"]), top=Inches(layout["top_in"]),
-        width=Inches(layout["width_in"]), height=Inches(layout["height_in"]),
+        left=Inches(layout["left_in"]),
+        top=Inches(layout["top_in"]),
+        width=Inches(layout["width_in"]),
+        height=Inches(layout["height_in"]),
     )
     shape.name = SCRIM_SHAPE_NAME
     sp = shape._element
@@ -248,8 +281,10 @@ def ensure_scrim(slide, zone: str, scrim_hex: str, scrim_alpha: int) -> int:
         if nvSpPr is not None:
             cNvSpPr = nvSpPr.find(qn("p:cNvSpPr"))
             has_txbox = cNvSpPr is not None and cNvSpPr.get("txBox") == "1"
-            has_placeholder = nvSpPr.find(qn("p:nvPr")) is not None and \
-                nvSpPr.find(qn("p:nvPr")).find(qn("p:ph")) is not None
+            has_placeholder = (
+                nvSpPr.find(qn("p:nvPr")) is not None
+                and nvSpPr.find(qn("p:nvPr")).find(qn("p:ph")) is not None
+            )
             has_txbody = child.find(qn("p:txBody")) is not None
             if has_txbox or (has_placeholder and has_txbody):
                 first_text_idx = i
@@ -279,8 +314,10 @@ def reposition_title(slide, zone: str) -> int:
     # Fall back to text boxes if no placeholders found
     if not title_shapes:
         title_shapes = [
-            s for s in slide.shapes
-            if s.has_text_frame and s.name != SCRIM_SHAPE_NAME
+            s
+            for s in slide.shapes
+            if s.has_text_frame
+            and s.name != SCRIM_SHAPE_NAME
             and s.shape_type == MSO_SHAPE_TYPE.TEXT_BOX
         ]
     title_shapes.sort(key=lambda s: s.top)
@@ -327,7 +364,8 @@ def apply_img_txt_layout(slide) -> tuple[int, int]:
     # Reposition any non-title placeholder (body/content) into the right column.
     # Subtitle (idx 1) shares the body's column-and-stack treatment.
     body_shapes = [
-        s for s in slide.placeholders
+        s
+        for s in slide.placeholders
         if s.has_text_frame
         and s is not title
         and s.placeholder_format.idx != 0  # idx 0 is the title; already handled
@@ -346,8 +384,14 @@ def apply_img_txt_layout(slide) -> tuple[int, int]:
 
 
 def apply(
-    deck: Path, illust_dir: Path, zones: dict, img_txt_slides: set,
-    out_deck: Path, ext: str, scrim_hex: str, scrim_alpha: int,
+    deck: Path,
+    illust_dir: Path,
+    zones: dict,
+    img_txt_slides: set,
+    out_deck: Path,
+    ext: str,
+    scrim_hex: str,
+    scrim_alpha: int,
     poster_full_slides: set | None = None,
 ) -> tuple[list[dict], dict]:
     """Apply scrim + title for FULL slides and the IMG+TXT layout.
@@ -381,11 +425,18 @@ def apply(
 
         scrim_added = ensure_scrim(slide, zone, scrim_hex, scrim_alpha)
         moved = reposition_title(slide, zone)
-        print(f"  [{n:02d}] zone={zone}  moved={moved} text  scrim+{scrim_added}  bg->VBA")
-        results.append({
-            "slide": n, "format": "FULL", "zone": zone,
-            "text_moved": moved, "scrim_added": scrim_added,
-        })
+        print(
+            f"  [{n:02d}] zone={zone}  moved={moved} text  scrim+{scrim_added}  bg->VBA"
+        )
+        results.append(
+            {
+                "slide": n,
+                "format": "FULL",
+                "zone": zone,
+                "text_moved": moved,
+                "scrim_added": scrim_added,
+            }
+        )
 
     # IMG+TXT slides — image-left + text-right layout
     for n in sorted(img_txt_slides):
@@ -402,10 +453,14 @@ def apply(
 
         pic_moved, text_moved = apply_img_txt_layout(slide)
         print(f"  [{n:02d}] format=IMG+TXT  pic+{pic_moved}  text+{text_moved}")
-        results.append({
-            "slide": n, "format": "IMG+TXT",
-            "picture_repositioned": pic_moved, "text_moved": text_moved,
-        })
+        results.append(
+            {
+                "slide": n,
+                "format": "IMG+TXT",
+                "picture_repositioned": pic_moved,
+                "text_moved": text_moved,
+            }
+        )
 
     # Poster-theatrical FULL slides — background only. Title + footer are baked
     # into the image, so no scrim and no overlaid title; QR (added later) is the
@@ -429,23 +484,45 @@ def apply(
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("deck", type=Path, help="Path to source .pptx")
-    ap.add_argument("illustrations", type=Path, help="Directory with slide-NN.<ext> files")
-    ap.add_argument("outline", type=Path, help="Path to outline.yaml (the single source of truth)")
-    ap.add_argument("--out", type=Path, default=None, help="Output deck (default: <stem>-with-titles.pptx)")
+    ap.add_argument(
+        "illustrations", type=Path, help="Directory with slide-NN.<ext> files"
+    )
+    ap.add_argument(
+        "outline", type=Path, help="Path to outline.yaml (the single source of truth)"
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output deck (default: <stem>-with-titles.pptx)",
+    )
     ap.add_argument("--image-ext", default="jpg", choices=["jpg", "jpeg", "png"])
-    ap.add_argument("--scrim-color", default=DEFAULT_SCRIM_HEX,
-                    help="Scrim color as 6-digit hex (default: %(default)s). "
-                         "Run suggest-scrim-color.py to sample one from the deck's illustrations.")
-    ap.add_argument("--scrim-alpha", type=int, default=DEFAULT_SCRIM_ALPHA,
-                    help="Scrim opacity in OOXML thousandths (0-100000, default: %(default)s = 45%%).")
-    ap.add_argument("--backgrounds-out", type=Path, default=None,
-                    help="Where to write the FULL-slide backgrounds manifest JSON "
-                         "(default: <out_stem>.backgrounds.json). Feed it to "
-                         "apply-backgrounds.sh to set the backgrounds via PowerPoint.")
+    ap.add_argument(
+        "--scrim-color",
+        default=DEFAULT_SCRIM_HEX,
+        help="Scrim color as 6-digit hex (default: %(default)s). "
+        "Run suggest-scrim-color.py to sample one from the deck's illustrations.",
+    )
+    ap.add_argument(
+        "--scrim-alpha",
+        type=int,
+        default=DEFAULT_SCRIM_ALPHA,
+        help="Scrim opacity in OOXML thousandths (0-100000, default: %(default)s = 45%%).",
+    )
+    ap.add_argument(
+        "--backgrounds-out",
+        type=Path,
+        default=None,
+        help="Where to write the FULL-slide backgrounds manifest JSON "
+        "(default: <out_stem>.backgrounds.json). Feed it to "
+        "apply-backgrounds.sh to set the backgrounds via PowerPoint.",
+    )
     args = ap.parse_args()
 
     out_deck = args.out or args.deck.with_name(args.deck.stem + "-with-titles.pptx")
-    backgrounds_out = args.backgrounds_out or out_deck.with_name(out_deck.stem + ".backgrounds.json")
+    backgrounds_out = args.backgrounds_out or out_deck.with_name(
+        out_deck.stem + ".backgrounds.json"
+    )
     poster = parse_composition(args.outline) == POSTER_COMPOSITION
     zones = parse_zones(args.outline)
     img_txt_slides = parse_img_txt_slides(args.outline)
@@ -471,25 +548,40 @@ def main():
 
     scrim_hex = args.scrim_color.lstrip("#").upper()
     if len(scrim_hex) != 6 or any(c not in "0123456789ABCDEF" for c in scrim_hex):
-        raise SystemExit(f"--scrim-color must be a 6-digit hex, got {args.scrim_color!r}")
+        raise SystemExit(
+            f"--scrim-color must be a 6-digit hex, got {args.scrim_color!r}"
+        )
     if not (0 <= args.scrim_alpha <= 100000):
         raise SystemExit(f"--scrim-alpha must be 0..100000, got {args.scrim_alpha}")
 
     results, backgrounds = apply(
-        args.deck, args.illustrations, zones, img_txt_slides, out_deck,
-        args.image_ext, scrim_hex, args.scrim_alpha, poster_full_slides,
+        args.deck,
+        args.illustrations,
+        zones,
+        img_txt_slides,
+        out_deck,
+        args.image_ext,
+        scrim_hex,
+        args.scrim_alpha,
+        poster_full_slides,
     )
     print(f"\nSaved {out_deck}")
     print(f"Updated {len(results)}/{total_slides} slides")
 
     if backgrounds:
-        manifest = {"backgrounds": {str(n): path for n, path in sorted(backgrounds.items())}}
+        manifest = {
+            "backgrounds": {str(n): path for n, path in sorted(backgrounds.items())}
+        }
         backgrounds_out.write_text(json.dumps(manifest, indent=2) + "\n")
         print(f"Wrote {len(backgrounds)} FULL-slide background(s) -> {backgrounds_out}")
-        print(f"Apply them via: apply-backgrounds.sh <uniquely-named copy of {out_deck.name}> "
-              f"<final.pptx> {backgrounds_out.name}")
+        print(
+            f"Apply them via: apply-backgrounds.sh <uniquely-named copy of {out_deck.name}> "
+            f"<final.pptx> {backgrounds_out.name}"
+        )
     else:
-        print("No FULL background slides (Safe zone or poster) — no background manifest written.")
+        print(
+            "No FULL background slides (Safe zone or poster) — no background manifest written."
+        )
 
 
 if __name__ == "__main__":

--- a/skills/illustrations/scripts/build-expansion-manifest.py
+++ b/skills/illustrations/scripts/build-expansion-manifest.py
@@ -51,8 +51,11 @@ from pathlib import Path
 # presentation-creator scripts.
 sys.path.insert(
     0,
-    str(Path(__file__).resolve().parent.parent.parent
-        / "presentation-creator" / "scripts"),
+    str(
+        Path(__file__).resolve().parent.parent.parent
+        / "presentation-creator"
+        / "scripts"
+    ),
 )
 import outline_schema  # noqa: E402  (path appended above)
 
@@ -87,7 +90,9 @@ def frames_for(builds_dir: Path, parent: int) -> dict[int, Path]:
     return found
 
 
-def build_manifest(outline_path: Path, builds_dir: Path, notes_map: dict | None = None) -> dict:
+def build_manifest(
+    outline_path: Path, builds_dir: Path, notes_map: dict | None = None
+) -> dict:
     """Build the expansion manifest.
 
     notes_map: optional {"<0-based deck slide #>": "notes"} (the historical
@@ -124,23 +129,36 @@ def build_manifest(outline_path: Path, builds_dir: Path, notes_map: dict | None 
                 f"ERROR: note for slide {parent} (notes key {parent - 1}) must be a "
                 f"string, got {type(raw_note).__name__} — fix the --notes JSON."
             )
-        builds.append({
-            "parent": parent,
-            "frames": [str(found[s].resolve()) for s in steps],
-            "notes": raw_note,
-        })
+        builds.append(
+            {
+                "parent": parent,
+                "frames": [str(found[s].resolve()) for s in steps],
+                "notes": raw_note,
+            }
+        )
     return {"schema_version": SCHEMA_VERSION, "builds": builds}
 
 
 def main(argv=None):
     ap = argparse.ArgumentParser(
-        description="Emit the build-expansion manifest for deck assembly.")
-    ap.add_argument("outline", type=Path, help="Path to outline.yaml (the single source of truth)")
-    ap.add_argument("builds_dir", type=Path, help="Directory with slide-NN-build-MM.<ext> frames")
-    ap.add_argument("--out", type=Path, default=None, help="Also write the manifest JSON here")
-    ap.add_argument("--notes", type=Path, default=None,
-                    help='Optional notes JSON {"<0-based slide #>": "text"}; a build '
-                         "parent's notes ride onto its final frame so expansion keeps them")
+        description="Emit the build-expansion manifest for deck assembly."
+    )
+    ap.add_argument(
+        "outline", type=Path, help="Path to outline.yaml (the single source of truth)"
+    )
+    ap.add_argument(
+        "builds_dir", type=Path, help="Directory with slide-NN-build-MM.<ext> frames"
+    )
+    ap.add_argument(
+        "--out", type=Path, default=None, help="Also write the manifest JSON here"
+    )
+    ap.add_argument(
+        "--notes",
+        type=Path,
+        default=None,
+        help='Optional notes JSON {"<0-based slide #>": "text"}; a build '
+        "parent's notes ride onto its final frame so expansion keeps them",
+    )
     args = ap.parse_args(argv)
 
     if not args.outline.is_file():
@@ -153,7 +171,9 @@ def main(argv=None):
         except (OSError, json.JSONDecodeError) as exc:
             raise SystemExit(f"ERROR: cannot read notes JSON {args.notes}: {exc}")
         if not isinstance(notes_map, dict):
-            raise SystemExit(f"ERROR: notes JSON {args.notes} must be an object mapping slide # -> text")
+            raise SystemExit(
+                f"ERROR: notes JSON {args.notes} must be an object mapping slide # -> text"
+            )
 
     manifest = build_manifest(args.outline, args.builds_dir, notes_map)
     text = json.dumps(manifest, indent=2)
@@ -161,8 +181,11 @@ def main(argv=None):
         try:
             args.out.write_text(text + "\n", encoding="utf-8")
         except OSError as exc:
-            print(f"ERROR: cannot write manifest {args.out}: {exc.strerror or exc} — "
-                  "check the path and that its directory is writable", file=sys.stderr)
+            print(
+                f"ERROR: cannot write manifest {args.out}: {exc.strerror or exc} — "
+                "check the path and that its directory is writable",
+                file=sys.stderr,
+            )
             return 1
     print(text)
     return 0

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -67,8 +67,11 @@ sys.path.insert(
     0,
     os.path.abspath(
         os.path.join(
-            os.path.dirname(__file__), os.pardir, os.pardir,
-            "presentation-creator", "scripts",
+            os.path.dirname(__file__),
+            os.pardir,
+            os.pardir,
+            "presentation-creator",
+            "scripts",
         )
     ),
 )
@@ -108,6 +111,7 @@ def sizing_for(slide_format):
     """
     return FORMAT_SIZING.get(slide_format, FORMAT_SIZING["FULL"])
 
+
 RATE_LIMIT_DELAY = 5  # seconds between API requests
 
 # Max seconds to spend reading secrets.json before giving up and falling back to
@@ -122,8 +126,11 @@ IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp"]
 # --- Title safe-zone policy (see rules/title-overlay-rules.md) ---
 
 VALID_SAFE_ZONES = {
-    "upper_third", "middle_third", "lower_third",
-    "left_half", "right_half",
+    "upper_third",
+    "middle_third",
+    "lower_third",
+    "left_half",
+    "right_half",
 }
 
 DEFAULT_SAFE_ZONE_SURFACE = {
@@ -150,7 +157,7 @@ SAFE_ZONE_DIRECTIVE_TEMPLATE = (
 POSTER_COMPOSITION = "poster-theatrical"
 
 POSTER_EMBED_DIRECTIVE_TEMPLATE = (
-    " EMBEDDED TEXT -- CRITICAL COMPOSITION RULE: Render the title \"{title}\" "
+    ' EMBEDDED TEXT -- CRITICAL COMPOSITION RULE: Render the title "{title}" '
     "as an integral, stylized part of the scene itself — {treatment} — not "
     "pasted on as a flat overlay or caption. "
     "{footer_clause}All text must be fully blended and integrated into the "
@@ -167,7 +174,7 @@ DEFAULT_POSTER_TEXT_TREATMENT = (
 )
 
 POSTER_FOOTER_CLAUSE_TEMPLATE = (
-    "Also integrate the footer \"{footer}\" small along the lower edge of the "
+    'Also integrate the footer "{footer}" small along the lower edge of the '
     "frame, in the same stylized treatment. "
 )
 
@@ -187,6 +194,7 @@ _cli_vault_path = None  # set by main() from --vault arg
 
 
 # --- Model Family Dispatch ---
+
 
 def model_family(model_name):
     """Classify a model into a vendor family for endpoint dispatch.
@@ -216,6 +224,7 @@ def family_key_name(family):
 
 
 # --- Outline Parsing ---
+
 
 def _collapse_anchor(text):
     """Collapse a (possibly multi-line) anchor block into one prompt-ready line."""
@@ -274,7 +283,9 @@ def parse_outline(path):
         "anchors": {
             "FULL": _anchor_with_conventions(anchor.full),
             "IMG+TXT": _anchor_with_conventions(anchor.imgtxt),
-        } if anchor else {},
+        }
+        if anchor
+        else {},
         "conventions": conventions or None,
         "slides": [],
         "composition": (
@@ -311,9 +322,7 @@ def parse_outline(path):
                     # Normalized [x0, y0, x1, y1] erase box, or None. Drives the
                     # masked/composited edit path that keeps a static background
                     # pixel-stable across build frames (#90).
-                    "erase_region": (
-                        list(b.erase_region) if b.erase_region else None
-                    ),
+                    "erase_region": (list(b.erase_region) if b.erase_region else None),
                 }
                 for b in sorted(slide.builds, key=lambda b: b.step)
             ]
@@ -459,6 +468,7 @@ def effective_slide_format(slide_format, safe_zone):
 
 # --- Slide Number Selection ---
 
+
 def parse_slide_selection(args, available_slides, output_dir):
     """Parse CLI slide selection into a list of slide numbers.
 
@@ -499,6 +509,7 @@ def parse_slide_selection(args, available_slides, output_dir):
 
 # --- File Helpers ---
 
+
 def find_base_image(output_dir, slide_num):
     """Find the unversioned base image for a slide, or None."""
     for ext in IMAGE_EXTENSIONS:
@@ -529,7 +540,9 @@ def final_build_dest(builds_dir, slide_num, final_step, source_path):
     .webp depending on the generating vendor.
     """
     src_ext = os.path.splitext(source_path)[1].lower() or ".jpg"
-    return os.path.join(builds_dir, f"slide-{slide_num:02d}-build-{final_step:02d}{src_ext}")
+    return os.path.join(
+        builds_dir, f"slide-{slide_num:02d}-build-{final_step:02d}{src_ext}"
+    )
 
 
 def _has_keep_clause(description):
@@ -577,6 +590,7 @@ def ext_to_mime(ext):
 
 
 # --- Shared Setup ---
+
 
 def _read_file_with_timeout(path, timeout):
     """Read a file's bytes, abandoning the read if it overruns `timeout` seconds.
@@ -690,7 +704,9 @@ def _require_keys_for_families(keys, families, secrets_path):
                 print('    "gemini": {"api_key": "YOUR_KEY"}')
             else:
                 print(f"  Create {secrets_path}:")
-                print(f'    echo \'{{"gemini": {{"api_key": "YOUR_KEY"}}}}\' > {secrets_path}')
+                print(
+                    f'    echo \'{{"gemini": {{"api_key": "YOUR_KEY"}}}}\' > {secrets_path}'
+                )
                 print(f"    chmod 600 {secrets_path}")
             print("  Or set the GEMINI_API_KEY environment variable.")
         elif k == "openai":
@@ -702,13 +718,17 @@ def _require_keys_for_families(keys, families, secrets_path):
                 print('    "openai": {"api_key": "YOUR_KEY"}')
             else:
                 print(f"  Create {secrets_path}:")
-                print(f'    echo \'{{"openai": {{"api_key": "YOUR_KEY"}}}}\' > {secrets_path}')
+                print(
+                    f'    echo \'{{"openai": {{"api_key": "YOUR_KEY"}}}}\' > {secrets_path}'
+                )
                 print(f"    chmod 600 {secrets_path}")
             print("  Or set the OPENAI_API_KEY environment variable.")
     sys.exit(1)
 
 
-def _load_context(outline_path, require_model=True, vault_path=None, compare_mode=False):
+def _load_context(
+    outline_path, require_model=True, vault_path=None, compare_mode=False
+):
     """Common preamble: load API keys, parse outline, compute paths.
 
     Determines which vendor families need keys based on:
@@ -748,6 +768,7 @@ def _load_context(outline_path, require_model=True, vault_path=None, compare_mod
 
 
 # --- Gemini API ---
+
 
 def _call_gemini(parts, model, api_key):
     """Send parts to the Gemini generateContent API and extract the image.
@@ -841,6 +862,7 @@ def _call_imagen(prompt, model, api_key, aspect_ratio=IMAGEN_DEFAULT_ASPECT):
 
 
 # --- Masked / composited edits (build static-background stability, #90) ---
+
 
 def _require_pil():
     """Import Pillow lazily, exiting with an actionable message if it's absent.
@@ -938,6 +960,7 @@ def composite_region(prior_path, new_bytes, region):
 
 # --- OpenAI API ---
 
+
 def _multipart_body(fields, files):
     """Build a multipart/form-data body. Returns (bytes, boundary)."""
     boundary = "----GenIllustBnd" + uuid.uuid4().hex
@@ -950,8 +973,7 @@ def _multipart_body(fields, files):
     for name, filename, mime, content in files:
         body += f"--{boundary}\r\n".encode()
         body += (
-            f'Content-Disposition: form-data; name="{name}"; '
-            f'filename="{filename}"\r\n'
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
         ).encode()
         body += f"Content-Type: {mime}\r\n\r\n".encode()
         body += content
@@ -974,7 +996,10 @@ def _extract_openai_image(body):
                 return r.read(), "image/png"
         except (urllib.error.URLError, TimeoutError, OSError) as e:
             return None, f"Failed to fetch image URL: {e}"
-    return None, f"OpenAI response has neither b64_json nor url: {json.dumps(first)[:500]}"
+    return (
+        None,
+        f"OpenAI response has neither b64_json nor url: {json.dumps(first)[:500]}",
+    )
 
 
 def _call_openai_generate(prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
@@ -1014,8 +1039,9 @@ def _call_openai_generate(prompt, model, api_key, size=OPENAI_DEFAULT_SIZE):
     return _extract_openai_image(body)
 
 
-def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SIZE,
-                      mask_png=None):
+def _call_openai_edit(
+    input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SIZE, mask_png=None
+):
     """Call OpenAI /images/edits to edit an existing image.
 
     When `mask_png` is given (a PNG matching the image dimensions), only its
@@ -1034,8 +1060,13 @@ def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SI
     body, boundary = _multipart_body(
         # gpt-image-* returns base64 by default; do not send
         # `response_format` (legacy DALL-E knob; gpt-image-* 400s on it).
-        fields={"model": model, "prompt": prompt, "size": size,
-                "quality": "high", "n": "1"},
+        fields={
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "quality": "high",
+            "n": "1",
+        },
         files=files,
     )
     url = f"{OPENAI_API_BASE}/images/edits"
@@ -1059,6 +1090,7 @@ def _call_openai_edit(input_path, prompt, model, api_key, size=OPENAI_DEFAULT_SI
 
 
 # --- Vendor-Agnostic Dispatchers ---
+
 
 def generate_image(prompt, model, keys, slide_format=None):
     """Generate a fresh image via the appropriate vendor endpoint.
@@ -1088,8 +1120,9 @@ def generate_image(prompt, model, keys, slide_format=None):
     return _call_gemini([{"text": prompt}], model, keys["gemini"])
 
 
-def edit_image(input_path, edit_prompt, model, keys, slide_format=None,
-               erase_region=None):
+def edit_image(
+    input_path, edit_prompt, model, keys, slide_format=None, erase_region=None
+):
     """Edit an existing image via the appropriate vendor endpoint.
 
     Auto-appends vendor-agnostic safety suffixes to the prompt to prevent
@@ -1130,10 +1163,16 @@ def edit_image(input_path, edit_prompt, model, keys, slide_format=None,
     if family == "openai":
         # A mask lets the model edit in-place with surrounding context; the
         # composite below then guarantees the kept region byte-for-byte.
-        mask_png = build_edit_mask_png(input_path, erase_region) if erase_region else None
+        mask_png = (
+            build_edit_mask_png(input_path, erase_region) if erase_region else None
+        )
         image_bytes, result = _call_openai_edit(
-            input_path, edit_prompt, model, keys["openai"],
-            size=sizing["openai_size"], mask_png=mask_png,
+            input_path,
+            edit_prompt,
+            model,
+            keys["openai"],
+            size=sizing["openai_size"],
+            mask_png=mask_png,
         )
     else:
         # Gemini path: send image as base64 inline data on generateContent.
@@ -1163,9 +1202,7 @@ RENDERED_MANIFEST = "rendered.json"
 
 def style_explore_dir(outline_path):
     """The style-explore/ directory alongside the outline."""
-    return os.path.join(
-        os.path.dirname(os.path.abspath(outline_path)), "style-explore"
-    )
+    return os.path.join(os.path.dirname(os.path.abspath(outline_path)), "style-explore")
 
 
 def write_rendered_manifest(base_dir, outline_path, results):
@@ -1378,6 +1415,7 @@ def enforce_render_gate(outline_path):
 
 # --- Main Commands ---
 
+
 def run_generate(outline_path, slide_args, versioned=False):
     """Generate illustrations for selected slides."""
     keys, outline, output_dir = _load_context(outline_path)
@@ -1400,7 +1438,9 @@ def run_generate(outline_path, slide_args, versioned=False):
 
     print(f"Model: {model}")
     print(f"Style anchors: {', '.join(outline['anchors'].keys()) or 'none'}")
-    print(f"Generating {len(to_generate)} illustration(s): slides {', '.join(map(str, to_generate))}")
+    print(
+        f"Generating {len(to_generate)} illustration(s): slides {', '.join(map(str, to_generate))}"
+    )
     if versioned:
         print("Versioned mode: saving as slide-NN-vM.ext (never overwrites)")
     print(f"Output: {output_dir}/")
@@ -1418,7 +1458,8 @@ def run_generate(outline_path, slide_args, versioned=False):
         # prompt-bearing slides; EXCEPTION slides carry no prompt and render as
         # real assets, so they are correctly out of scope here.)
         bad = [
-            s["slide_num"] for s in outline["slides"]
+            s["slide_num"]
+            for s in outline["slides"]
             if s["format"] != "FULL" or s.get("safe_zone")
         ]
         if bad:
@@ -1458,7 +1499,7 @@ def run_generate(outline_path, slide_args, versioned=False):
         # to this slide's scene and keep deck-wide page-furniture from leaking (#87).
         prompt = apply_compose_only_directive(prompt)
 
-        print(f"[{i+1}/{len(to_generate)}] Slide {num}: {slide['title']}")
+        print(f"[{i + 1}/{len(to_generate)}] Slide {num}: {slide['title']}")
 
         image_bytes, result = generate_image(prompt, model, keys, eff_format)
 
@@ -1484,12 +1525,16 @@ def run_generate(outline_path, slide_args, versioned=False):
             time.sleep(RATE_LIMIT_DELAY)
 
     print()
-    print(f"Done: {success} generated, {failed} failed, out of {len(to_generate)} requested.")
+    print(
+        f"Done: {success} generated, {failed} failed, out of {len(to_generate)} requested."
+    )
 
 
 def run_compare(outline_path, slide_num):
     """Generate the same prompt across multiple models for comparison."""
-    keys, outline, _ = _load_context(outline_path, require_model=False, compare_mode=True)
+    keys, outline, _ = _load_context(
+        outline_path, require_model=False, compare_mode=True
+    )
 
     slides_by_num = {s["slide_num"]: s for s in outline["slides"]}
     if slide_num not in slides_by_num:
@@ -1526,7 +1571,7 @@ def run_compare(outline_path, slide_num):
     results = []
 
     for i, model in enumerate(models):
-        print(f"[{i+1}/{len(models)}] {model}...", end=" ", flush=True)
+        print(f"[{i + 1}/{len(models)}] {model}...", end=" ", flush=True)
 
         image_bytes, result = generate_image(prompt, model, keys, eff_format)
 
@@ -1562,6 +1607,7 @@ def run_compare(outline_path, slide_num):
 
 
 # --- Style Exploration (Phase 2 strategy: style x model x format grid) ---
+
 
 def style_slug(name):
     """Filesystem-safe kebab-case slug for a style name."""
@@ -1612,14 +1658,19 @@ def parse_candidates(path):
         raise ValueError(f"{path}: 'models' must be a non-empty list of model ids.")
     for i, m in enumerate(models):
         if not isinstance(m, str) or not m.strip():
-            raise ValueError(f"{path}: models[{i}] must be a non-empty string model id.")
+            raise ValueError(
+                f"{path}: models[{i}] must be a non-empty string model id."
+            )
     data["models"] = [m.strip() for m in models]
     styles = data.get("styles")
     if not isinstance(styles, list) or not styles:
         raise ValueError(f"{path}: 'styles' must be a non-empty list of style entries.")
     for i, style in enumerate(styles):
-        if not isinstance(style, dict) or not isinstance(style.get("name"), str) \
-                or not style["name"].strip():
+        if (
+            not isinstance(style, dict)
+            or not isinstance(style.get("name"), str)
+            or not style["name"].strip()
+        ):
             raise ValueError(f"{path}: styles[{i}] needs a non-empty string 'name'.")
         anchors = style.get("anchors")
         if not isinstance(anchors, dict) or not anchors:
@@ -1808,10 +1859,15 @@ def run_style_explore(outline_path, candidates_path):
         image_bytes, result = generate_image(prompt, model, keys, eff_format)
         if image_bytes is None:
             print(f"FAILED: {result[:80]}")
-            results.append({
-                "style": style_name, "format": fmt, "model": model,
-                "status": "FAIL", "error": result[:200],
-            })
+            results.append(
+                {
+                    "style": style_name,
+                    "format": fmt,
+                    "model": model,
+                    "status": "FAIL",
+                    "error": result[:200],
+                }
+            )
         else:
             ext = mime_to_ext(result)
             dest = explore_dest(base_dir, style_name, fmt, model, ext)
@@ -1819,10 +1875,15 @@ def run_style_explore(outline_path, candidates_path):
             with open(dest, "wb") as fh:
                 fh.write(image_bytes)
             print(f"OK ({len(image_bytes) / 1024:.0f} KB)")
-            results.append({
-                "style": style_name, "format": fmt, "model": model,
-                "status": "OK", "rel_path": os.path.relpath(dest, base_dir),
-            })
+            results.append(
+                {
+                    "style": style_name,
+                    "format": fmt,
+                    "model": model,
+                    "status": "OK",
+                    "rel_path": os.path.relpath(dest, base_dir),
+                }
+            )
         if i < total:
             time.sleep(RATE_LIMIT_DELAY)
 
@@ -1835,7 +1896,9 @@ def run_style_explore(outline_path, candidates_path):
     print()
     print(f"Wrote {index_path}")
     print(f"Wrote {manifest_path}")
-    print("Review the grid, pick a style + model, then bake them into outline.yaml's style_anchor.")
+    print(
+        "Review the grid, pick a style + model, then bake them into outline.yaml's style_anchor."
+    )
 
 
 def run_edit(outline_path, slide_num, edit_prompt):
@@ -1852,7 +1915,8 @@ def run_edit(outline_path, slide_num, edit_prompt):
     slide = next((s for s in outline["slides"] if s["slide_num"] == slide_num), None)
     eff_format = (
         effective_slide_format(slide["format"], slide.get("safe_zone"))
-        if slide else None
+        if slide
+        else None
     )
 
     print(f"Model: {model}")
@@ -1875,7 +1939,9 @@ def run_edit(outline_path, slide_num, edit_prompt):
         f.write(image_bytes)
     size_kb = len(image_bytes) / 1024
     print(f"OK: {filename} ({size_kb:.0f} KB)")
-    print(f"Review and compare with the original. If good, replace slide-{slide_num:02d}.")
+    print(
+        f"Review and compare with the original. If good, replace slide-{slide_num:02d}."
+    )
 
 
 def run_build(outline_path, slide_arg):
@@ -1950,16 +2016,26 @@ def run_build(outline_path, slide_arg):
         missing_keep = steps_missing_keep_clause(edit_steps)
         if missing_keep:
             build_failed = True
-            print(f"  ERROR: {len(missing_keep)} build step(s) lack an explicit "
-                  '"Keep ..." preservation list:', file=sys.stderr)
+            print(
+                f"  ERROR: {len(missing_keep)} build step(s) lack an explicit "
+                '"Keep ..." preservation list:',
+                file=sys.stderr,
+            )
             for s in missing_keep:
-                print(f"    build-{s['step']:02d}: {s['description'][:70]}",
-                      file=sys.stderr)
-            print("  Phrase each step as an erase instruction naming every element "
-                  "that must persist", file=sys.stderr)
-            print('  ("Erase X. Keep the Y. Keep the Z.") — see '
-                  "rules/illustration-rules.md component #3. Skipping slide.",
-                  file=sys.stderr)
+                print(
+                    f"    build-{s['step']:02d}: {s['description'][:70]}",
+                    file=sys.stderr,
+                )
+            print(
+                "  Phrase each step as an erase instruction naming every element "
+                "that must persist",
+                file=sys.stderr,
+            )
+            print(
+                '  ("Erase X. Keep the Y. Keep the Z.") — see '
+                "rules/illustration-rules.md component #3. Skipping slide.",
+                file=sys.stderr,
+            )
             continue
 
         # Copy full image as the final build step. The dest path preserves
@@ -1989,7 +2065,10 @@ def run_build(outline_path, slide_arg):
             # down the chain (#90). Without a region, the whole frame is
             # regenerated (historical behavior; may drift).
             image_bytes, result = edit_image(
-                prev_image, desc, model, keys,
+                prev_image,
+                desc,
+                model,
+                keys,
                 effective_slide_format(slide["format"], slide.get("safe_zone")),
                 erase_region=region,
             )
@@ -1997,10 +2076,14 @@ def run_build(outline_path, slide_arg):
             if image_bytes is None:
                 build_failed = True
                 print("FAILED")  # complete the stdout progress line opened above
-                print(f"  slide {num} build-{step_num:02d} edit failed: {result[:100]}",
-                      file=sys.stderr)
-                print(f"  Aborting remaining build steps for slide {num} (chain broken)",
-                      file=sys.stderr)
+                print(
+                    f"  slide {num} build-{step_num:02d} edit failed: {result[:100]}",
+                    file=sys.stderr,
+                )
+                print(
+                    f"  Aborting remaining build steps for slide {num} (chain broken)",
+                    file=sys.stderr,
+                )
                 break
 
             ext = mime_to_ext(result)
@@ -2024,8 +2107,10 @@ def run_build(outline_path, slide_arg):
     # policy: non-zero exit on failure). Exit before the success line so a failed
     # run never prints a success-sounding "Done".
     if build_failed:
-        print("ERROR: one or more slides did not produce a complete build chain.",
-              file=sys.stderr)
+        print(
+            "ERROR: one or more slides did not produce a complete build chain.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     print("Done. Review build images in:", builds_dir)
@@ -2044,7 +2129,8 @@ def run_fix(outline_path, slide_num, fix_prompt):
     slide = next((s for s in outline["slides"] if s["slide_num"] == slide_num), None)
     eff_format = (
         effective_slide_format(slide["format"], slide.get("safe_zone"))
-        if slide else None
+        if slide
+        else None
     )
 
     ver = next_version(output_dir, slide_num)
@@ -2070,24 +2156,27 @@ def run_fix(outline_path, slide_num, fix_prompt):
 
 # --- CLI ---
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate illustrations for a presentation outline.",
         epilog="Examples:\n"
-               "  %(prog)s outline.yaml all\n"
-               "  %(prog)s outline.yaml remaining\n"
-               "  %(prog)s outline.yaml 2 5 9\n"
-               "  %(prog)s outline.yaml 2-10\n"
-               "  %(prog)s outline.yaml --compare 2\n"
-               "  %(prog)s outline.yaml --style-explore style-explore/candidates.json\n"
-               "  %(prog)s outline.yaml --edit 5 \"Erase the label\"\n"
-               "  %(prog)s outline.yaml --build 5\n"
-               "  %(prog)s outline.yaml --build all\n"
-               "  %(prog)s outline.yaml --fix 5 \"Make the road wider\"\n"
-               "  %(prog)s outline.yaml -v 2 5 9\n",
+        "  %(prog)s outline.yaml all\n"
+        "  %(prog)s outline.yaml remaining\n"
+        "  %(prog)s outline.yaml 2 5 9\n"
+        "  %(prog)s outline.yaml 2-10\n"
+        "  %(prog)s outline.yaml --compare 2\n"
+        "  %(prog)s outline.yaml --style-explore style-explore/candidates.json\n"
+        '  %(prog)s outline.yaml --edit 5 "Erase the label"\n'
+        "  %(prog)s outline.yaml --build 5\n"
+        "  %(prog)s outline.yaml --build all\n"
+        '  %(prog)s outline.yaml --fix 5 "Make the road wider"\n'
+        "  %(prog)s outline.yaml -v 2 5 9\n",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("outline", help="Path to outline.yaml (the single source of truth)")
+    parser.add_argument(
+        "outline", help="Path to outline.yaml (the single source of truth)"
+    )
     parser.add_argument(
         "--vault",
         default=None,
@@ -2103,19 +2192,19 @@ def main():
         "--style-explore",
         metavar="CANDIDATES_JSON",
         help="Render a style x model x format grid from a candidates.json "
-             "(Phase 2 strategy); writes style-explore/ + index.md + rendered.json",
+        "(Phase 2 strategy); writes style-explore/ + index.md + rendered.json",
     )
     parser.add_argument(
         "--check-style-explore",
         action="store_true",
         help="Render-before-bake gate: verify the outline's baked model was "
-             "rendered in style-explore/; emits verdict JSON, exits non-zero on fail",
+        "rendered in style-explore/; emits verdict JSON, exits non-zero on fail",
     )
     parser.add_argument(
         "--edit",
         nargs=2,
         metavar=("SLIDE", "PROMPT"),
-        help="Edit an existing slide image (e.g., --edit 5 \"Erase the label\")",
+        help='Edit an existing slide image (e.g., --edit 5 "Erase the label")',
     )
     parser.add_argument(
         "--build",
@@ -2126,10 +2215,11 @@ def main():
         "--fix",
         nargs=2,
         metavar=("SLIDE", "PROMPT"),
-        help="Targeted fix pass on a slide (e.g., --fix 5 \"Make the road wider\")",
+        help='Targeted fix pass on a slide (e.g., --fix 5 "Make the road wider")',
     )
     parser.add_argument(
-        "-v", "--version",
+        "-v",
+        "--version",
         action="store_true",
         help="Save as slide-NN-vM.ext instead of overwriting (for generate mode)",
     )

--- a/skills/illustrations/scripts/generate-thumbnail.py
+++ b/skills/illustrations/scripts/generate-thumbnail.py
@@ -103,6 +103,7 @@ EXPRESSION_DEFAULT = (
 
 # --- API Key Loading ---
 
+
 def load_api_key(vault_path=None):
     """Load Gemini API key from secrets.json or environment.
 
@@ -136,6 +137,7 @@ def load_api_key(vault_path=None):
 
 
 # --- Image Utilities ---
+
 
 def load_image_as_base64(path):
     """Load an image file and return (base64_data, mime_type).
@@ -346,9 +348,15 @@ VALID_AESTHETICS = (AESTHETIC_PHOTO, AESTHETIC_COMIC_BOOK)
 VALID_SOFTNESS = ("default", "softer", "softest")
 
 
-def build_thumbnail_prompt(title, style="slide_dominant", title_position="top",
-                           subtitle=None, brand_colors=None, softness="default",
-                           aesthetic=AESTHETIC_PHOTO):
+def build_thumbnail_prompt(
+    title,
+    style="slide_dominant",
+    title_position="top",
+    subtitle=None,
+    brand_colors=None,
+    softness="default",
+    aesthetic=AESTHETIC_PHOTO,
+):
     """Build the Gemini prompt for thumbnail generation.
 
     aesthetic:
@@ -370,8 +378,9 @@ def build_thumbnail_prompt(title, style="slide_dominant", title_position="top",
         )
 
     style_desc = STYLE_VARIANTS.get(style, STYLE_VARIANTS["slide_dominant"])
-    position_desc = TITLE_POSITION_GUIDANCE.get(title_position,
-                                                 TITLE_POSITION_GUIDANCE["top"])
+    position_desc = TITLE_POSITION_GUIDANCE.get(
+        title_position, TITLE_POSITION_GUIDANCE["top"]
+    )
 
     subtitle_line = ""
     if subtitle:
@@ -397,8 +406,9 @@ def build_thumbnail_prompt(title, style="slide_dominant", title_position="top",
     )
 
 
-def _build_photo_prompt(title, style_desc, position_desc, subtitle_line,
-                        brand_guidance, softness):
+def _build_photo_prompt(
+    title, style_desc, position_desc, subtitle_line, brand_guidance, softness
+):
     """Photographic composite: face natural, slide as background, viral typography."""
     base = f"""Combine the two provided images into a single 16:9 graphic, \
 1280x720 pixels.
@@ -435,8 +445,9 @@ the portrait adds human presence, the title carries the message."""
     return base + typography_styling + composition_energy + brand_guidance
 
 
-def _build_comic_book_prompt(title, style_desc, position_desc, subtitle_line,
-                             brand_guidance, softness):
+def _build_comic_book_prompt(
+    title, style_desc, position_desc, subtitle_line, brand_guidance, softness
+):
     """Comic-book illustration: caricatured speaker, halftone-shaded scene."""
     base = f"""Render a single 16:9 comic-book illustration, 1280x720 pixels, \
 combining the two provided images.
@@ -483,6 +494,7 @@ readable at thumbnail size: one idea, not cluttered."""
 
 # --- Slide Extraction ---
 
+
 def extract_slide_from_pptx(pptx_path, slide_num, output_path=None):
     """Extract a slide image from a PPTX deck.
 
@@ -499,13 +511,24 @@ def extract_slide_from_pptx(pptx_path, slide_num, output_path=None):
 
     # Try LibreOffice headless
     try:
-        tmpdir = os.path.join(os.path.dirname(os.path.abspath(pptx_path)), "_lo_export_tmp")
+        tmpdir = os.path.join(
+            os.path.dirname(os.path.abspath(pptx_path)), "_lo_export_tmp"
+        )
         os.makedirs(tmpdir, exist_ok=True)
 
         result = subprocess.run(
-            ["libreoffice", "--headless", "--convert-to", "png",
-             "--outdir", tmpdir, os.path.abspath(pptx_path)],
-            capture_output=True, text=True, timeout=120,
+            [
+                "libreoffice",
+                "--headless",
+                "--convert-to",
+                "png",
+                "--outdir",
+                tmpdir,
+                os.path.abspath(pptx_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
 
         if result.returncode == 0:
@@ -513,22 +536,28 @@ def extract_slide_from_pptx(pptx_path, slide_num, output_path=None):
             basename = os.path.splitext(os.path.basename(pptx_path))[0]
             # LibreOffice names them basename.png for single-page or
             # basename-N.png for multi-page (varies by version)
-            candidates = sorted([
-                f for f in os.listdir(tmpdir)
-                if f.startswith(basename) and f.endswith(".png")
-            ])
+            candidates = sorted(
+                [
+                    f
+                    for f in os.listdir(tmpdir)
+                    if f.startswith(basename) and f.endswith(".png")
+                ]
+            )
             if slide_num <= len(candidates):
                 src = os.path.join(tmpdir, candidates[slide_num - 1])
                 import shutil
+
                 shutil.move(src, output_path)
                 # Clean up
                 import shutil as _shutil
+
                 _shutil.rmtree(tmpdir, ignore_errors=True)
                 print(f"Extracted slide {slide_num} via LibreOffice: {output_path}")
                 return output_path
 
         # Clean up on failure
         import shutil
+
         shutil.rmtree(tmpdir, ignore_errors=True)
 
     except FileNotFoundError:
@@ -552,10 +581,14 @@ def extract_slide_from_pptx(pptx_path, slide_num, output_path=None):
             """
             result = subprocess.run(
                 ["osascript", "-e", script],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if result.returncode == 0 and os.path.isfile(output_path):
-                print(f"Extracted slide {slide_num} via PowerPoint AppleScript: {output_path}")
+                print(
+                    f"Extracted slide {slide_num} via PowerPoint AppleScript: {output_path}"
+                )
                 return output_path
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
@@ -568,6 +601,7 @@ def extract_slide_from_pptx(pptx_path, slide_num, output_path=None):
 
 
 # --- Compose Mode ---
+
 
 def compose_thumbnail(args):
     """Generate a thumbnail by composing slide image + speaker photo via Gemini."""
@@ -589,9 +623,9 @@ def compose_thumbnail(args):
     print(f"Model: {model}")
     print(f"Aesthetic: {args.aesthetic}")
     print(f"Style: {args.style}")
-    print(f"Title: \"{args.title}\"")
+    print(f'Title: "{args.title}"')
     if args.subtitle:
-        print(f"Subtitle: \"{args.subtitle}\"")
+        print(f'Subtitle: "{args.subtitle}"')
 
     # Pre-stylize portrait to match the deck's illustration anchor when set.
     # This makes the composition step's input photo already palette-matched
@@ -601,11 +635,17 @@ def compose_thumbnail(args):
         # Normalize whitespace for the preview log — anchors copied from
         # markdown blocks can carry newlines that break log readability.
         anchor_preview = " ".join(args.portrait_style.split())
-        print(f"Pre-stylizing portrait to anchor: {anchor_preview[:80]}"
-              f"{'...' if len(anchor_preview) > 80 else ''}")
+        print(
+            f"Pre-stylizing portrait to anchor: {anchor_preview[:80]}"
+            f"{'...' if len(anchor_preview) > 80 else ''}"
+        )
         try:
             speaker_b64, speaker_mime = stylize_portrait(
-                speaker_b64, speaker_mime, args.portrait_style, model, api_key,
+                speaker_b64,
+                speaker_mime,
+                args.portrait_style,
+                model,
+                api_key,
             )
         except RuntimeError as e:
             print(f"ERROR: {e}", file=sys.stderr)
@@ -649,8 +689,10 @@ def compose_thumbnail(args):
                 file=sys.stderr,
             )
             sys.exit(1)
-        print(f"  '{softness}' attempt rejected by safety filter: {last_error[:200]}",
-              file=sys.stderr)
+        print(
+            f"  '{softness}' attempt rejected by safety filter: {last_error[:200]}",
+            file=sys.stderr,
+        )
 
     if image_bytes is None:
         print(
@@ -690,6 +732,7 @@ def compose_thumbnail(args):
 
 # --- Main ---
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate a YouTube thumbnail for a presentation.",
@@ -702,31 +745,49 @@ def main():
     parser.add_argument("--title", help="Thumbnail title text (3-5 word hook)")
     parser.add_argument("--subtitle", help="Optional subtitle (e.g., conference name)")
     parser.add_argument("--output", "-o", help="Output path (default: thumbnail.png)")
-    parser.add_argument("--vault", help="Path to rhetoric-knowledge-vault (for secrets.json)")
-    parser.add_argument("--style", choices=["slide_dominant", "split_panel", "overlay"],
-                        default="slide_dominant",
-                        help="Thumbnail composition layout (default: slide_dominant)")
-    parser.add_argument("--aesthetic", choices=list(VALID_AESTHETICS),
-                        default=AESTHETIC_PHOTO,
-                        help="Rendering aesthetic (default: photo). 'comic_book' "
-                             "produces a caricatured, halftone-shaded illustration "
-                             "in the speaker's on-brand comic-book style.")
-    parser.add_argument("--portrait-style", default=None,
-                        help="Deck Illustration Style Anchor. When set, the "
-                             "speaker photo is first pre-stylized to match the "
-                             "anchor (e.g., retro tech-manual sepia, watercolor) "
-                             "before composition — fixes palette mismatch on "
-                             "decks with a strong visual style. Pass through from "
-                             "Phase 2's style_anchor block when present.")
-    parser.add_argument("--title-position", choices=["top", "bottom", "overlay"],
-                        default="top",
-                        help="Title text position (default: top)")
+    parser.add_argument(
+        "--vault", help="Path to rhetoric-knowledge-vault (for secrets.json)"
+    )
+    parser.add_argument(
+        "--style",
+        choices=["slide_dominant", "split_panel", "overlay"],
+        default="slide_dominant",
+        help="Thumbnail composition layout (default: slide_dominant)",
+    )
+    parser.add_argument(
+        "--aesthetic",
+        choices=list(VALID_AESTHETICS),
+        default=AESTHETIC_PHOTO,
+        help="Rendering aesthetic (default: photo). 'comic_book' "
+        "produces a caricatured, halftone-shaded illustration "
+        "in the speaker's on-brand comic-book style.",
+    )
+    parser.add_argument(
+        "--portrait-style",
+        default=None,
+        help="Deck Illustration Style Anchor. When set, the "
+        "speaker photo is first pre-stylized to match the "
+        "anchor (e.g., retro tech-manual sepia, watercolor) "
+        "before composition — fixes palette mismatch on "
+        "decks with a strong visual style. Pass through from "
+        "Phase 2's style_anchor block when present.",
+    )
+    parser.add_argument(
+        "--title-position",
+        choices=["top", "bottom", "overlay"],
+        default="top",
+        help="Title text position (default: top)",
+    )
     parser.add_argument("--brand-colors", help="Comma-separated brand hex colors")
     parser.add_argument("--model", help=f"Gemini model (default: {DEFAULT_MODEL})")
 
     # Extract-slide mode
-    parser.add_argument("--extract-slide", nargs=2, metavar=("PPTX", "SLIDE_NUM"),
-                        help="Extract a slide image from a PPTX deck")
+    parser.add_argument(
+        "--extract-slide",
+        nargs=2,
+        metavar=("PPTX", "SLIDE_NUM"),
+        help="Extract a slide image from a PPTX deck",
+    )
 
     args = parser.parse_args()
 

--- a/skills/illustrations/scripts/model_registry.py
+++ b/skills/illustrations/scripts/model_registry.py
@@ -71,7 +71,11 @@ MODEL_REGISTRY = [
         "id": "gemini-3-pro-image",
         "display": "Gemini 3 Pro Image (Nano Banana Pro)",
         "family": "gemini",
-        "aliases": ["gemini-3-pro-image-preview", "nano-banana-pro", "nano-banana-pro-preview"],
+        "aliases": [
+            "gemini-3-pro-image-preview",
+            "nano-banana-pro",
+            "nano-banana-pro-preview",
+        ],
         "cost": "medium",
         "speed": "medium",
         "quality": "high",
@@ -81,7 +85,11 @@ MODEL_REGISTRY = [
         "id": "gemini-3.1-flash-image",
         "display": "Gemini 3.1 Flash Image (Nano Banana)",
         "family": "gemini",
-        "aliases": ["gemini-3.1-flash-image-preview", "nano-banana", "gemini-flash-image"],
+        "aliases": [
+            "gemini-3.1-flash-image-preview",
+            "nano-banana",
+            "gemini-flash-image",
+        ],
         "cost": "low",
         "speed": "fast",
         "quality": "medium",
@@ -252,9 +260,9 @@ def main():
     parser = argparse.ArgumentParser(
         description="Query the image-generation model registry.",
         epilog="Examples:\n"
-               "  %(prog)s --check-freshness\n"
-               "  %(prog)s --shortlist quality,build-editability\n"
-               "  %(prog)s --shortlist cost\n",
+        "  %(prog)s --check-freshness\n"
+        "  %(prog)s --shortlist quality,build-editability\n"
+        "  %(prog)s --shortlist cost\n",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     group = parser.add_mutually_exclusive_group(required=True)
@@ -267,13 +275,13 @@ def main():
         "--shortlist",
         metavar="PRIORITIES",
         help="Comma-separated priorities (cost, speed, quality, "
-             "build-editability); emit ranked candidate JSON, best first",
+        "build-editability); emit ranked candidate JSON, best first",
     )
     parser.add_argument(
         "--add",
         metavar="JSON",
         help="JSON array of extra model entries to rank alongside the cached "
-             "roster (live injection of a web-discovered model); with --shortlist",
+        "roster (live injection of a web-discovered model); with --shortlist",
     )
     args = parser.parse_args()
 
@@ -289,7 +297,9 @@ def main():
             print(f"ERROR: --add is not valid JSON ({exc}).", file=sys.stderr)
             sys.exit(1)
         if not isinstance(extra_models, list):
-            print("ERROR: --add must be a JSON array of model entries.", file=sys.stderr)
+            print(
+                "ERROR: --add must be a JSON array of model entries.", file=sys.stderr
+            )
             sys.exit(1)
 
     priorities = [p.strip() for p in args.shortlist.split(",") if p.strip()]

--- a/skills/illustrations/scripts/suggest-scrim-color.py
+++ b/skills/illustrations/scripts/suggest-scrim-color.py
@@ -15,6 +15,7 @@ Algorithm:
 
 Output: suggested hex color + a recommended alpha (OOXML thousandths).
 """
+
 import argparse
 import sys
 from pathlib import Path
@@ -41,7 +42,7 @@ def sample_dark_pixels(img_paths, percentile=5.0, resize_to=200):
             img = raw.convert("RGB")
         img.thumbnail((resize_to, resize_to), Image.LANCZOS)
         arr = np.asarray(img, dtype=np.float32) / 255.0  # (H, W, 3)
-        lum = arr @ REC709                                # (H, W)
+        lum = arr @ REC709  # (H, W)
         flat_px = arr.reshape(-1, 3)
         flat_lum = lum.reshape(-1)
         cutoff = np.percentile(flat_lum, percentile)
@@ -88,10 +89,18 @@ def recommend_alpha(sample_rgb01):
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("illustrations_dir", type=Path)
-    ap.add_argument("--percentile", type=float, default=5.0,
-                    help="Sample the darkest N%% of pixels (default 5)")
-    ap.add_argument("--target-luminance", type=float, default=0.10,
-                    help="Clamp sample to this Rec. 709 luminance (default 0.10)")
+    ap.add_argument(
+        "--percentile",
+        type=float,
+        default=5.0,
+        help="Sample the darkest N%% of pixels (default 5)",
+    )
+    ap.add_argument(
+        "--target-luminance",
+        type=float,
+        default=0.10,
+        help="Clamp sample to this Rec. 709 luminance (default 0.10)",
+    )
     ap.add_argument("--glob", default="slide-*.jpg")
     args = ap.parse_args()
 
@@ -103,14 +112,18 @@ def main():
     scrim = clamp_to_scrim(raw, target_lum=args.target_luminance)
     alpha = recommend_alpha(raw)
 
-    print(f"Sampled {len(paths)} illustrations, darkest {args.percentile:.0f}% of pixels")
+    print(
+        f"Sampled {len(paths)} illustrations, darkest {args.percentile:.0f}% of pixels"
+    )
     print(f"  raw dark-pixel mean : #{to_hex(raw)} (lum={float(raw @ REC709):.3f})")
     print(f"  scrim base color    : #{to_hex(scrim)} (lum={float(scrim @ REC709):.3f})")
-    print(f"  recommended alpha   : {alpha} / 100000 ({alpha/1000:.1f}% opaque)")
+    print(f"  recommended alpha   : {alpha} / 100000 ({alpha / 1000:.1f}% opaque)")
     print()
     print("OOXML:")
-    print(f'  <a:solidFill><a:srgbClr val="{to_hex(scrim)}">'
-          f'<a:alpha val="{alpha}"/></a:srgbClr></a:solidFill>')
+    print(
+        f'  <a:solidFill><a:srgbClr val="{to_hex(scrim)}">'
+        f'<a:alpha val="{alpha}"/></a:srgbClr></a:solidFill>'
+    )
 
 
 if __name__ == "__main__":

--- a/skills/presentation-creator/scripts/backgrounds-manifest-to-spec.py
+++ b/skills/presentation-creator/scripts/backgrounds-manifest-to-spec.py
@@ -13,6 +13,7 @@ The spec string consumed by the ApplyBackgrounds VBA macro is
 Usage:
     backgrounds-manifest-to-spec.py <manifest.json>   # prints the spec to stdout
 """
+
 import json
 import sys
 from pathlib import Path
@@ -33,7 +34,9 @@ def manifest_to_spec(manifest: object) -> str:
         )
     backgrounds = manifest.get("backgrounds", {})
     if not isinstance(backgrounds, dict):
-        raise ValueError("manifest 'backgrounds' must be an object mapping slide # -> image path")
+        raise ValueError(
+            "manifest 'backgrounds' must be an object mapping slide # -> image path"
+        )
     if not backgrounds:
         raise ValueError(
             "manifest has no 'backgrounds' entries — nothing to apply; skip the "
@@ -50,7 +53,9 @@ def manifest_to_spec(manifest: object) -> str:
     for key in sorted(backgrounds, key=slide_num):
         path = backgrounds[key]
         if not isinstance(path, str):
-            raise ValueError(f"image path for slide {key} must be a string, got {type(path).__name__}")
+            raise ValueError(
+                f"image path for slide {key} must be a string, got {type(path).__name__}"
+            )
         if ";" in path or "=" in path:
             raise ValueError(
                 f"image path for slide {key} contains a reserved spec delimiter "
@@ -68,8 +73,11 @@ def main() -> None:
     try:
         raw = path.read_text()
     except OSError as exc:
-        print(f"ERROR: cannot read manifest {path}: {exc.strerror or exc} — "
-              f"generate it with apply-illustrations-to-deck.py --backgrounds-out", file=sys.stderr)
+        print(
+            f"ERROR: cannot read manifest {path}: {exc.strerror or exc} — "
+            f"generate it with apply-illustrations-to-deck.py --backgrounds-out",
+            file=sys.stderr,
+        )
         sys.exit(1)
     try:
         manifest = json.loads(raw)

--- a/skills/presentation-creator/scripts/build-expansion-to-packed.py
+++ b/skills/presentation-creator/scripts/build-expansion-to-packed.py
@@ -64,7 +64,9 @@ def manifest_to_packed(manifest: object) -> str:
                 raise ValueError(f"build entry 'parent' must be an integer, got {p!r}")
             p = int(p)
         if p < 1:
-            raise ValueError(f"build entry 'parent' must be a positive slide number, got {p}")
+            raise ValueError(
+                f"build entry 'parent' must be a positive slide number, got {p}"
+            )
         return p
 
     records = []
@@ -75,14 +77,20 @@ def manifest_to_packed(manifest: object) -> str:
             raise ValueError(f"build for parent {parent} has no frames")
         notes = b.get("notes", "") or ""
         if not isinstance(notes, str):
-            raise ValueError(f"notes for parent {parent} must be a string, got {type(notes).__name__}")
+            raise ValueError(
+                f"notes for parent {parent} must be a string, got {type(notes).__name__}"
+            )
         for f in frames:
             if not isinstance(f, str):
                 raise ValueError(f"frame for parent {parent} must be a string path")
             if any(c in f for c in (RS, US, GS)):
-                raise ValueError(f"frame path for parent {parent} contains a reserved control char: {f!r}")
+                raise ValueError(
+                    f"frame path for parent {parent} contains a reserved control char: {f!r}"
+                )
         if any(c in notes for c in (RS, US, GS)):
-            raise ValueError(f"notes for parent {parent} contain a reserved control char")
+            raise ValueError(
+                f"notes for parent {parent} contain a reserved control char"
+            )
         records.append(f"{parent}{US}{notes}{US}{GS.join(frames)}")
     return RS.join(records)
 
@@ -90,16 +98,24 @@ def manifest_to_packed(manifest: object) -> str:
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if len(argv) != 2:
-        print("usage: build-expansion-to-packed.py <manifest.json> <packed_out>", file=sys.stderr)
+        print(
+            "usage: build-expansion-to-packed.py <manifest.json> <packed_out>",
+            file=sys.stderr,
+        )
         return 2
     manifest_path, out_path = Path(argv[0]), Path(argv[1])
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except OSError as exc:
-        print(f"ERROR: cannot read manifest {manifest_path}: {exc.strerror or exc}", file=sys.stderr)
+        print(
+            f"ERROR: cannot read manifest {manifest_path}: {exc.strerror or exc}",
+            file=sys.stderr,
+        )
         return 1
     except json.JSONDecodeError as exc:
-        print(f"ERROR: manifest {manifest_path} is not valid JSON: {exc}", file=sys.stderr)
+        print(
+            f"ERROR: manifest {manifest_path} is not valid JSON: {exc}", file=sys.stderr
+        )
         return 1
     try:
         packed = manifest_to_packed(manifest)
@@ -109,8 +125,11 @@ def main(argv=None) -> int:
     try:
         out_path.write_text(packed, encoding="utf-8")
     except OSError as exc:
-        print(f"ERROR: cannot write packed output {out_path}: {exc.strerror or exc} — "
-              "check the path and that its directory is writable", file=sys.stderr)
+        print(
+            f"ERROR: cannot write packed output {out_path}: {exc.strerror or exc} — "
+            "check the path and that its directory is writable",
+            file=sys.stderr,
+        )
         return 1
     return 0
 

--- a/skills/presentation-creator/scripts/check-rhetorical.py
+++ b/skills/presentation-creator/scripts/check-rhetorical.py
@@ -86,9 +86,7 @@ def _check_opening_punch(outline: _os.Outline) -> CheckResult:
             "Audiences grant ~2 min before forming a verdict — the opening "
             "needs at least one PUNCH flavor.",
         )
-    where = "; ".join(
-        f"slide {n}: flavors={flavors}" for n, flavors in flavored
-    )
+    where = "; ".join(f"slide {n}: flavors={flavors}" for n, flavors in flavored)
     return CheckResult("Opening PUNCH", "PASS", where)
 
 
@@ -111,7 +109,7 @@ def _check_big_idea(outline: _os.Outline) -> CheckResult:
         if p.id == "call-to-adventure" and p.big_idea_text:
             big_idea_text = p.big_idea_text
             break
-    detail = f"slide {slide.n}: \"{slide.title}\""
+    detail = f'slide {slide.n}: "{slide.title}"'
     if big_idea_text:
         detail += f" — text: {big_idea_text!r}"
     return CheckResult("Big Idea singleton", "PASS", detail)
@@ -143,8 +141,7 @@ def _check_thesis_ordering(outline: _os.Outline) -> CheckResult:
         return CheckResult(
             "Thesis preview/payoff",
             "FLAG",
-            f"Preview slides {previews} not strictly before payoff "
-            f"slides {payoffs}.",
+            f"Preview slides {previews} not strictly before payoff slides {payoffs}.",
         )
     return CheckResult(
         "Thesis preview/payoff",
@@ -161,11 +158,13 @@ def _check_sparkline_requirements(outline: _os.Outline) -> list[CheckResult]:
     - at least one star-moment
     """
     if outline.talk.architecture != "sparkline":
-        return [CheckResult(
-            "Sparkline elements",
-            "N/A",
-            f"Architecture is `{outline.talk.architecture}`, not sparkline.",
-        )]
+        return [
+            CheckResult(
+                "Sparkline elements",
+                "N/A",
+                f"Architecture is `{outline.talk.architecture}`, not sparkline.",
+            )
+        ]
     counts: dict[str, list[str]] = {
         "call-to-adventure": [],
         "call-to-action": [],
@@ -184,24 +183,30 @@ def _check_sparkline_requirements(outline: _os.Outline) -> list[CheckResult]:
     ]:
         n = len(counts[pid])
         if n < expected_min:
-            out.append(CheckResult(
-                label,
-                "FLAG",
-                f"Sparkline requires ≥{expected_min}, found {n}.",
-            ))
+            out.append(
+                CheckResult(
+                    label,
+                    "FLAG",
+                    f"Sparkline requires ≥{expected_min}, found {n}.",
+                )
+            )
         elif expected_max is not None and n > expected_max:
-            out.append(CheckResult(
-                label,
-                "FLAG",
-                f"Sparkline requires exactly {expected_max}, found {n} at "
-                f"{counts[pid]}.",
-            ))
+            out.append(
+                CheckResult(
+                    label,
+                    "FLAG",
+                    f"Sparkline requires exactly {expected_max}, found {n} at "
+                    f"{counts[pid]}.",
+                )
+            )
         else:
-            out.append(CheckResult(
-                label,
-                "PASS",
-                f"{n} declared at {counts[pid]}",
-            ))
+            out.append(
+                CheckResult(
+                    label,
+                    "PASS",
+                    f"{n} declared at {counts[pid]}",
+                )
+            )
     return out
 
 
@@ -245,64 +250,78 @@ def _check_register_coverage(outline: _os.Outline) -> list[CheckResult]:
     )
 
     if unannotated:
-        return [CheckResult(
-            label,
-            "FLAG",
-            f"`walk-around` declared at {unannotated} with no `registers:` set "
-            f"— name which of {{A, B, C, D}} each claim answers, or the audit "
-            f"cannot be checked.",
-        )]
+        return [
+            CheckResult(
+                label,
+                "FLAG",
+                f"`walk-around` declared at {unannotated} with no `registers:` set "
+                f"— name which of {{A, B, C, D}} each claim answers, or the audit "
+                f"cannot be checked.",
+            )
+        ]
 
     if spread == _os.AudienceSpread.homogeneous:
         dom = outline.talk.dominant_register
         assert dom is not None  # schema validator guarantees this
         if not declared:
-            return [CheckResult(
-                "Register match",
-                "FLAG",
-                f"Room declared homogeneous on register `{dom.value}`, but no "
-                f"claim declares a walk-around answering it. Matching a room "
-                f"is a claim about the talk, not just about the audience — "
-                f"answer `{dom.value}` on the load-bearing claims, or "
-                f"re-declare the spread as heterogeneous.",
-            )]
+            return [
+                CheckResult(
+                    "Register match",
+                    "FLAG",
+                    f"Room declared homogeneous on register `{dom.value}`, but no "
+                    f"claim declares a walk-around answering it. Matching a room "
+                    f"is a claim about the talk, not just about the audience — "
+                    f"answer `{dom.value}` on the load-bearing claims, or "
+                    f"re-declare the spread as heterogeneous.",
+                )
+            ]
         if dom.value not in declared:
-            return [CheckResult(
+            return [
+                CheckResult(
+                    "Register match",
+                    "FLAG",
+                    f"Room declared homogeneous on register `{dom.value}`, but no "
+                    f"walk-around answers it (declared: "
+                    f"{sorted(declared)}). Match the room or re-declare the spread.",
+                )
+            ]
+        return [
+            CheckResult(
                 "Register match",
-                "FLAG",
-                f"Room declared homogeneous on register `{dom.value}`, but no "
-                f"walk-around answers it (declared: "
-                f"{sorted(declared)}). Match the room or re-declare the spread.",
-            )]
-        return [CheckResult(
-            "Register match",
-            "PASS",
-            f"Homogeneous room matched on `{dom.value}` at {declared[dom.value]}",
-        )]
+                "PASS",
+                f"Homogeneous room matched on `{dom.value}` at {declared[dom.value]}",
+            )
+        ]
 
     missing = [r.value for r in _os.Register if r.value not in declared]
     if not declared:
-        return [CheckResult(
-            "Register coverage",
-            "FLAG",
-            "Room declared heterogeneous, but no claim declares a walk-around. "
-            "A mixed room contains all four questions — audit the load-bearing "
-            "claims, or re-declare the spread as homogeneous.",
-        )]
+        return [
+            CheckResult(
+                "Register coverage",
+                "FLAG",
+                "Room declared heterogeneous, but no claim declares a walk-around. "
+                "A mixed room contains all four questions — audit the load-bearing "
+                "claims, or re-declare the spread as homogeneous.",
+            )
+        ]
     if missing:
-        return [CheckResult(
-            "Register coverage",
-            "FLAG",
-            f"Room declared heterogeneous; registers {missing} unanswered "
-            f"(covered: {sorted(declared)}). Every register left unanswered is "
-            f"a slice of the room whose question the talk never reaches.",
-        )]
+        return [
+            CheckResult(
+                "Register coverage",
+                "FLAG",
+                f"Room declared heterogeneous; registers {missing} unanswered "
+                f"(covered: {sorted(declared)}). Every register left unanswered is "
+                f"a slice of the room whose question the talk never reaches.",
+            )
+        ]
     by_register = dict(sorted(declared.items()))
-    return [CheckResult(
-        "Register coverage",
-        "PASS",
-        f"All four registers answered: {by_register}",
-    )]
+    return [
+        CheckResult(
+            "Register coverage",
+            "PASS",
+            f"All four registers answered: {by_register}",
+        )
+    ]
 
 
 def _check_master_story_threading(outline: _os.Outline) -> CheckResult:
@@ -436,8 +455,7 @@ def _check_running_gags(outline: _os.Outline) -> CheckResult:
         summary.append(f"`{gid}` appearances {idxs}")
         if len(idxs) < 2:
             problems.append(
-                f"`{gid}` only has {len(idxs)} appearance "
-                f"— gags need ≥2 escalations",
+                f"`{gid}` only has {len(idxs)} appearance — gags need ≥2 escalations",
             )
         if idxs != list(range(1, len(idxs) + 1)):
             problems.append(f"`{gid}` indexes not contiguous from 1: {idxs}")
@@ -491,8 +509,7 @@ def _check_callback_ledger(outline: _os.Outline) -> CheckResult:
             "No callbacks declared.",
         )
     summary = " | ".join(
-        f"`{cid}`: plant {e['plant']} → pay {e['pay']}"
-        for cid, e in chains.items()
+        f"`{cid}`: plant {e['plant']} → pay {e['pay']}" for cid, e in chains.items()
     )
     return CheckResult("Callback chains", "PASS", summary)
 

--- a/skills/presentation-creator/scripts/export-pdf.py
+++ b/skills/presentation-creator/scripts/export-pdf.py
@@ -30,8 +30,7 @@ tell application "Microsoft PowerPoint"
 end tell
 '''
     result = subprocess.run(
-        ['osascript', '-e', script],
-        capture_output=True, text=True, timeout=30
+        ["osascript", "-e", script], capture_output=True, text=True, timeout=30
     )
     return result.returncode == 0
 
@@ -40,13 +39,24 @@ def try_libreoffice(pptx_path, pdf_path):
     """Export via LibreOffice CLI."""
     output_dir = os.path.dirname(pdf_path) or "."
     result = subprocess.run(
-        ['libreoffice', '--headless', '--convert-to', 'pdf',
-         '--outdir', output_dir, pptx_path],
-        capture_output=True, text=True, timeout=60
+        [
+            "libreoffice",
+            "--headless",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            output_dir,
+            pptx_path,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
     )
     if result.returncode == 0:
         # LibreOffice names output after the input file
-        lo_output = os.path.join(output_dir, os.path.splitext(os.path.basename(pptx_path))[0] + ".pdf")
+        lo_output = os.path.join(
+            output_dir, os.path.splitext(os.path.basename(pptx_path))[0] + ".pdf"
+        )
         if lo_output != pdf_path and os.path.exists(lo_output):
             shutil.move(lo_output, pdf_path)
     return result.returncode == 0
@@ -75,7 +85,10 @@ def main():
             print(f"Exported via LibreOffice: {pdf_path}")
             sys.exit(0)
 
-    print("ERROR: Neither PowerPoint nor LibreOffice available for PDF export", file=sys.stderr)
+    print(
+        "ERROR: Neither PowerPoint nor LibreOffice available for PDF export",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 

--- a/skills/presentation-creator/scripts/extract-narrative.py
+++ b/skills/presentation-creator/scripts/extract-narrative.py
@@ -82,7 +82,8 @@ def _slide_synopsis(slide: "_os.Slide") -> str:
 
 
 def _render_slide_walk(
-    outline: "_os.Outline | _os.PartialOutline", lines: list[str],
+    outline: "_os.Outline | _os.PartialOutline",
+    lines: list[str],
 ) -> None:
     """Full view: one line per slide, grouped by chapter, interludes inlined."""
     lines.append("## The Deck, Slide by Slide")
@@ -127,7 +128,8 @@ def _render_slide_walk(
 
 
 def _render_narrative_scaffold(
-    outline: "_os.Outline | _os.PartialOutline", lines: list[str],
+    outline: "_os.Outline | _os.PartialOutline",
+    lines: list[str],
 ) -> None:
     """Partial view (no slides yet): the Phase 2 chapter + argument-beat arc."""
     lines.append("## The Talk as a Narrative")

--- a/skills/presentation-creator/scripts/extract-resources.py
+++ b/skills/presentation-creator/scripts/extract-resources.py
@@ -108,19 +108,25 @@ def extract_urls(parsed_lines):
             url = match.group(0).rstrip(".,;:!?)")
             if url in seen:
                 for r in resources:
-                    if (r["value"] == url and slide_num
-                            and slide_num is not None and slide_num not in r["slide_nums"]):
+                    if (
+                        r["value"] == url
+                        and slide_num
+                        and slide_num is not None
+                        and slide_num not in r["slide_nums"]
+                    ):
                         r["slide_nums"].append(slide_num)
                         r["context"] = _merge_context(r["context"], section, slide_num)
                 continue
             seen.add(url)
-            resources.append({
-                "type": "url",
-                "value": url,
-                "context": _slide_context(section, slide_num),
-                "slide_nums": [slide_num] if slide_num is not None else [],
-                "approved": False,
-            })
+            resources.append(
+                {
+                    "type": "url",
+                    "value": url,
+                    "context": _slide_context(section, slide_num),
+                    "slide_nums": [slide_num] if slide_num is not None else [],
+                    "approved": False,
+                }
+            )
     return resources
 
 
@@ -138,28 +144,33 @@ def extract_repos(parsed_lines):
             key = repo.lower()
             if key in seen:
                 for r in resources:
-                    if (r["value"].lower().endswith("/" + key.split("/")[-1])
-                            and slide_num is not None and slide_num not in r["slide_nums"]):
+                    if (
+                        r["value"].lower().endswith("/" + key.split("/")[-1])
+                        and slide_num is not None
+                        and slide_num not in r["slide_nums"]
+                    ):
                         r["slide_nums"].append(slide_num)
                 continue
             seen.add(key)
             host = "github.com" if "github" in line else "gitlab.com"
-            resources.append({
-                "type": "repo",
-                "value": f"{host}/{repo}",
-                "context": _slide_context(section, slide_num),
-                "slide_nums": [slide_num] if slide_num is not None else [],
-                "url": f"https://{host}/{repo}",
-                "approved": False,
-            })
+            resources.append(
+                {
+                    "type": "repo",
+                    "value": f"{host}/{repo}",
+                    "context": _slide_context(section, slide_num),
+                    "slide_nums": [slide_num] if slide_num is not None else [],
+                    "url": f"https://{host}/{repo}",
+                    "approved": False,
+                }
+            )
     return resources
 
 
 def extract_books(parsed_lines):
     book_patterns = [
         re.compile(r'"([^"]{5,}?)"\s+by\s+([A-Z][a-zA-Z\s,.]+)', re.IGNORECASE),
-        re.compile(r'\*([^*]{5,}?)\*\s+by\s+([A-Z][a-zA-Z\s,.]+)', re.IGNORECASE),
-        re.compile(r'\*\*([^*]{5,}?)\*\*\s+by\s+([A-Z][a-zA-Z\s,.]+)', re.IGNORECASE),
+        re.compile(r"\*([^*]{5,}?)\*\s+by\s+([A-Z][a-zA-Z\s,.]+)", re.IGNORECASE),
+        re.compile(r"\*\*([^*]{5,}?)\*\*\s+by\s+([A-Z][a-zA-Z\s,.]+)", re.IGNORECASE),
     ]
     resources = []
     seen = set()
@@ -171,13 +182,15 @@ def extract_books(parsed_lines):
                 if key in seen:
                     continue
                 seen.add(key)
-                resources.append({
-                    "type": "book",
-                    "value": title,
-                    "context": _slide_context(section, slide_num),
-                    "slide_nums": [slide_num] if slide_num is not None else [],
-                    "approved": False,
-                })
+                resources.append(
+                    {
+                        "type": "book",
+                        "value": title,
+                        "context": _slide_context(section, slide_num),
+                        "slide_nums": [slide_num] if slide_num is not None else [],
+                        "approved": False,
+                    }
+                )
     return resources
 
 
@@ -190,19 +203,25 @@ def extract_rfcs(parsed_lines):
             rfc_num = match.group(1)
             if rfc_num in seen:
                 for r in resources:
-                    if (r["value"] == f"RFC {rfc_num}" and slide_num
-                            and slide_num is not None and slide_num not in r["slide_nums"]):
+                    if (
+                        r["value"] == f"RFC {rfc_num}"
+                        and slide_num
+                        and slide_num is not None
+                        and slide_num not in r["slide_nums"]
+                    ):
                         r["slide_nums"].append(slide_num)
                 continue
             seen.add(rfc_num)
-            resources.append({
-                "type": "rfc",
-                "value": f"RFC {rfc_num}",
-                "context": _slide_context(section, slide_num),
-                "slide_nums": [slide_num] if slide_num is not None else [],
-                "url": f"https://www.rfc-editor.org/rfc/rfc{rfc_num}",
-                "approved": False,
-            })
+            resources.append(
+                {
+                    "type": "rfc",
+                    "value": f"RFC {rfc_num}",
+                    "context": _slide_context(section, slide_num),
+                    "slide_nums": [slide_num] if slide_num is not None else [],
+                    "url": f"https://www.rfc-editor.org/rfc/rfc{rfc_num}",
+                    "approved": False,
+                }
+            )
     return resources
 
 
@@ -218,27 +237,40 @@ def extract_tools(parsed_lines):
             if len(name) <= 2 or name.startswith("--") or "=" in name:
                 continue
             if name.lower() in (
-                "true", "false", "null", "none", "n/a",
-                "todo", "tbd", "wip", "fixme",
+                "true",
+                "false",
+                "null",
+                "none",
+                "n/a",
+                "todo",
+                "tbd",
+                "wip",
+                "fixme",
             ):
                 continue
             key = name.lower()
             if key in seen:
                 for r in resources:
-                    if (r["value"].lower() == key and slide_num
-                            and slide_num is not None and slide_num not in r["slide_nums"]):
+                    if (
+                        r["value"].lower() == key
+                        and slide_num
+                        and slide_num is not None
+                        and slide_num not in r["slide_nums"]
+                    ):
                         r["slide_nums"].append(slide_num)
                         r["context"] = _merge_context(r["context"], section, slide_num)
                 continue
             seen.add(key)
-            resources.append({
-                "type": "tool",
-                "value": name,
-                "context": _slide_context(section, slide_num),
-                "slide_nums": [slide_num] if slide_num is not None else [],
-                "url": None,
-                "approved": False,
-            })
+            resources.append(
+                {
+                    "type": "tool",
+                    "value": name,
+                    "context": _slide_context(section, slide_num),
+                    "slide_nums": [slide_num] if slide_num is not None else [],
+                    "url": None,
+                    "approved": False,
+                }
+            )
     return resources
 
 
@@ -293,9 +325,11 @@ def format_markdown(data):
         lines.append(f"## {label} ({len(items)})")
         lines.append("")
         for item in items:
-            slides = ", ".join(
-                str(s) for s in item["slide_nums"]
-            ) if item["slide_nums"] else "n/a"
+            slides = (
+                ", ".join(str(s) for s in item["slide_nums"])
+                if item["slide_nums"]
+                else "n/a"
+            )
             url_part = f" — {item['url']}" if item.get("url") else ""
             lines.append(f"- [ ] **{item['value']}**{url_part}")
             lines.append(f"  Slides: {slides} | Context: {item['context']}")
@@ -313,11 +347,14 @@ def main():
     )
     parser.add_argument("outline", help="Path to outline.yaml")
     parser.add_argument(
-        "--output", "-o",
+        "--output",
+        "-o",
         help="Output path (default: resources.json next to outline.yaml)",
     )
     parser.add_argument(
-        "--format", choices=["json", "markdown"], default="json",
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
         help="Output format (default: json)",
     )
     args = parser.parse_args()
@@ -343,15 +380,16 @@ def main():
 
     url_values = {r["value"] for r in resources if r["type"] == "url"}
     resources = [
-        r for r in resources
-        if r["type"] != "repo" or r.get("url") not in url_values
+        r for r in resources if r["type"] != "repo" or r.get("url") not in url_values
     ]
 
     type_order = {"url": 0, "repo": 1, "book": 2, "rfc": 3, "tool": 4}
-    resources.sort(key=lambda r: (
-        type_order.get(r["type"], 99),
-        min(r["slide_nums"]) if r["slide_nums"] else 9999,
-    ))
+    resources.sort(
+        key=lambda r: (
+            type_order.get(r["type"], 99),
+            min(r["slide_nums"]) if r["slide_nums"] else 9999,
+        )
+    )
 
     data = build_output(resources, outline.talk.slug)
 
@@ -362,8 +400,11 @@ def main():
         ext = ".md" if args.format == "markdown" else ".json"
         output_path = os.path.join(outline_dir, f"resources{ext}")
 
-    content = format_markdown(data) if args.format == "markdown" \
+    content = (
+        format_markdown(data)
+        if args.format == "markdown"
         else json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    )
 
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(content)

--- a/skills/presentation-creator/scripts/extract-script.py
+++ b/skills/presentation-creator/scripts/extract-script.py
@@ -118,11 +118,13 @@ def render(outline: _os.Outline) -> str:
         f"{outline.talk.pacing_wpm[1]} WPM",
     )
     lines.append("")
-    lines.append("> Read top to bottom. Bold-bracketed lines are production "
-                 "cues. Italic parentheticals are delivery notes — pause, "
-                 "tone, audience interaction. Bolded ALL-CAPS names are "
-                 "speaker headers; consecutive items under one header are "
-                 "the same speaker.")
+    lines.append(
+        "> Read top to bottom. Bold-bracketed lines are production "
+        "cues. Italic parentheticals are delivery notes — pause, "
+        "tone, audience interaction. Bolded ALL-CAPS names are "
+        "speaker headers; consecutive items under one header are "
+        "the same speaker."
+    )
     lines.append("")
 
     for kind, ev in _ordered_events(outline):

--- a/skills/presentation-creator/scripts/extract-slides.py
+++ b/skills/presentation-creator/scripts/extract-slides.py
@@ -130,9 +130,9 @@ def render(outline: _os.Outline) -> str:
 
         if slide.placeholders:
             lines.append("")
-            lines.append("- **Placeholders:** " + ", ".join(
-                f"`{p}`" for p in slide.placeholders
-            ))
+            lines.append(
+                "- **Placeholders:** " + ", ".join(f"`{p}`" for p in slide.placeholders)
+            )
 
         if slide.applied_patterns:
             lines.append("")

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -81,6 +81,7 @@ from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingIm
     assess_tracking_database,
     require_current_tracking_database,
 )
+
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     TrackingDatabaseIOError,
@@ -92,8 +93,8 @@ from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissin
 
 # --- Constants ---
 
-QR_BOX_SIZE = 10       # pixels per QR module
-QR_BORDER = 4          # quiet-zone modules
+QR_BOX_SIZE = 10  # pixels per QR module
+QR_BORDER = 4  # quiet-zone modules
 QR_ERROR_CORRECTION = ERROR_CORRECT_M
 
 # QR placement: bottom-right, 2 inches wide, 0.3 inch margin from edges
@@ -113,13 +114,14 @@ QR_MARGIN_INCHES = 0.3
 # reconErr 0.0 / minority 0.34; a colored Venn 68 / 0.50; a martinfowler.com
 # screenshot 6.4 / 0.18. The VBA writer can't run PIL, so detection lives here and
 # the resulting geometry is handed to InsertQR.
-QR_DETECT_MIN_INCHES = 1.5      # side floor — excludes small 2-color icons
-QR_SQUARE_TOL_INCHES = 0.1      # |width − height| tolerance
-QR_RECON_ERR_MAX = 5.0          # max mean 2-color reconstruction error
-QR_MIN_MINORITY = 0.25          # min minority-color fraction (QRs are balanced)
+QR_DETECT_MIN_INCHES = 1.5  # side floor — excludes small 2-color icons
+QR_SQUARE_TOL_INCHES = 0.1  # |width − height| tolerance
+QR_RECON_ERR_MAX = 5.0  # max mean 2-color reconstruction error
+QR_MIN_MINORITY = 0.25  # min minority-color fraction (QRs are balanced)
 
 
 # --- Vault / Config Loading ---
+
 
 def load_vault_config(vault_path, profile_path=None):
     """Load speaker profile, secrets, and tracking database from the vault.
@@ -237,12 +239,13 @@ class EffectsReceipt:
 
     def __init__(self, talk_slug):
         self.talk_slug = talk_slug
-        self.short_link = None      # dict, or None when no link work happened
-        self.artifacts = []         # written PNG paths
-        self.deck = None            # deck path, or None if untouched
+        self.short_link = None  # dict, or None when no link work happened
+        self.artifacts = []  # written PNG paths
+        self.deck = None  # deck path, or None if untouched
 
-    def record_short_link(self, provider, link_id, short_url, *, action,
-                          prior_target=None):
+    def record_short_link(
+        self, provider, link_id, short_url, *, action, prior_target=None
+    ):
         """Record link work. ``action`` is created, retargeted, or preresolved.
 
         Rollback differs by action: a link this run created can be deleted, a
@@ -317,31 +320,37 @@ def unfinalized_effects_payload(receipt, message):
             }
         else:
             rollback = {"action": "none", "target": link["short_url"]}
-        effects.append({
-            "kind": "short_link",
-            "action": link["action"],
-            "short_url": link["short_url"],
-            "provider": link["provider"],
-            "link_id": link["link_id"],
-            "prior_target": link["prior_target"],
-            "rollback": rollback,
-        })
-    for path in (receipt.artifacts if receipt else []):
-        effects.append({
-            "kind": "png",
-            "path": path,
-            "rollback": {"action": "delete", "target": path},
-        })
+        effects.append(
+            {
+                "kind": "short_link",
+                "action": link["action"],
+                "short_url": link["short_url"],
+                "provider": link["provider"],
+                "link_id": link["link_id"],
+                "prior_target": link["prior_target"],
+                "rollback": rollback,
+            }
+        )
+    for path in receipt.artifacts if receipt else []:
+        effects.append(
+            {
+                "kind": "png",
+                "path": path,
+                "rollback": {"action": "delete", "target": path},
+            }
+        )
     if receipt and receipt.deck:
-        effects.append({
-            "kind": "deck",
-            "path": receipt.deck,
-            "backup_available": False,
-            "rollback": {
-                "action": "restore_from_version_control",
-                "target": receipt.deck,
-            },
-        })
+        effects.append(
+            {
+                "kind": "deck",
+                "path": receipt.deck,
+                "backup_available": False,
+                "rollback": {
+                    "action": "restore_from_version_control",
+                    "target": receipt.deck,
+                },
+            }
+        )
     return {
         "error": "qr_publication_unfinalized",
         "message": message,
@@ -417,6 +426,7 @@ def commit_qr_record(tdb_path, meta, artifacts, prior_record):
 
 
 # --- URL Shortening ---
+
 
 def _http_request(url, data=None, headers=None, method="GET"):
     """Make an HTTP request using stdlib urllib. Returns parsed JSON or raises."""
@@ -608,16 +618,24 @@ class ShortenerResolutionError(RuntimeError):
 
 def _print_missing_key_help(service, key_name, vault_path):
     """Print actionable help when an API key is missing from secrets.json."""
-    secrets_path = os.path.join(vault_path, "secrets.json") if vault_path else "secrets.json"
+    secrets_path = (
+        os.path.join(vault_path, "secrets.json") if vault_path else "secrets.json"
+    )
     if vault_path and not os.path.isfile(secrets_path):
-        print(f"  WARNING: No {service}.{key_name} found — secrets.json does not exist. Falling back to raw URL.")
+        print(
+            f"  WARNING: No {service}.{key_name} found — secrets.json does not exist. Falling back to raw URL."
+        )
         print("  Create it:")
-        print(f'    echo \'{{\"{service}\": {{\"{key_name}\": \"YOUR_KEY\"}}}}\' > {secrets_path}')
+        print(
+            f'    echo \'{{"{service}": {{"{key_name}": "YOUR_KEY"}}}}\' > {secrets_path}'
+        )
         print(f"    chmod 600 {secrets_path}")
     else:
-        print(f"  WARNING: No {service}.{key_name} in secrets.json, falling back to raw URL.")
+        print(
+            f"  WARNING: No {service}.{key_name} in secrets.json, falling back to raw URL."
+        )
         print(f"  Add to {secrets_path}:")
-        print(f'    \"{service}\": {{\"{key_name}\": \"YOUR_KEY\"}}')
+        print(f'    "{service}": {{"{key_name}": "YOUR_KEY"}}')
 
 
 def _require_domain_decision(config, shortener, vault_path):
@@ -630,17 +648,31 @@ def _require_domain_decision(config, shortener, vault_path):
     if key in config:
         return
     default_domain = "bit.ly" if shortener == "bitly" else "the shortener default"
-    profile = os.path.join(vault_path, "speaker-profile.json") if vault_path else "the speaker profile"
+    profile = (
+        os.path.join(vault_path, "speaker-profile.json")
+        if vault_path
+        else "the speaker profile"
+    )
     print(f"ERROR: No custom-domain decision recorded for shortener '{shortener}'.")
     print("  Before creating the first short link, ask the user whether they have a")
     print("  custom domain (e.g. jbaru.ch), then save the answer under")
     print(f"  publishing_process.qr_code.{key} in {profile}:")
-    print(f'    a domain string (e.g. "jbaru.ch"), or null for no custom domain ({default_domain}).')
+    print(
+        f'    a domain string (e.g. "jbaru.ch"), or null for no custom domain ({default_domain}).'
+    )
     sys.exit(1)
 
 
-def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
-                      dry_run=False, vault_path=None, effects_receipt=None):
+def resolve_short_url(
+    shownotes_url,
+    talk_slug,
+    config,
+    secrets,
+    tracking_db,
+    dry_run=False,
+    vault_path=None,
+    effects_receipt=None,
+):
     """Resolve the short URL for a talk, using cache or API as needed.
 
     Link selection, in order:
@@ -686,8 +718,14 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
     # Enforce slug-only back-half on EXISTING links too: a tracked shortened link
     # whose back-half isn't the slug is legacy — don't reuse it from cache or
     # retarget it in place; drop it so a slug-based link is recreated below.
-    if existing and existing.get("shortener_link_id") and existing.get("short_path") != talk_slug:
-        print(f"  Legacy non-slug back-half '{existing.get('short_path')}' for '{talk_slug}' — recreating with the slug")
+    if (
+        existing
+        and existing.get("shortener_link_id")
+        and existing.get("short_path") != talk_slug
+    ):
+        print(
+            f"  Legacy non-slug back-half '{existing.get('short_path')}' for '{talk_slug}' — recreating with the slug"
+        )
         existing = None
 
     # Configuration is validated BEFORE any cache reuse. A cached record proves
@@ -765,16 +803,22 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
 
             if existing and existing.get("shortener_link_id"):
                 # Update existing link target
-                print(f"  Updating bit.ly link {existing['shortener_link_id']} → {shownotes_url}")
-                update_bitly_link(existing["shortener_link_id"], shownotes_url, api_token)
+                print(
+                    f"  Updating bit.ly link {existing['shortener_link_id']} → {shownotes_url}"
+                )
+                update_bitly_link(
+                    existing["shortener_link_id"], shownotes_url, api_token
+                )
                 meta = dict(existing)
                 prior_target = existing.get("target_url")
                 meta["target_url"] = shownotes_url
                 meta["updated_at"] = datetime.date.today().isoformat()
                 if effects_receipt is not None:
                     effects_receipt.record_short_link(
-                        meta["shortener"], meta["shortener_link_id"],
-                        meta["short_url"], action="retargeted",
+                        meta["shortener"],
+                        meta["shortener_link_id"],
+                        meta["short_url"],
+                        action="retargeted",
                         prior_target=prior_target,
                     )
                 return existing["short_url"], meta
@@ -782,8 +826,12 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
                 _require_domain_decision(config, "bitly", vault_path)
                 # Create new link with talk slug as custom back-half
                 domain_label = bitly_domain or "bit.ly"
-                print(f"  Creating {domain_label} link for {shownotes_url} (back-half: {custom_back_half})")
-                result = create_bitly_link(shownotes_url, api_token, custom_back_half, domain=bitly_domain)
+                print(
+                    f"  Creating {domain_label} link for {shownotes_url} (back-half: {custom_back_half})"
+                )
+                result = create_bitly_link(
+                    shownotes_url, api_token, custom_back_half, domain=bitly_domain
+                )
                 meta = {
                     "talk_slug": talk_slug,
                     "target_url": shownotes_url,
@@ -794,8 +842,10 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
                 }
                 if effects_receipt is not None:
                     effects_receipt.record_short_link(
-                        meta["shortener"], meta["shortener_link_id"],
-                        meta["short_url"], action="created",
+                        meta["shortener"],
+                        meta["shortener_link_id"],
+                        meta["short_url"],
+                        action="created",
                     )
                 return result["short_url"], meta
 
@@ -811,23 +861,33 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
             domain = config.get("rebrandly_domain")
 
             if existing and existing.get("shortener_link_id"):
-                print(f"  Updating rebrand.ly link {existing['shortener_link_id']} → {shownotes_url}")
-                update_rebrandly_link(existing["shortener_link_id"], shownotes_url, api_key)
+                print(
+                    f"  Updating rebrand.ly link {existing['shortener_link_id']} → {shownotes_url}"
+                )
+                update_rebrandly_link(
+                    existing["shortener_link_id"], shownotes_url, api_key
+                )
                 meta = dict(existing)
                 prior_target = existing.get("target_url")
                 meta["target_url"] = shownotes_url
                 meta["updated_at"] = datetime.date.today().isoformat()
                 if effects_receipt is not None:
                     effects_receipt.record_short_link(
-                        meta["shortener"], meta["shortener_link_id"],
-                        meta["short_url"], action="retargeted",
+                        meta["shortener"],
+                        meta["shortener_link_id"],
+                        meta["short_url"],
+                        action="retargeted",
                         prior_target=prior_target,
                     )
                 return existing["short_url"], meta
             else:
                 _require_domain_decision(config, "rebrandly", vault_path)
-                print(f"  Creating rebrand.ly link for {shownotes_url} (slashtag: {custom_back_half})")
-                result = create_rebrandly_link(shownotes_url, api_key, domain, custom_back_half)
+                print(
+                    f"  Creating rebrand.ly link for {shownotes_url} (slashtag: {custom_back_half})"
+                )
+                result = create_rebrandly_link(
+                    shownotes_url, api_key, domain, custom_back_half
+                )
                 meta = {
                     "talk_slug": talk_slug,
                     "target_url": shownotes_url,
@@ -838,8 +898,10 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
                 }
                 if effects_receipt is not None:
                     effects_receipt.record_short_link(
-                        meta["shortener"], meta["shortener_link_id"],
-                        meta["short_url"], action="created",
+                        meta["shortener"],
+                        meta["shortener_link_id"],
+                        meta["short_url"],
+                        action="created",
                     )
                 return result["short_url"], meta
 
@@ -852,8 +914,10 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
     except ShortenerResolutionError as e:
         if e.partial_link is not None and effects_receipt is not None:
             effects_receipt.record_short_link(
-                e.partial_link["provider"], e.partial_link["link_id"],
-                e.partial_link["short_url"], action="created",
+                e.partial_link["provider"],
+                e.partial_link["link_id"],
+                e.partial_link["short_url"],
+                action="created",
             )
         raise
     except (
@@ -872,6 +936,7 @@ def resolve_short_url(shownotes_url, talk_slug, config, secrets, tracking_db,
 
 
 # --- Slide Background Color Resolution ---
+
 
 def resolve_slide_bg_rgb(slide):
     """Walk slide → layout → master to find an explicit solid fill background.
@@ -918,6 +983,7 @@ def choose_fg_color(bg_rgb):
 
 # --- QR Code Generation ---
 
+
 def generate_qr_png(url, fg_rgb, bg_rgb, out_path):
     """Generate a QR code PNG file.
 
@@ -944,6 +1010,7 @@ def generate_qr_png(url, fg_rgb, bg_rgb, out_path):
 
 
 # --- Slide Detection ---
+
 
 def find_shownotes_slide(prs, shownotes_url):
     """Find the slide index containing the shownotes URL text.
@@ -1003,7 +1070,9 @@ def _picture_is_qr(shape):
     w, h = shape.width, shape.height
     if w is None or h is None:
         return False
-    if abs(w - h) >= Inches(QR_SQUARE_TOL_INCHES) or min(w, h) < Inches(QR_DETECT_MIN_INCHES):
+    if abs(w - h) >= Inches(QR_SQUARE_TOL_INCHES) or min(w, h) < Inches(
+        QR_DETECT_MIN_INCHES
+    ):
         return False
     try:
         blob = shape.image.blob
@@ -1058,7 +1127,9 @@ def resolve_target_slide_indices(prs, config, shownotes_url):
         else:
             # Fallback: slide index 3 (common shownotes position)
             fallback = min(3, slide_count - 1)
-            print(f"  WARNING: Shownotes URL not found in slide text, falling back to slide {fallback + 1}")
+            print(
+                f"  WARNING: Shownotes URL not found in slide text, falling back to slide {fallback + 1}"
+            )
             indices.append(fallback)
 
     if position in ("closing", "both"):
@@ -1081,6 +1152,7 @@ def resolve_target_slide_indices(prs, config, shownotes_url):
 
 
 # --- QR Insertion ---
+
 
 def _format_qr_spec(slide_specs):
     """Encode per-slide insertion targets for the InsertQR macro.
@@ -1160,8 +1232,9 @@ def _validated_back_half(short_url, talk_slug):
 def _artifact_receipt(path, deck_dir, bg_hex):
     """Bind one generated PNG to the exact path written plus its digest."""
     absolute = os.path.abspath(path)
-    if deck_dir and os.path.commonpath([absolute, os.path.abspath(deck_dir)]) == \
-            os.path.abspath(deck_dir):
+    if deck_dir and os.path.commonpath(
+        [absolute, os.path.abspath(deck_dir)]
+    ) == os.path.abspath(deck_dir):
         path_root = "deck_dir"
         recorded = os.path.relpath(absolute, os.path.abspath(deck_dir))
     elif not os.path.isabs(path):
@@ -1180,6 +1253,7 @@ def _artifact_receipt(path, deck_dir, bg_hex):
 
 
 # --- Tracking Database ---
+
 
 def update_tracking_db(tracking_db, entry, artifacts):
     """Append or replace a qr_codes entry in the tracking database.
@@ -1226,44 +1300,74 @@ def update_tracking_db(tracking_db, entry, artifacts):
 
 # --- Main ---
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate a QR code and insert it into a PowerPoint deck.",
         epilog="Examples:\n"
-               "  %(prog)s deck.pptx --talk-slug arc-of-ai --shownotes-url https://example.com/arc-of-ai\n"
-               "  %(prog)s deck.pptx --talk-slug arc-of-ai --shownotes-url https://example.com/arc-of-ai"
-               " --short-url https://jbaru.ch/arc-of-ai --short-provider bitly --short-link-id bit.ly/abc\n"
-               "  %(prog)s deck.pptx --talk-slug arc-of-ai --shownotes-url https://example.com/arc-of-ai --dry-run\n"
-               "  %(prog)s --png-only --talk-slug SLUG --shownotes-url https://example.com/arc-of-ai --output qr.png\n"
-               "  %(prog)s --png-only --talk-slug SLUG --shownotes-url https://example.com/arc-of-ai"
-               " --short-url https://jbaru.ch/arc-of-ai --bg-color 128,0,128\n",
+        "  %(prog)s deck.pptx --talk-slug arc-of-ai --shownotes-url https://example.com/arc-of-ai\n"
+        "  %(prog)s deck.pptx --talk-slug arc-of-ai --shownotes-url https://example.com/arc-of-ai"
+        " --short-url https://jbaru.ch/arc-of-ai --short-provider bitly --short-link-id bit.ly/abc\n"
+        "  %(prog)s deck.pptx --talk-slug arc-of-ai --shownotes-url https://example.com/arc-of-ai --dry-run\n"
+        "  %(prog)s --png-only --talk-slug SLUG --shownotes-url https://example.com/arc-of-ai --output qr.png\n"
+        "  %(prog)s --png-only --talk-slug SLUG --shownotes-url https://example.com/arc-of-ai"
+        " --short-url https://jbaru.ch/arc-of-ai --bg-color 128,0,128\n",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("deck", nargs="?", default=None, help="Path to the .pptx deck file (not required with --png-only)")
-    parser.add_argument("--talk-slug", required=True, help="Unique talk identifier (e.g., arc-of-ai)")
+    parser.add_argument(
+        "deck",
+        nargs="?",
+        default=None,
+        help="Path to the .pptx deck file (not required with --png-only)",
+    )
+    parser.add_argument(
+        "--talk-slug", required=True, help="Unique talk identifier (e.g., arc-of-ai)"
+    )
 
     # The canonical redirect target is always required. --short-url supplies an
     # agent-preresolved managed link (MCP mode) and does NOT replace the target:
     # recording the short URL as its own target loses the redirect relationship
     # the catalog exists to describe.
-    parser.add_argument("--shownotes-url", required=True,
-                        help="Canonical shownotes URL — the short link's redirect target")
-    parser.add_argument("--short-url",
-                        help="Pre-resolved short URL (MCP mode; skips shortening)")
-    parser.add_argument("--short-provider", metavar="NAME",
-                        help="Provider that issued --short-url (e.g. bitly, rebrandly)")
-    parser.add_argument("--short-link-id", metavar="ID",
-                        help="Provider-side link id for --short-url")
+    parser.add_argument(
+        "--shownotes-url",
+        required=True,
+        help="Canonical shownotes URL — the short link's redirect target",
+    )
+    parser.add_argument(
+        "--short-url", help="Pre-resolved short URL (MCP mode; skips shortening)"
+    )
+    parser.add_argument(
+        "--short-provider",
+        metavar="NAME",
+        help="Provider that issued --short-url (e.g. bitly, rebrandly)",
+    )
+    parser.add_argument(
+        "--short-link-id", metavar="ID", help="Provider-side link id for --short-url"
+    )
 
-    parser.add_argument("--png-only", action="store_true",
-                        help="Generate QR PNG only, without opening or modifying a deck")
-    parser.add_argument("--output", metavar="PATH",
-                        help="Output path for QR PNG (default: {deck_dir}/{talk-slug}-qr.png, or ./{talk-slug}-qr.png with --png-only)")
-    parser.add_argument("--bg-color", metavar="R,G,B",
-                        help="QR background color as R,G,B (e.g., 128,0,128). Default: detected from deck, or white with --png-only")
-    parser.add_argument("--profile", help="Path to speaker-profile.json (default: {vault}/speaker-profile.json)")
+    parser.add_argument(
+        "--png-only",
+        action="store_true",
+        help="Generate QR PNG only, without opening or modifying a deck",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        help="Output path for QR PNG (default: {deck_dir}/{talk-slug}-qr.png, or ./{talk-slug}-qr.png with --png-only)",
+    )
+    parser.add_argument(
+        "--bg-color",
+        metavar="R,G,B",
+        help="QR background color as R,G,B (e.g., 128,0,128). Default: detected from deck, or white with --png-only",
+    )
+    parser.add_argument(
+        "--profile",
+        help="Path to speaker-profile.json (default: {vault}/speaker-profile.json)",
+    )
     parser.add_argument("--vault", help="Path to vault root directory")
-    parser.add_argument("--dry-run", action="store_true", help="Skip API calls and deck modification")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Skip API calls and deck modification"
+    )
 
     args = parser.parse_args()
 
@@ -1368,18 +1472,36 @@ def main():
                 prior_record = copy.deepcopy(
                     _qr_record_for(tracking_db, args.talk_slug)
                 )
-            _publish(args, effects_receipt, vault_path, vault_present_at_start,
-                     speaker_profile, secrets, tracking_db, qr_config,
-                     explicit_bg, prior_record)
+            _publish(
+                args,
+                effects_receipt,
+                vault_path,
+                vault_present_at_start,
+                speaker_profile,
+                secrets,
+                tracking_db,
+                qr_config,
+                explicit_bg,
+                prior_record,
+            )
     except ValueError as exc:
         # Lock acquisition failures are a CLI error path, not a traceback.
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
 
 
-def _publish(args, effects_receipt, vault_path, vault_present_at_start,
-             speaker_profile, secrets, tracking_db, qr_config, explicit_bg,
-             prior_record):
+def _publish(
+    args,
+    effects_receipt,
+    vault_path,
+    vault_present_at_start,
+    speaker_profile,
+    secrets,
+    tracking_db,
+    qr_config,
+    explicit_bg,
+    prior_record,
+):
     # Determine the URL to encode in the QR
     if args.short_url:
         # MCP-preresolved mode
@@ -1405,7 +1527,9 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
         print(f"Using pre-resolved short URL: {qr_url} -> {shownotes_url}")
         # The agent created this link, so a failed commit still leaves it behind.
         effects_receipt.record_short_link(
-            meta["shortener"], meta["shortener_link_id"], qr_url,
+            meta["shortener"],
+            meta["shortener_link_id"],
+            qr_url,
             action="preresolved",
         )
     else:
@@ -1414,8 +1538,13 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
         print(f"Resolving short URL for: {shownotes_url}")
         try:
             qr_url, meta = resolve_short_url(
-                shownotes_url, args.talk_slug, qr_config, secrets, tracking_db,
-                args.dry_run, vault_path=vault_path,
+                shownotes_url,
+                args.talk_slug,
+                qr_config,
+                secrets,
+                tracking_db,
+                args.dry_run,
+                vault_path=vault_path,
                 effects_receipt=effects_receipt,
             )
         except ShortenerResolutionError as e:
@@ -1432,7 +1561,6 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
                     file=sys.stderr,
                 )
             sys.exit(1)
-
 
     print(f"QR will encode: {qr_url}")
 
@@ -1461,7 +1589,9 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
 
         # Determine target slides
         target_url_for_detection = shownotes_url if args.shownotes_url else qr_url
-        slide_indices = resolve_target_slide_indices(prs, qr_config, target_url_for_detection)
+        slide_indices = resolve_target_slide_indices(
+            prs, qr_config, target_url_for_detection
+        )
         print(f"Target slides: {[i + 1 for i in slide_indices]}")
 
         bg_match = qr_config.get("bg_color_match", True)
@@ -1482,13 +1612,17 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
                 if slide_bg:
                     bg_rgb = slide_bg
                 else:
-                    print(f"  WARNING: Could not detect background for slide {idx + 1}, defaulting to white")
+                    print(
+                        f"  WARNING: Could not detect background for slide {idx + 1}, defaulting to white"
+                    )
                     bg_rgb = (255, 255, 255)
             qr_bg = bg_rgb if bg_match else (255, 255, 255)
             qr_fg = choose_fg_color(qr_bg)
             slide_colors[idx] = (qr_bg, qr_fg)
             qr_rects_by_idx[idx] = find_qr_rects(prs.slides[idx])
-            placement = "replace in place" if qr_rects_by_idx[idx] else "new (bottom-right)"
+            placement = (
+                "replace in place" if qr_rects_by_idx[idx] else "new (bottom-right)"
+            )
             print(f"  Slide {idx + 1}: bg=RGB{qr_bg}, fg=RGB{qr_fg} — {placement}")
 
         # Group slides by color scheme to generate minimal QR PNGs
@@ -1507,23 +1641,29 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
                     bg_hex = "{:02x}{:02x}{:02x}".format(*qr_bg)
                     qr_filename = f"{args.talk_slug}-qr-{bg_hex}.png"
 
-                qr_path = args.output if (args.output and len(color_groups) == 1) else os.path.join(deck_dir, qr_filename)
+                qr_path = (
+                    args.output
+                    if (args.output and len(color_groups) == 1)
+                    else os.path.join(deck_dir, qr_filename)
+                )
                 generate_qr_png(qr_url, qr_fg, qr_bg, qr_path)
                 size_kb = os.path.getsize(qr_path) / 1024
-                print(f"  QR PNG saved: {qr_filename} ({size_kb:.1f} KB) — for slide(s) {[i + 1 for i in indices]}")
+                print(
+                    f"  QR PNG saved: {qr_filename} ({size_kb:.1f} KB) — for slide(s) {[i + 1 for i in indices]}"
+                )
                 qr_paths_generated.append(
                     (qr_path, None if len(color_groups) == 1 else bg_hex)
                 )
                 # VBA is 1-based; pair each slide with its existing-QR rects
-                insert_jobs.append((qr_path, [(i + 1, qr_rects_by_idx[i]) for i in indices]))
+                insert_jobs.append(
+                    (qr_path, [(i + 1, qr_rects_by_idx[i]) for i in indices])
+                )
 
             # Release the read-only deck handle, then write via the real
             # PowerPoint app (valid OOXML; see rules/deck-editing-rules.md).
             prs = None
             here = os.path.dirname(os.path.abspath(__file__))
-            effects_receipt.record_artifacts(
-                [path for path, _bg in qr_paths_generated]
-            )
+            effects_receipt.record_artifacts([path for path, _bg in qr_paths_generated])
             insert_qr_via_powerpoint(args.deck, insert_jobs, here)
             print(f"Deck updated via PowerPoint: {args.deck}")
             effects_receipt.record_deck(args.deck)
@@ -1535,7 +1675,9 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
         else:
             # Dry run — just report what would happen
             for (qr_bg, qr_fg), indices in color_groups.items():
-                print(f"  DRY RUN: would generate QR bg=RGB{qr_bg} fg=RGB{qr_fg} for slides {[i + 1 for i in indices]}")
+                print(
+                    f"  DRY RUN: would generate QR bg=RGB{qr_bg} fg=RGB{qr_fg} for slides {[i + 1 for i in indices]}"
+                )
             artifacts = None
 
     # A dry run generated nothing, so there is no artifact to bind and the
@@ -1549,9 +1691,7 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
             try:
                 # Rebase onto the current generation rather than committing the
                 # snapshot taken before the link, PNGs, and deck were changed.
-                write_result = commit_qr_record(
-                    tdb_path, meta, artifacts, prior_record
-                )
+                write_result = commit_qr_record(tdb_path, meta, artifacts, prior_record)
             except ValueError as exc:
                 # Single JSON document on stderr; the skill renders it.
                 _emit_unfinalized_effects(effects_receipt, str(exc))
@@ -1569,7 +1709,9 @@ def _publish(args, effects_receipt, vault_path, vault_present_at_start,
             for warning in write_result.warnings:
                 print(f"WARNING: {warning}", file=sys.stderr)
         else:
-            print(f"  NOTE: Vault path {vault_path} not found, tracking DB not persisted")
+            print(
+                f"  NOTE: Vault path {vault_path} not found, tracking DB not persisted"
+            )
 
     print("\nDone.")
 

--- a/skills/presentation-creator/scripts/generate-talk-timings.py
+++ b/skills/presentation-creator/scripts/generate-talk-timings.py
@@ -59,11 +59,14 @@ def main():
     )
     parser.add_argument("outline", help="Path to outline.yaml")
     parser.add_argument(
-        "--qa", type=int, default=0,
+        "--qa",
+        type=int,
+        default=0,
         help="Q&A duration in minutes to add before FINISH",
     )
     parser.add_argument(
-        "--output", "-o",
+        "--output",
+        "-o",
         help="Output path (default: stdout)",
     )
     args = parser.parse_args()

--- a/skills/presentation-creator/scripts/notes-to-packed.py
+++ b/skills/presentation-creator/scripts/notes-to-packed.py
@@ -13,6 +13,7 @@ indices; PowerPoint VBA uses 1-based). Empty notes are dropped.
 Usage:
     notes-to-packed.py <notes.json> <out.packed>
 """
+
 import json
 import sys
 from pathlib import Path
@@ -29,7 +30,9 @@ def pack_notes(notes_map: object) -> str:
     non-string text, or text containing the RS/US control chars).
     """
     if not isinstance(notes_map, dict):
-        raise ValueError('notes JSON must be an object {"<0-based slide #>": "text", ...}')
+        raise ValueError(
+            'notes JSON must be an object {"<0-based slide #>": "text", ...}'
+        )
 
     def slide_num(key: object) -> int:
         try:
@@ -41,14 +44,20 @@ def pack_notes(notes_map: object) -> str:
     for key in sorted(notes_map, key=slide_num):
         num = slide_num(key)
         if num < 0:
-            raise ValueError(f"notes key {key!r} is negative; slide indices are 0-based (>= 0)")
+            raise ValueError(
+                f"notes key {key!r} is negative; slide indices are 0-based (>= 0)"
+            )
         text = notes_map[key]
         if text is None or text == "":
             continue
         if not isinstance(text, str):
-            raise ValueError(f"notes for slide {key} must be a string, got {type(text).__name__}")
+            raise ValueError(
+                f"notes for slide {key} must be a string, got {type(text).__name__}"
+            )
         if RS in text or US in text:
-            raise ValueError(f"notes for slide {key} contain a reserved control char (RS/US)")
+            raise ValueError(
+                f"notes for slide {key} contain a reserved control char (RS/US)"
+            )
         records.append(f"{num + 1}{US}{text}")
     return RS.join(records)
 

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -43,13 +43,12 @@ class _StrictModel(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+
 _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 # ── Pattern enum: discovered from the patterns directory ──────────────
 
-_PATTERNS_DIR = (
-    Path(__file__).resolve().parent.parent / "references" / "patterns"
-)
+_PATTERNS_DIR = Path(__file__).resolve().parent.parent / "references" / "patterns"
 
 
 def _discover_pattern_ids() -> tuple[frozenset[str], frozenset[str]]:
@@ -76,10 +75,19 @@ def _discover_pattern_ids() -> tuple[frozenset[str], frozenset[str]]:
 
 PATTERN_IDS, ANTIPATTERN_IDS = _discover_pattern_ids()
 
-ARCHITECTURE_IDS: frozenset[str] = frozenset({
-    "narrative-arc", "sparkline", "fourthought", "triad", "talklet",
-    "expansion-joints", "lightning-talk", "takahashi", "cave-painting",
-})
+ARCHITECTURE_IDS: frozenset[str] = frozenset(
+    {
+        "narrative-arc",
+        "sparkline",
+        "fourthought",
+        "triad",
+        "talklet",
+        "expansion-joints",
+        "lightning-talk",
+        "takahashi",
+        "cave-painting",
+    }
+)
 
 
 # ── Closed enums for instance metadata ───────────────────────────────
@@ -200,11 +208,19 @@ _PATTERN_INSTANCE_FIELDS: dict[str, frozenset[str]] = {
     "walk-around": frozenset({"registers"}),
 }
 
-_ALL_INSTANCE_FIELDS: frozenset[str] = frozenset({
-    "flavors", "subtype", "resistance_vector",
-    "story_id", "beat", "plant_id", "big_idea_text", "asks",
-    "registers",
-})
+_ALL_INSTANCE_FIELDS: frozenset[str] = frozenset(
+    {
+        "flavors",
+        "subtype",
+        "resistance_vector",
+        "story_id",
+        "beat",
+        "plant_id",
+        "big_idea_text",
+        "asks",
+        "registers",
+    }
+)
 
 
 class AppliedPattern(_StrictModel):
@@ -584,7 +600,8 @@ class Slide(_StrictModel):
 
 
 def _check_beat_slide_refs(
-    chapters: list["Chapter"], slides: list["Slide"],
+    chapters: list["Chapter"],
+    slides: list["Slide"],
 ) -> None:
     """Reject argument_beat slide_refs that point at a non-existent slide.
 
@@ -825,8 +842,7 @@ def main(argv: list[str]) -> int:
         sys.stdout.write("\n")
     else:
         print(
-            f"OK: {len(outline.slides)} slides across "
-            f"{len(outline.chapters)} chapters",
+            f"OK: {len(outline.slides)} slides across {len(outline.chapters)} chapters",
         )
     return 0
 

--- a/skills/presentation-creator/scripts/stage-images-into-container.py
+++ b/skills/presentation-creator/scripts/stage-images-into-container.py
@@ -111,8 +111,7 @@ def stage_manifest(manifest: object, stage_dir: Path) -> dict:
     if isinstance(manifest.get("backgrounds"), dict):
         bg = manifest["backgrounds"]
         staged = {
-            key: _stage_one(path, stage_dir, f"slide {key}")
-            for key, path in bg.items()
+            key: _stage_one(path, stage_dir, f"slide {key}") for key, path in bg.items()
         }
         out = dict(manifest)
         out["backgrounds"] = staged
@@ -152,21 +151,35 @@ def stage_manifest(manifest: object, stage_dir: Path) -> dict:
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
-        description="Copy a manifest's images into PowerPoint's container; rewrite paths.")
+        description="Copy a manifest's images into PowerPoint's container; rewrite paths."
+    )
     ap.add_argument("manifest", type=Path, help="Path to the deck-ops manifest JSON")
-    ap.add_argument("--stage-dir", type=Path, required=True,
-                    help="Staging dir inside PowerPoint's container Data dir")
-    ap.add_argument("--out", type=Path, default=None,
-                    help="Also write the rewritten manifest JSON here")
+    ap.add_argument(
+        "--stage-dir",
+        type=Path,
+        required=True,
+        help="Staging dir inside PowerPoint's container Data dir",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Also write the rewritten manifest JSON here",
+    )
     args = ap.parse_args(argv)
 
     try:
         manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
     except OSError as exc:
-        print(f"ERROR: cannot read manifest {args.manifest}: {exc.strerror or exc}", file=sys.stderr)
+        print(
+            f"ERROR: cannot read manifest {args.manifest}: {exc.strerror or exc}",
+            file=sys.stderr,
+        )
         return 1
     except json.JSONDecodeError as exc:
-        print(f"ERROR: manifest {args.manifest} is not valid JSON: {exc}", file=sys.stderr)
+        print(
+            f"ERROR: manifest {args.manifest} is not valid JSON: {exc}", file=sys.stderr
+        )
         return 1
 
     rewritten = stage_manifest(manifest, args.stage_dir)
@@ -175,8 +188,11 @@ def main(argv=None) -> int:
         try:
             args.out.write_text(text + "\n", encoding="utf-8")
         except OSError as exc:
-            print(f"ERROR: cannot write rewritten manifest {args.out}: {exc.strerror or exc} — "
-                  "check the path and that its directory is writable", file=sys.stderr)
+            print(
+                f"ERROR: cannot write rewritten manifest {args.out}: {exc.strerror or exc} — "
+                "check the path and that its directory is writable",
+                file=sys.stderr,
+            )
             return 1
     print(text)
     return 0

--- a/skills/presentation-creator/scripts/sync-deck-drivers.py
+++ b/skills/presentation-creator/scripts/sync-deck-drivers.py
@@ -122,12 +122,20 @@ def check(base: Path) -> list[str]:
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
-        description="Keep deck-ops .bas/.applescript drivers shippable past tessl's extension filter.")
+        description="Keep deck-ops .bas/.applescript drivers shippable past tessl's extension filter."
+    )
     ap.add_argument("mode", choices=("materialize", "mirror", "check"))
-    ap.add_argument("--force", action="store_true",
-                    help="materialize: overwrite existing real drivers (refresh after a plugin update)")
-    ap.add_argument("--dir", type=Path, default=Path(__file__).resolve().parent,
-                    help="the scripts dir holding the drivers (default: this script's dir)")
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="materialize: overwrite existing real drivers (refresh after a plugin update)",
+    )
+    ap.add_argument(
+        "--dir",
+        type=Path,
+        default=Path(__file__).resolve().parent,
+        help="the scripts dir holding the drivers (default: this script's dir)",
+    )
     args = ap.parse_args(argv)
     base = args.dir
 

--- a/skills/presentation-creator/scripts/validate-deckops.py
+++ b/skills/presentation-creator/scripts/validate-deckops.py
@@ -12,6 +12,7 @@ manual-validation-only (it drives PowerPoint).
 Usage:
     validate-deckops.py <ops-file>   # exit 0 + JSON summary, or exit 1 + errors on stderr
 """
+
 import json
 import sys
 from pathlib import Path
@@ -20,19 +21,39 @@ US = "\x1f"
 
 # op -> (exact field count including the op) or (min count, None) for variadic.
 ARITY = {
-    "SLIDE": (2, 2), "TITLE": (2, 2), "SUBTITLE": (2, 2), "BODY": (2, 2),
-    "FOOTER": (2, 2), "CAT": (2, 2), "BULLET": (3, 3), "TEXT": (6, 6),
-    "IMAGE": (6, 6), "SHAPE": (6, 6), "BG": (4, 4), "OPTIMIZE": (1, 1),
-    "TABLE": (7, 7), "CELL": (4, 4), "CHART": (6, 6), "SERIES": (3, None),
+    "SLIDE": (2, 2),
+    "TITLE": (2, 2),
+    "SUBTITLE": (2, 2),
+    "BODY": (2, 2),
+    "FOOTER": (2, 2),
+    "CAT": (2, 2),
+    "BULLET": (3, 3),
+    "TEXT": (6, 6),
+    "IMAGE": (6, 6),
+    "SHAPE": (6, 6),
+    "BG": (4, 4),
+    "OPTIMIZE": (1, 1),
+    "TABLE": (7, 7),
+    "CELL": (4, 4),
+    "CHART": (6, 6),
+    "SERIES": (3, None),
 }
 # 1-based field indices that must parse as int / float.
 INT_FIELDS = {
-    "SLIDE": [1], "BULLET": [1], "SHAPE": [1], "BG": [1, 2, 3],
-    "TABLE": [1, 2], "CELL": [1, 2], "CHART": [1],
+    "SLIDE": [1],
+    "BULLET": [1],
+    "SHAPE": [1],
+    "BG": [1, 2, 3],
+    "TABLE": [1, 2],
+    "CELL": [1, 2],
+    "CHART": [1],
 }
 FLOAT_FIELDS = {
-    "TEXT": [1, 2, 3, 4], "IMAGE": [1, 2, 3, 4], "SHAPE": [2, 3, 4, 5],
-    "TABLE": [3, 4, 5, 6], "CHART": [2, 3, 4, 5],
+    "TEXT": [1, 2, 3, 4],
+    "IMAGE": [1, 2, 3, 4],
+    "SHAPE": [2, 3, 4, 5],
+    "TABLE": [3, 4, 5, 6],
+    "CHART": [2, 3, 4, 5],
 }
 NEEDS_SLIDE = set(ARITY) - {"SLIDE"}
 
@@ -41,14 +62,16 @@ def validate_ops(text: str) -> list[str]:
     """Return a list of human-readable error strings (empty == valid)."""
     errors = []
     have_slide = have_table = have_chart = False
-    chart_open_line = 0          # line of the current CHART, 0 == none open
+    chart_open_line = 0  # line of the current CHART, 0 == none open
     chart_has_series = False
 
     def close_chart():
         # A CHART with no SERIES keeps PowerPoint's default sample data.
         if chart_open_line and not chart_has_series:
-            errors.append(f"line {chart_open_line}: CHART has no SERIES (the chart "
-                          "would keep PowerPoint's default sample data)")
+            errors.append(
+                f"line {chart_open_line}: CHART has no SERIES (the chart "
+                "would keep PowerPoint's default sample data)"
+            )
 
     for n, raw in enumerate(text.split("\n"), start=1):
         line = raw.rstrip("\r")
@@ -68,30 +91,40 @@ def validate_ops(text: str) -> list[str]:
             try:
                 int(fields[idx])
             except ValueError:
-                errors.append(f"line {n}: op {op} field {idx} must be an integer, got {fields[idx]!r}")
+                errors.append(
+                    f"line {n}: op {op} field {idx} must be an integer, got {fields[idx]!r}"
+                )
         for idx in FLOAT_FIELDS.get(op, []):
             try:
                 float(fields[idx])
             except ValueError:
-                errors.append(f"line {n}: op {op} field {idx} must be a number, got {fields[idx]!r}")
+                errors.append(
+                    f"line {n}: op {op} field {idx} must be a number, got {fields[idx]!r}"
+                )
         if op == "SERIES":
             for idx in range(2, len(fields)):
                 try:
                     float(fields[idx])
                 except ValueError:
-                    errors.append(f"line {n}: SERIES value {idx} must be a number, got {fields[idx]!r}")
+                    errors.append(
+                        f"line {n}: SERIES value {idx} must be a number, got {fields[idx]!r}"
+                    )
         if op == "BG":
             for idx in (1, 2, 3):
                 try:
                     if not 0 <= int(fields[idx]) <= 255:
-                        errors.append(f"line {n}: BG channel {idx} must be 0-255, got {fields[idx]}")
+                        errors.append(
+                            f"line {n}: BG channel {idx} must be 0-255, got {fields[idx]}"
+                        )
                 except ValueError:
                     pass  # already reported by INT_FIELDS
         # state rules
         if op == "SLIDE":
             try:
                 if int(fields[1]) < 0:
-                    errors.append(f"line {n}: SLIDE layout index must be >= 0, got {fields[1]}")
+                    errors.append(
+                        f"line {n}: SLIDE layout index must be >= 0, got {fields[1]}"
+                    )
             except (ValueError, IndexError):
                 pass  # already reported by INT_FIELDS / arity
             close_chart()
@@ -123,16 +156,25 @@ def main() -> None:
     try:
         text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        print(f"ERROR: ops file not found: {path} — emit it per "
-              "references/deckops-spec.md.", file=sys.stderr)
+        print(
+            f"ERROR: ops file not found: {path} — emit it per "
+            "references/deckops-spec.md.",
+            file=sys.stderr,
+        )
         sys.exit(1)
     except UnicodeDecodeError as e:
-        print(f"ERROR: ops file {path} is not valid UTF-8 ({e}) — re-emit it as "
-              "UTF-8 per references/deckops-spec.md.", file=sys.stderr)
+        print(
+            f"ERROR: ops file {path} is not valid UTF-8 ({e}) — re-emit it as "
+            "UTF-8 per references/deckops-spec.md.",
+            file=sys.stderr,
+        )
         sys.exit(1)
     except OSError as e:
-        print(f"ERROR: cannot read ops file {path}: {e.strerror or e} — check the "
-              "path and permissions.", file=sys.stderr)
+        print(
+            f"ERROR: cannot read ops file {path}: {e.strerror or e} — check the "
+            "path and permissions.",
+            file=sys.stderr,
+        )
         sys.exit(1)
     errors = validate_ops(text)
     if errors:
@@ -140,7 +182,9 @@ def main() -> None:
         for e in errors:
             print(f"  {e}", file=sys.stderr)
         sys.exit(1)
-    slides = sum(1 for ln in text.split("\n") if ln.split(US)[0].strip().upper() == "SLIDE")
+    slides = sum(
+        1 for ln in text.split("\n") if ln.split(US)[0].strip().upper() == "SLIDE"
+    )
     ops = sum(1 for ln in text.split("\n") if ln.strip())
     print(json.dumps({"slides": slides, "ops": ops}))
 

--- a/skills/vault-clarification/scripts/goal_generation_provenance.py
+++ b/skills/vault-clarification/scripts/goal_generation_provenance.py
@@ -189,8 +189,7 @@ def assess_goal_generation(
     unknown_fields = sorted(set(provenance) - allowed_fields)
     if unknown_fields:
         raise GoalGenerationProvenanceError(
-            "goal.baseline_provenance has unknown fields: "
-            f"{unknown_fields!r}"
+            f"goal.baseline_provenance has unknown fields: {unknown_fields!r}"
         )
     lane = _require_nonempty_string(
         provenance.get("lane"), "goal.baseline_provenance.lane"
@@ -236,10 +235,7 @@ def assess_goal_generation(
     )
 
     reason_codes = []
-    if (
-        fixed["pattern_catalog_fingerprint"]
-        != current["pattern_catalog_fingerprint"]
-    ):
+    if fixed["pattern_catalog_fingerprint"] != current["pattern_catalog_fingerprint"]:
         reason_codes.append(CATALOG_FINGERPRINT_MISMATCH)
     if (
         fixed["pattern_scoring_schema_version"]
@@ -281,9 +277,7 @@ def main() -> int:
     try:
         payload = json.load(sys.stdin)
         root = _require_mapping(payload, "stdin")
-        unknown_fields = sorted(
-            set(root) - {"goals", "current_pattern_baseline"}
-        )
+        unknown_fields = sorted(set(root) - {"goals", "current_pattern_baseline"})
         if unknown_fields:
             raise GoalGenerationProvenanceError(
                 f"stdin has unknown fields: {unknown_fields!r}"

--- a/skills/vault-ingress/scripts/aggregate-catalog-feedback.py
+++ b/skills/vault-ingress/scripts/aggregate-catalog-feedback.py
@@ -45,10 +45,17 @@ LANES = (
     "confusable_pairs",
 )
 LANE_SET = frozenset(LANES)
-RETURN_MARKERS = frozenset({
-    "status", "rhetoric_notes", "pattern_observations", "structured_data",
-    "areas_for_improvement", "summary_updates", "verbatim_examples",
-})
+RETURN_MARKERS = frozenset(
+    {
+        "status",
+        "rhetoric_notes",
+        "pattern_observations",
+        "structured_data",
+        "areas_for_improvement",
+        "summary_updates",
+        "verbatim_examples",
+    }
+)
 
 
 class DuplicateJSONKeyError(ValueError):
@@ -75,7 +82,9 @@ def normalize_suggestion(value: str) -> str:
 def default_catalog_path() -> Path:
     return (
         Path(__file__).resolve().parents[2]
-        / "presentation-creator" / "references" / "patterns"
+        / "presentation-creator"
+        / "references"
+        / "patterns"
     )
 
 
@@ -100,11 +109,13 @@ def load_catalog(catalog_path: str | Path) -> dict[str, Any]:
     claims_by_id: dict[str, list[str]] = {}
     errors: list[dict[str, Any]] = []
     if not root.is_dir():
-        errors.append(_issue(
-            "catalog_directory_unreadable",
-            "catalog path is not a readable directory",
-            path=str(root),
-        ))
+        errors.append(
+            _issue(
+                "catalog_directory_unreadable",
+                "catalog path is not a readable directory",
+                path=str(root),
+            )
+        )
         return {
             "path": str(root),
             "registry": registry,
@@ -116,66 +127,90 @@ def load_catalog(catalog_path: str | Path) -> dict[str, Any]:
         try:
             raw = path.read_text(encoding="utf-8")
         except (OSError, UnicodeError) as exc:
-            errors.append(_issue(
-                "catalog_file_unreadable", f"cannot read catalog file: {exc}",
-                path=str(path.resolve(strict=False)),
-            ))
+            errors.append(
+                _issue(
+                    "catalog_file_unreadable",
+                    f"cannot read catalog file: {exc}",
+                    path=str(path.resolve(strict=False)),
+                )
+            )
             continue
         try:
             metadata = _frontmatter(raw)
         except DuplicateYAMLKeyError as exc:
-            errors.append(_issue(
-                "catalog_frontmatter_duplicate_key",
-                f"duplicate YAML frontmatter key: {exc}",
-                path=str(path.resolve(strict=False)),
-            ))
+            errors.append(
+                _issue(
+                    "catalog_frontmatter_duplicate_key",
+                    f"duplicate YAML frontmatter key: {exc}",
+                    path=str(path.resolve(strict=False)),
+                )
+            )
             continue
         except YAMLError as exc:
-            errors.append(_issue(
-                "catalog_frontmatter_invalid", f"invalid YAML frontmatter: {exc}",
-                path=str(path.resolve(strict=False)),
-            ))
+            errors.append(
+                _issue(
+                    "catalog_frontmatter_invalid",
+                    f"invalid YAML frontmatter: {exc}",
+                    path=str(path.resolve(strict=False)),
+                )
+            )
             continue
         if metadata is None:
-            errors.append(_issue(
-                "catalog_frontmatter_missing",
-                "catalog file has no parseable YAML frontmatter",
-                path=str(path.resolve(strict=False)),
-            ))
+            errors.append(
+                _issue(
+                    "catalog_frontmatter_missing",
+                    "catalog file has no parseable YAML frontmatter",
+                    path=str(path.resolve(strict=False)),
+                )
+            )
             continue
 
         catalog_id = _nonempty_string(metadata.get("id"))
         polarity = metadata.get("type")
         relative_path = str(path.relative_to(root))
         if catalog_id is None:
-            errors.append(_issue(
-                "catalog_id_missing", "catalog file has no nonempty id",
-                path=relative_path,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_id_missing",
+                    "catalog file has no nonempty id",
+                    path=relative_path,
+                )
+            )
             continue
         if polarity not in POLARITIES:
-            errors.append(_issue(
-                "catalog_polarity_invalid",
-                "catalog type must be pattern or antipattern",
-                path=relative_path, catalog_id=catalog_id, actual=polarity,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_polarity_invalid",
+                    "catalog type must be pattern or antipattern",
+                    path=relative_path,
+                    catalog_id=catalog_id,
+                    actual=polarity,
+                )
+            )
             continue
 
         filename_is_anti = path.stem.startswith("_anti_")
         filename_polarity = "antipattern" if filename_is_anti else "pattern"
         if polarity != filename_polarity:
-            errors.append(_issue(
-                "catalog_filename_polarity_mismatch",
-                "catalog filename convention disagrees with frontmatter type",
-                path=relative_path, catalog_id=catalog_id,
-                expected=filename_polarity, actual=polarity,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_filename_polarity_mismatch",
+                    "catalog filename convention disagrees with frontmatter type",
+                    path=relative_path,
+                    catalog_id=catalog_id,
+                    expected=filename_polarity,
+                    actual=polarity,
+                )
+            )
         if catalog_id in registry:
-            errors.append(_issue(
-                "catalog_id_duplicate", "catalog id appears in multiple files",
-                catalog_id=catalog_id,
-                paths=[registry[catalog_id]["path"], relative_path],
-            ))
+            errors.append(
+                _issue(
+                    "catalog_id_duplicate",
+                    "catalog id appears in multiple files",
+                    catalog_id=catalog_id,
+                    paths=[registry[catalog_id]["path"], relative_path],
+                )
+            )
             continue
         registry[catalog_id] = {"polarity": polarity, "path": relative_path}
         claims = [catalog_id]
@@ -192,10 +227,13 @@ def load_catalog(catalog_path: str | Path) -> dict[str, Any]:
         claims_by_id[catalog_id] = claims
 
     if not registry:
-        errors.append(_issue(
-            "catalog_empty", "catalog directory contains no valid pattern entries",
-            path=str(root),
-        ))
+        errors.append(
+            _issue(
+                "catalog_empty",
+                "catalog directory contains no valid pattern entries",
+                path=str(root),
+            )
+        )
     alias_claims: defaultdict[str, set[str]] = defaultdict(set)
     for catalog_id, claims in claims_by_id.items():
         for claim in claims:
@@ -205,12 +243,14 @@ def load_catalog(catalog_path: str | Path) -> dict[str, Any]:
     alias_registry: dict[str, str] = {}
     for normalized, owners in sorted(alias_claims.items()):
         if len(owners) > 1:
-            errors.append(_issue(
-                "catalog_alias_collision",
-                "catalog IDs, names, or aliases share one normalized claim",
-                normalized_alias=normalized,
-                catalog_ids=sorted(owners),
-            ))
+            errors.append(
+                _issue(
+                    "catalog_alias_collision",
+                    "catalog IDs, names, or aliases share one normalized claim",
+                    normalized_alias=normalized,
+                    catalog_ids=sorted(owners),
+                )
+            )
             continue
         alias_registry[normalized] = next(iter(owners))
     return {
@@ -249,14 +289,20 @@ def _source_return_key(provenance: dict[str, Any]) -> tuple[str, int]:
 
 
 def _require_text(
-    entry: dict[str, Any], field: str, errors: list[dict[str, Any]],
+    entry: dict[str, Any],
+    field: str,
+    errors: list[dict[str, Any]],
 ) -> str | None:
     text = _nonempty_string(entry.get(field))
     if text is None:
-        errors.append(_issue(
-            "feedback_text_missing", f"{field} must be a nonempty string",
-            field=field, actual=entry.get(field),
-        ))
+        errors.append(
+            _issue(
+                "feedback_text_missing",
+                f"{field} must be a nonempty string",
+                field=field,
+                actual=entry.get(field),
+            )
+        )
     return text
 
 
@@ -269,48 +315,71 @@ def _validate_catalog_ids(
     minimum_count: int | None = None,
 ) -> list[str]:
     if not isinstance(value, list):
-        errors.append(_issue(
-            "catalog_ids_not_array", "pattern_ids must be an array",
-            field="pattern_ids", actual=value,
-        ))
+        errors.append(
+            _issue(
+                "catalog_ids_not_array",
+                "pattern_ids must be an array",
+                field="pattern_ids",
+                actual=value,
+            )
+        )
         return []
     if exact_count is not None and len(value) != exact_count:
-        errors.append(_issue(
-            "catalog_id_count_invalid",
-            f"pattern_ids must contain exactly {exact_count} IDs",
-            field="pattern_ids", expected=exact_count, actual=len(value),
-        ))
+        errors.append(
+            _issue(
+                "catalog_id_count_invalid",
+                f"pattern_ids must contain exactly {exact_count} IDs",
+                field="pattern_ids",
+                expected=exact_count,
+                actual=len(value),
+            )
+        )
     if minimum_count is not None and len(value) < minimum_count:
-        errors.append(_issue(
-            "catalog_id_count_invalid",
-            f"pattern_ids must contain at least {minimum_count} IDs",
-            field="pattern_ids", expected=f">={minimum_count}", actual=len(value),
-        ))
+        errors.append(
+            _issue(
+                "catalog_id_count_invalid",
+                f"pattern_ids must contain at least {minimum_count} IDs",
+                field="pattern_ids",
+                expected=f">={minimum_count}",
+                actual=len(value),
+            )
+        )
 
     ids: list[str] = []
     for position, value_id in enumerate(value):
         catalog_id = _nonempty_string(value_id)
         if catalog_id is None or catalog_id != value_id:
-            errors.append(_issue(
-                "catalog_id_not_exact",
-                "catalog IDs must be nonempty exact strings without normalization",
-                field=f"pattern_ids[{position}]", actual=value_id,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_id_not_exact",
+                    "catalog IDs must be nonempty exact strings without normalization",
+                    field=f"pattern_ids[{position}]",
+                    actual=value_id,
+                )
+            )
             continue
         ids.append(catalog_id)
         if catalog_id not in registry:
-            errors.append(_issue(
-                "catalog_id_unknown", "catalog ID does not exist",
-                field=f"pattern_ids[{position}]", actual=catalog_id,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_id_unknown",
+                    "catalog ID does not exist",
+                    field=f"pattern_ids[{position}]",
+                    actual=catalog_id,
+                )
+            )
     duplicates = sorted(
         catalog_id for catalog_id, count in Counter(ids).items() if count > 1
     )
     if duplicates:
-        errors.append(_issue(
-            "catalog_ids_duplicate", "pattern_ids must be distinct",
-            field="pattern_ids", actual=duplicates,
-        ))
+        errors.append(
+            _issue(
+                "catalog_ids_duplicate",
+                "pattern_ids must be distinct",
+                field="pattern_ids",
+                actual=duplicates,
+            )
+        )
     return ids
 
 
@@ -325,52 +394,72 @@ def _validate_polarity_assertions(
         actual = entry.get("catalog_polarity")
         expected = registry.get(ids[0], {}).get("polarity")
         if actual not in POLARITIES:
-            errors.append(_issue(
-                "catalog_polarity_invalid",
-                "catalog_polarity must be pattern or antipattern",
-                field="catalog_polarity", actual=actual,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_polarity_invalid",
+                    "catalog_polarity must be pattern or antipattern",
+                    field="catalog_polarity",
+                    actual=actual,
+                )
+            )
         elif expected is not None and actual != expected:
-            errors.append(_issue(
-                "catalog_polarity_mismatch",
-                "asserted polarity disagrees with the exact catalog ID",
-                field="catalog_polarity", catalog_id=ids[0],
-                expected=expected, actual=actual,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_polarity_mismatch",
+                    "asserted polarity disagrees with the exact catalog ID",
+                    field="catalog_polarity",
+                    catalog_id=ids[0],
+                    expected=expected,
+                    actual=actual,
+                )
+            )
 
     if "catalog_polarities" not in entry:
         return
     assertions = entry.get("catalog_polarities")
     if not isinstance(assertions, dict):
-        errors.append(_issue(
-            "catalog_polarities_not_object",
-            "catalog_polarities must map every referenced ID to its polarity",
-            field="catalog_polarities", actual=assertions,
-        ))
+        errors.append(
+            _issue(
+                "catalog_polarities_not_object",
+                "catalog_polarities must map every referenced ID to its polarity",
+                field="catalog_polarities",
+                actual=assertions,
+            )
+        )
         return
     if set(assertions) != set(ids):
-        errors.append(_issue(
-            "catalog_polarity_keys_mismatch",
-            "catalog_polarities keys must exactly match pattern_ids",
-            field="catalog_polarities", expected=sorted(set(ids)),
-            actual=sorted(str(key) for key in assertions),
-        ))
+        errors.append(
+            _issue(
+                "catalog_polarity_keys_mismatch",
+                "catalog_polarities keys must exactly match pattern_ids",
+                field="catalog_polarities",
+                expected=sorted(set(ids)),
+                actual=sorted(str(key) for key in assertions),
+            )
+        )
     for catalog_id in sorted(set(ids) & set(assertions)):
         actual = assertions[catalog_id]
         expected = registry.get(catalog_id, {}).get("polarity")
         if actual not in POLARITIES:
-            errors.append(_issue(
-                "catalog_polarity_invalid",
-                "asserted polarity must be pattern or antipattern",
-                field=f"catalog_polarities.{catalog_id}", actual=actual,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_polarity_invalid",
+                    "asserted polarity must be pattern or antipattern",
+                    field=f"catalog_polarities.{catalog_id}",
+                    actual=actual,
+                )
+            )
         elif expected is not None and actual != expected:
-            errors.append(_issue(
-                "catalog_polarity_mismatch",
-                "asserted polarity disagrees with the exact catalog ID",
-                field=f"catalog_polarities.{catalog_id}", catalog_id=catalog_id,
-                expected=expected, actual=actual,
-            ))
+            errors.append(
+                _issue(
+                    "catalog_polarity_mismatch",
+                    "asserted polarity disagrees with the exact catalog ID",
+                    field=f"catalog_polarities.{catalog_id}",
+                    catalog_id=catalog_id,
+                    expected=expected,
+                    actual=actual,
+                )
+            )
 
 
 def validate_entry(
@@ -385,13 +474,18 @@ def validate_entry(
     catalog_ids: list[str] = []
     suggestion: dict[str, Any] | None = None
     if not isinstance(entry, dict):
-        errors.append(_issue(
-            "feedback_entry_not_object", "feedback entry must be an object",
-            actual=entry,
-        ))
+        errors.append(
+            _issue(
+                "feedback_entry_not_object",
+                "feedback entry must be an object",
+                actual=entry,
+            )
+        )
         return {
-            "errors": errors, "warnings": warnings,
-            "catalog_ids": catalog_ids, "suggestion": suggestion,
+            "errors": errors,
+            "warnings": warnings,
+            "catalog_ids": catalog_ids,
+            "suggestion": suggestion,
         }
 
     if lane == "unmatched_observations":
@@ -400,58 +494,76 @@ def validate_entry(
         proposed = entry.get("proposed_name")
         proposed_name = _nonempty_string(proposed)
         if proposed is not None and proposed_name is None:
-            errors.append(_issue(
-                "suggestion_name_invalid",
-                "proposed_name must be null or a nonempty string",
-                field="proposed_name", actual=proposed,
-            ))
+            errors.append(
+                _issue(
+                    "suggestion_name_invalid",
+                    "proposed_name must be null or a nonempty string",
+                    field="proposed_name",
+                    actual=proposed,
+                )
+            )
         proposed_polarity = entry.get("proposed_polarity")
         if proposed_name is None:
             if proposed_polarity is not None:
-                errors.append(_issue(
-                    "suggestion_polarity_without_name",
-                    "proposed_polarity requires proposed_name",
-                    field="proposed_polarity", actual=proposed_polarity,
-                ))
+                errors.append(
+                    _issue(
+                        "suggestion_polarity_without_name",
+                        "proposed_polarity requires proposed_name",
+                        field="proposed_polarity",
+                        actual=proposed_polarity,
+                    )
+                )
         else:
             normalized = normalize_suggestion(proposed_name)
             if not normalized:
-                errors.append(_issue(
-                    "suggestion_name_invalid",
-                    "proposed_name normalizes to an empty value",
-                    field="proposed_name", actual=proposed_name,
-                ))
-            elif normalized in registry:
-                errors.append(_issue(
-                    "suggestion_matches_catalog_id",
-                    "unmatched suggestion normalizes to an existing exact catalog ID",
-                    field="proposed_name", actual=proposed_name,
-                    catalog_id=normalized,
-                ))
-            elif alias_registry is not None:
-                matched_id = alias_registry.get(
-                    normalize_catalog_alias(proposed_name)
-                )
-                if matched_id is not None:
-                    errors.append(_issue(
-                        "suggestion_matches_catalog_alias",
-                        "unmatched suggestion matches an existing catalog name or alias",
+                errors.append(
+                    _issue(
+                        "suggestion_name_invalid",
+                        "proposed_name normalizes to an empty value",
                         field="proposed_name",
                         actual=proposed_name,
-                        catalog_id=matched_id,
-                    ))
+                    )
+                )
+            elif normalized in registry:
+                errors.append(
+                    _issue(
+                        "suggestion_matches_catalog_id",
+                        "unmatched suggestion normalizes to an existing exact catalog ID",
+                        field="proposed_name",
+                        actual=proposed_name,
+                        catalog_id=normalized,
+                    )
+                )
+            elif alias_registry is not None:
+                matched_id = alias_registry.get(normalize_catalog_alias(proposed_name))
+                if matched_id is not None:
+                    errors.append(
+                        _issue(
+                            "suggestion_matches_catalog_alias",
+                            "unmatched suggestion matches an existing catalog name or alias",
+                            field="proposed_name",
+                            actual=proposed_name,
+                            catalog_id=matched_id,
+                        )
+                    )
             if proposed_polarity is None:
-                warnings.append(_issue(
-                    "suggestion_polarity_missing",
-                    "legacy suggestion needs human pattern/antipattern classification",
-                    field="proposed_polarity", suggestion=normalized,
-                ))
+                warnings.append(
+                    _issue(
+                        "suggestion_polarity_missing",
+                        "legacy suggestion needs human pattern/antipattern classification",
+                        field="proposed_polarity",
+                        suggestion=normalized,
+                    )
+                )
             elif proposed_polarity not in POLARITIES:
-                errors.append(_issue(
-                    "suggestion_polarity_invalid",
-                    "proposed_polarity must be pattern or antipattern",
-                    field="proposed_polarity", actual=proposed_polarity,
-                ))
+                errors.append(
+                    _issue(
+                        "suggestion_polarity_invalid",
+                        "proposed_polarity must be pattern or antipattern",
+                        field="proposed_polarity",
+                        actual=proposed_polarity,
+                    )
+                )
             suggestion = {
                 "normalized_suggestion": normalized,
                 "proposed_name": proposed_name,
@@ -460,7 +572,9 @@ def validate_entry(
 
     elif lane == "tensions":
         catalog_ids = _validate_catalog_ids(
-            entry.get("pattern_ids"), registry=registry, errors=errors,
+            entry.get("pattern_ids"),
+            registry=registry,
+            errors=errors,
             minimum_count=2,
         )
         _require_text(entry, "nature", errors)
@@ -470,7 +584,10 @@ def validate_entry(
     elif lane == "definition_problems":
         pattern_id = entry.get("pattern_id")
         catalog_ids = _validate_catalog_ids(
-            [pattern_id], registry=registry, errors=errors, exact_count=1,
+            [pattern_id],
+            registry=registry,
+            errors=errors,
+            exact_count=1,
         )
         _require_text(entry, "problem", errors)
         _require_text(entry, "detail", errors)
@@ -480,15 +597,21 @@ def validate_entry(
         _require_text(entry, "issue", errors)
         _require_text(entry, "detail", errors)
         if "polarity" in entry and entry.get("polarity") != "neutral":
-            errors.append(_issue(
-                "lane_polarity_invalid",
-                "scoring_problems is a neutral diagnostic lane",
-                field="polarity", expected="neutral", actual=entry.get("polarity"),
-            ))
+            errors.append(
+                _issue(
+                    "lane_polarity_invalid",
+                    "scoring_problems is a neutral diagnostic lane",
+                    field="polarity",
+                    expected="neutral",
+                    actual=entry.get("polarity"),
+                )
+            )
 
     elif lane == "confusable_pairs":
         catalog_ids = _validate_catalog_ids(
-            entry.get("pattern_ids"), registry=registry, errors=errors,
+            entry.get("pattern_ids"),
+            registry=registry,
+            errors=errors,
             exact_count=2,
         )
         _require_text(entry, "detail", errors)
@@ -512,10 +635,15 @@ def discover_inputs(values: list[str | Path]) -> dict[str, Any]:
         if argument.is_dir():
             files = sorted(argument.rglob("*.json"), key=lambda item: str(item))
             if not files:
-                immediate.append({
-                    "path": str(argument), "kind": "directory", "status": "rejected",
-                    "shape": None, "reason": "directory contains no JSON files",
-                })
+                immediate.append(
+                    {
+                        "path": str(argument),
+                        "kind": "directory",
+                        "status": "rejected",
+                        "shape": None,
+                        "reason": "directory contains no JSON files",
+                    }
+                )
             for path in files:
                 discovered[path.resolve(strict=False)].add(str(argument))
         else:
@@ -523,11 +651,14 @@ def discover_inputs(values: list[str | Path]) -> dict[str, Any]:
 
     for path, origins in discovered.items():
         if len(origins) > 1:
-            discovery_warnings.append(_issue(
-                "duplicate_input_suppressed",
-                "the same concrete file was discovered through multiple inputs",
-                path=str(path), discovered_from=sorted(origins),
-            ))
+            discovery_warnings.append(
+                _issue(
+                    "duplicate_input_suppressed",
+                    "the same concrete file was discovered through multiple inputs",
+                    path=str(path),
+                    discovered_from=sorted(origins),
+                )
+            )
     files = [
         {"path": path, "discovered_from": sorted(origins)}
         for path, origins in sorted(discovered.items(), key=lambda item: str(item[0]))
@@ -544,7 +675,8 @@ def _read_json(path: Path) -> tuple[Any | None, dict[str, Any] | None]:
         raw = path.read_text(encoding="utf-8")
     except UnicodeError as exc:
         return None, _issue(
-            "input_encoding_invalid", f"input is not valid UTF-8: {exc}",
+            "input_encoding_invalid",
+            f"input is not valid UTF-8: {exc}",
         )
     except OSError as exc:
         return None, _issue("input_unreadable", f"cannot read input: {exc}")
@@ -593,9 +725,11 @@ def _return_container(document: Any) -> tuple[list[Any] | None, str | None, str 
         returns = document.get("returns")
         if not isinstance(returns, list):
             return None, None, "top-level returns must be an array"
-        shape = "feedback_harvest" if any(
-            isinstance(item, dict) and "feedback" in item for item in returns
-        ) else "returns_wrapper"
+        shape = (
+            "feedback_harvest"
+            if any(isinstance(item, dict) and "feedback" in item for item in returns)
+            else "returns_wrapper"
+        )
         return returns, shape, None
     return_like = (
         "catalog_feedback" in document
@@ -617,13 +751,18 @@ class FeedbackAggregator:
         self.catalog = catalog
         self.registry: dict[str, dict[str, str]] = catalog["registry"]
         self.inputs: dict[str, list[dict[str, Any]]] = {
-            "accepted": [], "rejected": [], "invalid": [],
+            "accepted": [],
+            "rejected": [],
+            "invalid": [],
         }
         self.returns: dict[str, list[dict[str, Any]]] = {
-            "accepted": [], "rejected": [], "invalid": [],
+            "accepted": [],
+            "rejected": [],
+            "invalid": [],
         }
         self.entries: dict[str, list[dict[str, Any]]] = {
-            "accepted": [], "invalid": [],
+            "accepted": [],
+            "invalid": [],
         }
         self.warnings: list[dict[str, Any]] = []
         self.validation_errors: list[dict[str, Any]] = []
@@ -636,19 +775,33 @@ class FeedbackAggregator:
             "discovered_from": discovered_from,
         }
         if read_error:
-            self.inputs["invalid"].append({
-                **base, "status": "invalid", "shape": None,
-                "reason": read_error["message"], "issues": [read_error],
-            })
+            self.inputs["invalid"].append(
+                {
+                    **base,
+                    "status": "invalid",
+                    "shape": None,
+                    "reason": read_error["message"],
+                    "issues": [read_error],
+                }
+            )
             return
 
         return_items, shape, rejection = _return_container(document)
         if return_items is None:
-            status = "invalid" if rejection == "top-level returns must be an array" else "rejected"
-            self.inputs[status].append({
-                **base, "status": status, "shape": None,
-                "reason": rejection, "issues": [],
-            })
+            status = (
+                "invalid"
+                if rejection == "top-level returns must be an array"
+                else "rejected"
+            )
+            self.inputs[status].append(
+                {
+                    **base,
+                    "status": status,
+                    "shape": None,
+                    "reason": rejection,
+                    "issues": [],
+                }
+            )
             return
 
         before = self._counts()
@@ -666,18 +819,20 @@ class FeedbackAggregator:
         else:
             status = "rejected"
             reason = "recognized returns contain no catalog_feedback"
-        self.inputs[status].append({
-            **base,
-            "status": status,
-            "shape": shape,
-            "return_count": len(return_items),
-            "accepted_return_count": deltas["accepted_returns"],
-            "rejected_return_count": deltas["rejected_returns"],
-            "invalid_return_count": deltas["invalid_returns"],
-            "accepted_entry_count": deltas["accepted_entries"],
-            "invalid_entry_count": deltas["invalid_entries"],
-            "reason": reason,
-        })
+        self.inputs[status].append(
+            {
+                **base,
+                "status": status,
+                "shape": shape,
+                "return_count": len(return_items),
+                "accepted_return_count": deltas["accepted_returns"],
+                "rejected_return_count": deltas["rejected_returns"],
+                "invalid_return_count": deltas["invalid_returns"],
+                "accepted_entry_count": deltas["accepted_entries"],
+                "invalid_entry_count": deltas["invalid_entries"],
+                "reason": reason,
+            }
+        )
 
     def _counts(self) -> dict[str, int]:
         return {
@@ -691,50 +846,64 @@ class FeedbackAggregator:
     def _consume_return(self, path: Path, return_index: int, item: Any) -> None:
         if not isinstance(item, dict):
             provenance = _provenance(path, return_index, None, None)
-            self.returns["invalid"].append({
-                "provenance": provenance,
-                "issues": [_issue(
-                    "return_not_object", "return must be a JSON object", actual=item,
-                )],
-            })
+            self.returns["invalid"].append(
+                {
+                    "provenance": provenance,
+                    "issues": [
+                        _issue(
+                            "return_not_object",
+                            "return must be a JSON object",
+                            actual=item,
+                        )
+                    ],
+                }
+            )
             return
 
         talk_filename = _nonempty_string(item.get("filename"))
         talk_id = _nonempty_string(item.get("talk_id"))
         provenance = _provenance(path, return_index, talk_filename, talk_id)
-        feedback_keys = [
-            key for key in ("catalog_feedback", "feedback")
-            if key in item
-        ]
+        feedback_keys = [key for key in ("catalog_feedback", "feedback") if key in item]
         if not feedback_keys:
-            self.returns["rejected"].append({
-                "provenance": provenance,
-                "reason": "return has no catalog_feedback",
-            })
+            self.returns["rejected"].append(
+                {
+                    "provenance": provenance,
+                    "reason": "return has no catalog_feedback",
+                }
+            )
             return
         issues = []
         if len(feedback_keys) > 1:
-            issues.append(_issue(
-                "catalog_feedback_fields_conflict",
-                "return cannot contain both catalog_feedback and legacy feedback",
-                actual=feedback_keys,
-            ))
+            issues.append(
+                _issue(
+                    "catalog_feedback_fields_conflict",
+                    "return cannot contain both catalog_feedback and legacy feedback",
+                    actual=feedback_keys,
+                )
+            )
         if talk_filename is None and talk_id is None:
-            issues.append(_issue(
-                "talk_identity_missing",
-                "feedback return needs a nonempty filename or talk_id",
-            ))
+            issues.append(
+                _issue(
+                    "talk_identity_missing",
+                    "feedback return needs a nonempty filename or talk_id",
+                )
+            )
         feedback = item.get(feedback_keys[0])
         if not isinstance(feedback, dict):
-            issues.append(_issue(
-                "catalog_feedback_not_object",
-                "catalog_feedback must be an object of the five feedback lanes",
-                actual=feedback,
-            ))
+            issues.append(
+                _issue(
+                    "catalog_feedback_not_object",
+                    "catalog_feedback must be an object of the five feedback lanes",
+                    actual=feedback,
+                )
+            )
         if issues:
-            self.returns["invalid"].append({
-                "provenance": provenance, "issues": issues,
-            })
+            self.returns["invalid"].append(
+                {
+                    "provenance": provenance,
+                    "issues": issues,
+                }
+            )
             return
 
         assert isinstance(feedback, dict)  # narrowed by the validation above
@@ -742,53 +911,78 @@ class FeedbackAggregator:
         for lane, value in feedback.items():
             if lane not in LANE_SET:
                 lane_provenance = _provenance(
-                    path, return_index, talk_filename, talk_id, lane=lane,
+                    path,
+                    return_index,
+                    talk_filename,
+                    talk_id,
+                    lane=lane,
                 )
-                self.entries["invalid"].append({
-                    "provenance": lane_provenance,
-                    "feedback": value,
-                    "issues": [_issue(
-                        "feedback_lane_unsupported",
-                        "catalog_feedback contains a lane outside the five-lane contract",
-                        expected=list(LANES), actual=lane,
-                    )],
-                })
+                self.entries["invalid"].append(
+                    {
+                        "provenance": lane_provenance,
+                        "feedback": value,
+                        "issues": [
+                            _issue(
+                                "feedback_lane_unsupported",
+                                "catalog_feedback contains a lane outside the five-lane contract",
+                                expected=list(LANES),
+                                actual=lane,
+                            )
+                        ],
+                    }
+                )
                 continue
             if not isinstance(value, list):
                 lane_provenance = _provenance(
-                    path, return_index, talk_filename, talk_id, lane=lane,
+                    path,
+                    return_index,
+                    talk_filename,
+                    talk_id,
+                    lane=lane,
                 )
-                self.entries["invalid"].append({
-                    "provenance": lane_provenance,
-                    "feedback": value,
-                    "issues": [_issue(
-                        "feedback_lane_not_array",
-                        "each feedback lane must be an array",
-                        actual=type(value).__name__,
-                    )],
-                })
+                self.entries["invalid"].append(
+                    {
+                        "provenance": lane_provenance,
+                        "feedback": value,
+                        "issues": [
+                            _issue(
+                                "feedback_lane_not_array",
+                                "each feedback lane must be an array",
+                                actual=type(value).__name__,
+                            )
+                        ],
+                    }
+                )
                 continue
             for entry_index, entry in enumerate(value):
                 self._consume_entry(
-                    path, return_index, talk_filename, talk_id,
-                    lane, entry_index, entry,
+                    path,
+                    return_index,
+                    talk_filename,
+                    talk_id,
+                    lane,
+                    entry_index,
+                    entry,
                 )
 
         status = (
-            "invalid" if len(self.entries["invalid"]) > invalid_before
-            else "accepted"
+            "invalid" if len(self.entries["invalid"]) > invalid_before else "accepted"
         )
         target = self.returns[status]
         if status == "accepted":
             target.append({"provenance": provenance})
         else:
-            target.append({
-                "provenance": provenance,
-                "issues": [_issue(
-                    "feedback_entries_invalid",
-                    "one or more feedback lanes/entries are invalid",
-                )],
-            })
+            target.append(
+                {
+                    "provenance": provenance,
+                    "issues": [
+                        _issue(
+                            "feedback_entries_invalid",
+                            "one or more feedback lanes/entries are invalid",
+                        )
+                    ],
+                }
+            )
 
     def _consume_entry(
         self,
@@ -801,8 +995,12 @@ class FeedbackAggregator:
         entry: Any,
     ) -> None:
         provenance = _provenance(
-            path, return_index, talk_filename, talk_id,
-            lane=lane, entry_index=entry_index,
+            path,
+            return_index,
+            talk_filename,
+            talk_id,
+            lane=lane,
+            entry_index=entry_index,
         )
         validation = validate_entry(
             lane,
@@ -811,11 +1009,13 @@ class FeedbackAggregator:
             self.catalog.get("alias_registry", {}),
         )
         if validation["errors"]:
-            self.entries["invalid"].append({
-                "provenance": provenance,
-                "feedback": entry,
-                "issues": validation["errors"],
-            })
+            self.entries["invalid"].append(
+                {
+                    "provenance": provenance,
+                    "feedback": entry,
+                    "issues": validation["errors"],
+                }
+            )
             return
         for warning in validation["warnings"]:
             self.warnings.append({"provenance": provenance, **warning})
@@ -827,12 +1027,14 @@ class FeedbackAggregator:
             for catalog_id in validation["catalog_ids"]
             if catalog_id in self.registry
         ]
-        self.entries["accepted"].append({
-            "provenance": provenance,
-            "feedback": entry,
-            "catalog_references": references,
-            "suggestion": validation["suggestion"],
-        })
+        self.entries["accepted"].append(
+            {
+                "provenance": provenance,
+                "feedback": entry,
+                "catalog_references": references,
+                "suggestion": validation["suggestion"],
+            }
+        )
 
     def _exact_catalog_groups(self) -> list[dict[str, Any]]:
         groups: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -843,21 +1045,27 @@ class FeedbackAggregator:
         result = []
         for catalog_id, occurrences in groups.items():
             lane_counts = Counter(item["feedback_lane"] for item in occurrences)
-            result.append({
-                "catalog_id": catalog_id,
-                "polarity": self.registry[catalog_id]["polarity"],
-                "catalog_path": self.registry[catalog_id]["path"],
-                "occurrence_count": len(occurrences),
-                "talk_count": len({_talk_key(item) for item in occurrences}),
-                "source_return_count": len({
-                    _source_return_key(item) for item in occurrences
-                }),
-                "lane_counts": dict(sorted(lane_counts.items())),
-                "occurrences": sorted(occurrences, key=provenance_sort_key),
-            })
+            result.append(
+                {
+                    "catalog_id": catalog_id,
+                    "polarity": self.registry[catalog_id]["polarity"],
+                    "catalog_path": self.registry[catalog_id]["path"],
+                    "occurrence_count": len(occurrences),
+                    "talk_count": len({_talk_key(item) for item in occurrences}),
+                    "source_return_count": len(
+                        {_source_return_key(item) for item in occurrences}
+                    ),
+                    "lane_counts": dict(sorted(lane_counts.items())),
+                    "occurrences": sorted(occurrences, key=provenance_sort_key),
+                }
+            )
         return sorted(
             result,
-            key=lambda item: (-item["talk_count"], -item["occurrence_count"], item["catalog_id"]),
+            key=lambda item: (
+                -item["talk_count"],
+                -item["occurrence_count"],
+                item["catalog_id"],
+            ),
         )
 
     def _suggestion_groups(self) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -867,29 +1075,36 @@ class FeedbackAggregator:
             suggestion = accepted["suggestion"]
             if suggestion is None:
                 continue
-            groups[suggestion["normalized_suggestion"]].append({
-                "provenance": accepted["provenance"],
-                "proposed_name": suggestion["proposed_name"],
-                "proposed_polarity": suggestion["proposed_polarity"],
-            })
+            groups[suggestion["normalized_suggestion"]].append(
+                {
+                    "provenance": accepted["provenance"],
+                    "proposed_name": suggestion["proposed_name"],
+                    "proposed_polarity": suggestion["proposed_polarity"],
+                }
+            )
 
         result = []
         for normalized, occurrences in groups.items():
-            explicit = sorted({
-                item["proposed_polarity"] for item in occurrences
-                if item["proposed_polarity"] != "unspecified"
-            })
+            explicit = sorted(
+                {
+                    item["proposed_polarity"]
+                    for item in occurrences
+                    if item["proposed_polarity"] != "unspecified"
+                }
+            )
             unspecified = sum(
                 item["proposed_polarity"] == "unspecified" for item in occurrences
             )
             if len(explicit) > 1:
                 polarity_status = "conflict"
-                conflicts.append(_issue(
-                    "suggestion_polarity_conflict",
-                    "normalized suggestion is asserted as both pattern and antipattern",
-                    normalized_suggestion=normalized,
-                    asserted_polarities=explicit,
-                ))
+                conflicts.append(
+                    _issue(
+                        "suggestion_polarity_conflict",
+                        "normalized suggestion is asserted as both pattern and antipattern",
+                        normalized_suggestion=normalized,
+                        asserted_polarities=explicit,
+                    )
+                )
             elif explicit and unspecified:
                 polarity_status = "partial"
             elif explicit:
@@ -901,56 +1116,63 @@ class FeedbackAggregator:
                 _source_return_key(item["provenance"]) for item in occurrences
             }
             variants = Counter(item["proposed_name"] for item in occurrences)
-            result.append({
-                "normalized_suggestion": normalized,
-                "occurrence_count": len(occurrences),
-                "talk_count": len(talks),
-                "source_return_count": len(source_returns),
-                "variants": [
-                    {"value": value, "count": count}
-                    for value, count in sorted(variants.items())
-                ],
-                "asserted_polarities": explicit,
-                "unspecified_polarity_count": unspecified,
-                "polarity_status": polarity_status,
-                "occurrences": sorted(
-                    occurrences,
-                    key=lambda item: provenance_sort_key(item["provenance"]),
-                ),
-            })
+            result.append(
+                {
+                    "normalized_suggestion": normalized,
+                    "occurrence_count": len(occurrences),
+                    "talk_count": len(talks),
+                    "source_return_count": len(source_returns),
+                    "variants": [
+                        {"value": value, "count": count}
+                        for value, count in sorted(variants.items())
+                    ],
+                    "asserted_polarities": explicit,
+                    "unspecified_polarity_count": unspecified,
+                    "polarity_status": polarity_status,
+                    "occurrences": sorted(
+                        occurrences,
+                        key=lambda item: provenance_sort_key(item["provenance"]),
+                    ),
+                }
+            )
         return (
             sorted(
                 result,
                 key=lambda item: (
-                    -item["talk_count"], -item["occurrence_count"],
+                    -item["talk_count"],
+                    -item["occurrence_count"],
                     item["normalized_suggestion"],
                 ),
             ),
             conflicts,
         )
 
-    def report(self, requested_inputs: list[str], discovery: dict[str, Any]) -> dict[str, Any]:
+    def report(
+        self, requested_inputs: list[str], discovery: dict[str, Any]
+    ) -> dict[str, Any]:
         suggestions, suggestion_conflicts = self._suggestion_groups()
         catalog_groups = self._exact_catalog_groups()
         lane_summary = {}
         for lane in LANES:
             lane_entries = [
-                item for item in self.entries["accepted"]
+                item
+                for item in self.entries["accepted"]
                 if item["provenance"]["feedback_lane"] == lane
             ]
             invalid_lane_entries = [
-                item for item in self.entries["invalid"]
+                item
+                for item in self.entries["invalid"]
                 if item["provenance"]["feedback_lane"] == lane
             ]
             lane_summary[lane] = {
                 "accepted_entry_count": len(lane_entries),
                 "invalid_entry_count": len(invalid_lane_entries),
-                "talk_count": len({
-                    _talk_key(item["provenance"]) for item in lane_entries
-                }),
-                "source_return_count": len({
-                    _source_return_key(item["provenance"]) for item in lane_entries
-                }),
+                "talk_count": len(
+                    {_talk_key(item["provenance"]) for item in lane_entries}
+                ),
+                "source_return_count": len(
+                    {_source_return_key(item["provenance"]) for item in lane_entries}
+                ),
             }
 
         for classification in self.inputs:
@@ -963,9 +1185,7 @@ class FeedbackAggregator:
             self.entries[classification].sort(
                 key=lambda item: provenance_sort_key(item["provenance"])
             )
-        warnings = sorted(
-            [*self.warnings, *discovery["warnings"]], key=issue_sort_key
-        )
+        warnings = sorted([*self.warnings, *discovery["warnings"]], key=issue_sort_key)
         validation_errors = sorted(
             [*self.validation_errors, *suggestion_conflicts], key=issue_sort_key
         )
@@ -980,7 +1200,10 @@ class FeedbackAggregator:
             "schema_version": REPORT_SCHEMA_VERSION,
             "ok": invalid_count == 0,
             "read_only": True,
-            "requested_inputs": sorted(str(Path(value).expanduser().resolve(strict=False)) for value in requested_inputs),
+            "requested_inputs": sorted(
+                str(Path(value).expanduser().resolve(strict=False))
+                for value in requested_inputs
+            ),
             "catalog": {
                 "path": self.catalog["path"],
                 "id_count": len(self.registry),
@@ -993,11 +1216,13 @@ class FeedbackAggregator:
                 "errors": catalog_errors,
             },
             "input_summary": {
-                key: len(self.inputs[key]) for key in ("accepted", "rejected", "invalid")
+                key: len(self.inputs[key])
+                for key in ("accepted", "rejected", "invalid")
             },
             "inputs": self.inputs,
             "return_summary": {
-                key: len(self.returns[key]) for key in ("accepted", "rejected", "invalid")
+                key: len(self.returns[key])
+                for key in ("accepted", "rejected", "invalid")
             },
             "returns": self.returns,
             "entry_summary": {
@@ -1024,7 +1249,8 @@ def provenance_sort_key(provenance: dict[str, Any]) -> tuple[Any, ...]:
         provenance.get("talk_id") or "",
         provenance.get("feedback_lane") or "",
         provenance.get("feedback_entry_index")
-        if provenance.get("feedback_entry_index") is not None else -1,
+        if provenance.get("feedback_entry_index") is not None
+        else -1,
     )
 
 
@@ -1048,9 +1274,12 @@ def aggregate_feedback(
     discovery = discover_inputs(inputs)
     aggregator = FeedbackAggregator(catalog)
     if not inputs:
-        aggregator.validation_errors.append(_issue(
-            "inputs_missing", "at least one return file or directory is required",
-        ))
+        aggregator.validation_errors.append(
+            _issue(
+                "inputs_missing",
+                "at least one return file or directory is required",
+            )
+        )
     for immediate in discovery["immediate"]:
         aggregator.inputs[immediate["status"]].append(immediate)
     for discovered in discovery["files"]:
@@ -1073,10 +1302,13 @@ def _argument_error_report() -> dict[str, Any]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument(
-        "inputs", nargs="+", help="return JSON files or directories",
+        "inputs",
+        nargs="+",
+        help="return JSON files or directories",
     )
     parser.add_argument(
-        "--catalog", default=None,
+        "--catalog",
+        default=None,
         help="pattern catalog directory (defaults to the bundled catalog)",
     )
     try:

--- a/skills/vault-ingress/scripts/apply-source-repairs.py
+++ b/skills/vault-ingress/scripts/apply-source-repairs.py
@@ -53,27 +53,34 @@ from tracking_database_io import (
 PLAN_SCHEMA_VERSION = 1
 REPORT_SCHEMA_VERSION = 2
 MISSING_MARKER = {"$missing": True}
-ALLOWED_FIELDS = frozenset({
-    "video_url",
-    "youtube_id",
-    "slides_url",
-    "google_drive_id",
-    "pptx_path",
-    "slides_local_path",
-    "slides_pdf_path",
-    "pdf_path",
-    "transcript_path",
-    "transcript_source",
-    "slide_source",
-    "source_identity",
-    "source_relation",
-    "source_rejections",
-    "status",
-    "reprocess_reason",
-})
-ALLOWED_REPAIR_STATUSES = frozenset({
-    "pending", "needs-reprocessing", "processed_partial", "skipped_no_sources",
-})
+ALLOWED_FIELDS = frozenset(
+    {
+        "video_url",
+        "youtube_id",
+        "slides_url",
+        "google_drive_id",
+        "pptx_path",
+        "slides_local_path",
+        "slides_pdf_path",
+        "pdf_path",
+        "transcript_path",
+        "transcript_source",
+        "slide_source",
+        "source_identity",
+        "source_relation",
+        "source_rejections",
+        "status",
+        "reprocess_reason",
+    }
+)
+ALLOWED_REPAIR_STATUSES = frozenset(
+    {
+        "pending",
+        "needs-reprocessing",
+        "processed_partial",
+        "skipped_no_sources",
+    }
+)
 
 
 class SourceRepairError(ValueError):
@@ -140,9 +147,7 @@ def require_nonempty(value: Any, label: str) -> str:
 
 def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
     if not json_values_equal(plan.get("schema_version"), PLAN_SCHEMA_VERSION):
-        raise SourceRepairError(
-            f"plan schema_version must be {PLAN_SCHEMA_VERSION}"
-        )
+        raise SourceRepairError(f"plan schema_version must be {PLAN_SCHEMA_VERSION}")
     repairs = plan.get("repairs")
     if not isinstance(repairs, list) or not repairs:
         raise SourceRepairError("plan repairs must be a nonempty array")
@@ -190,10 +195,11 @@ def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
             )
         overlap = set(set_values) & set(clear)
         if overlap:
-            raise SourceRepairError(
-                f"{label} both sets and clears: {sorted(overlap)}"
-            )
-        if "status" in set_values and set_values["status"] not in ALLOWED_REPAIR_STATUSES:
+            raise SourceRepairError(f"{label} both sets and clears: {sorted(overlap)}")
+        if (
+            "status" in set_values
+            and set_values["status"] not in ALLOWED_REPAIR_STATUSES
+        ):
             raise SourceRepairError(
                 f"{label}.set.status must be one of {sorted(ALLOWED_REPAIR_STATUSES)}"
             )
@@ -208,7 +214,8 @@ def _matches_expected(talk: dict[str, Any], field: str, expected: Any) -> bool:
 
 
 def build_repaired_database(
-    database: dict[str, Any], repairs: list[dict[str, Any]],
+    database: dict[str, Any],
+    repairs: list[dict[str, Any]],
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     talks = database.get("talks")
     if not isinstance(talks, list) or any(not isinstance(talk, dict) for talk in talks):
@@ -236,7 +243,9 @@ def build_repaired_database(
         if current.get("status") == "reprocessing-inflight" or (
             isinstance(claim, dict) and claim.get("state") == "claimed"
         ):
-            errors.append(f"{filename}: source repair cannot change an active queue claim")
+            errors.append(
+                f"{filename}: source repair cannot change an active queue claim"
+            )
             continue
         for field, expected in repair["expect"].items():
             if not _matches_expected(current, field, expected):
@@ -246,7 +255,9 @@ def build_repaired_database(
                 )
 
     if errors:
-        raise SourceRepairError("repair preconditions failed:\n- " + "\n- ".join(errors))
+        raise SourceRepairError(
+            "repair preconditions failed:\n- " + "\n- ".join(errors)
+        )
 
     for repair in repairs:
         filename = repair["filename"]
@@ -265,12 +276,14 @@ def build_repaired_database(
             talk[field] = copy.deepcopy(value)
             after[field] = value
         if before:
-            changes.append({
-                "filename": filename,
-                "reason": repair["reason"],
-                "before": before,
-                "after": after,
-            })
+            changes.append(
+                {
+                    "filename": filename,
+                    "reason": repair["reason"],
+                    "before": before,
+                    "after": after,
+                }
+            )
     return result, changes
 
 
@@ -294,7 +307,10 @@ def atomic_write(
 
 
 def execute(
-    database_path: Path, plan_path: Path, *, apply: bool,
+    database_path: Path,
+    plan_path: Path,
+    *,
+    apply: bool,
     backup_dir: Path | None = None,
 ) -> dict[str, Any]:
     database, database_snapshot = load_database(database_path)
@@ -327,8 +343,7 @@ def execute(
         target_backup_dir = backup_dir or database_path.parent / ".backups"
         backup_request = BackupRequest(
             path=(
-                target_backup_dir
-                / f"{database_path.name}.source-repair-"
+                target_backup_dir / f"{database_path.name}.source-repair-"
                 f"{database_snapshot.sha256}.bak"
             ),
             input_sha256=database_snapshot.sha256,
@@ -369,7 +384,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         report = execute(
-            args.database, args.plan, apply=args.apply, backup_dir=args.backup_dir,
+            args.database,
+            args.plan,
+            apply=args.apply,
+            backup_dir=args.backup_dir,
         )
     except (SourceRepairError, OSError) as exc:
         print(

--- a/skills/vault-ingress/scripts/audit-pattern-catalog.py
+++ b/skills/vault-ingress/scripts/audit-pattern-catalog.py
@@ -58,47 +58,57 @@ from catalog_normalization import normalize_catalog_alias
 SCHEMA_VERSION = 1
 ENTRY_TYPES = frozenset({"pattern", "antipattern"})
 PARTS = frozenset({"prepare", "build", "deliver"})
-CREATOR_PHASES = frozenset({
-    "intake",
-    "intent",
-    "architecture",
-    "content",
-    "guardrails",
-    "slides",
-    "publishing",
-})
-EVIDENCE_SOURCES = frozenset({
-    "static_slides",
-    "native_deck",
-    "delivery_video",
-    "transcript",
-    "source_comparison",
-})
+CREATOR_PHASES = frozenset(
+    {
+        "intake",
+        "intent",
+        "architecture",
+        "content",
+        "guardrails",
+        "slides",
+        "publishing",
+    }
+)
+EVIDENCE_SOURCES = frozenset(
+    {
+        "static_slides",
+        "native_deck",
+        "delivery_video",
+        "transcript",
+        "source_comparison",
+    }
+)
 # Current-generation absence claims require a single, rendered/static artifact
 # or a complete transcript. Other source roles remain valid positive-evidence
 # grammar for external and historical catalogs, but cannot authorize absence in
 # the bundled catalog until a modality-specific completeness receipt exists.
-CURRENT_ABSENCE_CAPABILITY_SOURCES = frozenset({
-    "static_slides",
-    "transcript",
-})
-BASE_EVIDENCE_GATE_FIELDS = frozenset({
-    "evaluable_from",
-    "evidence_requirements",
-    "not_evaluable_when",
-})
-OUTCOME_EVIDENCE_GATE_FIELDS = frozenset({
-    "strong_evaluable_from",
-    "absence_evaluable_from",
-})
-APPLICABILITY_GATE_FIELDS = frozenset({
-    "not_applicable_when",
-    "applicability_evaluable_from",
-})
+CURRENT_ABSENCE_CAPABILITY_SOURCES = frozenset(
+    {
+        "static_slides",
+        "transcript",
+    }
+)
+BASE_EVIDENCE_GATE_FIELDS = frozenset(
+    {
+        "evaluable_from",
+        "evidence_requirements",
+        "not_evaluable_when",
+    }
+)
+OUTCOME_EVIDENCE_GATE_FIELDS = frozenset(
+    {
+        "strong_evaluable_from",
+        "absence_evaluable_from",
+    }
+)
+APPLICABILITY_GATE_FIELDS = frozenset(
+    {
+        "not_applicable_when",
+        "applicability_evaluable_from",
+    }
+)
 EVIDENCE_GATE_FIELDS = (
-    BASE_EVIDENCE_GATE_FIELDS
-    | OUTCOME_EVIDENCE_GATE_FIELDS
-    | APPLICABILITY_GATE_FIELDS
+    BASE_EVIDENCE_GATE_FIELDS | OUTCOME_EVIDENCE_GATE_FIELDS | APPLICABILITY_GATE_FIELDS
 )
 
 ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
@@ -262,42 +272,52 @@ def _parse_frontmatter(
     errors: list[Issue],
 ) -> dict[str, Any]:
     if not text.startswith("---\n"):
-        errors.append(Issue(
-            "frontmatter_missing",
-            "catalog entry must start with YAML frontmatter",
-            relative_path,
-        ))
+        errors.append(
+            Issue(
+                "frontmatter_missing",
+                "catalog entry must start with YAML frontmatter",
+                relative_path,
+            )
+        )
         return {}
     end = text.find("\n---\n", 4)
     if end < 0:
-        errors.append(Issue(
-            "frontmatter_unterminated",
-            "catalog entry frontmatter has no closing delimiter",
-            relative_path,
-        ))
+        errors.append(
+            Issue(
+                "frontmatter_unterminated",
+                "catalog entry frontmatter has no closing delimiter",
+                relative_path,
+            )
+        )
         return {}
     try:
         value = load_catalog_yaml(text[4:end]) or {}
     except DuplicateYAMLKeyError as exc:
-        errors.append(Issue(
-            "frontmatter_duplicate_key",
-            f"catalog entry frontmatter repeats a YAML mapping key: {exc}",
-            relative_path,
-        ))
+        errors.append(
+            Issue(
+                "frontmatter_duplicate_key",
+                f"catalog entry frontmatter repeats a YAML mapping key: {exc}",
+                relative_path,
+            )
+        )
         return {}
     except YAMLError as exc:
-        errors.append(Issue(
-            "frontmatter_invalid_yaml",
-            f"catalog entry frontmatter is invalid YAML: {exc}",
-            relative_path,
-        ))
+        errors.append(
+            Issue(
+                "frontmatter_invalid_yaml",
+                f"catalog entry frontmatter is invalid YAML: {exc}",
+                relative_path,
+            )
+        )
         return {}
     if not isinstance(value, dict):
-        errors.append(Issue(
-            "frontmatter_not_mapping",
-            "catalog entry frontmatter must be a mapping",
-            relative_path,
-        ))
+        errors.append(
+            Issue(
+                "frontmatter_not_mapping",
+                "catalog entry frontmatter must be a mapping",
+                relative_path,
+            )
+        )
         return {}
     return value
 
@@ -307,23 +327,29 @@ def _read_entry(path: Path, root: Path, errors: list[Issue]) -> CatalogEntry:
     try:
         content = path.read_bytes()
     except OSError as exc:
-        errors.append(Issue(
-            "entry_unreadable",
-            f"catalog entry cannot be read as UTF-8: {exc}",
-            relative_path,
-        ))
+        errors.append(
+            Issue(
+                "entry_unreadable",
+                f"catalog entry cannot be read as UTF-8: {exc}",
+                relative_path,
+            )
+        )
         return CatalogEntry(
-            path, relative_path, b"", "", {}, None, None, None, None, None)
+            path, relative_path, b"", "", {}, None, None, None, None, None
+        )
     try:
         text = content.decode("utf-8")
     except UnicodeError as exc:
-        errors.append(Issue(
-            "entry_unreadable",
-            f"catalog entry cannot be read as UTF-8: {exc}",
-            relative_path,
-        ))
+        errors.append(
+            Issue(
+                "entry_unreadable",
+                f"catalog entry cannot be read as UTF-8: {exc}",
+                relative_path,
+            )
+        )
         return CatalogEntry(
-            path, relative_path, content, "", {}, None, None, None, None, None)
+            path, relative_path, content, "", {}, None, None, None, None, None
+        )
 
     metadata = _parse_frontmatter(path, relative_path, text, errors)
     raw_id = metadata.get("id")
@@ -357,13 +383,15 @@ def _required_string(
 ) -> str | None:
     value = entry.metadata.get(field)
     if not isinstance(value, str) or not value.strip() or value != value.strip():
-        errors.append(Issue(
-            "field_invalid_string",
-            f"{field} must be a trimmed non-empty string",
-            entry.relative_path,
-            entry.pattern_id or "",
-            field,
-        ))
+        errors.append(
+            Issue(
+                "field_invalid_string",
+                f"{field} must be a trimmed non-empty string",
+                entry.relative_path,
+                entry.pattern_id or "",
+                field,
+            )
+        )
         return None
     return value
 
@@ -383,29 +411,31 @@ def _string_list(
         not isinstance(value, list)
         or (nonempty and not value)
         or any(
-            not isinstance(item, str)
-            or not item.strip()
-            or item != item.strip()
+            not isinstance(item, str) or not item.strip() or item != item.strip()
             for item in value
         )
     ):
         requirement = "non-empty " if nonempty else ""
-        errors.append(Issue(
-            "field_invalid_list",
-            f"{field} must be a {requirement}list of trimmed non-empty strings",
-            entry.relative_path,
-            entry.pattern_id or "",
-            field,
-        ))
+        errors.append(
+            Issue(
+                "field_invalid_list",
+                f"{field} must be a {requirement}list of trimmed non-empty strings",
+                entry.relative_path,
+                entry.pattern_id or "",
+                field,
+            )
+        )
         return None
     if len(value) != len(set(value)):
-        errors.append(Issue(
-            "field_duplicate_values",
-            f"{field} contains duplicate values",
-            entry.relative_path,
-            entry.pattern_id or "",
-            field,
-        ))
+        errors.append(
+            Issue(
+                "field_duplicate_values",
+                f"{field} contains duplicate values",
+                entry.relative_path,
+                entry.pattern_id or "",
+                field,
+            )
+        )
     return value
 
 
@@ -416,69 +446,83 @@ def _validate_entry_identity(entry: CatalogEntry, errors: list[Issue]) -> None:
     part = _required_string(entry, "part", errors)
 
     if pattern_id is not None and not ID_RE.fullmatch(pattern_id):
-        errors.append(Issue(
-            "id_invalid",
-            "id must be a lowercase kebab-case token",
-            entry.relative_path,
-            pattern_id,
-            "id",
-        ))
+        errors.append(
+            Issue(
+                "id_invalid",
+                "id must be a lowercase kebab-case token",
+                entry.relative_path,
+                pattern_id,
+                "id",
+            )
+        )
 
     stem = entry.path.stem
     expected_id = stem.removeprefix("_anti_")
     if pattern_id is not None and pattern_id != expected_id:
-        errors.append(Issue(
-            "filename_id_mismatch",
-            f"filename encodes id {expected_id!r}, frontmatter declares {pattern_id!r}",
-            entry.relative_path,
-            pattern_id,
-            "id",
-        ))
+        errors.append(
+            Issue(
+                "filename_id_mismatch",
+                f"filename encodes id {expected_id!r}, frontmatter declares {pattern_id!r}",
+                entry.relative_path,
+                pattern_id,
+                "id",
+            )
+        )
 
     expected_type = "antipattern" if stem.startswith("_anti_") else "pattern"
     if entry_type is not None and entry_type not in ENTRY_TYPES:
-        errors.append(Issue(
-            "type_invalid",
-            f"type must be one of {sorted(ENTRY_TYPES)}, got {entry_type!r}",
-            entry.relative_path,
-            pattern_id or "",
-            "type",
-        ))
+        errors.append(
+            Issue(
+                "type_invalid",
+                f"type must be one of {sorted(ENTRY_TYPES)}, got {entry_type!r}",
+                entry.relative_path,
+                pattern_id or "",
+                "type",
+            )
+        )
     elif entry_type is not None and entry_type != expected_type:
-        errors.append(Issue(
-            "filename_type_mismatch",
-            f"filename requires type {expected_type!r}, frontmatter declares {entry_type!r}",
-            entry.relative_path,
-            pattern_id or "",
-            "type",
-        ))
+        errors.append(
+            Issue(
+                "filename_type_mismatch",
+                f"filename requires type {expected_type!r}, frontmatter declares {entry_type!r}",
+                entry.relative_path,
+                pattern_id or "",
+                "type",
+            )
+        )
 
     parent_part = entry.path.parent.name
     if part is not None and part not in PARTS:
-        errors.append(Issue(
-            "part_invalid",
-            f"part must be one of {sorted(PARTS)}, got {part!r}",
-            entry.relative_path,
-            pattern_id or "",
-            "part",
-        ))
+        errors.append(
+            Issue(
+                "part_invalid",
+                f"part must be one of {sorted(PARTS)}, got {part!r}",
+                entry.relative_path,
+                pattern_id or "",
+                "part",
+            )
+        )
     elif part is not None and part != parent_part:
-        errors.append(Issue(
-            "directory_part_mismatch",
-            f"directory requires part {parent_part!r}, frontmatter declares {part!r}",
-            entry.relative_path,
-            pattern_id or "",
-            "part",
-        ))
+        errors.append(
+            Issue(
+                "directory_part_mismatch",
+                f"directory requires part {parent_part!r}, frontmatter declares {part!r}",
+                entry.relative_path,
+                pattern_id or "",
+                "part",
+            )
+        )
 
     relative_parts = Path(entry.relative_path).parts
     if len(relative_parts) != 2 or parent_part not in PARTS:
-        errors.append(Issue(
-            "entry_path_invalid",
-            "entry must live directly under prepare/, build/, or deliver/",
-            entry.relative_path,
-            pattern_id or "",
-        ))
+        errors.append(
+            Issue(
+                "entry_path_invalid",
+                "entry must live directly under prepare/, build/, or deliver/",
+                entry.relative_path,
+                pattern_id or "",
+            )
+        )
 
 
 def _validate_dimensions_and_phases(
@@ -498,23 +542,27 @@ def _validate_dimensions_and_phases(
             for value in raw_dimensions
         )
     ):
-        errors.append(Issue(
-            "vault_dimensions_invalid",
-            "vault_dimensions must be a non-empty list of integers from 1 through 14",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "vault_dimensions",
-        ))
-    else:
-        dimensions = tuple(raw_dimensions)
-        if len(dimensions) != len(set(dimensions)):
-            errors.append(Issue(
-                "vault_dimensions_duplicate",
-                "vault_dimensions contains duplicate values",
+        errors.append(
+            Issue(
+                "vault_dimensions_invalid",
+                "vault_dimensions must be a non-empty list of integers from 1 through 14",
                 entry.relative_path,
                 entry.pattern_id or "",
                 "vault_dimensions",
-            ))
+            )
+        )
+    else:
+        dimensions = tuple(raw_dimensions)
+        if len(dimensions) != len(set(dimensions)):
+            errors.append(
+                Issue(
+                    "vault_dimensions_duplicate",
+                    "vault_dimensions contains duplicate values",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "vault_dimensions",
+                )
+            )
 
     phases = _string_list(
         entry,
@@ -525,93 +573,108 @@ def _validate_dimensions_and_phases(
     phase_values = tuple(phases or ())
     unknown = sorted(set(phase_values) - CREATOR_PHASES)
     if unknown:
-        errors.append(Issue(
-            "creator_phase_invalid",
-            f"phase_relevance contains values outside the creator phase namespace: {unknown}",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "phase_relevance",
-        ))
+        errors.append(
+            Issue(
+                "creator_phase_invalid",
+                f"phase_relevance contains values outside the creator phase namespace: {unknown}",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "phase_relevance",
+            )
+        )
     return dimensions, phase_values
 
 
 def _validate_observability(entry: CatalogEntry, errors: list[Issue]) -> None:
     raw_observable = entry.metadata.get("observable", True)
     if not isinstance(raw_observable, bool):
-        errors.append(Issue(
-            "observable_invalid",
-            "observable must be a boolean when declared",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "observable",
-        ))
+        errors.append(
+            Issue(
+                "observable_invalid",
+                "observable must be a boolean when declared",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "observable",
+            )
+        )
 
     present_base = BASE_EVIDENCE_GATE_FIELDS.intersection(entry.metadata)
     present_outcomes = OUTCOME_EVIDENCE_GATE_FIELDS.intersection(entry.metadata)
     present_applicability = APPLICABILITY_GATE_FIELDS.intersection(entry.metadata)
     present = present_base | present_outcomes | present_applicability
-    has_evidence_section = _markdown_h2_section(
-        entry.text,
-        "Evidence Gate",
-    ) is not None
+    has_evidence_section = (
+        _markdown_h2_section(
+            entry.text,
+            "Evidence Gate",
+        )
+        is not None
+    )
     if present and present_base != BASE_EVIDENCE_GATE_FIELDS:
-        errors.append(Issue(
-            "source_gate_partial",
-            f"source gate is partial; present fields are {sorted(present)}",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "evaluable_from",
-        ))
+        errors.append(
+            Issue(
+                "source_gate_partial",
+                f"source gate is partial; present fields are {sorted(present)}",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "evaluable_from",
+            )
+        )
         return
 
     if not present:
         if has_evidence_section:
-            errors.append(Issue(
-                "source_gate_metadata_missing",
-                "Evidence Gate prose requires the complete source-gate frontmatter",
-                entry.relative_path,
-                entry.pattern_id or "",
-                "evaluable_from",
-            ))
+            errors.append(
+                Issue(
+                    "source_gate_metadata_missing",
+                    "Evidence Gate prose requires the complete source-gate frontmatter",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "evaluable_from",
+                )
+            )
         return
 
     if raw_observable is False:
-        errors.append(Issue(
-            "unobservable_source_gate_conflict",
-            "observable:false entries are skipped and cannot also declare a scoring source gate",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "observable",
-        ))
+        errors.append(
+            Issue(
+                "unobservable_source_gate_conflict",
+                "observable:false entries are skipped and cannot also declare a scoring source gate",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "observable",
+            )
+        )
 
-    for field in (
-            "evaluable_from", "strong_evaluable_from",
-            "absence_evaluable_from"):
+    for field in ("evaluable_from", "strong_evaluable_from", "absence_evaluable_from"):
         if field not in entry.metadata:
             continue
         if field == "absence_evaluable_from" and entry.metadata[field] is None:
             continue
         try:
             parse_evidence_source_groups(
-                entry.metadata.get(field), EVIDENCE_SOURCES,
-                field_name=field)
+                entry.metadata.get(field), EVIDENCE_SOURCES, field_name=field
+            )
         except ValueError as exc:
-            errors.append(Issue(
-                "evidence_source_invalid",
-                str(exc),
-                entry.relative_path,
-                entry.pattern_id or "",
-                field,
-            ))
+            errors.append(
+                Issue(
+                    "evidence_source_invalid",
+                    str(exc),
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    field,
+                )
+            )
 
     if present_applicability and present_applicability != APPLICABILITY_GATE_FIELDS:
-        errors.append(Issue(
-            "applicability_contract_partial",
-            "not_applicable_when and applicability_evaluable_from must be declared together",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "not_applicable_when",
-        ))
+        errors.append(
+            Issue(
+                "applicability_contract_partial",
+                "not_applicable_when and applicability_evaluable_from must be declared together",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "not_applicable_when",
+            )
+        )
     elif present_applicability == APPLICABILITY_GATE_FIELDS:
         try:
             parse_evidence_source_groups(
@@ -620,75 +683,92 @@ def _validate_observability(entry: CatalogEntry, errors: list[Issue]) -> None:
                 field_name="applicability_evaluable_from",
             )
         except ValueError as exc:
-            errors.append(Issue(
-                "applicability_evidence_source_invalid",
-                str(exc),
-                entry.relative_path,
-                entry.pattern_id or "",
-                "applicability_evaluable_from",
-            ))
+            errors.append(
+                Issue(
+                    "applicability_evidence_source_invalid",
+                    str(exc),
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "applicability_evaluable_from",
+                )
+            )
 
         conditions = entry.metadata.get("not_applicable_when")
         if not isinstance(conditions, list) or not conditions:
-            errors.append(Issue(
-                "not_applicable_conditions_invalid",
-                "not_applicable_when must be a non-empty list of condition objects",
-                entry.relative_path,
-                entry.pattern_id or "",
-                "not_applicable_when",
-            ))
+            errors.append(
+                Issue(
+                    "not_applicable_conditions_invalid",
+                    "not_applicable_when must be a non-empty list of condition objects",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "not_applicable_when",
+                )
+            )
         else:
             seen_condition_ids: set[str] = set()
             for position, condition in enumerate(conditions):
                 if not isinstance(condition, dict) or set(condition) != {
-                        "condition_id", "description"}:
-                    errors.append(Issue(
-                        "not_applicable_condition_invalid",
-                        "each applicability condition must contain exactly condition_id and description",
-                        entry.relative_path,
-                        entry.pattern_id or "",
-                        f"not_applicable_when[{position}]",
-                    ))
+                    "condition_id",
+                    "description",
+                }:
+                    errors.append(
+                        Issue(
+                            "not_applicable_condition_invalid",
+                            "each applicability condition must contain exactly condition_id and description",
+                            entry.relative_path,
+                            entry.pattern_id or "",
+                            f"not_applicable_when[{position}]",
+                        )
+                    )
                     continue
                 condition_id = condition.get("condition_id")
                 description = condition.get("description")
                 if not isinstance(condition_id, str) or not ID_RE.fullmatch(
-                        condition_id):
-                    errors.append(Issue(
-                        "not_applicable_condition_id_invalid",
-                        "condition_id must use the catalog's stable lowercase-hyphen identifier form",
-                        entry.relative_path,
-                        entry.pattern_id or "",
-                        f"not_applicable_when[{position}].condition_id",
-                    ))
+                    condition_id
+                ):
+                    errors.append(
+                        Issue(
+                            "not_applicable_condition_id_invalid",
+                            "condition_id must use the catalog's stable lowercase-hyphen identifier form",
+                            entry.relative_path,
+                            entry.pattern_id or "",
+                            f"not_applicable_when[{position}].condition_id",
+                        )
+                    )
                 elif condition_id in seen_condition_ids:
-                    errors.append(Issue(
-                        "not_applicable_condition_duplicate",
-                        "condition_id is duplicated within the entry",
-                        entry.relative_path,
-                        entry.pattern_id or "",
-                        f"not_applicable_when[{position}].condition_id",
-                    ))
+                    errors.append(
+                        Issue(
+                            "not_applicable_condition_duplicate",
+                            "condition_id is duplicated within the entry",
+                            entry.relative_path,
+                            entry.pattern_id or "",
+                            f"not_applicable_when[{position}].condition_id",
+                        )
+                    )
                 else:
                     seen_condition_ids.add(condition_id)
                 if not isinstance(description, str) or not description.strip():
-                    errors.append(Issue(
-                        "not_applicable_description_invalid",
-                        "applicability condition description must be a non-empty string",
-                        entry.relative_path,
-                        entry.pattern_id or "",
-                        f"not_applicable_when[{position}].description",
-                    ))
+                    errors.append(
+                        Issue(
+                            "not_applicable_description_invalid",
+                            "applicability condition description must be a non-empty string",
+                            entry.relative_path,
+                            entry.pattern_id or "",
+                            f"not_applicable_when[{position}].description",
+                        )
+                    )
     _string_list(entry, "evidence_requirements", errors, nonempty=True)
     _string_list(entry, "not_evaluable_when", errors, nonempty=True)
     if not has_evidence_section:
-        errors.append(Issue(
-            "source_gate_prose_missing",
-            "source-gated entry must include an Evidence Gate section",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "evaluable_from",
-        ))
+        errors.append(
+            Issue(
+                "source_gate_prose_missing",
+                "source-gated entry must include an Evidence Gate section",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "evaluable_from",
+            )
+        )
 
 
 def _validate_current_absence_capability(
@@ -730,14 +810,16 @@ def _validate_current_absence_capability(
             unsupported.append(f"alternative {position}: {', '.join(details)}")
 
     if unsupported:
-        errors.append(Issue(
-            "absence_source_capability_unsupported",
-            "current-generation absence gates require singleton static_slides "
-            "or transcript alternatives; " + "; ".join(unsupported),
-            entry.relative_path,
-            entry.pattern_id or "",
-            "absence_evaluable_from",
-        ))
+        errors.append(
+            Issue(
+                "absence_source_capability_unsupported",
+                "current-generation absence gates require singleton static_slides "
+                "or transcript alternatives; " + "; ".join(unsupported),
+                entry.relative_path,
+                entry.pattern_id or "",
+                "absence_evaluable_from",
+            )
+        )
 
 
 def _scoring_section(text: str) -> str | None:
@@ -747,32 +829,38 @@ def _scoring_section(text: str) -> str | None:
 def _validate_scoring(entry: CatalogEntry, errors: list[Issue]) -> None:
     section = _scoring_section(entry.text)
     if section is None:
-        errors.append(Issue(
-            "scoring_section_missing",
-            "entry must include a Scoring Criteria section",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "scoring_criteria",
-        ))
+        errors.append(
+            Issue(
+                "scoring_section_missing",
+                "entry must include a Scoring Criteria section",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "scoring_criteria",
+            )
+        )
         return
 
     if SCORING_ARITHMETIC_LABEL_RE.search(section):
-        errors.append(Issue(
-            "scoring_arithmetic_label_forbidden",
-            "scoring decision labels are non-arithmetic and must not declare point values",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "scoring_criteria",
-        ))
+        errors.append(
+            Issue(
+                "scoring_arithmetic_label_forbidden",
+                "scoring decision labels are non-arithmetic and must not declare point values",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "scoring_criteria",
+            )
+        )
     if SCORING_MEDIUM_LABEL_RE.search(section):
-        errors.append(Issue(
-            "scoring_medium_label_invalid",
-            "Medium signal is not canonical; use Moderate signal without "
-            "treating medium as an alias",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "scoring_criteria",
-        ))
+        errors.append(
+            Issue(
+                "scoring_medium_label_invalid",
+                "Medium signal is not canonical; use Moderate signal without "
+                "treating medium as an alias",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "scoring_criteria",
+            )
+        )
 
     strong = list(SCORING_STRONG_RE.finditer(section))
     moderate = list(SCORING_MODERATE_RE.finditer(section))
@@ -783,52 +871,64 @@ def _validate_scoring(entry: CatalogEntry, errors: list[Issue]) -> None:
         ("absent", absent),
     ):
         if len(matches) != 1:
-            errors.append(Issue(
-                "scoring_label_count_invalid",
-                f"scoring section must contain exactly one {label} label; found {len(matches)}",
-                entry.relative_path,
-                entry.pattern_id or "",
-                "scoring_criteria",
-            ))
+            errors.append(
+                Issue(
+                    "scoring_label_count_invalid",
+                    f"scoring section must contain exactly one {label} label; found {len(matches)}",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "scoring_criteria",
+                )
+            )
     if len(strong) != 1 or len(moderate) != 1 or len(absent) != 1:
         return
 
-    if not all(match.group("body").strip() for match in (strong[0], moderate[0], absent[0])):
-        errors.append(Issue(
-            "scoring_description_empty",
-            "every scoring label must have a non-empty same-line description",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "scoring_criteria",
-        ))
+    if not all(
+        match.group("body").strip() for match in (strong[0], moderate[0], absent[0])
+    ):
+        errors.append(
+            Issue(
+                "scoring_description_empty",
+                "every scoring label must have a non-empty same-line description",
+                entry.relative_path,
+                entry.pattern_id or "",
+                "scoring_criteria",
+            )
+        )
 
     strong_qualifier = (strong[0].group("qualifier") or "").strip().casefold()
     absent_qualifier = (absent[0].group("qualifier") or "").strip().casefold()
     if entry.entry_type == "antipattern":
         if strong_qualifier != "antipattern present":
-            errors.append(Issue(
-                "antipattern_scoring_polarity_inverted",
-                "Strong signal must be labelled as antipattern present",
-                entry.relative_path,
-                entry.pattern_id or "",
-                "scoring_criteria",
-            ))
+            errors.append(
+                Issue(
+                    "antipattern_scoring_polarity_inverted",
+                    "Strong signal must be labelled as antipattern present",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "scoring_criteria",
+                )
+            )
         if absent_qualifier != "antipattern not present":
-            errors.append(Issue(
-                "antipattern_scoring_polarity_inverted",
-                "Absent must be labelled as antipattern not present",
+            errors.append(
+                Issue(
+                    "antipattern_scoring_polarity_inverted",
+                    "Absent must be labelled as antipattern not present",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "scoring_criteria",
+                )
+            )
+    elif entry.entry_type == "pattern" and (strong_qualifier or absent_qualifier):
+        errors.append(
+            Issue(
+                "pattern_scoring_qualifier_invalid",
+                "pattern scoring labels must use the unqualified direct scale",
                 entry.relative_path,
                 entry.pattern_id or "",
                 "scoring_criteria",
-            ))
-    elif entry.entry_type == "pattern" and (strong_qualifier or absent_qualifier):
-        errors.append(Issue(
-            "pattern_scoring_qualifier_invalid",
-            "pattern scoring labels must use the unqualified direct scale",
-            entry.relative_path,
-            entry.pattern_id or "",
-            "scoring_criteria",
-        ))
+            )
+        )
 
 
 def _parse_csv(value: str) -> tuple[str, ...]:
@@ -845,27 +945,33 @@ def _parse_index(
     try:
         content = path.read_bytes()
     except FileNotFoundError:
-        errors.append(Issue(
-            "index_missing",
-            "catalog root must contain _index.md",
-            "_index.md",
-        ))
+        errors.append(
+            Issue(
+                "index_missing",
+                "catalog root must contain _index.md",
+                "_index.md",
+            )
+        )
         return "", b"", {}, set()
     except OSError as exc:
-        errors.append(Issue(
-            "index_unreadable",
-            f"catalog index cannot be read as UTF-8: {exc}",
-            "_index.md",
-        ))
+        errors.append(
+            Issue(
+                "index_unreadable",
+                f"catalog index cannot be read as UTF-8: {exc}",
+                "_index.md",
+            )
+        )
         return "", b"", {}, set()
     try:
         text = content.decode("utf-8")
     except UnicodeError as exc:
-        errors.append(Issue(
-            "index_unreadable",
-            f"catalog index cannot be read as UTF-8: {exc}",
-            "_index.md",
-        ))
+        errors.append(
+            Issue(
+                "index_unreadable",
+                f"catalog index cannot be read as UTF-8: {exc}",
+                "_index.md",
+            )
+        )
         return "", content, {}, set()
 
     rows: dict[str, IndexEntry] = {}
@@ -890,93 +996,113 @@ def _parse_index(
         if not cells or cells[0] == "ID" or set(cells[0]) <= {"-", ":"}:
             continue
         if len(cells) != 6:
-            errors.append(Issue(
-                "index_row_malformed",
-                f"catalog table row must have six cells; found {len(cells)} on line {line_number}",
-                "_index.md",
-            ))
+            errors.append(
+                Issue(
+                    "index_row_malformed",
+                    f"catalog table row must have six cells; found {len(cells)} on line {line_number}",
+                    "_index.md",
+                )
+            )
             continue
         pattern_id, name, entry_type, raw_dimensions, raw_phases, raw_related = cells
         if part is None:
-            errors.append(Issue(
-                "index_row_without_part",
-                f"catalog row {pattern_id!r} has no phase heading",
-                "_index.md",
-                pattern_id,
-            ))
+            errors.append(
+                Issue(
+                    "index_row_without_part",
+                    f"catalog row {pattern_id!r} has no phase heading",
+                    "_index.md",
+                    pattern_id,
+                )
+            )
             continue
         if not ID_RE.fullmatch(pattern_id):
-            errors.append(Issue(
-                "index_id_invalid",
-                f"index id {pattern_id!r} is not lowercase kebab-case",
-                "_index.md",
-                pattern_id,
-                "id",
-            ))
+            errors.append(
+                Issue(
+                    "index_id_invalid",
+                    f"index id {pattern_id!r} is not lowercase kebab-case",
+                    "_index.md",
+                    pattern_id,
+                    "id",
+                )
+            )
         if not name:
-            errors.append(Issue(
-                "index_name_invalid",
-                "index name must be non-empty",
-                "_index.md",
-                pattern_id,
-                "name",
-            ))
+            errors.append(
+                Issue(
+                    "index_name_invalid",
+                    "index name must be non-empty",
+                    "_index.md",
+                    pattern_id,
+                    "name",
+                )
+            )
         try:
             dimensions = tuple(int(value) for value in _parse_csv(raw_dimensions))
         except ValueError:
             dimensions = ()
-            errors.append(Issue(
-                "index_dimensions_invalid",
-                f"index dimensions are not integers on line {line_number}",
-                "_index.md",
-                pattern_id,
-                "vault_dimensions",
-            ))
+            errors.append(
+                Issue(
+                    "index_dimensions_invalid",
+                    f"index dimensions are not integers on line {line_number}",
+                    "_index.md",
+                    pattern_id,
+                    "vault_dimensions",
+                )
+            )
         else:
             if not dimensions or any(value < 1 or value > 14 for value in dimensions):
-                errors.append(Issue(
-                    "index_dimensions_invalid",
-                    "index dimensions must be a non-empty list of integers from 1 through 14",
-                    "_index.md",
-                    pattern_id,
-                    "vault_dimensions",
-                ))
+                errors.append(
+                    Issue(
+                        "index_dimensions_invalid",
+                        "index dimensions must be a non-empty list of integers from 1 through 14",
+                        "_index.md",
+                        pattern_id,
+                        "vault_dimensions",
+                    )
+                )
             if len(dimensions) != len(set(dimensions)):
-                errors.append(Issue(
-                    "index_dimensions_duplicate",
-                    "index dimensions contain duplicate values",
-                    "_index.md",
-                    pattern_id,
-                    "vault_dimensions",
-                ))
+                errors.append(
+                    Issue(
+                        "index_dimensions_duplicate",
+                        "index dimensions contain duplicate values",
+                        "_index.md",
+                        pattern_id,
+                        "vault_dimensions",
+                    )
+                )
 
         creator_phases = _parse_csv(raw_phases)
         if not creator_phases or set(creator_phases) - CREATOR_PHASES:
-            errors.append(Issue(
-                "index_creator_phases_invalid",
-                "index creator phases must be a non-empty list from the creator phase namespace",
-                "_index.md",
-                pattern_id,
-                "phase_relevance",
-            ))
+            errors.append(
+                Issue(
+                    "index_creator_phases_invalid",
+                    "index creator phases must be a non-empty list from the creator phase namespace",
+                    "_index.md",
+                    pattern_id,
+                    "phase_relevance",
+                )
+            )
         if len(creator_phases) != len(set(creator_phases)):
-            errors.append(Issue(
-                "index_creator_phases_duplicate",
-                "index creator phases contain duplicate values",
-                "_index.md",
-                pattern_id,
-                "phase_relevance",
-            ))
+            errors.append(
+                Issue(
+                    "index_creator_phases_duplicate",
+                    "index creator phases contain duplicate values",
+                    "_index.md",
+                    pattern_id,
+                    "phase_relevance",
+                )
+            )
 
         related_patterns = _parse_csv(raw_related)
         if len(related_patterns) != len(set(related_patterns)):
-            errors.append(Issue(
-                "index_related_duplicate",
-                "index related IDs contain duplicate values",
-                "_index.md",
-                pattern_id,
-                "related_patterns",
-            ))
+            errors.append(
+                Issue(
+                    "index_related_duplicate",
+                    "index related IDs contain duplicate values",
+                    "_index.md",
+                    pattern_id,
+                    "related_patterns",
+                )
+            )
         row = IndexEntry(
             pattern_id,
             name,
@@ -988,13 +1114,15 @@ def _parse_index(
             line_number,
         )
         if pattern_id in rows:
-            errors.append(Issue(
-                "index_id_duplicate",
-                f"index id appears more than once; duplicate is on line {line_number}",
-                "_index.md",
-                pattern_id,
-                "id",
-            ))
+            errors.append(
+                Issue(
+                    "index_id_duplicate",
+                    f"index id appears more than once; duplicate is on line {line_number}",
+                    "_index.md",
+                    pattern_id,
+                    "id",
+                )
+            )
         else:
             rows[pattern_id] = row
 
@@ -1016,20 +1144,24 @@ def _parse_index(
             cells = tuple(cell.strip() for cell in line.strip().strip("|").split("|"))
             if len(cells) == 3 and ID_RE.fullmatch(cells[0]):
                 if cells[0] in unobservable:
-                    errors.append(Issue(
-                        "index_unobservable_duplicate",
-                        "unobservable checklist ID appears more than once",
-                        "_index.md",
-                        cells[0],
-                        "observable",
-                    ))
+                    errors.append(
+                        Issue(
+                            "index_unobservable_duplicate",
+                            "unobservable checklist ID appears more than once",
+                            "_index.md",
+                            cells[0],
+                            "observable",
+                        )
+                    )
                 unobservable.add(cells[0])
     else:
-        errors.append(Issue(
-            "index_unobservable_section_missing",
-            "catalog index must contain the Unobservable Patterns section",
-            "_index.md",
-        ))
+        errors.append(
+            Issue(
+                "index_unobservable_section_missing",
+                "catalog index must contain the Unobservable Patterns section",
+                "_index.md",
+            )
+        )
     return text, content, rows, unobservable
 
 
@@ -1056,75 +1188,91 @@ def _compare_index(
     index_ids = set(index_rows)
     for pattern_id in sorted(file_ids - index_ids):
         entry = entries[pattern_id]
-        errors.append(Issue(
-            "index_entry_missing",
-            "catalog file has no master-index row",
-            entry.relative_path,
-            pattern_id,
-        ))
+        errors.append(
+            Issue(
+                "index_entry_missing",
+                "catalog file has no master-index row",
+                entry.relative_path,
+                pattern_id,
+            )
+        )
     for pattern_id in sorted(index_ids - file_ids):
         row = index_rows[pattern_id]
-        errors.append(Issue(
-            "index_entry_orphaned",
-            f"master-index row on line {row.line} has no catalog file",
-            "_index.md",
-            pattern_id,
-        ))
+        errors.append(
+            Issue(
+                "index_entry_orphaned",
+                f"master-index row on line {row.line} has no catalog file",
+                "_index.md",
+                pattern_id,
+            )
+        )
 
     for pattern_id in sorted(file_ids & index_ids):
         entry = entries[pattern_id]
         row = index_rows[pattern_id]
         if row.entry_type != entry.entry_type:
-            errors.append(Issue(
-                "index_type_mismatch",
-                f"index declares {row.entry_type!r}, file declares {entry.entry_type!r}",
-                entry.relative_path,
-                pattern_id,
-                "type",
-            ))
+            errors.append(
+                Issue(
+                    "index_type_mismatch",
+                    f"index declares {row.entry_type!r}, file declares {entry.entry_type!r}",
+                    entry.relative_path,
+                    pattern_id,
+                    "type",
+                )
+            )
         if row.part != entry.part:
-            errors.append(Issue(
-                "index_part_mismatch",
-                f"index places entry in {row.part!r}, file declares {entry.part!r}",
-                entry.relative_path,
-                pattern_id,
-                "part",
-            ))
+            errors.append(
+                Issue(
+                    "index_part_mismatch",
+                    f"index places entry in {row.part!r}, file declares {entry.part!r}",
+                    entry.relative_path,
+                    pattern_id,
+                    "part",
+                )
+            )
         if entry.name is not None and row.name != entry.name:
-            debts.append(Issue(
-                "index_name_drift",
-                f"index name {row.name!r} differs from file name {entry.name!r}",
-                entry.relative_path,
-                pattern_id,
-                "name",
-            ))
+            debts.append(
+                Issue(
+                    "index_name_drift",
+                    f"index name {row.name!r} differs from file name {entry.name!r}",
+                    entry.relative_path,
+                    pattern_id,
+                    "name",
+                )
+            )
         if set(row.dimensions) != set(dimensions.get(pattern_id, ())):
-            debts.append(Issue(
-                "index_dimensions_drift",
-                f"index dimensions {list(row.dimensions)} differ from file dimensions "
-                f"{list(dimensions.get(pattern_id, ()))}",
-                entry.relative_path,
-                pattern_id,
-                "vault_dimensions",
-            ))
+            debts.append(
+                Issue(
+                    "index_dimensions_drift",
+                    f"index dimensions {list(row.dimensions)} differ from file dimensions "
+                    f"{list(dimensions.get(pattern_id, ()))}",
+                    entry.relative_path,
+                    pattern_id,
+                    "vault_dimensions",
+                )
+            )
         if set(row.creator_phases) != set(phases.get(pattern_id, ())):
-            debts.append(Issue(
-                "index_phases_drift",
-                f"index phases {list(row.creator_phases)} differ from file phases "
-                f"{list(phases.get(pattern_id, ()))}",
-                entry.relative_path,
-                pattern_id,
-                "phase_relevance",
-            ))
+            debts.append(
+                Issue(
+                    "index_phases_drift",
+                    f"index phases {list(row.creator_phases)} differ from file phases "
+                    f"{list(phases.get(pattern_id, ()))}",
+                    entry.relative_path,
+                    pattern_id,
+                    "phase_relevance",
+                )
+            )
         if set(row.related_patterns) != set(related.get(pattern_id, ())):
-            debts.append(Issue(
-                "index_related_drift",
-                f"index related IDs {list(row.related_patterns)} differ from file IDs "
-                f"{list(related.get(pattern_id, ()))}",
-                entry.relative_path,
-                pattern_id,
-                "related_patterns",
-            ))
+            debts.append(
+                Issue(
+                    "index_related_drift",
+                    f"index related IDs {list(row.related_patterns)} differ from file IDs "
+                    f"{list(related.get(pattern_id, ()))}",
+                    entry.relative_path,
+                    pattern_id,
+                    "related_patterns",
+                )
+            )
 
 
 def _validate_graph(
@@ -1144,55 +1292,61 @@ def _validate_graph(
         ):
             for target in targets:
                 if target == pattern_id:
-                    errors.append(Issue(
-                        "reference_self",
-                        f"{field} cannot reference the entry itself",
-                        entry.relative_path,
-                        pattern_id,
-                        field,
-                        target,
-                    ))
+                    errors.append(
+                        Issue(
+                            "reference_self",
+                            f"{field} cannot reference the entry itself",
+                            entry.relative_path,
+                            pattern_id,
+                            field,
+                            target,
+                        )
+                    )
                 elif target not in ids:
-                    errors.append(Issue(
-                        "reference_dangling",
-                        f"{field} references unknown catalog id {target!r}",
-                        entry.relative_path,
-                        pattern_id,
-                        field,
-                        target,
-                    ))
+                    errors.append(
+                        Issue(
+                            "reference_dangling",
+                            f"{field} references unknown catalog id {target!r}",
+                            entry.relative_path,
+                            pattern_id,
+                            field,
+                            target,
+                        )
+                    )
 
         for target in inverse.get(pattern_id, ()):
             if target not in ids or target == pattern_id:
                 continue
             if pattern_id not in inverse.get(target, ()):
-                errors.append(Issue(
-                    "inverse_not_reciprocal",
-                    f"{target!r} does not declare {pattern_id!r} in inverse_of",
-                    entry.relative_path,
-                    pattern_id,
-                    "inverse_of",
-                    target,
-                ))
+                errors.append(
+                    Issue(
+                        "inverse_not_reciprocal",
+                        f"{target!r} does not declare {pattern_id!r} in inverse_of",
+                        entry.relative_path,
+                        pattern_id,
+                        "inverse_of",
+                        target,
+                    )
+                )
             target_entry = entries[target]
             pair = (
-                (pattern_id, target)
-                if pattern_id <= target
-                else (target, pattern_id)
+                (pattern_id, target) if pattern_id <= target else (target, pattern_id)
             )
             if (
                 entry.entry_type == target_entry.entry_type
                 and pair not in same_polarity_pairs
             ):
                 same_polarity_pairs.add(pair)
-                debts.append(Issue(
-                    "inverse_same_polarity",
-                    "inverse relationship joins entries with the same catalog polarity",
-                    entry.relative_path,
-                    pattern_id,
-                    "inverse_of",
-                    target,
-                ))
+                debts.append(
+                    Issue(
+                        "inverse_same_polarity",
+                        "inverse relationship joins entries with the same catalog polarity",
+                        entry.relative_path,
+                        pattern_id,
+                        "inverse_of",
+                        target,
+                    )
+                )
 
 
 def _validate_aliases(
@@ -1212,51 +1366,57 @@ def _validate_aliases(
         for field, value in raw_claims:
             normalized = normalize_alias(value)
             if not normalized:
-                errors.append(Issue(
-                    "alias_normalizes_empty",
-                    f"{field} value {value!r} has no alphanumeric alias form",
-                    entry.relative_path,
-                    pattern_id,
-                    field,
-                ))
+                errors.append(
+                    Issue(
+                        "alias_normalizes_empty",
+                        f"{field} value {value!r} has no alphanumeric alias form",
+                        entry.relative_path,
+                        pattern_id,
+                        field,
+                    )
+                )
                 continue
             if field == "aliases":
                 previous = explicit_seen.get(normalized)
                 if previous is not None:
-                    errors.append(Issue(
-                        "alias_duplicate",
-                        f"explicit aliases {previous!r} and {value!r} normalize identically",
-                        entry.relative_path,
-                        pattern_id,
-                        "aliases",
-                    ))
+                    errors.append(
+                        Issue(
+                            "alias_duplicate",
+                            f"explicit aliases {previous!r} and {value!r} normalize identically",
+                            entry.relative_path,
+                            pattern_id,
+                            "aliases",
+                        )
+                    )
                 else:
                     explicit_seen[normalized] = value
-            claims[normalized].append(
-                (pattern_id, field, value, entry.relative_path)
-            )
+            claims[normalized].append((pattern_id, field, value, entry.relative_path))
 
     namespace: list[dict[str, Any]] = []
     for normalized in sorted(claims):
         by_entry: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
         for pattern_id, field, value, path in claims[normalized]:
             by_entry[pattern_id].append((field, value, path))
-        namespace.append({
-            "entries": sorted(by_entry),
-            "normalized": normalized,
-        })
+        namespace.append(
+            {
+                "entries": sorted(by_entry),
+                "normalized": normalized,
+            }
+        )
         entry_ids = sorted(by_entry)
         for offset, pattern_id in enumerate(entry_ids):
-            for target in entry_ids[offset + 1:]:
+            for target in entry_ids[offset + 1 :]:
                 path = sorted(item[2] for item in by_entry[pattern_id])[0]
-                errors.append(Issue(
-                    "alias_collision",
-                    f"catalog entries claim the same normalized alias {normalized!r}",
-                    path,
-                    pattern_id,
-                    "aliases",
-                    target,
-                ))
+                errors.append(
+                    Issue(
+                        "alias_collision",
+                        f"catalog entries claim the same normalized alias {normalized!r}",
+                        path,
+                        pattern_id,
+                        "aliases",
+                        target,
+                    )
+                )
     return namespace
 
 
@@ -1266,27 +1426,31 @@ def _validate_unobservable_index(
     errors: list[Issue],
 ) -> None:
     flagged = {
-        pattern_id
-        for pattern_id, entry in entries.items()
-        if entry.observable is False
+        pattern_id for pattern_id, entry in entries.items() if entry.observable is False
     }
     for pattern_id in sorted(flagged - listed):
-        errors.append(Issue(
-            "index_unobservable_missing",
-            "observable:false entry is absent from the index go-live checklist",
-            entries[pattern_id].relative_path,
-            pattern_id,
-            "observable",
-        ))
+        errors.append(
+            Issue(
+                "index_unobservable_missing",
+                "observable:false entry is absent from the index go-live checklist",
+                entries[pattern_id].relative_path,
+                pattern_id,
+                "observable",
+            )
+        )
     for pattern_id in sorted(listed - flagged):
-        path = entries[pattern_id].relative_path if pattern_id in entries else "_index.md"
-        errors.append(Issue(
-            "index_unobservable_mismatch",
-            "index go-live checklist entry is not declared observable:false",
-            path,
-            pattern_id,
-            "observable",
-        ))
+        path = (
+            entries[pattern_id].relative_path if pattern_id in entries else "_index.md"
+        )
+        errors.append(
+            Issue(
+                "index_unobservable_mismatch",
+                "index go-live checklist entry is not declared observable:false",
+                path,
+                pattern_id,
+                "observable",
+            )
+        )
 
 
 def audit_catalog(
@@ -1301,20 +1465,23 @@ def audit_catalog(
     errors: list[Issue] = []
     debts: list[Issue] = []
     if not root.is_dir():
-        errors.append(Issue(
-            "catalog_directory_missing",
-            f"catalog directory does not exist: {root}",
-        ))
-        return _build_report(
-            root, b"", [], {}, {}, {}, {}, {}, [], errors, debts)
+        errors.append(
+            Issue(
+                "catalog_directory_missing",
+                f"catalog directory does not exist: {root}",
+            )
+        )
+        return _build_report(root, b"", [], {}, {}, {}, {}, {}, [], errors, debts)
 
     _, index_content, index_rows, unobservable_listed = _parse_index(root, errors)
     entry_paths = catalog_entry_paths(root)
     if not entry_paths:
-        errors.append(Issue(
-            "catalog_empty",
-            "catalog contains no entry Markdown files",
-        ))
+        errors.append(
+            Issue(
+                "catalog_empty",
+                "catalog contains no entry Markdown files",
+            )
+        )
 
     parsed_entries = [_read_entry(path, root, errors) for path in entry_paths]
     entries: dict[str, CatalogEntry] = {}
@@ -1335,13 +1502,15 @@ def audit_catalog(
         if entry.pattern_id is None:
             continue
         if entry.pattern_id in entries:
-            errors.append(Issue(
-                "id_duplicate",
-                f"id is already declared by {entries[entry.pattern_id].relative_path}",
-                entry.relative_path,
-                entry.pattern_id,
-                "id",
-            ))
+            errors.append(
+                Issue(
+                    "id_duplicate",
+                    f"id is already declared by {entries[entry.pattern_id].relative_path}",
+                    entry.relative_path,
+                    entry.pattern_id,
+                    "id",
+                )
+            )
             continue
         entries[entry.pattern_id] = entry
         dimensions[entry.pattern_id] = entry_dimensions
@@ -1366,23 +1535,27 @@ def audit_catalog(
     for row in index_rows.values():
         for target in row.related_patterns:
             if target == row.pattern_id:
-                errors.append(Issue(
-                    "index_reference_self",
-                    "index Related cell cannot reference its own catalog id",
-                    "_index.md",
-                    row.pattern_id,
-                    "related_patterns",
-                    target,
-                ))
+                errors.append(
+                    Issue(
+                        "index_reference_self",
+                        "index Related cell cannot reference its own catalog id",
+                        "_index.md",
+                        row.pattern_id,
+                        "related_patterns",
+                        target,
+                    )
+                )
             elif target not in entries:
-                errors.append(Issue(
-                    "index_reference_dangling",
-                    f"index Related cell references unknown catalog id {target!r}",
-                    "_index.md",
-                    row.pattern_id,
-                    "related_patterns",
-                    target,
-                ))
+                errors.append(
+                    Issue(
+                        "index_reference_dangling",
+                        f"index Related cell references unknown catalog id {target!r}",
+                        "_index.md",
+                        row.pattern_id,
+                        "related_patterns",
+                        target,
+                    )
+                )
 
     return _build_report(
         root,
@@ -1420,41 +1593,33 @@ def _build_report(
     observable = sum(entry.observable is True for entry in entry_values)
     unobservable = sum(entry.observable is False for entry in entry_values)
     source_gated = sum(
-        BASE_EVIDENCE_GATE_FIELDS <= set(entry.metadata)
-        for entry in entry_values
+        BASE_EVIDENCE_GATE_FIELDS <= set(entry.metadata) for entry in entry_values
     )
     absence_gated = sum(
         BASE_EVIDENCE_GATE_FIELDS <= set(entry.metadata)
         and entry.metadata.get(
             "absence_evaluable_from",
             entry.metadata.get("evaluable_from"),
-        ) is not None
+        )
+        is not None
         for entry in entry_values
     )
     applicability_gated = sum(
-        APPLICABILITY_GATE_FIELDS <= set(entry.metadata)
-        for entry in entry_values
+        APPLICABILITY_GATE_FIELDS <= set(entry.metadata) for entry in entry_values
     )
     positive_only = source_gated - absence_gated
     related_edges = sorted(
-        [source, target]
-        for source, targets in related.items()
-        for target in targets
+        [source, target] for source, targets in related.items() for target in targets
     )
     inverse_declarations = sorted(
-        [source, target]
-        for source, targets in inverse.items()
-        for target in targets
+        [source, target] for source, targets in inverse.items() for target in targets
     )
     explicit_alias_count = sum(len(values) for values in aliases.values())
     return {
         "catalog": {
             "fingerprint": catalog_fingerprint(
                 index_content,
-                (
-                    (entry.relative_path, entry.content)
-                    for entry in parsed_entries
-                ),
+                ((entry.relative_path, entry.content) for entry in parsed_entries),
             ),
             "index": "_index.md",
             "path": root.as_posix(),

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -43,22 +43,34 @@ REPORT_SCHEMA_VERSION = 1
 SOURCE_IDENTITY_SCHEMA_VERSION = 1
 YT_DLP_TIMEOUT_SECONDS = 60
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
-CLIP_MARKERS = frozenset({
-    "clip", "demo", "excerpt", "highlight", "highlights", "preview", "promo",
-    "short", "teaser", "trailer",
-})
-ERROR_CODES = frozenset({
-    "active_youtube_url_invalid",
-    "database_shape_invalid",
-    "metadata_fetch_failed",
-    "provider_metadata_incomplete",
-    "provider_video_id_mismatch",
-    "provider_webpage_identity_mismatch",
-    "talk_shape_invalid",
-    "talks_shape_invalid",
-    "tracking_database_schema_invalid",
-    "tracking_database_schema_unsupported",
-})
+CLIP_MARKERS = frozenset(
+    {
+        "clip",
+        "demo",
+        "excerpt",
+        "highlight",
+        "highlights",
+        "preview",
+        "promo",
+        "short",
+        "teaser",
+        "trailer",
+    }
+)
+ERROR_CODES = frozenset(
+    {
+        "active_youtube_url_invalid",
+        "database_shape_invalid",
+        "metadata_fetch_failed",
+        "provider_metadata_incomplete",
+        "provider_video_id_mismatch",
+        "provider_webpage_identity_mismatch",
+        "talk_shape_invalid",
+        "talks_shape_invalid",
+        "tracking_database_schema_invalid",
+        "tracking_database_schema_unsupported",
+    }
+)
 
 
 class MetadataFetchError(RuntimeError):
@@ -105,8 +117,12 @@ def is_youtube_url(value: Any) -> bool:
         candidate = "https://" + candidate
     host = (urlparse(candidate).hostname or "").casefold().rstrip(".")
     return host in {
-        "youtube.com", "www.youtube.com", "m.youtube.com",
-        "youtu.be", "www.youtu.be", "youtube-nocookie.com",
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "youtu.be",
+        "www.youtu.be",
+        "youtube-nocookie.com",
         "www.youtube-nocookie.com",
     }
 
@@ -119,11 +135,13 @@ def expected_duration_seconds(talk: dict[str, Any]) -> float | None:
     ]
     structured = talk.get("structured_data")
     if isinstance(structured, dict):
-        candidates.extend([
-            structured.get("video_duration_seconds"),
-            structured.get("recording_duration_seconds"),
-            structured.get("duration_seconds"),
-        ])
+        candidates.extend(
+            [
+                structured.get("video_duration_seconds"),
+                structured.get("recording_duration_seconds"),
+                structured.get("duration_seconds"),
+            ]
+        )
     for value in candidates:
         if (
             not isinstance(value, bool)
@@ -172,13 +190,20 @@ def fetch_youtube_metadata(
     if not YOUTUBE_ID_RE.fullmatch(video_id):
         raise MetadataFetchError(f"invalid YouTube ID: {video_id!r}")
     command = [
-        "yt-dlp", "--ignore-config", "--no-playlist", "--skip-download",
-        "--dump-single-json", "--no-warnings",
+        "yt-dlp",
+        "--ignore-config",
+        "--no-playlist",
+        "--skip-download",
+        "--dump-single-json",
+        "--no-warnings",
         f"https://www.youtube.com/watch?v={video_id}",
     ]
     try:
         completed = runner(
-            command, capture_output=True, text=True, check=False,
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
             timeout=YT_DLP_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
@@ -250,8 +275,13 @@ def provider_evidence(
         "captured_at": captured_at,
     }
     missing = [
-        field for field in (
-            "title", "uploader", "upload_date", "duration_seconds", "webpage_url",
+        field
+        for field in (
+            "title",
+            "uploader",
+            "upload_date",
+            "duration_seconds",
+            "webpage_url",
         )
         if evidence[field] is None
     ]
@@ -262,10 +292,7 @@ def provider_evidence(
 
 def proposed_source_identity(evidence: dict[str, Any]) -> dict[str, Any]:
     """Return provider facts only; uploader and upload date are not human identity."""
-    return {
-        key: value for key, value in evidence.items()
-        if value is not None
-    }
+    return {key: value for key, value in evidence.items() if value is not None}
 
 
 def _finding(
@@ -293,36 +320,45 @@ def _filename(talk: dict[str, Any], index: int) -> str:
 
 
 def _stored_identity_differences(
-    talk: dict[str, Any], proposal: dict[str, Any],
+    talk: dict[str, Any],
+    proposal: dict[str, Any],
 ) -> list[dict[str, Any]]:
     stored = talk.get("source_identity")
     if not isinstance(stored, dict):
         return []
     fields = (
-        "video_id", "title", "uploader", "uploader_id", "upload_date",
-        "duration_seconds", "webpage_url",
+        "video_id",
+        "title",
+        "uploader",
+        "uploader_id",
+        "upload_date",
+        "duration_seconds",
+        "webpage_url",
     )
     differences = []
     for field in fields:
         if field not in stored or field not in proposal:
             continue
         if stored[field] != proposal[field]:
-            differences.append({
-                "field": field,
-                "stored": stored[field],
-                "fetched": proposal[field],
-            })
+            differences.append(
+                {
+                    "field": field,
+                    "stored": stored[field],
+                    "fetched": proposal[field],
+                }
+            )
     return differences
 
 
 def _non_delivery_signals(
-    talk: dict[str, Any], evidence: dict[str, Any], title_agrees: bool | None,
+    talk: dict[str, Any],
+    evidence: dict[str, Any],
+    title_agrees: bool | None,
 ) -> list[str]:
     provider_title = evidence.get("title")
     duration = evidence.get("duration_seconds")
     expected = expected_duration_seconds(talk)
-    markers = sorted(
-        normalized_words(provider_title or "") & CLIP_MARKERS)
+    markers = sorted(normalized_words(provider_title or "") & CLIP_MARKERS)
     signals: list[str] = []
     if markers:
         signals.append("provider_title_has_clip_marker:" + ",".join(markers))
@@ -342,15 +378,14 @@ def _non_delivery_signals(
         for signal in signals
     )
     marker_with_support = bool(markers) and (
-        title_agrees is False
-        or (isinstance(duration, (int, float)) and duration < 900)
+        title_agrees is False or (isinstance(duration, (int, float)) and duration < 900)
     )
     return signals if strong or marker_with_support else []
 
 
 def _talks_collide(talks: list[dict[str, Any]]) -> bool:
     for left_index, left in enumerate(talks):
-        for right in talks[left_index + 1:]:
+        for right in talks[left_index + 1 :]:
             left_title = _nonempty(left.get("title"))
             right_title = _nonempty(right.get("title"))
             if left_title and right_title and not titles_agree(left_title, right_title):
@@ -379,11 +414,17 @@ def audit_database(
 
     talks: list[Any] = []
     if not isinstance(database, dict):
-        findings.append(_finding(
-            "database_shape_invalid", None, [], [],
-            "tracking database must be a JSON object",
-            {"actual": type(database).__name__}, "high",
-        ))
+        findings.append(
+            _finding(
+                "database_shape_invalid",
+                None,
+                [],
+                [],
+                "tracking database must be a JSON object",
+                {"actual": type(database).__name__},
+                "high",
+            )
+        )
     else:
         try:
             assessment = assess_tracking_database(database)
@@ -420,11 +461,17 @@ def audit_database(
             else:
                 raw_talks = database.get("talks")
                 if not isinstance(raw_talks, list):
-                    findings.append(_finding(
-                        "talks_shape_invalid", None, [], [],
-                        "tracking database talks must be an array",
-                        {"actual": type(raw_talks).__name__}, "high",
-                    ))
+                    findings.append(
+                        _finding(
+                            "talks_shape_invalid",
+                            None,
+                            [],
+                            [],
+                            "tracking database talks must be an array",
+                            {"actual": type(raw_talks).__name__},
+                            "high",
+                        )
+                    )
                 else:
                     talks = raw_talks
 
@@ -434,11 +481,17 @@ def audit_database(
     audits_by_index: dict[int, dict[str, Any]] = {}
     for index, talk in enumerate(talks):
         if not isinstance(talk, dict):
-            findings.append(_finding(
-                "talk_shape_invalid", None, [index], [f"talk[{index}]"],
-                "active source audit skipped a non-object talk record",
-                {"actual": type(talk).__name__}, "high",
-            ))
+            findings.append(
+                _finding(
+                    "talk_shape_invalid",
+                    None,
+                    [index],
+                    [f"talk[{index}]"],
+                    "active source audit skipped a non-object talk record",
+                    {"actual": type(talk).__name__},
+                    "high",
+                )
+            )
             continue
         video_url = _nonempty(talk.get("video_url"))
         if video_url is None:
@@ -465,23 +518,35 @@ def audit_database(
         audits_by_index[index] = audit
         if video_id is None:
             code = (
-                "active_youtube_url_invalid" if is_youtube_url(video_url)
+                "active_youtube_url_invalid"
+                if is_youtube_url(video_url)
                 else "active_video_provider_unsupported"
             )
-            findings.append(_finding(
-                code, None, [index], [filename],
-                "active video source cannot be audited as a YouTube identity",
-                {"active_video_url": video_url},
-                "high" if code in ERROR_CODES else "medium",
-            ))
+            findings.append(
+                _finding(
+                    code,
+                    None,
+                    [index],
+                    [filename],
+                    "active video source cannot be audited as a YouTube identity",
+                    {"active_video_url": video_url},
+                    "high" if code in ERROR_CODES else "medium",
+                )
+            )
             continue
         stored_id = _nonempty(talk.get("youtube_id"))
         if stored_id is not None and stored_id != video_id:
-            findings.append(_finding(
-                "stored_youtube_id_mismatch", video_id, [index], [filename],
-                "active video URL and stored youtube_id disagree",
-                {"url_video_id": video_id, "stored_youtube_id": stored_id}, "high",
-            ))
+            findings.append(
+                _finding(
+                    "stored_youtube_id_mismatch",
+                    video_id,
+                    [index],
+                    [filename],
+                    "active video URL and stored youtube_id disagree",
+                    {"url_video_id": video_id, "stored_youtube_id": stored_id},
+                    "high",
+                )
+            )
         groups[video_id].append((index, talk))
 
     evidence_by_id: dict[str, dict[str, Any]] = {}
@@ -504,42 +569,58 @@ def audit_database(
         except (MetadataFetchError, OSError, RuntimeError) as exc:
             source["fetch_status"] = "error"
             source["error"] = str(exc)
-            findings.append(_finding(
-                "metadata_fetch_failed", video_id, indexes, filenames,
-                "yt-dlp metadata capture failed",
-                {"error": str(exc)}, "high",
-            ))
+            findings.append(
+                _finding(
+                    "metadata_fetch_failed",
+                    video_id,
+                    indexes,
+                    filenames,
+                    "yt-dlp metadata capture failed",
+                    {"error": str(exc)},
+                    "high",
+                )
+            )
             sources.append(source)
             continue
 
         evidence, faults = provider_evidence(video_id, raw_metadata, captured)
         source["provider_evidence"] = evidence
         critical = {
-            "provider_video_id_mismatch", "provider_webpage_identity_mismatch",
+            "provider_video_id_mismatch",
+            "provider_webpage_identity_mismatch",
         }.intersection(faults)
         for code in sorted(set(faults)):
             missing = [
-                field for field in (
-                    "title", "uploader", "upload_date", "duration_seconds",
+                field
+                for field in (
+                    "title",
+                    "uploader",
+                    "upload_date",
+                    "duration_seconds",
                     "webpage_url",
                 )
                 if evidence[field] is None
             ]
-            findings.append(_finding(
-                code, video_id, indexes, filenames,
-                (
-                    "provider metadata is missing stable audit fields"
-                    if code == "provider_metadata_incomplete"
-                    else "provider metadata does not confirm the requested identity"
-                ),
-                {
-                    "requested_video_id": video_id,
-                    "provider_video_id": evidence["video_id"],
-                    "webpage_video_id": evidence["webpage_video_id"],
-                    "missing_fields": missing,
-                },
-                "high" if code in ERROR_CODES else "medium",
-            ))
+            findings.append(
+                _finding(
+                    code,
+                    video_id,
+                    indexes,
+                    filenames,
+                    (
+                        "provider metadata is missing stable audit fields"
+                        if code == "provider_metadata_incomplete"
+                        else "provider metadata does not confirm the requested identity"
+                    ),
+                    {
+                        "requested_video_id": video_id,
+                        "provider_video_id": evidence["video_id"],
+                        "webpage_video_id": evidence["webpage_video_id"],
+                        "missing_fields": missing,
+                    },
+                    "high" if code in ERROR_CODES else "medium",
+                )
+            )
         if critical:
             source["fetch_status"] = "invalid"
             sources.append(source)
@@ -559,25 +640,31 @@ def audit_database(
             catalog_title = _nonempty(talk.get("title"))
             title_agrees = (
                 titles_agree(catalog_title, provider_title)
-                if catalog_title and provider_title else None
+                if catalog_title and provider_title
+                else None
             )
             expected_duration = expected_duration_seconds(talk)
             provider_duration = proposal.get("duration_seconds")
             duration_within_tolerance: bool | None = None
             if expected_duration is not None and isinstance(
-                    provider_duration, (int, float)):
+                provider_duration, (int, float)
+            ):
                 tolerance = max(60.0, expected_duration * 0.05)
                 duration_within_tolerance = (
-                    abs(float(provider_duration) - expected_duration) <= tolerance)
+                    abs(float(provider_duration) - expected_duration) <= tolerance
+                )
             catalog_date = parse_catalog_date(talk.get("date"))
             upload_date = _provider_date(proposal.get("upload_date"))
             upload_predates = (
                 date.fromisoformat(upload_date) < catalog_date
-                if catalog_date is not None and upload_date is not None else None
+                if catalog_date is not None and upload_date is not None
+                else None
             )
             differences = _stored_identity_differences(talk, proposal)
             event_agrees, catalog_event, provider_events = event_agreement(
-                talk.get("conference"), provider_title or "", event_aliases,
+                talk.get("conference"),
+                provider_title or "",
+                event_aliases,
             )
             audit["comparison"] = {
                 "catalog_title_agrees": title_agrees,
@@ -591,67 +678,100 @@ def audit_database(
             }
             filename = _filename(talk, index)
             if title_agrees is False:
-                findings.append(_finding(
-                    "provider_title_mismatch", video_id, [index], [filename],
-                    "provider title does not materially overlap the catalog title",
-                    {"catalog_title": catalog_title, "provider_title": provider_title},
-                ))
+                findings.append(
+                    _finding(
+                        "provider_title_mismatch",
+                        video_id,
+                        [index],
+                        [filename],
+                        "provider title does not materially overlap the catalog title",
+                        {
+                            "catalog_title": catalog_title,
+                            "provider_title": provider_title,
+                        },
+                    )
+                )
             if event_agrees is False:
-                findings.append(_finding(
-                    "provider_event_mismatch", video_id, [index], [filename],
-                    "provider title explicitly names a different catalog event",
-                    {
-                        "catalog_conference": talk.get("conference"),
-                        "catalog_event_alias": " ".join(catalog_event or ()),
-                        "provider_event_aliases": [
-                            " ".join(alias) for alias in provider_events
-                        ],
-                        "provider_title": provider_title,
-                    },
-                    "high",
-                ))
+                findings.append(
+                    _finding(
+                        "provider_event_mismatch",
+                        video_id,
+                        [index],
+                        [filename],
+                        "provider title explicitly names a different catalog event",
+                        {
+                            "catalog_conference": talk.get("conference"),
+                            "catalog_event_alias": " ".join(catalog_event or ()),
+                            "provider_event_aliases": [
+                                " ".join(alias) for alias in provider_events
+                            ],
+                            "provider_title": provider_title,
+                        },
+                        "high",
+                    )
+                )
             if duration_within_tolerance is False:
-                findings.append(_finding(
-                    "provider_duration_mismatch", video_id, [index], [filename],
-                    "provider duration differs from the catalog duration beyond tolerance",
-                    {
-                        "catalog_duration_seconds": expected_duration,
-                        "provider_duration_seconds": provider_duration,
-                    },
-                ))
+                findings.append(
+                    _finding(
+                        "provider_duration_mismatch",
+                        video_id,
+                        [index],
+                        [filename],
+                        "provider duration differs from the catalog duration beyond tolerance",
+                        {
+                            "catalog_duration_seconds": expected_duration,
+                            "provider_duration_seconds": provider_duration,
+                        },
+                    )
+                )
             if (
                 upload_predates is True
                 and catalog_date is not None
                 and upload_date is not None
             ):
-                findings.append(_finding(
-                    "provider_upload_predates_catalog", video_id, [index], [filename],
-                    "provider upload date predates the cataloged delivery date",
-                    {
-                        "catalog_date": catalog_date.isoformat(),
-                        "provider_upload_date": upload_date,
-                    },
-                ))
+                findings.append(
+                    _finding(
+                        "provider_upload_predates_catalog",
+                        video_id,
+                        [index],
+                        [filename],
+                        "provider upload date predates the cataloged delivery date",
+                        {
+                            "catalog_date": catalog_date.isoformat(),
+                            "provider_upload_date": upload_date,
+                        },
+                    )
+                )
             if differences:
-                findings.append(_finding(
-                    "stored_source_identity_differs", video_id, [index], [filename],
-                    "fresh provider facts differ from stored source identity evidence",
-                    differences,
-                ))
+                findings.append(
+                    _finding(
+                        "stored_source_identity_differs",
+                        video_id,
+                        [index],
+                        [filename],
+                        "fresh provider facts differ from stored source identity evidence",
+                        differences,
+                    )
+                )
             signals = _non_delivery_signals(talk, proposal, title_agrees)
             if signals:
-                findings.append(_finding(
-                    "likely_non_delivery_clip", video_id, [index], [filename],
-                    "provider title/duration suggest this source may not be a full delivery",
-                    {
-                        "signals": signals,
-                        "catalog_title": catalog_title,
-                        "provider_title": provider_title,
-                        "catalog_duration_seconds": expected_duration,
-                        "provider_duration_seconds": provider_duration,
-                    },
-                    "high",
-                ))
+                findings.append(
+                    _finding(
+                        "likely_non_delivery_clip",
+                        video_id,
+                        [index],
+                        [filename],
+                        "provider title/duration suggest this source may not be a full delivery",
+                        {
+                            "signals": signals,
+                            "catalog_title": catalog_title,
+                            "provider_title": provider_title,
+                            "catalog_duration_seconds": expected_duration,
+                            "provider_duration_seconds": provider_duration,
+                        },
+                        "high",
+                    )
+                )
 
     for video_id in sorted(groups):
         members = groups[video_id]
@@ -671,21 +791,30 @@ def audit_database(
             for index, talk in members
         ]
         collision_records.sort(key=lambda item: str(item["filename"]))
-        findings.append(_finding(
-            "same_id_cross_talk_collision", video_id, indexes, filenames,
-            "one active YouTube identity is attached to distinct catalog talks/deliveries",
-            {
-                "catalog_records": collision_records,
-                "provider_title": evidence_by_id.get(video_id, {}).get("title"),
-            },
-            "high",
-        ))
+        findings.append(
+            _finding(
+                "same_id_cross_talk_collision",
+                video_id,
+                indexes,
+                filenames,
+                "one active YouTube identity is attached to distinct catalog talks/deliveries",
+                {
+                    "catalog_records": collision_records,
+                    "provider_title": evidence_by_id.get(video_id, {}).get("title"),
+                },
+                "high",
+            )
+        )
 
     priority_order = {"high": 0, "medium": 1, "low": 2}
-    findings.sort(key=lambda item: (
-        priority_order.get(item["review_priority"], 9),
-        item["code"], item["video_id"] or "", item["filenames"],
-    ))
+    findings.sort(
+        key=lambda item: (
+            priority_order.get(item["review_priority"], 9),
+            item["code"],
+            item["video_id"] or "",
+            item["filenames"],
+        )
+    )
     talk_audits.sort(key=lambda item: (item["talk_index"], item["filename"]))
     sources.sort(key=lambda item: item["video_id"])
     by_code = Counter(item["code"] for item in findings)
@@ -731,8 +860,10 @@ def audit_path(
         database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
         report = audit_database(
-            {}, database_path=database_path,
-            metadata_fetcher=metadata_fetcher, captured_at=captured_at,
+            {},
+            database_path=database_path,
+            metadata_fetcher=metadata_fetcher,
+            captured_at=captured_at,
         )
         report["complete"] = False
         report["review_required"] = True
@@ -740,15 +871,23 @@ def audit_path(
             "finding_count": 1,
             "by_code": {"database_unreadable": 1},
         }
-        report["findings"] = [_finding(
-            "database_unreadable", None, [], [],
-            "tracking database could not be read as UTF-8 JSON",
-            {"error": str(exc)}, "high",
-        )]
+        report["findings"] = [
+            _finding(
+                "database_unreadable",
+                None,
+                [],
+                [],
+                "tracking database could not be read as UTF-8 JSON",
+                {"error": str(exc)},
+                "high",
+            )
+        ]
         return report
     return audit_database(
-        database, database_path=database_path,
-        metadata_fetcher=metadata_fetcher, captured_at=captured_at,
+        database,
+        database_path=database_path,
+        metadata_fetcher=metadata_fetcher,
+        captured_at=captured_at,
     )
 
 
@@ -765,7 +904,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         report = audit_path(
-            args.vault_or_database, captured_at=args.captured_at,
+            args.vault_or_database,
+            captured_at=args.captured_at,
         )
     except ValueError as exc:
         parser.error(str(exc))

--- a/skills/vault-ingress/scripts/catalog_io.py
+++ b/skills/vault-ingress/scripts/catalog_io.py
@@ -65,11 +65,7 @@ def catalog_entry_paths(root: Path) -> list[Path]:
     """Return every recursive Markdown entry except the catalog-root index."""
     root_index = root / "_index.md"
     return sorted(
-        (
-            path
-            for path in root.rglob("*.md")
-            if path.is_file() and path != root_index
-        ),
+        (path for path in root.rglob("*.md") if path.is_file() and path != root_index),
         key=lambda path: path.relative_to(root).as_posix(),
     )
 
@@ -94,29 +90,32 @@ def parse_evidence_source_groups(
         else:
             raise ValueError(
                 f"{field_name}[{index}] must be a source string or an "
-                "all-of list containing at least two sources")
+                "all-of list containing at least two sources"
+            )
         if any(not isinstance(source, str) for source in raw_group):
-            raise ValueError(
-                f"{field_name}[{index}] sources must all be strings")
+            raise ValueError(f"{field_name}[{index}] sources must all be strings")
         if len(raw_group) != len(set(raw_group)):
-            raise ValueError(
-                f"{field_name}[{index}] contains duplicate sources")
+            raise ValueError(f"{field_name}[{index}] contains duplicate sources")
         unknown = sorted(set(raw_group) - allowed)
         if unknown:
             raise ValueError(
-                f"{field_name}[{index}] contains unknown sources: {unknown}")
+                f"{field_name}[{index}] contains unknown sources: {unknown}"
+            )
         group = frozenset(raw_group)
         if group == frozenset({SOURCE_COMPARISON}):
             raise ValueError(
                 f"{field_name}[{index}] cannot use source_comparison as a "
-                "singleton; name the exact underlying source pair")
+                "singleton; name the exact underlying source pair"
+            )
         if len(group) > 1 and SOURCE_COMPARISON in group:
             raise ValueError(
                 "source_comparison labels a completed comparison and cannot be "
-                "an underlying source in an all-of alternative")
+                "an underlying source in an all-of alternative"
+            )
         if group in groups:
             raise ValueError(
-                f"{field_name} contains duplicate alternative {sorted(group)}")
+                f"{field_name} contains duplicate alternative {sorted(group)}"
+            )
         groups.append(group)
     return tuple(groups)
 
@@ -130,8 +129,7 @@ def qualifying_evidence_groups(
     return tuple(
         group
         for group in groups
-        if group <= available and (
-            len(group) == 1 or SOURCE_COMPARISON in available)
+        if group <= available and (len(group) == 1 or SOURCE_COMPARISON in available)
     )
 
 

--- a/skills/vault-ingress/scripts/catalog_normalization.py
+++ b/skills/vault-ingress/scripts/catalog_normalization.py
@@ -10,8 +10,6 @@ def normalize_catalog_alias(value: str) -> str:
     """Map a catalog ID, name, or alias into the collision namespace."""
     decomposed = unicodedata.normalize("NFKD", value).casefold()
     folded = "".join(
-        character
-        for character in decomposed
-        if not unicodedata.combining(character)
+        character for character in decomposed if not unicodedata.combining(character)
     )
     return "-".join(re.findall(r"[a-z0-9]+", folded))

--- a/skills/vault-ingress/scripts/failure_diagnostics.py
+++ b/skills/vault-ingress/scripts/failure_diagnostics.py
@@ -83,9 +83,7 @@ def emit_unexpected_failure(
     """
     target = sys.stderr if stream is None else stream
     print(
-        json.dumps(
-            unexpected_failure_document(exc, error_code, state), sort_keys=True
-        ),
+        json.dumps(unexpected_failure_document(exc, error_code, state), sort_keys=True),
         file=target,
     )
     print(

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -87,8 +87,12 @@ def is_youtube_url(url: Any) -> bool:
         candidate = "https://" + candidate
     host = (urlparse(candidate).hostname or "").casefold().rstrip(".")
     return host in {
-        "youtube.com", "www.youtube.com", "m.youtube.com",
-        "youtu.be", "www.youtu.be", "youtube-nocookie.com",
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "youtu.be",
+        "www.youtu.be",
+        "youtube-nocookie.com",
         "www.youtube-nocookie.com",
     }
 
@@ -111,11 +115,7 @@ def parse_google_drive_id(url: Any) -> str | None:
     if path_match is not None:
         return path_match.group(1)
     values = parse_qs(parsed.query).get("id", [])
-    return (
-        values[0]
-        if values and GOOGLE_DRIVE_ID_RE.fullmatch(values[0])
-        else None
-    )
+    return values[0] if values and GOOGLE_DRIVE_ID_RE.fullmatch(values[0]) else None
 
 
 def _valid_http_url(value: object) -> bool:
@@ -146,7 +146,8 @@ def has_remote_slide_acquisition(talk: dict) -> bool:
         return False
     parsed = urlparse(str(slides_url).strip())
     if (parsed.hostname or "").casefold().rstrip(".") in {
-        "drive.google.com", "docs.google.com"
+        "drive.google.com",
+        "docs.google.com",
     }:
         return parse_google_drive_id(slides_url) is not None
     return True
@@ -161,11 +162,9 @@ def has_video_source(talk: dict) -> bool:
 
 def has_transcript_source(talk: dict) -> bool:
     """Return whether a transcript artifact exists or can be acquired."""
-    return (
-        any(has_nonempty_source_field(talk, field)
-            for field in TRANSCRIPT_ARTIFACT_FIELDS)
-        or has_video_source(talk)
-    )
+    return any(
+        has_nonempty_source_field(talk, field) for field in TRANSCRIPT_ARTIFACT_FIELDS
+    ) or has_video_source(talk)
 
 
 def has_pptx_source(talk: dict) -> bool:
@@ -199,17 +198,13 @@ def source_capabilities(talk: dict) -> list[str]:
 
 def has_remote_acquisition_source(talk: dict) -> bool:
     """Return whether a declared upstream path could mechanically fail to download."""
-    return (
-        has_remote_video_acquisition(talk)
-        or has_remote_slide_acquisition(talk)
-    )
+    return has_remote_video_acquisition(talk) or has_remote_slide_acquisition(talk)
 
 
 def has_local_source_artifact(talk: dict) -> bool:
     """Return whether a local transcript/deck/PDF reference remains usable."""
     return any(
-        has_nonempty_source_field(talk, field)
-        for field in LOCAL_ARTIFACT_FIELDS
+        has_nonempty_source_field(talk, field) for field in LOCAL_ARTIFACT_FIELDS
     )
 
 
@@ -221,18 +216,20 @@ def validate_talk_record_schemas(talks: object) -> list[dict]:
     for index, talk in enumerate(talks):
         if not isinstance(talk, dict):
             raise IngressContractError(
-                f"talks[{index}] must be a JSON object, got {type(talk).__name__}")
+                f"talks[{index}] must be a JSON object, got {type(talk).__name__}"
+            )
         version = talk.get("schema_version", 0)
-        if (isinstance(version, bool) or not isinstance(version, int)
-                or version < 0):
+        if isinstance(version, bool) or not isinstance(version, int) or version < 0:
             raise IngressContractError(
                 f"talks[{index}].schema_version must be a non-negative integer, "
-                f"got {version!r}")
+                f"got {version!r}"
+            )
         if version > TALK_SCHEMA_VERSION:
             filename = talk.get("filename", f"talks[{index}]")
             raise IngressContractError(
                 f"{filename} uses future talk schema_version {version}; this writer "
-                f"supports through {TALK_SCHEMA_VERSION} and will not downgrade it")
+                f"supports through {TALK_SCHEMA_VERSION} and will not downgrade it"
+            )
         validated.append(talk)
     return validated
 
@@ -244,4 +241,5 @@ def reject_tracking_database_symlink(path: str | os.PathLike[str]) -> None:
         raise IngressContractError(
             f"tracking database path {candidate} is a symbolic link; pass the "
             "canonical regular-file path so atomic replacement cannot split the "
-            "link from its target")
+            "link from its target"
+        )

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -57,14 +57,17 @@ from pptx_discovery_contract import (
 
 PLAN_SCHEMA_VERSION = 1
 OWNER_RECORD_SCHEMA_VERSION = CONFIRMED_INTENT_RECORD_SCHEMA_VERSION
-if len(
-    {
-        OWNER_RECORD_SCHEMA_VERSION,
-        PPTX_CATALOG_RECORD_SCHEMA_VERSION,
-        RESOURCE_RECORD_SCHEMA_VERSION,
-        THUMBNAIL_RECORD_SCHEMA_VERSION,
-    }
-) != 1:
+if (
+    len(
+        {
+            OWNER_RECORD_SCHEMA_VERSION,
+            PPTX_CATALOG_RECORD_SCHEMA_VERSION,
+            RESOURCE_RECORD_SCHEMA_VERSION,
+            THUMBNAIL_RECORD_SCHEMA_VERSION,
+        }
+    )
+    != 1
+):
     raise RuntimeError("typed owner collection versions require per-kind validation")
 MISSING_MARKER = {"$missing": True}
 COLLECTION_IDENTITIES = {
@@ -83,9 +86,7 @@ PUBLISHING_TALK_FIELDS = frozenset(
         "youtube_id",
     }
 )
-CLARIFICATION_TALK_FIELDS = frozenset(
-    {"blind_spot_observations", "humor_postmortem"}
-)
+CLARIFICATION_TALK_FIELDS = frozenset({"blind_spot_observations", "humor_postmortem"})
 GOAL_VERIFICATION_FIELDS = frozenset(
     {
         "status",
@@ -106,6 +107,8 @@ CONFIRMED_INTENT_REQUIRED_FIELDS = OWNER_CONFIRMED_INTENT_REQUIRED_FIELDS | {
 RESOURCE_REQUIRED_FIELDS = OWNER_RESOURCE_REQUIRED_FIELDS | {"schema_version"}
 PPTX_REQUIRED_FIELDS = PPTX_CATALOG_REQUIRED_FIELDS | {"schema_version"}
 THUMBNAIL_REQUIRED_FIELDS = OWNER_THUMBNAIL_REQUIRED_FIELDS | {"schema_version"}
+
+
 class TrackingDatabaseMutationError(ValueError):
     """A mutation plan, precondition, or database shape is invalid."""
 
@@ -130,7 +133,9 @@ def load_plan(path: Path) -> dict[str, Any]:
     try:
         raw = path.read_bytes()
     except OSError as exc:
-        raise TrackingDatabaseMutationError(f"cannot read mutation plan {path}: {exc}") from exc
+        raise TrackingDatabaseMutationError(
+            f"cannot read mutation plan {path}: {exc}"
+        ) from exc
     plan = _strict_json_object(raw, path, "mutation plan")
     if not json_values_equal(plan.get("schema_version"), PLAN_SCHEMA_VERSION):
         raise TrackingDatabaseMutationError(
@@ -142,7 +147,9 @@ def load_plan(path: Path) -> dict[str, Any]:
         )
     mutations = plan.get("mutations")
     if not isinstance(mutations, list) or not mutations:
-        raise TrackingDatabaseMutationError("mutation plan mutations must be a nonempty array")
+        raise TrackingDatabaseMutationError(
+            "mutation plan mutations must be a nonempty array"
+        )
     if any(not isinstance(mutation, dict) for mutation in mutations):
         raise TrackingDatabaseMutationError("every mutation must be a JSON object")
     return plan
@@ -160,7 +167,9 @@ def _require_keys(
     if missing:
         raise TrackingDatabaseMutationError(f"{label} is missing {sorted(missing)}")
     if unknown:
-        raise TrackingDatabaseMutationError(f"{label} has unknown fields {sorted(unknown)}")
+        raise TrackingDatabaseMutationError(
+            f"{label} has unknown fields {sorted(unknown)}"
+        )
 
 
 def _nonempty(value: object, label: str) -> str:
@@ -208,7 +217,9 @@ def _string_array(value: object, label: str, *, nonempty: bool = False) -> list[
         raise TrackingDatabaseMutationError(
             f"{label} must be {suffix} array of unique nonempty strings"
         )
-    normalized = [_nonempty(item, f"{label}[{index}]") for index, item in enumerate(value)]
+    normalized = [
+        _nonempty(item, f"{label}[{index}]") for index, item in enumerate(value)
+    ]
     if len(normalized) != len(set(normalized)):
         raise TrackingDatabaseMutationError(
             f"{label} must contain unique nonempty strings"
@@ -319,7 +330,9 @@ def _collection(
 ) -> list[dict[str, Any]]:
     value = database.setdefault(key, [])
     if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
-        raise TrackingDatabaseMutationError(f"database {key} must be an array of objects")
+        raise TrackingDatabaseMutationError(
+            f"database {key} must be an array of objects"
+        )
     return value
 
 
@@ -542,7 +555,9 @@ def _validate_collection_record(kind: str, record: dict[str, Any]) -> None:
             "shownotes_thumbnail_path",
         ):
             _nonempty(record[field], f"{label}.{field}")
-        _exact_integer(record["source_slide_num"], f"{label}.source_slide_num", minimum=1)
+        _exact_integer(
+            record["source_slide_num"], f"{label}.source_slide_num", minimum=1
+        )
         dimensions = _nonempty(record["dimensions"], f"{label}.dimensions")
         match = re.fullmatch(r"([1-9][0-9]*)x([1-9][0-9]*)", dimensions)
         if match is None:
@@ -570,10 +585,14 @@ def _apply_collection_upsert(
     )
     record = mutation["record"]
     if not isinstance(record, dict):
-        raise TrackingDatabaseMutationError(f"mutations[{index}].record must be an object")
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].record must be an object"
+        )
     _validate_collection_record(kind, record)
     collection_name, identity_field = COLLECTION_IDENTITIES[kind]
-    identity = _nonempty(record.get(identity_field), f"mutations[{index}].record.{identity_field}")
+    identity = _nonempty(
+        record.get(identity_field), f"mutations[{index}].record.{identity_field}"
+    )
     records = _collection(database, collection_name)
     record_index, current = _find_unique_record(
         records,
@@ -723,8 +742,14 @@ def _apply_record_patch(
     allowed_fields: frozenset[str],
     label: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    if not isinstance(expect, dict) or not isinstance(set_values, dict) or not set_values:
-        raise TrackingDatabaseMutationError(f"{label} expect/set must be nonempty objects")
+    if (
+        not isinstance(expect, dict)
+        or not isinstance(set_values, dict)
+        or not set_values
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label} expect/set must be nonempty objects"
+        )
     if set(set_values) - allowed_fields:
         raise TrackingDatabaseMutationError(
             f"{label} set has unsupported fields {sorted(set(set_values) - allowed_fields)}"
@@ -843,7 +868,9 @@ def _apply_goal_verification(
     goals = _collection(database, "improvement_goals")
     _, goal = _find_unique_record(goals, "id", identity, label="improvement_goals")
     if goal is None:
-        raise TrackingDatabaseMutationError(f"improvement goal {identity!r} does not exist")
+        raise TrackingDatabaseMutationError(
+            f"improvement goal {identity!r} does not exist"
+        )
     goal_version = goal.get("schema_version")
     goal_kind = goal.get("kind")
     if goal_version == 1:
@@ -941,7 +968,9 @@ def _apply_record_pptx(
     )
     record = mutation["record"]
     if not isinstance(record, dict):
-        raise TrackingDatabaseMutationError(f"mutations[{index}].record must be an object")
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].record must be an object"
+        )
     record_label = f"mutations[{index}].record"
     _require_keys(
         record,
@@ -951,7 +980,9 @@ def _apply_record_pptx(
     _validate_record_schema(record, record_label)
     pptx_path = _nonempty(record["pptx_path"], f"{record_label}.pptx_path")
     if type(record["matched"]) is not bool:
-        raise TrackingDatabaseMutationError(f"mutations[{index}].record.matched must be boolean")
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].record.matched must be boolean"
+        )
     _exact_integer(record["slide_count"], f"{record_label}.slide_count")
     if type(record["visual_extracted"]) is not bool:
         raise TrackingDatabaseMutationError(
@@ -959,7 +990,9 @@ def _apply_record_pptx(
         )
     talk_filename = record.get("talk_filename")
     if talk_filename is not None:
-        talk_filename = _nonempty(talk_filename, f"mutations[{index}].record.talk_filename")
+        talk_filename = _nonempty(
+            talk_filename, f"mutations[{index}].record.talk_filename"
+        )
     if record["matched"] != (talk_filename is not None):
         raise TrackingDatabaseMutationError(
             f"mutations[{index}] matched must be true exactly when talk_filename is set"
@@ -1025,12 +1058,16 @@ def _validate_database_shape(database: dict[str, Any]) -> None:
     if not isinstance(config, dict):
         raise TrackingDatabaseMutationError("database config must be an object")
     if not isinstance(talks, list) or any(not isinstance(talk, dict) for talk in talks):
-        raise TrackingDatabaseMutationError("database talks must be an array of objects")
+        raise TrackingDatabaseMutationError(
+            "database talks must be an array of objects"
+        )
     seen: set[str] = set()
     for index, talk in enumerate(talks):
         filename = _nonempty(talk.get("filename"), f"talks[{index}].filename")
         if filename in seen:
-            raise TrackingDatabaseMutationError(f"database repeats talk filename {filename!r}")
+            raise TrackingDatabaseMutationError(
+                f"database repeats talk filename {filename!r}"
+            )
         seen.add(filename)
 
 
@@ -1042,7 +1079,9 @@ def initial_database(mutation: dict[str, Any], *, index: int) -> dict[str, Any]:
     )
     config = mutation["config"]
     if not isinstance(config, dict):
-        raise TrackingDatabaseMutationError(f"mutations[{index}].config must be an object")
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].config must be an object"
+        )
     initial_config = copy.deepcopy(config)
     if "schema_version" in initial_config and not json_values_equal(
         initial_config["schema_version"],
@@ -1061,9 +1100,7 @@ def initial_database(mutation: dict[str, Any], *, index: int) -> dict[str, Any]:
         initial_config["pptx_directory_exclusions"] = (
             validate_pptx_directory_exclusions(
                 initial_config["pptx_directory_exclusions"],
-                label=(
-                    f"mutations[{index}].config.pptx_directory_exclusions"
-                ),
+                label=(f"mutations[{index}].config.pptx_directory_exclusions"),
             )
         )
     except PptxDiscoveryContractError as exc:
@@ -1135,7 +1172,9 @@ def build_candidate(
 def _validate_digest(value: str) -> None:
     if value == "missing":
         return
-    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
         raise TrackingDatabaseMutationError(
             "--expected-sha256 must be `missing` or 64 lowercase hexadecimal characters"
         )
@@ -1157,8 +1196,13 @@ def execute(
             "--apply requires --expected-sha256 from the reviewed dry-run report"
         )
 
-    initialize = len(mutations) == 1 and mutations[0].get("kind") == "initialize_database"
-    if any(mutation.get("kind") == "initialize_database" for mutation in mutations) and not initialize:
+    initialize = (
+        len(mutations) == 1 and mutations[0].get("kind") == "initialize_database"
+    )
+    if (
+        any(mutation.get("kind") == "initialize_database" for mutation in mutations)
+        and not initialize
+    ):
         raise TrackingDatabaseMutationError(
             "initialize_database must be the mutation plan's sole mutation"
         )

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -166,6 +166,7 @@ def normalize_stamp(value):
     """
     return normalize_processing_stamp(value)
 
+
 # Tracking-DB talk-record schema version, stamped by this writer on every merge.
 #
 # v1 is the implicit, unversioned shape every pre-2026-07-28 record carries:
@@ -186,16 +187,16 @@ def normalize_stamp(value):
 # (top_level_field, dotted source path within the return). To add a new queryable
 # scalar, add it here AND to the return schema — never reintroduce hand-mapping.
 PROMOTE = [
-    ("slide_count",                "structured_data.slide_count"),
-    ("slide_design_style",         "structured_data.slide_design_style"),
-    ("illustration_style",         "structured_data.illustration_style"),
-    ("opening_type",               "structured_data.opening_type"),
-    ("closing_type",               "structured_data.closing_type"),
-    ("narrative_arc_type",         "structured_data.narrative_arc_type"),
+    ("slide_count", "structured_data.slide_count"),
+    ("slide_design_style", "structured_data.slide_design_style"),
+    ("illustration_style", "structured_data.illustration_style"),
+    ("opening_type", "structured_data.opening_type"),
+    ("closing_type", "structured_data.closing_type"),
+    ("narrative_arc_type", "structured_data.narrative_arc_type"),
     ("audience_interaction_count", "structured_data.audience_interaction_count"),
-    ("co_presenter",               "structured_data.co_presenter"),
-    ("co_presenters",              "structured_data.co_presenters"),
-    ("delivery_language",          "structured_data.delivery_language"),
+    ("co_presenter", "structured_data.co_presenter"),
+    ("co_presenters", "structured_data.co_presenters"),
+    ("delivery_language", "structured_data.delivery_language"),
 ]
 
 # NOT in PROMOTE: `pattern_score`. It is set explicitly in merge_talk from
@@ -206,15 +207,21 @@ PROMOTE = [
 # processing stamp is writer-owned and handled separately below: a subagent's
 # legacy `processed_date` cannot override the batch timestamp.
 SCALARS = [
-    "status", "rhetoric_notes", "areas_for_improvement",
-    "adherence_assessment", "transcript_source", "transcript_path",
-    "slide_source", "slides_local_path",
+    "status",
+    "rhetoric_notes",
+    "areas_for_improvement",
+    "adherence_assessment",
+    "transcript_source",
+    "transcript_path",
+    "slide_source",
+    "slides_local_path",
 ]
 
 PROMOTED_BY_STRUCTURED_KEY = {
     path.removeprefix("structured_data."): field
     for field, path in PROMOTE
-    if path.startswith("structured_data.") and "." not in path.removeprefix("structured_data.")
+    if path.startswith("structured_data.")
+    and "." not in path.removeprefix("structured_data.")
 }
 
 
@@ -258,7 +265,8 @@ def require_stored_mapping(talk, field):
     if not isinstance(value, dict):
         raise ValueError(
             f"stored {field} is a {type(value).__name__}; refusing to merge a "
-            "new analysis into malformed prior state")
+            "new analysis into malformed prior state"
+        )
     return value
 
 
@@ -268,8 +276,8 @@ def merge_structured_v2(existing, incoming):
     if present_group and present_group != IMAGE_SOURCE_GROUP:
         missing = sorted(IMAGE_SOURCE_GROUP - present_group)
         raise ValueError(
-            "snapshot return image-source group is incomplete; missing "
-            f"{missing}")
+            f"snapshot return image-source group is incomplete; missing {missing}"
+        )
 
     validate_v2_structured_policy_shapes(incoming)
     merged = copy.deepcopy(existing)
@@ -285,7 +293,8 @@ def merge_structured_v2(existing, incoming):
             if not isinstance(current, dict):
                 raise ValueError(
                     f"stored structured_data.{field} is a "
-                    f"{type(current).__name__}; additive namespaces must be objects")
+                    f"{type(current).__name__}; additive namespaces must be objects"
+                )
             merged[field] = deep_merge(copy.deepcopy(current), copy.deepcopy(value))
         else:
             merged[field] = copy.deepcopy(value)
@@ -301,8 +310,9 @@ def merge_verbatim_v2(existing, incoming):
     return merged
 
 
-def _normalized_pattern_fields(patterns, antipatterns, not_evaluable,
-                               evidence_sources, score):
+def _normalized_pattern_fields(
+    patterns, antipatterns, not_evaluable, evidence_sources, score
+):
     return normalize_pattern_observations(
         {},
         copy.deepcopy(patterns),
@@ -319,14 +329,14 @@ def _sync_v2_promotions(talk, incoming_structured):
     for field, path in PROMOTE:
         structured_field = path.removeprefix("structured_data.")
         if structured_field in incoming_structured:
-            talk[field] = copy.deepcopy(
-                talk["structured_data"][structured_field])
+            talk[field] = copy.deepcopy(talk["structured_data"][structured_field])
             promoted.append(field)
     return promoted
 
 
 def validate_effective_v2_state(
-        talk, incoming_structured, *, pattern_snapshot_replaced):
+    talk, incoming_structured, *, pattern_snapshot_replaced
+):
     """Validate a post-v2–v5 snapshot candidate before publication."""
     validate_talk_record_schemas([talk])
     try:
@@ -342,11 +352,11 @@ def validate_effective_v2_state(
             nested = structured[structured_field]
             if field not in talk or talk[field] != nested:
                 raise ValueError(
-                    f"effective merged analysis has divergent promoted field {field}")
+                    f"effective merged analysis has divergent promoted field {field}"
+                )
 
     if not pattern_snapshot_replaced:
-        raise ValueError(
-            "snapshot return did not replace pattern_observations")
+        raise ValueError("snapshot return did not replace pattern_observations")
 
 
 def _delete_path(obj, parts):
@@ -372,8 +382,12 @@ def apply_clear_fields(talk, paths):
             promoted = PROMOTED_BY_STRUCTURED_KEY.get(parts[1])
             if promoted and talk.pop(promoted, None) is not None:
                 cleared.append(promoted)
-        if (len(parts) == 2 and parts[0] == "pattern_observations" and
-                parts[1] == "pattern_score" and talk.pop("pattern_score", None) is not None):
+        if (
+            len(parts) == 2
+            and parts[0] == "pattern_observations"
+            and parts[1] == "pattern_score"
+            and talk.pop("pattern_score", None) is not None
+        ):
             cleared.append("pattern_score")
     return cleared
 
@@ -415,7 +429,8 @@ def require_mapping(ret, field):
         raise ValueError(
             f"{field} is a {type(value).__name__}, but the return schema declares "
             f"it a JSON object. Refusing to skip it silently — a dropped {field} "
-            "loses the whole block while the merge still reports success.")
+            "loses the whole block while the merge still reports success."
+        )
     return value
 
 
@@ -434,13 +449,15 @@ def require_detections(observations, field):
     if not isinstance(value, list):
         raise ValueError(
             f"pattern_observations.{field} is a {type(value).__name__}, but the "
-            "return schema declares it an array of detection objects.")
+            "return schema declares it an array of detection objects."
+        )
     bad = next((e for e in value if not isinstance(e, dict)), None)
     if bad is not None:
         raise ValueError(
             f"pattern_observations.{field} contains {bad!r} "
             f"({type(bad).__name__}); every element must be an object carrying a "
-            "`pattern_id`.")
+            "`pattern_id`."
+        )
     return value
 
 
@@ -482,7 +499,8 @@ def resolve_pattern_score(observations, patterns, antipatterns):
         raise ValueError(
             "pattern_score is an object with no `score` key "
             f"(got keys {sorted(raw)}). Emit "
-            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
+            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.'
+        )
 
     label = "pattern_score" if coerced else "pattern_score.score"
     if isinstance(nested, bool) or not isinstance(nested, int):
@@ -490,7 +508,8 @@ def resolve_pattern_score(observations, patterns, antipatterns):
             f"{label} is {nested!r} ({type(nested).__name__}). It must be an "
             "integer — the score is count(patterns) minus count(antipatterns), "
             "so a float, a string and a bool are all wrong. Emit "
-            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.')
+            '{"patterns_used": N, "antipatterns_detected": M, "score": N-M}.'
+        )
 
     # Only the coerced form is cross-checked. It is the shape that arrived
     # without its accompanying counts, so the arrays are the only evidence that
@@ -501,12 +520,14 @@ def resolve_pattern_score(observations, patterns, antipatterns):
             raise ValueError(
                 f"pattern_score is the bare int {nested}, but patterns_detected "
                 f"({used}) minus antipatterns_detected ({against}) is "
-                f"{used - against}. Refusing to guess which is right.")
+                f"{used - against}. Refusing to guess which is right."
+            )
     return nested, coerced
 
 
-def normalize_pattern_observations(existing, patterns, antipatterns,
-                                   not_evaluable, evidence_sources, score):
+def normalize_pattern_observations(
+    existing, patterns, antipatterns, not_evaluable, evidence_sources, score
+):
     """Map the subagent return shape onto the DB shape, keeping both views.
 
     Takes already-validated inputs and decides nothing about their shape, so it
@@ -515,14 +536,19 @@ def normalize_pattern_observations(existing, patterns, antipatterns,
     obs = dict(existing) if isinstance(existing, dict) else {}
     if patterns is not None:
         obs["patterns_detected"] = patterns
-        obs["pattern_ids"] = [p.get("pattern_id") for p in patterns if p.get("pattern_id")]
+        obs["pattern_ids"] = [
+            p.get("pattern_id") for p in patterns if p.get("pattern_id")
+        ]
     if antipatterns is not None:
         obs["antipatterns_detected"] = antipatterns
-        obs["antipattern_ids"] = [p.get("pattern_id") for p in antipatterns if p.get("pattern_id")]
+        obs["antipattern_ids"] = [
+            p.get("pattern_id") for p in antipatterns if p.get("pattern_id")
+        ]
     if not_evaluable is not None:
         obs["not_evaluable"] = not_evaluable
         obs["not_evaluable_ids"] = [
-            item.get("pattern_id") for item in not_evaluable if item.get("pattern_id")]
+            item.get("pattern_id") for item in not_evaluable if item.get("pattern_id")
+        ]
     if evidence_sources is not None:
         obs["evidence_sources"] = evidence_sources
     if score is not None:
@@ -530,9 +556,17 @@ def normalize_pattern_observations(existing, patterns, antipatterns,
     return obs
 
 
-def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
-               *, enforce_queue_claim=False, catalog=None,
-               canonical_ret=None, artifact_capabilities=None):
+def merge_talk(
+    talk,
+    ret,
+    run_date=None,
+    catalog_fingerprint=None,
+    *,
+    enforce_queue_claim=False,
+    catalog=None,
+    canonical_ret=None,
+    artifact_capabilities=None,
+):
     """Merge one return into its talk.
 
     Returns (promoted, stamped, coerced_score, cleared).
@@ -549,19 +583,21 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
     if enforce_queue_claim and normalized_run_date is None:
         raise ValueError(
             "run_date is required when closing a queue claim so released_at is "
-            "deterministic")
+            "deterministic"
+        )
     if enforce_queue_claim:
         validate_claim_against_talk(
-            talk, ret, artifact_capabilities=artifact_capabilities)
+            talk, ret, artifact_capabilities=artifact_capabilities
+        )
 
     if return_schema_version in SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS:
         if not isinstance(canonical_ret, dict):
             raise ValueError(
                 f"return-schema v{return_schema_version} requires source evidence canonicalization "
-                "before merge")
+                "before merge"
+            )
         if return_evidence_claim(canonical_ret) != return_evidence_claim(ret):
-            raise ValueError(
-                "canonical evidence changed model-authored return fields")
+            raise ValueError("canonical evidence changed model-authored return fields")
         evidence_ret = canonical_ret
         if enforce_queue_claim:
             validate_v5_adherence_opportunity(talk, ret, canonical_ret)
@@ -587,12 +623,15 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
     returned_stamp = ret.get("processed_date")
     if normalized_run_date and not is_empty(returned_stamp):
         normalized_returned_stamp = normalize_stamp(returned_stamp)
-        if (len(normalized_returned_stamp) > 10
-                and normalized_returned_stamp != normalized_run_date):
+        if (
+            len(normalized_returned_stamp) > 10
+            and normalized_returned_stamp != normalized_run_date
+        ):
             raise ValueError(
                 "return processed_date is an explicit timestamp "
                 f"{normalized_returned_stamp!r} that conflicts with authoritative "
-                f"batch run_date {normalized_run_date!r}")
+                f"batch run_date {normalized_run_date!r}"
+            )
 
     structured = require_mapping(ret, "structured_data")
     verbatim = require_mapping(ret, "verbatim_examples")
@@ -603,23 +642,28 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
     not_evaluable = require_detections(observation_values, "not_evaluable")
     evidence_sources = observation_values.get("evidence_sources")
     resolved_catalog = catalog or load_catalog()
-    if (catalog_fingerprint is not None and
-            catalog_fingerprint != resolved_catalog.fingerprint):
+    if (
+        catalog_fingerprint is not None
+        and catalog_fingerprint != resolved_catalog.fingerprint
+    ):
         raise ValueError(
-            "catalog_fingerprint does not match the catalog used to assess "
-            "the return")
-    scoring_assessment = assess_scoring_generation(
-        evidence_ret, resolved_catalog)
-    if (return_schema_version == RETURN_SCHEMA_VERSION and
-            not scoring_assessment.current):
+            "catalog_fingerprint does not match the catalog used to assess the return"
+        )
+    scoring_assessment = assess_scoring_generation(evidence_ret, resolved_catalog)
+    if (
+        return_schema_version == RETURN_SCHEMA_VERSION
+        and not scoring_assessment.current
+    ):
         raise ValueError(
             f"return-schema v{return_schema_version} cannot satisfy the "
             "current scoring generation: "
-            f"{list(scoring_assessment.reasons)}")
+            f"{list(scoring_assessment.reasons)}"
+        )
     patterns = scoring_assessment.patterns_detected
     antipatterns = scoring_assessment.antipatterns_detected
     score, coerced_score = resolve_pattern_score(
-        observation_values, patterns, antipatterns)
+        observation_values, patterns, antipatterns
+    )
 
     if return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
         # Validate persisted block types before a clear could conceal malformed
@@ -631,14 +675,16 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
     cleared = apply_clear_fields(candidate, ret.get("clear_fields"))
     candidate["schema_version"] = TALK_SCHEMA_VERSION
     for f in SCALARS:
-        if (f in ret and
-                (return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS or
-                 not is_empty(ret[f]))):
+        if f in ret and (
+            return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS
+            or not is_empty(ret[f])
+        ):
             candidate[f] = copy.deepcopy(ret[f])
-    if (return_schema_version in SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS and
-            "adherence_comparison" in ret):
-        candidate["adherence_comparison"] = copy.deepcopy(
-            ret["adherence_comparison"])
+    if (
+        return_schema_version in SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS
+        and "adherence_comparison" in ret
+    ):
+        candidate["adherence_comparison"] = copy.deepcopy(ret["adherence_comparison"])
     elif return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
         # A v2–v4 replay is archival prose, never an authenticated current
         # comparison. Snapshot replacement therefore clears any stale
@@ -658,17 +704,22 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
     if structured is not None:
         if return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
             candidate["structured_data"] = merge_structured_v2(
-                require_stored_mapping(candidate, "structured_data"), structured)
+                require_stored_mapping(candidate, "structured_data"), structured
+            )
         else:
             candidate["structured_data"] = deep_merge(
-                candidate.get("structured_data") or {}, structured)
-        if (return_schema_version == LEGACY_RETURN_SCHEMA_VERSION and
-                "video_extraction" in structured):
+                candidate.get("structured_data") or {}, structured
+            )
+        if (
+            return_schema_version == LEGACY_RETURN_SCHEMA_VERSION
+            and "video_extraction" in structured
+        ):
             # This owner-generated schema is a complete manifest, not a bag of
             # independently additive observations. Replacement prevents v1/v2
             # keys such as `output_pdf` from contaminating a validated v3 record.
             candidate["structured_data"]["video_extraction"] = copy.deepcopy(
-                structured["video_extraction"])
+                structured["video_extraction"]
+            )
     if verbatim is not None:
         if return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
             existing_verbatim = candidate.get("verbatim_examples")
@@ -678,16 +729,24 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
             )
         else:
             candidate["verbatim_examples"] = deep_merge(
-                candidate.get("verbatim_examples") or {}, verbatim)
+                candidate.get("verbatim_examples") or {}, verbatim
+            )
     if observations is not None:
         if return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
-            candidate["pattern_observations"] = \
+            candidate["pattern_observations"] = (
                 canonical_persisted_pattern_observations(
-                    evidence_ret, resolved_catalog, scoring_assessment)
+                    evidence_ret, resolved_catalog, scoring_assessment
+                )
+            )
         elif observations:
             candidate["pattern_observations"] = normalize_pattern_observations(
-                candidate.get("pattern_observations"), patterns, antipatterns,
-                not_evaluable, evidence_sources, score)
+                candidate.get("pattern_observations"),
+                patterns,
+                antipatterns,
+                not_evaluable,
+                evidence_sources,
+                score,
+            )
 
     if return_schema_version not in SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS:
         persisted_observations = candidate.get("pattern_observations")
@@ -718,23 +777,26 @@ def merge_talk(talk, ret, run_date=None, catalog_fingerprint=None,
     if score is not None:
         candidate["pattern_score"] = score
         promoted.append("pattern_score")
-    elif (return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS and
-          observations is not None):
+    elif (
+        return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS
+        and observations is not None
+    ):
         candidate.pop("pattern_score", None)
     if ret.get("status") in ANALYSIS_STATUSES:
         if scoring_assessment.current:
-            candidate["pattern_scoring_generation_status"] = \
+            candidate["pattern_scoring_generation_status"] = (
                 CURRENT_PATTERN_SCORING_GENERATION_STATUS
+            )
             candidate["pattern_scoring_generation_reasons"] = []
-            candidate["pattern_scoring_schema_version"] = \
-                PATTERN_SCORING_SCHEMA_VERSION
-            candidate["pattern_catalog_fingerprint"] = \
-                resolved_catalog.fingerprint
+            candidate["pattern_scoring_schema_version"] = PATTERN_SCORING_SCHEMA_VERSION
+            candidate["pattern_catalog_fingerprint"] = resolved_catalog.fingerprint
         else:
-            candidate["pattern_scoring_generation_status"] = \
+            candidate["pattern_scoring_generation_status"] = (
                 LEGACY_UNBASELINEABLE_SCORING_STATUS
-            candidate["pattern_scoring_generation_reasons"] = \
-                list(scoring_assessment.reasons)
+            )
+            candidate["pattern_scoring_generation_reasons"] = list(
+                scoring_assessment.reasons
+            )
             candidate.pop("pattern_scoring_schema_version", None)
             candidate.pop("pattern_catalog_fingerprint", None)
     if return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
@@ -761,7 +823,9 @@ def atomic_write_json(
         snapshot = expected_snapshot or snapshot_tracking_database(path)
         return write_json_object(snapshot, payload)
     except TrackingDatabaseIOError as exc:
-        raise ValueError(f"cannot safely write tracking database {path}: {exc}") from exc
+        raise ValueError(
+            f"cannot safely write tracking database {path}: {exc}"
+        ) from exc
 
 
 def load_tracking_database(path):
@@ -816,8 +880,10 @@ def parse_args(argv):
     while i < len(argv):
         if argv[i] == "--run-date":
             if i + 1 >= len(argv):
-                print("ERROR: --run-date requires a YYYY-MM-DD or ISO-8601 value",
-                      file=sys.stderr)
+                print(
+                    "ERROR: --run-date requires a YYYY-MM-DD or ISO-8601 value",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
             run_date = argv[i + 1]
             i += 2
@@ -825,8 +891,11 @@ def parse_args(argv):
         args.append(argv[i])
         i += 1
     if len(args) != 2:
-        print(f"Usage: {sys.argv[0]} <tracking-database.json> <batch-returns.json> "
-              f"[--run-date YYYY-MM-DD|ISO-8601]", file=sys.stderr)
+        print(
+            f"Usage: {sys.argv[0]} <tracking-database.json> <batch-returns.json> "
+            f"[--run-date YYYY-MM-DD|ISO-8601]",
+            file=sys.stderr,
+        )
         sys.exit(1)
     if run_date is None:
         # Second resolution, not day. A date-only stamp cannot order a talk
@@ -839,8 +908,11 @@ def parse_args(argv):
         try:
             run_date = normalize_stamp(run_date)
         except ValueError as e:
-            print(f"ERROR: --run-date must be YYYY-MM-DD or a timezone-aware "
-                  f"ISO-8601 timestamp: {e}", file=sys.stderr)
+            print(
+                f"ERROR: --run-date must be YYYY-MM-DD or a timezone-aware "
+                f"ISO-8601 timestamp: {e}",
+                file=sys.stderr,
+            )
             sys.exit(1)
     return args[0], args[1], run_date
 
@@ -848,7 +920,6 @@ def parse_args(argv):
 # Whether the atomic database commit landed. The outer boundary reports this so
 # an operator never has to guess whether a late failure replayed a write.
 _COMMIT_STATE = {"database_written": False}
-
 
 
 def main():
@@ -870,7 +941,8 @@ def main():
     db, database_snapshot = load_tracking_database(db_path)
     raw_config = db.get("config")
     source_roots: dict[str, object] = (
-        copy.deepcopy(raw_config) if isinstance(raw_config, dict) else {})
+        copy.deepcopy(raw_config) if isinstance(raw_config, dict) else {}
+    )
     try:
         vault_root = resolve_vault_root_authority(
             database_path=db_path,
@@ -889,7 +961,8 @@ def main():
     artifact_capabilities_by_filename = assess_batch_artifact_capabilities(
         db["talks"],
         {
-            ret["filename"] for ret in returns
+            ret["filename"]
+            for ret in returns
             if isinstance(ret, dict) and isinstance(ret.get("filename"), str)
         },
         vault_root=vault_root,
@@ -898,8 +971,11 @@ def main():
     )
     try:
         by_name = validate_batch_claims_against_talks(
-            db["talks"], returns, required_state="claimed",
-            artifact_capabilities_by_filename=artifact_capabilities_by_filename)
+            db["talks"],
+            returns,
+            required_state="claimed",
+            artifact_capabilities_by_filename=artifact_capabilities_by_filename,
+        )
     except ReturnValidationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
@@ -919,22 +995,26 @@ def main():
                     ret,
                     video_evidence_assessment=video_evidence_assessment,
                 )
-            if (ret.get("status") in ANALYSIS_STATUSES and
-                    resolve_return_schema_version(ret) in
-                    SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS):
+            if (
+                ret.get("status") in ANALYSIS_STATUSES
+                and resolve_return_schema_version(ret)
+                in SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS
+            ):
                 canonical = canonicalize_return_evidence(
-                    ret, by_name[name], vault_root, catalog,
+                    ret,
+                    by_name[name],
+                    vault_root,
+                    catalog,
                     source_roots=source_roots,
-                    pattern_scoring_schema_version=(
-                        PATTERN_SCORING_SCHEMA_VERSION
-                    ),
+                    pattern_scoring_schema_version=(PATTERN_SCORING_SCHEMA_VERSION),
                     video_evidence_assessment=video_evidence_assessment,
                 )
             else:
                 canonical = copy.deepcopy(ret)
             if return_evidence_claim(canonical) != return_evidence_claim(ret):
                 raise PatternEvidenceError(
-                    "canonicalization changed model-authored return fields")
+                    "canonicalization changed model-authored return fields"
+                )
         except PatternEvidenceError as exc:
             print(f"ERROR: {name}: {exc}", file=sys.stderr)
             sys.exit(1)
@@ -950,25 +1030,39 @@ def main():
         talk = by_name[name]
         try:
             promoted, stamped, coerced, cleared = merge_talk(
-                talk, ret, run_date, catalog.fingerprint,
-                enforce_queue_claim=True, catalog=catalog,
+                talk,
+                ret,
+                run_date,
+                catalog.fingerprint,
+                enforce_queue_claim=True,
+                catalog=catalog,
                 canonical_ret=canonical_ret,
-                artifact_capabilities=(
-                    artifact_capabilities_by_filename.get(name)))
+                artifact_capabilities=(artifact_capabilities_by_filename.get(name)),
+            )
         except ValueError as exc:
             print(f"ERROR: {name}: {exc}", file=sys.stderr)
             sys.exit(1)
         analysis_result = talk.get("status") in ANALYSIS_STATUSES
-        summary.append({"filename": name, "status": talk.get("status"),
-                        "promoted": promoted, "stamped_processed_date": stamped,
-                        "coerced_pattern_score": coerced, "cleared": cleared,
-                        "pattern_scoring_generation_status": (
-                            talk.get("pattern_scoring_generation_status")
-                            if analysis_result else
-                            UNSCORED_PATTERN_SCORING_GENERATION_STATUS),
-                        "pattern_scoring_generation_reasons": (
-                            talk.get("pattern_scoring_generation_reasons", [])
-                            if analysis_result else [])})
+        summary.append(
+            {
+                "filename": name,
+                "status": talk.get("status"),
+                "promoted": promoted,
+                "stamped_processed_date": stamped,
+                "coerced_pattern_score": coerced,
+                "cleared": cleared,
+                "pattern_scoring_generation_status": (
+                    talk.get("pattern_scoring_generation_status")
+                    if analysis_result
+                    else UNSCORED_PATTERN_SCORING_GENERATION_STATUS
+                ),
+                "pattern_scoring_generation_reasons": (
+                    talk.get("pattern_scoring_generation_reasons", [])
+                    if analysis_result
+                    else []
+                ),
+            }
+        )
 
     # This all-inclusive cohort is derived only after every member merged into
     # the isolated in-memory candidate. It is intentionally distinct from the
@@ -982,14 +1076,16 @@ def main():
             pattern_scoring_schema_version=PATTERN_SCORING_SCHEMA_VERSION,
             evidence_freshness_assessor=lambda talk: (
                 assess_current_persisted_pattern_evidence_freshness(
-                    talk, vault_root=vault_root, source_roots=source_roots,
-                    video_evidence_assessment=video_evidence_assessment)
+                    talk,
+                    vault_root=vault_root,
+                    source_roots=source_roots,
+                    video_evidence_assessment=video_evidence_assessment,
+                )
             ),
         )
     except AdherenceBaselineError as exc:
         print(
-            "ERROR: cannot derive the post-batch current adherence cohort: "
-            f"{exc}",
+            f"ERROR: cannot derive the post-batch current adherence cohort: {exc}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1005,18 +1101,26 @@ def main():
         sys.exit(1)
     _COMMIT_STATE["database_written"] = bool(write_result.installed)
 
-    json.dump({"persisted": len(summary), "db_path": db_path, "run_date": run_date,
-               "schema_version": TALK_SCHEMA_VERSION,
-               "migrated_records": 0,
-               "pattern_scoring_schema_version": PATTERN_SCORING_SCHEMA_VERSION,
-               "pattern_catalog_fingerprint": catalog.fingerprint,
-               "current_adherence_baseline": current_adherence_baseline,
-               "input_sha256": write_result.input_sha256,
-               "output_sha256": write_result.output_sha256,
-               "database_written": write_result.installed,
-               "durability_state": write_result.durability_state,
-               "warnings": list(write_result.warnings),
-               "talks": summary}, sys.stdout, ensure_ascii=False)
+    json.dump(
+        {
+            "persisted": len(summary),
+            "db_path": db_path,
+            "run_date": run_date,
+            "schema_version": TALK_SCHEMA_VERSION,
+            "migrated_records": 0,
+            "pattern_scoring_schema_version": PATTERN_SCORING_SCHEMA_VERSION,
+            "pattern_catalog_fingerprint": catalog.fingerprint,
+            "current_adherence_baseline": current_adherence_baseline,
+            "input_sha256": write_result.input_sha256,
+            "output_sha256": write_result.output_sha256,
+            "database_written": write_result.installed,
+            "durability_state": write_result.durability_state,
+            "warnings": list(write_result.warnings),
+            "talks": summary,
+        },
+        sys.stdout,
+        ensure_ascii=False,
+    )
     sys.stdout.write("\n")
 
 

--- a/skills/vault-ingress/scripts/pptx-extraction.py
+++ b/skills/vault-ingress/scripts/pptx-extraction.py
@@ -2192,9 +2192,7 @@ def _decode_directory_manifest(value, *, expected_directory_exclusions=()):
             "directory worker exclusion policy does not match its request",
             reason_code="pptx_batch_manifest_invalid",
         )
-    exclusion_identities = {
-        component.casefold() for component in expected_exclusions
-    }
+    exclusion_identities = {component.casefold() for component in expected_exclusions}
     raw_files = value.get("files")
     raw_skipped = value.get("skipped")
     if (
@@ -2263,9 +2261,7 @@ def _decode_directory_manifest(value, *, expected_directory_exclusions=()):
         if path != ".":
             seen_nonroot_skip_paths.add(path)
         skipped.append({"path": path, "reason": reason})
-    skipped_nonroot_paths = {
-        item["path"] for item in skipped if item["path"] != "."
-    }
+    skipped_nonroot_paths = {item["path"] for item in skipped if item["path"] != "."}
     for item in skipped:
         path = item["path"]
         if path == ".":

--- a/skills/vault-ingress/scripts/pptx_discovery_contract.py
+++ b/skills/vault-ingress/scripts/pptx_discovery_contract.py
@@ -231,7 +231,9 @@ def validate_pptx_directory_exclusions(
                 unicodedata.category(character) in {"Cc", "Cf", "Cs"}
                 for character in component
             )
-            or any(character in _FORBIDDEN_PATTERN_CHARACTERS for character in component)
+            or any(
+                character in _FORBIDDEN_PATTERN_CHARACTERS for character in component
+            )
         ):
             raise PptxDiscoveryContractError(
                 f"{item_label} must be one literal directory-name component"
@@ -266,8 +268,7 @@ def _validate_relative_path(value: object, *, label: str) -> str:
         or "\\" in value
         or re.match(r"^[A-Za-z]:", value)
         or any(
-            unicodedata.category(character) in {"Cc", "Cf", "Cs"}
-            for character in value
+            unicodedata.category(character) in {"Cc", "Cf", "Cs"} for character in value
         )
     ):
         raise PptxDiscoveryContractError(
@@ -297,7 +298,10 @@ def _validate_skipped(value: object) -> list[dict[str, str]]:
             label=f"skipped[{index}].path",
         )
         reason = item.get("reason")
-        if not isinstance(reason, str) or reason not in PPTX_DIRECTORY_SKIP_REASON_CODES:
+        if (
+            not isinstance(reason, str)
+            or reason not in PPTX_DIRECTORY_SKIP_REASON_CODES
+        ):
             raise PptxDiscoveryContractError(
                 f"skipped[{index}].reason is outside the closed taxonomy"
             )
@@ -385,13 +389,9 @@ def build_pptx_directory_batch(
                 "error.details may contain only supervisor_reason_code"
             )
         supervisor_reason_code = details.get("supervisor_reason_code")
-        if (
-            "supervisor_reason_code" in details
-            and (
-                not isinstance(supervisor_reason_code, str)
-                or supervisor_reason_code
-                not in PPTX_DIRECTORY_SUPERVISOR_REASON_CODES
-            )
+        if "supervisor_reason_code" in details and (
+            not isinstance(supervisor_reason_code, str)
+            or supervisor_reason_code not in PPTX_DIRECTORY_SUPERVISOR_REASON_CODES
         ):
             raise PptxDiscoveryContractError(
                 "error.details supervisor_reason_code is outside the closed taxonomy"
@@ -439,9 +439,10 @@ def decode_pptx_directory_batch(value: object) -> dict[str, object]:
     )
     if has_error and not isinstance(error, Mapping):
         raise PptxDiscoveryContractError("directory batch error must be an object")
-    if value.get("complete") != built["complete"] or value.get(
-        "incomplete_reason_codes"
-    ) != built["incomplete_reason_codes"]:
+    if (
+        value.get("complete") != built["complete"]
+        or value.get("incomplete_reason_codes") != built["incomplete_reason_codes"]
+    ):
         raise PptxDiscoveryContractError(
             "directory batch completeness does not match its skip receipts"
         )

--- a/skills/vault-ingress/scripts/pptx_evidence.py
+++ b/skills/vault-ingress/scripts/pptx_evidence.py
@@ -4907,16 +4907,13 @@ def _run_supervised_pptx_extraction_impl(
     return extraction
 
 
-_INSPECTED_PAGES_GRAMMAR_ERROR = (
-    "--inspected-pages values must be PAGE or START-END"
-)
+_INSPECTED_PAGES_GRAMMAR_ERROR = "--inspected-pages values must be PAGE or START-END"
 _INSPECTED_PAGES_LIMIT_ERROR = (
     "--inspected-pages page numbers must not exceed the bounded PPTX "
     f"page limit {PPTX_ARCHIVE_MAX_MEMBERS}"
 )
 _INSPECTED_PAGES_COUNT_ERROR = (
-    "--inspected-pages must contain no more than "
-    f"{PPTX_ARCHIVE_MAX_MEMBERS} ranges"
+    f"--inspected-pages must contain no more than {PPTX_ARCHIVE_MAX_MEMBERS} ranges"
 )
 
 
@@ -4964,9 +4961,7 @@ def _parse_cli_page_range(
         stop_at_hyphen=True,
     )
     if start < 1:
-        raise PptxEvidenceError(
-            "--inspected-pages page numbers must be at least 1"
-        )
+        raise PptxEvidenceError("--inspected-pages page numbers must be at least 1")
     if index == end_index:
         return [start, start]
 

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1305,8 +1305,7 @@ class VaultPreflight:
                 ),
                 artifact_path=transcript_path,
                 actual=(
-                    "not_utf8" if decode_failure
-                    else f"unreadable:{type(exc).__name__}"
+                    "not_utf8" if decode_failure else f"unreadable:{type(exc).__name__}"
                 ),
             )
             return

--- a/skills/vault-ingress/scripts/queue_claim_contract.py
+++ b/skills/vault-ingress/scripts/queue_claim_contract.py
@@ -112,9 +112,7 @@ class QueueClaimContractError(ValueError):
 def parse_queue_timestamp(value: object, label: str) -> datetime:
     """Parse a timezone-aware timestamp and normalize it to UTC seconds."""
     if not isinstance(value, str) or not value:
-        raise QueueClaimContractError(
-            f"{label} must be a non-empty ISO-8601 timestamp"
-        )
+        raise QueueClaimContractError(f"{label} must be a non-empty ISO-8601 timestamp")
     candidate = value[:-1] + "+00:00" if value.endswith("Z") else value
     try:
         moment = datetime.fromisoformat(candidate)
@@ -153,9 +151,9 @@ def is_deliberate_reprocess_reason(value: object) -> bool:
         return True
     if not value.startswith(PATTERN_SCORING_REPROCESS_REASON_PREFIX):
         return False
-    encoded_codes = value.removeprefix(
-        PATTERN_SCORING_REPROCESS_REASON_PREFIX
-    ).split("+")
+    encoded_codes = value.removeprefix(PATTERN_SCORING_REPROCESS_REASON_PREFIX).split(
+        "+"
+    )
     return tuple(encoded_codes) in PATTERN_SCORING_REPROCESS_REASON_SEQUENCES
 
 
@@ -234,9 +232,7 @@ def validate_queue_claim(
     historical: bool = False,
 ) -> None:
     if not isinstance(claim, Mapping):
-        raise QueueClaimContractError(
-            f"{filename}: queue claim must be a JSON object"
-        )
+        raise QueueClaimContractError(f"{filename}: queue claim must be a JSON object")
     version = claim.get("schema_version")
     if (
         isinstance(version, int)
@@ -258,13 +254,9 @@ def validate_queue_claim(
             f"of {sorted(SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS)}"
         )
     require_queue_identifier(claim.get("run_id"), f"{filename}: claim.run_id")
-    require_queue_identifier(
-        claim.get("batch_id"), f"{filename}: claim.batch_id"
-    )
+    require_queue_identifier(claim.get("batch_id"), f"{filename}: claim.batch_id")
     claimed_at = queue_timestamp_text(
-        parse_queue_timestamp(
-            claim.get("claimed_at"), f"{filename}: claim.claimed_at"
-        )
+        parse_queue_timestamp(claim.get("claimed_at"), f"{filename}: claim.claimed_at")
     )
     previous = claim.get("previous_status")
     if previous not in CLAIMABLE_STATUSES:
@@ -306,13 +298,10 @@ def validate_queue_claim(
                 f"schema version {version}"
             )
         try:
-            baseline = validate_adherence_baseline(
-                claim.get("adherence_baseline")
-            )
+            baseline = validate_adherence_baseline(claim.get("adherence_baseline"))
         except AdherenceBaselineError as exc:
             raise QueueClaimContractError(
-                f"{filename}: invalid schema-v{version} claim "
-                f"adherence_baseline: {exc}"
+                f"{filename}: invalid schema-v{version} claim adherence_baseline: {exc}"
             ) from exc
         expected_baseline_schema = (
             ADHERENCE_BASELINE_SCHEMA_VERSION
@@ -334,10 +323,7 @@ def validate_queue_claim(
                 f"{filename}: schema-v{version} claim adherence_baseline must "
                 "exclude the active batch"
             )
-    elif (
-        "required_return_schema_version" in claim
-        or "adherence_baseline" in claim
-    ):
+    elif "required_return_schema_version" in claim or "adherence_baseline" in claim:
         raise QueueClaimContractError(
             f"{filename}: schema-v{version} claim cannot carry adherence-claim "
             "return or adherence-baseline fields"
@@ -361,8 +347,7 @@ def validate_queue_claim(
     if state == "completed":
         if claim.get("result_status") not in TERMINAL_RESULT_STATUSES:
             raise QueueClaimContractError(
-                f"{filename}: a completed claim must carry a terminal "
-                "result_status"
+                f"{filename}: a completed claim must carry a terminal result_status"
             )
         if (
             version in RECEIPT_QUEUE_CLAIM_SCHEMA_VERSIONS
@@ -391,9 +376,7 @@ def validate_queue_claim(
                 "for a migrated legacy claim or a lowercase SHA-256 receipt"
             )
     if historical and state == "claimed":
-        raise QueueClaimContractError(
-            f"{filename}: historical claims must be closed"
-        )
+        raise QueueClaimContractError(f"{filename}: historical claims must be closed")
 
 
 def validate_talk_queue_claim_state(
@@ -403,26 +386,18 @@ def validate_talk_queue_claim_state(
     allow_claim_status_drift: bool = False,
 ) -> None:
     if not isinstance(talk, Mapping):
-        raise QueueClaimContractError(
-            f"talks[{index}] must be a JSON object"
-        )
+        raise QueueClaimContractError(f"talks[{index}] must be a JSON object")
     filename = talk.get("filename")
-    if (
-        not isinstance(filename, str)
-        or not filename
-        or Path(filename).name != filename
-    ):
+    if not isinstance(filename, str) or not filename or Path(filename).name != filename:
         raise QueueClaimContractError(
-            f"talks[{index}].filename must be a non-empty basename, got "
-            f"{filename!r}"
+            f"talks[{index}].filename must be a non-empty basename, got {filename!r}"
         )
     if not filename.endswith(".md"):
         raise QueueClaimContractError(f"{filename}: filename must end in .md")
     status = talk.get("status")
     if status not in KNOWN_STATUSES:
         raise QueueClaimContractError(
-            f"{filename}: status {status!r} is unknown; reconcile it before "
-            "queueing"
+            f"{filename}: status {status!r} is unknown; reconcile it before queueing"
         )
 
     generation = talk.get("reprocess_generation", 0)
@@ -475,8 +450,7 @@ def validate_talk_queue_claim_state(
     if status == INFLIGHT_STATUS:
         if current is None:
             raise QueueClaimContractError(
-                f"{filename}: {INFLIGHT_STATUS} has no reconstructable "
-                "_queue_claim"
+                f"{filename}: {INFLIGHT_STATUS} has no reconstructable _queue_claim"
             )
         assert isinstance(current, Mapping)
         if current["state"] != "claimed":
@@ -516,14 +490,10 @@ def validate_queue_claim_database(
     allow_claim_status_drift: bool = False,
 ) -> None:
     if not isinstance(database, Mapping):
-        raise QueueClaimContractError(
-            "tracking database root must be a JSON object"
-        )
+        raise QueueClaimContractError("tracking database root must be a JSON object")
     talks = database.get("talks")
     if not isinstance(talks, list):
-        raise QueueClaimContractError(
-            "tracking database must contain a talks array"
-        )
+        raise QueueClaimContractError("tracking database must contain a talks array")
     seen: set[str] = set()
     typed_talks: list[Mapping[str, object]] = []
     for index, talk in enumerate(talks):
@@ -537,8 +507,7 @@ def validate_queue_claim_database(
         assert isinstance(filename, str)
         if filename in seen:
             raise QueueClaimContractError(
-                f"duplicate talk filename {filename!r} — filenames are queue "
-                "identities"
+                f"duplicate talk filename {filename!r} — filenames are queue identities"
             )
         seen.add(filename)
         typed_talks.append(talk)
@@ -560,9 +529,10 @@ def _validate_adherence_claim_batches(
         filename = talk["filename"]
         assert isinstance(filename, str)
         current = talk.get("_queue_claim")
-        if isinstance(current, Mapping) and current.get(
-            "schema_version"
-        ) in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS:
+        if (
+            isinstance(current, Mapping)
+            and current.get("schema_version") in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS
+        ):
             identity = (current["run_id"], current["batch_id"])
             current_batches.setdefault(identity, []).append((filename, current))
             epoch = (*identity, current["claimed_at"])
@@ -571,9 +541,7 @@ def _validate_adherence_claim_batches(
         assert isinstance(history, list)
         for claim in history:
             assert isinstance(claim, Mapping)
-            if claim.get(
-                "schema_version"
-            ) not in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS:
+            if claim.get("schema_version") not in ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSIONS:
                 continue
             epoch = (
                 claim["run_id"],

--- a/skills/vault-ingress/scripts/read-tracking-database.py
+++ b/skills/vault-ingress/scripts/read-tracking-database.py
@@ -34,8 +34,7 @@ def execute(path: Path) -> dict[str, object]:
     if not assessment.usable:
         reasons = ", ".join(assessment.reason_codes) or "unsupported_owner_state"
         raise TrackingDatabaseIOError(
-            "tracking database has no usable legacy/current owner state "
-            f"({reasons})"
+            f"tracking database has no usable legacy/current owner state ({reasons})"
         )
     return {
         "schema_version": REPORT_SCHEMA_VERSION,

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -106,6 +106,7 @@ RAW_URL_RE = re.compile(r"https?://[^\s<>]+")
 DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 FileGeneration = tuple[int, int, int, int, int]
 
+
 class ShownotesScanError(ValueError):
     """Input or state prevents a deterministic shownotes scan."""
 

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -36,15 +36,52 @@ TITLE_QUOTE_EQUIVALENTS = str.maketrans(
     }
 )
 
-TITLE_STOP_WORDS = frozenset({
-    "a", "an", "and", "at", "by", "conference", "for", "from", "in",
-    "keynote", "of", "on", "or", "session", "talk", "the", "to", "with",
-})
-EVENT_STOP_WORDS = frozenset({
-    "a", "an", "annual", "at", "conference", "conf", "convention", "day",
-    "days", "edition", "event", "events", "meetup", "meetups", "of", "open",
-    "summit", "the", "webinar", "webinars",
-})
+TITLE_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "at",
+        "by",
+        "conference",
+        "for",
+        "from",
+        "in",
+        "keynote",
+        "of",
+        "on",
+        "or",
+        "session",
+        "talk",
+        "the",
+        "to",
+        "with",
+    }
+)
+EVENT_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "annual",
+        "at",
+        "conference",
+        "conf",
+        "convention",
+        "day",
+        "days",
+        "edition",
+        "event",
+        "events",
+        "meetup",
+        "meetups",
+        "of",
+        "open",
+        "summit",
+        "the",
+        "webinar",
+        "webinars",
+    }
+)
 SHOWNOTES_EVENT_STOP_WORDS = frozenset({"a", "an", "at", "of", "the"})
 SHOWNOTES_OPTIONAL_EVENT_BIGRAMS = frozenset({("voxxed", "days")})
 AMBIGUOUS_EVENT_ALIASES = frozenset({"ai", "devops", "java", "spring"})
@@ -62,7 +99,8 @@ EventAlias = tuple[str, ...]
 
 def _ordered_words(value: str, stop_words: frozenset[str]) -> list[str]:
     return [
-        word for word in WORD_RE.findall(value.casefold())
+        word
+        for word in WORD_RE.findall(value.casefold())
         if word not in stop_words and len(word) > 1
     ]
 
@@ -80,8 +118,10 @@ def _contains_sequence(haystack: list[str] | EventAlias, needle: EventAlias) -> 
     if not needle or len(needle) > len(haystack):
         return False
     width = len(needle)
-    return any(tuple(haystack[index:index + width]) == needle
-               for index in range(len(haystack) - width + 1))
+    return any(
+        tuple(haystack[index : index + width]) == needle
+        for index in range(len(haystack) - width + 1)
+    )
 
 
 def _contains_ordered_subsequence(
@@ -99,7 +139,7 @@ def _explicit_base_title_agrees(expected: str, observed: str) -> bool:
     separator = TITLE_SUBTITLE_RE.search(expected)
     if separator is None:
         return False
-    lead = tuple(_ordered_words(expected[:separator.start()], TITLE_STOP_WORDS))
+    lead = tuple(_ordered_words(expected[: separator.start()], TITLE_STOP_WORDS))
     if len(lead) < 2:
         return False
     if len(lead) == 2 and not any(len(word) >= 8 for word in lead):
@@ -128,8 +168,9 @@ def titles_agree(expected: str, observed: str) -> bool:
     observed_words = normalized_words(observed)
     if expected_words and observed_words:
         overlap = len(expected_words & observed_words)
-        minimum = 1 if len(expected_words) == 1 else max(
-            2, (len(expected_words) + 1) // 2)
+        minimum = (
+            1 if len(expected_words) == 1 else max(2, (len(expected_words) + 1) // 2)
+        )
         if overlap >= minimum:
             return True
     return _explicit_base_title_agrees(expected, observed)
@@ -206,9 +247,7 @@ def shownotes_titles_agree(
     if not authored or not shownotes.startswith(authored):
         return False
 
-    qualifier_match = SHOWNOTES_EVENT_QUALIFIER_RE.fullmatch(
-        shownotes[len(authored):]
-    )
+    qualifier_match = SHOWNOTES_EVENT_QUALIFIER_RE.fullmatch(shownotes[len(authored) :])
     if qualifier_match is None:
         return False
     qualifier = qualifier_match.group("event")
@@ -256,12 +295,11 @@ def _provider_event_contexts(title: str) -> list[list[str]]:
     contexts: list[str] = []
     at_matches = list(AT_RE.finditer(title))
     if at_matches:
-        contexts.append(title[at_matches[-1].end():])
+        contexts.append(title[at_matches[-1].end() :])
     chunks = EVENT_CONTEXT_SEPARATOR_RE.split(title)
     if len(chunks) > 1:
         contexts.extend(
-            chunk for chunk in (chunks[0], chunks[-1])
-            if YEAR_RE.search(chunk)
+            chunk for chunk in (chunks[0], chunks[-1]) if YEAR_RE.search(chunk)
         )
 
     normalized: set[EventAlias] = set()
@@ -285,20 +323,13 @@ def provider_event_aliases(
     for context in _provider_event_contexts(provider_title):
         context_matches: list[EventAlias] = []
         for alias in ordered_aliases:
-            if (
-                len(alias) == 1
-                and alias[0] in AMBIGUOUS_EVENT_ALIASES
-            ):
+            if len(alias) == 1 and alias[0] in AMBIGUOUS_EVENT_ALIASES:
                 continue
             contiguous = _contains_sequence(context, alias)
-            ordered = (
-                len(alias) > 1
-                and _contains_ordered_subsequence(context, alias)
-            )
+            ordered = len(alias) > 1 and _contains_ordered_subsequence(context, alias)
             if not contiguous and not ordered:
                 continue
-            if any(_contains_sequence(existing, alias)
-                   for existing in context_matches):
+            if any(_contains_sequence(existing, alias) for existing in context_matches):
                 continue
             context_matches.append(alias)
         found.update(context_matches)
@@ -321,7 +352,5 @@ def event_agreement(
     mentions = provider_event_aliases(provider_title, known_aliases)
     if catalog_alias is None or not mentions:
         return None, catalog_alias, mentions
-    agrees = any(
-        _aliases_compatible(catalog_alias, mention) for mention in mentions
-    )
+    agrees = any(_aliases_compatible(catalog_alias, mention) for mention in mentions)
     return agrees, catalog_alias, mentions

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -91,13 +91,9 @@ QR_CODE_REQUIRED_FIELDS = frozenset(
 # the exact path written plus a SHA-256 so catalog validation can tell the
 # intended artifact from a stale replacement.
 QR_CODE_V2_REQUIRED_FIELDS = QR_CODE_REQUIRED_FIELDS | frozenset({"artifacts"})
-QR_ARTIFACT_REQUIRED_FIELDS = frozenset(
-    {"path", "path_root", "sha256", "bg_hex"}
-)
+QR_ARTIFACT_REQUIRED_FIELDS = frozenset({"path", "path_root", "sha256", "bg_hex"})
 QR_ARTIFACT_PATH_ROOTS = frozenset({"deck_dir", "cwd", "absolute"})
-RESOURCE_REQUIRED_FIELDS = frozenset(
-    {"talk_slug", "item_count", "category_breakdown"}
-)
+RESOURCE_REQUIRED_FIELDS = frozenset({"talk_slug", "item_count", "category_breakdown"})
 THUMBNAIL_REQUIRED_FIELDS = frozenset(
     {
         "talk_slug",
@@ -112,9 +108,7 @@ THUMBNAIL_REQUIRED_FIELDS = frozenset(
         "approved",
     }
 )
-CONFIRMED_INTENT_REQUIRED_FIELDS = frozenset(
-    {"pattern", "intent", "rule", "note"}
-)
+CONFIRMED_INTENT_REQUIRED_FIELDS = frozenset({"pattern", "intent", "rule", "note"})
 CONFIRMED_INTENT_OPTIONAL_FIELDS = frozenset(
     {
         "confirmed_date",
@@ -350,7 +344,9 @@ def _require_iso_date(value: object, label: str) -> None:
     try:
         parsed = dt.date.fromisoformat(date_text)
     except ValueError as exc:
-        raise TrackingDatabaseError(f"{label} must be a canonical YYYY-MM-DD date") from exc
+        raise TrackingDatabaseError(
+            f"{label} must be a canonical YYYY-MM-DD date"
+        ) from exc
     if parsed.isoformat() != date_text:
         raise TrackingDatabaseError(f"{label} must be a canonical YYYY-MM-DD date")
 
@@ -529,9 +525,7 @@ def _validate_collection_record(
             )
         _require_exact_integer(record["slide_count"], f"{label}.slide_count")
         if type(record["visual_extracted"]) is not bool:
-            raise TrackingDatabaseError(
-                f"{label}.visual_extracted must be a boolean"
-            )
+            raise TrackingDatabaseError(f"{label}.visual_extracted must be a boolean")
         return
     if collection == "qr_codes":
         version = record.get("schema_version", LEGACY_QR_CODE_RECORD_SCHEMA_VERSION)
@@ -576,9 +570,7 @@ def _validate_collection_record(
         )
         breakdown = record["category_breakdown"]
         if not isinstance(breakdown, Mapping):
-            raise TrackingDatabaseError(
-                f"{label}.category_breakdown must be an object"
-            )
+            raise TrackingDatabaseError(f"{label}.category_breakdown must be an object")
         category_total = 0
         for category, count in breakdown.items():
             _require_nonempty_string(category, f"{label}.category_breakdown key")
@@ -752,12 +744,9 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
         raise TrackingDatabaseError("tracking database root must be a JSON object")
     root_version_is_explicit = "schema_version" in database
     root_version = tracking_database_schema_version(database)
-    if (
-        root_version not in READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS
-        or (
-            root_version_is_explicit
-            and root_version == LEGACY_TRACKING_DATABASE_SCHEMA_VERSION
-        )
+    if root_version not in READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS or (
+        root_version_is_explicit
+        and root_version == LEGACY_TRACKING_DATABASE_SCHEMA_VERSION
     ):
         return TrackingDatabaseAssessment(
             usable=False,
@@ -848,9 +837,7 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
 
     _validate_config_record(config, version=config_version)
 
-    accepted_rejection_versions = frozenset(
-        {SOURCE_REJECTION_RECORD_SCHEMA_VERSION}
-    )
+    accepted_rejection_versions = frozenset({SOURCE_REJECTION_RECORD_SCHEMA_VERSION})
     supported_talks: list[Mapping[str, object]] = []
     for talk_index, talk in enumerate(collections["talks"]):
         talk_version = _record_version(
@@ -1010,9 +997,7 @@ def require_current_tracking_database(database: object) -> dict[str, Any]:
         raise
     if assessment.usable and assessment.state == "current":
         if not isinstance(database, dict):
-            raise TrackingDatabaseError(
-                "tracking database root must be a JSON object"
-            )
+            raise TrackingDatabaseError("tracking database root must be a JSON object")
         return database
     if assessment.usable and assessment.state == "legacy":
         raise TrackingDatabaseError(
@@ -1046,10 +1031,7 @@ def _migrate_talk_record(talk: dict[str, Any]) -> bool:
     rejections = talk.get("source_rejections", [])
     if isinstance(rejections, list):
         for rejection in rejections:
-            if (
-                isinstance(rejection, dict)
-                and "schema_version" not in rejection
-            ):
+            if isinstance(rejection, dict) and "schema_version" not in rejection:
                 rejection["schema_version"] = SOURCE_REJECTION_RECORD_SCHEMA_VERSION
     if talk_version_added:
         talk["schema_version"] = LEGACY_TALK_RECORD_SCHEMA_VERSION

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -216,7 +216,9 @@ def _path_metadata(path: Path, *, subject: str) -> os.stat_result:
             "(a regular file)"
         ) from exc
     except OSError as exc:
-        raise TrackingDatabaseIOError(f"cannot inspect {subject} {path}: {exc}") from exc
+        raise TrackingDatabaseIOError(
+            f"cannot inspect {subject} {path}: {exc}"
+        ) from exc
     if stat.S_ISLNK(metadata.st_mode):
         raise TrackingDatabaseIOError(
             f"{subject} {path} is a symbolic link; pass its canonical regular-file path"
@@ -297,8 +299,7 @@ def _validate_decoded_json_tree(payload: object, *, subject: str) -> None:
         if isinstance(value, str):
             if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
                 raise TrackingDatabaseIOError(
-                    f"{subject} contains an unpaired UTF-16 surrogate in a "
-                    "JSON string",
+                    f"{subject} contains an unpaired UTF-16 surrogate in a JSON string",
                     reason_code="json_unpaired_surrogate",
                 )
             continue
@@ -630,7 +631,9 @@ def _ensure_backup_directory(path: Path) -> int:
             f"tracking-database backup directory {path} must be a real directory"
         )
     if created:
-        parent_descriptor = _open_directory(path.parent, label="backup parent directory")
+        parent_descriptor = _open_directory(
+            path.parent, label="backup parent directory"
+        )
         try:
             _fsync_directory(parent_descriptor)
         except OSError as exc:
@@ -806,9 +809,7 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
         flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         for _ in range(128):
-            candidate_name = (
-                f".{path.name}.{secrets.token_hex(12)}.tracking-db.tmp"
-            )
+            candidate_name = f".{path.name}.{secrets.token_hex(12)}.tracking-db.tmp"
             try:
                 descriptor = os.open(
                     candidate_name,
@@ -1234,4 +1235,6 @@ def write_json_object(
     current = decode_json_object(expected)
     if json_values_equal(current, payload):
         return commit_tracking_database(expected, expected.raw, backup=backup)
-    return commit_tracking_database(expected, render_json_object(payload), backup=backup)
+    return commit_tracking_database(
+        expected, render_json_object(payload), backup=backup
+    )

--- a/skills/vault-ingress/scripts/validate-returns.py
+++ b/skills/vault-ingress/scripts/validate-returns.py
@@ -43,7 +43,8 @@ def parse_args(argv):
     if not args:
         raise ReturnValidationError(
             f"Usage: {sys.argv[0]} <batch-or-return.json> [...] "
-            "[--catalog-dir <patterns-dir>]")
+            "[--catalog-dir <patterns-dir>]"
+        )
     return args, catalog_dir
 
 
@@ -55,7 +56,9 @@ def load_inputs(paths):
         path = Path(raw)
         candidates = sorted(path.glob("*.json")) if path.is_dir() else [path]
         if path.is_dir() and not candidates:
-            raise ReturnValidationError(f"return directory contains no *.json files: {path}")
+            raise ReturnValidationError(
+                f"return directory contains no *.json files: {path}"
+            )
         for candidate in candidates:
             payload = load_json(candidate, "return")
             files.append(str(candidate))
@@ -66,7 +69,8 @@ def load_inputs(paths):
             else:
                 raise ReturnValidationError(
                     f"return file {candidate} must contain an object or array, "
-                    f"got {type(payload).__name__}")
+                    f"got {type(payload).__name__}"
+                )
     return returns, files
 
 
@@ -79,8 +83,11 @@ def main():
         if errors:
             for error in errors:
                 print(f"ERROR: {error['error']}", file=sys.stderr)
-            print(f"ERROR: {len(errors)} validation error(s) across "
-                  f"{len(returns)} return(s)", file=sys.stderr)
+            print(
+                f"ERROR: {len(errors)} validation error(s) across "
+                f"{len(returns)} return(s)",
+                file=sys.stderr,
+            )
             sys.exit(1)
     except ReturnValidationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/skills/vault-profile/scripts/compute-pacing-adherence.py
+++ b/skills/vault-profile/scripts/compute-pacing-adherence.py
@@ -118,14 +118,16 @@ def compute(payload: dict) -> dict:
         if budget is None:
             continue
         spm = slide_count / minutes
-        scored.append({
-            "filename": talk.get("filename"),
-            "date": talk.get("date", ""),
-            "slides_per_minute": round(spm, 2),
-            "budget_slides_per_minute": budget,
-            "over_budget": spm > budget,
-            "over_by_ratio": (spm / budget) - 1.0,
-        })
+        scored.append(
+            {
+                "filename": talk.get("filename"),
+                "date": talk.get("date", ""),
+                "slides_per_minute": round(spm, 2),
+                "budget_slides_per_minute": budget,
+                "over_budget": spm > budget,
+                "over_by_ratio": (spm / budget) - 1.0,
+            }
+        )
 
     over = [t for t in scored if t["over_budget"]]
     worst = sorted(over, key=lambda t: t["over_by_ratio"], reverse=True)[:worst_n]
@@ -164,14 +166,17 @@ def main() -> int:
         print(f"ERROR: stdin is not valid JSON: {exc}", file=sys.stderr)
         return 1
     if not isinstance(payload, dict):
-        print("ERROR: stdin JSON must be an object with 'talks' and "
-              "'slide_budgets'.", file=sys.stderr)
+        print(
+            "ERROR: stdin JSON must be an object with 'talks' and 'slide_budgets'.",
+            file=sys.stderr,
+        )
         return 1
     if not isinstance(payload.get("talks", []), list) or not isinstance(
         payload.get("slide_budgets", []), list
     ):
-        print("ERROR: 'talks' and 'slide_budgets' must be JSON arrays.",
-              file=sys.stderr)
+        print(
+            "ERROR: 'talks' and 'slide_budgets' must be JSON arrays.", file=sys.stderr
+        )
         return 1
     try:
         result = compute(payload)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,7 @@ def current_tracking_config(**updates: object) -> dict[str, object]:
     """Return the owner-current config generation for writer fixtures."""
     config: dict[str, object] = {
         "schema_version": 2,
-        "pptx_directory_exclusions": list(
-            DEFAULT_PPTX_DIRECTORY_EXCLUSIONS
-        ),
+        "pptx_directory_exclusions": list(DEFAULT_PPTX_DIRECTORY_EXCLUSIONS),
     }
     config.update(updates)
     return config

--- a/tests/test_adherence_baseline.py
+++ b/tests/test_adherence_baseline.py
@@ -157,14 +157,12 @@ def test_partitions_exact_generation_with_deterministic_exclusion_reasons(
         selected_invalid,
     ]
 
-    current, excluded, details = (
-        adherence_baseline.partition_pattern_scoring_cohort(
-            talks,
-            excluded_filenames=["selected.md"],
-            pattern_catalog_fingerprint=CATALOG,
-            pattern_scoring_schema_version=2,
-            evidence_freshness_assessor=None,
-        )
+    current, excluded, details = adherence_baseline.partition_pattern_scoring_cohort(
+        talks,
+        excluded_filenames=["selected.md"],
+        pattern_catalog_fingerprint=CATALOG,
+        pattern_scoring_schema_version=2,
+        evidence_freshness_assessor=None,
     )
 
     assert [talk["filename"] for talk in current] == ["current.md"]
@@ -192,9 +190,7 @@ def test_partitions_exact_generation_with_deterministic_exclusion_reasons(
         {
             "filename": "legacy.md",
             "reason_codes": ["legacy_generation"],
-            "observed_pattern_scoring_generation_status": (
-                "legacy_unbaselineable"
-            ),
+            "observed_pattern_scoring_generation_status": ("legacy_unbaselineable"),
             "observed_pattern_catalog_fingerprint": None,
             "observed_pattern_scoring_schema_version": None,
             **common_expected,
@@ -250,18 +246,16 @@ def test_scoring_v4_excludes_stale_evidence_with_canonical_details(
 ):
     talk = _talk("stale.md", 2, scoring_schema=4)
 
-    current, excluded, details = (
-        adherence_baseline.partition_pattern_scoring_cohort(
-            [talk],
-            excluded_filenames=(),
-            pattern_catalog_fingerprint=CATALOG,
-            pattern_scoring_schema_version=4,
-            evidence_freshness_assessor=lambda _talk: (
-                "source_inspection[0]:artifact_path:missing",
-                "patterns_detected[0].citation[0]:artifact_path:digest_mismatch",
-                "source_inspection[0]:artifact_path:missing",
-            ),
-        )
+    current, excluded, details = adherence_baseline.partition_pattern_scoring_cohort(
+        [talk],
+        excluded_filenames=(),
+        pattern_catalog_fingerprint=CATALOG,
+        pattern_scoring_schema_version=4,
+        evidence_freshness_assessor=lambda _talk: (
+            "source_inspection[0]:artifact_path:missing",
+            "patterns_detected[0].citation[0]:artifact_path:digest_mismatch",
+            "source_inspection[0]:artifact_path:missing",
+        ),
     )
 
     assert current == []
@@ -289,16 +283,14 @@ def test_historical_scoring_schema_never_invokes_freshness_assessor(
 ):
     talk = _talk("historical.md", 2, scoring_schema=2)
 
-    current, excluded, details = (
-        adherence_baseline.partition_pattern_scoring_cohort(
-            [talk],
-            excluded_filenames=(),
-            pattern_catalog_fingerprint=CATALOG,
-            pattern_scoring_schema_version=2,
-            evidence_freshness_assessor=lambda _talk: (_ for _ in ()).throw(
-                AssertionError("historical selector invoked freshness")
-            ),
-        )
+    current, excluded, details = adherence_baseline.partition_pattern_scoring_cohort(
+        [talk],
+        excluded_filenames=(),
+        pattern_catalog_fingerprint=CATALOG,
+        pattern_scoring_schema_version=2,
+        evidence_freshness_assessor=lambda _talk: (_ for _ in ()).throw(
+            AssertionError("historical selector invoked freshness")
+        ),
     )
 
     assert current == [talk]

--- a/tests/test_aggregate_catalog_feedback.py
+++ b/tests/test_aggregate_catalog_feedback.py
@@ -10,9 +10,7 @@ import pytest
 def _catalog_file(path, catalog_id, polarity, *, name=None, aliases=None):
     path.parent.mkdir(parents=True, exist_ok=True)
     name_field = f"name: {name}\n" if name is not None else ""
-    aliases_field = (
-        f"aliases: {json.dumps(aliases)}\n" if aliases is not None else ""
-    )
+    aliases_field = f"aliases: {json.dumps(aliases)}\n" if aliases is not None else ""
     path.write_text(
         "---\n"
         f"id: {catalog_id}\n"
@@ -42,36 +40,46 @@ def catalog_fixture(tmp_path):
 
 def _feedback():
     return {
-        "unmatched_observations": [{
-            "observation": "The room predicts before the reveal.",
-            "why_no_pattern_fits": "The existing mechanism differs.",
-            "proposed_name": "Fresh Move",
-            "proposed_polarity": "pattern",
-        }],
-        "tensions": [{
-            "pattern_ids": ["alpha", "beta"],
-            "catalog_polarities": {
-                "alpha": "pattern",
-                "beta": "antipattern",
-            },
-            "nature": "Using alpha can trigger beta.",
-            "evidence": "Both occur in the same minute.",
-        }],
-        "definition_problems": [{
-            "pattern_id": "beta",
-            "catalog_polarity": "antipattern",
-            "problem": "ambiguous",
-            "detail": "Its threshold is not testable.",
-        }],
-        "scoring_problems": [{
-            "issue": "Confidence is unweighted.",
-            "detail": "Weak and strong evidence both count one.",
-            "polarity": "neutral",
-        }],
-        "confusable_pairs": [{
-            "pattern_ids": ["alpha", "gamma"],
-            "detail": "The boundary is not observable.",
-        }],
+        "unmatched_observations": [
+            {
+                "observation": "The room predicts before the reveal.",
+                "why_no_pattern_fits": "The existing mechanism differs.",
+                "proposed_name": "Fresh Move",
+                "proposed_polarity": "pattern",
+            }
+        ],
+        "tensions": [
+            {
+                "pattern_ids": ["alpha", "beta"],
+                "catalog_polarities": {
+                    "alpha": "pattern",
+                    "beta": "antipattern",
+                },
+                "nature": "Using alpha can trigger beta.",
+                "evidence": "Both occur in the same minute.",
+            }
+        ],
+        "definition_problems": [
+            {
+                "pattern_id": "beta",
+                "catalog_polarity": "antipattern",
+                "problem": "ambiguous",
+                "detail": "Its threshold is not testable.",
+            }
+        ],
+        "scoring_problems": [
+            {
+                "issue": "Confidence is unweighted.",
+                "detail": "Weak and strong evidence both count one.",
+                "polarity": "neutral",
+            }
+        ],
+        "confusable_pairs": [
+            {
+                "pattern_ids": ["alpha", "gamma"],
+                "detail": "The boundary is not observable.",
+            }
+        ],
     }
 
 
@@ -110,7 +118,9 @@ def test_normalize_suggestion_is_format_only(aggregate_catalog_feedback):
 
 
 def test_valid_five_lane_return_preserves_provenance_and_groups_ids(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     source = _write(tmp_path / "returns" / "one.json", _return())
 
@@ -125,7 +135,9 @@ def test_valid_five_lane_return_preserves_provenance_and_groups_ids(
     assert {item["provenance"]["feedback_lane"] for item in accepted} == set(
         aggregate_catalog_feedback.LANES
     )
-    assert all(item["provenance"]["source_path"] == str(source.resolve()) for item in accepted)
+    assert all(
+        item["provenance"]["source_path"] == str(source.resolve()) for item in accepted
+    )
     assert all(item["provenance"]["talk_filename"] == "talk.md" for item in accepted)
     assert all(item["provenance"]["source_return_index"] == 0 for item in accepted)
 
@@ -141,14 +153,20 @@ def test_valid_five_lane_return_preserves_provenance_and_groups_ids(
 
 
 def test_normalized_suggestion_recurrence_counts_talks_and_returns(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     directory = tmp_path / "returns"
     first = _return("one.md")
     second = _return("two.md")
-    second["catalog_feedback"]["unmatched_observations"][0]["proposed_name"] = "fresh_move"
+    second["catalog_feedback"]["unmatched_observations"][0]["proposed_name"] = (
+        "fresh_move"
+    )
     third = _return("two.md")
-    third["catalog_feedback"]["unmatched_observations"][0]["proposed_name"] = "Fresh-Move!"
+    third["catalog_feedback"]["unmatched_observations"][0]["proposed_name"] = (
+        "Fresh-Move!"
+    )
     _write(directory / "a.json", [first, second])
     _write(directory / "nested" / "b.json", third)
 
@@ -157,7 +175,8 @@ def test_normalized_suggestion_recurrence_counts_talks_and_returns(
     )
 
     group = next(
-        item for item in report["normalized_suggestions"]
+        item
+        for item in report["normalized_suggestions"]
         if item["normalized_suggestion"] == "fresh-move"
     )
     assert group["occurrence_count"] == 3
@@ -165,12 +184,16 @@ def test_normalized_suggestion_recurrence_counts_talks_and_returns(
     assert group["source_return_count"] == 3
     assert group["polarity_status"] == "consistent"
     assert {item["value"] for item in group["variants"]} == {
-        "Fresh Move", "fresh_move", "Fresh-Move!",
+        "Fresh Move",
+        "fresh_move",
+        "Fresh-Move!",
     }
 
 
 def test_exact_catalog_ids_are_not_folded_into_suggestions(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     feedback = _feedback()
     feedback["unmatched_observations"][0]["proposed_name"] = "Alpha"
@@ -188,11 +211,14 @@ def test_exact_catalog_ids_are_not_folded_into_suggestions(
     assert any(item["catalog_id"] == "alpha" for item in report["exact_catalog_ids"])
 
 
-@pytest.mark.parametrize("proposed_name", [
-    "Alpha Signal",
-    "Alpha—Signal!",
-    "First_Move",
-])
+@pytest.mark.parametrize(
+    "proposed_name",
+    [
+        "Alpha Signal",
+        "Alpha—Signal!",
+        "First_Move",
+    ],
+)
 def test_existing_catalog_names_and_aliases_are_not_novel_suggestions(
     aggregate_catalog_feedback,
     catalog_fixture,
@@ -210,14 +236,17 @@ def test_existing_catalog_names_and_aliases_are_not_novel_suggestions(
     assert report["ok"] is False
     assert "suggestion_matches_catalog_alias" in _issues(report)
     invalid = [
-        item for item in report["entries"]["invalid"]
+        item
+        for item in report["entries"]["invalid"]
         if item["provenance"]["feedback_lane"] == "unmatched_observations"
     ]
     assert invalid[0]["issues"][0]["catalog_id"] == "alpha"
 
 
 def test_missing_legacy_suggestion_polarity_is_warning_not_rejection(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     feedback = _feedback()
     del feedback["unmatched_observations"][0]["proposed_polarity"]
@@ -235,14 +264,21 @@ def test_missing_legacy_suggestion_polarity_is_warning_not_rejection(
     }
 
 
-@pytest.mark.parametrize(("mutation", "code"), [
-    ("bad_suggestion_polarity", "suggestion_polarity_invalid"),
-    ("wrong_catalog_polarity", "catalog_polarity_mismatch"),
-    ("wrong_pair_polarities", "catalog_polarity_mismatch"),
-    ("non_neutral_scoring", "lane_polarity_invalid"),
-])
+@pytest.mark.parametrize(
+    ("mutation", "code"),
+    [
+        ("bad_suggestion_polarity", "suggestion_polarity_invalid"),
+        ("wrong_catalog_polarity", "catalog_polarity_mismatch"),
+        ("wrong_pair_polarities", "catalog_polarity_mismatch"),
+        ("non_neutral_scoring", "lane_polarity_invalid"),
+    ],
+)
 def test_lane_polarity_mismatches_are_invalid(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path, mutation, code,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
+    mutation,
+    code,
 ):
     feedback = _feedback()
     if mutation == "bad_suggestion_polarity":
@@ -265,13 +301,15 @@ def test_lane_polarity_mismatches_are_invalid(
 
 
 def test_cross_return_suggestion_polarity_conflict_is_reported(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     first = _return("first.md")
     second = _return("second.md")
-    second["catalog_feedback"]["unmatched_observations"][0][
-        "proposed_polarity"
-    ] = "antipattern"
+    second["catalog_feedback"]["unmatched_observations"][0]["proposed_polarity"] = (
+        "antipattern"
+    )
     source = _write(tmp_path / "batch.json", [first, second])
 
     report = aggregate_catalog_feedback.aggregate_feedback(
@@ -286,7 +324,9 @@ def test_cross_return_suggestion_polarity_conflict_is_reported(
 
 
 def test_confusable_pair_requires_exactly_two_ids_but_tension_allows_more(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     feedback = _feedback()
     feedback["confusable_pairs"][0]["pattern_ids"] = ["alpha", "beta", "gamma"]
@@ -299,7 +339,8 @@ def test_confusable_pair_requires_exactly_two_ids_but_tension_allows_more(
     )
 
     invalid = [
-        item for item in report["entries"]["invalid"]
+        item
+        for item in report["entries"]["invalid"]
         if item["provenance"]["feedback_lane"] == "confusable_pairs"
     ]
     assert len(invalid) == 1
@@ -310,16 +351,23 @@ def test_confusable_pair_requires_exactly_two_ids_but_tension_allows_more(
     )
 
 
-@pytest.mark.parametrize(("mutation", "code"), [
-    ("unknown_lane", "feedback_lane_unsupported"),
-    ("lane_not_array", "feedback_lane_not_array"),
-    ("entry_not_object", "feedback_entry_not_object"),
-    ("missing_text", "feedback_text_missing"),
-    ("unknown_id", "catalog_id_unknown"),
-    ("duplicate_ids", "catalog_ids_duplicate"),
-])
+@pytest.mark.parametrize(
+    ("mutation", "code"),
+    [
+        ("unknown_lane", "feedback_lane_unsupported"),
+        ("lane_not_array", "feedback_lane_not_array"),
+        ("entry_not_object", "feedback_entry_not_object"),
+        ("missing_text", "feedback_text_missing"),
+        ("unknown_id", "catalog_id_unknown"),
+        ("duplicate_ids", "catalog_ids_duplicate"),
+    ],
+)
 def test_feedback_lane_shape_validation(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path, mutation, code,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
+    mutation,
+    code,
 ):
     feedback = _feedback()
     if mutation == "unknown_lane":
@@ -345,12 +393,18 @@ def test_feedback_lane_shape_validation(
 
 
 def test_inputs_are_classified_accepted_rejected_and_invalid(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     accepted = _write(tmp_path / "accepted.json", _return())
-    rejected = _write(tmp_path / "rejected.json", {
-        "filename": "thin.md", "status": "processed",
-    })
+    rejected = _write(
+        tmp_path / "rejected.json",
+        {
+            "filename": "thin.md",
+            "status": "processed",
+        },
+    )
     invalid = tmp_path / "invalid.json"
     invalid.write_text('{"filename":', encoding="utf-8")
 
@@ -366,7 +420,9 @@ def test_inputs_are_classified_accepted_rejected_and_invalid(
 
 
 def test_nonstandard_json_constant_is_invalid(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     source = tmp_path / "nan.json"
     source.write_text(
@@ -402,7 +458,9 @@ def test_duplicate_json_object_keys_are_invalid_before_feedback_is_lost(
 
     assert report["ok"] is False
     assert report["input_summary"] == {
-        "accepted": 0, "rejected": 0, "invalid": 1,
+        "accepted": 0,
+        "rejected": 0,
+        "invalid": 1,
     }
     assert "input_json_duplicate_key" in _issues(report)
 
@@ -414,11 +472,13 @@ def test_current_and_legacy_feedback_fields_cannot_coexist(
 ):
     value = _return()
     value["feedback"] = {
-        "definition_problems": [{
-            "pattern_id": "alpha",
-            "problem": "would be discarded",
-            "detail": "dual representations are ambiguous",
-        }],
+        "definition_problems": [
+            {
+                "pattern_id": "alpha",
+                "problem": "would be discarded",
+                "detail": "dual representations are ambiguous",
+            }
+        ],
     }
     source = _write(tmp_path / "dual-feedback.json", value)
 
@@ -432,7 +492,8 @@ def test_current_and_legacy_feedback_fields_cannot_coexist(
 
 
 def test_programmatic_api_rejects_no_inputs(
-    aggregate_catalog_feedback, catalog_fixture,
+    aggregate_catalog_feedback,
+    catalog_fixture,
 ):
     report = aggregate_catalog_feedback.aggregate_feedback(
         [], catalog_path=catalog_fixture
@@ -443,7 +504,9 @@ def test_programmatic_api_rejects_no_inputs(
 
 
 def test_feedback_return_requires_talk_provenance(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     source = _write(tmp_path / "anonymous.json", {"catalog_feedback": {}})
 
@@ -456,7 +519,9 @@ def test_feedback_return_requires_talk_provenance(
 
 
 def test_feedback_harvest_wrapper_is_supported(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     wrapper = {
         "harvested_from": "legacy reparse",
@@ -477,7 +542,9 @@ def test_feedback_harvest_wrapper_is_supported(
 
 
 def test_empty_feedback_is_an_accepted_return(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     source = _write(tmp_path / "empty.json", _return(feedback={}))
 
@@ -491,7 +558,9 @@ def test_empty_feedback_is_an_accepted_return(
 
 
 def test_duplicate_discovery_does_not_double_count(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     directory = tmp_path / "returns"
     source = _write(directory / "one.json", _return())
@@ -508,7 +577,9 @@ def test_duplicate_discovery_does_not_double_count(
 
 
 def test_report_is_stable_across_input_argument_order(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     first = _write(tmp_path / "b.json", _return("b.md"))
     second = _write(tmp_path / "a.json", _return("a.md"))
@@ -524,7 +595,9 @@ def test_report_is_stable_across_input_argument_order(
 
 
 def test_catalog_polarity_fault_is_reported_without_modifying_catalog(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     bad = catalog_fixture / "build" / "wrong.md"
     _catalog_file(bad, "wrong", "antipattern")
@@ -553,7 +626,9 @@ def test_bundled_catalog_registry_uses_frontmatter_polarity(
 
 
 def test_cli_emits_stable_json_and_does_not_edit_inputs_or_catalog(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     source = _write(tmp_path / "return.json", _return())
     source_before = source.read_bytes()
@@ -564,7 +639,8 @@ def test_cli_emits_stable_json_and_does_not_edit_inputs_or_catalog(
             sys.executable,
             aggregate_catalog_feedback.__file__,
             str(source),
-            "--catalog", str(catalog_fixture),
+            "--catalog",
+            str(catalog_fixture),
         ],
         capture_output=True,
         text=True,
@@ -576,11 +652,15 @@ def test_cli_emits_stable_json_and_does_not_edit_inputs_or_catalog(
     assert report["ok"] is True
     assert report["read_only"] is True
     assert source.read_bytes() == source_before
-    assert {path: path.read_bytes() for path in catalog_fixture.rglob("*.md")} == catalog_before
+    assert {
+        path: path.read_bytes() for path in catalog_fixture.rglob("*.md")
+    } == catalog_before
 
 
 def test_cli_exits_nonzero_on_invalid_feedback(
-    aggregate_catalog_feedback, catalog_fixture, tmp_path,
+    aggregate_catalog_feedback,
+    catalog_fixture,
+    tmp_path,
 ):
     feedback = _feedback()
     feedback["confusable_pairs"][0]["pattern_ids"] = ["alpha", "beta", "gamma"]
@@ -591,7 +671,8 @@ def test_cli_exits_nonzero_on_invalid_feedback(
             sys.executable,
             aggregate_catalog_feedback.__file__,
             str(source),
-            "--catalog", str(catalog_fixture),
+            "--catalog",
+            str(catalog_fixture),
         ],
         capture_output=True,
         text=True,
@@ -604,9 +685,12 @@ def test_cli_exits_nonzero_on_invalid_feedback(
 
 # --- #203: the CLI has a closed failure boundary ---
 
+
 def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
-        aggregate_catalog_feedback, capsys, monkeypatch):
+    aggregate_catalog_feedback, capsys, monkeypatch
+):
     """Every documented outcome is JSON; a traceback would be the one exception."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("injected failure at /private/vault/returns/a.json")
 
@@ -615,7 +699,7 @@ def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
     assert aggregate_catalog_feedback.run_cli(["some-return.json"]) == 3
 
     captured = capsys.readouterr()
-    assert captured.out == ""                     # stdout stays clean
+    assert captured.out == ""  # stdout stays clean
     payload = json.loads(captured.err.splitlines()[0])
     assert payload["error"] == "catalog_feedback_unexpected_failure"
     assert payload["error_type"] == "RuntimeError"
@@ -626,8 +710,10 @@ def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
 
 
 def test_unexpected_failure_exit_is_distinct_from_the_argparse_exit(
-        aggregate_catalog_feedback, capsys, monkeypatch):
+    aggregate_catalog_feedback, capsys, monkeypatch
+):
     """argparse already owns 2 — reusing it would conflate the two causes."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("boom")
 
@@ -641,7 +727,8 @@ def test_unexpected_failure_exit_is_distinct_from_the_argparse_exit(
 
 
 def test_the_argument_error_report_still_reaches_stdout(
-        aggregate_catalog_feedback, capsys):
+    aggregate_catalog_feedback, capsys
+):
     """The boundary must not swallow the documented invalid-arguments report."""
     with pytest.raises(SystemExit):
         aggregate_catalog_feedback.run_cli([])
@@ -651,7 +738,8 @@ def test_the_argument_error_report_still_reaches_stdout(
 
 
 def test_outer_boundary_lets_the_documented_verdicts_through(
-        aggregate_catalog_feedback, monkeypatch):
+    aggregate_catalog_feedback, monkeypatch
+):
     """An `ok: false` report is exit 1, not an unexpected failure."""
     monkeypatch.setattr(aggregate_catalog_feedback, "main", lambda *a, **k: 1)
     assert aggregate_catalog_feedback.run_cli([]) == 1

--- a/tests/test_apply_illustrations.py
+++ b/tests/test_apply_illustrations.py
@@ -18,8 +18,9 @@ FIXTURE = Path(__file__).parent / "fixtures" / "outline-example.yaml"
 _TALK = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))["talk"]
 
 
-def _write_outline(tmp_path, slides, *, composition=None, embedded_footer=None,
-                   name="outline.yaml"):
+def _write_outline(
+    tmp_path, slides, *, composition=None, embedded_footer=None, name="outline.yaml"
+):
     """Write a minimal partial outline.yaml for the apply parsers.
 
     `slides` is a list of dicts; each needs at least `n` + `format`. chapter and
@@ -40,9 +41,21 @@ def _write_outline(tmp_path, slides, *, composition=None, embedded_footer=None,
 
 
 ZONES_SLIDES = [
-    {"n": 2, "format": "FULL", "safe_zone": {"zone": "upper_third", "surface": "painted sky"}},
-    {"n": 5, "format": "FULL", "safe_zone": {"zone": "lower_third", "surface": "flat gradient"}},
-    {"n": 8, "format": "FULL", "safe_zone": {"zone": "left_half", "surface": "studio backdrop"}},
+    {
+        "n": 2,
+        "format": "FULL",
+        "safe_zone": {"zone": "upper_third", "surface": "painted sky"},
+    },
+    {
+        "n": 5,
+        "format": "FULL",
+        "safe_zone": {"zone": "lower_third", "surface": "flat gradient"},
+    },
+    {
+        "n": 8,
+        "format": "FULL",
+        "safe_zone": {"zone": "left_half", "surface": "studio backdrop"},
+    },
 ]
 
 NO_ZONES_SLIDES = [{"n": 1, "format": "FULL", "image_prompt": "A title slide"}]
@@ -61,13 +74,16 @@ def test_parse_zones_empty(apply_illustrations, tmp_path):
 
 
 def test_parse_zones_all_types(apply_illustrations, tmp_path):
-    outline = _write_outline(tmp_path, [
-        {"n": 1, "format": "FULL", "safe_zone": {"zone": "upper_third"}},
-        {"n": 2, "format": "FULL", "safe_zone": {"zone": "middle_third"}},
-        {"n": 3, "format": "FULL", "safe_zone": {"zone": "lower_third"}},
-        {"n": 4, "format": "FULL", "safe_zone": {"zone": "left_half"}},
-        {"n": 5, "format": "FULL", "safe_zone": {"zone": "right_half"}},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        [
+            {"n": 1, "format": "FULL", "safe_zone": {"zone": "upper_third"}},
+            {"n": 2, "format": "FULL", "safe_zone": {"zone": "middle_third"}},
+            {"n": 3, "format": "FULL", "safe_zone": {"zone": "lower_third"}},
+            {"n": 4, "format": "FULL", "safe_zone": {"zone": "left_half"}},
+            {"n": 5, "format": "FULL", "safe_zone": {"zone": "right_half"}},
+        ],
+    )
     zones = apply_illustrations.parse_zones(outline)
     assert len(zones) == 5
     assert zones[1] == "upper_third"
@@ -79,7 +95,13 @@ def test_parse_zones_all_types(apply_illustrations, tmp_path):
 
 def test_zone_layout_keys(apply_illustrations):
     """All five zones have layout entries."""
-    for zone in ["upper_third", "middle_third", "lower_third", "left_half", "right_half"]:
+    for zone in [
+        "upper_third",
+        "middle_third",
+        "lower_third",
+        "left_half",
+        "right_half",
+    ]:
         assert zone in apply_illustrations.ZONE_LAYOUT
         layout = apply_illustrations.ZONE_LAYOUT[zone]
         assert "top_in" in layout
@@ -151,11 +173,18 @@ def test_reposition_title_placeholder(apply_illustrations, tmp_path):
 
 def test_parse_zones_no_cross_slide_match(apply_illustrations, tmp_path):
     """A slide without a safe_zone stays absent; the neighbouring zone doesn't leak."""
-    outline = _write_outline(tmp_path, [
-        {"n": 4, "format": "FULL", "image_prompt": "A scene"},
-        {"n": 5, "format": "FULL", "image_prompt": "Another scene",
-         "safe_zone": {"zone": "lower_third", "surface": "gradient"}},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        [
+            {"n": 4, "format": "FULL", "image_prompt": "A scene"},
+            {
+                "n": 5,
+                "format": "FULL",
+                "image_prompt": "Another scene",
+                "safe_zone": {"zone": "lower_third", "surface": "gradient"},
+            },
+        ],
+    )
     zones = apply_illustrations.parse_zones(outline)
     assert 4 not in zones
     assert zones.get(5) == "lower_third"
@@ -165,13 +194,25 @@ def test_parse_zones_no_cross_slide_match(apply_illustrations, tmp_path):
 
 
 MIXED_FORMAT_SLIDES = [
-    {"n": 1, "format": "FULL", "image_prompt": "Opening scene",
-     "safe_zone": {"zone": "upper_third", "surface": "sky"}},
+    {
+        "n": 1,
+        "format": "FULL",
+        "image_prompt": "Opening scene",
+        "safe_zone": {"zone": "upper_third", "surface": "sky"},
+    },
     {"n": 2, "format": "IMG+TXT", "image_prompt": "A diagram with explanation"},
-    {"n": 3, "format": "EXCEPTION", "format_justification": "real screenshot",
-     "visual": "screenshot of the dashboard"},
-    {"n": 4, "format": "IMG+TXT", "image_prompt": "Mixed signals",
-     "safe_zone": {"zone": "lower_third", "surface": "gradient"}},
+    {
+        "n": 3,
+        "format": "EXCEPTION",
+        "format_justification": "real screenshot",
+        "visual": "screenshot of the dashboard",
+    },
+    {
+        "n": 4,
+        "format": "IMG+TXT",
+        "image_prompt": "Mixed signals",
+        "safe_zone": {"zone": "lower_third", "surface": "gradient"},
+    },
 ]
 
 
@@ -320,14 +361,28 @@ def test_apply_full_records_background_not_picture(apply_illustrations, tmp_path
     illust_dir.mkdir()
     (illust_dir / "slide-02.png").write_bytes(_MIN_PNG)
 
-    outline = _write_outline(tmp_path, [
-        {"n": 2, "format": "FULL", "safe_zone": {"zone": "upper_third", "surface": "sky"}},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        [
+            {
+                "n": 2,
+                "format": "FULL",
+                "safe_zone": {"zone": "upper_third", "surface": "sky"},
+            },
+        ],
+    )
     out_deck = tmp_path / "out.pptx"
 
     zones = apply_illustrations.parse_zones(outline)
     _, backgrounds = apply_illustrations.apply(
-        deck, illust_dir, zones, set(), out_deck, "png", "000000", 45000,
+        deck,
+        illust_dir,
+        zones,
+        set(),
+        out_deck,
+        "png",
+        "000000",
+        45000,
     )
 
     # FULL slide 2 is recorded for the background pass with an absolute path…
@@ -355,7 +410,14 @@ def test_apply_imgtxt_keeps_picture_shape(apply_illustrations, tmp_path):
 
     img_txt = apply_illustrations.parse_img_txt_slides(outline)
     _, backgrounds = apply_illustrations.apply(
-        deck, illust_dir, {}, img_txt, out_deck, "png", "000000", 45000,
+        deck,
+        illust_dir,
+        {},
+        img_txt,
+        out_deck,
+        "png",
+        "000000",
+        45000,
     )
 
     # IMG+TXT is not a background; it stays a picture shape
@@ -368,8 +430,7 @@ def test_apply_imgtxt_keeps_picture_shape(apply_illustrations, tmp_path):
 def test_imgtxt_geometry_constants_consistent(apply_illustrations):
     """IMG+TXT image + text columns + margins fit the 13.333" slide."""
     img_right = (
-        apply_illustrations.IMGTXT_IMG_LEFT_IN
-        + apply_illustrations.IMGTXT_IMG_WIDTH_IN
+        apply_illustrations.IMGTXT_IMG_LEFT_IN + apply_illustrations.IMGTXT_IMG_WIDTH_IN
     )
     text_right = (
         apply_illustrations.IMGTXT_TEXT_LEFT_IN
@@ -386,17 +447,27 @@ def test_imgtxt_geometry_constants_consistent(apply_illustrations):
 # ── Poster-theatrical composition ────────────────────────────────────
 
 POSTER_SLIDES = [
-    {"n": 3, "format": "FULL", "text_overlay": "One team, one bench",
-     "image_prompt": "[STYLE ANCHOR] one team at a workbench"},
-    {"n": 7, "format": "FULL", "text_overlay": "Many teams, many wires",
-     "image_prompt": "[STYLE ANCHOR] many teams, snarl of wires"},
+    {
+        "n": 3,
+        "format": "FULL",
+        "text_overlay": "One team, one bench",
+        "image_prompt": "[STYLE ANCHOR] one team at a workbench",
+    },
+    {
+        "n": 7,
+        "format": "FULL",
+        "text_overlay": "Many teams, many wires",
+        "image_prompt": "[STYLE ANCHOR] many teams, snarl of wires",
+    },
 ]
 
 
 def test_parse_composition_poster(apply_illustrations, tmp_path):
     outline = _write_outline(
-        tmp_path, POSTER_SLIDES,
-        composition="poster-theatrical", embedded_footer="jbaruch • Devoxx 2026",
+        tmp_path,
+        POSTER_SLIDES,
+        composition="poster-theatrical",
+        embedded_footer="jbaruch • Devoxx 2026",
     )
     assert apply_illustrations.parse_composition(outline) == "poster-theatrical"
 
@@ -409,29 +480,47 @@ def test_parse_composition_absent(apply_illustrations, tmp_path):
 def test_parse_full_slides_poster(apply_illustrations, tmp_path):
     # Poster FULL slides (no safe_zone) are collected for background-only apply.
     outline = _write_outline(
-        tmp_path, POSTER_SLIDES,
-        composition="poster-theatrical", embedded_footer="jbaruch • Devoxx 2026",
+        tmp_path,
+        POSTER_SLIDES,
+        composition="poster-theatrical",
+        embedded_footer="jbaruch • Devoxx 2026",
     )
     assert apply_illustrations.parse_full_slides(outline) == {3, 7}
 
 
 def test_parse_full_slides_excludes_safe_zone(apply_illustrations, tmp_path):
     # A FULL slide with a safe_zone belongs to the zones path, not poster.
-    outline = _write_outline(tmp_path, [
-        {"n": 1, "format": "FULL", "image_prompt": "x",
-         "safe_zone": {"zone": "upper_third"}},
-        {"n": 2, "format": "FULL", "image_prompt": "y"},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        [
+            {
+                "n": 1,
+                "format": "FULL",
+                "image_prompt": "x",
+                "safe_zone": {"zone": "upper_third"},
+            },
+            {"n": 2, "format": "FULL", "image_prompt": "y"},
+        ],
+    )
     assert apply_illustrations.parse_full_slides(outline) == {2}
 
 
-def test_apply_main_rejects_poster_with_safe_zone(apply_illustrations, tmp_path, monkeypatch):
+def test_apply_main_rejects_poster_with_safe_zone(
+    apply_illustrations, tmp_path, monkeypatch
+):
     # Poster mode + a safe_zone slide is contradictory — main() must fail fast.
     import pytest
+
     outline = _write_outline(
         tmp_path,
-        [{"n": 1, "format": "FULL", "image_prompt": "x",
-          "safe_zone": {"zone": "upper_third"}}],
+        [
+            {
+                "n": 1,
+                "format": "FULL",
+                "image_prompt": "x",
+                "safe_zone": {"zone": "upper_third"},
+            }
+        ],
         composition="poster-theatrical",
     )
     deck = tmp_path / "deck.pptx"

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -17,14 +17,16 @@ def base_database():
     return {
         "schema_version": 1,
         "config": current_tracking_config(),
-        "talks": [{
-            "schema_version": 5,
-            "filename": "talk.md",
-            "status": "processed",
-            "video_url": "https://youtu.be/AbCdEfGhI_1",
-            "youtube_id": "AbCdEfGhI_1",
-            "transcript_source": "youtube_auto",
-        }],
+        "talks": [
+            {
+                "schema_version": 5,
+                "filename": "talk.md",
+                "status": "processed",
+                "video_url": "https://youtu.be/AbCdEfGhI_1",
+                "youtube_id": "AbCdEfGhI_1",
+                "transcript_source": "youtube_auto",
+            }
+        ],
         "pptx_catalog": [],
         "qr_codes": [],
         "resources": [],
@@ -57,7 +59,8 @@ def repair_plan(**overrides):
 
 
 def test_dry_run_reports_changes_without_writing(
-    apply_source_repairs, tmp_path,
+    apply_source_repairs,
+    tmp_path,
 ):
     database_path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
@@ -67,7 +70,9 @@ def test_dry_run_reports_changes_without_writing(
     before = database_path.read_bytes()
 
     report = apply_source_repairs.execute(
-        database_path, plan_path, apply=False,
+        database_path,
+        plan_path,
+        apply=False,
     )
 
     assert report["schema_version"] == 2
@@ -83,7 +88,8 @@ def test_dry_run_reports_changes_without_writing(
 
 
 def test_legacy_database_rejects_repair_dry_run_without_writing(
-    apply_source_repairs, tmp_path,
+    apply_source_repairs,
+    tmp_path,
 ):
     database_path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
@@ -105,20 +111,23 @@ def test_legacy_database_rejects_repair_dry_run_without_writing(
 
 
 def test_repair_cannot_create_unversioned_source_rejection(
-    apply_source_repairs, tmp_path,
+    apply_source_repairs,
+    tmp_path,
 ):
     database_path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
     write_json(database_path, base_database())
     plan = repair_plan()
     plan["repairs"][0]["expect"]["source_rejections"] = {"$missing": True}
-    plan["repairs"][0]["set"]["source_rejections"] = [{
-        "source_type": "video",
-        "url": "https://youtu.be/AbCdEfGhI_1",
-        "reason": "wrong_delivery",
-        "evidence": "provider metadata identifies another delivery",
-        "verified_at": "2026-08-01T12:00:00+00:00",
-    }]
+    plan["repairs"][0]["set"]["source_rejections"] = [
+        {
+            "source_type": "video",
+            "url": "https://youtu.be/AbCdEfGhI_1",
+            "reason": "wrong_delivery",
+            "evidence": "provider metadata identifies another delivery",
+            "verified_at": "2026-08-01T12:00:00+00:00",
+        }
+    ]
     write_json(plan_path, plan)
     before = database_path.read_bytes()
 
@@ -132,7 +141,8 @@ def test_repair_cannot_create_unversioned_source_rejection(
 
 
 def test_apply_writes_atomically_and_creates_exact_backup(
-    apply_source_repairs, tmp_path,
+    apply_source_repairs,
+    tmp_path,
 ):
     database_path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
@@ -142,7 +152,10 @@ def test_apply_writes_atomically_and_creates_exact_backup(
     before = database_path.read_bytes()
 
     report = apply_source_repairs.execute(
-        database_path, plan_path, apply=True, backup_dir=backup_dir,
+        database_path,
+        plan_path,
+        apply=True,
+        backup_dir=backup_dir,
     )
 
     repaired = json.loads(database_path.read_text(encoding="utf-8"))
@@ -156,9 +169,10 @@ def test_apply_writes_atomically_and_creates_exact_backup(
     assert report["backup"] is not None
     assert report["schema_version"] == 2
     assert report["input_sha256"] == hashlib.sha256(before).hexdigest()
-    assert report["output_sha256"] == hashlib.sha256(
-        database_path.read_bytes()
-    ).hexdigest()
+    assert (
+        report["output_sha256"]
+        == hashlib.sha256(database_path.read_bytes()).hexdigest()
+    )
     assert report["database_written"] is True
     assert report["durability_state"] == "durable"
     assert report["input_sha256"] in Path(report["backup"]).name
@@ -179,12 +193,14 @@ def test_idempotent_apply_preserves_exact_bytes_inode_and_skips_backup(
         plan_path,
         {
             "schema_version": 1,
-            "repairs": [{
-                "filename": "talk.md",
-                "reason": "idempotent replay",
-                "expect": {"transcript_source": "youtube_auto"},
-                "set": {"transcript_source": "youtube_auto"},
-            }],
+            "repairs": [
+                {
+                    "filename": "talk.md",
+                    "reason": "idempotent replay",
+                    "expect": {"transcript_source": "youtube_auto"},
+                    "set": {"transcript_source": "youtube_auto"},
+                }
+            ],
         },
     )
 
@@ -206,7 +222,10 @@ def test_idempotent_apply_preserves_exact_bytes_inode_and_skips_backup(
 
 
 def test_atomic_write_cleans_stage_and_propagates_interrupt(
-    apply_source_repairs, tracking_database_io, tmp_path, monkeypatch,
+    apply_source_repairs,
+    tracking_database_io,
+    tmp_path,
+    monkeypatch,
 ):
     target = tmp_path / "tracking-database.json"
     target.write_text('{"value": "old"}\n', encoding="utf-8")
@@ -227,7 +246,8 @@ def test_atomic_write_cleans_stage_and_propagates_interrupt(
 
 
 def test_expectation_mismatch_aborts_whole_plan_without_backup(
-    apply_source_repairs, tmp_path,
+    apply_source_repairs,
+    tmp_path,
 ):
     database_path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
@@ -243,7 +263,10 @@ def test_expectation_mismatch_aborts_whole_plan_without_backup(
         apply_source_repairs.SourceRepairError, match="preconditions failed"
     ):
         apply_source_repairs.execute(
-            database_path, plan_path, apply=True, backup_dir=backup_dir,
+            database_path,
+            plan_path,
+            apply=True,
+            backup_dir=backup_dir,
         )
 
     assert database_path.read_bytes() == before
@@ -251,7 +274,8 @@ def test_expectation_mismatch_aborts_whole_plan_without_backup(
 
 
 def test_missing_marker_distinguishes_absent_from_null(
-    apply_source_repairs, tmp_path,
+    apply_source_repairs,
+    tmp_path,
 ):
     database_path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
@@ -266,14 +290,17 @@ def test_missing_marker_distinguishes_absent_from_null(
     write_json(plan_path, plan)
 
     report = apply_source_repairs.execute(
-        database_path, plan_path, apply=False,
+        database_path,
+        plan_path,
+        apply=False,
     )
 
     assert report["changes"][0]["before"]["youtube_id"] == {"$missing": True}
 
 
 def test_active_queue_claim_cannot_be_repaired(
-    apply_source_repairs, tmp_path,
+    apply_source_repairs,
+    tmp_path,
 ):
     database_path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
@@ -298,11 +325,14 @@ def test_active_queue_claim_cannot_be_repaired(
         apply_source_repairs.execute(database_path, plan_path, apply=False)
 
 
-@pytest.mark.parametrize("mutation", [
-    {"set": {"rhetoric_notes": "not a source repair"}},
-    {"clear": ["rhetoric_notes"]},
-    {"set": {"status": "processed"}},
-])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"set": {"rhetoric_notes": "not a source repair"}},
+        {"clear": ["rhetoric_notes"]},
+        {"set": {"status": "processed"}},
+    ],
+)
 def test_plan_rejects_out_of_scope_mutations(apply_source_repairs, mutation):
     plan = repair_plan(**mutation)
 

--- a/tests/test_audit_pattern_catalog.py
+++ b/tests/test_audit_pattern_catalog.py
@@ -90,7 +90,10 @@ def _write_catalog(
             scoring = entry.get("_scoring", _scoring(entry["type"]))
             evidence = ""
             gate_fields = {
-                "evaluable_from", "evidence_requirements", "not_evaluable_when"}
+                "evaluable_from",
+                "evidence_requirements",
+                "not_evaluable_when",
+            }
             has_gate = gate_fields <= set(entry)
             if entry.get("_evidence_section", has_gate):
                 evidence = "\n## Evidence Gate\nNamed sources must satisfy the gate.\n"
@@ -100,50 +103,56 @@ def _write_catalog(
     rows = [entry for entry in values if entry.get("_in_index", True)]
     rows.extend(copy.deepcopy(extra_index_rows or []))
     lines = ["# Test Catalog", "", "## Pattern Catalog", ""]
-    for part, label in (("prepare", "Prepare"), ("build", "Build"), ("deliver", "Deliver")):
+    for part, label in (
+        ("prepare", "Prepare"),
+        ("build", "Build"),
+        ("deliver", "Deliver"),
+    ):
         part_rows = [
-            entry for entry in rows
-            if entry.get("_index_part", entry["part"]) == part
+            entry for entry in rows if entry.get("_index_part", entry["part"]) == part
         ]
-        lines.extend([
-            f"### {label} Phase",
-            "",
-            "| ID | Name | Type | Vault Dims | Creator Phases | Related |",
-            "|----|------|------|------------|----------------|---------|",
-        ])
+        lines.extend(
+            [
+                f"### {label} Phase",
+                "",
+                "| ID | Name | Type | Vault Dims | Creator Phases | Related |",
+                "|----|------|------|------------|----------------|---------|",
+            ]
+        )
         for entry in part_rows:
             dimensions = entry.get("_index_dimensions", entry["vault_dimensions"])
             phases = entry.get("_index_phases", entry["phase_relevance"])
             related = entry.get("_index_related", entry["related_patterns"])
             lines.append(
                 "| "
-                + " | ".join([
-                    entry["id"],
-                    entry.get("_index_name", entry["name"]),
-                    entry.get("_index_type", entry["type"]),
-                    ", ".join(str(value) for value in dimensions) or "—",
-                    ", ".join(phases) or "—",
-                    ", ".join(related) or "—",
-                ])
+                + " | ".join(
+                    [
+                        entry["id"],
+                        entry.get("_index_name", entry["name"]),
+                        entry.get("_index_type", entry["type"]),
+                        ", ".join(str(value) for value in dimensions) or "—",
+                        ", ".join(phases) or "—",
+                        ", ".join(related) or "—",
+                    ]
+                )
                 + " |"
             )
         lines.append("")
 
     if unobservable_ids is None:
-        listed = {
-            entry["id"] for entry in values
-            if entry.get("observable") is False
-        }
+        listed = {entry["id"] for entry in values if entry.get("observable") is False}
     else:
         listed = unobservable_ids
-    lines.extend([
-        "## Phase-Grouped Lookup Table",
-        "",
-        "## Unobservable Patterns — Go-Live Checklist",
-        "",
-        "| ID | Name | Action |",
-        "|----|------|--------|",
-    ])
+    lines.extend(
+        [
+            "## Phase-Grouped Lookup Table",
+            "",
+            "## Unobservable Patterns — Go-Live Checklist",
+            "",
+            "| ID | Name | Action |",
+            "|----|------|--------|",
+        ]
+    )
     names = {entry["id"]: entry["name"] for entry in values}
     for pattern_id in sorted(listed):
         lines.append(f"| {pattern_id} | {names.get(pattern_id, pattern_id)} | Review |")
@@ -262,16 +271,18 @@ def test_index_and_file_inventories_must_match(tmp_path, audit_pattern_catalog):
     root = _write_catalog(
         tmp_path,
         entries,
-        extra_index_rows=[{
-            "id": "ghost-path",
-            "name": "Ghost Path",
-            "type": "pattern",
-            "part": "build",
-            "phase_relevance": ["content"],
-            "vault_dimensions": [2],
-            "related_patterns": [],
-            "inverse_of": [],
-        }],
+        extra_index_rows=[
+            {
+                "id": "ghost-path",
+                "name": "Ghost Path",
+                "type": "pattern",
+                "part": "build",
+                "phase_relevance": ["content"],
+                "vault_dimensions": [2],
+                "related_patterns": [],
+                "inverse_of": [],
+            }
+        ],
     )
 
     report = audit_pattern_catalog.audit_catalog(root)
@@ -314,16 +325,18 @@ def test_anti_word_without_reserved_prefix_remains_pattern(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries.append({
-        "id": "anti-sell",
-        "name": "Anti-Sell",
-        "type": "pattern",
-        "part": "deliver",
-        "phase_relevance": ["content"],
-        "vault_dimensions": [6],
-        "related_patterns": [],
-        "inverse_of": [],
-    })
+    entries.append(
+        {
+            "id": "anti-sell",
+            "name": "Anti-Sell",
+            "type": "pattern",
+            "part": "deliver",
+            "phase_relevance": ["content"],
+            "vault_dimensions": [6],
+            "related_patterns": [],
+            "inverse_of": [],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -361,11 +374,13 @@ def test_source_gate_requires_all_fields(tmp_path, audit_pattern_catalog):
 
 def test_source_gate_rejects_unknown_source(tmp_path, audit_pattern_catalog):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["speaker_memory"],
-        "evidence_requirements": ["The event is visible."],
-        "not_evaluable_when": ["The event is hidden."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["speaker_memory"],
+            "evidence_requirements": ["The event is visible."],
+            "not_evaluable_when": ["The event is hidden."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -377,40 +392,47 @@ def test_source_gate_accepts_conjunctive_alternatives(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": [
-            "delivery_video",
-            ["static_slides", "transcript"],
-            ["native_deck", "transcript"],
-        ],
-        "evidence_requirements": ["The compared facts are visible."],
-        "not_evaluable_when": ["The required pair is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": [
+                "delivery_video",
+                ["static_slides", "transcript"],
+                ["native_deck", "transcript"],
+            ],
+            "evidence_requirements": ["The compared facts are visible."],
+            "not_evaluable_when": ["The required pair is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
     assert report["valid"] is True
 
 
-@pytest.mark.parametrize("alternatives", [
-    [["delivery_video"]],
-    [["transcript", "transcript"]],
-    [["source_comparison", "transcript"]],
-    [["static_slides", "speaker_memory"]],
-    ["delivery_video", "delivery_video"],
-    ["source_comparison"],
-])
+@pytest.mark.parametrize(
+    "alternatives",
+    [
+        [["delivery_video"]],
+        [["transcript", "transcript"]],
+        [["source_comparison", "transcript"]],
+        [["static_slides", "speaker_memory"]],
+        ["delivery_video", "delivery_video"],
+        ["source_comparison"],
+    ],
+)
 def test_source_gate_rejects_invalid_alternatives(
     tmp_path,
     audit_pattern_catalog,
     alternatives,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": alternatives,
-        "evidence_requirements": ["The compared facts are visible."],
-        "not_evaluable_when": ["The required pair is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": alternatives,
+            "evidence_requirements": ["The compared facts are visible."],
+            "not_evaluable_when": ["The required pair is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -418,40 +440,48 @@ def test_source_gate_rejects_invalid_alternatives(
 
 
 def test_optional_outcome_gates_use_the_base_gate_grammar(
-        tmp_path, audit_pattern_catalog):
+    tmp_path, audit_pattern_catalog
+):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["static_slides", "native_deck"],
-        "strong_evaluable_from": ["native_deck"],
-        "absence_evaluable_from": ["native_deck", "delivery_video"],
-        "evidence_requirements": ["The outcome is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["static_slides", "native_deck"],
+            "strong_evaluable_from": ["native_deck"],
+            "absence_evaluable_from": ["native_deck", "delivery_video"],
+            "evidence_requirements": ["The outcome is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
     assert report["valid"] is True
 
 
-@pytest.mark.parametrize("absence_gate", [
-    ["native_deck"],
-    ["delivery_video"],
-    ["source_comparison"],
-    [["static_slides", "transcript"]],
-])
+@pytest.mark.parametrize(
+    "absence_gate",
+    [
+        ["native_deck"],
+        ["delivery_video"],
+        ["source_comparison"],
+        [["static_slides", "transcript"]],
+    ],
+)
 def test_current_catalog_rejects_absence_sources_without_complete_receipts(
     tmp_path,
     audit_pattern_catalog,
     absence_gate,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["static_slides", "transcript"],
-        "strong_evaluable_from": ["static_slides", "transcript"],
-        "absence_evaluable_from": absence_gate,
-        "evidence_requirements": ["The outcome is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["static_slides", "transcript"],
+            "strong_evaluable_from": ["static_slides", "transcript"],
+            "absence_evaluable_from": absence_gate,
+            "evidence_requirements": ["The outcome is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(
         _write_catalog(tmp_path, entries),
@@ -466,11 +496,13 @@ def test_current_catalog_checks_inherited_absence_gate_capability(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The outcome is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The outcome is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(
         _write_catalog(tmp_path, entries),
@@ -485,13 +517,15 @@ def test_external_catalog_preserves_generic_absence_gate_grammar(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "strong_evaluable_from": ["delivery_video"],
-        "absence_evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The outcome is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "strong_evaluable_from": ["delivery_video"],
+            "absence_evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The outcome is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -504,13 +538,15 @@ def test_explicit_null_absence_gate_is_valid_and_positive_only(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "strong_evaluable_from": ["delivery_video"],
-        "absence_evaluable_from": None,
-        "evidence_requirements": ["The positive behavior is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "strong_evaluable_from": ["delivery_video"],
+            "absence_evaluable_from": None,
+            "evidence_requirements": ["The positive behavior is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -525,11 +561,13 @@ def test_omitted_absence_gate_inherits_the_base_gate(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The positive behavior is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The positive behavior is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -541,12 +579,14 @@ def test_omitted_absence_gate_inherits_the_base_gate(
 
 def test_null_strong_gate_is_rejected(tmp_path, audit_pattern_catalog):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "strong_evaluable_from": None,
-        "evidence_requirements": ["The positive behavior is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "strong_evaluable_from": None,
+            "evidence_requirements": ["The positive behavior is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -558,15 +598,19 @@ def test_applicability_fields_must_be_declared_together(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The behavior is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-        "not_applicable_when": [{
-            "condition_id": "independent-context",
-            "description": "The complete delivery establishes independent context.",
-        }],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The behavior is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+            "not_applicable_when": [
+                {
+                    "condition_id": "independent-context",
+                    "description": "The complete delivery establishes independent context.",
+                }
+            ],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -578,16 +622,20 @@ def test_complete_applicability_contract_is_valid(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The behavior is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-        "not_applicable_when": [{
-            "condition_id": "independent-context",
-            "description": "The complete delivery establishes independent context.",
-        }],
-        "applicability_evaluable_from": ["delivery_video"],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The behavior is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+            "not_applicable_when": [
+                {
+                    "condition_id": "independent-context",
+                    "description": "The complete delivery establishes independent context.",
+                }
+            ],
+            "applicability_evaluable_from": ["delivery_video"],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -595,18 +643,28 @@ def test_complete_applicability_contract_is_valid(
     assert report["summary"]["applicability_gated"] == 1
 
 
-@pytest.mark.parametrize(("conditions", "code"), [
-    ([], "not_applicable_conditions_invalid"),
-    (["independent-context"], "not_applicable_condition_invalid"),
-    ([{"condition_id": "Independent Context", "description": "Complete."}],
-     "not_applicable_condition_id_invalid"),
-    ([{"condition_id": "independent-context", "description": ""}],
-     "not_applicable_description_invalid"),
-    ([
-        {"condition_id": "independent-context", "description": "First."},
-        {"condition_id": "independent-context", "description": "Second."},
-    ], "not_applicable_condition_duplicate"),
-])
+@pytest.mark.parametrize(
+    ("conditions", "code"),
+    [
+        ([], "not_applicable_conditions_invalid"),
+        (["independent-context"], "not_applicable_condition_invalid"),
+        (
+            [{"condition_id": "Independent Context", "description": "Complete."}],
+            "not_applicable_condition_id_invalid",
+        ),
+        (
+            [{"condition_id": "independent-context", "description": ""}],
+            "not_applicable_description_invalid",
+        ),
+        (
+            [
+                {"condition_id": "independent-context", "description": "First."},
+                {"condition_id": "independent-context", "description": "Second."},
+            ],
+            "not_applicable_condition_duplicate",
+        ),
+    ],
+)
 def test_applicability_conditions_are_structurally_validated(
     tmp_path,
     audit_pattern_catalog,
@@ -614,13 +672,15 @@ def test_applicability_conditions_are_structurally_validated(
     code,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The behavior is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-        "not_applicable_when": conditions,
-        "applicability_evaluable_from": ["delivery_video"],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The behavior is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+            "not_applicable_when": conditions,
+            "applicability_evaluable_from": ["delivery_video"],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -632,26 +692,30 @@ def test_applicability_gate_rejects_unknown_source(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The behavior is visible."],
-        "not_evaluable_when": ["The qualifying source is unavailable."],
-        "not_applicable_when": [{
-            "condition_id": "independent-context",
-            "description": "The complete delivery establishes independent context.",
-        }],
-        "applicability_evaluable_from": ["speaker-memory"],
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The behavior is visible."],
+            "not_evaluable_when": ["The qualifying source is unavailable."],
+            "not_applicable_when": [
+                {
+                    "condition_id": "independent-context",
+                    "description": "The complete delivery establishes independent context.",
+                }
+            ],
+            "applicability_evaluable_from": ["speaker-memory"],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
     assert "applicability_evidence_source_invalid" in _codes(report)
 
 
-@pytest.mark.parametrize(
-    "field", ["strong_evaluable_from", "absence_evaluable_from"])
+@pytest.mark.parametrize("field", ["strong_evaluable_from", "absence_evaluable_from"])
 def test_optional_outcome_gate_requires_complete_base_metadata(
-        tmp_path, audit_pattern_catalog, field):
+    tmp_path, audit_pattern_catalog, field
+):
     entries = _base_entries()
     entries[0][field] = ["delivery_video"]
 
@@ -662,12 +726,14 @@ def test_optional_outcome_gate_requires_complete_base_metadata(
 
 def test_unobservable_entry_cannot_have_source_gate(tmp_path, audit_pattern_catalog):
     entries = _base_entries()
-    entries[0].update({
-        "observable": False,
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The event is visible."],
-        "not_evaluable_when": ["The event is hidden."],
-    })
+    entries[0].update(
+        {
+            "observable": False,
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The event is visible."],
+            "not_evaluable_when": ["The event is hidden."],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -676,12 +742,14 @@ def test_unobservable_entry_cannot_have_source_gate(tmp_path, audit_pattern_cata
 
 def test_source_gate_metadata_requires_matching_prose(tmp_path, audit_pattern_catalog):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The event is visible."],
-        "not_evaluable_when": ["The event is hidden."],
-        "_evidence_section": False,
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The event is visible."],
+            "not_evaluable_when": ["The event is hidden."],
+            "_evidence_section": False,
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -702,14 +770,16 @@ def test_inline_evidence_gate_phrase_is_not_a_section(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The event is visible."],
-        "not_evaluable_when": ["The event is hidden."],
-        "_evidence_section": False,
-        "_scoring": _scoring("pattern")
-        + "\nProse may mention ## Evidence Gate without creating one.\n",
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The event is visible."],
+            "not_evaluable_when": ["The event is hidden."],
+            "_evidence_section": False,
+            "_scoring": _scoring("pattern")
+            + "\nProse may mention ## Evidence Gate without creating one.\n",
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -721,14 +791,16 @@ def test_fenced_evidence_gate_is_not_a_section(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "evaluable_from": ["delivery_video"],
-        "evidence_requirements": ["The event is visible."],
-        "not_evaluable_when": ["The event is hidden."],
-        "_evidence_section": False,
-        "_scoring": _scoring("pattern")
-        + "\n```markdown\n## Evidence Gate\nOnly a code example.\n```\n",
-    })
+    entries[0].update(
+        {
+            "evaluable_from": ["delivery_video"],
+            "evidence_requirements": ["The event is visible."],
+            "not_evaluable_when": ["The event is hidden."],
+            "_evidence_section": False,
+            "_scoring": _scoring("pattern")
+            + "\n```markdown\n## Evidence Gate\nOnly a code example.\n```\n",
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -755,11 +827,12 @@ def test_related_and_inverse_references_must_resolve(tmp_path, audit_pattern_cat
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
     dangling = [
-        issue for issue in report["errors"]
-        if issue["code"] == "reference_dangling"
+        issue for issue in report["errors"] if issue["code"] == "reference_dangling"
     ]
     assert {issue["related_id"] for issue in dangling} == {
-        "missing-related", "missing-inverse"}
+        "missing-related",
+        "missing-inverse",
+    }
 
 
 def test_index_related_references_must_resolve(tmp_path, audit_pattern_catalog):
@@ -778,8 +851,7 @@ def test_inverse_declarations_are_reciprocal(tmp_path, audit_pattern_catalog):
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
     issue = next(
-        issue for issue in report["errors"]
-        if issue["code"] == "inverse_not_reciprocal"
+        issue for issue in report["errors"] if issue["code"] == "inverse_not_reciprocal"
     )
     assert issue["entry_id"] == "clear-path"
     assert issue["related_id"] == "blocked-path"
@@ -795,13 +867,15 @@ def test_same_polarity_inverse_is_semantic_debt(tmp_path, audit_pattern_catalog)
     assert report["valid"] is True
     assert _codes(report, "semantic_debts") == {"inverse_same_polarity"}
     debts = [
-        issue for issue in report["semantic_debts"]
+        issue
+        for issue in report["semantic_debts"]
         if issue["code"] == "inverse_same_polarity"
     ]
     assert len(debts) == 1
-    assert {
-        debts[0]["entry_id"], debts[0]["related_id"]
-    } == {"blocked-path", "clear-path"}
+    assert {debts[0]["entry_id"], debts[0]["related_id"]} == {
+        "blocked-path",
+        "clear-path",
+    }
 
 
 def test_antipattern_scoring_uses_direct_polarity(tmp_path, audit_pattern_catalog):
@@ -874,11 +948,7 @@ def test_fenced_scoring_criteria_are_not_a_section(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0]["_scoring"] = (
-        "```markdown\n"
-        + _scoring("pattern")
-        + "```\n"
-    )
+    entries[0]["_scoring"] = "```markdown\n" + _scoring("pattern") + "```\n"
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -891,10 +961,7 @@ def test_fenced_scoring_labels_do_not_duplicate_visible_scale(
 ):
     entries = _base_entries()
     entries[0]["_scoring"] = (
-        _scoring("pattern")
-        + "\n~~~markdown\n"
-        + _scoring("pattern")
-        + "~~~\n"
+        _scoring("pattern") + "\n~~~markdown\n" + _scoring("pattern") + "~~~\n"
     )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
@@ -910,8 +977,7 @@ def test_normalized_alias_collision_is_rejected(tmp_path, audit_pattern_catalog)
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
     collision = next(
-        issue for issue in report["errors"]
-        if issue["code"] == "alias_collision"
+        issue for issue in report["errors"] if issue["code"] == "alias_collision"
     )
     assert collision["entry_id"] == "blocked-path"
     assert collision["related_id"] == "clear-path"
@@ -940,12 +1006,14 @@ def test_index_metadata_drift_is_separate_semantic_debt(
     audit_pattern_catalog,
 ):
     entries = _base_entries()
-    entries[0].update({
-        "_index_name": "Clear Route",
-        "_index_dimensions": [3],
-        "_index_phases": ["slides"],
-        "_index_related": [],
-    })
+    entries[0].update(
+        {
+            "_index_name": "Clear Route",
+            "_index_dimensions": [3],
+            "_index_phases": ["slides"],
+            "_index_related": [],
+        }
+    )
 
     report = audit_pattern_catalog.audit_catalog(_write_catalog(tmp_path, entries))
 
@@ -1026,9 +1094,7 @@ def test_fenced_catalog_row_does_not_create_an_orphaned_index_entry(
     index = root / "_index.md"
     text = index.read_text(encoding="utf-8")
     fenced_row = (
-        "~~~markdown\n"
-        "| ghost-path | Ghost Path | pattern | 2 | content | — |\n"
-        "~~~\n\n"
+        "~~~markdown\n| ghost-path | Ghost Path | pattern | 2 | content | — |\n~~~\n\n"
     )
     text = text.replace("### Build Phase", fenced_row + "### Build Phase", 1)
     index.write_text(text, encoding="utf-8")
@@ -1075,12 +1141,10 @@ def test_fenced_unobservable_row_does_not_create_a_checklist_entry(
     root = _write_catalog(tmp_path)
     index = root / "_index.md"
     text = index.read_text(encoding="utf-8")
-    fenced_row = (
-        "~~~markdown\n"
-        "| clear-path | Clear Path | Review |\n"
-        "~~~\n"
+    fenced_row = "~~~markdown\n| clear-path | Clear Path | Review |\n~~~\n"
+    text = text.replace(
+        "## Summary Statistics", fenced_row + "\n## Summary Statistics", 1
     )
-    text = text.replace("## Summary Statistics", fenced_row + "\n## Summary Statistics", 1)
     index.write_text(text, encoding="utf-8")
 
     report = audit_pattern_catalog.audit_catalog(root)
@@ -1089,13 +1153,16 @@ def test_fenced_unobservable_row_does_not_create_a_checklist_entry(
     assert report["valid"] is True
 
 
-@pytest.mark.parametrize(("field", "value", "code"), [
-    ("_index_dimensions", [2, 2], "index_dimensions_duplicate"),
-    ("_index_dimensions", [0], "index_dimensions_invalid"),
-    ("_index_phases", ["content", "content"], "index_creator_phases_duplicate"),
-    ("_index_phases", ["rehearsal"], "index_creator_phases_invalid"),
-    ("_index_related", ["blocked-path", "blocked-path"], "index_related_duplicate"),
-])
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("_index_dimensions", [2, 2], "index_dimensions_duplicate"),
+        ("_index_dimensions", [0], "index_dimensions_invalid"),
+        ("_index_phases", ["content", "content"], "index_creator_phases_duplicate"),
+        ("_index_phases", ["rehearsal"], "index_creator_phases_invalid"),
+        ("_index_related", ["blocked-path", "blocked-path"], "index_related_duplicate"),
+    ],
+)
 def test_index_list_shape_is_validated_independently_of_set_drift(
     tmp_path,
     audit_pattern_catalog,
@@ -1178,9 +1245,12 @@ def test_cli_emits_stable_json_for_valid_catalog(tmp_path, audit_pattern_catalog
 
 # --- #203: the CLI has a closed failure boundary ---
 
+
 def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
-        audit_pattern_catalog, capsys, monkeypatch):
+    audit_pattern_catalog, capsys, monkeypatch
+):
     """Ingress gates on this audit; a bare traceback is not a verdict."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("injected failure at /private/vault/patterns/x.md")
 
@@ -1189,7 +1259,7 @@ def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
     assert audit_pattern_catalog.run_cli([]) == 3
 
     captured = capsys.readouterr()
-    assert captured.out == ""                     # stdout stays clean
+    assert captured.out == ""  # stdout stays clean
     payload = json.loads(captured.err.splitlines()[0])
     assert payload["error"] == "catalog_audit_unexpected_failure"
     assert payload["error_type"] == "RuntimeError"
@@ -1200,8 +1270,10 @@ def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
 
 
 def test_unexpected_failure_exit_is_distinct_from_the_argparse_exit(
-        audit_pattern_catalog, capsys, monkeypatch):
+    audit_pattern_catalog, capsys, monkeypatch
+):
     """argparse already owns 2 — reusing it would conflate the two causes."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("boom")
 
@@ -1215,16 +1287,16 @@ def test_unexpected_failure_exit_is_distinct_from_the_argparse_exit(
 
 
 def test_outer_boundary_lets_the_documented_verdicts_through(
-        audit_pattern_catalog, monkeypatch):
+    audit_pattern_catalog, monkeypatch
+):
     """A structural-error verdict is exit 1, not an unexpected failure."""
-    monkeypatch.setattr(
-        audit_pattern_catalog, "main", lambda *a, **k: 1
-    )
+    monkeypatch.setattr(audit_pattern_catalog, "main", lambda *a, **k: 1)
     assert audit_pattern_catalog.run_cli([]) == 1
 
 
 def test_a_failed_report_write_does_not_leave_partial_json_on_stdout(
-        audit_pattern_catalog, capsys, monkeypatch):
+    audit_pattern_catalog, capsys, monkeypatch
+):
     """The report is serialized before it is written, so it lands whole or not at all."""
     monkeypatch.setattr(
         audit_pattern_catalog,

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -46,11 +46,14 @@ def finding_codes(report):
 
 
 def test_fetches_once_per_youtube_id_and_flags_cross_talk_collision(
-        audit_source_identities):
-    database = {"talks": [
-        talk("first.md", "Perfect Vault Ingress"),
-        talk("second.md", "Unrelated Platform Keynote", date="2025-04-10"),
-    ]}
+    audit_source_identities,
+):
+    database = {
+        "talks": [
+            talk("first.md", "Perfect Vault Ingress"),
+            talk("second.md", "Unrelated Platform Keynote", date="2025-04-10"),
+        ]
+    }
     original = deepcopy(database)
     calls = []
 
@@ -59,8 +62,10 @@ def test_fetches_once_per_youtube_id_and_flags_cross_talk_collision(
         return metadata(video_id)
 
     report = audit_source_identities.audit_database(
-        database, database_path="/vault/tracking-database.json",
-        metadata_fetcher=fetcher, captured_at=CAPTURED_AT,
+        database,
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=fetcher,
+        captured_at=CAPTURED_AT,
     )
 
     assert calls == [VIDEO_ID]
@@ -72,9 +77,11 @@ def test_fetches_once_per_youtube_id_and_flags_cross_talk_collision(
 
 
 def test_captures_provider_facts_without_inventing_speakers_or_recorded_date(
-        audit_source_identities):
+    audit_source_identities,
+):
     report = audit_source_identities.audit_database(
-        {"talks": [talk()]}, database_path="/vault/tracking-database.json",
+        {"talks": [talk()]},
+        database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(video_id),
         captured_at=CAPTURED_AT,
     )
@@ -102,84 +109,95 @@ def test_captures_provider_facts_without_inventing_speakers_or_recorded_date(
 
 
 def test_likely_non_delivery_clip_uses_title_and_duration_evidence(
-        audit_source_identities):
+    audit_source_identities,
+):
     report = audit_source_identities.audit_database(
-        {"talks": [talk()]}, database_path="/vault/tracking-database.json",
+        {"talks": [talk()]},
+        database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(
-            video_id, title="Two-minute product demo clip", duration=180,
+            video_id,
+            title="Two-minute product demo clip",
+            duration=180,
         ),
         captured_at=CAPTURED_AT,
     )
 
     finding = next(
-        item for item in report["findings"]
+        item
+        for item in report["findings"]
         if item["code"] == "likely_non_delivery_clip"
     )
     assert finding["review_priority"] == "high"
     assert "provider_title_mismatch" in finding_codes(report)
-    assert "provider_duration_under_55_percent_of_catalog" in (
-        finding["evidence"]["signals"])
+    assert (
+        "provider_duration_under_55_percent_of_catalog"
+        in (finding["evidence"]["signals"])
+    )
 
 
-@pytest.mark.parametrize(("catalog_title", "conference", "provider_title"), [
-    (
-        'Influencing DevOps without Authority - how "DevOps engineer" can '
-        "advance real DevOps",
-        "DevOps Vision 2023",
-        "Influencing DevOps without Authority at DevOps Vision 2023",
-    ),
-    (
-        "The Epic Groovy Puzzlers: As Usual — Traps, Pitfalls and End Cases",
-        "DevNexus 2015",
-        "Devnexus 2015 - The Epic Groovy Puzzlers - Baruch and Leonid",
-    ),
-    (
-        "Coding Fast and Slow: Applying Kahneman's Insights to Improve "
-        "Development Practices and Efficiency",
-        "Dev2Next 2024",
-        "Coding Fast and Slow at Dev2Next 2024",
-    ),
-    (
-        "Technical Enshittification: Why Everything in IT is Horrible Right "
-        "Now and How to Fix It",
-        "JCON 2025",
-        "Technical Enshittification at JCON 2025",
-    ),
-    (
-        "Back to the Future of Software: How to Survive AI with Intent "
-        "Integrity Chain",
-        "DevNexus 2026",
-        "Back to the Future of Software at DevNexus 2026",
-    ),
-    (
-        "DevOps Reframed: Embracing the Path to Developer Productivity "
-        "Engineering",
-        "Dev2Next 2024",
-        "DevOps Reframed at Dev2Next 2024",
-    ),
-    (
-        "Runtime Rumble: Tool Alpha vs. Tool Beta at ExampleConf 2025",
-        "ExampleConf 2025",
-        "Runtime Rumble Tool Alpha vs Tool Beta",
-    ),
-    (
-        "DevOps for developers (or maybe against them?!)",
-        "Devoxx Belgium 2024",
-        "DevOps for Developers at Devoxx Belgium 2024",
-    ),
-    (
-        "Data-Driven DevOps",
-        "DevOpsDays Indianapolis 2024",
-        "#DataDrivenDevOps as presented at #DevOpsDaysIndy",
-    ),
-])
+@pytest.mark.parametrize(
+    ("catalog_title", "conference", "provider_title"),
+    [
+        (
+            'Influencing DevOps without Authority - how "DevOps engineer" can '
+            "advance real DevOps",
+            "DevOps Vision 2023",
+            "Influencing DevOps without Authority at DevOps Vision 2023",
+        ),
+        (
+            "The Epic Groovy Puzzlers: As Usual — Traps, Pitfalls and End Cases",
+            "DevNexus 2015",
+            "Devnexus 2015 - The Epic Groovy Puzzlers - Baruch and Leonid",
+        ),
+        (
+            "Coding Fast and Slow: Applying Kahneman's Insights to Improve "
+            "Development Practices and Efficiency",
+            "Dev2Next 2024",
+            "Coding Fast and Slow at Dev2Next 2024",
+        ),
+        (
+            "Technical Enshittification: Why Everything in IT is Horrible Right "
+            "Now and How to Fix It",
+            "JCON 2025",
+            "Technical Enshittification at JCON 2025",
+        ),
+        (
+            "Back to the Future of Software: How to Survive AI with Intent "
+            "Integrity Chain",
+            "DevNexus 2026",
+            "Back to the Future of Software at DevNexus 2026",
+        ),
+        (
+            "DevOps Reframed: Embracing the Path to Developer Productivity Engineering",
+            "Dev2Next 2024",
+            "DevOps Reframed at Dev2Next 2024",
+        ),
+        (
+            "Runtime Rumble: Tool Alpha vs. Tool Beta at ExampleConf 2025",
+            "ExampleConf 2025",
+            "Runtime Rumble Tool Alpha vs Tool Beta",
+        ),
+        (
+            "DevOps for developers (or maybe against them?!)",
+            "Devoxx Belgium 2024",
+            "DevOps for Developers at Devoxx Belgium 2024",
+        ),
+        (
+            "Data-Driven DevOps",
+            "DevOpsDays Indianapolis 2024",
+            "#DataDrivenDevOps as presented at #DevOpsDaysIndy",
+        ),
+    ],
+)
 def test_explicit_base_title_accepts_real_provider_subtitle_omissions(
-        audit_source_identities, catalog_title, conference, provider_title):
+    audit_source_identities, catalog_title, conference, provider_title
+):
     report = audit_source_identities.audit_database(
         {"talks": [talk(title=catalog_title, conference=conference)]},
         database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(
-            video_id, title=provider_title,
+            video_id,
+            title=provider_title,
         ),
         captured_at=CAPTURED_AT,
     )
@@ -190,7 +208,8 @@ def test_explicit_base_title_accepts_real_provider_subtitle_omissions(
 
 
 @pytest.mark.parametrize(
-    ("catalog_conference", "provider_conference", "provider_title"), [
+    ("catalog_conference", "provider_conference", "provider_title"),
+    [
         (
             "Conference Alpha 2024",
             "Devoxx Poland 2024",
@@ -204,30 +223,33 @@ def test_explicit_base_title_accepts_real_provider_subtitle_omissions(
     ],
 )
 def test_shared_base_title_does_not_hide_wrong_delivery_event(
-        audit_source_identities, catalog_conference, provider_conference,
-        provider_title):
+    audit_source_identities, catalog_conference, provider_conference, provider_title
+):
     catalog_title = (
         "Coding Fast and Slow: Applying Kahneman's Insights to Improve "
         "Development Practices and Efficiency"
     )
     active = talk(title=catalog_title, conference=catalog_conference)
     known_other_event = talk(
-        "other-event.md", catalog_title,
-        conference=provider_conference, video_url=None, youtube_id=None,
+        "other-event.md",
+        catalog_title,
+        conference=provider_conference,
+        video_url=None,
+        youtube_id=None,
     )
     report = audit_source_identities.audit_database(
         {"talks": [active, known_other_event]},
         database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(
-            video_id, title=provider_title,
+            video_id,
+            title=provider_title,
         ),
         captured_at=CAPTURED_AT,
     )
 
     assert "provider_title_mismatch" not in finding_codes(report)
     finding = next(
-        item for item in report["findings"]
-        if item["code"] == "provider_event_mismatch"
+        item for item in report["findings"] if item["code"] == "provider_event_mismatch"
     )
     assert finding["review_priority"] == "high"
     assert finding["evidence"]["catalog_conference"] == catalog_conference
@@ -238,7 +260,8 @@ def test_shared_base_title_does_not_hide_wrong_delivery_event(
 
 
 @pytest.mark.parametrize(
-    ("catalog_conference", "provider_title", "other_conferences"), [
+    ("catalog_conference", "provider_title", "other_conferences"),
+    [
         (
             "DevIgnition 2024",
             'Baruch Sadogursky — "DevOps Reframed: Embracing the Path"',
@@ -277,8 +300,8 @@ def test_shared_base_title_does_not_hide_wrong_delivery_event(
     ],
 )
 def test_event_matcher_ignores_live_generic_and_cobrand_false_positives(
-        audit_source_identities, catalog_conference, provider_title,
-        other_conferences):
+    audit_source_identities, catalog_conference, provider_title, other_conferences
+):
     active = talk(conference=catalog_conference)
     catalog_only = [
         talk(
@@ -293,7 +316,8 @@ def test_event_matcher_ignores_live_generic_and_cobrand_false_positives(
         {"talks": [active, *catalog_only]},
         database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(
-            video_id, title=provider_title,
+            video_id,
+            title=provider_title,
         ),
         captured_at=CAPTURED_AT,
     )
@@ -302,14 +326,19 @@ def test_event_matcher_ignores_live_generic_and_cobrand_false_positives(
 
 
 def test_short_matching_lightning_talk_is_not_automatically_called_a_clip(
-        audit_source_identities):
+    audit_source_identities,
+):
     lightning = talk(
-        title="Fast Lightning", duration_seconds=300,
+        title="Fast Lightning",
+        duration_seconds=300,
     )
     report = audit_source_identities.audit_database(
-        {"talks": [lightning]}, database_path="/vault/tracking-database.json",
+        {"talks": [lightning]},
+        database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(
-            video_id, title="Fast Lightning", duration=240,
+            video_id,
+            title="Fast Lightning",
+            duration=240,
         ),
         captured_at=CAPTURED_AT,
     )
@@ -317,45 +346,53 @@ def test_short_matching_lightning_talk_is_not_automatically_called_a_clip(
 
 
 def test_fetch_order_and_report_are_deterministic(audit_source_identities):
-    database = {"talks": [
-        talk(
-            "other.md", "Other Talk",
-            video_url=f"https://youtu.be/{OTHER_VIDEO_ID}",
-            youtube_id=OTHER_VIDEO_ID,
-        ),
-        talk("first.md"),
-        talk("same-id.md", video_url=f"https://youtu.be/{VIDEO_ID}"),
-    ]}
+    database = {
+        "talks": [
+            talk(
+                "other.md",
+                "Other Talk",
+                video_url=f"https://youtu.be/{OTHER_VIDEO_ID}",
+                youtube_id=OTHER_VIDEO_ID,
+            ),
+            talk("first.md"),
+            talk("same-id.md", video_url=f"https://youtu.be/{VIDEO_ID}"),
+        ]
+    }
     calls = []
 
     def fetcher(video_id):
         calls.append(video_id)
-        return metadata(video_id, title=(
-            "Other Talk" if video_id == OTHER_VIDEO_ID
-            else "Perfect Vault Ingress"
-        ))
+        return metadata(
+            video_id,
+            title=(
+                "Other Talk" if video_id == OTHER_VIDEO_ID else "Perfect Vault Ingress"
+            ),
+        )
 
     first = audit_source_identities.audit_database(
-        deepcopy(database), database_path="/vault/tracking-database.json",
-        metadata_fetcher=fetcher, captured_at=CAPTURED_AT,
+        deepcopy(database),
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=fetcher,
+        captured_at=CAPTURED_AT,
     )
     second = audit_source_identities.audit_database(
-        deepcopy(database), database_path="/vault/tracking-database.json",
-        metadata_fetcher=fetcher, captured_at=CAPTURED_AT,
+        deepcopy(database),
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=fetcher,
+        captured_at=CAPTURED_AT,
     )
 
     expected_order = sorted({VIDEO_ID, OTHER_VIDEO_ID})
     assert calls == expected_order + expected_order
     assert first == second
     assert [source["video_id"] for source in first["sources"]] == expected_order
-    assert list(first["summary"]["by_code"]) == sorted(
-        first["summary"]["by_code"])
+    assert list(first["summary"]["by_code"]) == sorted(first["summary"]["by_code"])
 
 
-def test_provider_identity_mismatch_blocks_evidence_proposal(
-        audit_source_identities):
+def test_provider_identity_mismatch_blocks_evidence_proposal(audit_source_identities):
     report = audit_source_identities.audit_database(
-        {"talks": [talk()]}, database_path="/vault/tracking-database.json",
+        {"talks": [talk()]},
+        database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(OTHER_VIDEO_ID),
         captured_at=CAPTURED_AT,
     )
@@ -366,11 +403,11 @@ def test_provider_identity_mismatch_blocks_evidence_proposal(
     assert report["talks"][0]["proposed_evidence"] is None
 
 
-def test_audit_path_leaves_database_bytes_unchanged(
-        audit_source_identities, tmp_path):
+def test_audit_path_leaves_database_bytes_unchanged(audit_source_identities, tmp_path):
     database_path = tmp_path / "tracking-database.json"
     database_path.write_text(
-        json.dumps({"talks": [talk()]}, indent=2) + "\n", encoding="utf-8",
+        json.dumps({"talks": [talk()]}, indent=2) + "\n",
+        encoding="utf-8",
     )
     before = database_path.read_bytes()
 
@@ -384,13 +421,13 @@ def test_audit_path_leaves_database_bytes_unchanged(
     assert database_path.read_bytes() == before
 
 
-def test_inactive_stored_id_is_not_fetched_or_resurrected(
-        audit_source_identities):
+def test_inactive_stored_id_is_not_fetched_or_resurrected(audit_source_identities):
     database = {"talks": [talk(video_url=None)]}
     calls = []
 
     report = audit_source_identities.audit_database(
-        database, database_path="/vault/tracking-database.json",
+        database,
+        database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: calls.append(video_id),
         captured_at=CAPTURED_AT,
     )
@@ -401,8 +438,7 @@ def test_inactive_stored_id_is_not_fetched_or_resurrected(
     assert report["talks"] == []
 
 
-def test_future_tracking_database_is_not_fetched_or_rewritten(
-        audit_source_identities):
+def test_future_tracking_database_is_not_fetched_or_rewritten(audit_source_identities):
     database = {
         "schema_version": 99,
         "future_inventory": {"records": "not-an-old-talks-array"},
@@ -424,11 +460,16 @@ def test_future_tracking_database_is_not_fetched_or_rewritten(
 
 
 def test_incomplete_provider_metadata_is_proposed_without_invented_values(
-        audit_source_identities):
+    audit_source_identities,
+):
     report = audit_source_identities.audit_database(
-        {"talks": [talk()]}, database_path="/vault/tracking-database.json",
+        {"talks": [talk()]},
+        database_path="/vault/tracking-database.json",
         metadata_fetcher=lambda video_id: metadata(
-            video_id, uploader=None, uploader_id=None, upload_date=None,
+            video_id,
+            uploader=None,
+            uploader_id=None,
+            upload_date=None,
         ),
         captured_at=CAPTURED_AT,
     )
@@ -443,18 +484,20 @@ def test_incomplete_provider_metadata_is_proposed_without_invented_values(
     assert "recorded_date" not in proposal
 
 
-def test_yt_dlp_fetch_is_dependency_injected_and_download_free(
-        audit_source_identities):
+def test_yt_dlp_fetch_is_dependency_injected_and_download_free(audit_source_identities):
     calls = []
 
     def runner(command, **kwargs):
         calls.append((command, kwargs))
         return SimpleNamespace(
-            returncode=0, stdout=json.dumps(metadata()), stderr="",
+            returncode=0,
+            stdout=json.dumps(metadata()),
+            stderr="",
         )
 
     result = audit_source_identities.fetch_youtube_metadata(
-        VIDEO_ID, runner=runner,
+        VIDEO_ID,
+        runner=runner,
     )
 
     assert result["id"] == VIDEO_ID
@@ -474,18 +517,23 @@ def test_yt_dlp_fetch_is_dependency_injected_and_download_free(
 def test_capture_timestamp_requires_explicit_timezone(audit_source_identities):
     with pytest.raises(ValueError, match="timezone"):
         audit_source_identities.normalize_captured_at("2026-07-31T12:00:00")
-    assert audit_source_identities.normalize_captured_at(
-        "2026-07-31T14:00:00-05:00") == CAPTURED_AT
+    assert (
+        audit_source_identities.normalize_captured_at("2026-07-31T14:00:00-05:00")
+        == CAPTURED_AT
+    )
 
 
 def test_cli_failure_emits_json_and_actionable_stderr(
-        audit_source_identities, monkeypatch, capsys):
+    audit_source_identities, monkeypatch, capsys
+):
     report = {
         "complete": False,
         "findings": [{"code": "metadata_fetch_failed"}],
     }
     monkeypatch.setattr(
-        audit_source_identities, "audit_path", lambda *args, **kwargs: report,
+        audit_source_identities,
+        "audit_path",
+        lambda *args, **kwargs: report,
     )
 
     exit_code = audit_source_identities.main(["/vault"])

--- a/tests/test_backgrounds_manifest_to_spec.py
+++ b/tests/test_backgrounds_manifest_to_spec.py
@@ -12,7 +12,9 @@ def test_spec_sorted_by_slide_number(backgrounds_manifest_to_spec):
 
 def test_spec_single_entry(backgrounds_manifest_to_spec):
     manifest = {"backgrounds": {"3": "/img/slide-03.png"}}
-    assert backgrounds_manifest_to_spec.manifest_to_spec(manifest) == "3=/img/slide-03.png"
+    assert (
+        backgrounds_manifest_to_spec.manifest_to_spec(manifest) == "3=/img/slide-03.png"
+    )
 
 
 def test_empty_manifest_raises(backgrounds_manifest_to_spec):
@@ -25,9 +27,13 @@ def test_empty_manifest_raises(backgrounds_manifest_to_spec):
 def test_reserved_delimiter_in_path_raises(backgrounds_manifest_to_spec):
     # A ';' or '=' in a path would corrupt the spec the VBA macro parses.
     with pytest.raises(ValueError):
-        backgrounds_manifest_to_spec.manifest_to_spec({"backgrounds": {"1": "/a/b;c.jpg"}})
+        backgrounds_manifest_to_spec.manifest_to_spec(
+            {"backgrounds": {"1": "/a/b;c.jpg"}}
+        )
     with pytest.raises(ValueError):
-        backgrounds_manifest_to_spec.manifest_to_spec({"backgrounds": {"1": "/a/b=c.jpg"}})
+        backgrounds_manifest_to_spec.manifest_to_spec(
+            {"backgrounds": {"1": "/a/b=c.jpg"}}
+        )
 
 
 def test_malformed_input_raises_valueerror_not_traceback(backgrounds_manifest_to_spec):
@@ -35,10 +41,10 @@ def test_malformed_input_raises_valueerror_not_traceback(backgrounds_manifest_to
     # Non-object manifest, non-object backgrounds, non-int key, non-string path
     # all surface as ValueError (actionable), never an unhandled TypeError/etc.
     for bad in (
-        [1, 2, 3],                                  # manifest not a dict
-        {"backgrounds": ["/a/slide-01.jpg"]},        # backgrounds not a dict
-        {"backgrounds": {"one": "/a/slide-01.jpg"}}, # key not an integer
-        {"backgrounds": {"1": 12345}},               # path not a string
+        [1, 2, 3],  # manifest not a dict
+        {"backgrounds": ["/a/slide-01.jpg"]},  # backgrounds not a dict
+        {"backgrounds": {"one": "/a/slide-01.jpg"}},  # key not an integer
+        {"backgrounds": {"1": 12345}},  # path not a string
     ):
         with pytest.raises(ValueError):
             m2s(bad)

--- a/tests/test_batch_download.py
+++ b/tests/test_batch_download.py
@@ -6,8 +6,12 @@ import stat
 
 
 SCRIPT = os.path.join(
-    os.path.dirname(__file__), os.pardir,
-    "skills", "vault-ingress", "scripts", "batch-download-videos.sh",
+    os.path.dirname(__file__),
+    os.pardir,
+    "skills",
+    "vault-ingress",
+    "scripts",
+    "batch-download-videos.sh",
 )
 SCRIPT = os.path.abspath(SCRIPT)
 
@@ -43,7 +47,10 @@ def test_creates_directory_structure(tmp_path):
 
     result = subprocess.run(
         ["bash", SCRIPT, str(vault), "abc123", "def456"],
-        capture_output=True, text=True, env=env, timeout=10,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
     )
     assert result.returncode == 0
     assert (vault / "slides-rebuild" / "abc123").is_dir()
@@ -61,7 +68,10 @@ def test_downloads_to_correct_path(tmp_path):
 
     subprocess.run(
         ["bash", SCRIPT, str(vault), "xyz789"],
-        capture_output=True, text=True, env=env, timeout=10,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
     )
     expected = vault / "slides-rebuild" / "xyz789" / "xyz789.mp4"
     assert expected.exists()

--- a/tests/test_build_expansion_manifest.py
+++ b/tests/test_build_expansion_manifest.py
@@ -16,20 +16,37 @@ FIXTURE = Path(__file__).parent / "fixtures" / "outline-example.yaml"
 _TALK = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))["talk"]
 
 DEFAULT_SLIDES = [
-    {"n": 3, "chapter": "c", "title": "Plain", "format": "FULL",
-     "image_prompt": "[STYLE ANCHOR] a thing"},
-    {"n": 7, "chapter": "c", "title": "The Pipeline", "format": "FULL",
-     "image_prompt": "[STYLE ANCHOR] a pipeline", "builds": [
-         {"step": 0, "desc": "Empty track"},
-         {"step": 1, "desc": "Build stage revealed"},
-         {"step": 2, "desc": "Test stage revealed"},
-         {"step": 3, "desc": "Full pipeline"},
-     ]},
-    {"n": 9, "chapter": "c", "title": "Rollback", "format": "FULL",
-     "image_prompt": "[STYLE ANCHOR] rollback", "builds": [
-         {"step": 0, "desc": "Empty"},
-         {"step": 1, "desc": "Full"},
-     ]},
+    {
+        "n": 3,
+        "chapter": "c",
+        "title": "Plain",
+        "format": "FULL",
+        "image_prompt": "[STYLE ANCHOR] a thing",
+    },
+    {
+        "n": 7,
+        "chapter": "c",
+        "title": "The Pipeline",
+        "format": "FULL",
+        "image_prompt": "[STYLE ANCHOR] a pipeline",
+        "builds": [
+            {"step": 0, "desc": "Empty track"},
+            {"step": 1, "desc": "Build stage revealed"},
+            {"step": 2, "desc": "Test stage revealed"},
+            {"step": 3, "desc": "Full pipeline"},
+        ],
+    },
+    {
+        "n": 9,
+        "chapter": "c",
+        "title": "Rollback",
+        "format": "FULL",
+        "image_prompt": "[STYLE ANCHOR] rollback",
+        "builds": [
+            {"step": 0, "desc": "Empty"},
+            {"step": 1, "desc": "Full"},
+        ],
+    },
 ]
 
 
@@ -75,7 +92,9 @@ def test_non_string_note_is_rejected(build_expansion_manifest, tmp_path):
     _make_frames(builds, 7, 4)
     _make_frames(builds, 9, 2)
     with pytest.raises(SystemExit) as exc:
-        build_expansion_manifest.build_manifest(outline, builds, {"6": 123})  # slide 7 -> key 6
+        build_expansion_manifest.build_manifest(
+            outline, builds, {"6": 123}
+        )  # slide 7 -> key 6
     assert "must be a string" in str(exc.value)
 
 
@@ -167,6 +186,8 @@ def test_unwritable_out_returns_error(build_expansion_manifest, tmp_path, capsys
     _make_frames(builds, 9, 2)
     out_dir = tmp_path / "outdir"
     out_dir.mkdir()
-    rc = build_expansion_manifest.main([str(outline), str(builds), "--out", str(out_dir)])
+    rc = build_expansion_manifest.main(
+        [str(outline), str(builds), "--out", str(out_dir)]
+    )
     assert rc == 1
     assert "cannot write manifest" in capsys.readouterr().err

--- a/tests/test_build_expansion_to_packed.py
+++ b/tests/test_build_expansion_to_packed.py
@@ -10,10 +10,12 @@ def _manifest(builds):
 
 
 def test_packs_descending_by_parent(build_expansion_to_packed):
-    m = _manifest([
-        {"parent": 7, "frames": ["/b/s7-00.jpg", "/b/s7-01.jpg"], "notes": ""},
-        {"parent": 9, "frames": ["/b/s9-00.jpg", "/b/s9-01.jpg"], "notes": "final"},
-    ])
+    m = _manifest(
+        [
+            {"parent": 7, "frames": ["/b/s7-00.jpg", "/b/s7-01.jpg"], "notes": ""},
+            {"parent": 9, "frames": ["/b/s9-00.jpg", "/b/s9-01.jpg"], "notes": "final"},
+        ]
+    )
     packed = build_expansion_to_packed.manifest_to_packed(m)
     records = packed.split(RS)
     # Descending: parent 9 first so its insertion can't shift parent 7's index.
@@ -22,7 +24,15 @@ def test_packs_descending_by_parent(build_expansion_to_packed):
 
 
 def test_record_fields_and_frame_order(build_expansion_to_packed):
-    m = _manifest([{"parent": 7, "frames": ["/b/00.jpg", "/b/01.jpg", "/b/02.jpg"], "notes": "spk"}])
+    m = _manifest(
+        [
+            {
+                "parent": 7,
+                "frames": ["/b/00.jpg", "/b/01.jpg", "/b/02.jpg"],
+                "notes": "spk",
+            }
+        ]
+    )
     packed = build_expansion_to_packed.manifest_to_packed(m)
     parent, notes, frames = packed.split(US)
     assert parent == "7"
@@ -51,10 +61,15 @@ def test_reserved_control_char_in_path_errors(build_expansion_to_packed):
 
 def test_cli_writes_packed_file(build_expansion_to_packed, tmp_path):
     import json
+
     manifest = tmp_path / "builds.json"
-    manifest.write_text(json.dumps(_manifest(
-        [{"parent": 4, "frames": ["/b/00.jpg", "/b/01.jpg"], "notes": ""}]
-    )))
+    manifest.write_text(
+        json.dumps(
+            _manifest(
+                [{"parent": 4, "frames": ["/b/00.jpg", "/b/01.jpg"], "notes": ""}]
+            )
+        )
+    )
     out = tmp_path / "packed.txt"
     rc = build_expansion_to_packed.main([str(manifest), str(out)])
     assert rc == 0
@@ -64,7 +79,10 @@ def test_cli_writes_packed_file(build_expansion_to_packed, tmp_path):
 
 
 def test_wrong_schema_version_errors(build_expansion_to_packed):
-    bad = {"schema_version": 2, "builds": [{"parent": 7, "frames": ["/b/00.jpg"], "notes": ""}]}
+    bad = {
+        "schema_version": 2,
+        "builds": [{"parent": 7, "frames": ["/b/00.jpg"], "notes": ""}],
+    }
     with pytest.raises(ValueError, match="schema_version"):
         build_expansion_to_packed.manifest_to_packed(bad)
 
@@ -76,7 +94,10 @@ def test_missing_schema_version_errors(build_expansion_to_packed):
 
 
 def test_non_string_notes_errors(build_expansion_to_packed):
-    bad = {"schema_version": 1, "builds": [{"parent": 7, "frames": ["/b/00.jpg"], "notes": 123}]}
+    bad = {
+        "schema_version": 1,
+        "builds": [{"parent": 7, "frames": ["/b/00.jpg"], "notes": 123}],
+    }
     with pytest.raises(ValueError, match="notes for parent 7 must be a string"):
         build_expansion_to_packed.manifest_to_packed(bad)
 
@@ -102,10 +123,16 @@ def test_non_positive_parent_rejected(build_expansion_to_packed):
 
 def test_unwritable_out_returns_error(build_expansion_to_packed, tmp_path, capsys):
     import json
+
     manifest = tmp_path / "builds.json"
-    manifest.write_text(json.dumps(
-        {"schema_version": 1, "builds": [{"parent": 4, "frames": ["/b/00.jpg"], "notes": ""}]}
-    ))
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "builds": [{"parent": 4, "frames": ["/b/00.jpg"], "notes": ""}],
+            }
+        )
+    )
     out_dir = tmp_path / "outdir"
     out_dir.mkdir()
     rc = build_expansion_to_packed.main([str(manifest), str(out_dir)])

--- a/tests/test_catalog_consumer_integrity.py
+++ b/tests/test_catalog_consumer_integrity.py
@@ -10,7 +10,9 @@ import pytest
 
 
 def _copy_bundled_catalog(return_validation, tmp_path: Path, name: str) -> Path:
-    return Path(shutil.copytree(return_validation.default_catalog_dir(), tmp_path / name))
+    return Path(
+        shutil.copytree(return_validation.default_catalog_dir(), tmp_path / name)
+    )
 
 
 def test_auditor_and_return_validator_share_complete_fingerprint(
@@ -19,12 +21,15 @@ def test_auditor_and_return_validator_share_complete_fingerprint(
     return_validation,
 ):
     baseline_root = _copy_bundled_catalog(
-        return_validation, tmp_path, "baseline-patterns")
+        return_validation, tmp_path, "baseline-patterns"
+    )
     changed_root = _copy_bundled_catalog(
-        return_validation, tmp_path, "changed-patterns")
+        return_validation, tmp_path, "changed-patterns"
+    )
     changed_index = changed_root / "_index.md"
     changed_index.write_bytes(
-        changed_index.read_bytes() + b"\n<!-- fingerprint regression -->\n")
+        changed_index.read_bytes() + b"\n<!-- fingerprint regression -->\n"
+    )
 
     baseline_report = audit_pattern_catalog.audit_catalog(baseline_root)
     changed_report = audit_pattern_catalog.audit_catalog(changed_root)
@@ -59,22 +64,27 @@ def test_duplicate_nested_yaml_key_fails_every_catalog_consumer(
     audit_report = audit_pattern_catalog.audit_catalog(root)
     feedback_path = tmp_path / "return.json"
     feedback_path.write_text(
-        json.dumps({
-            "filename": "talk.md",
-            "status": "processed",
-            "catalog_feedback": {},
-        }),
+        json.dumps(
+            {
+                "filename": "talk.md",
+                "status": "processed",
+                "catalog_feedback": {},
+            }
+        ),
         encoding="utf-8",
     )
     aggregate_report = aggregate_catalog_feedback.aggregate_feedback(
-        [feedback_path], catalog_path=root)
+        [feedback_path], catalog_path=root
+    )
 
     assert audit_report["valid"] is False
     assert "frontmatter_duplicate_key" in {
-        issue["code"] for issue in audit_report["errors"]}
+        issue["code"] for issue in audit_report["errors"]
+    }
     assert aggregate_report["ok"] is False
     assert "catalog_frontmatter_duplicate_key" in {
-        issue["code"] for issue in aggregate_report["catalog"]["errors"]}
+        issue["code"] for issue in aggregate_report["catalog"]["errors"]
+    }
     with pytest.raises(
         return_validation.ReturnValidationError,
         match="duplicate YAML frontmatter keys",

--- a/tests/test_compute_pacing_adherence.py
+++ b/tests/test_compute_pacing_adherence.py
@@ -16,12 +16,15 @@ BUDGETS = [
 
 def _talk(filename, date, slides, dur):
     return {
-        "filename": filename, "date": date,
-        "slide_count": slides, "talk_duration_estimate": dur,
+        "filename": filename,
+        "date": date,
+        "slide_count": slides,
+        "talk_duration_estimate": dur,
     }
 
 
 # ── parse_minutes ────────────────────────────────────────────────────
+
 
 def test_parse_minutes_plain(compute_pacing_adherence):
     assert compute_pacing_adherence.parse_minutes("35 min") == 35
@@ -39,6 +42,7 @@ def test_parse_minutes_unparseable_is_none(compute_pacing_adherence):
 
 
 # ── budget_for ───────────────────────────────────────────────────────
+
 
 def test_budget_band_picks_largest_le(compute_pacing_adherence):
     # 60 min -> 45-min band (largest duration_min <= 60)
@@ -60,10 +64,11 @@ def test_budget_accepts_duration_minutes_key(compute_pacing_adherence):
 
 # ── compute: counts + rate ───────────────────────────────────────────
 
+
 def test_over_budget_count_and_rate(compute_pacing_adherence):
     talks = [
-        _talk("over.md", "2024-01-01", 90, "45 min"),    # 2.0 spm > 1.5 -> over
-        _talk("under.md", "2024-02-01", 60, "45 min"),   # 1.33 spm < 1.5 -> ok
+        _talk("over.md", "2024-01-01", 90, "45 min"),  # 2.0 spm > 1.5 -> over
+        _talk("under.md", "2024-02-01", 60, "45 min"),  # 1.33 spm < 1.5 -> ok
     ]
     out = compute_pacing_adherence.compute({"talks": talks, "slide_budgets": BUDGETS})
     assert out["talks_scored"] == 2
@@ -73,7 +78,7 @@ def test_over_budget_count_and_rate(compute_pacing_adherence):
 
 def test_worst_offenders_sorted_by_over_by_desc(compute_pacing_adherence):
     talks = [
-        _talk("a.md", "2024-01-01", 90, "45 min"),   # 2.0/1.5 -> +33%
+        _talk("a.md", "2024-01-01", 90, "45 min"),  # 2.0/1.5 -> +33%
         _talk("c.md", "2024-02-01", 180, "90 min"),  # 2.0/1.4 -> +43%
     ]
     out = compute_pacing_adherence.compute({"talks": talks, "slide_budgets": BUDGETS})
@@ -103,6 +108,7 @@ def test_unparseable_and_zero_slides_skipped(compute_pacing_adherence):
 
 
 # ── compute: trend ───────────────────────────────────────────────────
+
 
 def test_trend_worsening(compute_pacing_adherence):
     # older two ok, newer two over -> worsening
@@ -139,15 +145,22 @@ def test_trend_stable_when_too_few(compute_pacing_adherence):
 def test_empty_input(compute_pacing_adherence):
     out = compute_pacing_adherence.compute({"talks": [], "slide_budgets": BUDGETS})
     assert out == {
-        "talks_over_budget": 0, "talks_scored": 0, "over_budget_rate": 0.0,
-        "trend": "stable", "worst_offenders": [],
+        "talks_over_budget": 0,
+        "talks_scored": 0,
+        "over_budget_rate": 0.0,
+        "trend": "stable",
+        "worst_offenders": [],
     }
 
 
 # ── main: I/O contract ───────────────────────────────────────────────
 
+
 def test_main_reads_stdin_emits_json(compute_pacing_adherence, monkeypatch, capsys):
-    payload = {"talks": [_talk("o.md", "2024-01-01", 90, "45 min")], "slide_budgets": BUDGETS}
+    payload = {
+        "talks": [_talk("o.md", "2024-01-01", 90, "45 min")],
+        "slide_budgets": BUDGETS,
+    }
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
     rc = compute_pacing_adherence.main()
     out = json.loads(capsys.readouterr().out)

--- a/tests/test_content_only_gate.py
+++ b/tests/test_content_only_gate.py
@@ -18,8 +18,9 @@ GATE = REPO_ROOT / "skills" / "shownotes-publisher" / "scripts" / "content-only-
 
 
 def _git(repo: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(repo), *args], check=True,
-                   capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
 
 
 def _commit(repo: Path, rel: str, body: str = "x\n") -> None:
@@ -34,11 +35,15 @@ def _commit(repo: Path, rel: str, body: str = "x\n") -> None:
 def repo(tmp_path: Path) -> Path:
     """A work repo on `main` tracking a bare origin, seeded and pushed."""
     origin = tmp_path / "origin.git"
-    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)],
-                   check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        check=True,
+        capture_output=True,
+    )
     work = tmp_path / "work"
-    subprocess.run(["git", "clone", str(origin), str(work)],
-                   check=True, capture_output=True)
+    subprocess.run(
+        ["git", "clone", str(origin), str(work)], check=True, capture_output=True
+    )
     _git(work, "config", "user.email", "test@example.com")
     _git(work, "config", "user.name", "Test")
     _commit(work, "seed.txt", "seed\n")
@@ -47,8 +52,9 @@ def repo(tmp_path: Path) -> Path:
 
 
 def _run(target: Path, *extra: str) -> subprocess.CompletedProcess:
-    return subprocess.run(["bash", str(GATE), str(target), *extra],
-                          capture_output=True, text=True)
+    return subprocess.run(
+        ["bash", str(GATE), str(target), *extra], capture_output=True, text=True
+    )
 
 
 def _payload(result: subprocess.CompletedProcess) -> dict:

--- a/tests/test_deck_driver_mirrors.py
+++ b/tests/test_deck_driver_mirrors.py
@@ -13,7 +13,11 @@ Two layers here:
 import os
 
 SCRIPTS_PC = os.path.join(
-    os.path.dirname(__file__), os.pardir, "skills", "presentation-creator", "scripts",
+    os.path.dirname(__file__),
+    os.pardir,
+    "skills",
+    "presentation-creator",
+    "scripts",
 )
 
 
@@ -23,7 +27,7 @@ def _write(p, data: bytes):
 
 
 def test_mirror_then_materialize_roundtrip(sync_deck_drivers, tmp_path):
-    bas = _write(tmp_path / "Foo.bas", b"Attribute VB_Name=\"Foo\"\nSub X()\nEnd Sub\n")
+    bas = _write(tmp_path / "Foo.bas", b'Attribute VB_Name="Foo"\nSub X()\nEnd Sub\n')
     scpt = _write(tmp_path / "do-thing.applescript", b"on run\nreturn 1\nend run\n")
 
     # mirror: real -> .txt
@@ -39,8 +43,12 @@ def test_mirror_then_materialize_roundtrip(sync_deck_drivers, tmp_path):
     # materialize: .txt -> real
     made = sync_deck_drivers.materialize(tmp_path)
     assert {p.name for p in made} == {"Foo.bas", "do-thing.applescript"}
-    assert (tmp_path / "Foo.bas").read_bytes() == (tmp_path / "Foo.bas.txt").read_bytes()
-    assert (tmp_path / "do-thing.applescript").read_bytes() == (tmp_path / "do-thing.applescript.txt").read_bytes()
+    assert (tmp_path / "Foo.bas").read_bytes() == (
+        tmp_path / "Foo.bas.txt"
+    ).read_bytes()
+    assert (tmp_path / "do-thing.applescript").read_bytes() == (
+        tmp_path / "do-thing.applescript.txt"
+    ).read_bytes()
 
 
 def test_materialize_is_create_if_missing_by_default(sync_deck_drivers, tmp_path):
@@ -61,7 +69,7 @@ def test_materialize_force_overwrites(sync_deck_drivers, tmp_path):
 
 
 def test_check_flags_missing_and_drifted_mirrors(sync_deck_drivers, tmp_path):
-    _write(tmp_path / "A.bas", b"aaa")               # mirror missing
+    _write(tmp_path / "A.bas", b"aaa")  # mirror missing
     _write(tmp_path / "B.applescript", b"bbb")
     _write(tmp_path / "B.applescript.txt", b"DIFFERENT")  # drifted
     problems = sync_deck_drivers.check(tmp_path)
@@ -89,5 +97,6 @@ def test_committed_repo_mirrors_are_in_sync(sync_deck_drivers):
     `sync-deck-drivers.py mirror` — the install-restore would ship a stale driver.
     """
     from pathlib import Path
+
     problems = sync_deck_drivers.check(Path(SCRIPTS_PC).resolve())
     assert problems == [], "deck-driver mirror drift:\n" + "\n".join(problems)

--- a/tests/test_extract_resources.py
+++ b/tests/test_extract_resources.py
@@ -22,16 +22,26 @@ def _outline_with(outline_schema, base, mutator):
 
 
 def test_extracts_url_from_text_overlay(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0].__setitem__("text_overlay", "Visit https://example.com/intro"))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0].__setitem__(
+            "text_overlay", "Visit https://example.com/intro"
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     urls = extract_resources.extract_urls(parsed)
     assert any(r["value"] == "https://example.com/intro" for r in urls)
 
 
 def test_extracts_url_from_script_line(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0]["script"].append({"line": "See https://example.com/docs"}))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0]["script"].append(
+            {"line": "See https://example.com/docs"}
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     urls = extract_resources.extract_urls(parsed)
     assert any(r["value"] == "https://example.com/docs" for r in urls)
@@ -39,9 +49,13 @@ def test_extracts_url_from_script_line(extract_resources, outline_schema, base_d
 
 def test_excludes_url_from_image_prompt(extract_resources, outline_schema, base_data):
     """Image prompts are excluded — generation prompts often have incidental URLs."""
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0].__setitem__("image_prompt",
-                                    "[STYLE ANCHOR]. See https://nope.example.com"))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0].__setitem__(
+            "image_prompt", "[STYLE ANCHOR]. See https://nope.example.com"
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     urls = extract_resources.extract_urls(parsed)
     assert not any("nope.example.com" in r["value"] for r in urls)
@@ -51,6 +65,7 @@ def test_url_dedup(extract_resources, outline_schema, base_data):
     def mutate(d):
         d["slides"][0]["text_overlay"] = "https://example.com/intro"
         d["slides"][1]["text_overlay"] = "Also https://example.com/intro"
+
     o = _outline_with(outline_schema, base_data, mutate)
     parsed = extract_resources.parse_outline_yaml(o)
     urls = extract_resources.extract_urls(parsed)
@@ -59,35 +74,52 @@ def test_url_dedup(extract_resources, outline_schema, base_data):
 
 
 def test_extracts_github_repo(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0]["script"].append(
-            {"line": "Code: github.com/hashicorp/terraform"}))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0]["script"].append(
+            {"line": "Code: github.com/hashicorp/terraform"}
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     repos = extract_resources.extract_repos(parsed)
     assert any("hashicorp/terraform" in r["value"] for r in repos)
 
 
 def test_extracts_book(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0]["script"].append(
-            {"line": '"Design Patterns" by Erich Gamma is the classic.'}))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0]["script"].append(
+            {"line": '"Design Patterns" by Erich Gamma is the classic.'}
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     books = extract_resources.extract_books(parsed)
     assert any(r["value"] == "Design Patterns" for r in books)
 
 
 def test_extracts_rfc(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0]["script"].append({"line": "Reference: RFC 7231 for HTTP semantics."}))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0]["script"].append(
+            {"line": "Reference: RFC 7231 for HTTP semantics."}
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     rfcs = extract_resources.extract_rfcs(parsed)
     assert any(r["value"] == "RFC 7231" for r in rfcs)
 
 
 def test_extracts_tool_from_speaker_notes(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0]["script"].append(
-            {"line": "We use `Kubernetes` and `Prometheus` for ops."}))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0]["script"].append(
+            {"line": "We use `Kubernetes` and `Prometheus` for ops."}
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     tools = extract_resources.extract_tools(parsed)
     values = [r["value"] for r in tools]
@@ -95,9 +127,14 @@ def test_extracts_tool_from_speaker_notes(extract_resources, outline_schema, bas
     assert "Prometheus" in values
 
 
-def test_slide_context_carries_chapter_title(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["slides"][0].__setitem__("text_overlay", "https://example.com/x"))
+def test_slide_context_carries_chapter_title(
+    extract_resources, outline_schema, base_data
+):
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["slides"][0].__setitem__("text_overlay", "https://example.com/x"),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     urls = extract_resources.extract_urls(parsed)
     first = next(r for r in urls if r["value"] == "https://example.com/x")
@@ -107,10 +144,17 @@ def test_slide_context_carries_chapter_title(extract_resources, outline_schema, 
 
 
 def test_url_in_thesis_has_no_slide_num(extract_resources, outline_schema, base_data):
-    o = _outline_with(outline_schema, base_data, lambda d:
-        d["talk"].__setitem__("thesis", "See https://example.com/thesis-link"))
+    o = _outline_with(
+        outline_schema,
+        base_data,
+        lambda d: d["talk"].__setitem__(
+            "thesis", "See https://example.com/thesis-link"
+        ),
+    )
     parsed = extract_resources.parse_outline_yaml(o)
     urls = extract_resources.extract_urls(parsed)
-    thesis_url = next(r for r in urls if r["value"] == "https://example.com/thesis-link")
+    thesis_url = next(
+        r for r in urls if r["value"] == "https://example.com/thesis-link"
+    )
     assert thesis_url["slide_nums"] == []
     assert thesis_url["context"] == "preamble"

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -151,16 +151,18 @@ def test_slides_omits_interludes(extract_slides, outline_schema):
     import yaml as _yaml
 
     data = _yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
-    data["interludes"] = [{
-        "id": "demo-test-only",
-        "after_slide": 1,
-        "chapter": "ch1",
-        "title": "DEMO TEST — Should Not Appear In slides.md",
-        "script": [
-            {"cue": "TERMINAL UP"},
-            {"line": "This line should only appear in script.md."},
-        ],
-    }]
+    data["interludes"] = [
+        {
+            "id": "demo-test-only",
+            "after_slide": 1,
+            "chapter": "ch1",
+            "title": "DEMO TEST — Should Not Appear In slides.md",
+            "script": [
+                {"cue": "TERMINAL UP"},
+                {"line": "This line should only appear in script.md."},
+            ],
+        }
+    ]
     outline_with_interlude = outline_schema.Outline.model_validate(data)
     out = extract_slides.render(outline_with_interlude)
     assert "demo-test-only" not in out
@@ -177,16 +179,18 @@ def test_script_interleaves_interludes_after_anchor(extract_script, outline_sche
     import yaml
 
     data = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
-    data["interludes"] = [{
-        "id": "demo-X",
-        "after_slide": 1,
-        "chapter": "ch1",
-        "title": "DEMO X — Live Terminal",
-        "script": [
-            {"cue": "TERMINAL UP"},
-            {"line": "Watch this."},
-        ],
-    }]
+    data["interludes"] = [
+        {
+            "id": "demo-X",
+            "after_slide": 1,
+            "chapter": "ch1",
+            "title": "DEMO X — Live Terminal",
+            "script": [
+                {"cue": "TERMINAL UP"},
+                {"line": "Watch this."},
+            ],
+        }
+    ]
     outline_with_interlude = outline_schema.Outline.model_validate(data)
     out = extract_script.render(outline_with_interlude)
 

--- a/tests/test_failure_diagnostics.py
+++ b/tests/test_failure_diagnostics.py
@@ -23,8 +23,7 @@ def _raised(exc):
     return excinfo.value
 
 
-def test_sanitized_frames_report_location_without_paths_or_text(
-        failure_diagnostics):
+def test_sanitized_frames_report_location_without_paths_or_text(failure_diagnostics):
     """`no-secrets` forbids exception text; the frames replace it."""
     caught = _raised(RuntimeError("token=SECRET at /private/vault/creds.json"))
 
@@ -33,12 +32,11 @@ def test_sanitized_frames_report_location_without_paths_or_text(
     assert frames, "the failing code location must be reported"
     for frame in frames:
         assert ":" in frame and " in " in frame
-        assert "/" not in frame          # basename only, never a host path
+        assert "/" not in frame  # basename only, never a host path
         assert "SECRET" not in frame
 
 
-def test_failure_document_carries_the_type_but_never_the_message(
-        failure_diagnostics):
+def test_failure_document_carries_the_type_but_never_the_message(failure_diagnostics):
     """The type says which failure it was; the message would say where."""
     caught = _raised(FileNotFoundError(2, "No such file", "/private/vault/db.json"))
 
@@ -74,9 +72,7 @@ def test_state_adds_fields_beside_the_identity(failure_diagnostics):
         state={"analyses_written": False},
     )
 
-    assert set(document) == {
-        "error", "error_type", "origin", "analyses_written"
-    }
+    assert set(document) == {"error", "error_type", "origin", "analyses_written"}
 
 
 def test_state_cannot_overwrite_the_error_identity(failure_diagnostics):
@@ -103,13 +99,10 @@ def test_state_cannot_overwrite_the_error_identity(failure_diagnostics):
     assert document["error_type"] == "RuntimeError"
     assert document["origin"] != ["forged.py:1 in nowhere"]
     assert document["database_written"] is True, "non-identity state survives"
-    assert failure_diagnostics.IDENTITY_FIELDS == {
-        "error", "error_type", "origin"
-    }
+    assert failure_diagnostics.IDENTITY_FIELDS == {"error", "error_type", "origin"}
 
 
-def test_emitted_failure_is_one_json_document_then_a_recovery_note(
-        failure_diagnostics):
+def test_emitted_failure_is_one_json_document_then_a_recovery_note(failure_diagnostics):
     """Callers parse line one; a human reads the rest."""
     caught = _raised(RuntimeError("boom at /private/vault/db.json"))
     stream = io.StringIO()
@@ -136,7 +129,10 @@ def test_emitted_document_is_key_ordered_for_stable_diffs(failure_diagnostics):
     stream = io.StringIO()
 
     failure_diagnostics.emit_unexpected_failure(
-        caught, "example_unexpected_failure", "retry", state={"z": 1, "a": 2},
+        caught,
+        "example_unexpected_failure",
+        "retry",
+        state={"z": 1, "a": 2},
         stream=stream,
     )
 

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -17,9 +17,16 @@ FIXTURE = Path(__file__).parent / "fixtures" / "outline-example.yaml"
 _FIXTURE_DATA = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
 
 
-def _write_outline(tmp_path, *, slides, model: str | None = "imagen-4",
-                   composition=None, embedded_footer=None, text_treatment=None,
-                   name="outline.yaml"):
+def _write_outline(
+    tmp_path,
+    *,
+    slides,
+    model: str | None = "imagen-4",
+    composition=None,
+    embedded_footer=None,
+    text_treatment=None,
+    name="outline.yaml",
+):
     """Write a minimal valid outline.yaml (partial view) for parser tests.
 
     Reuses the canonical fixture's talk block, then sets the style anchor and
@@ -122,10 +129,14 @@ def test_parse_builds_maps_erase_and_is_full(generate_illustrations, tmp_path):
 def _single_build_slide(steps):
     return {
         "model": "gemini-3-pro-image",
-        "slides": [{
-            "slide_num": 60, "title": "Trials", "format": "WIDE",
-            "builds": {"count": len(steps), "steps": steps},
-        }],
+        "slides": [
+            {
+                "slide_num": 60,
+                "title": "Trials",
+                "format": "WIDE",
+                "builds": {"count": len(steps), "steps": steps},
+            }
+        ],
     }
 
 
@@ -137,9 +148,12 @@ def _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls):
     monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
     # Render-before-bake gate passes by default here; the gate-fail test overrides it.
-    monkeypatch.setattr(gi, "check_style_explore", lambda p: {"gate_passed": True, "error": ""})
     monkeypatch.setattr(
-        gi, "edit_image",
+        gi, "check_style_explore", lambda p: {"gate_passed": True, "error": ""}
+    )
+    monkeypatch.setattr(
+        gi,
+        "edit_image",
         lambda *a, **k: (edit_calls.append(a), (b"x", "image/png"))[1],
     )
 
@@ -150,10 +164,16 @@ def test_run_build_missing_keep_exits_nonzero_without_editing(
     # Outcome: an erase step with no Keep clause skips the slide *before* any
     # edit API call and exits non-zero so `--build all` automation can detect it.
     gi = generate_illustrations
-    outline = _single_build_slide([
-        {"step": 0, "description": "Panel 1 revealed -- sergeant", "is_full": False},
-        {"step": 1, "description": "[FULL] all panels", "is_full": True},
-    ])
+    outline = _single_build_slide(
+        [
+            {
+                "step": 0,
+                "description": "Panel 1 revealed -- sergeant",
+                "is_full": False,
+            },
+            {"step": 1, "description": "[FULL] all panels", "is_full": True},
+        ]
+    )
     edit_calls = []
     _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls)
 
@@ -176,10 +196,16 @@ def test_run_build_negated_keep_is_not_a_preservation_clause(
     # skipped (exit 1, no edit) exactly like a bare description, so the bare
     # `keep` token can't satisfy the rule.
     gi = generate_illustrations
-    outline = _single_build_slide([
-        {"step": 0, "description": "Erase Panel 1. Do not keep the old stamp.", "is_full": False},
-        {"step": 1, "description": "[FULL] all panels", "is_full": True},
-    ])
+    outline = _single_build_slide(
+        [
+            {
+                "step": 0,
+                "description": "Erase Panel 1. Do not keep the old stamp.",
+                "is_full": False,
+            },
+            {"step": 1, "description": "[FULL] all panels", "is_full": True},
+        ]
+    )
     edit_calls = []
     _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls)
 
@@ -196,10 +222,16 @@ def test_run_build_with_keep_clause_runs_chain(
     # Outcome: a compliant erase step runs the edit chain. Uppercase KEEP also
     # proves the clause check is case-insensitive at the behavior level.
     gi = generate_illustrations
-    outline = _single_build_slide([
-        {"step": 0, "description": "Erase Panel 1. KEEP the page chrome.", "is_full": False},
-        {"step": 1, "description": "[FULL] all panels", "is_full": True},
-    ])
+    outline = _single_build_slide(
+        [
+            {
+                "step": 0,
+                "description": "Erase Panel 1. KEEP the page chrome.",
+                "is_full": False,
+            },
+            {"step": 1, "description": "[FULL] all panels", "is_full": True},
+        ]
+    )
     edit_calls = []
     _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls)
 
@@ -215,13 +247,23 @@ def test_run_build_forwards_erase_region_to_edit(
     # kwarg so the masked/composited path engages; a step without one forwards
     # None (historical whole-frame edit).
     gi = generate_illustrations
-    outline = _single_build_slide([
-        {"step": 0, "description": "Erase Panel 0. Keep the chrome.",
-         "is_full": False, "erase_region": None},
-        {"step": 1, "description": "Erase Panel 1. Keep the chrome.",
-         "is_full": False, "erase_region": [0.1, 0.2, 0.5, 0.8]},
-        {"step": 2, "description": "[FULL] all panels", "is_full": True},
-    ])
+    outline = _single_build_slide(
+        [
+            {
+                "step": 0,
+                "description": "Erase Panel 0. Keep the chrome.",
+                "is_full": False,
+                "erase_region": None,
+            },
+            {
+                "step": 1,
+                "description": "Erase Panel 1. Keep the chrome.",
+                "is_full": False,
+                "erase_region": [0.1, 0.2, 0.5, 0.8],
+            },
+            {"step": 2, "description": "[FULL] all panels", "is_full": True},
+        ]
+    )
     base = tmp_path / "slide-60.png"
     base.write_bytes(b"img")
     calls = []
@@ -229,9 +271,12 @@ def test_run_build_forwards_erase_region_to_edit(
     monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
     monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
-    monkeypatch.setattr(gi, "check_style_explore", lambda p: {"gate_passed": True, "error": ""})
     monkeypatch.setattr(
-        gi, "edit_image",
+        gi, "check_style_explore", lambda p: {"gate_passed": True, "error": ""}
+    )
+    monkeypatch.setattr(
+        gi,
+        "edit_image",
         lambda *a, **k: (calls.append(k.get("erase_region")), (b"x", "image/png"))[1],
     )
 
@@ -250,15 +295,23 @@ def test_run_build_exits_nonzero_when_edit_fails(
     gi = generate_illustrations
     base = tmp_path / "slide-60.png"
     base.write_bytes(b"img")
-    outline = _single_build_slide([
-        {"step": 0, "description": "Erase Panel 1. Keep the page chrome.", "is_full": False},
-        {"step": 1, "description": "[FULL] all panels", "is_full": True},
-    ])
+    outline = _single_build_slide(
+        [
+            {
+                "step": 0,
+                "description": "Erase Panel 1. Keep the page chrome.",
+                "is_full": False,
+            },
+            {"step": 1, "description": "[FULL] all panels", "is_full": True},
+        ]
+    )
     monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline, str(tmp_path)))
     monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
     monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
-    monkeypatch.setattr(gi, "check_style_explore", lambda p: {"gate_passed": True, "error": ""})
+    monkeypatch.setattr(
+        gi, "check_style_explore", lambda p: {"gate_passed": True, "error": ""}
+    )
     monkeypatch.setattr(gi, "edit_image", lambda *a, **k: (None, "api boom"))
 
     with pytest.raises(SystemExit) as exc:
@@ -279,16 +332,26 @@ def test_run_build_refuses_when_render_gate_fails(
     # an unrendered baked model can't produce build frames either. Refuse before
     # spending any edit API call.
     gi = generate_illustrations
-    outline = _single_build_slide([
-        {"step": 0, "description": "Erase Panel 1. Keep the chrome.", "is_full": False},
-        {"step": 1, "description": "[FULL] all panels", "is_full": True},
-    ])
+    outline = _single_build_slide(
+        [
+            {
+                "step": 0,
+                "description": "Erase Panel 1. Keep the chrome.",
+                "is_full": False,
+            },
+            {"step": 1, "description": "[FULL] all panels", "is_full": True},
+        ]
+    )
     edit_calls = []
     _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls)
     # gate fails (baked model never rendered / manifest missing)
     monkeypatch.setattr(
-        gi, "check_style_explore",
-        lambda p: {"gate_passed": False, "error": "model 'x' was never rendered in a grid"},
+        gi,
+        "check_style_explore",
+        lambda p: {
+            "gate_passed": False,
+            "error": "model 'x' was never rendered in a grid",
+        },
     )
 
     with pytest.raises(SystemExit) as exc:
@@ -321,19 +384,25 @@ def test_resolve_prompt_missing_anchor(generate_illustrations):
 
 def test_slide_selection_all(generate_illustrations, tmp_path):
     slides = [{"slide_num": 2}, {"slide_num": 5}, {"slide_num": 9}]
-    result = generate_illustrations.parse_slide_selection(["all"], slides, str(tmp_path))
+    result = generate_illustrations.parse_slide_selection(
+        ["all"], slides, str(tmp_path)
+    )
     assert result == [2, 5, 9]
 
 
 def test_slide_selection_explicit(generate_illustrations, tmp_path):
     slides = [{"slide_num": 2}, {"slide_num": 5}, {"slide_num": 9}]
-    result = generate_illustrations.parse_slide_selection(["2", "9"], slides, str(tmp_path))
+    result = generate_illustrations.parse_slide_selection(
+        ["2", "9"], slides, str(tmp_path)
+    )
     assert result == [2, 9]
 
 
 def test_slide_selection_range(generate_illustrations, tmp_path):
     slides = [{"slide_num": n} for n in range(1, 11)]
-    result = generate_illustrations.parse_slide_selection(["2-5"], slides, str(tmp_path))
+    result = generate_illustrations.parse_slide_selection(
+        ["2-5"], slides, str(tmp_path)
+    )
     assert result == [2, 3, 4, 5]
 
 
@@ -341,7 +410,9 @@ def test_slide_selection_remaining(generate_illustrations, tmp_path):
     slides = [{"slide_num": 2}, {"slide_num": 5}, {"slide_num": 9}]
     # Create a fake existing image for slide 5
     (tmp_path / "slide-05.png").write_bytes(b"fake")
-    result = generate_illustrations.parse_slide_selection(["remaining"], slides, str(tmp_path))
+    result = generate_illustrations.parse_slide_selection(
+        ["remaining"], slides, str(tmp_path)
+    )
     assert 5 not in result
     assert 2 in result
     assert 9 in result
@@ -369,11 +440,20 @@ def test_mime_ext_roundtrip(generate_illustrations):
 
 
 def test_parse_safe_zone(generate_illustrations, tmp_path):
-    outline = _write_outline(tmp_path, model="gemini-3-pro-image", slides=[
-        {"n": 3, "chapter": "c", "title": "The Question", "format": "FULL",
-         "image_prompt": "[STYLE ANCHOR] A confused developer",
-         "safe_zone": {"zone": "upper_third", "surface": "painted sky"}},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 3,
+                "chapter": "c",
+                "title": "The Question",
+                "format": "FULL",
+                "image_prompt": "[STYLE ANCHOR] A confused developer",
+                "safe_zone": {"zone": "upper_third", "surface": "painted sky"},
+            },
+        ],
+    )
     result = generate_illustrations.parse_outline(str(outline))
     slide3 = next(s for s in result["slides"] if s["slide_num"] == 3)
     assert "safe_zone" in slide3
@@ -382,10 +462,19 @@ def test_parse_safe_zone(generate_illustrations, tmp_path):
 
 
 def test_parse_no_safe_zone(generate_illustrations, tmp_path):
-    outline = _write_outline(tmp_path, model="gemini-3-pro-image", slides=[
-        {"n": 7, "chapter": "c", "title": "No Zone", "format": "FULL",
-         "image_prompt": "A terminal output"},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 7,
+                "chapter": "c",
+                "title": "No Zone",
+                "format": "FULL",
+                "image_prompt": "A terminal output",
+            },
+        ],
+    )
     result = generate_illustrations.parse_outline(str(outline))
     slide7 = next(s for s in result["slides"] if s["slide_num"] == 7)
     assert "safe_zone" not in slide7
@@ -445,8 +534,8 @@ def test_apply_compose_only_preserves_caller_text_with_phrase(generate_illustrat
     gi = generate_illustrations
     prompt = "A lab. COMPOSE ONLY THE SCENE as the author noted. TITLE SAFE ZONE -- reserve the top."
     result = gi.apply_compose_only_directive(prompt)
-    assert result.startswith(prompt)            # nothing dropped
-    assert "TITLE SAFE ZONE" in result          # prior directive survives
+    assert result.startswith(prompt)  # nothing dropped
+    assert "TITLE SAFE ZONE" in result  # prior directive survives
     assert result.endswith(gi.COMPOSE_ONLY_DIRECTIVE)
 
 
@@ -470,13 +559,16 @@ def test_effective_slide_format_safe_zone_wins(generate_illustrations):
 
 # --- Model family dispatch ---
 
+
 def test_model_family_openai(generate_illustrations):
     assert generate_illustrations.model_family("gpt-image-2") == "openai"
     assert generate_illustrations.model_family("gpt-image-1") == "openai"
 
 
 def test_model_family_imagen(generate_illustrations):
-    assert generate_illustrations.model_family("imagen-4.0-ultra-generate-001") == "imagen"
+    assert (
+        generate_illustrations.model_family("imagen-4.0-ultra-generate-001") == "imagen"
+    )
     assert generate_illustrations.model_family("imagen-3.0-generate-002") == "imagen"
 
 
@@ -497,8 +589,10 @@ def test_family_key_name(generate_illustrations):
 def test_compare_models_curated_list(generate_illustrations):
     # COMPARE_MODELS is re-exported from model_registry.py — it must still
     # carry at least one current-flagship entry per major vendor.
-    families = {generate_illustrations.model_family(m)
-                for m in generate_illustrations.COMPARE_MODELS}
+    families = {
+        generate_illustrations.model_family(m)
+        for m in generate_illustrations.COMPARE_MODELS
+    }
     assert "openai" in families, "COMPARE_MODELS missing OpenAI entry"
     assert "gemini" in families, "COMPARE_MODELS missing Gemini entry"
     assert "imagen" in families, "COMPARE_MODELS missing Imagen entry"
@@ -507,12 +601,19 @@ def test_compare_models_curated_list(generate_illustrations):
 def test_resolve_model_id_reexported(generate_illustrations):
     # generate-illustrations.py dispatches through resolve_model_id so a baked
     # codename (nano-banana-pro) reaches the canonical API endpoint id.
-    assert generate_illustrations.resolve_model_id("nano-banana-pro") == "gemini-3-pro-image"
+    assert (
+        generate_illustrations.resolve_model_id("nano-banana-pro")
+        == "gemini-3-pro-image"
+    )
     # The deprecated preview id is kept as an alias resolving to the GA canonical.
-    assert generate_illustrations.resolve_model_id("gemini-3-pro-image-preview") == "gemini-3-pro-image"
+    assert (
+        generate_illustrations.resolve_model_id("gemini-3-pro-image-preview")
+        == "gemini-3-pro-image"
+    )
 
 
 # --- Secrets loading ---
+
 
 def test_load_secrets_from_file(generate_illustrations, tmp_path, monkeypatch):
     secrets = {"gemini": {"api_key": "g-key"}, "openai": {"api_key": "o-key"}}
@@ -536,7 +637,9 @@ def test_load_secrets_env_fallback(generate_illustrations, tmp_path, monkeypatch
     assert keys["openai"] == "env-o"
 
 
-def test_load_secrets_malformed_json_warns(generate_illustrations, tmp_path, monkeypatch, capsys):
+def test_load_secrets_malformed_json_warns(
+    generate_illustrations, tmp_path, monkeypatch, capsys
+):
     # Malformed secrets.json must not crash — load_secrets warns to stderr
     # and falls through to env-var resolution
     (tmp_path / "secrets.json").write_text("{not valid json")
@@ -598,22 +701,37 @@ def test_load_secrets_timeout_warns_and_falls_back(
 
     keys, _ = gi.load_secrets(str(tmp_path))
     err = capsys.readouterr().err
-    assert keys["gemini"] == "env-g"   # fell back to env
+    assert keys["gemini"] == "env-g"  # fell back to env
     assert keys["openai"] is None
     assert "timed out" in err and "secrets.json" in err
 
 
 # --- Multipart body for OpenAI edits ---
 
+
 def test_parse_outline_handles_img_plus_txt_format(generate_illustrations, tmp_path):
     # The IMG+TXT portrait format must survive the round-trip: it keys the
     # anchor map and drives 2:3 sizing in the cross-vendor dispatchers.
-    outline = _write_outline(tmp_path, model="gpt-image-2", slides=[
-        {"n": 3, "chapter": "c", "title": "A wide slide", "format": "FULL",
-         "image_prompt": "[STYLE ANCHOR] something wide"},
-        {"n": 7, "chapter": "c", "title": "A portrait slide", "format": "IMG+TXT",
-         "image_prompt": "[STYLE ANCHOR] something tall"},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        model="gpt-image-2",
+        slides=[
+            {
+                "n": 3,
+                "chapter": "c",
+                "title": "A wide slide",
+                "format": "FULL",
+                "image_prompt": "[STYLE ANCHOR] something wide",
+            },
+            {
+                "n": 7,
+                "chapter": "c",
+                "title": "A portrait slide",
+                "format": "IMG+TXT",
+                "image_prompt": "[STYLE ANCHOR] something tall",
+            },
+        ],
+    )
     result = generate_illustrations.parse_outline(str(outline))
 
     assert "FULL" in result["anchors"]
@@ -667,10 +785,20 @@ def test_parse_empty_builds_list_yields_no_builds_key(generate_illustrations, tm
     # must omit the "builds" key entirely (the schema forbids a count without
     # contiguous steps, so the old "declared N steps, zero entries" markdown
     # failure mode can no longer occur).
-    outline = _write_outline(tmp_path, model="gemini-3-pro-image", slides=[
-        {"n": 4, "chapter": "c", "title": "Empty builds", "format": "FULL",
-         "image_prompt": "[STYLE ANCHOR] something", "builds": []},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 4,
+                "chapter": "c",
+                "title": "Empty builds",
+                "format": "FULL",
+                "image_prompt": "[STYLE ANCHOR] something",
+                "builds": [],
+            },
+        ],
+    )
     result = generate_illustrations.parse_outline(str(outline))
     slide4 = next(s for s in result["slides"] if s["slide_num"] == 4)
     assert "builds" not in slide4
@@ -698,16 +826,27 @@ def test_multipart_body_structure(generate_illustrations):
 
 # --- Style exploration (Phase 2 strategy grid) ---
 
+
 def _candidates(**overrides):
     base = {
         "schema_version": 1,
         "slides": {"FULL": 3, "IMG+TXT": 7},
         "models": ["gemini-3-pro-image", "gpt-image-2"],
         "styles": [
-            {"name": "Blueprint Schematic",
-             "anchors": {"FULL": "A blueprint anchor.", "IMG+TXT": "A portrait blueprint anchor."}},
-            {"name": "Watercolor",
-             "anchors": {"FULL": "A watercolor anchor.", "IMG+TXT": "A portrait watercolor anchor."}},
+            {
+                "name": "Blueprint Schematic",
+                "anchors": {
+                    "FULL": "A blueprint anchor.",
+                    "IMG+TXT": "A portrait blueprint anchor.",
+                },
+            },
+            {
+                "name": "Watercolor",
+                "anchors": {
+                    "FULL": "A watercolor anchor.",
+                    "IMG+TXT": "A portrait watercolor anchor.",
+                },
+            },
         ],
     }
     base.update(overrides)
@@ -721,7 +860,10 @@ def _write_candidates(tmp_path, data):
 
 
 def test_style_slug(generate_illustrations):
-    assert generate_illustrations.style_slug("Blueprint Schematic!") == "blueprint-schematic"
+    assert (
+        generate_illustrations.style_slug("Blueprint Schematic!")
+        == "blueprint-schematic"
+    )
     assert generate_illustrations.style_slug("  Mixed_Case 2 ") == "mixed-case-2"
     assert generate_illustrations.style_slug("///") == "style"
 
@@ -739,7 +881,9 @@ def test_explore_dest_path(generate_illustrations):
 
 
 def test_explore_dest_sanitizes_model_slash(generate_illustrations):
-    dest = generate_illustrations.explore_dest("/base", "S", "FULL", "vendor/model", ".jpg")
+    dest = generate_illustrations.explore_dest(
+        "/base", "S", "FULL", "vendor/model", ".jpg"
+    )
     assert dest.endswith("vendor_model.jpg")
 
 
@@ -752,6 +896,7 @@ def test_parse_candidates_valid(generate_illustrations, tmp_path):
 
 def test_parse_candidates_bad_version(generate_illustrations, tmp_path):
     import pytest
+
     path = _write_candidates(tmp_path, _candidates(schema_version=2))
     with pytest.raises(ValueError) as exc:
         generate_illustrations.parse_candidates(path)
@@ -760,6 +905,7 @@ def test_parse_candidates_bad_version(generate_illustrations, tmp_path):
 
 def test_parse_candidates_missing_models(generate_illustrations, tmp_path):
     import pytest
+
     path = _write_candidates(tmp_path, _candidates(models=[]))
     with pytest.raises(ValueError) as exc:
         generate_illustrations.parse_candidates(path)
@@ -768,6 +914,7 @@ def test_parse_candidates_missing_models(generate_illustrations, tmp_path):
 
 def test_parse_candidates_style_without_anchors(generate_illustrations, tmp_path):
     import pytest
+
     bad = _candidates(styles=[{"name": "No Anchors"}])
     path = _write_candidates(tmp_path, bad)
     with pytest.raises(ValueError) as exc:
@@ -777,6 +924,7 @@ def test_parse_candidates_style_without_anchors(generate_illustrations, tmp_path
 
 def test_parse_candidates_non_string_model_rejected(generate_illustrations, tmp_path):
     import pytest
+
     path = _write_candidates(tmp_path, _candidates(models=["gpt-image-2", 7]))
     with pytest.raises(ValueError) as exc:
         generate_illustrations.parse_candidates(path)
@@ -791,6 +939,7 @@ def test_parse_candidates_strips_model_whitespace(generate_illustrations, tmp_pa
 
 def test_parse_candidates_blank_anchor_rejected(generate_illustrations, tmp_path):
     import pytest
+
     bad = _candidates(styles=[{"name": "S", "anchors": {"FULL": "   "}}])
     path = _write_candidates(tmp_path, bad)
     with pytest.raises(ValueError) as exc:
@@ -800,6 +949,7 @@ def test_parse_candidates_blank_anchor_rejected(generate_illustrations, tmp_path
 
 def test_parse_candidates_non_string_name_rejected(generate_illustrations, tmp_path):
     import pytest
+
     bad = _candidates(styles=[{"name": 42, "anchors": {"FULL": "x"}}])
     path = _write_candidates(tmp_path, bad)
     with pytest.raises(ValueError) as exc:
@@ -807,8 +957,11 @@ def test_parse_candidates_non_string_name_rejected(generate_illustrations, tmp_p
     assert "non-empty string 'name'" in str(exc.value)
 
 
-def test_parse_candidates_string_slide_number_rejected(generate_illustrations, tmp_path):
+def test_parse_candidates_string_slide_number_rejected(
+    generate_illustrations, tmp_path
+):
     import pytest
+
     # A string slide number would key slides_by_num by the wrong type and
     # silently skip the format — reject it up front with an actionable message.
     path = _write_candidates(tmp_path, _candidates(slides={"FULL": "7"}))
@@ -819,6 +972,7 @@ def test_parse_candidates_string_slide_number_rejected(generate_illustrations, t
 
 def test_parse_candidates_malformed_json(generate_illustrations, tmp_path):
     import pytest
+
     p = tmp_path / "candidates.json"
     p.write_text("{not json")
     with pytest.raises(ValueError) as exc:
@@ -826,8 +980,11 @@ def test_parse_candidates_malformed_json(generate_illustrations, tmp_path):
     assert "valid JSON" in str(exc.value)
 
 
-def test_run_style_explore_missing_candidates_exits_cleanly(generate_illustrations, tmp_path, capsys):
+def test_run_style_explore_missing_candidates_exits_cleanly(
+    generate_illustrations, tmp_path, capsys
+):
     import pytest
+
     # A missing candidates file must produce an actionable stderr error + a
     # non-zero exit, not a FileNotFoundError traceback.
     with pytest.raises(SystemExit) as exc:
@@ -838,8 +995,11 @@ def test_run_style_explore_missing_candidates_exits_cleanly(generate_illustratio
     assert "candidates file not found" in capsys.readouterr().err
 
 
-def test_run_style_explore_bad_candidates_exits_cleanly(generate_illustrations, tmp_path, capsys):
+def test_run_style_explore_bad_candidates_exits_cleanly(
+    generate_illustrations, tmp_path, capsys
+):
     import pytest
+
     # A malformed candidates file surfaces the ValueError as a clean stderr
     # message + non-zero exit, not a traceback.
     p = tmp_path / "candidates.json"
@@ -851,16 +1011,28 @@ def test_run_style_explore_bad_candidates_exits_cleanly(generate_illustrations, 
     assert "ERROR" in err and "schema_version" in err
 
 
-def test_run_style_explore_empty_plan_exits_cleanly(generate_illustrations, tmp_path, monkeypatch, capsys):
+def test_run_style_explore_empty_plan_exits_cleanly(
+    generate_illustrations, tmp_path, monkeypatch, capsys
+):
     import pytest
+
     # A schema-valid candidate set whose styles cover none of the selected
     # formats yields zero renders — exit non-zero before writing an empty
     # index.md, rather than succeeding with an empty contact sheet.
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")
-    outline = _write_outline(tmp_path, model="gemini-3-pro-image", slides=[
-        {"n": 3, "chapter": "c", "title": "Wide", "format": "FULL",
-         "image_prompt": "[STYLE ANCHOR] wide"},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 3,
+                "chapter": "c",
+                "title": "Wide",
+                "format": "FULL",
+                "image_prompt": "[STYLE ANCHOR] wide",
+            },
+        ],
+    )
     cand = _candidates(
         slides={"FULL": 3},
         models=["gemini-3-pro-image"],
@@ -873,15 +1045,27 @@ def test_run_style_explore_empty_plan_exits_cleanly(generate_illustrations, tmp_
     assert "nothing to render" in capsys.readouterr().err
 
 
-def test_run_style_explore_unsupported_model_exits(generate_illustrations, tmp_path, monkeypatch, capsys):
+def test_run_style_explore_unsupported_model_exits(
+    generate_illustrations, tmp_path, monkeypatch, capsys
+):
     import pytest
+
     # A candidate model with no vendor adapter must fail fast with an actionable
     # stderr message, not get misrouted to the Gemini endpoint.
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")
-    outline = _write_outline(tmp_path, model="gemini-3-pro-image", slides=[
-        {"n": 3, "chapter": "c", "title": "Wide", "format": "FULL",
-         "image_prompt": "[STYLE ANCHOR] wide"},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 3,
+                "chapter": "c",
+                "title": "Wide",
+                "format": "FULL",
+                "image_prompt": "[STYLE ANCHOR] wide",
+            },
+        ],
+    )
     cand = _candidates(
         slides={"FULL": 3},
         models=["midjourney-v7"],
@@ -895,17 +1079,29 @@ def test_run_style_explore_unsupported_model_exits(generate_illustrations, tmp_p
     assert "unsupported model" in err and "midjourney-v7" in err
 
 
-def test_run_style_explore_safezone_format_mismatch_skipped(generate_illustrations, tmp_path, monkeypatch, capsys):
+def test_run_style_explore_safezone_format_mismatch_skipped(
+    generate_illustrations, tmp_path, monkeypatch, capsys
+):
     import pytest
+
     # A non-FULL format mapped to a slide whose Safe zone forces FULL is skipped
     # (its geometry would disagree); with no usable targets left, the run exits
     # non-zero and both diagnostics go to stderr.
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")
-    outline = _write_outline(tmp_path, model="gemini-3-pro-image", slides=[
-        {"n": 4, "chapter": "c", "title": "Portrait with zone", "format": "IMG+TXT",
-         "image_prompt": "[STYLE ANCHOR] tall",
-         "safe_zone": {"zone": "upper_third", "surface": "sky"}},
-    ])
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 4,
+                "chapter": "c",
+                "title": "Portrait with zone",
+                "format": "IMG+TXT",
+                "image_prompt": "[STYLE ANCHOR] tall",
+                "safe_zone": {"zone": "upper_third", "surface": "sky"},
+            },
+        ],
+    )
     cand = _candidates(
         slides={"IMG+TXT": 4},
         models=["gemini-3-pro-image"],
@@ -922,12 +1118,20 @@ def test_run_style_explore_safezone_format_mismatch_skipped(generate_illustratio
 def test_render_explore_index_groups_by_style(generate_illustrations):
     candidates = _candidates()
     results = [
-        {"style": "Blueprint Schematic", "format": "FULL",
-         "model": "gpt-image-2", "status": "OK",
-         "rel_path": "blueprint-schematic/full/gpt-image-2.png"},
-        {"style": "Watercolor", "format": "IMG+TXT",
-         "model": "gemini-3-pro-image", "status": "FAIL",
-         "error": "rate limited"},
+        {
+            "style": "Blueprint Schematic",
+            "format": "FULL",
+            "model": "gpt-image-2",
+            "status": "OK",
+            "rel_path": "blueprint-schematic/full/gpt-image-2.png",
+        },
+        {
+            "style": "Watercolor",
+            "format": "IMG+TXT",
+            "model": "gemini-3-pro-image",
+            "status": "FAIL",
+            "error": "rate limited",
+        },
     ]
     md = generate_illustrations.render_explore_index(candidates, results)
     assert "# Style Exploration" in md
@@ -946,10 +1150,19 @@ def test_render_explore_index_groups_by_style(generate_illustrations):
 
 def _write_gate_outline(tmp_path, model=None):
     """Write an outline with a style anchor and one FULL slide; optional model."""
-    return _write_outline(tmp_path, model=model, slides=[
-        {"n": 1, "chapter": "c", "title": "Intro", "format": "FULL",
-         "image_prompt": "[STYLE ANCHOR] a thing"},
-    ])
+    return _write_outline(
+        tmp_path,
+        model=model,
+        slides=[
+            {
+                "n": 1,
+                "chapter": "c",
+                "title": "Intro",
+                "format": "FULL",
+                "image_prompt": "[STYLE ANCHOR] a thing",
+            },
+        ],
+    )
 
 
 def _write_manifest(tmp_path, ok_models, cells=None, outline_dir=None):
@@ -964,10 +1177,16 @@ def _write_manifest(tmp_path, ok_models, cells=None, outline_dir=None):
             fp = se / rel
             fp.parent.mkdir(parents=True, exist_ok=True)
             fp.write_bytes(b"img")
-            cells.append({
-                "style": "S", "format": "FULL", "model": m,
-                "model_resolved": m, "status": "OK", "rel_path": rel,
-            })
+            cells.append(
+                {
+                    "style": "S",
+                    "format": "FULL",
+                    "model": m,
+                    "model_resolved": m,
+                    "status": "OK",
+                    "rel_path": rel,
+                }
+            )
     manifest = {
         "schema_version": 1,
         "outline": "outline.yaml",
@@ -990,10 +1209,20 @@ def test_rendered_manifest_excludes_failed(generate_illustrations, tmp_path):
     outline = tmp_path / "outline.yaml"
     outline.write_text("x")
     results = [
-        {"style": "A", "format": "FULL", "model": "nano-banana-pro",
-         "status": "OK", "rel_path": "a/full/x.png"},
-        {"style": "A", "format": "FULL", "model": "gpt-image-2",
-         "status": "FAIL", "error": "boom"},
+        {
+            "style": "A",
+            "format": "FULL",
+            "model": "nano-banana-pro",
+            "status": "OK",
+            "rel_path": "a/full/x.png",
+        },
+        {
+            "style": "A",
+            "format": "FULL",
+            "model": "gpt-image-2",
+            "status": "FAIL",
+            "error": "boom",
+        },
     ]
     path = gi.write_rendered_manifest(str(base), str(outline), results)
     m = json.loads(open(path).read())
@@ -1052,12 +1281,16 @@ def test_gate_fails_when_no_model_baked(generate_illustrations, tmp_path):
 def test_gate_fails_when_model_only_failed(generate_illustrations, tmp_path):
     gi = generate_illustrations
     outline = _write_gate_outline(tmp_path, model="gemini-3-pro-image")
-    cells = [{
-        "style": "A", "format": "FULL",
-        "model": "gemini-3-pro-image",
-        "model_resolved": "gemini-3-pro-image",
-        "status": "FAIL", "error": "boom",
-    }]
+    cells = [
+        {
+            "style": "A",
+            "format": "FULL",
+            "model": "gemini-3-pro-image",
+            "model_resolved": "gemini-3-pro-image",
+            "status": "FAIL",
+            "error": "boom",
+        }
+    ]
     _write_manifest(tmp_path, [], cells=cells)
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
@@ -1067,7 +1300,8 @@ def _stub_generate(gi, monkeypatch, outline_dict, output_dir, gen_calls):
     monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline_dict, output_dir))
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
     monkeypatch.setattr(
-        gi, "generate_image",
+        gi,
+        "generate_image",
         lambda *a, **k: (gen_calls.append(a), (b"x", "image/png"))[1],
     )
 
@@ -1109,15 +1343,28 @@ def test_run_generate_proceeds_when_gate_passes(
 # ── Poster-theatrical composition (embedded title + footer) ──────────
 
 
-def _write_poster_outline(tmp_path, model="gemini-3-pro-image",
-                          footer="jbaruch • Devoxx 2026", text="One team, one bench",
-                          text_treatment="glowing hand-script neon on an in-scene surface"):
+def _write_poster_outline(
+    tmp_path,
+    model="gemini-3-pro-image",
+    footer="jbaruch • Devoxx 2026",
+    text="One team, one bench",
+    text_treatment="glowing hand-script neon on an in-scene surface",
+):
     return _write_outline(
-        tmp_path, model=model, composition="poster-theatrical",
-        embedded_footer=footer, text_treatment=text_treatment, slides=[
-            {"n": 3, "chapter": "c", "title": "The Coordination Tax",
-             "format": "FULL", "text_overlay": text,
-             "image_prompt": "[STYLE ANCHOR] one team at a shared workbench"},
+        tmp_path,
+        model=model,
+        composition="poster-theatrical",
+        embedded_footer=footer,
+        text_treatment=text_treatment,
+        slides=[
+            {
+                "n": 3,
+                "chapter": "c",
+                "title": "The Coordination Tax",
+                "format": "FULL",
+                "text_overlay": text,
+                "image_prompt": "[STYLE ANCHOR] one team at a shared workbench",
+            },
         ],
     )
 
@@ -1134,7 +1381,9 @@ def test_parse_poster_composition_and_footer(generate_illustrations, tmp_path):
 
 def test_poster_embed_directive_includes_title_and_footer(generate_illustrations):
     gi = generate_illustrations
-    d = gi.apply_poster_embed_directive("a scene", "One team, one bench", "jbaruch • Devoxx 2026")
+    d = gi.apply_poster_embed_directive(
+        "a scene", "One team, one bench", "jbaruch • Devoxx 2026"
+    )
     assert "EMBEDDED TEXT" in d
     assert "One team, one bench" in d
     assert "jbaruch • Devoxx 2026" in d
@@ -1145,7 +1394,9 @@ def test_poster_embed_directive_uses_anchor_text_treatment(generate_illustration
     # slide's baked title/footer renders identically.
     gi = generate_illustrations
     d = gi.apply_poster_embed_directive(
-        "a scene", "One team, one bench", "footer",
+        "a scene",
+        "One team, one bench",
+        "footer",
         "glowing hand-script neon on an in-scene surface",
     )
     assert "glowing hand-script neon on an in-scene surface" in d
@@ -1184,10 +1435,13 @@ def test_run_generate_poster_embeds_text_and_skips_safe_zone(
     _write_manifest(tmp_path, ["gemini-3-pro-image"])  # satisfy the render gate
 
     prompts = []
-    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline_dict, str(tmp_path)))
+    monkeypatch.setattr(
+        gi, "_load_context", lambda p: ({}, outline_dict, str(tmp_path))
+    )
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
     monkeypatch.setattr(
-        gi, "generate_image",
+        gi,
+        "generate_image",
         lambda prompt, *a, **k: (prompts.append(prompt), (b"x", "image/png"))[1],
     )
 
@@ -1214,10 +1468,15 @@ def _write_raw_manifest(tmp_path, payload):
 def test_gate_fails_on_unsupported_schema_version(generate_illustrations, tmp_path):
     gi = generate_illustrations
     outline = _write_gate_outline(tmp_path, model="gemini-3-pro-image")
-    _write_raw_manifest(tmp_path, {
-        "schema_version": 2, "outline": "outline.yaml",
-        "models_rendered_ok": ["gemini-3-pro-image"], "cells": [],
-    })
+    _write_raw_manifest(
+        tmp_path,
+        {
+            "schema_version": 2,
+            "outline": "outline.yaml",
+            "models_rendered_ok": ["gemini-3-pro-image"],
+            "cells": [],
+        },
+    )
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
     assert "schema_version" in v["error"]
@@ -1227,10 +1486,15 @@ def test_gate_fails_on_outline_mismatch(generate_illustrations, tmp_path):
     # A manifest copied in from a different talk must not pass the gate.
     gi = generate_illustrations
     outline = _write_gate_outline(tmp_path, model="gemini-3-pro-image")
-    _write_raw_manifest(tmp_path, {
-        "schema_version": 1, "outline": "some-other-talk.yaml",
-        "models_rendered_ok": ["gemini-3-pro-image"], "cells": [],
-    })
+    _write_raw_manifest(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "outline": "some-other-talk.yaml",
+            "models_rendered_ok": ["gemini-3-pro-image"],
+            "cells": [],
+        },
+    )
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
     assert "copied or stale" in v["error"]
@@ -1242,15 +1506,25 @@ def test_gate_fails_when_rendered_file_missing(generate_illustrations, tmp_path)
     # a hand-edited manifest can't fake a render the speaker never saw.
     gi = generate_illustrations
     outline = _write_gate_outline(tmp_path, model="gemini-3-pro-image")
-    _write_raw_manifest(tmp_path, {
-        "schema_version": 1, "outline": "outline.yaml", "outline_dir": tmp_path.name,
-        "models_rendered_ok": ["gemini-3-pro-image"],
-        "cells": [{
-            "style": "S", "format": "FULL", "model": "gemini-3-pro-image",
-            "model_resolved": "gemini-3-pro-image", "status": "OK",
-            "rel_path": "style/full/gemini-3-pro-image.png",  # never created
-        }],
-    })
+    _write_raw_manifest(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "outline": "outline.yaml",
+            "outline_dir": tmp_path.name,
+            "models_rendered_ok": ["gemini-3-pro-image"],
+            "cells": [
+                {
+                    "style": "S",
+                    "format": "FULL",
+                    "model": "gemini-3-pro-image",
+                    "model_resolved": "gemini-3-pro-image",
+                    "status": "OK",
+                    "rel_path": "style/full/gemini-3-pro-image.png",  # never created
+                }
+            ],
+        },
+    )
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
     assert v["rendered_models"] == []
@@ -1269,10 +1543,16 @@ def test_gate_fails_on_outline_dir_mismatch(generate_illustrations, tmp_path):
 def test_gate_fails_on_malformed_cells(generate_illustrations, tmp_path):
     gi = generate_illustrations
     outline = _write_gate_outline(tmp_path, model="gemini-3-pro-image")
-    _write_raw_manifest(tmp_path, {
-        "schema_version": 1, "outline": "outline.yaml", "outline_dir": tmp_path.name,
-        "models_rendered_ok": [], "cells": "not-a-list",
-    })
+    _write_raw_manifest(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "outline": "outline.yaml",
+            "outline_dir": tmp_path.name,
+            "models_rendered_ok": [],
+            "cells": "not-a-list",
+        },
+    )
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
     assert "cells" in v["error"]
@@ -1308,13 +1588,27 @@ def test_run_generate_poster_validates_whole_outline_not_just_subset(
     # outline violates the poster invariant — the invariant is deck-level.
     gi = generate_illustrations
     outline = _write_outline(
-        tmp_path, model="gemini-3-pro-image",
-        composition="poster-theatrical", embedded_footer="jbaruch • Devoxx 2026",
+        tmp_path,
+        model="gemini-3-pro-image",
+        composition="poster-theatrical",
+        embedded_footer="jbaruch • Devoxx 2026",
         slides=[
-            {"n": 1, "chapter": "c", "title": "Good", "format": "FULL",
-             "text_overlay": "ok", "image_prompt": "[STYLE ANCHOR] a thing"},
-            {"n": 2, "chapter": "c", "title": "Bad", "format": "IMG+TXT",
-             "text_overlay": "nope", "image_prompt": "[STYLE ANCHOR] another thing"},
+            {
+                "n": 1,
+                "chapter": "c",
+                "title": "Good",
+                "format": "FULL",
+                "text_overlay": "ok",
+                "image_prompt": "[STYLE ANCHOR] a thing",
+            },
+            {
+                "n": 2,
+                "chapter": "c",
+                "title": "Bad",
+                "format": "IMG+TXT",
+                "text_overlay": "nope",
+                "image_prompt": "[STYLE ANCHOR] another thing",
+            },
         ],
     )
     outline_dict = gi.parse_outline(str(outline))
@@ -1336,15 +1630,25 @@ def test_gate_rejects_rel_path_traversal(generate_illustrations, tmp_path):
     gi = generate_illustrations
     outline = _write_gate_outline(tmp_path, model="gemini-3-pro-image")
     (tmp_path / "evil.png").write_bytes(b"img")  # a real file OUTSIDE style-explore/
-    _write_raw_manifest(tmp_path, {
-        "schema_version": 1, "outline": "outline.yaml", "outline_dir": tmp_path.name,
-        "models_rendered_ok": ["gemini-3-pro-image"],
-        "cells": [{
-            "style": "S", "format": "FULL", "model": "gemini-3-pro-image",
-            "model_resolved": "gemini-3-pro-image", "status": "OK",
-            "rel_path": "../evil.png",
-        }],
-    })
+    _write_raw_manifest(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "outline": "outline.yaml",
+            "outline_dir": tmp_path.name,
+            "models_rendered_ok": ["gemini-3-pro-image"],
+            "cells": [
+                {
+                    "style": "S",
+                    "format": "FULL",
+                    "model": "gemini-3-pro-image",
+                    "model_resolved": "gemini-3-pro-image",
+                    "status": "OK",
+                    "rel_path": "../evil.png",
+                }
+            ],
+        },
+    )
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
     assert v["rendered_models"] == []
@@ -1360,15 +1664,24 @@ def test_gate_fails_when_outline_dir_missing(generate_illustrations, tmp_path):
     rel = "style/full/gemini-3-pro-image.png"
     (se / rel).parent.mkdir(parents=True, exist_ok=True)
     (se / rel).write_bytes(b"img")
-    _write_raw_manifest(tmp_path, {
-        "schema_version": 1, "outline": "outline.yaml",  # no outline_dir
-        "models_rendered_ok": ["gemini-3-pro-image"],
-        "cells": [{
-            "style": "S", "format": "FULL", "model": "gemini-3-pro-image",
-            "model_resolved": "gemini-3-pro-image", "status": "OK",
-            "rel_path": rel,
-        }],
-    })
+    _write_raw_manifest(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "outline": "outline.yaml",  # no outline_dir
+            "models_rendered_ok": ["gemini-3-pro-image"],
+            "cells": [
+                {
+                    "style": "S",
+                    "format": "FULL",
+                    "model": "gemini-3-pro-image",
+                    "model_resolved": "gemini-3-pro-image",
+                    "status": "OK",
+                    "rel_path": rel,
+                }
+            ],
+        },
+    )
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
     assert "outline_dir" in v["error"]
@@ -1378,7 +1691,7 @@ def test_poster_embed_directive_normalizes_embedded_quotes(generate_illustration
     # A title/footer containing double quotes must not create nested double
     # quotes in the directive (they degrade model compliance).
     gi = generate_illustrations
-    d = gi.apply_poster_embed_directive('a scene', 'He said "Hello"', 'tag "x"')
+    d = gi.apply_poster_embed_directive("a scene", 'He said "Hello"', 'tag "x"')
     # The wrapping quotes around title/footer remain, but embedded ones are now '
     assert '""' not in d
     assert "He said 'Hello'" in d
@@ -1407,14 +1720,25 @@ def test_gate_fails_closed_on_non_string_cell_model(generate_illustrations, tmp_
     rel = "style/full/x.png"
     (se / rel).parent.mkdir(parents=True, exist_ok=True)
     (se / rel).write_bytes(b"img")
-    _write_raw_manifest(tmp_path, {
-        "schema_version": 1, "outline": "outline.yaml", "outline_dir": tmp_path.name,
-        "models_rendered_ok": [],
-        "cells": [{
-            "style": "S", "format": "FULL", "model": ["not", "a", "string"],
-            "model_resolved": None, "status": "OK", "rel_path": rel,
-        }],
-    })
+    _write_raw_manifest(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "outline": "outline.yaml",
+            "outline_dir": tmp_path.name,
+            "models_rendered_ok": [],
+            "cells": [
+                {
+                    "style": "S",
+                    "format": "FULL",
+                    "model": ["not", "a", "string"],
+                    "model_resolved": None,
+                    "status": "OK",
+                    "rel_path": rel,
+                }
+            ],
+        },
+    )
     v = gi.check_style_explore(str(outline))  # must not raise
     assert v["gate_passed"] is False
 
@@ -1446,7 +1770,9 @@ def test_region_to_pixels_clamps_and_is_nonempty(generate_illustrations):
     # Normal box maps to floor/ceil pixel coords.
     assert gi._region_to_pixels([0.0, 0.0, 0.5, 0.5], 100, 200) == (0, 0, 50, 100)
     # A degenerate (zero-width after flooring) box is widened to >= 1px, never empty.
-    left, top, right, bottom = gi._region_to_pixels([0.5, 0.5, 0.5001, 0.5001], 100, 100)
+    left, top, right, bottom = gi._region_to_pixels(
+        [0.5, 0.5, 0.5001, 0.5001], 100, 100
+    )
     assert right > left and bottom > top
 
 
@@ -1457,15 +1783,18 @@ def test_region_to_pixels_edge_box_at_one_is_nonempty(generate_illustrations):
     # and right both at 100 (empty); floor/ceil + the boundary guard keep it >=1px.
     left, top, right, bottom = gi._region_to_pixels([0.999, 0.999, 1.0, 1.0], 100, 100)
     assert right > left and bottom > top
-    assert right <= 100 and bottom <= 100   # stays in bounds
+    assert right <= 100 and bottom <= 100  # stays in bounds
     # A full-frame box maps to the whole image.
     assert gi._region_to_pixels([0.0, 0.0, 1.0, 1.0], 100, 80) == (0, 0, 100, 80)
 
 
-def test_build_edit_mask_is_transparent_only_in_region(generate_illustrations, tmp_path):
+def test_build_edit_mask_is_transparent_only_in_region(
+    generate_illustrations, tmp_path
+):
     # The OpenAI mask must be opaque (keep) everywhere except a transparent hole
     # over the erase box (the only region the model may redraw).
     from PIL import Image
+
     gi = generate_illustrations
     src = tmp_path / "frame.png"
     Image.new("RGB", (100, 100), (10, 20, 30)).save(src)
@@ -1473,38 +1802,50 @@ def test_build_edit_mask_is_transparent_only_in_region(generate_illustrations, t
     mask_png = gi.build_edit_mask_png(str(src), [0.4, 0.4, 0.6, 0.6])
     mask = Image.open(io.BytesIO(mask_png)).convert("RGBA")
     assert mask.size == (100, 100)
-    assert mask.getpixel((50, 50))[3] == 0     # inside box -> transparent
-    assert mask.getpixel((5, 5))[3] == 255     # outside box -> opaque
+    assert mask.getpixel((50, 50))[3] == 0  # inside box -> transparent
+    assert mask.getpixel((5, 5))[3] == 255  # outside box -> opaque
 
 
-def test_composite_region_keeps_background_pixel_identical(generate_illustrations, tmp_path):
+def test_composite_region_keeps_background_pixel_identical(
+    generate_illustrations, tmp_path
+):
     # The guarantee behind #90: outside the box, output == prior frame exactly;
     # inside the box, output == the edited (new) content.
     from PIL import Image
+
     gi = generate_illustrations
     prior = tmp_path / "prior.png"
     Image.new("RGB", (100, 100), (10, 20, 30)).save(prior)
     new_buf = io.BytesIO()
     Image.new("RGB", (100, 100), (200, 100, 50)).save(new_buf, format="PNG")
 
-    out_bytes, mime = gi.composite_region(str(prior), new_buf.getvalue(), [0.4, 0.4, 0.6, 0.6])
+    out_bytes, mime = gi.composite_region(
+        str(prior), new_buf.getvalue(), [0.4, 0.4, 0.6, 0.6]
+    )
     assert mime == "image/png"
     out = Image.open(io.BytesIO(out_bytes)).convert("RGB")
-    assert out.getpixel((5, 5)) == (10, 20, 30)    # background preserved
+    assert out.getpixel((5, 5)) == (10, 20, 30)  # background preserved
     assert out.getpixel((50, 50)) == (200, 100, 50)  # box replaced with new content
 
 
-def test_composite_region_resizes_mismatched_new_image(generate_illustrations, tmp_path):
+def test_composite_region_resizes_mismatched_new_image(
+    generate_illustrations, tmp_path
+):
     # When the vendor returns a different geometry, the new image is resized to
     # the prior frame before compositing, so the box still lands correctly.
     from PIL import Image
+
     gi = generate_illustrations
     prior = tmp_path / "prior.png"
     Image.new("RGB", (100, 100), (0, 0, 0)).save(prior)
     new_buf = io.BytesIO()
-    Image.new("RGB", (40, 40), (255, 255, 255)).save(new_buf, format="PNG")  # different size
+    Image.new("RGB", (40, 40), (255, 255, 255)).save(
+        new_buf, format="PNG"
+    )  # different size
 
-    out_bytes, _ = gi.composite_region(str(prior), new_buf.getvalue(), [0.0, 0.0, 1.0, 1.0])
+    out_bytes, _ = gi.composite_region(
+        str(prior), new_buf.getvalue(), [0.0, 0.0, 1.0, 1.0]
+    )
     out = Image.open(io.BytesIO(out_bytes)).convert("RGB")
     assert out.size == (100, 100)
     assert out.getpixel((50, 50)) == (255, 255, 255)

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -119,7 +119,9 @@ def test_generate_qr_png(generate_qr, tmp_path):
 
 def test_generate_qr_png_custom_colors(generate_qr, tmp_path):
     out = str(tmp_path / "custom.png")
-    generate_qr.generate_qr_png("https://example.com", (255, 255, 255), (128, 0, 128), out)
+    generate_qr.generate_qr_png(
+        "https://example.com", (255, 255, 255), (128, 0, 128), out
+    )
     assert os.path.isfile(out)
 
 
@@ -139,15 +141,19 @@ def test_tracking_db_crud_insert(generate_qr):
 
 
 def test_tracking_db_crud_update(generate_qr):
-    db = {"qr_codes": [{
-        "talk_slug": "test-talk",
-        "target_url": "https://old-url.com",
-        "shortener": "none",
-        "short_url": "https://old-url.com",
-        "qr_png_rel_path": "old.png",
-        "created_at": "2024-01-01",
-        "updated_at": "2024-01-01",
-    }]}
+    db = {
+        "qr_codes": [
+            {
+                "talk_slug": "test-talk",
+                "target_url": "https://old-url.com",
+                "shortener": "none",
+                "short_url": "https://old-url.com",
+                "qr_png_rel_path": "old.png",
+                "created_at": "2024-01-01",
+                "updated_at": "2024-01-01",
+            }
+        ]
+    }
     entry = {
         "talk_slug": "test-talk",
         "target_url": "https://new-url.com",
@@ -358,13 +364,17 @@ def test_resolve_slide_bg_rgb_none_for_plain_deck(generate_qr, tmp_path):
 
 def test_slide_has_existing_qr_detects_square_qr_sized_picture(generate_qr, tmp_path):
     prs = make_deck(1)
-    prs.slides[0].shapes.add_picture(_square_png(tmp_path), Inches(8), Inches(5), Inches(2.0), Inches(2.0))
+    prs.slides[0].shapes.add_picture(
+        _square_png(tmp_path), Inches(8), Inches(5), Inches(2.0), Inches(2.0)
+    )
     assert generate_qr.slide_has_existing_qr(prs.slides[0]) is True
 
 
 def test_slide_has_existing_qr_ignores_non_square_picture(generate_qr, tmp_path):
     prs = make_deck(1)
-    prs.slides[0].shapes.add_picture(_square_png(tmp_path), Inches(1), Inches(1), Inches(6.0), Inches(2.0))
+    prs.slides[0].shapes.add_picture(
+        _square_png(tmp_path), Inches(1), Inches(1), Inches(6.0), Inches(2.0)
+    )
     assert generate_qr.slide_has_existing_qr(prs.slides[0]) is False
 
 
@@ -372,21 +382,27 @@ def test_slide_has_existing_qr_detects_large_square_qr(generate_qr, tmp_path):
     # Size-independent: a 2.8in two-color square is still a QR (the inherited
     # shownotes QR in the #56 repro deck was 2.78in — outside the old 1.5-2.5 band).
     prs = make_deck(1)
-    prs.slides[0].shapes.add_picture(_square_png(tmp_path), Inches(1), Inches(1), Inches(2.8), Inches(2.8))
+    prs.slides[0].shapes.add_picture(
+        _square_png(tmp_path), Inches(1), Inches(1), Inches(2.8), Inches(2.8)
+    )
     assert generate_qr.slide_has_existing_qr(prs.slides[0]) is True
 
 
 def test_slide_has_existing_qr_ignores_multicolor_square(generate_qr, tmp_path):
     # Square and in size range, but many colors (e.g. a Venn diagram) → not a QR.
     prs = make_deck(1)
-    prs.slides[0].shapes.add_picture(_multicolor_png(tmp_path), Inches(2), Inches(2), Inches(2.0), Inches(2.0))
+    prs.slides[0].shapes.add_picture(
+        _multicolor_png(tmp_path), Inches(2), Inches(2), Inches(2.0), Inches(2.0)
+    )
     assert generate_qr.slide_has_existing_qr(prs.slides[0]) is False
 
 
 def test_slide_has_existing_qr_ignores_small_two_color_icon(generate_qr, tmp_path):
     # Two-color but below the 1.5in floor → a small icon, not a QR.
     prs = make_deck(1)
-    prs.slides[0].shapes.add_picture(_square_png(tmp_path), Inches(1), Inches(1), Inches(1.0), Inches(1.0))
+    prs.slides[0].shapes.add_picture(
+        _square_png(tmp_path), Inches(1), Inches(1), Inches(1.0), Inches(1.0)
+    )
     assert generate_qr.slide_has_existing_qr(prs.slides[0]) is False
 
 
@@ -395,7 +411,9 @@ def test_slide_has_existing_qr_ignores_text_screenshot(generate_qr, tmp_path):
     # (unbalanced) → not a QR. Regression: a martinfowler.com screenshot (slide 28
     # of the #56 repro deck) that the recon-error-only test wrongly accepted.
     prs = make_deck(1)
-    prs.slides[0].shapes.add_picture(_sparse_text_png(tmp_path), Inches(2), Inches(1), Inches(4.0), Inches(4.0))
+    prs.slides[0].shapes.add_picture(
+        _sparse_text_png(tmp_path), Inches(2), Inches(1), Inches(4.0), Inches(4.0)
+    )
     assert generate_qr.slide_has_existing_qr(prs.slides[0]) is False
 
 
@@ -405,18 +423,26 @@ def test_slide_has_existing_qr_false_for_plain_slide(generate_qr):
 
 
 def test_two_color_metrics_separate_qr_screenshot_photo(generate_qr, tmp_path):
-    qr_err, qr_min = generate_qr._two_color_metrics(open(_square_png(tmp_path, "q.png"), "rb").read())
-    multi_err, _ = generate_qr._two_color_metrics(open(_multicolor_png(tmp_path, "m.png"), "rb").read())
-    _, sshot_min = generate_qr._two_color_metrics(open(_sparse_text_png(tmp_path, "s.png"), "rb").read())
-    assert qr_err < 5.0 and qr_min >= 0.25     # QR: two-color AND balanced
-    assert multi_err > 20.0                     # photo/diagram: many colors
-    assert sshot_min < 0.25                     # screenshot: mostly background
+    qr_err, qr_min = generate_qr._two_color_metrics(
+        open(_square_png(tmp_path, "q.png"), "rb").read()
+    )
+    multi_err, _ = generate_qr._two_color_metrics(
+        open(_multicolor_png(tmp_path, "m.png"), "rb").read()
+    )
+    _, sshot_min = generate_qr._two_color_metrics(
+        open(_sparse_text_png(tmp_path, "s.png"), "rb").read()
+    )
+    assert qr_err < 5.0 and qr_min >= 0.25  # QR: two-color AND balanced
+    assert multi_err > 20.0  # photo/diagram: many colors
+    assert sshot_min < 0.25  # screenshot: mostly background
 
 
 def test_find_qr_rects_returns_points_geometry(generate_qr, tmp_path):
     prs = make_deck(1)
     # placed at 8in,5in, 2in square → points: 576, 360, 144, 144
-    prs.slides[0].shapes.add_picture(_square_png(tmp_path), Inches(8), Inches(5), Inches(2.0), Inches(2.0))
+    prs.slides[0].shapes.add_picture(
+        _square_png(tmp_path), Inches(8), Inches(5), Inches(2.0), Inches(2.0)
+    )
     rects = generate_qr.find_qr_rects(prs.slides[0])
     assert len(rects) == 1
     L, T, W, H = rects[0]
@@ -428,25 +454,45 @@ def test_resolve_target_includes_inherited_qr_slides(generate_qr, tmp_path):
     """A deck adapted from another talk: config targets only the closing slide,
     but an earlier slide carries an inherited QR — it must also be targeted."""
     prs = make_deck(4)
-    prs.slides[1].shapes.add_picture(_square_png(tmp_path), Inches(8), Inches(5), Inches(2.0), Inches(2.0))
-    indices = generate_qr.resolve_target_slide_indices(prs, {"slide_position": "closing"}, "https://example.com/notes")
-    assert 1 in indices   # inherited-QR slide
-    assert 3 in indices   # closing slide
+    prs.slides[1].shapes.add_picture(
+        _square_png(tmp_path), Inches(8), Inches(5), Inches(2.0), Inches(2.0)
+    )
+    indices = generate_qr.resolve_target_slide_indices(
+        prs, {"slide_position": "closing"}, "https://example.com/notes"
+    )
+    assert 1 in indices  # inherited-QR slide
+    assert 3 in indices  # closing slide
 
 
-def test_back_half_is_always_slug_ignoring_preferred_short_path(generate_qr, monkeypatch):
+def test_back_half_is_always_slug_ignoring_preferred_short_path(
+    generate_qr, monkeypatch
+):
     """The back-half is ALWAYS the talk slug — a legacy preferred_short_path is ignored."""
     captured = {}
 
     def fake_create_bitly_link(long_url, api_token, custom_back_half=None, domain=None):
         captured["back_half"] = custom_back_half
-        return {"short_url": "https://jbaru.ch/my-slug", "link_id": "id", "short_path": custom_back_half}
+        return {
+            "short_url": "https://jbaru.ch/my-slug",
+            "link_id": "id",
+            "short_path": custom_back_half,
+        }
 
     monkeypatch.setattr(generate_qr, "create_bitly_link", fake_create_bitly_link)
-    config = {"shortener": "bitly", "preferred_short_path": "legacy-override", "bitly_domain": "jbaru.ch"}
+    config = {
+        "shortener": "bitly",
+        "preferred_short_path": "legacy-override",
+        "bitly_domain": "jbaru.ch",
+    }
     secrets = {"bitly": {"api_token": "tok"}}
     generate_qr.resolve_short_url(
-        "https://jbaru.ch/my-slug", "my-slug", config, secrets, {}, dry_run=False, vault_path=None
+        "https://jbaru.ch/my-slug",
+        "my-slug",
+        config,
+        secrets,
+        {},
+        dry_run=False,
+        vault_path=None,
     )
     assert captured["back_half"] == "my-slug"
 
@@ -457,7 +503,9 @@ def test_insert_qr_via_powerpoint_orchestration(generate_qr, monkeypatch):
     variant, the deck threaded through uniquely-named intermediates, intermediates
     cleaned up, and the final result moved back onto the deck."""
     calls = []
-    monkeypatch.setattr(generate_qr.subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+    monkeypatch.setattr(
+        generate_qr.subprocess, "run", lambda cmd, **kw: calls.append(cmd)
+    )
     removed = []
     monkeypatch.setattr(generate_qr.os, "remove", lambda p: removed.append(p))
     moved = []
@@ -477,8 +525,20 @@ def test_insert_qr_via_powerpoint_orchestration(generate_qr, monkeypatch):
     # one subprocess call per job; deck threaded through intermediates; spec is
     # 1-based, ";"-joined, with per-slide removal rects after ":"
     assert calls == [
-        [wrapper, "/decks/talk.pptx", "/decks/talk.pptx.qrtmp0.pptx", "/q/a.png", "1:100.00,200.00,144.00,144.00;3"],
-        [wrapper, "/decks/talk.pptx.qrtmp0.pptx", "/decks/talk.pptx.qrtmp1.pptx", "/q/b.png", "5"],
+        [
+            wrapper,
+            "/decks/talk.pptx",
+            "/decks/talk.pptx.qrtmp0.pptx",
+            "/q/a.png",
+            "1:100.00,200.00,144.00,144.00;3",
+        ],
+        [
+            wrapper,
+            "/decks/talk.pptx.qrtmp0.pptx",
+            "/decks/talk.pptx.qrtmp1.pptx",
+            "/q/b.png",
+            "5",
+        ],
     ]
     # the prior intermediate is cleaned up; the final intermediate is moved onto the deck
     assert removed == ["/decks/talk.pptx.qrtmp0.pptx"]
@@ -488,12 +548,17 @@ def test_insert_qr_via_powerpoint_orchestration(generate_qr, monkeypatch):
 def test_insert_qr_via_powerpoint_missing_wrapper(generate_qr, monkeypatch):
     """A missing insert-qr.sh fails fast with an actionable error, not a traceback."""
     import pytest
+
     monkeypatch.setattr(generate_qr.os.path, "isfile", lambda p: False)
     with pytest.raises(SystemExit):
-        generate_qr.insert_qr_via_powerpoint("/decks/talk.pptx", [("/q/a.png", [(1, [])])], "/scripts")
+        generate_qr.insert_qr_via_powerpoint(
+            "/decks/talk.pptx", [("/q/a.png", [(1, [])])], "/scripts"
+        )
 
 
-def test_insert_qr_via_powerpoint_wrapper_failure_is_actionable(generate_qr, monkeypatch):
+def test_insert_qr_via_powerpoint_wrapper_failure_is_actionable(
+    generate_qr, monkeypatch
+):
     """A wrapper (insert-qr.sh) failure surfaces as an actionable SystemExit
     pointing at the DeckOps setup, not a raw CalledProcessError traceback."""
     import pytest
@@ -504,7 +569,9 @@ def test_insert_qr_via_powerpoint_wrapper_failure_is_actionable(generate_qr, mon
     monkeypatch.setattr(generate_qr.subprocess, "run", boom)
     monkeypatch.setattr(generate_qr.os.path, "isfile", lambda p: True)
     with pytest.raises(SystemExit) as exc:
-        generate_qr.insert_qr_via_powerpoint("/decks/talk.pptx", [("/q/a.png", [(1, [])])], "/scripts")
+        generate_qr.insert_qr_via_powerpoint(
+            "/decks/talk.pptx", [("/q/a.png", [(1, [])])], "/scripts"
+        )
     assert "deck-editing-setup.md" in str(exc.value)
 
 
@@ -512,11 +579,15 @@ def test_format_qr_spec_new_placement_and_replace(generate_qr):
     # No rects → bare slide number (new bottom-right placement)
     assert generate_qr._format_qr_spec([(5, [])]) == "5"
     # One rect → "num:L,T,W,H" (replace in place), 2-decimal points
-    assert generate_qr._format_qr_spec([(12, [(450.0, 80.0, 200.16, 200.16)])]) == \
-        "12:450.00,80.00,200.16,200.16"
+    assert (
+        generate_qr._format_qr_spec([(12, [(450.0, 80.0, 200.16, 200.16)])])
+        == "12:450.00,80.00,200.16,200.16"
+    )
     # Multiple slides + a duplicate-QR slide (two rects) → flattened, ";"-joined
-    assert generate_qr._format_qr_spec([(12, [(1, 2, 3, 4), (5, 6, 7, 8)]), (38, [])]) == \
-        "12:1.00,2.00,3.00,4.00,5.00,6.00,7.00,8.00;38"
+    assert (
+        generate_qr._format_qr_spec([(12, [(1, 2, 3, 4), (5, 6, 7, 8)]), (38, [])])
+        == "12:1.00,2.00,3.00,4.00,5.00,6.00,7.00,8.00;38"
+    )
 
 
 def test_create_bitly_link_raises_when_custom_back_half_fails(generate_qr, monkeypatch):
@@ -535,7 +606,10 @@ def test_create_bitly_link_raises_when_custom_back_half_fails(generate_qr, monke
         generate_qr.ShortenerResolutionError, match="could not set custom back-half"
     ) as excinfo:
         generate_qr.create_bitly_link(
-            "https://example.com/notes", "tok", custom_back_half="my-slug", domain="jbaru.ch"
+            "https://example.com/notes",
+            "tok",
+            custom_back_half="my-slug",
+            domain="jbaru.ch",
         )
     # The link exists provider-side; its identity must travel with the failure
     # so the operator can reuse or delete it deterministically.
@@ -546,6 +620,7 @@ def test_create_bitly_link_raises_when_custom_back_half_fails(generate_qr, monke
 
 def test_create_bitly_link_lets_programming_errors_propagate(generate_qr, monkeypatch):
     """Only documented provider failures are wrapped; bugs surface as themselves."""
+
     def fake_http(url, data=None, headers=None, method="GET"):
         if url.endswith("/v4/bitlinks"):
             return {"id": "bit.ly/abc123", "link": "https://bit.ly/abc123"}
@@ -554,7 +629,10 @@ def test_create_bitly_link_lets_programming_errors_propagate(generate_qr, monkey
     monkeypatch.setattr(generate_qr, "_http_request", fake_http)
     with pytest.raises(TypeError, match="bug in the caller"):
         generate_qr.create_bitly_link(
-            "https://example.com/notes", "tok", custom_back_half="my-slug", domain="jbaru.ch"
+            "https://example.com/notes",
+            "tok",
+            custom_back_half="my-slug",
+            domain="jbaru.ch",
         )
 
 
@@ -565,25 +643,39 @@ def test_legacy_non_slug_cache_entry_is_recreated_with_slug(generate_qr, monkeyp
 
     def fake_create_bitly_link(long_url, api_token, custom_back_half=None, domain=None):
         created["back_half"] = custom_back_half
-        return {"short_url": f"https://jbaru.ch/{custom_back_half}", "link_id": "new-id", "short_path": custom_back_half}
+        return {
+            "short_url": f"https://jbaru.ch/{custom_back_half}",
+            "link_id": "new-id",
+            "short_path": custom_back_half,
+        }
 
     def boom_update(*a, **k):
-        raise AssertionError("update_bitly_link must not be called for a legacy non-slug entry")
+        raise AssertionError(
+            "update_bitly_link must not be called for a legacy non-slug entry"
+        )
 
     monkeypatch.setattr(generate_qr, "create_bitly_link", fake_create_bitly_link)
     monkeypatch.setattr(generate_qr, "update_bitly_link", boom_update)
-    tracking_db = {"qr_codes": [{
-        "talk_slug": "my-slug",
-        "target_url": "https://jbaru.ch/my-slug",   # cached target matches → would reuse without the fix
-        "shortener": "bitly",
-        "short_path": "legacy-hash",                # NON-slug back-half
-        "short_url": "https://bit.ly/legacy-hash",
-        "shortener_link_id": "old-id",
-    }]}
+    tracking_db = {
+        "qr_codes": [
+            {
+                "talk_slug": "my-slug",
+                "target_url": "https://jbaru.ch/my-slug",  # cached target matches → would reuse without the fix
+                "shortener": "bitly",
+                "short_path": "legacy-hash",  # NON-slug back-half
+                "short_url": "https://bit.ly/legacy-hash",
+                "shortener_link_id": "old-id",
+            }
+        ]
+    }
     short_url, meta = generate_qr.resolve_short_url(
-        "https://jbaru.ch/my-slug", "my-slug",
+        "https://jbaru.ch/my-slug",
+        "my-slug",
         {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
-        {"bitly": {"api_token": "tok"}}, tracking_db, dry_run=False, vault_path=None,
+        {"bitly": {"api_token": "tok"}},
+        tracking_db,
+        dry_run=False,
+        vault_path=None,
     )
     assert created["back_half"] == "my-slug"
     assert meta["short_path"] == "my-slug"
@@ -591,17 +683,29 @@ def test_legacy_non_slug_cache_entry_is_recreated_with_slug(generate_qr, monkeyp
     assert short_url == "https://jbaru.ch/my-slug"
 
 
-def test_missing_custom_domain_decision_stops_before_first_link(generate_qr, monkeypatch):
+def test_missing_custom_domain_decision_stops_before_first_link(
+    generate_qr, monkeypatch
+):
     """First short link with NO recorded custom-domain decision (key absent) STOPS
     so the agent asks the user — it must not silently default to bit.ly."""
     import pytest
-    monkeypatch.setattr(generate_qr, "create_bitly_link",
-                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must STOP before creating")))
+
+    monkeypatch.setattr(
+        generate_qr,
+        "create_bitly_link",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("must STOP before creating")
+        ),
+    )
     with pytest.raises(SystemExit):
         generate_qr.resolve_short_url(
-            "https://jbaru.ch/my-slug", "my-slug",
-            {"shortener": "bitly"},   # no bitly_domain key → decision not recorded
-            {"bitly": {"api_token": "tok"}}, {}, dry_run=False, vault_path=None,
+            "https://jbaru.ch/my-slug",
+            "my-slug",
+            {"shortener": "bitly"},  # no bitly_domain key → decision not recorded
+            {"bitly": {"api_token": "tok"}},
+            {},
+            dry_run=False,
+            vault_path=None,
         )
 
 
@@ -612,13 +716,24 @@ def test_explicit_null_custom_domain_proceeds(generate_qr, monkeypatch):
 
     def fake_create_bitly_link(long_url, api_token, custom_back_half=None, domain=None):
         captured["domain"] = domain
-        return {"short_url": f"https://bit.ly/{custom_back_half}", "link_id": "id", "short_path": custom_back_half}
+        return {
+            "short_url": f"https://bit.ly/{custom_back_half}",
+            "link_id": "id",
+            "short_path": custom_back_half,
+        }
 
     monkeypatch.setattr(generate_qr, "create_bitly_link", fake_create_bitly_link)
     short_url, meta = generate_qr.resolve_short_url(
-        "https://jbaru.ch/my-slug", "my-slug",
-        {"shortener": "bitly", "bitly_domain": None},   # recorded decision: no custom domain
-        {"bitly": {"api_token": "tok"}}, {}, dry_run=False, vault_path=None,
+        "https://jbaru.ch/my-slug",
+        "my-slug",
+        {
+            "shortener": "bitly",
+            "bitly_domain": None,
+        },  # recorded decision: no custom domain
+        {"bitly": {"api_token": "tok"}},
+        {},
+        dry_run=False,
+        vault_path=None,
     )
     assert captured["domain"] is None
     assert meta["short_path"] == "my-slug"
@@ -627,36 +742,59 @@ def test_explicit_null_custom_domain_proceeds(generate_qr, monkeypatch):
 def test_slug_cache_entry_is_reused(generate_qr, monkeypatch):
     """A tracked entry whose back-half is already the slug is reused from cache —
     no API call — when the target matches."""
+
     def boom_create(*a, **k):
         raise AssertionError("must reuse cache, not create a new link")
 
     monkeypatch.setattr(generate_qr, "create_bitly_link", boom_create)
-    tracking_db = {"qr_codes": [{
-        "talk_slug": "my-slug",
-        "target_url": "https://jbaru.ch/my-slug",
-        "shortener": "bitly",
-        "short_path": "my-slug",
-        "short_url": "https://jbaru.ch/my-slug",
-        "shortener_link_id": "id",
-    }]}
+    tracking_db = {
+        "qr_codes": [
+            {
+                "talk_slug": "my-slug",
+                "target_url": "https://jbaru.ch/my-slug",
+                "shortener": "bitly",
+                "short_path": "my-slug",
+                "short_url": "https://jbaru.ch/my-slug",
+                "shortener_link_id": "id",
+            }
+        ]
+    }
     short_url, meta = generate_qr.resolve_short_url(
-        "https://jbaru.ch/my-slug", "my-slug", {"shortener": "bitly"}, {}, tracking_db, dry_run=False,
+        "https://jbaru.ch/my-slug",
+        "my-slug",
+        {"shortener": "bitly"},
+        {},
+        tracking_db,
+        dry_run=False,
     )
     assert short_url == "https://jbaru.ch/my-slug"
     assert meta["short_path"] == "my-slug"
 
 
 def test_main_dry_run_dual_reads_legacy_database_without_writing(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     database = {"config": {}, "talks": [], "pptx_catalog": []}
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(database), encoding="utf-8")
     before = path.read_bytes()
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "legacy",
-        "--short-url", "https://example.test/legacy", "--shownotes-url", "https://example.test/notes", "--vault", str(tmp_path),
-        "--dry-run",
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "legacy",
+            "--short-url",
+            "https://example.test/legacy",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--vault",
+            str(tmp_path),
+            "--dry-run",
+        ],
+    )
 
     generate_qr.main()
 
@@ -664,7 +802,8 @@ def test_main_dry_run_dual_reads_legacy_database_without_writing(
 
 
 def test_main_rejects_legacy_database_before_qr_side_effect(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     database = {"config": {}, "talks": [], "pptx_catalog": []}
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(database), encoding="utf-8")
@@ -674,10 +813,22 @@ def test_main_rejects_legacy_database_before_qr_side_effect(
         "generate_qr_png",
         lambda *_: pytest.fail("QR generation must not start on legacy state"),
     )
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "legacy",
-        "--short-url", "https://example.test/legacy", "--shownotes-url", "https://example.test/notes", "--vault", str(tmp_path),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "legacy",
+            "--short-url",
+            "https://example.test/legacy",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--vault",
+            str(tmp_path),
+        ],
+    )
 
     with pytest.raises(SystemExit, match="current tracking schema"):
         generate_qr.main()
@@ -686,7 +837,8 @@ def test_main_rejects_legacy_database_before_qr_side_effect(
 
 
 def test_main_current_database_stamps_qr_record_and_writes_atomically(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     database = _current_tracking_database()
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(database), encoding="utf-8")
@@ -696,32 +848,47 @@ def test_main_current_database_stamps_qr_record_and_writes_atomically(
         "generate_qr_png",
         lambda _url, _fg, _bg, target: Path(target).write_bytes(b"qr"),
     )
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "current",
-        "--short-url", "https://example.test/current", "--shownotes-url", "https://example.test/notes", "--vault", str(tmp_path),
-        "--output", str(output),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "current",
+            "--short-url",
+            "https://example.test/current",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--vault",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ],
+    )
 
     generate_qr.main()
 
     written = json.loads(path.read_text(encoding="utf-8"))
     assert written["schema_version"] == 1
     record = written["qr_codes"][0]
-    assert written["qr_codes"] == [{
-        "schema_version": 2,
-        "talk_slug": "current",
-        # The canonical redirect target, never the short URL standing in for it.
-        "target_url": "https://example.test/notes",
-        "shortener": "mcp_preresolved",
-        # The back-half is recovered from the short URL and matches the slug.
-        "short_path": "current",
-        "short_url": "https://example.test/current",
-        "shortener_link_id": None,
-        "qr_png_rel_path": record["qr_png_rel_path"],
-        "artifacts": record["artifacts"],
-        "created_at": record["created_at"],
-        "updated_at": record["updated_at"],
-    }]
+    assert written["qr_codes"] == [
+        {
+            "schema_version": 2,
+            "talk_slug": "current",
+            # The canonical redirect target, never the short URL standing in for it.
+            "target_url": "https://example.test/notes",
+            "shortener": "mcp_preresolved",
+            # The back-half is recovered from the short URL and matches the slug.
+            "short_path": "current",
+            "short_url": "https://example.test/current",
+            "shortener_link_id": None,
+            "qr_png_rel_path": record["qr_png_rel_path"],
+            "artifacts": record["artifacts"],
+            "created_at": record["created_at"],
+            "updated_at": record["updated_at"],
+        }
+    ]
     # The exact written path is recorded, not the default {slug}-qr.png name.
     assert len(record["artifacts"]) == 1
     artifact = record["artifacts"][0]
@@ -733,7 +900,8 @@ def test_main_current_database_stamps_qr_record_and_writes_atomically(
 
 
 def test_main_rejects_future_database_without_side_effect(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     database = _current_tracking_database() | {"schema_version": 2}
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(database), encoding="utf-8")
@@ -743,11 +911,23 @@ def test_main_rejects_future_database_without_side_effect(
         "generate_qr_png",
         lambda *_: pytest.fail("QR generation must not start on future state"),
     )
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "future",
-        "--short-url", "https://example.test/future", "--shownotes-url", "https://example.test/notes", "--vault", str(tmp_path),
-        "--dry-run",
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "future",
+            "--short-url",
+            "https://example.test/future",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--vault",
+            str(tmp_path),
+            "--dry-run",
+        ],
+    )
 
     with pytest.raises(SystemExit, match="no usable prior state"):
         generate_qr.main()
@@ -756,16 +936,29 @@ def test_main_rejects_future_database_without_side_effect(
 
 
 def test_main_rejects_tracking_database_symlink_before_loading_config(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     target = tmp_path / "target.json"
     target.write_text(json.dumps(_current_tracking_database()), encoding="utf-8")
     path = tmp_path / "tracking-database.json"
     path.symlink_to(target.name)
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "link",
-        "--short-url", "https://example.test/link", "--shownotes-url", "https://example.test/notes", "--vault", str(tmp_path),
-        "--dry-run",
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "link",
+            "--short-url",
+            "https://example.test/link",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--vault",
+            str(tmp_path),
+            "--dry-run",
+        ],
+    )
 
     with pytest.raises(SystemExit, match="symbolic link"):
         generate_qr.main()
@@ -773,41 +966,56 @@ def test_main_rejects_tracking_database_symlink_before_loading_config(
 
 # --- #170: a configured shortener must fail closed, never ship a raw URL ---
 
+
 def _qr_db():
     """Tracking DB carrying one managed link for `my-talk`."""
     return {
-        "qr_codes": [{
-            "talk_slug": "my-talk",
-            "target_url": "https://example.com/old",
-            "shortener": "bitly",
-            "short_path": "my-talk",
-            "short_url": "https://jbaru.ch/my-talk",
-            "shortener_link_id": "bit.ly/abc123",
-        }]
+        "qr_codes": [
+            {
+                "talk_slug": "my-talk",
+                "target_url": "https://example.com/old",
+                "shortener": "bitly",
+                "short_path": "my-talk",
+                "short_url": "https://jbaru.ch/my-talk",
+                "shortener_link_id": "bit.ly/abc123",
+            }
+        ]
     }
 
 
 def test_unconfigured_shortener_fails_closed(generate_qr):
-    with pytest.raises(generate_qr.ShortenerResolutionError, match="no URL shortener configured"):
+    with pytest.raises(
+        generate_qr.ShortenerResolutionError, match="no URL shortener configured"
+    ):
         generate_qr.resolve_short_url(
             "https://example.com/notes", "my-talk", {}, {}, {"qr_codes": []}
         )
 
 
 def test_unknown_shortener_fails_closed(generate_qr):
-    with pytest.raises(generate_qr.ShortenerResolutionError, match="unknown shortener 'tinyurl'"):
+    with pytest.raises(
+        generate_qr.ShortenerResolutionError, match="unknown shortener 'tinyurl'"
+    ):
         generate_qr.resolve_short_url(
-            "https://example.com/notes", "my-talk",
-            {"shortener": "tinyurl"}, {}, {"qr_codes": []}
+            "https://example.com/notes",
+            "my-talk",
+            {"shortener": "tinyurl"},
+            {},
+            {"qr_codes": []},
         )
 
 
-@pytest.mark.parametrize("service,key", [("bitly", "api_token"), ("rebrandly", "api_key")])
+@pytest.mark.parametrize(
+    "service,key", [("bitly", "api_token"), ("rebrandly", "api_key")]
+)
 def test_missing_credentials_fail_closed(generate_qr, service, key):
     with pytest.raises(generate_qr.ShortenerResolutionError, match=f"{key} is missing"):
         generate_qr.resolve_short_url(
-            "https://example.com/notes", "my-talk",
-            {"shortener": service, f"{service}_domain": None}, {}, {"qr_codes": []}
+            "https://example.com/notes",
+            "my-talk",
+            {"shortener": service, f"{service}_domain": None},
+            {},
+            {"qr_codes": []},
         )
 
 
@@ -818,25 +1026,34 @@ def test_provider_error_fails_closed(generate_qr, monkeypatch):
         raise urllib.error.URLError("connection refused")
 
     monkeypatch.setattr(generate_qr, "_http_request", fake_http)
-    with pytest.raises(generate_qr.ShortenerResolutionError, match="could not produce the managed"):
+    with pytest.raises(
+        generate_qr.ShortenerResolutionError, match="could not produce the managed"
+    ):
         generate_qr.resolve_short_url(
-            "https://example.com/notes", "my-talk",
+            "https://example.com/notes",
+            "my-talk",
             {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
-            {"bitly": {"api_token": "tok"}}, {"qr_codes": []}
+            {"bitly": {"api_token": "tok"}},
+            {"qr_codes": []},
         )
 
 
 def test_malformed_provider_response_fails_closed(generate_qr, monkeypatch):
     """A response missing an expected field is a provider failure, not a raw-URL cue."""
     monkeypatch.setattr(
-        generate_qr, "_http_request",
+        generate_qr,
+        "_http_request",
         lambda url, data=None, headers=None, method="GET": {"unexpected": "shape"},
     )
-    with pytest.raises(generate_qr.ShortenerResolutionError, match="could not produce the managed"):
+    with pytest.raises(
+        generate_qr.ShortenerResolutionError, match="could not produce the managed"
+    ):
         generate_qr.resolve_short_url(
-            "https://example.com/notes", "my-talk",
+            "https://example.com/notes",
+            "my-talk",
             {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
-            {"bitly": {"api_token": "tok"}}, {"qr_codes": []}
+            {"bitly": {"api_token": "tok"}},
+            {"qr_codes": []},
         )
 
 
@@ -847,9 +1064,11 @@ def test_programming_errors_propagate_unwrapped(generate_qr, monkeypatch):
     monkeypatch.setattr(generate_qr, "_http_request", fake_http)
     with pytest.raises(AttributeError, match="bug in the caller"):
         generate_qr.resolve_short_url(
-            "https://example.com/notes", "my-talk",
+            "https://example.com/notes",
+            "my-talk",
             {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
-            {"bitly": {"api_token": "tok"}}, {"qr_codes": []}
+            {"bitly": {"api_token": "tok"}},
+            {"qr_codes": []},
         )
 
 
@@ -862,14 +1081,17 @@ def test_failure_never_downgrades_an_existing_managed_record(generate_qr, monkey
     before = copy.deepcopy(db)
 
     monkeypatch.setattr(
-        generate_qr, "_http_request",
+        generate_qr,
+        "_http_request",
         lambda *a, **k: (_ for _ in ()).throw(urllib.error.URLError("down")),
     )
     with pytest.raises(generate_qr.ShortenerResolutionError):
         generate_qr.resolve_short_url(
-            "https://example.com/new", "my-talk",
+            "https://example.com/new",
+            "my-talk",
             {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
-            {"bitly": {"api_token": "tok"}}, db
+            {"bitly": {"api_token": "tok"}},
+            db,
         )
 
     assert db == before
@@ -879,8 +1101,11 @@ def test_failure_never_downgrades_an_existing_managed_record(generate_qr, monkey
 def test_explicit_none_still_authorizes_a_raw_url(generate_qr):
     """The one sanctioned path to a raw target URL stays open."""
     url, meta = generate_qr.resolve_short_url(
-        "https://example.com/notes", "my-talk",
-        {"shortener": "none"}, {}, {"qr_codes": []}
+        "https://example.com/notes",
+        "my-talk",
+        {"shortener": "none"},
+        {},
+        {"qr_codes": []},
     )
     assert url == "https://example.com/notes"
     assert meta["shortener"] == "none"
@@ -889,28 +1114,42 @@ def test_explicit_none_still_authorizes_a_raw_url(generate_qr):
 
 def test_cached_raw_record_is_not_reused_when_config_is_missing(generate_qr):
     """A stale `shortener: none` entry must not re-authorize a raw URL."""
-    db = {"qr_codes": [{
-        "talk_slug": "my-talk",
-        "target_url": "https://example.com/notes",
-        "shortener": "none",
-        "short_path": None,
-        "short_url": "https://example.com/notes",
-        "shortener_link_id": None,
-    }]}
-    with pytest.raises(generate_qr.ShortenerResolutionError, match="no URL shortener configured"):
-        generate_qr.resolve_short_url("https://example.com/notes", "my-talk", {}, {}, db)
+    db = {
+        "qr_codes": [
+            {
+                "talk_slug": "my-talk",
+                "target_url": "https://example.com/notes",
+                "shortener": "none",
+                "short_path": None,
+                "short_url": "https://example.com/notes",
+                "shortener_link_id": None,
+            }
+        ]
+    }
+    with pytest.raises(
+        generate_qr.ShortenerResolutionError, match="no URL shortener configured"
+    ):
+        generate_qr.resolve_short_url(
+            "https://example.com/notes", "my-talk", {}, {}, db
+        )
 
 
-def test_cached_raw_record_is_not_reused_under_a_managed_shortener(generate_qr, monkeypatch):
+def test_cached_raw_record_is_not_reused_under_a_managed_shortener(
+    generate_qr, monkeypatch
+):
     """Switching config from none to bitly must re-resolve, not replay the raw URL."""
-    db = {"qr_codes": [{
-        "talk_slug": "my-talk",
-        "target_url": "https://example.com/notes",
-        "shortener": "none",
-        "short_path": None,
-        "short_url": "https://example.com/notes",
-        "shortener_link_id": None,
-    }]}
+    db = {
+        "qr_codes": [
+            {
+                "talk_slug": "my-talk",
+                "target_url": "https://example.com/notes",
+                "shortener": "none",
+                "short_path": None,
+                "short_url": "https://example.com/notes",
+                "shortener_link_id": None,
+            }
+        ]
+    }
     calls = []
 
     def fake_http(url, data=None, headers=None, method="GET"):
@@ -921,9 +1160,11 @@ def test_cached_raw_record_is_not_reused_under_a_managed_shortener(generate_qr, 
 
     monkeypatch.setattr(generate_qr, "_http_request", fake_http)
     url, meta = generate_qr.resolve_short_url(
-        "https://example.com/notes", "my-talk",
+        "https://example.com/notes",
+        "my-talk",
         {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
-        {"bitly": {"api_token": "tok"}}, db
+        {"bitly": {"api_token": "tok"}},
+        db,
     )
 
     assert calls, "the managed shortener must actually be called"
@@ -936,9 +1177,11 @@ def test_cached_managed_record_is_still_reused(generate_qr):
     db = _qr_db()
     db["qr_codes"][0]["target_url"] = "https://example.com/notes"
     url, meta = generate_qr.resolve_short_url(
-        "https://example.com/notes", "my-talk",
+        "https://example.com/notes",
+        "my-talk",
         {"shortener": "bitly", "bitly_domain": "jbaru.ch"},
-        {"bitly": {"api_token": "tok"}}, db
+        {"bitly": {"api_token": "tok"}},
+        db,
     )
     assert url == "https://jbaru.ch/my-talk"
     assert meta["shortener"] == "bitly"
@@ -947,36 +1190,55 @@ def test_cached_managed_record_is_still_reused(generate_qr):
 def test_unknown_shortener_is_rejected_before_cache_reuse(generate_qr):
     db = _qr_db()
     db["qr_codes"][0]["target_url"] = "https://example.com/notes"
-    with pytest.raises(generate_qr.ShortenerResolutionError, match="unknown shortener 'tinyurl'"):
+    with pytest.raises(
+        generate_qr.ShortenerResolutionError, match="unknown shortener 'tinyurl'"
+    ):
         generate_qr.resolve_short_url(
-            "https://example.com/notes", "my-talk",
-            {"shortener": "tinyurl"}, {}, db
+            "https://example.com/notes", "my-talk", {"shortener": "tinyurl"}, {}, db
         )
 
 
 # --- #171: catalog fidelity — canonical target, provider identity, every artifact ---
 
+
 def test_mcp_mode_records_canonical_target_and_provider_identity(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     """MCP mode must persist the redirect target, provider, and link id."""
     output = tmp_path / "talk-qr.png"
     # An explicit vault keeps the run hermetic. Without --vault the script
     # falls back to ~/.claude/rhetoric-knowledge-vault, so the test would read
     # the developer's real vault and behave differently in CI.
     (tmp_path / "tracking-database.json").write_text(
-        json.dumps(_current_tracking_database()), encoding="utf-8")
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "my-talk",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://jbaru.ch/my-talk",
-        "--short-provider", "bitly",
-        "--short-link-id", "bit.ly/abc123",
-        "--vault", str(tmp_path),
-        "--output", str(output),
-    ])
-    monkeypatch.setattr(generate_qr, "update_tracking_db",
-                        lambda db, entry, artifacts: captured.update(
-                            entry=entry, artifacts=artifacts))
+        json.dumps(_current_tracking_database()), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "my-talk",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://jbaru.ch/my-talk",
+            "--short-provider",
+            "bitly",
+            "--short-link-id",
+            "bit.ly/abc123",
+            "--vault",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ],
+    )
+    monkeypatch.setattr(
+        generate_qr,
+        "update_tracking_db",
+        lambda db, entry, artifacts: captured.update(entry=entry, artifacts=artifacts),
+    )
     captured = {}
     generate_qr.main()
 
@@ -995,16 +1257,31 @@ def test_png_only_records_the_path_actually_written(generate_qr, monkeypatch, tm
     captured = {}
     # Explicit vault — see the note in the MCP test above.
     (tmp_path / "tracking-database.json").write_text(
-        json.dumps(_current_tracking_database()), encoding="utf-8")
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "my-talk",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://jbaru.ch/my-talk",
-        "--vault", str(tmp_path),
-        "--output", str(output),
-    ])
-    monkeypatch.setattr(generate_qr, "update_tracking_db",
-                        lambda db, entry, artifacts: captured.update(artifacts=artifacts))
+        json.dumps(_current_tracking_database()), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "my-talk",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://jbaru.ch/my-talk",
+            "--vault",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ],
+    )
+    monkeypatch.setattr(
+        generate_qr,
+        "update_tracking_db",
+        lambda db, entry, artifacts: captured.update(artifacts=artifacts),
+    )
     generate_qr.main()
 
     assert len(captured["artifacts"]) == 1
@@ -1013,6 +1290,7 @@ def test_png_only_records_the_path_actually_written(generate_qr, monkeypatch, tm
     assert "my-talk-qr.png" not in artifact["path"]
     # The digest binds the record to these exact bytes.
     import hashlib
+
     assert artifact["sha256"] == hashlib.sha256(output.read_bytes()).hexdigest()
 
 
@@ -1036,20 +1314,36 @@ def test_artifact_receipt_records_an_explicit_path_root(generate_qr, tmp_path):
 
 def test_back_half_that_is_not_the_slug_stops_the_run(generate_qr):
     """§2 admits no exception: a non-slug back-half is the random-hash failure."""
-    with pytest.raises(generate_qr.ShortenerResolutionError, match="is not the talk slug"):
+    with pytest.raises(
+        generate_qr.ShortenerResolutionError, match="is not the talk slug"
+    ):
         generate_qr._validated_back_half("https://bit.ly/a3xK9f", "my-talk")
-    assert generate_qr._validated_back_half("https://jbaru.ch/my-talk", "my-talk") == "my-talk"
+    assert (
+        generate_qr._validated_back_half("https://jbaru.ch/my-talk", "my-talk")
+        == "my-talk"
+    )
 
 
 def test_mcp_non_slug_back_half_exits_before_any_side_effect(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     output = tmp_path / "qr.png"
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "my-talk",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://bit.ly/a3xK9f",
-        "--output", str(output),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "my-talk",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://bit.ly/a3xK9f",
+            "--output",
+            str(output),
+        ],
+    )
     with pytest.raises(SystemExit) as excinfo:
         generate_qr.main()
     assert excinfo.value.code == 1
@@ -1058,28 +1352,55 @@ def test_mcp_non_slug_back_half_exits_before_any_side_effect(
 
 def test_provider_flags_require_short_url(generate_qr, monkeypatch):
     """Provider identity without --short-url would be silently dropped."""
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "my-talk",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-provider", "bitly", "--short-link-id", "bit.ly/abc",
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "my-talk",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-provider",
+            "bitly",
+            "--short-link-id",
+            "bit.ly/abc",
+        ],
+    )
     with pytest.raises(SystemExit):
         generate_qr.main()
 
 
-@pytest.mark.parametrize("flag,value", [
-    ("--short-provider", "bitly"),
-    ("--short-link-id", "bit.ly/abc123"),
-])
-def test_provider_identity_is_all_or_neither(generate_qr, monkeypatch, tmp_path, flag, value):
+@pytest.mark.parametrize(
+    "flag,value",
+    [
+        ("--short-provider", "bitly"),
+        ("--short-link-id", "bit.ly/abc123"),
+    ],
+)
+def test_provider_identity_is_all_or_neither(
+    generate_qr, monkeypatch, tmp_path, flag, value
+):
     """Half an identity catalogs an incomplete provider record."""
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "my-talk",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://jbaru.ch/my-talk",
-        flag, value,
-        "--output", str(tmp_path / "qr.png"),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "my-talk",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://jbaru.ch/my-talk",
+            flag,
+            value,
+            "--output",
+            str(tmp_path / "qr.png"),
+        ],
+    )
     with pytest.raises(SystemExit):
         generate_qr.main()
 
@@ -1095,11 +1416,18 @@ def test_every_colour_variant_is_cataloged(generate_qr, tmp_path):
         receipts.append(generate_qr._artifact_receipt(str(path), str(deck_dir), bg))
 
     db = {"qr_codes": []}
-    generate_qr.update_tracking_db(db, {
-        "talk_slug": "a", "target_url": "https://example.test/notes",
-        "shortener": "bitly", "short_url": "https://jbaru.ch/a",
-        "short_path": "a", "shortener_link_id": "bit.ly/a",
-    }, receipts)
+    generate_qr.update_tracking_db(
+        db,
+        {
+            "talk_slug": "a",
+            "target_url": "https://example.test/notes",
+            "shortener": "bitly",
+            "short_url": "https://jbaru.ch/a",
+            "short_path": "a",
+            "shortener_link_id": "bit.ly/a",
+        },
+        receipts,
+    )
 
     record = db["qr_codes"][0]
     assert record["schema_version"] == 2
@@ -1110,20 +1438,34 @@ def test_every_colour_variant_is_cataloged(generate_qr, tmp_path):
 
 # --- #172: publication stays recoverable when the CAS commit rejects ---
 
+
 def test_unrelated_concurrent_write_no_longer_rejects_the_qr_commit(
-        generate_qr, monkeypatch, tmp_path, capsys):
+    generate_qr, monkeypatch, tmp_path, capsys
+):
     """A concurrent writer touching an unrelated collection must not reject us."""
     database = _current_tracking_database()
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(database), encoding="utf-8")
     output = tmp_path / "current.png"
 
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "current",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://example.test/current",
-        "--vault", str(tmp_path), "--output", str(output),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "current",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://example.test/current",
+            "--vault",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ],
+    )
 
     # Simulate an unrelated writer landing a change after our snapshot but
     # before our commit: mutate a different collection on disk.
@@ -1132,10 +1474,14 @@ def test_unrelated_concurrent_write_no_longer_rejects_the_qr_commit(
     def generate_then_race(*args, **kwargs):
         result = real_generate(*args, **kwargs)
         raced = json.loads(path.read_text(encoding="utf-8"))
-        raced["resources"] = [{
-            "schema_version": 1, "talk_slug": "other",
-            "item_count": 1, "category_breakdown": {"url": 1},
-        }]
+        raced["resources"] = [
+            {
+                "schema_version": 1,
+                "talk_slug": "other",
+                "item_count": 1,
+                "category_breakdown": {"url": 1},
+            }
+        ]
         path.write_text(json.dumps(raced), encoding="utf-8")
         return result
 
@@ -1150,21 +1496,35 @@ def test_unrelated_concurrent_write_no_longer_rejects_the_qr_commit(
 
 
 def test_commit_rejection_emits_a_structured_effects_payload(
-        generate_qr, monkeypatch, tmp_path, capsys):
+    generate_qr, monkeypatch, tmp_path, capsys
+):
     """A post-effect commit failure must not look side-effect-free."""
     database = _current_tracking_database()
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(database), encoding="utf-8")
     output = tmp_path / "current.png"
 
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "current",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://example.test/current",
-        "--vault", str(tmp_path), "--output", str(output),
-    ])
     monkeypatch.setattr(
-        generate_qr, "commit_qr_record",
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "current",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://example.test/current",
+            "--vault",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ],
+    )
+    monkeypatch.setattr(
+        generate_qr,
+        "commit_qr_record",
         lambda *a, **k: (_ for _ in ()).throw(ValueError("generation conflict")),
     )
 
@@ -1191,19 +1551,34 @@ def test_payload_is_one_valid_json_document(generate_qr):
     assert payload["talk_slug"] == "my-talk"
 
 
-@pytest.mark.parametrize("action,prior,expected", [
-    ("created", None, {"action": "delete", "target": "https://jbaru.ch/my-talk"}),
-    ("retargeted", "https://example.test/old",
-     {"action": "restore_target", "target": "https://jbaru.ch/my-talk",
-      "restore_to": "https://example.test/old"}),
-    ("preresolved", None, {"action": "none", "target": "https://jbaru.ch/my-talk"}),
-])
+@pytest.mark.parametrize(
+    "action,prior,expected",
+    [
+        ("created", None, {"action": "delete", "target": "https://jbaru.ch/my-talk"}),
+        (
+            "retargeted",
+            "https://example.test/old",
+            {
+                "action": "restore_target",
+                "target": "https://jbaru.ch/my-talk",
+                "restore_to": "https://example.test/old",
+            },
+        ),
+        ("preresolved", None, {"action": "none", "target": "https://jbaru.ch/my-talk"}),
+    ],
+)
 def test_link_rollback_matches_how_the_link_came_to_be(
-        generate_qr, action, prior, expected):
+    generate_qr, action, prior, expected
+):
     """Deleting a link this run did not create is destructive, not a rollback."""
     receipt = generate_qr.EffectsReceipt("my-talk")
-    receipt.record_short_link("bitly", "bit.ly/abc123", "https://jbaru.ch/my-talk",
-                              action=action, prior_target=prior)
+    receipt.record_short_link(
+        "bitly",
+        "bit.ly/abc123",
+        "https://jbaru.ch/my-talk",
+        action=action,
+        prior_target=prior,
+    )
     payload = generate_qr.unfinalized_effects_payload(receipt, "boom")
     link = [e for e in payload["effects"] if e["kind"] == "short_link"][0]
     assert link["rollback"] == expected
@@ -1213,8 +1588,9 @@ def test_link_rollback_matches_how_the_link_came_to_be(
 def test_payload_covers_every_landed_effect(generate_qr):
     """Link-only recovery would imply the PNGs and deck were reverted too."""
     receipt = generate_qr.EffectsReceipt("my-talk")
-    receipt.record_short_link("bitly", "bit.ly/abc", "https://jbaru.ch/my-talk",
-                              action="created")
+    receipt.record_short_link(
+        "bitly", "bit.ly/abc", "https://jbaru.ch/my-talk", action="created"
+    )
     receipt.record_artifacts(["/tmp/a.png", "/tmp/b.png"])
     receipt.record_deck("/tmp/deck.pptx")
 
@@ -1238,7 +1614,8 @@ def test_publication_lock_is_per_slug(generate_qr, tmp_path):
 
 
 def test_run_reloads_state_after_the_lock_so_it_retargets_instead_of_duplicating(
-        generate_qr, monkeypatch, tmp_path):
+    generate_qr, monkeypatch, tmp_path
+):
     """State loaded before the lock is stale; resolving from it duplicates links.
 
     Simulates the real interleaving: this run loads the database, and a
@@ -1248,21 +1625,40 @@ def test_run_reloads_state_after_the_lock_so_it_retargets_instead_of_duplicating
     """
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(_current_tracking_database()), encoding="utf-8")
-    (tmp_path / "speaker-profile.json").write_text(json.dumps(
-        {"publishing_process": {"qr_code": {
-            "shortener": "bitly", "bitly_domain": "jbaru.ch"}}}), encoding="utf-8")
+    (tmp_path / "speaker-profile.json").write_text(
+        json.dumps(
+            {
+                "publishing_process": {
+                    "qr_code": {"shortener": "bitly", "bitly_domain": "jbaru.ch"}
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     (tmp_path / "secrets.json").write_text(
-        json.dumps({"bitly": {"api_token": "tok"}}), encoding="utf-8")
+        json.dumps({"bitly": {"api_token": "tok"}}), encoding="utf-8"
+    )
 
     created, updated = [], []
-    monkeypatch.setattr(generate_qr, "create_bitly_link",
-                        lambda long_url, api_token, custom_back_half=None, domain=None: (
-                            created.append(long_url) or {
-                                "short_url": f"https://jbaru.ch/{custom_back_half}",
-                                "link_id": "bit.ly/NEW", "short_path": custom_back_half}))
-    monkeypatch.setattr(generate_qr, "update_bitly_link",
-                        lambda link_id, new_long_url, api_token: updated.append(
-                            (link_id, new_long_url)))
+    monkeypatch.setattr(
+        generate_qr,
+        "create_bitly_link",
+        lambda long_url, api_token, custom_back_half=None, domain=None: (
+            created.append(long_url)
+            or {
+                "short_url": f"https://jbaru.ch/{custom_back_half}",
+                "link_id": "bit.ly/NEW",
+                "short_path": custom_back_half,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        generate_qr,
+        "update_bitly_link",
+        lambda link_id, new_long_url, api_token: updated.append(
+            (link_id, new_long_url)
+        ),
+    )
 
     real_lock = generate_qr.qr_publication_lock
 
@@ -1272,28 +1668,48 @@ def test_run_reloads_state_after_the_lock_so_it_retargets_instead_of_duplicating
             # A competing process finished while we waited: its link is now
             # committed, and our pre-lock view does not contain it.
             raced = json.loads(path.read_text(encoding="utf-8"))
-            raced["qr_codes"] = [{
-                "schema_version": 2,
-                "talk_slug": "current",
-                "target_url": "https://example.test/other",
-                "shortener": "bitly",
-                "short_path": "current",
-                "short_url": "https://jbaru.ch/current",
-                "shortener_link_id": "bit.ly/RACED",
-                "qr_png_rel_path": "current.png",
-                "artifacts": [{"path": "current.png", "path_root": "cwd",
-                               "sha256": "b" * 64, "bg_hex": None}],
-                "created_at": "2026-08-09", "updated_at": "2026-08-09",
-            }]
+            raced["qr_codes"] = [
+                {
+                    "schema_version": 2,
+                    "talk_slug": "current",
+                    "target_url": "https://example.test/other",
+                    "shortener": "bitly",
+                    "short_path": "current",
+                    "short_url": "https://jbaru.ch/current",
+                    "shortener_link_id": "bit.ly/RACED",
+                    "qr_png_rel_path": "current.png",
+                    "artifacts": [
+                        {
+                            "path": "current.png",
+                            "path_root": "cwd",
+                            "sha256": "b" * 64,
+                            "bg_hex": None,
+                        }
+                    ],
+                    "created_at": "2026-08-09",
+                    "updated_at": "2026-08-09",
+                }
+            ]
             path.write_text(json.dumps(raced), encoding="utf-8")
             yield held
 
     monkeypatch.setattr(generate_qr, "qr_publication_lock", lock_then_race)
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "current",
-        "--shownotes-url", "https://example.test/notes",
-        "--vault", str(tmp_path), "--output", str(tmp_path / "current.png"),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "current",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--vault",
+            str(tmp_path),
+            "--output",
+            str(tmp_path / "current.png"),
+        ],
+    )
     generate_qr.main()
 
     assert created == [], "the raced link must be retargeted, never duplicated"
@@ -1304,7 +1720,8 @@ def test_run_reloads_state_after_the_lock_so_it_retargets_instead_of_duplicating
 
 
 def test_lock_failure_exits_cleanly_without_a_traceback(
-        generate_qr, monkeypatch, tmp_path, capsys):
+    generate_qr, monkeypatch, tmp_path, capsys
+):
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(_current_tracking_database()), encoding="utf-8")
 
@@ -1314,12 +1731,24 @@ def test_lock_failure_exits_cleanly_without_a_traceback(
         yield  # pragma: no cover
 
     monkeypatch.setattr(generate_qr, "qr_publication_lock", refuse)
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "current",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://example.test/current",
-        "--vault", str(tmp_path), "--output", str(tmp_path / "qr.png"),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "current",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://example.test/current",
+            "--vault",
+            str(tmp_path),
+            "--output",
+            str(tmp_path / "qr.png"),
+        ],
+    )
 
     with pytest.raises(SystemExit) as excinfo:
         generate_qr.main()
@@ -1329,19 +1758,23 @@ def test_lock_failure_exits_cleanly_without_a_traceback(
 
 # --- slug is a path component: it must never escape the vault ---
 
-@pytest.mark.parametrize("bad", [
-    "../../etc/passwd",
-    "a/b",
-    "..",
-    ".",
-    "Talk-Slug",
-    "talk slug",
-    "talk_slug",
-    "-leading",
-    "trailing-",
-    "double--hyphen",
-    "",
-])
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "../../etc/passwd",
+        "a/b",
+        "..",
+        ".",
+        "Talk-Slug",
+        "talk slug",
+        "talk_slug",
+        "-leading",
+        "trailing-",
+        "double--hyphen",
+        "",
+    ],
+)
 def test_invalid_talk_slug_is_rejected(generate_qr, bad):
     with pytest.raises(ValueError, match="kebab-case"):
         generate_qr.require_valid_talk_slug(bad)
@@ -1353,7 +1786,8 @@ def test_valid_talk_slug_is_accepted(generate_qr, good):
 
 
 def test_unsafe_slug_is_rejected_at_the_cli_boundary(
-        generate_qr, monkeypatch, tmp_path, capsys):
+    generate_qr, monkeypatch, tmp_path, capsys
+):
     """A path-shaped slug fails on the slug contract, before any file is touched.
 
     Without validation the same input fails later and less usefully — the lock
@@ -1363,14 +1797,27 @@ def test_unsafe_slug_is_rejected_at_the_cli_boundary(
     vault = tmp_path / "vault"
     vault.mkdir()
     (vault / "tracking-database.json").write_text(
-        json.dumps(_current_tracking_database()), encoding="utf-8")
+        json.dumps(_current_tracking_database()), encoding="utf-8"
+    )
 
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "../escaped",
-        "--shownotes-url", "https://example.test/notes",
-        "--short-url", "https://example.test/escaped",
-        "--vault", str(vault), "--output", str(tmp_path / "qr.png"),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "../escaped",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--short-url",
+            "https://example.test/escaped",
+            "--vault",
+            str(vault),
+            "--output",
+            str(tmp_path / "qr.png"),
+        ],
+    )
     with pytest.raises(SystemExit):
         generate_qr.main()
 
@@ -1384,17 +1831,27 @@ def test_unsafe_slug_is_rejected_at_the_cli_boundary(
 
 
 def test_back_half_failure_after_link_creation_reports_the_created_link(
-        generate_qr, monkeypatch, tmp_path, capsys):
+    generate_qr, monkeypatch, tmp_path, capsys
+):
     """The link exists provider-side; claiming no effects landed would be false."""
     vault = tmp_path / "vault"
     vault.mkdir()
     (vault / "tracking-database.json").write_text(
-        json.dumps(_current_tracking_database()), encoding="utf-8")
-    (vault / "speaker-profile.json").write_text(json.dumps(
-        {"publishing_process": {"qr_code": {
-            "shortener": "bitly", "bitly_domain": "jbaru.ch"}}}), encoding="utf-8")
+        json.dumps(_current_tracking_database()), encoding="utf-8"
+    )
+    (vault / "speaker-profile.json").write_text(
+        json.dumps(
+            {
+                "publishing_process": {
+                    "qr_code": {"shortener": "bitly", "bitly_domain": "jbaru.ch"}
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     (vault / "secrets.json").write_text(
-        json.dumps({"bitly": {"api_token": "tok"}}), encoding="utf-8")
+        json.dumps({"bitly": {"api_token": "tok"}}), encoding="utf-8"
+    )
 
     import urllib.error
 
@@ -1405,11 +1862,22 @@ def test_back_half_failure_after_link_creation_reports_the_created_link(
         raise urllib.error.HTTPError(url, 422, "Unprocessable", {}, None)
 
     monkeypatch.setattr(generate_qr, "_http_request", fake_http)
-    monkeypatch.setattr(sys, "argv", [
-        "generate-qr.py", "--png-only", "--talk-slug", "current",
-        "--shownotes-url", "https://example.test/notes",
-        "--vault", str(vault), "--output", str(tmp_path / "qr.png"),
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate-qr.py",
+            "--png-only",
+            "--talk-slug",
+            "current",
+            "--shownotes-url",
+            "https://example.test/notes",
+            "--vault",
+            str(vault),
+            "--output",
+            str(tmp_path / "qr.png"),
+        ],
+    )
 
     with pytest.raises(SystemExit) as excinfo:
         generate_qr.main()
@@ -1421,28 +1889,44 @@ def test_back_half_failure_after_link_creation_reports_the_created_link(
     assert link[0]["link_id"] == "jbaru.ch/abc123"
     assert link[0]["action"] == "created"
     assert link[0]["rollback"] == {
-        "action": "delete", "target": "https://jbaru.ch/abc123"}
+        "action": "delete",
+        "target": "https://jbaru.ch/abc123",
+    }
 
 
 def test_partial_link_identity_is_structured_not_only_in_the_message(generate_qr):
     err = generate_qr.ShortenerResolutionError(
-        "boom", partial_link={"provider": "bitly", "link_id": "x",
-                              "short_url": "https://jbaru.ch/x"})
+        "boom",
+        partial_link={
+            "provider": "bitly",
+            "link_id": "x",
+            "short_url": "https://jbaru.ch/x",
+        },
+    )
     assert err.partial_link["link_id"] == "x"
     assert generate_qr.ShortenerResolutionError("boom").partial_link is None
 
 
-@pytest.mark.parametrize("action,idempotent", [
-    ("created", False),
-    ("retargeted", True),
-    ("preresolved", True),
-])
+@pytest.mark.parametrize(
+    "action,idempotent",
+    [
+        ("created", False),
+        ("retargeted", True),
+        ("preresolved", True),
+    ],
+)
 def test_retry_idempotency_depends_on_whether_a_record_can_find_the_link(
-        generate_qr, action, idempotent):
+    generate_qr, action, idempotent
+):
     """A link this run created has no committed record, so a retry cannot find it."""
     receipt = generate_qr.EffectsReceipt("my-talk")
-    receipt.record_short_link("bitly", "bit.ly/abc", "https://jbaru.ch/my-talk",
-                              action=action, prior_target="https://x.test/old")
+    receipt.record_short_link(
+        "bitly",
+        "bit.ly/abc",
+        "https://jbaru.ch/my-talk",
+        action=action,
+        prior_target="https://x.test/old",
+    )
     payload = generate_qr.unfinalized_effects_payload(receipt, "boom")
     assert payload["retry"]["idempotent"] is idempotent
     if not idempotent:
@@ -1452,8 +1936,10 @@ def test_retry_idempotency_depends_on_whether_a_record_can_find_the_link(
 def test_retry_is_idempotent_when_no_link_work_happened(generate_qr):
     receipt = generate_qr.EffectsReceipt("my-talk")
     receipt.record_artifacts(["/tmp/a.png"])
-    assert generate_qr.unfinalized_effects_payload(
-        receipt, "boom")["retry"]["idempotent"] is True
+    assert (
+        generate_qr.unfinalized_effects_payload(receipt, "boom")["retry"]["idempotent"]
+        is True
+    )
 
 
 def test_lock_guidance_never_advises_deleting_the_lock_file(generate_qr, tmp_path):
@@ -1465,10 +1951,12 @@ def test_lock_guidance_never_advises_deleting_the_lock_file(generate_qr, tmp_pat
     held = os.open(str(lock_path), os.O_RDWR)
     _fcntl.flock(held, _fcntl.LOCK_EX)
     try:
+
         def blocking_flock(fd, op):
             raise OSError("Resource temporarily unavailable")
 
         import unittest.mock as mock
+
         with mock.patch.object(generate_qr.fcntl, "flock", blocking_flock):
             with pytest.raises(ValueError) as excinfo:
                 with generate_qr.qr_publication_lock(str(tmp_path), "my-talk"):

--- a/tests/test_generate_thumbnail.py
+++ b/tests/test_generate_thumbnail.py
@@ -47,7 +47,9 @@ def test_validate_and_resize_correct_dimensions(generate_thumbnail):
     img.save(buf, format="PNG")
     image_bytes = buf.getvalue()
 
-    result_bytes, mime = generate_thumbnail.validate_and_resize(image_bytes, "image/png")
+    result_bytes, mime = generate_thumbnail.validate_and_resize(
+        image_bytes, "image/png"
+    )
     result_img = Image.open(BytesIO(result_bytes))
     assert result_img.size == (1280, 720)
 
@@ -59,7 +61,9 @@ def test_validate_and_resize_rescales(generate_thumbnail):
     img.save(buf, format="PNG")
     image_bytes = buf.getvalue()
 
-    result_bytes, mime = generate_thumbnail.validate_and_resize(image_bytes, "image/png")
+    result_bytes, mime = generate_thumbnail.validate_and_resize(
+        image_bytes, "image/png"
+    )
     result_img = Image.open(BytesIO(result_bytes))
     assert result_img.size == (1280, 720)
 
@@ -77,7 +81,9 @@ def test_validate_and_resize_rgba_to_rgb(generate_thumbnail):
     img.save(buf, format="PNG")
     image_bytes = buf.getvalue()
 
-    result_bytes, mime = generate_thumbnail.validate_and_resize(image_bytes, "image/png")
+    result_bytes, mime = generate_thumbnail.validate_and_resize(
+        image_bytes, "image/png"
+    )
     result_img = Image.open(BytesIO(result_bytes))
     assert result_img.mode == "RGB"
 
@@ -136,7 +142,9 @@ def test_brand_colors_carry_through_all_softness_levels(generate_thumbnail):
     even on a retry."""
     for softness in ("default", "softer", "softest"):
         prompt = generate_thumbnail.build_thumbnail_prompt(
-            "T", brand_colors=["#5B2C6F", "#C0392B"], softness=softness,
+            "T",
+            brand_colors=["#5B2C6F", "#C0392B"],
+            softness=softness,
         )
         assert "#5B2C6F" in prompt, f"brand color missing at softness={softness}"
         assert "#C0392B" in prompt, f"brand color missing at softness={softness}"
@@ -171,9 +179,7 @@ def test_comic_book_prompt_uses_caricature_framing(generate_thumbnail):
 def test_comic_book_preserves_identifying_features_language(generate_thumbnail):
     """The speaker still needs to be recognizable in caricature form — the
     prompt must explicitly call out preserving identifying features."""
-    prompt = generate_thumbnail.build_thumbnail_prompt(
-        "T", aesthetic="comic_book"
-    )
+    prompt = generate_thumbnail.build_thumbnail_prompt("T", aesthetic="comic_book")
     assert "identifying features" in prompt.lower()
     # And we shouldn't fall back to forbidden assertive face-preservation
     # phrases that triggered the safety filter for photo realism (issue #19).
@@ -200,6 +206,7 @@ def test_comic_book_softness_levels_monotonic(generate_thumbnail):
 def test_unknown_aesthetic_raises(generate_thumbnail):
     """Unknown aesthetic value should fail loud, not silently fall back."""
     import pytest
+
     with pytest.raises(ValueError):
         generate_thumbnail.build_thumbnail_prompt("T", aesthetic="watercolor")
 
@@ -209,6 +216,7 @@ def test_unknown_softness_raises(generate_thumbnail):
     not silently produce default-strength output and break the retry ladder
     semantics."""
     import pytest
+
     with pytest.raises(ValueError):
         generate_thumbnail.build_thumbnail_prompt("T", softness="softrer")
 
@@ -216,13 +224,17 @@ def test_unknown_softness_raises(generate_thumbnail):
 def test_call_gemini_filter_rejection_prefix(generate_thumbnail, monkeypatch):
     """call_gemini must prefix safety-filter rejections with _ERR_FILTER so the
     retry ladder can distinguish them from transport-level failures."""
+
     class _FakeResp:
         def __init__(self, body):
             self._body = body
+
         def __enter__(self):
             return self
+
         def __exit__(self, *args):
             return False
+
         def read(self):
             return self._body.encode("utf-8")
 
@@ -246,7 +258,11 @@ def test_call_gemini_http_error_prefix(generate_thumbnail, monkeypatch):
 
     def _raise_http(req, timeout=None):
         raise urllib.error.HTTPError(
-            req.full_url, 429, "Too Many Requests", {}, BytesIO(b"rate limited"),
+            req.full_url,
+            429,
+            "Too Many Requests",
+            {},
+            BytesIO(b"rate limited"),
         )
 
     monkeypatch.setattr(generate_thumbnail.urllib.request, "urlopen", _raise_http)
@@ -270,13 +286,16 @@ def test_stylize_portrait_returns_stylized_bytes(generate_thumbnail, monkeypatch
 
     monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
     b64, mime = generate_thumbnail.stylize_portrait(
-        "ORIGINAL_B64", "image/jpeg",
+        "ORIGINAL_B64",
+        "image/jpeg",
         "retro tech-manual, sepia, pen-and-ink crosshatching",
-        "gemini-3-pro-image", "key",
+        "gemini-3-pro-image",
+        "key",
     )
     assert mime == "image/png"
     # Stylized bytes are returned base64-encoded
     import base64
+
     assert base64.b64decode(b64) == b"STYLIZED_BYTES"
     # The single Gemini call had exactly the photo + a prompt mentioning the anchor
     assert len(captured["parts"]) == 2
@@ -296,7 +315,11 @@ def test_stylize_portrait_raises_on_filter_rejection(generate_thumbnail, monkeyp
     monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
     with pytest.raises(RuntimeError) as excinfo:
         generate_thumbnail.stylize_portrait(
-            "B64", "image/jpeg", "any anchor", "model", "key",
+            "B64",
+            "image/jpeg",
+            "any anchor",
+            "model",
+            "key",
         )
     assert "Portrait pre-stylization failed" in str(excinfo.value)
 
@@ -312,7 +335,11 @@ def test_stylize_portrait_raises_on_http_error(generate_thumbnail, monkeypatch):
     monkeypatch.setattr(generate_thumbnail, "call_gemini", fake_call_gemini)
     with pytest.raises(RuntimeError):
         generate_thumbnail.stylize_portrait(
-            "B64", "image/jpeg", "any anchor", "model", "key",
+            "B64",
+            "image/jpeg",
+            "any anchor",
+            "model",
+            "key",
         )
 
 
@@ -336,7 +363,9 @@ def test_stylize_portrait_error_message_is_actionable(generate_thumbnail, monkey
 
 
 def test_compose_thumbnail_two_pass_threads_stylized_portrait(
-    generate_thumbnail, monkeypatch, tmp_path,
+    generate_thumbnail,
+    monkeypatch,
+    tmp_path,
 ):
     """When --portrait-style is set, compose_thumbnail must:
     (a) call stylize_portrait with the original photo bytes, and
@@ -363,9 +392,12 @@ def test_compose_thumbnail_two_pass_threads_stylized_portrait(
         composition_photo_data = None
         if len(parts) >= 2 and "inlineData" in parts[1]:
             composition_photo_data = parts[1]["inlineData"]["data"]
-        calls.append({"parts_count": len(parts), "composition_photo": composition_photo_data})
+        calls.append(
+            {"parts_count": len(parts), "composition_photo": composition_photo_data}
+        )
         # Return a 1280x720 PNG to satisfy validate_and_resize.
         from io import BytesIO
+
         img = Image.new("RGB", (1280, 720), (10, 20, 30))
         buf = BytesIO()
         img.save(buf, format="PNG")
@@ -376,6 +408,7 @@ def test_compose_thumbnail_two_pass_threads_stylized_portrait(
     def fake_stylize(speaker_b64, speaker_mime, anchor, model, api_key):
         # Confirm the original photo bytes reach the stylize step
         import base64
+
         assert base64.b64decode(speaker_b64) == b"PHOTO_RAW"
         assert anchor == "sepia tech-manual, pen-and-ink"
         return "STYLIZED_B64", "image/png"
@@ -409,7 +442,9 @@ def test_compose_thumbnail_two_pass_threads_stylized_portrait(
 
 
 def test_compose_thumbnail_skips_pre_stylize_when_no_anchor(
-    generate_thumbnail, monkeypatch, tmp_path,
+    generate_thumbnail,
+    monkeypatch,
+    tmp_path,
 ):
     """Without --portrait-style, stylize_portrait must NOT be invoked; the
     original photo bytes go directly to composition."""
@@ -435,6 +470,7 @@ def test_compose_thumbnail_skips_pre_stylize_when_no_anchor(
         if len(parts) >= 2 and "inlineData" in parts[1]:
             captured_photo.append(parts[1]["inlineData"]["data"])
         from io import BytesIO
+
         img = Image.new("RGB", (1280, 720), (10, 20, 30))
         buf = BytesIO()
         img.save(buf, format="PNG")
@@ -446,7 +482,8 @@ def test_compose_thumbnail_skips_pre_stylize_when_no_anchor(
     args = argparse.Namespace(
         slide_image=str(slide_path),
         speaker_photo=str(speaker_path),
-        title="T", subtitle=None,
+        title="T",
+        subtitle=None,
         output=str(tmp_path / "out.png"),
         vault=str(tmp_path),
         style="slide_dominant",
@@ -459,7 +496,9 @@ def test_compose_thumbnail_skips_pre_stylize_when_no_anchor(
 
     generate_thumbnail.compose_thumbnail(args)
 
-    assert stylize_called == [], "stylize_portrait must not run without --portrait-style"
+    assert stylize_called == [], (
+        "stylize_portrait must not run without --portrait-style"
+    )
     # The composition call received the ORIGINAL photo (base64-encoded raw).
     expected_b64 = base64.b64encode(b"PHOTO_RAW").decode("utf-8")
     assert captured_photo[0] == expected_b64
@@ -468,12 +507,17 @@ def test_compose_thumbnail_skips_pre_stylize_when_no_anchor(
 def _make_large_image_bytes():
     """Create a large random-ish image that exceeds 2MB as PNG."""
     import random
+
     random.seed(42)
     img = Image.new("RGB", (1280, 720))
     pixels = img.load()
     for x in range(1280):
         for y in range(720):
-            pixels[x, y] = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
+            pixels[x, y] = (
+                random.randint(0, 255),
+                random.randint(0, 255),
+                random.randint(0, 255),
+            )
     buf = BytesIO()
     img.save(buf, format="PNG")
     return buf.getvalue()

--- a/tests/test_goal_generation_provenance.py
+++ b/tests/test_goal_generation_provenance.py
@@ -163,9 +163,7 @@ def test_missing_current_pattern_baseline_is_unverifiable(goal_provenance):
         ),
     ],
 )
-def test_malformed_v2_goal_provenance_fails_closed(
-    goal_provenance, mutation, message
-):
+def test_malformed_v2_goal_provenance_fails_closed(goal_provenance, mutation, message):
     goal = _goal()
     mutation(goal)
 
@@ -217,9 +215,10 @@ def test_cli_emits_all_decisions_only_after_complete_validation():
     )
 
     assert valid.returncode == 0, valid.stderr
-    assert [
-        item["decision"] for item in json.loads(valid.stdout)["assessments"]
-    ] == ["comparable", "comparable"]
+    assert [item["decision"] for item in json.loads(valid.stdout)["assessments"]] == [
+        "comparable",
+        "comparable",
+    ]
 
     invalid_payload = copy.deepcopy(valid_payload)
     invalid_payload["goals"][1]["schema_version"] = 99

--- a/tests/test_insert_qr_wrapper.py
+++ b/tests/test_insert_qr_wrapper.py
@@ -3,6 +3,7 @@ validation, staging/move, JSON-only stdout, macro-failure path), with `osascript
 (the real PowerPoint/VBA call) faked on PATH. Only the VBA macro itself is the
 manual-validation gap; the wrapper scaffolding around it is testable.
 """
+
 import json
 import os
 import subprocess
@@ -30,8 +31,8 @@ def _fake_osascript(dirpath, *, succeed):
 
 def _run(args, tmp_path):
     env = dict(os.environ)
-    env["PATH"] = f"{tmp_path}:{env['PATH']}"   # shadow the real osascript
-    env["HOME"] = str(tmp_path)                  # isolate ~/.deckops-staging
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"  # shadow the real osascript
+    env["HOME"] = str(tmp_path)  # isolate ~/.deckops-staging
     return subprocess.run(
         ["bash", str(WRAPPER), *args], capture_output=True, text=True, env=env
     )
@@ -57,7 +58,9 @@ def test_missing_base_fails_with_actionable_error(tmp_path):
     png.write_text("x")
     _fake_osascript(tmp_path, succeed=True)
 
-    r = _run([str(tmp_path / "nope.pptx"), str(tmp_path / "o.pptx"), str(png), "1"], tmp_path)
+    r = _run(
+        [str(tmp_path / "nope.pptx"), str(tmp_path / "o.pptx"), str(png), "1"], tmp_path
+    )
     assert r.returncode != 0
     assert "base deck not found" in r.stderr
 
@@ -67,7 +70,9 @@ def test_missing_png_fails(tmp_path):
     base.write_text("x")
     _fake_osascript(tmp_path, succeed=True)
 
-    r = _run([str(base), str(tmp_path / "o.pptx"), str(tmp_path / "nope.png"), "1"], tmp_path)
+    r = _run(
+        [str(base), str(tmp_path / "o.pptx"), str(tmp_path / "nope.png"), "1"], tmp_path
+    )
     assert r.returncode != 0
     assert "QR PNG not found" in r.stderr
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -5,8 +5,18 @@ from datetime import date
 
 # --- Registry shape ---
 
+
 def test_registry_entries_well_formed(model_registry):
-    required = {"id", "display", "family", "aliases", "cost", "speed", "quality", "edit"}
+    required = {
+        "id",
+        "display",
+        "family",
+        "aliases",
+        "cost",
+        "speed",
+        "quality",
+        "edit",
+    }
     for m in model_registry.MODEL_REGISTRY:
         assert required <= set(m), f"{m.get('id')} missing keys"
         assert m["family"] in {"gemini", "imagen", "openai"}
@@ -17,7 +27,9 @@ def test_registry_entries_well_formed(model_registry):
 
 
 def test_compare_models_derived_from_registry(model_registry):
-    assert model_registry.COMPARE_MODELS == [m["id"] for m in model_registry.MODEL_REGISTRY]
+    assert model_registry.COMPARE_MODELS == [
+        m["id"] for m in model_registry.MODEL_REGISTRY
+    ]
 
 
 def test_registry_ids_unique(model_registry):
@@ -33,16 +45,26 @@ def test_imagen_has_no_edit_support(model_registry):
 
 # --- Alias resolution (the nano-banana fix) ---
 
+
 def test_resolve_nano_banana_pro_alias(model_registry):
-    assert model_registry.resolve_model_id("nano-banana-pro-preview") == "gemini-3-pro-image"
+    assert (
+        model_registry.resolve_model_id("nano-banana-pro-preview")
+        == "gemini-3-pro-image"
+    )
     assert model_registry.resolve_model_id("nano-banana-pro") == "gemini-3-pro-image"
 
 
 def test_resolve_deprecated_preview_ids_to_ga(model_registry):
     # Google deprecates the "-preview" Gemini ids 2026-06-25; they're kept as
     # aliases so a baked outline still resolves to the GA canonical id.
-    assert model_registry.resolve_model_id("gemini-3-pro-image-preview") == "gemini-3-pro-image"
-    assert model_registry.resolve_model_id("gemini-3.1-flash-image-preview") == "gemini-3.1-flash-image"
+    assert (
+        model_registry.resolve_model_id("gemini-3-pro-image-preview")
+        == "gemini-3-pro-image"
+    )
+    assert (
+        model_registry.resolve_model_id("gemini-3.1-flash-image-preview")
+        == "gemini-3.1-flash-image"
+    )
 
 
 def test_resolve_rolling_openai_alias_to_snapshot(model_registry):
@@ -52,11 +74,16 @@ def test_resolve_rolling_openai_alias_to_snapshot(model_registry):
 
 def test_resolve_is_case_insensitive(model_registry):
     assert model_registry.resolve_model_id("Nano-Banana-Pro") == "gemini-3-pro-image"
-    assert model_registry.resolve_model_id("  GPT-IMAGE-2  ") == "gpt-image-2-2026-04-21"
+    assert (
+        model_registry.resolve_model_id("  GPT-IMAGE-2  ") == "gpt-image-2-2026-04-21"
+    )
 
 
 def test_resolve_canonical_id_unchanged(model_registry):
-    assert model_registry.resolve_model_id("gpt-image-2-2026-04-21") == "gpt-image-2-2026-04-21"
+    assert (
+        model_registry.resolve_model_id("gpt-image-2-2026-04-21")
+        == "gpt-image-2-2026-04-21"
+    )
 
 
 def test_resolve_unknown_passthrough(model_registry):
@@ -67,7 +94,9 @@ def test_resolve_unknown_passthrough(model_registry):
 def test_resolve_unknown_strips_whitespace(model_registry):
     # Stray whitespace on an unknown id must not survive — it would misclassify
     # the vendor family in model_family()'s prefix check.
-    assert model_registry.resolve_model_id("  imagen-9.9-future  ") == "imagen-9.9-future"
+    assert (
+        model_registry.resolve_model_id("  imagen-9.9-future  ") == "imagen-9.9-future"
+    )
 
 
 def test_resolve_empty(model_registry):
@@ -94,6 +123,7 @@ def test_model_attributes_via_alias(model_registry):
 
 
 # --- Shortlist ranking ---
+
 
 def test_shortlist_build_editability_excludes_imagen(model_registry):
     ranked = model_registry.shortlist_models(["build-editability"])
@@ -126,6 +156,7 @@ def test_shortlist_empty_returns_full_registry_in_order(model_registry):
 
 def test_shortlist_unknown_priority_raises(model_registry):
     import pytest
+
     with pytest.raises(ValueError) as exc:
         model_registry.shortlist_models(["cost", "bogus"])
     assert "bogus" in str(exc.value)
@@ -140,11 +171,16 @@ def test_shortlist_does_not_mutate_registry(model_registry):
 
 # --- Live injection (hybrid: cache + inject) ---
 
+
 def test_shortlist_injects_web_discovered_model(model_registry):
     # A brand-new flagship not in the cache, injected with its attributes.
     breakthrough = {
-        "id": "gemini-5-ultra-image", "family": "gemini",
-        "cost": "low", "speed": "fast", "quality": "high", "edit": "strong",
+        "id": "gemini-5-ultra-image",
+        "family": "gemini",
+        "cost": "low",
+        "speed": "fast",
+        "quality": "high",
+        "edit": "strong",
     }
     ranked = model_registry.shortlist_models(
         ["quality", "cost"], extra_models=[breakthrough]
@@ -158,8 +194,12 @@ def test_shortlist_injects_web_discovered_model(model_registry):
 def test_shortlist_injected_model_respects_editability_filter(model_registry):
     # An injected model that can't edit is dropped under build-editability.
     no_edit = {
-        "id": "fancy-but-no-edit", "family": "other",
-        "cost": "low", "speed": "fast", "quality": "high", "edit": "none",
+        "id": "fancy-but-no-edit",
+        "family": "other",
+        "cost": "low",
+        "speed": "fast",
+        "quality": "high",
+        "edit": "none",
     }
     ranked = model_registry.shortlist_models(
         ["build-editability"], extra_models=[no_edit]
@@ -179,23 +219,27 @@ def test_shortlist_build_editability_excludes_missing_edit(model_registry):
 
 def test_shortlist_injected_model_without_id_raises(model_registry):
     import pytest
+
     with pytest.raises(ValueError) as exc:
         model_registry.shortlist_models(["cost"], extra_models=[{"family": "gemini"}])
     assert "id" in str(exc.value)
 
 
 def test_shortlist_extra_none_is_noop(model_registry):
-    assert model_registry.shortlist_models(["cost"], extra_models=None) == \
-        model_registry.shortlist_models(["cost"])
+    assert model_registry.shortlist_models(
+        ["cost"], extra_models=None
+    ) == model_registry.shortlist_models(["cost"])
 
 
 def test_shortlist_deduplicates_priorities(model_registry):
     # A repeated priority must not double its weight — repetition is meaningless.
-    assert model_registry.shortlist_models(["cost", "cost"]) == \
-        model_registry.shortlist_models(["cost"])
+    assert model_registry.shortlist_models(
+        ["cost", "cost"]
+    ) == model_registry.shortlist_models(["cost"])
 
 
 # --- Freshness ---
+
 
 def test_freshness_fresh_when_recent(model_registry):
     reviewed = date.fromisoformat(model_registry.REGISTRY_LAST_REVIEWED)

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -44,9 +44,7 @@ def _base_database() -> dict[str, object]:
     return {
         "schema_version": 1,
         "config": _current_config(),
-        "talks": [
-            {"schema_version": 5, "filename": "talk.md", "status": "processed"}
-        ],
+        "talks": [{"schema_version": 5, "filename": "talk.md", "status": "processed"}],
         "pptx_catalog": [],
         "qr_codes": [],
         "resources": [],
@@ -508,14 +506,20 @@ def test_plan_strict_json_rejects_non_roundtrippable_number(
     ("raw", "message"),
     [
         pytest.param(
-            b'{"schema_version":1,"mutations":' + b"[" * 500 + b"{}"
-            + b"]" * 500 + b"}\n",
+            b'{"schema_version":1,"mutations":'
+            + b"[" * 500
+            + b"{}"
+            + b"]" * 500
+            + b"}\n",
             "maximum supported JSON nesting depth 200",
             id="decoded-depth-limit",
         ),
         pytest.param(
-            b'{"schema_version":1,"mutations":' + b"[" * 10_000 + b"{}"
-            + b"]" * 10_000 + b"}\n",
+            b'{"schema_version":1,"mutations":'
+            + b"[" * 10_000
+            + b"{}"
+            + b"]" * 10_000
+            + b"}\n",
             "maximum supported JSON nesting depth 200",
             id="decoder-recursion-limit",
         ),
@@ -568,9 +572,7 @@ def test_talk_clarification_operation_accepts_only_structured_exact_fields(
         ],
     )
 
-    assert candidate["talks"][0]["blind_spot_observations"] == {
-        "room_energy": "high"
-    }
+    assert candidate["talks"][0]["blind_spot_observations"] == {"room_energy": "high"}
     assert candidate["talks"][0]["humor_postmortem"] == ["opening joke landed"]
     assert changes[0]["kind"] == "update_talk_clarification"
 

--- a/tests/test_narrative_rhetorical.py
+++ b/tests/test_narrative_rhetorical.py
@@ -69,7 +69,8 @@ def test_narrative_full_renders_per_slide_walk(extract_narrative, outline):
 
 
 def test_narrative_slide_synopsis_prefers_overlay_then_visual(
-    extract_narrative, outline,
+    extract_narrative,
+    outline,
 ):
     out = extract_narrative.render(outline)
     # Slide 2 has a text_overlay — use it
@@ -79,17 +80,21 @@ def test_narrative_slide_synopsis_prefers_overlay_then_visual(
 
 
 def test_narrative_inlines_interlude_at_anchor(
-    extract_narrative, outline_schema, base_data,
+    extract_narrative,
+    outline_schema,
+    base_data,
 ):
     """An interlude renders as a live-demo line right after its anchor slide."""
     data = copy.deepcopy(base_data)
-    data["interludes"] = [{
-        "id": "demo-vat",
-        "after_slide": 8,
-        "title": "Live coding: agent rewrites the VAT calc",
-        "chapter": "ch2",
-        "script": [{"line": "Watch what happens."}],
-    }]
+    data["interludes"] = [
+        {
+            "id": "demo-vat",
+            "after_slide": 8,
+            "title": "Live coding: agent rewrites the VAT calc",
+            "chapter": "ch2",
+            "script": [{"line": "Watch what happens."}],
+        }
+    ]
     outline = outline_schema.Outline.model_validate(data)
     out = extract_narrative.render(outline)
     assert "- *Live coding: agent rewrites the VAT calc — live demo*" in out
@@ -121,7 +126,9 @@ def test_narrative_renders_tldr_when_present(extract_narrative, outline):
 
 
 def test_narrative_never_reprints_full_thesis(
-    extract_narrative, outline_schema, base_data,
+    extract_narrative,
+    outline_schema,
+    base_data,
 ):
     """The elaborated talk.thesis must never appear — only the tldr does."""
     data = copy.deepcopy(base_data)
@@ -136,7 +143,9 @@ def test_narrative_never_reprints_full_thesis(
 
 
 def test_narrative_partial_tldr_only_stub(
-    extract_narrative, outline_schema, base_data,
+    extract_narrative,
+    outline_schema,
+    base_data,
 ):
     """Phase 1 stub: tldr renders, chapter body is a 'not yet authored' note."""
     data = {"talk": copy.deepcopy(base_data["talk"])}
@@ -150,7 +159,9 @@ def test_narrative_partial_tldr_only_stub(
 
 
 def test_narrative_partial_renders_chapters_without_slides(
-    extract_narrative, outline_schema, base_data,
+    extract_narrative,
+    outline_schema,
+    base_data,
 ):
     """Phase 2: chapters present, slides absent — full chapter body renders."""
     chapters = copy.deepcopy(base_data["chapters"])
@@ -167,7 +178,10 @@ def test_narrative_partial_renders_chapters_without_slides(
 
 
 def test_narrative_cli_partial_renders_talk_only(
-    extract_narrative, base_data, tmp_path, capsys,
+    extract_narrative,
+    base_data,
+    tmp_path,
+    capsys,
 ):
     """CLI --partial renders a talk-only outline to stdout."""
     data = {"talk": copy.deepcopy(base_data["talk"])}
@@ -180,7 +194,10 @@ def test_narrative_cli_partial_renders_talk_only(
 
 
 def test_narrative_cli_full_mode_rejects_slideless_outline(
-    extract_narrative, base_data, tmp_path, capsys,
+    extract_narrative,
+    base_data,
+    tmp_path,
+    capsys,
 ):
     """Without --partial, a slides-less outline fails full validation (exit 1)."""
     data = {"talk": copy.deepcopy(base_data["talk"])}
@@ -215,7 +232,8 @@ def _outline_from(outline_schema, base_data, mutate):
 
 
 def test_register_coverage_passes_when_all_four_answered(
-    check_rhetorical, outline,
+    check_rhetorical,
+    outline,
 ):
     content, flag_count = check_rhetorical.render(outline)
     assert "### Register coverage — ✅ **PASS**" in content
@@ -223,15 +241,20 @@ def test_register_coverage_passes_when_all_four_answered(
 
 
 def test_register_coverage_flags_missing_register(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     """Dropping the C+D walk-around leaves a heterogeneous room half-answered."""
+
     def mutate(data):
         for slide in data["slides"]:
             slide["applied_patterns"] = [
-                p for p in slide.get("applied_patterns", [])
+                p
+                for p in slide.get("applied_patterns", [])
                 if p.get("id") != "walk-around" or p.get("registers") != ["C", "D"]
             ]
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, flag_count = check_rhetorical.render(o)
     assert "Register coverage" in content
@@ -240,14 +263,18 @@ def test_register_coverage_flags_missing_register(
 
 
 def test_register_coverage_flags_heterogeneous_with_no_walk_around(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     def mutate(data):
         for slide in data["slides"]:
             slide["applied_patterns"] = [
-                p for p in slide.get("applied_patterns", [])
+                p
+                for p in slide.get("applied_patterns", [])
                 if p.get("id") != "walk-around"
             ]
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, flag_count = check_rhetorical.render(o)
     assert "no claim declares a walk-around" in content
@@ -255,17 +282,22 @@ def test_register_coverage_flags_heterogeneous_with_no_walk_around(
 
 
 def test_register_match_flags_unmatched_homogeneous_room(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     """A room declared homogeneous on C, with no walk-around answering C."""
+
     def mutate(data):
         data["talk"]["audience_spread"] = "homogeneous"
         data["talk"]["dominant_register"] = "C"
         for slide in data["slides"]:
             slide["applied_patterns"] = [
-                p for p in slide.get("applied_patterns", [])
+                p
+                for p in slide.get("applied_patterns", [])
                 if p.get("id") != "walk-around" or p.get("registers") != ["C", "D"]
             ]
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, flag_count = check_rhetorical.render(o)
     assert "Register match" in content
@@ -274,32 +306,40 @@ def test_register_match_flags_unmatched_homogeneous_room(
 
 
 def test_register_match_passes_when_dominant_answered(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     def mutate(data):
         data["talk"]["audience_spread"] = "homogeneous"
         data["talk"]["dominant_register"] = "C"
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, _ = check_rhetorical.render(o)
     assert "### Register match — ✅ **PASS**" in content
 
 
 def test_register_match_flags_homogeneous_with_zero_walk_arounds(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     """A homogeneous room with no audit at all must not pass as N/A.
 
     Declaring `dominant_register: C` and supplying no register evidence is an
     unanswered claim, not an inapplicable check.
     """
+
     def mutate(data):
         data["talk"]["audience_spread"] = "homogeneous"
         data["talk"]["dominant_register"] = "C"
         for slide in data["slides"]:
             slide["applied_patterns"] = [
-                p for p in slide.get("applied_patterns", [])
+                p
+                for p in slide.get("applied_patterns", [])
                 if p.get("id") != "walk-around"
             ]
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, flag_count = check_rhetorical.render(o)
     assert "Register match — ⚠️" in content
@@ -309,14 +349,18 @@ def test_register_match_flags_homogeneous_with_zero_walk_arounds(
 
 
 def test_register_coverage_flags_walk_around_without_registers(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     """A walk-around with no `registers:` is unverifiable, not absent."""
+
     def mutate(data):
         for slide in data["slides"]:
             for p in slide.get("applied_patterns", []):
                 if p.get("id") == "walk-around":
                     p.pop("registers", None)
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, flag_count = check_rhetorical.render(o)
     assert "no `registers:` set" in content
@@ -324,28 +368,35 @@ def test_register_coverage_flags_walk_around_without_registers(
 
 
 def test_register_coverage_counts_interlude_walk_around(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     """An interlude is a located, claim-bearing unit — its walk-around counts.
 
     A live demo answering "how does it work, in what order" is a B answer no
     slide can match. Only talk-level (which has no claim to locate) is barred.
     """
+
     def mutate(data):
         # Drop the slide-level C+D audit, and answer C+D from a demo instead.
         for slide in data["slides"]:
             slide["applied_patterns"] = [
-                p for p in slide.get("applied_patterns", [])
+                p
+                for p in slide.get("applied_patterns", [])
                 if p.get("id") != "walk-around" or p.get("registers") != ["C", "D"]
             ]
-        data["interludes"] = [{
-            "id": "demo-migration",
-            "after_slide": 8,
-            "title": "Live: migrating a service",
-            "chapter": "ch2",
-            "script": [{"line": "Watch who has to be paged."}],
-            "applied_patterns": [{"id": "walk-around", "registers": ["C", "D"]}],
-        }]
+        data["interludes"] = [
+            {
+                "id": "demo-migration",
+                "after_slide": 8,
+                "title": "Live: migrating a service",
+                "chapter": "ch2",
+                "script": [{"line": "Watch who has to be paged."}],
+                "applied_patterns": [{"id": "walk-around", "registers": ["C", "D"]}],
+            }
+        ]
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, flag_count = check_rhetorical.render(o)
     assert "### Register coverage — ✅ **PASS**" in content
@@ -354,13 +405,16 @@ def test_register_coverage_counts_interlude_walk_around(
 
 
 def test_unannotated_walk_around_label_tracks_spread(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     """The section header must stay 'Register match' for a homogeneous room.
 
     A homogeneous run that emits 'Register coverage' breaks the header any
     reader — or downstream parse — keys on.
     """
+
     def mutate(data):
         data["talk"]["audience_spread"] = "homogeneous"
         data["talk"]["dominant_register"] = "A"
@@ -368,6 +422,7 @@ def test_unannotated_walk_around_label_tracks_spread(
             for p in slide.get("applied_patterns", []):
                 if p.get("id") == "walk-around":
                     p.pop("registers", None)
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, _ = check_rhetorical.render(o)
     assert "### Register match — ⚠️" in content
@@ -375,12 +430,15 @@ def test_unannotated_walk_around_label_tracks_spread(
 
 
 def test_register_coverage_flags_unannotated_before_absent(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     """The unannotated message must win over 'no claim declares a walk-around'.
 
     Reporting an unannotated walk-around as absent misdescribes the outline.
     """
+
     def mutate(data):
         data["talk"]["audience_spread"] = "homogeneous"
         data["talk"]["dominant_register"] = "A"
@@ -388,6 +446,7 @@ def test_register_coverage_flags_unannotated_before_absent(
             for p in slide.get("applied_patterns", []):
                 if p.get("id") == "walk-around":
                     p.pop("registers", None)
+
     o = _outline_from(outline_schema, base_data, mutate)
     content, _ = check_rhetorical.render(o)
     assert "no `registers:` set" in content
@@ -406,7 +465,9 @@ def test_rhetorical_reports_thesis_ordering(check_rhetorical, outline):
     assert "preview slide 5 → payoff slide 11" in content
 
 
-def test_rhetorical_passes_sparkline_when_complete(check_rhetorical, outline_schema, base_data):
+def test_rhetorical_passes_sparkline_when_complete(
+    check_rhetorical, outline_schema, base_data
+):
     """Fixture's architecture is sparkline with call-to-adventure, new-bliss,
     star-moment. Add call-to-action to complete the set."""
     data = copy.deepcopy(base_data)
@@ -439,11 +500,14 @@ def test_rhetorical_includes_duration_accounting(check_rhetorical, outline):
 # ── check-rhetorical.py — FLAG cases via mutation ────────────────────
 
 
-def test_rhetorical_flags_missing_opening_punch(check_rhetorical, outline_schema, base_data):
+def test_rhetorical_flags_missing_opening_punch(
+    check_rhetorical, outline_schema, base_data
+):
     data = copy.deepcopy(base_data)
     # Remove opening-punch from slide 1
     data["slides"][0]["applied_patterns"] = [
-        p for p in data["slides"][0]["applied_patterns"]
+        p
+        for p in data["slides"][0]["applied_patterns"]
         if p.get("id") != "opening-punch"
     ]
     outline = outline_schema.Outline.model_validate(data)
@@ -453,14 +517,15 @@ def test_rhetorical_flags_missing_opening_punch(check_rhetorical, outline_schema
 
 
 def test_rhetorical_flags_sparkline_missing_call_to_action(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     data = copy.deepcopy(base_data)
     # Remove call-to-action from slide 10
     slide_10 = next(s for s in data["slides"] if s["n"] == 10)
     slide_10["applied_patterns"] = [
-        p for p in slide_10["applied_patterns"]
-        if p.get("id") != "call-to-action"
+        p for p in slide_10["applied_patterns"] if p.get("id") != "call-to-action"
     ]
     outline = outline_schema.Outline.model_validate(data)
     content, flag_count = check_rhetorical.render(outline)
@@ -469,16 +534,20 @@ def test_rhetorical_flags_sparkline_missing_call_to_action(
 
 
 def test_rhetorical_flags_too_many_inoculations(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     data = copy.deepcopy(base_data)
     # Fixture has 1 inoculation; add 3 more to push past the ≤3 limit
     for slide_n, vector in [(8, "fear"), (10, "obstacles"), (11, "comfort-zone")]:
         slide = next(s for s in data["slides"] if s["n"] == slide_n)
-        slide.setdefault("applied_patterns", []).append({
-            "id": "inoculation",
-            "resistance_vector": vector,
-        })
+        slide.setdefault("applied_patterns", []).append(
+            {
+                "id": "inoculation",
+                "resistance_vector": vector,
+            }
+        )
     outline = outline_schema.Outline.model_validate(data)
     content, flag_count = check_rhetorical.render(outline)
     assert flag_count >= 1
@@ -486,7 +555,9 @@ def test_rhetorical_flags_too_many_inoculations(
 
 
 def test_rhetorical_na_for_non_sparkline_arch(
-    check_rhetorical, outline_schema, base_data,
+    check_rhetorical,
+    outline_schema,
+    base_data,
 ):
     data = copy.deepcopy(base_data)
     data["talk"]["architecture"] = "talklet"
@@ -499,11 +570,14 @@ def test_rhetorical_na_for_non_sparkline_arch(
     assert "Sparkline elements — — *N/A*" in content
 
 
-def test_rhetorical_strict_mode_returns_flag_count(check_rhetorical, outline_schema, base_data):
+def test_rhetorical_strict_mode_returns_flag_count(
+    check_rhetorical, outline_schema, base_data
+):
     """Verify the render() function returns the flag count for --strict gating."""
     data = copy.deepcopy(base_data)
     data["slides"][0]["applied_patterns"] = [
-        p for p in data["slides"][0]["applied_patterns"]
+        p
+        for p in data["slides"][0]["applied_patterns"]
         if p.get("id") != "opening-punch"
     ]
     outline = outline_schema.Outline.model_validate(data)

--- a/tests/test_outline_schema.py
+++ b/tests/test_outline_schema.py
@@ -152,7 +152,8 @@ def test_rejects_out_of_order_slides(outline_schema, base_data):
     data = copy.deepcopy(base_data)
     # Swap first two slide numbers without duplicating
     data["slides"][0]["n"], data["slides"][1]["n"] = (
-        data["slides"][1]["n"], data["slides"][0]["n"],
+        data["slides"][1]["n"],
+        data["slides"][0]["n"],
     )
     with pytest.raises(ValidationError, match="ascending order"):
         outline_schema.Outline.model_validate(data)
@@ -274,10 +275,12 @@ def test_rejects_unknown_pattern_id(outline_schema, base_data):
 def test_rejects_instance_field_on_wrong_pattern(outline_schema, base_data):
     data = copy.deepcopy(base_data)
     # flavors only belongs on opening-punch — putting it on bookends should fail
-    data["talk"]["applied_patterns"].append({
-        "id": "bookends",
-        "flavors": ["personal"],
-    })
+    data["talk"]["applied_patterns"].append(
+        {
+            "id": "bookends",
+            "flavors": ["personal"],
+        }
+    )
     with pytest.raises(ValidationError, match="does not accept"):
         outline_schema.Outline.model_validate(data)
 
@@ -298,7 +301,8 @@ def test_rejects_unpaid_callback_plant(outline_schema, base_data):
     # Remove the pay for receipt-motif (currently on slide n=7)
     for slide in data["slides"]:
         slide["callbacks"] = [
-            cb for cb in slide.get("callbacks", [])
+            cb
+            for cb in slide.get("callbacks", [])
             if not (cb.get("kind") == "pay" and cb.get("id") == "receipt-motif")
         ]
     with pytest.raises(ValidationError, match="unpaid plants"):
@@ -352,17 +356,19 @@ def test_accepts_slide_n_zero(outline_schema, base_data):
 def test_accepts_demo_format(outline_schema, base_data):
     """DEMO is a production-interlude slide — live terminal, no image prompt."""
     data = copy.deepcopy(base_data)
-    data["slides"].append({
-        "n": 99,
-        "chapter": "ch1",
-        "title": "DEMO 01 — Live Terminal",
-        "format": "DEMO",
-        "visual": "Live terminal. Claude Code TUI.",
-        "script": [
-            {"cue": "TERMINAL UP"},
-            {"line": "Let me show you something."},
-        ],
-    })
+    data["slides"].append(
+        {
+            "n": 99,
+            "chapter": "ch1",
+            "title": "DEMO 01 — Live Terminal",
+            "format": "DEMO",
+            "visual": "Live terminal. Claude Code TUI.",
+            "script": [
+                {"cue": "TERMINAL UP"},
+                {"line": "Let me show you something."},
+            ],
+        }
+    )
     data["talk"]["slide_budget"] = 30
     outline = outline_schema.Outline.model_validate(data)
     assert outline.slides[-1].format.value == "DEMO"
@@ -371,12 +377,14 @@ def test_accepts_demo_format(outline_schema, base_data):
 def test_accepts_title_format(outline_schema, base_data):
     """TITLE is a title-card slide — passive display, often n=0."""
     data = copy.deepcopy(base_data)
-    data["slides"].append({
-        "n": 99,
-        "chapter": "ch1",
-        "title": "Title Card",
-        "format": "TITLE",
-    })
+    data["slides"].append(
+        {
+            "n": 99,
+            "chapter": "ch1",
+            "title": "Title Card",
+            "format": "TITLE",
+        }
+    )
     data["talk"]["slide_budget"] = 30
     outline = outline_schema.Outline.model_validate(data)
     assert outline.slides[-1].format.value == "TITLE"
@@ -412,10 +420,13 @@ def test_accepts_speaker_on_parenthetical_multi_speaker(outline_schema, base_dat
             if item.get("line") is not None:
                 item["speaker"] = "Speaker One"
     # Add a speaker-attributed parenthetical
-    data["slides"][0]["script"].insert(0, {
-        "speaker": "Speaker Two",
-        "parenthetical": "(to Speaker One)",
-    })
+    data["slides"][0]["script"].insert(
+        0,
+        {
+            "speaker": "Speaker Two",
+            "parenthetical": "(to Speaker One)",
+        },
+    )
     outline = outline_schema.Outline.model_validate(data)
     assert outline.slides[0].script[0].speaker == "Speaker Two"
 
@@ -423,10 +434,13 @@ def test_accepts_speaker_on_parenthetical_multi_speaker(outline_schema, base_dat
 def test_rejects_speaker_on_parenthetical_single_speaker(outline_schema, base_data):
     """Single-speaker talks must not attribute parentheticals — there's only one voice."""
     data = copy.deepcopy(base_data)
-    data["slides"][0]["script"].insert(0, {
-        "speaker": "Speaker One",
-        "parenthetical": "(beat)",
-    })
+    data["slides"][0]["script"].insert(
+        0,
+        {
+            "speaker": "Speaker One",
+            "parenthetical": "(beat)",
+        },
+    )
     with pytest.raises(ValidationError, match="must not attribute parentheticals"):
         outline_schema.Outline.model_validate(data)
 
@@ -450,10 +464,13 @@ def test_rejects_unknown_speaker_on_parenthetical(outline_schema, base_data):
         for item in slide.get("script", []):
             if item.get("line") is not None:
                 item["speaker"] = "Speaker One"
-    data["slides"][0]["script"].insert(0, {
-        "speaker": "Speaker Three",
-        "parenthetical": "(to Speaker One)",
-    })
+    data["slides"][0]["script"].insert(
+        0,
+        {
+            "speaker": "Speaker Three",
+            "parenthetical": "(to Speaker One)",
+        },
+    )
     with pytest.raises(ValidationError, match="not in talk.speakers"):
         outline_schema.Outline.model_validate(data)
 
@@ -463,16 +480,18 @@ def test_rejects_unknown_speaker_on_parenthetical(outline_schema, base_data):
 
 def test_accepts_interlude(outline_schema, base_data):
     data = copy.deepcopy(base_data)
-    data["interludes"] = [{
-        "id": "demo-01",
-        "after_slide": 1,
-        "chapter": "ch1",
-        "title": "DEMO 01 — Cold Open",
-        "script": [
-            {"cue": "TERMINAL UP"},
-            {"line": "Let me show you something."},
-        ],
-    }]
+    data["interludes"] = [
+        {
+            "id": "demo-01",
+            "after_slide": 1,
+            "chapter": "ch1",
+            "title": "DEMO 01 — Cold Open",
+            "script": [
+                {"cue": "TERMINAL UP"},
+                {"line": "Let me show you something."},
+            ],
+        }
+    ]
     outline = outline_schema.Outline.model_validate(data)
     assert len(outline.interludes) == 1
     assert outline.interludes[0].after_slide == 1
@@ -480,26 +499,30 @@ def test_accepts_interlude(outline_schema, base_data):
 
 def test_rejects_interlude_unknown_chapter(outline_schema, base_data):
     data = copy.deepcopy(base_data)
-    data["interludes"] = [{
-        "id": "demo-01",
-        "after_slide": 1,
-        "chapter": "ch99",
-        "title": "DEMO 01",
-        "script": [{"cue": "TERMINAL UP"}],
-    }]
+    data["interludes"] = [
+        {
+            "id": "demo-01",
+            "after_slide": 1,
+            "chapter": "ch99",
+            "title": "DEMO 01",
+            "script": [{"cue": "TERMINAL UP"}],
+        }
+    ]
     with pytest.raises(ValidationError, match="unknown chapter"):
         outline_schema.Outline.model_validate(data)
 
 
 def test_rejects_interlude_bad_anchor(outline_schema, base_data):
     data = copy.deepcopy(base_data)
-    data["interludes"] = [{
-        "id": "demo-01",
-        "after_slide": 999,
-        "chapter": "ch1",
-        "title": "DEMO 01",
-        "script": [{"cue": "TERMINAL UP"}],
-    }]
+    data["interludes"] = [
+        {
+            "id": "demo-01",
+            "after_slide": 999,
+            "chapter": "ch1",
+            "title": "DEMO 01",
+            "script": [{"cue": "TERMINAL UP"}],
+        }
+    ]
     with pytest.raises(ValidationError, match="after_slide=999"):
         outline_schema.Outline.model_validate(data)
 
@@ -529,14 +552,16 @@ def test_rejects_duplicate_interlude_ids(outline_schema, base_data):
 def test_interlude_callbacks_count_toward_ledger(outline_schema, base_data):
     """An interlude that plants a callback must be paid (somewhere)."""
     data = copy.deepcopy(base_data)
-    data["interludes"] = [{
-        "id": "demo-01",
-        "after_slide": 1,
-        "chapter": "ch1",
-        "title": "DEMO 01",
-        "script": [{"cue": "TERMINAL UP"}],
-        "callbacks": [{"kind": "plant", "id": "demo-plant"}],
-    }]
+    data["interludes"] = [
+        {
+            "id": "demo-01",
+            "after_slide": 1,
+            "chapter": "ch1",
+            "title": "DEMO 01",
+            "script": [{"cue": "TERMINAL UP"}],
+            "callbacks": [{"kind": "plant", "id": "demo-plant"}],
+        }
+    ]
     with pytest.raises(ValidationError, match="unpaid plants"):
         outline_schema.Outline.model_validate(data)
 
@@ -556,12 +581,12 @@ def test_requires_slug(outline_schema, base_data):
 def test_rejects_non_kebab_slug(outline_schema, base_data):
     data = copy.deepcopy(base_data)
     bad_slugs = [
-        "Demo Talk",          # spaces + caps
-        "demo_talk",          # underscore
-        "demo--talk",         # double dash
-        "-demo-talk",         # leading dash
-        "demo-talk-",         # trailing dash
-        "DemoTalk",           # camelCase
+        "Demo Talk",  # spaces + caps
+        "demo_talk",  # underscore
+        "demo--talk",  # double dash
+        "-demo-talk",  # leading dash
+        "demo-talk-",  # trailing dash
+        "DemoTalk",  # camelCase
     ]
     for slug in bad_slugs:
         data["talk"]["slug"] = slug
@@ -666,7 +691,7 @@ def test_rejects_builds_not_starting_at_zero(outline_schema, base_data):
     data = copy.deepcopy(base_data)
     slide_with_builds = next(s for s in data["slides"] if s.get("builds"))
     for i, b in enumerate(slide_with_builds["builds"]):
-        b["step"] = i + 1   # shift to start at 1
+        b["step"] = i + 1  # shift to start at 1
     with pytest.raises(ValidationError, match="contiguous starting at 0"):
         outline_schema.Outline.model_validate(data)
 
@@ -675,7 +700,7 @@ def test_rejects_builds_with_holes(outline_schema, base_data):
     """Build sequences must be contiguous — no gaps."""
     data = copy.deepcopy(base_data)
     slide_with_builds = next(s for s in data["slides"] if s.get("builds"))
-    slide_with_builds["builds"][-1]["step"] = 99   # gap
+    slide_with_builds["builds"][-1]["step"] = 99  # gap
     with pytest.raises(ValidationError, match="contiguous"):
         outline_schema.Outline.model_validate(data)
 
@@ -745,7 +770,9 @@ def test_accepts_style_anchor_composition_and_footer(outline_schema, base_data):
     data["style_anchor"]["composition"] = "poster-theatrical"
     data["style_anchor"]["embedded_footer"] = "@speaker · example.com/talk"
     outline = outline_schema.Outline.model_validate(data)
-    assert outline.style_anchor.composition == outline_schema.Composition.poster_theatrical
+    assert (
+        outline.style_anchor.composition == outline_schema.Composition.poster_theatrical
+    )
     assert outline.style_anchor.embedded_footer == "@speaker · example.com/talk"
 
 
@@ -877,11 +904,13 @@ def test_cli_emit_json_dumps_validated_outline(outline_schema, capsys):
     re-parsing YAML by hand."""
     import json as _json
 
-    rc = outline_schema.main([
-        "outline_schema.py",
-        "--emit-json",
-        str(FIXTURE),
-    ])
+    rc = outline_schema.main(
+        [
+            "outline_schema.py",
+            "--emit-json",
+            str(FIXTURE),
+        ]
+    )
     assert rc == 0
     captured = capsys.readouterr()
     assert captured.err == ""
@@ -906,11 +935,13 @@ def test_cli_emit_json_validation_failure_to_stderr(outline_schema, capsys, tmp_
     not silently emit a partial payload on failure."""
     bad = tmp_path / "bad-outline.yaml"
     bad.write_text("talk: {}\n", encoding="utf-8")
-    rc = outline_schema.main([
-        "outline_schema.py",
-        "--emit-json",
-        str(bad),
-    ])
+    rc = outline_schema.main(
+        [
+            "outline_schema.py",
+            "--emit-json",
+            str(bad),
+        ]
+    )
     assert rc == 1
     captured = capsys.readouterr()
     assert captured.out == ""

--- a/tests/test_outline_source_is_yaml.py
+++ b/tests/test_outline_source_is_yaml.py
@@ -34,9 +34,7 @@ FORBIDDEN_MD_OUTLINE_FIELDS = ("**Composition:**", "**Embedded footer:**")
 
 def _script_files() -> list[Path]:
     return sorted(
-        p
-        for p in SKILLS_DIR.glob("*/scripts/*.py")
-        if "__pycache__" not in p.parts
+        p for p in SKILLS_DIR.glob("*/scripts/*.py") if "__pycache__" not in p.parts
     )
 
 
@@ -47,9 +45,11 @@ def _outline_arg_help(tree: ast.AST) -> str | None:
     `add_argument("--outline", ...)`.
     """
     for node in ast.walk(tree):
-        if not (isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "add_argument"):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_argument"
+        ):
             continue
         if not (node.args and isinstance(node.args[0], ast.Constant)):
             continue

--- a/tests/test_package_contents_gate.py
+++ b/tests/test_package_contents_gate.py
@@ -18,8 +18,9 @@ GATE = REPO_ROOT / "scripts" / "check-package-contents.sh"
 
 
 def _git(repo: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(repo), *args], check=True,
-                   capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
 
 
 def _write(repo: Path, rel: str, body: str) -> None:
@@ -29,8 +30,9 @@ def _write(repo: Path, rel: str, body: str) -> None:
 
 
 def _run(repo: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(["bash", str(GATE), str(repo)],
-                          capture_output=True, text=True)
+    return subprocess.run(
+        ["bash", str(GATE), str(repo)], capture_output=True, text=True
+    )
 
 
 @pytest.fixture()
@@ -38,18 +40,25 @@ def plugin(tmp_path: Path) -> Path:
     """A committed plugin repo: one skill with a script, one rule, no ignores."""
     repo = tmp_path / "plugin"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)],
-                   check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(repo)], check=True, capture_output=True
+    )
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test")
 
-    _write(repo, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget",
-        "version": "1.0.0",
-        "description": "Test plugin",
-        "skills": ["skills/builder"],
-        "rules": ["rules/house-style.md"],
-    }))
+    _write(
+        repo,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "Test plugin",
+                "skills": ["skills/builder"],
+                "rules": ["rules/house-style.md"],
+            }
+        ),
+    )
     _write(repo, "skills/builder/SKILL.md", "# Builder\n")
     _write(repo, "skills/builder/scripts/build.py", "print('build')\n")
     _write(repo, "skills/builder/references/notes.md", "notes\n")
@@ -144,10 +153,18 @@ def test_malformed_manifest_fails(plugin: Path) -> None:
 
 
 def test_wrong_field_shape_fails(plugin: Path) -> None:
-    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget", "version": "1.0.0", "description": "d",
-        "skills": 42,
-    }))
+    _write(
+        plugin,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "d",
+                "skills": 42,
+            }
+        ),
+    )
     _write(plugin, ".tesslignore", "/scripts/\n")
     result = _run(plugin)
     assert result.returncode == 1
@@ -155,9 +172,17 @@ def test_wrong_field_shape_fails(plugin: Path) -> None:
 
 
 def test_manifest_declaring_no_content_fails(plugin: Path) -> None:
-    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget", "version": "1.0.0", "description": "d",
-    }))
+    _write(
+        plugin,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "d",
+            }
+        ),
+    )
     _write(plugin, ".tesslignore", "/scripts/\n")
     result = _run(plugin)
     assert result.returncode == 1
@@ -165,10 +190,18 @@ def test_manifest_declaring_no_content_fails(plugin: Path) -> None:
 
 
 def test_declared_path_with_no_tracked_files_fails(plugin: Path) -> None:
-    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget", "version": "1.0.0", "description": "d",
-        "skills": ["skills/builder", "skills/ghost"],
-    }))
+    _write(
+        plugin,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "d",
+                "skills": ["skills/builder", "skills/ghost"],
+            }
+        ),
+    )
     _write(plugin, ".tesslignore", "/scripts/\n")
     result = _run(plugin)
     assert result.returncode == 1
@@ -177,10 +210,18 @@ def test_declared_path_with_no_tracked_files_fails(plugin: Path) -> None:
 
 def test_skills_declared_as_directory_string(plugin: Path) -> None:
     """`skills` may be a directory path instead of an array of paths."""
-    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget", "version": "1.0.0", "description": "d",
-        "skills": "skills/",
-    }))
+    _write(
+        plugin,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "d",
+                "skills": "skills/",
+            }
+        ),
+    )
     _write(plugin, ".tesslignore", "scripts/\n")
     result = _run(plugin)
     assert result.returncode == 1
@@ -189,10 +230,18 @@ def test_skills_declared_as_directory_string(plugin: Path) -> None:
 
 def test_non_string_array_item_reports_a_shape_error(plugin: Path) -> None:
     """A non-string array item is a broken manifest, not a missing directory."""
-    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget", "version": "1.0.0", "description": "d",
-        "skills": [42],
-    }))
+    _write(
+        plugin,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "d",
+                "skills": [42],
+            }
+        ),
+    )
     _write(plugin, ".tesslignore", "/scripts/\n")
     result = _run(plugin)
     assert result.returncode == 1
@@ -203,11 +252,19 @@ def test_non_string_array_item_reports_a_shape_error(plugin: Path) -> None:
 
 def test_overlapping_declared_paths_are_counted_once(plugin: Path) -> None:
     """Declaring a directory and a path beneath it must not double-count files."""
-    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget", "version": "1.0.0", "description": "d",
-        "skills": ["skills/", "skills/builder"],
-        "rules": ["rules/house-style.md"],
-    }))
+    _write(
+        plugin,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "d",
+                "skills": ["skills/", "skills/builder"],
+                "rules": ["rules/house-style.md"],
+            }
+        ),
+    )
     # An ignore file that excludes no declared content, so the gate reaches its
     # counting path instead of short-circuiting on a missing .tesslignore.
     _write(plugin, ".tesslignore", "/build/\n")
@@ -219,11 +276,19 @@ def test_overlapping_declared_paths_are_counted_once(plugin: Path) -> None:
 
 def test_overlapping_declared_paths_report_each_violation_once(plugin: Path) -> None:
     """An excluded file under overlapping globs is reported once, not twice."""
-    _write(plugin, ".tessl-plugin/plugin.json", json.dumps({
-        "name": "acme/widget", "version": "1.0.0", "description": "d",
-        "skills": ["skills/", "skills/builder"],
-        "rules": ["rules/house-style.md"],
-    }))
+    _write(
+        plugin,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "d",
+                "skills": ["skills/", "skills/builder"],
+                "rules": ["rules/house-style.md"],
+            }
+        ),
+    )
     _write(plugin, ".tesslignore", "scripts/\n")
     result = _run(plugin)
     assert result.returncode == 1

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -24,27 +24,24 @@ import yaml
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PATTERNS = os.path.join(
-    REPO_ROOT, "skills", "presentation-creator", "references", "patterns")
+    REPO_ROOT, "skills", "presentation-creator", "references", "patterns"
+)
 INDEX = os.path.join(PATTERNS, "_index.md")
 
-STRONG_RE = re.compile(
-    r"^- Strong signal(?: \((?P<qualifier>[^)]*)\))?:", re.M)
+STRONG_RE = re.compile(r"^- Strong signal(?: \((?P<qualifier>[^)]*)\))?:", re.M)
 MODERATE_RE = re.compile(r"^- Moderate signal:", re.M)
-ABSENT_RE = re.compile(
-    r"^- Absent(?: \((?P<qualifier>[^)]*)\))?:", re.M)
+ABSENT_RE = re.compile(r"^- Absent(?: \((?P<qualifier>[^)]*)\))?:", re.M)
 ARITHMETIC_LABEL_RE = re.compile(
     r"^- (?:Strong signal|Moderate signal|Absent) "
     r"\([^)]*\b(?:pt|pts|point|points)\b[^)]*\):",
     re.I | re.M,
 )
-MEDIUM_LABEL_RE = re.compile(
-    r"^- Medium signal(?: \([^)]*\))?:", re.I | re.M)
+MEDIUM_LABEL_RE = re.compile(r"^- Medium signal(?: \([^)]*\))?:", re.I | re.M)
 
 ENTRY_FILES = sorted(f for f in glob.glob(os.path.join(PATTERNS, "*", "*.md")))
 ANTI_FILES = [f for f in ENTRY_FILES if os.path.basename(f).startswith("_anti_")]
 ENTRY_BY_ID = {
-    os.path.basename(path)[:-3].removeprefix("_anti_"): path
-    for path in ENTRY_FILES
+    os.path.basename(path)[:-3].removeprefix("_anti_"): path for path in ENTRY_FILES
 }
 
 NAME_TRAP_GUARDS = {
@@ -74,162 +71,204 @@ NAME_TRAP_GUARDS = {
     ),
 }
 
-EVIDENCE_SOURCE_VALUES = frozenset({
-    "static_slides",
-    "native_deck",
-    "delivery_video",
-    "transcript",
-    "source_comparison",
-})
+EVIDENCE_SOURCE_VALUES = frozenset(
+    {
+        "static_slides",
+        "native_deck",
+        "delivery_video",
+        "transcript",
+        "source_comparison",
+    }
+)
 EVIDENCE_SOURCE_CHANNELS = {
     "static_slides": frozenset({"slides", "slide_sequence", "talk_metadata"}),
     "native_deck": frozenset({"slides", "slide_sequence", "talk_metadata"}),
     "delivery_video": frozenset({"video", "talk_metadata"}),
     "transcript": frozenset({"transcript", "timed_transcript", "talk_metadata"}),
 }
-EVIDENCE_GATE_FIELDS = frozenset({
-    "evaluable_from",
-    "evidence_requirements",
-    "not_evaluable_when",
-})
-OUTCOME_EVIDENCE_GATE_FIELDS = frozenset({
-    "strong_evaluable_from",
-    "absence_evaluable_from",
-})
-ABSENCE_STATIC_IDS = frozenset({
-    "analog-noise",
-    "ant-fonts",
-    "bookends",
-    "breadcrumbs",
-    "cookie-cutter",
-    "defy-defaults",
-    "floodmarks",
-    "fontaholic",
-    "injured-outlines",
-    "takahashi",
-    "unifying-visual-theme",
-})
-ABSENCE_TRANSCRIPT_IDS = frozenset({
-    "concrete-before-abstract",
-    "flyover",
-    "going-meta",
-    "mentor",
-    "negative-ignorance",
-})
+EVIDENCE_GATE_FIELDS = frozenset(
+    {
+        "evaluable_from",
+        "evidence_requirements",
+        "not_evaluable_when",
+    }
+)
+OUTCOME_EVIDENCE_GATE_FIELDS = frozenset(
+    {
+        "strong_evaluable_from",
+        "absence_evaluable_from",
+    }
+)
+ABSENCE_STATIC_IDS = frozenset(
+    {
+        "analog-noise",
+        "ant-fonts",
+        "bookends",
+        "breadcrumbs",
+        "cookie-cutter",
+        "defy-defaults",
+        "floodmarks",
+        "fontaholic",
+        "injured-outlines",
+        "takahashi",
+        "unifying-visual-theme",
+    }
+)
+ABSENCE_TRANSCRIPT_IDS = frozenset(
+    {
+        "concrete-before-abstract",
+        "flyover",
+        "going-meta",
+        "mentor",
+        "negative-ignorance",
+    }
+)
 EXPECTED_ABSENCE_GATES = {
     **{pattern_id: ["static_slides"] for pattern_id in ABSENCE_STATIC_IDS},
     **{pattern_id: ["transcript"] for pattern_id in ABSENCE_TRANSCRIPT_IDS},
 }
 assert len(EXPECTED_ABSENCE_GATES) == 16
-APPLICABILITY_GATE_FIELDS = frozenset({
-    "not_applicable_when",
-    "applicability_evaluable_from",
-})
+APPLICABILITY_GATE_FIELDS = frozenset(
+    {
+        "not_applicable_when",
+        "applicability_evaluable_from",
+    }
+)
 ALL_EVIDENCE_GATE_FIELDS = (
-    EVIDENCE_GATE_FIELDS
-    | OUTCOME_EVIDENCE_GATE_FIELDS
-    | APPLICABILITY_GATE_FIELDS
+    EVIDENCE_GATE_FIELDS | OUTCOME_EVIDENCE_GATE_FIELDS | APPLICABILITY_GATE_FIELDS
 )
 EXISTING_REQUIRED_EVIDENCE_GATES = {
-    "progressive-reveal": frozenset({
-        frozenset({"static_slides"}),
-        frozenset({"native_deck"}),
-        frozenset({"delivery_video"}),
-    }),
-    "composite-animation": frozenset({
-        frozenset({"native_deck"}),
-        frozenset({"delivery_video"}),
-    }),
-    "invisibility": frozenset({
-        frozenset({"native_deck"}),
-        frozenset({"native_deck", "static_slides"}),
-        frozenset({"delivery_video", "static_slides"}),
-    }),
-    "exuberant-title-top": frozenset({
-        frozenset({"native_deck"}),
-        frozenset({"delivery_video"}),
-    }),
-    "gradual-consistency": frozenset({
-        frozenset({"native_deck"}),
-        frozenset({"native_deck", "static_slides"}),
-        frozenset({"delivery_video", "static_slides"}),
-    }),
-    "traveling-highlights": frozenset({
-        frozenset({"static_slides"}),
-        frozenset({"native_deck"}),
-        frozenset({"delivery_video"}),
-    }),
-    "second-look": frozenset({
-        frozenset({"delivery_video"}),
-        frozenset({"static_slides", "transcript"}),
-        frozenset({"native_deck", "transcript"}),
-    }),
-    "vacation-photos": frozenset({
-        frozenset({"delivery_video"}),
-        frozenset({"static_slides", "transcript"}),
-        frozenset({"native_deck", "transcript"}),
-    }),
+    "progressive-reveal": frozenset(
+        {
+            frozenset({"static_slides"}),
+            frozenset({"native_deck"}),
+            frozenset({"delivery_video"}),
+        }
+    ),
+    "composite-animation": frozenset(
+        {
+            frozenset({"native_deck"}),
+            frozenset({"delivery_video"}),
+        }
+    ),
+    "invisibility": frozenset(
+        {
+            frozenset({"native_deck"}),
+            frozenset({"native_deck", "static_slides"}),
+            frozenset({"delivery_video", "static_slides"}),
+        }
+    ),
+    "exuberant-title-top": frozenset(
+        {
+            frozenset({"native_deck"}),
+            frozenset({"delivery_video"}),
+        }
+    ),
+    "gradual-consistency": frozenset(
+        {
+            frozenset({"native_deck"}),
+            frozenset({"native_deck", "static_slides"}),
+            frozenset({"delivery_video", "static_slides"}),
+        }
+    ),
+    "traveling-highlights": frozenset(
+        {
+            frozenset({"static_slides"}),
+            frozenset({"native_deck"}),
+            frozenset({"delivery_video"}),
+        }
+    ),
+    "second-look": frozenset(
+        {
+            frozenset({"delivery_video"}),
+            frozenset({"static_slides", "transcript"}),
+            frozenset({"native_deck", "transcript"}),
+        }
+    ),
+    "vacation-photos": frozenset(
+        {
+            frozenset({"delivery_video"}),
+            frozenset({"static_slides", "transcript"}),
+            frozenset({"native_deck", "transcript"}),
+        }
+    ),
 }
 
-SAFE_VISUAL_GATE_IDS = frozenset({
-    "analog-noise",
-    "bookends",
-    "breadcrumbs",
-    "context-keeper",
-    "cookie-cutter",
-    "defy-defaults",
-    "floodmarks",
-    "fontaholic",
-    "injured-outlines",
-    "intermezzi",
-    "three-part-close",
-    "unifying-visual-theme",
-})
-SAFE_MOTION_GATE_IDS = frozenset({
-    "cave-painting",
-    "crawling-credits",
-    "soft-transitions",
-})
-SAFE_DELIVERY_GATE_IDS = frozenset({
-    "a-la-carte-content",
-    "brain-breaks",
-    "breathing-room",
-    "celery",
-    "dead-demo",
-    "dual-headed-monster",
-    "hecklers",
-    "lightning-talk",
-    "live-demo",
-    "make-it-rain",
-    "weatherman",
-})
+SAFE_VISUAL_GATE_IDS = frozenset(
+    {
+        "analog-noise",
+        "bookends",
+        "breadcrumbs",
+        "context-keeper",
+        "cookie-cutter",
+        "defy-defaults",
+        "floodmarks",
+        "fontaholic",
+        "injured-outlines",
+        "intermezzi",
+        "three-part-close",
+        "unifying-visual-theme",
+    }
+)
+SAFE_MOTION_GATE_IDS = frozenset(
+    {
+        "cave-painting",
+        "crawling-credits",
+        "soft-transitions",
+    }
+)
+SAFE_DELIVERY_GATE_IDS = frozenset(
+    {
+        "a-la-carte-content",
+        "brain-breaks",
+        "breathing-room",
+        "celery",
+        "dead-demo",
+        "dual-headed-monster",
+        "hecklers",
+        "lightning-talk",
+        "live-demo",
+        "make-it-rain",
+        "weatherman",
+    }
+)
 SAFE_SPOKEN_GATE_IDS = frozenset({"echo-chamber"})
 SAFE_COMBINED_GATE_IDS = frozenset({"lipstick-on-a-pig"})
 SAFE_CODA_GATE_IDS = frozenset({"coda"})
 
-VISUAL_GATE = frozenset({
-    frozenset({"static_slides"}),
-    frozenset({"native_deck"}),
-    frozenset({"delivery_video"}),
-})
-MOTION_GATE = frozenset({
-    frozenset({"native_deck"}),
-    frozenset({"delivery_video"}),
-})
+VISUAL_GATE = frozenset(
+    {
+        frozenset({"static_slides"}),
+        frozenset({"native_deck"}),
+        frozenset({"delivery_video"}),
+    }
+)
+MOTION_GATE = frozenset(
+    {
+        frozenset({"native_deck"}),
+        frozenset({"delivery_video"}),
+    }
+)
 DELIVERY_GATE = frozenset({frozenset({"delivery_video"})})
-SPOKEN_GATE = frozenset({
-    frozenset({"transcript"}),
-    frozenset({"delivery_video"}),
-})
-COMBINED_GATE = frozenset({
-    frozenset({"delivery_video"}),
-    frozenset({"static_slides", "transcript"}),
-    frozenset({"native_deck", "transcript"}),
-})
-CODA_GATE = frozenset({
-    frozenset({"static_slides", "transcript"}),
-    frozenset({"native_deck", "transcript"}),
-})
+SPOKEN_GATE = frozenset(
+    {
+        frozenset({"transcript"}),
+        frozenset({"delivery_video"}),
+    }
+)
+COMBINED_GATE = frozenset(
+    {
+        frozenset({"delivery_video"}),
+        frozenset({"static_slides", "transcript"}),
+        frozenset({"native_deck", "transcript"}),
+    }
+)
+CODA_GATE = frozenset(
+    {
+        frozenset({"static_slides", "transcript"}),
+        frozenset({"native_deck", "transcript"}),
+    }
+)
 
 SAFE_SOURCE_GATE_GROUPS = (
     (SAFE_VISUAL_GATE_IDS, VISUAL_GATE),
@@ -248,16 +287,12 @@ assert len(SAFE_SOURCE_GATES) == 29
 
 APPROVED_MECHANICAL_OUTCOME_GATES = {
     "ant-fonts": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
-        "strong_evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
-        "absence_evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
+        "strong_evaluable_from": ["static_slides", "native_deck", "delivery_video"],
+        "absence_evaluable_from": ["static_slides", "native_deck", "delivery_video"],
     },
     "bullet-riddled-corpse": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": ["delivery_video"],
     },
@@ -272,27 +307,27 @@ APPROVED_MECHANICAL_OUTCOME_GATES = {
         "absence_evaluable_from": ["transcript", "delivery_video"],
     },
     "charred-trail": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
-        "strong_evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
+        "strong_evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "absence_evaluable_from": ["native_deck", "delivery_video"],
     },
     "concrete-before-abstract": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["transcript", "delivery_video"],
         "absence_evaluable_from": ["transcript", "delivery_video"],
     },
     "crawling-code": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "strong_evaluable_from": ["native_deck", "delivery_video"],
         "absence_evaluable_from": ["native_deck", "delivery_video"],
     },
     "emergence": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": ["native_deck", "delivery_video"],
     },
@@ -317,12 +352,9 @@ APPROVED_MECHANICAL_OUTCOME_GATES = {
         "absence_evaluable_from": ["transcript", "delivery_video"],
     },
     "meme-as-argument": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
-        "strong_evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
-        "absence_evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
+        "strong_evaluable_from": ["static_slides", "native_deck", "delivery_video"],
+        "absence_evaluable_from": ["static_slides", "native_deck", "delivery_video"],
     },
     "negative-ignorance": {
         "evaluable_from": ["transcript", "delivery_video"],
@@ -341,15 +373,31 @@ APPROVED_MECHANICAL_OUTCOME_GATES = {
     },
     "triad": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "absence_evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
     },
     "delayed-self-introduction": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": [
             "delivery_video",
             ["transcript", "static_slides"],
@@ -378,7 +426,11 @@ APPROVED_MECHANICAL_OUTCOME_GATES = {
     },
     "inoculation": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["transcript", "delivery_video"],
         "absence_evaluable_from": None,
     },
@@ -398,11 +450,9 @@ APPROVED_MECHANICAL_OUTCOME_GATES = {
         "absence_evaluable_from": ["delivery_video"],
     },
     "takahashi": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "strong_evaluable_from": ["delivery_video"],
-        "absence_evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "absence_evaluable_from": ["static_slides", "native_deck", "delivery_video"],
     },
 }
 assert len(APPROVED_MECHANICAL_OUTCOME_GATES) == 25
@@ -418,9 +468,17 @@ APPROVED_MECHANICAL_SOURCE_GATES = {
 SEMANTIC_OUTCOME_GATES = {
     "alienating-artifact": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "absence_evaluable_from": [
             "delivery_video",
             ["transcript", "static_slides"],
@@ -434,7 +492,11 @@ SEMANTIC_OUTCOME_GATES = {
     },
     "backtracking": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": [
             "delivery_video",
@@ -444,7 +506,11 @@ SEMANTIC_OUTCOME_GATES = {
     },
     "entertainment": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": [
             "delivery_video",
@@ -453,14 +519,17 @@ SEMANTIC_OUTCOME_GATES = {
         ],
     },
     "expansion-joints": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": None,
     },
     "foreshadowing": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": [
             "delivery_video",
@@ -469,8 +538,7 @@ SEMANTIC_OUTCOME_GATES = {
         ],
     },
     "greek-chorus": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": ["delivery_video"],
     },
@@ -486,13 +554,21 @@ SEMANTIC_OUTCOME_GATES = {
     },
     "mentor": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["transcript", "delivery_video"],
         "absence_evaluable_from": ["transcript", "delivery_video"],
     },
     "narrative-arc": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["transcript", "delivery_video"],
         "absence_evaluable_from": [
             "delivery_video",
@@ -507,7 +583,11 @@ SEMANTIC_OUTCOME_GATES = {
     },
     "opening-punch": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": [
             "delivery_video",
             ["transcript", "static_slides"],
@@ -520,8 +600,7 @@ SEMANTIC_OUTCOME_GATES = {
         ],
     },
     "photomaniac": {
-        "evaluable_from": [
-            "static_slides", "native_deck", "delivery_video"],
+        "evaluable_from": ["static_slides", "native_deck", "delivery_video"],
         "strong_evaluable_from": ["delivery_video"],
         "absence_evaluable_from": ["delivery_video"],
     },
@@ -532,7 +611,11 @@ SEMANTIC_OUTCOME_GATES = {
     },
     "sparkline": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": [
             "delivery_video",
             ["transcript", "static_slides"],
@@ -551,13 +634,21 @@ SEMANTIC_OUTCOME_GATES = {
     },
     "talklet": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": ["transcript", "delivery_video"],
         "absence_evaluable_from": ["delivery_video"],
     },
     "walk-around": {
         "evaluable_from": [
-            "transcript", "static_slides", "native_deck", "delivery_video"],
+            "transcript",
+            "static_slides",
+            "native_deck",
+            "delivery_video",
+        ],
         "strong_evaluable_from": [
             "delivery_video",
             ["transcript", "static_slides"],
@@ -581,15 +672,14 @@ SEMANTIC_SOURCE_GATES = {
 # only a complete, separately declared rendered PDF or a complete transcript.
 # Keep the historical maps readable while overriding their absence lane with
 # the single canonical release decision.
-for _outcome_map in (
-        APPROVED_MECHANICAL_OUTCOME_GATES, SEMANTIC_OUTCOME_GATES):
+for _outcome_map in (APPROVED_MECHANICAL_OUTCOME_GATES, SEMANTIC_OUTCOME_GATES):
     for _pattern_id, _expected_gates in _outcome_map.items():
-        _expected_gates["absence_evaluable_from"] = (
-            EXPECTED_ABSENCE_GATES.get(_pattern_id))
+        _expected_gates["absence_evaluable_from"] = EXPECTED_ABSENCE_GATES.get(
+            _pattern_id
+        )
 
 EXPECTED_APPLICABILITY_CONDITION_IDS = {
-    "a-la-carte-content": (
-        "short-talk-under-30-minutes", "fixed-prerequisite-order"),
+    "a-la-carte-content": ("short-talk-under-30-minutes", "fixed-prerequisite-order"),
     "backtracking": ("lightning-format",),
     "bookends": ("fewer-than-three-major-sections",),
     "brain-breaks": ("short-talk-at-most-15-minutes",),
@@ -608,50 +698,77 @@ EXPECTED_APPLICABILITY_CONDITION_IDS = {
     "expansion-joints": ("short-talk-at-most-20-minutes",),
     "foreshadowing": (
         "short-talk-at-most-15-minutes",
-        "strictly-sequential-instructional-contract"),
+        "strictly-sequential-instructional-contract",
+    ),
     "hecklers": ("no-audience-disruption",),
-    "intermezzi": (
-        "short-talk-at-most-15-minutes", "continuous-single-theme-flow"),
+    "intermezzi": ("short-talk-at-most-15-minutes", "continuous-single-theme-flow"),
     "lightning-talk": ("not-lightning-format",),
     "lipsync": ("no-executable-subject",),
     "live-demo": ("no-executable-subject",),
-    "master-story": (
-        "short-talk-under-20-minutes", "purely-informational-big-idea"),
+    "master-story": ("short-talk-under-20-minutes", "purely-informational-big-idea"),
     "new-bliss": ("non-persuasive-talk",),
     "nodding-room": ("performance-shaped-talk",),
     "opening-punch": ("tightly-formatted-ceremonial-slot",),
     "preroll": ("no-prestart-display-opportunity",),
     "progressive-reveal": ("no-complex-reveal-opportunity",),
     "retrieval-beat": ("performance-shaped-talk",),
-    "screen-blackout": (
-        "screen-only-remote-presentation", "no-projected-screen"),
+    "screen-blackout": ("screen-only-remote-presentation", "no-projected-screen"),
     "seeding-the-first-question": ("no-q-and-a-segment",),
     "sparkline": ("non-persuasive-talk",),
-    "talklet": (
-        "short-talk-at-most-30-minutes", "cumulative-prerequisite-chain"),
-    "three-part-close": (
-        "short-talk-under-25-minutes", "non-action-oriented-talk"),
+    "talklet": ("short-talk-at-most-30-minutes", "cumulative-prerequisite-chain"),
+    "three-part-close": ("short-talk-under-25-minutes", "non-action-oriented-talk"),
     "traveling-highlights": ("no-dense-visual",),
     "weatherman": ("no-projected-slides",),
 }
 assert len(EXPECTED_APPLICABILITY_CONDITION_IDS) == 37
 
-APP_VIDEO_GATE_IDS = frozenset({
-    "a-la-carte-content", "backtracking", "brain-breaks", "context-keeper",
-    "dead-demo", "dual-headed-monster", "expansion-joints", "foreshadowing",
-    "hecklers", "intermezzi", "lightning-talk", "lipsync", "live-demo",
-    "master-story", "nodding-room", "preroll", "screen-blackout",
-    "seeding-the-first-question", "talklet",
-    "three-part-close", "weatherman",
-})
-APP_VISUAL_GATE_IDS = frozenset({
-    "bookends", "breadcrumbs", "charred-trail", "crawling-code",
-    "emergence", "progressive-reveal", "traveling-highlights",
-})
-APP_SPOKEN_GATE_IDS = frozenset({
-    "call-to-action", "call-to-adventure", "echo-chamber", "new-bliss",
-    "opening-punch", "retrieval-beat", "sparkline",
-})
+APP_VIDEO_GATE_IDS = frozenset(
+    {
+        "a-la-carte-content",
+        "backtracking",
+        "brain-breaks",
+        "context-keeper",
+        "dead-demo",
+        "dual-headed-monster",
+        "expansion-joints",
+        "foreshadowing",
+        "hecklers",
+        "intermezzi",
+        "lightning-talk",
+        "lipsync",
+        "live-demo",
+        "master-story",
+        "nodding-room",
+        "preroll",
+        "screen-blackout",
+        "seeding-the-first-question",
+        "talklet",
+        "three-part-close",
+        "weatherman",
+    }
+)
+APP_VISUAL_GATE_IDS = frozenset(
+    {
+        "bookends",
+        "breadcrumbs",
+        "charred-trail",
+        "crawling-code",
+        "emergence",
+        "progressive-reveal",
+        "traveling-highlights",
+    }
+)
+APP_SPOKEN_GATE_IDS = frozenset(
+    {
+        "call-to-action",
+        "call-to-adventure",
+        "echo-chamber",
+        "new-bliss",
+        "opening-punch",
+        "retrieval-beat",
+        "sparkline",
+    }
+)
 EXPECTED_APPLICABILITY_GATES = {
     **{pattern_id: ["delivery_video"] for pattern_id in APP_VIDEO_GATE_IDS},
     **{
@@ -668,8 +785,7 @@ EXPECTED_APPLICABILITY_GATES = {
         ["native_deck", "transcript"],
     ],
 }
-assert set(EXPECTED_APPLICABILITY_GATES) == set(
-    EXPECTED_APPLICABILITY_CONDITION_IDS)
+assert set(EXPECTED_APPLICABILITY_GATES) == set(EXPECTED_APPLICABILITY_CONDITION_IDS)
 
 OBSERVABLE_GATE_IDS = frozenset(
     set(EXISTING_REQUIRED_EVIDENCE_GATES)
@@ -681,16 +797,18 @@ POSITIVE_ONLY_IDS = OBSERVABLE_GATE_IDS - frozenset(EXPECTED_ABSENCE_GATES)
 assert len(OBSERVABLE_GATE_IDS) == 81
 assert len(POSITIVE_ONLY_IDS) == 65
 
-RECLASSIFIED_UNOBSERVABLE_IDS = frozenset({
-    "disowning-your-topic",
-    "golden-rule",
-    "infodeck",
-    "leet-grammars",
-    "live-on-tape",
-    "slideuments",
-    "the-big-why",
-    "tower-of-babble",
-})
+RECLASSIFIED_UNOBSERVABLE_IDS = frozenset(
+    {
+        "disowning-your-topic",
+        "golden-rule",
+        "infodeck",
+        "leet-grammars",
+        "live-on-tape",
+        "slideuments",
+        "the-big-why",
+        "tower-of-babble",
+    }
+)
 assert len(RECLASSIFIED_UNOBSERVABLE_IDS) == 8
 
 REQUIRED_EVIDENCE_GATES = {
@@ -721,13 +839,13 @@ def _metadata(path):
     assert len(parts) == 3, f"{os.path.basename(path)}: malformed frontmatter"
     metadata = yaml.safe_load(parts[1])
     assert isinstance(metadata, dict), (
-        f"{os.path.basename(path)}: frontmatter is not a mapping")
+        f"{os.path.basename(path)}: frontmatter is not a mapping"
+    )
     return metadata
 
 
 def _path_for_id(pattern_id):
-    matches = [path for path in ENTRY_FILES
-               if _front(path, "id") == pattern_id]
+    matches = [path for path in ENTRY_FILES if _front(path, "id") == pattern_id]
     assert len(matches) == 1, f"expected one catalog entry for {pattern_id!r}"
     return matches[0]
 
@@ -754,7 +872,8 @@ def test_antipattern_scoring_polarity_is_direct(path):
     assert strong, f"{os.path.basename(path)}: no Strong signal bullet"
     assert strong.group("qualifier") == "antipattern present", (
         f"{os.path.basename(path)} scores on the inverted scale: "
-        f"Strong signal must read 'Strong signal (antipattern present)'")
+        f"Strong signal must read 'Strong signal (antipattern present)'"
+    )
 
 
 @pytest.mark.parametrize("path", ANTI_FILES, ids=_ids(ANTI_FILES))
@@ -763,7 +882,8 @@ def test_antipattern_absent_bullet_is_labelled(path):
     assert absent, f"{os.path.basename(path)}: no Absent bullet"
     assert absent.group("qualifier") == "antipattern not present", (
         f"{os.path.basename(path)}: Absent must read "
-        f"'Absent (antipattern not present)' so polarity is unambiguous")
+        f"'Absent (antipattern not present)' so polarity is unambiguous"
+    )
 
 
 @pytest.mark.parametrize("path", ENTRY_FILES, ids=_ids(ENTRY_FILES))
@@ -772,7 +892,9 @@ def test_scoring_block_is_complete(path):
     text = _read(path)
     assert "## Scoring Criteria" in text, f"{os.path.basename(path)}: no scoring block"
     assert STRONG_RE.search(text), f"{os.path.basename(path)}: missing Strong bullet"
-    assert MODERATE_RE.search(text), f"{os.path.basename(path)}: missing Moderate bullet"
+    assert MODERATE_RE.search(text), (
+        f"{os.path.basename(path)}: missing Moderate bullet"
+    )
     assert ABSENT_RE.search(text), f"{os.path.basename(path)}: missing Absent bullet"
 
 
@@ -781,23 +903,25 @@ def test_scoring_labels_are_non_arithmetic_and_use_moderate(path):
     """Decision labels are not weights, and ``medium`` is not an alias."""
     text = _read(path)
     assert not ARITHMETIC_LABEL_RE.search(text), (
-        f"{os.path.basename(path)}: scoring labels must not declare point values")
+        f"{os.path.basename(path)}: scoring labels must not declare point values"
+    )
     assert not MEDIUM_LABEL_RE.search(text), (
-        f"{os.path.basename(path)}: use Moderate signal, never Medium signal")
+        f"{os.path.basename(path)}: use Moderate signal, never Medium signal"
+    )
 
 
 def test_compact_list_alone_is_not_bullet_riddled_corpse():
     text = _read(_entry("bullet-riddled-corpse"))
-    section = text[
-        text.index("## Scoring Criteria"):
-        text.index("## Evidence Gate")
-    ]
+    section = text[text.index("## Scoring Criteria") : text.index("## Evidence Gate")]
     normalized = " ".join(section.split())
 
     assert "Repeated bullet-heavy slides" in normalized
     assert "duplicate the speaker's narration" in normalized
     assert "reading-ahead or cognitive competition" in normalized
-    assert "a compact list of three or fewer short items by itself is not a signal" in normalized
+    assert (
+        "a compact list of three or fewer short items by itself is not a signal"
+        in normalized
+    )
 
 
 @pytest.mark.parametrize("path", ENTRY_FILES, ids=_ids(ENTRY_FILES))
@@ -806,7 +930,8 @@ def test_id_matches_filename(path):
     exist in the catalog, `terminal-as-deck` fourteen times."""
     expected = os.path.basename(path)[:-3].removeprefix("_anti_")
     assert _front(path, "id") == expected, (
-        f"{os.path.basename(path)}: frontmatter id is {_front(path, 'id')!r}")
+        f"{os.path.basename(path)}: frontmatter id is {_front(path, 'id')!r}"
+    )
 
 
 def test_ids_are_unique():
@@ -839,7 +964,8 @@ def test_catalog_references_resolve():
         for field in ("related_patterns", "inverse_of"):
             references = metadata.get(field)
             assert isinstance(references, list), (
-                f"{metadata.get('id')}: {field} must be a list")
+                f"{metadata.get('id')}: {field} must be a list"
+            )
             dangling.extend(
                 (metadata.get("id"), field, target)
                 for target in references
@@ -855,7 +981,8 @@ def test_type_matches_anti_prefix(path):
     declared = _front(path, "type")
     is_anti = os.path.basename(path).startswith("_anti_")
     assert declared == ("antipattern" if is_anti else "pattern"), (
-        f"{os.path.basename(path)}: type is {declared!r}")
+        f"{os.path.basename(path)}: type is {declared!r}"
+    )
 
 
 @pytest.mark.parametrize("path", ENTRY_FILES, ids=_ids(ENTRY_FILES))
@@ -870,55 +997,68 @@ def test_evidence_gate_frontmatter_is_well_formed(path):
 
     assert present_base == EVIDENCE_GATE_FIELDS, (
         f"{os.path.basename(path)}: partial evidence gate; "
-        f"present={sorted(present_base | present_outcomes)}")
+        f"present={sorted(present_base | present_outcomes)}"
+    )
 
     requirements = metadata["evidence_requirements"]
     disqualifiers = metadata["not_evaluable_when"]
     for gate_field in (
-            "evaluable_from", "strong_evaluable_from",
-            "absence_evaluable_from"):
+        "evaluable_from",
+        "strong_evaluable_from",
+        "absence_evaluable_from",
+    ):
         if gate_field not in metadata:
             continue
         sources = metadata[gate_field]
         if gate_field == "absence_evaluable_from" and sources is None:
             continue
         assert isinstance(sources, list) and sources, (
-            f"{os.path.basename(path)}: {gate_field} must be a non-empty list")
+            f"{os.path.basename(path)}: {gate_field} must be a non-empty list"
+        )
         groups = []
         for option in sources:
             if isinstance(option, list):
                 assert len(option) >= 2, (
-                    f"{os.path.basename(path)}: nested alternatives need two sources")
+                    f"{os.path.basename(path)}: nested alternatives need two sources"
+                )
             group = [option] if isinstance(option, str) else option
             assert isinstance(group, list) and group, (
-                f"{os.path.basename(path)}: invalid evidence-source alternative")
+                f"{os.path.basename(path)}: invalid evidence-source alternative"
+            )
             assert all(isinstance(source, str) for source in group), (
-                f"{os.path.basename(path)}: evidence sources must be strings")
+                f"{os.path.basename(path)}: evidence sources must be strings"
+            )
             assert set(group) <= EVIDENCE_SOURCE_VALUES, (
                 f"{os.path.basename(path)}: unknown evidence sources "
-                f"{sorted(set(group) - EVIDENCE_SOURCE_VALUES)}")
+                f"{sorted(set(group) - EVIDENCE_SOURCE_VALUES)}"
+            )
             assert len(group) == len(set(group)), (
-                f"{os.path.basename(path)}: duplicate evidence sources")
+                f"{os.path.basename(path)}: duplicate evidence sources"
+            )
             assert group != ["source_comparison"], (
-                f"{os.path.basename(path)}: comparison label needs an exact pair")
+                f"{os.path.basename(path)}: comparison label needs an exact pair"
+            )
             assert len(group) == 1 or "source_comparison" not in group, (
-                f"{os.path.basename(path)}: comparison label cannot be an underlying source")
+                f"{os.path.basename(path)}: comparison label cannot be an underlying source"
+            )
             groups.append(frozenset(group))
         assert len(groups) == len(set(groups)), (
-            f"{os.path.basename(path)}: duplicate evidence-source alternatives")
+            f"{os.path.basename(path)}: duplicate evidence-source alternatives"
+        )
 
     assert present_applicability in (frozenset(), APPLICABILITY_GATE_FIELDS), (
-        f"{os.path.basename(path)}: applicability fields must be declared together")
+        f"{os.path.basename(path)}: applicability fields must be declared together"
+    )
     if present_applicability:
         conditions = metadata["not_applicable_when"]
         assert isinstance(conditions, list) and conditions, (
-            f"{os.path.basename(path)}: not_applicable_when must be non-empty")
+            f"{os.path.basename(path)}: not_applicable_when must be non-empty"
+        )
         condition_ids = []
         for condition in conditions:
             assert isinstance(condition, dict)
             assert set(condition) == {"condition_id", "description"}
-            assert re.fullmatch(
-                r"[a-z0-9]+(?:-[a-z0-9]+)*", condition["condition_id"])
+            assert re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", condition["condition_id"])
             assert isinstance(condition["description"], str)
             assert condition["description"].strip()
             condition_ids.append(condition["condition_id"])
@@ -935,12 +1075,16 @@ def test_evidence_gate_frontmatter_is_well_formed(path):
             assert len(group) == len(set(group))
             groups.append(frozenset(group))
         assert len(groups) == len(set(groups))
-    for field, values in (("evidence_requirements", requirements),
-                          ("not_evaluable_when", disqualifiers)):
+    for field, values in (
+        ("evidence_requirements", requirements),
+        ("not_evaluable_when", disqualifiers),
+    ):
         assert isinstance(values, list) and values, (
-            f"{os.path.basename(path)}: {field} must be a non-empty list")
+            f"{os.path.basename(path)}: {field} must be a non-empty list"
+        )
         assert all(isinstance(value, str) and value.strip() for value in values), (
-            f"{os.path.basename(path)}: {field} values must be non-empty strings")
+            f"{os.path.basename(path)}: {field} values must be non-empty strings"
+        )
 
 
 @pytest.mark.parametrize(
@@ -948,7 +1092,8 @@ def test_evidence_gate_frontmatter_is_well_formed(path):
     sorted(REQUIRED_EVIDENCE_GATES.items()),
 )
 def test_source_dependent_patterns_have_required_evidence_gates(
-        pattern_id, expected_sources):
+    pattern_id, expected_sources
+):
     """Known source traps must never fall back to visual guesswork."""
     path = _path_for_id(pattern_id)
     metadata = _metadata(path)
@@ -967,7 +1112,8 @@ def test_source_dependent_patterns_have_required_evidence_gates(
     sorted(APPROVED_MECHANICAL_OUTCOME_GATES.items()),
 )
 def test_approved_mechanical_gates_preserve_owner_reviewed_outcomes(
-        pattern_id, expected_gates):
+    pattern_id, expected_gates
+):
     """Owner-reviewed mechanical proposals pin all three outcome contracts."""
     metadata = _metadata(_path_for_id(pattern_id))
 
@@ -986,7 +1132,8 @@ def test_approved_mechanical_gates_preserve_owner_reviewed_outcomes(
     sorted(SEMANTIC_OUTCOME_GATES.items()),
 )
 def test_semantic_owner_review_pins_positive_strong_and_absence_gates(
-        pattern_id, expected_gates):
+    pattern_id, expected_gates
+):
     metadata = _metadata(_path_for_id(pattern_id))
     assert {
         field: metadata[field]
@@ -1083,9 +1230,7 @@ def test_evidence_gate_prose_matches_machine_absence_authority(path):
             "does not authorize absence" in evidence_gate
         )
     elif absence_gate == ["transcript"]:
-        assert (
-            "only from a complete transcript (`transcript`)" in evidence_gate
-        )
+        assert "only from a complete transcript (`transcript`)" in evidence_gate
         assert (
             "delivery video, rendered/static slides, native decks, and "
             "comparison artifacts do not authorize absence" in evidence_gate
@@ -1113,12 +1258,16 @@ def test_positive_only_absence_null_set_is_exact():
 def test_applicability_contracts_pin_conditions_and_source_gates(pattern_id):
     metadata = _metadata(_path_for_id(pattern_id))
 
-    assert tuple(
-        condition["condition_id"]
-        for condition in metadata["not_applicable_when"]
-    ) == EXPECTED_APPLICABILITY_CONDITION_IDS[pattern_id]
-    assert metadata["applicability_evaluable_from"] == (
-        EXPECTED_APPLICABILITY_GATES[pattern_id])
+    assert (
+        tuple(
+            condition["condition_id"] for condition in metadata["not_applicable_when"]
+        )
+        == EXPECTED_APPLICABILITY_CONDITION_IDS[pattern_id]
+    )
+    assert (
+        metadata["applicability_evaluable_from"]
+        == (EXPECTED_APPLICABILITY_GATES[pattern_id])
+    )
     assert all(
         condition["description"].strip()
         for condition in metadata["not_applicable_when"]
@@ -1141,21 +1290,22 @@ def test_lipsync_executable_subject_condition_is_the_applicability_canary():
     assert metadata["evaluable_from"] == ["delivery_video"]
     assert metadata["absence_evaluable_from"] is None
     assert metadata["applicability_evaluable_from"] == ["delivery_video"]
-    assert metadata["not_applicable_when"] == [{
-        "condition_id": "no-executable-subject",
-        "description": (
-            "Complete delivery video establishes that the talk explains or "
-            "claims no executable tool, system, or workflow that could be "
-            "demonstrated."
-        ),
-    }]
+    assert metadata["not_applicable_when"] == [
+        {
+            "condition_id": "no-executable-subject",
+            "description": (
+                "Complete delivery video establishes that the talk explains or "
+                "claims no executable tool, system, or workflow that could be "
+                "demonstrated."
+            ),
+        }
+    ]
 
 
 def test_traveling_highlights_is_the_outcome_gate_canary():
     metadata = _metadata(_path_for_id("traveling-highlights"))
 
-    assert metadata["strong_evaluable_from"] == [
-        "native_deck", "delivery_video"]
+    assert metadata["strong_evaluable_from"] == ["native_deck", "delivery_video"]
     assert metadata["absence_evaluable_from"] is None
 
 
@@ -1169,70 +1319,69 @@ def test_progressive_reveal_explicitly_disables_absence():
 def test_index_defines_confidence_and_binary_pattern_score_exactly():
     index = _read(INDEX)
     section = index[
-        index.index("## Decision Labels, Confidence, and Binary Pattern Score"):
-        index.index("## Evidence-Source Contract")
+        index.index(
+            "## Decision Labels, Confidence, and Binary Pattern Score"
+        ) : index.index("## Evidence-Source Contract")
     ]
     normalized = " ".join(section.split())
 
     assert "three **non-arithmetic** decision labels" in normalized
     assert (
         "`confidence` records evidence certainty and has exactly three valid "
-        "values: `weak`, `moderate`, and `strong`"
-        in normalized
+        "values: `weak`, `moderate`, and `strong`" in normalized
     )
     assert "`strong` maps to the entry's Strong signal decision criterion" in normalized
-    assert "`moderate` maps to the entry's Moderate signal decision criterion" in normalized
+    assert (
+        "`moderate` maps to the entry's Moderate signal decision criterion"
+        in normalized
+    )
     assert (
         "`weak` means direct, source-located but incomplete positive evidence "
-        "that satisfies the base gate"
-        in normalized
+        "that satisfies the base gate" in normalized
     )
     assert (
         "It never means speculation, a failed source gate, `not_evaluable`, "
-        "or `not_applicable`"
-        in normalized
+        "or `not_applicable`" in normalized
     )
     assert "`medium` is invalid and is never an alias for `moderate`" in normalized
     assert "Each detected pattern contributes **+1**" in normalized
     assert "each detected antipattern contributes **−1**" in normalized
     assert (
         "`Absent`, undetected, `not_evaluable`, and `not_applicable` outcomes "
-        "contribute zero"
-        in normalized
+        "contribute zero" in normalized
     )
     assert (
         "`pattern_score = count(patterns_detected) - "
-        "count(antipatterns_detected)`"
-        in normalized
+        "count(antipatterns_detected)`" in normalized
     )
 
 
 def test_evidence_source_enum_is_documented_in_index():
     index = _read(INDEX)
-    section = index[index.index("## Evidence-Source Contract"):
-                    index.index("## Pattern Catalog")]
+    section = index[
+        index.index("## Evidence-Source Contract") : index.index("## Pattern Catalog")
+    ]
     for source in EVIDENCE_SOURCE_VALUES:
         assert f"`{source}`" in section, f"index does not document {source!r}"
 
 
 def test_index_scopes_exact_comparison_proof_to_positive_detections():
     index = _read(INDEX)
-    section = index[index.index("## Evidence-Source Contract"):
-                    index.index("## Pattern Catalog")]
+    section = index[
+        index.index("## Evidence-Source Contract") : index.index("## Pattern Catalog")
+    ]
     normalized = " ".join(section.split())
 
     assert "For a positive comparison detection" in normalized
     assert "For an undetected absence outcome" in normalized
-    assert (
-        "there is no detection object or `evidence_sources_used` field"
-        in normalized
-    )
+    assert "there is no detection object or `evidence_sources_used` field" in normalized
 
 
 def test_index_documents_null_absence_and_applicability_denominators():
     index = _read(INDEX)
-    section = index[index.index("## Evidence-Source Contract"):
-                    index.index("## Pattern Catalog")]
+    section = index[
+        index.index("## Evidence-Source Contract") : index.index("## Pattern Catalog")
+    ]
     normalized = " ".join(section.split())
 
     assert "`absence_evaluable_from: null`" in normalized
@@ -1240,13 +1389,11 @@ def test_index_documents_null_absence_and_applicability_denominators():
     assert "`applicability_evaluable_from`" in normalized
     assert (
         "An explicit null absence gate permits source-gated positive detections "
-        "but never authorizes an absence"
-        in normalized
+        "but never authorizes an absence" in normalized
     )
     assert (
         "only an applicable assessment plus complete absence-gate coverage "
-        "yields undetected"
-        in normalized
+        "yields undetected" in normalized
     )
 
 
@@ -1255,14 +1402,16 @@ def test_unobservable_files_match_the_index():
     `observable: false` flag is what a scorer consults. Drift between them means
     an entry gets scored that the index says cannot be, or vice versa.
     """
-    flagged = {str(_front(f, "id")) for f in ENTRY_FILES
-               if _front(f, "observable") == "false"}
+    flagged = {
+        str(_front(f, "id")) for f in ENTRY_FILES if _front(f, "observable") == "false"
+    }
     index = _read(INDEX)
-    section = index[index.index("## Unobservable Patterns"):]
+    section = index[index.index("## Unobservable Patterns") :]
     listed = set(re.findall(r"^\| ([a-z0-9-]+) \|", section, re.M))
     assert flagged == listed, (
         f"only in files: {sorted(flagged - listed)}; "
-        f"only in index: {sorted(listed - flagged)}")
+        f"only in index: {sorted(listed - flagged)}"
+    )
 
 
 @pytest.mark.parametrize("pattern_id", sorted(RECLASSIFIED_UNOBSERVABLE_IDS))
@@ -1283,22 +1432,29 @@ def test_index_summary_statistics_are_accurate():
     anti = len(ANTI_FILES)
     unobs = sum(1 for f in ENTRY_FILES if _front(f, "observable") == "false")
     unobs_anti = sum(1 for f in ANTI_FILES if _front(f, "observable") == "false")
-    positive = sum(
-        EVIDENCE_GATE_FIELDS <= set(_metadata(f)) for f in ENTRY_FILES)
+    positive = sum(EVIDENCE_GATE_FIELDS <= set(_metadata(f)) for f in ENTRY_FILES)
     absence = sum(
         EVIDENCE_GATE_FIELDS <= set(_metadata(f))
         and _metadata(f).get("absence_evaluable_from", "default") is not None
         for f in ENTRY_FILES
     )
     applicability = sum(
-        APPLICABILITY_GATE_FIELDS <= set(_metadata(f)) for f in ENTRY_FILES)
+        APPLICABILITY_GATE_FIELDS <= set(_metadata(f)) for f in ENTRY_FILES
+    )
     positive_only = positive - absence
-    assert f"**Total entries:** {total} ({total - anti} patterns + {anti} antipatterns)" in index
-    assert (f"**Observable (vault-scorable):** {total - unobs} "
-            f"({total - anti - (unobs - unobs_anti)} patterns + "
-            f"{anti - unobs_anti} antipatterns)") in index
-    assert (f"**Unobservable (go-live checklist):** {unobs} "
-            f"({unobs - unobs_anti} patterns + {unobs_anti} antipatterns)") in index
+    assert (
+        f"**Total entries:** {total} ({total - anti} patterns + {anti} antipatterns)"
+        in index
+    )
+    assert (
+        f"**Observable (vault-scorable):** {total - unobs} "
+        f"({total - anti - (unobs - unobs_anti)} patterns + "
+        f"{anti - unobs_anti} antipatterns)"
+    ) in index
+    assert (
+        f"**Unobservable (go-live checklist):** {unobs} "
+        f"({unobs - unobs_anti} patterns + {unobs_anti} antipatterns)"
+    ) in index
     assert f"**Positive source-gated:** {positive}" in index
     assert f"**Absence source-gated:** {absence}" in index
     assert f"**Applicability-gated:** {applicability}" in index
@@ -1317,9 +1473,11 @@ def test_public_catalog_totals_are_accurate():
     total = len(ENTRY_FILES)
     anti = len(ANTI_FILES)
     unobservable = sum(
-        _metadata(path).get("observable") is False for path in ENTRY_FILES)
+        _metadata(path).get("observable") is False for path in ENTRY_FILES
+    )
     unobservable_anti = sum(
-        _metadata(path).get("observable") is False for path in ANTI_FILES)
+        _metadata(path).get("observable") is False for path in ANTI_FILES
+    )
     observable = total - unobservable
     observable_anti = anti - unobservable_anti
     observable_patterns = observable - observable_anti
@@ -1363,9 +1521,11 @@ def test_evidence_channels_use_the_closed_source_channel_vocabulary():
         if _metadata(path).get("observable") is not False:
             assert isinstance(channels, list) and channels, (
                 f"{os.path.basename(path)}: every observable entry needs a "
-                "non-empty evidence_channels list")
+                "non-empty evidence_channels list"
+            )
             assert set(channels) <= allowed, (
-                f"{os.path.basename(path)}: unknown channels {set(channels) - allowed}")
+                f"{os.path.basename(path)}: unknown channels {set(channels) - allowed}"
+            )
 
 
 def test_unobservable_entries_do_not_declare_evidence_gates():
@@ -1374,7 +1534,8 @@ def test_unobservable_entries_do_not_declare_evidence_gates():
         if metadata.get("observable") is False:
             assert ALL_EVIDENCE_GATE_FIELDS.isdisjoint(metadata), (
                 f"{os.path.basename(path)}: unobservable entries cannot declare "
-                "per-talk evidence gates")
+                "per-talk evidence gates"
+            )
 
 
 @pytest.mark.parametrize("path", ENTRY_FILES, ids=_ids(ENTRY_FILES))
@@ -1382,8 +1543,11 @@ def test_every_gated_source_has_an_allowed_citation_channel(path):
     metadata = _metadata(path)
     channels = set(metadata.get("evidence_channels") or [])
     for gate_field in (
-            "evaluable_from", "strong_evaluable_from",
-            "absence_evaluable_from", "applicability_evaluable_from"):
+        "evaluable_from",
+        "strong_evaluable_from",
+        "absence_evaluable_from",
+        "applicability_evaluable_from",
+    ):
         if metadata.get(gate_field) is None:
             continue
         for option in metadata.get(gate_field, []):
@@ -1391,7 +1555,8 @@ def test_every_gated_source_has_an_allowed_citation_channel(path):
             for source in sources:
                 assert channels.intersection(EVIDENCE_SOURCE_CHANNELS[source]), (
                     f"{os.path.basename(path)}: {gate_field} source {source!r} "
-                    "has no permitted source-located citation channel")
+                    "has no permitted source-located citation channel"
+                )
 
 
 def test_metadata_channel_declares_the_fields_it_can_use():
@@ -1401,9 +1566,11 @@ def test_metadata_channel_declares_the_fields_it_can_use():
         fields = metadata.get("evidence_metadata_fields") or []
         assert bool(fields) == ("talk_metadata" in channels), (
             f"{os.path.basename(path)}: talk_metadata and evidence_metadata_fields "
-            "must be declared together")
+            "must be declared together"
+        )
         assert len(fields) == len(set(fields)), (
-            f"{os.path.basename(path)}: duplicate evidence metadata fields")
+            f"{os.path.basename(path)}: duplicate evidence metadata fields"
+        )
 
 
 @pytest.mark.parametrize(
@@ -1429,8 +1596,7 @@ def test_metadata_channel_declares_the_fields_it_can_use():
         ("takahashi", {"slides", "slide_sequence", "video"}),
     ],
 )
-def test_channel_sensitive_patterns_require_exact_source_channels(
-        pattern_id, channels):
+def test_channel_sensitive_patterns_require_exact_source_channels(pattern_id, channels):
     assert set(_metadata(_entry(pattern_id))["evidence_channels"]) == channels
 
 
@@ -1438,7 +1604,10 @@ def test_lightning_talk_metadata_corroborates_without_widening_the_video_gate():
     metadata = _metadata(_entry("lightning-talk"))
 
     assert metadata["evidence_metadata_fields"] == [
-        "title", "conference", "slide_count"]
+        "title",
+        "conference",
+        "slide_count",
+    ]
     assert "talk_metadata" in metadata["evidence_channels"]
     assert metadata["evaluable_from"] == ["delivery_video"]
 
@@ -1471,13 +1640,18 @@ def test_hidden_process_and_provenance_ids_are_not_auto_scorable():
         ("progressive-reveal", ("same base image", "adding one annotation per slide")),
         ("meme-as-argument", ("internet memes", "argumentative devices")),
         ("dead-demo", ("time filler", "no narrative connection")),
-        ("three-part-close", ("three distinct slides", "summary, call to action, thanks")),
+        (
+            "three-part-close",
+            ("three distinct slides", "summary, call to action, thanks"),
+        ),
         ("anti-sell", ("products, employer, or credentials", "expects a pitch")),
-        ("negative-ignorance", ('who here is not familiar with x?',)),
+        ("negative-ignorance", ("who here is not familiar with x?",)),
         ("shortchanged", ("last-minute reduction", "previous speakers running long")),
     ],
 )
 def test_stable_ids_retain_their_distinguishing_source_meaning(pattern_id, anchors):
     text = _read(_entry(pattern_id)).casefold()
     for anchor in anchors:
-        assert anchor.casefold() in text, f"{pattern_id}: missing source-meaning anchor {anchor!r}"
+        assert anchor.casefold() in text, (
+            f"{pattern_id}: missing source-meaning anchor {anchor!r}"
+        )

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -3577,7 +3577,9 @@ def test_bounded_pptx_resolver_names_the_violated_root(tmp_path: Path) -> None:
     assert "the trusted root" not in message
 
 
-def test_unknown_root_kind_falls_back_without_claiming_the_vault(tmp_path: Path) -> None:
+def test_unknown_root_kind_falls_back_without_claiming_the_vault(
+    tmp_path: Path,
+) -> None:
     vault = tmp_path / "vault"
     _symlink_escaping(vault, "notes.txt", tmp_path / "external" / "notes.txt")
 

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -20,7 +20,10 @@ from conftest import current_tracking_config
 
 
 def test_atomic_json_write_cleans_stage_and_propagates_interrupt(
-    persist_results, tracking_database_io, tmp_path, monkeypatch,
+    persist_results,
+    tracking_database_io,
+    tmp_path,
+    monkeypatch,
 ):
     target = tmp_path / "tracking-database.json"
     target.write_text('{"old": true}\n', encoding="utf-8")
@@ -72,22 +75,40 @@ def _return(**overrides):
         "verbatim_examples": {"jokes": ["j1"]},
         "pattern_observations": {
             "patterns_detected": [
-                {"pattern_id": "narrative-arc", "confidence": "strong",
-                 "evidence_source": "transcript",
-                 "evidence": "The talk follows a four-act argument."},
-                {"pattern_id": "bookends", "confidence": "moderate",
-                 "evidence_source": "static_slides",
-                 "evidence": "Repeated dividers mark section boundaries."},
+                {
+                    "pattern_id": "narrative-arc",
+                    "confidence": "strong",
+                    "evidence_source": "transcript",
+                    "evidence": "The talk follows a four-act argument.",
+                },
+                {
+                    "pattern_id": "bookends",
+                    "confidence": "moderate",
+                    "evidence_source": "static_slides",
+                    "evidence": "Repeated dividers mark section boundaries.",
+                },
             ],
             "antipatterns_detected": [
-                {"pattern_id": "shortchanged", "confidence": "weak",
-                 "evidence_source": "transcript",
-                 "evidence": "The close is compressed."},
+                {
+                    "pattern_id": "shortchanged",
+                    "confidence": "weak",
+                    "evidence_source": "transcript",
+                    "evidence": "The close is compressed.",
+                },
             ],
-            "evidence_sources": ["transcript", "native_deck", "static_slides",
-                                 "delivery_video", "source_comparison"],
+            "evidence_sources": [
+                "transcript",
+                "native_deck",
+                "static_slides",
+                "delivery_video",
+                "source_comparison",
+            ],
             "not_evaluable": [],
-            "pattern_score": {"patterns_used": 2, "antipatterns_detected": 1, "score": 1},
+            "pattern_score": {
+                "patterns_used": 2,
+                "antipatterns_detected": 1,
+                "score": 1,
+            },
         },
         "catalog_feedback": {
             "unmatched_observations": [],
@@ -98,9 +119,11 @@ def _return(**overrides):
         },
     }
     ret.update(overrides)
-    if (ret.get("return_schema_version") == 3 and
-            "adherence_assessment" not in overrides and
-            "adherence_comparison" not in overrides):
+    if (
+        ret.get("return_schema_version") == 3
+        and "adherence_assessment" not in overrides
+        and "adherence_comparison" not in overrides
+    ):
         ret["adherence_assessment"] = ""
     return ret
 
@@ -126,7 +149,11 @@ def _talk(**overrides):
         },
         "structured_data": {},
         "verbatim_examples": {},
-        "pattern_observations": {"pattern_ids": [], "antipattern_ids": [], "pattern_score": 0},
+        "pattern_observations": {
+            "pattern_ids": [],
+            "antipattern_ids": [],
+            "pattern_score": 0,
+        },
     }
     talk.update(overrides)
     return talk
@@ -162,9 +189,7 @@ def _write_tiny_mp4(path):
         capture_output=True,
         check=False,
     )
-    assert created.returncode == 0, created.stderr.decode(
-        "utf-8", errors="replace"
-    )
+    assert created.returncode == 0, created.stderr.decode("utf-8", errors="replace")
 
 
 def _db_json(database):
@@ -196,7 +221,8 @@ def _adherence_baseline(persist_results, *, count=0, filenames=("talk.md",)):
         "pattern_scoring_generation_reasons": [],
         "pattern_catalog_fingerprint": persist_results.load_catalog().fingerprint,
         "pattern_scoring_schema_version": (
-            persist_results.PATTERN_SCORING_SCHEMA_VERSION),
+            persist_results.PATTERN_SCORING_SCHEMA_VERSION
+        ),
         "scored_talk_count": count,
         "pattern_score_sum": count,
         "average_pattern_score": 1.0 if count else None,
@@ -210,14 +236,16 @@ def _v3_talk_and_return(persist_results, *, filename="talk.md"):
         adherence_assessment="",
     )
     talk = _talk(filename=filename)
-    talk["_queue_claim"].update({
-        "schema_version": 3,
-        "required_return_schema_version": 3,
-        "adherence_baseline": _adherence_baseline(
-            persist_results,
-            filenames=(filename,),
-        ),
-    })
+    talk["_queue_claim"].update(
+        {
+            "schema_version": 3,
+            "required_return_schema_version": 3,
+            "adherence_baseline": _adherence_baseline(
+                persist_results,
+                filenames=(filename,),
+            ),
+        }
+    )
     return talk, ret
 
 
@@ -240,9 +268,7 @@ def _v4_transcript_batch(return_validation, tmp_path, *, language="en"):
     """Build one real-artifact v4 batch with exhaustive catalog outcomes."""
     transcript = tmp_path / "transcripts" / "manual-talk.txt"
     transcript.parent.mkdir()
-    lines = [
-        "A uniquely phrased production failure opens this synthetic talk clearly."
-    ]
+    lines = ["A uniquely phrased production failure opens this synthetic talk clearly."]
     lines.extend(
         f"Synthetic transcript line {number} provides substantive source evidence "
         "for deterministic catalog verification."
@@ -258,8 +284,7 @@ def _v4_transcript_batch(return_validation, tmp_path, *, language="en"):
         {"kind": "fixed_default"},
     )
     filename = "talk.md"
-    baseline = _adherence_baseline(
-        return_validation, count=0, filenames=(filename,))
+    baseline = _adherence_baseline(return_validation, count=0, filenames=(filename,))
     claim = {
         "schema_version": 4,
         "run_id": "reparse-v4",
@@ -291,19 +316,23 @@ def _v4_transcript_batch(return_validation, tmp_path, *, language="en"):
             continue
         gate = entry.absence_evaluable_from
         if gate is None:
-            not_evaluable.append({
-                "pattern_id": pattern_id,
-                "reason_code": (
-                    "absence_not_authorized_by_catalog"
-                    if entry.evaluable_from is not None
-                    else "source_gate_pending_owner_review"
-                ),
-            })
+            not_evaluable.append(
+                {
+                    "pattern_id": pattern_id,
+                    "reason_code": (
+                        "absence_not_authorized_by_catalog"
+                        if entry.evaluable_from is not None
+                        else "source_gate_pending_owner_review"
+                    ),
+                }
+            )
         elif not any(group == frozenset({"transcript"}) for group in gate):
-            not_evaluable.append({
-                "pattern_id": pattern_id,
-                "reason_code": "missing_required_source_coverage",
-            })
+            not_evaluable.append(
+                {
+                    "pattern_id": pattern_id,
+                    "reason_code": "missing_required_source_coverage",
+                }
+            )
     ret = {
         "filename": filename,
         "return_schema_version": 4,
@@ -326,23 +355,29 @@ def _v4_transcript_batch(return_validation, tmp_path, *, language="en"):
         },
         "verbatim_examples": {},
         "pattern_observations": {
-            "patterns_detected": [{
-                "pattern_id": detected_id,
-                "confidence": "moderate",
-                "evidence_source": "transcript",
-                "evidence": "A concrete production failure opens the narrative.",
-                "evidence_citations": [{
-                    "source": "transcript",
-                    "channel": "transcript",
-                    "quote": lines[0],
-                }],
-            }],
+            "patterns_detected": [
+                {
+                    "pattern_id": detected_id,
+                    "confidence": "moderate",
+                    "evidence_source": "transcript",
+                    "evidence": "A concrete production failure opens the narrative.",
+                    "evidence_citations": [
+                        {
+                            "source": "transcript",
+                            "channel": "transcript",
+                            "quote": lines[0],
+                        }
+                    ],
+                }
+            ],
             "antipatterns_detected": [],
             "evidence_sources": ["transcript"],
-            "source_inspection": [{
-                "source": "transcript",
-                "line_ranges": [[1, len(lines)]],
-            }],
+            "source_inspection": [
+                {
+                    "source": "transcript",
+                    "line_ranges": [[1, len(lines)]],
+                }
+            ],
             "not_evaluable": not_evaluable,
             "pattern_score": {
                 "patterns_used": 1,
@@ -364,20 +399,25 @@ def _v4_transcript_batch(return_validation, tmp_path, *, language="en"):
 def _complete_unavailable_source_gates(return_validation, ret):
     available = set(ret["pattern_observations"]["evidence_sources"])
     catalog = return_validation.load_catalog()
-    ret["pattern_observations"]["not_evaluable"] = [{
-        "pattern_id": pattern_id,
-        "evidence_source": sorted(available)[0],
-        "reason": "The inspected fixture sources cannot evaluate this pattern.",
-    } for pattern_id, entry in sorted(catalog.entries.items())
-        if entry.observable and entry.evaluable_from is not None and
-        not return_validation.qualifying_evidence_groups(
-            entry.evaluable_from, available)]
+    ret["pattern_observations"]["not_evaluable"] = [
+        {
+            "pattern_id": pattern_id,
+            "evidence_source": sorted(available)[0],
+            "reason": "The inspected fixture sources cannot evaluate this pattern.",
+        }
+        for pattern_id, entry in sorted(catalog.entries.items())
+        if entry.observable
+        and entry.evaluable_from is not None
+        and not return_validation.qualifying_evidence_groups(
+            entry.evaluable_from, available
+        )
+    ]
     return ret
 
 
 def _gradual_comparison_return(
-        return_validation, *, version=2, include_delivery=False,
-        evidence_sources_used=None):
+    return_validation, *, version=2, include_delivery=False, evidence_sources_used=None
+):
     """Build one exact-pair legacy/current comparison fixture."""
     sources = ["transcript", "static_slides", "native_deck"]
     if include_delivery:
@@ -392,16 +432,18 @@ def _gradual_comparison_return(
     if evidence_sources_used is not None:
         detection["evidence_sources_used"] = evidence_sources_used
     ret = _return(return_schema_version=version)
-    ret["pattern_observations"].update({
-        "patterns_detected": [detection],
-        "antipatterns_detected": [],
-        "evidence_sources": sources,
-        "pattern_score": {
-            "patterns_used": 1,
-            "antipatterns_detected": 0,
-            "score": 1,
-        },
-    })
+    ret["pattern_observations"].update(
+        {
+            "patterns_detected": [detection],
+            "antipatterns_detected": [],
+            "evidence_sources": sources,
+            "pattern_score": {
+                "patterns_used": 1,
+                "antipatterns_detected": 0,
+                "score": 1,
+            },
+        }
+    )
     return _complete_unavailable_source_gates(return_validation, ret)
 
 
@@ -438,7 +480,8 @@ def test_full_structured_data_persisted(persist_results):
 
 
 def test_skipped_merge_cannot_mutate_prior_analysis_even_without_validator(
-        persist_results):
+    persist_results,
+):
     talk = _talk(
         processed_date="2026-06-18",
         transcript_source="youtube_auto",
@@ -488,10 +531,10 @@ def test_legacy_deep_merge_is_additive(persist_results):
     assert acts["named_acts"] is True  # new data merged in
 
 
-@pytest.mark.parametrize(
-    "field", ["slides_local_path", "slides_pdf_path", "pdf_path"])
+@pytest.mark.parametrize("field", ["slides_local_path", "slides_pdf_path", "pdf_path"])
 def test_legacy_return_persists_exact_local_pdf_preclaim_before_drive(
-        persist_results, return_validation, tmp_path, field):
+    persist_results, return_validation, tmp_path, field
+):
     local_path = "slides/descriptive-name.pdf"
     pdf_path = tmp_path / local_path
     pdf_path.parent.mkdir()
@@ -506,7 +549,10 @@ def test_legacy_return_persists_exact_local_pdf_preclaim_before_drive(
     )
     ret = _return(slide_source="pdf", slides_local_path=local_path)
     ret["pattern_observations"]["evidence_sources"] = [
-        "transcript", "static_slides", "delivery_video"]
+        "transcript",
+        "static_slides",
+        "delivery_video",
+    ]
     _complete_unavailable_source_gates(return_validation, ret)
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
@@ -525,7 +571,8 @@ def test_legacy_return_persists_exact_local_pdf_preclaim_before_drive(
 
 
 def test_nonvideo_return_cannot_persist_video_extraction_manifest(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     ret = _return(slide_source="pptx")
     ret["structured_data"]["video_extraction"] = {
         "schema_version": 3,
@@ -557,15 +604,14 @@ def test_nonvideo_return_cannot_persist_video_extraction_manifest(
     ],
 )
 def test_legacy_video_return_bounds_every_manifest_artifact_before_merge(
-        persist_results, return_validation, tmp_path, fault, expected_error):
+    persist_results, return_validation, tmp_path, fault, expected_error
+):
     video_id = "AbCdEfGhI_1"
     rebuild = tmp_path / "slides-rebuild" / video_id
     rebuild.mkdir(parents=True)
     source_video = rebuild / f"{video_id}.mp4"
     if fault == "outside_source":
-        source_video = (
-            tmp_path.parent / f"{tmp_path.name}-outside" / f"{video_id}.mp4"
-        )
+        source_video = tmp_path.parent / f"{tmp_path.name}-outside" / f"{video_id}.mp4"
         source_video.parent.mkdir()
     _write_tiny_mp4(source_video)
     slide_region = rebuild / f"{video_id}.slide-region.pdf"
@@ -664,9 +710,11 @@ def test_legacy_video_return_bounds_every_manifest_artifact_before_merge(
 
 
 def test_v2_adds_only_inside_registered_extension_namespace(persist_results):
-    talk = _talk(structured_data={
-        "extensions": {"argument_map": {"act_count": 4}},
-    })
+    talk = _talk(
+        structured_data={
+            "extensions": {"argument_map": {"act_count": 4}},
+        }
+    )
     ret = _return()
     ret["structured_data"]["extensions"] = {
         "argument_map": {"named_acts": True},
@@ -679,26 +727,31 @@ def test_v2_adds_only_inside_registered_extension_namespace(persist_results):
     }
 
 
-@pytest.mark.parametrize("field", [
-    "color_coded_backgrounds",
-    "typography_observations",
-    "footer_observations",
-    "shape_observations",
-    "video_extraction",
-    "key_data_points",
-    "named_authorities",
-    "time_bound_promotion",
-    "native_deck_audit",
-    "native_timing_audit",
-    "source_comparison",
-    "source_identity",
-    "animation_observations",
-    "pptx_pdf_reconciliation",
-])
+@pytest.mark.parametrize(
+    "field",
+    [
+        "color_coded_backgrounds",
+        "typography_observations",
+        "footer_observations",
+        "shape_observations",
+        "video_extraction",
+        "key_data_points",
+        "named_authorities",
+        "time_bound_promotion",
+        "native_deck_audit",
+        "native_timing_audit",
+        "source_comparison",
+        "source_identity",
+        "animation_observations",
+        "pptx_pdf_reconciliation",
+    ],
+)
 def test_v2_registered_maps_are_atomic_snapshots(persist_results, field):
-    talk = _talk(structured_data={
-        field: {"current": {"value": 1}, "stale_child": True},
-    })
+    talk = _talk(
+        structured_data={
+            field: {"current": {"value": 1}, "stale_child": True},
+        }
+    )
     ret = _return()
     ret["structured_data"][field] = {"current": {"value": 2}}
 
@@ -712,7 +765,8 @@ def test_v2_registered_maps_are_atomic_snapshots(persist_results, field):
     [(1, 1, 2), (2, 2, 2), (3, 3, 3)],
 )
 def test_queue_claim_closure_preserves_the_version_matrix(
-        persist_results, claim_version, return_version, closed_version):
+    persist_results, claim_version, return_version, closed_version
+):
     if claim_version == 3:
         talk, ret = _v3_talk_and_return(persist_results)
     else:
@@ -730,12 +784,12 @@ def test_queue_claim_closure_preserves_the_version_matrix(
     claim = talk["_queue_claim"]
     assert claim["schema_version"] == closed_version
     assert claim["state"] == "completed"
-    assert claim["result_payload_sha256"] == \
-        persist_results.canonical_return_sha256(ret)
+    assert claim["result_payload_sha256"] == persist_results.canonical_return_sha256(
+        ret
+    )
 
 
-def test_v2_snapshot_clears_stale_authenticated_adherence_comparison(
-        persist_results):
+def test_v2_snapshot_clears_stale_authenticated_adherence_comparison(persist_results):
     stale = {
         "schema_version": 1,
         "baseline": {"untrusted": "stale"},
@@ -752,17 +806,18 @@ def test_v2_snapshot_clears_stale_authenticated_adherence_comparison(
     assert legacy["adherence_comparison"] == stale
 
 
-def test_v2_atomic_snapshot_matches_rendered_analysis(
-        persist_results, tmp_path):
+def test_v2_atomic_snapshot_matches_rendered_analysis(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     analyses = tmp_path / "analyses"
-    talk = _talk(structured_data={
-        "typography_observations": {
-            "current_marker": "legacy",
-            "stale_child": "must disappear",
-        },
-    })
+    talk = _talk(
+        structured_data={
+            "typography_observations": {
+                "current_marker": "legacy",
+                "stale_child": "must disappear",
+            },
+        }
+    )
     ret = _return()
     ret["structured_data"]["typography_observations"] = {
         "current_marker": "current",
@@ -777,17 +832,25 @@ def test_v2_atomic_snapshot_matches_rendered_analysis(
     )
     assert persisted.returncode == 0, persisted.stderr
     analysis_script = persist_results.__file__.replace(
-        "persist-results.py", "write-analysis.py")
+        "persist-results.py", "write-analysis.py"
+    )
     rendered = subprocess.run(
-        [sys.executable, analysis_script, str(batch), str(analyses),
-         "--talks", str(db)],
+        [
+            sys.executable,
+            analysis_script,
+            str(batch),
+            str(analyses),
+            "--talks",
+            str(db),
+        ],
         capture_output=True,
         text=True,
     )
 
     assert rendered.returncode == 0, rendered.stderr
     stored_map = json.loads(db.read_text())["talks"][0]["structured_data"][
-        "typography_observations"]
+        "typography_observations"
+    ]
     markdown = (analyses / "talk.md").read_text()
     assert stored_map == ret["structured_data"]["typography_observations"]
     assert "current_marker" in markdown
@@ -796,21 +859,26 @@ def test_v2_atomic_snapshot_matches_rendered_analysis(
 
 
 def test_v2_image_distribution_and_basis_replace_as_one_snapshot(persist_results):
-    talk = _talk(structured_data={
-        "image_source_distribution": {"legacy": 9, "unknown": 1},
-        "image_source_distribution_basis": "Unit: legacy asset.",
-    })
+    talk = _talk(
+        structured_data={
+            "image_source_distribution": {"legacy": 9, "unknown": 1},
+            "image_source_distribution_basis": "Unit: legacy asset.",
+        }
+    )
     ret = _return()
-    ret["structured_data"].update({
-        "image_source_distribution": {"unknown": 2},
-        "image_source_distribution_basis": "Unit: slide; unknown origins stay unknown.",
-    })
+    ret["structured_data"].update(
+        {
+            "image_source_distribution": {"unknown": 2},
+            "image_source_distribution_basis": "Unit: slide; unknown origins stay unknown.",
+        }
+    )
 
     persist_results.merge_talk(talk, ret)
 
     assert talk["structured_data"]["image_source_distribution"] == {"unknown": 2}
     assert talk["structured_data"]["image_source_distribution_basis"] == (
-        "Unit: slide; unknown origins stay unknown.")
+        "Unit: slide; unknown origins stay unknown."
+    )
 
 
 def test_v2_per_slide_ledger_replaces_atomically(persist_results):
@@ -818,18 +886,19 @@ def test_v2_per_slide_ledger_replaces_atomically(persist_results):
     old_row["legacy_note"] = "must disappear"
     talk = _talk(structured_data={"per_slide_visual": [old_row]})
     ret = _return()
-    ret["structured_data"].update({
-        "slide_count": 1,
-        "per_slide_visual": [_visual_row()],
-    })
+    ret["structured_data"].update(
+        {
+            "slide_count": 1,
+            "per_slide_visual": [_visual_row()],
+        }
+    )
 
     persist_results.merge_talk(talk, ret)
 
     assert talk["structured_data"]["per_slide_visual"] == [_visual_row()]
 
 
-def test_v2_empty_verbatim_and_structured_lists_replace_prior_findings(
-        persist_results):
+def test_v2_empty_verbatim_and_structured_lists_replace_prior_findings(persist_results):
     talk = _talk(
         structured_data={"visual_continuity_devices": ["legacy_device"]},
         verbatim_examples={"jokes": ["legacy line"]},
@@ -861,10 +930,12 @@ def test_v2_empty_promoted_list_stays_synchronized(persist_results):
         },
     )
     ret = _return()
-    ret["structured_data"].update({
-        "co_presenter": False,
-        "co_presenters": [],
-    })
+    ret["structured_data"].update(
+        {
+            "co_presenter": False,
+            "co_presenters": [],
+        }
+    )
 
     persist_results.merge_talk(talk, ret)
 
@@ -894,7 +965,8 @@ def test_v2_unknown_object_fails_without_mutating_talk(persist_results):
     ],
 )
 def test_v2_nonempty_type_changes_replace_exactly(
-        persist_results, field, old_value, new_value):
+    persist_results, field, old_value, new_value
+):
     talk = _talk(structured_data={field: old_value})
     ret = _return()
     ret["structured_data"][field] = new_value
@@ -926,15 +998,16 @@ def test_v2_repairs_legacy_verbatim_and_pattern_array_containers(persist_results
 
     assert talk["verbatim_examples"] == {}
     assert isinstance(talk["pattern_observations"], dict)
-    assert talk["pattern_observations"]["pattern_ids"] == [
-        "narrative-arc", "bookends"]
+    assert talk["pattern_observations"]["pattern_ids"] == ["narrative-arc", "bookends"]
 
 
 def test_v2_clear_can_remove_an_undeclared_legacy_verbatim_lane(persist_results):
-    talk = _talk(verbatim_examples={
-        "jokes": ["legacy line"],
-        "legacy_lane": ["undeclared"],
-    })
+    talk = _talk(
+        verbatim_examples={
+            "jokes": ["legacy line"],
+            "legacy_lane": ["undeclared"],
+        }
+    )
     ret = _return(
         clear_fields=["verbatim_examples.legacy_lane"],
         verbatim_examples={"jokes": []},
@@ -956,7 +1029,8 @@ def test_v2_malformed_structured_container_fails_before_mutation(persist_results
 
 
 def test_v2_pattern_snapshot_removes_stale_children_and_accepts_zero_score(
-        persist_results):
+    persist_results,
+):
     talk = _talk(
         pattern_score=7,
         pattern_observations={
@@ -966,16 +1040,18 @@ def test_v2_pattern_snapshot_removes_stale_children_and_accepts_zero_score(
         },
     )
     ret = _return()
-    ret["pattern_observations"].update({
-        "patterns_detected": [],
-        "antipatterns_detected": [],
-        "not_evaluable": [],
-        "pattern_score": {
-            "patterns_used": 0,
-            "antipatterns_detected": 0,
-            "score": 0,
-        },
-    })
+    ret["pattern_observations"].update(
+        {
+            "patterns_detected": [],
+            "antipatterns_detected": [],
+            "not_evaluable": [],
+            "pattern_score": {
+                "patterns_used": 0,
+                "antipatterns_detected": 0,
+                "score": 0,
+            },
+        }
+    )
 
     persist_results.merge_talk(talk, ret)
 
@@ -988,8 +1064,12 @@ def test_v2_pattern_snapshot_removes_stale_children_and_accepts_zero_score(
         "not_evaluable": [],
         "not_evaluable_ids": [],
         "evidence_sources": [
-            "transcript", "native_deck", "static_slides", "delivery_video",
-            "source_comparison"],
+            "transcript",
+            "native_deck",
+            "static_slides",
+            "delivery_video",
+            "source_comparison",
+        ],
         "pattern_score": 0,
     }
 
@@ -1003,15 +1083,16 @@ def test_legacy_omitted_verbatim_lane_preserves_prior_value(persist_results):
     assert talk["verbatim_examples"]["jokes"] == ["legacy line"]
 
 
-def test_video_extraction_manifest_replaces_legacy_manifest_atomically(
-        persist_results):
-    talk = _talk(structured_data={
-        "video_extraction": {
-            "schema_version": 2,
-            "output_pdf": "/legacy/full-frame.pdf",
-            "unique_slides_count": 80,
-        },
-    })
+def test_video_extraction_manifest_replaces_legacy_manifest_atomically(persist_results):
+    talk = _talk(
+        structured_data={
+            "video_extraction": {
+                "schema_version": 2,
+                "output_pdf": "/legacy/full-frame.pdf",
+                "unique_slides_count": 80,
+            },
+        }
+    )
     ret = _return()
     ret["structured_data"]["video_extraction"] = {
         "schema_version": 3,
@@ -1059,14 +1140,19 @@ def test_pattern_observations_normalized(persist_results):
     assert obs["pattern_score"] == 1  # flattened from {"score": 1}
     assert len(obs["patterns_detected"]) == 2  # detailed arrays kept for Section 15
     assert obs["evidence_sources"] == [
-        "transcript", "native_deck", "static_slides", "delivery_video",
-        "source_comparison"]
+        "transcript",
+        "native_deck",
+        "static_slides",
+        "delivery_video",
+        "source_comparison",
+    ]
     assert obs["not_evaluable"] == []
     assert obs["not_evaluable_ids"] == []
 
 
 def test_transcript_quote_is_verified_and_locations_are_engine_owned(
-        persist_results, return_validation, tmp_path):
+    persist_results, return_validation, tmp_path
+):
     talk, ret = _v4_transcript_batch(return_validation, tmp_path)
     talk["schema_version"] = persist_results.TALK_SCHEMA_VERSION
     db = tmp_path / "tracking-database.json"
@@ -1098,55 +1184,60 @@ def test_transcript_quote_is_verified_and_locations_are_engine_owned(
     assert len(citation["artifact_sha256"]) == 64
     assert observations["evidence_schema_version"] == 1
     assert observations["source_inspection"][0]["coverage_complete"] is True
-    assert stored["pattern_scoring_generation_status"] == \
-        "legacy_unbaselineable"
-    assert "return_schema_precedes_exhaustive_outcomes" in stored[
-        "pattern_scoring_generation_reasons"
-    ]
+    assert stored["pattern_scoring_generation_status"] == "legacy_unbaselineable"
+    assert (
+        "return_schema_precedes_exhaustive_outcomes"
+        in stored["pattern_scoring_generation_reasons"]
+    )
     assert "pattern_scoring_schema_version" not in stored
     assert "pattern_catalog_fingerprint" not in stored
     # The worker receipt remains the exact raw claim; engine-owned locations
     # exist only in the canonical persisted projection.
     raw = json.loads(batch.read_text())[0]
-    assert "line_start" not in raw["pattern_observations"][
-        "patterns_detected"][0]["evidence_citations"][0]
+    assert (
+        "line_start"
+        not in raw["pattern_observations"]["patterns_detected"][0][
+            "evidence_citations"
+        ][0]
+    )
 
 
 @pytest.mark.parametrize("version", [1, 2])
 def test_legacy_single_comparison_pair_is_inferred_but_remains_historical(
-        persist_results, return_validation, version):
+    persist_results, return_validation, version
+):
     talk = _talk()
     ret = _gradual_comparison_return(return_validation, version=version)
 
     persist_results.merge_talk(talk, ret)
 
     detection = talk["pattern_observations"]["patterns_detected"][0]
-    assert detection["evidence_sources_used"] == [
-        "static_slides", "native_deck"]
-    assert talk["pattern_scoring_generation_status"] == \
-        "legacy_unbaselineable"
+    assert detection["evidence_sources_used"] == ["static_slides", "native_deck"]
+    assert talk["pattern_scoring_generation_status"] == "legacy_unbaselineable"
     assert talk["pattern_scoring_generation_reasons"] == [
-        "return_schema_precedes_source_locations"]
+        "return_schema_precedes_source_locations"
+    ]
     assert "pattern_scoring_schema_version" not in talk
     assert "pattern_catalog_fingerprint" not in talk
 
 
 @pytest.mark.parametrize("version", [1, 2])
 def test_legacy_ambiguous_comparison_replays_but_is_excluded_from_baselines(
-        persist_results, return_validation, version):
+    persist_results, return_validation, version
+):
     talk = _talk(
         pattern_scoring_schema_version=2,
         pattern_catalog_fingerprint="0" * 64,
     )
     ret = _gradual_comparison_return(
-        return_validation, version=version, include_delivery=True)
+        return_validation, version=version, include_delivery=True
+    )
 
     persist_results.merge_talk(talk, ret)
 
     detection = talk["pattern_observations"]["patterns_detected"][0]
     assert "evidence_sources_used" not in detection
-    assert talk["pattern_scoring_generation_status"] == \
-        "legacy_unbaselineable"
+    assert talk["pattern_scoring_generation_status"] == "legacy_unbaselineable"
     assert talk["pattern_scoring_generation_reasons"] == [
         "comparison_group_ambiguous:gradual-consistency",
         "return_schema_precedes_source_locations",
@@ -1157,31 +1248,35 @@ def test_legacy_ambiguous_comparison_replays_but_is_excluded_from_baselines(
 
 @pytest.mark.parametrize("version", [1, 2])
 def test_legacy_new_strong_gate_failure_replays_without_current_fingerprint(
-        persist_results, version):
+    persist_results, version
+):
     talk = _talk(
         pattern_scoring_schema_version=2,
         pattern_catalog_fingerprint="0" * 64,
     )
     ret = _return(return_schema_version=version)
-    ret["pattern_observations"].update({
-        "patterns_detected": [{
-            "pattern_id": "traveling-highlights",
-            "confidence": "strong",
-            "evidence_source": "static_slides",
-            "evidence": "The highlight appears in the static rendering.",
-        }],
-        "antipatterns_detected": [],
-        "pattern_score": {
-            "patterns_used": 1,
-            "antipatterns_detected": 0,
-            "score": 1,
-        },
-    })
+    ret["pattern_observations"].update(
+        {
+            "patterns_detected": [
+                {
+                    "pattern_id": "traveling-highlights",
+                    "confidence": "strong",
+                    "evidence_source": "static_slides",
+                    "evidence": "The highlight appears in the static rendering.",
+                }
+            ],
+            "antipatterns_detected": [],
+            "pattern_score": {
+                "patterns_used": 1,
+                "antipatterns_detected": 0,
+                "score": 1,
+            },
+        }
+    )
 
     persist_results.merge_talk(talk, ret)
 
-    assert talk["pattern_scoring_generation_status"] == \
-        "legacy_unbaselineable"
+    assert talk["pattern_scoring_generation_status"] == "legacy_unbaselineable"
     assert talk["pattern_scoring_generation_reasons"] == [
         "return_schema_precedes_source_locations",
         "strong_gate_unsatisfied:traveling-highlights",
@@ -1190,29 +1285,31 @@ def test_legacy_new_strong_gate_failure_replays_without_current_fingerprint(
     assert "pattern_catalog_fingerprint" not in talk
 
 
-def test_direct_v3_ineligible_merge_replays_as_historical(
-        persist_results):
+def test_direct_v3_ineligible_merge_replays_as_historical(persist_results):
     talk = _talk()
     ret = _return(return_schema_version=3)
-    ret["pattern_observations"].update({
-        "patterns_detected": [{
-            "pattern_id": "traveling-highlights",
-            "confidence": "strong",
-            "evidence_source": "static_slides",
-            "evidence": "Static pages cannot establish a strong detection.",
-        }],
-        "antipatterns_detected": [],
-        "pattern_score": {
-            "patterns_used": 1,
-            "antipatterns_detected": 0,
-            "score": 1,
-        },
-    })
+    ret["pattern_observations"].update(
+        {
+            "patterns_detected": [
+                {
+                    "pattern_id": "traveling-highlights",
+                    "confidence": "strong",
+                    "evidence_source": "static_slides",
+                    "evidence": "Static pages cannot establish a strong detection.",
+                }
+            ],
+            "antipatterns_detected": [],
+            "pattern_score": {
+                "patterns_used": 1,
+                "antipatterns_detected": 0,
+                "score": 1,
+            },
+        }
+    )
 
     persist_results.merge_talk(talk, ret)
 
-    assert talk["pattern_scoring_generation_status"] == \
-        "legacy_unbaselineable"
+    assert talk["pattern_scoring_generation_status"] == "legacy_unbaselineable"
     assert talk["pattern_scoring_generation_reasons"] == [
         "return_schema_precedes_source_locations",
         "strong_gate_unsatisfied:traveling-highlights",
@@ -1220,7 +1317,8 @@ def test_direct_v3_ineligible_merge_replays_as_historical(
 
 
 def test_direct_catalog_fingerprint_mismatch_fails_without_mutating_talk(
-        persist_results, return_validation):
+    persist_results, return_validation
+):
     talk = _talk()
     original = copy.deepcopy(talk)
 
@@ -1240,7 +1338,8 @@ def test_direct_catalog_fingerprint_mismatch_fails_without_mutating_talk(
     [(1, "legacy assessment"), (2, ""), (3, "")],
 )
 def test_only_v2_and_v3_use_snapshot_scalar_semantics(
-        persist_results, return_schema_version, expected):
+    persist_results, return_schema_version, expected
+):
     talk = _talk(adherence_assessment="legacy assessment")
     ret = _return(
         return_schema_version=return_schema_version,
@@ -1253,20 +1352,24 @@ def test_only_v2_and_v3_use_snapshot_scalar_semantics(
 
 
 def test_not_evaluable_patterns_are_persisted_but_never_scored(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     ret = _return()
-    ret["pattern_observations"]["not_evaluable"] = [{
-        "pattern_id": "composite-animation",
-        "evidence_source": "static_slides",
-        "reason": "No animation timing survives in the rendered pages.",
-    }]
+    ret["pattern_observations"]["not_evaluable"] = [
+        {
+            "pattern_id": "composite-animation",
+            "evidence_source": "static_slides",
+            "reason": "No animation timing survives in the rendered pages.",
+        }
+    ]
     db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     obs = json.loads(db.read_text())["talks"][0]["pattern_observations"]
@@ -1276,8 +1379,7 @@ def test_not_evaluable_patterns_are_persisted_but_never_scored(
 
 def test_scalar_result_fields_copied(persist_results):
     talk = _talk()
-    persist_results.merge_talk(
-        talk, _return(slides_local_path="slides/source.pdf"))
+    persist_results.merge_talk(talk, _return(slides_local_path="slides/source.pdf"))
     assert talk["status"] == "processed"
     assert talk["processed_date"] == "2026-06-18"
     assert talk["rhetoric_notes"] == "notes"
@@ -1299,7 +1401,8 @@ def test_run_date_stamped_when_return_omits_processed_date(persist_results):
 def test_batch_run_date_wins_over_legacy_return_date(persist_results):
     talk = _talk()
     _, stamped, _, _ = persist_results.merge_talk(
-        talk, _return(), run_date="2026-07-26")
+        talk, _return(), run_date="2026-07-26"
+    )
     assert talk["processed_date"] == "2026-07-26"
     assert stamped is True
 
@@ -1307,7 +1410,8 @@ def test_batch_run_date_wins_over_legacy_return_date(persist_results):
 def test_empty_processed_date_is_stamped(persist_results):
     talk = _talk(processed_date="2026-04-09")
     _, stamped, _, _ = persist_results.merge_talk(
-        talk, _return(processed_date=""), run_date="2026-07-26")
+        talk, _return(processed_date=""), run_date="2026-07-26"
+    )
     assert talk["processed_date"] == "2026-07-26"
     assert stamped is True
 
@@ -1329,9 +1433,16 @@ def test_cli_run_date_pins_the_stamp(persist_results, tmp_path):
     db.write_text(_db_json({"talks": [_talk(processed_date="2026-04-09")]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch),
-         "--run-date", "2026-07-26"],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(db),
+            str(batch),
+            "--run-date",
+            "2026-07-26",
+        ],
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(db.read_text())["talks"][0]["processed_date"] == "2026-07-26"
@@ -1341,7 +1452,8 @@ def test_cli_run_date_pins_the_stamp(persist_results, tmp_path):
 
 
 def test_cli_batch_timestamp_overrides_date_only_return_stamp_everywhere(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     authoritative = "2026-07-27T14:03:22+00:00"
@@ -1349,9 +1461,16 @@ def test_cli_batch_timestamp_overrides_date_only_return_stamp_everywhere(
     batch.write_text(json.dumps([_return(processed_date="2026-07-27")]))
 
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch),
-         "--run-date", authoritative],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(db),
+            str(batch),
+            "--run-date",
+            authoritative,
+        ],
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 0, result.stderr
@@ -1362,18 +1481,25 @@ def test_cli_batch_timestamp_overrides_date_only_return_stamp_everywhere(
 
 
 def test_cli_rejects_conflicting_explicit_return_timestamp_before_write(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk(processed_date="2026-04-09")]}
     db.write_text(_db_json(original))
-    batch.write_text(json.dumps([
-        _return(processed_date="2026-07-27T08:00:00+00:00")]))
+    batch.write_text(json.dumps([_return(processed_date="2026-07-27T08:00:00+00:00")]))
 
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch),
-         "--run-date", "2026-07-27T14:03:22+00:00"],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(db),
+            str(batch),
+            "--run-date",
+            "2026-07-27T14:03:22+00:00",
+        ],
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
@@ -1383,7 +1509,8 @@ def test_cli_rejects_conflicting_explicit_return_timestamp_before_write(
 
 
 def test_matching_explicit_return_timestamp_is_accepted_and_batch_stamped(
-        persist_results):
+    persist_results,
+):
     talk = _talk(processed_date="2026-04-09")
     _, stamped, _, _ = persist_results.merge_talk(
         talk,
@@ -1400,9 +1527,16 @@ def test_cli_rejects_malformed_run_date(persist_results, tmp_path):
     db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch),
-         "--run-date", "26-07-2026"],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(db),
+            str(batch),
+            "--run-date",
+            "26-07-2026",
+        ],
+        capture_output=True,
+        text=True,
     )
     assert result.returncode != 0
     assert "YYYY-MM-DD" in result.stderr
@@ -1416,7 +1550,8 @@ def test_cli_writes_db_and_reports(persist_results, tmp_path):
     script = persist_results.__file__
     result = subprocess.run(
         [sys.executable, script, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     out = json.loads(db.read_text())["talks"][0]
@@ -1476,9 +1611,7 @@ def test_cli_compares_symlinked_vault_roots_by_lexical_identity_before_persisten
     batch = tmp_path / "batch-returns.json"
     database = {"talks": [_talk()]}
     _db_json(database)
-    configured_root = (
-        alias_root if configured_identity == "alias" else physical_root
-    )
+    configured_root = alias_root if configured_identity == "alias" else physical_root
     database["config"]["vault_storage_path"] = str(configured_root)
     db.write_text(json.dumps(database), encoding="utf-8")
     batch.write_text(json.dumps([_return()]), encoding="utf-8")
@@ -1492,9 +1625,10 @@ def test_cli_compares_symlinked_vault_roots_by_lexical_identity_before_persisten
 
     if configured_identity == "alias":
         assert result.returncode == 0, result.stderr
-        assert json.loads(db.read_text(encoding="utf-8"))["talks"][0][
-            "status"
-        ] == "processed"
+        assert (
+            json.loads(db.read_text(encoding="utf-8"))["talks"][0]["status"]
+            == "processed"
+        )
     else:
         assert result.returncode == 1
         assert result.stderr == (
@@ -1549,9 +1683,7 @@ def test_cli_rejects_invalid_configured_vault_root_before_persistence(
     )
 
     assert result.returncode == 1
-    assert result.stderr == (
-        f"ERROR: vault_root_config_invalid:{locator_reason}\n"
-    )
+    assert result.stderr == (f"ERROR: vault_root_config_invalid:{locator_reason}\n")
     assert "Traceback" not in result.stderr
     if configured_root.strip():
         assert configured_root not in result.stderr
@@ -1606,8 +1738,7 @@ def test_cli_rejects_relative_database_authority_before_open(
 
     assert result.returncode == 1
     assert result.stderr == (
-        "ERROR: vault_root_database_path_invalid:"
-        "artifact_root_not_native_absolute\n"
+        "ERROR: vault_root_database_path_invalid:artifact_root_not_native_absolute\n"
     )
     assert db.name not in result.stderr
     assert db.read_text(encoding="utf-8") == original
@@ -1659,8 +1790,7 @@ def test_root_authority_rejection_precedes_every_artifact_and_write_boundary(
     assert caught.value.code == 1
     assert called == []
     assert capsys.readouterr().err == (
-        "ERROR: vault_root_config_invalid:"
-        "artifact_locator_home_expansion_unsupported\n"
+        "ERROR: vault_root_config_invalid:artifact_locator_home_expansion_unsupported\n"
     )
     assert db.read_text(encoding="utf-8") == original
 
@@ -1672,7 +1802,8 @@ def test_cli_fails_visibly_on_filename_mismatch(persist_results, tmp_path):
     batch.write_text(json.dumps([_return(filename="missing.md")]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "must exactly match" in result.stderr
@@ -1683,8 +1814,14 @@ def test_cli_missing_input_file_is_actionable(persist_results, tmp_path):
     batch = tmp_path / "batch-returns.json"
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(tmp_path / "nope.json"), str(batch)],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(tmp_path / "nope.json"),
+            str(batch),
+        ],
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "tracking database file not found" in result.stderr
@@ -1698,7 +1835,8 @@ def test_cli_malformed_json_is_actionable(persist_results, tmp_path):
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "not valid JSON" in result.stderr
@@ -1712,7 +1850,8 @@ def test_cli_non_array_batch_is_actionable(persist_results, tmp_path):
     batch.write_text(json.dumps({"filename": "talk.md"}))  # object, not array
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "must be a JSON array" in result.stderr
@@ -1736,8 +1875,10 @@ def test_default_stamp_normalizes_to_utc(persist_results):
 
 
 def test_explicit_offset_timestamp_is_normalized_to_utc(persist_results):
-    assert persist_results.normalize_stamp(
-        "2026-07-27T16:03:22.987654+02:00") == "2026-07-27T14:03:22+00:00"
+    assert (
+        persist_results.normalize_stamp("2026-07-27T16:03:22.987654+02:00")
+        == "2026-07-27T14:03:22+00:00"
+    )
 
 
 def test_return_processed_timestamp_is_persisted_in_canonical_utc(persist_results):
@@ -1764,9 +1905,16 @@ def test_cli_rejects_a_naive_timestamp(persist_results, tmp_path):
     db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch),
-         "--run-date", "2026-07-27T14:03:22"],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(db),
+            str(batch),
+            "--run-date",
+            "2026-07-27T14:03:22",
+        ],
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "timezone-aware" in result.stderr
@@ -1782,9 +1930,16 @@ def test_explicit_date_only_stamp_is_still_accepted(persist_results, tmp_path):
     db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch),
-         "--run-date", "2026-07-26"],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(db),
+            str(batch),
+            "--run-date",
+            "2026-07-26",
+        ],
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(db.read_text())["talks"][0]["processed_date"] == "2026-07-26"
@@ -1798,12 +1953,21 @@ def test_explicit_timestamp_is_accepted(persist_results, tmp_path):
     db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
-        [sys.executable, persist_results.__file__, str(db), str(batch),
-         "--run-date", "2026-07-27T14:03:22+00:00"],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            persist_results.__file__,
+            str(db),
+            str(batch),
+            "--run-date",
+            "2026-07-27T14:03:22+00:00",
+        ],
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
-    assert json.loads(db.read_text())["talks"][0]["processed_date"].startswith("2026-07-27T14:03:22")
+    assert json.loads(db.read_text())["talks"][0]["processed_date"].startswith(
+        "2026-07-27T14:03:22"
+    )
 
 
 def test_bare_int_pattern_score_is_coerced_and_promoted(persist_results, tmp_path):
@@ -1822,7 +1986,8 @@ def test_bare_int_pattern_score_is_coerced_and_promoted(persist_results, tmp_pat
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
@@ -1840,7 +2005,8 @@ def test_dict_pattern_score_is_not_reported_as_coerced(persist_results, tmp_path
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
@@ -1862,7 +2028,8 @@ def test_bare_int_contradicting_the_arrays_fails_loudly(persist_results, tmp_pat
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "2 patterns minus 1 antipatterns is 1" in result.stderr
@@ -1887,17 +2054,21 @@ def test_non_numeric_pattern_score_never_reaches_the_db(persist_results, tmp_pat
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1, f"{bad!r} was accepted: {result.stdout}"
     assert "pattern_score" in result.stderr
     stored = json.loads(db.read_text())["talks"][0]
-    assert "pattern_score" not in stored, f"{bad!r} reached the DB as {stored.get('pattern_score')!r}"
+    assert "pattern_score" not in stored, (
+        f"{bad!r} reached the DB as {stored.get('pattern_score')!r}"
+    )
 
 
 @pytest.mark.parametrize("inner", [True, False, "19", ["19"], 1.5, 1.0])
 def test_invalid_score_inside_the_declared_dict_is_rejected(
-        persist_results, tmp_path, inner):
+    persist_results, tmp_path, inner
+):
     """The dict is the declared shape, but its `score` is what PROMOTE writes.
 
     Type-checking only the bare form left `{"score": True}` reaching the DB
@@ -1907,12 +2078,16 @@ def test_invalid_score_inside_the_declared_dict_is_rejected(
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret["pattern_observations"]["pattern_score"] = {
-        "patterns_used": 2, "antipatterns_detected": 1, "score": inner}
+        "patterns_used": 2,
+        "antipatterns_detected": 1,
+        "score": inner,
+    }
     db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1, f"{inner!r} was accepted: {result.stdout}"
     assert "pattern_score.score" in result.stderr
@@ -1928,7 +2103,8 @@ def test_merge_stamps_the_talk_schema_version(persist_results, tmp_path):
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     talk = json.loads(db.read_text())["talks"][0]
@@ -1936,7 +2112,8 @@ def test_merge_stamps_the_talk_schema_version(persist_results, tmp_path):
 
 
 def test_persistence_accepts_historical_talk_under_current_root(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     """Current roots may retain v1-v4 talks until that exact talk is persisted."""
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
@@ -1946,7 +2123,8 @@ def test_persistence_accepts_historical_talk_under_current_root(
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     assert (
@@ -1956,7 +2134,8 @@ def test_persistence_accepts_historical_talk_under_current_root(
 
 
 def test_persistence_refuses_legacy_database_without_rewriting(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(json.dumps({"talks": [_talk()]}))
@@ -1980,22 +2159,28 @@ def test_root_migration_preserves_historical_pattern_evidence(tracking_database)
         "schema_version": 2,
         "status": "processed",
         "pattern_observations": {
-            "patterns_detected": [{
-                "pattern_id": "narrative-arc",
-                "confidence": "strong",
-                "evidence": "Legacy prose without a source location.",
-            }],
-            "antipatterns_detected": [{
-                "pattern_id": "shortchanged",
-                "confidence": "moderate",
-                "evidence": "A legacy model-supplied location is untrusted.",
-                "evidence_citations": [{
-                    "source": "transcript",
-                    "channel": "transcript",
-                    "line_start": 999,
-                    "line_end": 999,
-                }],
-            }],
+            "patterns_detected": [
+                {
+                    "pattern_id": "narrative-arc",
+                    "confidence": "strong",
+                    "evidence": "Legacy prose without a source location.",
+                }
+            ],
+            "antipatterns_detected": [
+                {
+                    "pattern_id": "shortchanged",
+                    "confidence": "moderate",
+                    "evidence": "A legacy model-supplied location is untrusted.",
+                    "evidence_citations": [
+                        {
+                            "source": "transcript",
+                            "channel": "transcript",
+                            "line_start": 999,
+                            "line_end": 999,
+                        }
+                    ],
+                }
+            ],
         },
     }
     database = {"talks": [talk]}
@@ -2008,7 +2193,8 @@ def test_root_migration_preserves_historical_pattern_evidence(tracking_database)
 
 
 def test_future_talk_schema_rejects_before_any_record_is_migrated(
-        persist_results, tracking_database):
+    persist_results, tracking_database
+):
     database = {
         "talks": [
             {"filename": "legacy.md", "schema_version": 1},
@@ -2029,8 +2215,7 @@ def test_future_talk_schema_rejects_before_any_record_is_migrated(
     assert database == before
 
 
-def test_cli_rejects_future_talk_schema_without_rewriting(
-        persist_results, tmp_path):
+def test_cli_rejects_future_talk_schema_without_rewriting(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk(schema_version=99)]}
@@ -2076,7 +2261,8 @@ def test_cli_assesses_future_root_before_old_talks_shape(
 
 
 def test_non_object_talk_member_is_actionable_and_does_not_rewrite(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(_db_json({"talks": [_talk(), "not-a-talk"]}))
@@ -2096,7 +2282,8 @@ def test_non_object_talk_member_is_actionable_and_does_not_rewrite(
 
 
 def test_tracking_database_symlink_is_rejected_without_splitting_state(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     target = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     target.write_text(json.dumps({"talks": [_talk()]}))
@@ -2117,8 +2304,9 @@ def test_tracking_database_symlink_is_rejected_without_splitting_state(
     assert target.read_bytes() == before
 
 
-@pytest.mark.parametrize("block", ["structured_data", "verbatim_examples",
-                                   "pattern_observations"])
+@pytest.mark.parametrize(
+    "block", ["structured_data", "verbatim_examples", "pattern_observations"]
+)
 def test_a_malformed_content_block_fails_loudly(persist_results, tmp_path, block):
     """A wrong-typed block used to be SKIPPED while the merge reported success.
 
@@ -2133,17 +2321,21 @@ def test_a_malformed_content_block_fails_loudly(persist_results, tmp_path, block
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1, f"{block} was skipped silently: {result.stdout}"
     assert block in result.stderr
 
 
-@pytest.mark.parametrize("bad", [
-    ["narrative-arc", "bookends"],          # bare id strings
-    "narrative-arc",                        # a string: len() counts characters
-    {"pattern_id": "narrative-arc"},        # a single object, not an array
-])
+@pytest.mark.parametrize(
+    "bad",
+    [
+        ["narrative-arc", "bookends"],  # bare id strings
+        "narrative-arc",  # a string: len() counts characters
+        {"pattern_id": "narrative-arc"},  # a single object, not an array
+    ],
+)
 def test_malformed_detection_arrays_fail_loudly(persist_results, tmp_path, bad):
     """List-of-strings raised AttributeError mid-merge and killed the script
     before it printed its JSON; a plain string made `len()` count characters as
@@ -2156,7 +2348,8 @@ def test_malformed_detection_arrays_fail_loudly(persist_results, tmp_path, bad):
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1, f"{bad!r} was accepted: {result.stdout}"
     assert "patterns_detected" in result.stderr
@@ -2174,7 +2367,8 @@ def test_a_malformed_return_leaves_the_talk_untouched(persist_results, tmp_path)
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert json.loads(db.read_text())["talks"][0] == original
@@ -2190,14 +2384,19 @@ def test_a_malformed_return_leaves_the_talk_untouched(persist_results, tmp_path)
     ],
 )
 def test_v2_destructive_empty_scalars_leave_database_byte_stable(
-        persist_results, tmp_path, field, value, message):
+    persist_results, tmp_path, field, value, message
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    original = {"talks": [_talk(
-        rhetoric_notes="trusted prior analysis",
-        areas_for_improvement="trusted prior improvement notes",
-        transcript_source="manual",
-    )]}
+    original = {
+        "talks": [
+            _talk(
+                rhetoric_notes="trusted prior analysis",
+                areas_for_improvement="trusted prior improvement notes",
+                transcript_source="manual",
+            )
+        ]
+    }
     ret = _return(**{field: value})
     db.write_text(_db_json(original))
     before = db.read_bytes()
@@ -2215,20 +2414,25 @@ def test_v2_destructive_empty_scalars_leave_database_byte_stable(
 
 
 def test_malformed_per_slide_visual_leaves_database_untouched(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     ret = _return()
-    ret["structured_data"].update({
-        "slide_count": 1,
-        # Synthetic legacy four-key shape: aliases cannot cross persistence.
-        "per_slide_visual": [{
-            "slide_number": 1,
-            "content_type": "title",
-            "background": "purple_halftone",
-            "has_text_footer": True,
-        }],
-    })
+    ret["structured_data"].update(
+        {
+            "slide_count": 1,
+            # Synthetic legacy four-key shape: aliases cannot cross persistence.
+            "per_slide_visual": [
+                {
+                    "slide_number": 1,
+                    "content_type": "title",
+                    "background": "purple_halftone",
+                    "has_text_footer": True,
+                }
+            ],
+        }
+    )
     original = {"talks": [_talk()]}
     db.write_text(_db_json(original))
     before = db.read_bytes()
@@ -2241,24 +2445,31 @@ def test_malformed_per_slide_visual_leaves_database_untouched(
     )
 
     assert result.returncode == 1
-    assert "per_slide_visual[0] must contain exactly the canonical fields" in result.stderr
+    assert (
+        "per_slide_visual[0] must contain exactly the canonical fields" in result.stderr
+    )
     assert db.read_bytes() == before
 
 
 def test_effective_per_slide_dependencies_fail_before_database_write(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    talk = _talk(structured_data={
-        "slide_count": 1,
-        "background_color_sequence": ["legacy"],
-        "meme_count": 1,
-    })
+    talk = _talk(
+        structured_data={
+            "slide_count": 1,
+            "background_color_sequence": ["legacy"],
+            "meme_count": 1,
+        }
+    )
     ret = _return()
-    ret["structured_data"].update({
-        "slide_count": 1,
-        "per_slide_visual": [_visual_row()],
-    })
+    ret["structured_data"].update(
+        {
+            "slide_count": 1,
+            "per_slide_visual": [_visual_row()],
+        }
+    )
     db.write_text(_db_json({"talks": [talk]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([ret]))
@@ -2276,7 +2487,8 @@ def test_effective_per_slide_dependencies_fail_before_database_write(
 
 
 def test_late_effective_failure_keeps_complete_database_byte_stable(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     first_talk = _talk(filename="first.md")
@@ -2289,10 +2501,12 @@ def test_late_effective_failure_keeps_complete_database_byte_stable(
     )
     first_return = _return(filename="first.md")
     second_return = _return(filename="second.md")
-    second_return["structured_data"].update({
-        "slide_count": 1,
-        "per_slide_visual": [_visual_row()],
-    })
+    second_return["structured_data"].update(
+        {
+            "slide_count": 1,
+            "per_slide_visual": [_visual_row()],
+        }
+    )
     db.write_text(_db_json({"talks": [first_talk, second_talk]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([first_return, second_return]))
@@ -2309,7 +2523,8 @@ def test_late_effective_failure_keeps_complete_database_byte_stable(
 
 
 def test_malformed_stored_structured_container_keeps_database_byte_stable(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(_db_json({"talks": [_talk(structured_data=["legacy"])]}))
@@ -2328,13 +2543,16 @@ def test_malformed_stored_structured_container_keeps_database_byte_stable(
 
 
 def test_undeclared_legacy_verbatim_lane_keeps_database_byte_stable(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    talk = _talk(verbatim_examples={
-        "jokes": ["legacy line"],
-        "legacy_lane": ["undeclared"],
-    })
+    talk = _talk(
+        verbatim_examples={
+            "jokes": ["legacy line"],
+            "legacy_lane": ["undeclared"],
+        }
+    )
     db.write_text(_db_json({"talks": [talk]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([_return(verbatim_examples={"jokes": []})]))
@@ -2351,7 +2569,8 @@ def test_undeclared_legacy_verbatim_lane_keeps_database_byte_stable(
 
 
 def test_missing_image_source_distribution_basis_leaves_database_untouched(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     ret = _return()
@@ -2376,12 +2595,14 @@ def test_missing_image_source_distribution_basis_leaves_database_untouched(
 
 
 def test_v2_image_source_basis_without_map_leaves_database_untouched(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret["structured_data"]["image_source_distribution_basis"] = (
-        "Unit: slide; unknown origins stay unknown.")
+        "Unit: slide; unknown origins stay unknown."
+    )
     db.write_text(_db_json({"talks": [_talk()]}))
     before = db.read_bytes()
     batch.write_text(json.dumps([ret]))
@@ -2398,7 +2619,8 @@ def test_v2_image_source_basis_without_map_leaves_database_untouched(
 
 
 def test_persistence_reports_that_schema_migration_was_not_run(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     merged, untouched = _talk(), _talk()
@@ -2408,7 +2630,8 @@ def test_persistence_reports_that_schema_migration_was_not_run(
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout)["migrated_records"] == 0
@@ -2423,12 +2646,15 @@ def test_score_object_without_a_score_key_fails_loudly(persist_results, tmp_path
     batch = tmp_path / "batch-returns.json"
     ret = _return()
     ret["pattern_observations"]["pattern_score"] = {
-        "patterns_used": 2, "antipatterns_detected": 1}
+        "patterns_used": 2,
+        "antipatterns_detected": 1,
+    }
     db.write_text(_db_json({"talks": [_talk()]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "pattern_score.score must be an integer" in result.stderr
@@ -2436,7 +2662,8 @@ def test_score_object_without_a_score_key_fails_loudly(persist_results, tmp_path
 
 
 def test_clear_fields_removes_contaminated_values_and_promoted_scalars(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     """A corrective reparse can explicitly remove claims disproved by artifacts."""
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
@@ -2446,19 +2673,22 @@ def test_clear_fields_removes_contaminated_values_and_promoted_scalars(
         structured_data={"slide_count": 999, "stale_claim": "borrowed deck"},
         verbatim_examples={"jokes": ["quote from a sibling delivery"]},
     )
-    ret = _return(clear_fields=[
-        "slides_local_path",
-        "structured_data.slide_count",
-        "structured_data.stale_claim",
-        "verbatim_examples.jokes",
-    ])
+    ret = _return(
+        clear_fields=[
+            "slides_local_path",
+            "structured_data.slide_count",
+            "structured_data.stale_claim",
+            "verbatim_examples.jokes",
+        ]
+    )
     del ret["structured_data"]["slide_count"]
     ret["verbatim_examples"]["jokes"] = []
     db.write_text(_db_json({"talks": [talk]}))
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     stored = json.loads(db.read_text())["talks"][0]
@@ -2474,7 +2704,8 @@ def test_clear_fields_removes_contaminated_values_and_promoted_scalars(
 
 
 def test_pattern_score_clear_removes_both_nested_and_promoted_value(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talk = _talk(
@@ -2488,7 +2719,8 @@ def test_pattern_score_clear_removes_both_nested_and_promoted_value(
     batch.write_text(json.dumps([ret]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     stored = json.loads(db.read_text())["talks"][0]
@@ -2497,7 +2729,8 @@ def test_pattern_score_clear_removes_both_nested_and_promoted_value(
 
 
 def test_historical_return_is_marked_unbaselineable_and_claim_is_closed(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talk = _talk(reprocess_reason="pattern_scoring_generation:legacy_generation")
@@ -2505,33 +2738,39 @@ def test_historical_return_is_marked_unbaselineable_and_claim_is_closed(
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, result.stderr
     report = json.loads(result.stdout)
     stored = json.loads(db.read_text())["talks"][0]
-    assert stored["pattern_scoring_generation_status"] == \
-        "legacy_unbaselineable"
+    assert stored["pattern_scoring_generation_status"] == "legacy_unbaselineable"
     assert stored["pattern_scoring_generation_reasons"] == [
-        "return_schema_precedes_source_locations"]
+        "return_schema_precedes_source_locations"
+    ]
     assert "pattern_scoring_schema_version" not in stored
     assert "pattern_catalog_fingerprint" not in stored
     assert report["pattern_catalog_fingerprint"]
     assert stored["_queue_claim"]["state"] == "completed"
-    assert stored["_queue_claim"]["schema_version"] == \
-        persist_results.PREVIOUS_QUEUE_CLAIM_SCHEMA_VERSION
+    assert (
+        stored["_queue_claim"]["schema_version"]
+        == persist_results.PREVIOUS_QUEUE_CLAIM_SCHEMA_VERSION
+    )
     assert stored["_queue_claim"]["result_status"] == "processed"
     assert stored["_queue_claim"]["release_reason"] == "return_persisted"
-    assert stored["_queue_claim"]["result_payload_sha256"] == \
-        persist_results.canonical_return_sha256(_return())
+    assert stored["_queue_claim"][
+        "result_payload_sha256"
+    ] == persist_results.canonical_return_sha256(_return())
     assert "reprocess_reason" not in stored
 
 
 @pytest.mark.parametrize("status", ["processed", "processed_partial"])
 def test_analysis_terminal_outcome_clears_live_reprocess_reason(
-        persist_results, status):
+    persist_results, status
+):
     talk = _talk(
-        reprocess_reason="pattern_scoring_generation:missing_generation_status")
+        reprocess_reason="pattern_scoring_generation:missing_generation_status"
+    )
     ret = _return(status=status)
 
     persist_results.merge_talk(
@@ -2547,25 +2786,26 @@ def test_analysis_terminal_outcome_clears_live_reprocess_reason(
 
 
 def test_v3_member_baseline_mismatch_rejects_whole_batch_without_write(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     filenames = ("a.md", "b.md")
-    baseline = _adherence_baseline(
-        persist_results, filenames=filenames)
+    baseline = _adherence_baseline(persist_results, filenames=filenames)
     talks = []
     returns = []
     for filename in filenames:
-        talk, ret = _v3_talk_and_return(
-            persist_results, filename=filename)
+        talk, ret = _v3_talk_and_return(persist_results, filename=filename)
         talk["_queue_claim"]["adherence_baseline"] = copy.deepcopy(baseline)
         talks.append(talk)
         returns.append(ret)
-    talks[1]["_queue_claim"]["adherence_baseline"].update({
-        "scored_talk_count": 1,
-        "pattern_score_sum": 1,
-        "average_pattern_score": 1.0,
-    })
+    talks[1]["_queue_claim"]["adherence_baseline"].update(
+        {
+            "scored_talk_count": 1,
+            "pattern_score_sum": 1,
+            "average_pattern_score": 1.0,
+        }
+    )
     original = {"talks": talks}
     db.write_text(_db_json(original))
     before = db.read_bytes()
@@ -2583,38 +2823,45 @@ def test_v3_member_baseline_mismatch_rejects_whole_batch_without_write(
 
 
 def test_post_batch_stdout_uses_complete_replacement_cohort_and_keeps_claim(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talk, ret = _v3_talk_and_return(persist_results)
     claim_baseline = copy.deepcopy(talk["_queue_claim"]["adherence_baseline"])
-    talk.update({
-        "pattern_score": 99,
-        "pattern_observations": {
-            **talk["pattern_observations"],
+    talk.update(
+        {
             "pattern_score": 99,
-        },
-        "pattern_scoring_generation_status": "current",
-        "pattern_scoring_generation_reasons": [],
-        "pattern_scoring_schema_version": (
-            persist_results.PATTERN_SCORING_SCHEMA_VERSION),
-        "pattern_catalog_fingerprint": persist_results.load_catalog().fingerprint,
-    })
+            "pattern_observations": {
+                **talk["pattern_observations"],
+                "pattern_score": 99,
+            },
+            "pattern_scoring_generation_status": "current",
+            "pattern_scoring_generation_reasons": [],
+            "pattern_scoring_schema_version": (
+                persist_results.PATTERN_SCORING_SCHEMA_VERSION
+            ),
+            "pattern_catalog_fingerprint": persist_results.load_catalog().fingerprint,
+        }
+    )
     prior = _talk(filename="prior.md", status="processed")
     prior.pop("_queue_claim")
-    prior.update({
-        "pattern_score": 3,
-        "pattern_observations": {
-            **prior["pattern_observations"],
+    prior.update(
+        {
             "pattern_score": 3,
-            "opportunity_coverage_identity": "0" * 64,
-        },
-        "pattern_scoring_generation_status": "current",
-        "pattern_scoring_generation_reasons": [],
-        "pattern_scoring_schema_version": (
-            persist_results.PATTERN_SCORING_SCHEMA_VERSION),
-        "pattern_catalog_fingerprint": persist_results.load_catalog().fingerprint,
-    })
+            "pattern_observations": {
+                **prior["pattern_observations"],
+                "pattern_score": 3,
+                "opportunity_coverage_identity": "0" * 64,
+            },
+            "pattern_scoring_generation_status": "current",
+            "pattern_scoring_generation_reasons": [],
+            "pattern_scoring_schema_version": (
+                persist_results.PATTERN_SCORING_SCHEMA_VERSION
+            ),
+            "pattern_catalog_fingerprint": persist_results.load_catalog().fingerprint,
+        }
+    )
     db.write_text(_db_json({"talks": [talk, prior]}))
     batch.write_text(json.dumps([ret]))
 
@@ -2646,7 +2893,8 @@ def test_post_batch_stdout_uses_complete_replacement_cohort_and_keeps_claim(
 
 
 def test_missing_status_rejects_the_whole_batch_without_migrating_db(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk()]}
@@ -2656,7 +2904,8 @@ def test_missing_status_rejects_the_whole_batch_without_migrating_db(
     batch.write_text(json.dumps([_return(filename="talk.md"), invalid]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "status is required" in result.stderr
@@ -2671,7 +2920,8 @@ def test_duplicate_db_filenames_are_rejected_before_write(persist_results, tmp_p
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "duplicate talk filename" in result.stderr
@@ -2679,7 +2929,8 @@ def test_duplicate_db_filenames_are_rejected_before_write(persist_results, tmp_p
 
 
 def test_partial_three_member_batch_is_rejected_before_any_db_write(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talks = [_talk(filename=f"{name}.md") for name in ("a", "b", "c")]
@@ -2690,7 +2941,8 @@ def test_partial_three_member_batch_is_rejected_before_any_db_write(
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
@@ -2698,27 +2950,30 @@ def test_partial_three_member_batch_is_rejected_before_any_db_write(
     assert json.loads(db.read_text()) == original
 
 
-def test_partially_closed_batch_cannot_be_finished_piecemeal(
-        persist_results, tmp_path):
+def test_partially_closed_batch_cannot_be_finished_piecemeal(persist_results, tmp_path):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talks = [_talk(filename=f"{name}.md") for name in ("a", "b", "c")]
     for talk in talks[:2]:
         talk["status"] = "processed"
-        talk["_queue_claim"].update({
-            "state": "completed",
-            "released_at": "2026-07-31T18:05:00+00:00",
-            "release_reason": "return_persisted",
-            "result_status": "processed",
-        })
+        talk["_queue_claim"].update(
+            {
+                "state": "completed",
+                "released_at": "2026-07-31T18:05:00+00:00",
+                "release_reason": "return_persisted",
+                "result_status": "processed",
+            }
+        )
     original = {"talks": talks}
     db.write_text(_db_json(original))
-    batch.write_text(json.dumps([
-        _return(filename=f"{name}.md") for name in ("a", "b", "c")]))
+    batch.write_text(
+        json.dumps([_return(filename=f"{name}.md") for name in ("a", "b", "c")])
+    )
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
@@ -2737,7 +2992,8 @@ def test_stale_return_generation_cannot_roll_back_a_requeue(persist_results, tmp
     batch.write_text(json.dumps([stale]))
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 1
     assert "does not match active claim value 2" in result.stderr
@@ -2754,16 +3010,20 @@ def test_claim_generation_cannot_lag_top_level_generation(persist_results, tmp_p
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
-    assert "current claim generation 1 disagrees with talk generation 2" in result.stderr
+    assert (
+        "current claim generation 1 disagrees with talk generation 2" in result.stderr
+    )
     assert json.loads(db.read_text()) == original
 
 
 def test_active_claim_with_undeclared_fields_is_rejected_before_write(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talk = _talk()
@@ -2774,7 +3034,8 @@ def test_active_claim_with_undeclared_fields_is_rejected_before_write(
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
@@ -2784,7 +3045,8 @@ def test_active_claim_with_undeclared_fields_is_rejected_before_write(
 
 
 def test_skipped_return_preserves_prior_analysis_and_persists_terminal_metadata(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talk = _talk(
@@ -2809,7 +3071,8 @@ def test_skipped_return_preserves_prior_analysis_and_persists_terminal_metadata(
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 0, result.stderr
@@ -2827,15 +3090,14 @@ def test_skipped_return_preserves_prior_analysis_and_persists_terminal_metadata(
     assert stored["_queue_claim"]["state"] == "completed"
     assert "reprocess_reason" not in stored
     report = json.loads(result.stdout)
-    assert report["talks"][0]["pattern_scoring_generation_status"] == \
-        "not_applicable"
+    assert report["talks"][0]["pattern_scoring_generation_status"] == "not_applicable"
     assert report["talks"][0]["pattern_scoring_generation_reasons"] == []
 
 
-@pytest.mark.parametrize(
-    "capability", ["remote_video", "transcript", "pptx", "pdf"])
+@pytest.mark.parametrize("capability", ["remote_video", "transcript", "pptx", "pdf"])
 def test_skipped_no_sources_rejects_each_live_capability(
-        persist_results, tmp_path, capability):
+    persist_results, tmp_path, capability
+):
     base = {
         "video_url": None,
         "youtube_id": None,
@@ -2852,8 +3114,7 @@ def test_skipped_no_sources_rejects_each_live_capability(
         path = tmp_path / "transcripts" / "AbCdEfGhI_1.txt"
         path.parent.mkdir()
         path.write_text(" ".join(["substantive"] * 600), encoding="utf-8")
-        source_fields = {
-            "transcript_path": "transcripts/AbCdEfGhI_1.txt"}
+        source_fields = {"transcript_path": "transcripts/AbCdEfGhI_1.txt"}
     elif capability == "pptx":
         path = tmp_path / "decks" / "talk.pptx"
         path.parent.mkdir()
@@ -2889,7 +3150,8 @@ def test_skipped_no_sources_rejects_each_live_capability(
 
 @pytest.mark.parametrize("surviving_source", ["deck", "transcript"])
 def test_invalid_source_cannot_hide_independent_terminal_capability(
-        persist_results, tmp_path, surviving_source):
+    persist_results, tmp_path, surviving_source
+):
     fields = {
         "video_url": None,
         "youtube_id": None,
@@ -2903,10 +3165,12 @@ def test_invalid_source_cannot_hide_independent_terminal_capability(
         presentation = Presentation()
         presentation.slides.add_slide(presentation.slide_layouts[6])
         presentation.save(deck)
-        fields.update({
-            "transcript_path": "../bad.txt",
-            "pptx_path": "decks/talk.pptx",
-        })
+        fields.update(
+            {
+                "transcript_path": "../bad.txt",
+                "pptx_path": "decks/talk.pptx",
+            }
+        )
     else:
         transcript = tmp_path / "transcripts" / "manual-talk.txt"
         transcript.parent.mkdir()
@@ -2919,11 +3183,13 @@ def test_invalid_source_cannot_hide_independent_terminal_capability(
             transcript_timing.build_quality_policy(400),
             {"kind": "fixed_default"},
         )
-        fields.update({
-            "transcript_path": "transcripts/manual-talk.txt",
-            "transcript_source": "manual",
-            "pptx_path": "../bad.pptx",
-        })
+        fields.update(
+            {
+                "transcript_path": "transcripts/manual-talk.txt",
+                "transcript_source": "manual",
+                "pptx_path": "../bad.pptx",
+            }
+        )
     talk = _talk(**fields)
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
@@ -2939,12 +3205,14 @@ def test_invalid_source_cannot_hide_independent_terminal_capability(
     assert result.returncode == 1
     assert "cannot finish skipped_no_sources" in result.stderr
     assert surviving_source in result.stderr or (
-        surviving_source == "deck" and "slides" in result.stderr)
+        surviving_source == "deck" and "slides" in result.stderr
+    )
 
 
 @pytest.mark.parametrize("artifact_kind", ["transcript", "pptx", "pdf"])
 def test_download_failure_rejects_when_a_local_artifact_remains(
-        persist_results, tmp_path, artifact_kind):
+    persist_results, tmp_path, artifact_kind
+):
     local_source = {}
     if artifact_kind == "transcript":
         path = tmp_path / "transcripts" / "AbCdEfGhI_1.txt"
@@ -2966,18 +3234,19 @@ def test_download_failure_rejects_when_a_local_artifact_remains(
         with path.open("wb") as stream:
             writer.write(stream)
         local_source = {"slides_local_path": "slides/talk.pdf"}
-    talk = _talk(**{
-        "pptx_path": None,
-        "slides_url": None,
-        "transcript_path": None,
-        "slides_local_path": None,
-        **local_source,
-    })
+    talk = _talk(
+        **{
+            "pptx_path": None,
+            "slides_url": None,
+            "transcript_path": None,
+            "slides_local_path": None,
+            **local_source,
+        }
+    )
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(_db_json({"talks": [talk]}))
-    batch.write_text(json.dumps([
-        _skipped_return(status="skipped_download_failed")]))
+    batch.write_text(json.dumps([_skipped_return(status="skipped_download_failed")]))
     before = db.read_bytes()
 
     result = subprocess.run(
@@ -2991,8 +3260,7 @@ def test_download_failure_rejects_when_a_local_artifact_remains(
     assert db.read_bytes() == before
 
 
-def test_broken_local_reference_allows_no_sources_terminal(
-        persist_results, tmp_path):
+def test_broken_local_reference_allows_no_sources_terminal(persist_results, tmp_path):
     talk = _talk(
         video_url=None,
         youtube_id=None,
@@ -3011,12 +3279,12 @@ def test_broken_local_reference_allows_no_sources_terminal(
     )
 
     assert result.returncode == 0, result.stderr
-    assert json.loads(db.read_text())["talks"][0]["status"] == \
-        "skipped_no_sources"
+    assert json.loads(db.read_text())["talks"][0]["status"] == "skipped_no_sources"
 
 
 def test_broken_local_reference_with_remote_allows_download_failed(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     talk = _talk(
         slides_url=None,
         pptx_path="decks/missing.pptx",
@@ -3024,8 +3292,7 @@ def test_broken_local_reference_with_remote_allows_download_failed(
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(_db_json({"talks": [talk]}))
-    batch.write_text(json.dumps([
-        _skipped_return(status="skipped_download_failed")]))
+    batch.write_text(json.dumps([_skipped_return(status="skipped_download_failed")]))
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -3034,12 +3301,10 @@ def test_broken_local_reference_with_remote_allows_download_failed(
     )
 
     assert result.returncode == 0, result.stderr
-    assert json.loads(db.read_text())["talks"][0]["status"] == \
-        "skipped_download_failed"
+    assert json.loads(db.read_text())["talks"][0]["status"] == "skipped_download_failed"
 
 
-def test_download_failure_requires_a_remote_acquisition_path(
-        persist_results, tmp_path):
+def test_download_failure_requires_a_remote_acquisition_path(persist_results, tmp_path):
     talk = _talk(
         video_url=None,
         youtube_id=None,
@@ -3049,8 +3314,7 @@ def test_download_failure_requires_a_remote_acquisition_path(
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(_db_json({"talks": [talk]}))
-    batch.write_text(json.dumps([
-        _skipped_return(status="skipped_download_failed")]))
+    batch.write_text(json.dumps([_skipped_return(status="skipped_download_failed")]))
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -3066,7 +3330,8 @@ def test_download_failure_requires_a_remote_acquisition_path(
 
 
 def test_malformed_remote_references_do_not_authorize_download_failed(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     talk = _talk(
         video_url="https://youtu.be/too-short",
         youtube_id=None,
@@ -3077,8 +3342,7 @@ def test_malformed_remote_references_do_not_authorize_download_failed(
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(_db_json({"talks": [talk]}))
-    batch.write_text(json.dumps([
-        _skipped_return(status="skipped_download_failed")]))
+    batch.write_text(json.dumps([_skipped_return(status="skipped_download_failed")]))
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
@@ -3090,8 +3354,7 @@ def test_malformed_remote_references_do_not_authorize_download_failed(
     assert "without a usable remote video" in result.stderr
 
 
-def test_duplicate_skip_requires_a_bound_canonical_talk(
-        persist_results, tmp_path):
+def test_duplicate_skip_requires_a_bound_canonical_talk(persist_results, tmp_path):
     talk = _talk(video_url=None, pptx_path=None, slides_url=None)
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
@@ -3127,16 +3390,19 @@ def test_duplicate_skip_requires_a_bound_canonical_talk(
     ],
 )
 def test_mechanically_bound_skip_status_can_close_claim(
-        persist_results, tmp_path, status, talk_overrides):
-    talk = _talk(**{
-        "reprocess_reason": "source_identity_correction",
-        "video_url": None,
-        "pptx_path": None,
-        "slides_url": None,
-        "transcript_path": None,
-        "slides_local_path": None,
-        **talk_overrides,
-    })
+    persist_results, tmp_path, status, talk_overrides
+):
+    talk = _talk(
+        **{
+            "reprocess_reason": "source_identity_correction",
+            "video_url": None,
+            "pptx_path": None,
+            "slides_url": None,
+            "transcript_path": None,
+            "slides_local_path": None,
+            **talk_overrides,
+        }
+    )
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     db.write_text(_db_json({"talks": [talk]}))
@@ -3156,7 +3422,8 @@ def test_mechanically_bound_skip_status_can_close_claim(
 
 
 def test_skipped_return_with_analysis_fields_aborts_without_write(
-        persist_results, tmp_path):
+    persist_results, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     original = {"talks": [_talk(rhetoric_notes="trusted prior analysis")]}
@@ -3166,7 +3433,8 @@ def test_skipped_return_with_analysis_fields_aborts_without_write(
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
@@ -3175,7 +3443,8 @@ def test_skipped_return_with_analysis_fields_aborts_without_write(
 
 
 def test_wrong_transcript_source_cannot_be_resurrected(
-        persist_results, return_validation, tmp_path):
+    persist_results, return_validation, tmp_path
+):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
     talk = _talk(
@@ -3187,8 +3456,7 @@ def test_wrong_transcript_source_cannot_be_resurrected(
         google_drive_id="slides-id",
     )
     ret = _return(status="processed_partial", slide_source="pdf")
-    ret["pattern_observations"]["evidence_sources"] = [
-        "transcript", "static_slides"]
+    ret["pattern_observations"]["evidence_sources"] = ["transcript", "static_slides"]
     _complete_unavailable_source_gates(return_validation, ret)
     original = {"talks": [talk]}
     db.write_text(_db_json(original))
@@ -3196,7 +3464,8 @@ def test_wrong_transcript_source_cannot_be_resurrected(
 
     result = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
@@ -3211,13 +3480,15 @@ def test_completed_generation_cannot_be_replayed(persist_results, tmp_path):
     batch.write_text(json.dumps([_return()]))
     first = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert first.returncode == 0, first.stderr
     completed = db.read_bytes()
     replay = subprocess.run(
         [sys.executable, persist_results.__file__, str(db), str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert replay.returncode == 1
     assert "closed or stranded member" in replay.stderr
@@ -3226,14 +3497,17 @@ def test_completed_generation_cannot_be_replayed(persist_results, tmp_path):
 
 # --- #203: the CLI has a closed failure boundary that names commit position ---
 
+
 @pytest.mark.parametrize("committed", [False, True])
 def test_outer_boundary_reports_whether_the_commit_landed(
-        persist_results, capsys, monkeypatch, committed):
+    persist_results, capsys, monkeypatch, committed
+):
     """A late failure must say whether the atomic write already happened.
 
     Without it an operator cannot tell a pre-commit abort from a post-commit
     reporting failure, and a blind retry could re-persist the batch.
     """
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("injected failure at /private/vault/tracking.json")
 
@@ -3243,7 +3517,7 @@ def test_outer_boundary_reports_whether_the_commit_landed(
     assert persist_results.run_cli() == 2
 
     captured = capsys.readouterr()
-    assert captured.out == ""                     # stdout stays clean
+    assert captured.out == ""  # stdout stays clean
     payload = json.loads(captured.err.splitlines()[0])
     assert payload["error"] == "persist_results_unexpected_failure"
     assert payload["error_type"] == "RuntimeError"
@@ -3254,8 +3528,7 @@ def test_outer_boundary_reports_whether_the_commit_landed(
     assert "Traceback" not in captured.err
 
 
-def test_commit_state_does_not_leak_between_runs(
-        persist_results, capsys, monkeypatch):
+def test_commit_state_does_not_leak_between_runs(persist_results, capsys, monkeypatch):
     """A stale True would make a pre-commit failure claim the batch was written.
 
     Exercises the real main(): it resets the flag before doing anything, so a
@@ -3276,8 +3549,7 @@ def test_commit_state_does_not_leak_between_runs(
     assert persist_results._COMMIT_STATE["database_written"] is False
 
 
-def test_outer_boundary_lets_a_clean_run_report_success(
-        persist_results, monkeypatch):
+def test_outer_boundary_lets_a_clean_run_report_success(persist_results, monkeypatch):
     """The boundary must not swallow or alter a normal run."""
     monkeypatch.setattr(persist_results, "main", lambda *a, **k: None)
     assert persist_results.run_cli() == 0
@@ -3285,6 +3557,7 @@ def test_outer_boundary_lets_a_clean_run_report_success(
 
 def test_outer_boundary_does_not_catch_sys_exit(persist_results, monkeypatch):
     """main()'s own sys.exit paths keep their exit codes."""
+
     def bail(*_args, **_kwargs):
         raise SystemExit(1)
 
@@ -3294,11 +3567,11 @@ def test_outer_boundary_does_not_catch_sys_exit(persist_results, monkeypatch):
     assert excinfo.value.code == 1
 
 
-
-
 def test_failure_payload_names_code_locations_without_exception_text(
-        persist_results, capsys, monkeypatch):
+    persist_results, capsys, monkeypatch
+):
     """no-secrets forbids exception text; the origin frames replace it."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("token=SECRET at /private/vault/creds.json")
 

--- a/tests/test_pptx_discovery_contract.py
+++ b/tests/test_pptx_discovery_contract.py
@@ -88,8 +88,7 @@ def test_directory_exclusions_use_exact_casefolded_component_matching() -> None:
 
     assert contract.directory_component_is_excluded(".venv", exclusions) is True
     assert (
-        contract.directory_component_is_excluded("generated assets", exclusions)
-        is True
+        contract.directory_component_is_excluded("generated assets", exclusions) is True
     )
     assert contract.directory_component_is_excluded("my.venv", exclusions) is False
     assert (
@@ -166,7 +165,9 @@ def test_public_batch_round_trip_is_strict_and_recomputes_completeness() -> None
             contract.decode_pptx_directory_batch(malformed)
 
 
-def test_public_batch_rejects_nonobjects_unknown_reasons_and_duplicate_receipts() -> None:
+def test_public_batch_rejects_nonobjects_unknown_reasons_and_duplicate_receipts() -> (
+    None
+):
     for results, skipped in (
         (["not-an-object"], []),
         ([], [{"path": ".", "reason": "typo"}]),
@@ -238,8 +239,7 @@ def test_public_batch_bounds_skip_path_length() -> None:
             [],
             [
                 {
-                    "path": "x"
-                    * (contract.PPTX_DIRECTORY_RELATIVE_PATH_MAX_CHARS + 1),
+                    "path": "x" * (contract.PPTX_DIRECTORY_RELATIVE_PATH_MAX_CHARS + 1),
                     "reason": "pptx_batch_skip_pattern",
                 }
             ],
@@ -262,9 +262,7 @@ def test_whole_root_failure_is_bound_to_the_same_public_envelope() -> None:
 
 
 def test_whole_root_receipt_requires_error_and_zero_results() -> None:
-    receipt = [
-        {"path": ".", "reason": "pptx_batch_discovery_start_failure"}
-    ]
+    receipt = [{"path": ".", "reason": "pptx_batch_discovery_start_failure"}]
     with pytest.raises(
         contract.PptxDiscoveryContractError,
         match="require a matching top-level error",
@@ -337,9 +335,7 @@ def test_top_level_error_details_are_closed_and_path_neutral(details: object) ->
 
 
 def test_legacy_unversioned_batch_never_authorizes_absence() -> None:
-    assessment = contract.assess_pptx_directory_batch(
-        {"results": [], "skipped": []}
-    )
+    assessment = contract.assess_pptx_directory_batch({"results": [], "skipped": []})
 
     assert assessment.state == "unknown_legacy"
     assert assessment.schema_version == 0
@@ -353,14 +349,10 @@ def test_ingress_and_config_docs_bind_directory_completeness_and_migration() -> 
     root = Path(__file__).parents[1]
     relative_paths = {
         "skill": "skills/vault-ingress/SKILL.md",
-        "bootstrap": (
-            "skills/vault-ingress/references/bootstrap-and-preflight.md"
-        ),
+        "bootstrap": ("skills/vault-ingress/references/bootstrap-and-preflight.md"),
         "followup": "skills/vault-ingress/references/pptx-followup.md",
         "schemas": "skills/vault-ingress/references/schemas-db.md",
-        "preflight": (
-            "skills/vault-ingress/references/source-identity-preflight.md"
-        ),
+        "preflight": ("skills/vault-ingress/references/source-identity-preflight.md"),
         "profile_config": "skills/vault-profile/references/schemas-config.md",
         "clarification": "skills/vault-clarification/SKILL.md",
         "clarification_config": (
@@ -380,8 +372,7 @@ def test_ingress_and_config_docs_bind_directory_completeness_and_migration() -> 
     for name in ("bootstrap", "schemas", "profile_config"):
         assert "pptx_directory_exclusions" in docs[name]
         assert (
-            '"schema_version": 2' in docs[name]
-            or "`schema_version: 2`" in docs[name]
+            '"schema_version": 2' in docs[name] or "`schema_version: 2`" in docs[name]
         )
     assert "config schema 2" in docs["clarification"]
     assert "config schema v2" in docs["clarification_config"]
@@ -392,8 +383,9 @@ def test_ingress_and_config_docs_bind_directory_completeness_and_migration() -> 
     assert docs["bootstrap"].count("DEFAULT_PPTX_DIRECTORY_EXCLUSIONS") == 1
     assert "DEFAULT_PPTX_DIRECTORY_EXCLUSIONS" not in docs["profile_config"]
     assert "DEFAULT_PPTX_DIRECTORY_EXCLUSIONS" not in docs["schemas"]
-    assert '"pptx_directory_exclusions": ["example-tool-cache"]' in (
-        docs["profile_config"]
+    assert (
+        '"pptx_directory_exclusions": ["example-tool-cache"]'
+        in (docs["profile_config"])
     )
     assert '"pptx_directory_exclusions": ["example-tool-cache"]' in docs["schemas"]
     taxonomy_reference = (
@@ -407,9 +399,7 @@ def test_ingress_and_config_docs_bind_directory_completeness_and_migration() -> 
         if name != "schemas"
     )
     assert "never reclassify receipts by\nreason string" in docs["bootstrap"]
-    assert "without an explicit speaker-specific customization" in (
-        docs["bootstrap"]
-    )
-    assert "without an explicit speaker-specific customization" in (
-        docs["profile_config"]
+    assert "without an explicit speaker-specific customization" in (docs["bootstrap"])
+    assert (
+        "without an explicit speaker-specific customization" in (docs["profile_config"])
     )

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -366,12 +366,8 @@ def test_directory_exclusion_prunes_before_scandir_and_keeps_authored_default_de
         [".VENV"],
     )
 
-    assert [relative for _path, relative in discovered] == [
-        "templates/default.pptx"
-    ]
-    assert skipped == [
-        {"path": ".venv", "reason": "pptx_batch_directory_excluded"}
-    ]
+    assert [relative for _path, relative in discovered] == ["templates/default.pptx"]
+    assert skipped == [{"path": ".venv", "reason": "pptx_batch_directory_excluded"}]
     assert pptx_extraction.directory_incomplete_reason_codes(skipped) == []
 
 
@@ -394,9 +390,7 @@ def test_excluded_directory_cannot_starve_authored_sibling_at_entry_cap(
     )
 
     assert [relative for _path, relative in discovered] == ["talk.pptx"]
-    assert skipped == [
-        {"path": ".venv", "reason": "pptx_batch_directory_excluded"}
-    ]
+    assert skipped == [{"path": ".venv", "reason": "pptx_batch_directory_excluded"}]
 
 
 def test_policy_exclusion_enumeration_has_its_own_closed_cap(
@@ -444,9 +438,7 @@ def test_named_exclusion_keeps_symlink_rejection_precedence(
     )
 
     assert discovered == []
-    assert skipped == [
-        {"path": ".venv", "reason": "pptx_batch_symlink_rejected"}
-    ]
+    assert skipped == [{"path": ".venv", "reason": "pptx_batch_symlink_rejected"}]
 
 
 def test_named_exclusion_keeps_reparse_rejection_precedence(
@@ -471,9 +463,7 @@ def test_named_exclusion_keeps_reparse_rejection_precedence(
     )
 
     assert discovered == []
-    assert skipped == [
-        {"path": ".venv", "reason": "pptx_batch_reparse_point_rejected"}
-    ]
+    assert skipped == [{"path": ".venv", "reason": "pptx_batch_reparse_point_rejected"}]
 
 
 def test_excluded_directories_do_not_consume_directory_budget(
@@ -489,9 +479,7 @@ def test_excluded_directories_do_not_consume_directory_budget(
     monkeypatch.setattr(pptx_extraction, "_BATCH_MAX_DIRECTORIES", 2)
 
     _files, exact_skipped, _started = pptx_extraction._discover_pptx_files(root, [])
-    assert exact_skipped == [
-        {"path": ".", "reason": "pptx_batch_directory_limit"}
-    ]
+    assert exact_skipped == [{"path": ".", "reason": "pptx_batch_directory_limit"}]
 
     _files, excluded_skipped, _started = pptx_extraction._discover_pptx_files(
         root,
@@ -519,9 +507,7 @@ def test_exact_directory_budget_is_complete_but_one_more_directory_is_partial(
 
     (root / "second").mkdir()
     _files, skipped, _started = pptx_extraction._discover_pptx_files(root, [])
-    assert skipped == [
-        {"path": ".", "reason": "pptx_batch_directory_limit"}
-    ]
+    assert skipped == [{"path": ".", "reason": "pptx_batch_directory_limit"}]
 
 
 def test_depth_budget_marks_only_unvisited_descendants_partial(
@@ -539,9 +525,7 @@ def test_depth_budget_marks_only_unvisited_descendants_partial(
 
     (child / "grandchild").mkdir()
     _files, skipped, _started = pptx_extraction._discover_pptx_files(root, [])
-    assert skipped == [
-        {"path": "child/grandchild", "reason": "pptx_batch_depth_limit"}
-    ]
+    assert skipped == [{"path": "child/grandchild", "reason": "pptx_batch_depth_limit"}]
 
 
 def test_bounded_discovery_rejects_symlink_root(pptx_extraction, tmp_path):
@@ -1754,9 +1738,7 @@ def test_directory_cli_partial_batch_exits_zero_with_exact_public_envelope(
         ),
     )
 
-    exit_code = pptx_extraction.main(
-        ["--directory", "/lexical/root", "--no-ocr"]
-    )
+    exit_code = pptx_extraction.main(["--directory", "/lexical/root", "--no-ocr"])
 
     captured = capsys.readouterr()
     assert exit_code == 0
@@ -1767,9 +1749,7 @@ def test_directory_cli_partial_batch_exits_zero_with_exact_public_envelope(
         "complete": False,
         "incomplete_reason_codes": ["pptx_parse_failure"],
         "results": [],
-        "skipped": [
-            {"path": "broken.pptx", "reason": "pptx_parse_failure"}
-        ],
+        "skipped": [{"path": "broken.pptx", "reason": "pptx_parse_failure"}],
     }
 
 
@@ -3179,9 +3159,7 @@ _PAGE_DECIMAL_ALPHABET_IDS = (
     "fullwidth",
     "mathematical",
 )
-_INSPECTED_PAGES_GRAMMAR_ERROR = (
-    "--inspected-pages values must be PAGE or START-END"
-)
+_INSPECTED_PAGES_GRAMMAR_ERROR = "--inspected-pages values must be PAGE or START-END"
 
 
 def _render_page_decimal(value, alphabet):
@@ -3220,10 +3198,7 @@ def test_page_range_parser_supports_unicode_decimal_digits_at_global_ceiling(
     )
 
     assert pptx_extraction.parse_page_range_arguments(
-        [
-            f"{_render_page_decimal(1, alphabet)}-"
-            f"{_render_page_decimal(3, alphabet)}"
-        ]
+        [f"{_render_page_decimal(1, alphabet)}-{_render_page_decimal(3, alphabet)}"]
     ) == [[1, 3]]
     assert pptx_extraction.parse_page_range_arguments(
         [_render_page_decimal(limit, alphabet)]
@@ -3247,10 +3222,7 @@ def test_page_range_parser_supports_mixed_script_decimal_numbers(
     )
 
     assert pptx_extraction.parse_page_range_arguments(
-        [
-            f"{_render_mixed_page_decimal(12345)}-"
-            f"{_render_mixed_page_decimal(12347)}"
-        ]
+        [f"{_render_mixed_page_decimal(12345)}-{_render_mixed_page_decimal(12347)}"]
     ) == [[12345, 12347]]
     assert pptx_extraction.parse_page_range_arguments(
         [_render_mixed_page_decimal(limit)]
@@ -3325,9 +3297,7 @@ def test_page_range_parser_enforces_range_count_without_split_amplification(
         pptx_extraction.parse_page_range_arguments([limit_plus_one])
 
     diagnostic = str(caught.value)
-    assert diagnostic == (
-        f"--inspected-pages must contain no more than {limit} ranges"
-    )
+    assert diagnostic == (f"--inspected-pages must contain no more than {limit} ranges")
     assert malformed not in diagnostic
     assert len(diagnostic.encode("utf-8")) < 128
 
@@ -3337,9 +3307,7 @@ def test_page_range_parser_preserves_repeated_comma_and_leading_zero_inputs(
 ):
     leading_zero_page = ("0" * 5_000) + "1"
     leading_zero_end = ("０" * 5_000) + "３"
-    canonical = pptx_extraction.parse_page_range_arguments(
-        ["1", "2-4,6", "8-9"]
-    )
+    canonical = pptx_extraction.parse_page_range_arguments(["1", "2-4,6", "8-9"])
     equivalent = pptx_extraction.parse_page_range_arguments(
         [leading_zero_page, "0002-０００４,٠٠٠٦", "０００８-0009"]
     )

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -2036,14 +2036,20 @@ def test_preflight_preserves_unrelated_schema_fault_with_invalid_exclusions(
     blocking_codes = finding_codes(report, "blocking")
     assert "pptx_directory_exclusions_invalid" in blocking_codes
     assert "tracking_database_schema_invalid" in blocking_codes
-    assert sum(
-        finding["code"] == "pptx_directory_exclusions_invalid"
-        for finding in report["findings"]
-    ) == 1
-    assert sum(
-        finding["code"] == "tracking_database_schema_invalid"
-        for finding in report["findings"]
-    ) == 1
+    assert (
+        sum(
+            finding["code"] == "pptx_directory_exclusions_invalid"
+            for finding in report["findings"]
+        )
+        == 1
+    )
+    assert (
+        sum(
+            finding["code"] == "tracking_database_schema_invalid"
+            for finding in report["findings"]
+        )
+        == 1
+    )
 
 
 def test_preflight_accepts_historical_config_v1_for_owner_migration(
@@ -3337,13 +3343,16 @@ def test_non_utf8_database_is_a_structured_blocking_report(
 
 # --- #203: the CLI has a closed failure boundary ---
 
+
 def test_outer_boundary_emits_one_blocking_report_without_a_traceback(
-        preflight_vault, capsys, monkeypatch):
+    preflight_vault, capsys, monkeypatch
+):
     """An unexpected failure still produces the machine-readable blocking signal.
 
     Callers gate claiming on this report. A traceback with no JSON would read as
     "preflight did not run", and a partial document would not parse.
     """
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("injected outer failure at /private/vault/secret.md")
 
@@ -3351,7 +3360,7 @@ def test_outer_boundary_emits_one_blocking_report_without_a_traceback(
     assert preflight_vault.run_cli() == 2
 
     captured = capsys.readouterr()
-    report = json.loads(captured.out)            # exactly one valid document
+    report = json.loads(captured.out)  # exactly one valid document
     assert report["ok"] is False
     assert report["blocking_count"] == 1
     finding = report["findings"][0]
@@ -3366,14 +3375,18 @@ def test_outer_boundary_emits_one_blocking_report_without_a_traceback(
 
 
 def test_outer_boundary_finding_matches_the_normal_finding_shape(
-        preflight_vault, vault_fixture, capsys, monkeypatch):
+    preflight_vault, vault_fixture, capsys, monkeypatch
+):
     """The failure finding must parse like every other finding."""
     write_database(vault_fixture, [base_talk()], current=True)
     normal = preflight_vault.run_preflight(vault_fixture["root"])
     capsys.readouterr()
 
-    monkeypatch.setattr(preflight_vault, "main",
-                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        preflight_vault,
+        "main",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
     assert preflight_vault.run_cli() == 2
 
     failure = json.loads(capsys.readouterr().out)
@@ -3385,8 +3398,7 @@ def test_outer_boundary_finding_matches_the_normal_finding_shape(
     assert failure["schema_version"] == normal["schema_version"]
 
 
-def test_outer_boundary_passes_a_clean_exit_code_through(
-        preflight_vault, monkeypatch):
+def test_outer_boundary_passes_a_clean_exit_code_through(preflight_vault, monkeypatch):
     """A normal run's exit code is not rewritten by the boundary."""
     monkeypatch.setattr(preflight_vault, "main", lambda *a, **k: 0)
     assert preflight_vault.run_cli() == 0
@@ -3395,11 +3407,15 @@ def test_outer_boundary_passes_a_clean_exit_code_through(
 
 
 def test_failure_guidance_names_a_concrete_next_action(
-        preflight_vault, capsys, monkeypatch):
+    preflight_vault, capsys, monkeypatch
+):
     """Telling the operator to repair whatever the exception type named is not
     an actionable message."""
-    monkeypatch.setattr(preflight_vault, "main",
-                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        preflight_vault,
+        "main",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
     assert preflight_vault.run_cli() == 2
     err = capsys.readouterr().err
     assert "code locations that failed" in err
@@ -3408,8 +3424,10 @@ def test_failure_guidance_names_a_concrete_next_action(
 
 
 def test_failure_report_names_code_locations_without_exception_text(
-        preflight_vault, capsys, monkeypatch):
+    preflight_vault, capsys, monkeypatch
+):
     """no-secrets forbids exception text; the origin frames replace it."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("token=SECRET at /private/vault/creds.json")
 
@@ -3431,15 +3449,20 @@ def test_failure_report_names_code_locations_without_exception_text(
 
 # --- #200: public diagnostics route on typed reasons, not exception prose ---
 
-@pytest.mark.parametrize("payload,expected_code", [
-    (b"\xff\xfe not utf-8", "database_encoding_invalid"),
-    (b"{not json", "database_json_invalid"),
-    (b'{"a": 1, "a": 2}', "database_json_invalid"),
-    (b'{"a": NaN}', "database_json_invalid"),
-    (b'["not", "an", "object"]', "database_json_invalid"),
-])
+
+@pytest.mark.parametrize(
+    "payload,expected_code",
+    [
+        (b"\xff\xfe not utf-8", "database_encoding_invalid"),
+        (b"{not json", "database_json_invalid"),
+        (b'{"a": 1, "a": 2}', "database_json_invalid"),
+        (b'{"a": NaN}', "database_json_invalid"),
+        (b'["not", "an", "object"]', "database_json_invalid"),
+    ],
+)
 def test_database_read_finding_code_comes_from_the_typed_reason(
-        preflight_vault, tmp_path, payload, expected_code):
+    preflight_vault, tmp_path, payload, expected_code
+):
     """The public taxonomy must not depend on upstream message wording."""
     database = tmp_path / "tracking-database.json"
     database.write_bytes(payload)
@@ -3456,7 +3479,8 @@ def test_unmapped_decoder_reason_falls_back_to_unreadable(preflight_vault):
 
 
 def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
-        preflight_vault, vault_fixture):
+    preflight_vault, vault_fixture
+):
     """`actual` is public: a raw OSError string carries the host path."""
     # The transcript resolves from youtube_id, so the file must use that name.
     transcript = vault_fixture["root"] / "transcripts" / f"{VIDEO_ID}.txt"
@@ -3466,8 +3490,13 @@ def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
 
     report = preflight_vault.run_preflight(vault_fixture["root"])
     finding = next(
-        (f for f in report["findings"]
-         if f["code"] == "transcript_artifact_unreadable"), None)
+        (
+            f
+            for f in report["findings"]
+            if f["code"] == "transcript_artifact_unreadable"
+        ),
+        None,
+    )
     assert finding is not None, [f["code"] for f in report["findings"]]
     assert finding["actual"] == "not_utf8"
     assert finding["message"].startswith(
@@ -3487,7 +3516,8 @@ def test_transcript_decode_failure_reports_a_typed_reason_not_os_text(
 
 
 def test_transcript_read_failure_does_not_claim_a_decode_failure(
-        preflight_vault, vault_fixture, monkeypatch):
+    preflight_vault, vault_fixture, monkeypatch
+):
     """A permission denial is a read failure — the message must say so (#253)."""
     transcript = vault_fixture["root"] / "transcripts" / f"{VIDEO_ID}.txt"
     transcript.parent.mkdir(parents=True, exist_ok=True)
@@ -3505,13 +3535,16 @@ def test_transcript_read_failure_does_not_claim_a_decode_failure(
 
     report = preflight_vault.run_preflight(vault_fixture["root"])
     finding = next(
-        (f for f in report["findings"]
-         if f["code"] == "transcript_artifact_unreadable"), None)
+        (
+            f
+            for f in report["findings"]
+            if f["code"] == "transcript_artifact_unreadable"
+        ),
+        None,
+    )
     assert finding is not None, [f["code"] for f in report["findings"]]
     assert finding["actual"] == "unreadable:PermissionError"
-    assert finding["message"].startswith(
-        "transcript artifact could not be read"
-    )
+    assert finding["message"].startswith("transcript artifact could not be read")
     assert "rerun preflight" in finding["message"], (
         "error-handling requires the message to say what to do next"
     )
@@ -3523,7 +3556,8 @@ def test_transcript_read_failure_does_not_claim_a_decode_failure(
 
 
 def test_reworded_decoder_message_keeps_its_finding_code(
-        preflight_vault, tmp_path, monkeypatch):
+    preflight_vault, tmp_path, monkeypatch
+):
     """The taxonomy survives upstream rewording — that is the point of the fix.
 
     Substring matching on the message would fall through to the generic
@@ -3535,7 +3569,7 @@ def test_reworded_decoder_message_keeps_its_finding_code(
 
     def reworded(*_args, **_kwargs):
         raise io_module.TrackingDatabaseIOError(
-            "the file could not be interpreted as text",   # no legacy substring
+            "the file could not be interpreted as text",  # no legacy substring
             reason_code="encoding_invalid",
         )
 
@@ -3548,7 +3582,8 @@ def test_reworded_decoder_message_keeps_its_finding_code(
 
 
 def test_manifest_rejection_reports_a_typed_reason_not_the_rejected_value(
-        preflight_vault, vault_fixture):
+    preflight_vault, vault_fixture
+):
     """ReturnValidationError text can echo the malformed input it rejected."""
     poisoned = "SENSITIVE_VALUE_abc123"
     talk = base_talk(
@@ -3561,19 +3596,34 @@ def test_manifest_rejection_reports_a_typed_reason_not_the_rejected_value(
 
     report = preflight_vault.run_preflight(vault_fixture["root"])
     finding = next(
-        (f for f in report["findings"]
-         if f["code"] == "video_extraction_provenance_invalid"), None)
+        (
+            f
+            for f in report["findings"]
+            if f["code"] == "video_extraction_provenance_invalid"
+        ),
+        None,
+    )
     assert finding is not None, [f["code"] for f in report["findings"]]
     assert finding["actual"].startswith("video_extraction.")
     assert poisoned not in json.dumps(finding, sort_keys=True)
 
 
-@pytest.mark.parametrize("payload,leaked", [
-    (b'{"a": 1, "SENSITIVE_KEY_abc": 2, "SENSITIVE_KEY_abc": 3}', "SENSITIVE_KEY_abc"),
-    (b'{"a": 123456789012345678901234567890123456789.5}', "123456789012345678901234567890"),
-])
+@pytest.mark.parametrize(
+    "payload,leaked",
+    [
+        (
+            b'{"a": 1, "SENSITIVE_KEY_abc": 2, "SENSITIVE_KEY_abc": 3}',
+            "SENSITIVE_KEY_abc",
+        ),
+        (
+            b'{"a": 123456789012345678901234567890123456789.5}',
+            "123456789012345678901234567890",
+        ),
+    ],
+)
 def test_database_read_report_never_echoes_malformed_input(
-        preflight_vault, tmp_path, payload, leaked):
+    preflight_vault, tmp_path, payload, leaked
+):
     """Decoder messages embed the rejected key or value; the report must not."""
     database = tmp_path / "tracking-database.json"
     database.write_bytes(payload)
@@ -3587,8 +3637,7 @@ def test_database_read_report_never_echoes_malformed_input(
     assert "database_json_invalid" in serialized
 
 
-def test_database_read_report_never_echoes_the_host_path(
-        preflight_vault, tmp_path):
+def test_database_read_report_never_echoes_the_host_path(preflight_vault, tmp_path):
     """The decoder message embeds the artifact path; findings must not."""
     database = tmp_path / "secret-vault-name" / "tracking-database.json"
     database.parent.mkdir(parents=True)
@@ -3601,20 +3650,25 @@ def test_database_read_report_never_echoes_the_host_path(
     assert report["findings"][0]["code"] == "database_encoding_invalid"
 
 
-@pytest.mark.parametrize("payload,expected_message", [
-    (
-        # MAX_JSON_NESTING_DEPTH is 200; go comfortably past it.
-        ('{"config": {}, "talks": [], "deep": '
-         + "[" * 260 + "]" * 260 + "}").encode(),
-        "tracking database exceeds the maximum supported JSON nesting depth",
-    ),
-    (
-        b'{"config": {}, "talks": [], "s": "\\ud800"}',
-        "tracking database contains an unpaired UTF-16 surrogate in a JSON string",
-    ),
-])
+@pytest.mark.parametrize(
+    "payload,expected_message",
+    [
+        (
+            # MAX_JSON_NESTING_DEPTH is 200; go comfortably past it.
+            (
+                '{"config": {}, "talks": [], "deep": ' + "[" * 260 + "]" * 260 + "}"
+            ).encode(),
+            "tracking database exceeds the maximum supported JSON nesting depth",
+        ),
+        (
+            b'{"config": {}, "talks": [], "s": "\\ud800"}',
+            "tracking database contains an unpaired UTF-16 surrogate in a JSON string",
+        ),
+    ],
+)
 def test_tree_validator_defects_route_to_their_specific_reason(
-        preflight_vault, tmp_path, payload, expected_message):
+    preflight_vault, tmp_path, payload, expected_message
+):
     """These raise after a successful decode; untyped they fall back to generic."""
     database = tmp_path / "tracking-database.json"
     database.write_bytes(payload)
@@ -3628,6 +3682,7 @@ def test_tree_validator_defects_route_to_their_specific_reason(
 def test_every_emitted_decoder_reason_is_mapped(preflight_vault):
     """A reason with no mapping silently degrades to the generic code."""
     import re
+
     io_source = pathlib.Path(
         importlib.import_module("tracking_database_io").__file__
     ).read_text(encoding="utf-8")

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3396,7 +3396,8 @@ def test_outer_boundary_passes_a_clean_exit_code_through(
 
 def test_failure_guidance_names_a_concrete_next_action(
         preflight_vault, capsys, monkeypatch):
-    """"Repair the condition named by the exception type" is not actionable."""
+    """Telling the operator to repair whatever the exception type named is not
+    an actionable message."""
     monkeypatch.setattr(preflight_vault, "main",
                         lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
     assert preflight_vault.run_cli() == 2

--- a/tests/test_pyproject_pins.py
+++ b/tests/test_pyproject_pins.py
@@ -105,16 +105,19 @@ def test_every_requirement_pins_an_exact_version(label, requirements):
     )
 
 
-@pytest.mark.parametrize("raw", [
-    "pytest",                              # bare name
-    "setuptools>=68",                      # range
-    "numpy>=2.0,<3.0",                     # two-sided range
-    "numpy==2.2.6,>=2.0",                  # pin plus a range that reopens it
-    "numpy===2.2.6",                       # arbitrary-equality, not exact
-    "numpy==2.2.*",                        # wildcard
-    "numpy~=2.2.6",                        # compatible-release
-    "lxml @ https://example.invalid/a==b.whl",   # URL containing '=='
-])
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "pytest",  # bare name
+        "setuptools>=68",  # range
+        "numpy>=2.0,<3.0",  # two-sided range
+        "numpy==2.2.6,>=2.0",  # pin plus a range that reopens it
+        "numpy===2.2.6",  # arbitrary-equality, not exact
+        "numpy==2.2.*",  # wildcard
+        "numpy~=2.2.6",  # compatible-release
+        "lxml @ https://example.invalid/a==b.whl",  # URL containing '=='
+    ],
+)
 def test_the_pin_check_rejects_specifiers_that_are_not_exact(raw):
     """The last four beat a naive `'==' in raw` check; the first four do not.
 
@@ -124,13 +127,16 @@ def test_the_pin_check_rejects_specifiers_that_are_not_exact(raw):
     assert pin_violation(raw) is not None, raw
 
 
-@pytest.mark.parametrize("raw", [
-    "numpy==2.2.6",
-    "Pillow==12.3.0",
-    "python-pptx==1.0.2",
-    "tomli==2.4.1; python_version < '3.11'",     # a marker is not a version
-    "qrcode[pil]==8.2",                          # an extra is not a version
-])
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "numpy==2.2.6",
+        "Pillow==12.3.0",
+        "python-pptx==1.0.2",
+        "tomli==2.4.1; python_version < '3.11'",  # a marker is not a version
+        "qrcode[pil]==8.2",  # an extra is not a version
+    ],
+)
 def test_the_pin_check_accepts_real_pins(raw):
     assert pin_violation(raw) is None, pin_violation(raw)
 
@@ -143,8 +149,7 @@ def test_dependabot_actively_covers_the_pip_ecosystem():
     """
     config = yaml.safe_load(DEPENDABOT.read_text(encoding="utf-8"))
     pip_updates = [
-        entry for entry in config["updates"]
-        if entry.get("package-ecosystem") == "pip"
+        entry for entry in config["updates"] if entry.get("package-ecosystem") == "pip"
     ]
     assert len(pip_updates) == 1, (
         f"expected exactly one active pip update entry, got {len(pip_updates)}"

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -48,9 +48,7 @@ def _talk(
         "filename": filename,
         "title": filename,
         "status": status,
-        "video_url": (
-            f"https://www.youtube.com/watch?v={video_id}" if video else ""
-        ),
+        "video_url": (f"https://www.youtube.com/watch?v={video_id}" if video else ""),
         "youtube_id": video_id if youtube_identity else None,
     }
 
@@ -69,15 +67,17 @@ def _scored_talk(
     if generation_reasons is None:
         generation_reasons = []
     talk = _talk(video_id, status=status, filename=filename)
-    talk.update({
-        "processed_date": "2001-01-01T00:00:00+00:00",
-        "pattern_scoring_generation_status": generation_status,
-        "pattern_scoring_generation_reasons": generation_reasons,
-        "pattern_catalog_fingerprint": fingerprint,
-        "pattern_scoring_schema_version": scoring_schema,
-        "pattern_score": score,
-        "pattern_observations": {"pattern_score": score},
-    })
+    talk.update(
+        {
+            "processed_date": "2001-01-01T00:00:00+00:00",
+            "pattern_scoring_generation_status": generation_status,
+            "pattern_scoring_generation_reasons": generation_reasons,
+            "pattern_catalog_fingerprint": fingerprint,
+            "pattern_scoring_schema_version": scoring_schema,
+            "pattern_score": score,
+            "pattern_observations": {"pattern_score": score},
+        }
+    )
     return talk
 
 
@@ -97,16 +97,18 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
         relative = artifact.relative_to(tmp_path).as_posix()
         quality = artifact.with_suffix(".quality.json")
         quality.write_text(
-            json.dumps({
-                "schema_version": 1,
-                "transcript_sha256": digest,
-                "policy": {
+            json.dumps(
+                {
                     "schema_version": 1,
-                    "min_words": 400,
-                    "duration_seconds": None,
-                },
-                "provenance": {"kind": "fixed_default"},
-            }),
+                    "transcript_sha256": digest,
+                    "policy": {
+                        "schema_version": 1,
+                        "min_words": 400,
+                        "duration_seconds": None,
+                    },
+                    "provenance": {"kind": "fixed_default"},
+                }
+            ),
             encoding="utf-8",
         )
         quality_digest = hashlib.sha256(quality.read_bytes()).hexdigest()
@@ -138,19 +140,21 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
                 "confidence": "moderate",
                 "evidence_source": "transcript",
                 "evidence": "Synthetic source-located fixture evidence.",
-                "evidence_citations": [{
-                    "source": "transcript",
-                    "channel": "transcript",
-                    "quote": "synthetic evidence synthetic evidence",
-                    "line_start": 1,
-                    "line_end": 1,
-                    "artifact_root": "vault",
-                    "artifact_path": relative,
-                    "artifact_sha256": digest,
-                    "quality_artifact_root": "vault",
-                    "quality_artifact_path": quality_relative,
-                    "quality_artifact_sha256": quality_digest,
-                }],
+                "evidence_citations": [
+                    {
+                        "source": "transcript",
+                        "channel": "transcript",
+                        "quote": "synthetic evidence synthetic evidence",
+                        "line_start": 1,
+                        "line_end": 1,
+                        "artifact_root": "vault",
+                        "artifact_path": relative,
+                        "artifact_sha256": digest,
+                        "quality_artifact_root": "vault",
+                        "quality_artifact_path": quality_relative,
+                        "quality_artifact_sha256": quality_digest,
+                    }
+                ],
             }
             for index in range(max(int(score), 0))
         ]
@@ -160,19 +164,21 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
                 "confidence": "moderate",
                 "evidence_source": "transcript",
                 "evidence": "Synthetic source-located fixture evidence.",
-                "evidence_citations": [{
-                    "source": "transcript",
-                    "channel": "transcript",
-                    "quote": "synthetic evidence synthetic evidence",
-                    "line_start": 1,
-                    "line_end": 1,
-                    "artifact_root": "vault",
-                    "artifact_path": relative,
-                    "artifact_sha256": digest,
-                    "quality_artifact_root": "vault",
-                    "quality_artifact_path": quality_relative,
-                    "quality_artifact_sha256": quality_digest,
-                }],
+                "evidence_citations": [
+                    {
+                        "source": "transcript",
+                        "channel": "transcript",
+                        "quote": "synthetic evidence synthetic evidence",
+                        "line_start": 1,
+                        "line_end": 1,
+                        "artifact_root": "vault",
+                        "artifact_path": relative,
+                        "artifact_sha256": digest,
+                        "quality_artifact_root": "vault",
+                        "quality_artifact_path": quality_relative,
+                        "quality_artifact_sha256": quality_digest,
+                    }
+                ],
             }
             for index in range(max(-int(score), 0))
         ]
@@ -201,12 +207,14 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
             }
             observations.setdefault(
                 "opportunity_coverage_identity",
-                hashlib.sha256(json.dumps(
-                    payload,
-                    ensure_ascii=False,
-                    separators=(",", ":"),
-                    sort_keys=True,
-                ).encode("utf-8")).hexdigest(),
+                hashlib.sha256(
+                    json.dumps(
+                        payload,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ).encode("utf-8")
+                ).hexdigest(),
             )
     path = tmp_path / "tracking-database.json"
     database = {
@@ -221,9 +229,7 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
     }
     if current:
         database["schema_version"] = 1
-        database["config"] = current_tracking_config(
-            **database["config"]
-        )
+        database["config"] = current_tracking_config(**database["config"])
     else:
         for talk in talks:
             talk.pop("schema_version", None)
@@ -237,17 +243,18 @@ def _write_verified_transcript(tmp_path, name="talk"):
     text = " ".join(["substantive transcript evidence"] * 200)
     transcript.write_text(text, encoding="utf-8")
     transcript.with_suffix(".quality.json").write_text(
-        json.dumps({
-            "schema_version": 1,
-            "transcript_sha256": hashlib.sha256(
-                text.encode("utf-8")).hexdigest(),
-            "policy": {
+        json.dumps(
+            {
                 "schema_version": 1,
-                "min_words": 400,
-                "duration_seconds": None,
-            },
-            "provenance": {"kind": "fixed_default"},
-        }),
+                "transcript_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                "policy": {
+                    "schema_version": 1,
+                    "min_words": 400,
+                    "duration_seconds": None,
+                },
+                "provenance": {"kind": "fixed_default"},
+            }
+        ),
         encoding="utf-8",
     )
     return transcript
@@ -296,10 +303,14 @@ def _run(path, *arguments):
 def _claim(path, *, run_id="run-1", batch_id="batch-1", limit=5, filenames=()):
     arguments = [
         "claim",
-        "--run-id", run_id,
-        "--batch-id", batch_id,
-        "--now", NOW,
-        "--limit", str(limit),
+        "--run-id",
+        run_id,
+        "--batch-id",
+        batch_id,
+        "--now",
+        NOW,
+        "--limit",
+        str(limit),
     ]
     for filename in filenames:
         arguments.extend(("--filename", filename))
@@ -337,9 +348,7 @@ def test_queue_compares_symlinked_vault_roots_by_lexical_identity(
     physical_root.mkdir()
     alias_root = tmp_path / "alias-vault"
     alias_root.symlink_to(physical_root, target_is_directory=True)
-    configured_root = (
-        alias_root if configured_identity == "alias" else physical_root
-    )
+    configured_root = alias_root if configured_identity == "alias" else physical_root
     database = _write_db(
         physical_root,
         [],
@@ -512,13 +521,19 @@ def test_claim_recovers_the_two_stranded_transcript_statuses(tmp_path):
         _talk("eixm_f7Jpdc", status="skipped_no_transcript"),
         _talk("QS-_4k7o7A4", status="skipped_no_transcript"),
         _talk(
-            "abcdefghijk", status="skipped_no_video", video=False,
-            youtube_identity=False, filename="catalog-no-source.md",
+            "abcdefghijk",
+            status="skipped_no_video",
+            video=False,
+            youtube_identity=False,
+            filename="catalog-no-source.md",
         ),
         _talk("lmnopqrstuv", status="skipped_duplicate"),
         _talk(
-            "wxyzABCDEF0", status="pending", video=False,
-            youtube_identity=False, filename="catalog-pending.md",
+            "wxyzABCDEF0",
+            status="pending",
+            video=False,
+            youtube_identity=False,
+            filename="catalog-pending.md",
         ),
     ]
     path = _write_db(tmp_path, talks)
@@ -552,26 +567,34 @@ def test_legacy_no_video_status_with_video_is_normalized_and_claimed(tmp_path):
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert payload["normalizations"] == [{
-        "filename": "playlist-eg6gqvUFh6Q.md",
-        "previous_status": "skipped_no_video",
-        "status": "pending",
-        "video_present": True,
-        "source_capabilities": ["video", "transcript"],
-    }]
+    assert payload["normalizations"] == [
+        {
+            "filename": "playlist-eg6gqvUFh6Q.md",
+            "previous_status": "skipped_no_video",
+            "status": "pending",
+            "video_present": True,
+            "source_capabilities": ["video", "transcript"],
+        }
+    ]
     assert payload["claimed"][0]["previous_status"] == "pending"
 
 
-@pytest.mark.parametrize("source_kind,expected_capability", [
-    ("remote_slides", "slides"),
-    ("pptx", "slides"),
-    ("pdf", "slides"),
-    ("transcript", "transcript"),
-])
+@pytest.mark.parametrize(
+    "source_kind,expected_capability",
+    [
+        ("remote_slides", "slides"),
+        ("pptx", "slides"),
+        ("pdf", "slides"),
+        ("transcript", "transcript"),
+    ],
+)
 def test_legacy_no_video_talk_with_nonvideo_source_is_claimable(
-        tmp_path, source_kind, expected_capability):
+    tmp_path, source_kind, expected_capability
+):
     talk = _talk(
-        "abcdefghijk", status="skipped_no_video", video=False,
+        "abcdefghijk",
+        status="skipped_no_video",
+        video=False,
         youtube_identity=False,
         filename="source-only.md",
     )
@@ -603,13 +626,15 @@ def test_legacy_no_video_talk_with_nonvideo_source_is_claimable(
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert payload["normalizations"] == [{
-        "filename": "source-only.md",
-        "previous_status": "skipped_no_video",
-        "status": "pending",
-        "video_present": False,
-        "source_capabilities": [expected_capability],
-    }]
+    assert payload["normalizations"] == [
+        {
+            "filename": "source-only.md",
+            "previous_status": "skipped_no_video",
+            "status": "pending",
+            "video_present": False,
+            "source_capabilities": [expected_capability],
+        }
+    ]
     assert payload["claimed"][0]["filename"] == "source-only.md"
     assert payload["claimed"][0]["previous_status"] == "pending"
 
@@ -737,10 +762,12 @@ def test_invalid_transcript_does_not_hide_valid_deck_from_queue(tmp_path):
         youtube_identity=False,
         filename="deck-survives.md",
     )
-    talk.update({
-        "transcript_path": "../bad.txt",
-        "pptx_path": "decks/talk.pptx",
-    })
+    talk.update(
+        {
+            "transcript_path": "../bad.txt",
+            "pptx_path": "decks/talk.pptx",
+        }
+    )
     path = _write_db(tmp_path, [talk])
 
     result = _claim(path)
@@ -760,19 +787,20 @@ def test_invalid_deck_does_not_hide_valid_transcript_from_queue(tmp_path):
         youtube_identity=False,
         filename="transcript-survives.md",
     )
-    talk.update({
-        "transcript_path": transcript.relative_to(tmp_path).as_posix(),
-        "transcript_source": "manual",
-        "pptx_path": "../bad.pptx",
-    })
+    talk.update(
+        {
+            "transcript_path": transcript.relative_to(tmp_path).as_posix(),
+            "transcript_source": "manual",
+            "pptx_path": "../bad.pptx",
+        }
+    )
     path = _write_db(tmp_path, [talk])
 
     result = _claim(path)
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert payload["normalizations"][0]["source_capabilities"] == [
-        "transcript"]
+    assert payload["normalizations"][0]["source_capabilities"] == ["transcript"]
     assert payload["claimed"][0]["filename"] == "transcript-survives.md"
 
 
@@ -878,10 +906,12 @@ def test_required_degraded_pptx_cannot_create_a_fresh_current_claim(tmp_path):
         "abcdefghijk",
         filename="required-damaged-deck.md",
     )
-    talk.update({
-        "pptx_path": "decks/damaged.pptx",
-        "slide_source": "pptx",
-    })
+    talk.update(
+        {
+            "pptx_path": "decks/damaged.pptx",
+            "slide_source": "pptx",
+        }
+    )
     path = _write_db(tmp_path, [talk])
     before = path.read_bytes()
 
@@ -932,9 +962,7 @@ def test_claim_reassesses_after_eligibility_and_refuses_mutated_deck(
     def assessor(_talk):
         return next(assessments)
 
-    assert queue_state.has_claimable_source(
-        talk, capability_assessor=assessor
-    ) is True
+    assert queue_state.has_claimable_source(talk, capability_assessor=assessor) is True
     before = copy.deepcopy(talk)
     with pytest.raises(queue_state.QueueStateError, match="cannot claim"):
         queue_state.claim_talk(
@@ -957,10 +985,12 @@ def test_unused_optional_degraded_pptx_does_not_block_independent_source(
         "abcdefghijk",
         filename="optional-damaged-deck.md",
     )
-    talk.update({
-        "pptx_path": "decks/optional-damaged.pptx",
-        "slide_source": "pdf",
-    })
+    talk.update(
+        {
+            "pptx_path": "decks/optional-damaged.pptx",
+            "slide_source": "pdf",
+        }
+    )
     path = _write_db(tmp_path, [talk])
 
     result = _claim(path, filenames=(str(talk["filename"]),))
@@ -1010,12 +1040,14 @@ def test_optional_degraded_deck_allows_an_independent_healthy_transcript(
         video=False,
         youtube_identity=False,
     )
-    talk.update({
-        "pptx_path": "decks/optional-damaged.pptx",
-        "slide_source": "none",
-        "transcript_path": transcript.relative_to(tmp_path).as_posix(),
-        "transcript_source": "manual",
-    })
+    talk.update(
+        {
+            "pptx_path": "decks/optional-damaged.pptx",
+            "slide_source": "none",
+            "transcript_path": transcript.relative_to(tmp_path).as_posix(),
+            "transcript_source": "manual",
+        }
+    )
     path = _write_db(tmp_path, [talk])
 
     result = _claim(path, filenames=(str(talk["filename"]),))
@@ -1041,48 +1073,63 @@ def test_manual_provenance_label_without_artifact_is_not_a_capability(tmp_path):
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert payload["normalizations"] == [{
-        "filename": "label-only.md",
-        "previous_status": "skipped_no_video",
-        "status": "skipped_no_sources",
-        "video_present": False,
-        "source_capabilities": [],
-    }]
+    assert payload["normalizations"] == [
+        {
+            "filename": "label-only.md",
+            "previous_status": "skipped_no_video",
+            "status": "skipped_no_sources",
+            "video_present": False,
+            "source_capabilities": [],
+        }
+    ]
     assert payload["claimed"] == []
 
 
 def test_normalize_requeues_every_noncurrent_or_stale_generation_atomically(
-        tmp_path, return_validation):
+    tmp_path, return_validation
+):
     fingerprint = return_validation.load_catalog().fingerprint
     scoring_schema = return_validation.PATTERN_SCORING_SCHEMA_VERSION
     other_fingerprint = "0" * 64 if fingerprint != "0" * 64 else "1" * 64
     current = _scored_talk(
-        "AAAAAAAAAAA", filename="current-old-date.md",
-        fingerprint=fingerprint, scoring_schema=scoring_schema,
+        "AAAAAAAAAAA",
+        filename="current-old-date.md",
+        fingerprint=fingerprint,
+        scoring_schema=scoring_schema,
     )
     legacy = _scored_talk(
-        "BBBBBBBBBBB", filename="legacy-recent.md",
-        fingerprint=fingerprint, scoring_schema=scoring_schema, score=100,
+        "BBBBBBBBBBB",
+        filename="legacy-recent.md",
+        fingerprint=fingerprint,
+        scoring_schema=scoring_schema,
+        score=100,
         generation_status="legacy_unbaselineable",
     )
     legacy.pop("pattern_catalog_fingerprint")
     legacy.pop("pattern_scoring_schema_version")
     old_catalog = _scored_talk(
-        "CCCCCCCCCCC", filename="old-catalog-recent.md",
-        fingerprint=other_fingerprint, scoring_schema=scoring_schema,
+        "CCCCCCCCCCC",
+        filename="old-catalog-recent.md",
+        fingerprint=other_fingerprint,
+        scoring_schema=scoring_schema,
     )
     old_schema = _scored_talk(
-        "DDDDDDDDDDD", filename="old-schema-recent.md",
-        fingerprint=fingerprint, scoring_schema=scoring_schema - 1,
+        "DDDDDDDDDDD",
+        filename="old-schema-recent.md",
+        fingerprint=fingerprint,
+        scoring_schema=scoring_schema - 1,
         status="processed_partial",
     )
     missing = _scored_talk(
-        "EEEEEEEEEEE", filename="missing-generation.md",
-        fingerprint=fingerprint, scoring_schema=scoring_schema,
+        "EEEEEEEEEEE",
+        filename="missing-generation.md",
+        fingerprint=fingerprint,
+        scoring_schema=scoring_schema,
     )
     missing.pop("pattern_scoring_generation_status")
     legacy_source = _talk(
-        "FFFFFFFFFFF", filename="legacy-source-status.md",
+        "FFFFFFFFFFF",
+        filename="legacy-source-status.md",
         status="skipped_no_video",
     )
     path = _write_db(
@@ -1101,8 +1148,7 @@ def test_normalize_requeues_every_noncurrent_or_stale_generation_atomically(
         if "reason_codes" in item
     }
     assert {
-        filename: item["reason_codes"]
-        for filename, item in generation_changes.items()
+        filename: item["reason_codes"] for filename, item in generation_changes.items()
     } == {
         "current-old-date.md": ["persisted_evidence_stale"],
         "legacy-recent.md": ["legacy_generation"],
@@ -1120,8 +1166,10 @@ def test_normalize_requeues_every_noncurrent_or_stale_generation_atomically(
     records = {talk["filename"]: talk for talk in _read_db(path)["talks"]}
     for filename in generation_changes:
         assert records[filename]["status"] == "needs-reprocessing"
-        assert records[filename]["reprocess_reason"] == \
-            generation_changes[filename]["reprocess_reason"]
+        assert (
+            records[filename]["reprocess_reason"]
+            == generation_changes[filename]["reprocess_reason"]
+        )
     assert records["legacy-source-status.md"]["status"] == "pending"
 
     first_bytes = path.read_bytes()
@@ -1137,8 +1185,10 @@ def test_normalize_preserves_ordered_generation_reasons(tmp_path, return_validat
     scoring_schema = return_validation.PATTERN_SCORING_SCHEMA_VERSION
     other_fingerprint = "0" * 64 if fingerprint != "0" * 64 else "1" * 64
     talk = _scored_talk(
-        "GGGGGGGGGGG", filename="both-generations-stale.md",
-        fingerprint=other_fingerprint, scoring_schema=scoring_schema - 1,
+        "GGGGGGGGGGG",
+        filename="both-generations-stale.md",
+        fingerprint=other_fingerprint,
+        scoring_schema=scoring_schema - 1,
     )
     path = _write_db(tmp_path, [talk])
 
@@ -1171,9 +1221,7 @@ def test_normalize_requeues_current_generation_when_evidence_artifact_drifts(
     )
     path = _write_db(tmp_path, [talk])
     stored = _read_db(path)["talks"][0]
-    relative = stored["pattern_observations"]["source_inspection"][0][
-        "artifact_path"
-    ]
+    relative = stored["pattern_observations"]["source_inspection"][0]["artifact_path"]
     artifact = tmp_path / relative
     if drift == "missing":
         artifact.unlink()
@@ -1207,12 +1255,15 @@ def test_normalize_requeues_current_generation_when_evidence_artifact_drifts(
     ],
 )
 def test_normalize_rejects_malformed_generation_without_any_write(
-        tmp_path, return_validation, case, message):
+    tmp_path, return_validation, case, message
+):
     fingerprint = return_validation.load_catalog().fingerprint
     scoring_schema = return_validation.PATTERN_SCORING_SCHEMA_VERSION
     malformed = _scored_talk(
-        "HHHHHHHHHHH", filename="malformed-generation.md",
-        fingerprint=fingerprint, scoring_schema=scoring_schema,
+        "HHHHHHHHHHH",
+        filename="malformed-generation.md",
+        fingerprint=fingerprint,
+        scoring_schema=scoring_schema,
     )
     if case == "unknown_status":
         malformed["pattern_scoring_generation_status"] = "future"
@@ -1229,7 +1280,8 @@ def test_normalize_rejects_malformed_generation_without_any_write(
     elif case == "divergent_score":
         malformed["pattern_observations"]["pattern_score"] = 1
     legacy_source = _talk(
-        "IIIIIIIIIII", filename="would-normalize.md",
+        "IIIIIIIIIII",
+        filename="would-normalize.md",
         status="skipped_no_video",
     )
     path = _write_db(tmp_path, [legacy_source, malformed])
@@ -1245,28 +1297,33 @@ def test_normalize_rejects_malformed_generation_without_any_write(
 
 def test_normalize_does_not_inspect_generation_for_ineligible_statuses(tmp_path):
     inflight = _talk(
-        "JJJJJJJJJJJ", filename="inflight.md",
+        "JJJJJJJJJJJ",
+        filename="inflight.md",
         status="reprocessing-inflight",
     )
-    inflight.update({
-        "reprocess_generation": 1,
-        "_queue_claim": {
-            "schema_version": 1,
-            "run_id": "active-run",
-            "batch_id": "active-batch",
-            "claimed_at": NOW,
-            "previous_status": "pending",
+    inflight.update(
+        {
             "reprocess_generation": 1,
-            "state": "claimed",
-        },
-        "pattern_scoring_generation_status": "future",
-        "pattern_score": 4,
-        "pattern_observations": {"pattern_score": 5},
-    })
+            "_queue_claim": {
+                "schema_version": 1,
+                "run_id": "active-run",
+                "batch_id": "active-batch",
+                "claimed_at": NOW,
+                "previous_status": "pending",
+                "reprocess_generation": 1,
+                "state": "claimed",
+            },
+            "pattern_scoring_generation_status": "future",
+            "pattern_score": 4,
+            "pattern_observations": {"pattern_score": 5},
+        }
+    )
     pending = _talk("KKKKKKKKKKK", filename="pending.md")
     pending["pattern_scoring_generation_status"] = "future"
     skipped = _talk(
-        "LLLLLLLLLLL", filename="skipped.md", status="skipped_duplicate",
+        "LLLLLLLLLLL",
+        filename="skipped.md",
+        status="skipped_duplicate",
     )
     skipped["pattern_scoring_generation_status"] = True
     path = _write_db(tmp_path, [inflight, pending, skipped])
@@ -1280,12 +1337,15 @@ def test_normalize_does_not_inspect_generation_for_ineligible_statuses(tmp_path)
 
 
 def test_generation_requeue_preserves_completed_claim_until_next_claim(
-        tmp_path, return_validation):
+    tmp_path, return_validation
+):
     fingerprint = return_validation.load_catalog().fingerprint
     scoring_schema = return_validation.PATTERN_SCORING_SCHEMA_VERSION
     talk = _scored_talk(
-        "MMMMMMMMMMM", filename="completed-legacy.md",
-        fingerprint=fingerprint, scoring_schema=scoring_schema,
+        "MMMMMMMMMMM",
+        filename="completed-legacy.md",
+        fingerprint=fingerprint,
+        scoring_schema=scoring_schema,
         generation_status="legacy_unbaselineable",
     )
     talk.pop("pattern_catalog_fingerprint")
@@ -1316,7 +1376,9 @@ def test_generation_requeue_preserves_completed_claim_until_next_claim(
     assert requeued.get("_queue_claim_history", []) == []
 
     claimed = _claim(
-        path, run_id="replacement-run", batch_id="replacement-batch",
+        path,
+        run_id="replacement-run",
+        batch_id="replacement-batch",
         filenames=(talk["filename"],),
     )
 
@@ -1329,28 +1391,32 @@ def test_generation_requeue_preserves_completed_claim_until_next_claim(
 
 @pytest.mark.parametrize("reason", ["please_run_this_again", ["not", "a", "reason"]])
 def test_completed_claim_status_drift_rejects_unowned_reprocess_reason(
-        tmp_path, reason):
+    tmp_path, reason
+):
     talk = _talk(
-        "NNNNNNNNNNN", filename="unowned-requeue.md",
+        "NNNNNNNNNNN",
+        filename="unowned-requeue.md",
         status="needs-reprocessing",
     )
-    talk.update({
-        "reprocess_reason": reason,
-        "reprocess_generation": 1,
-        "_queue_claim": {
-            "schema_version": 2,
-            "run_id": "completed-run",
-            "batch_id": "completed-batch",
-            "claimed_at": "2026-07-31T17:00:00+00:00",
-            "previous_status": "pending",
+    talk.update(
+        {
+            "reprocess_reason": reason,
             "reprocess_generation": 1,
-            "state": "completed",
-            "released_at": "2026-07-31T17:30:00+00:00",
-            "release_reason": "return_persisted",
-            "result_status": "processed",
-            "result_payload_sha256": "0" * 64,
-        },
-    })
+            "_queue_claim": {
+                "schema_version": 2,
+                "run_id": "completed-run",
+                "batch_id": "completed-batch",
+                "claimed_at": "2026-07-31T17:00:00+00:00",
+                "previous_status": "pending",
+                "reprocess_generation": 1,
+                "state": "completed",
+                "released_at": "2026-07-31T17:30:00+00:00",
+                "release_reason": "return_persisted",
+                "result_status": "processed",
+                "result_payload_sha256": "0" * 64,
+            },
+        }
+    )
     path = _write_db(tmp_path, [talk])
     before = path.read_bytes()
 
@@ -1363,12 +1429,16 @@ def test_completed_claim_status_drift_rejects_unowned_reprocess_reason(
 
 def test_legacy_true_no_source_talk_is_the_only_one_skipped(tmp_path):
     no_source = _talk(
-        "abcdefghijk", status="skipped_no_transcript", video=False,
+        "abcdefghijk",
+        status="skipped_no_transcript",
+        video=False,
         youtube_identity=False,
         filename="no-source.md",
     )
     slides_only = _talk(
-        "lmnopqrstuv", status="skipped_no_transcript", video=False,
+        "lmnopqrstuv",
+        status="skipped_no_transcript",
+        video=False,
         youtube_identity=False,
         filename="slides-only.md",
     )
@@ -1425,8 +1495,7 @@ def test_new_claim_is_v5_with_one_immutable_batch_baseline(tmp_path):
     assert claims[0]["adherence_baseline"] == claims[1]["adherence_baseline"]
     baseline = claims[0]["adherence_baseline"]
     assert baseline["as_of"] == NOW
-    assert baseline["excluded_filenames"] == sorted(
-        talk["filename"] for talk in talks)
+    assert baseline["excluded_filenames"] == sorted(talk["filename"] for talk in talks)
 
 
 def test_inspect_dual_reads_a_schema_v3_adherence_claim(tmp_path):
@@ -1461,9 +1530,7 @@ def test_schema_v5_claim_cannot_request_a_schema_v3_return(tmp_path):
     claimed = _claim(path)
     assert claimed.returncode == 0, claimed.stderr
     database = _read_db(path)
-    database["talks"][0]["_queue_claim"][
-        "required_return_schema_version"
-    ] = 3
+    database["talks"][0]["_queue_claim"]["required_return_schema_version"] = 3
     path.write_text(json.dumps(database))
     before = path.read_bytes()
 
@@ -1476,12 +1543,14 @@ def test_schema_v5_claim_cannot_request_a_schema_v3_return(tmp_path):
 
 def test_claim_baseline_failure_is_copy_on_write(tmp_path):
     malformed = _talk("eg6gqvUFh6Q", status="processed")
-    malformed.update({
-        "pattern_scoring_generation_status": "current",
-        "pattern_scoring_generation_reasons": [],
-        "pattern_score": 1,
-        "pattern_observations": {"pattern_score": 1},
-    })
+    malformed.update(
+        {
+            "pattern_scoring_generation_status": "current",
+            "pattern_scoring_generation_reasons": [],
+            "pattern_score": 1,
+            "pattern_observations": {"pattern_score": 1},
+        }
+    )
     path = _write_db(tmp_path, [malformed, _talk("iPYc7LCH608")])
     before = path.read_bytes()
 
@@ -1503,26 +1572,34 @@ def test_same_run_and_batch_reclaims_a_stale_recovered_generation(tmp_path):
     first = _run(
         path,
         "claim",
-        "--run-id", "reparse",
-        "--batch-id", "25",
-        "--now", "2026-07-31T17:00:00+00:00",
+        "--run-id",
+        "reparse",
+        "--batch-id",
+        "25",
+        "--now",
+        "2026-07-31T17:00:00+00:00",
     )
     assert first.returncode == 0, first.stderr
     first_claim = json.loads(first.stdout)["claimed"][0]
     recovered = _run(
         path,
         "recover",
-        "--now", "2026-07-31T18:00:00+00:00",
-        "--stale-after-seconds", "3600",
+        "--now",
+        "2026-07-31T18:00:00+00:00",
+        "--stale-after-seconds",
+        "3600",
     )
     assert recovered.returncode == 0, recovered.stderr
 
     retried = _run(
         path,
         "claim",
-        "--run-id", "reparse",
-        "--batch-id", "25",
-        "--now", "2026-07-31T18:01:00+00:00",
+        "--run-id",
+        "reparse",
+        "--batch-id",
+        "25",
+        "--now",
+        "2026-07-31T18:01:00+00:00",
     )
 
     assert retried.returncode == 0, retried.stderr
@@ -1540,18 +1617,22 @@ def test_same_run_and_batch_reclaims_a_stale_recovered_generation(tmp_path):
     assert archived["state"] == "stale_recovered"
     assert archived["released_at"] == "2026-07-31T18:00:00+00:00"
     assert archived["release_reason"] == "lease_expired"
-    assert talk["_queue_claim"]["adherence_baseline"]["as_of"] == \
-        "2026-07-31T18:01:00+00:00"
-    assert (talk["_queue_claim"]["adherence_baseline"] !=
-            archived["adherence_baseline"])
+    assert (
+        talk["_queue_claim"]["adherence_baseline"]["as_of"]
+        == "2026-07-31T18:01:00+00:00"
+    )
+    assert talk["_queue_claim"]["adherence_baseline"] != archived["adherence_baseline"]
 
     retried_bytes = path.read_bytes()
     replay = _run(
         path,
         "claim",
-        "--run-id", "reparse",
-        "--batch-id", "25",
-        "--now", "2026-07-31T18:02:00+00:00",
+        "--run-id",
+        "reparse",
+        "--batch-id",
+        "25",
+        "--now",
+        "2026-07-31T18:02:00+00:00",
     )
     assert replay.returncode == 0, replay.stderr
     replay_payload = json.loads(replay.stdout)
@@ -1561,8 +1642,7 @@ def test_same_run_and_batch_reclaims_a_stale_recovered_generation(tmp_path):
     assert path.read_bytes() == retried_bytes
 
 
-def test_v4_batch_epoch_can_span_current_and_history_after_member_reclaim(
-        tmp_path):
+def test_v4_batch_epoch_can_span_current_and_history_after_member_reclaim(tmp_path):
     path = _write_db(
         tmp_path,
         [_talk("eg6gqvUFh6Q"), _talk("iPYc7LCH608")],
@@ -1572,32 +1652,38 @@ def test_v4_batch_epoch_can_span_current_and_history_after_member_reclaim(
     database = _read_db(path)
     for talk in database["talks"]:
         talk["status"] = "processed"
-        talk["_queue_claim"].update({
-            "state": "completed",
-            "released_at": "2026-07-31T18:05:00+00:00",
-            "release_reason": "return_persisted",
-            "result_status": "processed",
-            "result_payload_sha256": "0" * 64,
-        })
+        talk["_queue_claim"].update(
+            {
+                "state": "completed",
+                "released_at": "2026-07-31T18:05:00+00:00",
+                "release_reason": "return_persisted",
+                "result_status": "processed",
+                "result_payload_sha256": "0" * 64,
+            }
+        )
 
     reclaimed = database["talks"][0]
     old_claim = copy.deepcopy(reclaimed["_queue_claim"])
     reclaimed["_queue_claim_history"] = [old_claim]
     new_claim = copy.deepcopy(old_claim)
     for field in (
-            "released_at", "release_reason", "result_status",
-            "result_payload_sha256"):
+        "released_at",
+        "release_reason",
+        "result_status",
+        "result_payload_sha256",
+    ):
         new_claim.pop(field)
-    new_claim.update({
-        "run_id": "new-run",
-        "batch_id": "new-batch",
-        "claimed_at": "2026-07-31T19:00:00+00:00",
-        "reprocess_generation": 2,
-        "state": "claimed",
-    })
+    new_claim.update(
+        {
+            "run_id": "new-run",
+            "batch_id": "new-batch",
+            "claimed_at": "2026-07-31T19:00:00+00:00",
+            "reprocess_generation": 2,
+            "state": "claimed",
+        }
+    )
     new_claim["adherence_baseline"]["as_of"] = new_claim["claimed_at"]
-    new_claim["adherence_baseline"]["excluded_filenames"] = [
-        reclaimed["filename"]]
+    new_claim["adherence_baseline"]["excluded_filenames"] = [reclaimed["filename"]]
     reclaimed["_queue_claim"] = new_claim
     reclaimed["reprocess_generation"] = 2
     reclaimed["status"] = "reprocessing-inflight"
@@ -1704,17 +1790,22 @@ def test_recover_uses_injected_time_and_exact_stale_threshold(tmp_path):
     claimed = _run(
         path,
         "claim",
-        "--run-id", "reparse",
-        "--batch-id", "25",
-        "--now", "2026-07-31T17:00:00+00:00",
+        "--run-id",
+        "reparse",
+        "--batch-id",
+        "25",
+        "--now",
+        "2026-07-31T17:00:00+00:00",
     )
     assert claimed.returncode == 0, claimed.stderr
 
     fresh = _run(
         path,
         "recover",
-        "--now", "2026-07-31T17:59:59+00:00",
-        "--stale-after-seconds", "3600",
+        "--now",
+        "2026-07-31T17:59:59+00:00",
+        "--stale-after-seconds",
+        "3600",
     )
     assert fresh.returncode == 0
     assert json.loads(fresh.stdout)["recovered"] == []
@@ -1722,18 +1813,22 @@ def test_recover_uses_injected_time_and_exact_stale_threshold(tmp_path):
     stale = _run(
         path,
         "recover",
-        "--now", "2026-07-31T18:00:00+00:00",
-        "--stale-after-seconds", "3600",
+        "--now",
+        "2026-07-31T18:00:00+00:00",
+        "--stale-after-seconds",
+        "3600",
     )
     assert stale.returncode == 0, stale.stderr
-    assert json.loads(stale.stdout)["recovered"] == [{
-        "filename": "playlist-eg6gqvUFh6Q.md",
-        "run_id": "reparse",
-        "batch_id": "25",
-        "reprocess_generation": 1,
-        "status": "needs-reprocessing",
-        "age_seconds": 3600,
-    }]
+    assert json.loads(stale.stdout)["recovered"] == [
+        {
+            "filename": "playlist-eg6gqvUFh6Q.md",
+            "run_id": "reparse",
+            "batch_id": "25",
+            "reprocess_generation": 1,
+            "status": "needs-reprocessing",
+            "age_seconds": 3600,
+        }
+    ]
     talk = _read_db(path)["talks"][0]
     assert talk["status"] == "needs-reprocessing"
     assert talk["_queue_claim"]["state"] == "stale_recovered"
@@ -1743,21 +1838,28 @@ def test_recover_uses_injected_time_and_exact_stale_threshold(tmp_path):
 def test_inspect_reconstructs_claims_after_stale_recovery(tmp_path):
     path = _write_db(tmp_path, [_talk("eg6gqvUFh6Q")])
     assert _claim(path, run_id="reparse", batch_id="25").returncode == 0
-    assert _run(
-        path,
-        "recover",
-        "--now", "2026-07-31T19:00:00+00:00",
-        "--stale-after-seconds", "1",
-    ).returncode == 0
+    assert (
+        _run(
+            path,
+            "recover",
+            "--now",
+            "2026-07-31T19:00:00+00:00",
+            "--stale-after-seconds",
+            "1",
+        ).returncode
+        == 0
+    )
 
     result = _run(path, "inspect", "--run-id", "reparse")
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert payload["batches"] == [{
-        "batch_id": "25",
-        "filenames": ["playlist-eg6gqvUFh6Q.md"],
-    }]
+    assert payload["batches"] == [
+        {
+            "batch_id": "25",
+            "filenames": ["playlist-eg6gqvUFh6Q.md"],
+        }
+    ]
     assert payload["claims"][0]["state"] == "stale_recovered"
 
 
@@ -1916,14 +2018,12 @@ def test_unknown_future_claim_schema_fails_without_rewriting(tmp_path):
 
     assert result.returncode == 2
     assert (
-        "queue_claim_schema_version_unsupported"
-        in json.loads(result.stdout)["error"]
+        "queue_claim_schema_version_unsupported" in json.loads(result.stdout)["error"]
     )
     assert path.read_bytes() == before
 
 
-def test_active_claim_with_terminal_status_rejects_every_command_but_recover(
-        tmp_path):
+def test_active_claim_with_terminal_status_rejects_every_command_but_recover(tmp_path):
     talk = _talk("eg6gqvUFh6Q", status="processed")
     talk["reprocess_generation"] = 1
     talk["_queue_claim"] = {
@@ -1947,21 +2047,25 @@ def test_active_claim_with_terminal_status_rejects_every_command_but_recover(
     recovered = _run(
         path,
         "recover",
-        "--now", NOW,
-        "--stale-after-seconds", "999",
+        "--now",
+        NOW,
+        "--stale-after-seconds",
+        "999",
     )
 
     assert recovered.returncode == 0, recovered.stderr
-    assert json.loads(recovered.stdout)["recovered"] == [{
-        "filename": "playlist-eg6gqvUFh6Q.md",
-        "run_id": "reparse",
-        "batch_id": "25",
-        "reprocess_generation": 1,
-        "status": "needs-reprocessing",
-        "age_seconds": 0,
-        "status_before": "processed",
-        "release_reason": "state_status_drift",
-    }]
+    assert json.loads(recovered.stdout)["recovered"] == [
+        {
+            "filename": "playlist-eg6gqvUFh6Q.md",
+            "run_id": "reparse",
+            "batch_id": "25",
+            "reprocess_generation": 1,
+            "status": "needs-reprocessing",
+            "age_seconds": 0,
+            "status_before": "processed",
+            "release_reason": "state_status_drift",
+        }
+    ]
     repaired = _read_db(path)["talks"][0]
     assert repaired["status"] == "needs-reprocessing"
     assert repaired["_queue_claim"]["state"] == "stale_recovered"
@@ -2047,8 +2151,11 @@ def test_malformed_claim_timestamp_rejects(tmp_path):
     [
         _talk("eg6gqvUFh6Q", status="skipped_duplicate"),
         _talk(
-            "iPYc7LCH608", status="pending", video=False,
-            youtube_identity=False, filename="catalog-pending.md",
+            "iPYc7LCH608",
+            status="pending",
+            video=False,
+            youtube_identity=False,
+            filename="catalog-pending.md",
         ),
     ],
 )
@@ -2069,9 +2176,12 @@ def test_cli_requires_timezone_aware_now(tmp_path):
     result = _run(
         path,
         "claim",
-        "--run-id", "reparse",
-        "--batch-id", "25",
-        "--now", "2026-07-31T18:00:00",
+        "--run-id",
+        "reparse",
+        "--batch-id",
+        "25",
+        "--now",
+        "2026-07-31T18:00:00",
     )
 
     assert result.returncode == 2

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -198,9 +198,10 @@ def test_apply_adds_only_complete_proposal_and_preserves_file_mode(
     assert report["database_written"] is True
     assert report["schema_version"] == 2
     assert report["input_sha256"] != report["output_sha256"]
-    assert report["output_sha256"] == hashlib.sha256(
-        database_path.read_bytes()
-    ).hexdigest()
+    assert (
+        report["output_sha256"]
+        == hashlib.sha256(database_path.read_bytes()).hexdigest()
+    )
     assert report["durability_state"] == "durable"
     assert report["entries"][0]["applied"] is True
     assert database_path.stat().st_mode & 0o777 == 0o640
@@ -274,8 +275,7 @@ def test_event_qualified_shownotes_title_preserves_authored_title(
     site, talks_directory = _shownotes_site(tmp_path)
     filename = "voxxed-lu-2026-monkey.md"
     authored_title = (
-        "Never Trust a Monkey: The Chasm, the Craft, and the Chain of "
-        "AI-Assisted Code"
+        "Never Trust a Monkey: The Chasm, the Craft, and the Chain of AI-Assisted Code"
     )
     conference = "Voxxed Days Luxembourg 2026"
     talk_date = "2026-06-18"
@@ -355,9 +355,7 @@ def test_event_qualified_title_requires_stored_conference_and_date(
     entry = report["entries"][0]
     assert entry["disposition"] == "review_required"
     assert entry["changes"] == {}
-    assert [issue["code"] for issue in entry["issues"]] == [
-        "existing_title_conflict"
-    ]
+    assert [issue["code"] for issue in entry["issues"]] == ["existing_title_conflict"]
     assert report["database_written"] is False
     assert database_path.read_bytes() == before
 
@@ -449,9 +447,7 @@ def test_event_qualified_title_preserves_event_type_identity(
     entry = report["entries"][0]
     assert entry["disposition"] == "review_required"
     assert entry["changes"] == {}
-    assert [issue["code"] for issue in entry["issues"]] == [
-        "existing_title_conflict"
-    ]
+    assert [issue["code"] for issue in entry["issues"]] == ["existing_title_conflict"]
     assert report["database_written"] is False
     assert database_path.read_bytes() == before
 
@@ -467,10 +463,7 @@ def test_event_qualified_title_preserves_event_type_identity(
             "Never Trust a Monkey: The Chasm, the Craft, and the Chain of "
             "AI-Assisted Code at Voxxed Days Luxembourg 2025"
         ),
-        (
-            "Never Trust a Monkey: A Different Subtitle at "
-            "Voxxed Days Luxembourg 2026"
-        ),
+        ("Never Trust a Monkey: A Different Subtitle at Voxxed Days Luxembourg 2026"),
         "Never Trust a Monkey Returns at Voxxed Days Luxembourg 2026",
     ],
 )
@@ -481,8 +474,7 @@ def test_event_qualified_title_rejects_wrong_identity_and_shared_prefixes(
     site, talks_directory = _shownotes_site(tmp_path)
     filename = "voxxed-lu-2026-monkey.md"
     authored_title = (
-        "Never Trust a Monkey: The Chasm, the Craft, and the Chain of "
-        "AI-Assisted Code"
+        "Never Trust a Monkey: The Chasm, the Craft, and the Chain of AI-Assisted Code"
     )
     conference = "Voxxed Days Luxembourg 2026"
     talk_date = "2026-06-18"
@@ -513,9 +505,7 @@ def test_event_qualified_title_rejects_wrong_identity_and_shared_prefixes(
     entry = report["entries"][0]
     assert entry["disposition"] == "review_required"
     assert entry["changes"] == {}
-    assert [issue["code"] for issue in entry["issues"]] == [
-        "existing_title_conflict"
-    ]
+    assert [issue["code"] for issue in entry["issues"]] == ["existing_title_conflict"]
     assert report["database_written"] is False
     assert database_path.read_bytes() == before
 

--- a/tests/test_script_invocation_style.py
+++ b/tests/test_script_invocation_style.py
@@ -118,9 +118,11 @@ def _bare_is_at_command_position(segment: str, match: re.Match) -> bool:
     (`DRIVER=skills/x/scripts/y.sh`) stores it instead, and survives the peel
     because no whitespace separates the `=` from the value.
     """
-    before = segment[:match.start(1)]
+    before = segment[: match.start(1)]
     while True:
-        peeled = ENV_ASSIGNMENT_PREFIX.sub("", CONTROL_PREFIX.sub("", before, count=1), count=1)
+        peeled = ENV_ASSIGNMENT_PREFIX.sub(
+            "", CONTROL_PREFIX.sub("", before, count=1), count=1
+        )
         if peeled == before:
             break
         before = peeled
@@ -146,7 +148,7 @@ def _unsafe_bare_references(line: str, in_fence: bool) -> list[str]:
 
     # In prose, only a span introduced by an execution verb is a command.
     for span in CODE_SPAN.finditer(line):
-        if not RUN_VERB_BEFORE.search(line[:span.start()]):
+        if not RUN_VERB_BEFORE.search(line[: span.start()]):
             continue
         content = span.group(1)
         match = BARE_PATH_REFERENCE.search(" " + content)
@@ -157,7 +159,7 @@ def _unsafe_bare_references(line: str, in_fence: bool) -> list[str]:
 
 def _reference_is_safe(segment: str, match: re.Match) -> bool:
     """True when this specific reference is named without needing the exec bit."""
-    before = segment[:match.start(1)]
+    before = segment[: match.start(1)]
 
     if INTERPRETER_BEFORE.search(before):
         return True
@@ -192,7 +194,9 @@ def _unsafe_references(line: str, reference: re.Pattern) -> list[str]:
 def _tracked(*globs: str) -> list[Path]:
     result = subprocess.run(
         ["git", "-C", str(REPO_ROOT), "ls-files", "--", *globs],
-        check=True, capture_output=True, text=True,
+        check=True,
+        capture_output=True,
+        text=True,
     )
     return [REPO_ROOT / line for line in result.stdout.splitlines() if line]
 
@@ -261,7 +265,9 @@ def test_both_categories_are_scanned(skill_files: list[Path]) -> None:
     scripts = [f for f in skill_files if "/scripts/" in f.as_posix()]
 
     assert len(docs) >= 100, f"skill docs missing from the scan (found {len(docs)})"
-    assert len(scripts) >= 40, f"skill scripts missing from the scan (found {len(scripts)})"
+    assert len(scripts) >= 40, (
+        f"skill scripts missing from the scan (found {len(scripts)})"
+    )
 
 
 def test_no_exec_bit_dependent_dot_slash_invocations(skill_files: list[Path]) -> None:
@@ -279,8 +285,8 @@ def test_no_exec_bit_dependent_sibling_invocations(skill_files: list[Path]) -> N
     offenders = _scan(skill_files, VAR_PATH_REFERENCE)
     assert not offenders, (
         "Sibling scripts executed directly through a variable path. tessl "
-        "install strips the executable bit; use `source \"$HERE/x.sh\"` or "
-        "`bash \"$HERE/x.sh\"`.\n" + "\n".join(offenders)
+        'install strips the executable bit; use `source "$HERE/x.sh"` or '
+        '`bash "$HERE/x.sh"`.\n' + "\n".join(offenders)
     )
 
 
@@ -301,68 +307,76 @@ def test_no_exec_bit_dependent_bare_path_invocations(skill_files: list[Path]) ->
 
 
 UNSAFE_BARE_FENCED = [
-    'skills/presentation-creator/scripts/apply-backgrounds.sh \\',
-    'scripts/load-vault.py > /tmp/out.json',
-    'if scripts/poll.sh; then',
+    "skills/presentation-creator/scripts/apply-backgrounds.sh \\",
+    "scripts/load-vault.py > /tmp/out.json",
+    "if scripts/poll.sh; then",
     # Environment-assignment PREFIX: the script still executes. Matches how the
     # `$VAR` detector already classifies `FOO=1 "$HERE/ensure-drivers.sh"`.
-    'FOO=1 scripts/poll.sh',
-    'A=1 B=2 skills/x/scripts/y.sh',
-    'DEBUG=1 skills/presentation-creator/scripts/apply-backgrounds.sh a b',
+    "FOO=1 scripts/poll.sh",
+    "A=1 B=2 skills/x/scripts/y.sh",
+    "DEBUG=1 skills/presentation-creator/scripts/apply-backgrounds.sh a b",
 ]
 
 SAFE_BARE_FENCED = [
-    'python3 skills/vault-profile/scripts/load-vault.py > /tmp/out.json',
-    'bash skills/presentation-creator/scripts/apply-backgrounds.sh a b c',
+    "python3 skills/vault-profile/scripts/load-vault.py > /tmp/out.json",
+    "bash skills/presentation-creator/scripts/apply-backgrounds.sh a b c",
     'cp skills/x/scripts/RunDeckOps.bas "$DEST"',
-    'cat skills/x/scripts/y.py',
+    "cat skills/x/scripts/y.py",
     # Assignment OF the path stores it; no whitespace after the `=`.
-    'DRIVER=skills/x/scripts/y.sh',
-    'FOO=1 bash scripts/poll.sh',
-    'cp deck-with-titles.pptx deck-bg-src.pptx',
+    "DRIVER=skills/x/scripts/y.sh",
+    "FOO=1 bash scripts/poll.sh",
+    "cp deck-with-titles.pptx deck-bg-src.pptx",
 ]
 
 UNSAFE_BARE_PROSE = [
-    'Run `scripts/load-vault.py` to read the vault sources.',
-    'Compute it by running `scripts/compute-pacing-adherence.py`. The',
-    'Pipe the profile dict through `scripts/validate-profile.py` to verify keys.',
+    "Run `scripts/load-vault.py` to read the vault sources.",
+    "Compute it by running `scripts/compute-pacing-adherence.py`. The",
+    "Pipe the profile dict through `scripts/validate-profile.py` to verify keys.",
 ]
 
 # Pointers, not commands. `rules/script-as-black-box.md` REQUIRES these — a
 # detector that flagged them would push authors to stop citing scripts at all.
 SAFE_BARE_PROSE = [
-    'Partition criterion: see `skills/vault-profile/scripts/load-vault.py` — the constant.',
-    'The validator (`scripts/validate-profile.py`, schema_version 2) checks keys.',
-    'Per-model attributes live in `skills/illustrations/scripts/model_registry.py`.',
-    '| `scripts/load-vault.py` | Read vault sources, emit JSON to stdout |',
-    '| `skills/illustrations/scripts/model_registry.py` | Model roster |',
-    'Run `python3 scripts/load-vault.py` to read the vault sources.',
+    "Partition criterion: see `skills/vault-profile/scripts/load-vault.py` — the constant.",
+    "The validator (`scripts/validate-profile.py`, schema_version 2) checks keys.",
+    "Per-model attributes live in `skills/illustrations/scripts/model_registry.py`.",
+    "| `scripts/load-vault.py` | Read vault sources, emit JSON to stdout |",
+    "| `skills/illustrations/scripts/model_registry.py` | Model roster |",
+    "Run `python3 scripts/load-vault.py` to read the vault sources.",
 ]
 
 
 @pytest.mark.parametrize("line", UNSAFE_BARE_FENCED)
 def test_bare_detector_flags_fenced_invocations(line: str) -> None:
-    assert _unsafe_bare_references(line, in_fence=True), f"should have been flagged: {line}"
+    assert _unsafe_bare_references(line, in_fence=True), (
+        f"should have been flagged: {line}"
+    )
 
 
 @pytest.mark.parametrize("line", SAFE_BARE_FENCED)
 def test_bare_detector_accepts_fenced_non_invocations(line: str) -> None:
-    assert not _unsafe_bare_references(line, in_fence=True), f"should have been accepted: {line}"
+    assert not _unsafe_bare_references(line, in_fence=True), (
+        f"should have been accepted: {line}"
+    )
 
 
 @pytest.mark.parametrize("line", UNSAFE_BARE_PROSE)
 def test_bare_detector_flags_prose_invocations(line: str) -> None:
-    assert _unsafe_bare_references(line, in_fence=False), f"should have been flagged: {line}"
+    assert _unsafe_bare_references(line, in_fence=False), (
+        f"should have been flagged: {line}"
+    )
 
 
 @pytest.mark.parametrize("line", SAFE_BARE_PROSE)
 def test_bare_detector_accepts_prose_pointers(line: str) -> None:
-    assert not _unsafe_bare_references(line, in_fence=False), f"should have been accepted: {line}"
+    assert not _unsafe_bare_references(line, in_fence=False), (
+        f"should have been accepted: {line}"
+    )
 
 
 UNSAFE_LINES = [
-    './scripts/build-deck.sh --deck x',
-    'run ./generate-qr.py',
+    "./scripts/build-deck.sh --deck x",
+    "run ./generate-qr.py",
     '"$HERE/ensure-drivers.sh"',
     'if "$HERE/ensure-drivers.sh"; then',
     'elif "$HERE/ensure-drivers.sh"; then',
@@ -371,7 +385,7 @@ UNSAFE_LINES = [
     'mkdir -p "$OUT" && "$HERE/ensure-drivers.sh"',
     # Environment-assignment PREFIX: the script still executes.
     'FOO=1 "$HERE/ensure-drivers.sh"',
-    'DEBUG=1 ./scripts/build-deck.sh',
+    "DEBUG=1 ./scripts/build-deck.sh",
 ]
 
 SAFE_LINES = [
@@ -380,9 +394,9 @@ SAFE_LINES = [
     'bash "$HERE/ensure-drivers.sh"',
     'python3 "$HERE/persist-results.py"',
     # An interpreter makes a './' path fine — the outcome, not the spelling.
-    'bash ./scripts/build-deck.sh',
-    'python3 ./scripts/generate-qr.py',
-    'Run `bash ./scripts/build-deck.sh` to build the deck.',
+    "bash ./scripts/build-deck.sh",
+    "python3 ./scripts/generate-qr.py",
+    "Run `bash ./scripts/build-deck.sh` to build the deck.",
     'if bash "$HERE/ensure-drivers.sh"; then',
     'if [ -f "$HERE/ensure-drivers.sh" ]; then',
     'if ! source "$HERE/ensure-drivers.sh"; then',
@@ -396,14 +410,16 @@ SAFE_LINES = [
 @pytest.mark.parametrize("line", UNSAFE_LINES)
 def test_detector_flags_exec_bit_dependent_lines(line: str) -> None:
     """A detector that never fires guards nothing."""
-    flagged = (_unsafe_references(line, DOT_SLASH_REFERENCE)
-               + _unsafe_references(line, VAR_PATH_REFERENCE))
+    flagged = _unsafe_references(line, DOT_SLASH_REFERENCE) + _unsafe_references(
+        line, VAR_PATH_REFERENCE
+    )
     assert flagged, f"should have been flagged: {line}"
 
 
 @pytest.mark.parametrize("line", SAFE_LINES)
 def test_detector_accepts_safe_references(line: str) -> None:
     """A detector that fires on everything is noise, not a guard."""
-    flagged = (_unsafe_references(line, DOT_SLASH_REFERENCE)
-               + _unsafe_references(line, VAR_PATH_REFERENCE))
+    flagged = _unsafe_references(line, DOT_SLASH_REFERENCE) + _unsafe_references(
+        line, VAR_PATH_REFERENCE
+    )
     assert not flagged, f"should have been accepted: {line}"

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -10,11 +10,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = (
-    REPO_ROOT
-    / "skills"
-    / "vault-ingress"
-    / "scripts"
-    / "source_identity_matching.py"
+    REPO_ROOT / "skills" / "vault-ingress" / "scripts" / "source_identity_matching.py"
 )
 SPEC = importlib.util.spec_from_file_location("source_identity_matching", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
@@ -35,12 +31,15 @@ def test_shownotes_title_presentation_rules_remain_narrow(
     shownotes_title: str,
     expected: bool,
 ) -> None:
-    assert source_identity_matching.shownotes_titles_agree(
-        authored_title,
-        shownotes_title,
-        conference=None,
-        talk_date=None,
-    ) is expected
+    assert (
+        source_identity_matching.shownotes_titles_agree(
+            authored_title,
+            shownotes_title,
+            conference=None,
+            talk_date=None,
+        )
+        is expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -144,9 +143,12 @@ def test_shownotes_event_qualifier_requires_exact_base_event_and_year(
     talk_date: str,
     expected: bool,
 ) -> None:
-    assert source_identity_matching.shownotes_titles_agree(
-        "Never Trust a Monkey",
-        shownotes_title,
-        conference=conference,
-        talk_date=talk_date,
-    ) is expected
+    assert (
+        source_identity_matching.shownotes_titles_agree(
+            "Never Trust a Monkey",
+            shownotes_title,
+            conference=conference,
+            talk_date=talk_date,
+        )
+        is expected
+    )

--- a/tests/test_stage_images_into_container.py
+++ b/tests/test_stage_images_into_container.py
@@ -18,7 +18,9 @@ def _img(dir_, name, data=b"PNGDATA"):
     return str(p)
 
 
-def test_backgrounds_paths_rewritten_into_stage_dir(stage_images_into_container, tmp_path):
+def test_backgrounds_paths_rewritten_into_stage_dir(
+    stage_images_into_container, tmp_path
+):
     src = tmp_path / "src"
     src.mkdir()
     stage = tmp_path / "stage"
@@ -39,7 +41,9 @@ def test_backgrounds_paths_rewritten_into_stage_dir(stage_images_into_container,
     assert open(out["backgrounds"]["3"], "rb").read() == b"BBB"
 
 
-def test_build_expansion_frames_rewritten_metadata_preserved(stage_images_into_container, tmp_path):
+def test_build_expansion_frames_rewritten_metadata_preserved(
+    stage_images_into_container, tmp_path
+):
     src = tmp_path / "src"
     src.mkdir()
     stage = tmp_path / "stage"
@@ -62,7 +66,9 @@ def test_build_expansion_frames_rewritten_metadata_preserved(stage_images_into_c
     assert open(build["frames"][1], "rb").read() == b"F1"
 
 
-def test_same_basename_different_dirs_get_distinct_staged_names(stage_images_into_container, tmp_path):
+def test_same_basename_different_dirs_get_distinct_staged_names(
+    stage_images_into_container, tmp_path
+):
     d1 = tmp_path / "a"
     d2 = tmp_path / "b"
     d1.mkdir()
@@ -124,7 +130,9 @@ def test_unrecognized_shape_rejected(stage_images_into_container, tmp_path):
     assert "unrecognized manifest shape" in str(exc.value)
 
 
-def test_non_string_path_rejected_with_actionable_error(stage_images_into_container, tmp_path):
+def test_non_string_path_rejected_with_actionable_error(
+    stage_images_into_container, tmp_path
+):
     stage = tmp_path / "stage"
     # a malformed manifest with a non-string (int) path value must not crash with
     # a raw TypeError — it should raise SystemExit naming the offending slot

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -41,7 +41,10 @@ def _metadata_view(
 @pytest.mark.parametrize(
     ("raw", "message"),
     [
-        (b'{"talks": [], "talks": [{"filename": "lost.md"}]}\n', "duplicate object key 'talks'"),
+        (
+            b'{"talks": [], "talks": [{"filename": "lost.md"}]}\n',
+            "duplicate object key 'talks'",
+        ),
         (
             b'{"talks": [{"filename": "a.md", "source_identity": '
             b'{"video_id": "one", "video_id": "two"}}]}\n',
@@ -109,13 +112,19 @@ def test_strict_decoder_rejects_numbers_that_cannot_round_trip(
     ("raw", "message"),
     [
         pytest.param(
-            b'{"config":{"value":' + b"[" * 500 + b"0" + b"]" * 500
+            b'{"config":{"value":'
+            + b"[" * 500
+            + b"0"
+            + b"]" * 500
             + b'},"talks":[]}\n',
             "maximum supported JSON nesting depth 200",
             id="decoded-depth-limit",
         ),
         pytest.param(
-            b'{"config":{"value":' + b"[" * 10_000 + b"0" + b"]" * 10_000
+            b'{"config":{"value":'
+            + b"[" * 10_000
+            + b"0"
+            + b"]" * 10_000
             + b'},"talks":[]}\n',
             "maximum supported JSON nesting depth 200",
             id="decoder-recursion-limit",
@@ -343,7 +352,9 @@ def test_symlink_substitution_before_commit_is_preserved(
     path.unlink()
     path.symlink_to(concurrent)
 
-    with pytest.raises(tracking_database_io.TrackingDatabaseIOError, match="symbolic link"):
+    with pytest.raises(
+        tracking_database_io.TrackingDatabaseIOError, match="symbolic link"
+    ):
         tracking_database_io.commit_tracking_database(
             expected,
             tracking_database_io.render_json_object({"talks": [], "config": {}}),
@@ -507,7 +518,9 @@ def test_staging_interrupt_cleans_candidate_and_preserves_database(
         real_write(descriptor, raw)
         raise KeyboardInterrupt
 
-    monkeypatch.setattr(tracking_database_io, "_write_descriptor", interrupt_after_write)
+    monkeypatch.setattr(
+        tracking_database_io, "_write_descriptor", interrupt_after_write
+    )
     with pytest.raises(KeyboardInterrupt):
         tracking_database_io.commit_tracking_database(
             expected,

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -267,9 +267,7 @@ def test_future_root_is_no_usable_prior_state(tracking_database):
 
     assert assessment.usable is False
     assert assessment.state == "unsupported"
-    assert assessment.reason_codes == (
-        "tracking_database_schema_version_unsupported",
-    )
+    assert assessment.reason_codes == ("tracking_database_schema_version_unsupported",)
 
 
 def test_explicit_root_zero_is_not_implicit_legacy_state(tracking_database):
@@ -279,9 +277,7 @@ def test_explicit_root_zero_is_not_implicit_legacy_state(tracking_database):
     assessment = tracking_database.assess_tracking_database(database)
 
     assert assessment.usable is False
-    assert assessment.reason_codes == (
-        "tracking_database_schema_version_unsupported",
-    )
+    assert assessment.reason_codes == ("tracking_database_schema_version_unsupported",)
     with pytest.raises(tracking_database.TrackingDatabaseError):
         tracking_database.migrate_tracking_database(database)
     assert database == original
@@ -315,9 +311,7 @@ def test_future_owner_shape_is_classified_before_legacy_identity_validation(
     assessment = tracking_database.assess_tracking_database(database)
 
     assert assessment.usable is False
-    assert assessment.reason_codes == (
-        f"{collection}_schema_version_unsupported",
-    )
+    assert assessment.reason_codes == (f"{collection}_schema_version_unsupported",)
 
 
 @pytest.mark.parametrize(
@@ -345,9 +339,9 @@ def test_explicit_sentinel_or_future_record_is_not_migrated(
     if record_class == "config":
         database["config"]["schema_version"] = unsupported_version
     elif record_class == "source_rejections":
-        database["talks"][0]["source_rejections"][0][
-            "schema_version"
-        ] = unsupported_version
+        database["talks"][0]["source_rejections"][0]["schema_version"] = (
+            unsupported_version
+        )
     else:
         database[record_class][0]["schema_version"] = unsupported_version
 
@@ -369,9 +363,7 @@ def test_future_pattern_evidence_is_no_usable_prior_state_without_mutation(
     assessment = tracking_database.assess_tracking_database(database)
 
     assert assessment.usable is False
-    assert assessment.reason_codes == (
-        "pattern_evidence_schema_version_unsupported",
-    )
+    assert assessment.reason_codes == ("pattern_evidence_schema_version_unsupported",)
     assert database == before
 
 
@@ -397,9 +389,7 @@ def test_future_pattern_evidence_is_no_usable_prior_state_without_mutation(
             "speaker_photo_used must be a non-empty",
         ),
         (
-            lambda value: value["confirmed_intents"][0].update(
-                source_talk="one.md"
-            ),
+            lambda value: value["confirmed_intents"][0].update(source_talk="one.md"),
             "may use only one",
         ),
         (
@@ -480,7 +470,9 @@ def test_owner_migration_only_adds_owned_version_keys(tracking_database):
         "improvement_goals": 1,
         "source_rejections": 1,
     }
-    assert tracking_database.assess_tracking_database(result.database).state == "current"
+    assert (
+        tracking_database.assess_tracking_database(result.database).state == "current"
+    )
 
 
 def test_talk_count_excludes_nested_source_rejection_stamp(tracking_database):
@@ -530,9 +522,7 @@ def test_implicit_v1_migration_preserves_legacy_observation_shapes(
     legacy_observations,
 ):
     database = _legacy_database()
-    database["talks"][0]["pattern_observations"] = copy.deepcopy(
-        legacy_observations
-    )
+    database["talks"][0]["pattern_observations"] = copy.deepcopy(legacy_observations)
 
     migrated = tracking_database.migrate_tracking_database(database).database
 
@@ -626,9 +616,7 @@ def test_legacy_and_current_roots_reject_malformed_claim_versions(
     if claim_location == "current":
         database["talks"][0]["_queue_claim"] = copy.deepcopy(malformed_claim)
     else:
-        database["talks"][0]["_queue_claim_history"] = [
-            copy.deepcopy(malformed_claim)
-        ]
+        database["talks"][0]["_queue_claim_history"] = [copy.deepcopy(malformed_claim)]
 
     with pytest.raises(tracking_database.TrackingDatabaseError):
         tracking_database.assess_tracking_database(database)
@@ -653,18 +641,14 @@ def test_future_claim_is_no_usable_state_before_old_nested_validation(
     }
     if claim_location == "current":
         database["talks"][0]["_queue_claim"] = future_claim
-        database["talks"][0]["_queue_claim_history"] = {
-            "future_history_shape": True
-        }
+        database["talks"][0]["_queue_claim_history"] = {"future_history_shape": True}
     else:
         database["talks"][0]["_queue_claim_history"] = [future_claim]
 
     assessment = tracking_database.assess_tracking_database(database)
 
     assert assessment.usable is False
-    assert assessment.reason_codes == (
-        "queue_claim_schema_version_unsupported",
-    )
+    assert assessment.reason_codes == ("queue_claim_schema_version_unsupported",)
 
 
 def test_future_claim_baseline_is_classified_before_known_baseline_shape(
@@ -682,9 +666,7 @@ def test_future_claim_baseline_is_classified_before_known_baseline_shape(
     assessment = tracking_database.assess_tracking_database(database)
 
     assert assessment.usable is False
-    assert assessment.reason_codes == (
-        "adherence_baseline_schema_version_unsupported",
-    )
+    assert assessment.reason_codes == ("adherence_baseline_schema_version_unsupported",)
 
 
 @pytest.mark.parametrize("current_root", [False, True])
@@ -826,9 +808,7 @@ def test_current_root_config_v1_migrates_only_config(tracking_database):
         "python_path": "/opt/python",
     }
     untouched = {
-        key: copy.deepcopy(value)
-        for key, value in current.items()
-        if key != "config"
+        key: copy.deepcopy(value) for key, value in current.items() if key != "config"
     }
 
     assessment = tracking_database.assess_tracking_database(current)
@@ -846,9 +826,7 @@ def test_current_root_config_v1_migrates_only_config(tracking_database):
         "pptx_directory_exclusions": DEFAULT_DIRECTORY_EXCLUSIONS,
     }
     assert {
-        key: value
-        for key, value in migration.database.items()
-        if key != "config"
+        key: value for key, value in migration.database.items() if key != "config"
     } == untouched
 
     second = tracking_database.migrate_tracking_database(migration.database)
@@ -1040,11 +1018,7 @@ def test_apply_writes_exact_backup_through_shared_transaction(
         expected_sha256=digest,
     )
 
-    backup = (
-        tmp_path
-        / ".backups"
-        / f"{path.name}.owner-migration-{digest}.bak"
-    )
+    backup = tmp_path / ".backups" / f"{path.name}.owner-migration-{digest}.bak"
     assert backup.read_bytes() == raw
     assert report["backup"] == str(backup)
     assert report["database_written"] is True
@@ -1072,11 +1046,7 @@ def test_config_only_migration_uses_generation_neutral_backup_name(
         expected_sha256=digest,
     )
 
-    backup = (
-        tmp_path
-        / ".backups"
-        / f"{path.name}.owner-migration-{digest}.bak"
-    )
+    backup = tmp_path / ".backups" / f"{path.name}.owner-migration-{digest}.bak"
     assert backup.read_bytes() == raw
     assert report["backup"] == str(backup)
     assert report["from_schema_version"] == 1
@@ -1312,24 +1282,25 @@ def test_legacy_queue_recovery_unblocks_migration_without_schema_stamping(
     assert path.read_bytes() == raw
     assert not (tmp_path / ".backups").exists()
 
-    assert queue_state.main(
-        [str(path), "inspect", "--run-id", "legacy-run"]
-    ) == 0
+    assert queue_state.main([str(path), "inspect", "--run-id", "legacy-run"]) == 0
     capsys.readouterr()
     assert path.read_bytes() == raw
 
-    assert queue_state.main(
-        [
-            str(path),
-            "recover",
-            "--now",
-            "2026-08-01T12:00:00+00:00",
-            "--stale-after-seconds",
-            "1",
-            "--run-id",
-            "legacy-run",
-        ]
-    ) == 0
+    assert (
+        queue_state.main(
+            [
+                str(path),
+                "recover",
+                "--now",
+                "2026-08-01T12:00:00+00:00",
+                "--stale-after-seconds",
+                "1",
+                "--run-id",
+                "legacy-run",
+            ]
+        )
+        == 0
+    )
     capsys.readouterr()
     recovered = json.loads(path.read_text())
     assert "schema_version" not in recovered
@@ -1392,9 +1363,13 @@ def test_non_roundtrippable_number_blocks_migration_before_backup(
     path = tmp_path / "tracking-database.json"
     database = _legacy_database()
     database["config"]["precision_marker"] = "NUMBER_TOKEN"
-    raw = (json.dumps(database, indent=2) + "\n").encode().replace(
-        b'"NUMBER_TOKEN"',
-        b"0.12345678901234567890123456789",
+    raw = (
+        (json.dumps(database, indent=2) + "\n")
+        .encode()
+        .replace(
+            b'"NUMBER_TOKEN"',
+            b"0.12345678901234567890123456789",
+        )
     )
     path.write_bytes(raw)
 
@@ -1428,9 +1403,13 @@ def test_cli_reports_extreme_number_as_json_without_write_or_backup(
     path = tmp_path / "tracking-database.json"
     database = _legacy_database()
     database["config"]["precision_marker"] = "NUMBER_TOKEN"
-    raw = (json.dumps(database, indent=2) + "\n").encode().replace(
-        b'"NUMBER_TOKEN"',
-        number_token.encode(),
+    raw = (
+        (json.dumps(database, indent=2) + "\n")
+        .encode()
+        .replace(
+            b'"NUMBER_TOKEN"',
+            number_token.encode(),
+        )
     )
     path.write_bytes(raw)
 
@@ -1458,13 +1437,19 @@ def test_cli_reports_extreme_number_as_json_without_write_or_backup(
     ("raw", "message"),
     [
         pytest.param(
-            b'{"config":{"value":' + b"[" * 500 + b"0" + b"]" * 500
+            b'{"config":{"value":'
+            + b"[" * 500
+            + b"0"
+            + b"]" * 500
             + b'},"talks":[]}\n',
             "maximum supported JSON nesting depth 200",
             id="decoded-depth-limit",
         ),
         pytest.param(
-            b'{"config":{"value":' + b"[" * 10_000 + b"0" + b"]" * 10_000
+            b'{"config":{"value":'
+            + b"[" * 10_000
+            + b"0"
+            + b"]" * 10_000
             + b'},"talks":[]}\n',
             "maximum supported JSON nesting depth 200",
             id="decoder-recursion-limit",
@@ -1540,6 +1525,7 @@ def test_cli_errors_follow_json_contract(
 
 # --- #171: qr_codes schema v2 — artifact receipts ---
 
+
 def _qr_v2_record(**overrides):
     record = {
         "schema_version": 2,
@@ -1550,12 +1536,14 @@ def _qr_v2_record(**overrides):
         "short_url": "https://jbaru.ch/my-talk",
         "shortener_link_id": "bit.ly/abc123",
         "qr_png_rel_path": "my-talk-qr.png",
-        "artifacts": [{
-            "path": "my-talk-qr.png",
-            "path_root": "deck_dir",
-            "sha256": "a" * 64,
-            "bg_hex": None,
-        }],
+        "artifacts": [
+            {
+                "path": "my-talk-qr.png",
+                "path_root": "deck_dir",
+                "sha256": "a" * 64,
+                "bg_hex": None,
+            }
+        ],
         "created_at": "2026-08-09",
         "updated_at": "2026-08-09",
     }
@@ -1609,28 +1597,36 @@ def test_qr_v1_must_not_carry_artifacts(tracking_database):
 
 
 def test_qr_v2_rejects_an_empty_artifact_list(tracking_database):
-    with pytest.raises(tracking_database.TrackingDatabaseError, match="non-empty array"):
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="non-empty array"
+    ):
         _validate_qr(tracking_database, _qr_v2_record(artifacts=[]))
 
 
 def test_qr_v2_rejects_an_unknown_path_root(tracking_database):
     record = _qr_v2_record()
     record["artifacts"][0]["path_root"] = "somewhere"
-    with pytest.raises(tracking_database.TrackingDatabaseError, match="path_root must be one of"):
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="path_root must be one of"
+    ):
         _validate_qr(tracking_database, record)
 
 
 def test_qr_v2_rejects_a_malformed_digest(tracking_database):
     record = _qr_v2_record()
     record["artifacts"][0]["sha256"] = "NOTHEX"
-    with pytest.raises(tracking_database.TrackingDatabaseError, match="64 lowercase hex"):
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="64 lowercase hex"
+    ):
         _validate_qr(tracking_database, record)
 
 
 def test_qr_v2_rejects_duplicate_artifact_paths(tracking_database):
     record = _qr_v2_record()
     record["artifacts"].append(dict(record["artifacts"][0]))
-    with pytest.raises(tracking_database.TrackingDatabaseError, match="recorded more than once"):
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="recorded more than once"
+    ):
         _validate_qr(tracking_database, record)
 
 
@@ -1638,6 +1634,7 @@ def test_qr_v2_requires_qr_png_rel_path_to_mirror_first_artifact(tracking_databa
     """The v1 reader's view must agree with the artifact it points at."""
     record = _qr_v2_record(qr_png_rel_path="something-else.png")
     with pytest.raises(
-        tracking_database.TrackingDatabaseError, match="must mirror artifacts\\[0\\].path"
+        tracking_database.TrackingDatabaseError,
+        match="must mirror artifacts\\[0\\].path",
     ):
         _validate_qr(tracking_database, record)

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -123,8 +123,7 @@ def test_source_repair_writer_preserves_final_window_generation(
     ):
         apply_source_repairs.atomic_write(
             path,
-            json.dumps({"config": {}, "talks": [], "writer": "source-repair"})
-            + "\n",
+            json.dumps({"config": {}, "talks": [], "writer": "source-repair"}) + "\n",
             expected_snapshot=expected,
         )
 

--- a/tests/test_validate_deckops.py
+++ b/tests/test_validate_deckops.py
@@ -17,28 +17,30 @@ def line(op, *fields):
 
 
 # A well-formed sequence exercising every op and state dependency.
-VALID = "\n".join([
-    line("SLIDE", 0),
-    line("TITLE", "Hello"),
-    line("SUBTITLE", "World"),
-    line("BODY", "Body text"),
-    line("BULLET", 0, "First point"),
-    line("BULLET", 1, "Sub point"),
-    line("TEXT", 10, 20, 300, 80, "A box"),
-    line("IMAGE", 10, 20, 100, 100, "/tmp/x.png"),
-    line("SHAPE", 1, 10, 20, 50, 50),
-    line("BG", 255, 242, 158),
-    line("FOOTER", "footer text"),
-    line("TABLE", 2, 3, 10, 20, 400, 200),
-    line("CELL", 1, 1, "r1c1"),
-    line("CHART", 51, 10, 20, 400, 300),
-    line("CAT", "Q1"),
-    line("CAT", "Q2"),
-    line("SERIES", "Revenue", 10, 20),
-    line("OPTIMIZE"),
-    line("SLIDE", 2),
-    line("TITLE", "Second slide"),
-])
+VALID = "\n".join(
+    [
+        line("SLIDE", 0),
+        line("TITLE", "Hello"),
+        line("SUBTITLE", "World"),
+        line("BODY", "Body text"),
+        line("BULLET", 0, "First point"),
+        line("BULLET", 1, "Sub point"),
+        line("TEXT", 10, 20, 300, 80, "A box"),
+        line("IMAGE", 10, 20, 100, 100, "/tmp/x.png"),
+        line("SHAPE", 1, 10, 20, 50, 50),
+        line("BG", 255, 242, 158),
+        line("FOOTER", "footer text"),
+        line("TABLE", 2, 3, 10, 20, 400, 200),
+        line("CELL", 1, 1, "r1c1"),
+        line("CHART", 51, 10, 20, 400, 300),
+        line("CAT", "Q1"),
+        line("CAT", "Q2"),
+        line("SERIES", "Revenue", 10, 20),
+        line("OPTIMIZE"),
+        line("SLIDE", 2),
+        line("TITLE", "Second slide"),
+    ]
+)
 
 
 def test_valid_sequence_has_no_errors(validate_deckops):
@@ -51,7 +53,9 @@ def test_blank_and_crlf_lines_ignored(validate_deckops):
 
 
 def test_unknown_op_reported(validate_deckops):
-    errors = validate_deckops.validate_ops(line("SLIDE", 0) + "\n" + line("WIDGET", "x"))
+    errors = validate_deckops.validate_ops(
+        line("SLIDE", 0) + "\n" + line("WIDGET", "x")
+    )
     assert any("unknown op" in e and "WIDGET" in e for e in errors)
 
 
@@ -63,16 +67,20 @@ def test_wrong_arity_too_few(validate_deckops):
 
 def test_wrong_arity_too_many(validate_deckops):
     # TITLE is exactly 2 fields; give it 3.
-    errors = validate_deckops.validate_ops(line("SLIDE", 0) + "\n" + line("TITLE", "a", "b"))
+    errors = validate_deckops.validate_ops(
+        line("SLIDE", 0) + "\n" + line("TITLE", "a", "b")
+    )
     assert any("TITLE" in e and "fields" in e for e in errors)
 
 
 def test_variadic_series_accepts_many_values(validate_deckops):
-    text = "\n".join([
-        line("SLIDE", 0),
-        line("CHART", 51, 10, 20, 400, 300),
-        line("SERIES", "S", 1, 2, 3, 4, 5),
-    ])
+    text = "\n".join(
+        [
+            line("SLIDE", 0),
+            line("CHART", 51, 10, 20, 400, 300),
+            line("SERIES", "S", 1, 2, 3, 4, 5),
+        ]
+    )
     assert validate_deckops.validate_ops(text) == []
 
 
@@ -90,33 +98,39 @@ def test_float_field_rejects_non_number(validate_deckops):
 
 
 def test_series_value_must_be_number(validate_deckops):
-    text = "\n".join([
-        line("SLIDE", 0),
-        line("CHART", 51, 10, 20, 400, 300),
-        line("SERIES", "S", "notanumber"),
-    ])
+    text = "\n".join(
+        [
+            line("SLIDE", 0),
+            line("CHART", 51, 10, 20, 400, 300),
+            line("SERIES", "S", "notanumber"),
+        ]
+    )
     errors = validate_deckops.validate_ops(text)
     assert any("SERIES" in e and "number" in e for e in errors)
 
 
 def test_series_requires_at_least_one_value(validate_deckops):
     # SERIES with a name but no values would build an empty series — reject it.
-    text = "\n".join([
-        line("SLIDE", 0),
-        line("CHART", 51, 10, 20, 400, 300),
-        line("SERIES", "Revenue"),
-    ])
+    text = "\n".join(
+        [
+            line("SLIDE", 0),
+            line("CHART", 51, 10, 20, 400, 300),
+            line("SERIES", "Revenue"),
+        ]
+    )
     errors = validate_deckops.validate_ops(text)
     assert any("SERIES" in e and "fields" in e for e in errors)
 
 
 def test_chart_without_series_rejected(validate_deckops):
     # A CHART with no SERIES keeps PowerPoint's default sample data.
-    text = "\n".join([
-        line("SLIDE", 0),
-        line("CHART", 51, 10, 20, 400, 300),
-        line("CAT", "Q1"),
-    ])
+    text = "\n".join(
+        [
+            line("SLIDE", 0),
+            line("CHART", 51, 10, 20, 400, 300),
+            line("CAT", "Q1"),
+        ]
+    )
     errors = validate_deckops.validate_ops(text)
     assert any("CHART has no SERIES" in e for e in errors)
 
@@ -127,12 +141,17 @@ def test_negative_slide_layout_index_rejected(validate_deckops):
 
 
 def test_bg_channel_out_of_range(validate_deckops):
-    errors = validate_deckops.validate_ops(line("SLIDE", 0) + "\n" + line("BG", 300, 0, 0))
+    errors = validate_deckops.validate_ops(
+        line("SLIDE", 0) + "\n" + line("BG", 300, 0, 0)
+    )
     assert any("0-255" in e for e in errors)
 
 
 def test_bg_channel_in_range_ok(validate_deckops):
-    assert validate_deckops.validate_ops(line("SLIDE", 0) + "\n" + line("BG", 0, 128, 255)) == []
+    assert (
+        validate_deckops.validate_ops(line("SLIDE", 0) + "\n" + line("BG", 0, 128, 255))
+        == []
+    )
 
 
 def test_op_before_any_slide(validate_deckops):
@@ -141,7 +160,9 @@ def test_op_before_any_slide(validate_deckops):
 
 
 def test_cell_before_table(validate_deckops):
-    errors = validate_deckops.validate_ops(line("SLIDE", 0) + "\n" + line("CELL", 1, 1, "x"))
+    errors = validate_deckops.validate_ops(
+        line("SLIDE", 0) + "\n" + line("CELL", 1, 1, "x")
+    )
     assert any("CELL before any TABLE" in e for e in errors)
 
 
@@ -152,12 +173,14 @@ def test_cat_and_series_before_chart(validate_deckops):
 
 def test_table_state_resets_on_new_slide(validate_deckops):
     # A TABLE on slide 1 must not satisfy a CELL on slide 2.
-    text = "\n".join([
-        line("SLIDE", 0),
-        line("TABLE", 2, 2, 10, 20, 300, 200),
-        line("SLIDE", 1),
-        line("CELL", 1, 1, "x"),
-    ])
+    text = "\n".join(
+        [
+            line("SLIDE", 0),
+            line("TABLE", 2, 2, 10, 20, 300, 200),
+            line("SLIDE", 1),
+            line("CELL", 1, 1, "x"),
+        ]
+    )
     errors = validate_deckops.validate_ops(text)
     assert any("CELL before any TABLE" in e for e in errors)
 
@@ -165,13 +188,15 @@ def test_table_state_resets_on_new_slide(validate_deckops):
 def test_chart_state_resets_on_new_slide(validate_deckops):
     # The slide-1 chart gets its own SERIES so the only error is the slide-2
     # SERIES landing with no chart in scope.
-    text = "\n".join([
-        line("SLIDE", 0),
-        line("CHART", 51, 10, 20, 400, 300),
-        line("SERIES", "S1", 1, 2),
-        line("SLIDE", 1),
-        line("SERIES", "S2", 1, 2),
-    ])
+    text = "\n".join(
+        [
+            line("SLIDE", 0),
+            line("CHART", 51, 10, 20, 400, 300),
+            line("SERIES", "S1", 1, 2),
+            line("SLIDE", 1),
+            line("SERIES", "S2", 1, 2),
+        ]
+    )
     errors = validate_deckops.validate_ops(text)
     assert any("SERIES before any CHART" in e for e in errors)
     assert not any("CHART has no SERIES" in e for e in errors)
@@ -181,7 +206,9 @@ def test_op_name_is_case_insensitive(validate_deckops):
     assert validate_deckops.validate_ops("slide\x1f0\ntitle\x1fHi") == []
 
 
-def test_main_missing_file_actionable_error(validate_deckops, capsys, monkeypatch, tmp_path):
+def test_main_missing_file_actionable_error(
+    validate_deckops, capsys, monkeypatch, tmp_path
+):
     missing = tmp_path / "nope.txt"
     monkeypatch.setattr(sys, "argv", ["validate-deckops.py", str(missing)])
     with pytest.raises(SystemExit) as exc:
@@ -191,7 +218,9 @@ def test_main_missing_file_actionable_error(validate_deckops, capsys, monkeypatc
     assert "not found" in err and str(missing) in err
 
 
-def test_main_valid_file_prints_summary(validate_deckops, capsys, monkeypatch, tmp_path):
+def test_main_valid_file_prints_summary(
+    validate_deckops, capsys, monkeypatch, tmp_path
+):
     ops = tmp_path / "ops.txt"
     ops.write_text(line("SLIDE", 0) + "\n" + line("TITLE", "Hi"), encoding="utf-8")
     monkeypatch.setattr(sys, "argv", ["validate-deckops.py", str(ops)])

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -281,9 +281,9 @@ def test_supplied_vault_root_that_cannot_recompute_omits_the_missing_flag_error(
 
     assert rc == 1
     assert report["valid"] is False
-    assert not any(
-        "requires --vault-root" in error for error in report["errors"]
-    ), report["errors"]
+    assert not any("requires --vault-root" in error for error in report["errors"]), (
+        report["errors"]
+    )
     assert any(
         "could not recompute occurrence rows" in error for error in report["errors"]
     ), report["errors"]

--- a/tests/test_validate_returns.py
+++ b/tests/test_validate_returns.py
@@ -25,14 +25,14 @@ def _return():
     }
 
 
-def test_a_clean_batch_leaves_one_json_document_on_stdout(
-        validate_returns, tmp_path):
+def test_a_clean_batch_leaves_one_json_document_on_stdout(validate_returns, tmp_path):
     batch = tmp_path / "batch.json"
     batch.write_text(json.dumps([_return()]), encoding="utf-8")
 
     result = subprocess.run(
         [sys.executable, validate_returns.__file__, str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 0, result.stderr
@@ -41,14 +41,16 @@ def test_a_clean_batch_leaves_one_json_document_on_stdout(
 
 
 def test_a_rejected_batch_exits_one_with_a_stderr_diagnostic(
-        validate_returns, tmp_path):
+    validate_returns, tmp_path
+):
     """Exit 1 is a failed validation — distinct from a failed validator."""
     batch = tmp_path / "batch.json"
     batch.write_text(json.dumps([{"filename": "x.md"}]), encoding="utf-8")
 
     result = subprocess.run(
         [sys.executable, validate_returns.__file__, str(batch)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 1
@@ -58,9 +60,12 @@ def test_a_rejected_batch_exits_one_with_a_stderr_diagnostic(
 
 # --- #203: the CLI has a closed failure boundary ---
 
+
 def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
-        validate_returns, capsys, monkeypatch):
+    validate_returns, capsys, monkeypatch
+):
     """The gate reads a non-zero exit; it must still say what happened."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("injected failure at /private/vault/returns/a.json")
 
@@ -69,7 +74,7 @@ def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
     assert validate_returns.run_cli() == 2
 
     captured = capsys.readouterr()
-    assert captured.out == ""                     # stdout stays clean
+    assert captured.out == ""  # stdout stays clean
     payload = json.loads(captured.err.splitlines()[0])
     assert payload["error"] == "validate_returns_unexpected_failure"
     assert payload["error_type"] == "RuntimeError"
@@ -80,8 +85,10 @@ def test_outer_boundary_reports_an_unexpected_failure_without_a_traceback(
 
 
 def test_failure_note_says_the_batch_is_unvalidated_not_invalid(
-        validate_returns, capsys, monkeypatch):
+    validate_returns, capsys, monkeypatch
+):
     """A broken validator must never read as a clean batch."""
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("boom")
 
@@ -93,6 +100,7 @@ def test_failure_note_says_the_batch_is_unvalidated_not_invalid(
 
 def test_outer_boundary_does_not_catch_sys_exit(validate_returns, monkeypatch):
     """main()'s own documented sys.exit(1) validation failures keep exit 1."""
+
     def bail(*_args, **_kwargs):
         raise SystemExit(1)
 
@@ -102,14 +110,14 @@ def test_outer_boundary_does_not_catch_sys_exit(validate_returns, monkeypatch):
     assert excinfo.value.code == 1
 
 
-def test_outer_boundary_lets_a_clean_run_report_success(
-        validate_returns, monkeypatch):
+def test_outer_boundary_lets_a_clean_run_report_success(validate_returns, monkeypatch):
     monkeypatch.setattr(validate_returns, "main", lambda *a, **k: None)
     assert validate_returns.run_cli() == 0
 
 
 def test_a_failed_report_write_does_not_leave_partial_json_on_stdout(
-        validate_returns, tmp_path, capsys, monkeypatch):
+    validate_returns, tmp_path, capsys, monkeypatch
+):
     """The report is serialized before it is written, so it lands whole or not at all."""
     batch = tmp_path / "batch.json"
     batch.write_text(json.dumps([_return()]), encoding="utf-8")

--- a/tests/test_vault_root_authority.py
+++ b/tests/test_vault_root_authority.py
@@ -32,7 +32,9 @@ def _foreign_root_text() -> str:
 
 
 def _native_dot_root_text() -> str:
-    return r"C:\trusted\other\..\vault" if os.name == "nt" else "/trusted/other/../vault"
+    return (
+        r"C:\trusted\other\..\vault" if os.name == "nt" else "/trusted/other/../vault"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -715,10 +715,8 @@ DISTINCT_FRAME_PATTERNS = (
     # concentric rings about the center, derived from the frame's own extent so
     # the pattern stays centered at any size
     lambda rows, cols: (
-        (
-            (rows - rows.size // 2) ** 2 + (cols - cols.size // 2) ** 2
-        ) // 400 % 2
-    ) * 255,
+        (((rows - rows.size // 2) ** 2 + (cols - cols.size // 2) ** 2) // 400 % 2) * 255
+    ),
 )
 
 

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -325,17 +325,21 @@ def _write_tracking_db(
             talk["pattern_score"] = score
         talks.append(talk)
     path = tmp_path / name
-    path.write_text(json.dumps({
-        "schema_version": 1,
-        "config": current_tracking_config(),
-        "talks": talks,
-        "pptx_catalog": [],
-        "qr_codes": [],
-        "resources": [],
-        "thumbnails": [],
-        "confirmed_intents": [],
-        "improvement_goals": [],
-    }))
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "config": current_tracking_config(),
+                "talks": talks,
+                "pptx_catalog": [],
+                "qr_codes": [],
+                "resources": [],
+                "thumbnails": [],
+                "confirmed_intents": [],
+                "improvement_goals": [],
+            }
+        )
+    )
     return path
 
 
@@ -986,9 +990,7 @@ def test_cli_compares_symlinked_vault_roots_by_lexical_identity_before_write(
     )
     alias_db = alias_root / db.name
     database = json.loads(db.read_text(encoding="utf-8"))
-    configured_root = (
-        alias_root if configured_identity == "alias" else physical_root
-    )
+    configured_root = alias_root if configured_identity == "alias" else physical_root
     database["config"]["vault_storage_path"] = str(configured_root)
     db.write_text(json.dumps(database), encoding="utf-8")
     before = db.read_bytes()
@@ -1072,9 +1074,7 @@ def test_cli_rejects_invalid_configured_vault_root_before_analysis_write(
     )
 
     assert result.returncode == 1
-    assert result.stderr == (
-        f"ERROR: vault_root_config_invalid:{locator_reason}\n"
-    )
+    assert result.stderr == (f"ERROR: vault_root_config_invalid:{locator_reason}\n")
     assert "Traceback" not in result.stderr
     if configured_root.strip():
         assert configured_root not in result.stderr
@@ -1146,8 +1146,7 @@ def test_cli_rejects_relative_database_authority_before_open_or_write(
 
     assert result.returncode == 1
     assert result.stderr == (
-        "ERROR: vault_root_database_path_invalid:"
-        "artifact_root_not_native_absolute\n"
+        "ERROR: vault_root_database_path_invalid:artifact_root_not_native_absolute\n"
     )
     assert db.name not in result.stderr
     assert db.read_text(encoding="utf-8") == original
@@ -1205,8 +1204,7 @@ def test_root_authority_rejection_precedes_artifact_and_analysis_boundaries(
     assert caught.value.code == 1
     assert called == []
     assert capsys.readouterr().err == (
-        "ERROR: vault_root_config_invalid:"
-        "artifact_locator_home_expansion_unsupported\n"
+        "ERROR: vault_root_config_invalid:artifact_locator_home_expansion_unsupported\n"
     )
     assert db.read_text(encoding="utf-8") == original
     assert not out.exists()
@@ -1961,7 +1959,9 @@ def test_top_level_generation_mismatch_cannot_overwrite_analysis(
     )
 
     assert result.returncode == 1
-    assert "current claim generation 1 disagrees with talk generation 2" in result.stderr
+    assert (
+        "current claim generation 1 disagrees with talk generation 2" in result.stderr
+    )
     assert target.read_text() == "# current generation\n"
 
 
@@ -2907,15 +2907,18 @@ def test_cli_missing_input_file_is_actionable(write_analysis, tmp_path):
 
 # --- #203: the CLI has a closed failure boundary that names commit position ---
 
+
 @pytest.mark.parametrize("committed", [False, True])
 def test_outer_boundary_reports_whether_the_analyses_landed(
-        write_analysis, capsys, monkeypatch, committed):
+    write_analysis, capsys, monkeypatch, committed
+):
     """A late failure must say whether the atomic batch commit already happened.
 
     The DB half of Step 4 and this half must agree. Without commit position an
     operator cannot tell a pre-commit abort — where every target was rolled
     back — from a post-commit reporting failure where the files are current.
     """
+
     def explode(*_args, **_kwargs):
         raise RuntimeError("injected failure at /private/vault/analyses/x.md")
 
@@ -2925,7 +2928,7 @@ def test_outer_boundary_reports_whether_the_analyses_landed(
     assert write_analysis.run_cli() == 2
 
     captured = capsys.readouterr()
-    assert captured.out == ""                     # stdout stays clean
+    assert captured.out == ""  # stdout stays clean
     payload = json.loads(captured.err.splitlines()[0])
     assert payload["error"] == "write_analysis_unexpected_failure"
     assert payload["error_type"] == "RuntimeError"
@@ -2935,8 +2938,7 @@ def test_outer_boundary_reports_whether_the_analyses_landed(
     assert "Traceback" not in captured.err
 
 
-def test_commit_state_does_not_leak_between_runs(
-        write_analysis, capsys, monkeypatch):
+def test_commit_state_does_not_leak_between_runs(write_analysis, capsys, monkeypatch):
     """A stale True would make a pre-commit failure claim files were replaced."""
     write_analysis._COMMIT_STATE["analyses_written"] = True
 
@@ -2955,6 +2957,7 @@ def test_commit_state_does_not_leak_between_runs(
 
 def test_outer_boundary_does_not_catch_sys_exit(write_analysis, monkeypatch):
     """main()'s own documented sys.exit paths keep their exit codes."""
+
     def bail(*_args, **_kwargs):
         raise SystemExit(1)
 
@@ -2964,15 +2967,15 @@ def test_outer_boundary_does_not_catch_sys_exit(write_analysis, monkeypatch):
     assert excinfo.value.code == 1
 
 
-def test_outer_boundary_lets_a_clean_run_report_success(
-        write_analysis, monkeypatch):
+def test_outer_boundary_lets_a_clean_run_report_success(write_analysis, monkeypatch):
     """The boundary must not swallow or alter a normal run."""
     monkeypatch.setattr(write_analysis, "main", lambda *a, **k: None)
     assert write_analysis.run_cli() == 0
 
 
 def test_a_committed_batch_reports_written_when_the_receipt_fails(
-        write_analysis, tmp_path, capsys, monkeypatch):
+    write_analysis, tmp_path, capsys, monkeypatch
+):
     """The real failure this guards: files installed, receipt write dies.
 
     Exercises the whole CLI rather than a stubbed main(), so the commit flag is
@@ -2992,7 +2995,8 @@ def test_a_committed_batch_reports_written_when_the_receipt_fails(
 
     monkeypatch.setattr(write_analysis.sys.stdout, "write", refuse_receipt)
     monkeypatch.setattr(
-        sys, "argv",
+        sys,
+        "argv",
         ["write-analysis.py", str(batch), str(out_dir), "--talks", str(db)],
     )
 


### PR DESCRIPTION
Refs #162 — second of the adoption sequence. Reformat only; the Pyright baseline and the CI gate follow separately.

## Read the commits, not the diff

94 of 153 tracked Python files, +8802 −5300. Nobody can eyeball that, so it is structured to not need eyeballing:

| Commit | What |
|---|---|
| `827331a` | one docstring reworded — the only non-mechanical line in the PR |
| `be59c0f` | `ruff format .`, nothing else |
| CHANGELOG | the entry |

## The formatting commit is provably mechanical

Not "should be" — checked. Every one of the 94 files in `be59c0f` satisfies:

```python
ast.dump(ast.parse(before)) == ast.dump(ast.parse(after))
```

compared file by file against its parent commit. `AST mismatches: none`. A formatter that silently altered a string, dropped a decorator, or reassociated an expression would fail that check on the file it touched.

## Why the docstring needed its own commit first

```python
"""" Repair the condition named by the exception type" is not actionable."""
```

That docstring opens with a quote character. `ruff format` inserts a disambiguating space, which changes the string's **value** — a real AST difference, and the one file that failed the check on my first attempt. Rewording it in a separate commit is what lets the formatting commit claim "AST-identical" without an asterisk.

It is also the honest version of the advisory raised twice on #257: a formatting change and a functional change do not share a commit here, even though the squash means main sees one either way.

## Verification

- `ruff format --check .` → 358 files already formatted
- `ruff check .` → All checks passed
- Full suite: 5015 passed, 3 skipped — identical to the count before the reformat

🤖 Generated with [Claude Code](https://claude.com/claude-code)