### PR TITLE
chore(ci): resolve Pyright's module graph and pin the checker (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+### chore(ci) — resolve Pyright's module graph and pin the checker (#162)
+
+Third of the #162 adoption sequence. `language-diagnostics` Resolve Modules
+First: configure resolution before raising strictness, because unresolved
+modules stop deep checking and real null-flow bugs hide behind import
+false-positives. This PR does the resolution and nothing else — no gate, no
+finding fixes.
+
+Every script directory is its own `sys.path` root at runtime: each script runs
+directly so its own directory leads `sys.path`, `conftest.py` inserts all of
+them for the tests, and vault-clarification, vault-profile, and illustrations
+splice a sibling skill's scripts on to share its validators.
+`[tool.pyright].executionEnvironments` now models that per root.
+
+Unresolved imports went 116 → 0. The one remaining suppression is targeted and
+states its cause: `tests/test_pyproject_pins.py` imports `tomli` on Python 3.10
+only, and Pyright analyzes at the declared 3.10 floor while resolving against a
+3.11+ environment that correctly has no `tomli`.
+
+`pyright==1.1.411` joins the `lint` group beside Ruff. The pip distribution
+bundles its own Node runtime, so the CI gate will need no Node setup step.
+
+Resolution changes what the checker reports, so the baseline is now
+measured, not guessed: **223 findings — 16 in shipped scripts, 207 in tests**,
+concentrated in four test modules. `reportArgumentType` (122),
+`reportOptionalSubscript` (30), and `reportIndexIssue` (24) lead. Fixing those
+by shape, then wiring Ruff check, Ruff format check, and Pyright into CI, are
+what remain on #162.
+
 ### chore(ci) — clear the `ruff format` baseline (#162)
 
 Second of the #162 adoption sequence. `ruff format` rewrites 94 of the repo's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ test = [
 lint = [
     # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
     "ruff==0.16.2",
+    # The pip distribution bundles its own Node runtime, so CI needs no
+    # separate Node setup step.
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "pyright==1.1.411",
 ]
 # Local Whisper transcription, used by vault-ingress/scripts/fetch-transcript.py
 # when a video has no caption track. Optional and not in the base dependency set
@@ -92,6 +96,48 @@ target-version = "py310"
 # and running both makes the linter argue with the formatter over lines the
 # formatter cannot split (long URLs, literal error strings).
 select = ["E4", "E7", "E9", "F", "BLE"]
+
+[tool.pyright]
+# `language-diagnostics` Resolve Modules First: imports must resolve before
+# strictness is worth raising, or real null-flow bugs hide behind resolution
+# false-positives. Every script directory is its own sys.path root at runtime
+# (each script is executed directly, so its own directory leads sys.path), and
+# conftest.py inserts each of them for the tests.
+#
+# Pyright resolves third-party imports against the ACTIVE interpreter, so it
+# must run in the same environment the tests do — `pip install '.[test,lint]'`
+# then `pyright`. Run against a bare system Python and 94 resolution
+# false-positives reappear, hiding the real findings underneath.
+pythonVersion = "3.10"
+include = ["skills", "tests"]
+exclude = ["**/__pycache__", ".venv", ".tessl"]
+executionEnvironments = [
+    # illustrations reads the outline schema from presentation-creator.
+    { root = "skills/illustrations/scripts", extraPaths = [
+        "skills/illustrations/scripts",
+        "skills/presentation-creator/scripts",
+    ] },
+    { root = "skills/presentation-creator/scripts", extraPaths = ["skills/presentation-creator/scripts"] },
+    # clarification and profile splice the vault-ingress scripts onto sys.path
+    # at import time to share its validators.
+    { root = "skills/vault-clarification/scripts", extraPaths = [
+        "skills/vault-clarification/scripts",
+        "skills/vault-ingress/scripts",
+    ] },
+    { root = "skills/vault-ingress/scripts", extraPaths = ["skills/vault-ingress/scripts"] },
+    { root = "skills/vault-profile/scripts", extraPaths = [
+        "skills/vault-profile/scripts",
+        "skills/vault-ingress/scripts",
+    ] },
+    { root = "tests", extraPaths = [
+        "tests",
+        "skills/illustrations/scripts",
+        "skills/presentation-creator/scripts",
+        "skills/vault-clarification/scripts",
+        "skills/vault-ingress/scripts",
+        "skills/vault-profile/scripts",
+    ] },
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_pyproject_pins.py
+++ b/tests/test_pyproject_pins.py
@@ -24,7 +24,11 @@ from packaging.requirements import InvalidRequirement, Requirement
 if sys.version_info >= (3, 11):
     import tomllib
 else:  # requires-python admits 3.10, where tomllib is not in the stdlib
-    import tomli as tomllib
+    # Pyright analyzes at the declared floor (3.10) but resolves imports against
+    # the ambient environment, which is 3.11+ and correctly has no `tomli`. The
+    # guard above is the contract; only the checker's two-version view needs
+    # telling.
+    import tomli as tomllib  # pyright: ignore[reportMissingImports]
 
 REPO_ROOT = Path(__file__).parents[1]
 PYPROJECT = REPO_ROOT / "pyproject.toml"


### PR DESCRIPTION
Refs #162 — third of the adoption sequence. Resolution only; the finding fixes and the CI gate follow.

## Why resolution comes first

`language-diagnostics` Resolve Modules First: unresolved modules stop deep checking, so real null-flow bugs hide behind import false-positives. Turning strictness or a gate on before this measures noise, not code.

Every script directory is its own `sys.path` root at runtime — each script is executed directly so its own directory leads `sys.path`, and `conftest.py` inserts all of them for the tests. Three skills go further and splice a sibling's scripts on to share its validators:

| Root | Also needs |
|---|---|
| `skills/illustrations/scripts` | `presentation-creator/scripts` (`outline_schema`) |
| `skills/vault-clarification/scripts` | `vault-ingress/scripts` (`adherence_baseline`) |
| `skills/vault-profile/scripts` | `vault-ingress/scripts` (`return_validation`, `video_evidence`, `vault_root_authority`) |
| `tests` | all five script roots |

`[tool.pyright].executionEnvironments` models that. **Unresolved imports: 116 → 0.**

## The one suppression

`tests/test_pyproject_pins.py` imports `tomli` under `if sys.version_info >= (3, 11): ... else:`. Pyright analyzes at the declared 3.10 floor while resolving against a 3.11+ environment that correctly has no `tomli`, so the guarded branch reports missing. Targeted `# pyright: ignore[reportMissingImports]` with a comment naming the cause — not a file-wide `# pyright: basic`, which `language-diagnostics` forbids.

## The environment trap, documented in the config

Pyright resolves third-party imports against the **active interpreter**. Run it against a bare system Python and all 94 third-party imports (`pptx`, `PIL`, `numpy`, …) report missing — I hit exactly that mid-way through this. The config comment says it: install `.[test,lint]` and run `pyright` in that same environment. The CI step will do so naturally.

## The baseline, measured rather than guessed

With resolution correct and `pyright==1.1.411`:

**223 findings — 16 in shipped scripts, 207 in tests**, concentrated in four test modules.

| Rule | Count |
|---|---|
| `reportArgumentType` | 122 |
| `reportOptionalSubscript` | 30 |
| `reportIndexIssue` | 24 |
| `reportOptionalMemberAccess` | 13 |
| `reportOptionalOperand` | 13 |
| `reportCallIssue` | 12 |
| `reportAttributeAccessIssue` | 7 |
| `reportPossiblyUnboundVariable` | 1 |
| `reportGeneralTypeIssues` | 1 |

That 16-in-shipped-scripts number is the useful one, and it includes at least two worth a real look — a `jpg_bytes` that is only bound because a literal loop always runs at least once, and a `bg_hex` guarded by a re-evaluated condition rather than a structural one.

Pyright is pinned in the `lint` group beside Ruff. Its pip distribution bundles a Node runtime, so the CI gate will need no Node setup step.

## Verification

`ruff check .` clean, `ruff format --check .` clean, full suite 5015 passed / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)