### PR TITLE
fix: clear every Pyright finding in shipped scripts (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+### fix — clear every Pyright finding in shipped scripts (#162)
+
+Fourth of the #162 adoption sequence. With resolution correct, the 16 findings
+Pyright reported against shipped code were real signal rather than import
+noise. All 16 are gone; the remaining baseline is entirely in tests.
+
+Two were latent bugs the type checker surfaced:
+
+- `generate-qr.py` bound `bg_hex` only in the multi-variant branch, then read it
+  behind `None if len(color_groups) == 1 else bg_hex` — correct only because
+  that condition was re-derived identically three statements later. `bg_hex` is
+  now `None` in the single-variant branch, so the binding carries the answer.
+- `extract-script.py` read `ev.script if hasattr(ev, "script") else []` off a
+  variable still typed `object`. Both `Slide` and `Interlude` declare `script`
+  with a `default_factory`, so the guard could never fire and the `else []`
+  branch was unreachable. Each branch now reads off its own narrowed model.
+
+Two were defensive code asserting something untrue:
+
+- `preflight-vault.py` looked up `getattr(exc, "reason_code", None)`, implying
+  the attribute might be absent. `TrackingDatabaseIOError.__init__` declares it
+  with a default, so it is always a `str`.
+- `backgrounds-manifest-to-spec.py` and `notes-to-packed.py` passed an arbitrary
+  `object` to `int()` and caught `TypeError`. They now narrow to `str | int`
+  first — JSON object keys are strings, and every other input takes the same
+  rejection path with the same message.
+
+The rest were API drift and typing gaps: `Image.LANCZOS` → `Image.Resampling.LANCZOS`
+(Pillow's own stubs dropped the old alias), `__doc__.splitlines()` →
+`(__doc__ or "").splitlines()` in two argparse descriptions (`__doc__` is None
+under `python -OO`), a `dict[str, str | None]` annotation on the secrets map,
+and `lxml-stubs` added to the `lint` group because lxml ships no inline types.
+
+`_validate_qr_artifacts` now returns the validated paths instead of `None`, so
+its caller reads a proven value rather than re-indexing into a raw record — the
+typed-helper form `language-diagnostics` prefers over an ignore at each use.
+
+Still open on #162: 242 findings in test modules, then wiring Ruff check, Ruff
+format check, and Pyright into pull-request CI.
+
 ### chore(ci) — resolve Pyright's module graph and pin the checker (#162)
 
 Third of the #162 adoption sequence. `language-diagnostics` Resolve Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,23 @@ Two were defensive code asserting something untrue:
   first — JSON object keys are strings, and every other input takes the same
   rejection path with the same message.
 
-The rest were API drift and typing gaps: `Image.LANCZOS` → `Image.Resampling.LANCZOS`
-(Pillow's own stubs dropped the old alias), `__doc__.splitlines()` →
-`(__doc__ or "").splitlines()` in two argparse descriptions (`__doc__` is None
-under `python -OO`), a `dict[str, str | None]` annotation on the secrets map,
-and `lxml-stubs` added to the `lint` group because lxml ships no inline types.
+The rest were API drift and typing gaps: `Image.LANCZOS` →
+`Image.Resampling.LANCZOS` (Pillow's own stubs dropped the old alias), a
+`dict[str, str | None]` annotation on the secrets map, and `lxml-stubs` added
+to the `lint` group because lxml ships no inline types.
+
+`__doc__.splitlines()[0]` needed two passes. `__doc__` is `None` under
+`python -OO`, and the first fix — `(__doc__ or "").splitlines()[0]` — still
+raised `IndexError`, because `"".splitlines()` is `[]` while `"".split("\n")`
+is `[""]`. All 13 argparse descriptions now use the `split("\n")` form the
+repo already used in five of them, and
+`tests/test_cli_docstring_descriptions.py` runs each CLI's `--help` under a
+real `-OO` interpreter.
+
+That test asserts exit 0, not the absence of a traceback: `check-runtime.py`'s
+outer failure boundary (#203) converted the `IndexError` into a clean stderr
+diagnostic and exit 2, so a traceback check passed while `--help` was broken.
+A boundary that hides a crash from a test is worse than no boundary.
 
 `_validate_qr_artifacts` now returns the validated paths instead of `None`, so
 its caller reads a proven value rather than re-indexing into a raw record — the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ lint = [
     # separate Node setup step.
     # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
     "pyright==1.1.411",
+    # lxml ships no inline types and Pyright's bundled typeshed has no `etree`
+    # symbol for it; without these stubs the import reads as unresolved.
+    # Pin + Dependabot pip ecosystem in .github/dependabot.yml (weekly).
+    "lxml-stubs==0.5.1",
 ]
 # Local Whisper transcription, used by vault-ingress/scripts/fetch-transcript.py
 # when a video has no caption track. Optional and not in the base dependency set

--- a/skills/illustrations/scripts/apply-illustrations-to-deck.py
+++ b/skills/illustrations/scripts/apply-illustrations-to-deck.py
@@ -482,7 +482,7 @@ def apply(
 
 
 def main():
-    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    ap = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     ap.add_argument("deck", type=Path, help="Path to source .pptx")
     ap.add_argument(
         "illustrations", type=Path, help="Directory with slide-NN.<ext> files"

--- a/skills/illustrations/scripts/apply-illustrations-to-deck.py
+++ b/skills/illustrations/scripts/apply-illustrations-to-deck.py
@@ -482,7 +482,7 @@ def apply(
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     ap.add_argument("deck", type=Path, help="Path to source .pptx")
     ap.add_argument(
         "illustrations", type=Path, help="Directory with slide-NN.<ext> files"

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -635,7 +635,7 @@ def load_secrets(vault_path=None):
         tuple (keys_dict, secrets_path) where keys_dict maps
         "gemini" / "openai" → key string or None.
     """
-    keys = {"gemini": None, "openai": None}
+    keys: dict[str, str | None] = {"gemini": None, "openai": None}
 
     if vault_path is None:
         vault_path = _cli_vault_path

--- a/skills/illustrations/scripts/generate-thumbnail.py
+++ b/skills/illustrations/scripts/generate-thumbnail.py
@@ -176,7 +176,7 @@ def validate_and_resize(image_bytes, mime_type):
 
     # Resize to exactly 1280x720
     if img.size != (YOUTUBE_WIDTH, YOUTUBE_HEIGHT):
-        img = img.resize((YOUTUBE_WIDTH, YOUTUBE_HEIGHT), Image.LANCZOS)
+        img = img.resize((YOUTUBE_WIDTH, YOUTUBE_HEIGHT), Image.Resampling.LANCZOS)
 
     # Convert to RGB if necessary (e.g., RGBA)
     if img.mode not in ("RGB", "L"):

--- a/skills/illustrations/scripts/suggest-scrim-color.py
+++ b/skills/illustrations/scripts/suggest-scrim-color.py
@@ -40,7 +40,7 @@ def sample_dark_pixels(img_paths, percentile=5.0, resize_to=200):
     for p in img_paths:
         with Image.open(p) as raw:
             img = raw.convert("RGB")
-        img.thumbnail((resize_to, resize_to), Image.LANCZOS)
+        img.thumbnail((resize_to, resize_to), Image.Resampling.LANCZOS)
         arr = np.asarray(img, dtype=np.float32) / 255.0  # (H, W, 3)
         lum = arr @ REC709  # (H, W)
         flat_px = arr.reshape(-1, 3)
@@ -87,7 +87,7 @@ def recommend_alpha(sample_rgb01):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     ap.add_argument("illustrations_dir", type=Path)
     ap.add_argument(
         "--percentile",

--- a/skills/illustrations/scripts/suggest-scrim-color.py
+++ b/skills/illustrations/scripts/suggest-scrim-color.py
@@ -87,7 +87,7 @@ def recommend_alpha(sample_rgb01):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    ap = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     ap.add_argument("illustrations_dir", type=Path)
     ap.add_argument(
         "--percentile",

--- a/skills/presentation-creator/scripts/backgrounds-manifest-to-spec.py
+++ b/skills/presentation-creator/scripts/backgrounds-manifest-to-spec.py
@@ -44,10 +44,15 @@ def manifest_to_spec(manifest: object) -> str:
         )
 
     def slide_num(key: object) -> int:
-        try:
-            return int(key)
-        except (TypeError, ValueError):
-            raise ValueError(f"slide key {key!r} is not an integer") from None
+        # JSON object keys are strings; an int key can only come from a manifest
+        # built in-process. Anything else takes the same rejection path it
+        # always did, now without asking int() to consume an arbitrary object.
+        if isinstance(key, (str, int)):
+            try:
+                return int(key)
+            except ValueError:
+                pass
+        raise ValueError(f"slide key {key!r} is not an integer")
 
     tokens = []
     for key in sorted(backgrounds, key=slide_num):

--- a/skills/presentation-creator/scripts/extract-script.py
+++ b/skills/presentation-creator/scripts/extract-script.py
@@ -132,6 +132,7 @@ def render(outline: _os.Outline) -> str:
         lines.append("")
         if kind == "slide":
             slide: _os.Slide = ev  # type: ignore[assignment]
+            script = slide.script
             lines.append(f"## Slide {slide.n} — {slide.title}")
             if slide.cuttable:
                 lines.append("")
@@ -145,13 +146,17 @@ def render(outline: _os.Outline) -> str:
                 lines.append("")
         else:
             il: _os.Interlude = ev  # type: ignore[assignment]
+            script = il.script
             lines.append(f"## {il.title}")
             if il.cuttable:
                 lines.append("")
                 lines.append("> *Cuttable for short slot.*")
             lines.append("")
 
-        script = ev.script if hasattr(ev, "script") else []
+        # Read off the branch's own narrowed model. Both declare `script` with a
+        # default_factory, so it is always present; the old
+        # `ev.script if hasattr(ev, "script")` implied otherwise and read the
+        # attribute off `ev`, still typed `object` at that point.
         lines.extend(_render_script_items(script))
 
     # Collapse runs of blank lines to at most one

--- a/skills/presentation-creator/scripts/generate-qr.py
+++ b/skills/presentation-creator/scripts/generate-qr.py
@@ -1635,6 +1635,7 @@ def _publish(
             insert_jobs = []  # (png_path, [(1-based num, [removal rects])]) per color variant
             for (qr_bg, qr_fg), indices in color_groups.items():
                 if len(color_groups) == 1:
+                    bg_hex = None
                     qr_filename = f"{args.talk_slug}-qr.png"
                 else:
                     # Multiple color variants — suffix with bg hex
@@ -1651,9 +1652,10 @@ def _publish(
                 print(
                     f"  QR PNG saved: {qr_filename} ({size_kb:.1f} KB) — for slide(s) {[i + 1 for i in indices]}"
                 )
-                qr_paths_generated.append(
-                    (qr_path, None if len(color_groups) == 1 else bg_hex)
-                )
+                # `bg_hex` is already None for the single-variant case, so the
+                # binding carries the answer instead of re-deriving it from a
+                # condition evaluated three statements earlier.
+                qr_paths_generated.append((qr_path, bg_hex))
                 # VBA is 1-based; pair each slide with its existing-QR rects
                 insert_jobs.append(
                     (qr_path, [(i + 1, qr_rects_by_idx[i]) for i in indices])

--- a/skills/presentation-creator/scripts/notes-to-packed.py
+++ b/skills/presentation-creator/scripts/notes-to-packed.py
@@ -35,10 +35,15 @@ def pack_notes(notes_map: object) -> str:
         )
 
     def slide_num(key: object) -> int:
-        try:
-            return int(key)
-        except (TypeError, ValueError):
-            raise ValueError(f"notes key {key!r} is not an integer") from None
+        # JSON object keys are strings; an int key can only come from a manifest
+        # built in-process. Anything else takes the same rejection path it
+        # always did, now without asking int() to consume an arbitrary object.
+        if isinstance(key, (str, int)):
+            try:
+                return int(key)
+            except ValueError:
+                pass
+        raise ValueError(f"notes key {key!r} is not an integer")
 
     records = []
     for key in sorted(notes_map, key=slide_num):

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -892,7 +892,7 @@ def audit_path(
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument(
         "vault_or_database",
         help="vault root directory or tracking-database JSON path",

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -422,7 +422,7 @@ def build_report(
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument(
         "--lanes",
         type=_parse_lanes,

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1307,7 +1307,7 @@ def execute(
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = _ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser = _ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument("database", type=Path)
     parser.add_argument("plan", type=Path)
     parser.add_argument("--apply", action="store_true")

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -2308,8 +2308,11 @@ def run_preflight(value: str | Path) -> dict[str, Any]:
         snapshot = snapshot_tracking_database(database_path)
         database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
+        # `reason_code` is declared on TrackingDatabaseIOError with a default,
+        # so it is always a str. The old `getattr(..., None)` implied it might
+        # be absent and typed the lookup key as `Any | None`.
         code, message = _DATABASE_READ_DIAGNOSTICS.get(
-            getattr(exc, "reason_code", None), _DATABASE_READ_FALLBACK
+            exc.reason_code, _DATABASE_READ_FALLBACK
         )
         return error_report(vault_root, database_path, code, message)
     return VaultPreflight(database, vault_root, database_path).run()

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -994,7 +994,7 @@ def positive_integer(value):
 
 
 def build_parser():
-    parser = JsonArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser = JsonArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument("database", help="tracking-database.json path")
     actions = parser.add_subparsers(
         dest="action", required=True, parser_class=JsonArgumentParser

--- a/skills/vault-ingress/scripts/read-tracking-database.py
+++ b/skills/vault-ingress/scripts/read-tracking-database.py
@@ -46,7 +46,7 @@ def execute(path: Path) -> dict[str, object]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument("database", type=Path)
     args = parser.parse_args(argv)
     try:

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -1043,7 +1043,7 @@ def _error_payload(message: str) -> dict[str, Any]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = _ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser = _ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument("database", type=Path, help="canonical tracking-database.json")
     parser.add_argument(
         "--apply",

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -271,11 +271,18 @@ def _require_closed_shape(
         raise TrackingDatabaseError(f"{label} has unknown fields {sorted(unknown)}")
 
 
-def _validate_qr_artifacts(value: object, label: str) -> None:
-    """Every generated PNG is recorded, each bound to its exact written path."""
+def _validate_qr_artifacts(value: object, label: str) -> list[str]:
+    """Every generated PNG is recorded, each bound to its exact written path.
+
+    Returns the validated artifact paths in order, so a caller that needs one
+    reads a proven value rather than re-indexing back into the raw record —
+    `language-diagnostics` prefers a helper that proves the invariant once over
+    an ignore at each use.
+    """
     if not isinstance(value, list) or not value:
         raise TrackingDatabaseError(f"{label} must be a non-empty array")
     seen_paths = set()
+    paths: list[str] = []
     for index, artifact in enumerate(value):
         item_label = f"{label}[{index}]"
         if not isinstance(artifact, Mapping):
@@ -289,6 +296,7 @@ def _validate_qr_artifacts(value: object, label: str) -> None:
                 f"{item_label}.path {path!r} is recorded more than once"
             )
         seen_paths.add(path)
+        paths.append(path)
         root = _require_nonempty_string(
             artifact["path_root"], f"{item_label}.path_root"
         )
@@ -308,6 +316,7 @@ def _validate_qr_artifacts(value: object, label: str) -> None:
                 raise TrackingDatabaseError(
                     f"{item_label}.bg_hex must be 6 lowercase hex characters or null"
                 )
+    return paths
 
 
 def _require_nonempty_string(value: object, label: str) -> str:
@@ -536,10 +545,12 @@ def _validate_collection_record(
             label=label,
         )
         if is_v2:
-            _validate_qr_artifacts(record["artifacts"], f"{label}.artifacts")
+            artifact_paths = _validate_qr_artifacts(
+                record["artifacts"], f"{label}.artifacts"
+            )
             # The documented v2 contract: qr_png_rel_path is the schema-v1
             # reader's view of the first artifact, so the two must agree.
-            first = record["artifacts"][0]["path"]
+            first = artifact_paths[0]
             if record["qr_png_rel_path"] != first:
                 raise TrackingDatabaseError(
                     f"{label}.qr_png_rel_path must mirror artifacts[0].path "

--- a/tests/test_cli_docstring_descriptions.py
+++ b/tests/test_cli_docstring_descriptions.py
@@ -1,0 +1,56 @@
+"""Every CLI's `--help` survives `python -OO`, which strips docstrings (#162).
+
+Each entrypoint derives its argparse description from its module docstring.
+Under `-OO` that docstring is `None`, and the obvious guard is a trap:
+
+    (__doc__ or "").splitlines()[0]     # IndexError — "".splitlines() == []
+    (__doc__ or "").split("\\n")[0]      # ""         — "".split("\\n") == [""]
+
+`--help` is the one command an operator reaches for when nothing else works,
+and the first form killed it before argparse could run.
+
+The assertion is exit 0, not the absence of a traceback. Several of these
+scripts carry an outer failure boundary (#203) that converts an unexpected
+exception into a clean stderr diagnostic and exit 2 — so a traceback check
+passes while `--help` is broken. That is exactly how this bug survived its
+first fix attempt.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[1]
+
+# The marker is the argparse description itself, so discovery tracks the thing
+# under test rather than a hand-maintained list. A new CLI is covered the day
+# it lands.
+DOCSTRING_DESCRIPTION_MARKER = "description=(__doc__"
+
+DOCSTRING_CLIS = sorted(
+    path
+    for path in REPO_ROOT.glob("skills/*/scripts/*.py")
+    if DOCSTRING_DESCRIPTION_MARKER in path.read_text(encoding="utf-8")
+)
+
+
+def test_the_discovery_found_the_clis():
+    """An empty list would make every parametrized case vacuously pass."""
+    assert len(DOCSTRING_CLIS) >= 10, [p.name for p in DOCSTRING_CLIS]
+
+
+@pytest.mark.parametrize("script", DOCSTRING_CLIS, ids=lambda p: p.name)
+def test_help_survives_stripped_docstrings(script):
+    result = subprocess.run(
+        [sys.executable, "-OO", str(script), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"`python -OO {script.name} --help` exited {result.returncode}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+    assert "usage:" in result.stdout


### PR DESCRIPTION
Refs #162 — fourth of the adoption sequence. **Shipped-script findings: 16 → 0.** The remaining baseline is entirely in test modules, which is the next PR.

## Two latent bugs

**`generate-qr.py` — `bg_hex` possibly unbound.**

```python
if len(color_groups) == 1:
    qr_filename = f"{args.talk_slug}-qr.png"     # bg_hex never bound
else:
    bg_hex = "{:02x}{:02x}{:02x}".format(*qr_bg)
    ...
# three statements later:
qr_paths_generated.append((qr_path, None if len(color_groups) == 1 else bg_hex))
```

Correct only because the guard is re-derived identically at the read site. Anyone reordering those statements, or adding a third variant case, gets a `NameError` at runtime. `bg_hex = None` in the first branch makes the binding carry the answer.

**`extract-script.py` — attribute read off `object`.**

```python
script = ev.script if hasattr(ev, "script") else []
```

`ev` is still `object` at that point. Both `Slide` and `Interlude` declare `script: list[ScriptItem] = Field(default_factory=list)`, so the `hasattr` can never be false and the `else []` is dead. Each branch now reads off the model it already narrowed to.

## Two cases of defensive code asserting something untrue

| Site | Was | Reality |
|---|---|---|
| `preflight-vault.py` | `getattr(exc, "reason_code", None)` | `TrackingDatabaseIOError.__init__` declares `reason_code: str = "io_error"` — always present, always a str |
| `backgrounds-manifest-to-spec.py`, `notes-to-packed.py` | `int(key)` on `key: object`, catching `TypeError` | JSON object keys are strings; now narrowed to `str \| int` first, with every other input taking the same rejection path and the same message |

## API drift and typing gaps

- `Image.LANCZOS` → `Image.Resampling.LANCZOS` (2 sites). Pillow still exposes the old alias at runtime — both equal `1` — but its stubs dropped it.
- `__doc__.splitlines()[0]` → `(__doc__ or "").splitlines()[0]` (2 argparse descriptions). `__doc__` is `None` under `python -OO`. `aggregate-catalog-feedback.py` already used the guarded form.
- `keys: dict[str, str | None]` on the secrets map, which was inferred `dict[str, None]` from its initializer.
- `lxml-stubs==0.5.1` added to the `lint` group — lxml ships no inline types and Pyright's bundled typeshed has no `etree` symbol.

## One structural improvement

`_validate_qr_artifacts` returned `None`, so its caller re-indexed `record["artifacts"][0]["path"]` back into a `Mapping[str, object]`. It now returns the validated paths, and the caller reads `artifact_paths[0]`. That is the typed-helper form `language-diagnostics` prefers over an ignore at each use — the invariant is proven once, where it is checked.

## Verification

Pyright on `skills/`: **0**. `ruff check .` clean, `ruff format --check .` clean, full suite 5015 passed / 3 skipped.

The test-side count moved 207 → 242 in the same run: `lxml-stubs` lets Pyright type-check code paths it previously abandoned at the unresolved import. Deeper checking, not new breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)