### PR TITLE
fix: clear the Pyright test baseline (#162)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Runs before/alongside the suite and finishes in about a minute — the slow
+  # apt install belongs to `test` alone, so a style or type regression reports
+  # in ~1 min instead of ~6 (`coding-policy: code-formatting` CI Integration).
+  lint:
+    name: Lint, format, and type gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # Pyright resolves third-party imports against the ACTIVE interpreter, so
+      # the runtime dependencies must be present even though nothing here runs
+      # them. Without them it reports ~94 resolution false-positives and stops
+      # deep-checking the code underneath (`[tool.pyright]` in pyproject.toml).
+      - run: pip install ".[test,lint]"
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+      - name: Pyright
+        run: pyright
+
   test:
     runs-on: ubuntu-latest
     # Backstop against the apt step hanging on flaky runner networking: fail

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,30 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Runs before/alongside the suite and finishes in about a minute — the slow
-  # apt install belongs to `test` alone, so a style or type regression reports
-  # in ~1 min instead of ~6 (`coding-policy: code-formatting` CI Integration).
-  lint:
-    name: Lint, format, and type gates
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-      # Pyright resolves third-party imports against the ACTIVE interpreter, so
-      # the runtime dependencies must be present even though nothing here runs
-      # them. Without them it reports ~94 resolution false-positives and stops
-      # deep-checking the code underneath (`[tool.pyright]` in pyproject.toml).
-      - run: pip install ".[test,lint]"
-      - name: Ruff lint
-        run: ruff check .
-      - name: Ruff format check
-        run: ruff format --check .
-      - name: Pyright
-        run: pyright
-
   test:
     runs-on: ubuntu-latest
     # Backstop against the apt step hanging on flaky runner networking: fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-### chore(ci) — clear the Pyright test baseline and gate all three checks (#162)
+### fix — clear the Pyright test baseline (#162)
 
-Closes #162. Pyright reports **0 errors across all 153 files**, and
-`.github/workflows/tests.yml` gains a `lint` job running `ruff check`,
-`ruff format --check`, and `pyright` on every pull request.
+Fifth of the #162 adoption sequence. Pyright reports **0 errors across all 153
+files**. The CI gate is the next and final PR: `language-diagnostics` Adopting
+on a Dirty Tree wants the tree green before the gate is wired, in its own
+change.
 
 The 242 test-file findings were resolved by proving invariants once rather than
 suppressing them at each use, per `language-diagnostics`. Seven `conftest.py`
@@ -31,11 +32,8 @@ naming their cause: python-pptx annotates `CT_Background.bgPr` as Optional but
 leaves `CT_BackgroundProperties.eg_fillProperties` unannotated, so a reader sees
 the `ZeroOrOneChoice` descriptor instead of the element it returns.
 
-The `lint` job installs `.[test,lint]` and finishes in about a minute — the
-long apt install stays with `test`, so a style or type regression reports in ~1
-minute rather than ~6. Pyright needs the runtime dependencies present because
-it resolves imports against the active interpreter; without them it reports ~94
-resolution false-positives and stops deep-checking underneath.
+Verified against a clean venv built the way CI builds one: `ruff check` clean,
+`ruff format --check` 359 files already formatted, `pyright` 0 errors.
 
 ## 0.20.36 — 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+### chore(ci) — clear the Pyright test baseline and gate all three checks (#162)
+
+Closes #162. Pyright reports **0 errors across all 153 files**, and
+`.github/workflows/tests.yml` gains a `lint` job running `ruff check`,
+`ruff format --check`, and `pyright` on every pull request.
+
+The 242 test-file findings were resolved by proving invariants once rather than
+suppressing them at each use, per `language-diagnostics`. Seven `conftest.py`
+helpers now carry what was previously re-derived or ignored at ~90 call sites:
+`deck_width` / `deck_height` (python-pptx types slide extents Optional),
+`slide_title` (a layout may have no title placeholder), `slide_element` /
+`graphic_frame_element` (`element` is typed as the union of every CT_* shape),
+and `background_fill_element` / `background_properties` /
+`clear_background_fill`.
+
+`_load_vault_payload` in `test_validate_profile.py` is the same move at the
+test layer: `_run_load_vault` legitimately returns None when the command wrote
+nothing — three tests assert exactly that — so the six tests that go on to read
+the payload now assert its presence once instead of subscripting an Optional 24
+times.
+
+Mechanical shapes handled in bulk: 34 `Path` arguments where python-pptx
+declares `str | IO[bytes]`, 41 zero-valued `Length` positions, and JSON-document
+fixtures annotated `dict[str, Any]` — `object` values forced every nested
+subscript to be re-narrowed, while `Any` is what `json.loads` returns anyway.
+
+Exactly two suppressions survive, both in one `conftest.py` helper and both
+naming their cause: python-pptx annotates `CT_Background.bgPr` as Optional but
+leaves `CT_BackgroundProperties.eg_fillProperties` unannotated, so a reader sees
+the `ZeroOrOneChoice` descriptor instead of the element it returns.
+
+The `lint` job installs `.[test,lint]` and finishes in about a minute — the
+long apt install stays with `test`, so a style or type regression reports in ~1
+minute rather than ~6. Pyright needs the runtime dependencies present because
+it resolves imports against the active interpreter; without them it reports ~94
+resolution false-positives and stops deep-checking underneath.
+
 ### fix — clear every Pyright finding in shipped scripts (#162)
 
 Fourth of the #162 adoption sequence. With resolution correct, the 16 findings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 from pptx import Presentation
+from pptx.util import Emu
 
 
 DEFAULT_PPTX_DIRECTORY_EXCLUSIONS = [
@@ -464,6 +465,26 @@ def generate_talk_timings():
 
 NS_P = "http://schemas.openxmlformats.org/presentationml/2006/main"
 NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+
+def deck_width(presentation) -> Emu:
+    """A deck's slide width, proven present.
+
+    python-pptx types `slide_width` `Length | None` because a malformed package
+    can omit `sldSz`. A `Presentation()` built in-process always carries it, so
+    the invariant is asserted once here rather than ignored at every arithmetic
+    site (`language-diagnostics` prefers the typed helper).
+    """
+    width = presentation.slide_width
+    assert width is not None, "in-process decks always carry a slide width"
+    return Emu(width)
+
+
+def deck_height(presentation) -> Emu:
+    """A deck's slide height, proven present. See `deck_width`."""
+    height = presentation.slide_height
+    assert height is not None, "in-process decks always carry a slide height"
+    return Emu(height)
 
 
 def _make_deck(slide_count, *, slide_width=None, slide_height=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import sys
 import pytest
 from pptx import Presentation
 from pptx.oxml.shapes.graphfrm import CT_GraphicalObjectFrame
+from pptx.oxml.slide import CT_Slide
+from pptx.oxml.xmlchemy import BaseOxmlElement
 from pptx.util import Emu
 
 
@@ -87,6 +89,10 @@ def _import_script(path, name):
     if name in sys.modules:
         return sys.modules[name]
     spec = importlib.util.spec_from_file_location(name, path)
+    # Both are Optional for a path no loader claims. Every caller passes a real
+    # .py file, so a None here is a broken fixture path, not a missing feature —
+    # naming it beats an AttributeError two lines later.
+    assert spec is not None and spec.loader is not None, f"no loader for {path}"
     mod = importlib.util.module_from_spec(spec)
     sys.modules[name] = mod
     spec.loader.exec_module(mod)
@@ -498,6 +504,48 @@ def slide_title(slide):
     title = slide.shapes.title
     assert title is not None, "this layout has no title placeholder"
     return title
+
+
+def slide_element(slide) -> CT_Slide:
+    """The `<p:sld>` element behind a slide, narrowed from `BaseOxmlElement`.
+
+    python-pptx types `Slide.element` as the generic base, which carries no
+    `cSld`. Fixtures that author background DrawingML reach through it, so the
+    narrowing happens once here.
+    """
+    element = slide.element
+    assert isinstance(element, CT_Slide), type(element).__name__
+    return element
+
+
+def background_fill_element(slide) -> BaseOxmlElement:
+    """The fill element under a slide's authored `<p:bg><p:bgPr>`.
+
+    python-pptx annotates `CT_Background.bgPr` as Optional but leaves
+    `CT_BackgroundProperties.eg_fillProperties` unannotated, so a reader sees
+    the `ZeroOrOneChoice` descriptor rather than the element it returns. The
+    Optional chain is asserted here and the descriptor gap is suppressed once,
+    instead of at each fixture that reaches through it.
+    """
+    background = slide_element(slide).cSld.bg
+    assert background is not None, "slide has no authored background"
+    properties = background.bgPr
+    assert properties is not None, "slide background has no <p:bgPr>"
+    fill: BaseOxmlElement | None = properties.eg_fillProperties  # pyright: ignore[reportAssignmentType]
+    assert fill is not None, "slide background has no fill element"
+    return fill
+
+
+def background_properties(slide):
+    """A slide's `<p:bgPr>`, created if absent. See `background_fill_element`."""
+    return slide_element(slide).cSld.get_or_add_bgPr()
+
+
+def clear_background_fill(properties) -> None:
+    """Drop any existing fill under a `<p:bgPr>`. See `background_fill_element`."""
+    existing: BaseOxmlElement | None = properties.eg_fillProperties  # pyright: ignore[reportAssignmentType]
+    if existing is not None:
+        properties.remove(existing)
 
 
 def graphic_frame_element(shape) -> CT_GraphicalObjectFrame:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 from pptx import Presentation
+from pptx.oxml.shapes.graphfrm import CT_GraphicalObjectFrame
 from pptx.util import Emu
 
 
@@ -487,6 +488,31 @@ def deck_height(presentation) -> Emu:
     return Emu(height)
 
 
+def slide_title(slide):
+    """A slide's title placeholder, proven present.
+
+    `shapes.title` is Optional because a layout may have none. Fixtures that
+    set a title have already chosen a layout that has one, so the assertion
+    belongs here rather than at every assignment.
+    """
+    title = slide.shapes.title
+    assert title is not None, "this layout has no title placeholder"
+    return title
+
+
+def graphic_frame_element(shape) -> CT_GraphicalObjectFrame:
+    """The `<p:graphicFrame>` element behind a table or chart shape.
+
+    python-pptx types `BaseShape.element` as the union of every CT_* shape
+    element, and only the graphic-frame member carries `.graphic`. `add_table`
+    always returns a GraphicFrame, so narrowing once here beats an ignore at
+    each fixture site that retags a table as SmartArt.
+    """
+    element = shape.element
+    assert isinstance(element, CT_GraphicalObjectFrame), type(element).__name__
+    return element
+
+
 def _make_deck(slide_count, *, slide_width=None, slide_height=None):
     """Create a minimal PPTX with *slide_count* blank slides."""
     prs = Presentation()
@@ -525,7 +551,7 @@ def deck_with_text(tmp_path):
     layout = prs.slide_layouts[1]  # Title + Content
     for i in range(3):
         slide = prs.slides.add_slide(layout)
-        slide.shapes.title.text = f"Slide {i + 1} Title"
+        slide_title(slide).text = f"Slide {i + 1} Title"
     path = str(tmp_path / "text_deck.pptx")
     prs.save(path)
     return prs, path

--- a/tests/test_apply_illustrations.py
+++ b/tests/test_apply_illustrations.py
@@ -11,7 +11,7 @@ import yaml
 from pptx import Presentation
 from pptx.util import Inches
 
-from conftest import make_deck
+from conftest import make_deck, slide_title
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "outline-example.yaml"
@@ -283,8 +283,8 @@ def test_apply_img_txt_layout_repositions_title(apply_illustrations):
 
     _, text_moved = apply_illustrations.apply_img_txt_layout(slide)
     assert text_moved >= 1
-    assert slide.shapes.title.left == Inches(apply_illustrations.IMGTXT_TEXT_LEFT_IN)
-    assert slide.shapes.title.top == Inches(apply_illustrations.IMGTXT_TITLE_TOP_IN)
+    assert slide_title(slide).left == Inches(apply_illustrations.IMGTXT_TEXT_LEFT_IN)
+    assert slide_title(slide).top == Inches(apply_illustrations.IMGTXT_TITLE_TOP_IN)
 
 
 def test_swap_or_insert_picture_inserts_when_missing(apply_illustrations, tmp_path):

--- a/tests/test_artifact_metadata.py
+++ b/tests/test_artifact_metadata.py
@@ -9,7 +9,7 @@ import sys
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -697,7 +697,7 @@ def test_pptx_metadata_invocation_contract_includes_fixed_identity(
         flags=None,
         file_attributes=None,
     )
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def runner(
         command,

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -1802,8 +1802,13 @@ def test_build_edit_mask_is_transparent_only_in_region(
     mask_png = gi.build_edit_mask_png(str(src), [0.4, 0.4, 0.6, 0.6])
     mask = Image.open(io.BytesIO(mask_png)).convert("RGBA")
     assert mask.size == (100, 100)
-    assert mask.getpixel((50, 50))[3] == 0  # inside box -> transparent
-    assert mask.getpixel((5, 5))[3] == 255  # outside box -> opaque
+    # `getpixel` is typed as a scalar-or-tuple union across image modes; an
+    # RGBA mask always yields the 4-tuple this test indexes.
+    inside = mask.getpixel((50, 50))
+    outside = mask.getpixel((5, 5))
+    assert isinstance(inside, tuple) and isinstance(outside, tuple)
+    assert inside[3] == 0  # inside box -> transparent
+    assert outside[3] == 255  # outside box -> opaque
 
 
 def test_composite_region_keeps_background_pixel_identical(

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+from email.message import Message
 import os
 import sys
 from pathlib import Path
@@ -35,6 +36,7 @@ def _square_png(tmp_path, name="sq.png"):
     path = str(tmp_path / name)
     im = Image.new("RGB", (50, 50), (255, 255, 255))
     px = im.load()
+    assert px is not None, "a loaded image always exposes pixel access"
     for x in range(50):
         for y in range(50):
             if (x + y) % 2 == 0:
@@ -49,6 +51,7 @@ def _multicolor_png(tmp_path, name="multi.png"):
     path = str(tmp_path / name)
     im = Image.new("RGB", (60, 60))
     px = im.load()
+    assert px is not None, "a loaded image always exposes pixel access"
     for x in range(60):
         for y in range(60):
             px[x, y] = ((x * 4) % 256, (y * 4) % 256, ((x + y) * 2) % 256)
@@ -62,6 +65,7 @@ def _sparse_text_png(tmp_path, name="screenshot.png"):
     path = str(tmp_path / name)
     im = Image.new("RGB", (80, 80), (255, 255, 255))
     px = im.load()
+    assert px is not None, "a loaded image always exposes pixel access"
     for y in range(0, 80, 6):
         for x in range(0, 80, 3):
             px[x, y] = (0, 0, 0)
@@ -599,7 +603,7 @@ def test_create_bitly_link_raises_when_custom_back_half_fails(generate_qr, monke
         if url.endswith("/v4/bitlinks"):
             return {"id": "bit.ly/abc123", "link": "https://bit.ly/abc123"}
         # bit.ly answers 422 when the requested back-half is already taken.
-        raise urllib.error.HTTPError(url, 422, "Unprocessable", {}, None)
+        raise urllib.error.HTTPError(url, 422, "Unprocessable", Message(), None)
 
     monkeypatch.setattr(generate_qr, "_http_request", fake_http)
     with pytest.raises(
@@ -1859,7 +1863,7 @@ def test_back_half_failure_after_link_creation_reports_the_created_link(
         if url.endswith("/v4/bitlinks"):
             return {"id": "jbaru.ch/abc123", "link": "https://jbaru.ch/abc123"}
         # Creation succeeded; the back-half assignment is what fails.
-        raise urllib.error.HTTPError(url, 422, "Unprocessable", {}, None)
+        raise urllib.error.HTTPError(url, 422, "Unprocessable", Message(), None)
 
     monkeypatch.setattr(generate_qr, "_http_request", fake_http)
     monkeypatch.setattr(

--- a/tests/test_generate_thumbnail.py
+++ b/tests/test_generate_thumbnail.py
@@ -1,5 +1,6 @@
 """Tests for generate-thumbnail.py — prompt building and image validation (no API calls)."""
 
+from email.message import Message
 from io import BytesIO
 
 from PIL import Image
@@ -261,7 +262,7 @@ def test_call_gemini_http_error_prefix(generate_thumbnail, monkeypatch):
             req.full_url,
             429,
             "Too Many Requests",
-            {},
+            Message(),
             BytesIO(b"rate limited"),
         )
 
@@ -511,6 +512,7 @@ def _make_large_image_bytes():
     random.seed(42)
     img = Image.new("RGB", (1280, 720))
     pixels = img.load()
+    assert pixels is not None, "a loaded image always exposes pixel access"
     for x in range(1280):
         for y in range(720):
             pixels[x, y] = (

--- a/tests/test_goal_generation_provenance.py
+++ b/tests/test_goal_generation_provenance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+from typing import Any
 import subprocess
 import sys
 from pathlib import Path
@@ -63,7 +64,7 @@ def _goal(*, kind: str = "underuse", schema_version: int = 2):
             "pacing": "pacing",
             "other": "independent",
         }
-        provenance = {"lane": lanes[kind]}
+        provenance: dict[str, Any] = {"lane": lanes[kind]}
         if kind in {"antipattern", "underuse"}:
             provenance["pattern_baseline"] = _baseline()
         goal["baseline_provenance"] = provenance

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+from typing import Any
 from pathlib import Path
 
 import pytest
@@ -27,7 +28,7 @@ DEFAULT_DIRECTORY_EXCLUSIONS = [
 ]
 
 
-def _current_config(**updates: object) -> dict[str, object]:
+def _current_config(**updates: object) -> dict[str, Any]:
     config: dict[str, object] = {
         "schema_version": 2,
         "pptx_directory_exclusions": copy.deepcopy(DEFAULT_DIRECTORY_EXCLUSIONS),
@@ -40,7 +41,7 @@ def _write_json(path: Path, value: object) -> None:
     path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
 
 
-def _base_database() -> dict[str, object]:
+def _base_database() -> dict[str, Any]:
     return {
         "schema_version": 1,
         "config": _current_config(),
@@ -54,7 +55,7 @@ def _base_database() -> dict[str, object]:
     }
 
 
-def _goal() -> dict[str, object]:
+def _goal() -> dict[str, Any]:
     return {
         "id": "reduce-shortchanged",
         "schema_version": 2,
@@ -77,7 +78,7 @@ def _goal() -> dict[str, object]:
     }
 
 
-def _complete_plan() -> dict[str, object]:
+def _complete_plan() -> dict[str, Any]:
     goal = _goal()
     return {
         "schema_version": 1,
@@ -635,7 +636,7 @@ def test_talk_metadata_mutations_require_exact_current_talk_schema(
     assert database == original
 
 
-def _legacy_goal_for_mutation(kind: str) -> dict[str, object]:
+def _legacy_goal_for_mutation(kind: str) -> dict[str, Any]:
     goal = {
         key: copy.deepcopy(value)
         for key, value in _goal().items()

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -10,6 +10,7 @@ import json
 import shutil
 import subprocess
 import sys
+from typing import Any
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -1571,7 +1572,7 @@ def test_cli_accepts_database_bound_vault_root_authority(
 ):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    database = {"talks": [_talk()]}
+    database: dict[str, Any] = {"talks": [_talk()]}
     _db_json(database)
     if config_mode == "null":
         database["config"]["vault_storage_path"] = None
@@ -1609,7 +1610,7 @@ def test_cli_compares_symlinked_vault_roots_by_lexical_identity_before_persisten
     db = physical_root / "tracking-database.json"
     alias_db = alias_root / db.name
     batch = tmp_path / "batch-returns.json"
-    database = {"talks": [_talk()]}
+    database: dict[str, Any] = {"talks": [_talk()]}
     _db_json(database)
     configured_root = alias_root if configured_identity == "alias" else physical_root
     database["config"]["vault_storage_path"] = str(configured_root)
@@ -1669,7 +1670,7 @@ def test_cli_rejects_invalid_configured_vault_root_before_persistence(
 ):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    database = {"talks": [_talk()]}
+    database: dict[str, Any] = {"talks": [_talk()]}
     _db_json(database)
     database["config"]["vault_storage_path"] = configured_root
     original = json.dumps(database)
@@ -1696,7 +1697,7 @@ def test_cli_rejects_configured_vault_root_authority_mismatch(
 ):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    database = {"talks": [_talk()]}
+    database: dict[str, Any] = {"talks": [_talk()]}
     _db_json(database)
     mismatched_root = tmp_path / "other-vault"
     database["config"]["vault_storage_path"] = str(mismatched_root)
@@ -1724,7 +1725,7 @@ def test_cli_rejects_relative_database_authority_before_open(
 ):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    database = {"talks": [_talk()]}
+    database: dict[str, Any] = {"talks": [_talk()]}
     original = _db_json(database)
     db.write_text(original, encoding="utf-8")
     batch.write_text(json.dumps([_return()]), encoding="utf-8")
@@ -1752,7 +1753,7 @@ def test_root_authority_rejection_precedes_every_artifact_and_write_boundary(
 ):
     db = tmp_path / "tracking-database.json"
     batch = tmp_path / "batch-returns.json"
-    database = {"talks": [_talk()]}
+    database: dict[str, Any] = {"talks": [_talk()]}
     _db_json(database)
     database["config"]["vault_storage_path"] = "~/private-vault"
     original = json.dumps(database)
@@ -3152,7 +3153,7 @@ def test_skipped_no_sources_rejects_each_live_capability(
 def test_invalid_source_cannot_hide_independent_terminal_capability(
     persist_results, tmp_path, surviving_source
 ):
-    fields = {
+    fields: dict[str, Any] = {
         "video_url": None,
         "youtube_id": None,
         "slides_url": None,

--- a/tests/test_pptx_evidence_recovery.py
+++ b/tests/test_pptx_evidence_recovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import importlib
 import json
+from typing import Any
 import os
 import struct
 import subprocess
@@ -18,6 +19,7 @@ from PIL import Image
 from pptx import Presentation
 from pptx.oxml import parse_xml
 from pptx.oxml.ns import nsdecls
+from pptx.shapes.placeholder import PicturePlaceholder
 from pptx.util import Emu, Inches
 
 from conftest import deck_height, deck_width, graphic_frame_element
@@ -155,7 +157,7 @@ def test_metadata_generation_never_calls_owner_lstat(
     deck = tmp_path / "metadata-only-child.pptx"
     _write_deck(deck, with_image=False)
     generation = pptx_evidence.FileGeneration.from_stat(deck.stat())
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def metadata_child(command, payload, sensitive_values, _limits):
         captured.update(
@@ -822,7 +824,7 @@ def test_live_badzipfile_media_path_recovers_with_structured_loss(
     damaged_part = _damage_member_crc(deck, lambda name: name.startswith("ppt/media/"))
 
     with pytest.raises(zipfile.BadZipFile):
-        Presentation(deck)
+        Presentation(str(deck))
 
     probe = pptx_evidence.probe_pptx_artifact(deck)
 
@@ -2245,7 +2247,7 @@ def test_metadata_admission_timeout_reports_enclosing_batch_wall_limit(
 ) -> None:
     deck = tmp_path / "metadata-deadline.pptx"
     _write_deck(deck, with_image=False)
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def blocked_metadata(_command, _payload, _sensitive, limits):
         captured["wall_seconds"] = limits.wall_seconds
@@ -3135,7 +3137,7 @@ def test_inserted_picture_placeholder_round_trips_as_picture_evidence(
     picture_placeholder = next(
         placeholder
         for placeholder in slide.placeholders
-        if hasattr(placeholder, "insert_picture")
+        if isinstance(placeholder, PicturePlaceholder)
     )
     picture_placeholder.insert_picture(str(image_path))
     deck = tmp_path / "placeholder-picture.pptx"

--- a/tests/test_pptx_evidence_recovery.py
+++ b/tests/test_pptx_evidence_recovery.py
@@ -20,7 +20,7 @@ from pptx.oxml import parse_xml
 from pptx.oxml.ns import nsdecls
 from pptx.util import Emu, Inches
 
-from conftest import deck_height, deck_width
+from conftest import deck_height, deck_width, graphic_frame_element
 from pypdf import PdfWriter
 
 
@@ -2457,7 +2457,9 @@ def test_full_extraction_accepts_derived_render_and_ocr_contracts(
         0, 0
     ).text = "table text"
     smartart = slide.shapes.add_table(1, 1, Inches(1), Inches(3), Inches(2), Inches(1))
-    smartart.element.graphic.graphicData.uri = (
+    graphic_frame_element(
+        smartart
+    ).graphic.graphicData.uri = (
         "http://schemas.openxmlformats.org/drawingml/2006/diagram"
     )
     _set_background_image(slide, background_image)
@@ -2524,7 +2526,9 @@ def test_catalog_bindings_reject_detached_worker_evidence(
     table = slide.shapes.add_table(1, 1, Inches(1), Inches(1.5), Inches(2), Inches(1))
     table.table.cell(0, 0).text = "table text"
     smartart = slide.shapes.add_table(1, 1, Inches(1), Inches(3), Inches(2), Inches(1))
-    smartart.element.graphic.graphicData.uri = (
+    graphic_frame_element(
+        smartart
+    ).graphic.graphicData.uri = (
         "http://schemas.openxmlformats.org/drawingml/2006/diagram"
     )
     _set_background_image(slide, background_image)
@@ -2844,7 +2848,9 @@ def test_smartart_shape_cannot_omit_unsupported_evidence(
     presentation = Presentation()
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     smartart = slide.shapes.add_table(1, 1, Inches(1), Inches(1), Inches(2), Inches(1))
-    smartart.element.graphic.graphicData.uri = (
+    graphic_frame_element(
+        smartart
+    ).graphic.graphicData.uri = (
         "http://schemas.openxmlformats.org/drawingml/2006/diagram"
     )
     deck = tmp_path / "hidden-smartart.pptx"
@@ -2893,7 +2899,7 @@ def test_graphic_frame_without_uri_round_trips_as_unsupported(
         Inches(2),
         Inches(1),
     )
-    graphic_frame.element.graphic.graphicData.uri = ""
+    graphic_frame_element(graphic_frame).graphic.graphicData.uri = ""
     deck = tmp_path / "missing-graphic-uri.pptx"
     presentation.save(str(deck))
 
@@ -3463,7 +3469,9 @@ def test_duplicate_and_empty_unsupported_names_preserve_multiplicity(
     ]
     for shape, name in zip(shapes, ("Same", "Same", "")):
         shape.name = name
-        shape.element.graphic.graphicData.uri = (
+        graphic_frame_element(
+            shape
+        ).graphic.graphicData.uri = (
             "http://schemas.openxmlformats.org/drawingml/2006/diagram"
         )
     deck = tmp_path / "duplicate-empty-unsupported.pptx"

--- a/tests/test_pptx_evidence_recovery.py
+++ b/tests/test_pptx_evidence_recovery.py
@@ -18,7 +18,9 @@ from PIL import Image
 from pptx import Presentation
 from pptx.oxml import parse_xml
 from pptx.oxml.ns import nsdecls
-from pptx.util import Inches
+from pptx.util import Emu, Inches
+
+from conftest import deck_height, deck_width
 from pypdf import PdfWriter
 
 
@@ -30,7 +32,7 @@ def _write_deck(path: Path, *, with_image: bool) -> None:
         image_path = path.with_suffix(".png")
         Image.new("RGB", (64, 64), "navy").save(image_path)
         slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
-    deck.save(path)
+    deck.save(str(path))
 
 
 def _damage_member(path: Path, predicate) -> str:
@@ -1777,7 +1779,7 @@ def test_extraction_rejects_conflicting_equivalent_package_part_names(
     textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(2), Inches(1))
     textbox.text_frame.text = "REAL"
     deck = tmp_path / "duplicate-slide-part.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     with zipfile.ZipFile(deck, "a") as archive:
         original = archive.read("ppt/slides/slide1.xml")
@@ -1856,7 +1858,7 @@ def test_extraction_rejects_duplicate_relationship_ids_before_asset_cataloging(
     slide.shapes.add_picture(str(first_image), Inches(1), Inches(1))
     slide.shapes.add_picture(str(second_image), Inches(3), Inches(1))
     deck = tmp_path / "duplicate-relationship-id.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     relationships_name = "ppt/slides/_rels/slide1.xml.rels"
     with zipfile.ZipFile(deck) as archive:
@@ -2016,12 +2018,12 @@ def test_render_receipt_binds_exact_source_render_and_ranges(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=presentation.slide_width,
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(presentation),
+        height=deck_height(presentation),
     )
-    presentation.save(deck)
+    presentation.save(str(deck))
     rendered = tmp_path / "rendered.pdf"
     _write_pdf(rendered, page_count=1)
 
@@ -2071,12 +2073,12 @@ def test_full_extraction_render_binding_rejects_unrequested_or_broader_receipt(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=presentation.slide_width,
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(presentation),
+        height=deck_height(presentation),
     )
-    presentation.save(deck)
+    presentation.save(str(deck))
     rendered = tmp_path / "render-binding.pdf"
     _write_pdf(rendered, page_count=1)
     extraction = pptx_extraction._extract_pptx_in_process(
@@ -2527,7 +2529,7 @@ def test_catalog_bindings_reject_detached_worker_evidence(
     )
     _set_background_image(slide, background_image)
     deck = tmp_path / f"catalog-binding-{binding}.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -2627,13 +2629,13 @@ def test_near_threshold_picture_uses_reported_ratio_for_render_decision(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=int(presentation.slide_width * 4996 / 10_000),
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=Emu(int(deck_width(presentation) * 4996 / 10_000)),
+        height=deck_height(presentation),
     )
     deck = tmp_path / "threshold.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     slide_result = extraction["per_slide_visual"][0]
@@ -2668,13 +2670,13 @@ def test_extraction_payload_is_bound_to_requested_ocr_mode(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=presentation.slide_width,
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(presentation),
+        height=deck_height(presentation),
     )
     deck = tmp_path / "ocr-mode.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     disabled = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     with pytest.raises(pptx_evidence.PptxEvidenceError) as disabled_mismatch:
@@ -2740,7 +2742,7 @@ def test_footer_threshold_uses_reported_geometry_for_round_trip_validation(
     )
     textbox.text_frame.text = "boundary footer"
     deck = tmp_path / f"footer-{top_inches}.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     slide_result = extraction["per_slide_visual"][0]
@@ -2770,13 +2772,13 @@ def test_full_slide_picture_cannot_hide_its_geometry_and_render_requirement(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=presentation.slide_width,
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(presentation),
+        height=deck_height(presentation),
     )
     deck = tmp_path / "full-slide.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -2846,7 +2848,7 @@ def test_smartart_shape_cannot_omit_unsupported_evidence(
         "http://schemas.openxmlformats.org/drawingml/2006/diagram"
     )
     deck = tmp_path / "hidden-smartart.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -2893,7 +2895,7 @@ def test_graphic_frame_without_uri_round_trips_as_unsupported(
     )
     graphic_frame.element.graphic.graphicData.uri = ""
     deck = tmp_path / "missing-graphic-uri.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     slide_result = extraction["per_slide_visual"][0]
@@ -3016,7 +3018,7 @@ def test_native_shape_text_channel_cannot_be_omitted(
         Inches(1), Inches(1), Inches(2), Inches(1)
     ).text_frame.text = "bound text"
     deck = tmp_path / "omitted-shape-text.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -3048,7 +3050,7 @@ def test_textbox_capability_cannot_be_erased_with_its_channel(
         Inches(1), Inches(1), Inches(2), Inches(1)
     ).text_frame.text = "SECRET"
     deck = tmp_path / "erased-textbox.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -3131,7 +3133,7 @@ def test_inserted_picture_placeholder_round_trips_as_picture_evidence(
     )
     picture_placeholder.insert_picture(str(image_path))
     deck = tmp_path / "placeholder-picture.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     slide_result = extraction["per_slide_visual"][0]
@@ -3218,7 +3220,7 @@ def test_known_shape_capabilities_cannot_be_coherently_relabelled(
     textbox.text_frame.text = "bound text"
     slide.shapes.add_table(1, 1, Inches(1), Inches(3), Inches(2), Inches(1))
     deck = tmp_path / f"shape-relabel-{mutation}.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     shapes = extraction["per_slide_visual"][0]["shapes_summary"]
 
@@ -3268,7 +3270,7 @@ def test_shape_catalog_fields_follow_their_native_capabilities(
     textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(2), Inches(1))
     textbox.text_frame.text = "formatted"
     slide.shapes.add_picture(str(image_path), Inches(1), Inches(3))
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     shapes = extraction["per_slide_visual"][0]["shapes_summary"]
 
@@ -3304,7 +3306,7 @@ def test_table_capability_cannot_be_erased_with_channel_and_render_flags(
     )
     table_shape.table.cell(0, 0).text = "SECRET TABLE"
     deck = tmp_path / "erased-table.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -3362,7 +3364,7 @@ def test_media_shape_cannot_forge_a_native_text_frame(
         mime_type="video/mp4",
     )
     deck = tmp_path / "media-native-text.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -3419,7 +3421,7 @@ def test_duplicate_and_empty_shape_names_round_trip_with_canonical_paths(
     second.text_frame.text = "second"
     unnamed.text_frame.text = "third"
     deck = tmp_path / "duplicate-empty-names.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     paths = [
@@ -3465,7 +3467,7 @@ def test_duplicate_and_empty_unsupported_names_preserve_multiplicity(
             "http://schemas.openxmlformats.org/drawingml/2006/diagram"
         )
     deck = tmp_path / "duplicate-empty-unsupported.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
     unsupported_names = [
@@ -3498,12 +3500,12 @@ def test_picture_ocr_cannot_forge_or_duplicate_shape_paths(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=presentation.slide_width,
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(presentation),
+        height=deck_height(presentation),
     )
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -3543,12 +3545,12 @@ def test_picture_ocr_receipts_are_exactly_bound_to_readable_assets(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=presentation.slide_width,
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(presentation),
+        height=deck_height(presentation),
     )
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -3634,7 +3636,7 @@ def test_one_picture_part_cannot_claim_conflicting_asset_digests(
     slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
     slide.shapes.add_picture(str(image_path), Inches(3), Inches(1))
     deck = tmp_path / "conflicting-picture-digests.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(pptx_extraction._extract_pptx_in_process(deck, ocr=False))
     )
@@ -3673,7 +3675,7 @@ def test_empty_image_parts_round_trip_as_unavailable_assets(
     else:
         _set_background_image(slide, image_path)
     deck = tmp_path / f"empty-{asset_kind}.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     with zipfile.ZipFile(deck) as archive:
         members = [(member, archive.read(member)) for member in archive.infolist()]
@@ -3722,7 +3724,7 @@ def test_background_ocr_cannot_duplicate_its_single_bound_asset(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     _set_background_image(slide, image_path)
     deck = tmp_path / "background-duplicate.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
     extraction = json.loads(
         json.dumps(
             pptx_extraction._extract_pptx_in_process(
@@ -3775,12 +3777,12 @@ def test_unhashable_channel_and_ocr_enums_fail_as_malformed_results(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(
         str(image_path),
-        0,
-        0,
-        width=presentation.slide_width,
-        height=presentation.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(presentation),
+        height=deck_height(presentation),
     )
-    presentation.save(deck)
+    presentation.save(str(deck))
     baseline = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
 
     for field, invalid in (("status", []), ("confidence", [])):

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -21,7 +21,13 @@ from pptx.oxml import parse_xml
 from pptx.oxml.ns import nsdecls
 from pptx.util import Emu, Inches, Pt
 
-from conftest import deck_height, deck_width, make_deck
+from conftest import (
+    deck_height,
+    deck_width,
+    graphic_frame_element,
+    make_deck,
+    slide_title,
+)
 
 
 def _use_in_process_directory_discovery(pptx_extraction, monkeypatch):
@@ -224,7 +230,7 @@ def test_shape_text_extraction(pptx_extraction, tmp_path):
     prs = Presentation()
     layout = prs.slide_layouts[1]
     slide = prs.slides.add_slide(layout)
-    slide.shapes.title.text = "Hello World"
+    slide_title(slide).text = "Hello World"
     path = str(tmp_path / "deck.pptx")
     prs.save(path)
 
@@ -1925,7 +1931,7 @@ def test_text_slide_is_high_confidence(pptx_extraction, tmp_path):
     """No picture — extractable text is the whole story."""
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
-    slide.shapes.title.text = "A real title"
+    slide_title(slide).text = "A real title"
     data = _first_slide(pptx_extraction, prs, tmp_path)
     assert data["has_text_frame_shapes"] is True
     assert data["text_extraction_confidence"] == "high"
@@ -1938,7 +1944,7 @@ def test_small_decorative_image_stays_high_confidence(
     """A logo-sized picture cannot be hiding the slide's content."""
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
-    slide.shapes.title.text = "Title"
+    slide_title(slide).text = "Title"
     slide.shapes.add_picture(
         _png(tmp_path / "i.png"),
         Inches(0),
@@ -1959,7 +1965,7 @@ def test_text_overlay_over_full_bleed_is_still_low_confidence(
     """Extracting *some* text is not evidence of extracting *all* of it."""
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
-    slide.shapes.title.text = "Overlay"
+    slide_title(slide).text = "Overlay"
     slide.shapes.add_picture(
         _png(tmp_path / "i.png"),
         Inches(0),
@@ -2095,7 +2101,7 @@ def test_ocr_confidence_is_paired_only_with_retained_token(pptx_extraction):
 def test_high_confidence_slide_method_is_shapes_only(pptx_extraction, tmp_path):
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
-    slide.shapes.title.text = "A real title"
+    slide_title(slide).text = "A real title"
     data = _first_slide(pptx_extraction, prs, tmp_path)
     assert data["text_extraction_confidence"] == "high"
     assert data["text_extraction_method"] == "shapes"
@@ -2379,7 +2385,7 @@ def test_small_decorative_image_does_not_ocr(pptx_extraction, tmp_path):
     """High-confidence slides must not pay for OCR."""
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
-    slide.shapes.title.text = "Title"
+    slide_title(slide).text = "Title"
     slide.shapes.add_picture(
         _png_with_text(tmp_path / "logo.png", text="LOGO"),
         Inches(0),
@@ -2700,7 +2706,9 @@ def test_smartart_and_unknown_graphic_frames_are_explicitly_unsupported(
         Inches(3),
         Inches(1),
     )
-    smartart.element.graphic.graphicData.uri = (
+    graphic_frame_element(
+        smartart
+    ).graphic.graphicData.uri = (
         "http://schemas.openxmlformats.org/drawingml/2006/diagram"
     )
     other = slide.shapes.add_table(
@@ -2711,7 +2719,9 @@ def test_smartart_and_unknown_graphic_frames_are_explicitly_unsupported(
         Inches(3),
         Inches(1),
     )
-    other.element.graphic.graphicData.uri = "urn:example:unsupported-graphic"
+    graphic_frame_element(
+        other
+    ).graphic.graphicData.uri = "urn:example:unsupported-graphic"
 
     data = _first_slide(pptx_extraction, prs, tmp_path)
 

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -19,9 +19,9 @@ from pypdf import PdfWriter
 from pptx import Presentation
 from pptx.oxml import parse_xml
 from pptx.oxml.ns import nsdecls
-from pptx.util import Inches, Pt
+from pptx.util import Emu, Inches, Pt
 
-from conftest import make_deck
+from conftest import deck_height, deck_width, make_deck
 
 
 def _use_in_process_directory_discovery(pptx_extraction, monkeypatch):
@@ -1874,10 +1874,10 @@ def test_picture_area_ratio_full_bleed(pptx_extraction, tmp_path):
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png(tmp_path / "i.png"),
-        0,
-        0,
-        width=prs.slide_width,
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(prs),
+        height=deck_height(prs),
     )
     data = _first_slide(pptx_extraction, prs, tmp_path)
     assert data["image_area_ratio"] > 0.99
@@ -1906,10 +1906,10 @@ def test_full_bleed_image_slide_does_not_assert_absence(
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png(tmp_path / "i.png"),
-        0,
-        0,
-        width=prs.slide_width,
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(prs),
+        height=deck_height(prs),
     )
     data = _first_slide(pptx_extraction, prs, tmp_path)
 
@@ -1941,10 +1941,10 @@ def test_small_decorative_image_stays_high_confidence(
     slide.shapes.title.text = "Title"
     slide.shapes.add_picture(
         _png(tmp_path / "i.png"),
-        0,
-        0,
-        width=int(prs.slide_width * 0.1),
-        height=int(prs.slide_height * 0.1),
+        Inches(0),
+        Inches(0),
+        width=Emu(int(deck_width(prs) * 0.1)),
+        height=Emu(int(deck_height(prs) * 0.1)),
     )
     data = _first_slide(pptx_extraction, prs, tmp_path)
     assert data["has_image"] is True
@@ -1962,10 +1962,10 @@ def test_text_overlay_over_full_bleed_is_still_low_confidence(
     slide.shapes.title.text = "Overlay"
     slide.shapes.add_picture(
         _png(tmp_path / "i.png"),
-        0,
-        0,
-        width=prs.slide_width,
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(prs),
+        height=deck_height(prs),
     )
     data = _first_slide(pptx_extraction, prs, tmp_path)
     assert data["has_text_frame_shapes"] is True
@@ -2111,10 +2111,10 @@ def test_full_bleed_runs_ocr_fn_and_records_inventory(
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png_with_text(tmp_path / "labeled.png"),
-        0,
-        0,
-        width=prs.slide_width,
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(prs),
+        height=deck_height(prs),
     )
     path = str(tmp_path / "deck.pptx")
     prs.save(path)
@@ -2138,17 +2138,17 @@ def test_multi_image_ocr_emits_one_identity_and_outcome_receipt_per_asset(
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png_with_text(tmp_path / "left.png", text="LEFT LABEL"),
-        0,
-        0,
-        width=int(prs.slide_width / 2),
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=Emu(int(deck_width(prs) / 2)),
+        height=deck_height(prs),
     )
     slide.shapes.add_picture(
         _png_with_text(tmp_path / "right.png", text="RIGHT LABEL"),
-        int(prs.slide_width / 2),
-        0,
-        width=int(prs.slide_width / 2),
-        height=prs.slide_height,
+        Emu(int(deck_width(prs) / 2)),
+        Inches(0),
+        width=Emu(int(deck_width(prs) / 2)),
+        height=deck_height(prs),
     )
     path = tmp_path / "multi-image.pptx"
     prs.save(path)
@@ -2213,10 +2213,10 @@ def test_genuine_empty_ocr_is_distinct_from_asset_failure(
     for index in range(2):
         slide.shapes.add_picture(
             _png(tmp_path / f"asset-{index}.png", w=16 + index),
-            int(prs.slide_width * index / 2),
-            0,
-            width=int(prs.slide_width / 2),
-            height=prs.slide_height,
+            Emu(int(deck_width(prs) * index / 2)),
+            Inches(0),
+            width=Emu(int(deck_width(prs) / 2)),
+            height=deck_height(prs),
         )
     path = tmp_path / "empty-vs-failure.pptx"
     prs.save(path)
@@ -2270,17 +2270,17 @@ def test_truncated_picture_is_one_failed_receipt_not_a_deck_abort(
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png(tmp_path / "healthy.png", w=64),
-        0,
-        0,
-        width=int(prs.slide_width / 2),
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=Emu(int(deck_width(prs) / 2)),
+        height=deck_height(prs),
     )
     slide.shapes.add_picture(
         _png(tmp_path / "truncated.png", w=65),
-        int(prs.slide_width / 2),
-        0,
-        width=int(prs.slide_width / 2),
-        height=prs.slide_height,
+        Emu(int(deck_width(prs) / 2)),
+        Inches(0),
+        width=Emu(int(deck_width(prs) / 2)),
+        height=deck_height(prs),
     )
     path = tmp_path / "mixed-assets.pptx"
     prs.save(path)
@@ -2342,10 +2342,10 @@ def test_no_ocr_flag_skips_inventory(pptx_extraction, tmp_path):
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png_with_text(tmp_path / "labeled.png"),
-        0,
-        0,
-        width=prs.slide_width,
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(prs),
+        height=deck_height(prs),
     )
     path = str(tmp_path / "deck.pptx")
     prs.save(path)
@@ -2382,10 +2382,10 @@ def test_small_decorative_image_does_not_ocr(pptx_extraction, tmp_path):
     slide.shapes.title.text = "Title"
     slide.shapes.add_picture(
         _png_with_text(tmp_path / "logo.png", text="LOGO"),
-        0,
-        0,
-        width=int(prs.slide_width * 0.1),
-        height=int(prs.slide_height * 0.1),
+        Inches(0),
+        Inches(0),
+        width=Emu(int(deck_width(prs) * 0.1)),
+        height=Emu(int(deck_height(prs) * 0.1)),
     )
     path = str(tmp_path / "deck.pptx")
     prs.save(path)
@@ -2407,10 +2407,10 @@ def test_ocr_unavailable_records_method_not_crash(pptx_extraction, tmp_path):
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png(tmp_path / "i.png"),
-        0,
-        0,
-        width=prs.slide_width,
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(prs),
+        height=deck_height(prs),
     )
     path = str(tmp_path / "deck.pptx")
     prs.save(path)
@@ -2584,10 +2584,10 @@ def test_full_bleed_with_baked_text_end_to_end(pptx_extraction, tmp_path):
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     slide.shapes.add_picture(
         _png_with_text(tmp_path / "labeled.png", text="VENUE PREPARATION"),
-        0,
-        0,
-        width=prs.slide_width,
-        height=prs.slide_height,
+        Inches(0),
+        Inches(0),
+        width=deck_width(prs),
+        height=deck_height(prs),
     )
     path = str(tmp_path / "deck.pptx")
     prs.save(path)

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -22,10 +22,14 @@ from pptx.oxml.ns import nsdecls
 from pptx.util import Emu, Inches, Pt
 
 from conftest import (
+    background_fill_element,
+    background_properties,
+    clear_background_fill,
     deck_height,
     deck_width,
     graphic_frame_element,
     make_deck,
+    slide_element,
     slide_title,
 )
 
@@ -2741,10 +2745,8 @@ def test_smartart_and_unknown_graphic_frames_are_explicitly_unsupported(
 def _set_background_image(slide, image_path):
     """Author an image background directly in DrawingML for fixture coverage."""
     _, r_id = slide.part.get_or_add_image_part(str(image_path))
-    bg_pr = slide.element.cSld.get_or_add_bgPr()
-    existing_fill = bg_pr.eg_fillProperties
-    if existing_fill is not None:
-        bg_pr.remove(existing_fill)
+    bg_pr = background_properties(slide)
+    clear_background_fill(bg_pr)
     blip_fill = parse_xml(
         f"<a:blipFill {nsdecls('a', 'r')}>"
         f'<a:blip r:embed="{r_id}"/>'
@@ -2795,13 +2797,13 @@ def test_background_image_blob_is_ocrd_with_distinct_provenance(
 def test_background_inspection_does_not_break_inheritance(pptx_extraction):
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[6])
-    assert slide.element.cSld.bg is None
+    assert slide_element(slide).cSld.bg is None
 
     assert pptx_extraction.get_background_color(slide) == (None, "unknown")
 
     # Access through python-pptx's public fill property would author a noFill
     # node here and sever inheritance. Extraction must stay read-only.
-    assert slide.element.cSld.bg is None
+    assert slide_element(slide).cSld.bg is None
 
 
 def test_missing_background_blob_requires_render_without_claiming_ocr(
@@ -2813,13 +2815,7 @@ def test_missing_background_blob_requires_render_without_claiming_ocr(
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[6])
     _set_background_image(slide, image_path)
-    blip = next(
-        iter(
-            slide.element.cSld.bg.bgPr.eg_fillProperties.iter(
-                pptx_extraction.qn("a:blip")
-            )
-        )
-    )
+    blip = next(iter(background_fill_element(slide).iter(pptx_extraction.qn("a:blip"))))
     blip.set(pptx_extraction.qn("r:embed"), "rIdMissing")
 
     data = _first_slide(pptx_extraction, prs, tmp_path)

--- a/tests/test_pptx_extraction_boundaries.py
+++ b/tests/test_pptx_extraction_boundaries.py
@@ -12,6 +12,8 @@ from pptx.oxml import parse_xml
 from pptx.oxml.ns import nsdecls
 from pptx.util import Inches
 
+from conftest import graphic_frame_element
+
 
 def _round_trip(pptx_extraction, pptx_evidence, deck: Path):
     extraction = pptx_extraction._extract_pptx_in_process(deck, ocr=False)
@@ -105,7 +107,7 @@ def test_graphic_uri_is_canonicalized_across_all_provenance(
     presentation = Presentation()
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     shape = slide.shapes.add_table(1, 1, Inches(1), Inches(1), Inches(2), Inches(1))
-    shape.element.graphic.graphicData.uri = "u" * 4097
+    graphic_frame_element(shape).graphic.graphicData.uri = "u" * 4097
     deck = tmp_path / "long-graphic-uri.pptx"
     presentation.save(str(deck))
 

--- a/tests/test_pptx_extraction_boundaries.py
+++ b/tests/test_pptx_extraction_boundaries.py
@@ -63,7 +63,7 @@ def test_layout_name_is_canonicalized_before_validation(
     presentation.slide_layouts[6].name = "L" * 4097
     presentation.slides.add_slide(presentation.slide_layouts[6])
     deck = tmp_path / "long-layout-name.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = _round_trip(pptx_extraction, pptx_evidence, deck)
     slide = extraction["per_slide_visual"][0]
@@ -87,7 +87,7 @@ def test_font_name_is_canonicalized_before_global_cataloging(
     run.text = "x"
     run.font.name = "F" * 4097
     deck = tmp_path / "long-font-name.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = _round_trip(pptx_extraction, pptx_evidence, deck)
     font_name = extraction["per_slide_visual"][0]["shapes_summary"][0]["font_name"]
@@ -107,7 +107,7 @@ def test_graphic_uri_is_canonicalized_across_all_provenance(
     shape = slide.shapes.add_table(1, 1, Inches(1), Inches(1), Inches(2), Inches(1))
     shape.element.graphic.graphicData.uri = "u" * 4097
     deck = tmp_path / "long-graphic-uri.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     extraction = _round_trip(pptx_extraction, pptx_evidence, deck)
     slide_result = extraction["per_slide_visual"][0]
@@ -131,7 +131,7 @@ def test_background_relationship_id_is_canonicalized_before_validation(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     relationship_id = _set_background_image(slide, image_path)
     deck = tmp_path / "long-background-relationship.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     with zipfile.ZipFile(deck) as archive:
         slide_xml = archive.read("ppt/slides/slide1.xml")
@@ -176,7 +176,7 @@ def test_group_depth_over_contract_fails_with_stable_resource_reason(
     for _index in range(64):
         group = group.shapes.add_group_shape()
     deck = tmp_path / "group-depth-65.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
         pptx_extraction._extract_pptx_in_process(deck, ocr=False)
@@ -195,7 +195,7 @@ def test_archive_part_name_over_contract_fails_with_stable_resource_reason(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
     deck = tmp_path / "long-picture-part.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     old_part_name = "ppt/media/image1.png"
     part_prefix = "ppt/media/"
@@ -236,7 +236,7 @@ def test_valid_encoded_space_in_part_name_round_trips(
     slide = presentation.slides.add_slide(presentation.slide_layouts[6])
     slide.shapes.add_picture(str(image_path), Inches(1), Inches(1))
     deck = tmp_path / "encoded-space-part.pptx"
-    presentation.save(deck)
+    presentation.save(str(deck))
 
     old_part_name = "ppt/media/image1.png"
     new_part_name = "ppt/media/image%201.png"

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3683,9 +3683,11 @@ def test_every_emitted_decoder_reason_is_mapped(preflight_vault):
     """A reason with no mapping silently degrades to the generic code."""
     import re
 
-    io_source = pathlib.Path(
-        importlib.import_module("tracking_database_io").__file__
-    ).read_text(encoding="utf-8")
+    # `__file__` is Optional because a namespace or builtin module has none;
+    # this one is imported from a real path.
+    io_module_file = importlib.import_module("tracking_database_io").__file__
+    assert io_module_file is not None
+    io_source = pathlib.Path(io_module_file).read_text(encoding="utf-8")
     emitted = set(re.findall(r'reason_code="([a-z_]+)"', io_source))
     mapped = set(preflight_vault._DATABASE_READ_DIAGNOSTICS)
     assert emitted <= mapped, sorted(emitted - mapped)

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -7,6 +7,7 @@ network or reads subagent returns.
 import copy
 import hashlib
 import json
+from typing import Any
 import os
 import shutil
 import struct
@@ -1259,7 +1260,7 @@ def test_normalize_rejects_malformed_generation_without_any_write(
 ):
     fingerprint = return_validation.load_catalog().fingerprint
     scoring_schema = return_validation.PATTERN_SCORING_SCHEMA_VERSION
-    malformed = _scored_talk(
+    malformed: dict[str, Any] = _scored_talk(
         "HHHHHHHHHHH",
         filename="malformed-generation.md",
         fingerprint=fingerprint,
@@ -1493,9 +1494,11 @@ def test_new_claim_is_v5_with_one_immutable_batch_baseline(tmp_path):
     assert {claim["schema_version"] for claim in claims} == {5}
     assert {claim["required_return_schema_version"] for claim in claims} == {5}
     assert claims[0]["adherence_baseline"] == claims[1]["adherence_baseline"]
-    baseline = claims[0]["adherence_baseline"]
+    baseline: dict[str, Any] = claims[0]["adherence_baseline"]
     assert baseline["as_of"] == NOW
-    assert baseline["excluded_filenames"] == sorted(talk["filename"] for talk in talks)
+    assert baseline["excluded_filenames"] == sorted(
+        str(talk["filename"]) for talk in talks
+    )
 
 
 def test_inspect_dual_reads_a_schema_v3_adherence_claim(tmp_path):

--- a/tests/test_schema5_pattern_outcomes.py
+++ b/tests/test_schema5_pattern_outcomes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import copy
 from pathlib import Path
 
@@ -196,7 +198,7 @@ def _persisted_v5(return_validation, transcript_timing, tmp_path):
     )
     return_validation.validate_return(raw, catalog)
     vault, owner = _artifact(tmp_path, transcript_timing)
-    canonical = pattern_evidence.canonicalize_return_evidence(
+    canonical: dict[str, Any] = pattern_evidence.canonicalize_return_evidence(
         raw,
         owner,
         vault,
@@ -262,14 +264,14 @@ def test_v5_persists_one_exhaustive_outcome_and_opportunity_identity(
     return_validation.validate_return(raw, catalog)
     vault, talk = _artifact(tmp_path, transcript_timing)
 
-    canonical = pattern_evidence.canonicalize_return_evidence(
+    canonical: dict[str, Any] = pattern_evidence.canonicalize_return_evidence(
         raw,
         talk,
         vault,
         catalog,
         pattern_scoring_schema_version=5,
     )
-    observations = canonical["pattern_observations"]
+    observations: dict[str, Any] = canonical["pattern_observations"]
     transcript_inspection = observations["source_inspection"][0]
     assert transcript_inspection["coverage_complete"] is True
     assert transcript_inspection["absence_capability_complete"] is True
@@ -563,7 +565,7 @@ def test_incomplete_applicability_gate_forbids_assessment_and_is_not_evaluable(
     )
     return_validation.validate_return(raw, catalog)
     vault, talk = _artifact(tmp_path, transcript_timing)
-    canonical = pattern_evidence.canonicalize_return_evidence(
+    canonical: dict[str, Any] = pattern_evidence.canonicalize_return_evidence(
         raw, talk, vault, catalog, pattern_scoring_schema_version=5
     )
 
@@ -657,7 +659,7 @@ def test_bare_native_deck_is_fail_closed_for_applicability_and_fresh_with_root(
     )
     roots = {"pptx_source_dir": str(source_root)}
     return_validation.validate_return(raw, catalog)
-    canonical = pattern_evidence.canonicalize_return_evidence(
+    canonical: dict[str, Any] = pattern_evidence.canonicalize_return_evidence(
         raw,
         owner,
         vault,

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -8,6 +8,7 @@ optional/additive and not part of REQUIRED_KEYS.
 import hashlib
 import importlib
 import json
+from typing import Any
 import os
 import pathlib
 from datetime import datetime, timezone
@@ -104,7 +105,7 @@ def _set_projection(talk, source: str | None) -> None:
 # Built programmatically per testing-standards (no fixture file). A current
 # profile carries explicit zero-cohort pattern provenance rather than borrowing
 # historical pattern values.
-def _minimal_profile(validate_profile):
+def _minimal_profile(validate_profile) -> dict[str, Any]:
     catalog_fingerprint, scoring_schema = (
         validate_profile.active_pattern_generation_identity()
     )
@@ -117,7 +118,7 @@ def _minimal_profile(validate_profile):
             pathlib.Path(__file__).resolve().parent / "__no_policy_override__"
         ),
     )
-    profile = {
+    profile: dict[str, Any] = {
         k: []
         for k in (
             "generated_date",

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -635,6 +635,22 @@ def _run_load_vault(load_vault, vault_root, monkeypatch, capsys):
     return rc, payload, captured.err
 
 
+def _load_vault_payload(load_vault, vault_root, monkeypatch, capsys):
+    """Run load-vault and return the payload it must have produced.
+
+    `_run_load_vault` returns None when the command wrote nothing — a real
+    outcome three tests assert. A test that goes on to read the payload has
+    already required output, so asserting it once here turns a confusing
+    `'NoneType' is not subscriptable` into a named failure and proves the
+    value present at one place rather than at every subscript.
+    """
+    rc, payload, error = _run_load_vault(load_vault, vault_root, monkeypatch, capsys)
+    assert payload is not None, (
+        f"load-vault wrote no stdout (rc={rc}, stderr={error!r})"
+    )
+    return rc, payload, error
+
+
 def test_load_vault_separates_pattern_generation_from_instrumentation(
     load_vault,
     tmp_path,
@@ -686,7 +702,7 @@ def test_load_vault_separates_pattern_generation_from_instrumentation(
             pending_duplicate,
         ],
     )
-    rc, payload, error = _run_load_vault(load_vault, tmp_path, monkeypatch, capsys)
+    rc, payload, error = _load_vault_payload(load_vault, tmp_path, monkeypatch, capsys)
 
     assert rc == 0
     assert error == ""
@@ -796,7 +812,7 @@ def test_load_vault_projects_confirmed_intents_without_storage_metadata(
     raw = (json.dumps(database, indent=2) + "\n").encode()
     database_path.write_bytes(raw)
 
-    rc, payload, error = _run_load_vault(load_vault, tmp_path, monkeypatch, capsys)
+    rc, payload, error = _load_vault_payload(load_vault, tmp_path, monkeypatch, capsys)
 
     assert rc == 0
     assert error == ""
@@ -872,7 +888,7 @@ def test_load_vault_does_not_fallback_when_current_pattern_cohort_is_empty(
     )
     _write_vault(tmp_path, [legacy])
 
-    rc, payload, error = _run_load_vault(load_vault, tmp_path, monkeypatch, capsys)
+    rc, payload, error = _load_vault_payload(load_vault, tmp_path, monkeypatch, capsys)
 
     assert rc == 0
     assert error == ""
@@ -906,7 +922,7 @@ def test_load_vault_excludes_current_generation_with_stale_evidence(
     else:
         artifact.write_text("Replacement with a different digest.\n", encoding="utf-8")
 
-    rc, payload, error = _run_load_vault(load_vault, tmp_path, monkeypatch, capsys)
+    rc, payload, error = _load_vault_payload(load_vault, tmp_path, monkeypatch, capsys)
 
     assert rc == 0
     assert error == ""
@@ -976,7 +992,7 @@ def test_load_vault_passes_configured_source_roots_to_freshness_assessor(
         config={"pptx_source_dir": str(source_root)},
     )
 
-    rc, payload, error = _run_load_vault(load_vault, tmp_path, monkeypatch, capsys)
+    rc, payload, error = _load_vault_payload(load_vault, tmp_path, monkeypatch, capsys)
 
     assert rc == 0
     assert error == ""
@@ -1169,7 +1185,7 @@ def test_load_vault_accepts_one_matching_lexical_symlink_authority(
     _directory_symlink(locator, storage)
     _write_vault(storage, [], config={"vault_storage_path": str(locator)})
 
-    rc, payload, error = _run_load_vault(
+    rc, payload, error = _load_vault_payload(
         load_vault,
         locator,
         monkeypatch,


### PR DESCRIPTION
Refs #162 — fifth of the adoption sequence. **Pyright: 0 errors across all 153 files.**

No CI change here. Per `language-diagnostics` Adopting on a Dirty Tree the gate is its own PR, landing once this tree is green on main.

## How the 242 test findings were cleared

By proving invariants once, not by suppressing them at each use — the rule prefers "a typed helper that proves the invariant once over scattered ignores".

Seven `conftest.py` helpers now hold what was re-derived or ignored at ~90 call sites:

| Helper | The invariant python-pptx cannot express |
|---|---|
| `deck_width` / `deck_height` | slide extents are Optional (a malformed package can omit `sldSz`); an in-process deck always has them |
| `slide_title` | `shapes.title` is Optional; a fixture that sets a title picked a layout that has one |
| `slide_element` | `Slide.element` is typed as the generic base, which carries no `cSld` |
| `graphic_frame_element` | `BaseShape.element` is the union of every CT_* shape element; only the graphic-frame member has `.graphic` |
| `background_fill_element` / `background_properties` / `clear_background_fill` | the `<p:bg>` → `<p:bgPr>` → fill chain, Optional at every hop |

`_load_vault_payload` in `test_validate_profile.py` is the same move one layer up. `_run_load_vault` legitimately returns `None` when the command wrote nothing — three tests assert exactly that — so the six tests that go on to read the payload assert its presence once instead of subscripting an Optional 24 times. The assertion message names the rc and stderr, so a future failure reads as "load-vault wrote no stdout" rather than `'NoneType' is not subscriptable`.

## Mechanical shapes, handled in bulk

- **34** `Path` arguments where python-pptx declares `str | IO[bytes]`
- **41** zero-valued `Length` positions (`add_picture(img, 0, 0, ...)` → `Inches(0)`)
- JSON-document fixtures annotated `dict[str, Any]` — `object` values forced every nested subscript to be re-narrowed, and `Any` is what `json.loads` hands back anyway
- PIL: `Image.load()` and `getpixel()` return unions; asserted at the fixture
- `urllib.error.HTTPError`'s `hdrs` parameter wants an `email.message.Message`, not `{}`

## Two suppressions survive

Both in one `conftest.py` helper, both naming their cause:

```python
fill: BaseOxmlElement | None = (
    properties.eg_fillProperties  # pyright: ignore[reportAssignmentType]
)
```

python-pptx annotates `CT_Background.bgPr` as `| None` (with its own upstream ignore) but leaves `CT_BackgroundProperties.eg_fillProperties` unannotated, so a reader sees the `ZeroOrOneChoice` descriptor rather than the element it returns. No file-wide `# pyright: basic` anywhere.

## Verification

Built a clean venv the way CI builds one (`pip install '.[test,lint]'`, nothing else) and ran all three: `ruff check` clean · `ruff format --check` 359 files already formatted · `pyright` 0 errors · full suite 5029 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)