### PR TITLE
ci: enforce the Ruff, format, and Pyright gates (#162)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # `coding-policy: code-formatting` CI Integration — format/lint checks run
+  # BEFORE tests, in their own fast job. `test` carries a multi-minute apt
+  # install for ffmpeg/libreoffice/tesseract; gating on `lint` means a style or
+  # type regression reports in about a minute and never pays for that install.
+  lint:
+    name: Lint, format, and type gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # Pyright resolves third-party imports against the ACTIVE interpreter, so
+      # the runtime dependencies must be present even though nothing here runs
+      # them. Without them it reports ~94 resolution false-positives and stops
+      # deep-checking the code underneath (`[tool.pyright]` in pyproject.toml).
+      - run: pip install ".[test,lint]"
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+      - name: Pyright
+        run: pyright
+
   test:
+    needs: lint
     runs-on: ubuntu-latest
     # Backstop against the apt step hanging on flaky runner networking: fail
     # fast and re-runnable instead of consuming the 6h default job limit.
@@ -86,6 +112,7 @@ jobs:
   # Exercise native artifact supervision, path handling, private video
   # workspaces, and atomic PDF publication; Ubuntu already runs the full suite.
   supervisor-platform:
+    needs: lint
     name: Artifact platform contracts (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+### chore(ci) — enforce the Ruff, format, and Pyright gates (#162)
+
+Closes #162, and it is the last step of the adoption sequence by design:
+`language-diagnostics` Adopting on a Dirty Tree wires the gate only once the
+tree reports zero, in its own change. Four PRs cleared the baseline first
+(#257 Ruff lint, #258 `ruff format`, #259 Pyright resolution, #260 and #261 the
+findings); this one turns them into a gate.
+
+`.github/workflows/tests.yml` gains a `lint` job running `ruff check`,
+`ruff format --check`, and `pyright`. `test` and `supervisor-platform` declare
+`needs: lint`, so the checks run BEFORE tests as `code-formatting` CI
+Integration requires — a style or type regression reports in about a minute
+and never pays for `test`'s multi-minute apt install of
+ffmpeg/libreoffice/tesseract.
+
+The job installs `.[test,lint]` even though it executes nothing: Pyright
+resolves third-party imports against the active interpreter, and without the
+runtime dependencies it reports ~94 resolution false-positives and stops
+deep-checking the code underneath.
+
+Branch protection is untouched. Promoting `lint` to a required check is a
+repo-settings decision, not a file in this change.
+
 ### fix — clear the Pyright test baseline (#162)
 
 Fifth of the #162 adoption sequence. Pyright reports **0 errors across all 153


### PR DESCRIPTION
Closes #162. Last step of the adoption sequence.

> **This PR's stated scope IS the CI change**, per `ci-safety` Hands Off CI Config. `.github/workflows/tests.yml` and `CHANGELOG.md` are the only files touched.

## What lands

```yaml
lint:
  name: Lint, format, and type gates
  steps:
    - run: pip install ".[test,lint]"
    - run: ruff check .
    - run: ruff format --check .
    - run: pyright

test:
  needs: lint
supervisor-platform:
  needs: lint
```

## Why `needs:` and not just "a job that also runs"

`code-formatting` CI Integration says format/lint checks run **before** tests, and my first draft of this said "before/alongside" — which the reviewer correctly read as not-before. `test` carries a multi-minute apt install for ffmpeg/libreoffice/tesseract; gating it on `lint` means a one-character style regression reports in about a minute and never pays for that install.

## Why it installs dependencies it never runs

Pyright resolves third-party imports against the **active interpreter**. Against a bare Python it reports ~94 resolution false-positives (`pptx`, `PIL`, `numpy`, …) and stops deep-checking the code underneath — the exact trap documented in `[tool.pyright]` and hit once during #259.

## Why this is its own PR

`language-diagnostics` Adopting on a Dirty Tree: config, then fix PRs grouped by finding shape, then the CI gate. Turning the gate on before the tree is green produces an immediately-red default branch — which is what #162 opened by warning about.

| PR | What it cleared |
|---|---|
| #257 | Ruff lint config + 11 findings + two policy-shaped defects |
| #258 | `ruff format` — 94 files, each verified AST-identical |
| #259 | Pyright module resolution — 116 unresolved imports → 0 |
| #260 | Pyright findings in shipped scripts — 16 → 0 |
| #261 | Pyright findings in tests — 242 → 0 |

Verified on the merged `main` in a clean venv built the way this job builds one: `ruff check` clean · `ruff format --check` 359 files already formatted · `pyright` 0 errors, 0 warnings.

Branch protection is untouched — promoting `lint` to a required check is a repo-settings decision, not a file in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)