### PR TITLE
test(vault-ingress): pin the return-self-validation boundary (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+### test(vault-ingress) — pin the return-self-validation boundary (#159)
+
+Closes #159. The enforcement it asked for is already in the tree: it landed
+with the video and PDF supervision work that reworked `build_evidence_context`.
+`context["metadata"]` is copied from the persisted talk record alone, and slide
+bounds come from probing real artifacts, so `structured_data.slide_count` and a
+return's `slide_source` reach neither. What was missing is the issue's last
+acceptance criterion — the regression tests, without which nothing stops a
+future refactor from quietly reconnecting the return to its own validation.
+
+Four outcome-level tests in `tests/test_pattern_evidence.py` lock both
+directions:
+
+- a return-supplied `slide_count` stays out of the evidence metadata, so a
+  `talk_metadata` citation on it fails as an absent pre-return field;
+- a return-supplied `slide_source: pdf` produces no slide count, so `slides` and
+  `slide_sequence` citations fail for want of a readable local artifact;
+- a persisted `slide_count` still validates and stamps from owner state, not
+  from the return's competing value;
+- a real PDF on disk still bounds citations at its actual page count, and an
+  inflated returned count buys nothing past it.
+
+The remaining criterion — partial timing and video citations rendering without
+internal `None` — was already covered by
+`test_partial_citation_bounds_render_without_internal_none` across all seven
+single-sided cases.
+
+One path still reads the return: `delivery_language` falls back to
+`structured_data.delivery_language` when the persisted record has none. That is
+not a self-validation hole, because the value can only add the English-
+translation requirement to transcript citations, never remove one.
+
 ## 0.20.39 — 2026-08-10
 
 ### chore(ci) — hold skill entrypoints inside Tessl's token budget (#163)

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -3593,3 +3593,169 @@ def test_unknown_root_kind_falls_back_without_claiming_the_vault(
         )
 
     assert "resolves outside the trusted root" in str(excinfo.value)
+
+
+# --- #159: a return must not validate its own citations ----------------------
+#
+# The enforcement lives in build_evidence_context: `metadata` is copied from the
+# persisted talk record alone, and slide bounds come from probing real artifacts
+# rather than from any count the return supplies. Neither property is obvious
+# from reading the call sites, and nothing pinned them, so these lock the
+# boundary at the outcome level.
+
+
+def _slide_detection(channel: str, **citation: Any) -> dict[str, Any]:
+    return {
+        "pattern_id": "synthetic-pattern",
+        "confidence": "moderate",
+        "evidence_source": "static_slides",
+        "evidence": "The exact source contains the synthetic opening.",
+        "evidence_citations": [
+            {"source": "static_slides", "channel": channel, **citation}
+        ],
+    }
+
+
+def test_return_supplied_slide_count_stays_out_of_evidence_metadata(
+    tmp_path: Path,
+) -> None:
+    """A count the return invented is not owner state, so it cannot be cited."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {"filename": "talk.md", "title": "Synthetic Talk"},
+        {"slide_source": "pdf", "structured_data": {"slide_count": 42}},
+    )
+
+    assert "slide_count" not in context["metadata"]
+    assert "slide_source" not in context["metadata"]
+
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match="talk_metadata cites absent pre-return field 'slide_count'",
+    ):
+        pattern_evidence.canonicalize_detection_citations(
+            _slide_detection("talk_metadata", field="slide_count"),
+            evidence_channels=frozenset({"talk_metadata"}),
+            evidence_metadata_fields=frozenset({"slide_count"}),
+            context=context,
+        )
+
+
+@pytest.mark.parametrize("channel", ["slides", "slide_sequence"])
+def test_return_supplied_slide_source_cannot_validate_slide_evidence(
+    tmp_path: Path, channel: str
+) -> None:
+    """`slide_source: pdf` in a return is a claim, not a readable artifact."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {"filename": "talk.md", "title": "Synthetic Talk"},
+        {"slide_source": "pdf", "structured_data": {"slide_count": 42}},
+    )
+
+    assert context["slide_counts"] == {}
+    assert "static_slides" not in context["verified_evidence_sources"]
+
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match="slide evidence cannot be verified from a predeclared local artifact",
+    ):
+        pattern_evidence.canonicalize_detection_citations(
+            _slide_detection(channel, slide_numbers=[1, 2]),
+            evidence_channels=frozenset({channel}),
+            evidence_metadata_fields=frozenset(),
+            context=context,
+        )
+
+
+def test_persisted_slide_count_still_validates_talk_metadata(tmp_path: Path) -> None:
+    """The other half of the boundary: owner state must keep working.
+
+    `talk_metadata` supplements a located citation rather than locating one, so
+    the detection carries a real slides citation alongside it.
+    """
+    vault = tmp_path / "vault"
+    rendered = vault / "slides" / "rendered.pdf"
+    _write_pdf(rendered, page_count=2)
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {
+            "filename": "talk.md",
+            "slides_local_path": rendered.relative_to(vault).as_posix(),
+            "slide_source": "pdf",
+            "slide_count": 7,
+        },
+        {"structured_data": {"slide_count": 42}},
+    )
+
+    assert context["metadata"]["slide_count"] == 7
+
+    detection = {
+        "pattern_id": "synthetic-pattern",
+        "confidence": "moderate",
+        "evidence_source": "static_slides",
+        "evidence": "The exact source contains the synthetic opening.",
+        "evidence_citations": [
+            {"source": "static_slides", "channel": "slides", "slide_numbers": [1]},
+            {
+                "source": "static_slides",
+                "channel": "talk_metadata",
+                "field": "slide_count",
+            },
+        ],
+    }
+    canonical = pattern_evidence.canonicalize_detection_citations(
+        detection,
+        evidence_channels=frozenset({"slides", "talk_metadata"}),
+        evidence_metadata_fields=frozenset({"slide_count"}),
+        context=context,
+    )
+    # Stamped from the persisted record, not from the return's 42.
+    assert canonical["evidence_citations"][1]["value"] == 7
+
+
+def test_verified_local_artifact_still_validates_slide_evidence(
+    tmp_path: Path,
+) -> None:
+    """A real PDF on disk bounds citations; the return's count is ignored."""
+    vault = tmp_path / "vault"
+    rendered = vault / "slides" / "rendered.pdf"
+    _write_pdf(rendered, page_count=2)
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        {
+            "filename": "talk.md",
+            "slides_local_path": rendered.relative_to(vault).as_posix(),
+            "slide_source": "pdf",
+        },
+        {"structured_data": {"slide_count": 999}},
+    )
+
+    assert context["slide_counts"]["static_slides"] == 2
+
+    canonical = pattern_evidence.canonicalize_detection_citations(
+        _slide_detection("slides", slide_numbers=[1, 2]),
+        evidence_channels=frozenset({"slides"}),
+        evidence_metadata_fields=frozenset(),
+        context=context,
+    )
+    assert canonical["evidence_citations"][0]["artifact_sha256"]
+
+    # The return's inflated count buys nothing past the real page count.
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match="the claimed talk has 2 slides",
+    ):
+        pattern_evidence.canonicalize_detection_citations(
+            _slide_detection("slides", slide_numbers=[3]),
+            evidence_channels=frozenset({"slides"}),
+            evidence_metadata_fields=frozenset(),
+            context=context,
+        )


### PR DESCRIPTION
Closes #159.

## What I found

**The enforcement is already in the tree.** It landed with the video/PDF supervision work that reworked `build_evidence_context`. I verified this against `main` before writing anything:

| Attempt | Result on `main` |
|---|---|
| Return supplies `structured_data.slide_count: 42`, talk record has none | `talk_metadata cites absent pre-return field 'slide_count'` |
| Return supplies `slide_source: pdf`, no artifact on disk | `slide evidence cannot be verified from a predeclared local artifact` |

`context["metadata"]` is built from the persisted talk record alone, and slide bounds come from probing real artifacts (`PdfArtifactProbe.page_count`), never from a count the return supplies.

The rendering criterion was already covered too — `test_partial_citation_bounds_render_without_internal_none` exercises all seven single-sided cases (`from line N`, `through line N`, `@ from Ns`, `@ through Ns`, `from Ns`, `through Ns`, `location unavailable`).

## What was actually missing

The issue's last acceptance criterion: **"Outcome-level regression tests cover each case."** Nothing pinned these properties, so a future refactor could quietly reconnect a return to its own validation and no test would notice.

Four tests in `tests/test_pattern_evidence.py` lock both directions:

- a return-supplied `slide_count` stays out of evidence metadata → `talk_metadata` citation fails
- a return-supplied `slide_source: pdf` produces no slide count → `slides` **and** `slide_sequence` citations fail (parametrized)
- a persisted `slide_count` still validates and stamps `7`, not the return's competing `42`
- a real 2-page PDF still bounds citations at 2; the return's inflated `999` buys nothing, and citing slide 3 fails

## One path that still reads the return

`delivery_language` falls back to `structured_data.delivery_language` when the persisted record has none. I left it: the value can only **add** the English-translation requirement to transcript citations, never remove one, so it can't be used to self-validate. Noted in the CHANGELOG rather than silently passed over.

## Verification

- `pytest` — 5123 passed, 3 skipped, 0 failed
- `ruff check` / `ruff format --check` / `pyright` on the changed file — clean
- `./scripts/pre-publish-checks.sh` — all three gates OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)