### PR TITLE
feat(vault-ingress): carry the matched rejection into scan reports (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+### feat(vault-ingress) — carry the matched rejection into scan reports (#177)
+
+Closes #177. `scan-shownotes.py` blocked a reappearing known-bad source but
+reported only that it had; recovering the reason, evidence, timestamp, and
+stored identity meant a second trip into the tracking database before anyone
+could judge whether the candidate was still wrong.
+
+A `rejected_source_reappeared` issue now carries the ledger record that matched
+— `source_type`, stored `url`, parsed `provider_id`, `reason`, `evidence`,
+`verified_at` — plus a `match` object naming how the match was established
+(`exact_url` or `provider_id`) and the candidate identity compared against.
+Only the matched record travels; unrelated `source_rejections` entries stay
+private to the talk, asserted by a test that greps the serialized report for
+the other two URLs.
+
+Report schema goes to v3, documented in `references/schemas-db.md`. Two tests
+that hardcoded `2` now read `REPORT_SCHEMA_VERSION`, so the next bump does not
+touch them.
+
+The acceptance criterion about validating the record before reporting it turned
+out to be satisfied more strictly upstream: `_load_database` refuses the whole
+scan when any `source_rejections` entry fails
+`tracking_database._validate_source_rejection`, so a partially trusted record
+cannot reach a report at all. A re-check inside the matcher would have been
+unreachable, so the matcher points at that owner instead of restating it, and
+the test asserts the loader-level refusal across a blank reason, a missing
+evidence field, a naive timestamp, and an unparseable one.
+
+Mutation behavior is unchanged: a reappeared source stays `review_required` and
+is never reactivated.
+
 ### test(vault-ingress) — pin the return-self-validation boundary (#159)
 
 Closes #159. The enforcement it asked for is already in the tree: it landed

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -481,11 +481,11 @@ emits `existing_title_conflict` and leaves the entry `review_required`. An exact
 title can still fill empty non-title metadata through the existing update
 contract.
 
-The command emits report schema v2:
+The command emits report schema v3:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "ok": true,
   "mode": "dry-run|apply",
   "operation": "scan|skipped_disabled|skipped_nonlocal",
@@ -522,6 +522,35 @@ The command emits report schema v2:
   }]
 }
 ```
+
+A `rejected_source_reappeared` issue carries the exact ledger record that
+produced the match, so a reviewer decides from the report alone:
+
+```json
+{
+  "code": "rejected_source_reappeared",
+  "field": "video_url",
+  "message": "shownotes proposes a known-bad video_url; ...",
+  "matched_rejection": {
+    "source_type": "video|slides",
+    "url": "the stored known-bad URL",
+    "provider_id": "parsed provider ID, or null when the URL has none",
+    "reason": "non_delivery_clip|wrong_delivery|unrelated_recording",
+    "evidence": "how the rejection was verified",
+    "verified_at": "timezone-aware ISO-8601 timestamp"
+  },
+  "match": {
+    "method": "exact_url|provider_id",
+    "candidate_url": "the URL the shownotes page proposes",
+    "candidate_provider_id": "its parsed provider ID, or null"
+  }
+}
+```
+
+Only the matched record appears; unrelated `source_rejections` entries stay
+private to the talk. A malformed ledger record never reaches this shape — the
+scanner refuses to load a database whose `source_rejections` fail
+`tracking_database._validate_source_rejection`.
 
 Dry-run is the default and never writes. `--apply` adds complete new records
 with current talk schema and status `pending`, or fills empty fields on an exact

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -61,7 +61,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10 only
         tomllib = None
 
 
-REPORT_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 3
 LOCAL_SOURCE_TYPES = frozenset(
     {"local_jekyll", "local_hugo", "local_eleventy", "local_astro"}
 )
@@ -337,7 +337,7 @@ def resolve_shownotes_location(config: dict[str, Any]) -> ShownotesLocation:
     )
 
 
-def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str, list[dict[str, str]]]:
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str, list[dict[str, Any]]]:
     lines = text.splitlines()
     if not lines:
         return {}, "", []
@@ -492,7 +492,7 @@ def _choose_value(
     filename: str,
     field: str,
     values: list[object],
-    issues: list[dict[str, str]],
+    issues: list[dict[str, Any]],
 ) -> object | None:
     normalized: list[object] = []
     for value in values:
@@ -587,9 +587,9 @@ def _read_markdown_text(path: Path) -> str:
         ) from exc
 
 
-def parse_shownotes_file(path: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
+def parse_shownotes_file(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Return a normalized talk proposal and review issues for one Markdown file."""
-    issues: list[dict[str, str]] = []
+    issues: list[dict[str, Any]] = []
     try:
         text = _read_markdown_text(path)
     except ShownotesScanError as exc:
@@ -719,17 +719,27 @@ def parse_shownotes_file(path: Path) -> tuple[dict[str, Any], list[dict[str, str
     return proposal, issues
 
 
+def _source_id(field: str, url: str) -> str | None:
+    parser = parse_youtube_id if field == "video_url" else parse_google_drive_id
+    return parser(url)
+
+
 def _same_source(field: str, left: str, right: str) -> bool:
     if left == right:
         return True
-    parser = parse_youtube_id if field == "video_url" else parse_google_drive_id
-    left_id = parser(left)
-    return left_id is not None and parser(right) == left_id
+    left_id = _source_id(field, left)
+    return left_id is not None and _source_id(field, right) == left_id
 
 
 def _rejected_source_issue(
     talk: dict[str, Any], field: str, candidate: str
-) -> dict[str, str] | None:
+) -> dict[str, Any] | None:
+    """The blocking review item for a candidate that a ledger entry rejects.
+
+    A match carries the exact ledger record that produced it, so the reviewer
+    decides from the report instead of reopening the database. Only the matched
+    record is included — unrelated rejections stay private to the talk.
+    """
     if "source_rejections" not in talk:
         return None
     rejections = talk.get("source_rejections")
@@ -752,23 +762,44 @@ def _rejected_source_issue(
         rejected_url = _nonempty(rejection.get("url"))
         if rejection.get("source_type") != expected_type or rejected_url is None:
             continue
-        if _same_source(field, candidate, rejected_url):
-            return {
-                "code": "rejected_source_reappeared",
-                "field": field,
-                "message": (
-                    f"shownotes proposes a known-bad {field}; keep it inactive until "
-                    "human review supplies replacement evidence"
-                ),
-            }
+        if not _same_source(field, candidate, rejected_url):
+            continue
+        # reason / evidence / verified_at are reported verbatim as review
+        # evidence. They are safe to read unchecked because _load_database
+        # rejects the whole scan on a malformed ledger record before reaching
+        # here — see tracking_database._validate_source_rejection for the exact
+        # required shape. Re-checking here would be unreachable.
+        candidate_id = _source_id(field, candidate)
+        rejected_id = _source_id(field, rejected_url)
+        return {
+            "code": "rejected_source_reappeared",
+            "field": field,
+            "message": (
+                f"shownotes proposes a known-bad {field}; keep it inactive until "
+                "human review supplies replacement evidence"
+            ),
+            "matched_rejection": {
+                "source_type": expected_type,
+                "url": rejected_url,
+                "provider_id": rejected_id,
+                "reason": rejection["reason"],
+                "evidence": rejection["evidence"],
+                "verified_at": rejection["verified_at"],
+            },
+            "match": {
+                "method": "exact_url" if candidate == rejected_url else "provider_id",
+                "candidate_url": candidate,
+                "candidate_provider_id": candidate_id,
+            },
+        }
     return None
 
 
 def _existing_entry(
     talk: dict[str, Any],
     proposal: dict[str, Any],
-    parse_issues: list[dict[str, str]],
-) -> tuple[str, dict[str, Any], list[dict[str, str]]]:
+    parse_issues: list[dict[str, Any]],
+) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
     issues = list(parse_issues)
     patch: dict[str, Any] = {}
     stored_conference = talk.get("conference")

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -124,7 +124,7 @@ def test_dry_run_parses_jekyll_links_and_derives_exact_source_ids(
 
     report = scan_shownotes.execute(database_path, apply_requested=False)
 
-    assert report["schema_version"] == 2
+    assert report["schema_version"] == scan_shownotes.REPORT_SCHEMA_VERSION
     assert report["ok"] is True
     assert report["mode"] == "dry-run"
     assert report["database_written"] is False
@@ -196,7 +196,7 @@ def test_apply_adds_only_complete_proposal_and_preserves_file_mode(
         }
     ]
     assert report["database_written"] is True
-    assert report["schema_version"] == 2
+    assert report["schema_version"] == scan_shownotes.REPORT_SCHEMA_VERSION
     assert report["input_sha256"] != report["output_sha256"]
     assert (
         report["output_sha256"]
@@ -672,6 +672,13 @@ def test_presentation_comparison_stays_narrow(
             f"https://drive.google.com/open?id={DRIVE_ID}",
             f"https://docs.google.com/presentation/d/{DRIVE_ID}/edit",
         ),
+        # Byte-identical URL: the match method must say exact_url, not provider_id.
+        (
+            "video",
+            "video_url",
+            f"https://www.youtube.com/watch?v={YOUTUBE_ID}",
+            f"https://www.youtube.com/watch?v={YOUTUBE_ID}",
+        ),
     ],
 )
 def test_rejected_source_identity_cannot_reappear_in_another_url_form(
@@ -712,10 +719,26 @@ def test_rejected_source_identity_cannot_reappear_in_another_url_form(
 
     entry = report["entries"][0]
     assert entry["disposition"] == "review_required"
-    assert any(
-        issue["code"] == "rejected_source_reappeared" and issue["field"] == field
+    matched = [
+        issue
         for issue in entry["issues"]
+        if issue["code"] == "rejected_source_reappeared" and issue["field"] == field
+    ]
+    assert len(matched) == 1
+    # The report is self-contained: the reviewer decides from this item alone,
+    # without reopening the tracking database for the ledger entry.
+    assert matched[0]["matched_rejection"] == {
+        "source_type": source_type,
+        "url": rejected_url,
+        "provider_id": YOUTUBE_ID if source_type == "video" else DRIVE_ID,
+        "reason": "wrong_delivery",
+        "evidence": "provider page identifies another delivery",
+        "verified_at": "2026-08-01T12:00:00+00:00",
+    }
+    assert matched[0]["match"]["method"] == (
+        "exact_url" if proposed_url == rejected_url else "provider_id"
     )
+    assert matched[0]["match"]["candidate_url"] == proposed_url
     assert database_path.read_bytes() == before
 
 
@@ -998,3 +1021,126 @@ def test_main_emits_one_json_error_and_actionable_stderr(
     assert payload["ok"] is False
     assert "tracking database is missing" in payload["error"]
     assert "pass its canonical file path" in captured.err
+
+
+def _talk_with_rejections(rejections: list[object]) -> dict[str, object]:
+    return {
+        "filename": "2026-08-01-deterministic-ingress.md",
+        "title": "Deterministic Ingress",
+        "conference": "TestConf",
+        "date": "2026-08-01",
+        "schema_version": 5,
+        "status": "pending",
+        "source_rejections": rejections,
+    }
+
+
+def _valid_rejection(url: str, **overrides: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "source_type": "video",
+        "url": url,
+        "reason": "wrong_delivery",
+        "evidence": "provider page identifies another delivery",
+        "verified_at": "2026-08-01T12:00:00+00:00",
+    }
+    record.update(overrides)
+    return record
+
+
+def test_only_the_matched_rejection_is_reported(tmp_path: Path) -> None:
+    """Unrelated ledger entries stay private to the talk record."""
+    site, talks_directory = _shownotes_site(tmp_path)
+    proposed = f"https://www.youtube.com/watch?v={YOUTUBE_ID}"
+    _write_jekyll_talk(talks_directory, video_url=proposed)
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[
+            _talk_with_rejections(
+                [
+                    _valid_rejection(
+                        "https://youtu.be/zzzzzzzzzzz",
+                        reason="non_delivery_clip",
+                        evidence="unrelated earlier upload",
+                    ),
+                    _valid_rejection(f"https://youtu.be/{YOUTUBE_ID}"),
+                    _valid_rejection(
+                        "https://youtu.be/qqqqqqqqqqq",
+                        reason="unrelated_recording",
+                        evidence="different speaker entirely",
+                    ),
+                ]
+            )
+        ],
+    )
+
+    report = scan_shownotes.execute(database_path, apply_requested=True)
+
+    issues = report["entries"][0]["issues"]
+    matched = [
+        issue for issue in issues if issue["code"] == "rejected_source_reappeared"
+    ]
+    assert len(matched) == 1
+    assert matched[0]["matched_rejection"]["url"] == f"https://youtu.be/{YOUTUBE_ID}"
+    assert matched[0]["matched_rejection"]["reason"] == "wrong_delivery"
+    serialized = json.dumps(report)
+    assert "zzzzzzzzzzz" not in serialized
+    assert "qqqqqqqqqqq" not in serialized
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"reason": ""}, id="blank-reason"),
+        pytest.param({"evidence": None}, id="missing-evidence"),
+        pytest.param({"verified_at": "2026-08-01T12:00:00"}, id="naive-timestamp"),
+        pytest.param({"verified_at": "not-a-timestamp"}, id="unparseable-timestamp"),
+    ],
+)
+def test_malformed_rejection_blocks_the_scan_before_any_match(
+    tmp_path: Path, overrides: dict[str, object]
+) -> None:
+    """A record that would be reported as evidence is repaired, never half-trusted.
+
+    The guarantee is stronger than a per-entry issue: the loader rejects the
+    whole scan, so no report can carry an unverifiable ledger record. See
+    tracking_database._validate_source_rejection.
+    """
+    site, talks_directory = _shownotes_site(tmp_path)
+    proposed = f"https://www.youtube.com/watch?v={YOUTUBE_ID}"
+    _write_jekyll_talk(talks_directory, video_url=proposed)
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[
+            _talk_with_rejections(
+                [_valid_rejection(f"https://youtu.be/{YOUTUBE_ID}", **overrides)]
+            )
+        ],
+    )
+    before = database_path.read_bytes()
+
+    with pytest.raises(scan_shownotes.ShownotesScanError, match="source_rejections"):
+        scan_shownotes.execute(database_path, apply_requested=True)
+
+    assert database_path.read_bytes() == before
+
+
+def test_matched_rejection_report_is_byte_stable(tmp_path: Path) -> None:
+    """Two scans of unchanged state serialize identically."""
+    site, talks_directory = _shownotes_site(tmp_path)
+    proposed = f"https://www.youtube.com/watch?v={YOUTUBE_ID}"
+    _write_jekyll_talk(talks_directory, video_url=proposed)
+    database_path = _database_path(
+        tmp_path,
+        _local_config(site),
+        talks=[
+            _talk_with_rejections([_valid_rejection(f"https://youtu.be/{YOUTUBE_ID}")])
+        ],
+    )
+
+    first = scan_shownotes.execute(database_path, apply_requested=False)
+    second = scan_shownotes.execute(database_path, apply_requested=False)
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert first["schema_version"] == scan_shownotes.REPORT_SCHEMA_VERSION


### PR DESCRIPTION
Closes #177.

## Problem

`scan-shownotes.py` correctly blocked a reappearing known-bad source, but the review item said only *that* it matched. Recovering the reason, evidence, timestamp, and stored identity meant a second trip into the tracking database before anyone could decide whether the candidate was still wrong.

## Change

A `rejected_source_reappeared` issue now carries the exact ledger record that produced the match:

```json
{
  "code": "rejected_source_reappeared",
  "field": "video_url",
  "matched_rejection": {
    "source_type": "video",
    "url": "https://youtu.be/AbCdEfGhI_1",
    "provider_id": "AbCdEfGhI_1",
    "reason": "wrong_delivery",
    "evidence": "provider page identifies another delivery",
    "verified_at": "2026-08-01T12:00:00+00:00"
  },
  "match": {
    "method": "exact_url|provider_id",
    "candidate_url": "https://www.youtube.com/watch?v=AbCdEfGhI_1",
    "candidate_provider_id": "AbCdEfGhI_1"
  }
}
```

Only the matched record travels — a test serializes the whole report and greps for the two unrelated ledger URLs to prove they stay private.

Report schema → **v3**, documented in `references/schemas-db.md`. Two tests that hardcoded `2` now read `REPORT_SCHEMA_VERSION`, so the next bump doesn't touch them.

## One AC was already satisfied upstream — more strictly

*"Validate the stored rejection record before reporting it. Malformed state remains a separate blocking `source_rejections_invalid` result rather than a partially trusted match."*

I first implemented this as a guard inside the matcher, then found it unreachable: `_load_database` already refuses the **whole scan** when any `source_rejections` entry fails `tracking_database._validate_source_rejection` (closed shape, non-empty url/reason/evidence, `source_type` enum, timezone-aware `verified_at`).

So I removed the dead guard rather than shipping a check that can never fire. The matcher points at that owner in a comment, and the tests assert the real loader-level refusal across four malformed shapes: blank reason, missing evidence, naive timestamp, unparseable timestamp.

## Tests

Per the AC: exact-URL match (added — both pre-existing cases were different-URL-form matches), equivalent provider-ID match, multiple unrelated ledger entries, malformed rejection state, and byte-stable JSON across two scans.

## Verification

- `pytest` — 5130 passed, 3 skipped, 0 failed
- `ruff check` / `pyright` — clean
- `./scripts/pre-publish-checks.sh` — all gates OK
- Mutation behavior unchanged: reappeared source stays `review_required`, database bytes identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)