### PR TITLE
fix(vault-ingress): share one retained named-stage across owner writers (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ was never established and an orphan may remain; it gets its own
 `staged_cleanup_inspect_failed` disposition. The test fixture stopped
 suppressing cleanup errors.
 
+A third round found the analysis writer still exiting 0 after a failed
+post-install proof: the warning was collected, the batch marked committed, and
+the CLI reported success over a target that might hold substituted bytes. That
+now raises `AnalysisBatchUnverifiedError` — a distinct type, because rolling
+back would be wrong here (the replace already happened and the target holds the
+new file). The batch completes, the recovery backup for each unproven target is
+retained rather than deleted, and the run fails so an operator inspects instead
+of trusting it. The staging-failure path also released its stages inside a
+`finally` that ran after the error was constructed, so those cleanup warnings
+went nowhere; cleanup now happens first and the detail rides out on the error.
+
 Two Copilot findings folded in. `_stage_candidate` ran cleanup on a
 verification failure and dropped the report, reintroducing the vanished-warning
 problem one level up; the cleanup detail now rides out inside the typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ resolves to a different inode or file type is left untouched rather than
 unlinked: it is someone else's data, and removing it to tidy up after ourselves
 would be the second bug. `KeyboardInterrupt` and `SystemExit` still propagate.
 
+Two Copilot findings folded in. `_stage_candidate` ran cleanup on a
+verification failure and dropped the report, reintroducing the vanished-warning
+problem one level up; the cleanup detail now rides out inside the typed
+conflict's `detail`. And the module docstring claimed no-follow for the
+directory open, which is deliberately not the case — the vault root is
+documented as possibly being a symlink, so refusing a symlinked component there
+would break supported installs. The no-follow guarantee covers the staged file
+and every later name resolution, which is anchored to the retained directory
+descriptor. The docstring now says that instead of over-claiming. A dead
+`_visible_descriptor_identity` wrapper left by the extraction is gone.
+
 Test seams followed the implementation. Five injection points that patched
 `tracking_database_io` internals now patch `retained_stage` where the
 observation loop actually lives; the two that wrap the owner's typed-error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ resolves to a different inode or file type is left untouched rather than
 unlinked: it is someone else's data, and removing it to tidy up after ourselves
 would be the second bug. `KeyboardInterrupt` and `SystemExit` still propagate.
 
+The policy reviewer caught the same failure shape inside the new module: the
+incomplete-stage path used `except OSError: pass`, so a failed unlink orphaned
+a temp with no diagnostic — the exact bug this primitive exists to stop, one
+layer down, and a violation of Never Suppress Errors besides. Cleanup now
+returns what it could not do; a `RetainedStageError` carries that detail in its
+message with its type and `reason_code` intact, and anything else surfaces on
+stderr. The interrupt path cleans up and warns without trapping the interrupt.
+`_stage_candidate`'s `except BaseException` narrowed to `except Exception` with
+a `finally` for interrupt-safe release, since it is an inner helper and none of
+the Outer-Boundary Carve-Out's preconditions apply.
+
 Two Copilot findings folded in. `_stage_candidate` ran cleanup on a
 verification failure and dropped the report, reintroducing the vanished-warning
 problem one level up; the cleanup detail now rides out inside the typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+### fix(vault-ingress) — share one retained named-stage across owner writers (#243)
+
+Closes #243, and folds in #240.
+
+`write-analysis.py` had a live defect, not a duplicated invariant.
+`_stage_text` created its stage with `tempfile.mkstemp`, wrote the body,
+**closed the descriptor**, and returned a pathname; `atomic_write_batch` then
+installed it with `os.replace(name, target)`. Between those two steps the staged
+name was just a name in a directory, so anything able to write there could
+substitute it and have the writer install those bytes. Reproduced before the
+fix: the batch returned normally while the target held attacker-supplied
+content. The writer had no byte verification of its stage at all — every
+`sha256` in that file was citation rendering.
+
+`retained_stage.py` now owns the staged-file lifecycle for both writers: unique
+no-follow creation with a retained file and directory descriptor, regular-file
+and single-link validation, exact descriptor/name device and inode identity at
+every preinstall observation, exact size/bytes/SHA-256 binding, and bounded
+same-view `mtime_ns`/`ctime_ns` stabilization. Each owner keeps its own
+compare-and-swap and backup behavior, which is what differs between them;
+`tracking_database_io` maps the shared `StagedInvariantError` into its existing
+`StagedCandidateConflictError` so its public error contract is unchanged.
+
+The analysis writer re-verifies immediately before each replace rather than only
+at stage time, so the staging-plus-preflight window is covered too, and runs a
+post-install check whose failure is reported as installed-but-unverified — never
+as a pre-install failure, because the replace already happened.
+
+Cleanup is truthful (#240). `close_retained_stage` returns a report carrying a
+disposition and stable reason codes — `staged_cleanup_unlink_failed`,
+`staged_cleanup_descriptor_close_failed`,
+`staged_cleanup_directory_close_failed`, `staged_cleanup_name_not_owned` — so a
+pre-install failure can no longer discard them on the way out. A name that now
+resolves to a different inode or file type is left untouched rather than
+unlinked: it is someone else's data, and removing it to tidy up after ourselves
+would be the second bug. `KeyboardInterrupt` and `SystemExit` still propagate.
+
+Test seams followed the implementation. Five injection points that patched
+`tracking_database_io` internals now patch `retained_stage` where the
+observation loop actually lives; the two that wrap the owner's typed-error
+mapping keep patching the owner, because that mapping is the owner's. All 342
+existing writer race, interrupt, backup, durability, analysis-body-preservation,
+and CloudStorage migration tests stay green unchanged.
+
+
 ### feat(vault-ingress) — carry the matched rejection into scan reports (#177)
 
 Closes #177. `scan-shownotes.py` blocked a reappearing known-bad source but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ stderr. The interrupt path cleans up and warns without trapping the interrupt.
 a `finally` for interrupt-safe release, since it is an inner helper and none of
 the Outer-Boundary Carve-Out's preconditions apply.
 
+A second review round caught four more, three of them in the error contract I
+had just written. The enrichment path rebuilt the failure with
+`type(exc)(message, reason_code=...)`, which is the wrong constructor for
+`StagedInvariantError` — a cleanup failure would have raised `TypeError` in
+place of the real diagnostic. Each type is now rebuilt through its own
+constructor, and both helpers catch only their anticipated typed failure with a
+cleanup-only `finally` for everything else, interrupts included. A failed
+inspection of the staged name no longer reports `already_absent`, since absence
+was never established and an orphan may remain; it gets its own
+`staged_cleanup_inspect_failed` disposition. The test fixture stopped
+suppressing cleanup errors.
+
 Two Copilot findings folded in. `_stage_candidate` ran cleanup on a
 verification failure and dropped the report, reintroducing the vanished-warning
 problem one level up; the cleanup detail now rides out inside the typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ of trusting it. The staging-failure path also released its stages inside a
 `finally` that ran after the error was constructed, so those cleanup warnings
 went nowhere; cleanup now happens first and the detail rides out on the error.
 
+Two more cleanup dispositions stopped lying. A failed `os.unlink` reported
+`already_absent` — the same untruth already fixed for a failed inspection, but
+missed one branch over — so a consumer could record a clean cleanup over a
+confirmed orphan. It gets `staged_cleanup_unlink_failed`, and only `removed`
+and `already_absent` now assert the name is gone. The tracking-DB helper's
+interrupt path also discarded its report; those warnings go to stderr rather
+than nowhere.
+
 Two Copilot findings folded in. `_stage_candidate` ran cleanup on a
 verification failure and dropped the report, reintroducing the vanished-warning
 problem one level up; the cleanup detail now rides out inside the typed

--- a/skills/vault-ingress/scripts/retained_stage.py
+++ b/skills/vault-ingress/scripts/retained_stage.py
@@ -11,8 +11,8 @@ This module keeps a descriptor open on the staged inode for the whole
 transaction and proves, at every observation, that the visible name still
 resolves to that exact inode with the exact bytes. The invariants it enforces:
 
-- unique no-follow creation with a retained file descriptor and directory
-  descriptor;
+- unique ``O_NOFOLLOW`` creation of the staged file itself, with a retained
+  file descriptor and a directory descriptor every later syscall anchors to;
 - regular-file and single-link validation;
 - exact descriptor/name device and inode identity at every preinstall
   observation;
@@ -174,7 +174,15 @@ def _identity(metadata: os.stat_result) -> tuple[int, int]:
 
 
 def open_directory(path: Path, *, label: str) -> int:
-    """Open a directory descriptor the stage anchors every later syscall to."""
+    """Open a directory descriptor the stage anchors every later syscall to.
+
+    Deliberately not ``O_NOFOLLOW``: the vault root is documented as possibly
+    being a symlink to a custom location, so refusing a symlinked component
+    here would break supported installs. The no-follow guarantee this module
+    makes is about the staged *file* and every later name resolution, which is
+    anchored to this descriptor and so cannot be redirected by a directory
+    swapped after the open.
+    """
     flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_DIRECTORY", 0)
     try:

--- a/skills/vault-ingress/scripts/retained_stage.py
+++ b/skills/vault-ingress/scripts/retained_stage.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import sys
 import secrets
 import stat
 from dataclasses import dataclass, field
@@ -240,6 +241,44 @@ def visible_descriptor_identity(
     )
 
 
+def _warn(notes: list[str]) -> None:
+    """Surface best-effort cleanup failures that have nowhere else to go.
+
+    `error-handling` Shell Error Handling: best-effort work that legitimately
+    continues past a failure emits a warning, never nothing.
+    """
+    for note in notes:
+        print(f"WARNING: {note}", file=sys.stderr)
+
+
+def _release_incomplete_stage(
+    name: str | None,
+    descriptor: int | None,
+    directory_descriptor: int,
+) -> list[str]:
+    """Drop a half-built stage, returning what could not be cleaned up."""
+    notes: list[str] = []
+    if descriptor is not None and name is not None:
+        if visible_descriptor_identity(name, descriptor, directory_descriptor):
+            try:
+                os.unlink(name, dir_fd=directory_descriptor)
+            except OSError as exc:
+                notes.append(f"could not remove incomplete staged file {name}: {exc}")
+        else:
+            notes.append(
+                f"incomplete staged name {name} was substituted; left it untouched"
+            )
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            notes.append(f"could not close incomplete staged file {name}: {exc}")
+    try:
+        os.close(directory_descriptor)
+    except OSError as exc:
+        notes.append(f"could not close staging directory descriptor: {exc}")
+    return notes
+
+
 def open_retained_stage(
     path: Path,
     payload: bytes,
@@ -266,6 +305,7 @@ def open_retained_stage(
     descriptor: int | None = None
     name: str | None = None
     completed = False
+    released = False
     try:
         flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
@@ -311,25 +351,24 @@ def open_retained_stage(
             verify_retained_stage(stage, payload)
         completed = True
         return stage
+    except Exception as exc:
+        released = True
+        notes = _release_incomplete_stage(name, descriptor, directory_descriptor)
+        if notes and isinstance(exc, RetainedStageError):
+            # Attach rather than discard: an orphaned staged temp with no
+            # diagnostic naming it is the exact failure this module exists to
+            # stop. Attaching keeps the primary error's type and reason_code.
+            raise type(exc)(
+                f"{exc}; staged cleanup: {'; '.join(notes)}",
+                reason_code=exc.reason_code,
+            ) from exc
+        _warn(notes)
+        raise
     finally:
-        if not completed:
-            # An incomplete stage still owns a name and two descriptors. Their
-            # cleanup failures are reported by the caller's error path, not
-            # discarded here — but they must never mask the primary failure.
-            if descriptor is not None and name is not None:
-                if visible_descriptor_identity(name, descriptor, directory_descriptor):
-                    try:
-                        os.unlink(name, dir_fd=directory_descriptor)
-                    except OSError:
-                        pass
-                try:
-                    os.close(descriptor)
-                except OSError:
-                    pass
-            try:
-                os.close(directory_descriptor)
-            except OSError:
-                pass
+        if not completed and not released:
+            # Interrupt path: cleanup still runs, and its diagnostics still go
+            # somewhere. Re-raising here would replace the interrupt.
+            _warn(_release_incomplete_stage(name, descriptor, directory_descriptor))
 
 
 def _observe(stage: RetainedStage) -> _StagedObservation:

--- a/skills/vault-ingress/scripts/retained_stage.py
+++ b/skills/vault-ingress/scripts/retained_stage.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""Retained named-stage primitive shared by every owner file writer.
+
+An owner writer that stages bytes beside its target and then renames them into
+place has one hard problem: between staging and install, the staged *pathname*
+is just a name in a directory anyone can write to. A writer that stages by path,
+closes the descriptor, and later calls ``os.replace(name, target)`` installs
+whatever the name points at by then — and reports success.
+
+This module keeps a descriptor open on the staged inode for the whole
+transaction and proves, at every observation, that the visible name still
+resolves to that exact inode with the exact bytes. The invariants it enforces:
+
+- unique no-follow creation with a retained file descriptor and directory
+  descriptor;
+- regular-file and single-link validation;
+- exact descriptor/name device and inode identity at every preinstall
+  observation;
+- exact size, bytes, and candidate SHA-256 binding;
+- bounded same-view ``mtime_ns``/``ctime_ns`` stabilization, without requiring
+  the descriptor and path timestamp caches to agree with each other;
+- immediate typed failure for identity, type, link, size, byte, or digest
+  changes.
+
+Target-specific compare-and-swap and backup behavior stay with each owner. This
+module owns the staged-file lifecycle and the typed observations only.
+
+Cleanup is truthful about what it did: a still-owned staged name is removed, a
+name that now resolves to a different inode or file type is left untouched and
+reported as ``staged_cleanup_name_not_owned``, and unlink/close failures surface
+as structured reasons rather than being discarded. ``KeyboardInterrupt`` and
+``SystemExit`` propagate untouched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+
+READ_CHUNK_SIZE = 1024 * 1024
+
+# Bounded retries for the same-view timestamp stabilization window. A busy
+# filesystem can update mtime_ns/ctime_ns between the two observations that
+# bracket one byte read; permanent churn is a failure, not an infinite wait.
+STAGED_METADATA_STABILIZATION_ATTEMPTS = 4
+
+# How many unique staged names to try before giving up on collision.
+STAGED_NAME_ATTEMPTS = 128
+
+# Stable cleanup reason codes. Callers route on these; prose may be reworded.
+STAGED_CLEANUP_UNLINK_FAILED = "staged_cleanup_unlink_failed"
+STAGED_CLEANUP_DESCRIPTOR_CLOSE_FAILED = "staged_cleanup_descriptor_close_failed"
+STAGED_CLEANUP_DIRECTORY_CLOSE_FAILED = "staged_cleanup_directory_close_failed"
+STAGED_CLEANUP_NAME_NOT_OWNED = "staged_cleanup_name_not_owned"
+STAGED_CLEANUP_INSPECT_FAILED = "staged_cleanup_inspect_failed"
+
+
+class RetainedStageError(ValueError):
+    """A retained stage could not be created or kept trustworthy.
+
+    ``reason_code`` is the stable, typed classification. Consumers route on it;
+    the message is human prose and may be reworded without notice.
+    """
+
+    def __init__(self, message: str, *, reason_code: str = "staged_error") -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+class StagedInvariantError(RetainedStageError):
+    """One named staged invariant failed before installation.
+
+    ``invariant`` names which binding broke, so a caller can branch without
+    parsing prose.
+    """
+
+    def __init__(self, path: Path, invariant: str, detail: str, *, label: str) -> None:
+        self.path = path
+        self.invariant = invariant
+        self.detail = detail
+        super().__init__(
+            f"staged {label} {path} changed before install: "
+            f"invariant={invariant}; {detail}",
+            reason_code="staged_invariant_failed",
+        )
+
+
+@dataclass(frozen=True)
+class FileGeneration:
+    """Stable identity fields for one observed regular-file generation."""
+
+    device: int
+    inode: int
+    size: int
+    modified_ns: int
+    changed_ns: int
+
+    @classmethod
+    def from_stat(cls, metadata: os.stat_result) -> "FileGeneration":
+        return cls(
+            device=metadata.st_dev,
+            inode=metadata.st_ino,
+            size=metadata.st_size,
+            modified_ns=metadata.st_mtime_ns,
+            changed_ns=metadata.st_ctime_ns,
+        )
+
+
+@dataclass
+class RetainedStage:
+    """Open, directory-anchored staged bytes retained through installation."""
+
+    path: Path
+    name: str
+    descriptor: int
+    directory_descriptor: int
+    generation: FileGeneration
+    sha256: str
+    size: int
+    label: str
+    directory_label: str
+
+
+@dataclass(frozen=True)
+class StageCleanupReport:
+    """What cleanup actually did, in stable terms a caller can report.
+
+    ``disposition`` is one of ``removed``, ``already_absent``, or
+    ``staged_cleanup_name_not_owned``. A cleanup that could not finish carries
+    ``reason_codes`` alongside human ``warnings``; neither ever converts an
+    installed outcome into a failure.
+    """
+
+    disposition: str
+    warnings: tuple[str, ...] = ()
+    reason_codes: tuple[str, ...] = ()
+
+    @property
+    def clean(self) -> bool:
+        return not self.reason_codes
+
+
+@dataclass(frozen=True)
+class _StagedObservation:
+    """One descriptor/name observation around an exact staged-byte read."""
+
+    opened_before: os.stat_result
+    visible_before: os.stat_result
+    raw: bytes
+    opened_after: os.stat_result
+    visible_after: os.stat_result
+
+
+@dataclass
+class _CleanupCollector:
+    warnings: list[str] = field(default_factory=list)
+    reason_codes: list[str] = field(default_factory=list)
+
+    def add(self, reason_code: str, message: str) -> None:
+        self.reason_codes.append(reason_code)
+        self.warnings.append(message)
+
+
+def sha256_hex(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _identity(metadata: os.stat_result) -> tuple[int, int]:
+    return metadata.st_dev, metadata.st_ino
+
+
+def open_directory(path: Path, *, label: str) -> int:
+    """Open a directory descriptor the stage anchors every later syscall to."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise RetainedStageError(
+            f"cannot open {label} {path}: {exc}",
+            reason_code="staged_directory_unavailable",
+        ) from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise RetainedStageError(
+            f"{label} {path} is not a directory",
+            reason_code="staged_directory_unavailable",
+        )
+    return descriptor
+
+
+def _write_descriptor(descriptor: int, raw: bytes) -> None:
+    offset = 0
+    while offset < len(raw):
+        written = os.write(descriptor, raw[offset:])
+        if written <= 0:
+            raise OSError("staged write made no progress")
+        offset += written
+
+
+def _pread_descriptor(descriptor: int, size: int) -> bytes:
+    chunks: list[bytes] = []
+    offset = 0
+    while offset < size:
+        chunk = os.pread(descriptor, min(READ_CHUNK_SIZE, size - offset), offset)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        offset += len(chunk)
+    return b"".join(chunks)
+
+
+def visible_descriptor_identity(
+    name: str,
+    descriptor: int,
+    directory_descriptor: int,
+) -> bool:
+    """Whether the visible name still resolves to the retained descriptor."""
+    try:
+        opened = os.fstat(descriptor)
+        visible = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(opened.st_mode)
+        and stat.S_ISREG(visible.st_mode)
+        and _identity(opened) == _identity(visible)
+    )
+
+
+def open_retained_stage(
+    path: Path,
+    payload: bytes,
+    *,
+    mode: int,
+    suffix: str,
+    label: str,
+    directory_label: str | None = None,
+    verify: bool = True,
+) -> RetainedStage:
+    """Create, fill, fsync, and bind one staged file beside ``path``.
+
+    The returned stage keeps its descriptor and directory descriptor open. The
+    caller owns closing it through :func:`close_retained_stage`.
+
+    ``verify=False`` skips the initial verification so an owner that wraps
+    :func:`verify_retained_stage` in its own typed-error mapping runs every
+    verification through that one seam.
+    """
+    directory_prose = directory_label or label
+    directory_descriptor = open_directory(
+        path.parent, label=f"{directory_prose} directory"
+    )
+    descriptor: int | None = None
+    name: str | None = None
+    completed = False
+    try:
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for _ in range(STAGED_NAME_ATTEMPTS):
+            candidate_name = f".{path.name}.{secrets.token_hex(12)}{suffix}"
+            try:
+                descriptor = os.open(
+                    candidate_name,
+                    flags,
+                    0o600,
+                    dir_fd=directory_descriptor,
+                )
+                name = candidate_name
+                break
+            except FileExistsError:
+                continue
+        if descriptor is None or name is None:
+            raise RetainedStageError(
+                f"cannot allocate a unique staged {label} beside {path}",
+                reason_code="staged_name_unavailable",
+            )
+        os.fchmod(descriptor, mode)
+        _write_descriptor(descriptor, payload)
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise RetainedStageError(
+                f"staged {label} {path.parent / name} must be one regular file",
+                reason_code="staged_shape_invalid",
+            )
+        stage = RetainedStage(
+            path=path.parent / name,
+            name=name,
+            descriptor=descriptor,
+            directory_descriptor=directory_descriptor,
+            generation=FileGeneration.from_stat(metadata),
+            sha256=sha256_hex(payload),
+            size=len(payload),
+            label=label,
+            directory_label=directory_prose,
+        )
+        if verify:
+            verify_retained_stage(stage, payload)
+        completed = True
+        return stage
+    finally:
+        if not completed:
+            # An incomplete stage still owns a name and two descriptors. Their
+            # cleanup failures are reported by the caller's error path, not
+            # discarded here — but they must never mask the primary failure.
+            if descriptor is not None and name is not None:
+                if visible_descriptor_identity(name, descriptor, directory_descriptor):
+                    try:
+                        os.unlink(name, dir_fd=directory_descriptor)
+                    except OSError:
+                        pass
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+            try:
+                os.close(directory_descriptor)
+            except OSError:
+                pass
+
+
+def _observe(stage: RetainedStage) -> _StagedObservation:
+    try:
+        opened_before = os.fstat(stage.descriptor)
+        visible_before = os.stat(
+            stage.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+        raw = _pread_descriptor(stage.descriptor, stage.size)
+        opened_after = os.fstat(stage.descriptor)
+        visible_after = os.stat(
+            stage.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        raise StagedInvariantError(
+            stage.path,
+            "metadata_read",
+            str(exc),
+            label=stage.label,
+        ) from exc
+    return _StagedObservation(
+        opened_before=opened_before,
+        visible_before=visible_before,
+        raw=raw,
+        opened_after=opened_after,
+        visible_after=visible_after,
+    )
+
+
+def _samples(
+    observation: _StagedObservation,
+) -> tuple[tuple[str, os.stat_result], ...]:
+    return (
+        ("descriptor_before", observation.opened_before),
+        ("name_before", observation.visible_before),
+        ("descriptor_after", observation.opened_after),
+        ("name_after", observation.visible_after),
+    )
+
+
+def _require_invariants(
+    stage: RetainedStage,
+    payload: bytes,
+    observation: _StagedObservation,
+) -> None:
+    samples = _samples(observation)
+    non_regular = [
+        label for label, metadata in samples if not stat.S_ISREG(metadata.st_mode)
+    ]
+    if non_regular:
+        raise StagedInvariantError(
+            stage.path,
+            "regular_file",
+            f"non-regular observations={non_regular}",
+            label=stage.label,
+        )
+    expected_identity = (stage.generation.device, stage.generation.inode)
+    identities = {label: _identity(metadata) for label, metadata in samples}
+    if any(identity != expected_identity for identity in identities.values()):
+        raise StagedInvariantError(
+            stage.path,
+            "descriptor_name_identity",
+            f"expected={expected_identity}; observed={identities}",
+            label=stage.label,
+        )
+    link_counts = {label: metadata.st_nlink for label, metadata in samples}
+    if any(link_count != 1 for link_count in link_counts.values()):
+        raise StagedInvariantError(
+            stage.path,
+            "link_count",
+            f"expected one link; observed={link_counts}",
+            label=stage.label,
+        )
+    sizes = {label: metadata.st_size for label, metadata in samples}
+    if (
+        len(payload) != stage.size
+        or len(observation.raw) != stage.size
+        or any(size != stage.size for size in sizes.values())
+    ):
+        raise StagedInvariantError(
+            stage.path,
+            "size",
+            f"expected={stage.size}; candidate={len(payload)}; "
+            f"read={len(observation.raw)}; observed={sizes}",
+            label=stage.label,
+        )
+    if observation.raw != payload:
+        raise StagedInvariantError(
+            stage.path,
+            "exact_bytes",
+            "descriptor bytes differ from the exact candidate",
+            label=stage.label,
+        )
+    payload_sha256 = sha256_hex(payload)
+    observed_sha256 = sha256_hex(observation.raw)
+    if stage.sha256 != payload_sha256 or observed_sha256 != stage.sha256:
+        raise StagedInvariantError(
+            stage.path,
+            "sha256",
+            f"expected={stage.sha256}; candidate={payload_sha256}; "
+            f"observed={observed_sha256}",
+            label=stage.label,
+        )
+
+
+def verify_retained_stage(stage: RetainedStage, payload: bytes) -> None:
+    """Prove the staged name still holds the exact retained bytes.
+
+    Stabilization compares each view against itself across one read window.
+    Requiring the descriptor and path timestamp caches to agree with each other
+    would fail on filesystems that update them independently.
+    """
+    last_timestamps: dict[str, tuple[int, int]] = {}
+    last_unstable_fields: list[str] = []
+    for _ in range(STAGED_METADATA_STABILIZATION_ATTEMPTS):
+        observation = _observe(stage)
+        _require_invariants(stage, payload, observation)
+        last_timestamps = {
+            label: (metadata.st_mtime_ns, metadata.st_ctime_ns)
+            for label, metadata in _samples(observation)
+        }
+        last_unstable_fields = []
+        for view in ("descriptor", "name"):
+            before = last_timestamps[f"{view}_before"]
+            after = last_timestamps[f"{view}_after"]
+            if before[0] != after[0]:
+                last_unstable_fields.append(f"{view}.mtime_ns")
+            if before[1] != after[1]:
+                last_unstable_fields.append(f"{view}.ctime_ns")
+        if not last_unstable_fields:
+            return
+    raise StagedInvariantError(
+        stage.path,
+        "timestamp_stability",
+        "staged mtime_ns/ctime_ns changed within every read window across "
+        f"{STAGED_METADATA_STABILIZATION_ATTEMPTS} bounded observations; "
+        f"unstable_fields={last_unstable_fields}; last_observed={last_timestamps}",
+        label=stage.label,
+    )
+
+
+def install_retained_stage(stage: RetainedStage, target: Path) -> None:
+    """Rename the staged name onto ``target`` within the anchored directory.
+
+    Raises ``OSError`` so each owner classifies install failure in its own
+    terms. Directory-anchored where the platform supports it, so a renamed or
+    replaced parent directory cannot redirect the install.
+    """
+    if os.replace in os.supports_dir_fd:
+        os.replace(
+            stage.name,
+            target.name,
+            src_dir_fd=stage.directory_descriptor,
+            dst_dir_fd=stage.directory_descriptor,
+        )
+    else:  # pragma: no cover - supported on the Unix platforms this plugin targets.
+        os.replace(stage.path, target)
+
+
+def installed_target_warning(
+    stage: RetainedStage,
+    target: Path,
+    payload: bytes,
+) -> str | None:
+    """Post-install proof that ``target`` is the exact staged generation.
+
+    Returns a warning when the installed target cannot be confirmed. The caller
+    reports it as ``installed-but-verification-failed`` — never as a pre-install
+    failure, because the replace already happened.
+    """
+    try:
+        opened_before = os.fstat(stage.descriptor)
+        visible_before = os.stat(
+            target.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+        raw = _pread_descriptor(stage.descriptor, stage.size)
+        opened_after = os.fstat(stage.descriptor)
+        visible_after = os.stat(
+            target.name,
+            dir_fd=stage.directory_descriptor,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        return f"could not verify installed {stage.label} {target}: {exc}"
+    if (
+        not stat.S_ISREG(opened_before.st_mode)
+        or not stat.S_ISREG(visible_before.st_mode)
+        or not stat.S_ISREG(opened_after.st_mode)
+        or not stat.S_ISREG(visible_after.st_mode)
+        or _identity(opened_before) != _identity(visible_before)
+        or _identity(opened_after) != _identity(visible_after)
+        or _identity(opened_before) != _identity(opened_after)
+        or opened_before.st_size != stage.size
+        or visible_before.st_size != stage.size
+        or opened_after.st_size != stage.size
+        or visible_after.st_size != stage.size
+        or raw != payload
+        or sha256_hex(raw) != stage.sha256
+    ):
+        return (
+            f"installed {stage.label} {target} no longer matches the staged "
+            "candidate; inspect the live path and output SHA before retrying"
+        )
+    return None
+
+
+def _unlink_staged_name(stage: RetainedStage, collector: _CleanupCollector) -> str:
+    try:
+        os.stat(stage.name, dir_fd=stage.directory_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return "already_absent"
+    except OSError as exc:
+        collector.add(
+            STAGED_CLEANUP_INSPECT_FAILED,
+            f"could not inspect staged {stage.label} {stage.path}: {exc}",
+        )
+        return "already_absent"
+    if not visible_descriptor_identity(
+        stage.name,
+        stage.descriptor,
+        stage.directory_descriptor,
+    ):
+        # Someone else's file now answers to this name. Removing it would
+        # delete a stranger's data to tidy up after ourselves.
+        collector.add(
+            STAGED_CLEANUP_NAME_NOT_OWNED,
+            f"staged {stage.label} name {stage.path} was substituted; "
+            "left it untouched",
+        )
+        return STAGED_CLEANUP_NAME_NOT_OWNED
+    try:
+        os.unlink(stage.name, dir_fd=stage.directory_descriptor)
+    except OSError as exc:
+        collector.add(
+            STAGED_CLEANUP_UNLINK_FAILED,
+            f"could not remove staged {stage.label} {stage.path}: {exc}",
+        )
+        return "already_absent"
+    return "removed"
+
+
+def release_staged_name(stage: RetainedStage) -> StageCleanupReport:
+    """Unlink a still-owned staged name while keeping both descriptors open.
+
+    For an owner that installs by hard link rather than rename: the target now
+    exists, the staged name is a second link to drop, and the directory
+    descriptor is still needed for the durability fsync.
+    """
+    collector = _CleanupCollector()
+    disposition = _unlink_staged_name(stage, collector)
+    return StageCleanupReport(
+        disposition=disposition,
+        warnings=tuple(collector.warnings),
+        reason_codes=tuple(collector.reason_codes),
+    )
+
+
+def close_retained_stage(stage: RetainedStage) -> StageCleanupReport:
+    """Unlink a still-owned staged name and close both descriptors.
+
+    Always attempted, and always truthful: the report says what happened rather
+    than silently swallowing an orphaned temp file. Callers attach it to their
+    result (installed or not) instead of letting it change the outcome.
+    """
+    collector = _CleanupCollector()
+    disposition = _unlink_staged_name(stage, collector)
+    try:
+        os.close(stage.descriptor)
+    except OSError as exc:
+        collector.add(
+            STAGED_CLEANUP_DESCRIPTOR_CLOSE_FAILED,
+            f"could not close staged {stage.label} {stage.path}: {exc}",
+        )
+    try:
+        os.close(stage.directory_descriptor)
+    except OSError as exc:
+        collector.add(
+            STAGED_CLEANUP_DIRECTORY_CLOSE_FAILED,
+            f"could not close {stage.directory_label} directory {stage.path.parent}: {exc}",
+        )
+    return StageCleanupReport(
+        disposition=disposition,
+        warnings=tuple(collector.warnings),
+        reason_codes=tuple(collector.reason_codes),
+    )

--- a/skills/vault-ingress/scripts/retained_stage.py
+++ b/skills/vault-ingress/scripts/retained_stage.py
@@ -132,8 +132,9 @@ class StageCleanupReport:
     """What cleanup actually did, in stable terms a caller can report.
 
     ``disposition`` is one of ``removed``, ``already_absent``,
-    ``staged_cleanup_name_not_owned``, or ``staged_cleanup_inspect_failed`` —
-    the last meaning absence was never established, so an orphan may remain. A cleanup that could not finish carries
+    ``staged_cleanup_name_not_owned``, ``staged_cleanup_inspect_failed``, or
+    ``staged_cleanup_unlink_failed``. Only ``removed`` and ``already_absent``
+    assert the name is gone; the rest mean an orphan may remain. A cleanup that could not finish carries
     ``reason_codes`` alongside human ``warnings``; neither ever converts an
     installed outcome into a failure.
     """
@@ -626,11 +627,13 @@ def _unlink_staged_name(stage: RetainedStage, collector: _CleanupCollector) -> s
     try:
         os.unlink(stage.name, dir_fd=stage.directory_descriptor)
     except OSError as exc:
+        # The name is still there. Reporting "already_absent" would let a
+        # consumer record a clean cleanup over a confirmed orphan.
         collector.add(
             STAGED_CLEANUP_UNLINK_FAILED,
             f"could not remove staged {stage.label} {stage.path}: {exc}",
         )
-        return "already_absent"
+        return STAGED_CLEANUP_UNLINK_FAILED
     return "removed"
 
 

--- a/skills/vault-ingress/scripts/retained_stage.py
+++ b/skills/vault-ingress/scripts/retained_stage.py
@@ -83,6 +83,7 @@ class StagedInvariantError(RetainedStageError):
         self.path = path
         self.invariant = invariant
         self.detail = detail
+        self.label = label
         super().__init__(
             f"staged {label} {path} changed before install: "
             f"invariant={invariant}; {detail}",
@@ -130,8 +131,9 @@ class RetainedStage:
 class StageCleanupReport:
     """What cleanup actually did, in stable terms a caller can report.
 
-    ``disposition`` is one of ``removed``, ``already_absent``, or
-    ``staged_cleanup_name_not_owned``. A cleanup that could not finish carries
+    ``disposition`` is one of ``removed``, ``already_absent``,
+    ``staged_cleanup_name_not_owned``, or ``staged_cleanup_inspect_failed`` —
+    the last meaning absence was never established, so an orphan may remain. A cleanup that could not finish carries
     ``reason_codes`` alongside human ``warnings``; neither ever converts an
     installed outcome into a failure.
     """
@@ -238,6 +240,23 @@ def visible_descriptor_identity(
         stat.S_ISREG(opened.st_mode)
         and stat.S_ISREG(visible.st_mode)
         and _identity(opened) == _identity(visible)
+    )
+
+
+def _with_cleanup_detail(
+    exc: RetainedStageError, notes: list[str]
+) -> RetainedStageError:
+    """Rebuild a staged error carrying its cleanup detail, type intact."""
+    detail = "; ".join(notes)
+    if isinstance(exc, StagedInvariantError):
+        return StagedInvariantError(
+            exc.path,
+            exc.invariant,
+            f"{exc.detail}; staged cleanup: {detail}",
+            label=exc.label,
+        )
+    return RetainedStageError(
+        f"{exc}; staged cleanup: {detail}", reason_code=exc.reason_code
     )
 
 
@@ -351,23 +370,19 @@ def open_retained_stage(
             verify_retained_stage(stage, payload)
         completed = True
         return stage
-    except Exception as exc:
+    except RetainedStageError as exc:
+        # Attach rather than discard: an orphaned staged temp with no diagnostic
+        # naming it is the exact failure this module exists to stop. Each type
+        # is rebuilt through its own constructor so the typed failure survives.
         released = True
         notes = _release_incomplete_stage(name, descriptor, directory_descriptor)
-        if notes and isinstance(exc, RetainedStageError):
-            # Attach rather than discard: an orphaned staged temp with no
-            # diagnostic naming it is the exact failure this module exists to
-            # stop. Attaching keeps the primary error's type and reason_code.
-            raise type(exc)(
-                f"{exc}; staged cleanup: {'; '.join(notes)}",
-                reason_code=exc.reason_code,
-            ) from exc
-        _warn(notes)
-        raise
+        if not notes:
+            raise
+        raise _with_cleanup_detail(exc, notes) from exc
     finally:
         if not completed and not released:
-            # Interrupt path: cleanup still runs, and its diagnostics still go
-            # somewhere. Re-raising here would replace the interrupt.
+            # Every other failure, interrupts included, propagates unchanged;
+            # cleanup still runs and its diagnostics still go somewhere.
             _warn(_release_incomplete_stage(name, descriptor, directory_descriptor))
 
 
@@ -587,11 +602,14 @@ def _unlink_staged_name(stage: RetainedStage, collector: _CleanupCollector) -> s
     except FileNotFoundError:
         return "already_absent"
     except OSError as exc:
+        # Absence was never established, so the name may still be there. Saying
+        # "already_absent" would let a caller record a clean cleanup over an
+        # orphan.
         collector.add(
             STAGED_CLEANUP_INSPECT_FAILED,
             f"could not inspect staged {stage.label} {stage.path}: {exc}",
         )
-        return "already_absent"
+        return STAGED_CLEANUP_INSPECT_FAILED
     if not visible_descriptor_identity(
         stage.name,
         stage.descriptor,

--- a/skills/vault-ingress/scripts/retained_stage.py
+++ b/skills/vault-ingress/scripts/retained_stage.py
@@ -134,9 +134,9 @@ class StageCleanupReport:
     ``disposition`` is one of ``removed``, ``already_absent``,
     ``staged_cleanup_name_not_owned``, ``staged_cleanup_inspect_failed``, or
     ``staged_cleanup_unlink_failed``. Only ``removed`` and ``already_absent``
-    assert the name is gone; the rest mean an orphan may remain. A cleanup that could not finish carries
-    ``reason_codes`` alongside human ``warnings``; neither ever converts an
-    installed outcome into a failure.
+    assert the name is gone; the rest mean an orphan may remain. A cleanup that
+    could not finish carries ``reason_codes`` alongside human ``warnings``;
+    neither ever converts an installed outcome into a failure.
     """
 
     disposition: str
@@ -177,6 +177,15 @@ def _identity(metadata: os.stat_result) -> tuple[int, int]:
     return metadata.st_dev, metadata.st_ino
 
 
+def _close_or_note(descriptor: int, *, label: str) -> list[str]:
+    """Close a descriptor on a failure path without masking that failure."""
+    try:
+        os.close(descriptor)
+    except OSError as exc:
+        return [f"could not close {label} descriptor: {exc}"]
+    return []
+
+
 def open_directory(path: Path, *, label: str) -> int:
     """Open a directory descriptor the stage anchors every later syscall to.
 
@@ -196,10 +205,22 @@ def open_directory(path: Path, *, label: str) -> int:
             f"cannot open {label} {path}: {exc}",
             reason_code="staged_directory_unavailable",
         ) from exc
-    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
-        os.close(descriptor)
+    # Every failure past the open has to close the descriptor: a bare fstat
+    # raise here leaks it and skips this function's typed contract.
+    try:
+        is_directory = stat.S_ISDIR(os.fstat(descriptor).st_mode)
+    except OSError as exc:
+        notes = _close_or_note(descriptor, label=f"{label} {path}")
         raise RetainedStageError(
-            f"{label} {path} is not a directory",
+            f"cannot inspect {label} {path}: {exc}"
+            + (f"; {'; '.join(notes)}" if notes else ""),
+            reason_code="staged_directory_unavailable",
+        ) from exc
+    if not is_directory:
+        notes = _close_or_note(descriptor, label=f"{label} {path}")
+        raise RetainedStageError(
+            f"{label} {path} is not a directory"
+            + (f"; {'; '.join(notes)}" if notes else ""),
             reason_code="staged_directory_unavailable",
         )
     return descriptor

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -716,22 +716,29 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
         )
     except RetainedStageError as exc:
         raise TrackingDatabaseIOError(str(exc)) from exc
+    verified = False
+    released = False
     try:
         _verify_staged_candidate(stage, candidate)
-    except BaseException as exc:
+        verified = True
+    except Exception as exc:
         # Cleanup detail must ride out with the primary failure. Discarding the
         # report here would reintroduce exactly the vanished-warning problem
         # this primitive exists to close (#240): an orphaned staged temp with
-        # no diagnostic naming it. BaseException so an interrupt still reports.
+        # no diagnostic naming it.
+        released = True
         report = close_retained_stage(stage)
-        if report.warnings:
-            if isinstance(exc, StagedCandidateConflictError):
-                raise StagedCandidateConflictError(
-                    exc.path,
-                    exc.invariant,
-                    f"{exc.detail}; staged cleanup: {'; '.join(report.warnings)}",
-                ) from exc
+        if report.warnings and isinstance(exc, StagedCandidateConflictError):
+            raise StagedCandidateConflictError(
+                exc.path,
+                exc.invariant,
+                f"{exc.detail}; staged cleanup: {'; '.join(report.warnings)}",
+            ) from exc
         raise
+    finally:
+        # Interrupt path: release the stage without trapping the interrupt.
+        if not verified and not released:
+            close_retained_stage(stage)
     return stage
 
 

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -721,22 +721,22 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
     try:
         _verify_staged_candidate(stage, candidate)
         verified = True
-    except Exception as exc:
+    except StagedCandidateConflictError as exc:
         # Cleanup detail must ride out with the primary failure. Discarding the
         # report here would reintroduce exactly the vanished-warning problem
         # this primitive exists to close (#240): an orphaned staged temp with
         # no diagnostic naming it.
         released = True
         report = close_retained_stage(stage)
-        if report.warnings and isinstance(exc, StagedCandidateConflictError):
-            raise StagedCandidateConflictError(
-                exc.path,
-                exc.invariant,
-                f"{exc.detail}; staged cleanup: {'; '.join(report.warnings)}",
-            ) from exc
-        raise
+        if not report.warnings:
+            raise
+        raise StagedCandidateConflictError(
+            exc.path,
+            exc.invariant,
+            f"{exc.detail}; staged cleanup: {'; '.join(report.warnings)}",
+        ) from exc
     finally:
-        # Interrupt path: release the stage without trapping the interrupt.
+        # Every other failure, interrupts included, propagates unchanged.
         if not verified and not released:
             close_retained_stage(stage)
     return stage

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -36,7 +36,6 @@ from retained_stage import (
     open_retained_stage,
     release_staged_name,
     verify_retained_stage,
-    visible_descriptor_identity,
 )
 
 
@@ -691,14 +690,6 @@ def _staged_conflict(exc: StagedInvariantError) -> StagedCandidateConflictError:
     return StagedCandidateConflictError(exc.path, exc.invariant, exc.detail)
 
 
-def _visible_descriptor_identity(
-    name: str,
-    descriptor: int,
-    directory_descriptor: int,
-) -> bool:
-    return visible_descriptor_identity(name, descriptor, directory_descriptor)
-
-
 def _close_staged_candidate(stage: StagedCandidate, warnings: list[str]) -> None:
     """Release the stage, appending truthful cleanup detail for the caller.
 
@@ -725,13 +716,22 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
         )
     except RetainedStageError as exc:
         raise TrackingDatabaseIOError(str(exc)) from exc
-    verified = False
     try:
         _verify_staged_candidate(stage, candidate)
-        verified = True
-    finally:
-        if not verified:
-            close_retained_stage(stage)
+    except BaseException as exc:
+        # Cleanup detail must ride out with the primary failure. Discarding the
+        # report here would reintroduce exactly the vanished-warning problem
+        # this primitive exists to close (#240): an orphaned staged temp with
+        # no diagnostic naming it. BaseException so an interrupt still reports.
+        report = close_retained_stage(stage)
+        if report.warnings:
+            if isinstance(exc, StagedCandidateConflictError):
+                raise StagedCandidateConflictError(
+                    exc.path,
+                    exc.invariant,
+                    f"{exc.detail}; staged cleanup: {'; '.join(report.warnings)}",
+                ) from exc
+        raise
     return stage
 
 

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -22,14 +22,31 @@ import json
 import math
 import os
 from pathlib import Path
-import secrets
 import stat
 from typing import Any, Iterator, NoReturn
+
+from retained_stage import (
+    FileGeneration,
+    RetainedStage as StagedCandidate,
+    RetainedStageError,
+    StagedInvariantError,
+    close_retained_stage,
+    install_retained_stage,
+    installed_target_warning,
+    open_retained_stage,
+    release_staged_name,
+    verify_retained_stage,
+    visible_descriptor_identity,
+)
 
 
 READ_CHUNK_SIZE = 1024 * 1024
 MAX_JSON_NESTING_DEPTH = 200
 STAGED_METADATA_STABILIZATION_ATTEMPTS = 4
+
+
+STAGED_CANDIDATE_SUFFIX = ".tracking-db.tmp"
+STAGED_CANDIDATE_LABEL = "tracking-database candidate"
 
 
 class TrackingDatabaseIOError(ValueError):
@@ -60,27 +77,6 @@ class StagedCandidateConflictError(TrackingDatabaseConflictError):
         super().__init__(
             f"staged tracking-database candidate {path} changed before install: "
             f"invariant={invariant}; {detail}"
-        )
-
-
-@dataclass(frozen=True)
-class FileGeneration:
-    """Stable identity fields for one observed regular-file generation."""
-
-    device: int
-    inode: int
-    size: int
-    modified_ns: int
-    changed_ns: int
-
-    @classmethod
-    def from_stat(cls, metadata: os.stat_result) -> "FileGeneration":
-        return cls(
-            device=metadata.st_dev,
-            inode=metadata.st_ino,
-            size=metadata.st_size,
-            modified_ns=metadata.st_mtime_ns,
-            changed_ns=metadata.st_ctime_ns,
         )
 
 
@@ -134,30 +130,6 @@ class _DatabaseLock:
     descriptor: int
     path: Path
     warnings: list[str]
-
-
-@dataclass
-class StagedCandidate:
-    """Open, directory-anchored staged bytes retained through installation."""
-
-    path: Path
-    name: str
-    descriptor: int
-    directory_descriptor: int
-    generation: FileGeneration
-    sha256: str
-    size: int
-
-
-@dataclass(frozen=True)
-class _StagedCandidateObservation:
-    """One descriptor/name observation around an exact staged-byte read."""
-
-    opened_before: os.stat_result
-    visible_before: os.stat_result
-    raw: bytes
-    opened_after: os.stat_result
-    visible_after: os.stat_result
 
 
 def unchanged_write_result(
@@ -714,25 +686,9 @@ def _write_exact_backup(
     return str(backup_path)
 
 
-def _write_descriptor(descriptor: int, raw: bytes) -> None:
-    offset = 0
-    while offset < len(raw):
-        written = os.write(descriptor, raw[offset:])
-        if written <= 0:
-            raise OSError("staged tracking-database write made no progress")
-        offset += written
-
-
-def _pread_descriptor(descriptor: int, size: int) -> bytes:
-    chunks: list[bytes] = []
-    offset = 0
-    while offset < size:
-        chunk = os.pread(descriptor, min(READ_CHUNK_SIZE, size - offset), offset)
-        if not chunk:
-            break
-        chunks.append(chunk)
-        offset += len(chunk)
-    return b"".join(chunks)
+def _staged_conflict(exc: StagedInvariantError) -> StagedCandidateConflictError:
+    """Re-raise a shared staged-invariant failure in this owner's terms."""
+    return StagedCandidateConflictError(exc.path, exc.invariant, exc.detail)
 
 
 def _visible_descriptor_identity(
@@ -740,271 +696,54 @@ def _visible_descriptor_identity(
     descriptor: int,
     directory_descriptor: int,
 ) -> bool:
-    try:
-        opened = os.fstat(descriptor)
-        visible = os.stat(
-            name,
-            dir_fd=directory_descriptor,
-            follow_symlinks=False,
-        )
-    except OSError:
-        return False
-    return (
-        stat.S_ISREG(opened.st_mode)
-        and stat.S_ISREG(visible.st_mode)
-        and _lock_identity(opened) == _lock_identity(visible)
-    )
-
-
-def _unlink_staged_name(stage: StagedCandidate, warnings: list[str]) -> None:
-    try:
-        os.stat(
-            stage.name,
-            dir_fd=stage.directory_descriptor,
-            follow_symlinks=False,
-        )
-    except FileNotFoundError:
-        return
-    except OSError as exc:
-        warnings.append(f"could not inspect staged candidate {stage.path}: {exc}")
-        return
-    if not _visible_descriptor_identity(
-        stage.name,
-        stage.descriptor,
-        stage.directory_descriptor,
-    ):
-        warnings.append(
-            f"staged candidate name {stage.path} was substituted; left it untouched"
-        )
-        return
-    try:
-        os.unlink(stage.name, dir_fd=stage.directory_descriptor)
-    except OSError as exc:
-        warnings.append(f"could not remove staged candidate {stage.path}: {exc}")
+    return visible_descriptor_identity(name, descriptor, directory_descriptor)
 
 
 def _close_staged_candidate(stage: StagedCandidate, warnings: list[str]) -> None:
-    _unlink_staged_name(stage, warnings)
-    _append_close_warning(
-        stage.descriptor,
-        label=f"staged tracking-database candidate {stage.path}",
-        warnings=warnings,
-    )
-    _append_close_warning(
-        stage.directory_descriptor,
-        label=f"tracking-database directory {stage.path.parent}",
-        warnings=warnings,
-    )
+    """Release the stage, appending truthful cleanup detail for the caller.
+
+    The report is also returned by the shared primitive with stable reason
+    codes; this owner surfaces the prose in its `warnings` tuple.
+    """
+    report = close_retained_stage(stage)
+    warnings.extend(report.warnings)
 
 
 def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate:
-    directory_descriptor = _open_directory(
-        path.parent,
-        label="tracking-database directory",
-    )
-    descriptor: int | None = None
-    name: str | None = None
-    completed = False
     try:
-        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
-        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
-        for _ in range(128):
-            candidate_name = f".{path.name}.{secrets.token_hex(12)}.tracking-db.tmp"
-            try:
-                descriptor = os.open(
-                    candidate_name,
-                    flags,
-                    0o600,
-                    dir_fd=directory_descriptor,
-                )
-                name = candidate_name
-                break
-            except FileExistsError:
-                continue
-        if descriptor is None or name is None:
-            raise TrackingDatabaseIOError(
-                f"cannot allocate a unique staged candidate beside {path}"
-            )
-        os.fchmod(descriptor, mode)
-        _write_descriptor(descriptor, candidate)
-        os.fsync(descriptor)
-        metadata = os.fstat(descriptor)
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
-            raise TrackingDatabaseIOError(
-                f"staged tracking-database candidate {path.parent / name} "
-                "must be one regular file"
-            )
-        stage = StagedCandidate(
-            path=path.parent / name,
-            name=name,
-            descriptor=descriptor,
-            directory_descriptor=directory_descriptor,
-            generation=FileGeneration.from_stat(metadata),
-            sha256=_sha256(candidate),
-            size=len(candidate),
+        # verify=False, then this module's own wrapper: every verification for
+        # this owner goes through the one seam that maps the shared invariant
+        # error into StagedCandidateConflictError.
+        stage = open_retained_stage(
+            path,
+            candidate,
+            mode=mode,
+            suffix=STAGED_CANDIDATE_SUFFIX,
+            label=STAGED_CANDIDATE_LABEL,
+            directory_label="tracking-database",
+            verify=False,
         )
+    except RetainedStageError as exc:
+        raise TrackingDatabaseIOError(str(exc)) from exc
+    verified = False
+    try:
         _verify_staged_candidate(stage, candidate)
-        completed = True
-        return stage
+        verified = True
     finally:
-        if not completed:
-            if descriptor is not None and name is not None:
-                if _visible_descriptor_identity(name, descriptor, directory_descriptor):
-                    try:
-                        os.unlink(name, dir_fd=directory_descriptor)
-                    except OSError:
-                        pass
-                try:
-                    os.close(descriptor)
-                except OSError:
-                    pass
-            try:
-                os.close(directory_descriptor)
-            except OSError:
-                pass
-
-
-def _observe_staged_candidate(
-    stage: StagedCandidate,
-) -> _StagedCandidateObservation:
-    try:
-        opened_before = os.fstat(stage.descriptor)
-        visible_before = os.stat(
-            stage.name,
-            dir_fd=stage.directory_descriptor,
-            follow_symlinks=False,
-        )
-        raw = _pread_descriptor(stage.descriptor, stage.size)
-        opened_after = os.fstat(stage.descriptor)
-        visible_after = os.stat(
-            stage.name,
-            dir_fd=stage.directory_descriptor,
-            follow_symlinks=False,
-        )
-    except OSError as exc:
-        raise StagedCandidateConflictError(
-            stage.path,
-            "metadata_read",
-            str(exc),
-        ) from exc
-    return _StagedCandidateObservation(
-        opened_before=opened_before,
-        visible_before=visible_before,
-        raw=raw,
-        opened_after=opened_after,
-        visible_after=visible_after,
-    )
-
-
-def _staged_metadata_samples(
-    observation: _StagedCandidateObservation,
-) -> tuple[tuple[str, os.stat_result], ...]:
-    return (
-        ("descriptor_before", observation.opened_before),
-        ("name_before", observation.visible_before),
-        ("descriptor_after", observation.opened_after),
-        ("name_after", observation.visible_after),
-    )
-
-
-def _require_staged_candidate_invariants(
-    stage: StagedCandidate,
-    candidate: bytes,
-    observation: _StagedCandidateObservation,
-) -> None:
-    samples = _staged_metadata_samples(observation)
-    non_regular = [
-        label for label, metadata in samples if not stat.S_ISREG(metadata.st_mode)
-    ]
-    if non_regular:
-        raise StagedCandidateConflictError(
-            stage.path,
-            "regular_file",
-            f"non-regular observations={non_regular}",
-        )
-    expected_identity = (stage.generation.device, stage.generation.inode)
-    identities = {label: _lock_identity(metadata) for label, metadata in samples}
-    if any(identity != expected_identity for identity in identities.values()):
-        raise StagedCandidateConflictError(
-            stage.path,
-            "descriptor_name_identity",
-            f"expected={expected_identity}; observed={identities}",
-        )
-    link_counts = {label: metadata.st_nlink for label, metadata in samples}
-    if any(link_count != 1 for link_count in link_counts.values()):
-        raise StagedCandidateConflictError(
-            stage.path,
-            "link_count",
-            f"expected one link; observed={link_counts}",
-        )
-    sizes = {label: metadata.st_size for label, metadata in samples}
-    if (
-        len(candidate) != stage.size
-        or len(observation.raw) != stage.size
-        or any(size != stage.size for size in sizes.values())
-    ):
-        raise StagedCandidateConflictError(
-            stage.path,
-            "size",
-            f"expected={stage.size}; candidate={len(candidate)}; "
-            f"read={len(observation.raw)}; observed={sizes}",
-        )
-    if observation.raw != candidate:
-        raise StagedCandidateConflictError(
-            stage.path,
-            "exact_bytes",
-            "descriptor bytes differ from the exact candidate",
-        )
-    candidate_sha256 = _sha256(candidate)
-    observed_sha256 = _sha256(observation.raw)
-    if stage.sha256 != candidate_sha256 or observed_sha256 != stage.sha256:
-        raise StagedCandidateConflictError(
-            stage.path,
-            "sha256",
-            f"expected={stage.sha256}; candidate={candidate_sha256}; "
-            f"observed={observed_sha256}",
-        )
+        if not verified:
+            close_retained_stage(stage)
+    return stage
 
 
 def _verify_staged_candidate(stage: StagedCandidate, candidate: bytes) -> None:
-    last_timestamps: dict[str, tuple[int, int]] = {}
-    last_unstable_fields: list[str] = []
-    for _ in range(STAGED_METADATA_STABILIZATION_ATTEMPTS):
-        observation = _observe_staged_candidate(stage)
-        _require_staged_candidate_invariants(stage, candidate, observation)
-        last_timestamps = {
-            label: (metadata.st_mtime_ns, metadata.st_ctime_ns)
-            for label, metadata in _staged_metadata_samples(observation)
-        }
-        last_unstable_fields = []
-        for view in ("descriptor", "name"):
-            before = last_timestamps[f"{view}_before"]
-            after = last_timestamps[f"{view}_after"]
-            if before[0] != after[0]:
-                last_unstable_fields.append(f"{view}.mtime_ns")
-            if before[1] != after[1]:
-                last_unstable_fields.append(f"{view}.ctime_ns")
-        if not last_unstable_fields:
-            return
-    raise StagedCandidateConflictError(
-        stage.path,
-        "timestamp_stability",
-        "staged mtime_ns/ctime_ns changed within every read window across "
-        f"{STAGED_METADATA_STABILIZATION_ATTEMPTS} bounded observations; "
-        f"unstable_fields={last_unstable_fields}; last_observed={last_timestamps}",
-    )
+    try:
+        verify_retained_stage(stage, candidate)
+    except StagedInvariantError as exc:
+        raise _staged_conflict(exc) from exc
 
 
 def _replace_staged_candidate(stage: StagedCandidate, target: Path) -> None:
-    if os.replace in os.supports_dir_fd:
-        os.replace(
-            stage.name,
-            target.name,
-            src_dir_fd=stage.directory_descriptor,
-            dst_dir_fd=stage.directory_descriptor,
-        )
-    else:  # pragma: no cover - supported on the Unix platforms this plugin targets.
-        os.replace(stage.path, target)
+    install_retained_stage(stage, target)
 
 
 def _link_staged_candidate(stage: StagedCandidate, target: Path) -> None:
@@ -1025,42 +764,7 @@ def _installed_target_warning(
     target: Path,
     candidate: bytes,
 ) -> str | None:
-    try:
-        opened_before = os.fstat(stage.descriptor)
-        visible_before = os.stat(
-            target.name,
-            dir_fd=stage.directory_descriptor,
-            follow_symlinks=False,
-        )
-        raw = _pread_descriptor(stage.descriptor, stage.size)
-        opened_after = os.fstat(stage.descriptor)
-        visible_after = os.stat(
-            target.name,
-            dir_fd=stage.directory_descriptor,
-            follow_symlinks=False,
-        )
-    except OSError as exc:
-        return f"could not verify installed tracking database {target}: {exc}"
-    if (
-        not stat.S_ISREG(opened_before.st_mode)
-        or not stat.S_ISREG(visible_before.st_mode)
-        or not stat.S_ISREG(opened_after.st_mode)
-        or not stat.S_ISREG(visible_after.st_mode)
-        or _lock_identity(opened_before) != _lock_identity(visible_before)
-        or _lock_identity(opened_after) != _lock_identity(visible_after)
-        or _lock_identity(opened_before) != _lock_identity(opened_after)
-        or opened_before.st_size != stage.size
-        or visible_before.st_size != stage.size
-        or opened_after.st_size != stage.size
-        or visible_after.st_size != stage.size
-        or raw != candidate
-        or _sha256(raw) != stage.sha256
-    ):
-        return (
-            f"installed tracking database {target} no longer matches the staged "
-            "candidate; inspect the live path and output SHA before retrying"
-        )
-    return None
+    return installed_target_warning(stage, target, candidate)
 
 
 def commit_tracking_database(
@@ -1190,7 +894,7 @@ def initialize_tracking_database(
             if verification_warning is not None:
                 durability_state = "installed_verification_failed"
                 warnings.append(verification_warning)
-            _unlink_staged_name(stage, warnings)
+            warnings.extend(release_staged_name(stage).warnings)
             try:
                 _fsync_directory(stage.directory_descriptor)
             except OSError as exc:

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -23,6 +23,7 @@ import math
 import os
 from pathlib import Path
 import stat
+import sys
 from typing import Any, Iterator, NoReturn
 
 from retained_stage import (
@@ -736,9 +737,13 @@ def _stage_candidate(path: Path, candidate: bytes, mode: int) -> StagedCandidate
             f"{exc.detail}; staged cleanup: {'; '.join(report.warnings)}",
         ) from exc
     finally:
-        # Every other failure, interrupts included, propagates unchanged.
+        # Every other failure, interrupts included, propagates unchanged — but
+        # its cleanup detail still has to reach someone, so it goes to stderr
+        # rather than being discarded with the report.
         if not verified and not released:
-            close_retained_stage(stage)
+            report = close_retained_stage(stage)
+            for warning in report.warnings:
+                print(f"WARNING: {warning}", file=sys.stderr)
     return stage
 
 

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -158,6 +158,16 @@ class AnalysisBatchWriteError(OSError):
     """A staged analysis batch could not commit or recover atomically."""
 
 
+class AnalysisBatchUnverifiedError(AnalysisBatchWriteError):
+    """Targets installed, but their post-install byte proof failed.
+
+    Distinct from a commit failure: rolling back here would be wrong, because
+    the replace already happened and the target holds the new file. The batch
+    is complete and the run still fails, so the operator inspects rather than
+    trusting a silent success.
+    """
+
+
 def effective_render_payload(ret, talk):
     """Build the single canonical payload rendered after persistence.
 
@@ -909,6 +919,12 @@ def _release_stages(items, warnings):
         warnings.extend(report.warnings)
 
 
+def _warn_cleanup(warnings):
+    """Emit staged-cleanup detail that has no exception to ride out on."""
+    for warning in warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+
+
 def _cleanup_suffix(warnings):
     """Append staged-cleanup detail to a failure without hiding the cause."""
     if not warnings:
@@ -950,7 +966,9 @@ def atomic_write_batch(rendered):
 
     items = []
     cleanup_warnings: list[str] = []
+    unverified: list[str] = []
     staging_complete = False
+    staging_released = False
     try:
         for name, path, body in rendered:
             items.append(
@@ -965,12 +983,18 @@ def atomic_write_batch(rendered):
             )
         staging_complete = True
     except (RetainedStageError, OSError) as exc:
+        # Release first: a `finally` here would collect cleanup warnings after
+        # the error was already constructed, and they would vanish.
+        _release_stages(items, cleanup_warnings)
+        staging_released = True
         raise AnalysisBatchWriteError(
             f"cannot stage complete analysis batch: {exc}"
+            + _cleanup_suffix(cleanup_warnings)
         ) from exc
     finally:
-        if not staging_complete:
+        if not staging_complete and not staging_released:
             _release_stages(items, cleanup_warnings)
+            _warn_cleanup(cleanup_warnings)
 
     committed = False
     rollback_done = False
@@ -1012,9 +1036,11 @@ def atomic_write_batch(rendered):
                 item["body"],
             )
             if warning is not None:
-                # The replace already happened, so this is an installed-but-
-                # unverified outcome, never a pre-install failure.
+                # The replace already happened, so this is never a pre-install
+                # failure and must not trigger rollback — the target now holds
+                # the new file. It is still a failure the caller must see.
                 cleanup_warnings.append(warning)
+                unverified.append(target)
         committed = True
     except (AnalysisBatchWriteError, RetainedStageError, OSError) as exc:
         rollback_errors = _rollback_analysis_batch(items)
@@ -1042,6 +1068,10 @@ def atomic_write_batch(rendered):
                     file=sys.stderr,
                 )
     for item in items:
+        if item["path"] in unverified:
+            # Keep this target's recovery backup: its installed bytes could not
+            # be proven, so the operator may need the original.
+            continue
         try:
             _safe_unlink(item["backup"])
             item["backup"] = None
@@ -1051,8 +1081,14 @@ def atomic_write_batch(rendered):
             # batch after other backups may already have been discarded.
             pass
     _release_stages(items, cleanup_warnings)
-    for warning in cleanup_warnings:
-        print(f"WARNING: {warning}", file=sys.stderr)
+    _warn_cleanup(cleanup_warnings)
+    if unverified:
+        retained = [item["backup"] for item in items if item["backup"]]
+        raise AnalysisBatchUnverifiedError(
+            "analysis batch installed, but these targets could not be proven to "
+            f"hold their staged bytes: {unverified}; inspect them before trusting "
+            f"the run. Recovery backups retained: {retained}"
+        )
 
 
 def load_json(path, label):

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -65,6 +65,7 @@ import stat
 import sys
 import tempfile
 import unicodedata
+from pathlib import Path
 
 from failure_diagnostics import emit_unexpected_failure
 from tracking_database import (
@@ -93,6 +94,14 @@ from return_validation import (
     validate_batch,
     validate_persisted_v2_analysis_state,
     validate_persisted_catalog_generation,
+)
+from retained_stage import (
+    RetainedStageError,
+    close_retained_stage,
+    install_retained_stage,
+    installed_target_warning,
+    open_retained_stage,
+    verify_retained_stage,
 )
 from tracking_database_io import (
     TrackingDatabaseIOError,
@@ -138,6 +147,11 @@ PERSISTED_RENDER_FIELDS = (
     "pattern_scoring_schema_version",
     "pattern_catalog_fingerprint",
 )
+
+
+# tempfile.mkstemp created the previous staged file at 0o600 and os.replace
+# carried that mode onto the installed analysis, so the retained stage keeps it.
+ANALYSIS_FILE_MODE = 0o600
 
 
 class AnalysisBatchWriteError(OSError):
@@ -853,26 +867,22 @@ def preflight_output_targets(out_dir, rendered):
 
 
 def _stage_text(path, body):
-    """Flush one complete body beside its target without changing the target."""
-    directory = os.path.dirname(os.path.abspath(path)) or "."
-    basename = os.path.basename(path)
-    fd, temp_path = tempfile.mkstemp(
-        prefix=f".{basename}.", suffix=".stage", dir=directory
+    """Retain one complete body beside its target as an open staged inode.
+
+    Returns a `RetainedStage`, not a pathname. Staging by path and installing
+    with `os.replace(name, target)` installs whatever the name resolves to at
+    replace time, so anything able to write to the output directory could swap
+    the staged name and have this writer install its bytes and report success.
+    The retained descriptor is what makes the later verification meaningful.
+    """
+    target = Path(os.path.abspath(path))
+    return open_retained_stage(
+        target,
+        body.encode("utf-8"),
+        mode=ANALYSIS_FILE_MODE,
+        suffix=".stage",
+        label="analysis",
     )
-    staged = False
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(body)
-            handle.flush()
-            os.fsync(handle.fileno())
-        staged = True
-        return temp_path
-    finally:
-        if not staged:
-            try:
-                os.unlink(temp_path)
-            except FileNotFoundError:
-                pass
 
 
 def _safe_unlink(path):
@@ -882,6 +892,28 @@ def _safe_unlink(path):
         os.unlink(path)
     except FileNotFoundError:
         pass
+
+
+def _release_stages(items, warnings):
+    """Close every still-open stage once, collecting truthful cleanup detail.
+
+    Idempotent: the batch releases on the staging path, the failure path, and
+    the success path, and only the first call for a given item does the work.
+    """
+    for item in items:
+        stage = item.get("stage")
+        if stage is None:
+            continue
+        item["stage"] = None
+        report = close_retained_stage(stage)
+        warnings.extend(report.warnings)
+
+
+def _cleanup_suffix(warnings):
+    """Append staged-cleanup detail to a failure without hiding the cause."""
+    if not warnings:
+        return ""
+    return "; staged cleanup: " + "; ".join(warnings)
 
 
 def _rollback_analysis_batch(items):
@@ -917,6 +949,7 @@ def atomic_write_batch(rendered):
     preflight_output_targets(out_dir, rendered)
 
     items = []
+    cleanup_warnings: list[str] = []
     staging_complete = False
     try:
         for name, path, body in rendered:
@@ -924,20 +957,20 @@ def atomic_write_batch(rendered):
                 {
                     "name": name,
                     "path": path,
+                    "body": body.encode("utf-8"),
                     "stage": _stage_text(path, body),
                     "backup": None,
                     "installed": False,
                 }
             )
         staging_complete = True
-    except OSError as exc:
+    except (RetainedStageError, OSError) as exc:
         raise AnalysisBatchWriteError(
             f"cannot stage complete analysis batch: {exc}"
         ) from exc
     finally:
         if not staging_complete:
-            for item in items:
-                _safe_unlink(item["stage"])
+            _release_stages(items, cleanup_warnings)
 
     committed = False
     rollback_done = False
@@ -947,6 +980,10 @@ def atomic_write_batch(rendered):
         preflight_output_targets(out_dir, rendered)
         for item in items:
             target = item["path"]
+            # Prove the staged inode still holds these exact bytes immediately
+            # before its replace. Verifying at stage time alone would leave the
+            # whole staging-plus-preflight window unguarded.
+            verify_retained_stage(item["stage"], item["body"])
             if os.path.lexists(target):
                 mode = os.lstat(target).st_mode
                 if stat.S_ISDIR(mode):
@@ -967,28 +1004,37 @@ def atomic_write_batch(rendered):
                     if not backup_installed:
                         _safe_unlink(backup)
                 item["backup"] = backup
-            os.replace(item["stage"], target)
+            install_retained_stage(item["stage"], Path(os.path.abspath(target)))
             item["installed"] = True
+            warning = installed_target_warning(
+                item["stage"],
+                Path(os.path.abspath(target)),
+                item["body"],
+            )
+            if warning is not None:
+                # The replace already happened, so this is an installed-but-
+                # unverified outcome, never a pre-install failure.
+                cleanup_warnings.append(warning)
         committed = True
-    except (AnalysisBatchWriteError, OSError) as exc:
+    except (AnalysisBatchWriteError, RetainedStageError, OSError) as exc:
         rollback_errors = _rollback_analysis_batch(items)
         rollback_done = True
-        for item in items:
-            _safe_unlink(item["stage"])
+        _release_stages(items, cleanup_warnings)
         if rollback_errors:
             backups = [item["backup"] for item in items if item["backup"]]
             raise AnalysisBatchWriteError(
                 f"analysis batch commit failed ({exc}); rollback also failed: "
                 f"{'; '.join(rollback_errors)}; recovery backups retained: {backups}"
+                + _cleanup_suffix(cleanup_warnings)
             ) from exc
         raise AnalysisBatchWriteError(
             f"analysis batch commit failed ({exc}); every prior target was restored"
+            + _cleanup_suffix(cleanup_warnings)
         ) from exc
     finally:
         if not committed and not rollback_done:
             rollback_errors = _rollback_analysis_batch(items)
-            for item in items:
-                _safe_unlink(item["stage"])
+            _release_stages(items, cleanup_warnings)
             if rollback_errors:
                 print(
                     "WARNING: interrupted analysis batch rollback retained recovery "
@@ -1004,8 +1050,9 @@ def atomic_write_batch(rendered):
             # recoverable cleanup artifact, not grounds to roll back a complete
             # batch after other backups may already have been discarded.
             pass
-    for item in items:
-        _safe_unlink(item["stage"])
+    _release_stages(items, cleanup_warnings)
+    for warning in cleanup_warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
 
 
 def load_json(path, label):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,19 @@ def tracking_database_io():
 
 
 @pytest.fixture(scope="session")
+def retained_stage():
+    """The staged-file lifecycle both owner writers share (#243).
+
+    Tests that inject staging faults patch this module, not an owner: the
+    observation loop, the byte read, and the descriptor closes live here.
+    """
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "retained_stage.py"),
+        "retained_stage",
+    )
+
+
+@pytest.fixture(scope="session")
 def mutate_tracking_database():
     return _import_script(
         os.path.join(SCRIPTS_VI, "mutate-tracking-database.py"),

--- a/tests/test_retained_stage.py
+++ b/tests/test_retained_stage.py
@@ -426,3 +426,41 @@ def test_a_verified_install_removes_its_backup_and_succeeds(
     assert target.read_text(encoding="utf-8") == "the new body\n"
     assert not list(tmp_path.glob(".*.backup"))
     assert not list(tmp_path.glob(".*.stage"))
+
+
+def test_unlink_failure_disposition_never_claims_absence(
+    retained_stage, staged, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed unlink leaves the name behind, so the report must say so."""
+    stage, _payload, _target = staged
+
+    def failing_unlink(*_args, **_kwargs):
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(retained_stage.os, "unlink", failing_unlink)
+    report = retained_stage.close_retained_stage(stage)
+
+    assert report.disposition == retained_stage.STAGED_CLEANUP_UNLINK_FAILED
+    assert report.disposition != "already_absent"
+    assert report.clean is False
+    assert stage.path.exists()
+    stage.descriptor = None
+
+
+def test_inspect_failure_disposition_never_claims_absence(
+    retained_stage, staged, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, _payload, _target = staged
+    real_stat = os.stat
+
+    def failing_stat(name, *args, **kwargs):
+        if name == stage.name:
+            raise OSError("simulated stat failure")
+        return real_stat(name, *args, **kwargs)
+
+    monkeypatch.setattr(retained_stage.os, "stat", failing_stat)
+    report = retained_stage.close_retained_stage(stage)
+
+    assert report.disposition == retained_stage.STAGED_CLEANUP_INSPECT_FAILED
+    assert report.disposition != "already_absent"
+    stage.descriptor = None

--- a/tests/test_retained_stage.py
+++ b/tests/test_retained_stage.py
@@ -385,3 +385,44 @@ def test_incomplete_stage_cleanup_failure_warns_when_it_cannot_attach(
         )
 
     assert "could not remove incomplete staged file" in capsys.readouterr().err
+
+
+def test_unverified_install_fails_the_run_and_keeps_the_backup(
+    write_analysis, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed post-install proof must not exit 0.
+
+    Rolling back would be wrong — the replace already happened — so the batch
+    completes, the recovery backup is retained, and the run still fails.
+    """
+    target = tmp_path / "analysis.md"
+    target.write_text("the original body\n", encoding="utf-8")
+    rendered = [("talk", str(target), "the new body\n")]
+
+    monkeypatch.setattr(
+        write_analysis,
+        "installed_target_warning",
+        lambda *_args, **_kwargs: "injected post-install verification failure",
+    )
+
+    with pytest.raises(write_analysis.AnalysisBatchUnverifiedError) as caught:
+        write_analysis.atomic_write_batch(rendered)
+
+    assert str(target) in str(caught.value)
+    assert "Recovery backups retained" in str(caught.value)
+    # The install itself still happened; rollback here would be the wrong move.
+    assert target.read_text(encoding="utf-8") == "the new body\n"
+    assert list(tmp_path.glob(".*.backup"))
+
+
+def test_a_verified_install_removes_its_backup_and_succeeds(
+    write_analysis, tmp_path: Path
+) -> None:
+    target = tmp_path / "analysis.md"
+    target.write_text("the original body\n", encoding="utf-8")
+
+    write_analysis.atomic_write_batch([("talk", str(target), "the new body\n")])
+
+    assert target.read_text(encoding="utf-8") == "the new body\n"
+    assert not list(tmp_path.glob(".*.backup"))
+    assert not list(tmp_path.glob(".*.stage"))

--- a/tests/test_retained_stage.py
+++ b/tests/test_retained_stage.py
@@ -325,3 +325,64 @@ def test_stage_verification_failure_carries_its_cleanup_detail(
     # Both the primary invariant and the cleanup failure are reported.
     assert "staged cleanup" in caught.value.detail
     assert "could not remove" in caught.value.detail
+
+
+def test_incomplete_stage_cleanup_failure_is_not_swallowed(
+    retained_stage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`except OSError: pass` here would orphan a temp with no diagnostic.
+
+    The primary error keeps its type and reason_code; the cleanup detail is
+    appended rather than discarded.
+    """
+
+    def failing_write(descriptor: int, raw: bytes) -> None:
+        raise retained_stage.RetainedStageError(
+            "injected staging failure", reason_code="staged_shape_invalid"
+        )
+
+    def failing_unlink(*_args, **_kwargs):
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(retained_stage, "_write_descriptor", failing_write)
+    monkeypatch.setattr(retained_stage.os, "unlink", failing_unlink)
+
+    with pytest.raises(retained_stage.RetainedStageError) as caught:
+        retained_stage.open_retained_stage(
+            tmp_path / "target.txt",
+            b"body\n",
+            mode=0o600,
+            suffix=".test.tmp",
+            label="test artifact",
+        )
+
+    assert "injected staging failure" in str(caught.value)
+    assert "staged cleanup" in str(caught.value)
+    assert "could not remove incomplete staged file" in str(caught.value)
+    assert caught.value.reason_code == "staged_shape_invalid"
+
+
+def test_incomplete_stage_cleanup_failure_warns_when_it_cannot_attach(
+    retained_stage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A non-RetainedStageError still gets its cleanup detail surfaced."""
+
+    def failing_write(descriptor: int, raw: bytes) -> None:
+        raise ValueError("injected non-staged failure")
+
+    def failing_unlink(*_args, **_kwargs):
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(retained_stage, "_write_descriptor", failing_write)
+    monkeypatch.setattr(retained_stage.os, "unlink", failing_unlink)
+
+    with pytest.raises(ValueError):
+        retained_stage.open_retained_stage(
+            tmp_path / "target.txt",
+            b"body\n",
+            mode=0o600,
+            suffix=".test.tmp",
+            label="test artifact",
+        )
+
+    assert "could not remove incomplete staged file" in capsys.readouterr().err

--- a/tests/test_retained_stage.py
+++ b/tests/test_retained_stage.py
@@ -1,0 +1,290 @@
+"""Tests for the retained named-stage primitive shared by owner writers (#243).
+
+The defect that motivated extraction: `write-analysis.py` staged by pathname,
+closed the descriptor, and installed with `os.replace(name, target)`. Anything
+able to write to the output directory could substitute the staged name between
+those steps and have the writer install its bytes while reporting success.
+
+These tests pin the primitive itself and prove both consumers now inherit its
+invariants rather than reimplementing or omitting them.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def staged(retained_stage, tmp_path: Path):
+    """One retained stage over known bytes, released after the test."""
+    payload = b"the exact staged bytes\n"
+    target = tmp_path / "target.txt"
+    stage = retained_stage.open_retained_stage(
+        target,
+        payload,
+        mode=0o600,
+        suffix=".test.tmp",
+        label="test artifact",
+    )
+    try:
+        yield stage, payload, target
+    finally:
+        if stage.descriptor is not None:
+            try:
+                retained_stage.close_retained_stage(stage)
+            except OSError:
+                pass
+
+
+# --- the invariants ----------------------------------------------------------
+
+
+def test_a_clean_stage_verifies_and_installs(retained_stage, staged) -> None:
+    stage, payload, target = staged
+    retained_stage.verify_retained_stage(stage, payload)
+    retained_stage.install_retained_stage(stage, target)
+    assert target.read_bytes() == payload
+    assert retained_stage.installed_target_warning(stage, target, payload) is None
+
+
+def test_pathname_substitution_fails_before_install(retained_stage, staged) -> None:
+    """Acceptance test 2: a real regular file at the staged name is refused.
+
+    This is the live defect. Before extraction the analysis writer installed the
+    substituted bytes here and reported success.
+    """
+    stage, payload, _target = staged
+    foreign = b"attacker-supplied content\n"
+    os.unlink(stage.path)
+    stage.path.write_bytes(foreign)
+
+    with pytest.raises(retained_stage.StagedInvariantError) as caught:
+        retained_stage.verify_retained_stage(stage, payload)
+
+    assert caught.value.invariant == "descriptor_name_identity"
+    # The foreign file is someone else's data — cleanup must not delete it.
+    report = retained_stage.close_retained_stage(stage)
+    assert report.disposition == retained_stage.STAGED_CLEANUP_NAME_NOT_OWNED
+    assert stage.path.read_bytes() == foreign
+    stage.descriptor = None
+
+
+def test_hard_link_fails_the_link_count_invariant(
+    retained_stage, staged, tmp_path: Path
+) -> None:
+    stage, payload, _target = staged
+    os.link(stage.path, tmp_path / "second-link")
+
+    with pytest.raises(retained_stage.StagedInvariantError) as caught:
+        retained_stage.verify_retained_stage(stage, payload)
+
+    assert caught.value.invariant == "link_count"
+
+
+def test_size_change_fails_the_size_invariant(retained_stage, staged) -> None:
+    stage, payload, _target = staged
+    os.pwrite(stage.descriptor, b"extra", len(payload))
+
+    with pytest.raises(retained_stage.StagedInvariantError) as caught:
+        retained_stage.verify_retained_stage(stage, payload)
+
+    assert caught.value.invariant == "size"
+
+
+def test_same_size_byte_change_fails_the_exact_bytes_invariant(
+    retained_stage, staged
+) -> None:
+    """A rewrite that preserves length still has to be caught."""
+    stage, payload, _target = staged
+    os.pwrite(stage.descriptor, b"X", 0)
+
+    with pytest.raises(retained_stage.StagedInvariantError) as caught:
+        retained_stage.verify_retained_stage(stage, payload)
+
+    assert caught.value.invariant == "exact_bytes"
+
+
+def test_digest_binding_fails_when_the_caller_swaps_the_payload(
+    retained_stage, staged
+) -> None:
+    stage, payload, _target = staged
+    assert len(payload) > 1
+    different = b"Y" * len(payload)
+
+    with pytest.raises(retained_stage.StagedInvariantError) as caught:
+        retained_stage.verify_retained_stage(stage, different)
+
+    assert caught.value.invariant == "exact_bytes"
+
+
+def test_a_directory_at_the_staged_name_is_refused(retained_stage, staged) -> None:
+    stage, payload, _target = staged
+    os.unlink(stage.path)
+    stage.path.mkdir()
+
+    with pytest.raises(retained_stage.StagedInvariantError) as caught:
+        retained_stage.verify_retained_stage(stage, payload)
+
+    assert caught.value.invariant in {"descriptor_name_identity", "regular_file"}
+    report = retained_stage.close_retained_stage(stage)
+    assert report.disposition == retained_stage.STAGED_CLEANUP_NAME_NOT_OWNED
+    assert stage.path.is_dir()
+    stage.descriptor = None
+
+
+# --- cleanup reporting (#240, folded in) -------------------------------------
+
+
+def test_clean_cleanup_removes_the_owned_name(retained_stage, staged) -> None:
+    stage, _payload, _target = staged
+    report = retained_stage.close_retained_stage(stage)
+    assert report.disposition == "removed"
+    assert report.clean is True
+    assert report.reason_codes == ()
+    assert not stage.path.exists()
+    stage.descriptor = None
+
+
+def test_an_already_absent_name_is_reported_not_failed(retained_stage, staged) -> None:
+    stage, _payload, _target = staged
+    os.unlink(stage.path)
+    report = retained_stage.close_retained_stage(stage)
+    assert report.disposition == "already_absent"
+    assert report.clean is True
+    stage.descriptor = None
+
+
+def test_descriptor_close_failure_is_reported_with_a_stable_reason(
+    retained_stage, staged, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, _payload, _target = staged
+    real_close = os.close
+    failed = {"done": False}
+
+    def failing_close(descriptor: int) -> None:
+        if descriptor == stage.descriptor and not failed["done"]:
+            failed["done"] = True
+            real_close(descriptor)
+            raise OSError("simulated descriptor close failure")
+        real_close(descriptor)
+
+    monkeypatch.setattr(retained_stage.os, "close", failing_close)
+    report = retained_stage.close_retained_stage(stage)
+
+    assert retained_stage.STAGED_CLEANUP_DESCRIPTOR_CLOSE_FAILED in report.reason_codes
+    assert report.clean is False
+    assert any("could not close" in warning for warning in report.warnings)
+    stage.descriptor = None
+
+
+def test_unlink_failure_is_reported_with_a_stable_reason(
+    retained_stage, staged, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, _payload, _target = staged
+
+    def failing_unlink(*_args, **_kwargs):
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(retained_stage.os, "unlink", failing_unlink)
+    report = retained_stage.close_retained_stage(stage)
+
+    assert retained_stage.STAGED_CLEANUP_UNLINK_FAILED in report.reason_codes
+    # The diagnostic names the orphan explicitly rather than leaving it silent.
+    assert any(str(stage.path) in warning for warning in report.warnings)
+    stage.descriptor = None
+
+
+def test_interrupts_propagate_through_staging(
+    retained_stage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Acceptance test 12: cleanup runs, then the interrupt keeps going."""
+    real_write = retained_stage._write_descriptor
+
+    def interrupt_after_write(descriptor: int, raw: bytes) -> None:
+        real_write(descriptor, raw)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(retained_stage, "_write_descriptor", interrupt_after_write)
+
+    with pytest.raises(KeyboardInterrupt):
+        retained_stage.open_retained_stage(
+            tmp_path / "target.txt",
+            b"body\n",
+            mode=0o600,
+            suffix=".test.tmp",
+            label="test artifact",
+        )
+
+    assert not list(tmp_path.glob(".*.test.tmp"))
+
+
+# --- both consumers actually share it ----------------------------------------
+
+
+def test_both_owner_writers_install_through_the_shared_primitive() -> None:
+    """Acceptance test 1: one implementation, not two copies.
+
+    A grep-level assertion on purpose: the point of the extraction is that
+    neither owner carries its own staging lifecycle any more.
+    """
+    scripts = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
+    analysis = (scripts / "write-analysis.py").read_text(encoding="utf-8")
+    database = (scripts / "tracking_database_io.py").read_text(encoding="utf-8")
+
+    for source in (analysis, database):
+        assert "from retained_stage import" in source
+        assert "open_retained_stage" in source
+        assert (
+            "install_retained_stage" in source or "_replace_staged_candidate" in source
+        )
+
+    # The analysis writer must not fall back to a pathname-only stage-and-rename.
+    assert (
+        'tempfile.mkstemp(\n        prefix=f".{basename}.", suffix=".stage"'
+        not in analysis
+    )
+
+
+def test_analysis_writer_refuses_a_substituted_stage(
+    write_analysis, retained_stage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end proof of the live defect, through the real batch writer.
+
+    Before the extraction this installed the foreign bytes and returned
+    normally. The batch must now fail closed and leave the target absent.
+    """
+    target = tmp_path / "analysis.md"
+    rendered = [("talk", str(target), "THE REAL ANALYSIS BODY\n")]
+    real_stage_text = write_analysis._stage_text
+    substituted: dict[str, Path] = {}
+
+    def substituting_stage_text(path, body):
+        stage = real_stage_text(path, body)
+        os.unlink(stage.path)
+        stage.path.write_bytes(b"attacker-supplied content\n")
+        substituted["path"] = stage.path
+        return stage
+
+    monkeypatch.setattr(write_analysis, "_stage_text", substituting_stage_text)
+
+    with pytest.raises(write_analysis.AnalysisBatchWriteError):
+        write_analysis.atomic_write_batch(rendered)
+
+    assert not target.exists()
+    # The foreign file was left alone rather than deleted during cleanup.
+    assert substituted["path"].read_bytes() == b"attacker-supplied content\n"
+
+
+def test_analysis_writer_still_writes_a_clean_batch(
+    write_analysis, tmp_path: Path
+) -> None:
+    """The guard must not cost the ordinary path."""
+    first = tmp_path / "one.md"
+    second = tmp_path / "two.md"
+    write_analysis.atomic_write_batch(
+        [("one", str(first), "first body\n"), ("two", str(second), "second body\n")]
+    )
+    assert first.read_text(encoding="utf-8") == "first body\n"
+    assert second.read_text(encoding="utf-8") == "second body\n"
+    assert not list(tmp_path.glob(".*.stage"))

--- a/tests/test_retained_stage.py
+++ b/tests/test_retained_stage.py
@@ -31,10 +31,9 @@ def staged(retained_stage, tmp_path: Path):
         yield stage, payload, target
     finally:
         if stage.descriptor is not None:
-            try:
-                retained_stage.close_retained_stage(stage)
-            except OSError:
-                pass
+            # No suppression: a cleanup failure here is a leaked descriptor or
+            # a leaked temp file, and the test should say so.
+            retained_stage.close_retained_stage(stage)
 
 
 # --- the invariants ----------------------------------------------------------

--- a/tests/test_retained_stage.py
+++ b/tests/test_retained_stage.py
@@ -288,3 +288,40 @@ def test_analysis_writer_still_writes_a_clean_batch(
     assert first.read_text(encoding="utf-8") == "first body\n"
     assert second.read_text(encoding="utf-8") == "second body\n"
     assert not list(tmp_path.glob(".*.stage"))
+
+
+def test_stage_verification_failure_carries_its_cleanup_detail(
+    tracking_database_io, retained_stage, tmp_path: Path, monkeypatch
+) -> None:
+    """A pre-install failure must not swallow a failed cleanup.
+
+    This is the #240 shape one level up: the owner catches the invariant error,
+    runs cleanup, and would otherwise drop the report on the floor — leaving an
+    orphaned staged temp with no diagnostic naming it.
+    """
+    path = tmp_path / "tracking-database.json"
+    path.write_bytes(b'{\n  "talks": []\n}\n')
+    expected = tracking_database_io.snapshot_tracking_database(path)
+    candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
+
+    def failing_verify(stage, raw: bytes) -> None:
+        raise tracking_database_io.StagedCandidateConflictError(
+            stage.path, "exact_bytes", "injected verification failure"
+        )
+
+    def failing_unlink(*_args, **_kwargs):
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(
+        tracking_database_io, "_verify_staged_candidate", failing_verify
+    )
+    monkeypatch.setattr(retained_stage.os, "unlink", failing_unlink)
+
+    with pytest.raises(tracking_database_io.StagedCandidateConflictError) as caught:
+        tracking_database_io.commit_tracking_database(expected, candidate)
+
+    assert caught.value.invariant == "exact_bytes"
+    assert "injected verification failure" in caught.value.detail
+    # Both the primary invariant and the cleanup failure are reported.
+    assert "staged cleanup" in caught.value.detail
+    assert "could not remove" in caught.value.detail

--- a/tests/test_retained_stage.py
+++ b/tests/test_retained_stage.py
@@ -464,3 +464,46 @@ def test_inspect_failure_disposition_never_claims_absence(
     assert report.disposition == retained_stage.STAGED_CLEANUP_INSPECT_FAILED
     assert report.disposition != "already_absent"
     stage.descriptor = None
+
+
+def test_directory_inspect_failure_closes_the_descriptor(
+    retained_stage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An fstat raise after the open must not leak the directory descriptor."""
+    closed: list[int] = []
+    real_close = os.close
+    real_fstat = os.fstat
+
+    def failing_fstat(descriptor: int):
+        raise OSError("simulated fstat failure")
+
+    def recording_close(descriptor: int) -> None:
+        closed.append(descriptor)
+        real_close(descriptor)
+
+    monkeypatch.setattr(retained_stage.os, "fstat", failing_fstat)
+    monkeypatch.setattr(retained_stage.os, "close", recording_close)
+
+    with pytest.raises(retained_stage.RetainedStageError) as caught:
+        retained_stage.open_directory(tmp_path, label="test directory")
+
+    assert caught.value.reason_code == "staged_directory_unavailable"
+    assert "simulated fstat failure" in str(caught.value)
+    assert closed, "the directory descriptor was leaked"
+    monkeypatch.setattr(retained_stage.os, "fstat", real_fstat)
+
+
+def test_a_non_directory_target_is_refused_at_open(
+    retained_stage, tmp_path: Path
+) -> None:
+    """O_DIRECTORY refuses a regular file at the open, so nothing to leak.
+
+    The typed error still has to come out rather than a bare OSError.
+    """
+    regular = tmp_path / "not-a-directory"
+    regular.write_text("x", encoding="utf-8")
+
+    with pytest.raises(retained_stage.RetainedStageError) as caught:
+        retained_stage.open_directory(regular, label="test directory")
+
+    assert caught.value.reason_code == "staged_directory_unavailable"

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -505,6 +505,7 @@ def test_lock_acquisition_interrupt_closes_descriptor(
 
 
 def test_staging_interrupt_cleans_candidate_and_preserves_database(
+    retained_stage,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -512,15 +513,13 @@ def test_staging_interrupt_cleans_candidate_and_preserves_database(
     path = tmp_path / "tracking-database.json"
     original = _write(path, {"talks": []})
     expected = tracking_database_io.snapshot_tracking_database(path)
-    real_write = tracking_database_io._write_descriptor
+    real_write = retained_stage._write_descriptor
 
     def interrupt_after_write(descriptor: int, raw: bytes) -> None:
         real_write(descriptor, raw)
         raise KeyboardInterrupt
 
-    monkeypatch.setattr(
-        tracking_database_io, "_write_descriptor", interrupt_after_write
-    )
+    monkeypatch.setattr(retained_stage, "_write_descriptor", interrupt_after_write)
     with pytest.raises(KeyboardInterrupt):
         tracking_database_io.commit_tracking_database(
             expected,
@@ -533,6 +532,7 @@ def test_staging_interrupt_cleans_candidate_and_preserves_database(
 
 
 def test_staged_timestamp_churn_retries_same_candidate_then_installs_once(
+    retained_stage,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -541,11 +541,11 @@ def test_staged_timestamp_churn_retries_same_candidate_then_installs_once(
     _write(path, {"talks": []})
     expected = tracking_database_io.snapshot_tracking_database(path)
     candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
-    original_observe = tracking_database_io._observe_staged_candidate
+    original_observe = retained_stage._observe
     original_verify = tracking_database_io._verify_staged_candidate
     original_replace = tracking_database_io._replace_staged_candidate
-    real_fstat = tracking_database_io.os.fstat
-    real_stat = tracking_database_io.os.stat
+    real_fstat = retained_stage.os.fstat
+    real_stat = retained_stage.os.stat
     staged_descriptor: int | None = None
     staged_name: str | None = None
     staged_directory_descriptor: int | None = None
@@ -609,8 +609,8 @@ def test_staged_timestamp_churn_retries_same_candidate_then_installs_once(
             staged_descriptor = stage.descriptor
             staged_name = stage.name
             staged_directory_descriptor = stage.directory_descriptor
-            monkeypatch.setattr(tracking_database_io.os, "fstat", churning_fstat)
-            monkeypatch.setattr(tracking_database_io.os, "stat", churning_stat)
+            monkeypatch.setattr(retained_stage.os, "fstat", churning_fstat)
+            monkeypatch.setattr(retained_stage.os, "stat", churning_stat)
         original_verify(stage, raw)
 
     def counted_replace(stage, target: Path) -> None:
@@ -618,20 +618,12 @@ def test_staged_timestamp_churn_retries_same_candidate_then_installs_once(
         replacements += 1
         original_replace(stage, target)
 
+    monkeypatch.setattr(retained_stage, "_observe", counted_observe)
     monkeypatch.setattr(
-        tracking_database_io,
-        "_observe_staged_candidate",
-        counted_observe,
+        tracking_database_io, "_verify_staged_candidate", verify_with_initial_churn
     )
     monkeypatch.setattr(
-        tracking_database_io,
-        "_verify_staged_candidate",
-        verify_with_initial_churn,
-    )
-    monkeypatch.setattr(
-        tracking_database_io,
-        "_replace_staged_candidate",
-        counted_replace,
+        tracking_database_io, "_replace_staged_candidate", counted_replace
     )
 
     result = tracking_database_io.commit_tracking_database(expected, candidate)
@@ -645,6 +637,7 @@ def test_staged_timestamp_churn_retries_same_candidate_then_installs_once(
 
 
 def test_never_stable_staged_timestamps_fail_with_bounded_typed_diagnostic(
+    retained_stage,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -653,10 +646,10 @@ def test_never_stable_staged_timestamps_fail_with_bounded_typed_diagnostic(
     original = _write(path, {"talks": []})
     expected = tracking_database_io.snapshot_tracking_database(path)
     candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
-    original_observe = tracking_database_io._observe_staged_candidate
+    original_observe = retained_stage._observe
     original_verify = tracking_database_io._verify_staged_candidate
-    real_fstat = tracking_database_io.os.fstat
-    real_stat = tracking_database_io.os.stat
+    real_fstat = retained_stage.os.fstat
+    real_stat = retained_stage.os.stat
     staged_descriptor: int | None = None
     staged_name: str | None = None
     staged_directory_descriptor: int | None = None
@@ -706,15 +699,11 @@ def test_never_stable_staged_timestamps_fail_with_bounded_typed_diagnostic(
         staged_descriptor = stage.descriptor
         staged_name = stage.name
         staged_directory_descriptor = stage.directory_descriptor
-        monkeypatch.setattr(tracking_database_io.os, "fstat", churning_fstat)
-        monkeypatch.setattr(tracking_database_io.os, "stat", churning_stat)
+        monkeypatch.setattr(retained_stage.os, "fstat", churning_fstat)
+        monkeypatch.setattr(retained_stage.os, "stat", churning_stat)
         original_verify(stage, raw)
 
-    monkeypatch.setattr(
-        tracking_database_io,
-        "_observe_staged_candidate",
-        counted_observe,
-    )
+    monkeypatch.setattr(retained_stage, "_observe", counted_observe)
     monkeypatch.setattr(
         tracking_database_io,
         "_verify_staged_candidate",
@@ -739,6 +728,7 @@ def test_never_stable_staged_timestamps_fail_with_bounded_typed_diagnostic(
 
 
 def test_staged_name_identity_change_fails_typed_and_cleans_owned_candidate(
+    retained_stage,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -748,7 +738,7 @@ def test_staged_name_identity_change_fails_typed_and_cleans_owned_candidate(
     expected = tracking_database_io.snapshot_tracking_database(path)
     candidate = tracking_database_io.render_json_object({"talks": [], "config": {}})
     original_stage = tracking_database_io._stage_candidate
-    real_stat = tracking_database_io.os.stat
+    real_stat = retained_stage.os.stat
     staged_name: str | None = None
     staged_directory_descriptor: int | None = None
     substituted = False
@@ -1132,6 +1122,7 @@ def test_directory_fsync_failure_reports_installed_generation(
 
 @pytest.mark.parametrize("initialize", [False, True], ids=["commit", "initialize"])
 def test_directory_close_failure_is_an_installed_warning(
+    retained_stage,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1162,7 +1153,7 @@ def test_directory_close_failure_is_an_installed_warning(
         real_close(descriptor)
 
     monkeypatch.setattr(tracking_database_io, "_stage_candidate", capture_stage)
-    monkeypatch.setattr(tracking_database_io.os, "close", fail_directory_close)
+    monkeypatch.setattr(retained_stage.os, "close", fail_directory_close)
     if initialize:
         result = tracking_database_io.initialize_tracking_database(path, payload)
     else:
@@ -1265,6 +1256,7 @@ def test_lock_close_failure_is_an_installed_warning(
 
 
 def test_postinstall_verification_failure_reports_installed_unknown_state(
+    retained_stage,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #243, and folds in #240.

## This is a live defect, not a duplicated invariant

`write-analysis.py`'s `_stage_text` created its stage with `tempfile.mkstemp`, wrote the body, **closed the descriptor**, and returned a pathname. `atomic_write_batch` then installed it with `os.replace(name, target)`.

Between those two steps the staged name is just a name in a directory. Anything able to write there could substitute it and have the writer install those bytes. Reproduced on `main` before touching anything:

```
atomic_write_batch: reported SUCCESS
installed bytes: 'ATTACKER-SUPPLIED CONTENT\n'
VERDICT: GAP — substituted bytes installed while reporting success
```

Worse than the issue described: the writer had **no byte verification of its stage at all**. Every `sha256` in that file is citation rendering.

## The shared primitive

`skills/vault-ingress/scripts/retained_stage.py` owns the staged-file lifecycle for both writers:

- unique no-follow creation with a retained file descriptor **and** directory descriptor
- regular-file and single-link validation
- exact descriptor/name device+inode identity at every preinstall observation
- exact size, bytes, and SHA-256 binding
- bounded same-view `mtime_ns`/`ctime_ns` stabilization (each view against itself — requiring the descriptor and path caches to agree would fail on filesystems that update them independently)

Each owner keeps its own compare-and-swap and backup behavior, which is what actually differs between them. `tracking_database_io` maps the shared `StagedInvariantError` into its existing `StagedCandidateConflictError`, so its public error contract is unchanged.

The analysis writer re-verifies immediately before each replace, not only at stage time, so the staging-plus-preflight window is covered too. Its post-install check reports installed-but-unverified — never a pre-install failure, because the replace already happened.

## Truthful cleanup (#240)

`close_retained_stage` returns a report with a disposition and stable reason codes (`staged_cleanup_unlink_failed`, `staged_cleanup_descriptor_close_failed`, `staged_cleanup_directory_close_failed`, `staged_cleanup_name_not_owned`). Previously these were appended to a local list inside a `finally`, so a propagating pre-install exception returned no result and the warnings vanished — leaving an orphaned temp file with no diagnostic naming it.

A name that now resolves to a different inode or file type is **left untouched** rather than unlinked. It is someone else's data; removing it to tidy up after ourselves would be the second bug.

`KeyboardInterrupt` and `SystemExit` still propagate.

## Test seams followed the implementation

Five injection points that patched `tracking_database_io` internals now patch `retained_stage`, where the observation loop actually lives. The two that wrap the owner's typed-error mapping keep patching the owner, because that mapping *is* the owner's — one of them was calling the shared function directly and losing the mapping, which is how I caught the layering.

`open_retained_stage(verify=False)` lets an owner route every verification through its own error-mapping seam instead of one path bypassing it.

## Verification

- `pytest` — 5145 passed, 3 skipped, 0 failed
- **342 existing writer tests green unchanged**: race, interrupt, backup, durability, analysis-body-preservation, CloudStorage migration (acceptance test 7)
- 15 new tests in `tests/test_retained_stage.py`: substitution, hard-link, size, same-size byte change, digest, directory-at-name, each cleanup disposition, interrupt propagation, plus end-to-end proof through the real `atomic_write_batch`
- `ruff check` / `ruff format --check` / `pyright` — clean
- `./scripts/pre-publish-checks.sh` — all gates OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)