### PR TITLE
feat(vault-ingress): add an owner writer for reviewed catalog conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+### feat(vault-ingress) — an owner writer for reviewed shownotes catalog conflicts (#236)
+
+Closes #236.
+
+`scan-shownotes.py` correctly reports a title or conference conflict as
+`review_required`, and `--apply` deliberately refuses those entries. Nothing
+could then install the reviewed decision: `apply-source-repairs.py` does not
+allow `title` or `conference`, and `mutate-tracking-database.py` limited talk
+updates to publishing and clarification fields. A vault operator had to either
+leave a known-wrong catalog fact in place or bypass the database ownership
+contract by hand. The 2026-08-05 rhetoric-vault reconciliation hit exactly that
+with two conflicts — `DevOps Nashville 2024` versus `DevOps Days Nashville
+2024`, and a base title versus its event-qualified form.
+
+`apply_reviewed_metadata` is that writer, and it stays narrow:
+
+- A closed writable set (`title`, `conference`) — a reviewed metadata decision
+  is not a licence to edit arbitrary talk fields, and source lanes stay with
+  `apply-source-repairs.py`.
+- An exact old-value precondition per changed field, so a decision reviewed
+  against one value cannot silently install over another.
+- The full current talk/database shape validated before atomic replacement; a
+  stale precondition, unsupported field, unknown or duplicate filename, or
+  legacy talk schema installs nothing.
+- Every unrelated field preserved, and the shownotes candidate never made
+  authoritative on its own.
+
+Whether a repair invalidates derived analysis is proven rather than assumed:
+each writable field is classified metadata-only or analysis-invalidating, and
+an import-time guard refuses to start if a field is left unclassified — a new
+field cannot default to "safe". `title` and `conference` are metadata-only,
+since rhetoric analysis derives from transcript and slide content. An
+analysis-invalidating field requires the status and `reprocess_reason`
+transition in the same plan, applied atomically with the value: a plan that
+repaired the field and left the talk `processed` would leave stale analysis
+looking current.
+
 ## 0.20.47 — 2026-08-10
 
 ### feat(vault-ingress) — audit shownotes conflict candidates alongside the active source (#230)

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -479,8 +479,18 @@ exact-type rule. The supported mutation kinds are:
 | `retire_improvement_goal` | Expect one complete current goal record and change only its `status` to `retired`, preserving legacy fields |
 | `upsert_resource` | Replace/add one complete schema-v1 record identified by `talk_slug` |
 | `upsert_thumbnail` | Replace/add one complete schema-v1 record identified by `talk_slug` |
+| `apply_reviewed_metadata` | Install one human-reviewed shownotes catalog-conflict decision on one exact talk filename, over a closed identity field set, with `expect` covering exactly the same fields |
 | `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
 | `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |
+
+`apply_reviewed_metadata` exists because `scan-shownotes.py --apply` refuses
+review-required entries by design: an approved catalog correction otherwise had
+no owner writer at all. It stays narrow — the writable field set, the
+metadata-only versus analysis-invalidating classification, and the reprocessing
+transition it demands are named at the top of
+`skills/vault-ingress/scripts/mutate-tracking-database.py`. Deterministic scan
+updates and human-approved conflict decisions stay separate paths; source lanes
+stay with `apply-source-repairs.py`.
 
 The command owns each operation's closed fields and record validation; do not
 reimplement those allowlists in skill prose. PPTX catalog records require exact

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -90,6 +90,28 @@ PUBLISHING_TALK_FIELDS = frozenset(
     }
 )
 CLARIFICATION_TALK_FIELDS = frozenset({"blind_spot_observations", "humor_postmortem"})
+# Catalog-identity fields a reviewed shownotes conflict may repair. Closed on
+# purpose: `scan-shownotes.py --apply` refuses review-required entries, and the
+# answer is one narrow owner path, never arbitrary talk-field mutation. Source
+# lanes stay with apply-source-repairs.py.
+METADATA_TALK_FIELDS = frozenset({"title", "conference"})
+# Whether repairing a field invalidates derived analysis. Rhetoric analysis
+# derives from transcript and slide content, so correcting a talk's catalog
+# title or conference cannot stale it — the writer proves that rather than
+# assuming it. A field that DOES invalidate belongs in the second set, and the
+# writer then requires the reprocessing transition in the same plan.
+METADATA_ONLY_FIELDS = frozenset({"title", "conference"})
+ANALYSIS_INVALIDATING_METADATA_FIELDS: frozenset[str] = frozenset()
+_UNCLASSIFIED_METADATA_FIELDS = METADATA_TALK_FIELDS - (
+    METADATA_ONLY_FIELDS | ANALYSIS_INVALIDATING_METADATA_FIELDS
+)
+if _UNCLASSIFIED_METADATA_FIELDS:
+    raise RuntimeError(
+        "every reviewed-metadata field must be classified metadata-only or "
+        f"analysis-invalidating: {sorted(_UNCLASSIFIED_METADATA_FIELDS)}"
+    )
+METADATA_REPROCESS_FIELDS = frozenset({"status", "reprocess_reason"})
+METADATA_REPROCESS_STATUSES = frozenset({"needs-reprocessing"})
 GOAL_VERIFICATION_FIELDS = frozenset(
     {
         "status",
@@ -823,6 +845,97 @@ def _apply_update_talk(
     )
 
 
+def _validate_metadata_values(values: object, label: str) -> None:
+    """Every repaired catalog value is a non-empty trimmed string."""
+    if not isinstance(values, dict):
+        raise TrackingDatabaseMutationError(f"{label} must be an object")
+    for field, value in values.items():
+        _nonempty(value, f"{label}.{field}")
+
+
+def _apply_reviewed_metadata(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    """Install one human-reviewed shownotes catalog-conflict decision.
+
+    `scan-shownotes.py --apply` deliberately refuses review-required entries, so
+    an approved title or conference correction had no owner writer and could
+    only be made by editing the database directly. This is that writer, and it
+    stays narrow: a closed field set, an exact old-value precondition per field,
+    and no way to reach an unrelated talk field.
+    """
+    _require_keys(
+        mutation,
+        required={"kind", "filename", "expect", "set"},
+        optional={"reprocess"},
+        label=f"mutations[{index}]",
+    )
+    filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
+    talk = _talk_by_filename(database, filename)
+    _require_current_talk_record(talk, filename=filename)
+    _validate_metadata_values(mutation["set"], f"mutations[{index}].set")
+
+    set_values = mutation["set"]
+    invalidating = sorted(set(set_values) & ANALYSIS_INVALIDATING_METADATA_FIELDS)
+    reprocess = mutation.get("reprocess")
+    if invalidating and reprocess is None:
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}] changes {invalidating} which invalidates derived "
+            f"analysis; the same plan must carry the reprocess transition"
+        )
+    if not invalidating and reprocess is not None:
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}] is metadata-only, so it must not carry a "
+            f"reprocess transition"
+        )
+    if reprocess is not None:
+        if not isinstance(reprocess, dict):
+            raise TrackingDatabaseMutationError(
+                f"mutations[{index}].reprocess must be an object"
+            )
+        _require_keys(
+            reprocess,
+            required=METADATA_REPROCESS_FIELDS,
+            label=f"mutations[{index}].reprocess",
+        )
+        status = _nonempty(reprocess["status"], f"mutations[{index}].reprocess.status")
+        if status not in METADATA_REPROCESS_STATUSES:
+            raise TrackingDatabaseMutationError(
+                f"mutations[{index}].reprocess.status must be one of "
+                f"{sorted(METADATA_REPROCESS_STATUSES)}"
+            )
+        _nonempty(
+            reprocess["reprocess_reason"],
+            f"mutations[{index}].reprocess.reprocess_reason",
+        )
+
+    before, after = _apply_record_patch(
+        talk,
+        expect=mutation["expect"],
+        set_values=set_values,
+        allowed_fields=METADATA_TALK_FIELDS,
+        label=f"talks[{filename!r}]",
+    )
+    if reprocess is not None:
+        # Atomic with the field change: a plan that repaired the value and left
+        # the talk `processed` would leave stale analysis looking current.
+        for field in sorted(METADATA_REPROCESS_FIELDS):
+            before[field] = talk.get(field, MISSING_MARKER)
+            talk[field] = reprocess[field]
+            after[field] = reprocess[field]
+    _record_change(
+        changes,
+        kind="apply_reviewed_metadata",
+        identity=filename,
+        before=before,
+        after=after,
+    )
+
+
 def _apply_update_talk_clarification(
     database: dict[str, Any],
     mutation: dict[str, Any],
@@ -1171,6 +1284,8 @@ def build_candidate(
             _apply_collection_upsert(candidate, mutation, changes, index=index)
         elif kind == "record_pptx":
             _apply_record_pptx(candidate, mutation, changes, index=index)
+        elif kind == "apply_reviewed_metadata":
+            _apply_reviewed_metadata(candidate, mutation, changes, index=index)
         elif kind == "update_talk_publishing":
             _apply_update_talk(candidate, mutation, changes, index=index)
         elif kind == "update_talk_clarification":

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1104,3 +1104,286 @@ def test_initialization_rejects_noncurrent_config_schema_version(
             },
             index=0,
         )
+
+
+# Reviewed shownotes catalog-conflict repair (#236). `scan-shownotes.py --apply`
+# refuses review-required entries, so an approved title or conference
+# correction had no owner writer at all — the operator's only options were to
+# leave a known-wrong catalog fact in place or edit the database directly.
+
+
+def _catalog_database(**talk_fields: Any) -> dict[str, Any]:
+    database = _base_database()
+    database["talks"][0].update(
+        {
+            "title": "Monkey See Monkey Do",
+            "conference": "DevOps Nashville 2024",
+            **talk_fields,
+        }
+    )
+    return database
+
+
+def _repair(set_values: dict[str, Any], expect: dict[str, Any], **extra: Any):
+    mutation = {
+        "kind": "apply_reviewed_metadata",
+        "filename": "talk.md",
+        "expect": expect,
+        "set": set_values,
+    }
+    mutation.update(extra)
+    return mutation
+
+
+def test_a_reviewed_conference_conflict_applies_with_an_exact_precondition(
+    mutate_tracking_database,
+) -> None:
+    """Acceptance 1: the live DevOps Nashville case."""
+    database = _catalog_database()
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database,
+        [
+            _repair(
+                {"conference": "DevOps Days Nashville 2024"},
+                {"conference": "DevOps Nashville 2024"},
+            )
+        ],
+    )
+
+    assert candidate["talks"][0]["conference"] == "DevOps Days Nashville 2024"
+    assert changes[0]["kind"] == "apply_reviewed_metadata"
+    assert changes[0]["before"] == {"conference": "DevOps Nashville 2024"}
+    # The input object is never mutated; only the candidate carries the repair.
+    assert database["talks"][0]["conference"] == "DevOps Nashville 2024"
+
+
+def test_a_reviewed_title_conflict_applies_without_opening_other_fields(
+    mutate_tracking_database,
+) -> None:
+    """Acceptance 2: the live Voxxed Luxembourg case, and nothing wider."""
+    database = _catalog_database()
+
+    candidate, _changes = mutate_tracking_database.build_candidate(
+        database,
+        [
+            _repair(
+                {"title": "Monkey See Monkey Do at Voxxed Days Luxembourg 2026"},
+                {"title": "Monkey See Monkey Do"},
+            )
+        ],
+    )
+
+    assert candidate["talks"][0]["title"].endswith("Voxxed Days Luxembourg 2026")
+    assert candidate["talks"][0]["status"] == "processed"
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["status", "video_url", "slides_url", "date", "transcript_source"],
+)
+def test_the_writer_refuses_every_field_outside_the_catalog_set(
+    mutate_tracking_database, field
+) -> None:
+    """A reviewed metadata decision is not a licence to edit arbitrary talk fields."""
+    database = _catalog_database()
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="unsupported"
+    ):
+        mutate_tracking_database.build_candidate(
+            database, [_repair({field: "anything"}, {field: None})]
+        )
+
+
+def test_a_stale_precondition_installs_nothing(mutate_tracking_database) -> None:
+    """Acceptance 3: the reviewed value must still be the one that was reviewed."""
+    database = _catalog_database()
+    original = copy.deepcopy(database)
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                _repair(
+                    {"conference": "DevOps Days Nashville 2024"},
+                    {"conference": "Something Else Entirely"},
+                )
+            ],
+        )
+
+    assert database == original
+
+
+def test_an_unknown_filename_installs_nothing(mutate_tracking_database) -> None:
+    database = _catalog_database()
+    mutation = _repair(
+        {"conference": "DevOps Days Nashville 2024"},
+        {"conference": "DevOps Nashville 2024"},
+    )
+    mutation["filename"] = "nobody.md"
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(database, [mutation])
+
+
+def test_a_duplicate_filename_installs_nothing(mutate_tracking_database) -> None:
+    database = _catalog_database()
+    database["talks"].append(copy.deepcopy(database["talks"][0]))
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                _repair(
+                    {"conference": "DevOps Days Nashville 2024"},
+                    {"conference": "DevOps Nashville 2024"},
+                )
+            ],
+        )
+
+
+def test_a_legacy_talk_schema_installs_nothing(mutate_tracking_database) -> None:
+    database = _catalog_database()
+    database["talks"][0]["schema_version"] = 4
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                _repair(
+                    {"conference": "DevOps Days Nashville 2024"},
+                    {"conference": "DevOps Nashville 2024"},
+                )
+            ],
+        )
+
+
+def test_a_metadata_only_change_refuses_a_reprocess_transition(
+    mutate_tracking_database,
+) -> None:
+    """Acceptance 4, first half: the writer proves the change is metadata-only."""
+    database = _catalog_database()
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="metadata-only"
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                _repair(
+                    {"conference": "DevOps Days Nashville 2024"},
+                    {"conference": "DevOps Nashville 2024"},
+                    reprocess={
+                        "status": "needs-reprocessing",
+                        "reprocess_reason": "not needed",
+                    },
+                )
+            ],
+        )
+
+
+def test_an_analysis_invalidating_field_requires_the_transition_atomically(
+    mutate_tracking_database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Acceptance 4, second half.
+
+    Both current fields are metadata-only, so the invalidating branch is
+    exercised by classifying one as invalidating — which is exactly what adding
+    such a field would do.
+    """
+    monkeypatch.setattr(
+        mutate_tracking_database,
+        "ANALYSIS_INVALIDATING_METADATA_FIELDS",
+        frozenset({"conference"}),
+    )
+    database = _catalog_database()
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="invalidates derived analysis",
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                _repair(
+                    {"conference": "DevOps Days Nashville 2024"},
+                    {"conference": "DevOps Nashville 2024"},
+                )
+            ],
+        )
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database,
+        [
+            _repair(
+                {"conference": "DevOps Days Nashville 2024"},
+                {"conference": "DevOps Nashville 2024"},
+                reprocess={
+                    "status": "needs-reprocessing",
+                    "reprocess_reason": "catalog conference corrected",
+                },
+            )
+        ],
+    )
+
+    talk = candidate["talks"][0]
+    assert talk["conference"] == "DevOps Days Nashville 2024"
+    assert talk["status"] == "needs-reprocessing"
+    assert talk["reprocess_reason"] == "catalog conference corrected"
+    assert changes[0]["after"]["status"] == "needs-reprocessing"
+
+
+def test_a_reprocess_transition_rejects_an_unsupported_status(
+    mutate_tracking_database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        mutate_tracking_database,
+        "ANALYSIS_INVALIDATING_METADATA_FIELDS",
+        frozenset({"conference"}),
+    )
+    database = _catalog_database()
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="must be one of"
+    ):
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                _repair(
+                    {"conference": "DevOps Days Nashville 2024"},
+                    {"conference": "DevOps Nashville 2024"},
+                    reprocess={"status": "processed", "reprocess_reason": "nope"},
+                )
+            ],
+        )
+
+
+def test_unrelated_talk_fields_survive_the_repair(mutate_tracking_database) -> None:
+    database = _catalog_database(
+        date="2024-07-10", video_url="https://youtu.be/AbCdEfGhI_1"
+    )
+
+    candidate, _changes = mutate_tracking_database.build_candidate(
+        database,
+        [
+            _repair(
+                {"conference": "DevOps Days Nashville 2024"},
+                {"conference": "DevOps Nashville 2024"},
+            )
+        ],
+    )
+
+    talk = candidate["talks"][0]
+    assert talk["date"] == "2024-07-10"
+    assert talk["video_url"] == "https://youtu.be/AbCdEfGhI_1"
+    assert talk["title"] == "Monkey See Monkey Do"
+
+
+def test_every_writable_metadata_field_is_classified(mutate_tracking_database) -> None:
+    """The import-time guard that keeps a new field from defaulting to safe."""
+    classified = (
+        mutate_tracking_database.METADATA_ONLY_FIELDS
+        | mutate_tracking_database.ANALYSIS_INVALIDATING_METADATA_FIELDS
+    )
+    assert mutate_tracking_database.METADATA_TALK_FIELDS <= classified

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -1144,3 +1144,49 @@ def test_matched_rejection_report_is_byte_stable(tmp_path: Path) -> None:
 
     assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
     assert first["schema_version"] == scan_shownotes.REPORT_SCHEMA_VERSION
+
+
+def test_an_approved_repair_makes_the_scan_report_the_entry_unchanged(
+    tmp_path: Path,
+    mutate_tracking_database,
+) -> None:
+    """#236 acceptance 5: the loop closes.
+
+    A review-required conflict is refused by `--apply`, repaired through the
+    owner writer, and the next scan sees no conflict left to review.
+    """
+    site, talks_directory = _shownotes_site(tmp_path)
+    _write_jekyll_talk(talks_directory, title="Changed Title")
+    existing = {
+        "filename": "2026-08-01-deterministic-ingress.md",
+        "title": "Authoritative Title",
+        "conference": "TestConf",
+        "date": "2026-08-01",
+        "schema_version": 5,
+        "status": "processed",
+    }
+    database_path = _database_path(tmp_path, _local_config(site), talks=[existing])
+
+    first = scan_shownotes.execute(database_path, apply_requested=True)
+    assert first["entries"][0]["disposition"] == "review_required"
+    assert first["database_written"] is False
+
+    database = json.loads(database_path.read_text(encoding="utf-8"))
+    candidate, _changes = mutate_tracking_database.build_candidate(
+        database,
+        [
+            {
+                "kind": "apply_reviewed_metadata",
+                "filename": "2026-08-01-deterministic-ingress.md",
+                "expect": {"title": "Authoritative Title"},
+                "set": {"title": "Changed Title"},
+            }
+        ],
+    )
+    database_path.write_text(json.dumps(candidate, indent=2), encoding="utf-8")
+
+    second = scan_shownotes.execute(database_path, apply_requested=False)
+
+    entry = second["entries"][0]
+    assert entry["disposition"] == "unchanged"
+    assert entry["issues"] == []


### PR DESCRIPTION
Closes #236.

## Problem

`scan-shownotes.py` correctly emits `review_required` when a stored title or conference conflicts with the shownotes page — and `--apply` deliberately refuses those entries. But nothing could then install the reviewed decision:

- `apply-source-repairs.py` does not allow `title` or `conference`
- `mutate-tracking-database.py` limited talk updates to publishing and clarification fields

So a vault operator had to either leave a known-wrong catalog fact in place or bypass the database ownership contract by hand. The 2026-08-05 rhetoric-vault reconciliation produced exactly two such conflicts after every deterministic repair had merged: `DevOps Nashville 2024` vs `DevOps Days Nashville 2024`, and a base title vs its event-qualified form.

## The writer

`apply_reviewed_metadata` — one narrow, expectation-bound path:

- **Closed writable set** (`title`, `conference`). A reviewed metadata decision is not a licence to edit arbitrary talk fields; source lanes stay with `apply-source-repairs.py`.
- **Exact old-value precondition per changed field**, so a decision reviewed against one value cannot silently install over another.
- **Full current talk/database shape validated before atomic replacement.** A stale precondition, unsupported field, unknown or duplicate filename, or legacy talk schema installs nothing.
- **Every unrelated field preserved**, and the shownotes candidate never made authoritative on its own.
- **Deterministic scan updates stay separate** from human-approved conflict decisions.

## Proving the change is metadata-only

The issue asks the writer to *report* whether a repair invalidates derived analysis. Rather than assert it in prose, each writable field is classified `METADATA_ONLY_FIELDS` or `ANALYSIS_INVALIDATING_METADATA_FIELDS`, and an **import-time guard refuses to start if any writable field is unclassified** — a field added later cannot default to "safe."

`title` and `conference` are metadata-only: rhetoric analysis derives from transcript and slide content. An analysis-invalidating field requires the status + `reprocess_reason` transition in the same plan, applied atomically with the value — a plan that repaired the field and left the talk `processed` would leave stale analysis looking current.

## Verification

The issue's five acceptance tests:

1. reviewed conference conflict dry-runs and applies with an exact old-value precondition ✅ (the live DevOps Nashville case)
2. reviewed title conflict applies without opening arbitrary talk-field mutation ✅ (the live Voxxed Luxembourg case)
3. stale precondition / unsupported field / unknown or duplicate filename / legacy schema installs nothing ✅
4. the writer proves metadata-only, or atomically requires the reprocessing transition ✅ (both halves, the invalidating branch driven by classifying a field as such)
5. re-running `scan-shownotes.py` after the approved repair reports the entry `unchanged` ✅ — the full refuse → repair → rescan loop in one test

Full suite: 5310 passed, 3 skipped. `ruff check` / `ruff format --check` / `pyright` / entrypoints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)