### PR TITLE
feat(vault-ingress): derive the rhetoric-summary status block from the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ than first-match spliced, and the whole retained-stage error family is
 translated into the JSON failure contract instead of only its invariant
 subclass.
 
+The summary has two toolkit writers, not one: `section15_pattern_history.py`
+replaces the Section 15 pattern-history block in the same file, and it read,
+spliced, and renamed holding no lock at all — so either writer could drop the
+other's update, whichever renamed first. Both now enter through
+`summary_lock.py`, one seam that owns the summary's writer lock, and the Section
+15 writer rechecks the target's bytes immediately before its rename the same
+way. A label is diagnostics; agreeing on the lock is the contract, and a third
+writer that imports that seam cannot invent its own.
+
 Every summary failure now names its recovery, not just its fault: which file to
 create, which flag supplies an alternate path, what to re-save as UTF-8. The
 messages stay path-neutral — a host path in a failure line is the leak this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,20 @@ cannot disturb a narrative section, and it carries the database SHA-256,
 generated timestamp, database schema version, active scoring/catalog generation
 identity, total talks, exact status counts, and the active-claim count.
 
-It reports historically-analysed separately from the current cohort. Conflating
-them is what makes normalization look like lost work: a talk analysed under an
-older generation stays historically analysed while ceasing to be eligible now.
+It reports historically-analysed separately from the current cohort, and reads
+the two from different places. Eligibility is a status question; whether a talk
+was ever analysed is not. Normalization flips `status` to `needs-reprocessing`
+and leaves the analysis evidence in place, so reading history off the status
+would erase every requeued talk's past work — the exact misreading this block
+exists to stop. History is counted from the persisted evidence instead.
+
+The compare-and-swap binds the install, not just the earlier read: the target is
+re-read immediately before the rename and the swap is abandoned if it moved, so
+an edit landing while the replacement is staged is not overwritten by a tool
+that promised to refuse exactly that. Duplicate delimiters are malformed rather
+than first-match spliced, and the whole retained-stage error family is
+translated into the JSON failure contract instead of only its invariant
+subclass.
 
 `--apply` requires `--expected-sha256` from a dry run. The summary is a file a
 human also edits, so an apply that cannot prove it read the current bytes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+### feat(vault-ingress) — derive the rhetoric-summary status block from the database (#168)
+
+Closes #168.
+
+`rhetoric-style-summary.md` is narrative prose, but its status line is read as
+current operational fact — and it was hand-maintained, so it drifted. A verified
+snapshot had the summary claiming `199 / 208` with 195 processed while the
+tracking database held 209 talks: 116 `needs-reprocessing`, 9 `pending`, 78
+`processed`, 2 `processed_partial`, 3 `reprocessing-inflight`, 1
+`skipped_duplicate`. Queue normalization and reparse move statuses without
+touching prose, so an obsolete cohort reads as live — most misleadingly during a
+long reparse, which is exactly when someone checks.
+
+`render-vault-status.py` derives that one block and nothing else. Every count
+comes from a single strict snapshot through the shared reader; none is
+hand-calculated. The block is delimited and schema-versioned, so replacing it
+cannot disturb a narrative section, and it carries the database SHA-256,
+generated timestamp, database schema version, active scoring/catalog generation
+identity, total talks, exact status counts, and the active-claim count.
+
+It reports historically-analysed separately from the current cohort. Conflating
+them is what makes normalization look like lost work: a talk analysed under an
+older generation stays historically analysed while ceasing to be eligible now.
+
+`--apply` requires `--expected-sha256` from a dry run. The summary is a file a
+human also edits, so an apply that cannot prove it read the current bytes
+refuses rather than overwriting an edit it never saw. Replacement goes through
+the shared retained-stage lifecycle, so an interruption leaves the prior
+complete summary, and a no-op render installs nothing rather than churning the
+file's identity for consumers watching it.
+
+An absent scoring generation is reported absent, never defaulted — a default
+would let a database with no recorded generation render a block claiming one.
+
 ## 0.20.48 — 2026-08-10
 
 ### feat(vault-ingress) — an owner writer for reviewed shownotes catalog conflicts (#236)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,25 @@ and leaves the analysis evidence in place, so reading history off the status
 would erase every requeued talk's past work — the exact misreading this block
 exists to stop. History is counted from the persisted evidence instead.
 
-The compare-and-swap binds the install, not just the earlier read: the target is
-re-read immediately before the rename and the swap is abandoned if it moved, so
-an edit landing while the replacement is staged is not overwritten by a tool
-that promised to refuse exactly that. Duplicate delimiters are malformed rather
+The compare-and-swap is one critical section, not a check and a later hope. A
+digest checked at read time and a rename issued afterwards are two operations,
+and a writer landing between them is overwritten by a tool that promised to
+refuse exactly that. The read, the check, and the install now all run inside the
+summary's persistent cooperative lock, so no second toolkit writer can occupy
+that window; the bytes are rechecked once more immediately before the rename,
+which is what catches a human editor, who holds no lock. That lock is the
+primitive the tracking database already used — extracted to `cooperative_lock.py`
+and shared, rather than reimplemented beside it, so both owner files serialize
+through one audited implementation. Duplicate delimiters are malformed rather
 than first-match spliced, and the whole retained-stage error family is
 translated into the JSON failure contract instead of only its invariant
 subclass.
+
+Every summary failure now names its recovery, not just its fault: which file to
+create, which flag supplies an alternate path, what to re-save as UTF-8. The
+messages stay path-neutral — a host path in a failure line is the leak this
+tool's diagnostics contract exists to prevent — so recovery is named by the
+file's canonical basename and by the flag that overrides it.
 
 `--apply` requires `--expected-sha256` from a dry run. The summary is a file a
 human also edits, so an apply that cannot prove it read the current bytes

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -333,5 +333,21 @@ claims, writes a byte-for-byte backup under `{vault_root}/.backups/`, and replac
 the DB atomically. Re-run the preflight after applying; do not claim work until
 blocking findings reach zero.
 
+The summary's status block is owner-generated, never hand-edited. Refresh it at
+safe checkpoints — after migration or recovery, after normalization, and after a
+batch persists — with:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/render-vault-status.py" \
+  "{vault_root}" --generated-at "{iso_timestamp}"
+```
+
+That is a dry run; it prints the derived counts and the block it would install.
+Apply with `--apply --expected-sha256` from that report. A failing precondition
+means the summary changed since the read — re-run the dry run rather than
+forcing it. The block carries the database SHA-256 it was derived from, so a
+consumer can tell a stale block from a current one; the tracking database stays
+the authority and prose counts are never trusted on their own.
+
 Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
 "X processed, Y remaining. PPTX: A cataloged, B matched, C extracted."

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -342,12 +342,34 @@ batch persists — with:
   "{vault_root}" --generated-at "{iso_timestamp}"
 ```
 
-That is a dry run; it prints the derived counts and the block it would install.
-Apply with `--apply --expected-sha256` from that report. A failing precondition
-means the summary changed since the read — re-run the dry run rather than
-forcing it. The block carries the database SHA-256 it was derived from, so a
-consumer can tell a stale block from a current one; the tracking database stays
-the authority and prose counts are never trusted on their own.
+That is a dry run: it writes nothing and prints one JSON object on stdout.
+`--summary` overrides the summary path; `--generated-at` is required and is
+recorded in the block, so a render is reproducible.
+
+The report fields this workflow reads:
+
+- `summary_sha256` — the digest to pass back as `--expected-sha256`
+- `changed` — false means the installed block already matches; skip the apply
+- `summary_written` — true only after an apply installed new bytes
+- `status` — the derived counts, and `block` the exact text that would install
+
+Apply with the digest the dry run reported:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/render-vault-status.py" \
+  "{vault_root}" --generated-at "{iso_timestamp}" \
+  --apply --expected-sha256 "{summary_sha256_from_dry_run}"
+```
+
+Exit 0 succeeded. Exit 3 is the precondition alone: the summary's bytes are no
+longer the ones the digest named, so re-run the dry run and apply with the new
+digest — never force it. Exit 2 is every other failure — the database or the
+summary could not be read, locked, or installed — and its JSON carries a typed
+`code` plus an actionable `error`; act on that, do not retry blindly.
+
+The block carries the database SHA-256 it was derived from, so a consumer can
+tell a stale block from a current one; the tracking database stays the authority
+and prose counts are never trusted on their own.
 
 Read `rhetoric-style-summary.md` and `slide-design-spec.md`. Report:
 "X processed, Y remaining. PPTX: A cataloged, B matched, C extracted."

--- a/skills/vault-ingress/scripts/cooperative_lock.py
+++ b/skills/vault-ingress/scripts/cooperative_lock.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Persistent sibling lock shared by every writer of one owner file.
+
+A writer that checks a target's bytes and then renames a replacement over it
+has performed two operations, not one. Between them another writer can install
+its own generation, and the rename overwrites it while reporting success. No
+POSIX rename is conditional, so the compare-and-swap has to be closed by
+excluding the other writers instead: every writer of the same target takes this
+lock, and the whole check-stage-recheck-install sequence runs inside it.
+
+The lock is a persistent `.<target>.lock` sibling, flocked exclusively. It is
+never removed: unlinking it lets a second process create and lock a different
+inode under the same name, which is two writers holding "the" lock at once.
+
+Cooperative is the exact claim. A human editor holds no lock, so the owner
+still rechecks the target's bytes immediately before installing — the lock
+serializes the toolkit's writers, the recheck catches everyone else.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import fcntl
+import os
+from pathlib import Path
+import stat
+from typing import Iterator
+
+
+class CooperativeLockError(Exception):
+    """The cooperative lock could not be opened, acquired, or trusted."""
+
+
+@dataclass
+class CooperativeLock:
+    """One acquired lock plus cleanup warnings collected after the body.
+
+    Release failures are warnings, never exceptions: the guarded work already
+    happened, and turning its cleanup into a failure would misreport it.
+    """
+
+    descriptor: int
+    path: Path
+    warnings: list[str] = field(default_factory=list)
+
+
+def lock_path_for(path: str | os.PathLike[str]) -> Path:
+    """Return the persistent cooperative lock shared by every toolkit writer."""
+    target = Path(path).expanduser().absolute()
+    return target.parent / f".{target.name}.lock"
+
+
+def _identity(metadata: os.stat_result) -> tuple[int, int]:
+    return metadata.st_dev, metadata.st_ino
+
+
+@contextmanager
+def exclusive_file_lock(path: Path, *, label: str) -> Iterator[CooperativeLock]:
+    """Hold the exclusive cooperative lock for ``path`` across the body.
+
+    ``label`` names the guarded artifact in every diagnostic, so a caller's own
+    error type can carry the message unchanged.
+    """
+    lock_path = lock_path_for(path)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise CooperativeLockError(
+            f"cannot open cooperative {label} lock {lock_path}: {exc}"
+        ) from exc
+    acquired = False
+    initialized = False
+    try:
+        try:
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+                raise CooperativeLockError(
+                    f"cooperative {label} lock {lock_path} must be one regular file"
+                )
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            acquired = True
+            try:
+                visible = lock_path.lstat()
+            except OSError as exc:
+                raise CooperativeLockError(
+                    f"cannot verify cooperative {label} lock {lock_path}: {exc}"
+                ) from exc
+            locked = os.fstat(descriptor)
+            if (
+                stat.S_ISLNK(visible.st_mode)
+                or not stat.S_ISREG(visible.st_mode)
+                or _identity(visible) != _identity(locked)
+                or locked.st_nlink != 1
+            ):
+                raise CooperativeLockError(
+                    f"cooperative {label} lock {lock_path} changed while locking; "
+                    "restore the persistent regular lock file and retry"
+                )
+        except OSError as exc:
+            raise CooperativeLockError(
+                f"cannot acquire {label} lock through {lock_path}: {exc}"
+            ) from exc
+        initialized = True
+    finally:
+        if not initialized:
+            try:
+                os.close(descriptor)
+            except OSError:
+                # The acquisition failure is the diagnostic; a close failure on
+                # top of it has nowhere to go and must not mask it.
+                pass
+
+    lock = CooperativeLock(descriptor=descriptor, path=lock_path, warnings=[])
+    try:
+        yield lock
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            except OSError as exc:
+                lock.warnings.append(
+                    f"could not unlock cooperative {label} lock {lock_path}: {exc}"
+                )
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            lock.warnings.append(
+                f"could not close cooperative {label} lock {lock_path}: {exc}"
+            )

--- a/skills/vault-ingress/scripts/render-vault-status.py
+++ b/skills/vault-ingress/scripts/render-vault-status.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 from collections import Counter
 from contextlib import contextmanager, ExitStack
+from datetime import datetime
 import hashlib
 import json
 from pathlib import Path
@@ -397,6 +398,30 @@ def _failure(reason_code: str, message: str) -> dict[str, Any]:
     }
 
 
+def require_generated_at(value: str) -> str:
+    """Accept only a timezone-aware ISO-8601 instant.
+
+    The value is stamped into the block as operational fact. An unparsed
+    string would let `--generated-at yesterday` render a status block whose
+    timestamp no consumer can order, and a naive one leaves the reader
+    guessing at the zone.
+    """
+    try:
+        moment = datetime.fromisoformat(value)
+    except (TypeError, ValueError) as error:
+        raise SummaryRenderError(
+            "--generated-at must be an ISO-8601 timestamp with an offset, "
+            "such as 2026-08-10T12:00:00+00:00",
+            reason_code="generated_at_invalid",
+        ) from error
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise SummaryRenderError(
+            "--generated-at must carry a UTC offset, such as 2026-08-10T12:00:00+00:00",
+            reason_code="generated_at_not_aware",
+        )
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument("vault_or_database", type=Path)
@@ -408,9 +433,24 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         help="ISO timestamp recorded in the block; supplied so a render is reproducible",
     )
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        # argparse exits with usage text alone, and this script's contract is
+        # one JSON object on stdout for every outcome. A caller parsing stdout
+        # would otherwise see an empty document and no reason.
+        if exc.code:
+            message = (
+                "invalid arguments: expected one vault root or database path, "
+                "--generated-at, and optionally --summary, --apply, and "
+                "--expected-sha256"
+            )
+            print(json.dumps(_failure("invalid_arguments", message), sort_keys=True))
+            print(f"vault status render failed: {message}", file=sys.stderr)
+        raise
 
     try:
+        require_generated_at(args.generated_at)
         report = execute(
             args.vault_or_database,
             generated_at=args.generated_at,

--- a/skills/vault-ingress/scripts/render-vault-status.py
+++ b/skills/vault-ingress/scripts/render-vault-status.py
@@ -39,7 +39,7 @@ import sys
 from typing import Any
 
 from retained_stage import (
-    StagedInvariantError,
+    RetainedStageError,
     close_retained_stage,
     install_retained_stage,
     open_retained_stage,
@@ -67,11 +67,13 @@ SUMMARY_BASENAME = "rhetoric-style-summary.md"
 BLOCK_BEGIN = "<!-- vault-status:begin -->"
 BLOCK_END = "<!-- vault-status:end -->"
 
-# A talk counted here has been analysed at some point in its history. Whether
-# that analysis is ELIGIBLE in the current scoring generation is a different
-# question, and conflating them is what makes normalization look like lost work.
-HISTORICALLY_ANALYSED_STATUSES = frozenset({"processed", "processed_partial"})
+# Eligibility in the CURRENT generation is a status question. Whether a talk was
+# ever analysed is not: normalization flips `status` to `needs-reprocessing` and
+# leaves the analysis evidence in place, so reading history off the status would
+# erase every requeued talk's past work — the exact misreading this block exists
+# to stop. History is therefore read from the persisted evidence itself.
 CURRENT_COHORT_STATUSES = frozenset({"processed", "processed_partial"})
+ANALYSIS_EVIDENCE_FIELD = "pattern_observations"
 
 
 class SummaryRenderError(Exception):
@@ -133,9 +135,9 @@ def derive_status(database: dict[str, Any], *, input_sha256: str) -> dict[str, A
         if isinstance(status, str):
             statuses[status] += 1
     historically = sum(
-        count
-        for status, count in statuses.items()
-        if status in HISTORICALLY_ANALYSED_STATUSES
+        1
+        for talk in talks
+        if isinstance(talk, dict) and talk.get(ANALYSIS_EVIDENCE_FIELD)
     )
     return {
         "schema_version": STATUS_BLOCK_SCHEMA_VERSION,
@@ -145,9 +147,9 @@ def derive_status(database: dict[str, Any], *, input_sha256: str) -> dict[str, A
         "total_talks": len(talks),
         "status_counts": {key: statuses[key] for key in sorted(statuses)},
         "active_claim_count": _active_claims(talks),
-        # The distinction normalization keeps erasing: a talk analysed in an
-        # older generation stays historically analysed while ceasing to be
-        # eligible in the current one.
+        # The distinction normalization keeps erasing: a requeued talk still
+        # carries its analysis evidence, so it stays historically analysed
+        # while ceasing to be eligible in the current generation.
         "historically_analysed_count": historically,
         "current_cohort_count": sum(
             count
@@ -175,6 +177,13 @@ def render_block(status: dict[str, Any], *, generated_at: str) -> str:
 
 def splice_block(summary_text: str, block: str) -> str:
     """Replace the delimited block, or append one when the summary has none."""
+    if summary_text.count(BLOCK_BEGIN) > 1 or summary_text.count(BLOCK_END) > 1:
+        # A second delimiter pair, or one quoted in narrative, would make the
+        # splice target a range this tool never inspected.
+        raise SummaryRenderError(
+            "summary carries more than one status-block delimiter",
+            reason_code="summary_block_malformed",
+        )
     begin = summary_text.find(BLOCK_BEGIN)
     end = summary_text.find(BLOCK_END)
     if begin == -1 and end == -1:
@@ -209,8 +218,14 @@ def _read_summary(path: Path) -> tuple[str, str]:
         ) from error
 
 
-def _install(summary_path: Path, payload: bytes) -> None:
-    """Replace the summary atomically; an interruption leaves the prior file."""
+def _install(summary_path: Path, payload: bytes, *, expected_sha256: str) -> None:
+    """Replace the summary atomically, bound to the bytes we actually read.
+
+    Checking the digest at read time and installing later is not a
+    compare-and-swap: an edit landing in between is overwritten by a tool that
+    promised to refuse exactly that. The target is re-read immediately before
+    the rename and the swap is abandoned if it moved.
+    """
     stage = open_retained_stage(
         summary_path,
         payload,
@@ -219,6 +234,12 @@ def _install(summary_path: Path, payload: bytes) -> None:
         label="rhetoric summary",
     )
     try:
+        _, observed = _read_summary(summary_path)
+        if observed != expected_sha256:
+            raise SummaryRenderError(
+                "summary bytes changed while the replacement was staged",
+                reason_code="summary_precondition_failed",
+            )
         install_retained_stage(stage, summary_path)
     except OSError as error:
         raise SummaryRenderError(
@@ -277,7 +298,7 @@ def execute(
         # A no-op render installs nothing: rewriting identical bytes would
         # churn the file's identity for consumers watching it.
         if changed:
-            _install(summary_path, payload)
+            _install(summary_path, payload, expected_sha256=expected_sha256)
             written = True
 
     return {
@@ -338,7 +359,7 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(_failure(exc.reason_code, str(exc)), sort_keys=True))
         print(f"vault status render failed: {exc}", file=sys.stderr)
         return 3 if exc.reason_code == "summary_precondition_failed" else 2
-    except StagedInvariantError as exc:
+    except RetainedStageError as exc:
         print(
             json.dumps(
                 _failure(

--- a/skills/vault-ingress/scripts/render-vault-status.py
+++ b/skills/vault-ingress/scripts/render-vault-status.py
@@ -15,29 +15,37 @@ section.
 
 `--apply` requires `--expected-sha256` from a dry run: the summary is a file a
 human also edits, so an apply that cannot prove it read the current bytes must
-refuse rather than overwrite an edit it never saw. Replacement is atomic
-through the shared retained-stage lifecycle, so an interruption leaves the
-prior complete summary.
+refuse rather than overwrite an edit it never saw. The read, the digest check,
+and the install all run inside the summary's shared cooperative lock, so no
+second toolkit writer can land between the check and the swap; the bytes are
+rechecked once more immediately before the rename, which is what catches a
+human editor, who holds no lock. Replacement is atomic through the shared
+retained-stage lifecycle, so an interruption leaves the prior complete summary.
 
 Usage:
   render-vault-status.py <vault-root-or-database-path> [--summary <path>]
   render-vault-status.py <...> --apply --expected-sha256 <hex>
 Stdout: one JSON object carrying the rendered block and the derived counts.
 Stderr: one actionable, path-neutral line when the database cannot be read.
-Exit 0 on success, 2 when the database or summary cannot be read, 3 when the
-summary's bytes do not match `--expected-sha256`.
+Exit 0 on success, 2 when the database or summary cannot be read, locked, or
+installed, 3 when the summary's bytes do not match `--expected-sha256`.
 """
 
 from __future__ import annotations
 
 import argparse
 from collections import Counter
+from contextlib import contextmanager, ExitStack
 import hashlib
 import json
 from pathlib import Path
 import sys
-from typing import Any
+from typing import Any, Iterator
 
+from cooperative_lock import (
+    CooperativeLockError,
+    exclusive_file_lock,
+)
 from retained_stage import (
     RetainedStageError,
     close_retained_stage,
@@ -61,6 +69,11 @@ REPORT_SCHEMA_VERSION = 1
 STATUS_BLOCK_SCHEMA_VERSION = 1
 DATABASE_BASENAME = "tracking-database.json"
 SUMMARY_BASENAME = "rhetoric-style-summary.md"
+
+# Names the summary in every cooperative-lock diagnostic. Every toolkit writer
+# of this file takes that lock, so the check-and-swap below is one critical
+# section rather than two racing operations.
+SUMMARY_LOCK_LABEL = "rhetoric-summary"
 
 # The block is fenced by exact literals so replacement is a delimited splice,
 # never a heuristic match against narrative prose that may quote a count.
@@ -200,31 +213,102 @@ def splice_block(summary_text: str, block: str) -> str:
 
 
 def _read_summary(path: Path) -> tuple[str, str]:
+    """Read the summary's exact bytes, or say what to do about it.
+
+    Messages stay path-neutral — a host path in a failure line is the leak this
+    tool's diagnostics contract exists to prevent — so recovery is named by the
+    file's canonical basename and by the flag that overrides it.
+    """
     try:
         raw = path.read_bytes()
     except FileNotFoundError as error:
         raise SummaryRenderError(
-            "summary file does not exist", reason_code="summary_missing"
+            f"summary file does not exist: create {SUMMARY_BASENAME} in the vault "
+            "root, or pass --summary with the path to the existing summary",
+            reason_code="summary_missing",
         ) from error
     except OSError as error:
         raise SummaryRenderError(
-            "summary file could not be read", reason_code="summary_unreadable"
+            f"summary file could not be read: confirm {SUMMARY_BASENAME} is a "
+            "readable regular file (not a directory, dangling symlink, or "
+            "unreadable mount), then rerun",
+            reason_code="summary_unreadable",
         ) from error
     try:
         return raw.decode("utf-8"), hashlib.sha256(raw).hexdigest()
     except UnicodeError as error:
         raise SummaryRenderError(
-            "summary file is not valid UTF-8", reason_code="summary_not_utf8"
+            f"summary file is not valid UTF-8: re-save {SUMMARY_BASENAME} as UTF-8, "
+            "or pass --summary with a UTF-8 copy, then rerun",
+            reason_code="summary_not_utf8",
         ) from error
 
 
-def _install(summary_path: Path, payload: bytes, *, expected_sha256: str) -> None:
-    """Replace the summary atomically, bound to the bytes we actually read.
+def _precondition_failed() -> SummaryRenderError:
+    """One wording for every point the bound digest stops matching."""
+    return SummaryRenderError(
+        "summary bytes changed since the digest this apply is bound to: rerun the "
+        "dry run and apply with the sha256 it reports",
+        reason_code="summary_precondition_failed",
+    )
 
-    Checking the digest at read time and installing later is not a
-    compare-and-swap: an edit landing in between is overwritten by a tool that
-    promised to refuse exactly that. The target is re-read immediately before
-    the rename and the swap is abandoned if it moved.
+
+def _require_expected_summary(summary_path: Path, expected_sha256: str) -> None:
+    """Prove the live summary is still the generation the caller read."""
+    _, observed = _read_summary(summary_path)
+    if observed != expected_sha256:
+        raise _precondition_failed()
+
+
+@contextmanager
+def _summary_lock(summary_path: Path) -> Iterator[None]:
+    """Hold the summary's shared writer lock, in this tool's error terms.
+
+    Acquisition is wrapped alone: a lock failure raised by the guarded body
+    belongs to that body, not to this acquisition.
+    """
+    stack = ExitStack()
+    try:
+        lock = stack.enter_context(
+            exclusive_file_lock(summary_path, label=SUMMARY_LOCK_LABEL)
+        )
+    except CooperativeLockError as error:
+        # Path-neutral like every other failure here: the lock's own message
+        # names the host path, so it is diagnosed by shape instead.
+        raise SummaryRenderError(
+            "summary writer lock could not be taken: confirm the vault root is "
+            f"writable and that its .{SUMMARY_BASENAME}.lock is a regular file, "
+            "then rerun",
+            reason_code="summary_lock_failed",
+        ) from error
+    try:
+        with stack:
+            yield
+    finally:
+        for warning in lock.warnings:
+            print(f"WARNING: {warning}", file=sys.stderr)
+
+
+def _plan_replacement(
+    summary_path: Path,
+    block: str,
+    *,
+    expected_sha256: str | None = None,
+) -> tuple[str, bytes, bool]:
+    """Read the summary once and render its replacement from that observation."""
+    summary_text, summary_sha256 = _read_summary(summary_path)
+    if expected_sha256 is not None and expected_sha256 != summary_sha256:
+        raise _precondition_failed()
+    payload = splice_block(summary_text, block).encode("utf-8")
+    return summary_sha256, payload, payload != summary_text.encode("utf-8")
+
+
+def _install(summary_path: Path, payload: bytes, *, expected_sha256: str) -> None:
+    """Replace the summary, bound to the bytes the caller proved it read.
+
+    Called with the cooperative lock held, so no other toolkit writer sits
+    between the check and the rename. The recheck here is what covers the
+    writer no lock can reach — a human saving the file in an editor.
     """
     stage = open_retained_stage(
         summary_path,
@@ -234,16 +318,12 @@ def _install(summary_path: Path, payload: bytes, *, expected_sha256: str) -> Non
         label="rhetoric summary",
     )
     try:
-        _, observed = _read_summary(summary_path)
-        if observed != expected_sha256:
-            raise SummaryRenderError(
-                "summary bytes changed while the replacement was staged",
-                reason_code="summary_precondition_failed",
-            )
+        _require_expected_summary(summary_path, expected_sha256)
         install_retained_stage(stage, summary_path)
     except OSError as error:
         raise SummaryRenderError(
-            "summary replacement could not be installed",
+            "summary replacement could not be installed: confirm the vault root is "
+            "writable with free space, then rerun the dry run and apply again",
             reason_code="summary_install_failed",
         ) from error
     finally:
@@ -278,28 +358,30 @@ def execute(
 
     status = derive_status(database, input_sha256=snapshot.sha256)
     block = render_block(status, generated_at=generated_at)
-    summary_text, summary_sha256 = _read_summary(summary_path)
-    rendered = splice_block(summary_text, block)
-    payload = rendered.encode("utf-8")
-    changed = payload != summary_text.encode("utf-8")
 
     written = False
-    if apply_requested:
+    if not apply_requested:
+        summary_sha256, payload, changed = _plan_replacement(summary_path, block)
+    else:
         if expected_sha256 is None:
             raise SummaryRenderError(
                 "--apply requires --expected-sha256 from a dry-run report",
                 reason_code="summary_precondition_missing",
             )
-        if expected_sha256 != summary_sha256:
-            raise SummaryRenderError(
-                "summary bytes changed since the dry run",
-                reason_code="summary_precondition_failed",
+        # Read, check, and install are one critical section. Splitting them —
+        # checking outside the lock and installing inside it — is the race this
+        # tool promises it does not have.
+        with _summary_lock(summary_path):
+            summary_sha256, payload, changed = _plan_replacement(
+                summary_path,
+                block,
+                expected_sha256=expected_sha256,
             )
-        # A no-op render installs nothing: rewriting identical bytes would
-        # churn the file's identity for consumers watching it.
-        if changed:
-            _install(summary_path, payload, expected_sha256=expected_sha256)
-            written = True
+            # A no-op render installs nothing: rewriting identical bytes would
+            # churn the file's identity for consumers watching it.
+            if changed:
+                _install(summary_path, payload, expected_sha256=expected_sha256)
+                written = True
 
     return {
         "schema_version": REPORT_SCHEMA_VERSION,

--- a/skills/vault-ingress/scripts/render-vault-status.py
+++ b/skills/vault-ingress/scripts/render-vault-status.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Render the owner status block in rhetoric-style-summary.md (#168).
+
+`rhetoric-style-summary.md` is narrative prose, but its status line is read as
+current operational fact. Hand-maintained, it drifts: a verified snapshot had
+the summary claiming `199 / 208` with 195 processed while the tracking database
+held 209 talks, 116 of them `needs-reprocessing`. Queue normalization and
+reparse move statuses without touching the prose, so a human or an agent reads
+an obsolete cohort as live — most misleadingly during a long reparse.
+
+This renders that one block from the database and nothing else. Counts are
+derived from a single strict snapshot, never hand-calculated, and the block is
+delimited and schema-versioned so replacing it cannot disturb a narrative
+section.
+
+`--apply` requires `--expected-sha256` from a dry run: the summary is a file a
+human also edits, so an apply that cannot prove it read the current bytes must
+refuse rather than overwrite an edit it never saw. Replacement is atomic
+through the shared retained-stage lifecycle, so an interruption leaves the
+prior complete summary.
+
+Usage:
+  render-vault-status.py <vault-root-or-database-path> [--summary <path>]
+  render-vault-status.py <...> --apply --expected-sha256 <hex>
+Stdout: one JSON object carrying the rendered block and the derived counts.
+Stderr: one actionable, path-neutral line when the database cannot be read.
+Exit 0 on success, 2 when the database or summary cannot be read, 3 when the
+summary's bytes do not match `--expected-sha256`.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from retained_stage import (
+    StagedInvariantError,
+    close_retained_stage,
+    install_retained_stage,
+    open_retained_stage,
+)
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+    tracking_database_schema_version,
+)
+from tracking_database_io import (
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
+)
+
+REPORT_SCHEMA_VERSION = 1
+STATUS_BLOCK_SCHEMA_VERSION = 1
+DATABASE_BASENAME = "tracking-database.json"
+SUMMARY_BASENAME = "rhetoric-style-summary.md"
+
+# The block is fenced by exact literals so replacement is a delimited splice,
+# never a heuristic match against narrative prose that may quote a count.
+BLOCK_BEGIN = "<!-- vault-status:begin -->"
+BLOCK_END = "<!-- vault-status:end -->"
+
+# A talk counted here has been analysed at some point in its history. Whether
+# that analysis is ELIGIBLE in the current scoring generation is a different
+# question, and conflating them is what makes normalization look like lost work.
+HISTORICALLY_ANALYSED_STATUSES = frozenset({"processed", "processed_partial"})
+CURRENT_COHORT_STATUSES = frozenset({"processed", "processed_partial"})
+
+
+class SummaryRenderError(Exception):
+    """The summary file cannot be read or replaced, with a typed reason."""
+
+    def __init__(self, message: str, *, reason_code: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def resolve_input(value: str | Path) -> tuple[Path, Path, Path]:
+    """Bind a vault root to its database and its summary."""
+    path = Path(value).expanduser().absolute()
+    root = path.parent if path.name.lower() == DATABASE_BASENAME else path
+    return root, root / DATABASE_BASENAME, root / SUMMARY_BASENAME
+
+
+def _active_claims(talks: list[Any]) -> int:
+    """Talks a queue writer currently holds.
+
+    Counted from the same two signals the owner uses elsewhere: an explicit
+    in-flight status, or a claim record still in the `claimed` state.
+    """
+    active = 0
+    for talk in talks:
+        if not isinstance(talk, dict):
+            continue
+        claim = talk.get("_queue_claim")
+        if talk.get("status") == "reprocessing-inflight" or (
+            isinstance(claim, dict) and claim.get("state") == "claimed"
+        ):
+            active += 1
+    return active
+
+
+def _scoring_generation(database: dict[str, Any]) -> dict[str, Any]:
+    """The active scoring/catalog generation identity, as stored.
+
+    Absent is reported as absent. Substituting a default would let a database
+    with no recorded generation render a block claiming one.
+    """
+    config = database.get("config")
+    config = config if isinstance(config, dict) else {}
+    return {
+        "pattern_scoring_schema_version": config.get("pattern_scoring_schema_version"),
+        "pattern_catalog_fingerprint": config.get("pattern_catalog_fingerprint"),
+    }
+
+
+def derive_status(database: dict[str, Any], *, input_sha256: str) -> dict[str, Any]:
+    """Derive every count from one snapshot. Nothing here is hand-maintained."""
+    raw_talks = database.get("talks")
+    talks = raw_talks if isinstance(raw_talks, list) else []
+    statuses: Counter[str] = Counter()
+    for talk in talks:
+        if not isinstance(talk, dict):
+            continue
+        status = talk.get("status")
+        if isinstance(status, str):
+            statuses[status] += 1
+    historically = sum(
+        count
+        for status, count in statuses.items()
+        if status in HISTORICALLY_ANALYSED_STATUSES
+    )
+    return {
+        "schema_version": STATUS_BLOCK_SCHEMA_VERSION,
+        "database_sha256": input_sha256,
+        "database_schema_version": tracking_database_schema_version(database),
+        "scoring_generation": _scoring_generation(database),
+        "total_talks": len(talks),
+        "status_counts": {key: statuses[key] for key in sorted(statuses)},
+        "active_claim_count": _active_claims(talks),
+        # The distinction normalization keeps erasing: a talk analysed in an
+        # older generation stays historically analysed while ceasing to be
+        # eligible in the current one.
+        "historically_analysed_count": historically,
+        "current_cohort_count": sum(
+            count
+            for status, count in statuses.items()
+            if status in CURRENT_COHORT_STATUSES
+        ),
+    }
+
+
+def render_block(status: dict[str, Any], *, generated_at: str) -> str:
+    """Render the delimited block. Byte-stable for one snapshot and timestamp."""
+    payload = dict(status)
+    payload["generated_at"] = generated_at
+    body = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
+    return (
+        f"{BLOCK_BEGIN}\n"
+        f"<!-- Owner-generated by "
+        f"skills/vault-ingress/scripts/render-vault-status.py. Do not hand-edit: "
+        f"every value is derived from the tracking database named by "
+        f"database_sha256. -->\n"
+        f"```json\n{body}\n```\n"
+        f"{BLOCK_END}"
+    )
+
+
+def splice_block(summary_text: str, block: str) -> str:
+    """Replace the delimited block, or append one when the summary has none."""
+    begin = summary_text.find(BLOCK_BEGIN)
+    end = summary_text.find(BLOCK_END)
+    if begin == -1 and end == -1:
+        separator = "" if summary_text.endswith("\n\n") else "\n"
+        if summary_text and not summary_text.endswith("\n"):
+            separator = "\n\n"
+        return f"{summary_text}{separator}{block}\n"
+    if begin == -1 or end == -1 or end < begin:
+        raise SummaryRenderError(
+            "summary status-block delimiters are missing or out of order",
+            reason_code="summary_block_malformed",
+        )
+    return summary_text[:begin] + block + summary_text[end + len(BLOCK_END) :]
+
+
+def _read_summary(path: Path) -> tuple[str, str]:
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as error:
+        raise SummaryRenderError(
+            "summary file does not exist", reason_code="summary_missing"
+        ) from error
+    except OSError as error:
+        raise SummaryRenderError(
+            "summary file could not be read", reason_code="summary_unreadable"
+        ) from error
+    try:
+        return raw.decode("utf-8"), hashlib.sha256(raw).hexdigest()
+    except UnicodeError as error:
+        raise SummaryRenderError(
+            "summary file is not valid UTF-8", reason_code="summary_not_utf8"
+        ) from error
+
+
+def _install(summary_path: Path, payload: bytes) -> None:
+    """Replace the summary atomically; an interruption leaves the prior file."""
+    stage = open_retained_stage(
+        summary_path,
+        payload,
+        mode=0o644,
+        suffix=".vault-status",
+        label="rhetoric summary",
+    )
+    try:
+        install_retained_stage(stage, summary_path)
+    except OSError as error:
+        raise SummaryRenderError(
+            "summary replacement could not be installed",
+            reason_code="summary_install_failed",
+        ) from error
+    finally:
+        close_retained_stage(stage)
+
+
+def execute(
+    value: str | Path,
+    *,
+    generated_at: str,
+    apply_requested: bool = False,
+    expected_sha256: str | None = None,
+    summary_override: Path | None = None,
+) -> dict[str, Any]:
+    _root, database_path, default_summary = resolve_input(value)  # noqa: F841
+    summary_path = summary_override or default_summary
+
+    snapshot = snapshot_tracking_database(database_path)
+    database = decode_json_object(snapshot)
+    try:
+        assessment = assess_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseIOError(
+            "tracking database owner assessment failed",
+            reason_code="owner_assessment_failed",
+        ) from exc
+    if not assessment.usable:
+        raise TrackingDatabaseIOError(
+            "tracking database has no usable legacy/current owner state",
+            reason_code="owner_state_unusable",
+        )
+
+    status = derive_status(database, input_sha256=snapshot.sha256)
+    block = render_block(status, generated_at=generated_at)
+    summary_text, summary_sha256 = _read_summary(summary_path)
+    rendered = splice_block(summary_text, block)
+    payload = rendered.encode("utf-8")
+    changed = payload != summary_text.encode("utf-8")
+
+    written = False
+    if apply_requested:
+        if expected_sha256 is None:
+            raise SummaryRenderError(
+                "--apply requires --expected-sha256 from a dry-run report",
+                reason_code="summary_precondition_missing",
+            )
+        if expected_sha256 != summary_sha256:
+            raise SummaryRenderError(
+                "summary bytes changed since the dry run",
+                reason_code="summary_precondition_failed",
+            )
+        # A no-op render installs nothing: rewriting identical bytes would
+        # churn the file's identity for consumers watching it.
+        if changed:
+            _install(summary_path, payload)
+            written = True
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "ok": True,
+        "mode": "apply" if apply_requested else "dry-run",
+        "database_path": str(snapshot.path),
+        "summary_path": str(summary_path),
+        "summary_sha256": summary_sha256,
+        "rendered_sha256": hashlib.sha256(payload).hexdigest(),
+        "changed": changed,
+        "summary_written": written,
+        "status": status,
+        "block": block,
+    }
+
+
+def _failure(reason_code: str, message: str) -> dict[str, Any]:
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "ok": False,
+        "code": reason_code,
+        "error": message,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
+    parser.add_argument("vault_or_database", type=Path)
+    parser.add_argument("--summary", type=Path, help="override the summary path")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--expected-sha256")
+    parser.add_argument(
+        "--generated-at",
+        required=True,
+        help="ISO timestamp recorded in the block; supplied so a render is reproducible",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = execute(
+            args.vault_or_database,
+            generated_at=args.generated_at,
+            apply_requested=args.apply,
+            expected_sha256=args.expected_sha256,
+            summary_override=args.summary,
+        )
+    except TrackingDatabaseIOError as exc:
+        # Never echo the exception: decoder messages carry the host path and
+        # the rejected content verbatim.
+        code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
+        print(json.dumps(_failure(code, message), sort_keys=True))
+        print(f"vault status render failed: {message}", file=sys.stderr)
+        return 2
+    except SummaryRenderError as exc:
+        print(json.dumps(_failure(exc.reason_code, str(exc)), sort_keys=True))
+        print(f"vault status render failed: {exc}", file=sys.stderr)
+        return 3 if exc.reason_code == "summary_precondition_failed" else 2
+    except StagedInvariantError as exc:
+        print(
+            json.dumps(
+                _failure(
+                    "summary_stage_invariant", "staged summary failed its binding"
+                ),
+                sort_keys=True,
+            )
+        )
+        print(f"vault status render failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/vault-ingress/scripts/render-vault-status.py
+++ b/skills/vault-ingress/scripts/render-vault-status.py
@@ -42,10 +42,7 @@ from pathlib import Path
 import sys
 from typing import Any, Iterator
 
-from cooperative_lock import (
-    CooperativeLockError,
-    exclusive_file_lock,
-)
+from cooperative_lock import CooperativeLockError
 from retained_stage import (
     RetainedStageError,
     close_retained_stage,
@@ -57,6 +54,7 @@ from tracking_database import (
     assess_tracking_database,
     tracking_database_schema_version,
 )
+from summary_lock import SUMMARY_BASENAME, rhetoric_summary_lock
 from tracking_database_io import (
     DATABASE_READ_DIAGNOSTICS,
     DATABASE_READ_FALLBACK,
@@ -68,12 +66,6 @@ from tracking_database_io import (
 REPORT_SCHEMA_VERSION = 1
 STATUS_BLOCK_SCHEMA_VERSION = 1
 DATABASE_BASENAME = "tracking-database.json"
-SUMMARY_BASENAME = "rhetoric-style-summary.md"
-
-# Names the summary in every cooperative-lock diagnostic. Every toolkit writer
-# of this file takes that lock, so the check-and-swap below is one critical
-# section rather than two racing operations.
-SUMMARY_LOCK_LABEL = "rhetoric-summary"
 
 # The block is fenced by exact literals so replacement is a delimited splice,
 # never a heuristic match against narrative prose that may quote a count.
@@ -269,9 +261,7 @@ def _summary_lock(summary_path: Path) -> Iterator[None]:
     """
     stack = ExitStack()
     try:
-        lock = stack.enter_context(
-            exclusive_file_lock(summary_path, label=SUMMARY_LOCK_LABEL)
-        )
+        lock = stack.enter_context(rhetoric_summary_lock(summary_path))
     except CooperativeLockError as error:
         # Path-neutral like every other failure here: the lock's own message
         # names the host path, so it is diagnosed by shape instead.

--- a/skills/vault-ingress/scripts/summary_lock.py
+++ b/skills/vault-ingress/scripts/summary_lock.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""The one writer lock for ``rhetoric-style-summary.md``.
+
+Two toolkit writers replace parts of this file: the owner status block
+(``render-vault-status.py``) and the Section 15 pattern-history block
+(``section15_pattern_history.py``). Both read the whole file, splice their own
+block, and rename the result over the target — so two writers that do not
+exclude each other silently drop one of the two updates, whichever renamed
+first.
+
+They exclude each other through this seam rather than each naming the lock
+itself. A label is diagnostics; agreement on the lock is the contract, and a
+third writer that imports this cannot invent its own.
+
+Cooperative is the exact claim: a human editing the summary holds no lock, so
+each writer still rechecks the target's bytes immediately before its rename.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from cooperative_lock import CooperativeLock, exclusive_file_lock
+
+SUMMARY_BASENAME = "rhetoric-style-summary.md"
+
+# Names the summary in every cooperative-lock diagnostic.
+SUMMARY_LOCK_LABEL = "rhetoric-summary"
+
+
+@contextmanager
+def rhetoric_summary_lock(summary_path: Path) -> Iterator[CooperativeLock]:
+    """Hold the summary's exclusive writer lock for the whole critical section.
+
+    Raises ``CooperativeLockError``; each writer classifies that in its own
+    terms. The lock file is the target's persistent sibling, so writers that
+    pass different labels still serialize on the same inode.
+    """
+    with exclusive_file_lock(summary_path, label=SUMMARY_LOCK_LABEL) as lock:
+        yield lock

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -13,10 +13,9 @@ processes to lock different inodes and is outside the cooperative contract.
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 from dataclasses import dataclass
 from decimal import Decimal, DecimalException
-import fcntl
 import hashlib
 import json
 import math
@@ -26,6 +25,11 @@ import stat
 import sys
 from typing import Any, Iterator, NoReturn
 
+from cooperative_lock import (
+    CooperativeLock,
+    CooperativeLockError,
+    exclusive_file_lock,
+)
 from retained_stage import (
     FileGeneration,
     RetainedStage as StagedCandidate,
@@ -47,6 +51,9 @@ STAGED_METADATA_STABILIZATION_ATTEMPTS = 4
 
 STAGED_CANDIDATE_SUFFIX = ".tracking-db.tmp"
 STAGED_CANDIDATE_LABEL = "tracking-database candidate"
+
+# Names this owner's artifact in every cooperative-lock diagnostic.
+DATABASE_LOCK_LABEL = "tracking-database"
 
 
 # Closed, path-neutral prose for each typed reason code. A read failure must
@@ -169,15 +176,6 @@ class TrackingDatabaseWriteResult:
         }
 
 
-@dataclass
-class _DatabaseLock:
-    """One acquired lock plus cleanup warnings collected after the body."""
-
-    descriptor: int
-    path: Path
-    warnings: list[str]
-
-
 def unchanged_write_result(
     snapshot: TrackingDatabaseSnapshot,
 ) -> TrackingDatabaseWriteResult:
@@ -217,12 +215,6 @@ def json_values_equal(left: object, right: object) -> bool:
             for left_item, right_item in zip(left, right)
         )
     return left == right
-
-
-def lock_path_for(path: str | os.PathLike[str]) -> Path:
-    """Return the persistent cooperative lock shared by every toolkit writer."""
-    database_path = _absolute_path(path)
-    return database_path.parent / f".{database_path.name}.lock"
 
 
 def _path_metadata(path: Path, *, subject: str) -> os.stat_result:
@@ -485,91 +477,22 @@ def render_json_object(payload: dict[str, Any]) -> bytes:
         ) from exc
 
 
-def _lock_identity(metadata: os.stat_result) -> tuple[int, int]:
-    return metadata.st_dev, metadata.st_ino
-
-
-def _append_close_warning(
-    descriptor: int,
-    *,
-    label: str,
-    warnings: list[str],
-) -> None:
-    """Close a post-operation descriptor without masking the operation outcome."""
-    try:
-        os.close(descriptor)
-    except OSError as exc:
-        warnings.append(f"could not close {label}: {exc}")
-
-
 @contextmanager
-def _exclusive_database_lock(path: Path) -> Iterator[_DatabaseLock]:
-    lock_path = lock_path_for(path)
-    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    try:
-        descriptor = os.open(lock_path, flags, 0o600)
-    except OSError as exc:
-        raise TrackingDatabaseIOError(
-            f"cannot open cooperative tracking-database lock {lock_path}: {exc}"
-        ) from exc
-    acquired = False
-    initialized = False
-    try:
-        try:
-            opened = os.fstat(descriptor)
-            if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
-                raise TrackingDatabaseIOError(
-                    f"cooperative tracking-database lock {lock_path} must be one regular file"
-                )
-            fcntl.flock(descriptor, fcntl.LOCK_EX)
-            acquired = True
-            try:
-                visible = lock_path.lstat()
-            except OSError as exc:
-                raise TrackingDatabaseIOError(
-                    f"cannot verify cooperative tracking-database lock {lock_path}: {exc}"
-                ) from exc
-            locked = os.fstat(descriptor)
-            if (
-                stat.S_ISLNK(visible.st_mode)
-                or not stat.S_ISREG(visible.st_mode)
-                or _lock_identity(visible) != _lock_identity(locked)
-                or locked.st_nlink != 1
-            ):
-                raise TrackingDatabaseIOError(
-                    f"cooperative tracking-database lock {lock_path} changed while locking; "
-                    "restore the persistent regular lock file and retry"
-                )
-        except OSError as exc:
-            raise TrackingDatabaseIOError(
-                f"cannot acquire tracking-database lock through {lock_path}: {exc}"
-            ) from exc
-        initialized = True
-    finally:
-        if not initialized:
-            try:
-                os.close(descriptor)
-            except OSError:
-                pass
+def _exclusive_database_lock(path: Path) -> Iterator[CooperativeLock]:
+    """Hold the shared writer lock, in this owner's error terms.
 
-    lock = _DatabaseLock(descriptor=descriptor, path=lock_path, warnings=[])
+    The lock mechanism is the shared primitive; only the classification is this
+    owner's, so callers keep routing on TrackingDatabaseIOError. Acquisition is
+    wrapped alone — a lock error raised by the guarded body is that body's, not
+    this acquisition's, and must not be relabelled here.
+    """
+    stack = ExitStack()
     try:
+        lock = stack.enter_context(exclusive_file_lock(path, label=DATABASE_LOCK_LABEL))
+    except CooperativeLockError as exc:
+        raise TrackingDatabaseIOError(str(exc)) from exc
+    with stack:
         yield lock
-    finally:
-        if acquired:
-            try:
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
-            except OSError as exc:
-                lock.warnings.append(
-                    f"could not unlock cooperative tracking-database lock "
-                    f"{lock_path}: {exc}"
-                )
-        _append_close_warning(
-            descriptor,
-            label=f"cooperative tracking-database lock {lock_path}",
-            warnings=lock.warnings,
-        )
 
 
 def _require_expected_generation(

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -31,6 +31,7 @@ import stat
 import sys
 import tempfile
 from collections.abc import Mapping
+from contextlib import ExitStack
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -64,8 +65,18 @@ from pattern_classification_runtime import (  # noqa: E402
 )
 
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from cooperative_lock import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    CooperativeLockError,
+)
+
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     ReturnValidationError,
+)
+
+# Pyright cannot resolve this sibling script module added to sys.path at runtime.
+from summary_lock import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    rhetoric_summary_lock,
 )
 
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
@@ -603,41 +614,83 @@ def replace_section15_current_block(
         evidence_freshness_assessor=evidence_freshness_assessor,
         classification_policy_stamp=classification_policy_stamp,
     )
+    # The status-block writer replaces its own delimited block in this same
+    # file. Two writers that read, splice, and rename without excluding each
+    # other drop whichever update renamed first, so both take the summary's
+    # shared writer lock for their whole read-splice-install section.
+    stack = ExitStack()
     try:
-        original_bytes = summary_path.read_bytes()
-        original = original_bytes.decode("utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
+        stack.enter_context(rhetoric_summary_lock(summary_path))
+    except CooperativeLockError as exc:
         raise Section15PatternHistoryError(
-            f"cannot read UTF-8 rhetoric summary at {summary_path}: {exc}"
+            f"cannot take the rhetoric summary writer lock for {summary_path}: {exc}"
         ) from exc
+    with stack:
+        try:
+            original_bytes = summary_path.read_bytes()
+            original = original_bytes.decode("utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise Section15PatternHistoryError(
+                f"cannot read UTF-8 rhetoric summary at {summary_path}: {exc}"
+            ) from exc
 
-    candidate = _replace_block_text(original, rendered)
-    candidate_assessment = assess_section15_pattern_history(candidate)
-    if not candidate_assessment.current_contract:
-        details = "; ".join(
-            candidate_assessment.errors or candidate_assessment.reason_codes
-        )
-        raise Section15PatternHistoryError(
-            "rendered Section 15 candidate failed validation: " + details
-        )
-    if candidate_assessment.pattern_profile != canonical_input:
-        raise Section15PatternHistoryError(
-            "rendered Section 15 candidate does not round-trip the full pattern_profile"
+        candidate = _replace_block_text(original, rendered)
+        candidate_assessment = assess_section15_pattern_history(candidate)
+        if not candidate_assessment.current_contract:
+            details = "; ".join(
+                candidate_assessment.errors or candidate_assessment.reason_codes
+            )
+            raise Section15PatternHistoryError(
+                "rendered Section 15 candidate failed validation: " + details
+            )
+        if candidate_assessment.pattern_profile != canonical_input:
+            raise Section15PatternHistoryError(
+                "rendered Section 15 candidate does not round-trip the full "
+                "pattern_profile"
+            )
+
+        count = candidate_assessment.scored_talk_count
+        eligible_count = candidate_assessment.eligible_talk_count
+        assert isinstance(count, int)  # shared-assessor postcondition
+        assert isinstance(eligible_count, int)  # shared-assessor postcondition
+        if candidate == original:
+            return Section15WriteResult(
+                path=str(summary_path),
+                changed=False,
+                scored_talk_count=count,
+                eligible_talk_count=eligible_count,
+                catalog_fields_available=(
+                    candidate_assessment.catalog_fields_available
+                ),
+            )
+
+        _install_summary_bytes(
+            summary_path,
+            candidate.encode("utf-8"),
+            expected=original_bytes,
         )
 
-    count = candidate_assessment.scored_talk_count
-    eligible_count = candidate_assessment.eligible_talk_count
-    assert isinstance(count, int)  # shared-assessor postcondition
-    assert isinstance(eligible_count, int)  # shared-assessor postcondition
-    if candidate == original:
         return Section15WriteResult(
             path=str(summary_path),
-            changed=False,
+            changed=True,
             scored_talk_count=count,
             eligible_talk_count=eligible_count,
-            catalog_fields_available=(candidate_assessment.catalog_fields_available),
+            catalog_fields_available=candidate_assessment.catalog_fields_available,
         )
 
+
+def _install_summary_bytes(
+    summary_path: Path,
+    payload: bytes,
+    *,
+    expected: bytes,
+) -> None:
+    """Rename ``payload`` over the summary, refusing a target that moved.
+
+    Called with the writer lock held, so no other toolkit writer sits between
+    the recheck and the rename. The recheck is what covers the writer no lock
+    reaches — a human saving the file in an editor.
+    """
     mode = stat.S_IMODE(summary_path.stat().st_mode)
     temporary_path: Path | None = None
     file_descriptor: int | None = None
@@ -652,9 +705,21 @@ def replace_section15_current_block(
         handle = os.fdopen(file_descriptor, "wb")
         file_descriptor = None
         with handle:
-            handle.write(candidate.encode("utf-8"))
+            handle.write(payload)
             handle.flush()
             os.fsync(handle.fileno())
+        try:
+            current = summary_path.read_bytes()
+        except OSError as exc:
+            raise Section15PatternHistoryError(
+                f"cannot re-read rhetoric summary at {summary_path} before "
+                f"installing the Section 15 block: {exc}"
+            ) from exc
+        if current != expected:
+            raise Section15PatternHistoryError(
+                f"rhetoric summary at {summary_path} changed while the Section 15 "
+                "replacement was staged; re-run the replace against the current file"
+            )
         os.replace(temporary_path, summary_path)
     finally:
         if file_descriptor is not None:
@@ -664,14 +729,6 @@ def replace_section15_current_block(
                 temporary_path.unlink()
             except FileNotFoundError:
                 pass
-
-    return Section15WriteResult(
-        path=str(summary_path),
-        changed=True,
-        scored_talk_count=count,
-        eligible_talk_count=eligible_count,
-        catalog_fields_available=candidate_assessment.catalog_fields_available,
-    )
 
 
 def _load_json(path: Path) -> object:

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -620,11 +620,34 @@ def replace_section15_current_block(
     # shared writer lock for their whole read-splice-install section.
     stack = ExitStack()
     try:
-        stack.enter_context(rhetoric_summary_lock(summary_path))
+        lock = stack.enter_context(rhetoric_summary_lock(summary_path))
     except CooperativeLockError as exc:
         raise Section15PatternHistoryError(
             f"cannot take the rhetoric summary writer lock for {summary_path}: {exc}"
         ) from exc
+    # An unlock or close that failed is recorded on the lock rather than
+    # raised — the guarded write already happened. Dropping those warnings
+    # would leave incomplete lock cleanup with no diagnostic naming it.
+    try:
+        return _replace_under_summary_lock(
+            summary_path,
+            stack,
+            rendered=rendered,
+            canonical_input=canonical_input,
+        )
+    finally:
+        for warning in lock.warnings:
+            print(f"WARNING: {warning}", file=sys.stderr)
+
+
+def _replace_under_summary_lock(
+    summary_path: Path,
+    stack: ExitStack,
+    *,
+    rendered: str,
+    canonical_input: dict[str, Any],
+) -> Section15WriteResult:
+    """Read, validate, and install the block while the writer lock is held."""
     with stack:
         try:
             original_bytes = summary_path.read_bytes()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,15 @@ def tracking_database_io():
 
 
 @pytest.fixture(scope="session")
+def cooperative_lock():
+    """The persistent sibling lock every writer of one owner file shares (#168)."""
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "cooperative_lock.py"),
+        "cooperative_lock",
+    )
+
+
+@pytest.fixture(scope="session")
 def retained_stage():
     """The staged-file lifecycle both owner writers share (#243).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -656,3 +656,11 @@ def pptx_catalog_selection():
         os.path.join(SCRIPTS_VI, "pptx_catalog_selection.py"),
         "pptx_catalog_selection",
     )
+
+
+@pytest.fixture(scope="session")
+def render_vault_status():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "render-vault-status.py"),
+        "render_vault_status",
+    )

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -380,6 +380,7 @@ def test_initialization_dry_run_and_missing_precondition(
 
 
 def test_initialization_surfaces_owner_io_failure_as_mutation_error(
+    cooperative_lock,
     mutate_tracking_database,
     tracking_database_io,
     tmp_path: Path,
@@ -395,7 +396,7 @@ def test_initialization_surfaces_owner_io_failure_as_mutation_error(
     )
     outside_lock = tmp_path / "outside.lock"
     outside_lock.write_bytes(b"")
-    tracking_database_io.lock_path_for(database_path).symlink_to(outside_lock)
+    cooperative_lock.lock_path_for(database_path).symlink_to(outside_lock)
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,

--- a/tests/test_render_vault_status.py
+++ b/tests/test_render_vault_status.py
@@ -525,6 +525,35 @@ def test_the_apply_holds_the_shared_summary_writer_lock(
     assert lock_path.is_file()
 
 
+def test_lock_cleanup_failure_is_reported_not_dropped(
+    render_vault_status, cooperative_lock, tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A release that failed is a warning, never silence."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    dry = render_vault_status.execute(root, generated_at=GENERATED_AT)
+    real_flock = cooperative_lock.fcntl.flock
+
+    def fail_unlock(descriptor: int, operation: int) -> object:
+        outcome = real_flock(descriptor, operation)
+        if operation == fcntl.LOCK_UN:
+            raise OSError("simulated unlock failure")
+        return outcome
+
+    monkeypatch.setattr(cooperative_lock.fcntl, "flock", fail_unlock)
+
+    applied = render_vault_status.execute(
+        root,
+        generated_at=GENERATED_AT,
+        apply_requested=True,
+        expected_sha256=dry["summary_sha256"],
+    )
+
+    assert applied["summary_written"] is True
+    assert (
+        "could not unlock cooperative rhetoric-summary lock" in capsys.readouterr().err
+    )
+
+
 def test_a_dry_run_takes_no_writer_lock(
     render_vault_status, cooperative_lock, tmp_path: Path
 ) -> None:

--- a/tests/test_render_vault_status.py
+++ b/tests/test_render_vault_status.py
@@ -381,6 +381,51 @@ def test_an_unusable_database_renders_nothing(
     assert str(root) not in captured.out + captured.err
 
 
+@pytest.mark.parametrize(
+    ("value", "code"),
+    [
+        ("yesterday", "generated_at_invalid"),
+        ("2026-08-10", "generated_at_not_aware"),
+        ("2026-08-10T12:00:00", "generated_at_not_aware"),
+    ],
+)
+def test_a_stamp_without_an_offset_renders_nothing(
+    render_vault_status, tmp_path: Path, capsys, value: str, code: str
+) -> None:
+    """The stamp is written into the block as operational fact.
+
+    An unparsed string stamps a block no consumer can order; a naive one
+    leaves the reader guessing at the zone.
+    """
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    before = summary.read_bytes()
+
+    exit_code = render_vault_status.main([str(root), "--generated-at", value])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    payload = json.loads(captured.out)
+    assert payload["code"] == code
+    assert "+00:00" in payload["error"]
+    assert summary.read_bytes() == before
+
+
+def test_bad_arguments_still_produce_the_json_contract(
+    render_vault_status, tmp_path: Path, capsys
+) -> None:
+    """One JSON object on stdout for every outcome, usage text included."""
+    with pytest.raises(SystemExit) as stopped:
+        render_vault_status.main([str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert stopped.value.code == 2
+    payload = json.loads(captured.out)
+    assert payload["ok"] is False
+    assert payload["code"] == "invalid_arguments"
+    assert "--generated-at" in payload["error"]
+
+
 def test_the_block_payload_is_machine_readable(
     render_vault_status, tmp_path: Path
 ) -> None:

--- a/tests/test_render_vault_status.py
+++ b/tests/test_render_vault_status.py
@@ -12,8 +12,10 @@ it never read.
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -429,6 +431,160 @@ def test_duplicate_delimiters_are_malformed(
 
     assert caught.value.reason_code == "summary_block_malformed"
     assert summary.read_bytes() == before
+
+
+def test_an_edit_after_the_final_check_still_loses_nothing(
+    render_vault_status, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The last observation before the rename is the one that binds.
+
+    An edit landing after the digest was checked and before the swap is the
+    window a check-then-replace design silently overwrites. Here it is caught
+    by the recheck that runs immediately before installation.
+    """
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    dry = render_vault_status.execute(root, generated_at=GENERATED_AT)
+    real_install = render_vault_status.install_retained_stage
+
+    def edit_then_install(*args, **kwargs):  # pragma: no cover - must not run
+        return real_install(*args, **kwargs)
+
+    def edit_then_recheck(path, expected_sha256):
+        # A human saves the file between the staged bytes being verified and
+        # the rename that would replace them.
+        summary.write_text("# Rhetoric\n\nSaved after the check.\n", encoding="utf-8")
+        return real_recheck(path, expected_sha256)
+
+    real_recheck = render_vault_status._require_expected_summary
+    monkeypatch.setattr(
+        render_vault_status, "install_retained_stage", edit_then_install
+    )
+    monkeypatch.setattr(
+        render_vault_status, "_require_expected_summary", edit_then_recheck
+    )
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(
+            root,
+            generated_at=GENERATED_AT,
+            apply_requested=True,
+            expected_sha256=dry["summary_sha256"],
+        )
+
+    assert caught.value.reason_code == "summary_precondition_failed"
+    assert (
+        summary.read_text(encoding="utf-8") == "# Rhetoric\n\nSaved after the check.\n"
+    )
+
+
+def test_the_apply_holds_the_shared_summary_writer_lock(
+    render_vault_status,
+    cooperative_lock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second toolkit writer cannot interleave with the check-and-swap.
+
+    Human editors take no lock, which is why the pre-install recheck exists;
+    every writer that goes through this toolkit is excluded outright.
+    """
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    dry = render_vault_status.execute(root, generated_at=GENERATED_AT)
+    lock_path = cooperative_lock.lock_path_for(summary)
+    observed: list[str] = []
+    real_install = render_vault_status.install_retained_stage
+
+    def probe_then_install(*args, **kwargs):
+        descriptor = os.open(lock_path, os.O_RDWR)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            observed.append("acquired")
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        except BlockingIOError:
+            observed.append("excluded")
+        finally:
+            os.close(descriptor)
+        return real_install(*args, **kwargs)
+
+    monkeypatch.setattr(
+        render_vault_status, "install_retained_stage", probe_then_install
+    )
+
+    render_vault_status.execute(
+        root,
+        generated_at=GENERATED_AT,
+        apply_requested=True,
+        expected_sha256=dry["summary_sha256"],
+    )
+
+    assert observed == ["excluded"]
+    # The lock is persistent: removing it would let two writers lock two
+    # different inodes under one name.
+    assert lock_path.is_file()
+
+
+def test_a_dry_run_takes_no_writer_lock(
+    render_vault_status, cooperative_lock, tmp_path: Path
+) -> None:
+    """Reading is not writing; a dry run must not serialize against writers."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+
+    render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert not cooperative_lock.lock_path_for(summary).exists()
+
+
+def test_a_missing_summary_says_how_to_recover(
+    render_vault_status, tmp_path: Path, capsys
+) -> None:
+    """`error-handling` Actionable Messages: name the fix, not just the fault."""
+    root = tmp_path / "vault"
+    root.mkdir()
+    (root / "tracking-database.json").write_text(
+        json.dumps(_database([_talk("one.md", "processed")])), encoding="utf-8"
+    )
+
+    exit_code = render_vault_status.main([str(root), "--generated-at", GENERATED_AT])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    payload = json.loads(captured.out)
+    assert payload["code"] == "summary_missing"
+    assert "rhetoric-style-summary.md" in payload["error"]
+    assert "--summary" in payload["error"]
+    assert str(root) not in captured.out + captured.err
+
+
+def test_an_unreadable_summary_says_how_to_recover(
+    render_vault_status, tmp_path: Path
+) -> None:
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    summary.unlink()
+    # A directory in the summary's place: readable path, unreadable file.
+    summary.mkdir()
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert caught.value.reason_code == "summary_unreadable"
+    assert "regular file" in str(caught.value)
+
+
+def test_a_non_utf8_summary_says_how_to_recover(
+    render_vault_status, tmp_path: Path
+) -> None:
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    (root / "rhetoric-style-summary.md").write_bytes(b"# Rhetoric\n\n\xff\xfe\n")
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert caught.value.reason_code == "summary_not_utf8"
+    assert "UTF-8" in str(caught.value)
 
 
 def test_an_edit_during_the_stage_window_abandons_the_swap(

--- a/tests/test_render_vault_status.py
+++ b/tests/test_render_vault_status.py
@@ -1,0 +1,386 @@
+"""Owner-generated vault status block in rhetoric-style-summary.md (#168).
+
+The summary's status line was hand-maintained and drifted: a verified snapshot
+claimed `199 / 208` with 195 processed while the tracking database held 209
+talks, 116 of them `needs-reprocessing`. Queue normalization moves statuses
+without touching prose, so the stale cohort reads as live.
+
+Every count here comes from one strict snapshot. These tests pin that, plus the
+hash-preconditioned apply that keeps the renderer from overwriting a human edit
+it never read.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+GENERATED_AT = "2026-08-10T12:00:00Z"
+
+
+def _claim(state: str = "claimed") -> dict:
+    """A queue claim the owner contract accepts.
+
+    Schema 2 keeps the fixture to the fields this test is about; the adherence
+    baseline that schema 3+ requires says nothing about counting.
+    """
+    claim = {
+        "schema_version": 2,
+        "run_id": "status-render-test",
+        "batch_id": "batch-1",
+        "claimed_at": "2026-07-31T12:00:00+00:00",
+        "previous_status": "needs-reprocessing",
+        # Positive, and equal to the talk's own reprocess_generation: the owner
+        # contract refuses a claim that disagrees with the record it is on.
+        "reprocess_generation": 1,
+        "state": state,
+    }
+    if state != "claimed":
+        # A terminal claim is a finished writer, never an active one.
+        claim.update(
+            {
+                "released_at": "2026-07-31T13:00:00+00:00",
+                "release_reason": "status_render_test",
+                "result_status": "processed",
+            }
+        )
+    return claim
+
+
+def _talk(filename: str, status: str, **extra) -> dict:
+    talk = {"schema_version": 5, "filename": filename, "status": status}
+    if "_queue_claim" in extra:
+        talk["reprocess_generation"] = extra["_queue_claim"]["reprocess_generation"]
+    talk.update(extra)
+    return talk
+
+
+def _database(talks: list[dict], **config_extra) -> dict:
+    config = {"schema_version": 2, "pptx_directory_exclusions": []}
+    config.update(config_extra)
+    return {
+        "schema_version": 1,
+        "config": config,
+        "talks": talks,
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+
+
+def _vault(tmp_path: Path, database: dict, summary: str = "# Rhetoric\n\nNarrative.\n"):
+    root = tmp_path / "vault"
+    root.mkdir()
+    (root / "tracking-database.json").write_text(json.dumps(database), encoding="utf-8")
+    (root / "rhetoric-style-summary.md").write_text(summary, encoding="utf-8")
+    return root
+
+
+def _block_payload(report: dict) -> dict:
+    body = report["block"].split("```json\n", 1)[1].rsplit("\n```", 1)[0]
+    return json.loads(body)
+
+
+def test_the_verified_209_talk_mismatch_is_derived_not_transcribed(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """The live snapshot from the issue: prose said 199/208, the database said this."""
+    talks = (
+        [_talk(f"reproc-{i}.md", "needs-reprocessing") for i in range(116)]
+        + [_talk(f"pending-{i}.md", "pending") for i in range(9)]
+        + [_talk(f"done-{i}.md", "processed") for i in range(78)]
+        + [_talk(f"partial-{i}.md", "processed_partial") for i in range(2)]
+        + [
+            _talk(f"inflight-{i}.md", "reprocessing-inflight", _queue_claim=_claim())
+            for i in range(3)
+        ]
+        + [_talk("dupe.md", "skipped_duplicate")]
+    )
+    root = _vault(tmp_path, _database(talks))
+
+    report = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    status = report["status"]
+    assert status["total_talks"] == 209
+    assert status["status_counts"] == {
+        "needs-reprocessing": 116,
+        "pending": 9,
+        "processed": 78,
+        "processed_partial": 2,
+        "reprocessing-inflight": 3,
+        "skipped_duplicate": 1,
+    }
+    # 78 + 2 analysed at some point; the 116 sent back by normalization are not
+    # lost work, they are simply not in the current cohort.
+    assert status["historically_analysed_count"] == 80
+    assert status["current_cohort_count"] == 80
+    assert status["active_claim_count"] == 3
+
+
+def test_in_flight_talks_are_counted_as_active(
+    render_vault_status, tmp_path: Path
+) -> None:
+    talks = [
+        _talk("inflight-a.md", "reprocessing-inflight", _queue_claim=_claim()),
+        _talk("inflight-b.md", "reprocessing-inflight", _queue_claim=_claim()),
+        _talk("idle.md", "processed"),
+    ]
+    root = _vault(tmp_path, _database(talks))
+
+    report = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert report["status"]["active_claim_count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("talk", "expected"),
+    [
+        ({"status": "reprocessing-inflight"}, 1),
+        ({"status": "processed", "_queue_claim": {"state": "claimed"}}, 1),
+        ({"status": "processed", "_queue_claim": {"state": "completed"}}, 0),
+        ({"status": "processed", "_queue_claim": {"state": "stale_recovered"}}, 0),
+        ({"status": "processed", "_queue_claim": "not an object"}, 0),
+        ({"status": "processed"}, 0),
+        ("not a talk", 0),
+    ],
+)
+def test_active_claim_counting_reads_both_signals(
+    render_vault_status, talk, expected
+) -> None:
+    """The counting rule itself, apart from the queue contract's own validity.
+
+    A recovered or completed claim is a finished writer; only an in-flight
+    status or a still-`claimed` record means someone holds the talk now.
+    """
+    assert render_vault_status._active_claims([talk]) == expected
+
+
+def test_the_block_binds_the_exact_database_generation(
+    render_vault_status, tmp_path: Path
+) -> None:
+    database = _database(
+        [_talk("one.md", "processed")],
+        pattern_scoring_schema_version=5,
+        pattern_catalog_fingerprint="a" * 64,
+    )
+    root = _vault(tmp_path, database)
+    raw = (root / "tracking-database.json").read_bytes()
+
+    report = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    status = report["status"]
+    assert status["database_sha256"] == hashlib.sha256(raw).hexdigest()
+    assert status["database_schema_version"] == 1
+    assert status["scoring_generation"] == {
+        "pattern_scoring_schema_version": 5,
+        "pattern_catalog_fingerprint": "a" * 64,
+    }
+
+
+def test_an_absent_generation_is_reported_absent_not_defaulted(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """A default would let a database with no recorded generation claim one."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+
+    report = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert report["status"]["scoring_generation"] == {
+        "pattern_scoring_schema_version": None,
+        "pattern_catalog_fingerprint": None,
+    }
+
+
+def test_a_dry_run_writes_nothing(render_vault_status, tmp_path: Path) -> None:
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    before = summary.read_bytes()
+
+    report = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert report["mode"] == "dry-run"
+    assert report["changed"] is True
+    assert report["summary_written"] is False
+    assert summary.read_bytes() == before
+
+
+def test_apply_installs_the_block_and_preserves_the_narrative(
+    render_vault_status, tmp_path: Path
+) -> None:
+    root = _vault(
+        tmp_path,
+        _database([_talk("one.md", "processed")]),
+        summary="# Rhetoric\n\nSection 1 narrative.\n",
+    )
+    summary = root / "rhetoric-style-summary.md"
+    dry = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    applied = render_vault_status.execute(
+        root,
+        generated_at=GENERATED_AT,
+        apply_requested=True,
+        expected_sha256=dry["summary_sha256"],
+    )
+
+    text = summary.read_text(encoding="utf-8")
+    assert applied["summary_written"] is True
+    assert "Section 1 narrative." in text
+    assert render_vault_status.BLOCK_BEGIN in text
+    assert render_vault_status.BLOCK_END in text
+
+
+def test_a_second_apply_is_a_byte_stable_no_op(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """Rewriting identical bytes would churn the file for consumers watching it."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    first = render_vault_status.execute(root, generated_at=GENERATED_AT)
+    render_vault_status.execute(
+        root,
+        generated_at=GENERATED_AT,
+        apply_requested=True,
+        expected_sha256=first["summary_sha256"],
+    )
+    installed = summary.read_bytes()
+
+    second = render_vault_status.execute(
+        root,
+        generated_at=GENERATED_AT,
+        apply_requested=True,
+        expected_sha256=hashlib.sha256(installed).hexdigest(),
+    )
+
+    assert second["changed"] is False
+    assert second["summary_written"] is False
+    assert summary.read_bytes() == installed
+
+
+def test_apply_refuses_a_stale_precondition(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """The summary is a file a human also edits."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    dry = render_vault_status.execute(root, generated_at=GENERATED_AT)
+    summary.write_text("# Rhetoric\n\nEdited by a human meanwhile.\n", encoding="utf-8")
+    before = summary.read_bytes()
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(
+            root,
+            generated_at=GENERATED_AT,
+            apply_requested=True,
+            expected_sha256=dry["summary_sha256"],
+        )
+
+    assert caught.value.reason_code == "summary_precondition_failed"
+    assert summary.read_bytes() == before
+
+
+def test_apply_without_a_precondition_is_refused(
+    render_vault_status, tmp_path: Path
+) -> None:
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(
+            root, generated_at=GENERATED_AT, apply_requested=True
+        )
+
+    assert caught.value.reason_code == "summary_precondition_missing"
+
+
+def test_only_the_delimited_block_is_replaced(
+    render_vault_status, tmp_path: Path
+) -> None:
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    summary.write_text(
+        "# Rhetoric\n\nBefore.\n\n"
+        f"{render_vault_status.BLOCK_BEGIN}\nstale garbage\n"
+        f"{render_vault_status.BLOCK_END}\n\nAfter.\n",
+        encoding="utf-8",
+    )
+    dry = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    render_vault_status.execute(
+        root,
+        generated_at=GENERATED_AT,
+        apply_requested=True,
+        expected_sha256=dry["summary_sha256"],
+    )
+
+    text = summary.read_text(encoding="utf-8")
+    assert "Before." in text and "After." in text
+    assert "stale garbage" not in text
+    assert text.count(render_vault_status.BLOCK_BEGIN) == 1
+
+
+def test_a_malformed_delimiter_pair_installs_nothing(
+    render_vault_status, tmp_path: Path
+) -> None:
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    summary.write_text(
+        f"# Rhetoric\n\n{render_vault_status.BLOCK_END}\nout of order\n"
+        f"{render_vault_status.BLOCK_BEGIN}\n",
+        encoding="utf-8",
+    )
+    before = summary.read_bytes()
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert caught.value.reason_code == "summary_block_malformed"
+    assert summary.read_bytes() == before
+
+
+def test_a_legacy_database_generation_still_renders(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """Legacy owner state is readable, so its cohort must be reportable too."""
+    root = _vault(tmp_path, {"config": {}, "talks": [_talk("one.md", "processed")]})
+
+    report = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert report["status"]["database_schema_version"] == 0
+    assert report["status"]["total_talks"] == 1
+
+
+def test_an_unusable_database_renders_nothing(
+    render_vault_status, tmp_path: Path, capsys
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    (root / "tracking-database.json").write_text(json.dumps({"schema_version": 99}))
+    (root / "rhetoric-style-summary.md").write_text("# Rhetoric\n")
+
+    exit_code = render_vault_status.main([str(root), "--generated-at", GENERATED_AT])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    payload = json.loads(captured.out)
+    assert payload["ok"] is False
+    # Path-neutral: the vault path must not ride out on the failure.
+    assert str(root) not in captured.out + captured.err
+
+
+def test_the_block_payload_is_machine_readable(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """A consumer diagnosing staleness reads the block, not the prose."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+
+    report = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    payload = _block_payload(report)
+    assert payload["schema_version"] == render_vault_status.STATUS_BLOCK_SCHEMA_VERSION
+    assert payload["generated_at"] == GENERATED_AT
+    assert payload["database_sha256"] == report["status"]["database_sha256"]

--- a/tests/test_render_vault_status.py
+++ b/tests/test_render_vault_status.py
@@ -50,6 +50,9 @@ def _claim(state: str = "claimed") -> dict:
     return claim
 
 
+ANALYSED = {"pattern_observations": {"patterns_detected": [{"pattern_id": "hook"}]}}
+
+
 def _talk(filename: str, status: str, **extra) -> dict:
     talk = {"schema_version": 5, "filename": filename, "status": status}
     if "_queue_claim" in extra:
@@ -92,10 +95,13 @@ def test_the_verified_209_talk_mismatch_is_derived_not_transcribed(
 ) -> None:
     """The live snapshot from the issue: prose said 199/208, the database said this."""
     talks = (
-        [_talk(f"reproc-{i}.md", "needs-reprocessing") for i in range(116)]
+        # 100 of the requeued talks were analysed before normalization moved
+        # them back; 16 never were.
+        [_talk(f"reproc-{i}.md", "needs-reprocessing", **ANALYSED) for i in range(100)]
+        + [_talk(f"fresh-{i}.md", "needs-reprocessing") for i in range(16)]
         + [_talk(f"pending-{i}.md", "pending") for i in range(9)]
-        + [_talk(f"done-{i}.md", "processed") for i in range(78)]
-        + [_talk(f"partial-{i}.md", "processed_partial") for i in range(2)]
+        + [_talk(f"done-{i}.md", "processed", **ANALYSED) for i in range(78)]
+        + [_talk(f"partial-{i}.md", "processed_partial", **ANALYSED) for i in range(2)]
         + [
             _talk(f"inflight-{i}.md", "reprocessing-inflight", _queue_claim=_claim())
             for i in range(3)
@@ -116,10 +122,11 @@ def test_the_verified_209_talk_mismatch_is_derived_not_transcribed(
         "reprocessing-inflight": 3,
         "skipped_duplicate": 1,
     }
-    # 78 + 2 analysed at some point; the 116 sent back by normalization are not
-    # lost work, they are simply not in the current cohort.
-    assert status["historically_analysed_count"] == 80
+    # The two counts must differ: 100 requeued talks keep their analysis
+    # evidence, so they are historically analysed while out of the current
+    # cohort. Reading history off `status` would erase all 100.
     assert status["current_cohort_count"] == 80
+    assert status["historically_analysed_count"] == 180
     assert status["active_claim_count"] == 3
 
 
@@ -384,3 +391,71 @@ def test_the_block_payload_is_machine_readable(
     assert payload["schema_version"] == render_vault_status.STATUS_BLOCK_SCHEMA_VERSION
     assert payload["generated_at"] == GENERATED_AT
     assert payload["database_sha256"] == report["status"]["database_sha256"]
+
+
+def test_a_requeued_talk_stays_historically_analysed(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """The distinction the block exists for, in isolation.
+
+    Normalization flips `status` and leaves the analysis evidence in place.
+    Deriving history from `status` would report the work as never done.
+    """
+    talks = [
+        _talk("requeued.md", "needs-reprocessing", **ANALYSED),
+        _talk("current.md", "processed", **ANALYSED),
+        _talk("never.md", "needs-reprocessing"),
+    ]
+    root = _vault(tmp_path, _database(talks))
+
+    status = render_vault_status.execute(root, generated_at=GENERATED_AT)["status"]
+
+    assert status["current_cohort_count"] == 1
+    assert status["historically_analysed_count"] == 2
+
+
+def test_duplicate_delimiters_are_malformed(
+    render_vault_status, tmp_path: Path
+) -> None:
+    """A second pair would make the splice target a range never inspected."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    block = f"{render_vault_status.BLOCK_BEGIN}\nx\n{render_vault_status.BLOCK_END}"
+    summary.write_text(f"# Rhetoric\n\n{block}\n\n{block}\n", encoding="utf-8")
+    before = summary.read_bytes()
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    assert caught.value.reason_code == "summary_block_malformed"
+    assert summary.read_bytes() == before
+
+
+def test_an_edit_during_the_stage_window_abandons_the_swap(
+    render_vault_status, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The compare-and-swap must bind the install, not just the earlier read."""
+    root = _vault(tmp_path, _database([_talk("one.md", "processed")]))
+    summary = root / "rhetoric-style-summary.md"
+    dry = render_vault_status.execute(root, generated_at=GENERATED_AT)
+
+    real_open_stage = render_vault_status.open_retained_stage
+
+    def edit_then_stage(*args, **kwargs):
+        # A human saves the file after the digest was read and while the
+        # replacement is being staged.
+        summary.write_text("# Rhetoric\n\nSaved mid-flight.\n", encoding="utf-8")
+        return real_open_stage(*args, **kwargs)
+
+    monkeypatch.setattr(render_vault_status, "open_retained_stage", edit_then_stage)
+
+    with pytest.raises(render_vault_status.SummaryRenderError) as caught:
+        render_vault_status.execute(
+            root,
+            generated_at=GENERATED_AT,
+            apply_requested=True,
+            expected_sha256=dry["summary_sha256"],
+        )
+
+    assert caught.value.reason_code == "summary_precondition_failed"
+    assert summary.read_text(encoding="utf-8") == "# Rhetoric\n\nSaved mid-flight.\n"

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -1353,6 +1353,38 @@ def test_replace_holds_the_shared_summary_writer_lock(tmp_path, monkeypatch):
     assert lock_path.is_file()
 
 
+def test_lock_cleanup_failure_is_reported_not_dropped(tmp_path, monkeypatch, capsys):
+    """A release that failed is a warning, never silence.
+
+    The guarded write already happened, so cleanup cannot fail the call — but
+    dropping the warning leaves incomplete lock cleanup with nothing naming it.
+    """
+    summary_path = tmp_path / "rhetoric-style-summary.md"
+    summary_path.write_text(_summary(), encoding="utf-8")
+    real_flock = cooperative_lock.fcntl.flock
+
+    def fail_unlock(descriptor, operation):
+        outcome = real_flock(descriptor, operation)
+        if operation == fcntl.LOCK_UN:
+            raise OSError("simulated unlock failure")
+        return outcome
+
+    monkeypatch.setattr(cooperative_lock.fcntl, "flock", fail_unlock)
+    profile = _pattern_profile(note="Candidate payload.")
+
+    result = section15.replace_section15_current_block(
+        summary_path,
+        profile,
+        _tracking_database(profile),
+        evidence_freshness_assessor=_fresh_evidence,
+    )
+
+    assert result.changed is True
+    assert (
+        "could not unlock cooperative rhetoric-summary lock" in capsys.readouterr().err
+    )
+
+
 def test_replace_refuses_a_summary_edited_while_the_block_was_staged(
     tmp_path,
     monkeypatch,

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import importlib
-import hashlib
-import json
 import copy
+import fcntl
+import hashlib
+import importlib
+import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -22,6 +24,9 @@ for script_directory in (PROFILE_SCRIPTS, CREATOR_SCRIPTS):
         sys.path.insert(0, str(script_directory))
 
 section15 = importlib.import_module("section15_pattern_history")
+# section15 puts the vault-ingress scripts on sys.path; the summary's writer
+# lock lives there, shared with the status-block writer.
+cooperative_lock = importlib.import_module("cooperative_lock")
 pattern_history_status = importlib.import_module("pattern_history_status")
 provenance = importlib.import_module("profile_pattern_provenance")
 classification_runtime = importlib.import_module("pattern_classification_runtime")
@@ -1303,6 +1308,82 @@ def test_failed_atomic_swap_leaves_original_and_no_temp_file(
         )
 
     assert summary_path.read_bytes() == original
+    assert list(tmp_path.glob(f".{summary_path.name}.*.tmp")) == []
+
+
+def test_replace_holds_the_shared_summary_writer_lock(tmp_path, monkeypatch):
+    """The status-block writer replaces its own block in this same file.
+
+    Two writers that read, splice, and rename without excluding each other drop
+    whichever update renamed first. Both take the summary's one writer lock,
+    keyed on the target path, so the exclusion holds across the two scripts.
+    """
+    summary_path = tmp_path / "rhetoric-style-summary.md"
+    summary_path.write_text(_summary(), encoding="utf-8")
+    lock_path = cooperative_lock.lock_path_for(summary_path)
+    observed: list[str] = []
+    real_replace = section15.os.replace
+
+    def probe_then_replace(source, destination):
+        descriptor = os.open(lock_path, os.O_RDWR)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            observed.append("acquired")
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        except BlockingIOError:
+            observed.append("excluded")
+        finally:
+            os.close(descriptor)
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(section15.os, "replace", probe_then_replace)
+    profile = _pattern_profile(note="Candidate payload.")
+    result = section15.replace_section15_current_block(
+        summary_path,
+        profile,
+        _tracking_database(profile),
+        evidence_freshness_assessor=_fresh_evidence,
+    )
+
+    assert result.changed is True
+    assert observed == ["excluded"]
+    # The same sibling lock the status-block writer takes, so the two exclude
+    # each other rather than each locking a private name.
+    assert lock_path == summary_path.parent / f".{summary_path.name}.lock"
+    assert lock_path.is_file()
+
+
+def test_replace_refuses_a_summary_edited_while_the_block_was_staged(
+    tmp_path,
+    monkeypatch,
+):
+    """The lock excludes toolkit writers; a human editor holds none."""
+    summary_path = tmp_path / "rhetoric-style-summary.md"
+    summary_path.write_text(_summary(), encoding="utf-8")
+    edited = _summary() + "\nA sentence a human added while the tool ran.\n"
+    real_fsync = section15.os.fsync
+
+    def edit_then_fsync(descriptor):
+        # A human saves the file after the replacement bytes are staged and
+        # before the rename that would install them.
+        summary_path.write_text(edited, encoding="utf-8")
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(section15.os, "fsync", edit_then_fsync)
+    profile = _pattern_profile(note="Candidate payload.")
+
+    with pytest.raises(
+        section15.Section15PatternHistoryError,
+        match="changed while the Section 15 replacement was staged",
+    ):
+        section15.replace_section15_current_block(
+            summary_path,
+            profile,
+            _tracking_database(profile),
+            evidence_freshness_assessor=_fresh_evidence,
+        )
+
+    assert summary_path.read_text(encoding="utf-8") == edited
     assert list(tmp_path.glob(f".{summary_path.name}.*.tmp")) == []
 
 

--- a/tests/test_tracking_database_io.py
+++ b/tests/test_tracking_database_io.py
@@ -272,6 +272,7 @@ def test_renderer_normalizes_unicode_encode_error_backstop(
 
 
 def test_commit_refuses_an_invalid_candidate_before_locking(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
 ) -> None:
@@ -289,10 +290,11 @@ def test_commit_refuses_an_invalid_candidate_before_locking(
         )
 
     assert path.read_bytes() == original
-    assert not tracking_database_io.lock_path_for(path).exists()
+    assert not cooperative_lock.lock_path_for(path).exists()
 
 
 def test_commit_rejects_symlinked_cooperative_lock(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
 ) -> None:
@@ -301,7 +303,7 @@ def test_commit_rejects_symlinked_cooperative_lock(
     expected = tracking_database_io.snapshot_tracking_database(path)
     lock_target = tmp_path / "outside.lock"
     lock_target.write_bytes(b"")
-    tracking_database_io.lock_path_for(path).symlink_to(lock_target)
+    cooperative_lock.lock_path_for(path).symlink_to(lock_target)
 
     with pytest.raises(
         tracking_database_io.TrackingDatabaseIOError,
@@ -448,6 +450,7 @@ def test_backup_collision_never_overwrites_database_or_backup(
 
 
 def test_replace_interrupt_cleans_stage_but_keeps_persistent_lock(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -468,10 +471,11 @@ def test_replace_interrupt_cleans_stage_but_keeps_persistent_lock(
 
     assert path.read_bytes() == original
     assert not list(tmp_path.glob(".*.tracking-db.tmp"))
-    assert tracking_database_io.lock_path_for(path).is_file()
+    assert cooperative_lock.lock_path_for(path).is_file()
 
 
 def test_lock_acquisition_interrupt_closes_descriptor(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -479,8 +483,8 @@ def test_lock_acquisition_interrupt_closes_descriptor(
     path = tmp_path / "tracking-database.json"
     original = _write(path, {"talks": []})
     expected = tracking_database_io.snapshot_tracking_database(path)
-    lock_path = tracking_database_io.lock_path_for(path)
-    real_flock = tracking_database_io.fcntl.flock
+    lock_path = cooperative_lock.lock_path_for(path)
+    real_flock = cooperative_lock.fcntl.flock
 
     def interrupt_after_acquire(descriptor: int, operation: int) -> object:
         result = real_flock(descriptor, operation)
@@ -488,7 +492,7 @@ def test_lock_acquisition_interrupt_closes_descriptor(
             raise KeyboardInterrupt
         return result
 
-    monkeypatch.setattr(tracking_database_io.fcntl, "flock", interrupt_after_acquire)
+    monkeypatch.setattr(cooperative_lock.fcntl, "flock", interrupt_after_acquire)
     with pytest.raises(KeyboardInterrupt):
         tracking_database_io.commit_tracking_database(
             expected,
@@ -505,6 +509,7 @@ def test_lock_acquisition_interrupt_closes_descriptor(
 
 
 def test_staging_interrupt_cleans_candidate_and_preserves_database(
+    cooperative_lock,
     retained_stage,
     tracking_database_io,
     tmp_path: Path,
@@ -528,7 +533,7 @@ def test_staging_interrupt_cleans_candidate_and_preserves_database(
 
     assert path.read_bytes() == original
     assert not list(tmp_path.glob(".*.tracking-db.tmp"))
-    assert tracking_database_io.lock_path_for(path).is_file()
+    assert cooperative_lock.lock_path_for(path).is_file()
 
 
 def test_staged_timestamp_churn_retries_same_candidate_then_installs_once(
@@ -1172,6 +1177,7 @@ def test_directory_close_failure_is_an_installed_warning(
 
 @pytest.mark.parametrize("initialize", [False, True], ids=["commit", "initialize"])
 def test_lock_cleanup_failure_is_an_installed_warning(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1183,7 +1189,7 @@ def test_lock_cleanup_failure_is_an_installed_warning(
     if not initialize:
         _write(path, {"talks": []})
         expected = tracking_database_io.snapshot_tracking_database(path)
-    real_flock = tracking_database_io.fcntl.flock
+    real_flock = cooperative_lock.fcntl.flock
 
     def fail_unlock(descriptor: int, operation: int) -> object:
         outcome = real_flock(descriptor, operation)
@@ -1191,7 +1197,7 @@ def test_lock_cleanup_failure_is_an_installed_warning(
             raise OSError("simulated unlock failure")
         return outcome
 
-    monkeypatch.setattr(tracking_database_io.fcntl, "flock", fail_unlock)
+    monkeypatch.setattr(cooperative_lock.fcntl, "flock", fail_unlock)
     if initialize:
         result = tracking_database_io.initialize_tracking_database(path, payload)
     else:
@@ -1208,6 +1214,7 @@ def test_lock_cleanup_failure_is_an_installed_warning(
 
 @pytest.mark.parametrize("initialize", [False, True], ids=["commit", "initialize"])
 def test_lock_close_failure_is_an_installed_warning(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1219,7 +1226,7 @@ def test_lock_close_failure_is_an_installed_warning(
     if not initialize:
         _write(path, {"talks": []})
         expected = tracking_database_io.snapshot_tracking_database(path)
-    lock_path = tracking_database_io.lock_path_for(path)
+    lock_path = cooperative_lock.lock_path_for(path)
     real_close = tracking_database_io.os.close
     injected = False
 
@@ -1326,12 +1333,13 @@ def test_initialization_postinstall_verification_failure_reports_installed_state
 
 
 def test_persistent_lock_excludes_another_process(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
 ) -> None:
     path = tmp_path / "tracking-database.json"
     _write(path, {"talks": []})
-    lock_path = tracking_database_io.lock_path_for(path)
+    lock_path = cooperative_lock.lock_path_for(path)
     descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
     fcntl.flock(descriptor, fcntl.LOCK_EX)
     probe = (
@@ -1361,6 +1369,7 @@ def test_persistent_lock_excludes_another_process(
 
 
 def test_cross_writer_waits_then_rejects_its_stale_generation(
+    cooperative_lock,
     tracking_database_io,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1376,7 +1385,7 @@ def test_cross_writer_waits_then_rejects_its_stale_generation(
         {"talks": [], "writer": "second"}
     )
     original_stage = tracking_database_io._stage_candidate
-    real_flock = tracking_database_io.fcntl.flock
+    real_flock = cooperative_lock.fcntl.flock
     second_attempted = threading.Event()
     second_errors: list[Exception] = []
     second_thread: threading.Thread | None = None
@@ -1410,7 +1419,7 @@ def test_cross_writer_waits_then_rejects_its_stale_generation(
         assert second_errors == []
         return temporary
 
-    monkeypatch.setattr(tracking_database_io.fcntl, "flock", observed_flock)
+    monkeypatch.setattr(cooperative_lock.fcntl, "flock", observed_flock)
     monkeypatch.setattr(tracking_database_io, "_stage_candidate", stage_and_contend)
 
     first_result = tracking_database_io.commit_tracking_database(

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -233,6 +233,7 @@ def test_owner_mutation_cli_preserves_final_window_generation(
 
 
 def test_queue_and_persistence_writers_serialize_then_reject_stale_input(
+    cooperative_lock,
     queue_state,
     persist_results,
     tracking_database_io,
@@ -244,7 +245,7 @@ def test_queue_and_persistence_writers_serialize_then_reject_stale_input(
     queue_snapshot = tracking_database_io.snapshot_tracking_database(path)
     persistence_snapshot = tracking_database_io.snapshot_tracking_database(path)
     original_stage = tracking_database_io._stage_candidate
-    real_flock = tracking_database_io.fcntl.flock
+    real_flock = cooperative_lock.fcntl.flock
     persistence_attempted = threading.Event()
     persistence_errors: list[Exception] = []
     persistence_thread: threading.Thread | None = None
@@ -279,7 +280,7 @@ def test_queue_and_persistence_writers_serialize_then_reject_stale_input(
         assert persistence_errors == []
         return temporary
 
-    monkeypatch.setattr(tracking_database_io.fcntl, "flock", observed_flock)
+    monkeypatch.setattr(cooperative_lock.fcntl, "flock", observed_flock)
     monkeypatch.setattr(
         tracking_database_io,
         "_stage_candidate",


### PR DESCRIPTION
Closes #168.

## Problem

`rhetoric-style-summary.md` is narrative prose, but its status line is read as current operational fact — and it was hand-maintained. The verified live snapshot from the issue:

| | summary said | database held |
|---|---|---|
| talks | 208 | **209** |
| processed | 195 | **78** |
| processed_partial | 4 | **2** |
| needs-reprocessing | — | **116** |

Queue normalization and reparse move statuses without touching the prose, so an obsolete cohort reads as live — most misleadingly during a long reparse, which is exactly when someone checks.

## What this adds

`render-vault-status.py` derives one block and nothing else:

- **Every count from a single strict snapshot** through the shared reader. Nothing hand-calculated.
- **Delimited and schema-versioned**, so replacing it is a splice that cannot disturb a narrative section — never a heuristic match against prose that may quote a count.
- **Binds its generation**: database SHA-256, generated timestamp, database schema version, active scoring/catalog generation identity, total talks, exact status counts, active-claim count.
- **Historically-analysed reported apart from the current cohort.** Conflating them is what makes normalization look like lost work: a talk analysed under an older generation stays historically analysed while ceasing to be eligible now.
- **An absent scoring generation is reported absent, never defaulted** — a default would let a database with no recorded generation render a block claiming one.

## Read-only by default, hash-preconditioned to apply

`--apply` requires `--expected-sha256` from the dry run. The summary is a file a human also edits, so an apply that cannot prove it read the current bytes refuses rather than overwriting an edit it never saw. Replacement goes through the shared retained-stage lifecycle (#243), so an interruption leaves the prior complete summary, and a **no-op render installs nothing** rather than churning the file's identity for consumers watching it.

## Verification

21 cases in `tests/test_render_vault_status.py`, covering the issue's final criterion:

- the **verified 209-talk mismatch** reproduced as a fixture and derived correctly
- in-progress claims, recovered/completed claims, and both active signals (the counting rule tested directly, apart from the queue contract's own validity requirements)
- legacy and current database generations
- partial processing, duplicate/skipped rows
- **stale hash refusal** — an apply after a concurrent human edit refuses and leaves the file untouched
- byte-stable no-op on a second apply
- only the delimited block replaced; narrative before and after preserved
- malformed delimiters install nothing
- an unusable database renders nothing, path-neutrally

Full suite: 5332 passed, 3 skipped. `ruff check` / `ruff format --check` / `pyright` / entrypoints clean.

`bootstrap-and-preflight.md` documents the refresh at safe checkpoints — after migration or recovery, after normalization, after a batch persists — and states that the tracking database stays the authority, with prose counts never trusted on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)