### PR TITLE
fix(vault-ingress): stop echoing tracking-database decoder text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+### fix(vault-ingress) — stop echoing tracking-database decoder text (#275)
+
+Closes #275.
+
+`read-tracking-database.py` printed `str(exc)` on its failure path, to both
+stdout and stderr. A `TrackingDatabaseIOError` message names the host database
+path, and a decoder failure interpolates the rejected content verbatim — a
+duplicate object key, a non-round-trippable number. That is input data, and
+`no-secrets` → Logging forbids putting it in output. This is the script every
+agent-driven read of the tracking database goes through, so its failure path is
+the one every agent sees.
+
+Every public reader now routes its typed reason code through the closed
+vocabulary that already existed for exactly this in `tracking_database_io`:
+`read-tracking-database.py`, `write-analysis.py`, `load-vault.py`,
+`validate-profile.py`, and the Section 15 reader, plus
+`audit-source-identities.py`, which was writing the decoder's text into a report
+other agents read. The regression tests assert the printed message is a member
+of that fixed set — membership is itself the leak guard, since a message drawn
+from a dozen constants cannot carry an offending key or value.
+
+Redaction cost actionability until the vocabulary grew to cover the failures
+that never reach the decoder. A symlinked database, a missing one, a directory
+in its place: those raised untyped, fell through to the fallback, and reported
+"tracking database could not be read" with no next step. Each now carries a
+typed code and prose naming what to fix. The public finding codes are unchanged
+— the new reasons map onto `database_unreadable` — so no consumer routing on
+code has to change.
+
+Schema-assessment messages (`TrackingDatabaseError`) are untouched. Those
+describe the database's own structure rather than echoing its content, and the
+readers that print them stay as they were.
+
 ## 0.20.48 — 2026-08-10
 
 ### feat(vault-ingress) — an owner writer for reviewed shownotes catalog conflicts (#236)

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -33,6 +33,8 @@ from tracking_database import (
     assess_tracking_database,
 )
 from tracking_database_io import (
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
@@ -1222,6 +1224,13 @@ def audit_path(
         snapshot = snapshot_tracking_database(database_path)
         database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
+        # Never echo the exception into the report: decoder messages carry the
+        # host database path and the rejected key or value verbatim, and this
+        # report is written out and read by agents. The typed reason code
+        # routes to the shared closed vocabulary instead.
+        code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
         report = audit_database(
             {},
             database_path=database_path,
@@ -1241,7 +1250,7 @@ def audit_path(
                 [],
                 [],
                 "tracking database could not be read as UTF-8 JSON",
-                {"error": str(exc)},
+                {"read_failure_code": code, "error": message},
                 "high",
             )
         ]

--- a/skills/vault-ingress/scripts/read-tracking-database.py
+++ b/skills/vault-ingress/scripts/read-tracking-database.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
-"""Read one tracking database through the owner strict snapshot contract."""
+"""Read one tracking database through the owner strict snapshot contract.
+
+Every agent-driven read of `tracking-database.json` goes through this script,
+so its failure path is the one every agent sees. A `TrackingDatabaseIOError`
+message names the host database path, and a decoder failure interpolates the
+rejected content — a duplicate key, a non-round-trippable number — verbatim.
+Failures therefore report a typed code from the shared closed vocabulary in
+`tracking_database_io.DATABASE_READ_DIAGNOSTICS`, never the exception text.
+
+Stdout: one JSON object — the database and its digest, or a typed failure.
+Stderr: one path-neutral line drawn from that same closed vocabulary.
+Exit 0 on success, 2 when the database cannot be read.
+"""
 
 from __future__ import annotations
 
@@ -13,6 +25,8 @@ from tracking_database import (
     assess_tracking_database,
 )
 from tracking_database_io import (
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
@@ -28,13 +42,16 @@ def execute(path: Path) -> dict[str, object]:
     try:
         assessment = assess_tracking_database(database)
     except TrackingDatabaseError as exc:
+        # The assessment's own message names the offending record; the typed
+        # code is what a caller routes on, and it is what gets reported.
         raise TrackingDatabaseIOError(
-            f"tracking database owner assessment failed: {exc}"
+            "tracking database owner assessment failed",
+            reason_code="owner_assessment_failed",
         ) from exc
     if not assessment.usable:
-        reasons = ", ".join(assessment.reason_codes) or "unsupported_owner_state"
         raise TrackingDatabaseIOError(
-            f"tracking database has no usable legacy/current owner state ({reasons})"
+            "tracking database has no usable legacy/current owner state",
+            reason_code="owner_state_unusable",
         )
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -52,16 +69,23 @@ def main(argv: list[str] | None = None) -> int:
     try:
         report = execute(args.database)
     except TrackingDatabaseIOError as exc:
+        # Never echo the exception: decoder messages carry the host database
+        # path and the rejected key or value verbatim. Route the typed reason
+        # code through the shared closed vocabulary instead.
+        code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
         print(
             json.dumps(
                 {
                     "schema_version": REPORT_SCHEMA_VERSION,
                     "ok": False,
-                    "error": str(exc),
+                    "code": code,
+                    "error": message,
                 }
             )
         )
-        print(f"tracking-database read failed: {exc}", file=sys.stderr)
+        print(f"tracking-database read failed: {message}", file=sys.stderr)
         return 2
     print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
     return 0

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -120,6 +120,18 @@ DATABASE_READ_DIAGNOSTICS = {
         "tracking database bytes could not be read; confirm the file is readable "
         "and the volume is healthy, then retry",
     ),
+    # Nothing is wrong with the file: another writer installed a generation
+    # mid-read. Rerunning against the new one is the whole remedy.
+    "generation_conflict": (
+        "database_generation_conflict",
+        "tracking database changed while it was being read; rerun the operation "
+        "against the current generation",
+    ),
+    "staged_candidate_conflict": (
+        "database_generation_conflict",
+        "a staged tracking-database candidate changed before it could be "
+        "installed; rerun the operation against the current generation",
+    ),
 }
 DATABASE_READ_FALLBACK = (
     "database_unreadable",
@@ -142,7 +154,21 @@ class TrackingDatabaseIOError(ValueError):
 
 
 class TrackingDatabaseConflictError(TrackingDatabaseIOError):
-    """The expected database generation is no longer current."""
+    """The expected database generation is no longer current.
+
+    Defaults its reason code so a reader routing through
+    DATABASE_READ_DIAGNOSTICS reports "rerun the operation" rather than the
+    generic could-not-be-read fallback: a concurrent write is the one read
+    failure that is fixed by simply trying again.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str = "generation_conflict",
+    ) -> None:
+        super().__init__(message, reason_code=reason_code)
 
 
 class StagedCandidateConflictError(TrackingDatabaseConflictError):
@@ -154,7 +180,8 @@ class StagedCandidateConflictError(TrackingDatabaseConflictError):
         self.detail = detail
         super().__init__(
             f"staged tracking-database candidate {path} changed before install: "
-            f"invariant={invariant}; {detail}"
+            f"invariant={invariant}; {detail}",
+            reason_code="staged_candidate_conflict",
         )
 
 

--- a/skills/vault-ingress/scripts/tracking_database_io.py
+++ b/skills/vault-ingress/scripts/tracking_database_io.py
@@ -88,6 +88,38 @@ DATABASE_READ_DIAGNOSTICS = {
         "database_json_invalid",
         "tracking database contains an unpaired UTF-16 surrogate in a JSON string",
     ),
+    # The path never reached the decoder. Each of these names what to do about
+    # the file itself; without them the fallback would erase the one detail
+    # that makes the failure fixable.
+    "path_missing": (
+        "database_unreadable",
+        "tracking database is missing at the path given; pass the canonical "
+        "tracking-database.json file path",
+    ),
+    "path_uninspectable": (
+        "database_unreadable",
+        "tracking database path could not be inspected; check permissions on it "
+        "and on its parent directory",
+    ),
+    "path_symlink": (
+        "database_unreadable",
+        "tracking database path is a symbolic link; pass its canonical "
+        "regular-file path",
+    ),
+    "path_not_regular_file": (
+        "database_unreadable",
+        "tracking database path is not a regular file; repair it before retrying",
+    ),
+    "open_failed": (
+        "database_unreadable",
+        "tracking database could not be opened without following symlinks; "
+        "confirm it is a readable regular file, then retry",
+    ),
+    "read_failed": (
+        "database_unreadable",
+        "tracking database bytes could not be read; confirm the file is readable "
+        "and the volume is healthy, then retry",
+    ),
 }
 DATABASE_READ_FALLBACK = (
     "database_unreadable",
@@ -231,19 +263,23 @@ def _path_metadata(path: Path, *, subject: str) -> os.stat_result:
     except FileNotFoundError as exc:
         raise TrackingDatabaseIOError(
             f"{subject} is missing at {path}; pass its canonical file path "
-            "(a regular file)"
+            "(a regular file)",
+            reason_code="path_missing",
         ) from exc
     except OSError as exc:
         raise TrackingDatabaseIOError(
-            f"cannot inspect {subject} {path}: {exc}"
+            f"cannot inspect {subject} {path}: {exc}",
+            reason_code="path_uninspectable",
         ) from exc
     if stat.S_ISLNK(metadata.st_mode):
         raise TrackingDatabaseIOError(
-            f"{subject} {path} is a symbolic link; pass its canonical regular-file path"
+            f"{subject} {path} is a symbolic link; pass its canonical regular-file path",
+            reason_code="path_symlink",
         )
     if not stat.S_ISREG(metadata.st_mode):
         raise TrackingDatabaseIOError(
-            f"{subject} {path} is not a regular file; repair it before retrying"
+            f"{subject} {path} is not a regular file; repair it before retrying",
+            reason_code="path_not_regular_file",
         )
     return metadata
 
@@ -269,13 +305,16 @@ def snapshot_tracking_database(
     except OSError as exc:
         raise TrackingDatabaseIOError(
             f"cannot open tracking database {database_path} without following "
-            f"symlinks: {exc}"
+            f"symlinks: {exc}",
+            reason_code="open_failed",
         ) from exc
     try:
         opened = os.fstat(descriptor)
         if not stat.S_ISREG(opened.st_mode):
             raise TrackingDatabaseIOError(
-                f"tracking database {database_path} changed to a non-regular file; retry"
+                f"tracking database {database_path} changed to a non-regular file; "
+                "retry",
+                reason_code="path_not_regular_file",
             )
         if FileGeneration.from_stat(opened) != FileGeneration.from_stat(path_before):
             raise TrackingDatabaseConflictError(
@@ -285,7 +324,8 @@ def snapshot_tracking_database(
         read_complete = os.fstat(descriptor)
     except OSError as exc:
         raise TrackingDatabaseIOError(
-            f"cannot read tracking database {database_path}: {exc}"
+            f"cannot read tracking database {database_path}: {exc}",
+            reason_code="read_failed",
         ) from exc
     finally:
         os.close(descriptor)

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -104,6 +104,8 @@ from retained_stage import (
     verify_retained_stage,
 )
 from tracking_database_io import (
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
@@ -1113,8 +1115,14 @@ def load_tracking_database(path):
         snapshot = snapshot_tracking_database(path)
         database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
-        message = str(exc)
-        if "root must be a JSON object" in message:
+        # Never echo the exception: decoder messages carry the host database
+        # path and the rejected key or value verbatim. The typed reason code
+        # routes to the shared closed vocabulary, and the one hint this reader
+        # adds keys off that code rather than off the message text.
+        _code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
+        if exc.reason_code == "json_root_not_object":
             message += "; expected an object with a `talks` array"
         print(f"ERROR: {message}", file=sys.stderr)
         sys.exit(1)

--- a/skills/vault-profile/scripts/load-vault.py
+++ b/skills/vault-profile/scripts/load-vault.py
@@ -88,6 +88,8 @@ from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingIm
 
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
@@ -203,7 +205,13 @@ def main(argv: list[str]) -> int:
         database_snapshot = snapshot_tracking_database(db_path)
         db = decode_json_object(database_snapshot)
     except TrackingDatabaseIOError as exc:
-        print(f"ERROR: tracking-database.json is malformed: {exc}", file=sys.stderr)
+        # Never echo the exception: decoder messages carry the host database
+        # path and the rejected key or value verbatim. Route the typed reason
+        # code through the shared closed vocabulary instead.
+        _code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
+        print(f"ERROR: {message}", file=sys.stderr)
         return 1
     try:
         database_assessment = assess_tracking_database(db)

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -719,8 +719,11 @@ def _load_tracking_database(path: Path) -> dict[str, Any]:
         _code, message = DATABASE_READ_DIAGNOSTICS.get(
             exc.reason_code, DATABASE_READ_FALLBACK
         )
+        # The path goes no further either: this message is printed, and the
+        # host path is the other half of what the redaction contract keeps out
+        # of output. The caller supplied the path and already knows it.
         raise Section15PatternHistoryError(
-            f"cannot load strict tracking database from {path}: {message}"
+            f"cannot load the strict tracking database: {message}"
         ) from exc
     _require_usable_tracking_database(tracking_database)
     return tracking_database

--- a/skills/vault-profile/scripts/section15_pattern_history.py
+++ b/skills/vault-profile/scripts/section15_pattern_history.py
@@ -76,6 +76,8 @@ from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingIm
 
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
@@ -711,8 +713,14 @@ def _load_tracking_database(path: Path) -> dict[str, Any]:
         snapshot = snapshot_tracking_database(path)
         tracking_database = decode_json_object(snapshot)
     except TrackingDatabaseIOError as exc:
+        # Never carry the exception text forward: this error is printed, and
+        # decoder messages name the rejected key or value verbatim. The typed
+        # reason code routes to the shared closed vocabulary instead.
+        _code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
         raise Section15PatternHistoryError(
-            f"cannot load strict tracking database from {path}: {exc}"
+            f"cannot load strict tracking database from {path}: {message}"
         ) from exc
     _require_usable_tracking_database(tracking_database)
     return tracking_database

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -69,6 +69,8 @@ from tracking_database import (  # noqa: E402  # pyright: ignore[reportMissingIm
 
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from tracking_database_io import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
     TrackingDatabaseIOError,
     decode_json_object,
     snapshot_tracking_database,
@@ -204,7 +206,13 @@ def _load_live_pattern_snapshot(
         database_snapshot = snapshot_tracking_database(database_path)
         database = decode_json_object(database_snapshot)
     except TrackingDatabaseIOError as exc:
-        raise ValueError(f"tracking-database.json is invalid: {exc}") from exc
+        # This message is printed and emitted in the result object, and decoder
+        # messages name the rejected key or value verbatim. The typed reason
+        # code routes to the shared closed vocabulary instead.
+        _code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
+        raise ValueError(f"tracking-database.json is invalid: {message}") from exc
     try:
         assessment = assess_tracking_database(database)
     except TrackingDatabaseError as exc:

--- a/tests/test_tracking_database_strict_readers.py
+++ b/tests/test_tracking_database_strict_readers.py
@@ -54,6 +54,34 @@ def _database(tmp_path: Path, raw: bytes) -> Path:
     return path
 
 
+def _closed_messages(tracking_database_io) -> set[str]:
+    """The whole vocabulary a public reader may say about a read failure.
+
+    Membership in a fixed set is itself the leak guard: a message drawn from
+    these constants cannot carry the offending key, value, or host path.
+    """
+    return {
+        text for _code, text in tracking_database_io.DATABASE_READ_DIAGNOSTICS.values()
+    } | {tracking_database_io.DATABASE_READ_FALLBACK[1]}
+
+
+def _says_one_closed_message(text: str, tracking_database_io) -> bool:
+    return any(message in text for message in _closed_messages(tracking_database_io))
+
+
+def _assert_defect_detail_absent(text: str, detail: str, tracking_database_io) -> None:
+    """Assert the decoder's account of the defect never reaches ``text``.
+
+    Two of the cases inject nothing the closed vocabulary does not already say
+    — invalid UTF-8 and a non-object root — so for those the detail IS the
+    closed prose and its absence cannot be asserted. Every other case names a
+    key or value taken from the input, which must never surface.
+    """
+    if any(detail in closed for closed in _closed_messages(tracking_database_io)):
+        return
+    assert detail not in text
+
+
 def test_owner_reader_accepts_implicit_legacy_after_schema_assessment(
     read_tracking_database,
     tmp_path: Path,
@@ -108,7 +136,83 @@ def test_owner_reader_rejects_no_usable_owner_state_without_database_output(
     assert result == 2
     assert output["ok"] is False
     assert "database" not in output
+    assert output["error"] in _closed_messages(tracking_database_io)
     assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
+def test_owner_reader_reports_a_closed_code_without_echoing_the_defect(
+    read_tracking_database,
+    tracking_database_io,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    raw: bytes,
+    message: str,
+) -> None:
+    """Every agent-driven read goes through this script's failure path.
+
+    A decoder message names the rejected key or value verbatim and the host
+    database path — input data, never diagnostics (#275, `no-secrets`).
+    """
+    database = _database(tmp_path, raw)
+
+    result = read_tracking_database.main([str(database)])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert result == 2
+    assert output["ok"] is False
+    assert output["code"] in {
+        "database_encoding_invalid",
+        "database_json_invalid",
+        "database_unreadable",
+    }
+    assert output["error"] in _closed_messages(tracking_database_io)
+    # Neither the injected defect nor the host path rides out on either stream.
+    _assert_defect_detail_absent(captured.out, message, tracking_database_io)
+    _assert_defect_detail_absent(captured.err, message, tracking_database_io)
+    assert str(database) not in captured.out + captured.err
+    assert database.read_bytes() == raw
+
+
+@pytest.mark.parametrize(
+    ("shape", "expected"),
+    [
+        ("missing", "pass the canonical"),
+        ("symlink", "symbolic link"),
+        ("directory", "not a regular file"),
+    ],
+)
+def test_a_path_that_never_reached_the_decoder_still_says_what_to_do(
+    read_tracking_database,
+    tracking_database_io,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    shape: str,
+    expected: str,
+) -> None:
+    """Redaction must not cost actionability.
+
+    These failures never reach the decoder, so there is no rejected content to
+    withhold — only the shape of the path, which is what the caller has to fix.
+    Collapsing them into the generic fallback would leave a symlinked database
+    reported as "could not be read", with no next step (`error-handling`).
+    """
+    database = tmp_path / "tracking-database.json"
+    if shape == "symlink":
+        database.symlink_to(tmp_path / "elsewhere.json")
+    elif shape == "directory":
+        database.mkdir()
+
+    result = read_tracking_database.main([str(database)])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert result == 2
+    assert output["code"] == "database_unreadable"
+    assert output["error"] in _closed_messages(tracking_database_io)
+    assert expected in output["error"]
+    assert str(database) not in captured.out + captured.err
 
 
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
@@ -160,6 +264,7 @@ def test_preflight_blocks_every_strict_json_defect_without_rewrite(
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
 def test_source_audit_stops_before_metadata_fetch_without_rewrite(
     audit_source_identities,
+    tracking_database_io,
     tmp_path: Path,
     raw: bytes,
     message: str,
@@ -179,7 +284,11 @@ def test_source_audit_stops_before_metadata_fetch_without_rewrite(
 
     assert report["complete"] is False
     assert report["findings"][0]["code"] == "database_unreadable"
-    assert message in report["findings"][0]["evidence"]["error"]
+    # The report is written out and read by agents, so its evidence carries the
+    # typed code and closed prose, never the decoder's text (#275).
+    evidence = report["findings"][0]["evidence"]
+    assert evidence["error"] in _closed_messages(tracking_database_io)
+    _assert_defect_detail_absent(json.dumps(report), message, tracking_database_io)
     assert fetched == []
     assert database.read_bytes() == raw
 
@@ -187,6 +296,7 @@ def test_source_audit_stops_before_metadata_fetch_without_rewrite(
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
 def test_analysis_reader_fails_before_output_without_rewrite(
     write_analysis,
+    tracking_database_io,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     raw: bytes,
@@ -197,14 +307,17 @@ def test_analysis_reader_fails_before_output_without_rewrite(
     with pytest.raises(SystemExit) as stopped:
         write_analysis.load_tracking_database(database)
 
+    captured = capsys.readouterr()
     assert stopped.value.code == 1
-    assert message in capsys.readouterr().err
+    assert _says_one_closed_message(captured.err, tracking_database_io)
+    _assert_defect_detail_absent(captured.err, message, tracking_database_io)
     assert database.read_bytes() == raw
 
 
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
 def test_profile_loader_fails_before_reading_other_vault_outputs(
     load_vault,
+    tracking_database_io,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     raw: bytes,
@@ -219,13 +332,15 @@ def test_profile_loader_fails_before_reading_other_vault_outputs(
     captured = capsys.readouterr()
     assert result == 1
     assert captured.out == ""
-    assert message in captured.err
+    assert _says_one_closed_message(captured.err, tracking_database_io)
+    _assert_defect_detail_absent(captured.err, message, tracking_database_io)
     assert database.read_bytes() == raw
 
 
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
 def test_section15_reader_fails_before_summary_replacement(
     section15_pattern_history,
+    tracking_database_io,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     raw: bytes,
@@ -245,7 +360,8 @@ def test_section15_reader_fails_before_summary_replacement(
     captured = capsys.readouterr()
     assert result == 1
     assert captured.out == ""
-    assert message in captured.err
+    assert _says_one_closed_message(captured.err, tracking_database_io)
+    _assert_defect_detail_absent(captured.err, message, tracking_database_io)
     assert summary.read_bytes() == original_summary
     assert database.read_bytes() == raw
 
@@ -253,13 +369,18 @@ def test_section15_reader_fails_before_summary_replacement(
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
 def test_profile_validator_rejects_live_database_before_snapshot_generation(
     validate_profile,
+    tracking_database_io,
     tmp_path: Path,
     raw: bytes,
     message: str,
 ) -> None:
     database = _database(tmp_path, raw)
 
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(ValueError) as caught:
         validate_profile._load_live_pattern_snapshot(tmp_path, {})
 
+    # This error is printed and emitted in the result object, so it carries
+    # closed prose rather than the decoder's text (#275).
+    assert _says_one_closed_message(str(caught.value), tracking_database_io)
+    _assert_defect_detail_absent(str(caught.value), message, tracking_database_io)
     assert database.read_bytes() == raw

--- a/tests/test_tracking_database_strict_readers.py
+++ b/tests/test_tracking_database_strict_readers.py
@@ -215,6 +215,41 @@ def test_a_path_that_never_reached_the_decoder_still_says_what_to_do(
     assert str(database) not in captured.out + captured.err
 
 
+def test_a_concurrent_write_still_says_to_rerun(
+    read_tracking_database,
+    tracking_database_io,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing is wrong with the file; rerunning is the whole remedy.
+
+    A conflict routed through the generic fallback would report "could not be
+    read" and drop the one instruction that fixes it (`error-handling` →
+    Actionable Messages).
+    """
+    database = _database(tmp_path, b'{"config":{},"talks":[]}\n')
+    real_snapshot = read_tracking_database.snapshot_tracking_database
+
+    def conflict(path):
+        real_snapshot(path)
+        raise tracking_database_io.TrackingDatabaseConflictError(
+            "tracking database changed while it was read; rerun the operation"
+        )
+
+    monkeypatch.setattr(read_tracking_database, "snapshot_tracking_database", conflict)
+
+    result = read_tracking_database.main([str(database)])
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert result == 2
+    assert output["code"] == "database_generation_conflict"
+    assert "rerun the operation" in output["error"]
+    assert output["error"] in _closed_messages(tracking_database_io)
+    assert str(database) not in captured.out + captured.err
+
+
 @pytest.mark.parametrize(("raw", "message"), STRICT_INVALID_CASES)
 def test_owner_reader_rejects_every_strict_json_defect_without_rewrite(
     read_tracking_database,
@@ -362,6 +397,9 @@ def test_section15_reader_fails_before_summary_replacement(
     assert captured.out == ""
     assert _says_one_closed_message(captured.err, tracking_database_io)
     _assert_defect_detail_absent(captured.err, message, tracking_database_io)
+    # The host path is the other half of what redaction keeps out of output;
+    # the caller supplied it and already knows it.
+    assert str(database) not in captured.err
     assert summary.read_bytes() == original_summary
     assert database.read_bytes() == raw
 


### PR DESCRIPTION
Closes #275.

`read-tracking-database.py` printed `str(exc)` on its failure path, to both stdout and stderr. A `TrackingDatabaseIOError` message names the host database path, and a decoder failure interpolates the rejected content verbatim — a duplicate object key, a non-round-trippable number. That is input data, and `no-secrets` → Logging forbids putting it in output. This is the script every agent-driven read of the tracking database goes through, so its failure path is the one every agent sees.

## What changed

- Every public reader routes its typed reason code through `DATABASE_READ_DIAGNOSTICS`, the closed vocabulary that already existed for exactly this: `read-tracking-database.py`, `write-analysis.py`, `load-vault.py`, `validate-profile.py`, and the Section 15 reader.
- `audit-source-identities.py` was writing the decoder's text into a report other agents read; its finding evidence now carries the typed code and closed prose.
- The vocabulary grew to cover failures that never reach the decoder — a symlinked database, a missing one, a directory in its place. Those raised untyped and fell through to "tracking database could not be read" with no next step. Each now has a typed code and prose naming what to fix.

Public finding codes are unchanged — the new reasons map onto `database_unreadable` — so nothing routing on code has to change. Schema-assessment messages (`TrackingDatabaseError`) are untouched: they describe the database's structure rather than echoing its content.

## Tests

Regression coverage asserts the printed message is a member of the fixed set, and that the injected defect and the host path reach neither stream. Membership is itself the leak guard: a message drawn from a dozen constants cannot carry an offending key or value. The path-shape cases assert redaction did not cost actionability.

Full suite: 5320 passed, 3 skipped. Lint, format, and type gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)