### PR TITLE
docs(vault-ingress): point candidate mode at the script that owns it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ per-fault classification. Two copies of a predicate drift, and the reference is
 the copy nobody runs.
 
 It now carries the contract only — input, output shape, exit conditions, side
-effects — and names each internal once by pointer:
-`CANDIDATE_REPORT_SCHEMA_VERSION`, `CANDIDATE_DISPOSITIONS`, `CANDIDATE_LANES`,
-`CANDIDATE_LANE_LOCAL_CODES`, and `candidate_bindings()`, whose docstring
-carries the binding contract. The reasoning stays where the constants are, which
-is where it can be checked against the code that reads them.
+effects — and each internal is a table row pointing at the constant or function
+that owns it: `CANDIDATE_REPORT_SCHEMA_VERSION`, `CANDIDATE_DISPOSITIONS`,
+`CANDIDATE_LANES`, `CANDIDATE_LANE_LOCAL_CODES`, and `candidate_bindings()`. The
+reasoning stays where the constants are, which is where it can be checked
+against the code that reads them. Naming a predicate and then restating it is
+still two copies; the reference states what a caller observes and stops there.
 
 Raised as an advisory on PR #276 and deferred rather than folded in: the PR was
 otherwise green, and `review-severity` spends a re-review round on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### docs(vault-ingress) — point the candidate-mode reference at its script (#278)
+
+Closes #278.
+
+The candidate-mode section of `source-identity-audit.md` restated what
+`audit-source-identities.py` implements: the accepted report generation, the
+closed disposition set, the lane allowlist, the dedupe behaviour, and the
+per-fault classification. Two copies of a predicate drift, and the reference is
+the copy nobody runs.
+
+It now carries the contract only — input, output shape, exit conditions, side
+effects — and names each internal once by pointer:
+`CANDIDATE_REPORT_SCHEMA_VERSION`, `CANDIDATE_DISPOSITIONS`, `CANDIDATE_LANES`,
+`CANDIDATE_LANE_LOCAL_CODES`, and `candidate_bindings()`, whose docstring
+carries the binding contract. The reasoning stays where the constants are, which
+is where it can be checked against the code that reads them.
+
+Raised as an advisory on PR #276 and deferred rather than folded in: the PR was
+otherwise green, and `review-severity` spends a re-review round on a
+presentation-only change only when a blocking round is already happening.
+
 ## 0.20.48 — 2026-08-10
 
 ### feat(vault-ingress) — an owner writer for reviewed shownotes catalog conflicts (#236)

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -85,7 +85,7 @@ instead of an ad hoc provider lookup outside the ingress workflow:
 **Input.** `--candidates-from` takes one `scan-shownotes.py` report path. Which
 report generation is accepted, which dispositions are valid, and which lanes
 carry an auditable provider identity are the script's to decide — see
-`audit-source-identities.py`, top-of-file constants
+`skills/vault-ingress/scripts/audit-source-identities.py`, top-of-file constants
 `CANDIDATE_REPORT_SCHEMA_VERSION`, `CANDIDATE_DISPOSITIONS`, and
 `CANDIDATE_LANES`, each with the reasoning beside it.
 

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -82,42 +82,29 @@ instead of an ad hoc provider lookup outside the ingress workflow:
   "{vault_root}" --candidates-from "{scan_report_path}"
 ```
 
-**Input.** `--candidates-from` takes one `scan-shownotes.py` report path. Which
-report generation is accepted, which dispositions are valid, and which lanes
-carry an auditable provider identity are the script's to decide — see
-`skills/vault-ingress/scripts/audit-source-identities.py`, top-of-file constants
-`CANDIDATE_REPORT_SCHEMA_VERSION`, `CANDIDATE_DISPOSITIONS`, and
-`CANDIDATE_LANES`, each with the reasoning beside it.
+**Input.** `--candidates-from` takes one `scan-shownotes.py` report path. See
+`skills/vault-ingress/scripts/audit-source-identities.py`:
 
-The report is validated whole before anything is bound, and the verdict is
-all-or-nothing: one refused entry discards **every** candidate binding, because
-a partly malformed report is not a complete conflict set and auditing its
-well-formed remainder would report an unknown subset as "these are the
-conflicts". Every binding resolves before any provider request, so a report
-naming an unknown talk is refused without spending a fetch. What counts as
-refused, and the finding each refusal emits, live in `candidate_bindings()` —
-its docstring carries the contract.
+| What | Anchor |
+|---|---|
+| Accepted report generation | `CANDIDATE_REPORT_SCHEMA_VERSION` |
+| Valid dispositions | `CANDIDATE_DISPOSITIONS` |
+| Lanes with an auditable provider identity | `CANDIDATE_LANES` |
+| Which reports and entries bind, and the finding each refusal emits | `candidate_bindings()` docstring |
+| Faults eligible to stay lane-local, and the code each takes | `CANDIDATE_LANE_LOCAL_CODES` |
 
 **Output.** `candidates[]` carries `provider_evidence` and
 `active_provider_evidence` in the same shape for field-for-field comparison,
 plus `same_source_as_active`. `sources[].lanes` names which lane claimed each
-fetched identity. Candidate identities share the active lane's dedupe, so a
-candidate repeated across conflicts, or one equal to an active source, is
-fetched once.
+fetched identity.
 
-Candidate identities never enter the active-source assignment: the cross-talk
-collision analysis reads that map, so a candidate shared by two talks would
-otherwise fabricate a collision between active identities that share nothing.
+Candidate identities never enter the active-source assignment, so a candidate
+shared by two talks cannot appear as a collision between active identities.
 
-**Exit conditions.** A fault on an identity only a candidate claims is
-lane-local: the audit stays `complete` and the CLI exit stays clean, because a
-candidate the provider would not serve says nothing about the sources already in
-the database. The same fault on an identity the ACTIVE lane also claims keeps
-its blocking code — lane-local is about which lane failed, not about forgiving
-failures. Which faults are eligible, and the `candidate_`-prefixed code each
-takes, is `CANDIDATE_LANE_LOCAL_CODES`. A refused report costs coverage of the
-conflicts, never of the sources already in the database: the active lane still
-audits.
+**Exit conditions.** A refused report leaves `candidates[]` empty and the active
+lane audited; the report's own findings name the refusal. A lane-local candidate
+fault leaves the audit `complete` and the CLI exit clean. Every other fault
+keeps its blocking code and fails the run.
 
 **Side effects.** None. The audit writes nothing, and a candidate is never
 promoted or persisted here — reviewing this evidence and applying a decision are

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -82,47 +82,46 @@ instead of an ad hoc provider lookup outside the ingress workflow:
   "{vault_root}" --candidates-from "{scan_report_path}"
 ```
 
+**Input.** `--candidates-from` takes one `scan-shownotes.py` report path. Which
+report generation is accepted, which dispositions are valid, and which lanes
+carry an auditable provider identity are the script's to decide — see
+`audit-source-identities.py`, top-of-file constants
+`CANDIDATE_REPORT_SCHEMA_VERSION`, `CANDIDATE_DISPOSITIONS`, and
+`CANDIDATE_LANES`, each with the reasoning beside it.
+
+The report is validated whole before anything is bound, and the verdict is
+all-or-nothing: one refused entry discards **every** candidate binding, because
+a partly malformed report is not a complete conflict set and auditing its
+well-formed remainder would report an unknown subset as "these are the
+conflicts". Every binding resolves before any provider request, so a report
+naming an unknown talk is refused without spending a fetch. What counts as
+refused, and the finding each refusal emits, live in `candidate_bindings()` —
+its docstring carries the contract.
+
+**Output.** `candidates[]` carries `provider_evidence` and
+`active_provider_evidence` in the same shape for field-for-field comparison,
+plus `same_source_as_active`. `sources[].lanes` names which lane claimed each
+fetched identity. Candidate identities share the active lane's dedupe, so a
+candidate repeated across conflicts, or one equal to an active source, is
+fetched once.
+
 Candidate identities never enter the active-source assignment: the cross-talk
 collision analysis reads that map, so a candidate shared by two talks would
 otherwise fabricate a collision between active identities that share nothing.
-`sources[].lanes` names which lane claimed each fetched identity.
 
-The report is validated whole before anything is bound, and the verdict is
-all-or-nothing: only `schema_version: 3` with `ok: true` is accepted, and one
-malformed entry, malformed issue, or unbindable candidate discards **every**
-candidate binding. A partly malformed report is not a complete conflict set, so
-auditing its well-formed remainder would report an unknown subset as "these are
-the conflicts". The active lane still audits, so the cost is coverage of the
-conflicts, never of the sources already in the database.
-
-An entry whose `disposition` falls outside the scan report's closed set
-(`add`, `update`, `unchanged`, `review_required`) is malformed, not a row to
-pass over — skipping an unrecognized value would let a typo hide a conflict
-behind an apparently clean audit. A report file containing JSON `null` is a
-supplied-but-invalid report, never "no report given".
-
-An unsupported lane is not a malformed report: a `slides_url` candidate leaves
-the report intact and simply names a source with no auditable provider
-identity, so it stays a lane-local finding and the other candidates proceed.
-
-Every binding resolves before any provider request — a report naming an unknown
-or ambiguous talk is refused without spending a fetch. Candidate identities
-share the active lane's dedupe, so a candidate repeated across conflicts, or one
-equal to an active source, is fetched once. `candidates[]` carries
-`provider_evidence` and `active_provider_evidence` in the same shape for
-field-for-field comparison, plus `same_source_as_active`. A candidate lane with
-no auditable provider identity (`slides_url`), a malformed YouTube URL, and an
-unavailable or rate-limited fetch each stay lane-local structured findings.
-
-Lane-local means the audit stays `complete` and the CLI exit stays clean: a
-candidate the provider would not serve says nothing about the sources already
-in the database. Those faults carry `candidate_`-prefixed codes outside
-`ERROR_CODES`. The same fault on an identity the ACTIVE lane also claims keeps
+**Exit conditions.** A fault on an identity only a candidate claims is
+lane-local: the audit stays `complete` and the CLI exit stays clean, because a
+candidate the provider would not serve says nothing about the sources already in
+the database. The same fault on an identity the ACTIVE lane also claims keeps
 its blocking code — lane-local is about which lane failed, not about forgiving
-failures.
+failures. Which faults are eligible, and the `candidate_`-prefixed code each
+takes, is `CANDIDATE_LANE_LOCAL_CODES`. A refused report costs coverage of the
+conflicts, never of the sources already in the database: the active lane still
+audits.
 
-The audit still writes nothing. A candidate is never promoted or persisted here
-— reviewing this evidence and applying a decision are separate steps.
+**Side effects.** None. The audit writes nothing, and a candidate is never
+promoted or persisted here — reviewing this evidence and applying a decision are
+separate steps.
 
 ## Report contract (v2)
 

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -90,7 +90,7 @@ instead of an ad hoc provider lookup outside the ingress workflow:
 | Accepted report generation | `CANDIDATE_REPORT_SCHEMA_VERSION` |
 | Valid dispositions | `CANDIDATE_DISPOSITIONS` |
 | Lanes with an auditable provider identity | `CANDIDATE_LANES` |
-| Which reports and entries bind, and the finding each refusal emits | `candidate_bindings()` docstring |
+| Which reports and entries bind, and the finding each refusal emits | `candidate_bindings()` |
 | Faults eligible to stay lane-local, and the code each takes | `CANDIDATE_LANE_LOCAL_CODES` |
 
 **Output.** `candidates[]` carries `provider_evidence` and

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -468,6 +468,24 @@ def candidate_bindings(
     Returns the accepted bindings and the findings for everything refused.
     Every binding is resolved here, before any provider request: a report that
     names an unknown talk must not cost a network fetch first.
+
+    Refusals, and the finding each emits:
+
+    - ``candidate_report_invalid`` — the report is not a complete conflict set:
+      a non-object report, a schema version other than
+      CANDIDATE_REPORT_SCHEMA_VERSION, ``ok`` not true, a malformed entry or
+      issue, or a disposition outside CANDIDATE_DISPOSITIONS. Any one of these
+      discards EVERY candidate binding; binding the well-formed remainder would
+      audit an unknown subset and read as "these are the conflicts".
+    - ``candidate_binding_invalid`` — the entry is well-formed but names a talk
+      this database cannot resolve to exactly one record. Fatal for the same
+      reason: the conflict set is incomplete.
+    - ``candidate_provider_unsupported`` — the entry names a lane outside
+      CANDIDATE_LANES, so it carries no provider identity to audit. The report
+      stays intact and every other candidate proceeds.
+
+    A fatal refusal returns no bindings. The active lane still audits, so the
+    cost is coverage of the conflicts, never of the sources already stored.
     """
     findings: list[dict[str, Any]] = []
     # Faults that condemn the whole report, kept apart from lane-local notes.


### PR DESCRIPTION
Closes #278.

The candidate-mode section of `source-identity-audit.md` restated what `audit-source-identities.py` implements: the accepted report generation, the closed disposition set, the lane allowlist, the dedupe behaviour, and the per-fault classification. Two copies of a predicate drift, and the reference is the copy nobody runs.

## What changed

The section now carries the contract only — input, output shape, exit conditions, side effects — and names each internal once by pointer:

- `CANDIDATE_REPORT_SCHEMA_VERSION` — the accepted scan-report generation
- `CANDIDATE_DISPOSITIONS` — the closed disposition set
- `CANDIDATE_LANES` — which lanes carry an auditable provider identity
- `CANDIDATE_LANE_LOCAL_CODES` — which faults stay lane-local, and their codes
- `candidate_bindings()` — binding resolution and the all-or-nothing verdict

The reasoning stays beside the constants, where it can be checked against the code that reads them.

Raised as an advisory on PR #276 and deferred rather than folded in: that PR was otherwise green, and `review-severity` spends a re-review round on a presentation-only change only when a blocking round is already happening.

## Tests

Docs-only; no test pins this file's prose. Full suite: 5310 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)