### PR TITLE
test(vault-ingress): assert the probe's promise, not the allocator's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### test(vault-ingress) — assert the probe's promise, not the allocator's (#277)
+
+Closes #277.
+
+`test_same_size_replacement_invalidates_cached_probe` failed once in a local
+full-suite run and passed every time it was run alone. Its first assertion
+required the replacement's inode to differ from the original's — an allocation
+outcome the test does not control, and a claim about the filesystem rather than
+about the probe.
+
+The test now asserts what the probe promises: after a same-size replacement, the
+second probe reports the replacement's SHA-256 and the same byte count. A cache
+that served the stale entry fails that digest assertion, so the defect worth
+catching is still caught — without a pass/fail that depends on which inode the
+allocator handed back.
+
+The original failure was never reproduced, so which assertion broke is not
+recorded. The inode assertion was the only one in the file whose outcome came
+from the filesystem rather than the code under test; the remaining assertions in
+`tests/test_pdf_evidence.py` compare against pinned synthetic generations.
+
 ### fix(vault-ingress) — stop echoing tracking-database decoder text (#275)
 
 Closes #275.

--- a/tests/test_pdf_evidence.py
+++ b/tests/test_pdf_evidence.py
@@ -223,21 +223,31 @@ def test_real_worker_probes_synthetic_pdf_and_reuses_exact_cache(
 
 
 def test_same_size_replacement_invalidates_cached_probe(tmp_path: Path) -> None:
+    """A same-size replacement is probed again, never served from the cache.
+
+    The promise is the content binding, so that is what is asserted (#277). An
+    earlier version also required the replacement's inode to differ from the
+    original's — an allocation outcome this test does not control, and a claim
+    about the filesystem rather than about the probe. A cache that did serve
+    the stale entry still fails the digest assertion below, which is the defect
+    worth catching either way.
+    """
     artifact = tmp_path / "talk.pdf"
     original = _synthetic_pdf(marker="a")
     replacement_bytes = _synthetic_pdf(marker="b")
     assert len(replacement_bytes) == len(original)
+    assert replacement_bytes != original
     artifact.write_bytes(original)
     first = pdf_evidence.probe_pdf_artifact(artifact, trusted_root=tmp_path)
+    assert first.source_sha256 == hashlib.sha256(original).hexdigest()
 
     replacement = tmp_path / "replacement.pdf"
     replacement.write_bytes(replacement_bytes)
     os.replace(replacement, artifact)
     second = pdf_evidence.probe_pdf_artifact(artifact, trusted_root=tmp_path)
 
-    assert second.generation.inode != first.generation.inode
+    assert second.source_sha256 == hashlib.sha256(replacement_bytes).hexdigest()
     assert second.source_size_bytes == first.source_size_bytes
-    assert second.source_sha256 != first.source_sha256
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #277.

`test_same_size_replacement_invalidates_cached_probe` failed once in a local full-suite run and passed every time it was run alone. Its first assertion required the replacement's inode to differ from the original's — an allocation outcome the test does not control, and a claim about the filesystem rather than about the probe.

## What changed

The test asserts what the probe promises: after a same-size replacement, the second probe reports the replacement's SHA-256 and the same byte count. A cache that served the stale entry fails that digest assertion, so the defect worth catching is still caught — without a pass/fail that depends on which inode the allocator handed back.

## On the un-reproduced failure

Acceptance criterion 1 asks for the failing assertion to be recorded. It was not reproduced here: the file passed 3/3 alone and 6/6 under parallel contention, both before and after the change. What can be recorded is the audit — the inode assertion was the only one in `tests/test_pdf_evidence.py` whose outcome came from the filesystem rather than from the code under test. Every other identity assertion in the file compares against pinned synthetic generations (`_generation(inode=...)`), which no allocator or clock can move.

## Tests

`tests/test_pdf_evidence.py`: 84 passed, 3× sequential and 6× in parallel on the cache/replacement subset. Full suite: 5360 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)