### PR TITLE
feat(vault-ingress): classify what is already stored, not just what arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+### feat(vault-ingress) — classify what is already stored, not just what arrives (#167)
+
+Part of #167.
+
+Return validation guards what a subagent hands in. Nothing guarded what was
+already persisted, and the live vault shows why that matters: across 209 talks
+and 5,222 detection objects, `pattern_observations` is a dict on 119 talks, a
+legacy list on 81, and absent on 9; 28 detections in one talk have `evidence`
+and `dimensions` swapped; 1,129 carry legacy or missing dimension arrays; 3 name
+IDs no catalog entry claims; and 641 reference entries since marked
+`observable: false`. A record-schema migration stamps any of those as current
+without ever looking inside the nested block, so the corruption survives into
+rendered analyses and derived profile state.
+
+`persisted_pattern_observations.py` is the read-only classifier the migration,
+preflight, rendering, profile, and queue paths will share. It reports stable
+reason codes for the container shape, the detection object, and the dimensions
+array, and it separates the cases by what an owner can actually do about them:
+
+- order-only drift is mechanical but still reported — the catalog owns the order
+- membership drift is a semantic claim, routed to the #156 catalog review and
+  never auto-mapped
+- an unknown ID is an owner decision about what the observation meant, never a
+  spelling correction to a near neighbour
+- a detection of an entry the catalog no longer observes is archival, not
+  malformed: reported so a caller can exclude it from the current cohort,
+  without making the talk unusable
+
+One defect is losslessly repairable: the exact inverse field swap, where
+`evidence` holds a valid dimensions array and `dimensions` holds the evidence
+text. The repair carries both original values, so applying it is a swap rather
+than a reconstruction, and it refuses a target that moved since it was assessed.
+Every other case stays a review or reparse finding. A half-swap — a malformed
+list on one side — is two defects, not a repair: guessing at one side would
+destroy the other.
+
+The classifier is a pure function of (talk, catalog) with no filesystem, clock,
+or network. Wiring it into migration, preflight, the writers, and queue
+normalization is the rest of #167.
+
 ### ci — fail the build on a committed conflict marker (#272)
 
 Closes #272.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ array, and it separates the cases by what an owner can actually do about them:
   malformed: reported so a caller can exclude it from the current cohort,
   without making the talk unusable
 
+Two things the record cannot leave unsaid. A current block carries every lane
+the canonical writer emits, so an absent `patterns_detected`,
+`antipatterns_detected`, or `not_evaluable` is a writer that never finished
+rather than a leaner block — reading an absent lane as an empty one reported
+`{}` as clean current evidence. And the lane is itself the claim: a catalog
+`pattern` filed under `antipatterns_detected` inverts what the record says the
+speaker did, and no field inside the detection says otherwise.
+
 One defect is losslessly repairable: the exact inverse field swap, where
 `evidence` holds a valid dimensions array and `dimensions` holds the evidence
 text. The repair carries both original values, so applying it is a swap rather

--- a/skills/vault-ingress/scripts/persisted_pattern_observations.py
+++ b/skills/vault-ingress/scripts/persisted_pattern_observations.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Structural audit of pattern detections already stored in the database (#167).
+
+Return validation guards what a subagent hands in. Nothing guarded what is
+already persisted, and the live vault shows why that matters: across 209 talks
+and 5,222 detection objects, `pattern_observations` is a dict on 119 talks, a
+legacy list on 81, and absent on 9; 28 detections in one talk have `evidence`
+and `dimensions` swapped; 1,129 carry legacy or missing dimension arrays; 3 name
+IDs no catalog entry claims; and 641 reference entries since marked
+`observable: false`.
+
+A record-schema migration can stamp any of those as current without ever
+looking inside the nested block, so the corruption survives into rendered
+analyses and derived profile state.
+
+This module is the read-only classifier the migration, preflight, rendering,
+profile, and queue paths share. It decides nothing about remediation: it says
+what is wrong, in stable reason codes, and says which single defect — the exact
+inverse-schema field swap — is losslessly repairable. Everything else is an
+owner decision, and semantic dimension mappings belong to the catalog review in
+#156, never here.
+
+Pure function of (talk, catalog): no filesystem, no clock, no network.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from return_validation import CONFIDENCE_LEVELS, PatternCatalog
+
+ASSESSMENT_SCHEMA_VERSION = 1
+
+# The detection collections a persisted block carries. `not_evaluable` holds
+# outcome records rather than detections, so it is audited for shape alone.
+DETECTION_COLLECTIONS = ("patterns_detected", "antipatterns_detected")
+
+# Catalog dimensions are integers 1-14 (`vault_dimensions` in every entry's
+# frontmatter). The bound is the catalog's, restated here only as the swap
+# signature's type test.
+MINIMUM_DIMENSION = 1
+MAXIMUM_DIMENSION = 14
+
+# Stable reason codes. Consumers route on these; the messages are prose and may
+# be reworded. Grouped by what the owner has to do about them.
+
+# The block itself, before any detection is read.
+CONTAINER_ABSENT = "observations_absent"
+CONTAINER_LEGACY_LIST = "observations_legacy_list"
+CONTAINER_INVALID = "observations_invalid"
+COLLECTION_INVALID = "detection_collection_invalid"
+
+# One detection object's own shape.
+DETECTION_NOT_OBJECT = "detection_not_object"
+DETECTION_ID_MISSING = "detection_pattern_id_missing"
+DETECTION_ID_UNKNOWN = "detection_pattern_id_unknown"
+DETECTION_CONFIDENCE_INVALID = "detection_confidence_invalid"
+DETECTION_EVIDENCE_INVALID = "detection_evidence_invalid"
+
+# The dimensions array, in increasing order of ambiguity.
+DIMENSIONS_ABSENT = "dimensions_absent"
+DIMENSIONS_INVALID = "dimensions_invalid"
+DIMENSIONS_ORDER_DRIFT = "dimensions_order_drift"
+DIMENSIONS_MEMBERSHIP_DRIFT = "dimensions_membership_drift"
+
+# The one signature that is unambiguous enough to repair without losing data.
+FIELDS_SWAPPED = "detection_fields_swapped"
+
+# Not a defect in the record: the catalog moved. Archival evidence, never
+# current observable scoring evidence.
+ENTRY_NOT_OBSERVABLE = "detection_entry_not_observable"
+
+# Findings that leave the talk unusable as current scoring evidence. A swapped
+# pair is repairable but still not current until the repair lands, and an
+# unobservable entry is archival rather than malformed — neither is silently
+# tolerated, and only the archival case leaves the record itself valid.
+BLOCKING_REASONS = frozenset(
+    {
+        CONTAINER_ABSENT,
+        CONTAINER_LEGACY_LIST,
+        CONTAINER_INVALID,
+        COLLECTION_INVALID,
+        DETECTION_NOT_OBJECT,
+        DETECTION_ID_MISSING,
+        DETECTION_ID_UNKNOWN,
+        DETECTION_CONFIDENCE_INVALID,
+        DETECTION_EVIDENCE_INVALID,
+        DIMENSIONS_ABSENT,
+        DIMENSIONS_INVALID,
+        DIMENSIONS_ORDER_DRIFT,
+        DIMENSIONS_MEMBERSHIP_DRIFT,
+        FIELDS_SWAPPED,
+    }
+)
+
+
+@dataclass(frozen=True)
+class ObservationFinding:
+    """One defect, located precisely enough to repair or review by hand."""
+
+    reason_code: str
+    location: str
+    pattern_id: str | None
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "reason_code": self.reason_code,
+            "location": self.location,
+            "pattern_id": self.pattern_id,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class SwappedFieldRepair:
+    """One detection whose `evidence` and `dimensions` are exact inverses.
+
+    Carries both original values, so applying the repair is a swap and never a
+    reconstruction: a repair that cannot restore what it replaced is a rewrite.
+    """
+
+    location: str
+    pattern_id: str
+    evidence: str
+    dimensions: tuple[int, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "location": self.location,
+            "pattern_id": self.pattern_id,
+            "evidence": self.evidence,
+            "dimensions": list(self.dimensions),
+        }
+
+
+@dataclass(frozen=True)
+class PersistedObservationAssessment:
+    """What one talk's persisted observations are, in stable terms."""
+
+    schema_version: int
+    usable: bool
+    findings: tuple[ObservationFinding, ...]
+    repairs: tuple[SwappedFieldRepair, ...]
+    detection_count: int
+    archival_count: int
+
+    @property
+    def reason_codes(self) -> tuple[str, ...]:
+        """Every distinct code, sorted, for a caller that routes on shape."""
+        return tuple(sorted({finding.reason_code for finding in self.findings}))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "usable": self.usable,
+            "findings": [finding.as_dict() for finding in self.findings],
+            "repairs": [repair.as_dict() for repair in self.repairs],
+            "detection_count": self.detection_count,
+            "archival_count": self.archival_count,
+            "reason_codes": list(self.reason_codes),
+        }
+
+
+def _is_dimension_list(value: Any) -> bool:
+    """A non-empty list of in-range dimension integers, booleans excluded."""
+    if not isinstance(value, list) or not value:
+        return False
+    return all(
+        not isinstance(item, bool)
+        and isinstance(item, int)
+        and MINIMUM_DIMENSION <= item <= MAXIMUM_DIMENSION
+        for item in value
+    )
+
+
+def _is_evidence_text(value: Any) -> bool:
+    return isinstance(value, str) and value.strip() != ""
+
+
+def _swapped_repair(
+    detection: dict[str, Any],
+    location: str,
+    pattern_id: str,
+) -> SwappedFieldRepair | None:
+    """The repair for an exact inverse-schema swap, or nothing.
+
+    Both sides must satisfy the other's schema exactly. A `dimensions` value
+    that is prose and an `evidence` value that is a half-valid list is not a
+    swap — it is two separate defects, and guessing at one would destroy the
+    other.
+    """
+    evidence = detection.get("evidence")
+    dimensions = detection.get("dimensions")
+    if not _is_dimension_list(evidence) or not _is_evidence_text(dimensions):
+        return None
+    assert isinstance(dimensions, str)  # _is_evidence_text postcondition
+    assert isinstance(evidence, list)  # _is_dimension_list postcondition
+    return SwappedFieldRepair(
+        location=location,
+        pattern_id=pattern_id,
+        evidence=dimensions,
+        dimensions=tuple(evidence),
+    )
+
+
+def _audit_dimensions(
+    detection: dict[str, Any],
+    location: str,
+    pattern_id: str,
+    expected: tuple[int, ...],
+) -> ObservationFinding | None:
+    """Classify the dimensions array against the catalog's ordered value."""
+    dimensions = detection.get("dimensions")
+    if dimensions is None:
+        return ObservationFinding(
+            DIMENSIONS_ABSENT,
+            location,
+            pattern_id,
+            "detection carries no dimensions array",
+        )
+    if not _is_dimension_list(dimensions):
+        return ObservationFinding(
+            DIMENSIONS_INVALID,
+            location,
+            pattern_id,
+            "dimensions must be a non-empty array of integers 1 through 14",
+        )
+    stored = tuple(dimensions)
+    if stored == expected:
+        return None
+    if sorted(stored) == sorted(expected):
+        # Same membership, different order. Mechanical to fix, but the catalog
+        # owns the order, so it is still reported rather than silently sorted.
+        return ObservationFinding(
+            DIMENSIONS_ORDER_DRIFT,
+            location,
+            pattern_id,
+            f"dimensions {list(stored)} reorder the catalog value {list(expected)}",
+        )
+    # Different membership is a semantic claim about what the pattern measures.
+    # #156 owns that review; auto-mapping it here would invent evidence.
+    return ObservationFinding(
+        DIMENSIONS_MEMBERSHIP_DRIFT,
+        location,
+        pattern_id,
+        f"dimensions {list(stored)} differ from the catalog value {list(expected)}",
+    )
+
+
+def _audit_detection(
+    detection: Any,
+    location: str,
+    catalog: PatternCatalog,
+) -> tuple[list[ObservationFinding], SwappedFieldRepair | None, bool]:
+    """Audit one detection object. Returns (findings, repair, archival)."""
+    if not isinstance(detection, dict):
+        return (
+            [
+                ObservationFinding(
+                    DETECTION_NOT_OBJECT,
+                    location,
+                    None,
+                    "detection must be an object",
+                )
+            ],
+            None,
+            False,
+        )
+    pattern_id = detection.get("pattern_id")
+    if not isinstance(pattern_id, str) or not pattern_id:
+        return (
+            [
+                ObservationFinding(
+                    DETECTION_ID_MISSING,
+                    location,
+                    None,
+                    "detection carries no pattern_id",
+                )
+            ],
+            None,
+            False,
+        )
+    entry = catalog.entries.get(pattern_id)
+    if entry is None:
+        # Never mapped to a near neighbour: a legacy ID is an owner decision
+        # about what the observation meant, not a spelling correction.
+        return (
+            [
+                ObservationFinding(
+                    DETECTION_ID_UNKNOWN,
+                    location,
+                    pattern_id,
+                    "no catalog entry claims this pattern_id",
+                )
+            ],
+            None,
+            False,
+        )
+
+    findings: list[ObservationFinding] = []
+    archival = not entry.observable
+    if archival:
+        findings.append(
+            ObservationFinding(
+                ENTRY_NOT_OBSERVABLE,
+                location,
+                pattern_id,
+                "catalog entry is no longer observable; evidence is archival",
+            )
+        )
+
+    repair = _swapped_repair(detection, location, pattern_id)
+    if repair is not None:
+        # One finding for the pair. Reporting the two fields separately would
+        # read as two independent defects and invite two independent guesses.
+        findings.append(
+            ObservationFinding(
+                FIELDS_SWAPPED,
+                location,
+                pattern_id,
+                "evidence holds the dimensions array and dimensions holds the "
+                "evidence text",
+            )
+        )
+        return findings, repair, archival
+
+    confidence = detection.get("confidence")
+    if confidence not in CONFIDENCE_LEVELS:
+        findings.append(
+            ObservationFinding(
+                DETECTION_CONFIDENCE_INVALID,
+                location,
+                pattern_id,
+                f"confidence must be one of {sorted(CONFIDENCE_LEVELS)}",
+            )
+        )
+    if not _is_evidence_text(detection.get("evidence")):
+        findings.append(
+            ObservationFinding(
+                DETECTION_EVIDENCE_INVALID,
+                location,
+                pattern_id,
+                "evidence must be non-empty text",
+            )
+        )
+    dimension_finding = _audit_dimensions(
+        detection,
+        location,
+        pattern_id,
+        entry.vault_dimensions,
+    )
+    if dimension_finding is not None:
+        findings.append(dimension_finding)
+    return findings, repair, archival
+
+
+def _audit_collection(
+    observations: dict[str, Any],
+    name: str,
+    catalog: PatternCatalog,
+) -> tuple[list[ObservationFinding], list[SwappedFieldRepair], int, int]:
+    """Audit one detection collection. Returns (findings, repairs, count, archival)."""
+    raw = observations.get(name)
+    if raw is None:
+        return [], [], 0, 0
+    if not isinstance(raw, list):
+        return (
+            [
+                ObservationFinding(
+                    COLLECTION_INVALID,
+                    name,
+                    None,
+                    f"{name} must be an array of detection objects",
+                )
+            ],
+            [],
+            0,
+            0,
+        )
+    findings: list[ObservationFinding] = []
+    repairs: list[SwappedFieldRepair] = []
+    archival = 0
+    for index, detection in enumerate(raw):
+        found, repair, is_archival = _audit_detection(
+            detection,
+            f"{name}[{index}]",
+            catalog,
+        )
+        findings.extend(found)
+        if repair is not None:
+            repairs.append(repair)
+        if is_archival:
+            archival += 1
+    return findings, repairs, len(raw), archival
+
+
+def _blocking(findings: Iterable[ObservationFinding]) -> bool:
+    return any(finding.reason_code in BLOCKING_REASONS for finding in findings)
+
+
+def assess_persisted_pattern_observations(
+    talk: Any,
+    catalog: PatternCatalog,
+) -> PersistedObservationAssessment:
+    """Classify one talk's persisted pattern observations.
+
+    ``usable`` means the block can be read as current scoring evidence. It is
+    false for every structural defect, the repairable swap included: the repair
+    has to land before the record is current, and reporting it as usable would
+    let the corruption through the gate that found it.
+    """
+    observations = talk.get("pattern_observations") if isinstance(talk, dict) else None
+    if observations is None:
+        return PersistedObservationAssessment(
+            schema_version=ASSESSMENT_SCHEMA_VERSION,
+            usable=False,
+            findings=(
+                ObservationFinding(
+                    CONTAINER_ABSENT,
+                    "pattern_observations",
+                    None,
+                    "talk carries no persisted pattern observations",
+                ),
+            ),
+            repairs=(),
+            detection_count=0,
+            archival_count=0,
+        )
+    if isinstance(observations, list):
+        # The pre-#147 shape. Readable as history, never as a current block:
+        # it carries no collection names to audit against.
+        return PersistedObservationAssessment(
+            schema_version=ASSESSMENT_SCHEMA_VERSION,
+            usable=False,
+            findings=(
+                ObservationFinding(
+                    CONTAINER_LEGACY_LIST,
+                    "pattern_observations",
+                    None,
+                    "pattern_observations is the legacy list shape",
+                ),
+            ),
+            repairs=(),
+            detection_count=len(observations),
+            archival_count=0,
+        )
+    if not isinstance(observations, dict):
+        return PersistedObservationAssessment(
+            schema_version=ASSESSMENT_SCHEMA_VERSION,
+            usable=False,
+            findings=(
+                ObservationFinding(
+                    CONTAINER_INVALID,
+                    "pattern_observations",
+                    None,
+                    "pattern_observations must be an object",
+                ),
+            ),
+            repairs=(),
+            detection_count=0,
+            archival_count=0,
+        )
+
+    findings: list[ObservationFinding] = []
+    repairs: list[SwappedFieldRepair] = []
+    detections = 0
+    archival = 0
+    for name in DETECTION_COLLECTIONS:
+        found, repaired, count, archived = _audit_collection(
+            observations,
+            name,
+            catalog,
+        )
+        findings.extend(found)
+        repairs.extend(repaired)
+        detections += count
+        archival += archived
+    return PersistedObservationAssessment(
+        schema_version=ASSESSMENT_SCHEMA_VERSION,
+        usable=not _blocking(findings),
+        findings=tuple(findings),
+        repairs=tuple(repairs),
+        detection_count=detections,
+        archival_count=archival,
+    )
+
+
+def apply_swapped_field_repairs(
+    talk: dict[str, Any],
+    repairs: Iterable[SwappedFieldRepair],
+) -> dict[str, Any]:
+    """Return a copy of ``talk`` with each exact inverse swap undone.
+
+    Only the two swapped values move, and both come from the repair record, so
+    the operation is reversible and loses nothing. A repair whose location no
+    longer holds the swapped shape is refused rather than forced: the talk
+    changed since it was assessed, and this is not the assessment.
+    """
+    repaired = copy.deepcopy(talk)
+    observations = repaired.get("pattern_observations")
+    if not isinstance(observations, dict):
+        raise ValueError(
+            "cannot repair a talk whose pattern_observations is not an object; "
+            "reassess the talk and apply the repairs it reports"
+        )
+    for repair in repairs:
+        name, _, index_text = repair.location.partition("[")
+        index = int(index_text.rstrip("]"))
+        collection = observations.get(name)
+        if not isinstance(collection, list) or index >= len(collection):
+            raise ValueError(
+                f"repair target {repair.location} is absent; reassess the talk "
+                "and apply the repairs it reports"
+            )
+        detection = collection[index]
+        if _swapped_repair(detection, repair.location, repair.pattern_id) != repair:
+            raise ValueError(
+                f"repair target {repair.location} no longer holds the swapped "
+                "shape it was assessed with; reassess the talk and apply the "
+                "repairs it reports"
+            )
+        detection["evidence"] = repair.evidence
+        detection["dimensions"] = list(repair.dimensions)
+    return repaired

--- a/skills/vault-ingress/scripts/persisted_pattern_observations.py
+++ b/skills/vault-ingress/scripts/persisted_pattern_observations.py
@@ -33,9 +33,22 @@ from return_validation import CONFIDENCE_LEVELS, PatternCatalog
 
 ASSESSMENT_SCHEMA_VERSION = 1
 
-# The detection collections a persisted block carries. `not_evaluable` holds
-# outcome records rather than detections, so it is audited for shape alone.
-DETECTION_COLLECTIONS = ("patterns_detected", "antipatterns_detected")
+# The detection collections a persisted block carries, each bound to the catalog
+# polarity its members must have: a `pattern` entry filed under
+# `antipatterns_detected` inverts what the record claims the speaker did.
+DETECTION_COLLECTIONS = {
+    "patterns_detected": "pattern",
+    "antipatterns_detected": "antipattern",
+}
+
+# `not_evaluable` holds outcome records rather than detections, so it is audited
+# for container shape and catalog identity alone.
+OUTCOME_COLLECTION = "not_evaluable"
+
+# Every lane the canonical writer emits. A current block missing one is not a
+# leaner current block: it is a block whose writer never finished, and treating
+# an absent lane as an empty one reports invented completeness.
+REQUIRED_COLLECTIONS = (*DETECTION_COLLECTIONS, OUTCOME_COLLECTION)
 
 # Catalog dimensions are integers 1-14 (`vault_dimensions` in every entry's
 # frontmatter). The bound is the catalog's, restated here only as the swap
@@ -50,6 +63,7 @@ MAXIMUM_DIMENSION = 14
 CONTAINER_ABSENT = "observations_absent"
 CONTAINER_LEGACY_LIST = "observations_legacy_list"
 CONTAINER_INVALID = "observations_invalid"
+COLLECTION_ABSENT = "detection_collection_absent"
 COLLECTION_INVALID = "detection_collection_invalid"
 
 # One detection object's own shape.
@@ -58,6 +72,7 @@ DETECTION_ID_MISSING = "detection_pattern_id_missing"
 DETECTION_ID_UNKNOWN = "detection_pattern_id_unknown"
 DETECTION_CONFIDENCE_INVALID = "detection_confidence_invalid"
 DETECTION_EVIDENCE_INVALID = "detection_evidence_invalid"
+DETECTION_POLARITY_MISMATCH = "detection_polarity_mismatch"
 
 # The dimensions array, in increasing order of ambiguity.
 DIMENSIONS_ABSENT = "dimensions_absent"
@@ -81,12 +96,14 @@ BLOCKING_REASONS = frozenset(
         CONTAINER_ABSENT,
         CONTAINER_LEGACY_LIST,
         CONTAINER_INVALID,
+        COLLECTION_ABSENT,
         COLLECTION_INVALID,
         DETECTION_NOT_OBJECT,
         DETECTION_ID_MISSING,
         DETECTION_ID_UNKNOWN,
         DETECTION_CONFIDENCE_INVALID,
         DETECTION_EVIDENCE_INVALID,
+        DETECTION_POLARITY_MISMATCH,
         DIMENSIONS_ABSENT,
         DIMENSIONS_INVALID,
         DIMENSIONS_ORDER_DRIFT,
@@ -254,6 +271,7 @@ def _audit_detection(
     detection: Any,
     location: str,
     catalog: PatternCatalog,
+    expected_type: str,
 ) -> tuple[list[ObservationFinding], SwappedFieldRepair | None, bool]:
     """Audit one detection object. Returns (findings, repair, archival)."""
     if not isinstance(detection, dict):
@@ -301,6 +319,18 @@ def _audit_detection(
         )
 
     findings: list[ObservationFinding] = []
+    if entry.entry_type != expected_type:
+        # The lane is the claim: a pattern filed as an antipattern inverts what
+        # the record says the speaker did, and no field inside the detection
+        # says otherwise.
+        findings.append(
+            ObservationFinding(
+                DETECTION_POLARITY_MISMATCH,
+                location,
+                pattern_id,
+                f"catalog entry is a {entry.entry_type} and cannot be filed here",
+            )
+        )
     archival = not entry.observable
     if archival:
         findings.append(
@@ -361,11 +391,25 @@ def _audit_collection(
     observations: dict[str, Any],
     name: str,
     catalog: PatternCatalog,
+    expected_type: str,
 ) -> tuple[list[ObservationFinding], list[SwappedFieldRepair], int, int]:
     """Audit one detection collection. Returns (findings, repairs, count, archival)."""
+    if name not in observations:
+        return (
+            [
+                ObservationFinding(
+                    COLLECTION_ABSENT,
+                    name,
+                    None,
+                    f"a current block carries {name}; an absent lane is not an "
+                    "empty one",
+                )
+            ],
+            [],
+            0,
+            0,
+        )
     raw = observations.get(name)
-    if raw is None:
-        return [], [], 0, 0
     if not isinstance(raw, list):
         return (
             [
@@ -388,6 +432,7 @@ def _audit_collection(
             detection,
             f"{name}[{index}]",
             catalog,
+            expected_type,
         )
         findings.extend(found)
         if repair is not None:
@@ -395,6 +440,73 @@ def _audit_collection(
         if is_archival:
             archival += 1
     return findings, repairs, len(raw), archival
+
+
+def _audit_outcomes(
+    observations: dict[str, Any],
+    catalog: PatternCatalog,
+) -> list[ObservationFinding]:
+    """Audit the `not_evaluable` lane's shape and catalog identity.
+
+    These are outcome records, not detections: they carry no evidence or
+    dimensions to check. What they must be is present, listed, and named by an
+    ID the catalog claims — an unreadable lane leaves the block's coverage
+    unknown, which is not the same as complete.
+    """
+    if OUTCOME_COLLECTION not in observations:
+        return [
+            ObservationFinding(
+                COLLECTION_ABSENT,
+                OUTCOME_COLLECTION,
+                None,
+                f"a current block carries {OUTCOME_COLLECTION}; an absent lane "
+                "is not an empty one",
+            )
+        ]
+    raw = observations.get(OUTCOME_COLLECTION)
+    if not isinstance(raw, list):
+        return [
+            ObservationFinding(
+                COLLECTION_INVALID,
+                OUTCOME_COLLECTION,
+                None,
+                f"{OUTCOME_COLLECTION} must be an array of outcome records",
+            )
+        ]
+    findings: list[ObservationFinding] = []
+    for index, record in enumerate(raw):
+        location = f"{OUTCOME_COLLECTION}[{index}]"
+        if not isinstance(record, dict):
+            findings.append(
+                ObservationFinding(
+                    DETECTION_NOT_OBJECT,
+                    location,
+                    None,
+                    "outcome record must be an object",
+                )
+            )
+            continue
+        pattern_id = record.get("pattern_id")
+        if not isinstance(pattern_id, str) or not pattern_id:
+            findings.append(
+                ObservationFinding(
+                    DETECTION_ID_MISSING,
+                    location,
+                    None,
+                    "outcome record carries no pattern_id",
+                )
+            )
+            continue
+        if pattern_id not in catalog.entries:
+            findings.append(
+                ObservationFinding(
+                    DETECTION_ID_UNKNOWN,
+                    location,
+                    pattern_id,
+                    "no catalog entry claims this pattern_id",
+                )
+            )
+    return findings
 
 
 def _blocking(findings: Iterable[ObservationFinding]) -> bool:
@@ -468,16 +580,18 @@ def assess_persisted_pattern_observations(
     repairs: list[SwappedFieldRepair] = []
     detections = 0
     archival = 0
-    for name in DETECTION_COLLECTIONS:
+    for name, expected_type in DETECTION_COLLECTIONS.items():
         found, repaired, count, archived = _audit_collection(
             observations,
             name,
             catalog,
+            expected_type,
         )
         findings.extend(found)
         repairs.extend(repaired)
         detections += count
         archival += archived
+    findings.extend(_audit_outcomes(observations, catalog))
     return PersistedObservationAssessment(
         schema_version=ASSESSMENT_SCHEMA_VERSION,
         usable=not _blocking(findings),

--- a/skills/vault-ingress/scripts/persisted_pattern_observations.py
+++ b/skills/vault-ingress/scripts/persisted_pattern_observations.py
@@ -630,7 +630,15 @@ def apply_swapped_field_repairs(
                 "and apply the repairs it reports"
             )
         detection = collection[index]
-        if _swapped_repair(detection, repair.location, repair.pattern_id) != repair:
+        # The identity is checked against the record, never supplied to it:
+        # passing the repair's own pattern_id into the shape check would let a
+        # detection that became a different pattern — same swapped fields, new
+        # id — compare equal and be rewritten.
+        if (
+            not isinstance(detection, dict)
+            or detection.get("pattern_id") != repair.pattern_id
+            or _swapped_repair(detection, repair.location, repair.pattern_id) != repair
+        ):
             raise ValueError(
                 f"repair target {repair.location} no longer holds the swapped "
                 "shape it was assessed with; reassess the talk and apply the "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,15 @@ def cooperative_lock():
 
 
 @pytest.fixture(scope="session")
+def persisted_pattern_observations():
+    """The persisted-observation structural classifier every reader shares (#167)."""
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "persisted_pattern_observations.py"),
+        "persisted_pattern_observations",
+    )
+
+
+@pytest.fixture(scope="session")
 def retained_stage():
     """The staged-file lifecycle both owner writers share (#243).
 

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -1,0 +1,454 @@
+"""The persisted-observation validator's classification contract (#167).
+
+Return validation guards what a subagent hands in; nothing guarded what was
+already stored. The live vault holds every shape these tests pin: a legacy list
+container, an absent one, 28 detections with `evidence` and `dimensions`
+swapped, order-only and membership dimension drift, missing dimension arrays,
+IDs no catalog entry claims, and detections of entries since marked
+`observable: false`.
+
+Fixtures are built from the live catalog rather than hardcoded IDs, so a catalog
+edit that removes an entry fails these tests instead of quietly reclassifying
+what they assert.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def catalog(return_validation):
+    return return_validation.load_catalog()
+
+
+@pytest.fixture(scope="session")
+def observable_entry(catalog):
+    """One observable entry with at least two dimensions, for order drift."""
+    for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id):
+        if entry.observable and len(entry.vault_dimensions) >= 2:
+            return entry
+    raise AssertionError("catalog has no observable entry with two dimensions")
+
+
+@pytest.fixture(scope="session")
+def archival_entry(catalog):
+    """One entry the catalog no longer treats as observable."""
+    for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id):
+        if not entry.observable:
+            return entry
+    raise AssertionError("catalog has no unobservable entry")
+
+
+def _detection(entry, **overrides):
+    detection = {
+        "pattern_id": entry.pattern_id,
+        "confidence": "strong",
+        "evidence": "The speaker did the thing, at 12:03.",
+        "dimensions": list(entry.vault_dimensions),
+    }
+    detection.update(overrides)
+    return detection
+
+
+def _collection_name(entry) -> str:
+    return (
+        "antipatterns_detected"
+        if entry.entry_type == "antipattern"
+        else "patterns_detected"
+    )
+
+
+def _talk(entry, *detections):
+    return {"pattern_observations": {_collection_name(entry): list(detections)}}
+
+
+def test_a_clean_block_is_usable(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    talk = _talk(observable_entry, _detection(observable_entry))
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is True
+    assert assessment.findings == ()
+    assert assessment.detection_count == 1
+    assert assessment.archival_count == 0
+
+
+def test_an_absent_block_is_not_current(
+    persisted_pattern_observations, catalog
+) -> None:
+    """Nine live talks carry no block at all."""
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        {"filename": "a.md"}, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (persisted_pattern_observations.CONTAINER_ABSENT,)
+
+
+def test_the_legacy_list_container_is_not_current(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """81 live talks carry the pre-#147 list shape.
+
+    It is readable as history and never as a current block: a bare list carries
+    no collection names to audit a detection against.
+    """
+    talk = {"pattern_observations": [_detection(observable_entry)]}
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.CONTAINER_LEGACY_LIST,
+    )
+    assert assessment.detection_count == 1
+
+
+@pytest.mark.parametrize("container", ["a string", 7, True])
+def test_a_non_container_is_refused(
+    persisted_pattern_observations, catalog, container
+) -> None:
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        {"pattern_observations": container}, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.CONTAINER_INVALID,
+    )
+
+
+def test_a_non_list_collection_is_refused(
+    persisted_pattern_observations, catalog
+) -> None:
+    talk = {"pattern_observations": {"patterns_detected": {"pattern_id": "x"}}}
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.COLLECTION_INVALID,
+    )
+
+
+def test_the_swapped_field_signature_is_reported_once_and_repairable(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """The 28-detection signature from one live talk.
+
+    Both fields satisfy the other's schema exactly, so the repair is a swap and
+    loses nothing. It is one finding, not two: reporting each field separately
+    would read as two independent defects and invite two independent guesses.
+    """
+    prose = "The speaker opened with the map, at 00:41."
+    swapped = _detection(
+        observable_entry,
+        evidence=list(observable_entry.vault_dimensions),
+        dimensions=prose,
+    )
+    talk = _talk(observable_entry, swapped)
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (persisted_pattern_observations.FIELDS_SWAPPED,)
+    assert len(assessment.repairs) == 1
+    repair = assessment.repairs[0]
+    assert repair.evidence == prose
+    assert repair.dimensions == observable_entry.vault_dimensions
+
+
+def test_applying_the_repair_restores_both_values(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    prose = "The speaker opened with the map, at 00:41."
+    talk = _talk(
+        observable_entry,
+        _detection(
+            observable_entry,
+            evidence=list(observable_entry.vault_dimensions),
+            dimensions=prose,
+        ),
+    )
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    repaired = persisted_pattern_observations.apply_swapped_field_repairs(
+        talk, assessment.repairs
+    )
+
+    collection = repaired["pattern_observations"][_collection_name(observable_entry)]
+    assert collection[0]["evidence"] == prose
+    assert collection[0]["dimensions"] == list(observable_entry.vault_dimensions)
+    # The input is untouched: a repair returns a new talk rather than mutating
+    # the generation it was assessed against.
+    original = talk["pattern_observations"][_collection_name(observable_entry)][0]
+    assert original["dimensions"] == prose
+    after = persisted_pattern_observations.assess_persisted_pattern_observations(
+        repaired, catalog
+    )
+    assert after.usable is True
+
+
+def test_a_repair_against_a_changed_talk_is_refused(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """The talk moved since it was assessed, and this is not the assessment."""
+    talk = _talk(
+        observable_entry,
+        _detection(
+            observable_entry,
+            evidence=list(observable_entry.vault_dimensions),
+            dimensions="prose",
+        ),
+    )
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+    moved = _talk(observable_entry, _detection(observable_entry))
+
+    with pytest.raises(ValueError, match="reassess the talk"):
+        persisted_pattern_observations.apply_swapped_field_repairs(
+            moved, assessment.repairs
+        )
+
+
+def test_a_half_swap_is_two_defects_not_a_repair(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """Guessing at one side of an inexact swap would destroy the other."""
+    talk = _talk(
+        observable_entry,
+        _detection(observable_entry, evidence=[99], dimensions="prose"),
+    )
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.repairs == ()
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DETECTION_EVIDENCE_INVALID,
+        persisted_pattern_observations.DIMENSIONS_INVALID,
+    )
+
+
+def test_order_only_drift_is_distinguished_from_membership_drift(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """23 live detections reorder the catalog value; 38 name a different set."""
+    reordered = list(reversed(observable_entry.vault_dimensions))
+    talk = _talk(observable_entry, _detection(observable_entry, dimensions=reordered))
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DIMENSIONS_ORDER_DRIFT,
+    )
+
+
+def test_membership_drift_is_never_auto_mapped(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """A different set is a semantic claim; #156 owns that review."""
+    foreign = [
+        dimension
+        for dimension in range(1, 15)
+        if dimension not in observable_entry.vault_dimensions
+    ][:1]
+    talk = _talk(observable_entry, _detection(observable_entry, dimensions=foreign))
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DIMENSIONS_MEMBERSHIP_DRIFT,
+    )
+    assert assessment.repairs == ()
+
+
+def test_a_missing_dimensions_array_is_reported(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """1,129 live detections carry legacy or missing dimension arrays."""
+    detection = _detection(observable_entry)
+    del detection["dimensions"]
+    talk = _talk(observable_entry, detection)
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DIMENSIONS_ABSENT,
+    )
+
+
+@pytest.mark.parametrize(
+    "legacy_id",
+    ["cultural_map_disclaimer", "plane_exercise_closing", "extended_qa_as_closing"],
+)
+def test_an_unknown_id_is_never_mapped_to_a_neighbour(
+    persisted_pattern_observations, catalog, observable_entry, legacy_id
+) -> None:
+    """The three live legacy IDs. What they meant is an owner decision."""
+    talk = _talk(observable_entry, _detection(observable_entry, pattern_id=legacy_id))
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DETECTION_ID_UNKNOWN,
+    )
+    assert assessment.findings[0].pattern_id == legacy_id
+
+
+def test_an_unobservable_entry_is_archival_not_malformed(
+    persisted_pattern_observations, catalog, archival_entry
+) -> None:
+    """641 live detections reference entries the catalog no longer observes.
+
+    The record is well-formed; the catalog moved. It is reported so a caller can
+    exclude it from the current cohort, and it does not make the talk unusable.
+    """
+    talk = _talk(archival_entry, _detection(archival_entry))
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is True
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.ENTRY_NOT_OBSERVABLE,
+    )
+    assert assessment.archival_count == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("confidence", "very sure", "DETECTION_CONFIDENCE_INVALID"),
+        ("confidence", None, "DETECTION_CONFIDENCE_INVALID"),
+        ("evidence", "", "DETECTION_EVIDENCE_INVALID"),
+        ("evidence", "   ", "DETECTION_EVIDENCE_INVALID"),
+        ("evidence", 12, "DETECTION_EVIDENCE_INVALID"),
+    ],
+)
+def test_malformed_detection_fields_are_typed(
+    persisted_pattern_observations, catalog, observable_entry, field, value, code
+) -> None:
+    talk = _talk(observable_entry, _detection(observable_entry, **{field: value}))
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (getattr(persisted_pattern_observations, code),)
+
+
+@pytest.mark.parametrize("detection", ["a string", 7, None, ["nested"]])
+def test_a_non_object_detection_is_refused(
+    persisted_pattern_observations, catalog, detection
+) -> None:
+    talk = {"pattern_observations": {"patterns_detected": [detection]}}
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DETECTION_NOT_OBJECT,
+    )
+
+
+def test_a_detection_without_an_id_is_refused(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    detection = _detection(observable_entry)
+    del detection["pattern_id"]
+    talk = _talk(observable_entry, detection)
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DETECTION_ID_MISSING,
+    )
+
+
+def test_every_defect_in_a_block_is_located(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """A corrupt talk usually holds several; a caller repairs by location."""
+    detection_missing_dimensions = _detection(observable_entry)
+    del detection_missing_dimensions["dimensions"]
+    talk = _talk(
+        observable_entry,
+        _detection(observable_entry),
+        detection_missing_dimensions,
+        _detection(observable_entry, pattern_id="cultural_map_disclaimer"),
+    )
+    collection = _collection_name(observable_entry)
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert [finding.location for finding in assessment.findings] == [
+        f"{collection}[1]",
+        f"{collection}[2]",
+    ]
+    assert assessment.detection_count == 3
+
+
+def test_the_report_is_json_ready(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """Consumers write this into reports, so it has to serialize as-is."""
+    import json
+
+    talk = _talk(
+        observable_entry,
+        _detection(
+            observable_entry,
+            evidence=list(observable_entry.vault_dimensions),
+            dimensions="prose",
+        ),
+    )
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    payload = json.loads(json.dumps(assessment.as_dict()))
+    assert payload["usable"] is False
+    assert payload["schema_version"] == (
+        persisted_pattern_observations.ASSESSMENT_SCHEMA_VERSION
+    )
+    assert payload["repairs"][0]["dimensions"] == list(
+        observable_entry.vault_dimensions
+    )

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -14,6 +14,8 @@ what they assert.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 
@@ -59,7 +61,7 @@ def _collection_name(entry) -> str:
     )
 
 
-def _talk(entry, *detections):
+def _talk(entry, *detections) -> dict[str, Any]:
     return {"pattern_observations": {_collection_name(entry): list(detections)}}
 
 
@@ -194,8 +196,8 @@ def test_applying_the_repair_restores_both_values(
     assert collection[0]["dimensions"] == list(observable_entry.vault_dimensions)
     # The input is untouched: a repair returns a new talk rather than mutating
     # the generation it was assessed against.
-    original = talk["pattern_observations"][_collection_name(observable_entry)][0]
-    assert original["dimensions"] == prose
+    stored: Any = talk["pattern_observations"][_collection_name(observable_entry)]
+    assert stored[0]["dimensions"] == prose
     after = persisted_pattern_observations.assess_persisted_pattern_observations(
         repaired, catalog
     )

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -374,6 +374,40 @@ def test_a_repair_against_a_changed_talk_is_refused(
         )
 
 
+def test_a_repair_whose_target_became_another_pattern_is_refused(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """Same swapped fields, different pattern: still a different record.
+
+    The identity is checked against the record rather than supplied to it, so
+    a location that now holds another pattern is refused instead of rewritten.
+    """
+    prose = "The speaker opened with the map, at 00:41."
+    swapped = dict(
+        _detection(
+            observable_entry,
+            evidence=list(observable_entry.vault_dimensions),
+            dimensions=prose,
+        )
+    )
+    talk = _talk(observable_entry, swapped)
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+    other = next(
+        entry
+        for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id)
+        if entry.pattern_id != observable_entry.pattern_id
+        and entry.entry_type == observable_entry.entry_type
+    )
+    moved = _talk(observable_entry, {**swapped, "pattern_id": other.pattern_id})
+
+    with pytest.raises(ValueError, match="reassess the talk"):
+        persisted_pattern_observations.apply_swapped_field_repairs(
+            moved, assessment.repairs
+        )
+
+
 def test_a_half_swap_is_two_defects_not_a_repair(
     persisted_pattern_observations, catalog, observable_entry
 ) -> None:

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -61,8 +61,21 @@ def _collection_name(entry) -> str:
     )
 
 
+def _block(**lanes) -> dict[str, Any]:
+    """A current block carries every lane the canonical writer emits."""
+    block: dict[str, Any] = {
+        "patterns_detected": [],
+        "antipatterns_detected": [],
+        "not_evaluable": [],
+    }
+    block.update(lanes)
+    return block
+
+
 def _talk(entry, *detections) -> dict[str, Any]:
-    return {"pattern_observations": {_collection_name(entry): list(detections)}}
+    return {
+        "pattern_observations": _block(**{_collection_name(entry): list(detections)})
+    }
 
 
 def test_a_clean_block_is_usable(
@@ -130,7 +143,7 @@ def test_a_non_container_is_refused(
 def test_a_non_list_collection_is_refused(
     persisted_pattern_observations, catalog
 ) -> None:
-    talk = {"pattern_observations": {"patterns_detected": {"pattern_id": "x"}}}
+    talk = {"pattern_observations": _block(patterns_detected={"pattern_id": "x"})}
 
     assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
         talk, catalog
@@ -139,6 +152,140 @@ def test_a_non_list_collection_is_refused(
     assert assessment.usable is False
     assert assessment.reason_codes == (
         persisted_pattern_observations.COLLECTION_INVALID,
+    )
+
+
+@pytest.mark.parametrize(
+    "lane", ["patterns_detected", "antipatterns_detected", "not_evaluable"]
+)
+def test_an_absent_lane_is_not_an_empty_lane(
+    persisted_pattern_observations, catalog, lane
+) -> None:
+    """A block missing a lane is one whose writer never finished.
+
+    Reading it as empty reports coverage the record never claimed — `{}` would
+    pass as a clean current block.
+    """
+    block = _block()
+    del block[lane]
+    talk = {"pattern_observations": block}
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.COLLECTION_ABSENT,
+    )
+    assert assessment.findings[0].location == lane
+
+
+def test_an_empty_block_is_refused(persisted_pattern_observations, catalog) -> None:
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        {"pattern_observations": {}}, catalog
+    )
+
+    assert assessment.usable is False
+    assert [finding.location for finding in assessment.findings] == [
+        "patterns_detected",
+        "antipatterns_detected",
+        "not_evaluable",
+    ]
+
+
+def test_a_malformed_outcome_lane_is_refused(
+    persisted_pattern_observations, catalog
+) -> None:
+    talk = {"pattern_observations": _block(not_evaluable={"pattern_id": "x"})}
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.COLLECTION_INVALID,
+    )
+
+
+@pytest.mark.parametrize(
+    ("record", "code"),
+    [
+        ("a string", "DETECTION_NOT_OBJECT"),
+        ({}, "DETECTION_ID_MISSING"),
+        ({"pattern_id": "cultural_map_disclaimer"}, "DETECTION_ID_UNKNOWN"),
+    ],
+)
+def test_outcome_records_are_audited_for_identity(
+    persisted_pattern_observations, catalog, record, code
+) -> None:
+    """Outcome records carry no evidence to check, but they do name a pattern."""
+    talk = {"pattern_observations": _block(not_evaluable=[record])}
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (getattr(persisted_pattern_observations, code),)
+
+
+def test_a_polarity_mismatch_is_refused(
+    persisted_pattern_observations, catalog, observable_entry
+) -> None:
+    """The lane is the claim: a pattern filed as an antipattern inverts it."""
+    wrong_lane = (
+        "patterns_detected"
+        if observable_entry.entry_type == "antipattern"
+        else "antipatterns_detected"
+    )
+    talk = {
+        "pattern_observations": _block(**{wrong_lane: [_detection(observable_entry)]})
+    }
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DETECTION_POLARITY_MISMATCH,
+    )
+    assert assessment.findings[0].pattern_id == observable_entry.pattern_id
+
+
+def test_both_lanes_reject_the_other_polarity(
+    persisted_pattern_observations, catalog
+) -> None:
+    """Neither lane is the lenient one."""
+    pattern = next(
+        entry
+        for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id)
+        if entry.observable and entry.entry_type == "pattern"
+    )
+    antipattern = next(
+        entry
+        for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id)
+        if entry.observable and entry.entry_type == "antipattern"
+    )
+    talk = {
+        "pattern_observations": _block(
+            patterns_detected=[_detection(antipattern)],
+            antipatterns_detected=[_detection(pattern)],
+        )
+    }
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert [finding.location for finding in assessment.findings] == [
+        "patterns_detected[0]",
+        "antipatterns_detected[0]",
+    ]
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.DETECTION_POLARITY_MISMATCH,
     )
 
 
@@ -373,7 +520,7 @@ def test_malformed_detection_fields_are_typed(
 def test_a_non_object_detection_is_refused(
     persisted_pattern_observations, catalog, detection
 ) -> None:
-    talk = {"pattern_observations": {"patterns_detected": [detection]}}
+    talk = {"pattern_observations": _block(patterns_detected=[detection])}
 
     assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
         talk, catalog


### PR DESCRIPTION
Part of #167. First of several PRs — this lands the classifier; wiring it into migration, preflight, the writers, and queue normalization follows.

Return validation guards what a subagent hands in. Nothing guarded what was already persisted, and the live vault shows why that matters: across 209 talks and 5,222 detection objects, `pattern_observations` is a dict on 119 talks, a legacy list on 81, and absent on 9; 28 detections in one talk have `evidence` and `dimensions` swapped; 1,129 carry legacy or missing dimension arrays; 3 name IDs no catalog entry claims; and 641 reference entries since marked `observable: false`. A record-schema migration stamps any of those as current without ever looking inside the nested block.

## What changed

`skills/vault-ingress/scripts/persisted_pattern_observations.py` — the read-only classifier the migration, preflight, rendering, profile, and queue paths will share. Stable reason codes for the container shape, the detection object, and the dimensions array, separated by what an owner can actually do about each:

- **order-only drift** — mechanical, but the catalog owns the order, so it is reported rather than silently sorted
- **membership drift** — a semantic claim about what the pattern measures; routed to the #156 catalog review, never auto-mapped
- **unknown ID** — an owner decision about what the observation meant, never a spelling correction to a near neighbour
- **unobservable entry** — archival, not malformed: reported so a caller can exclude it from the current cohort, without making the talk unusable

One defect is losslessly repairable: the exact inverse field swap, where `evidence` holds a valid dimensions array and `dimensions` holds the evidence text. `SwappedFieldRepair` carries both original values, so applying it is a swap rather than a reconstruction, and `apply_swapped_field_repairs` refuses a target that moved since it was assessed. A half-swap — a malformed list on one side — is two defects, not a repair: guessing at one side would destroy the other.

Pure function of (talk, catalog): no filesystem, no clock, no network.

## Acceptance criteria covered

- [x] Owner-side persisted-pattern-observation validator (consumers wired in follow-ups)
- [x] Container shape, detection shape, catalog ID resolution, confidence, evidence text, dimensions type/content
- [x] Deterministic reason codes distinguishing order-only drift, membership drift, legacy/missing dimensions, unknown IDs, and the swapped-field signature
- [x] Lossless swap repair only on exact inverse schema, preserving both original values
- [x] Unknown IDs and membership drift never auto-mapped
- [x] Unobservable entries stay archival and out of the current cohort
- [x] Regressions for every shape above

Deferred to follow-up PRs: #147 migration integration, preflight blocking, writer fail-closed, queue requeue, and the live 209-talk run.

## Tests

30 tests in `tests/test_persisted_pattern_observations.py`, built from the live catalog rather than hardcoded IDs so a catalog edit fails the test instead of quietly reclassifying it. Full suite: 5408 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)