### PR TITLE
feat(vault-ingress): block a corrupt persisted block before any claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ unscored talk belongs in a cohort is the scoring-generation fields' question,
 not this gate's. Blocking, or even warning on, every talk that predates pattern
 scoring would flood a queue that is working.
 
+Each finding names the field a repair would edit. A root-level finding already
+names the block and a lane finding is relative to it, so prefixing both produced
+`pattern_observations.pattern_observations` — a path pointing at a field that
+does not exist.
+
 ## 0.20.54 — 2026-08-11
 
 ### feat(vault-ingress) — classify what is already stored, not just what arrives (#167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### feat(vault-ingress) — block a corrupt persisted block before anything claims the talk (#167)
+
+Part of #167.
+
+The classifier landed with no caller. Preflight now runs it on every talk whose
+status claims analysis, so the swapped-field signature, an unknown pattern ID, a
+polarity-inverted lane, or a missing one is a blocking finding before a claim
+rather than a surprise in a rendered analysis.
+
+Two cases are deliberately not blocking. A detection of an entry the catalog no
+longer observes warns: the catalog moved, the record did not, and a cohort can
+exclude it without the talk being wrong. And a talk carrying no block at all is
+skipped entirely — absence is incompleteness, not corruption, and whether an
+unscored talk belongs in a cohort is the scoring-generation fields' question,
+not this gate's. Blocking, or even warning on, every talk that predates pattern
+scoring would flood a queue that is working.
+
 ### feat(vault-ingress) — classify what is already stored, not just what arrives (#167)
 
 Part of #167.

--- a/skills/vault-ingress/scripts/persisted_pattern_observations.py
+++ b/skills/vault-ingress/scripts/persisted_pattern_observations.py
@@ -33,6 +33,11 @@ from return_validation import CONFIDENCE_LEVELS, PatternCatalog
 
 ASSESSMENT_SCHEMA_VERSION = 1
 
+# The block's own field name. Root-level findings locate themselves here; every
+# other location is relative to it, so a caller composing a diagnostic path
+# prefixes the relative ones and leaves this one alone.
+OBSERVATIONS_FIELD = "pattern_observations"
+
 # The detection collections a persisted block carries, each bound to the catalog
 # polarity its members must have: a `pattern` entry filed under
 # `antipatterns_detected` inverts what the record claims the speaker did.
@@ -524,7 +529,7 @@ def assess_persisted_pattern_observations(
     has to land before the record is current, and reporting it as usable would
     let the corruption through the gate that found it.
     """
-    observations = talk.get("pattern_observations") if isinstance(talk, dict) else None
+    observations = talk.get(OBSERVATIONS_FIELD) if isinstance(talk, dict) else None
     if observations is None:
         return PersistedObservationAssessment(
             schema_version=ASSESSMENT_SCHEMA_VERSION,
@@ -532,7 +537,7 @@ def assess_persisted_pattern_observations(
             findings=(
                 ObservationFinding(
                     CONTAINER_ABSENT,
-                    "pattern_observations",
+                    OBSERVATIONS_FIELD,
                     None,
                     "talk carries no persisted pattern observations",
                 ),
@@ -550,7 +555,7 @@ def assess_persisted_pattern_observations(
             findings=(
                 ObservationFinding(
                     CONTAINER_LEGACY_LIST,
-                    "pattern_observations",
+                    OBSERVATIONS_FIELD,
                     None,
                     "pattern_observations is the legacy list shape",
                 ),
@@ -566,7 +571,7 @@ def assess_persisted_pattern_observations(
             findings=(
                 ObservationFinding(
                     CONTAINER_INVALID,
-                    "pattern_observations",
+                    OBSERVATIONS_FIELD,
                     None,
                     "pattern_observations must be an object",
                 ),

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -41,10 +41,17 @@ from ingress_contract import (
     source_capabilities,
 )
 
+from persisted_pattern_observations import (
+    ENTRY_NOT_OBSERVABLE,
+    assess_persisted_pattern_observations,
+)
 from return_validation import (
+    ANALYSIS_STATUSES,
     PATTERN_SCORING_SCHEMA_VERSION,
+    PatternCatalog,
     ReturnValidationError,
     VIDEO_EXTRACTION_SCHEMA_VERSION,
+    load_catalog,
     validate_video_extraction_manifest,
 )
 from pattern_evidence import (
@@ -266,6 +273,7 @@ class VaultPreflight:
         self.video_evidence_assessment = VideoEvidenceAssessment()
         self.reported_source_video_failures: set[int] = set()
         self.reported_config_exclusions_invalid = False
+        self._catalog: PatternCatalog | None = None
 
     def artifact_root(self) -> Path:
         """Map the trusted configured root lazily, without probing CLI input."""
@@ -509,6 +517,7 @@ class VaultPreflight:
             self._validate_source_rejections(index)
             self._validate_artifacts(index)
             self._validate_source_identity(index)
+            self._validate_persisted_observations(index)
         self._validate_relations()
         self._validate_duplicate_youtube_ids()
         return self.report(len(talks))
@@ -1614,6 +1623,64 @@ class VaultPreflight:
                 actual=extraction.get("review_required"),
                 artifact_path=promoted_pdf,
             )
+
+    def _validate_persisted_observations(self, index: int) -> None:
+        """Block on corrupt persisted detections before anything claims the talk.
+
+        The record-schema check above reads the talk's own fields; nothing read
+        the nested pattern block, so a swapped field pair or an unknown pattern
+        ID passed every gate and reached rendered analyses (#167).
+
+        Only a talk whose status claims analysis is held to the current-block
+        contract. A pending talk legitimately carries no observations, and
+        reporting that as corruption would block a queue that is working.
+        """
+        talk = self.talks[index]
+        if talk.get("status") not in ANALYSIS_STATUSES:
+            return
+        if "pattern_observations" not in talk:
+            # Absence is incompleteness, not corruption: the talk was never
+            # scored, and whether an unscored talk belongs in a cohort is the
+            # scoring-generation fields' question, not this gate's. This gate
+            # owns blocks that exist and are wrong.
+            return
+        try:
+            catalog = self._pattern_catalog()
+        except ReturnValidationError as exc:
+            self.add(
+                "blocking",
+                "pattern_catalog_unreadable",
+                "persisted pattern observations cannot be validated without the "
+                f"catalog: {exc}",
+                field="pattern_observations",
+            )
+            return
+        assessment = assess_persisted_pattern_observations(talk, catalog)
+        for finding in assessment.findings:
+            # An entry the catalog no longer observes is archival evidence,
+            # not a defect in the record: it warns so a cohort can exclude it,
+            # and never blocks a talk whose stored analysis is otherwise sound.
+            severity = (
+                "warning" if finding.reason_code == ENTRY_NOT_OBSERVABLE else "blocking"
+            )
+            self.talk_add(
+                index,
+                severity,
+                f"persisted_observations_{finding.reason_code}",
+                finding.detail,
+                field=f"pattern_observations.{finding.location}",
+                expected="a current persisted pattern block",
+                actual={
+                    "reason_code": finding.reason_code,
+                    "pattern_id": finding.pattern_id,
+                },
+            )
+
+    def _pattern_catalog(self) -> PatternCatalog:
+        """Load the catalog once per preflight run."""
+        if self._catalog is None:
+            self._catalog = load_catalog()
+        return self._catalog
 
     def _validate_source_identity(self, index: int) -> None:
         talk = self.talks[index]

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -43,6 +43,7 @@ from ingress_contract import (
 
 from persisted_pattern_observations import (
     ENTRY_NOT_OBSERVABLE,
+    OBSERVATIONS_FIELD,
     assess_persisted_pattern_observations,
 )
 from return_validation import (
@@ -1668,7 +1669,15 @@ class VaultPreflight:
                 severity,
                 f"persisted_observations_{finding.reason_code}",
                 finding.detail,
-                field=f"pattern_observations.{finding.location}",
+                # Root-level findings already name the block; the lane ones are
+                # relative to it. Prefixing both yields
+                # `pattern_observations.pattern_observations`, which points a
+                # repair at a field that does not exist.
+                field=(
+                    OBSERVATIONS_FIELD
+                    if finding.location == OBSERVATIONS_FIELD
+                    else f"{OBSERVATIONS_FIELD}.{finding.location}"
+                ),
                 expected="a current persisted pattern block",
                 actual={
                     "reason_code": finding.reason_code,

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1652,7 +1652,9 @@ class VaultPreflight:
                 "blocking",
                 "pattern_catalog_unreadable",
                 "persisted pattern observations cannot be validated without the "
-                f"catalog: {exc}",
+                f"bundled pattern catalog: {exc}. Restore it — reinstall the "
+                "plugin, or check out the catalog directory the message names — "
+                "then rerun preflight.",
                 field="pattern_observations",
             )
             return

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -275,6 +275,8 @@ class VaultPreflight:
         self.reported_source_video_failures: set[int] = set()
         self.reported_config_exclusions_invalid = False
         self._catalog: PatternCatalog | None = None
+        self._catalog_error: ReturnValidationError | None = None
+        self._reported_catalog_failure = False
 
     def artifact_root(self) -> Path:
         """Map the trusted configured root lazily, without probing CLI input."""
@@ -1649,6 +1651,11 @@ class VaultPreflight:
         try:
             catalog = self._pattern_catalog()
         except ReturnValidationError as exc:
+            if self._reported_catalog_failure:
+                # One condition, one finding: repeating it per talk inflates
+                # the blocking count and buries every other finding.
+                return
+            self._reported_catalog_failure = True
             self.add(
                 "blocking",
                 "pattern_catalog_unreadable",
@@ -1689,9 +1696,20 @@ class VaultPreflight:
             )
 
     def _pattern_catalog(self) -> PatternCatalog:
-        """Load the catalog once per preflight run."""
-        if self._catalog is None:
-            self._catalog = load_catalog()
+        """Load the catalog once per preflight run, failure included.
+
+        The failure is cached alongside the success: an unreadable catalog is
+        one condition of the run, not one per talk, and retrying the load for
+        every analyzed talk would re-read a directory that is still missing.
+        """
+        if self._catalog is None and self._catalog_error is None:
+            try:
+                self._catalog = load_catalog()
+            except ReturnValidationError as exc:
+                self._catalog_error = exc
+        if self._catalog_error is not None:
+            raise self._catalog_error
+        assert self._catalog is not None  # set together with _catalog_error
         return self._catalog
 
     def _validate_source_identity(self, index: int) -> None:

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1639,7 +1639,8 @@ class VaultPreflight:
         talk = self.talks[index]
         if talk.get("status") not in ANALYSIS_STATUSES:
             return
-        if "pattern_observations" not in talk:
+        if talk.get(OBSERVATIONS_FIELD) is None:
+            # Absent, or explicitly null as legacy records preserve it.
             # Absence is incompleteness, not corruption: the talk was never
             # scored, and whether an unscored talk belongs in a cohort is the
             # scoring-generation fields' question, not this gate's. This gate

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -2921,6 +2921,158 @@ def test_unverified_video_crop_cannot_support_completed_deck_analysis(
     assert "video_extraction_untrusted" in finding_codes(report, "blocking")
 
 
+def _observation_block(**lanes):
+    """A current persisted block, as the canonical writer emits it."""
+    block = {
+        "patterns_detected": [],
+        "antipatterns_detected": [],
+        "not_evaluable": [],
+    }
+    block.update(lanes)
+    return block
+
+
+def _catalog_entry(preflight_vault, entry_type="pattern"):
+    catalog = preflight_vault.load_catalog()
+    return next(
+        entry
+        for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id)
+        if entry.observable and entry.entry_type == entry_type
+    )
+
+
+def test_a_corrupt_persisted_block_blocks_before_any_claim(
+    preflight_vault,
+    vault_fixture,
+):
+    """The swapped-field signature from the live vault (#167).
+
+    The record-schema check reads the talk's own fields; nothing read the
+    nested block, so this reached rendered analyses.
+    """
+    entry = _catalog_entry(preflight_vault)
+    materialize_transcript(vault_fixture)
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                pattern_observations=_observation_block(
+                    patterns_detected=[
+                        {
+                            "pattern_id": entry.pattern_id,
+                            "confidence": "strong",
+                            "evidence": list(entry.vault_dimensions),
+                            "dimensions": "The speaker opened with the map.",
+                        }
+                    ]
+                )
+            )
+        ],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    findings = [
+        item
+        for item in report["findings"]
+        if item["code"].startswith("persisted_observations_")
+    ]
+    assert [item["code"] for item in findings] == [
+        "persisted_observations_detection_fields_swapped"
+    ]
+    assert findings[0]["severity"] == "blocking"
+    assert report["ok"] is False
+
+
+def test_an_unobservable_entry_warns_without_blocking(
+    preflight_vault,
+    vault_fixture,
+):
+    """The catalog moved; the record did not. 641 live detections are these."""
+    catalog = preflight_vault.load_catalog()
+    archival = next(
+        entry
+        for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id)
+        if not entry.observable
+    )
+    lane = (
+        "antipatterns_detected"
+        if archival.entry_type == "antipattern"
+        else "patterns_detected"
+    )
+    materialize_transcript(vault_fixture)
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                pattern_observations=_observation_block(
+                    **{
+                        lane: [
+                            {
+                                "pattern_id": archival.pattern_id,
+                                "confidence": "strong",
+                                "evidence": "The speaker did the thing, at 12:03.",
+                                "dimensions": list(archival.vault_dimensions),
+                            }
+                        ]
+                    }
+                )
+            )
+        ],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    findings = [
+        item
+        for item in report["findings"]
+        if item["code"].startswith("persisted_observations_")
+    ]
+    assert [item["severity"] for item in findings] == ["warning"]
+    assert report["blocking_count"] == 0
+
+
+def test_an_unscored_talk_is_not_reported_as_corrupt(
+    preflight_vault,
+    vault_fixture,
+):
+    """Absence is incompleteness, not corruption.
+
+    Blocking — or even warning on — every talk that predates pattern scoring
+    would flood a queue that is working.
+    """
+    materialize_transcript(vault_fixture)
+    write_database(vault_fixture, [base_talk()])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert [
+        item
+        for item in report["findings"]
+        if item["code"].startswith("persisted_observations_")
+    ] == []
+
+
+def test_a_pending_talk_is_never_held_to_the_current_block_contract(
+    preflight_vault,
+    vault_fixture,
+):
+    """A talk not claiming analysis carries whatever the queue left it."""
+    materialize_transcript(vault_fixture)
+    write_database(
+        vault_fixture,
+        [base_talk(status="pending", pattern_observations={"patterns_detected": "x"})],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert [
+        item
+        for item in report["findings"]
+        if item["code"].startswith("persisted_observations_")
+    ] == []
+
+
 def test_absent_legacy_identity_metadata_is_not_a_finding(
     preflight_vault,
     vault_fixture,

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3104,17 +3104,21 @@ def test_an_unobservable_entry_warns_without_blocking(
     assert report["blocking_count"] == 0
 
 
+@pytest.mark.parametrize("talk_updates", [{}, {"pattern_observations": None}])
 def test_an_unscored_talk_is_not_reported_as_corrupt(
     preflight_vault,
     vault_fixture,
+    talk_updates,
 ):
     """Absence is incompleteness, not corruption.
 
-    Blocking — or even warning on — every talk that predates pattern scoring
-    would flood a queue that is working.
+    A legacy record preserves the field as an explicit null rather than
+    dropping it, and that is the same "never scored" state. Blocking — or even
+    warning on — every talk that predates pattern scoring would flood a queue
+    that is working.
     """
     materialize_transcript(vault_fixture)
-    write_database(vault_fixture, [base_talk()])
+    write_database(vault_fixture, [base_talk(**talk_updates)])
 
     report = preflight_vault.run_preflight(vault_fixture["root"])
 

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3019,6 +3019,43 @@ def test_the_finding_names_the_field_a_repair_would_edit(
     assert fields == [expected_field]
 
 
+def test_an_unreadable_catalog_says_how_to_recover(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch,
+):
+    """`error-handling` Actionable Messages: name the fix, not just the fault."""
+    materialize_transcript(vault_fixture)
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                pattern_observations={
+                    "patterns_detected": [],
+                    "antipatterns_detected": [],
+                    "not_evaluable": [],
+                }
+            )
+        ],
+    )
+
+    def unreadable():
+        raise preflight_vault.ReturnValidationError("no pattern entries found")
+
+    monkeypatch.setattr(preflight_vault, "load_catalog", unreadable)
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    findings = [
+        item
+        for item in report["findings"]
+        if item["code"] == "pattern_catalog_unreadable"
+    ]
+    assert len(findings) == 1
+    assert "rerun preflight" in findings[0]["message"]
+    assert "Restore it" in findings[0]["message"]
+
+
 def test_an_unobservable_entry_warns_without_blocking(
     preflight_vault,
     vault_fixture,

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3039,7 +3039,10 @@ def test_an_unreadable_catalog_says_how_to_recover(
         ],
     )
 
+    attempts = []
+
     def unreadable():
+        attempts.append(1)
         raise preflight_vault.ReturnValidationError("no pattern entries found")
 
     monkeypatch.setattr(preflight_vault, "load_catalog", unreadable)
@@ -3054,6 +3057,52 @@ def test_an_unreadable_catalog_says_how_to_recover(
     assert len(findings) == 1
     assert "rerun preflight" in findings[0]["message"]
     assert "Restore it" in findings[0]["message"]
+    assert attempts == [1]
+
+
+def test_an_unreadable_catalog_is_one_finding_for_the_whole_run(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch,
+):
+    """One condition, one finding.
+
+    Repeating it per analyzed talk inflates the blocking count and buries
+    every other finding in the report.
+    """
+    block = {
+        "patterns_detected": [],
+        "antipatterns_detected": [],
+        "not_evaluable": [],
+    }
+    materialize_transcript(vault_fixture)
+    write_database(
+        vault_fixture,
+        [
+            base_talk(pattern_observations=block),
+            base_talk(
+                filename="2026-07-31-second-talk.md",
+                video_url="https://www.youtube.com/watch?v=SECONDVIDEO",
+                youtube_id="SECONDVIDEO",
+                pattern_observations=block,
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        preflight_vault,
+        "load_catalog",
+        lambda: (_ for _ in ()).throw(
+            preflight_vault.ReturnValidationError("no pattern entries found")
+        ),
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert [
+        item["code"]
+        for item in report["findings"]
+        if item["code"] == "pattern_catalog_unreadable"
+    ] == ["pattern_catalog_unreadable"]
 
 
 def test_an_unobservable_entry_warns_without_blocking(

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -2984,6 +2984,41 @@ def test_a_corrupt_persisted_block_blocks_before_any_claim(
     assert report["ok"] is False
 
 
+@pytest.mark.parametrize(
+    ("observations", "expected_field"),
+    [
+        ([{"pattern_id": "x"}], "pattern_observations"),
+        ("not a block", "pattern_observations"),
+        (
+            {"patterns_detected": [], "antipatterns_detected": []},
+            "pattern_observations.not_evaluable",
+        ),
+    ],
+)
+def test_the_finding_names_the_field_a_repair_would_edit(
+    preflight_vault,
+    vault_fixture,
+    observations,
+    expected_field,
+):
+    """A root finding already names the block; a lane finding is relative to it.
+
+    Prefixing both yields `pattern_observations.pattern_observations`, which
+    points a repair at a field that does not exist.
+    """
+    materialize_transcript(vault_fixture)
+    write_database(vault_fixture, [base_talk(pattern_observations=observations)])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    fields = [
+        item["field"]
+        for item in report["findings"]
+        if item["code"].startswith("persisted_observations_")
+    ]
+    assert fields == [expected_field]
+
+
 def test_an_unobservable_entry_warns_without_blocking(
     preflight_vault,
     vault_fixture,


### PR DESCRIPTION
Part of #167. Follows #285, which landed the classifier with no caller.

Preflight now runs `assess_persisted_pattern_observations` on every talk whose status claims analysis, so the swapped-field signature, an unknown pattern ID, a polarity-inverted lane, or a missing one is a blocking finding **before** a claim — rather than a surprise in a rendered analysis. Each finding keeps its typed reason code: `persisted_observations_<reason_code>`.

## Two cases deliberately do not block

- **An entry the catalog no longer observes** warns. The catalog moved; the record did not. A cohort can exclude it without the talk being wrong. 641 live detections are these.
- **A talk carrying no block at all** is skipped entirely. Absence is incompleteness, not corruption, and whether an unscored talk belongs in a cohort is the scoring-generation fields' question, not this gate's. Blocking — or even warning on — every talk that predates pattern scoring would flood a queue that is working.

## Acceptance criteria advanced

- [x] Preflight reports these defects as blocking before claim

Still open in #167: the #147 migration path, analysis/profile/Section 15 writers failing closed, queue-normalization requeue, and the live 209-talk run.

## Tests

4 new preflight tests: the swapped signature blocks, an unobservable entry warns without blocking, an unscored talk is not reported as corrupt, and a pending talk is never held to the current-block contract. Full suite: 5423 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)