### PR TITLE
feat(vault-ingress): prove a deck's talk before it becomes evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+### feat(vault-ingress) — prove which talk a deck belongs to before it becomes evidence (#176)
+
+Part of #176.
+
+`pptx_catalog` would bind a talk to any syntactically valid deck. Everything
+that guards deck evidence runs after that binding, so a deck attached to the
+wrong talk fed it slide counts, design evidence, OCR, and pattern observations
+with nothing downstream able to notice. The read-only audit found 25 stored
+catalog/talk path disagreements across 15 talks and nine unrelated decks
+assigned to a single talk.
+
+`pptx_talk_identity.py` assesses the binding instead of assuming it, from facts
+both sides already carry: the catalog's title, conference, and delivery date
+against the deck's path, document properties, and rendered title, footer, and
+hashtag text. Title and event comparison delegate to `source_identity_matching`
+— the same authority the video source-identity audit uses — so a deck cannot be
+matched by a weaker rule than a recording.
+
+Two signals report but never elect. Filename similarity is excluded because
+reused talk families produce near-identical filenames, which is what mis-assigned
+these decks in the first place. Delivery year is excluded because every talk
+delivered that year satisfies it equally — it narrows a candidate set without
+identifying anything in it. A year MISmatch still contradicts: vetoing and
+electing are separate powers, and a wrong year proves the wrong delivery while a
+right year proves nothing.
+
+A directory counts as a venue claim only when it names an event some talk in the
+vault actually uses. Without that vocabulary gate every generic folder —
+`Decks/`, `Downloads/` — parses as an unrecognized venue and contradicts every
+candidate, turning the discriminator into a blanket refusal.
+
+Ambiguity is a review finding, never a silent choice. Two corroborated
+candidates, a contradicted one, and a filename-only hit all route to
+`review_required`, and a master, backup, or static export never carries a bare
+`matched` verdict into persistence.
+
+This is the assessment only; wiring it into the apply path and preflight
+follows. Sequenced before the reparse — repairing observations derived from a
+mis-assigned deck is careful work on the wrong deck.
+
 ## 0.20.55 — 2026-08-11
 
 ### feat(vault-ingress) — block a corrupt persisted block before anything claims the talk (#167)

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -1,0 +1,621 @@
+"""Deterministic talk-identity assessment for candidate PPTX decks.
+
+A deck becomes evidence for whichever talk the catalog says it belongs to. That
+binding is made once, before persistence, and every later safeguard runs after
+it — so a deck bound to the wrong talk supplies slide counts, design evidence,
+OCR, and pattern observations to that wrong talk with nothing downstream able to
+notice.
+
+This module proves the binding instead of assuming it. It reads deterministic
+identity facts already present on both sides — the catalog's title, conference,
+and delivery date; the deck's path, document properties, and rendered title,
+footer, and hashtag text — and reports which talk the deck belongs to, or
+refuses to choose.
+
+Two rules shape the taxonomy:
+
+* Filename similarity alone never selects a talk. Reused talk families and
+  nearby years produce near-identical filenames, which is precisely the signal
+  that mis-assigned the live vault's decks in the first place.
+* An unproven binding is a review finding, never a silent match. Refusing to
+  choose costs one owner decision; choosing wrongly corrupts every derived
+  analysis for that talk until someone notices.
+
+Title and event comparison delegate to `source_identity_matching`, the same
+authority the video source-identity audit uses. A deck must not be matched by a
+weaker parallel rule than a recording.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from source_identity_matching import (
+    AMBIGUOUS_EVENT_ALIASES,
+    EventAlias,
+    YEAR_RE,
+    event_alias,
+    event_aliases_compatible,
+    known_event_aliases,
+    normalized_words,
+    titles_agree,
+)
+
+
+PPTX_TALK_IDENTITY_SCHEMA_VERSION = 1
+
+# Signal verdicts. `unknown` is the honest default: a fact the deck does not
+# carry is not evidence for or against any candidate.
+SIGNAL_AGREE = "agree"
+SIGNAL_CONFLICT = "conflict"
+SIGNAL_UNKNOWN = "unknown"
+SIGNAL_VERDICTS = frozenset({SIGNAL_AGREE, SIGNAL_CONFLICT, SIGNAL_UNKNOWN})
+
+# Signal names, in report order.
+SIGNAL_TITLE = "title"
+SIGNAL_VENUE = "venue"
+SIGNAL_DELIVERY_YEAR = "delivery_year"
+SIGNAL_HASHTAG = "hashtag"
+SIGNAL_PUBLISHED_PDF = "published_pdf"
+SIGNAL_FILENAME_SIMILARITY = "filename_similarity"
+
+SIGNAL_NAMES = (
+    SIGNAL_TITLE,
+    SIGNAL_VENUE,
+    SIGNAL_DELIVERY_YEAR,
+    SIGNAL_HASHTAG,
+    SIGNAL_PUBLISHED_PDF,
+    SIGNAL_FILENAME_SIMILARITY,
+)
+
+# A selecting signal must be one a same-family deck from another delivery could
+# not also satisfy. Two signals are deliberately excluded:
+#
+# * filename similarity — reused talk families produce near-identical filenames,
+#   which is what mis-assigned the live vault's decks in the first place;
+# * delivery year — every talk delivered that year satisfies it equally, so it
+#   narrows a candidate set without identifying anything in it.
+#
+# Both still report, and a year MISmatch still contradicts. Vetoing and electing
+# are separate powers: a wrong year is proof of the wrong delivery, while a
+# right year is proof of nothing.
+SELECTING_SIGNALS = frozenset(
+    {
+        SIGNAL_TITLE,
+        SIGNAL_VENUE,
+        SIGNAL_HASHTAG,
+        SIGNAL_PUBLISHED_PDF,
+    }
+)
+
+VERDICT_MATCHED = "matched"
+VERDICT_REVIEW_REQUIRED = "review_required"
+VERDICT_UNMATCHED = "unmatched"
+VERDICTS = frozenset({VERDICT_MATCHED, VERDICT_REVIEW_REQUIRED, VERDICT_UNMATCHED})
+
+REASON_NO_CANDIDATE_TALKS = "identity_no_candidate_talks"
+REASON_NO_AGREEING_SIGNAL = "identity_no_agreeing_signal"
+REASON_FILENAME_SIMILARITY_ONLY = "identity_filename_similarity_only"
+REASON_AMBIGUOUS_CANDIDATES = "identity_ambiguous_candidates"
+REASON_CONFLICTING_SIGNALS = "identity_conflicting_signals"
+REASON_MATCHED = "identity_matched"
+REASON_NON_DELIVERY_ARTIFACT = "identity_non_delivery_artifact"
+
+REASON_CODES = frozenset(
+    {
+        REASON_NO_CANDIDATE_TALKS,
+        REASON_NO_AGREEING_SIGNAL,
+        REASON_FILENAME_SIMILARITY_ONLY,
+        REASON_AMBIGUOUS_CANDIDATES,
+        REASON_CONFLICTING_SIGNALS,
+        REASON_MATCHED,
+        REASON_NON_DELIVERY_ARTIFACT,
+    }
+)
+
+# An editable master and a published static export are legitimate artifacts for
+# a delivery, but they are not the delivery deck and must not silently become
+# its evidence. Roles are reported so the owner records which artifact is the
+# published source and which is a later or editable variant.
+ROLE_DELIVERY = "delivery"
+ROLE_MASTER = "master"
+ROLE_STATIC_EXPORT = "static_export"
+ROLE_BACKUP = "backup"
+ARTIFACT_ROLES = frozenset(
+    {ROLE_DELIVERY, ROLE_MASTER, ROLE_STATIC_EXPORT, ROLE_BACKUP}
+)
+
+# Matched against whole path tokens, never substrings: `masterclass` is a talk
+# topic, `master` is an artifact role.
+_ROLE_TOKENS: tuple[tuple[str, frozenset[str]], ...] = (
+    (ROLE_BACKUP, frozenset({"backup", "backups", "bak", "archive", "archived", "old"})),
+    (ROLE_MASTER, frozenset({"master", "masters", "template", "templates", "source"})),
+    (ROLE_STATIC_EXPORT, frozenset({"static", "export", "exports", "exported"})),
+)
+
+_TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
+_HASHTAG_RE = re.compile(r"#(\w+)", re.UNICODE)
+_TALK_FILENAME_DATE_RE = re.compile(r"\A(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})-")
+
+# A deck whose filename shares this many significant words with a talk's slug is
+# similar enough to report — and never, on its own, similar enough to select.
+_FILENAME_OVERLAP_MINIMUM = 2
+
+
+class PptxTalkIdentityError(ValueError):
+    """A talk-identity assessment input violates the module's contract."""
+
+
+@dataclass(frozen=True)
+class DeckIdentityFacts:
+    """Deterministic identity facts observed on one candidate deck.
+
+    Every field beyond `pptx_path` is optional because a damaged or minimal
+    deck still deserves an assessment from whatever it does carry. Absence
+    weakens the evidence; it never invents agreement.
+    """
+
+    pptx_path: str
+    document_title: str | None = None
+    document_created_year: str | None = None
+    rendered_title: str | None = None
+    rendered_footers: tuple[str, ...] = ()
+    hashtags: tuple[str, ...] = ()
+    published_pdf_talk_filename: str | None = None
+
+    @property
+    def path_tokens(self) -> tuple[str, ...]:
+        return tuple(_TOKEN_RE.findall(self.pptx_path.casefold()))
+
+    @property
+    def basename(self) -> str:
+        return posixpath.basename(self.pptx_path.replace("\\", "/"))
+
+
+@dataclass(frozen=True)
+class CandidateAssessment:
+    """One talk's per-signal standing against the deck under assessment."""
+
+    talk_filename: str
+    signals: Mapping[str, str]
+    agreeing: tuple[str, ...]
+    conflicting: tuple[str, ...]
+
+    @property
+    def selectable(self) -> bool:
+        """A candidate is selectable on corroboration with no contradiction."""
+        return bool(self.agreeing) and not self.conflicting
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "talk_filename": self.talk_filename,
+            "signals": {name: self.signals[name] for name in SIGNAL_NAMES},
+            "agreeing": list(self.agreeing),
+            "conflicting": list(self.conflicting),
+        }
+
+
+@dataclass(frozen=True)
+class TalkIdentityAssessment:
+    """The full, schema-versioned identity verdict for one deck."""
+
+    pptx_path: str
+    verdict: str
+    artifact_role: str
+    selected_talk_filename: str | None
+    reason_codes: tuple[str, ...]
+    candidates: tuple[CandidateAssessment, ...] = field(default=())
+
+    @property
+    def matched(self) -> bool:
+        return self.verdict == VERDICT_MATCHED
+
+    @property
+    def review_required(self) -> bool:
+        return self.verdict == VERDICT_REVIEW_REQUIRED
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "schema_version": PPTX_TALK_IDENTITY_SCHEMA_VERSION,
+            "pptx_path": self.pptx_path,
+            "verdict": self.verdict,
+            "artifact_role": self.artifact_role,
+            "selected_talk_filename": self.selected_talk_filename,
+            "reason_codes": list(self.reason_codes),
+            "candidates": [candidate.as_json() for candidate in self.candidates],
+        }
+
+
+def _require_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise PptxTalkIdentityError(f"{label} must be a non-empty string")
+    return value
+
+
+def _optional_text(value: object, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PptxTalkIdentityError(f"{label} must be a string or null")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _text_tuple(value: object, label: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise PptxTalkIdentityError(f"{label} must be an array of strings")
+    items: list[str] = []
+    for index, item in enumerate(value):
+        text = _optional_text(item, f"{label}[{index}]")
+        if text is not None:
+            items.append(text)
+    return tuple(items)
+
+
+def deck_identity_facts(value: object) -> DeckIdentityFacts:
+    """Validate a caller-supplied deck fact mapping into the closed shape.
+
+    Typed `object` deliberately: this is the boundary where unvalidated caller
+    input becomes a closed shape, so the isinstance guard is the contract, not
+    a redundant assertion behind a narrower annotation.
+    """
+    if not isinstance(value, Mapping):
+        raise PptxTalkIdentityError("deck facts must be a mapping")
+    unknown = set(value) - {
+        "pptx_path",
+        "document_title",
+        "document_created_year",
+        "rendered_title",
+        "rendered_footers",
+        "hashtags",
+        "published_pdf_talk_filename",
+    }
+    if unknown:
+        raise PptxTalkIdentityError(
+            f"deck facts carry unknown keys: {sorted(unknown)}"
+        )
+    created_year = _optional_text(
+        value.get("document_created_year"), "deck facts document_created_year"
+    )
+    if created_year is not None and not re.fullmatch(r"(?:19|20)\d{2}", created_year):
+        raise PptxTalkIdentityError(
+            "deck facts document_created_year must be a four-digit year"
+        )
+    return DeckIdentityFacts(
+        pptx_path=_require_text(value.get("pptx_path"), "deck facts pptx_path"),
+        document_title=_optional_text(
+            value.get("document_title"), "deck facts document_title"
+        ),
+        document_created_year=created_year,
+        rendered_title=_optional_text(
+            value.get("rendered_title"), "deck facts rendered_title"
+        ),
+        rendered_footers=_text_tuple(
+            value.get("rendered_footers"), "deck facts rendered_footers"
+        ),
+        hashtags=_text_tuple(value.get("hashtags"), "deck facts hashtags"),
+        published_pdf_talk_filename=_optional_text(
+            value.get("published_pdf_talk_filename"),
+            "deck facts published_pdf_talk_filename",
+        ),
+    )
+
+
+def classify_artifact_role(facts: DeckIdentityFacts) -> str:
+    """Report whether the deck is a delivery artifact or a variant of one."""
+    tokens = set(facts.path_tokens)
+    for role, markers in _ROLE_TOKENS:
+        if tokens & markers:
+            return role
+    return ROLE_DELIVERY
+
+
+def _talk_year(talk: Mapping[str, Any]) -> str | None:
+    """Resolve a talk's delivery year from its date, else its filename prefix.
+
+    Both are recorded values. Neither consults the clock, so an assessment made
+    today and the same assessment made next year agree.
+    """
+    date_value = talk.get("date")
+    if isinstance(date_value, str):
+        match = YEAR_RE.search(date_value)
+        if match is not None:
+            return match.group(0)
+    filename = talk.get("filename")
+    if isinstance(filename, str):
+        match = _TALK_FILENAME_DATE_RE.match(filename)
+        if match is not None:
+            return match.group("year")
+    return None
+
+
+def _deck_path_years(facts: DeckIdentityFacts) -> tuple[str, ...]:
+    return tuple(
+        token
+        for token in facts.path_tokens
+        if re.fullmatch(r"(?:19|20)\d{2}", token) is not None
+    )
+
+
+def _deck_venue_aliases(
+    facts: DeckIdentityFacts, known_aliases: frozenset[EventAlias]
+) -> list[EventAlias]:
+    """Read venue aliases from the deck's directory components.
+
+    Only directories are consulted. A deck's own filename is the talk's name far
+    more often than the venue's, and reading a venue out of it would manufacture
+    agreement from the one signal this module refuses to trust alone.
+
+    A component counts as a venue claim only when it names an event some talk in
+    the vault actually uses. Without that gate every generic folder — `Decks/`,
+    `Downloads/` — would parse as an unrecognized venue and contradict every
+    candidate, turning the discriminator into a blanket refusal.
+    """
+    normalized = facts.pptx_path.replace("\\", "/")
+    components = [part for part in posixpath.dirname(normalized).split("/") if part]
+    aliases: list[EventAlias] = []
+    for component in components:
+        alias = event_alias(component)
+        if alias is None:
+            continue
+        if len(alias) == 1 and alias[0] in AMBIGUOUS_EVENT_ALIASES:
+            # `devops/` names a topic folder at least as often as an event.
+            continue
+        if not any(
+            event_aliases_compatible(alias, known) for known in known_aliases
+        ):
+            continue
+        aliases.append(alias)
+    return aliases
+
+
+def _title_signal(
+    facts: DeckIdentityFacts,
+    talk: Mapping[str, Any],
+    _known_aliases: frozenset[EventAlias],
+) -> str:
+    talk_title = talk.get("title")
+    if not isinstance(talk_title, str) or not talk_title.strip():
+        return SIGNAL_UNKNOWN
+    observed = [
+        text
+        for text in (facts.document_title, facts.rendered_title, *facts.rendered_footers)
+        if text
+    ]
+    if not observed:
+        return SIGNAL_UNKNOWN
+    if any(titles_agree(talk_title, text) for text in observed):
+        return SIGNAL_AGREE
+    # A deck legitimately carries a punchier title than its catalog entry, so a
+    # non-agreeing title is missing corroboration rather than contradiction.
+    return SIGNAL_UNKNOWN
+
+
+def _venue_signal(
+    facts: DeckIdentityFacts,
+    talk: Mapping[str, Any],
+    known_aliases: frozenset[EventAlias],
+) -> str:
+    talk_alias = event_alias(talk.get("conference"))
+    if talk_alias is None:
+        return SIGNAL_UNKNOWN
+    deck_aliases = _deck_venue_aliases(facts, known_aliases)
+    if not deck_aliases:
+        return SIGNAL_UNKNOWN
+    if any(event_aliases_compatible(talk_alias, alias) for alias in deck_aliases):
+        return SIGNAL_AGREE
+    # The deck sits under a named event that is not this talk's event. That is
+    # the discriminator between two deliveries of one reused talk.
+    return SIGNAL_CONFLICT
+
+
+def _delivery_year_signal(
+    facts: DeckIdentityFacts,
+    talk: Mapping[str, Any],
+    _known_aliases: frozenset[EventAlias],
+) -> str:
+    talk_year = _talk_year(talk)
+    if talk_year is None:
+        return SIGNAL_UNKNOWN
+    path_years = _deck_path_years(facts)
+    if path_years:
+        if talk_year in path_years:
+            return SIGNAL_AGREE
+        return SIGNAL_CONFLICT
+    if facts.document_created_year is not None:
+        if facts.document_created_year == talk_year:
+            return SIGNAL_AGREE
+        # A master edited or re-saved years later is normal, so a document
+        # timestamp corroborates but never contradicts.
+        return SIGNAL_UNKNOWN
+    return SIGNAL_UNKNOWN
+
+
+def _hashtag_signal(
+    facts: DeckIdentityFacts,
+    talk: Mapping[str, Any],
+    known_aliases: frozenset[EventAlias],
+) -> str:
+    talk_alias = event_alias(talk.get("conference"))
+    if talk_alias is None or not facts.hashtags:
+        return SIGNAL_UNKNOWN
+    # `#VoxxedTicino` carries no word boundary, so a compact comparison against
+    # the joined alias recovers what alias-wise compatibility cannot see.
+    compact_talk = "".join(talk_alias)
+    for raw in facts.hashtags:
+        for token in _HASHTAG_RE.findall(raw) or [raw.lstrip("#")]:
+            alias = event_alias(token)
+            if alias is None:
+                continue
+            if event_aliases_compatible(talk_alias, alias):
+                return SIGNAL_AGREE
+            if "".join(alias) == compact_talk:
+                return SIGNAL_AGREE
+    # Conference hashtags are inconsistently present and frequently abbreviated
+    # beyond alias recovery, so absence of agreement proves nothing.
+    return SIGNAL_UNKNOWN
+
+
+def _published_pdf_signal(
+    facts: DeckIdentityFacts,
+    talk: Mapping[str, Any],
+    _known_aliases: frozenset[EventAlias],
+) -> str:
+    if facts.published_pdf_talk_filename is None:
+        return SIGNAL_UNKNOWN
+    filename = talk.get("filename")
+    if not isinstance(filename, str) or not filename:
+        return SIGNAL_UNKNOWN
+    if facts.published_pdf_talk_filename == filename:
+        return SIGNAL_AGREE
+    return SIGNAL_CONFLICT
+
+
+def _filename_similarity_signal(
+    facts: DeckIdentityFacts,
+    talk: Mapping[str, Any],
+    _known_aliases: frozenset[EventAlias],
+) -> str:
+    filename = talk.get("filename")
+    if not isinstance(filename, str) or not filename:
+        return SIGNAL_UNKNOWN
+    slug = _TALK_FILENAME_DATE_RE.sub("", filename)
+    slug = re.sub(r"\.md\Z", "", slug)
+    talk_words = normalized_words(slug.replace("-", " "))
+    deck_words = normalized_words(posixpath.splitext(facts.basename)[0])
+    if not talk_words or not deck_words:
+        return SIGNAL_UNKNOWN
+    if len(talk_words & deck_words) >= _FILENAME_OVERLAP_MINIMUM:
+        return SIGNAL_AGREE
+    return SIGNAL_UNKNOWN
+
+
+_SIGNAL_EVALUATORS = {
+    SIGNAL_TITLE: _title_signal,
+    SIGNAL_VENUE: _venue_signal,
+    SIGNAL_DELIVERY_YEAR: _delivery_year_signal,
+    SIGNAL_HASHTAG: _hashtag_signal,
+    SIGNAL_PUBLISHED_PDF: _published_pdf_signal,
+    SIGNAL_FILENAME_SIMILARITY: _filename_similarity_signal,
+}
+
+
+def assess_candidate(
+    facts: DeckIdentityFacts,
+    talk: Mapping[str, Any],
+    known_aliases: frozenset[EventAlias] = frozenset(),
+) -> CandidateAssessment:
+    """Evaluate every signal for one candidate talk.
+
+    `known_aliases` is the vault's vocabulary of real event names. It defaults
+    to empty so a single-candidate caller still gets an assessment; the effect
+    of an empty vocabulary is that no directory reads as a venue, which loses
+    the signal rather than inventing one.
+    """
+    filename = talk.get("filename")
+    if not isinstance(filename, str) or not filename:
+        raise PptxTalkIdentityError("candidate talk requires a filename")
+    signals = {
+        name: evaluator(facts, talk, known_aliases)
+        for name, evaluator in _SIGNAL_EVALUATORS.items()
+    }
+    agreeing = tuple(
+        name
+        for name in SIGNAL_NAMES
+        if name in SELECTING_SIGNALS and signals[name] == SIGNAL_AGREE
+    )
+    conflicting = tuple(
+        name for name in SIGNAL_NAMES if signals[name] == SIGNAL_CONFLICT
+    )
+    return CandidateAssessment(
+        talk_filename=filename,
+        signals=signals,
+        agreeing=agreeing,
+        conflicting=conflicting,
+    )
+
+
+def assess_pptx_talk_identity(
+    deck: Mapping[str, Any] | DeckIdentityFacts,
+    candidates: Iterable[Mapping[str, Any]],
+) -> TalkIdentityAssessment:
+    """Decide which talk a deck belongs to, or refuse to decide.
+
+    The verdict is `matched` only when exactly one candidate is corroborated by
+    a signal filename similarity cannot fake and contradicted by none. Every
+    other outcome is `review_required` or `unmatched`; neither authorizes
+    catalog persistence or extraction.
+    """
+    facts = deck if isinstance(deck, DeckIdentityFacts) else deck_identity_facts(deck)
+    artifact_role = classify_artifact_role(facts)
+    talks = list(candidates)
+    # The candidate set is the vault's event vocabulary. A directory naming an
+    # event no talk uses is a folder, not a contradicting venue.
+    known_aliases = frozenset(known_event_aliases(talks))
+    assessments = tuple(
+        assess_candidate(facts, talk, known_aliases) for talk in talks
+    )
+
+    seen: set[str] = set()
+    for assessment in assessments:
+        if assessment.talk_filename in seen:
+            raise PptxTalkIdentityError(
+                f"candidate talk {assessment.talk_filename!r} appears twice"
+            )
+        seen.add(assessment.talk_filename)
+
+    def result(
+        verdict: str, selected: str | None, *reasons: str
+    ) -> TalkIdentityAssessment:
+        codes = list(reasons)
+        # A master, backup, or static export never carries a bare `matched`
+        # verdict into persistence: the owner records which artifact is the
+        # published source before its contents become a talk's evidence.
+        if artifact_role != ROLE_DELIVERY and verdict == VERDICT_MATCHED:
+            verdict = VERDICT_REVIEW_REQUIRED
+            codes.append(REASON_NON_DELIVERY_ARTIFACT)
+        elif artifact_role != ROLE_DELIVERY:
+            codes.append(REASON_NON_DELIVERY_ARTIFACT)
+        return TalkIdentityAssessment(
+            pptx_path=facts.pptx_path,
+            verdict=verdict,
+            artifact_role=artifact_role,
+            selected_talk_filename=selected if verdict == VERDICT_MATCHED else None,
+            reason_codes=tuple(dict.fromkeys(codes)),
+            candidates=assessments,
+        )
+
+    if not assessments:
+        return result(VERDICT_UNMATCHED, None, REASON_NO_CANDIDATE_TALKS)
+
+    selectable = [item for item in assessments if item.selectable]
+    if len(selectable) == 1:
+        return result(VERDICT_MATCHED, selectable[0].talk_filename, REASON_MATCHED)
+    if len(selectable) > 1:
+        return result(
+            VERDICT_REVIEW_REQUIRED, None, REASON_AMBIGUOUS_CANDIDATES
+        )
+
+    contradicted = [
+        item for item in assessments if item.agreeing and item.conflicting
+    ]
+    if contradicted:
+        return result(VERDICT_REVIEW_REQUIRED, None, REASON_CONFLICTING_SIGNALS)
+
+    filename_only = [
+        item
+        for item in assessments
+        if item.signals[SIGNAL_FILENAME_SIMILARITY] == SIGNAL_AGREE
+        and not item.conflicting
+    ]
+    if filename_only:
+        return result(
+            VERDICT_REVIEW_REQUIRED, None, REASON_FILENAME_SIMILARITY_ONLY
+        )
+
+    return result(VERDICT_UNMATCHED, None, REASON_NO_AGREEING_SIGNAL)

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -131,14 +131,19 @@ ARTIFACT_ROLES = frozenset(
 # Matched against whole path tokens, never substrings: `masterclass` is a talk
 # topic, `master` is an artifact role.
 _ROLE_TOKENS: tuple[tuple[str, frozenset[str]], ...] = (
-    (ROLE_BACKUP, frozenset({"backup", "backups", "bak", "archive", "archived", "old"})),
+    (
+        ROLE_BACKUP,
+        frozenset({"backup", "backups", "bak", "archive", "archived", "old"}),
+    ),
     (ROLE_MASTER, frozenset({"master", "masters", "template", "templates", "source"})),
     (ROLE_STATIC_EXPORT, frozenset({"static", "export", "exports", "exported"})),
 )
 
 _TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
 _HASHTAG_RE = re.compile(r"#(\w+)", re.UNICODE)
-_TALK_FILENAME_DATE_RE = re.compile(r"\A(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})-")
+_TALK_FILENAME_DATE_RE = re.compile(
+    r"\A(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})-"
+)
 
 # A deck whose filename shares this many significant words with a talk's slug is
 # similar enough to report — and never, on its own, similar enough to select.
@@ -276,9 +281,7 @@ def deck_identity_facts(value: object) -> DeckIdentityFacts:
         "published_pdf_talk_filename",
     }
     if unknown:
-        raise PptxTalkIdentityError(
-            f"deck facts carry unknown keys: {sorted(unknown)}"
-        )
+        raise PptxTalkIdentityError(f"deck facts carry unknown keys: {sorted(unknown)}")
     created_year = _optional_text(
         value.get("document_created_year"), "deck facts document_created_year"
     )
@@ -366,9 +369,7 @@ def _deck_venue_aliases(
         if len(alias) == 1 and alias[0] in AMBIGUOUS_EVENT_ALIASES:
             # `devops/` names a topic folder at least as often as an event.
             continue
-        if not any(
-            event_aliases_compatible(alias, known) for known in known_aliases
-        ):
+        if not any(event_aliases_compatible(alias, known) for known in known_aliases):
             continue
         aliases.append(alias)
     return aliases
@@ -384,7 +385,11 @@ def _title_signal(
         return SIGNAL_UNKNOWN
     observed = [
         text
-        for text in (facts.document_title, facts.rendered_title, *facts.rendered_footers)
+        for text in (
+            facts.document_title,
+            facts.rendered_title,
+            *facts.rendered_footers,
+        )
         if text
     ]
     if not observed:
@@ -557,9 +562,7 @@ def assess_pptx_talk_identity(
     # The candidate set is the vault's event vocabulary. A directory naming an
     # event no talk uses is a folder, not a contradicting venue.
     known_aliases = frozenset(known_event_aliases(talks))
-    assessments = tuple(
-        assess_candidate(facts, talk, known_aliases) for talk in talks
-    )
+    assessments = tuple(assess_candidate(facts, talk, known_aliases) for talk in talks)
 
     seen: set[str] = set()
     for assessment in assessments:
@@ -597,13 +600,9 @@ def assess_pptx_talk_identity(
     if len(selectable) == 1:
         return result(VERDICT_MATCHED, selectable[0].talk_filename, REASON_MATCHED)
     if len(selectable) > 1:
-        return result(
-            VERDICT_REVIEW_REQUIRED, None, REASON_AMBIGUOUS_CANDIDATES
-        )
+        return result(VERDICT_REVIEW_REQUIRED, None, REASON_AMBIGUOUS_CANDIDATES)
 
-    contradicted = [
-        item for item in assessments if item.agreeing and item.conflicting
-    ]
+    contradicted = [item for item in assessments if item.agreeing and item.conflicting]
     if contradicted:
         return result(VERDICT_REVIEW_REQUIRED, None, REASON_CONFLICTING_SIGNALS)
 
@@ -614,8 +613,6 @@ def assess_pptx_talk_identity(
         and not item.conflicting
     ]
     if filename_only:
-        return result(
-            VERDICT_REVIEW_REQUIRED, None, REASON_FILENAME_SIMILARITY_ONLY
-        )
+        return result(VERDICT_REVIEW_REQUIRED, None, REASON_FILENAME_SIMILARITY_ONLY)
 
     return result(VERDICT_UNMATCHED, None, REASON_NO_AGREEING_SIGNAL)

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -336,10 +336,21 @@ def provider_event_aliases(
     return sorted(found)
 
 
-def _aliases_compatible(left: EventAlias, right: EventAlias) -> bool:
+def event_aliases_compatible(left: EventAlias, right: EventAlias) -> bool:
+    """Report whether two event aliases can name the same event.
+
+    One alias containing every word of the other is compatibility, not equality:
+    a catalog conference is often the fuller form of what an artifact records.
+    Public because PPTX talk-identity assessment compares a deck-path venue with
+    a catalog conference and must not maintain a second, weaker rule.
+    """
     left_words = set(left)
     right_words = set(right)
     return left_words <= right_words or right_words <= left_words
+
+
+def _aliases_compatible(left: EventAlias, right: EventAlias) -> bool:
+    return event_aliases_compatible(left, right)
 
 
 def event_agreement(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,15 @@ def persisted_pattern_observations():
 
 
 @pytest.fixture(scope="session")
+def pptx_talk_identity():
+    """The talk-identity assessment run before catalog persistence (#176)."""
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "pptx_talk_identity.py"),
+        "pptx_talk_identity",
+    )
+
+
+@pytest.fixture(scope="session")
 def retained_stage():
     """The staged-file lifecycle both owner writers share (#243).
 

--- a/tests/test_pptx_talk_identity.py
+++ b/tests/test_pptx_talk_identity.py
@@ -1,0 +1,462 @@
+"""Tests for deterministic PPTX talk-identity assessment (#176).
+
+Every fixture is built in-test from fixed literals. No test reads the clock,
+the filesystem, or a live vault, so a run today and a run next year agree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+if "pptx_talk_identity" in sys.modules:
+    pptx_talk_identity = sys.modules["pptx_talk_identity"]
+else:
+    _SPEC = importlib.util.spec_from_file_location(
+        "pptx_talk_identity", SCRIPTS / "pptx_talk_identity.py"
+    )
+    assert _SPEC is not None and _SPEC.loader is not None
+    pptx_talk_identity = importlib.util.module_from_spec(_SPEC)
+    # Registered before exec so the module's dataclasses can resolve their own
+    # module during class construction.
+    sys.modules["pptx_talk_identity"] = pptx_talk_identity
+    _SPEC.loader.exec_module(pptx_talk_identity)
+
+
+VOXXED_TALK = {
+    "filename": "2025-01-17-voxxed-ticino-devops-developers.md",
+    "title": "DevOps for Developers",
+    "conference": "Voxxed Days Ticino",
+    "date": "2025-01-17",
+}
+DEVOXX_TALK = {
+    "filename": "2024-11-05-devoxx-belgium-devops-developers.md",
+    "title": "DevOps for Developers",
+    "conference": "Devoxx Belgium",
+    "date": "2024-11-05",
+}
+UNRELATED_TALK = {
+    "filename": "2025-03-02-kubecon-europe-supply-chain.md",
+    "title": "Securing the Software Supply Chain",
+    "conference": "KubeCon Europe",
+    "date": "2025-03-02",
+}
+
+
+def _deck(**overrides: Any) -> dict[str, Any]:
+    facts: dict[str, Any] = {
+        "pptx_path": "Conferences/Voxxed Days Ticino/2025/DevOps for Developers.pptx"
+    }
+    facts.update(overrides)
+    return facts
+
+
+def _assess(deck: dict[str, Any], candidates: list[dict[str, Any]]):
+    return pptx_talk_identity.assess_pptx_talk_identity(deck, candidates)
+
+
+class TestVerdicts:
+    def test_venue_and_year_agreement_selects_one_talk(self) -> None:
+        result = _assess(_deck(), [VOXXED_TALK, DEVOXX_TALK])
+        assert result.verdict == pptx_talk_identity.VERDICT_MATCHED
+        assert result.selected_talk_filename == VOXXED_TALK["filename"]
+        assert pptx_talk_identity.REASON_MATCHED in result.reason_codes
+
+    def test_same_title_across_venues_stays_distinguishable(self) -> None:
+        """The reused-talk-family case that mis-assigned the live vault."""
+        result = _assess(
+            _deck(
+                pptx_path="Conferences/Devoxx Belgium/2024/DevOps for Developers.pptx"
+            ),
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+        assert result.selected_talk_filename == DEVOXX_TALK["filename"]
+
+    def test_no_candidates_is_unmatched(self) -> None:
+        result = _assess(_deck(), [])
+        assert result.verdict == pptx_talk_identity.VERDICT_UNMATCHED
+        assert result.reason_codes == (
+            pptx_talk_identity.REASON_NO_CANDIDATE_TALKS,
+        )
+
+    def test_unrelated_deck_in_a_nearby_directory_is_not_matched(self) -> None:
+        result = _assess(
+            _deck(pptx_path="Conferences/KubeCon Europe/2025/Something Else.pptx"),
+            [VOXXED_TALK],
+        )
+        assert result.verdict != pptx_talk_identity.VERDICT_MATCHED
+        assert result.selected_talk_filename is None
+
+
+class TestFilenameSimilarityIsNeverSufficient:
+    def test_filename_agreement_alone_routes_to_review(self) -> None:
+        """The explicit acceptance criterion: fuzzy filename similarity alone
+        must not produce a match."""
+        result = _assess(
+            _deck(pptx_path="Decks/devops-developers.pptx"),
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_FILENAME_SIMILARITY]
+            == pptx_talk_identity.SIGNAL_AGREE
+        )
+        assert candidate.agreeing == ()
+        assert result.verdict == pptx_talk_identity.VERDICT_REVIEW_REQUIRED
+        assert (
+            pptx_talk_identity.REASON_FILENAME_SIMILARITY_ONLY in result.reason_codes
+        )
+
+    def test_filename_similarity_is_excluded_from_selecting_signals(self) -> None:
+        assert (
+            pptx_talk_identity.SIGNAL_FILENAME_SIMILARITY
+            not in pptx_talk_identity.SELECTING_SIGNALS
+        )
+
+
+class TestDeliveryYearVetoesButNeverElects:
+    """Every talk delivered in a year satisfies its year signal equally."""
+
+    def test_year_is_excluded_from_selecting_signals(self) -> None:
+        assert (
+            pptx_talk_identity.SIGNAL_DELIVERY_YEAR
+            not in pptx_talk_identity.SELECTING_SIGNALS
+        )
+
+    def test_a_matching_year_alone_does_not_select(self) -> None:
+        result = _assess(
+            _deck(pptx_path="Conferences/KubeCon Europe/2025/Something Else.pptx"),
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_DELIVERY_YEAR]
+            == pptx_talk_identity.SIGNAL_AGREE
+        )
+        assert candidate.agreeing == ()
+        assert result.verdict == pptx_talk_identity.VERDICT_UNMATCHED
+
+    def test_a_mismatched_year_still_vetoes(self) -> None:
+        result = _assess(
+            _deck(
+                pptx_path=(
+                    "Conferences/Voxxed Days Ticino/2019/DevOps for Developers.pptx"
+                )
+            ),
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert pptx_talk_identity.SIGNAL_DELIVERY_YEAR in candidate.conflicting
+        assert not candidate.selectable
+
+
+class TestVenueVocabulary:
+    """A directory is a venue claim only when it names an event some talk uses."""
+
+    def test_a_generic_directory_is_not_an_unrecognized_venue(self) -> None:
+        result = _assess(
+            {"pptx_path": "Decks/Downloads/deck.pptx", "rendered_title": "DevOps for Developers"},
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_VENUE]
+            == pptx_talk_identity.SIGNAL_UNKNOWN
+        )
+        assert result.verdict == pptx_talk_identity.VERDICT_MATCHED
+
+    def test_a_known_event_directory_that_is_not_this_talks_conflicts(self) -> None:
+        result = _assess(
+            _deck(pptx_path="Conferences/KubeCon Europe/2025/Supply Chain.pptx"),
+            [VOXXED_TALK, UNRELATED_TALK],
+        )
+        voxxed = next(
+            item
+            for item in result.candidates
+            if item.talk_filename == VOXXED_TALK["filename"]
+        )
+        assert (
+            voxxed.signals[pptx_talk_identity.SIGNAL_VENUE]
+            == pptx_talk_identity.SIGNAL_CONFLICT
+        )
+        assert result.selected_talk_filename == UNRELATED_TALK["filename"]
+
+
+class TestConflictAndAmbiguity:
+    def test_wrong_year_under_right_venue_conflicts(self) -> None:
+        result = _assess(
+            _deck(
+                pptx_path="Conferences/Voxxed Days Ticino/2019/DevOps for Developers.pptx"
+            ),
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_DELIVERY_YEAR]
+            == pptx_talk_identity.SIGNAL_CONFLICT
+        )
+        assert result.verdict == pptx_talk_identity.VERDICT_REVIEW_REQUIRED
+        assert pptx_talk_identity.REASON_CONFLICTING_SIGNALS in result.reason_codes
+
+    def test_two_selectable_candidates_are_ambiguous(self) -> None:
+        twin = dict(VOXXED_TALK)
+        twin["filename"] = "2025-01-17-voxxed-ticino-devops-developers-part-two.md"
+        result = _assess(_deck(), [VOXXED_TALK, twin])
+        assert result.verdict == pptx_talk_identity.VERDICT_REVIEW_REQUIRED
+        assert pptx_talk_identity.REASON_AMBIGUOUS_CANDIDATES in result.reason_codes
+        assert result.selected_talk_filename is None
+
+    def test_published_pdf_disambiguates_two_candidates(self) -> None:
+        twin = dict(VOXXED_TALK)
+        twin["filename"] = "2025-01-17-voxxed-ticino-devops-developers-part-two.md"
+        result = _assess(
+            _deck(published_pdf_talk_filename=VOXXED_TALK["filename"]),
+            [VOXXED_TALK, twin],
+        )
+        assert result.verdict == pptx_talk_identity.VERDICT_MATCHED
+        assert result.selected_talk_filename == VOXXED_TALK["filename"]
+
+    def test_a_conflicting_signal_outranks_agreement(self) -> None:
+        result = _assess(
+            _deck(published_pdf_talk_filename=UNRELATED_TALK["filename"]),
+            [VOXXED_TALK],
+        )
+        assert result.verdict == pptx_talk_identity.VERDICT_REVIEW_REQUIRED
+        assert result.selected_talk_filename is None
+
+
+class TestArtifactRoles:
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            (
+                "Conferences/Voxxed Days Ticino/2025/DevOps for Developers.pptx",
+                pptx_talk_identity.ROLE_DELIVERY,
+            ),
+            (
+                "Masters/Voxxed Days Ticino/2025/DevOps for Developers.pptx",
+                pptx_talk_identity.ROLE_MASTER,
+            ),
+            (
+                "Conferences/Voxxed Days Ticino/2025/DevOps static export.pptx",
+                pptx_talk_identity.ROLE_STATIC_EXPORT,
+            ),
+            (
+                "Backup/Voxxed Days Ticino/2025/DevOps for Developers.pptx",
+                pptx_talk_identity.ROLE_BACKUP,
+            ),
+        ],
+    )
+    def test_role_classification(self, path: str, expected: str) -> None:
+        facts = pptx_talk_identity.deck_identity_facts({"pptx_path": path})
+        assert pptx_talk_identity.classify_artifact_role(facts) == expected
+
+    def test_masterclass_is_a_topic_not_a_role(self) -> None:
+        """Role tokens match whole path words, never substrings."""
+        facts = pptx_talk_identity.deck_identity_facts(
+            {"pptx_path": "Conferences/Devoxx Belgium/2024/Kafka Masterclass.pptx"}
+        )
+        assert (
+            pptx_talk_identity.classify_artifact_role(facts)
+            == pptx_talk_identity.ROLE_DELIVERY
+        )
+
+    def test_a_master_never_carries_a_bare_matched_verdict(self) -> None:
+        result = _assess(
+            _deck(
+                pptx_path="Masters/Voxxed Days Ticino/2025/DevOps for Developers.pptx"
+            ),
+            [VOXXED_TALK],
+        )
+        assert result.artifact_role == pptx_talk_identity.ROLE_MASTER
+        assert result.verdict == pptx_talk_identity.VERDICT_REVIEW_REQUIRED
+        assert (
+            pptx_talk_identity.REASON_NON_DELIVERY_ARTIFACT in result.reason_codes
+        )
+        assert result.selected_talk_filename is None
+
+
+class TestSignalSemantics:
+    def test_a_deck_title_that_differs_is_not_a_conflict(self) -> None:
+        """Decks routinely carry a punchier title than the catalog entry."""
+        result = _assess(
+            _deck(rendered_title="Ship It Like You Mean It"), [VOXXED_TALK]
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_TITLE]
+            == pptx_talk_identity.SIGNAL_UNKNOWN
+        )
+
+    def test_rendered_title_agreement_corroborates(self) -> None:
+        result = _assess(
+            {
+                "pptx_path": "Decks/deck.pptx",
+                "rendered_title": "DevOps for Developers",
+            },
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_TITLE]
+            == pptx_talk_identity.SIGNAL_AGREE
+        )
+        assert result.verdict == pptx_talk_identity.VERDICT_MATCHED
+
+    def test_hashtag_agreement_corroborates(self) -> None:
+        result = _assess(
+            {"pptx_path": "Decks/deck.pptx", "hashtags": ["#VoxxedTicino"]},
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_HASHTAG]
+            == pptx_talk_identity.SIGNAL_AGREE
+        )
+
+    def test_an_ambiguous_directory_token_is_not_a_venue(self) -> None:
+        """`devops/` names a topic folder at least as often as an event."""
+        result = _assess(
+            _deck(pptx_path="devops/DevOps for Developers.pptx"), [VOXXED_TALK]
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_VENUE]
+            != pptx_talk_identity.SIGNAL_CONFLICT
+        )
+
+    def test_document_timestamp_corroborates_but_never_contradicts(self) -> None:
+        """A master re-saved years later is normal, not evidence of the wrong
+        talk."""
+        result = _assess(
+            {"pptx_path": "Decks/deck.pptx", "document_created_year": "2019"},
+            [VOXXED_TALK],
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_DELIVERY_YEAR]
+            == pptx_talk_identity.SIGNAL_UNKNOWN
+        )
+
+    def test_deck_filename_is_not_read_as_a_venue(self) -> None:
+        """Reading a venue from the filename would manufacture agreement from
+        the one signal the module refuses to trust alone."""
+        result = _assess(
+            {"pptx_path": "Decks/Voxxed Days Ticino.pptx"}, [VOXXED_TALK]
+        )
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_VENUE]
+            == pptx_talk_identity.SIGNAL_UNKNOWN
+        )
+
+    def test_a_talk_year_falls_back_to_the_filename_prefix(self) -> None:
+        undated = {
+            "filename": "2025-01-17-voxxed-ticino-devops-developers.md",
+            "title": "DevOps for Developers",
+            "conference": "Voxxed Days Ticino",
+        }
+        result = _assess(_deck(), [undated])
+        candidate = result.candidates[0]
+        assert (
+            candidate.signals[pptx_talk_identity.SIGNAL_DELIVERY_YEAR]
+            == pptx_talk_identity.SIGNAL_AGREE
+        )
+
+
+class TestInputValidation:
+    def test_unknown_deck_keys_are_rejected(self) -> None:
+        with pytest.raises(pptx_talk_identity.PptxTalkIdentityError):
+            pptx_talk_identity.deck_identity_facts(
+                {"pptx_path": "a.pptx", "confidence": 0.9}
+            )
+
+    def test_missing_path_is_rejected(self) -> None:
+        with pytest.raises(pptx_talk_identity.PptxTalkIdentityError):
+            pptx_talk_identity.deck_identity_facts({"pptx_path": "  "})
+
+    def test_a_non_mapping_is_rejected(self) -> None:
+        with pytest.raises(pptx_talk_identity.PptxTalkIdentityError):
+            pptx_talk_identity.deck_identity_facts(["a.pptx"])
+
+    def test_a_malformed_created_year_is_rejected(self) -> None:
+        with pytest.raises(pptx_talk_identity.PptxTalkIdentityError):
+            pptx_talk_identity.deck_identity_facts(
+                {"pptx_path": "a.pptx", "document_created_year": "25"}
+            )
+
+    def test_a_duplicate_candidate_is_rejected(self) -> None:
+        with pytest.raises(pptx_talk_identity.PptxTalkIdentityError):
+            _assess(_deck(), [VOXXED_TALK, dict(VOXXED_TALK)])
+
+    def test_a_candidate_without_a_filename_is_rejected(self) -> None:
+        with pytest.raises(pptx_talk_identity.PptxTalkIdentityError):
+            _assess(_deck(), [{"title": "No Filename"}])
+
+
+class TestSerialization:
+    def test_assessment_json_is_closed_and_stable(self) -> None:
+        payload = _assess(_deck(), [VOXXED_TALK]).as_json()
+        assert set(payload) == {
+            "schema_version",
+            "pptx_path",
+            "verdict",
+            "artifact_role",
+            "selected_talk_filename",
+            "reason_codes",
+            "candidates",
+        }
+        assert payload["schema_version"] == (
+            pptx_talk_identity.PPTX_TALK_IDENTITY_SCHEMA_VERSION
+        )
+        assert set(payload["candidates"][0]["signals"]) == set(
+            pptx_talk_identity.SIGNAL_NAMES
+        )
+
+    def test_every_emitted_reason_code_is_in_the_closed_taxonomy(self) -> None:
+        cases = [
+            (_deck(), [VOXXED_TALK, DEVOXX_TALK]),
+            (_deck(), []),
+            (_deck(pptx_path="Decks/devops-developers.pptx"), [VOXXED_TALK]),
+            (
+                _deck(
+                    pptx_path="Masters/Voxxed Days Ticino/2025/DevOps for Developers.pptx"
+                ),
+                [VOXXED_TALK],
+            ),
+            (
+                _deck(
+                    pptx_path="Conferences/Voxxed Days Ticino/2019/DevOps for Developers.pptx"
+                ),
+                [VOXXED_TALK],
+            ),
+            (_deck(pptx_path="Decks/unrelated-thing.pptx"), [UNRELATED_TALK]),
+        ]
+        for deck, candidates in cases:
+            result = _assess(deck, candidates)
+            assert result.verdict in pptx_talk_identity.VERDICTS
+            assert set(result.reason_codes) <= pptx_talk_identity.REASON_CODES
+            assert result.artifact_role in pptx_talk_identity.ARTIFACT_ROLES
+
+    def test_a_non_matched_verdict_never_carries_a_selection(self) -> None:
+        for deck, candidates in [
+            (_deck(), []),
+            (_deck(pptx_path="Decks/devops-developers.pptx"), [VOXXED_TALK]),
+            (
+                _deck(
+                    pptx_path="Conferences/Voxxed Days Ticino/2019/DevOps for Developers.pptx"
+                ),
+                [VOXXED_TALK],
+            ),
+        ]:
+            result = _assess(deck, candidates)
+            assert result.selected_talk_filename is None

--- a/tests/test_pptx_talk_identity.py
+++ b/tests/test_pptx_talk_identity.py
@@ -84,9 +84,7 @@ class TestVerdicts:
     def test_no_candidates_is_unmatched(self) -> None:
         result = _assess(_deck(), [])
         assert result.verdict == pptx_talk_identity.VERDICT_UNMATCHED
-        assert result.reason_codes == (
-            pptx_talk_identity.REASON_NO_CANDIDATE_TALKS,
-        )
+        assert result.reason_codes == (pptx_talk_identity.REASON_NO_CANDIDATE_TALKS,)
 
     def test_unrelated_deck_in_a_nearby_directory_is_not_matched(self) -> None:
         result = _assess(
@@ -112,9 +110,7 @@ class TestFilenameSimilarityIsNeverSufficient:
         )
         assert candidate.agreeing == ()
         assert result.verdict == pptx_talk_identity.VERDICT_REVIEW_REQUIRED
-        assert (
-            pptx_talk_identity.REASON_FILENAME_SIMILARITY_ONLY in result.reason_codes
-        )
+        assert pptx_talk_identity.REASON_FILENAME_SIMILARITY_ONLY in result.reason_codes
 
     def test_filename_similarity_is_excluded_from_selecting_signals(self) -> None:
         assert (
@@ -164,7 +160,10 @@ class TestVenueVocabulary:
 
     def test_a_generic_directory_is_not_an_unrecognized_venue(self) -> None:
         result = _assess(
-            {"pptx_path": "Decks/Downloads/deck.pptx", "rendered_title": "DevOps for Developers"},
+            {
+                "pptx_path": "Decks/Downloads/deck.pptx",
+                "rendered_title": "DevOps for Developers",
+            },
             [VOXXED_TALK],
         )
         candidate = result.candidates[0]
@@ -279,9 +278,7 @@ class TestArtifactRoles:
         )
         assert result.artifact_role == pptx_talk_identity.ROLE_MASTER
         assert result.verdict == pptx_talk_identity.VERDICT_REVIEW_REQUIRED
-        assert (
-            pptx_talk_identity.REASON_NON_DELIVERY_ARTIFACT in result.reason_codes
-        )
+        assert pptx_talk_identity.REASON_NON_DELIVERY_ARTIFACT in result.reason_codes
         assert result.selected_talk_filename is None
 
 
@@ -350,9 +347,7 @@ class TestSignalSemantics:
     def test_deck_filename_is_not_read_as_a_venue(self) -> None:
         """Reading a venue from the filename would manufacture agreement from
         the one signal the module refuses to trust alone."""
-        result = _assess(
-            {"pptx_path": "Decks/Voxxed Days Ticino.pptx"}, [VOXXED_TALK]
-        )
+        result = _assess({"pptx_path": "Decks/Voxxed Days Ticino.pptx"}, [VOXXED_TALK])
         candidate = result.candidates[0]
         assert (
             candidate.signals[pptx_talk_identity.SIGNAL_VENUE]


### PR DESCRIPTION
## What

Adds `pptx_talk_identity.py` — a deterministic, schema-versioned assessment of
which talk a candidate PPTX deck belongs to, plus 37 tests.

Part of #176. Assessment only; wiring into the apply path and preflight follows
in a second PR, mirroring how #285 landed the persisted-observation classifier
before #286 wired it.

## Why now

This is the first item in the reparse-prep sequence, ahead of #156, #153, #160,
and #167's repair path. The read-only audit found 25 stored catalog/talk path
disagreements across 15 talks and nine unrelated decks assigned to one talk. A
reparse re-derives slide counts, OCR, and pattern observations from whatever
deck the catalog names — so repairing persisted observations before fixing
mis-assignment is careful work on the wrong deck.

## Design

Signals come from facts both sides already carry. Title and event comparison
delegate to `source_identity_matching`, the same authority the video
source-identity audit uses, rather than a second weaker matcher.

**Two signals report but never elect:**

| Signal | Why excluded from selection |
|---|---|
| `filename_similarity` | Reused talk families produce near-identical filenames — the signal that mis-assigned these decks in the first place |
| `delivery_year` | Every talk delivered that year satisfies it equally; it narrows a candidate set without identifying anything in it |

A year MISmatch still contradicts. Vetoing and electing are separate powers: a
wrong year proves the wrong delivery, a right year proves nothing.

**Venue vocabulary gate.** A directory is a venue claim only when it names an
event some talk in the vault actually uses. Without it, every generic folder
(`Decks/`, `Downloads/`) parses as an unrecognized venue and contradicts every
candidate — the discriminator becomes a blanket refusal.

**Refusing is the safe outcome.** Two corroborated candidates, a contradicted
one, and a filename-only hit all route to `review_required`. A master, backup,
or static export never carries a bare `matched` verdict into persistence.

## Also

`source_identity_matching._aliases_compatible` is promoted to public
`event_aliases_compatible` in its owner module rather than duplicated here. The
private name stays as a thin delegate so existing callers are untouched.

## Verification

- `tests/test_pptx_talk_identity.py` — 37 tests, all fixtures built from fixed
  literals; no test reads the clock, the filesystem, or a live vault
- Full suite: **5466 passed, 3 skipped**
- `pyright`: 0 errors on every changed file
- `git diff --check`: clean

Two tests pin design corrections the suite forced during development: a matching
year alone must not select, and a generic directory must not read as a
contradicting venue.
