### PR TITLE
feat(vault-ingress): refuse a talk binding nothing proved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+### feat(vault-ingress) — refuse a talk binding nothing proved (#176)
+
+Part of #176.
+
+The assessment landed with no caller. `pptx_catalog` records advance to v3,
+where a matched record carries the assessment that proves its deck belongs to
+the talk it names, and `record_pptx` refuses to persist one that does not.
+
+Three things must hold together, and checking fewer is checking none: the
+verdict is `matched`, the `selected_talk_filename` equals the record's own
+`talk_filename`, and the artifact is a delivery deck. The middle check is the
+one that catches the live defect — a perfectly valid assessment pasted onto the
+wrong record. A `review_required` verdict naming the right talk is still an
+owner decision nobody has made yet, so it cannot bind either.
+
+Readers accept v1, v2, and v3, and check v3 shape only — the field is null
+exactly when `talk_filename` is null. The binding's semantics stay the writer's
+gate, matching how `visual_evidence` is already handled: a malformed receipt is
+per-record trouble for a reader, but a record that cannot be proven is a record
+that must not be persisted.
+
+Existing v2 records keep reading and classifying. They carry no identity proof,
+which is what the catalog-wide preflight sweep is for; this change stops new
+unproven bindings from being written while that lands.
+
 ### feat(vault-ingress) — prove which talk a deck belongs to before it becomes evidence (#176)
 
 Part of #176.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ### feat(vault-ingress) — refuse a talk binding nothing proved (#176)
 
+The candidate table's `signals` map is the evidence; `agreeing` and `conflicting`
+are its summary. The gate read the summary and trusted it, so a fabricated
+candidate could claim `agreeing: ["venue"]` over a signal map where venue
+conflicts, or carries no venue reading at all — and authorize the binding on a
+standing its own readings never supported.
+
+`derive_candidate_standing` is now the single rule, used by the producer that
+writes a candidate and by the owner gate that reads one back. The gate validates
+the complete signal map and recomputes both arrays from it, refusing on
+`identity_candidate_signals_invalid` or
+`identity_candidate_standing_contradicts_signals`. That also makes
+`identity_candidate_agreement_not_selecting` unreachable: the derivation admits
+only selecting signals to `agreeing`, so the state it named cannot be
+represented.
+
+`schemas-db.md`'s matched example carried `candidates: []` — a record the new
+writer rejects outright, so the schema reference was telling agents to build
+mutations that cannot persist. It now shows a complete selectable candidate,
+including the non-selecting `delivery_year` and `filename_similarity` readings
+that report without electing. Two tests parse that example straight out of the
+reference and run it through the gate, so the document cannot drift from the
+contract again.
+
 Part of #176.
 
 The assessment landed with no caller. `pptx_catalog` records advance to v3,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,20 @@ gate, matching how `visual_evidence` is already handled: a malformed receipt is
 per-record trouble for a reader, but a record that cannot be proven is a record
 that must not be persisted.
 
-Existing v2 records keep reading and classifying. They carry no identity proof,
-which is what the catalog-wide preflight sweep is for; this change stops new
-unproven bindings from being written while that lands.
+Existing v2 records migrate rather than linger. Migration cannot prove a binding
+it did not witness, and forging a `matched` verdict would manufacture exactly the
+evidence v3 exists to require — so a v2 record upgrades carrying a
+`review_required` assessment with reason `identity_unassessed_legacy_binding`.
+The binding survives; only its provenance is marked unproven, and nothing
+downstream may treat it as current until someone looks. v1 records stay at v1,
+matching the established position that migration preserves such a record rather
+than inventing a binding for it.
+
+Fixing that also closed a bypass: `migrate_tracking_database` returned early
+whenever the database ROOT was current, which is true of every live database. A
+record-level shape bump would have been skipped for all of them. Record
+migrations now run before that check, and only a genuinely unchanged database
+takes the no-op path.
 ## 0.20.56 — 2026-08-11
 
 ### feat(vault-ingress) — prove which talk a deck belongs to before it becomes evidence (#176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,23 @@ downstream may treat it as current until someone looks. v1 records stay at v1,
 matching the established position that migration preserves such a record rather
 than inventing a binding for it.
 
-Preflight consumes the stamp, which is what keeps it from being inert. A row
-whose binding is not proven is reported by the catalog-wide sweep, with severity
-split on where the doubt came from: migration's own stamp warns, because it
-applies to every legacy row at once and blocking on all of them would refuse the
-whole vault over a condition the migration created; a verdict from a real
-assessment blocks, because an assessor that looked and refused is one specific,
-actionable row.
+Preflight consumes the stamp, which is what keeps it from being inert. Every
+unproven binding blocks, the migration's own stamp included. A warning would let
+Step 1's blocking-only gate proceed on state the database itself marks unproven,
+which is the whole failure this exists to stop.
+
+The cost is real and deliberate: **a vault carrying legacy catalog rows stays
+blocked until those rows are assessed.** That makes assessing them reparse
+prerequisite work rather than something to discover mid-run.
+
+One predicate decides whether an assessment authorizes a binding —
+`binding_refusal` — and both the writer and preflight call it. Two copies would
+drift, and the direction they drift is a reader trusting what a writer would
+have refused. It checks the evidence, not just the verdict: a `matched` verdict
+over an empty candidate table is a conclusion with nothing under it, so the
+table must show the talk winning the way the assessor makes it win —
+corroborated by a selecting signal, contradicted by none, with no rival equally
+corroborated.
 
 Identity is deliberately not currency. A row can hold a perfectly current
 extraction receipt for the wrong talk, so none of this touches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ downstream may treat it as current until someone looks. v1 records stay at v1,
 matching the established position that migration preserves such a record rather
 than inventing a binding for it.
 
+Preflight consumes the stamp, which is what keeps it from being inert. A row
+whose binding is not proven is reported by the catalog-wide sweep, with severity
+split on where the doubt came from: migration's own stamp warns, because it
+applies to every legacy row at once and blocking on all of them would refuse the
+whole vault over a condition the migration created; a verdict from a real
+assessment blocks, because an assessor that looked and refused is one specific,
+actionable row.
+
+Identity is deliberately not currency. A row can hold a perfectly current
+extraction receipt for the wrong talk, so none of this touches
+`classify_pptx_visual_evidence` — a wrong binding is not stale evidence, it is
+evidence filed against the wrong talk, and conflating them would send every
+migrated deck back through extraction to fix a problem extraction cannot fix.
+
 Fixing that also closed a bypass: `migrate_tracking_database` returned early
 whenever the database ROOT was current, which is true of every live database. A
 record-level shape bump would have been skipped for all of them. Record

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ The assessment landed with no caller. `pptx_catalog` records advance to v3,
 where a matched record carries the assessment that proves its deck belongs to
 the talk it names, and `record_pptx` refuses to persist one that does not.
 
-Three things must hold together, and checking fewer is checking none: the
-verdict is `matched`, the `selected_talk_filename` equals the record's own
-`talk_filename`, and the artifact is a delivery deck. The middle check is the
-one that catches the live defect — a perfectly valid assessment pasted onto the
-wrong record. A `review_required` verdict naming the right talk is still an
-owner decision nobody has made yet, so it cannot bind either.
+Four things must hold together, and checking fewer is checking none: the
+verdict is `matched`, the assessment is about this record's deck, it names this
+record's talk, and the artifact is a delivery deck. A `review_required` verdict
+naming the right talk is still an owner decision nobody has made yet, so it
+cannot bind either.
+
+Both endpoints are checked because an assessment binds a pair. Verifying the
+talk alone leaves the deck free: a real, correctly-decided assessment for deck A
+pasted onto deck B's record would pass every other check and bind B's contents
+to A's talk — the same defect running the other way.
 
 Readers accept v1, v2, and v3, and check v3 shape only — the field is null
 exactly when `talk_filename` is null. The binding's semantics stay the writer's

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -230,9 +230,9 @@ A matched record also carries `identity_assessment`: the assessment produced by
 the database's talks, serialized whole. Obtain it by assessing the deck BEFORE
 deciding the binding — the assessment is what decides it, not a confirmation of a
 decision already made. An unmatched record carries `identity_assessment: null`.
-The writer rejects an assessment that does not authorize the binding; its
-acceptance predicate lives in `skills/vault-ingress/scripts/mutate-tracking-database.py`
-`_require_bound_identity_assessment`. Route a rejected deck to owner review
+The writer rejects an assessment that does not authorize the binding; the
+predicate is `binding_refusal` in
+`skills/vault-ingress/scripts/pptx_talk_identity.py`, shared with preflight. Route a rejected deck to owner review
 rather than persisting it.
 Never decide from
 `visual_extracted` alone whether a deck needs extraction. Run:

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -219,11 +219,20 @@ do not omit `--directory` or
 pre-probe the root with `find`, a recursive glob, or a per-file loop. The bounded
 authenticated discovery worker owns root validation and enumeration. Report counts,
 then persist each reviewed result with a `record_pptx`
-mutation and `schema_version: 2`, including the exact prior catalog record and, for
+mutation and `schema_version: 3`, including the exact prior catalog record and, for
 a match, the talk's exact prior `pptx_path` expectation. A record whose deck has
 had no extraction attempt carries `visual_evidence: null`; a record claiming
 visual evidence carries the receipt binding extractor schema, pipeline version,
-exact source fingerprint, and artifact identity. Never decide from
+exact source fingerprint, and artifact identity.
+
+A matched record also carries `identity_assessment`: the assessment produced by
+`skills/vault-ingress/scripts/pptx_talk_identity.py` for that exact deck against
+the database's talks, serialized whole. Obtain it by assessing the deck BEFORE
+deciding the binding — the assessment is what decides it, not a confirmation of a
+decision already made. The writer accepts only a `matched` verdict naming that
+record's own deck and talk; route any other verdict to owner review rather than
+persisting the binding. An unmatched record carries `identity_assessment: null`.
+Never decide from
 `visual_extracted` alone whether a deck needs extraction. Run:
 
 ```bash

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -229,9 +229,11 @@ A matched record also carries `identity_assessment`: the assessment produced by
 `skills/vault-ingress/scripts/pptx_talk_identity.py` for that exact deck against
 the database's talks, serialized whole. Obtain it by assessing the deck BEFORE
 deciding the binding — the assessment is what decides it, not a confirmation of a
-decision already made. The writer accepts only a `matched` verdict naming that
-record's own deck and talk; route any other verdict to owner review rather than
-persisting the binding. An unmatched record carries `identity_assessment: null`.
+decision already made. An unmatched record carries `identity_assessment: null`.
+The writer rejects an assessment that does not authorize the binding; its
+acceptance predicate lives in `skills/vault-ingress/scripts/mutate-tracking-database.py`
+`_require_bound_identity_assessment`. Route a rejected deck to owner review
+rather than persisting it.
 Never decide from
 `visual_extracted` alone whether a deck needs extraction. Run:
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -66,10 +66,11 @@ v2, and v3.
   belongs to the talk the record names. v2 bound a visual claim to the bytes it
   came from but said nothing about whose deck those bytes were, so a deck could
   carry a perfectly-attested extraction receipt for the wrong talk.
-- The writer refuses an assessment that does not authorize the binding; the
-  acceptance predicate lives in
-  `skills/vault-ingress/scripts/mutate-tracking-database.py`
-  `_require_bound_identity_assessment`. Verdicts, artifact roles, and reason
+- One predicate decides whether an assessment authorizes a binding —
+  `binding_refusal` in `skills/vault-ingress/scripts/pptx_talk_identity.py`.
+  The owner writer raises on it so an unproven binding is never persisted, and
+  preflight reports it so a binding persisted before this contract existed
+  cannot pass as proven. Verdicts, artifact roles, and reason
   codes are the assessor's closed taxonomies, in
   `skills/vault-ingress/scripts/pptx_talk_identity.py` top-of-file constants.
 - Readers validate v3 shape only — that the field is null exactly when

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -143,7 +143,7 @@ no-op.
 | database root | 1 |
 | config | 2 (schema 1 remains readable owner-migration input) |
 | talk | 5 |
-| PPTX catalog | 1 |
+| PPTX catalog | 3 (schemas 1 and 2 remain readable legacy state) |
 | QR code | 2 (schema 1 remains readable legacy state) |
 | resource summary | 1 |
 | thumbnail | 1 |
@@ -497,7 +497,7 @@ exact-type rule. The supported mutation kinds are:
 |---|---|
 | `initialize_database` | Sole mutation for a missing database; carries initial `config` |
 | `set_config` | Set or delete one nested config path against its exact prior value |
-| `record_pptx` | Replace/add one complete schema-v2 PPTX catalog record, generation binding included, and, when matched, bind the talk's expected `pptx_path` |
+| `record_pptx` | Replace/add one complete schema-v3 PPTX catalog record — generation binding included, plus the identity assessment proving the deck belongs to the talk it names — and, when matched, bind the talk's expected `pptx_path` |
 | `upsert_confirmed_intent` | Replace/add one complete schema-v1 record identified by `pattern` |
 | `upsert_improvement_goal` | Replace/add one complete record identified by `id` |
 | `patch_improvement_goal_verification` | Set only verification fields, with `expect` covering exactly the same fields |

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -43,11 +43,11 @@ attempts. Exhaustion and every hard staged mismatch raise
 `StagedCandidateConflictError` carrying the failed invariant. The class is
 defined in `skills/vault-ingress/scripts/tracking_database_io.py`.
 
-### `pptx_catalog` v1 -> v2
+### `pptx_catalog` v1 -> v2 -> v3
 
 Writer: the `record_pptx` mutation in
-`skills/vault-ingress/scripts/mutate-tracking-database.py`. Readers dual-accept
-v1 and v2.
+`skills/vault-ingress/scripts/mutate-tracking-database.py`. Readers accept v1,
+v2, and v3.
 
 - v1 records a bare `visual_extracted` boolean and nothing about which extractor
   produced it, so a stored `true` may refer to extractor schema v0, v1, v2, v3,
@@ -60,6 +60,21 @@ v1 and v2.
 - `artifact` is required when `outcome` is `succeeded` and must be null when it
   is `failed`. A success naming no artifact cannot be proven to still exist,
   which is the ambiguity this schema removes.
+- v3 requires `identity_assessment`: `null` on an unmatched record, and on a
+  matched one the assessment from
+  `skills/vault-ingress/scripts/pptx_talk_identity.py` that proves the deck
+  belongs to the talk the record names. v2 bound a visual claim to the bytes it
+  came from but said nothing about whose deck those bytes were, so a deck could
+  carry a perfectly-attested extraction receipt for the wrong talk.
+- The writer accepts an assessment only when its `verdict` is `matched`, its
+  `selected_talk_filename` equals the record's `talk_filename`, and its
+  `artifact_role` is `delivery` — see `_require_bound_identity_assessment`. A
+  `review_required` verdict naming the right talk is an owner decision nobody
+  has made yet. Verdicts, roles, and reason codes are the assessor's closed
+  taxonomies, not restated here.
+- Readers validate v3 shape only — that the field is null exactly when
+  `talk_filename` is null, and an object otherwise. The binding's semantics are
+  the writer's gate, matching how `visual_evidence` is handled.
 - The receipt's shape is fatal at the writer and at the classifier, never at
   the database assessment. A malformed receipt is per-record evidence trouble:
   `record_pptx` refuses to persist it and the classifier refuses to trust it,
@@ -304,7 +319,7 @@ customization, not the owner default. See the
   "_comment_schema_version": "Database schema v1 is owner-migrated by vault-ingress. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, evidence ledger v2, and current scoring schema v5. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
-    "schema_version": 2,
+    "schema_version": 3,
     "pptx_path": "Conference/Year/Talk Name.pptx",
     "talk_filename": "2024-04-10-talk-slug.md or null",
     "matched": true,
@@ -323,10 +338,20 @@ customization, not the owner default. See the
         "path": "vault-root-relative extraction artifact path",
         "sha256": "64 lowercase hex characters"
       }
+    },
+    "identity_assessment": {
+      "schema_version": 1,
+      "pptx_path": "Conference/Year/Talk Name.pptx",
+      "verdict": "matched",
+      "artifact_role": "delivery",
+      "selected_talk_filename": "2024-04-10-talk-slug.md",
+      "reason_codes": ["identity_matched"],
+      "candidates": []
     }
   }],
   "_comment_pptx_catalog_failed": {
-    "schema_version": 2,
+    "schema_version": 3,
+    "identity_assessment": null,
     "pptx_path": "Conference/Year/Broken.pptx",
     "talk_filename": null,
     "matched": false,

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -73,6 +73,13 @@ v2, and v3.
   cannot pass as proven. Verdicts, artifact roles, and reason
   codes are the assessor's closed taxonomies, in
   `skills/vault-ingress/scripts/pptx_talk_identity.py` top-of-file constants.
+- A matched assessment carries a non-empty `candidates` table, and each entry's
+  `signals` map is the evidence its `agreeing` / `conflicting` arrays summarize.
+  The gate recomputes those arrays from the map rather than trusting them, so a
+  candidate cannot assert a standing its own readings do not support. Only
+  selecting signals reach `agreeing` — the example's agreeing `delivery_year`
+  and `filename_similarity` report without electing, which is why they appear in
+  `signals` and not in `agreeing`.
 - Readers validate v3 shape only — that the field is null exactly when
   `talk_filename` is null, and an object otherwise. The binding's semantics are
   the writer's gate, matching how `visual_evidence` is handled.
@@ -347,7 +354,21 @@ customization, not the owner default. See the
       "artifact_role": "delivery",
       "selected_talk_filename": "2024-04-10-talk-slug.md",
       "reason_codes": ["identity_matched"],
-      "candidates": []
+      "candidates": [
+        {
+          "talk_filename": "2024-04-10-talk-slug.md",
+          "signals": {
+            "title": "agree",
+            "venue": "agree",
+            "delivery_year": "agree",
+            "hashtag": "unknown",
+            "published_pdf": "unknown",
+            "filename_similarity": "agree"
+          },
+          "agreeing": ["title", "venue"],
+          "conflicting": []
+        }
+      ]
     }
   }],
   "_comment_pptx_catalog_failed": {

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -66,12 +66,12 @@ v2, and v3.
   belongs to the talk the record names. v2 bound a visual claim to the bytes it
   came from but said nothing about whose deck those bytes were, so a deck could
   carry a perfectly-attested extraction receipt for the wrong talk.
-- The writer accepts an assessment only when its `verdict` is `matched`, its
-  `selected_talk_filename` equals the record's `talk_filename`, and its
-  `artifact_role` is `delivery` — see `_require_bound_identity_assessment`. A
-  `review_required` verdict naming the right talk is an owner decision nobody
-  has made yet. Verdicts, roles, and reason codes are the assessor's closed
-  taxonomies, not restated here.
+- The writer refuses an assessment that does not authorize the binding; the
+  acceptance predicate lives in
+  `skills/vault-ingress/scripts/mutate-tracking-database.py`
+  `_require_bound_identity_assessment`. Verdicts, artifact roles, and reason
+  codes are the assessor's closed taxonomies, in
+  `skills/vault-ingress/scripts/pptx_talk_identity.py` top-of-file constants.
 - Readers validate v3 shape only — that the field is null exactly when
   `talk_filename` is null, and an object otherwise. The binding's semantics are
   the writer's gate, matching how `visual_evidence` is handled.

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -56,6 +56,7 @@ from pptx_discovery_contract import (
     validate_pptx_directory_exclusions,
 )
 from pptx_talk_identity import (
+    MATCHED_REASON_CODES,
     PPTX_TALK_IDENTITY_SCHEMA_VERSION,
     REASON_CODES,
     ROLE_DELIVERY,
@@ -1159,6 +1160,15 @@ def _require_bound_identity_assessment(
     if unknown:
         raise TrackingDatabaseMutationError(
             f"{label}.reason_codes carries codes outside the closed taxonomy: {unknown}"
+        )
+    # Membership in the taxonomy is not enough. Every code but the matched one
+    # explains a refusal, so a `matched` verdict carrying one describes an
+    # assessment that cannot exist — and the legacy-binding code means the exact
+    # opposite of proven.
+    if sorted(set(reason_codes)) != sorted(MATCHED_REASON_CODES):
+        raise TrackingDatabaseMutationError(
+            f"{label}.reason_codes must be exactly {sorted(MATCHED_REASON_CODES)} "
+            f"for a {VERDICT_MATCHED!r} verdict, got {reason_codes}"
         )
 
 

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -28,7 +28,8 @@ from tracking_database import (
     IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION,
     IMPROVEMENT_GOAL_REQUIRED_FIELDS as OWNER_IMPROVEMENT_GOAL_REQUIRED_FIELDS,
     PPTX_CATALOG_RECORD_SCHEMA_VERSION,
-    PPTX_CATALOG_V2_REQUIRED_FIELDS,
+    PPTX_CATALOG_V3_REQUIRED_FIELDS,
+    PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS,
     validate_pptx_visual_evidence,
     RESOURCE_RECORD_SCHEMA_VERSION,
     RESOURCE_REQUIRED_FIELDS as OWNER_RESOURCE_REQUIRED_FIELDS,
@@ -54,13 +55,20 @@ from pptx_discovery_contract import (
     PptxDiscoveryContractError,
     validate_pptx_directory_exclusions,
 )
+from pptx_talk_identity import (
+    PPTX_TALK_IDENTITY_SCHEMA_VERSION,
+    REASON_CODES,
+    ROLE_DELIVERY,
+    VERDICT_MATCHED,
+)
 
 
 PLAN_SCHEMA_VERSION = 1
 OWNER_RECORD_SCHEMA_VERSION = CONFIRMED_INTENT_RECORD_SCHEMA_VERSION
-# pptx_catalog left this shared version behind at v2, where each record binds
-# its visual evidence to an extractor generation, and is validated per kind by
-# _apply_record_pptx against PPTX_CATALOG_RECORD_SCHEMA_VERSION.
+# pptx_catalog left this shared version behind at v3, where each record binds
+# its visual evidence to an extractor generation AND its talk binding to a
+# proven identity assessment. Validated per kind by _apply_record_pptx against
+# PPTX_CATALOG_RECORD_SCHEMA_VERSION.
 if (
     len(
         {
@@ -130,7 +138,7 @@ CONFIRMED_INTENT_REQUIRED_FIELDS = OWNER_CONFIRMED_INTENT_REQUIRED_FIELDS | {
     "schema_version"
 }
 RESOURCE_REQUIRED_FIELDS = OWNER_RESOURCE_REQUIRED_FIELDS | {"schema_version"}
-PPTX_REQUIRED_FIELDS = PPTX_CATALOG_V2_REQUIRED_FIELDS | {"schema_version"}
+PPTX_REQUIRED_FIELDS = PPTX_CATALOG_V3_REQUIRED_FIELDS | {"schema_version"}
 THUMBNAIL_REQUIRED_FIELDS = OWNER_THUMBNAIL_REQUIRED_FIELDS | {"schema_version"}
 
 
@@ -1069,6 +1077,80 @@ def _apply_retire_improvement_goal(
     )
 
 
+def _require_bound_identity_assessment(
+    assessment: object,
+    *,
+    talk_filename: str | None,
+    label: str,
+) -> None:
+    """Refuse a talk binding the assessment does not actually prove.
+
+    This is the gate the whole of #176 exists for. Everything guarding deck
+    evidence runs after persistence, so if an unproven binding gets written here
+    nothing downstream can tell that a talk's slide counts, OCR, and pattern
+    observations came from someone else's deck.
+
+    Three things must hold together, and checking fewer is checking none: the
+    assessment must be a `matched` verdict, it must name THIS record's talk, and
+    it must be for a delivery artifact. A `review_required` verdict that names
+    the right talk is still an owner decision nobody made yet.
+    """
+    if talk_filename is None:
+        if assessment is not None:
+            raise TrackingDatabaseMutationError(
+                f"{label} must be null on an unmatched record"
+            )
+        return
+    if not isinstance(assessment, dict):
+        raise TrackingDatabaseMutationError(
+            f"{label} is required on a matched record: a talk binding must be "
+            "proven before the deck's contents become that talk's evidence"
+        )
+    _require_keys(
+        assessment,
+        required=PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS,
+        optional={"pptx_path", "candidates"},
+        label=label,
+    )
+    if not json_values_equal(
+        assessment["schema_version"], PPTX_TALK_IDENTITY_SCHEMA_VERSION
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label}.schema_version must be exact integer "
+            f"{PPTX_TALK_IDENTITY_SCHEMA_VERSION}"
+        )
+    verdict = assessment["verdict"]
+    if verdict != VERDICT_MATCHED:
+        raise TrackingDatabaseMutationError(
+            f"{label}.verdict must be {VERDICT_MATCHED!r} to bind a talk, got "
+            f"{verdict!r}; route a {verdict!r} deck to owner review instead"
+        )
+    selected = assessment["selected_talk_filename"]
+    if selected != talk_filename:
+        raise TrackingDatabaseMutationError(
+            f"{label}.selected_talk_filename {selected!r} does not match the "
+            f"record's talk_filename {talk_filename!r}"
+        )
+    role = assessment["artifact_role"]
+    if role != ROLE_DELIVERY:
+        raise TrackingDatabaseMutationError(
+            f"{label}.artifact_role {role!r} is not a delivery artifact; record "
+            "which artifact is the published source before binding it"
+        )
+    reason_codes = assessment["reason_codes"]
+    if not isinstance(reason_codes, list) or not all(
+        isinstance(code, str) for code in reason_codes
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label}.reason_codes must be an array of strings"
+        )
+    unknown = sorted(set(reason_codes) - REASON_CODES)
+    if unknown:
+        raise TrackingDatabaseMutationError(
+            f"{label}.reason_codes carries codes outside the closed taxonomy: {unknown}"
+        )
+
+
 def _apply_record_pptx(
     database: dict[str, Any],
     mutation: dict[str, Any],
@@ -1139,6 +1221,11 @@ def _apply_record_pptx(
         raise TrackingDatabaseMutationError(
             f"mutations[{index}] matched must be true exactly when talk_filename is set"
         )
+    _require_bound_identity_assessment(
+        record.get("identity_assessment"),
+        talk_filename=talk_filename,
+        label=f"{record_label}.identity_assessment",
+    )
     records = _collection(database, "pptx_catalog")
     record_index, current = _find_unique_record(
         records,

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -29,7 +29,6 @@ from tracking_database import (
     IMPROVEMENT_GOAL_REQUIRED_FIELDS as OWNER_IMPROVEMENT_GOAL_REQUIRED_FIELDS,
     PPTX_CATALOG_RECORD_SCHEMA_VERSION,
     PPTX_CATALOG_V3_REQUIRED_FIELDS,
-    PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS,
     validate_pptx_visual_evidence,
     RESOURCE_RECORD_SCHEMA_VERSION,
     RESOURCE_REQUIRED_FIELDS as OWNER_RESOURCE_REQUIRED_FIELDS,
@@ -55,13 +54,7 @@ from pptx_discovery_contract import (
     PptxDiscoveryContractError,
     validate_pptx_directory_exclusions,
 )
-from pptx_talk_identity import (
-    MATCHED_REASON_CODES,
-    PPTX_TALK_IDENTITY_SCHEMA_VERSION,
-    REASON_CODES,
-    ROLE_DELIVERY,
-    VERDICT_MATCHED,
-)
+from pptx_talk_identity import binding_refusal
 
 
 PLAN_SCHEMA_VERSION = 1
@@ -1107,67 +1100,14 @@ def _require_bound_identity_assessment(
                 f"{label} must be null on an unmatched record"
             )
         return
-    if not isinstance(assessment, dict):
-        raise TrackingDatabaseMutationError(
-            f"{label} is required on a matched record: a talk binding must be "
-            "proven before the deck's contents become that talk's evidence"
-        )
-    _require_keys(
-        assessment,
-        required=PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS,
-        label=label,
+    refusal = binding_refusal(
+        assessment, pptx_path=pptx_path, talk_filename=talk_filename
     )
-    assessed_path = assessment["pptx_path"]
-    if assessed_path != pptx_path:
+    if refusal is not None:
         raise TrackingDatabaseMutationError(
-            f"{label}.pptx_path {assessed_path!r} does not match the record's "
-            f"pptx_path {pptx_path!r}"
-        )
-    if not json_values_equal(
-        assessment["schema_version"], PPTX_TALK_IDENTITY_SCHEMA_VERSION
-    ):
-        raise TrackingDatabaseMutationError(
-            f"{label}.schema_version must be exact integer "
-            f"{PPTX_TALK_IDENTITY_SCHEMA_VERSION}"
-        )
-    verdict = assessment["verdict"]
-    if verdict != VERDICT_MATCHED:
-        raise TrackingDatabaseMutationError(
-            f"{label}.verdict must be {VERDICT_MATCHED!r} to bind a talk, got "
-            f"{verdict!r}; route a {verdict!r} deck to owner review instead"
-        )
-    selected = assessment["selected_talk_filename"]
-    if selected != talk_filename:
-        raise TrackingDatabaseMutationError(
-            f"{label}.selected_talk_filename {selected!r} does not match the "
-            f"record's talk_filename {talk_filename!r}"
-        )
-    role = assessment["artifact_role"]
-    if role != ROLE_DELIVERY:
-        raise TrackingDatabaseMutationError(
-            f"{label}.artifact_role {role!r} is not a delivery artifact; record "
-            "which artifact is the published source before binding it"
-        )
-    reason_codes = assessment["reason_codes"]
-    if not isinstance(reason_codes, list) or not all(
-        isinstance(code, str) for code in reason_codes
-    ):
-        raise TrackingDatabaseMutationError(
-            f"{label}.reason_codes must be an array of strings"
-        )
-    unknown = sorted(set(reason_codes) - REASON_CODES)
-    if unknown:
-        raise TrackingDatabaseMutationError(
-            f"{label}.reason_codes carries codes outside the closed taxonomy: {unknown}"
-        )
-    # Membership in the taxonomy is not enough. Every code but the matched one
-    # explains a refusal, so a `matched` verdict carrying one describes an
-    # assessment that cannot exist — and the legacy-binding code means the exact
-    # opposite of proven.
-    if sorted(set(reason_codes)) != sorted(MATCHED_REASON_CODES):
-        raise TrackingDatabaseMutationError(
-            f"{label}.reason_codes must be exactly {sorted(MATCHED_REASON_CODES)} "
-            f"for a {VERDICT_MATCHED!r} verdict, got {reason_codes}"
+            f"{label} does not authorize this binding ({refusal}); a talk "
+            "binding must be proven before the deck's contents become that "
+            "talk's evidence"
         )
 
 

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1080,6 +1080,7 @@ def _apply_retire_improvement_goal(
 def _require_bound_identity_assessment(
     assessment: object,
     *,
+    pptx_path: str,
     talk_filename: str | None,
     label: str,
 ) -> None:
@@ -1090,10 +1091,14 @@ def _require_bound_identity_assessment(
     nothing downstream can tell that a talk's slide counts, OCR, and pattern
     observations came from someone else's deck.
 
-    Three things must hold together, and checking fewer is checking none: the
-    assessment must be a `matched` verdict, it must name THIS record's talk, and
-    it must be for a delivery artifact. A `review_required` verdict that names
-    the right talk is still an owner decision nobody made yet.
+    Four things must hold together, and checking fewer is checking none: the
+    assessment must be a `matched` verdict, it must be ABOUT this record's deck,
+    it must name THIS record's talk, and it must be for a delivery artifact.
+
+    Both endpoints are checked because an assessment binds a pair. Verifying the
+    talk alone leaves the deck free: a real, correctly-decided assessment for
+    deck A pasted onto deck B's record would pass every other check and bind B's
+    contents to A's talk — the same defect in the other direction.
     """
     if talk_filename is None:
         if assessment is not None:
@@ -1109,9 +1114,15 @@ def _require_bound_identity_assessment(
     _require_keys(
         assessment,
         required=PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS,
-        optional={"pptx_path", "candidates"},
+        optional={"candidates"},
         label=label,
     )
+    assessed_path = assessment["pptx_path"]
+    if assessed_path != pptx_path:
+        raise TrackingDatabaseMutationError(
+            f"{label}.pptx_path {assessed_path!r} does not match the record's "
+            f"pptx_path {pptx_path!r}"
+        )
     if not json_values_equal(
         assessment["schema_version"], PPTX_TALK_IDENTITY_SCHEMA_VERSION
     ):
@@ -1223,6 +1234,7 @@ def _apply_record_pptx(
         )
     _require_bound_identity_assessment(
         record.get("identity_assessment"),
+        pptx_path=pptx_path,
         talk_filename=talk_filename,
         label=f"{record_label}.identity_assessment",
     )

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1115,7 +1115,6 @@ def _require_bound_identity_assessment(
     _require_keys(
         assessment,
         required=PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS,
-        optional={"candidates"},
         label=label,
     )
     assessed_path = assessment["pptx_path"]

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -646,4 +646,7 @@ def unassessed_legacy_binding(pptx_path: str) -> dict[str, Any]:
         "artifact_role": ROLE_DELIVERY,
         "selected_talk_filename": None,
         "reason_codes": [REASON_UNASSESSED_LEGACY_BINDING],
+        # Empty rather than absent: migration assessed no candidates, which is
+        # a different statement from having assessed some and reported none.
+        "candidates": [],
     }

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -650,3 +650,53 @@ def unassessed_legacy_binding(pptx_path: str) -> dict[str, Any]:
         # a different statement from having assessed some and reported none.
         "candidates": [],
     }
+
+
+def binding_refusal(
+    assessment: object,
+    *,
+    pptx_path: str,
+    talk_filename: str,
+) -> str | None:
+    """Say why an assessment fails to authorize a binding, or None if it does.
+
+    One predicate, two callers. The owner writer raises on it so an unproven
+    binding is never persisted; preflight reports it so a binding persisted
+    before this contract existed cannot pass as proven. Two copies of this rule
+    would drift, and the direction they drift is a reader trusting what a writer
+    would have refused (`stateful-artifacts` -> Hints, Not Authority).
+
+    Checks the whole triple, not the verdict alone: an assessment names a deck
+    AND a talk, so one that proves a different pair proves nothing about this
+    row. Reason codes are checked because every code but the matched one
+    explains a refusal.
+    """
+    if not isinstance(assessment, Mapping):
+        return "identity_assessment_missing"
+    missing = {
+        "schema_version",
+        "pptx_path",
+        "verdict",
+        "artifact_role",
+        "selected_talk_filename",
+        "reason_codes",
+        "candidates",
+    } - set(assessment)
+    if missing:
+        return "identity_assessment_incomplete"
+    if assessment["schema_version"] != PPTX_TALK_IDENTITY_SCHEMA_VERSION:
+        return "identity_assessment_schema_unsupported"
+    if assessment["verdict"] != VERDICT_MATCHED:
+        return "identity_verdict_not_matched"
+    if assessment["pptx_path"] != pptx_path:
+        return "identity_deck_mismatch"
+    if assessment["selected_talk_filename"] != talk_filename:
+        return "identity_talk_mismatch"
+    if assessment["artifact_role"] != ROLE_DELIVERY:
+        return "identity_non_delivery_artifact"
+    codes = assessment["reason_codes"]
+    if not isinstance(codes, list) or not all(isinstance(code, str) for code in codes):
+        return "identity_reason_codes_invalid"
+    if sorted(set(codes)) != sorted(MATCHED_REASON_CODES):
+        return "identity_reason_codes_contradict_verdict"
+    return None

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -103,6 +103,10 @@ REASON_AMBIGUOUS_CANDIDATES = "identity_ambiguous_candidates"
 REASON_CONFLICTING_SIGNALS = "identity_conflicting_signals"
 REASON_MATCHED = "identity_matched"
 REASON_NON_DELIVERY_ARTIFACT = "identity_non_delivery_artifact"
+# Stamped by migration onto a record that bound its talk before any assessment
+# existed. The binding is not declared wrong — it is declared unproven, which is
+# the honest reading and the one that routes it to review instead of trusting it.
+REASON_UNASSESSED_LEGACY_BINDING = "identity_unassessed_legacy_binding"
 
 REASON_CODES = frozenset(
     {
@@ -113,6 +117,7 @@ REASON_CODES = frozenset(
         REASON_CONFLICTING_SIGNALS,
         REASON_MATCHED,
         REASON_NON_DELIVERY_ARTIFACT,
+        REASON_UNASSESSED_LEGACY_BINDING,
     }
 )
 
@@ -616,3 +621,23 @@ def assess_pptx_talk_identity(
         return result(VERDICT_REVIEW_REQUIRED, None, REASON_FILENAME_SIMILARITY_ONLY)
 
     return result(VERDICT_UNMATCHED, None, REASON_NO_AGREEING_SIGNAL)
+
+
+def unassessed_legacy_binding(pptx_path: str) -> dict[str, Any]:
+    """The assessment for a talk binding made before assessments existed.
+
+    Migration cannot prove a binding it did not witness, and inventing a
+    `matched` verdict for one would forge exactly the evidence this module was
+    written to require. It cannot call the binding wrong either — most legacy
+    bindings are right. `review_required` is the only honest verdict: the record
+    upgrades, the binding survives, and nothing downstream may treat it as
+    proven until someone looks.
+    """
+    return {
+        "schema_version": PPTX_TALK_IDENTITY_SCHEMA_VERSION,
+        "pptx_path": pptx_path,
+        "verdict": VERDICT_REVIEW_REQUIRED,
+        "artifact_role": ROLE_DELIVERY,
+        "selected_talk_filename": None,
+        "reason_codes": [REASON_UNASSESSED_LEGACY_BINDING],
+    }

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -121,6 +121,12 @@ REASON_CODES = frozenset(
     }
 )
 
+# The only reason a `matched` verdict may claim. Every other code in the
+# taxonomy explains a refusal, so pairing one with `matched` describes an
+# assessment that cannot exist — most dangerously the legacy-binding code, which
+# means the opposite of proven.
+MATCHED_REASON_CODES = frozenset({REASON_MATCHED})
+
 # An editable master and a published static export are legitimate artifacts for
 # a delivery, but they are not the delivery deck and must not silently become
 # its evidence. Roles are reported so the owner records which artifact is the

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -214,6 +214,30 @@ class CandidateAssessment:
         }
 
 
+def derive_candidate_standing(
+    signals: Mapping[str, str],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Derive `(agreeing, conflicting)` from a candidate's per-signal map.
+
+    One rule, used by the producer that writes a candidate and by the owner gate
+    that later reads one back. A stored candidate's arrays are a summary of its
+    signal map, so a gate that trusts the summary without recomputing it accepts
+    any pair of values a caller cares to put there — `agreeing: ["venue"]` over a
+    signal map where venue conflicts, or over no venue reading at all.
+
+    Only selecting signals can corroborate; every signal can contradict.
+    """
+    agreeing = tuple(
+        name
+        for name in SIGNAL_NAMES
+        if name in SELECTING_SIGNALS and signals.get(name) == SIGNAL_AGREE
+    )
+    conflicting = tuple(
+        name for name in SIGNAL_NAMES if signals.get(name) == SIGNAL_CONFLICT
+    )
+    return agreeing, conflicting
+
+
 @dataclass(frozen=True)
 class TalkIdentityAssessment:
     """The full, schema-versioned identity verdict for one deck."""
@@ -540,14 +564,7 @@ def assess_candidate(
         name: evaluator(facts, talk, known_aliases)
         for name, evaluator in _SIGNAL_EVALUATORS.items()
     }
-    agreeing = tuple(
-        name
-        for name in SIGNAL_NAMES
-        if name in SELECTING_SIGNALS and signals[name] == SIGNAL_AGREE
-    )
-    conflicting = tuple(
-        name for name in SIGNAL_NAMES if signals[name] == SIGNAL_CONFLICT
-    )
+    agreeing, conflicting = derive_candidate_standing(signals)
     return CandidateAssessment(
         talk_filename=filename,
         signals=signals,
@@ -713,32 +730,43 @@ def _candidate_table_refusal(candidates: object, talk_filename: str) -> str | No
     """
     if not isinstance(candidates, list) or not candidates:
         return "identity_candidate_table_missing"
-    selected: Mapping[str, Any] | None = None
+    selected: tuple[tuple[str, ...], tuple[str, ...]] | None = None
     rivals = 0
     for candidate in candidates:
         if not isinstance(candidate, Mapping):
             return "identity_candidate_table_invalid"
         name = candidate.get("talk_filename")
-        agreeing = candidate.get("agreeing")
-        conflicting = candidate.get("conflicting")
+        signals = candidate.get("signals")
+        stored_agreeing = candidate.get("agreeing")
+        stored_conflicting = candidate.get("conflicting")
         if (
             not isinstance(name, str)
-            or not isinstance(agreeing, list)
-            or not isinstance(conflicting, list)
+            or not isinstance(signals, Mapping)
+            or not isinstance(stored_agreeing, list)
+            or not isinstance(stored_conflicting, list)
         ):
             return "identity_candidate_table_invalid"
+        # The signal map is the evidence; the two arrays are its summary. Read
+        # the evidence and recompute the summary, so a candidate cannot assert a
+        # standing its own readings do not support.
+        if set(signals) != set(SIGNAL_NAMES) or any(
+            signals[key] not in SIGNAL_VERDICTS for key in signals
+        ):
+            return "identity_candidate_signals_invalid"
+        agreeing, conflicting = derive_candidate_standing(signals)
+        if list(agreeing) != stored_agreeing or list(conflicting) != stored_conflicting:
+            return "identity_candidate_standing_contradicts_signals"
         if name == talk_filename:
             if selected is not None:
                 return "identity_candidate_table_invalid"
-            selected = candidate
+            selected = (agreeing, conflicting)
         elif agreeing and not conflicting:
             rivals += 1
     if selected is None:
         return "identity_candidate_absent"
-    if not selected["agreeing"] or selected["conflicting"]:
+    selected_agreeing, selected_conflicting = selected
+    if not selected_agreeing or selected_conflicting:
         return "identity_candidate_not_selectable"
-    if any(signal not in SELECTING_SIGNALS for signal in selected["agreeing"]):
-        return "identity_candidate_agreement_not_selecting"
     if rivals:
         return "identity_candidate_not_unique"
     return None

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -699,4 +699,46 @@ def binding_refusal(
         return "identity_reason_codes_invalid"
     if sorted(set(codes)) != sorted(MATCHED_REASON_CODES):
         return "identity_reason_codes_contradict_verdict"
+    return _candidate_table_refusal(assessment["candidates"], talk_filename)
+
+
+def _candidate_table_refusal(candidates: object, talk_filename: str) -> str | None:
+    """Check the evidence behind the verdict, not just the verdict.
+
+    A `matched` verdict over an empty candidate table is a conclusion with
+    nothing under it — which is exactly what a fabricated assessment looks like.
+    The table must show this talk winning the way `assess_pptx_talk_identity`
+    makes it win: corroborated by a selecting signal, contradicted by none, and
+    with no rival equally corroborated.
+    """
+    if not isinstance(candidates, list) or not candidates:
+        return "identity_candidate_table_missing"
+    selected: Mapping[str, Any] | None = None
+    rivals = 0
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            return "identity_candidate_table_invalid"
+        name = candidate.get("talk_filename")
+        agreeing = candidate.get("agreeing")
+        conflicting = candidate.get("conflicting")
+        if (
+            not isinstance(name, str)
+            or not isinstance(agreeing, list)
+            or not isinstance(conflicting, list)
+        ):
+            return "identity_candidate_table_invalid"
+        if name == talk_filename:
+            if selected is not None:
+                return "identity_candidate_table_invalid"
+            selected = candidate
+        elif agreeing and not conflicting:
+            rivals += 1
+    if selected is None:
+        return "identity_candidate_absent"
+    if not selected["agreeing"] or selected["conflicting"]:
+        return "identity_candidate_not_selectable"
+    if any(signal not in SELECTING_SIGNALS for signal in selected["agreeing"]):
+        return "identity_candidate_agreement_not_selecting"
+    if rivals:
+        return "identity_candidate_not_unique"
     return None

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -373,11 +373,15 @@ class VaultPreflight:
                 # A v1 or v2 row that migration has not reached yet. Its binding
                 # is no more proven than a migrated one, and saying so is the
                 # point of the sweep.
+                # v1 rows stay at v1 by design, so migration will not reach
+                # this one. That makes it MORE unproven than a migrated row,
+                # not less, and a warning would let Step 1 proceed on it.
                 self.add(
-                    "warning",
+                    "blocking",
                     "pptx_talk_binding_unassessed",
                     "catalog row binds a talk with no identity assessment; "
-                    "migrate the database so the binding is classified",
+                    "assess the deck before its contents become that talk's "
+                    "evidence",
                     field=f"pptx_catalog[{index}].identity_assessment",
                     expected=VERDICT_MATCHED,
                     actual=None,

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -73,7 +73,6 @@ from source_identity_matching import (
 )
 from pptx_catalog_selection import classify_catalog
 from pptx_talk_identity import (
-    REASON_UNASSESSED_LEGACY_BINDING,
     VERDICT_MATCHED,
     binding_refusal,
 )
@@ -349,11 +348,12 @@ class VaultPreflight:
         that stamp it would be inert — the deck would still feed slide counts,
         OCR, and pattern observations to whichever talk the row names.
 
-        Severity splits on where the doubt came from. Migration's own stamp
-        warns: it applies to every legacy row at once, and blocking on all of
-        them would refuse the whole vault over a condition the migration
-        created. A verdict from a REAL assessment blocks — an assessor that
-        looked and refused is a specific, actionable finding about one row.
+        Every unproven binding blocks, including the one migration stamped.
+        A warning would let Step 1's blocking-only gate proceed on state the
+        database itself marks unproven, which is the whole failure this exists
+        to stop. The cost is real and deliberate: a vault carrying legacy rows
+        stays blocked until they are assessed, so assessing them is reparse
+        prerequisite work rather than something to discover mid-run.
 
         Identity is not currency. A row can hold a perfectly current extraction
         receipt for the wrong talk, so this never touches
@@ -398,9 +398,8 @@ class VaultPreflight:
                 continue
             reason_codes = assessment.get("reason_codes")
             codes = reason_codes if isinstance(reason_codes, list) else []
-            legacy_only = codes == [REASON_UNASSESSED_LEGACY_BINDING]
             self.add(
-                "warning" if legacy_only else "blocking",
+                "blocking",
                 "pptx_talk_binding_unproven",
                 "catalog row binds a talk its identity assessment does not "
                 "prove; review before its contents become that talk's evidence",

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -75,6 +75,7 @@ from pptx_catalog_selection import classify_catalog
 from pptx_talk_identity import (
     REASON_UNASSESSED_LEGACY_BINDING,
     VERDICT_MATCHED,
+    binding_refusal,
 )
 from pptx_evidence import (
     PPTX_EXTRACTION_PIPELINE_VERSION,
@@ -382,7 +383,18 @@ class VaultPreflight:
                     actual=None,
                 )
                 continue
-            if assessment.get("verdict") == VERDICT_MATCHED:
+            pptx_path = record.get("pptx_path")
+            talk_filename = record.get("talk_filename")
+            refusal = (
+                binding_refusal(
+                    assessment,
+                    pptx_path=pptx_path,
+                    talk_filename=talk_filename,
+                )
+                if isinstance(pptx_path, str) and isinstance(talk_filename, str)
+                else "identity_assessment_incomplete"
+            )
+            if refusal is None:
                 continue
             reason_codes = assessment.get("reason_codes")
             codes = reason_codes if isinstance(reason_codes, list) else []
@@ -395,6 +407,7 @@ class VaultPreflight:
                 field=f"pptx_catalog[{index}].identity_assessment",
                 expected=VERDICT_MATCHED,
                 actual={
+                    "refusal": refusal,
                     "verdict": assessment.get("verdict"),
                     "reason_codes": codes,
                     "pptx_path": record.get("pptx_path"),

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -72,6 +72,10 @@ from source_identity_matching import (
     titles_agree,
 )
 from pptx_catalog_selection import classify_catalog
+from pptx_talk_identity import (
+    REASON_UNASSESSED_LEGACY_BINDING,
+    VERDICT_MATCHED,
+)
 from pptx_evidence import (
     PPTX_EXTRACTION_PIPELINE_VERSION,
     PPTX_EXTRACTION_SCHEMA_VERSION,
@@ -334,6 +338,70 @@ class VaultPreflight:
                 },
             )
 
+    def _check_pptx_talk_identity(self) -> None:
+        """Report catalog rows whose talk binding is not proven (#176).
+
+        This is the catalog-wide sweep. The writer refuses a NEW unproven
+        binding, but the rows already in the database were bound before any
+        assessment existed, and migration deliberately stamped them
+        `review_required` rather than forging proof. Without a reader consuming
+        that stamp it would be inert — the deck would still feed slide counts,
+        OCR, and pattern observations to whichever talk the row names.
+
+        Severity splits on where the doubt came from. Migration's own stamp
+        warns: it applies to every legacy row at once, and blocking on all of
+        them would refuse the whole vault over a condition the migration
+        created. A verdict from a REAL assessment blocks — an assessor that
+        looked and refused is a specific, actionable finding about one row.
+
+        Identity is not currency. A row can hold a perfectly current extraction
+        receipt for the wrong talk, so this never touches
+        `classify_pptx_visual_evidence` — a wrong binding is not stale evidence,
+        it is evidence filed against the wrong talk.
+        """
+        records = self.database.get("pptx_catalog")
+        if not isinstance(records, list):
+            return
+        for index, record in enumerate(records):
+            if not isinstance(record, dict):
+                continue
+            if record.get("talk_filename") is None:
+                continue
+            assessment = record.get("identity_assessment")
+            if not isinstance(assessment, dict):
+                # A v1 or v2 row that migration has not reached yet. Its binding
+                # is no more proven than a migrated one, and saying so is the
+                # point of the sweep.
+                self.add(
+                    "warning",
+                    "pptx_talk_binding_unassessed",
+                    "catalog row binds a talk with no identity assessment; "
+                    "migrate the database so the binding is classified",
+                    field=f"pptx_catalog[{index}].identity_assessment",
+                    expected=VERDICT_MATCHED,
+                    actual=None,
+                )
+                continue
+            if assessment.get("verdict") == VERDICT_MATCHED:
+                continue
+            reason_codes = assessment.get("reason_codes")
+            codes = reason_codes if isinstance(reason_codes, list) else []
+            legacy_only = codes == [REASON_UNASSESSED_LEGACY_BINDING]
+            self.add(
+                "warning" if legacy_only else "blocking",
+                "pptx_talk_binding_unproven",
+                "catalog row binds a talk its identity assessment does not "
+                "prove; review before its contents become that talk's evidence",
+                field=f"pptx_catalog[{index}].identity_assessment",
+                expected=VERDICT_MATCHED,
+                actual={
+                    "verdict": assessment.get("verdict"),
+                    "reason_codes": codes,
+                    "pptx_path": record.get("pptx_path"),
+                    "talk_filename": record.get("talk_filename"),
+                },
+            )
+
     def add(
         self,
         severity: str,
@@ -482,6 +550,7 @@ class VaultPreflight:
             )
 
         self._check_pptx_visual_evidence()
+        self._check_pptx_talk_identity()
 
         talks = self.database.get("talks")
         if not isinstance(talks, list):

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -91,6 +91,7 @@ PPTX_CATALOG_V3_REQUIRED_FIELDS = PPTX_CATALOG_V2_REQUIRED_FIELDS | {
 PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS = frozenset(
     {
         "schema_version",
+        "pptx_path",
         "verdict",
         "artifact_role",
         "selected_talk_filename",

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -25,6 +25,7 @@ from pptx_discovery_contract import (
     PptxDiscoveryContractError,
     validate_pptx_directory_exclusions,
 )
+from pptx_talk_identity import unassessed_legacy_binding
 
 
 LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
@@ -1398,6 +1399,45 @@ def _migrate_talk_record(talk: dict[str, Any]) -> bool:
     return talk_version_added
 
 
+def _migrate_pptx_catalog_records(candidate: dict[str, Any]) -> int:
+    """Upgrade evidence-bound catalog records to the identity-bound shape.
+
+    A v2 record's talk binding was made before any assessment existed, so
+    migration cannot prove it. It must not invent a `matched` verdict — that
+    would forge the evidence the v3 shape exists to require — and it must not
+    call the binding wrong, because most legacy bindings are right. Stamping
+    `review_required` upgrades the record, preserves the binding, and stops
+    anything downstream from treating it as proven until someone looks.
+
+    v1 records stay at v1: they carry no `visual_evidence` either, and the
+    established position is that migration preserves such a record rather than
+    inventing a binding for it.
+    """
+    records = candidate.get("pptx_catalog")
+    if not isinstance(records, list):
+        return 0
+    migrated = 0
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        if (
+            record.get("schema_version")
+            != PPTX_CATALOG_EVIDENCE_BOUND_RECORD_SCHEMA_VERSION
+        ):
+            continue
+        pptx_path = record.get("pptx_path")
+        if not isinstance(pptx_path, str) or not pptx_path.strip():
+            continue
+        record["schema_version"] = PPTX_CATALOG_RECORD_SCHEMA_VERSION
+        record["identity_assessment"] = (
+            unassessed_legacy_binding(pptx_path)
+            if record.get("talk_filename") is not None
+            else None
+        )
+        migrated += 1
+    return migrated
+
+
 def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
     """Build the deterministic owner migration to root v1/config v2."""
     assessment = assess_tracking_database(database)
@@ -1407,13 +1447,20 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
             + ", ".join(assessment.reason_codes)
         )
     if assessment.state == "current":
-        current = require_current_tracking_database(database)
+        # A current ROOT does not mean current RECORDS. Returning here on the
+        # root version alone is how a record-level shape bump gets skipped for
+        # every live database, since they all reached root v1 long ago — so the
+        # record migrations run first and only a genuinely unchanged database
+        # takes the no-op path.
+        current = copy.deepcopy(require_current_tracking_database(database))
+        counts = _empty_record_counts()
+        counts["pptx_catalog"] = _migrate_pptx_catalog_records(current)
         return TrackingDatabaseMigration(
-            database=copy.deepcopy(current),
-            changed=False,
+            database=current,
+            changed=any(counts.values()),
             from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
             to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
-            record_counts=_empty_record_counts(),
+            record_counts=counts,
         )
     if not isinstance(database, dict):
         raise TrackingDatabaseError("tracking database root must be a JSON object")
@@ -1471,6 +1518,8 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
             )
         if _migrate_talk_record(talk):
             counts["talks"] += 1
+
+    counts["pptx_catalog"] += _migrate_pptx_catalog_records(candidate)
 
     simple_collections = {
         # An unversioned pptx_catalog record persisted no extractor generation,

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -97,6 +97,10 @@ PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS = frozenset(
         "artifact_role",
         "selected_talk_filename",
         "reason_codes",
+        # The assessor always emits its candidate table, and it is the only
+        # record of what the other talks scored. Accepting an assessment without
+        # it would persist a verdict nobody can re-examine.
+        "candidates",
     }
 )
 # Both versions bind a visual claim to the extractor generation that produced

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -34,7 +34,8 @@ TALK_RECORD_SCHEMA_VERSION = 5
 LEGACY_CONFIG_RECORD_SCHEMA_VERSION = 1
 CONFIG_RECORD_SCHEMA_VERSION = 2
 LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION = 1
-PPTX_CATALOG_RECORD_SCHEMA_VERSION = 2
+PPTX_CATALOG_EVIDENCE_BOUND_RECORD_SCHEMA_VERSION = 2
+PPTX_CATALOG_RECORD_SCHEMA_VERSION = 3
 LEGACY_QR_CODE_RECORD_SCHEMA_VERSION = 1
 QR_CODE_RECORD_SCHEMA_VERSION = 2
 RESOURCE_RECORD_SCHEMA_VERSION = 1
@@ -80,6 +81,31 @@ PPTX_CATALOG_REQUIRED_FIELDS = frozenset(
 # source bytes that produced it. A v1 record carries no such binding, so its
 # bare `visual_extracted: true` cannot say which extractor schema it refers to.
 PPTX_CATALOG_V2_REQUIRED_FIELDS = PPTX_CATALOG_REQUIRED_FIELDS | {"visual_evidence"}
+# v3 adds the identity assessment that proves the deck belongs to the talk it
+# names. v2 bound a visual claim to the bytes it came from but said nothing
+# about WHOSE deck those bytes were, so a deck could carry a perfectly-attested
+# extraction receipt for the wrong talk.
+PPTX_CATALOG_V3_REQUIRED_FIELDS = PPTX_CATALOG_V2_REQUIRED_FIELDS | {
+    "identity_assessment"
+}
+PPTX_IDENTITY_ASSESSMENT_REQUIRED_FIELDS = frozenset(
+    {
+        "schema_version",
+        "verdict",
+        "artifact_role",
+        "selected_talk_filename",
+        "reason_codes",
+    }
+)
+# Both versions bind a visual claim to the extractor generation that produced
+# it, so both classify. They differ only in whether the talk binding is proven,
+# which is an identity question, not a currency one.
+_EVIDENCE_BOUND_PPTX_CATALOG_SCHEMA_VERSIONS = frozenset(
+    {
+        PPTX_CATALOG_EVIDENCE_BOUND_RECORD_SCHEMA_VERSION,
+        PPTX_CATALOG_RECORD_SCHEMA_VERSION,
+    }
+)
 PPTX_VISUAL_EVIDENCE_REQUIRED_FIELDS = frozenset(
     {
         "outcome",
@@ -527,14 +553,15 @@ def classify_pptx_visual_evidence(
         if record.get("visual_extracted") is True:
             return PPTX_EVIDENCE_UNKNOWN_LEGACY
         return PPTX_EVIDENCE_PENDING
-    if version != PPTX_CATALOG_RECORD_SCHEMA_VERSION:
+    if version not in _EVIDENCE_BOUND_PPTX_CATALOG_SCHEMA_VERSIONS:
         # A record newer than this reader accepts means the reader is lagging,
         # not that the record is legacy. Classifying it as pending would send
         # a deck back through extraction on the strength of a shape this
         # function cannot read; the caller must update instead.
         raise TrackingDatabaseError(
             f"pptx_catalog record schema_version {version} is newer than this "
-            f"reader accepts (v{LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION} and "
+            f"reader accepts (v{LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION}, "
+            f"v{PPTX_CATALOG_EVIDENCE_BOUND_RECORD_SCHEMA_VERSION}, and "
             f"v{PPTX_CATALOG_RECORD_SCHEMA_VERSION}); update speaker-toolkit"
         )
     # Validate before trusting. A receipt is the licence to SKIP extraction, so
@@ -803,16 +830,15 @@ def _validate_collection_record(
         version = record.get(
             "schema_version", LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION
         )
-        is_v2 = version == PPTX_CATALOG_RECORD_SCHEMA_VERSION
-        _require_closed_shape(
-            record,
-            required=(
-                PPTX_CATALOG_V2_REQUIRED_FIELDS
-                if is_v2
-                else PPTX_CATALOG_REQUIRED_FIELDS
-            ),
-            label=label,
-        )
+        is_v3 = version == PPTX_CATALOG_RECORD_SCHEMA_VERSION
+        is_v2 = version == PPTX_CATALOG_EVIDENCE_BOUND_RECORD_SCHEMA_VERSION
+        if is_v3:
+            required = PPTX_CATALOG_V3_REQUIRED_FIELDS
+        elif is_v2:
+            required = PPTX_CATALOG_V2_REQUIRED_FIELDS
+        else:
+            required = PPTX_CATALOG_REQUIRED_FIELDS
+        _require_closed_shape(record, required=required, label=label)
         _require_nonempty_string(record["pptx_path"], f"{label}.pptx_path")
         talk_filename = record["talk_filename"]
         if talk_filename is not None:
@@ -826,10 +852,27 @@ def _validate_collection_record(
         _require_exact_integer(record["slide_count"], f"{label}.slide_count")
         if type(record["visual_extracted"]) is not bool:
             raise TrackingDatabaseError(f"{label}.visual_extracted must be a boolean")
-        if is_v2 and not isinstance(record["visual_evidence"], (Mapping, type(None))):
+        if (is_v2 or is_v3) and not isinstance(
+            record["visual_evidence"], (Mapping, type(None))
+        ):
             raise TrackingDatabaseError(
                 f"{label}.visual_evidence must be an object or null"
             )
+        if is_v3:
+            # Shape only, and only enough to keep a reader from mistaking an
+            # unproven binding for a proven one. The binding's own semantics are
+            # the writer's gate — see `_apply_record_pptx`.
+            assessment = record["identity_assessment"]
+            if talk_filename is None:
+                if assessment is not None:
+                    raise TrackingDatabaseError(
+                        f"{label}.identity_assessment must be null when "
+                        "talk_filename is null"
+                    )
+            elif not isinstance(assessment, Mapping):
+                raise TrackingDatabaseError(
+                    f"{label}.identity_assessment must be an object on a matched record"
+                )
         # The receipt's own shape is NOT validated here. A malformed receipt is
         # per-record evidence trouble, not unusable owner state: failing the
         # whole assessment would make preflight refuse the vault over one bad
@@ -1105,7 +1148,7 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
         "pptx_catalog": frozenset(
             {
                 LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION,
-                PPTX_CATALOG_RECORD_SCHEMA_VERSION,
+                *_EVIDENCE_BOUND_PPTX_CATALOG_SCHEMA_VERSIONS,
             }
         ),
         "qr_codes": frozenset(

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1399,6 +1399,16 @@ def _migrate_talk_record(talk: dict[str, Any]) -> bool:
     return talk_version_added
 
 
+def _require_no_active_writers(talks: list[Any]) -> None:
+    """Refuse to change persisted shape while a writer owns the database."""
+    active = _active_claim_filenames(talks)
+    if active:
+        raise TrackingDatabaseError(
+            "tracking database has active queue writers; recover or complete these "
+            f"claims before migration: {active}"
+        )
+
+
 def _migrate_pptx_catalog_records(candidate: dict[str, Any]) -> int:
     """Upgrade evidence-bound catalog records to the identity-bound shape.
 
@@ -1450,17 +1460,7 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
         raise TrackingDatabaseError("tracking database root must be a JSON object")
 
     candidate: dict[str, Any] = copy.deepcopy(database)
-    # Ahead of both migration branches. A shape change is a shape change whether
-    # the root version moves or only a record's does, so an active writer must
-    # block it either way — gating only the root-migration path would let a
-    # record-level bump rewrite the database out from under a live claim.
     talks = _object_collection(candidate, "talks", required=True)
-    active = _active_claim_filenames(talks)
-    if active:
-        raise TrackingDatabaseError(
-            "tracking database has active queue writers; recover or complete these "
-            f"claims before migration: {active}"
-        )
 
     if assessment.state == "current":
         # A current ROOT does not mean current RECORDS. Returning on the root
@@ -1471,6 +1471,12 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
         require_current_tracking_database(candidate)
         counts = _empty_record_counts()
         counts["pptx_catalog"] = _migrate_pptx_catalog_records(candidate)
+        if any(counts.values()):
+            # Guarded only once state would actually change. A no-op migration
+            # must stay callable while a claim is live: Step 1 migrates before
+            # Step 2 can recover a stranded claim, so refusing here would leave
+            # an interrupted run unable to resume.
+            _require_no_active_writers(talks)
         return TrackingDatabaseMigration(
             database=candidate,
             changed=any(counts.values()),
@@ -1479,6 +1485,9 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
             record_counts=counts,
         )
 
+    # Reaching here means the root or config shape moves, which is always a
+    # state change.
+    _require_no_active_writers(talks)
     root_version = tracking_database_schema_version(candidate)
 
     config = candidate.setdefault("config", {})

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1514,11 +1514,16 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
         config["schema_version"] = CONFIG_RECORD_SCHEMA_VERSION
         counts["config"] = 1
 
+    # Ahead of the root-current return. A database at root v1 with a legacy
+    # config takes that return, so a record migration placed after it would be
+    # skipped for exactly the databases whose config still needed upgrading.
+    counts["pptx_catalog"] += _migrate_pptx_catalog_records(candidate)
+
     if root_version == TRACKING_DATABASE_SCHEMA_VERSION:
         require_current_tracking_database(candidate)
         return TrackingDatabaseMigration(
             database=candidate,
-            changed=bool(counts["config"]),
+            changed=bool(counts["config"] or counts["pptx_catalog"]),
             from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
             to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
             record_counts=counts,
@@ -1533,8 +1538,6 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
             )
         if _migrate_talk_record(talk):
             counts["talks"] += 1
-
-    counts["pptx_catalog"] += _migrate_pptx_catalog_records(candidate)
 
     simple_collections = {
         # An unversioned pptx_catalog record persisted no extractor generation,

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1446,27 +1446,14 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
             "tracking database cannot be migrated by this owner version: "
             + ", ".join(assessment.reason_codes)
         )
-    if assessment.state == "current":
-        # A current ROOT does not mean current RECORDS. Returning here on the
-        # root version alone is how a record-level shape bump gets skipped for
-        # every live database, since they all reached root v1 long ago — so the
-        # record migrations run first and only a genuinely unchanged database
-        # takes the no-op path.
-        current = copy.deepcopy(require_current_tracking_database(database))
-        counts = _empty_record_counts()
-        counts["pptx_catalog"] = _migrate_pptx_catalog_records(current)
-        return TrackingDatabaseMigration(
-            database=current,
-            changed=any(counts.values()),
-            from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
-            to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
-            record_counts=counts,
-        )
     if not isinstance(database, dict):
         raise TrackingDatabaseError("tracking database root must be a JSON object")
 
     candidate: dict[str, Any] = copy.deepcopy(database)
-    root_version = tracking_database_schema_version(candidate)
+    # Ahead of both migration branches. A shape change is a shape change whether
+    # the root version moves or only a record's does, so an active writer must
+    # block it either way — gating only the root-migration path would let a
+    # record-level bump rewrite the database out from under a live claim.
     talks = _object_collection(candidate, "talks", required=True)
     active = _active_claim_filenames(talks)
     if active:
@@ -1474,6 +1461,25 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
             "tracking database has active queue writers; recover or complete these "
             f"claims before migration: {active}"
         )
+
+    if assessment.state == "current":
+        # A current ROOT does not mean current RECORDS. Returning on the root
+        # version alone is how a record-level shape bump gets skipped for every
+        # live database, since they all reached root v1 long ago — so the record
+        # migrations run first and only a genuinely unchanged database takes the
+        # no-op path.
+        require_current_tracking_database(candidate)
+        counts = _empty_record_counts()
+        counts["pptx_catalog"] = _migrate_pptx_catalog_records(candidate)
+        return TrackingDatabaseMigration(
+            database=candidate,
+            changed=any(counts.values()),
+            from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+            to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+            record_counts=counts,
+        )
+
+    root_version = tracking_database_schema_version(candidate)
 
     config = candidate.setdefault("config", {})
     if not isinstance(config, dict):

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -103,6 +103,7 @@ def _complete_plan() -> dict[str, Any]:
                     "visual_evidence": None,
                     "identity_assessment": {
                         "schema_version": 1,
+                        "pptx_path": "Conference/Talk.pptx",
                         "verdict": "matched",
                         "artifact_role": "delivery",
                         "selected_talk_filename": "talk.md",

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -108,7 +108,14 @@ def _complete_plan() -> dict[str, Any]:
                         "artifact_role": "delivery",
                         "selected_talk_filename": "talk.md",
                         "reason_codes": ["identity_matched"],
-                        "candidates": [],
+                        "candidates": [
+                            {
+                                "talk_filename": "talk.md",
+                                "signals": {},
+                                "agreeing": ["venue"],
+                                "conflicting": [],
+                            }
+                        ],
                     },
                 },
             },

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -94,13 +94,20 @@ def _complete_plan() -> dict[str, Any]:
                 "expect": MISSING,
                 "expect_talk_pptx_path": MISSING,
                 "record": {
-                    "schema_version": 2,
+                    "schema_version": 3,
                     "pptx_path": "Conference/Talk.pptx",
                     "talk_filename": "talk.md",
                     "matched": True,
                     "slide_count": 10,
                     "visual_extracted": False,
                     "visual_evidence": None,
+                    "identity_assessment": {
+                        "schema_version": 1,
+                        "verdict": "matched",
+                        "artifact_role": "delivery",
+                        "selected_talk_filename": "talk.md",
+                        "reason_codes": ["identity_matched"],
+                    },
                 },
             },
             {

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -111,7 +111,14 @@ def _complete_plan() -> dict[str, Any]:
                         "candidates": [
                             {
                                 "talk_filename": "talk.md",
-                                "signals": {},
+                                "signals": {
+                                    "title": "unknown",
+                                    "venue": "agree",
+                                    "delivery_year": "unknown",
+                                    "hashtag": "unknown",
+                                    "published_pdf": "unknown",
+                                    "filename_similarity": "unknown",
+                                },
                                 "agreeing": ["venue"],
                                 "conflicting": [],
                             }

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -108,6 +108,7 @@ def _complete_plan() -> dict[str, Any]:
                         "artifact_role": "delivery",
                         "selected_talk_filename": "talk.md",
                         "reason_codes": ["identity_matched"],
+                        "candidates": [],
                     },
                 },
             },

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -1039,3 +1039,90 @@ def test_an_assessment_the_assessor_produced_satisfies_the_writer(
     )
 
     assert candidate["pptx_catalog"][0]["identity_assessment"] == assessment.as_json()
+
+
+# Owner migration: v2 records upgrade to v3 without inventing proof (#176).
+
+
+def test_migration_upgrades_a_matched_v2_record_to_review_required(
+    tracking_database,
+) -> None:
+    database = _database([_evidence_bound_record()])
+
+    migration = tracking_database.migrate_tracking_database(database)
+    record = migration.database["pptx_catalog"][0]
+
+    assert record["schema_version"] == 3
+    assessment = record["identity_assessment"]
+    assert assessment["verdict"] == "review_required"
+    assert assessment["selected_talk_filename"] is None
+    assert assessment["reason_codes"] == ["identity_unassessed_legacy_binding"]
+    assert assessment["pptx_path"] == record["pptx_path"]
+
+
+def test_migration_preserves_the_legacy_binding_it_cannot_prove(
+    tracking_database,
+) -> None:
+    """The binding survives; only its provenance is marked unproven."""
+    database = _database([_evidence_bound_record()])
+
+    migration = tracking_database.migrate_tracking_database(database)
+    record = migration.database["pptx_catalog"][0]
+
+    assert record["talk_filename"] == "2024-04-10-talk.md"
+    assert record["matched"] is True
+    assert record["visual_evidence"] == _evidence()
+
+
+def test_migration_never_invents_a_matched_verdict(tracking_database) -> None:
+    """Forging `matched` would manufacture the evidence v3 exists to require."""
+    database = _database([_evidence_bound_record()])
+
+    migration = tracking_database.migrate_tracking_database(database)
+
+    assessment = migration.database["pptx_catalog"][0]["identity_assessment"]
+    assert assessment["verdict"] != "matched"
+
+
+def test_migration_gives_an_unmatched_v2_record_a_null_assessment(
+    tracking_database,
+) -> None:
+    database = _database([_evidence_bound_record(talk_filename=None, matched=False)])
+
+    migration = tracking_database.migrate_tracking_database(database)
+    record = migration.database["pptx_catalog"][0]
+
+    assert record["schema_version"] == 3
+    assert record["identity_assessment"] is None
+
+
+def test_migration_leaves_v1_records_at_v1(tracking_database) -> None:
+    """A v1 record has no visual_evidence either; the established position is
+    to preserve it rather than invent one."""
+    database = _database([_legacy_record()])
+
+    migration = tracking_database.migrate_tracking_database(database)
+    record = migration.database["pptx_catalog"][0]
+
+    assert record["schema_version"] == 1
+    assert "identity_assessment" not in record
+
+
+def test_a_migrated_record_reads_as_a_current_database_shape(
+    tracking_database,
+) -> None:
+    database = _database([_evidence_bound_record()])
+
+    migration = tracking_database.migrate_tracking_database(database)
+    assessment = tracking_database.assess_tracking_database(migration.database)
+
+    assert assessment.usable is True
+
+
+def test_migration_is_idempotent(tracking_database) -> None:
+    database = _database([_evidence_bound_record()])
+
+    once = tracking_database.migrate_tracking_database(database)
+    twice = tracking_database.migrate_tracking_database(copy.deepcopy(once.database))
+
+    assert twice.database["pptx_catalog"] == once.database["pptx_catalog"]

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -1126,3 +1126,31 @@ def test_migration_is_idempotent(tracking_database) -> None:
     twice = tracking_database.migrate_tracking_database(copy.deepcopy(once.database))
 
     assert twice.database["pptx_catalog"] == once.database["pptx_catalog"]
+
+
+def test_an_active_claim_blocks_a_record_level_migration(tracking_database) -> None:
+    """A shape change is a shape change whether the root moves or a record does;
+    an active writer must block it either way."""
+    database = _database([_evidence_bound_record()])
+    database["talks"] = [
+        {
+            "schema_version": 5,
+            "filename": "2024-04-10-talk.md",
+            "status": "reprocessing-inflight",
+            "reprocess_generation": 1,
+            "_queue_claim": {
+                "schema_version": 2,
+                "run_id": "reparse-2026-08",
+                "batch_id": "1",
+                "claimed_at": "2026-08-01T00:00:00+00:00",
+                "previous_status": "needs-reprocessing",
+                "reprocess_generation": 1,
+                "state": "claimed",
+            },
+        }
+    ]
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="active queue writers"
+    ):
+        tracking_database.migrate_tracking_database(database)

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -834,7 +834,7 @@ def test_a_matched_record_with_a_null_assessment_is_refused(
 ) -> None:
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="required on a matched record",
+        match="identity_assessment_missing",
     ):
         mutate_tracking_database.build_candidate(
             _database([]),
@@ -851,7 +851,7 @@ def test_an_unproven_verdict_cannot_bind_a_talk(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="must be 'matched' to bind a talk",
+        match="identity_verdict_not_matched",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -867,7 +867,7 @@ def test_an_assessment_without_a_deck_identity_is_refused(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match=r"missing \['pptx_path'\]",
+        match="identity_assessment_incomplete",
     ):
         mutate_tracking_database.build_candidate(
             _database([]),
@@ -888,7 +888,7 @@ def test_an_assessment_for_another_deck_is_refused(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="does not match the record's pptx_path",
+        match="identity_deck_mismatch",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -907,7 +907,7 @@ def test_an_assessment_naming_another_talk_is_refused(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="does not match the record's talk_filename",
+        match="identity_talk_mismatch",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -924,7 +924,7 @@ def test_a_non_delivery_artifact_cannot_bind_a_talk(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="is not a delivery artifact",
+        match="identity_non_delivery_artifact",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -938,7 +938,7 @@ def test_an_assessment_from_a_future_schema_is_refused(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="schema_version must be exact integer 1",
+        match="identity_assessment_schema_unsupported",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -954,7 +954,7 @@ def test_a_reason_code_outside_the_taxonomy_is_refused(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="outside the closed taxonomy",
+        match="identity_reason_codes_contradict_verdict",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -996,18 +996,15 @@ def test_a_proven_binding_is_persisted(mutate_tracking_database) -> None:
     assert any(change["kind"] == "match_pptx_talk" for change in changes)
 
 
-def test_the_assessment_binds_to_the_module_that_produces_it(
-    mutate_tracking_database, pptx_talk_identity
+def test_the_writer_and_preflight_share_one_binding_predicate(
+    mutate_tracking_database, preflight_vault, pptx_talk_identity
 ) -> None:
-    """The writer's constants are the assessor's, not a second copy of them."""
+    """Two copies of this rule would drift, and the direction they drift is a
+    reader trusting what a writer would have refused."""
     assert (
-        mutate_tracking_database.PPTX_TALK_IDENTITY_SCHEMA_VERSION
-        == pptx_talk_identity.PPTX_TALK_IDENTITY_SCHEMA_VERSION
+        mutate_tracking_database.binding_refusal is pptx_talk_identity.binding_refusal
     )
-    assert mutate_tracking_database.VERDICT_MATCHED == (
-        pptx_talk_identity.VERDICT_MATCHED
-    )
-    assert mutate_tracking_database.ROLE_DELIVERY == pptx_talk_identity.ROLE_DELIVERY
+    assert preflight_vault.binding_refusal is pptx_talk_identity.binding_refusal
 
 
 def test_an_assessment_the_assessor_produced_satisfies_the_writer(
@@ -1195,7 +1192,7 @@ def test_a_matched_verdict_cannot_claim_a_refusal_reason(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="must be exactly",
+        match="identity_reason_codes_contradict_verdict",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -1216,7 +1213,7 @@ def test_the_migration_stamp_cannot_be_replayed_as_a_proven_binding(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="must be exactly",
+        match="identity_reason_codes_contradict_verdict",
     ):
         mutate_tracking_database.build_candidate(
             _database([]),
@@ -1308,3 +1305,33 @@ def test_preflight_flags_a_row_migration_has_not_reached(
     )
 
     assert ("pptx_talk_binding_unassessed", "warning") in codes
+
+
+def test_preflight_refuses_an_assessment_that_proves_another_pair(
+    preflight_vault, tmp_path
+) -> None:
+    """Hints, Not Authority: a persisted `matched` verdict for a different deck
+    must not read as proof of this row."""
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            pptx_path="Conference/2024/Some Other Deck.pptx"
+        )
+    )
+
+    codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
+
+    assert ("pptx_talk_binding_unproven", "blocking") in codes
+
+
+def test_preflight_refuses_a_matched_verdict_naming_another_talk(
+    preflight_vault, tmp_path
+) -> None:
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            selected_talk_filename="2023-01-01-someone-elses-talk.md"
+        )
+    )
+
+    codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
+
+    assert ("pptx_talk_binding_unproven", "blocking") in codes

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -1221,3 +1221,19 @@ def test_the_migration_stamp_cannot_be_replayed_as_a_proven_binding(
             _database([]),
             [_identity_mutation(_current_record(identity_assessment=assessment))],
         )
+
+
+def test_a_legacy_config_does_not_skip_the_record_migration(
+    tracking_database,
+) -> None:
+    """Root v1 with a legacy config takes its own return path; the record
+    migration must run before it, not after."""
+    database = _database([_evidence_bound_record()])
+    database["config"] = {"schema_version": 1}
+
+    migration = tracking_database.migrate_tracking_database(database)
+    record = migration.database["pptx_catalog"][0]
+
+    assert migration.changed is True
+    assert record["schema_version"] == 3
+    assert record["identity_assessment"]["verdict"] == "review_required"

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -75,6 +75,7 @@ def _identity_assessment(**overrides) -> dict:
         "artifact_role": "delivery",
         "selected_talk_filename": "2024-04-10-talk.md",
         "reason_codes": ["identity_matched"],
+        "candidates": [],
     }
     assessment.update(overrides)
     return assessment

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -66,6 +66,28 @@ def _evidence(**overrides) -> dict:
     return evidence
 
 
+_SIGNAL_NAMES = (
+    "title",
+    "venue",
+    "delivery_year",
+    "hashtag",
+    "published_pdf",
+    "filename_similarity",
+)
+
+
+def _signals(*, agree=(), conflict=()) -> dict:
+    """A complete per-signal map, the evidence a candidate's arrays summarize.
+
+    The owner gate recomputes `agreeing`/`conflicting` from this map, so a
+    fixture asserting a standing has to supply readings that produce it.
+    """
+    verdicts = dict.fromkeys(_SIGNAL_NAMES, "unknown")
+    verdicts.update(dict.fromkeys(agree, "agree"))
+    verdicts.update(dict.fromkeys(conflict, "conflict"))
+    return verdicts
+
+
 def _identity_assessment(**overrides) -> dict:
     """A v3 record's proof that this deck belongs to the talk it names (#176)."""
     assessment = {
@@ -78,7 +100,7 @@ def _identity_assessment(**overrides) -> dict:
         "candidates": [
             {
                 "talk_filename": "2024-04-10-talk.md",
-                "signals": {},
+                "signals": _signals(agree=("venue",)),
                 "agreeing": ["venue"],
                 "conflicting": [],
             }
@@ -1367,7 +1389,7 @@ def test_a_candidate_table_that_does_not_name_the_selected_talk_is_refused(
             candidates=[
                 {
                     "talk_filename": "2023-01-01-other.md",
-                    "signals": {},
+                    "signals": _signals(agree=("venue",)),
                     "agreeing": ["venue"],
                     "conflicting": [],
                 }
@@ -1392,7 +1414,7 @@ def test_a_selected_candidate_with_no_agreement_is_refused(
             candidates=[
                 {
                     "talk_filename": "2024-04-10-talk.md",
-                    "signals": {},
+                    "signals": _signals(),
                     "agreeing": [],
                     "conflicting": [],
                 }
@@ -1418,8 +1440,8 @@ def test_a_candidate_agreeing_only_on_a_non_selecting_signal_is_refused(
             candidates=[
                 {
                     "talk_filename": "2024-04-10-talk.md",
-                    "signals": {},
-                    "agreeing": ["filename_similarity", "delivery_year"],
+                    "signals": _signals(agree=("filename_similarity", "delivery_year")),
+                    "agreeing": [],
                     "conflicting": [],
                 }
             ]
@@ -1428,7 +1450,7 @@ def test_a_candidate_agreeing_only_on_a_non_selecting_signal_is_refused(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="identity_candidate_agreement_not_selecting",
+        match="identity_candidate_not_selectable",
     ):
         mutate_tracking_database.build_candidate(
             _database([]), [_identity_mutation(record)]
@@ -1441,13 +1463,13 @@ def test_an_equally_corroborated_rival_is_refused(mutate_tracking_database) -> N
             candidates=[
                 {
                     "talk_filename": "2024-04-10-talk.md",
-                    "signals": {},
+                    "signals": _signals(agree=("venue",)),
                     "agreeing": ["venue"],
                     "conflicting": [],
                 },
                 {
                     "talk_filename": "2024-04-11-rival.md",
-                    "signals": {},
+                    "signals": _signals(agree=("venue",)),
                     "agreeing": ["venue"],
                     "conflicting": [],
                 },

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -857,6 +857,43 @@ def test_an_unproven_verdict_cannot_bind_a_talk(
         )
 
 
+def test_an_assessment_without_a_deck_identity_is_refused(
+    mutate_tracking_database,
+) -> None:
+    """An assessment binds a pair; the deck endpoint is not optional."""
+    assessment = _identity_assessment()
+    del assessment["pptx_path"]
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match=r"missing \['pptx_path'\]",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]),
+            [_identity_mutation(_current_record(identity_assessment=assessment))],
+        )
+
+
+def test_an_assessment_for_another_deck_is_refused(
+    mutate_tracking_database,
+) -> None:
+    """The same defect in the other direction: a correct assessment for deck A
+    pasted onto deck B would bind B's contents to A's talk."""
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            pptx_path="Conference/2024/Some Other Deck.pptx"
+        )
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="does not match the record's pptx_path",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
 def test_an_assessment_naming_another_talk_is_refused(
     mutate_tracking_database,
 ) -> None:

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -1171,3 +1171,53 @@ def test_a_no_op_migration_stays_callable_under_an_active_claim(
 
     assert migration.changed is False
     assert migration.database["pptx_catalog"][0]["schema_version"] == 3
+
+
+@pytest.mark.parametrize(
+    "codes",
+    [
+        ["identity_unassessed_legacy_binding"],
+        ["identity_matched", "identity_unassessed_legacy_binding"],
+        ["identity_ambiguous_candidates"],
+        [],
+    ],
+)
+def test_a_matched_verdict_cannot_claim_a_refusal_reason(
+    mutate_tracking_database, codes
+) -> None:
+    """Taxonomy membership is not enough: every code but the matched one
+    explains a refusal, and the legacy-binding code means the opposite of
+    proven."""
+    record = _current_record(
+        identity_assessment=_identity_assessment(reason_codes=codes)
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="must be exactly",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_the_migration_stamp_cannot_be_replayed_as_a_proven_binding(
+    mutate_tracking_database, tracking_database
+) -> None:
+    """The exact escalation: take migration's own output, flip the verdict."""
+    database = _database([_evidence_bound_record()])
+    migrated = tracking_database.migrate_tracking_database(database)
+    assessment = copy.deepcopy(
+        migrated.database["pptx_catalog"][0]["identity_assessment"]
+    )
+    assessment["verdict"] = "matched"
+    assessment["selected_talk_filename"] = "2024-04-10-talk.md"
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="must be exactly",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]),
+            [_identity_mutation(_current_record(identity_assessment=assessment))],
+        )

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -66,7 +66,22 @@ def _evidence(**overrides) -> dict:
     return evidence
 
 
-def _current_record(**overrides) -> dict:
+def _identity_assessment(**overrides) -> dict:
+    """A v3 record's proof that this deck belongs to the talk it names (#176)."""
+    assessment = {
+        "schema_version": 1,
+        "pptx_path": "Conference/2024/Talk.pptx",
+        "verdict": "matched",
+        "artifact_role": "delivery",
+        "selected_talk_filename": "2024-04-10-talk.md",
+        "reason_codes": ["identity_matched"],
+    }
+    assessment.update(overrides)
+    return assessment
+
+
+def _evidence_bound_record(**overrides) -> dict:
+    """A schema-v2 record: evidence bound to a generation, talk binding assumed."""
     record = {
         "schema_version": 2,
         "pptx_path": "Conference/2024/Talk.pptx",
@@ -76,6 +91,14 @@ def _current_record(**overrides) -> dict:
         "visual_extracted": True,
         "visual_evidence": _evidence(),
     }
+    record.update(overrides)
+    return record
+
+
+def _current_record(**overrides) -> dict:
+    record = _evidence_bound_record()
+    record["schema_version"] = 3
+    record["identity_assessment"] = _identity_assessment()
     record.update(overrides)
     return record
 
@@ -269,7 +292,7 @@ def test_unknown_classification_is_rejected_rather_than_treated_as_current(
 
 def test_a_future_record_says_the_reader_is_lagging(tracking_database) -> None:
     """stateful-artifacts: newer than accepted is no usable prior state."""
-    record = _current_record(schema_version=3)
+    record = _current_record(schema_version=4)
 
     with pytest.raises(
         tracking_database.TrackingDatabaseError, match="newer than this reader accepts"
@@ -382,12 +405,12 @@ def test_owner_writer_refuses_a_record_without_the_generation_binding(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match=r"missing \['visual_evidence'\]",
+        match=r"missing \['identity_assessment', 'visual_evidence'\]",
     ):
         mutate_tracking_database.build_candidate(_database([]), [mutation])
 
 
-def test_owner_writer_refuses_a_v2_shape_declared_as_v1(
+def test_owner_writer_refuses_a_current_shape_declared_as_v1(
     mutate_tracking_database,
 ) -> None:
     """The version is validated per kind: pptx_catalog left v1 behind."""
@@ -395,12 +418,17 @@ def test_owner_writer_refuses_a_v2_shape_declared_as_v1(
         "kind": "record_pptx",
         "expect": {"$missing": True},
         "record": _current_record()
-        | {"talk_filename": None, "matched": False, "schema_version": 1},
+        | {
+            "talk_filename": None,
+            "matched": False,
+            "identity_assessment": None,
+            "schema_version": 1,
+        },
     }
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="schema_version must be exact integer 2",
+        match="schema_version must be exact integer 3",
     ):
         mutate_tracking_database.build_candidate(_database([]), [mutation])
 
@@ -408,7 +436,11 @@ def test_owner_writer_refuses_a_v2_shape_declared_as_v1(
 def test_owner_writer_accepts_a_bound_receipt_the_reader_calls_current(
     mutate_tracking_database, tracking_database
 ) -> None:
-    record = _current_record() | {"talk_filename": None, "matched": False}
+    record = _current_record() | {
+        "talk_filename": None,
+        "matched": False,
+        "identity_assessment": None,
+    }
     mutation = {
         "kind": "record_pptx",
         "expect": {"$missing": True},
@@ -771,3 +803,202 @@ def test_a_rejected_receipt_reports_a_code_not_the_persisted_value(
     assert rows[0]["needs_extraction"] is True
     assert rows[0]["reason_code"] == "source_fingerprint_invalid"
     assert "sekrit-algorithm-name" not in json.dumps(rows)
+
+
+# The identity gate: a talk binding must be proven before the deck's contents
+# become that talk's evidence (#176).
+
+
+def _identity_mutation(record: dict) -> dict:
+    return {"kind": "record_pptx", "expect": {"$missing": True}, "record": record}
+
+
+def test_a_matched_record_without_an_assessment_is_refused(
+    mutate_tracking_database,
+) -> None:
+    record = _current_record()
+    del record["identity_assessment"]
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match=r"missing \['identity_assessment'\]",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_a_matched_record_with_a_null_assessment_is_refused(
+    mutate_tracking_database,
+) -> None:
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="required on a matched record",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]),
+            [_identity_mutation(_current_record(identity_assessment=None))],
+        )
+
+
+@pytest.mark.parametrize("verdict", ["review_required", "unmatched"])
+def test_an_unproven_verdict_cannot_bind_a_talk(
+    mutate_tracking_database, verdict
+) -> None:
+    """A `review_required` deck is an owner decision nobody has made yet."""
+    record = _current_record(identity_assessment=_identity_assessment(verdict=verdict))
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="must be 'matched' to bind a talk",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_an_assessment_naming_another_talk_is_refused(
+    mutate_tracking_database,
+) -> None:
+    """The exact defect: a proven assessment pasted onto the wrong record."""
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            selected_talk_filename="2023-01-01-someone-elses-talk.md"
+        )
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="does not match the record's talk_filename",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+@pytest.mark.parametrize("role", ["master", "static_export", "backup"])
+def test_a_non_delivery_artifact_cannot_bind_a_talk(
+    mutate_tracking_database, role
+) -> None:
+    record = _current_record(
+        identity_assessment=_identity_assessment(artifact_role=role)
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="is not a delivery artifact",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_an_assessment_from_a_future_schema_is_refused(
+    mutate_tracking_database,
+) -> None:
+    record = _current_record(identity_assessment=_identity_assessment(schema_version=2))
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="schema_version must be exact integer 1",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_a_reason_code_outside_the_taxonomy_is_refused(
+    mutate_tracking_database,
+) -> None:
+    record = _current_record(
+        identity_assessment=_identity_assessment(reason_codes=["looked_about_right"])
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="outside the closed taxonomy",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_an_unmatched_record_must_not_carry_an_assessment(
+    mutate_tracking_database,
+) -> None:
+    record = _current_record(talk_filename=None, matched=False)
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="must be null on an unmatched record",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def _database_with_talk(filename: str) -> dict:
+    database = _database([])
+    database["talks"] = [
+        {"schema_version": 5, "filename": filename, "status": "pending"}
+    ]
+    return database
+
+
+def test_a_proven_binding_is_persisted(mutate_tracking_database) -> None:
+    record = _current_record()
+    mutation = _identity_mutation(copy.deepcopy(record))
+    mutation["expect_talk_pptx_path"] = {"$missing": True}
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        _database_with_talk(record["talk_filename"]), [mutation]
+    )
+
+    assert candidate["pptx_catalog"][0] == record
+    assert any(change["kind"] == "match_pptx_talk" for change in changes)
+
+
+def test_the_assessment_binds_to_the_module_that_produces_it(
+    mutate_tracking_database, pptx_talk_identity
+) -> None:
+    """The writer's constants are the assessor's, not a second copy of them."""
+    assert (
+        mutate_tracking_database.PPTX_TALK_IDENTITY_SCHEMA_VERSION
+        == pptx_talk_identity.PPTX_TALK_IDENTITY_SCHEMA_VERSION
+    )
+    assert mutate_tracking_database.VERDICT_MATCHED == (
+        pptx_talk_identity.VERDICT_MATCHED
+    )
+    assert mutate_tracking_database.ROLE_DELIVERY == pptx_talk_identity.ROLE_DELIVERY
+
+
+def test_an_assessment_the_assessor_produced_satisfies_the_writer(
+    mutate_tracking_database, pptx_talk_identity
+) -> None:
+    """End to end: the assessor's own output is what the gate accepts."""
+    talk = {
+        "filename": "2024-04-10-talk.md",
+        "title": "A Talk About Things",
+        "conference": "Voxxed Days Ticino",
+        "date": "2024-04-10",
+    }
+    assessment = pptx_talk_identity.assess_pptx_talk_identity(
+        {"pptx_path": "Voxxed Days Ticino/2024/A Talk About Things.pptx"},
+        [talk],
+    )
+    assert assessment.verdict == pptx_talk_identity.VERDICT_MATCHED
+
+    record = _current_record(
+        pptx_path=assessment.pptx_path,
+        talk_filename=talk["filename"],
+        identity_assessment=assessment.as_json(),
+    )
+
+    mutation = _identity_mutation(copy.deepcopy(record))
+    mutation["expect_talk_pptx_path"] = {"$missing": True}
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        _database_with_talk(talk["filename"]), [mutation]
+    )
+
+    assert candidate["pptx_catalog"][0]["identity_assessment"] == assessment.as_json()

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -1128,29 +1128,46 @@ def test_migration_is_idempotent(tracking_database) -> None:
     assert twice.database["pptx_catalog"] == once.database["pptx_catalog"]
 
 
+def _claimed_talk() -> dict:
+    """A talk whose queue claim is live."""
+    return {
+        "schema_version": 5,
+        "filename": "2024-04-10-talk.md",
+        "status": "reprocessing-inflight",
+        "reprocess_generation": 1,
+        "_queue_claim": {
+            "schema_version": 2,
+            "run_id": "reparse-2026-08",
+            "batch_id": "1",
+            "claimed_at": "2026-08-01T00:00:00+00:00",
+            "previous_status": "needs-reprocessing",
+            "reprocess_generation": 1,
+            "state": "claimed",
+        },
+    }
+
+
 def test_an_active_claim_blocks_a_record_level_migration(tracking_database) -> None:
     """A shape change is a shape change whether the root moves or a record does;
     an active writer must block it either way."""
     database = _database([_evidence_bound_record()])
-    database["talks"] = [
-        {
-            "schema_version": 5,
-            "filename": "2024-04-10-talk.md",
-            "status": "reprocessing-inflight",
-            "reprocess_generation": 1,
-            "_queue_claim": {
-                "schema_version": 2,
-                "run_id": "reparse-2026-08",
-                "batch_id": "1",
-                "claimed_at": "2026-08-01T00:00:00+00:00",
-                "previous_status": "needs-reprocessing",
-                "reprocess_generation": 1,
-                "state": "claimed",
-            },
-        }
-    ]
+    database["talks"] = [_claimed_talk()]
 
     with pytest.raises(
         tracking_database.TrackingDatabaseError, match="active queue writers"
     ):
         tracking_database.migrate_tracking_database(database)
+
+
+def test_a_no_op_migration_stays_callable_under_an_active_claim(
+    tracking_database,
+) -> None:
+    """Step 1 migrates before Step 2 can recover a stranded claim, so refusing a
+    no-op here would leave an interrupted run unable to resume."""
+    database = _database([_current_record()])
+    database["talks"] = [_claimed_talk()]
+
+    migration = tracking_database.migrate_tracking_database(database)
+
+    assert migration.changed is False
+    assert migration.database["pptx_catalog"][0]["schema_version"] == 3

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -1303,14 +1303,14 @@ def test_preflight_ignores_an_unmatched_row(preflight_vault, tmp_path) -> None:
     assert not any(code.startswith("pptx_talk_binding") for code, _ in codes)
 
 
-def test_preflight_flags_a_row_migration_has_not_reached(
+def test_preflight_blocks_a_row_migration_will_never_reach(
     preflight_vault, tmp_path
 ) -> None:
     codes = _preflight_codes(
         preflight_vault, _database([_evidence_bound_record()]), tmp_path
     )
 
-    assert ("pptx_talk_binding_unassessed", "warning") in codes
+    assert ("pptx_talk_binding_unassessed", "blocking") in codes
 
 
 def test_preflight_refuses_an_assessment_that_proves_another_pair(

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -75,7 +75,14 @@ def _identity_assessment(**overrides) -> dict:
         "artifact_role": "delivery",
         "selected_talk_filename": "2024-04-10-talk.md",
         "reason_codes": ["identity_matched"],
-        "candidates": [],
+        "candidates": [
+            {
+                "talk_filename": "2024-04-10-talk.md",
+                "signals": {},
+                "agreeing": ["venue"],
+                "conflicting": [],
+            }
+        ],
     }
     assessment.update(overrides)
     return assessment
@@ -1249,18 +1256,17 @@ def _preflight_codes(preflight_vault, database, tmp_path):
     return {(finding["code"], finding["severity"]) for finding in validator.findings}
 
 
-def test_preflight_warns_on_a_migrated_legacy_binding(
+def test_preflight_blocks_on_a_migrated_legacy_binding(
     preflight_vault, tracking_database, tmp_path
 ) -> None:
-    """Migration's own stamp applies to every legacy row at once, so blocking
-    on it would refuse the whole vault over a condition migration created."""
+    """A warning would let Step 1's blocking-only gate proceed on state the
+    database itself marks unproven."""
     database = _database([_evidence_bound_record()])
     migrated = tracking_database.migrate_tracking_database(database).database
 
     codes = _preflight_codes(preflight_vault, migrated, tmp_path)
 
-    assert ("pptx_talk_binding_unproven", "warning") in codes
-    assert ("pptx_talk_binding_unproven", "blocking") not in codes
+    assert ("pptx_talk_binding_unproven", "blocking") in codes
 
 
 def test_preflight_blocks_on_an_assessment_that_actually_refused(
@@ -1335,3 +1341,124 @@ def test_preflight_refuses_a_matched_verdict_naming_another_talk(
     codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
 
     assert ("pptx_talk_binding_unproven", "blocking") in codes
+
+
+def test_a_matched_verdict_over_an_empty_candidate_table_proves_nothing(
+    mutate_tracking_database,
+) -> None:
+    """A conclusion with nothing under it is what a fabricated assessment
+    looks like."""
+    record = _current_record(identity_assessment=_identity_assessment(candidates=[]))
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="identity_candidate_table_missing",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_a_candidate_table_that_does_not_name_the_selected_talk_is_refused(
+    mutate_tracking_database,
+) -> None:
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            candidates=[
+                {
+                    "talk_filename": "2023-01-01-other.md",
+                    "signals": {},
+                    "agreeing": ["venue"],
+                    "conflicting": [],
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="identity_candidate_absent",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_a_selected_candidate_with_no_agreement_is_refused(
+    mutate_tracking_database,
+) -> None:
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            candidates=[
+                {
+                    "talk_filename": "2024-04-10-talk.md",
+                    "signals": {},
+                    "agreeing": [],
+                    "conflicting": [],
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="identity_candidate_not_selectable",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_a_candidate_agreeing_only_on_a_non_selecting_signal_is_refused(
+    mutate_tracking_database,
+) -> None:
+    """Filename similarity and delivery year report but never elect."""
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            candidates=[
+                {
+                    "talk_filename": "2024-04-10-talk.md",
+                    "signals": {},
+                    "agreeing": ["filename_similarity", "delivery_year"],
+                    "conflicting": [],
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="identity_candidate_agreement_not_selecting",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )
+
+
+def test_an_equally_corroborated_rival_is_refused(mutate_tracking_database) -> None:
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            candidates=[
+                {
+                    "talk_filename": "2024-04-10-talk.md",
+                    "signals": {},
+                    "agreeing": ["venue"],
+                    "conflicting": [],
+                },
+                {
+                    "talk_filename": "2024-04-11-rival.md",
+                    "signals": {},
+                    "agreeing": ["venue"],
+                    "conflicting": [],
+                },
+            ]
+        )
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="identity_candidate_not_unique",
+    ):
+        mutate_tracking_database.build_candidate(
+            _database([]), [_identity_mutation(record)]
+        )

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -1238,3 +1238,73 @@ def test_a_legacy_config_does_not_skip_the_record_migration(
     assert migration.changed is True
     assert record["schema_version"] == 3
     assert record["identity_assessment"]["verdict"] == "review_required"
+
+
+# The catalog-wide sweep: preflight consumes the assessment (#176).
+
+
+def _preflight_codes(preflight_vault, database, tmp_path):
+    """Run only the identity sweep; the rest of preflight needs a real vault."""
+    validator = preflight_vault.VaultPreflight(
+        database, tmp_path, tmp_path / "tracking-database.json"
+    )
+    validator._check_pptx_talk_identity()
+    return {(finding["code"], finding["severity"]) for finding in validator.findings}
+
+
+def test_preflight_warns_on_a_migrated_legacy_binding(
+    preflight_vault, tracking_database, tmp_path
+) -> None:
+    """Migration's own stamp applies to every legacy row at once, so blocking
+    on it would refuse the whole vault over a condition migration created."""
+    database = _database([_evidence_bound_record()])
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    codes = _preflight_codes(preflight_vault, migrated, tmp_path)
+
+    assert ("pptx_talk_binding_unproven", "warning") in codes
+    assert ("pptx_talk_binding_unproven", "blocking") not in codes
+
+
+def test_preflight_blocks_on_an_assessment_that_actually_refused(
+    preflight_vault, tmp_path
+) -> None:
+    """An assessor that looked and refused is a specific, actionable finding."""
+    record = _current_record(
+        identity_assessment=_identity_assessment(
+            verdict="review_required",
+            selected_talk_filename=None,
+            reason_codes=["identity_ambiguous_candidates"],
+        )
+    )
+
+    codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
+
+    assert ("pptx_talk_binding_unproven", "blocking") in codes
+
+
+def test_preflight_is_silent_on_a_proven_binding(preflight_vault, tmp_path) -> None:
+    codes = _preflight_codes(preflight_vault, _database([_current_record()]), tmp_path)
+
+    assert not any(code.startswith("pptx_talk_binding") for code, _ in codes)
+
+
+def test_preflight_ignores_an_unmatched_row(preflight_vault, tmp_path) -> None:
+    """No talk is bound, so there is no binding to prove."""
+    record = _current_record(
+        talk_filename=None, matched=False, identity_assessment=None
+    )
+
+    codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
+
+    assert not any(code.startswith("pptx_talk_binding") for code, _ in codes)
+
+
+def test_preflight_flags_a_row_migration_has_not_reached(
+    preflight_vault, tmp_path
+) -> None:
+    codes = _preflight_codes(
+        preflight_vault, _database([_evidence_bound_record()]), tmp_path
+    )
+
+    assert ("pptx_talk_binding_unassessed", "warning") in codes

--- a/tests/test_pptx_talk_identity.py
+++ b/tests/test_pptx_talk_identity.py
@@ -7,6 +7,7 @@ the filesystem, or a live vault, so a run today and a run next year agree.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -455,3 +456,54 @@ class TestSerialization:
         ]:
             result = _assess(deck, candidates)
             assert result.selected_talk_filename is None
+
+
+def _documented_identity_assessment() -> dict:
+    """Pull the schema reference's own matched-assessment example."""
+    text = (
+        Path(__file__).resolve().parent.parent
+        / "skills"
+        / "vault-ingress"
+        / "references"
+        / "schemas-db.md"
+    ).read_text(encoding="utf-8")
+    start = text.index('"identity_assessment": {') + len('"identity_assessment": ')
+    depth = 0
+    for offset, char in enumerate(text[start:], start):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(text[start : offset + 1])
+    raise AssertionError("unbalanced identity_assessment example in schemas-db.md")
+
+
+def test_the_documented_matched_example_authorizes_its_binding(
+    pptx_talk_identity,
+) -> None:
+    """A schema reference prescribing a record the writer rejects is worse than
+    none: it tells an agent to build mutations that cannot persist."""
+    assessment = _documented_identity_assessment()
+
+    refusal = pptx_talk_identity.binding_refusal(
+        assessment,
+        pptx_path=assessment["pptx_path"],
+        talk_filename=assessment["selected_talk_filename"],
+    )
+
+    assert refusal is None, refusal
+
+
+def test_the_documented_example_agrees_with_the_derivation(
+    pptx_talk_identity,
+) -> None:
+    """Its arrays are what the signal map produces — not a hand-written summary."""
+    candidate = _documented_identity_assessment()["candidates"][0]
+
+    agreeing, conflicting = pptx_talk_identity.derive_candidate_standing(
+        candidate["signals"]
+    )
+
+    assert list(agreeing) == candidate["agreeing"]
+    assert list(conflicting) == candidate["conflicting"]

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -296,7 +296,7 @@ def test_explicit_root_zero_is_not_implicit_legacy_state(tracking_database):
         ),
         (
             "pptx_catalog",
-            {"schema_version": 3, "path": "future/deck.pptx"},
+            {"schema_version": 4, "path": "future/deck.pptx"},
         ),
     ],
 )


### PR DESCRIPTION
## What

Wires the #176 identity assessment into the owner writer. `pptx_catalog` records
advance to **v3**: a matched record carries the assessment that proves its deck
belongs to the talk it names, and `record_pptx` refuses to persist one that does
not.

Follows #288, which landed the assessment with no caller.

## The gate

`_require_bound_identity_assessment` checks three things together, because
checking fewer is checking none:

| Check | Catches |
|---|---|
| `verdict == "matched"` | A `review_required` deck — an owner decision nobody has made yet |
| `selected_talk_filename == record.talk_filename` | **The live defect**: a valid assessment pasted onto the wrong record |
| `artifact_role == "delivery"` | A master, backup, or static export binding as if it were the delivery deck |

Plus the assessment's own schema version and a closed reason-code taxonomy. The
constants come from `pptx_talk_identity` by import, never a second copy — one
test asserts exactly that, and another runs the assessor's real output through
the writer end to end.

## Reader side

Readers accept v1, v2, and v3. v3 validation is **shape only**: the field is
null exactly when `talk_filename` is null, an object otherwise. The binding's
semantics stay the writer's gate, matching the existing treatment of
`visual_evidence` — a malformed receipt is per-record trouble for a reader, but
a record that cannot be proven is a record that must not be persisted.

Existing v2 records keep reading and classifying. They carry no identity proof,
which is what the catalog-wide preflight sweep is for; this stops new unproven
bindings from being written while that lands.

## Fixture churn

Four existing tests moved with the schema, each keeping its original intent:

- the "future version" sentinel moves from 3 to 4, since v3 is now real
- two writer tests update the version and missing-field expectations
- one unmatched-record test now sets `identity_assessment: None`

## Verification

- 14 new tests covering every refusal path plus the assessor→writer round trip
- Full suite: **5480 passed, 3 skipped**
- `ruff format --check` and `ruff check`: clean
- `pyright`: 0 errors on all changed modules
- `schemas-db.md` updated for the v3 shape

## Remaining on #176

Preflight's catalog-wide identity sweep (including catalog-only rows), and
extracting richer deck facts — document properties and rendered title/footer/
hashtag text — in `pptx_evidence.py`.
