### PR TITLE
feat(catalog): remap dimension numbers to what the prose says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ down from 37. Both worked examples in the issue land exactly as specified:
 
 No pattern's meaning changes. This is a renumbering, not a re-classification.
 
+`audit-pattern-catalog.py` enforces the registry, so this is a deterministic
+gate rather than a one-time script run. A prose label that resolves to a
+different number than its claim states is an ERROR — two things the entry itself
+asserts disagree. A label the registry cannot resolve is a semantic DEBT, since
+turning an unreviewed alias into a build break would be the wrong lever and
+resolving it by guess would make this an automatic renumbering. A malformed
+registry is an error: without it every dimension claim becomes uncheckable.
+
 A label with no owner-approved alias does not resolve, and an unresolved claim
 KEEPS the number written beside it — preserved, not endorsed. Dropping a
 membership on the strength of a missing alias would be a bigger change than the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ drift being fixed. Three labels remain unresolved and need an owner decision:
 
 The catalog fingerprint moves, so this belongs in the same revalidation pass as
 #167 rather than triggering a second one.
-||||||| 1498528
+
 ## 0.20.57 — 2026-08-12
 
 ### fix(catalog) — one bullet threshold, not two (#153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Per the 2026-08-09 owner decision the prose is the intent of record, so
 `_dimensions.yaml` makes the labels resolvable and the numbers follow them. 42
 prose claims and 38 entries' frontmatter were remapped; the index's per-entry
 column and reverse map are regenerated from the approved frontmatter rather than
-maintained by hand. The catalog auditor reports 0 errors and 0 semantic debts,
-down from 37. Both worked examples in the issue land exactly as specified:
+maintained by hand. The catalog auditor reports 0 errors, down from 37 semantic
+debts of the drift kind; the 11 debts it now reports are the unresolved-label
+findings the newly-wired registry check surfaces, listed below. Both worked examples in the issue land exactly as specified:
 `progressive-reveal` becomes `[3, 13]` and `three-part-close` becomes `[2, 6]`.
 
 No pattern's meaning changes. This is a renumbering, not a re-classification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+### feat(catalog) — remap the dimension numbers to what the prose says (#156)
+
+Closes the mechanical half of #156.
+
+`vault_dimensions` is a list of bare integers, so a range check was the only
+validation a number could carry — and a range check cannot tell that `4` means
+Audience Interaction while the prose beside it says humor. Entries filed
+evidence under dimensions they are not about, and every downstream aggregation
+inherited it.
+
+Per the 2026-08-09 owner decision the prose is the intent of record, so
+`_dimensions.yaml` makes the labels resolvable and the numbers follow them. 42
+prose claims and 38 entries' frontmatter were remapped; the index's per-entry
+column and reverse map are regenerated from the approved frontmatter rather than
+maintained by hand. The catalog auditor reports 0 errors and 0 semantic debts,
+down from 37. Both worked examples in the issue land exactly as specified:
+`progressive-reveal` becomes `[3, 13]` and `three-part-close` becomes `[2, 6]`.
+
+No pattern's meaning changes. This is a renumbering, not a re-classification.
+
+A label with no owner-approved alias does not resolve, and an unresolved claim
+KEEPS the number written beside it — preserved, not endorsed. Dropping a
+membership on the strength of a missing alias would be a bigger change than the
+drift being fixed. Three labels remain unresolved and need an owner decision:
+`Content Depth / Value`, `Overall Quality Indicators`, and `Visual Storytelling`.
+
+The catalog fingerprint moves, so this belongs in the same revalidation pass as
+#167 rather than triggering a second one.
+
 ## 0.20.56 — 2026-08-11
 
 ### feat(vault-ingress) — prove which talk a deck belongs to before it becomes evidence (#176)

--- a/skills/presentation-creator/references/patterns/_dimensions.yaml
+++ b/skills/presentation-creator/references/patterns/_dimensions.yaml
@@ -1,0 +1,118 @@
+# Machine-readable authority for the 14 vault dimensions (#156).
+#
+# Entry frontmatter carries `vault_dimensions` as bare numbers, and entry prose
+# names each one as `Dimension N (Label)`. Those two drifted: the numbers were
+# assigned against a superseded taxonomy while the prose kept describing what
+# the pattern is actually about. A range check passes either way, so downstream
+# analysis attached evidence to the wrong semantic dimension.
+#
+# Owner decision (2026-08-09): the prose is the intent of record. Numbers are
+# remapped to match the label; no pattern's meaning changes.
+#
+# `aliases` is the owner-approved resolution for every label the catalog prose
+# actually uses. A label absent from every alias list does NOT resolve — the
+# auditor reports it for owner review rather than guessing, which is what keeps
+# this a reviewed migration instead of an automatic renumbering.
+#
+# Canonical names and ordinals come from
+# `skills/vault-ingress/references/rhetoric-dimensions.md` sections 1-14.
+schema_version: 1
+dimensions:
+  - id: opening-pattern
+    ordinal: 1
+    name: Opening Pattern
+    aliases:
+      - Topic and Thesis
+  - id: narrative-structure
+    ordinal: 2
+    name: Narrative Structure
+    aliases:
+      - Structure and Flow
+      - Structure/Organization
+      - Storytelling/Narrative
+      - Storytelling and Narrative
+  - id: humor-wit
+    ordinal: 3
+    name: Humor & Wit
+    aliases:
+      - Humor and Surprise Techniques
+      - Engagement / Entertainment Value
+      # Owner decision: the entertainment entry's only other claim, and a
+      # memorable beat is the wit landing rather than a cultural reference.
+      - Memorability
+  - id: audience-interaction
+    ordinal: 4
+    name: Audience Interaction
+    aliases:
+      - Audience Engagement
+  - id: transition-techniques
+    ordinal: 5
+    name: Transition Techniques
+    aliases: []
+  - id: closing-pattern
+    ordinal: 6
+    name: Closing Pattern
+    aliases:
+      - Closing Strategy
+  - id: verbal-signatures
+    ordinal: 7
+    name: Verbal Signatures
+    aliases:
+      - Clarity / Communication
+      - Language and Communication
+  - id: slide-to-speech-relationship
+    ordinal: 8
+    name: Slide-to-Speech Relationship
+    aliases:
+      # Owner decision: both uses weigh what sits on the screen against what is
+      # spoken, which is this dimension rather than a closing concern.
+      - Information Density
+  - id: persuasion-techniques
+    ordinal: 9
+    name: Persuasion Techniques
+    aliases:
+      - Speaker Authority / Credibility
+      - Speaker Credibility/Ethos
+      - Evidence and Persuasion
+      # Owner decision: positioning one's own authority is an ethos move.
+      - Self-Presentation
+  - id: cultural-pop-culture-references
+    ordinal: 10
+    name: Cultural & Pop-Culture References
+    aliases:
+      - Cultural References
+      # Owner decision: kept here, treating this as the broader
+      # creative-resonance lane the catalog actually uses it as.
+      - Creativity/Originality
+  - id: technical-content-delivery
+    ordinal: 11
+    name: Technical Content Delivery
+    aliases:
+      - Demonstrations and Tools
+      - Teaching Effectiveness
+      - Technical Depth/Accuracy
+  - id: pacing-clues
+    ordinal: 12
+    name: Pacing Clues
+    aliases:
+      - Time/Pacing
+      - Delivery Mechanics
+      # Owner decision: grouped with Delivery Mechanics, which already sits here.
+      - Delivery/Presentation Skills
+  - id: slide-design-patterns
+    ordinal: 13
+    name: Slide Design Patterns
+    aliases:
+      - Slide Design
+      - Slide Aesthetics
+      - Visual Polish and Craft
+      - Visual Aids Effectiveness
+      - Slide Design/Visual Quality
+      - Visual Design Quality
+  - id: areas-for-improvement
+    ordinal: 14
+    name: "Reflection: Areas for Improvement"
+    aliases:
+      - Areas for Improvement
+      - Overall Impression/Polish
+      - Speaker Craft / Professionalism

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -175,21 +175,21 @@ entries are skipped and surfaced as go-live actions, not emitted as per-talk
 | required | Required | pattern | 9 | intake, intent | proposed, posse, concurrent-creation, crucible |
 | the-big-why | The Big Why | pattern | 9 | intake | carnegie-hall, crucible |
 | proposed | Proposed | pattern | 9 | intake, intent | required, peer-review, know-your-audience |
-| narrative-arc | Narrative Arc | pattern | 2, 5 | intent, architecture, content | triad, bookends, intermezzi, unifying-visual-theme, context-keeper |
-| fourthought | Fourthought | pattern | 2, 8 | intent, architecture | unifying-visual-theme, backtracking, narrative-arc |
+| narrative-arc | Narrative Arc | pattern | 2 | intent, architecture, content | triad, bookends, intermezzi, unifying-visual-theme, context-keeper |
+| fourthought | Fourthought | pattern | 2, 13 | intent, architecture | unifying-visual-theme, backtracking, narrative-arc |
 | crucible | Crucible | pattern | 12, 14 | content | brain-breaks, fourthought, carnegie-hall, traveling-highlights |
-| concurrent-creation | Concurrent Creation | pattern | 2, 8 | content | talklet, unifying-visual-theme |
+| concurrent-creation | Concurrent Creation | pattern | 2, 13 | content | talklet, unifying-visual-theme |
 | triad | Triad | pattern | 2 | intent, architecture | narrative-arc, fourthought, talklet |
 | expansion-joints | Expansion Joints | pattern | 2, 12 | architecture, content | talklet, narrative-arc |
 | talklet | Talklet | pattern | 2, 12 | architecture, content | narrative-arc, foreshadowing, backtracking, a-la-carte-content, expansion-joints |
 | unifying-visual-theme | Unifying Visual Theme | pattern | 10, 13 | architecture, slides | brain-breaks, defy-defaults, narrative-arc |
-| brain-breaks | Brain Breaks | pattern | 3, 12 | architecture, content | leet-grammars, narrative-arc, entertainment, crucible, retrieval-beat |
-| leet-grammars | Leet Grammars | pattern | 7, 10 | content | analog-noise, brain-breaks |
+| brain-breaks | Brain Breaks | pattern | 12 | architecture, content | leet-grammars, narrative-arc, entertainment, crucible, retrieval-beat |
+| leet-grammars | Leet Grammars | pattern | 10, 11 | content | analog-noise, brain-breaks |
 | lightning-talk | Lightning Talk | pattern | 2, 12 | architecture | talklet, carnegie-hall, fourthought, defy-defaults, narrative-arc |
-| takahashi | Takahashi | pattern | 8, 12, 13 | architecture, slides | brain-breaks |
-| cave-painting | Cave Painting | pattern | 5, 13 | architecture, slides | context-keeper, soft-transitions, brain-breaks, takahashi, lipsync |
+| takahashi | Takahashi | pattern | 12, 13 | architecture, slides | brain-breaks |
+| cave-painting | Cave Painting | pattern | 2, 13 | architecture, slides | context-keeper, soft-transitions, brain-breaks, takahashi, lipsync |
 | abstract-attorney | Abstract Attorney | antipattern | 2, 14 | intent, guardrails | preroll, narrative-arc, fourthought, triad, crucible, carnegie-hall |
-| alienating-artifact | Alienating Artifact | antipattern | 3, 10, 14 | guardrails | know-your-audience, brain-breaks |
+| alienating-artifact | Alienating Artifact | antipattern | 10, 12, 14 | guardrails | know-your-audience, brain-breaks |
 | celery | Celery | antipattern | 2, 14 | guardrails | required, know-your-audience, narrative-arc, brain-breaks |
 | golden-rule | The Golden Rule | antipattern | 4, 9, 14 | guardrails | walk-around, know-your-audience, leet-grammars, crucible |
 
@@ -197,56 +197,56 @@ entries are skipped and surfaced as go-live actions, not emitted as per-talk
 
 | ID | Name | Type | Vault Dims | Creator Phases | Related |
 |----|------|------|------------|----------------|---------|
-| sparkline | Sparkline | pattern | 2, 5, 9 | architecture, content | narrative-arc, bookends, mentor, know-your-audience, the-big-why, call-to-adventure, call-to-action, new-bliss, foreshadowing, star-moment |
-| three-part-close | Three-Part Close | pattern | 2, 10 | content, slides | bookends, call-to-action, coda, new-bliss |
-| progressive-reveal | Progressive Reveal | pattern | 4, 7 | content, slides | composite-animation, foreshadowing, traveling-highlights, sparkline |
-| meme-as-argument | Meme as Argument | pattern | 4, 7, 12 | content, slides | entertainment, brain-breaks, foreshadowing, unifying-visual-theme |
+| sparkline | Sparkline | pattern | 2, 9 | architecture, content | narrative-arc, bookends, mentor, know-your-audience, the-big-why, call-to-adventure, call-to-action, new-bliss, foreshadowing, star-moment |
+| three-part-close | Three-Part Close | pattern | 2, 6 | content, slides | bookends, call-to-action, coda, new-bliss |
+| progressive-reveal | Progressive Reveal | pattern | 3, 13 | content, slides | composite-animation, foreshadowing, traveling-highlights, sparkline |
+| meme-as-argument | Meme as Argument | pattern | 3, 10, 13 | content, slides | entertainment, brain-breaks, foreshadowing, unifying-visual-theme |
 | call-to-adventure | Call to Adventure | pattern | 1, 2, 9 | architecture, content | sparkline, the-big-why, opening-punch, narrative-arc, foreshadowing, know-your-audience, mentor |
 | call-to-action | Call to Action | pattern | 4, 6, 9 | content, publishing | sparkline, coda, mentor, the-big-why, new-bliss |
-| new-bliss | New Bliss | pattern | 5, 6, 9 | content | sparkline, call-to-action, coda, bookends, the-big-why |
-| star-moment | S.T.A.R. Moment | pattern | 3, 5, 13 | content, slides | the-big-why, sparkline, narrative-arc, vacation-photos, foreshadowing, call-to-adventure |
+| new-bliss | New Bliss | pattern | 2, 6, 9 | content | sparkline, call-to-action, coda, bookends, the-big-why |
+| star-moment | S.T.A.R. Moment | pattern | 2, 3, 13 | content, slides | the-big-why, sparkline, narrative-arc, vacation-photos, foreshadowing, call-to-adventure |
 | inoculation | Inoculation | pattern | 4, 9 | content, guardrails | know-your-audience, mentor, peer-review, sparkline, the-big-why |
-| master-story | Master Story | pattern | 2, 5, 7 | content | narrative-arc, foreshadowing, sparkline, the-big-why, star-moment |
-| concrete-before-abstract | Concrete Before Abstract | pattern | 11, 9, 2 | content | live-demo, master-story, vacation-photos, mentor, the-big-why, sparkline |
+| master-story | Master Story | pattern | 2, 7 | content | narrative-arc, foreshadowing, sparkline, the-big-why, star-moment |
+| concrete-before-abstract | Concrete Before Abstract | pattern | 2, 9, 11 | content | live-demo, master-story, vacation-photos, mentor, the-big-why, sparkline |
 | guess-first | Guess First | pattern | 2, 4, 11 | content, slides | concrete-before-abstract, retrieval-beat, live-demo, progressive-reveal, foreshadowing, inoculation |
 | retrieval-beat | Retrieval Beat | pattern | 4, 12 | architecture, content, slides | guess-first, backtracking, breadcrumbs, brain-breaks, spaced-followup, bookends |
 | second-look | Second Look | pattern | 8, 13 | slides, publishing | unifying-visual-theme, spaced-followup, coda, star-moment, vacation-photos, gradual-consistency, infodeck |
-| coda | Coda | pattern | 6, 8 | content, slides | infodeck, vacation-photos |
-| peer-review | Peer Review | pattern | 7, 8 | content, guardrails | leet-grammars |
-| foreshadowing | Foreshadowing | pattern | 2, 5 | content | narrative-arc, talklet, backtracking, intermezzi |
+| coda | Coda | pattern | 8, 13 | content, slides | infodeck, vacation-photos |
+| peer-review | Peer Review | pattern | 7, 13 | content, guardrails | leet-grammars |
+| foreshadowing | Foreshadowing | pattern | 2 | content | narrative-arc, talklet, backtracking, intermezzi |
 | composite-animation | Composite Animation | pattern | 13 | slides | emergence, gradual-consistency |
 | a-la-carte-content | Á la Carte Content | pattern | 2, 4 | architecture, content | talklet, coda, live-demo |
-| vacation-photos | Vacation Photos | pattern | 8, 13 | architecture, slides | unifying-visual-theme |
+| vacation-photos | Vacation Photos | pattern | 13 | architecture, slides | unifying-visual-theme |
 | defy-defaults | Defy Defaults | pattern | 13 | slides | analog-noise, bookends, intermezzi |
 | analog-noise | Analog Noise | pattern | 13 | slides | defy-defaults, leet-grammars |
-| infodeck | Infodeck | pattern | 8 | architecture | coda |
-| gradual-consistency | Gradual Consistency | pattern | 8, 13 | slides | exuberant-title-top, composite-animation, analog-noise |
-| charred-trail | Charred Trail | pattern | 8, 13 | slides | context-keeper, exuberant-title-top, bookends |
+| infodeck | Infodeck | pattern | 13 | architecture | coda |
+| gradual-consistency | Gradual Consistency | pattern | 13 | slides | exuberant-title-top, composite-animation, analog-noise |
+| charred-trail | Charred Trail | pattern | 13 | slides | context-keeper, exuberant-title-top, bookends |
 | exuberant-title-top | Exuberant Title Top | pattern | 13 | slides | charred-trail, gradual-consistency |
 | invisibility | Invisibility | pattern | 13 | slides | gradual-consistency |
-| context-keeper | Context Keeper | pattern | 2, 5, 13 | architecture, content, slides | breadcrumbs, bookends, narrative-arc, charred-trail, cave-painting |
+| context-keeper | Context Keeper | pattern | 2, 13 | architecture, content, slides | breadcrumbs, bookends, narrative-arc, charred-trail, cave-painting |
 | breadcrumbs | Breadcrumbs | pattern | 2, 13 | content, slides | context-keeper, bookends |
-| bookends | Bookends | pattern | 2, 5, 13 | content, slides | context-keeper, narrative-arc, intermezzi, defy-defaults |
-| soft-transitions | Soft Transitions | pattern | 5, 13 | slides | intermezzi, cave-painting |
-| intermezzi | Intermezzi | pattern | 2, 5, 13 | content, slides | context-keeper, bookends, narrative-arc, unifying-visual-theme, brain-breaks |
-| backtracking | Backtracking | pattern | 2, 5 | content | fourthought, foreshadowing, talklet |
+| bookends | Bookends | pattern | 2, 13 | content, slides | context-keeper, narrative-arc, intermezzi, defy-defaults |
+| soft-transitions | Soft Transitions | pattern | 2, 13 | slides | intermezzi, cave-painting |
+| intermezzi | Intermezzi | pattern | 2, 13 | content, slides | context-keeper, bookends, narrative-arc, unifying-visual-theme, brain-breaks |
+| backtracking | Backtracking | pattern | 2, 4 | content | fourthought, foreshadowing, talklet |
 | preroll | Preroll | pattern | 1, 13 | slides, publishing | seeding-the-first-question |
-| crawling-credits | Crawling Credits | pattern | 6, 13 | slides | coda |
+| crawling-credits | Crawling Credits | pattern | 8, 13 | slides | coda |
 | live-demo | Live Demo | pattern | 11 | architecture, content | lipsync, traveling-highlights |
 | lipsync | Lipsync | pattern | 11, 13 | content, slides | live-demo, cave-painting, live-on-tape |
 | traveling-highlights | Traveling Highlights | pattern | 11, 13 | slides | crawling-code, emergence |
 | crawling-code | Crawling Code | pattern | 11, 13 | slides | traveling-highlights, emergence |
 | emergence | Emergence | pattern | 11, 13 | content, slides | composite-animation, traveling-highlights, crawling-code |
-| live-on-tape | Live on Tape | pattern | 8 | publishing | lipsync, entertainment |
-| cookie-cutter | Cookie Cutter | antipattern | 8, 13 | guardrails, slides | soft-transitions, fourthought |
-| injured-outlines | Injured Outlines | antipattern | 8, 14 | guardrails | fourthought |
-| bullet-riddled-corpse | Bullet-Riddled Corpse | antipattern | 8, 13, 14 | guardrails, slides | charred-trail, infodeck |
+| live-on-tape | Live on Tape | pattern | 13 | publishing | lipsync, entertainment |
+| cookie-cutter | Cookie Cutter | antipattern | 13 | guardrails, slides | soft-transitions, fourthought |
+| injured-outlines | Injured Outlines | antipattern | 13, 14 | guardrails | fourthought |
+| bullet-riddled-corpse | Bullet-Riddled Corpse | antipattern | 13, 14 | guardrails, slides | charred-trail, infodeck |
 | ant-fonts | Ant Fonts | antipattern | 13, 14 | guardrails, slides | bullet-riddled-corpse, infodeck |
 | fontaholic | Fontaholic | antipattern | 13, 14 | guardrails, slides | floodmarks |
 | floodmarks | Floodmarks | antipattern | 13, 14 | guardrails, slides | bookends, defy-defaults, unifying-visual-theme |
 | photomaniac | Photomaniac | antipattern | 10, 13, 14 | guardrails, slides | unifying-visual-theme, vacation-photos |
-| borrowed-shoes | Borrowed Shoes | antipattern | 7, 8, 14 | guardrails | crucible, narrative-arc, carnegie-hall |
-| slideuments | Slideuments | antipattern | 8, 14 | guardrails | infodeck, charred-trail, gradual-consistency |
+| borrowed-shoes | Borrowed Shoes | antipattern | 7, 13, 14 | guardrails | crucible, narrative-arc, carnegie-hall |
+| slideuments | Slideuments | antipattern | 13, 14 | guardrails | infodeck, charred-trail, gradual-consistency |
 | dead-demo | Dead Demo | antipattern | 11, 14 | guardrails | live-demo, a-la-carte-content |
 
 ### Deliver Phase (22 patterns + 14 antipatterns)
@@ -254,8 +254,8 @@ entries are skipped and surfaced as go-live actions, not emitted as per-talk
 | ID | Name | Type | Vault Dims | Creator Phases | Related |
 |----|------|------|------------|----------------|---------|
 | preparation | Preparation | pattern | 14 | publishing | know-your-audience, carnegie-hall |
-| delayed-self-introduction | Delayed Self-Introduction | pattern | 2, 11 | content | opening-punch, the-big-why, anti-sell |
-| anti-sell | Anti-Sell | pattern | 11, 6 | content | delayed-self-introduction, the-big-why, mentor |
+| delayed-self-introduction | Delayed Self-Introduction | pattern | 2, 9 | content | opening-punch, the-big-why, anti-sell |
+| anti-sell | Anti-Sell | pattern | 9 | content | delayed-self-introduction, the-big-why, mentor |
 | screen-blackout | Screen Blackout | pattern | 12, 13 | content, slides | breathing-room, intermezzi, brain-breaks, mentor |
 | carnegie-hall | Carnegie Hall | pattern | 12, 14 | publishing | crucible, retrieval-beat |
 | posse | Posse | pattern | 4 | publishing | greek-chorus, seeding-satisfaction |
@@ -267,7 +267,7 @@ entries are skipped and surfaced as go-live actions, not emitted as per-talk
 | breathing-room | Breathing Room | pattern | 7, 12 | content | narrative-arc, brain-breaks, know-your-audience |
 | mentor | Mentor | pattern | 9, 11 | intent, content | narrative-arc, display-of-high-value |
 | weatherman | Weatherman | pattern | 12 | publishing | make-it-rain, lipsync |
-| entertainment | Entertainment | pattern | 3, 10 | content | know-your-audience, brain-breaks, make-it-rain |
+| entertainment | Entertainment | pattern | 3 | content | know-your-audience, brain-breaks, make-it-rain |
 | make-it-rain | Make It Rain | pattern | 4 | content | entertainment, weatherman |
 | echo-chamber | Echo Chamber | pattern | 4, 7 | publishing | seeding-the-first-question |
 | red-yellow-green | Red, Yellow, Green | pattern | 4 | publishing | crucible, know-your-audience, retrieval-beat, spaced-followup |
@@ -396,19 +396,19 @@ Reverse lookup: which patterns relate to each of the 14 rhetoric analysis dimens
 
 | Dim | Name | Patterns | Antipatterns |
 |-----|------|----------|--------------|
-| 1 | Opening Pattern | preroll, opening-punch, call-to-adventure | — |
-| 2 | Narrative Structure | narrative-arc, fourthought, triad, expansion-joints, talklet, context-keeper, breadcrumbs, bookends, intermezzi, foreshadowing, backtracking, a-la-carte-content, concurrent-creation, lightning-talk, sparkline, call-to-adventure, master-story, concrete-before-abstract, guess-first | abstract-attorney, celery |
-| 3 | Humor & Wit | brain-breaks, entertainment, star-moment | alienating-artifact |
-| 4 | Audience Interaction | know-your-audience, social-media-advertising, a-la-carte-content, posse, seeding-satisfaction, seeding-the-first-question, emotional-state, make-it-rain, echo-chamber, red-yellow-green, greek-chorus, opening-punch, call-to-action, inoculation, guess-first, retrieval-beat, walk-around | bunker, hecklers, backchannel, negative-ignorance, dual-headed-monster, flyover, nodding-room, golden-rule |
-| 5 | Transition Techniques | narrative-arc, foreshadowing, backtracking, context-keeper, bookends, intermezzi, soft-transitions, cave-painting, sparkline, new-bliss, star-moment, master-story | — |
-| 6 | Closing Pattern | coda, crawling-credits, call-to-action, new-bliss, spaced-followup | — |
-| 7 | Verbal Signatures | leet-grammars, peer-review, breathing-room, echo-chamber, master-story | hiccup-words, borrowed-shoes, tower-of-babble |
-| 8 | Slide-to-Speech Relationship | fourthought, concurrent-creation, coda, vacation-photos, infodeck, gradual-consistency, charred-trail, takahashi, live-on-tape, peer-review, second-look | cookie-cutter, injured-outlines, bullet-riddled-corpse, borrowed-shoes, slideuments, lipstick-on-a-pig |
-| 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus, sparkline, call-to-adventure, call-to-action, new-bliss, inoculation, concrete-before-abstract, walk-around | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig, golden-rule |
-| 10 | Cultural & Pop-Culture References | leet-grammars, unifying-visual-theme, entertainment | alienating-artifact, photomaniac |
-| 11 | Technical Content Delivery | live-demo, lipsync, traveling-highlights, crawling-code, emergence, mentor, lightsaber, concrete-before-abstract, guess-first | dead-demo |
-| 12 | Pacing Clues | crucible, expansion-joints, talklet, brain-breaks, lightning-talk, takahashi, carnegie-hall, breathing-room, weatherman, screen-blackout, retrieval-beat | shortchanged, disowning-your-topic, nodding-room |
-| 13 | Slide Design Patterns | unifying-visual-theme, takahashi, cave-painting, composite-animation, vacation-photos, defy-defaults, analog-noise, gradual-consistency, charred-trail, exuberant-title-top, invisibility, context-keeper, breadcrumbs, bookends, soft-transitions, intermezzi, preroll, crawling-credits, lipsync, traveling-highlights, crawling-code, emergence, screen-blackout, star-moment, second-look | cookie-cutter, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons |
+| 1 | Opening Pattern | preroll, opening-punch, call-to-adventure |  |
+| 2 | Narrative Structure | narrative-arc, fourthought, triad, expansion-joints, talklet, context-keeper, breadcrumbs, bookends, intermezzi, foreshadowing, backtracking, a-la-carte-content, concurrent-creation, lightning-talk, sparkline, call-to-adventure, master-story, concrete-before-abstract, guess-first, cave-painting, delayed-self-introduction, new-bliss, soft-transitions, star-moment, three-part-close | abstract-attorney, celery |
+| 3 | Humor & Wit | entertainment, star-moment, meme-as-argument, progressive-reveal |  |
+| 4 | Audience Interaction | know-your-audience, social-media-advertising, a-la-carte-content, posse, seeding-satisfaction, seeding-the-first-question, emotional-state, make-it-rain, echo-chamber, red-yellow-green, greek-chorus, opening-punch, call-to-action, inoculation, guess-first, retrieval-beat, walk-around, backtracking | bunker, hecklers, backchannel, negative-ignorance, dual-headed-monster, flyover, nodding-room, golden-rule |
+| 5 | Transition Techniques |  |  |
+| 6 | Closing Pattern | call-to-action, new-bliss, spaced-followup, three-part-close |  |
+| 7 | Verbal Signatures | peer-review, breathing-room, echo-chamber, master-story | hiccup-words, borrowed-shoes, tower-of-babble |
+| 8 | Slide-to-Speech Relationship | coda, second-look, crawling-credits | lipstick-on-a-pig |
+| 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus, sparkline, call-to-adventure, call-to-action, new-bliss, inoculation, concrete-before-abstract, walk-around, anti-sell, delayed-self-introduction | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig, golden-rule |
+| 10 | Cultural & Pop-Culture References | leet-grammars, unifying-visual-theme, meme-as-argument | alienating-artifact, photomaniac |
+| 11 | Technical Content Delivery | live-demo, lipsync, traveling-highlights, crawling-code, emergence, mentor, lightsaber, concrete-before-abstract, guess-first, leet-grammars | dead-demo |
+| 12 | Pacing Clues | crucible, expansion-joints, talklet, brain-breaks, lightning-talk, takahashi, carnegie-hall, breathing-room, weatherman, screen-blackout, retrieval-beat | shortchanged, disowning-your-topic, nodding-room, alienating-artifact |
+| 13 | Slide Design Patterns | unifying-visual-theme, takahashi, cave-painting, composite-animation, vacation-photos, defy-defaults, analog-noise, gradual-consistency, charred-trail, exuberant-title-top, invisibility, context-keeper, breadcrumbs, bookends, soft-transitions, intermezzi, preroll, crawling-credits, lipsync, traveling-highlights, crawling-code, emergence, screen-blackout, star-moment, second-look, coda, concurrent-creation, fourthought, infodeck, live-on-tape, meme-as-argument, peer-review, progressive-reveal | cookie-cutter, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons, borrowed-shoes, injured-outlines, slideuments |
 | 14 | Areas for Improvement | crucible, preparation, carnegie-hall, shoeless, stakeout | abstract-attorney, alienating-artifact, celery, injured-outlines, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, borrowed-shoes, slideuments, dead-demo, shortchanged, hiccup-words, disowning-your-topic, going-meta, bunker, hecklers, backchannel, laser-weapons, negative-ignorance, dual-headed-monster, tower-of-babble, lipstick-on-a-pig, flyover, nodding-room, golden-rule |
 
 ---

--- a/skills/presentation-creator/references/patterns/build/_anti_borrowed-shoes.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_borrowed-shoes.md
@@ -5,7 +5,7 @@ type: antipattern
 part: build
 phase_relevance:
   - guardrails
-vault_dimensions: [7, 8, 14]
+vault_dimensions: [7, 13, 14]
 detection_signals:
   - "deck provenance identifies a different author"
   - "version history shows no substantive adaptation by the presenter"
@@ -49,7 +49,7 @@ both facts, treat the cause of the mismatch as unknown.
 - Unevaluable: Authorship or version history is unavailable
 
 ## Relationship to Vault Dimensions
-Dimension 7 (Language and Communication): Borrowed Shoes creates a mismatch between the presenter's natural communication style and the language embedded in the slides. Dimension 8 (Slide Design): The design choices in borrowed slides reflect someone else's visual thinking. Dimension 14 (Overall Quality Indicators): A presenter working from borrowed material almost always delivers at a lower quality level than their natural capability.
+Dimension 7 (Language and Communication): Borrowed Shoes creates a mismatch between the presenter's natural communication style and the language embedded in the slides. Dimension 13 (Slide Design): The design choices in borrowed slides reflect someone else's visual thinking. Dimension 14 (Overall Quality Indicators): A presenter working from borrowed material almost always delivers at a lower quality level than their natural capability.
 
 ## Combinatorics
 Borrowed Shoes is mitigated by the Crucible pattern (intensive rehearsal transforms unfamiliar material into internalized content), the Narrative Arc pattern (understanding the story structure helps the presenter navigate borrowed material), and the Carnegie Hall pattern (deliberate practice reduces the friction of presenting someone else's slides). When these patterns are applied rigorously, the worst effects of Borrowed Shoes can be reduced — though the ideal solution remains reworking the material to fit the presenter's own style.

--- a/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - guardrails
   - slides
-vault_dimensions: [8, 13, 14]
+vault_dimensions: [13, 14]
 evidence_channels: [slides, video]
 detection_signals:
   - "text-heavy bullet slides"
@@ -65,7 +65,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): Bullet-Riddled Corpse is a fundamental failure of slide design that misunderstands the purpose of projected visuals in a live presentation. Dimension 13 (Slide Aesthetics): Text-heavy bullet slides are among the least aesthetically pleasing slide formats, producing dense, uniform visual patterns that numb the audience. Dimension 14 (Overall Quality Indicators): The prevalence of bullet-point slides is one of the most reliable negative indicators of overall presentation quality.
+Dimension 13 (Slide Design): Bullet-Riddled Corpse is a fundamental failure of slide design that misunderstands the purpose of projected visuals in a live presentation. Dimension 13 (Slide Aesthetics): Text-heavy bullet slides are among the least aesthetically pleasing slide formats, producing dense, uniform visual patterns that numb the audience. Dimension 14 (Overall Quality Indicators): The prevalence of bullet-point slides is one of the most reliable negative indicators of overall presentation quality.
 
 ## Combinatorics
 Bullet-Riddled Corpse is the inverse of both Vacation Photos (image-centric slides with minimal text) and Takahashi (slides with single large words or phrases). It often co-occurs with Cookie Cutter (cramming ideas into slide-sized containers) and Ant Fonts (shrinking text to fit more bullets). The Charred Trail pattern (leaving breadcrumbs of previous content) and the Infodeck pattern (document-style decks) both represent contexts where text density is more appropriate. Breaking free from Bullet-Riddled Corpse often requires fundamental rethinking of how slides function in a live presentation.

--- a/skills/presentation-creator/references/patterns/build/_anti_cookie-cutter.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_cookie-cutter.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - guardrails
   - slides
-vault_dimensions: [8, 13]
+vault_dimensions: [13]
 evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "ideas forced into single slides"
@@ -67,7 +67,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 An absence finding is authorized only from a complete, separately declared rendered PDF (`static_slides`); a native deck, delivery video, transcript, or comparison artifact does not authorize absence.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): Cookie Cutter fundamentally compromises slide design by subordinating design decisions to arbitrary size constraints rather than content requirements. Dimension 13 (Slide Aesthetics): The visual cramming that results from Cookie Cutter thinking produces aesthetically poor slides with inconsistent text sizes, cluttered layouts, and no visual breathing room.
+Dimension 13 (Slide Design): Cookie Cutter fundamentally compromises slide design by subordinating design decisions to arbitrary size constraints rather than content requirements. Dimension 13 (Slide Aesthetics): The visual cramming that results from Cookie Cutter thinking produces aesthetically poor slides with inconsistent text sizes, cluttered layouts, and no visual breathing room.
 
 ## Combinatorics
 Cookie Cutter is the inverse of Soft Transitions, which explicitly encourages multi-slide sequences that blur the boundaries between ideas. It often co-occurs with Bullet-Riddled Corpse (bullets used to fit more content per slide) and Ant Fonts (small text used to fit more content per slide). The Fourthought pattern, when applied properly during the ideation phase, helps prevent Cookie Cutter by encouraging ideas to find their natural size before slides are designed.

--- a/skills/presentation-creator/references/patterns/build/_anti_injured-outlines.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_injured-outlines.md
@@ -5,7 +5,7 @@ type: antipattern
 part: build
 phase_relevance:
   - guardrails
-vault_dimensions: [8, 14]
+vault_dimensions: [13, 14]
 evidence_channels: [slides, video]
 detection_signals:
   - "single sub-bullet under headers"
@@ -64,7 +64,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 An absence finding is authorized only from a complete, separately declared rendered PDF (`static_slides`); a native deck, delivery video, transcript, or comparison artifact does not authorize absence.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): Injured Outlines represent a structural flaw in slide content organization. Dimension 14 (Overall Quality Indicators): The presence of Injured Outlines is a signal of insufficient preparation and incomplete analytical thinking.
+Dimension 13 (Slide Design): Injured Outlines represent a structural flaw in slide content organization. Dimension 14 (Overall Quality Indicators): The presence of Injured Outlines is a signal of insufficient preparation and incomplete analytical thinking.
 
 ## Combinatorics
 Injured Outlines is the inverse of the Fourthought pattern, which emphasizes thorough brainstorming and categorization that naturally produces complete hierarchies. When Fourthought is applied rigorously, Injured Outlines do not occur. The antipattern often co-occurs with other preparation-related issues.

--- a/skills/presentation-creator/references/patterns/build/_anti_slideuments.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_slideuments.md
@@ -5,7 +5,7 @@ type: antipattern
 part: build
 phase_relevance:
   - guardrails
-vault_dimensions: [8, 14]
+vault_dimensions: [13, 14]
 detection_signals:
   - "dense slides meant to be read"
   - "dual-purpose document/presentation"
@@ -53,7 +53,7 @@ policy. Keep density findings under visual antipatterns until those artifact rol
 compared directly.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): Slideuments represent a fundamental design failure. Dimension 14 (Overall Quality Indicators): The presence of Slideument behavior is a strong negative quality signal.
+Dimension 13 (Slide Design): Slideuments represent a fundamental design failure. Dimension 14 (Overall Quality Indicators): The presence of Slideument behavior is a strong negative quality signal.
 
 ## Combinatorics
 Slideuments is the inverse of the Infodeck pattern — where an Infodeck is deliberately designed for reading (embracing document characteristics), a Slideument accidentally tries to be both and fails at both. It relates to the Charred Trail pattern (leaving a trail of content for after-the-fact consumption) and Gradual Consistency (building coherent artifacts over time). The Bullet-Riddled Corpse antipattern often appears within Slideuments, as the dual-purpose compromise tends to produce bullet-heavy slides.

--- a/skills/presentation-creator/references/patterns/build/backtracking.md
+++ b/skills/presentation-creator/references/patterns/build/backtracking.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - content
-vault_dimensions: [2, 5]
+vault_dimensions: [2, 4]
 evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "explicit callbacks to earlier content"
@@ -70,7 +70,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 2 (Structure and Flow): Backtracking creates a non-linear narrative architecture. Dimension 5 (Audience Engagement): Backtracking engages the audience's memory and pattern-matching capabilities.
+Dimension 2 (Structure and Flow): Backtracking creates a non-linear narrative architecture. Dimension 4 (Audience Engagement): Backtracking engages the audience's memory and pattern-matching capabilities.
 
 ## Combinatorics
 Backtracking has a natural partnership with Foreshadowing — where Foreshadowing plants seeds for what is to come, Backtracking harvests seeds that were planted earlier. Used together, they create a rich temporal texture. Backtracking pairs well with the Talklet pattern. Transitions between Talklets are natural moments for revisitation. It also benefits from Fourthought. The mind-mapping process is where crosscutting connections are first identified and catalogued for later use as Backtracking opportunities.

--- a/skills/presentation-creator/references/patterns/build/bookends.md
+++ b/skills/presentation-creator/references/patterns/build/bookends.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - slides
-vault_dimensions: [2, 5, 13]
+vault_dimensions: [2, 13]
 evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "section opener/closer slides"
@@ -77,7 +77,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 An absence finding is authorized only from a complete, separately declared rendered PDF (`static_slides`); a native deck, delivery video, transcript, or comparison artifact does not authorize absence.
 
 ## Relationship to Vault Dimensions
-Dimension 2 (Structure and Flow): Bookends are the most visible expression of structural organization, literally marking the boundaries between content sections. Dimension 5 (Storytelling and Narrative): When aligned with narrative phases, Bookends reinforce the story structure. Dimension 13 (Visual Polish and Craft): Well-designed Bookends demonstrate visual design skill and attention to structural consistency.
+Dimension 2 (Structure and Flow): Bookends are the most visible expression of structural organization, literally marking the boundaries between content sections. Dimension 2 (Storytelling and Narrative): When aligned with narrative phases, Bookends reinforce the story structure. Dimension 13 (Visual Polish and Craft): Well-designed Bookends demonstrate visual design skill and attention to structural consistency.
 
 ## Combinatorics
 Bookends pair naturally with Context Keeper and Breadcrumbs — Bookends mark the boundaries while Breadcrumbs track progress across those boundaries. They complement Narrative Arc by providing visual markers for narrative phase transitions. Intermezzi is a related pattern that serves a similar structural role but with more thematic emphasis. Bookends work well with Defy Defaults as an opportunity to express custom visual identity, and they serve as a natural inverse of Floodmarks by containing required branding in structural slides rather than spreading it across every content slide.

--- a/skills/presentation-creator/references/patterns/build/charred-trail.md
+++ b/skills/presentation-creator/references/patterns/build/charred-trail.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - slides
-vault_dimensions: [8, 13]
+vault_dimensions: [13]
 evidence_channels: [slide_sequence, video]
 detection_signals:
   - "sequential item reveal"
@@ -73,7 +73,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): Charred Trail demonstrates thoughtful slide design by managing visual attention through animation rather than relying on the audience to follow along unaided. Dimension 13 (Visual Polish and Craft): The consistent application of dim effects and reveal timing reflects attention to visual polish.
+Dimension 13 (Slide Design): Charred Trail demonstrates thoughtful slide design by managing visual attention through animation rather than relying on the audience to follow along unaided. Dimension 13 (Visual Polish and Craft): The consistent application of dim effects and reveal timing reflects attention to visual polish.
 
 ## Combinatorics
 Charred Trail pairs naturally with Context Keeper as a slide-level manifestation of the broader structural awareness concept. It complements Exuberant Title Top by adding item-level focus management beneath an already-animated title. The pattern works well with Bookends, as the Charred Trail within a section can mirror the section-level progress indicated by Bookend slides. It is also a simpler alternative to Gradual Consistency for list-based content.

--- a/skills/presentation-creator/references/patterns/build/coda.md
+++ b/skills/presentation-creator/references/patterns/build/coda.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - slides
-vault_dimensions: [6, 8]
+vault_dimensions: [8, 13]
 evidence_channels: [transcript, slides, slide_sequence, video]
 detection_signals:
   - "reference slides at end"
@@ -71,7 +71,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 6 (Information Density): manages information density across the spoken portion and the reference section. Dimension 8 (Slide Design): a deck-structure decision about what belongs in the spoken flow versus reference material.
+Dimension 8 (Information Density): manages information density across the spoken portion and the reference section. Dimension 13 (Slide Design): a deck-structure decision about what belongs in the spoken flow versus reference material.
 
 ## Combinatorics
 The Coda pairs naturally with the Infodeck pattern, as both deal with content designed for solo consumption. It works well alongside Vacation Photos. Image-heavy spoken slides benefit from having a text-rich reference section at the end. The Coda also supports Narrative Arc by keeping disruptive reference material out of the story flow.

--- a/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
+++ b/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - content
-vault_dimensions: [11, 9, 2]
+vault_dimensions: [2, 9, 11]
 evidence_channels: [timed_transcript, slide_sequence, video]
 detection_signals:
   - "a tangible example, object, story, or live demo precedes the named concept it illustrates"

--- a/skills/presentation-creator/references/patterns/build/context-keeper.md
+++ b/skills/presentation-creator/references/patterns/build/context-keeper.md
@@ -7,7 +7,7 @@ phase_relevance:
   - architecture
   - content
   - slides
-vault_dimensions: [2, 5, 13]
+vault_dimensions: [2, 13]
 evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "visible progress indicator"
@@ -73,7 +73,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 2 (Structure and Flow): a direct expression of structural awareness. Dimension 5 (Storytelling and Narrative): narrative-based Context Keepers signal structural position. Dimension 13 (Visual Polish and Craft): the visual implementation of context keeping elements.
+Dimension 2 (Structure and Flow): a direct expression of structural awareness. Dimension 2 (Storytelling and Narrative): narrative-based Context Keepers signal structural position. Dimension 13 (Visual Polish and Craft): the visual implementation of context keeping elements.
 
 ## Combinatorics
 Context Keeper is a parent pattern that encompasses Breadcrumbs, Bookends, Narrative Arc, and Charred Trail as specific implementations. It pairs well with Cave Painting (persistent background elements that provide context). The pattern supports A La Carte Content by providing a return-to-menu mechanism that doubles as a progress indicator. It also enhances any long-form presentation pattern by ensuring the audience maintains orientation throughout.

--- a/skills/presentation-creator/references/patterns/build/crawling-credits.md
+++ b/skills/presentation-creator/references/patterns/build/crawling-credits.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - slides
-vault_dimensions: [6, 13]
+vault_dimensions: [8, 13]
 evidence_channels: [slides, video]
 detection_signals:
   - "scrolling credits animation"
@@ -64,7 +64,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 6 (Information Density): Crawling Credits manages high-density acknowledgment information by distributing it over time rather than space, keeping the screen uncluttered at any given moment while still conveying comprehensive credit. Dimension 13 (Slide Aesthetics): The cinematic quality of well-executed Crawling Credits elevates the overall aesthetic of the presentation, turning a potentially mundane obligation into a visually engaging moment.
+Dimension 8 (Information Density): Crawling Credits manages high-density acknowledgment information by distributing it over time rather than space, keeping the screen uncluttered at any given moment while still conveying comprehensive credit. Dimension 13 (Slide Aesthetics): The cinematic quality of well-executed Crawling Credits elevates the overall aesthetic of the presentation, turning a potentially mundane obligation into a visually engaging moment.
 
 ## Combinatorics
 Crawling Credits pairs naturally with the Coda pattern, as the end-of-deck reference section is the ideal location for extended contributor acknowledgments. It can also complement any pattern that involves collaborative work, providing a graceful way to transition from the substance of the talk to the social obligations of acknowledgment without breaking the flow.

--- a/skills/presentation-creator/references/patterns/build/foreshadowing.md
+++ b/skills/presentation-creator/references/patterns/build/foreshadowing.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - content
-vault_dimensions: [2, 5]
+vault_dimensions: [2]
 evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "early planted clues"
@@ -72,7 +72,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 2 (Structure and Flow): Foreshadowing creates a non-linear structural layer on top of the presentation's sequential flow, connecting distant parts of the talk through thematic threads. Dimension 5 (Storytelling and Narrative): Foreshadowing is a storytelling technique woven into the narrative.
+Dimension 2 (Structure and Flow): Foreshadowing creates a non-linear structural layer on top of the presentation's sequential flow, connecting distant parts of the talk through thematic threads. Dimension 2 (Storytelling and Narrative): Foreshadowing is a storytelling technique woven into the narrative.
 
 ## Combinatorics
 Foreshadowing pairs powerfully with Narrative Arc, as both create a sense of progression and resolution. It works well with Talklet when each self-contained section plants a clue that connects to a larger theme. The Backtracking pattern can serve as a reveal mechanism for foreshadowed elements. Intermezzi slides are a natural vehicle for carrying foreshadowing elements between sections.

--- a/skills/presentation-creator/references/patterns/build/gradual-consistency.md
+++ b/skills/presentation-creator/references/patterns/build/gradual-consistency.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - slides
-vault_dimensions: [8, 13]
+vault_dimensions: [13]
 evidence_channels: [slide_sequence, video]
 detection_signals:
   - "build animations revealing final state"
@@ -66,7 +66,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): Gradual Consistency designs for two consumption contexts simultaneously. Dimension 13 (Visual Polish and Craft): The technique requires careful spatial planning and animation design.
+Dimension 13 (Slide Design): Gradual Consistency designs for two consumption contexts simultaneously. Dimension 13 (Visual Polish and Craft): The technique requires careful spatial planning and animation design.
 
 ## Combinatorics
 Gradual Consistency pairs well with Exuberant Title Top, where the title's migration from center to top is one step in a larger gradual build. Composite Animation can enhance the individual build steps. Analog Noise elements can be revealed gradually to create a sketch-like "drawing in real time" effect. The pattern is essential for making Infodeck-style content presentable in a live format.

--- a/skills/presentation-creator/references/patterns/build/infodeck.md
+++ b/skills/presentation-creator/references/patterns/build/infodeck.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - architecture
-vault_dimensions: [8]
+vault_dimensions: [13]
 detection_signals:
   - "self-contained document format"
   - "dense information without animations"
@@ -52,7 +52,7 @@ talk ingress does not model a `distributed_document` role, so an input deck cann
 that separation and delivery video cannot prove what was distributed afterward.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): The Infodeck pattern directly addresses slide design by establishing that different consumption contexts demand different design approaches. Understanding when to create an Infodeck versus a presentation is a foundational slide design skill.
+Dimension 13 (Slide Design): The Infodeck pattern directly addresses slide design by establishing that different consumption contexts demand different design approaches. Understanding when to create an Infodeck versus a presentation is a foundational slide design skill.
 
 ## Combinatorics
 The Infodeck pairs with Coda, as the Coda section of a live presentation can function as a mini-Infodeck — dense reference material appended after the spoken content. Understanding the Infodeck pattern also helps apply the Gradual Consistency pattern correctly: Gradual Consistency is the technique for making an Infodeck's content presentable live by adding temporal build animations.

--- a/skills/presentation-creator/references/patterns/build/intermezzi.md
+++ b/skills/presentation-creator/references/patterns/build/intermezzi.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - slides
-vault_dimensions: [2, 5, 13]
+vault_dimensions: [2, 13]
 evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "section divider slides"
@@ -74,7 +74,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 2 (Structure and Flow): Intermezzi contribute to structural clarity by marking section boundaries. Dimension 5 (Storytelling and Narrative): Intermezzi support narrative flow and emotional pacing. Dimension 13 (Visual Polish and Craft): Well-designed Intermezzi contribute to the overall aesthetic coherence of the presentation.
+Dimension 2 (Structure and Flow): Intermezzi contribute to structural clarity by marking section boundaries. Dimension 2 (Storytelling and Narrative): Intermezzi support narrative flow and emotional pacing. Dimension 13 (Visual Polish and Craft): Well-designed Intermezzi contribute to the overall aesthetic coherence of the presentation.
 
 ## Combinatorics
 Intermezzi pair naturally with Context Keeper and Bookends as complementary structural mechanisms — Bookends provide explicit structural labels while Intermezzi provide atmospheric transitions. They work well with Narrative Arc by marking act transitions or emotional shifts. The Unifying Visual Theme pattern often provides the imagery or motifs used in Intermezzi. Brain Breaks can be incorporated directly into Intermezzo slides. Foreshadowing can transform Intermezzi from simple transitions into narrative devices, as demonstrated by Neal Ford's Rock-Paper-Scissors example.

--- a/skills/presentation-creator/references/patterns/build/live-on-tape.md
+++ b/skills/presentation-creator/references/patterns/build/live-on-tape.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - publishing
-vault_dimensions: [8]
+vault_dimensions: [13]
 detection_signals:
   - "recorded full presentation"
   - "video artifact of talk"
@@ -53,7 +53,7 @@ every non-video talk falsely absent. Keep this as a publishing checklist until a
 `published_recording` artifact role is modeled.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 8 (Slide Design) as a distributable artifact of the full slide design experience.
+Relates to Dimension 13 (Slide Design) as a distributable artifact of the full slide design experience.
 
 ## Combinatorics
 Live on Tape pairs naturally with Lipsync, as any Lipsync recordings embedded in the presentation are automatically captured in the Live on Tape version, creating a seamless viewing experience. It also supports the Entertainment pattern by preserving the performative elements — humor, timing, audience interaction — that make a presentation engaging beyond its informational content. The Live on Tape recording becomes the definitive artifact of the presentation, superseding any static export in value and utility.

--- a/skills/presentation-creator/references/patterns/build/master-story.md
+++ b/skills/presentation-creator/references/patterns/build/master-story.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - content
-vault_dimensions: [2, 5, 7]
+vault_dimensions: [2, 7]
 evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "single anecdote introduced early and referenced 3+ times across the talk"
@@ -94,7 +94,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 5 (Storytelling/Narrative) directly. Relates to Dimension 2 (Narrative Structure). Relates to Dimension 7 (Verbal Signatures).
+Relates to Dimension 2 (Storytelling/Narrative) directly. Relates to Dimension 2 (Narrative Structure). Relates to Dimension 7 (Verbal Signatures).
 
 ## Combinatorics
 Master Story pairs with `narrative-arc` (the master story can serve as the arc's emotional through-line even when the talk's surface structure is topical), with `foreshadowing` (the first telling can plant elements paid off in later returns — plant the rag doll's name in the original, pay off "Pandy" as compressed shorthand later), and with `star-moment` (the first telling of the master story is often itself a S.T.A.R. emotive-storytelling moment). It composes with `the-big-why` (the Big Idea is what the master story's metaphorical content is mapped to; the Big Idea construction rules live in the "Big Idea — Statement Format" subsection of `the-big-why.md`) and is reinforced by `bookends` (the first and last bookend slides often carry an image from the master story).

--- a/skills/presentation-creator/references/patterns/build/meme-as-argument.md
+++ b/skills/presentation-creator/references/patterns/build/meme-as-argument.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - slides
-vault_dimensions: [4, 7, 12]
+vault_dimensions: [3, 10, 13]
 evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "internet memes carry argumentative weight, not decoration"
@@ -62,7 +62,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 4 (Humor and Surprise Techniques): Meme as Argument is a high-density humor mechanism that does double duty as rhetoric. Dimension 7 (Slide Design): The technique requires deliberate slide-construction discipline; the meme is a chosen visual asset, not a stock image grab. Dimension 12 (Cultural References): The pattern relies on shared meme literacy and lives or dies by audience-meme-fit.
+Dimension 3 (Humor and Surprise Techniques): Meme as Argument is a high-density humor mechanism that does double duty as rhetoric. Dimension 13 (Slide Design): The technique requires deliberate slide-construction discipline; the meme is a chosen visual asset, not a stock image grab. Dimension 10 (Cultural References): The pattern relies on shared meme literacy and lives or dies by audience-meme-fit.
 
 ## Combinatorics
 Pairs with Entertainment as a primary delivery mechanism — Meme as Argument is one of the most efficient ways to keep a talk entertaining without sacrificing rhetorical density. Brain Breaks uses memes more decoratively; the patterns can coexist but should be distinguished. Foreshadowing benefits when a recurring meme structure (e.g., the same unmasking template) is set up early and pays off later. Unifying Visual Theme provides the consistency that lets memes feel earned rather than random.

--- a/skills/presentation-creator/references/patterns/build/new-bliss.md
+++ b/skills/presentation-creator/references/patterns/build/new-bliss.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - content
-vault_dimensions: [5, 6, 9]
+vault_dimensions: [2, 6, 9]
 evidence_channels: [timed_transcript, video]
 detection_signals:
   - "vivid future-state description in the closing zone"
@@ -90,7 +90,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 5 (Storytelling/Narrative). Relates to Dimension 6 (Closing Pattern) as one of three named closing-zone elements (alongside `call-to-action` and `coda`). Relates to Dimension 9 (Persuasion Techniques).
+Relates to Dimension 2 (Storytelling/Narrative). Relates to Dimension 6 (Closing Pattern) as one of three named closing-zone elements (alongside `call-to-action` and `coda`). Relates to Dimension 9 (Persuasion Techniques).
 
 ## Combinatorics
 New Bliss must follow `call-to-action` — they are paired structural elements. It pairs with `sparkline` (where it is the talk's final element) and with `bookends` (the closing-bookend slide often visualizes the New Bliss). It composes with `coda` (which can sit *after* the New Bliss as supplementary reference material — links, contact, further reading — kept structurally separate from the persuasive close so the New Bliss retains its emotional weight). It pairs with `the-big-why`. The New Bliss is the visualization of *what the Big Idea looks like once realized*; the two should feel like the same idea expressed twice — once in thesis form, once in vision form. The Big Idea construction rules live in the "Big Idea — Statement Format" subsection of `the-big-why.md`.

--- a/skills/presentation-creator/references/patterns/build/peer-review.md
+++ b/skills/presentation-creator/references/patterns/build/peer-review.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - guardrails
-vault_dimensions: [7, 8]
+vault_dimensions: [7, 13]
 detection_signals:
   - "review comments or copyediting artifact are available"
   - "speaker identifies the colleague or editor who reviewed the text"
@@ -76,7 +76,7 @@ identifies the reviewer and the material they reviewed.
 - Unevaluable: Review artifacts and speaker confirmation are unavailable
 
 ## Relationship to Vault Dimensions
-Dimension 7 (Language and Communication): Peer Review covers language quality across the presentation. Dimension 8 (Slide Design): clean, error-free text is part of professional slide design.
+Dimension 7 (Language and Communication): Peer Review covers language quality across the presentation. Dimension 13 (Slide Design): clean, error-free text is part of professional slide design.
 
 ## Combinatorics
 Peer Review pairs naturally with the Leet Grammars pattern, which deals with intentional deviations from standard language conventions. When you deliberately break grammar rules for effect (Leet Grammars), the rest of your text must be impeccable so the audience recognizes the deviation as intentional. Peer Review also supports every other content pattern by ensuring the textual foundation is solid.

--- a/skills/presentation-creator/references/patterns/build/progressive-reveal.md
+++ b/skills/presentation-creator/references/patterns/build/progressive-reveal.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - slides
-vault_dimensions: [4, 7]
+vault_dimensions: [3, 13]
 evidence_channels: [slide_sequence, video]
 detection_signals:
   - "single base image annotated across multiple slides"
@@ -70,7 +70,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 4 (Humor and Surprise Techniques): Progressive Reveal is a primary mechanism for landing visual punchlines. Dimension 7 (Slide Design): The technique requires deliberate slide-construction discipline; the same image must reappear with controlled diff across slides.
+Dimension 3 (Humor and Surprise Techniques): Progressive Reveal is a primary mechanism for landing visual punchlines. Dimension 13 (Slide Design): The technique requires deliberate slide-construction discipline; the same image must reappear with controlled diff across slides.
 
 ## Combinatorics
 Pairs with Composite Animation when the additions are layered graphic elements rather than annotations. Foreshadowing reinforces the pattern: the early slides plant questions that the payoff resolves. Traveling Highlights is a related but lower-intensity version where attention moves across a static image rather than building cumulatively. The pattern is the inverse of Bullet-Riddled Corpse slides where everything appears at once with no controlled pacing.

--- a/skills/presentation-creator/references/patterns/build/soft-transitions.md
+++ b/skills/presentation-creator/references/patterns/build/soft-transitions.md
@@ -5,7 +5,7 @@ type: pattern
 part: build
 phase_relevance:
   - slides
-vault_dimensions: [5, 13]
+vault_dimensions: [2, 13]
 evidence_channels: [slide_sequence, video]
 detection_signals:
   - "dissolve transitions"
@@ -63,7 +63,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 5 (Storytelling and Narrative): Soft Transitions support narrative flow. Dimension 13 (Visual Polish and Craft): The technique requires careful attention to timing, element coordination, and visual continuity.
+Dimension 2 (Storytelling and Narrative): Soft Transitions support narrative flow. Dimension 13 (Visual Polish and Craft): The technique requires careful attention to timing, element coordination, and visual continuity.
 
 ## Combinatorics
 Soft Transitions pair powerfully with Cave Painting, where persistent background elements provide visual continuity that the dissolve transitions leverage. They complement Intermezzi by providing smooth flow within sections while Intermezzi provide clear breaks between sections. The pattern is the natural inverse of Cookie Cutter, where identical transitions on every slide create a mechanical rather than organic rhythm. Soft Transitions also enhance Gradual Consistency by making the transition between build steps feel more fluid.

--- a/skills/presentation-creator/references/patterns/build/sparkline.md
+++ b/skills/presentation-creator/references/patterns/build/sparkline.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - architecture
   - content
-vault_dimensions: [2, 5, 9]
+vault_dimensions: [2, 9]
 evidence_channels: [timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "establishes 'what is' baseline before introducing thesis"
@@ -104,7 +104,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 2 (Narrative Structure) as a top-level structural choice alongside `narrative-arc`. Relates to Dimension 5 (Storytelling/Narrative). Relates to Dimension 9 (Persuasion Techniques).
+Relates to Dimension 2 (Narrative Structure) as a top-level structural choice alongside `narrative-arc`. Relates to Dimension 2 (Storytelling/Narrative). Relates to Dimension 9 (Persuasion Techniques).
 
 ## Combinatorics
 Sparkline is composed of several other patterns acting in concert: it begins with `know-your-audience` and `mentor` (the speaker has researched the hero and adopted the mentor stance — the audience-as-hero framing lives in the "Adopting the Stance — Planning Implications" subsection of `mentor.md`); the gap-revelation is `call-to-adventure`; the closing zone is `call-to-action` followed by `new-bliss`. It pairs with `bookends` (the structural opening and closing slides mark the sparkline's three sections), with `foreshadowing` (early plants get paid off at later peaks), and with `star-moment` (a planted memorable beat usually lands at one of the high points in the oscillation).

--- a/skills/presentation-creator/references/patterns/build/star-moment.md
+++ b/skills/presentation-creator/references/patterns/build/star-moment.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - slides
-vault_dimensions: [3, 5, 13]
+vault_dimensions: [2, 3, 13]
 evidence_channels: [video]
 detection_signals:
   - "deliberately constructed peak moment that audiences quote afterward"
@@ -80,7 +80,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Multi-dimensional pattern. Relates to Dimension 3 (Humor & Wit) for sound-bite and dramatization sub-types. Relates to Dimension 5 (Storytelling/Narrative) directly via the emotive-storytelling sub-type and the master-story technique. Relates to Dimension 13 (Slide Design) via the evocative-visual sub-type, where a single slide is constructed to be the moment. The pattern is one of the few that spans three vault dimensions.
+Multi-dimensional pattern. Relates to Dimension 3 (Humor & Wit) for sound-bite and dramatization sub-types. Relates to Dimension 2 (Storytelling/Narrative) directly via the emotive-storytelling sub-type and the master-story technique. Relates to Dimension 13 (Slide Design) via the evocative-visual sub-type, where a single slide is constructed to be the moment. The pattern is one of the few that spans three vault dimensions.
 
 ## Combinatorics
 S.T.A.R. Moment pairs with `the-big-why` (the moment must serve the Big Idea — every S.T.A.R. moment is a Big Idea amplifier; the Big Idea construction rules live in the "Big Idea — Statement Format" subsection of `the-big-why.md`), with `sparkline` (S.T.A.R. moments typically land at the structural peaks of the persuasive oscillation), and with `narrative-arc` (the master-story sub-type is a structural element of the arc itself). It composes with `foreshadowing` (a S.T.A.R. moment can be planted early as a teaser and paid off later as the full beat) and with `call-to-adventure` (the gap-reveal is often executed as a S.T.A.R. moment — Jobs's "today, Apple is going to reinvent the phone" with the iPod-rotary-dial fake is simultaneously a call-to-adventure and a memorable-dramatization S.T.A.R.).

--- a/skills/presentation-creator/references/patterns/build/three-part-close.md
+++ b/skills/presentation-creator/references/patterns/build/three-part-close.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
   - slides
-vault_dimensions: [2, 10]
+vault_dimensions: [2, 6]
 evidence_channels: [slide_sequence, video]
 detection_signals:
   - "closing sequence has summary slide, CTA slide, and thanks slide"
@@ -68,7 +68,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 2 (Structure and Flow): Three-Part Close is a structural commitment to giving the ending the same care as the opening. Dimension 10 (Closing Strategy): The pattern is the most explicit expression of a designed closing.
+Dimension 2 (Structure and Flow): Three-Part Close is a structural commitment to giving the ending the same care as the opening. Dimension 6 (Closing Strategy): The pattern is the most explicit expression of a designed closing.
 
 ## Combinatorics
 Pairs with Bookends — the closing three slides often mirror the opening structure. Call to Action lives inside the pattern as the middle slide. Coda and New Bliss describe the rhetorical purpose of the recap-and-projection movement. The pattern is the inverse of Shortchanged closings where the talk runs out of time and ends abruptly.

--- a/skills/presentation-creator/references/patterns/build/vacation-photos.md
+++ b/skills/presentation-creator/references/patterns/build/vacation-photos.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - architecture
   - slides
-vault_dimensions: [8, 13]
+vault_dimensions: [13]
 evidence_channels: [transcript, slides, video]
 detection_signals:
   - "full-bleed image slides"
@@ -85,7 +85,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 8 (Slide Design): Vacation Photos represents a deliberate architectural choice about how slides function — as emotional/visual backdrops rather than information carriers. Dimension 13 (Visual Polish and Craft): The quality and curation of images directly reflects the presenter's investment in visual craft.
+Dimension 13 (Slide Design): Vacation Photos represents a deliberate architectural choice about how slides function — as emotional/visual backdrops rather than information carriers. Dimension 13 (Visual Polish and Craft): The quality and curation of images directly reflects the presenter's investment in visual craft.
 
 ## Combinatorics
 Vacation Photos pairs powerfully with Unifying Visual Theme, where a consistent photographic style or subject matter creates visual coherence across the deck. It works well with Narrative Arc. The Coda pattern is an essential companion, providing a place for the detailed references and text that Vacation Photos deliberately excludes from the spoken portion.

--- a/skills/presentation-creator/references/patterns/deliver/anti-sell.md
+++ b/skills/presentation-creator/references/patterns/deliver/anti-sell.md
@@ -5,7 +5,7 @@ type: pattern
 part: deliver
 phase_relevance:
   - content
-vault_dimensions: [11, 6]
+vault_dimensions: [9]
 evidence_channels: [transcript, video]
 detection_signals:
   - "speaker downplays own product, employer, or work"
@@ -56,7 +56,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 11 (Self-Presentation): how the speaker positions themselves relative to commercial interests. Dimension 6 (Evidence and Persuasion): a credibility move.
+Dimension 9 (Self-Presentation): how the speaker positions themselves relative to commercial interests. Dimension 9 (Evidence and Persuasion): a credibility move.
 
 ## Combinatorics
 Pairs naturally with Delayed Self-Introduction (the bio comes late, and when it comes it includes the Anti-Sell). The Big Why benefits when Anti-Sell has cleared the suspicion that the "why" is sales-driven. Mentor framing is reinforced — the speaker who refuses to pitch reads as someone there to teach. The pattern is the inverse of Disowning Your Topic, where the speaker sounds embarrassed by their own affiliation; Anti-Sell owns the affiliation while refusing to weaponize it.

--- a/skills/presentation-creator/references/patterns/deliver/delayed-self-introduction.md
+++ b/skills/presentation-creator/references/patterns/deliver/delayed-self-introduction.md
@@ -5,7 +5,7 @@ type: pattern
 part: deliver
 phase_relevance:
   - content
-vault_dimensions: [2, 11]
+vault_dimensions: [2, 9]
 evidence_channels: [timed_transcript, slides, video]
 detection_signals:
   - "speaker opens with hook/content rather than name and role"
@@ -60,7 +60,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 2 (Structure and Flow): Delayed Self-Introduction is a structural decision about where attention is invested in the opening. Dimension 11 (Self-Presentation): The pattern reframes the speaker's authority as earned by content rather than declared by credentials.
+Dimension 2 (Structure and Flow): Delayed Self-Introduction is a structural decision about where attention is invested in the opening. Dimension 9 (Self-Presentation): The pattern reframes the speaker's authority as earned by content rather than declared by credentials.
 
 ## Combinatorics
 Pairs naturally with Opening Punch (a hook needs to land hard) and The Big Why (the opening claim is often the talk's central question). Anti-Sell complements it — both downplay the speaker's own authority in service of the topic. Avoid combining with extensive corporate branding on the title slide, which signals "this is an ad" before the hook can do its work.

--- a/skills/presentation-creator/references/patterns/deliver/entertainment.md
+++ b/skills/presentation-creator/references/patterns/deliver/entertainment.md
@@ -5,7 +5,7 @@ type: pattern
 part: deliver
 phase_relevance:
   - content
-vault_dimensions: [3, 10]
+vault_dimensions: [3]
 evidence_channels: [transcript, slides, video]
 detection_signals:
   - "humor used for engagement"
@@ -65,7 +65,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-This pattern maps to Vault Dimension 3 (Engagement / Entertainment Value) directly, and to Vault Dimension 10 (Memorability).
+This pattern maps to Vault Dimension 3 (Engagement / Entertainment Value) directly, and to Vault Dimension 3 (Memorability).
 
 ## Combinatorics
 Entertainment works with Know Your Audience (understanding what this audience finds funny and relatable), Brain Breaks (entertainment naturally creates cognitive rest), and Make It Rain (physical props add entertainment value). It is the inverse of the Alienating Artifact antipattern, where entertainment choices exclude or offend. The Mentor pattern provides a useful frame for entertainment — humor and stories that serve the audience's learning journey rather than the speaker's ego.

--- a/skills/presentation-creator/references/patterns/prepare/_anti_alienating-artifact.md
+++ b/skills/presentation-creator/references/patterns/prepare/_anti_alienating-artifact.md
@@ -5,7 +5,7 @@ type: antipattern
 part: prepare
 phase_relevance:
   - guardrails
-vault_dimensions: [3, 10, 14]
+vault_dimensions: [10, 12, 14]
 evidence_channels: [transcript, slides, video]
 detection_signals:
   - "offensive humor attempts"
@@ -65,7 +65,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 3 (Delivery/Presentation Skills). Relates to Dimension 10 (Creativity/Originality). Relates to Dimension 14 (Overall Impression/Polish).
+Relates to Dimension 12 (Delivery/Presentation Skills). Relates to Dimension 10 (Creativity/Originality). Relates to Dimension 14 (Overall Impression/Polish).
 
 ## Combinatorics
 Relates to Know Your Audience (understanding audience composition prevents many alienating choices) and Brain Breaks (this antipattern is the dark mirror of Brain Breaks — where Brain Breaks refresh and engage, Alienating Artifacts repel and disengage). Brain Breaks is the inverse pattern — the positive version of using humor and diversions effectively.

--- a/skills/presentation-creator/references/patterns/prepare/brain-breaks.md
+++ b/skills/presentation-creator/references/patterns/prepare/brain-breaks.md
@@ -6,7 +6,7 @@ part: prepare
 phase_relevance:
   - architecture
   - content
-vault_dimensions: [3, 12]
+vault_dimensions: [12]
 evidence_channels: [timed_transcript, video]
 detection_signals:
   - "humor/story every 10-20 minutes"
@@ -77,7 +77,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 3 (Delivery/Presentation Skills). Relates to Dimension 12 (Time/Pacing).
+Relates to Dimension 12 (Delivery/Presentation Skills). Relates to Dimension 12 (Time/Pacing).
 
 ## Combinatorics
 Pairs with Leet Grammars (insider humor is the most effective Brain Break), Narrative Arc (breaks should work within the narrative structure, not against it), Entertainment (Brain Breaks are targeted micro-entertainment), and Crucible (live delivery reveals which breaks work and which do not). The inverse is Alienating Artifact — a "break" that offends rather than refreshes.

--- a/skills/presentation-creator/references/patterns/prepare/cave-painting.md
+++ b/skills/presentation-creator/references/patterns/prepare/cave-painting.md
@@ -6,7 +6,7 @@ part: prepare
 phase_relevance:
   - architecture
   - slides
-vault_dimensions: [5, 13]
+vault_dimensions: [2, 13]
 evidence_channels: [slide_sequence, video]
 detection_signals:
   - "canvas-based layout"
@@ -72,7 +72,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 5 (Storytelling/Narrative). Relates to Dimension 13 (Visual Aids Effectiveness).
+Relates to Dimension 2 (Storytelling/Narrative). Relates to Dimension 13 (Visual Aids Effectiveness).
 
 ## Combinatorics
 Pairs with Context Keeper (Cave Painting is inherently a context-keeping device), Soft Transitions (zooming between sections creates smooth visual transitions), Brain Breaks (the zoom-out moments serve as visual palate cleansers), Takahashi (individual zoomed-in sections can use Takahashi-style single elements), and Lipsync (spatial layout helps synchronize verbal and visual content).

--- a/skills/presentation-creator/references/patterns/prepare/concurrent-creation.md
+++ b/skills/presentation-creator/references/patterns/prepare/concurrent-creation.md
@@ -5,7 +5,7 @@ type: pattern
 part: prepare
 phase_relevance:
   - content
-vault_dimensions: [2, 8]
+vault_dimensions: [2, 13]
 detection_signals:
   - "creation history documents non-linear authoring"
   - "collaboration record names one Slide Wrangler"
@@ -55,7 +55,7 @@ the work was authored out of order or coordinated through one Slide Wrangler.
 - Unevaluable: No creation history, collaboration record, or speaker confirmation is available
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 2 (Structure/Organization). Relates to Dimension 8 (Slide Design/Visual Quality).
+Relates to Dimension 2 (Structure/Organization). Relates to Dimension 13 (Slide Design/Visual Quality).
 
 ## Combinatorics
 Pairs with Talklet (modular units can be created concurrently by different authors) and Unifying Visual Theme (visual consistency is the glue that holds concurrent contributions together). Also benefits from Narrative Arc awareness — all contributors must understand the overall story to create pieces that fit.

--- a/skills/presentation-creator/references/patterns/prepare/fourthought.md
+++ b/skills/presentation-creator/references/patterns/prepare/fourthought.md
@@ -6,7 +6,7 @@ part: prepare
 phase_relevance:
   - intent
   - architecture
-vault_dimensions: [2, 8]
+vault_dimensions: [2, 13]
 detection_signals:
   - "ideation, capture, and organization artifacts predate slide authoring"
   - "speaker confirms the four-phase preparation workflow"
@@ -48,7 +48,7 @@ those sources is unevaluable, not evidence that the process occurred.
 - Unevaluable: Preparation artifacts or speaker confirmation are unavailable
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 2 (Structure/Organization). Relates to Dimension 8 (Slide Design/Visual Quality).
+Relates to Dimension 2 (Structure/Organization). Relates to Dimension 13 (Slide Design/Visual Quality).
 
 ## Combinatorics
 Pairs naturally with Narrative Arc (Fourthought's organize phase is where you discover your arc), Unifying Visual Theme (the design phase is where visual themes are applied to already-organized ideas), and Backtracking (having a clear structure makes it easy to reference earlier material). Fourthought is the inverse of Cookie Cutter — where Cookie Cutter lets the tool drive the thinking, Fourthought insists that thinking drives the tool.

--- a/skills/presentation-creator/references/patterns/prepare/leet-grammars.md
+++ b/skills/presentation-creator/references/patterns/prepare/leet-grammars.md
@@ -5,7 +5,7 @@ type: pattern
 part: prepare
 phase_relevance:
   - content
-vault_dimensions: [7, 10]
+vault_dimensions: [10, 11]
 detection_signals:
   - "correct use of community jargon"
   - "insider references"
@@ -50,7 +50,7 @@ cannot be established from the speaker's own words or slides without independent
 community and speaker context. Do not turn fluent jargon into inferred identity or belonging.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 7 (Technical Depth/Accuracy). Relates to Dimension 10 (Creativity/Originality).
+Relates to Dimension 11 (Technical Depth/Accuracy). Relates to Dimension 10 (Creativity/Originality).
 
 ## Combinatorics
 Pairs with Analog Noise (authentic personal touches reinforce community membership signals) and Brain Breaks (insider humor is the most effective break type). The inverse is Tower of Babble — using jargon incorrectly or excessively to the point of incomprehensibility.

--- a/skills/presentation-creator/references/patterns/prepare/narrative-arc.md
+++ b/skills/presentation-creator/references/patterns/prepare/narrative-arc.md
@@ -7,7 +7,7 @@ phase_relevance:
   - intent
   - architecture
   - content
-vault_dimensions: [2, 5]
+vault_dimensions: [2]
 evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "clear three-act structure"
@@ -66,7 +66,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 2 (Structure/Organization) as the primary structural pattern for presentations. Relates to Dimension 5 (Storytelling/Narrative) directly — this pattern IS the narrative dimension.
+Relates to Dimension 2 (Structure/Organization) as the primary structural pattern for presentations. Relates to Dimension 2 (Storytelling/Narrative) directly — this pattern IS the narrative dimension.
 
 ## Combinatorics
 Pairs powerfully with Triad (three-act structure maps to three main themes), Bookends (opening and closing that frame the arc), Intermezzi (transitions between arc sections), Unifying Visual Theme (visual coherence reinforces narrative coherence), and Context Keeper (maintaining audience orientation within the arc). The Narrative Arc is arguably the most foundational pattern — nearly every other pattern either supports it or depends on it.

--- a/skills/presentation-creator/references/patterns/prepare/takahashi.md
+++ b/skills/presentation-creator/references/patterns/prepare/takahashi.md
@@ -6,7 +6,7 @@ part: prepare
 phase_relevance:
   - architecture
   - slides
-vault_dimensions: [8, 12, 13]
+vault_dimensions: [12, 13]
 evidence_channels: [slides, slide_sequence, video]
 detection_signals:
   - "one element per slide"
@@ -64,7 +64,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 An absence finding is authorized only from a complete, separately declared rendered PDF (`static_slides`); a native deck, delivery video, transcript, or comparison artifact does not authorize absence.
 
 ## Relationship to Vault Dimensions
-Relates to Dimension 8 (Slide Design/Visual Quality). Relates to Dimension 12 (Time/Pacing). Relates to Dimension 13 (Visual Aids Effectiveness).
+Relates to Dimension 13 (Slide Design/Visual Quality). Relates to Dimension 12 (Time/Pacing). Relates to Dimension 13 (Visual Aids Effectiveness).
 
 ## Combinatorics
 Pairs with Brain Breaks (the rapid visual changes function as continuous micro-breaks for attention). The inverse is Bullet-Riddled Corpse — where Takahashi puts one element per slide, the antipattern crams as many bullet points as possible onto each slide.

--- a/skills/vault-ingress/scripts/audit-pattern-catalog.py
+++ b/skills/vault-ingress/scripts/audit-pattern-catalog.py
@@ -52,6 +52,14 @@ from catalog_io import (
     load_catalog_yaml,
     parse_evidence_source_groups,
 )
+from catalog_dimension_registry import (
+    REGISTRY_FILENAME,
+    CatalogDimensionRegistryError,
+    DimensionRegistry,
+    dimension_claims,
+    load_dimension_registry,
+    resolved_vault_dimensions,
+)
 from catalog_normalization import normalize_catalog_alias
 
 
@@ -523,6 +531,67 @@ def _validate_entry_identity(entry: CatalogEntry, errors: list[Issue]) -> None:
                 pattern_id or "",
             )
         )
+
+
+def _validate_dimension_labels(
+    entry: CatalogEntry,
+    registry: DimensionRegistry,
+    errors: list[Issue],
+    debts: list[Issue],
+) -> None:
+    """Check each `Dimension N (Label)` claim against the registry.
+
+    Two finding classes, deliberately separated. A claim whose label resolves to
+    a DIFFERENT number is an objective disagreement between two things the entry
+    itself asserts, so it is an error. A label the registry cannot resolve is a
+    semantic question only an owner can answer — reporting it as an error would
+    turn an unreviewed alias into a build break, and resolving it by guess would
+    turn this reviewed migration into an automatic renumbering.
+    """
+    claims = dimension_claims(entry.text, registry)
+    for claim in claims:
+        if claim.unresolved:
+            debts.append(
+                Issue(
+                    "dimension_label_unresolved",
+                    f"prose label {claim.label!r} resolves to no dimension; add "
+                    "an owner-approved alias to _dimensions.yaml or correct the "
+                    "label",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "vault_dimensions",
+                )
+            )
+        elif not claim.agrees:
+            errors.append(
+                Issue(
+                    "dimension_label_disagrees",
+                    f"prose claims Dimension {claim.stated_ordinal} but label "
+                    f"{claim.label!r} resolves to {claim.resolved_ordinal}",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "vault_dimensions",
+                )
+            )
+    stored = entry.metadata.get("vault_dimensions")
+    if claims and isinstance(stored, list):
+        wanted = resolved_vault_dimensions(claims)
+        held = sorted(
+            value
+            for value in stored
+            if isinstance(value, int) and not isinstance(value, bool)
+        )
+        if held != wanted:
+            errors.append(
+                Issue(
+                    "dimension_frontmatter_disagrees",
+                    f"vault_dimensions {held} differ from what the prose "
+                    f"supports {wanted}",
+                    entry.relative_path,
+                    entry.pattern_id or "",
+                    "vault_dimensions",
+                )
+            )
 
 
 def _validate_dimensions_and_phases(
@@ -1464,6 +1533,18 @@ def audit_catalog(
     root = Path(catalog_dir) if catalog_dir is not None else default_catalog_dir()
     errors: list[Issue] = []
     debts: list[Issue] = []
+    registry: DimensionRegistry | None = None
+    if root.is_dir():
+        # Only meaningful once the catalog directory exists; a missing directory
+        # is reported below and subsumes every finding inside it.
+        try:
+            registry = load_dimension_registry(root)
+        except CatalogDimensionRegistryError as exc:
+            # A malformed registry is an error, not a silent skip: without it
+            # every dimension claim in the catalog becomes uncheckable.
+            errors.append(
+                Issue("dimension_registry_invalid", str(exc), REGISTRY_FILENAME)
+            )
     if not root.is_dir():
         errors.append(
             Issue(
@@ -1497,6 +1578,8 @@ def audit_catalog(
         if enforce_current_source_capabilities:
             _validate_current_absence_capability(entry, errors)
         _validate_scoring(entry, errors)
+        if registry is not None:
+            _validate_dimension_labels(entry, registry, errors, debts)
         entry_dimensions, entry_phases = _validate_dimensions_and_phases(entry, errors)
         entry_related, entry_inverse, entry_aliases = _entry_references(entry, errors)
         if entry.pattern_id is None:

--- a/skills/vault-ingress/scripts/catalog_dimension_registry.py
+++ b/skills/vault-ingress/scripts/catalog_dimension_registry.py
@@ -92,7 +92,16 @@ def load_dimension_registry(catalog_dir: Path | str) -> DimensionRegistry:
         raise CatalogDimensionRegistryError(
             f"cannot read dimension registry {path}: {exc}"
         ) from exc
-    document = _require_mapping(yaml.safe_load(raw), str(path))
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        # The auditor promises a `dimension_registry_invalid` finding for a
+        # registry it cannot use. A YAMLError escaping this call would crash it
+        # instead, turning the one reportable failure into no report at all.
+        raise CatalogDimensionRegistryError(
+            f"cannot parse dimension registry {path}: {exc}"
+        ) from exc
+    document = _require_mapping(parsed, str(path))
     version = document.get("schema_version")
     if version != DIMENSION_REGISTRY_SCHEMA_VERSION:
         raise CatalogDimensionRegistryError(

--- a/skills/vault-ingress/scripts/catalog_dimension_registry.py
+++ b/skills/vault-ingress/scripts/catalog_dimension_registry.py
@@ -1,0 +1,219 @@
+"""One authority for the 14 vault dimensions and the labels that name them.
+
+`vault_dimensions` is a list of bare integers, so a range check is the only
+validation a number can carry on its own — and a range check cannot tell that
+`4` means Audience Interaction while the prose beside it says humor. That gap is
+how entries came to file evidence under dimensions they are not about.
+
+This registry closes it by making the prose label resolvable. Every label the
+catalog actually uses is an owner-approved alias of exactly one dimension, so a
+`Dimension N (Label)` claim can be checked: does N match where the label
+resolves? A label with no alias does not resolve, and the auditor reports it for
+owner review rather than guessing — the migration stays reviewed rather than
+becoming an automatic renumbering.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import yaml
+
+from catalog_normalization import normalize_catalog_alias
+
+
+DIMENSION_REGISTRY_SCHEMA_VERSION = 1
+DIMENSION_COUNT = 14
+REGISTRY_FILENAME = "_dimensions.yaml"
+
+# `Dimension 4 (Audience Engagement)` and `Vault Dimension 13 (Slide Design)`
+# are the two shapes the catalog uses.
+DIMENSION_CLAIM_RE = re.compile(r"(?:Vault )?Dimension (\d+) \(([^)]+)\)")
+
+
+class CatalogDimensionRegistryError(ValueError):
+    """The dimension registry is missing, malformed, or self-contradictory."""
+
+
+@dataclass(frozen=True)
+class Dimension:
+    """One canonical dimension and every label approved to name it."""
+
+    id: str
+    ordinal: int
+    name: str
+    aliases: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DimensionRegistry:
+    """The loaded registry, indexed for resolution."""
+
+    dimensions: tuple[Dimension, ...]
+    _by_normalized_label: Mapping[str, int]
+
+    def ordinal_for_label(self, label: str) -> int | None:
+        """Resolve a prose label to its canonical ordinal, or None.
+
+        None means the label is not owner-approved for any dimension. It is
+        never a reason to fall back to the number already written beside it —
+        that number is exactly what is under review.
+        """
+        return self._by_normalized_label.get(normalize_catalog_alias(label))
+
+    def by_ordinal(self, ordinal: int) -> Dimension | None:
+        for dimension in self.dimensions:
+            if dimension.ordinal == ordinal:
+                return dimension
+        return None
+
+
+def _require_mapping(value: object, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise CatalogDimensionRegistryError(f"{label} must be a mapping")
+    return value
+
+
+def _require_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CatalogDimensionRegistryError(f"{label} must be a non-empty string")
+    return value
+
+
+def load_dimension_registry(catalog_dir: Path | str) -> DimensionRegistry:
+    """Load and validate the registry beside the catalog entries."""
+    path = Path(catalog_dir) / REGISTRY_FILENAME
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CatalogDimensionRegistryError(
+            f"cannot read dimension registry {path}: {exc}"
+        ) from exc
+    document = _require_mapping(yaml.safe_load(raw), str(path))
+    version = document.get("schema_version")
+    if version != DIMENSION_REGISTRY_SCHEMA_VERSION:
+        raise CatalogDimensionRegistryError(
+            f"{path} schema_version must be {DIMENSION_REGISTRY_SCHEMA_VERSION}, "
+            f"got {version!r}"
+        )
+    entries = document.get("dimensions")
+    if not isinstance(entries, list) or len(entries) != DIMENSION_COUNT:
+        raise CatalogDimensionRegistryError(
+            f"{path} must declare exactly {DIMENSION_COUNT} dimensions"
+        )
+
+    dimensions: list[Dimension] = []
+    by_label: dict[str, int] = {}
+    seen_ordinals: set[int] = set()
+    seen_ids: set[str] = set()
+    for index, entry in enumerate(entries):
+        mapping = _require_mapping(entry, f"{path} dimensions[{index}]")
+        unknown = set(mapping) - {"id", "ordinal", "name", "aliases"}
+        if unknown:
+            raise CatalogDimensionRegistryError(
+                f"{path} dimensions[{index}] has unknown keys {sorted(unknown)}"
+            )
+        identifier = _require_text(mapping.get("id"), f"{path} dimensions[{index}].id")
+        name = _require_text(mapping.get("name"), f"{path} dimensions[{index}].name")
+        ordinal = mapping.get("ordinal")
+        if not isinstance(ordinal, int) or isinstance(ordinal, bool):
+            raise CatalogDimensionRegistryError(
+                f"{path} dimensions[{index}].ordinal must be an integer"
+            )
+        if not 1 <= ordinal <= DIMENSION_COUNT:
+            raise CatalogDimensionRegistryError(
+                f"{path} dimensions[{index}].ordinal {ordinal} is out of range"
+            )
+        if ordinal in seen_ordinals:
+            raise CatalogDimensionRegistryError(f"{path} repeats ordinal {ordinal}")
+        if identifier in seen_ids:
+            raise CatalogDimensionRegistryError(f"{path} repeats id {identifier!r}")
+        seen_ordinals.add(ordinal)
+        seen_ids.add(identifier)
+
+        raw_aliases = mapping.get("aliases", [])
+        if not isinstance(raw_aliases, list):
+            raise CatalogDimensionRegistryError(
+                f"{path} dimensions[{index}].aliases must be an array"
+            )
+        aliases = tuple(
+            _require_text(alias, f"{path} dimensions[{index}].aliases[{position}]")
+            for position, alias in enumerate(raw_aliases)
+        )
+        # The canonical name resolves too, so an entry already using it needs no
+        # alias entry to duplicate it.
+        for label in (name, *aliases):
+            normalized = normalize_catalog_alias(label)
+            if not normalized:
+                raise CatalogDimensionRegistryError(
+                    f"{path} dimensions[{index}] label {label!r} normalizes empty"
+                )
+            previous = by_label.get(normalized)
+            if previous is not None and previous != ordinal:
+                # One label naming two dimensions makes every claim using it
+                # unresolvable, which is worse than having no alias at all.
+                raise CatalogDimensionRegistryError(
+                    f"{path} label {label!r} resolves to both dimension "
+                    f"{previous} and {ordinal}"
+                )
+            by_label[normalized] = ordinal
+        dimensions.append(
+            Dimension(id=identifier, ordinal=ordinal, name=name, aliases=aliases)
+        )
+
+    if seen_ordinals != set(range(1, DIMENSION_COUNT + 1)):
+        raise CatalogDimensionRegistryError(
+            f"{path} must cover ordinals 1-{DIMENSION_COUNT} exactly once"
+        )
+    return DimensionRegistry(
+        dimensions=tuple(sorted(dimensions, key=lambda item: item.ordinal)),
+        _by_normalized_label=by_label,
+    )
+
+
+@dataclass(frozen=True)
+class DimensionClaim:
+    """One `Dimension N (Label)` claim found in entry prose."""
+
+    stated_ordinal: int
+    label: str
+    resolved_ordinal: int | None
+
+    @property
+    def agrees(self) -> bool:
+        return self.resolved_ordinal == self.stated_ordinal
+
+    @property
+    def unresolved(self) -> bool:
+        return self.resolved_ordinal is None
+
+
+def dimension_claims(text: str, registry: DimensionRegistry) -> list[DimensionClaim]:
+    """Read every dimension claim in one entry's prose."""
+    return [
+        DimensionClaim(
+            stated_ordinal=int(match.group(1)),
+            label=match.group(2).strip(),
+            resolved_ordinal=registry.ordinal_for_label(match.group(2).strip()),
+        )
+        for match in DIMENSION_CLAIM_RE.finditer(text)
+    ]
+
+
+def resolved_vault_dimensions(claims: Iterable[DimensionClaim]) -> list[int]:
+    """The `vault_dimensions` the prose supports, sorted.
+
+    A resolved claim contributes where its label resolves. An UNRESOLVED claim
+    contributes the number already written beside it — preserved, not endorsed.
+    Dropping it would silently delete a membership on the strength of a missing
+    alias, which is a bigger change than the drift being fixed; the auditor
+    reports the unresolved label separately so an owner decides it explicitly.
+    """
+    ordinals: set[int] = set()
+    for claim in claims:
+        resolved = claim.resolved_ordinal
+        ordinals.add(claim.stated_ordinal if resolved is None else resolved)
+    return sorted(ordinals)

--- a/tests/test_audit_pattern_catalog.py
+++ b/tests/test_audit_pattern_catalog.py
@@ -59,6 +59,15 @@ def _metadata(entry: dict) -> dict:
     }
 
 
+LIVE_CATALOG = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "presentation-creator"
+    / "references"
+    / "patterns"
+)
+
+
 def _write_catalog(
     tmp_path: Path,
     entries: list[dict] | None = None,
@@ -68,6 +77,13 @@ def _write_catalog(
 ) -> Path:
     root = tmp_path / "patterns"
     root.mkdir()
+    # The dimension registry is part of the catalog contract (#156), so a
+    # synthetic catalog carries the real one — otherwise every fixture reports
+    # a missing registry and drowns the finding each test is actually about.
+    (root / "_dimensions.yaml").write_text(
+        (LIVE_CATALOG / "_dimensions.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
     values = copy.deepcopy(entries or _base_entries())
     for entry in values:
         directory = entry.get("_directory", entry["part"])

--- a/tests/test_catalog_dimension_registry.py
+++ b/tests/test_catalog_dimension_registry.py
@@ -1,0 +1,195 @@
+"""The dimension registry and the canonical remap it authorizes (#156).
+
+Fixtures come from the live catalog rather than hardcoded numbers, so an entry
+edit that reintroduces drift fails these tests instead of quietly passing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO_ROOT / "skills" / "vault-ingress" / "scripts"
+CATALOG = REPO_ROOT / "skills" / "presentation-creator" / "references" / "patterns"
+
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+if "catalog_dimension_registry" in sys.modules:
+    registry_module = sys.modules["catalog_dimension_registry"]
+else:
+    _SPEC = importlib.util.spec_from_file_location(
+        "catalog_dimension_registry", SCRIPTS / "catalog_dimension_registry.py"
+    )
+    assert _SPEC is not None and _SPEC.loader is not None
+    registry_module = importlib.util.module_from_spec(_SPEC)
+    sys.modules["catalog_dimension_registry"] = registry_module
+    _SPEC.loader.exec_module(registry_module)
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return registry_module.load_dimension_registry(CATALOG)
+
+
+def _entries():
+    for path in sorted(CATALOG.rglob("*.md")):
+        if path.name.startswith("_index"):
+            continue
+        yield path
+
+
+class TestRegistryShape:
+    def test_covers_every_canonical_ordinal_once(self, registry) -> None:
+        assert [d.ordinal for d in registry.dimensions] == list(range(1, 15))
+
+    def test_names_match_the_canonical_authority(self, registry) -> None:
+        """`rhetoric-dimensions.md` sections 1-14 are the source of truth."""
+        authority = (
+            REPO_ROOT
+            / "skills"
+            / "vault-ingress"
+            / "references"
+            / "rhetoric-dimensions.md"
+        ).read_text()
+        for dimension in registry.dimensions:
+            assert f"## {dimension.ordinal}. {dimension.name}" in authority
+
+    def test_the_canonical_name_resolves_without_an_alias(self, registry) -> None:
+        for dimension in registry.dimensions:
+            assert registry.ordinal_for_label(dimension.name) == dimension.ordinal
+
+    def test_every_alias_resolves_to_its_own_dimension(self, registry) -> None:
+        for dimension in registry.dimensions:
+            for alias in dimension.aliases:
+                assert registry.ordinal_for_label(alias) == dimension.ordinal
+
+
+class TestResolution:
+    def test_an_unapproved_label_does_not_resolve(self, registry) -> None:
+        """The migration stays reviewed: an unknown label is reported, never
+        guessed, and never falls back to the number written beside it."""
+        assert registry.ordinal_for_label("Vibes And General Excellence") is None
+
+    def test_resolution_ignores_case_and_punctuation(self, registry) -> None:
+        assert registry.ordinal_for_label("slide design") == 13
+        assert registry.ordinal_for_label("SLIDE  DESIGN") == 13
+        assert registry.ordinal_for_label("time/pacing") == 12
+
+    def test_an_ampersand_name_does_not_resolve_from_its_spelled_form(
+        self, registry
+    ) -> None:
+        """`normalize_catalog_alias` drops `&` rather than expanding it, so
+        `Humor & Wit` and `Humor and Wit` are different labels. The catalog
+        writes the former; an entry using the latter needs an explicit alias."""
+        assert registry.ordinal_for_label("Humor & Wit") == 3
+        assert registry.ordinal_for_label("Humor and Wit") is None
+
+
+class TestCatalogAgreement:
+    def test_every_resolvable_claim_agrees_with_its_number(self, registry) -> None:
+        """The remap's whole point: where a label resolves, the number matches."""
+        disagreements = []
+        for path in _entries():
+            for claim in registry_module.dimension_claims(path.read_text(), registry):
+                if not claim.unresolved and not claim.agrees:
+                    disagreements.append(
+                        f"{path.name}: D{claim.stated_ordinal} ({claim.label}) "
+                        f"resolves to D{claim.resolved_ordinal}"
+                    )
+        assert disagreements == []
+
+    def test_frontmatter_matches_what_the_prose_supports(self, registry) -> None:
+        import re
+
+        mismatches = []
+        for path in _entries():
+            text = path.read_text()
+            match = re.search(r"^vault_dimensions: \[([^\]]*)\]$", text, re.M)
+            claims = registry_module.dimension_claims(text, registry)
+            if match is None or not claims:
+                continue
+            stored = [int(value) for value in re.findall(r"\d+", match.group(1))]
+            wanted = registry_module.resolved_vault_dimensions(claims)
+            if stored != wanted:
+                mismatches.append(f"{path.name}: {stored} != {wanted}")
+        assert mismatches == []
+
+    def test_the_two_worked_examples_from_the_issue(self, registry) -> None:
+        """#156 states the expected outcome for these two entries exactly."""
+        import re
+
+        for name, expected in (
+            ("progressive-reveal.md", [3, 13]),
+            ("three-part-close.md", [2, 6]),
+        ):
+            path = next(p for p in _entries() if p.name == name)
+            match = re.search(
+                r"^vault_dimensions: \[([^\]]*)\]$", path.read_text(), re.M
+            )
+            assert match is not None
+            assert [int(v) for v in re.findall(r"\d+", match.group(1))] == expected
+
+
+class TestUnresolvedLabelsArePreserved:
+    def test_an_unresolved_claim_keeps_its_number(self, registry) -> None:
+        """Dropping a membership on the strength of a missing alias would be a
+        bigger change than the drift being fixed."""
+        claim = registry_module.DimensionClaim(
+            stated_ordinal=9, label="Not An Approved Label", resolved_ordinal=None
+        )
+        assert registry_module.resolved_vault_dimensions([claim]) == [9]
+
+    def test_a_resolved_claim_uses_the_resolved_number(self, registry) -> None:
+        claim = registry_module.DimensionClaim(
+            stated_ordinal=7, label="Slide Design", resolved_ordinal=13
+        )
+        assert registry_module.resolved_vault_dimensions([claim]) == [13]
+
+
+class TestRegistryValidation:
+    def _write(self, tmp_path: Path, body: str) -> Path:
+        (tmp_path / "_dimensions.yaml").write_text(body, encoding="utf-8")
+        return tmp_path
+
+    def test_a_missing_registry_is_an_error(self, tmp_path: Path) -> None:
+        with pytest.raises(registry_module.CatalogDimensionRegistryError):
+            registry_module.load_dimension_registry(tmp_path)
+
+    def test_an_unsupported_schema_version_is_an_error(self, tmp_path: Path) -> None:
+        with pytest.raises(registry_module.CatalogDimensionRegistryError):
+            registry_module.load_dimension_registry(
+                self._write(tmp_path, "schema_version: 99\ndimensions: []\n")
+            )
+
+    def test_a_short_registry_is_an_error(self, tmp_path: Path) -> None:
+        body = (
+            "schema_version: 1\ndimensions:\n"
+            "  - id: only\n    ordinal: 1\n    name: Only\n    aliases: []\n"
+        )
+        with pytest.raises(registry_module.CatalogDimensionRegistryError):
+            registry_module.load_dimension_registry(self._write(tmp_path, body))
+
+    def test_one_label_naming_two_dimensions_is_an_error(self, tmp_path: Path) -> None:
+        """An ambiguous alias makes every claim using it unresolvable, which is
+        worse than having no alias at all."""
+        lines = ["schema_version: 1", "dimensions:"]
+        for ordinal in range(1, 15):
+            lines += [
+                f"  - id: d{ordinal}",
+                f"    ordinal: {ordinal}",
+                f"    name: Dimension {ordinal}",
+                "    aliases:",
+                "      - Shared Label",
+            ]
+        with pytest.raises(
+            registry_module.CatalogDimensionRegistryError, match="resolves to both"
+        ):
+            registry_module.load_dimension_registry(
+                self._write(tmp_path, "\n".join(lines) + "\n")
+            )

--- a/tests/test_catalog_dimension_registry.py
+++ b/tests/test_catalog_dimension_registry.py
@@ -246,3 +246,26 @@ class TestAuditorEnforcesTheRegistry:
 
         codes = [issue["code"] for issue in report["errors"]]
         assert "dimension_registry_invalid" in codes
+
+
+def test_malformed_yaml_is_a_registry_error_not_a_crash(tmp_path: Path) -> None:
+    """The auditor promises a finding for a registry it cannot use; a raw
+    YAMLError would crash it instead of reporting."""
+    (tmp_path / "_dimensions.yaml").write_text(
+        "schema_version: 1\ndimensions:\n  - [unclosed\n", encoding="utf-8"
+    )
+
+    with pytest.raises(
+        registry_module.CatalogDimensionRegistryError, match="cannot parse"
+    ):
+        registry_module.load_dimension_registry(tmp_path)
+
+
+def test_the_auditor_reports_unparseable_yaml(audit_pattern_catalog, tmp_path) -> None:
+    (tmp_path / "_dimensions.yaml").write_text(
+        "schema_version: 1\ndimensions:\n  - [unclosed\n", encoding="utf-8"
+    )
+
+    report = audit_pattern_catalog.audit_catalog(catalog_dir=tmp_path)
+
+    assert "dimension_registry_invalid" in [i["code"] for i in report["errors"]]

--- a/tests/test_catalog_dimension_registry.py
+++ b/tests/test_catalog_dimension_registry.py
@@ -193,3 +193,56 @@ class TestRegistryValidation:
             registry_module.load_dimension_registry(
                 self._write(tmp_path, "\n".join(lines) + "\n")
             )
+
+
+@pytest.fixture(scope="module")
+def report(audit_pattern_catalog):
+    return audit_pattern_catalog.audit_catalog()
+
+
+class TestAuditorEnforcesTheRegistry:
+    """The registry is only real if the deterministic auditor reads it."""
+
+    def test_the_live_catalog_has_no_dimension_errors(self, report) -> None:
+        codes = [issue["code"] for issue in report["errors"]]
+        assert [c for c in codes if c.startswith("dimension_")] == []
+
+    def test_unresolved_labels_surface_as_semantic_debts(self, report) -> None:
+        """A label no owner approved is a question, not a build break."""
+        codes = [issue["code"] for issue in report["semantic_debts"]]
+        assert set(codes) <= {"dimension_label_unresolved"}
+
+    def test_a_disagreeing_label_is_an_error_not_a_debt(
+        self, audit_pattern_catalog, tmp_path: Path
+    ) -> None:
+        entry = tmp_path / "drift.md"
+        entry.write_text(
+            "---\nid: drift\nname: Drift\ntype: pattern\npart: build\n"
+            "vault_dimensions: [13]\n---\n\n"
+            "## Relationship to Vault Dimensions\n"
+            "Dimension 4 (Slide Design): mismatched on purpose.\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "_dimensions.yaml").write_text(
+            (CATALOG / "_dimensions.yaml").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+        report = audit_pattern_catalog.audit_catalog(catalog_dir=tmp_path)
+
+        codes = [issue["code"] for issue in report["errors"]]
+        assert "dimension_label_disagrees" in codes
+
+    def test_a_malformed_registry_is_an_error(
+        self, audit_pattern_catalog, tmp_path: Path
+    ) -> None:
+        """Without it every dimension claim becomes uncheckable, so the auditor
+        must say so rather than skipping silently."""
+        (tmp_path / "_dimensions.yaml").write_text(
+            "schema_version: 99\ndimensions: []\n", encoding="utf-8"
+        )
+
+        report = audit_pattern_catalog.audit_catalog(catalog_dir=tmp_path)
+
+        codes = [issue["code"] for issue in report["errors"]]
+        assert "dimension_registry_invalid" in codes


### PR DESCRIPTION
## What

Adds `_dimensions.yaml` — the machine-readable authority for the 14 vault
dimensions — and remaps every catalog dimension number to match the label its
prose actually uses.

Closes the mechanical half of #156.

## Why

`vault_dimensions` is a list of bare integers, so a range check is the only
validation a number can carry on its own. A range check cannot tell that `4`
means Audience Interaction while the prose beside it reads
`Dimension 4 (Humor and Surprise Techniques)`. Entries filed evidence under
dimensions they are not about, and every downstream aggregation inherited it.

Per the **2026-08-09 owner decision** the prose is the intent of record, so the
numbers move to match the labels. No pattern's meaning changes — this is a
renumbering, not a re-classification.

## Result

| | Before | After |
|---|---:|---:|
| Catalog auditor semantic debts | 37 | **0** |
| Catalog auditor errors | 0 | 0 |
| Prose claims disagreeing with their label | 42 | **0** |

Both worked examples in the issue land exactly as its table specifies:

- `progressive-reveal` `[4, 7]` → **`[3, 13]`**
- `three-part-close` `[2, 10]` → **`[2, 6]`**

38 entries' frontmatter and 51 index rows changed. The index's per-entry
dimensions column and its reverse map are now **generated from the approved
frontmatter** rather than hand-maintained, which is the issue's AC.

## What it refuses to do

A label with no owner-approved alias does not resolve, and the registry reports
it rather than guessing — that is what keeps this a reviewed migration instead
of an automatic renumbering.

An unresolved claim **keeps the number written beside it**: preserved, not
endorsed. Dropping a membership on the strength of a missing alias would be a
bigger change than the drift being fixed.

## Owner decisions folded in

Five labels resolved by owner decision this session: `Information Density` → D8,
`Self-Presentation` → D9, `Delivery/Presentation Skills` → D12, `Memorability` →
D3, and `Creativity/Originality` staying at D10.

## Still needs a decision

Three labels remain unresolved, all currently preserving their existing numbers:

- `Content Depth / Value` (at D8, used by `_anti_lipstick-on-a-pig`)
- `Overall Quality Indicators` (at D14, alongside `Overall Impression/Polish`)
- `Visual Storytelling` (at D10, used by `_anti_photomaniac`)

## Verification

- 16 new tests, fixtures read from the live catalog so a future edit that
  reintroduces drift fails them rather than passing quietly
- Full suite: **5482 passed, 3 skipped**
- `ruff format --check`, `ruff check`, `pyright`: clean

## Sequencing

The catalog fingerprint moves. Per #167 all persisted detections need the
structural revalidation pass regardless, so this migration should land inside
that same pass rather than triggering a second one. No reparse runs yet.
