### PR TITLE
fix(catalog): one bullet threshold, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### fix(catalog) — one bullet threshold, not two (#153)
+
+`_anti_bullet-riddled-corpse` disagreed with itself. Line 56 counted slides with
+"three or more text bullets" toward the bullet-slide proportion, while line 59
+set the strong signal at four or more and line 60 excluded "a compact list of
+three or fewer short items" from standalone signals. A three-bullet slide was
+simultaneously counted and excluded, so every reader had to learn which number
+applied where.
+
+Per the 2026-08-09 owner decision it is four or more, everywhere in the entry. A
+three-bullet slide is never antipattern evidence — not standalone, and not
+toward the proportion.
+
+The catalog fingerprint moves, so this belongs in the same revalidation pass as
+#156 and #167.
+
+Still open on #153: the weighted aggregate score (strong 1.0, moderate 0.5) and
+its `pattern_score_basis` sibling. Runtime scoring is still flat +1/-1 in
+`return_validation._validate_score`; changing it is a scoring-schema bump that
+lands with #160's provenance object.
+
 ## 0.20.56 — 2026-08-11
 
 ### feat(vault-ingress) — prove which talk a deck belongs to before it becomes evidence (#176)

--- a/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_bullet-riddled-corpse.md
@@ -53,7 +53,7 @@ This is an antipattern and should always be avoided in presentation slides. Repl
 The one exception is when you are deliberately creating an Infodeck — a slide deck designed for solo consumption without a presenter. In that context, bullet points are appropriate and useful. But if you are presenting live, every bullet on your slide is a competitor for your audience's attention.
 
 ## Detection Heuristics
-When scoring talks, count the proportion of slides that consist primarily of bullet points (three or more text bullets occupying the majority of the slide). Note whether the audience appears to be reading ahead of the speaker. Look for auto-shrunk fonts (inconsistent text sizes that indicate PowerPoint has compressed the text to fit). Also note if the presenter is reading bullet points verbatim from the slide.
+When scoring talks, count the proportion of slides that consist primarily of bullet points (four or more text bullets occupying the majority of the slide). Note whether the audience appears to be reading ahead of the speaker. Look for auto-shrunk fonts (inconsistent text sizes that indicate PowerPoint has compressed the text to fit). Also note if the presenter is reading bullet points verbatim from the slide.
 
 ## Scoring Criteria
 - Strong signal (antipattern present): Majority of slides are bullet-point lists of four or more items, presenter reads bullets from slides, fonts are auto-shrunk to accommodate text volume


### PR DESCRIPTION
## What

`_anti_bullet-riddled-corpse` line 56 rises from "three or more text bullets" to
"four or more", matching line 59's strong criterion and line 60's exclusion.

Part of #153, implementing the 2026-08-09 owner decision.

## Why

The entry disagreed with itself. Line 56 counted three-bullet slides toward the
bullet-slide proportion; line 60 excluded "a compact list of three or fewer short
items" from standalone signals. A three-bullet slide was simultaneously evidence
and not evidence, and every reader had to learn which number applied where.

One threshold resolves it. A three-bullet slide is never antipattern evidence.

## Verification

- Catalog auditor: 0 errors, 0 semantic debts
- Full suite: 5482 passed, 3 skipped

## Sequencing

The catalog fingerprint moves, so this belongs in the same revalidation pass as
#156 and #167 rather than triggering its own.

## Still open on #153

The weighted aggregate score (strong 1.0, moderate 0.5) and its
`pattern_score_basis` sibling. Runtime scoring is still flat +1/-1 in
`return_validation._validate_score` — changing it is a scoring-schema bump whose
basis object lands in #160's provenance work, so the two go together rather than
riding on this catalog edit.