### PR TITLE
fix(catalog): resolve the last three dimension labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+### fix(catalog) — resolve the last three dimension labels (#156)
+
+Closes #156.
+
+The remap left three labels unresolved because no owner had approved a mapping
+for them, so each preserved the number written beside it and the auditor kept
+reporting it. All three are now decided:
+
+- `Visual Storytelling` → D13. `_anti_photomaniac`'s failure is in how images
+  are chosen and composed, which is slide design.
+- `Content Depth / Value` → D14. Polish outrunning substance is an
+  overall-impression judgement, not a slide-to-speech mismatch.
+- `Overall Quality Indicators` → D14, joining `Overall Impression/Polish` in the
+  lane it already shares. No number changes.
+
+Two prose claims and two entries' frontmatter moved; four index rows followed.
+The catalog auditor now reports **0 errors and 0 semantic debts** — the first
+time both have been clean since the dimension contract was written.
+
 ### feat(catalog) — remap the dimension numbers to what the prose says (#156)
 
 Closes the mechanical half of #156.

--- a/skills/presentation-creator/references/patterns/_dimensions.yaml
+++ b/skills/presentation-creator/references/patterns/_dimensions.yaml
@@ -109,10 +109,17 @@ dimensions:
       - Visual Aids Effectiveness
       - Slide Design/Visual Quality
       - Visual Design Quality
+      # Owner decision: the failure is in how the images are chosen and
+      # composed, which is slide design.
+      - Visual Storytelling
   - id: areas-for-improvement
     ordinal: 14
     name: "Reflection: Areas for Improvement"
     aliases:
       - Areas for Improvement
       - Overall Impression/Polish
+      - Overall Quality Indicators
       - Speaker Craft / Professionalism
+      # Owner decision: polish outrunning substance is an overall-impression
+      # judgement, not a slide-to-speech mismatch.
+      - Content Depth / Value

--- a/skills/presentation-creator/references/patterns/_index.md
+++ b/skills/presentation-creator/references/patterns/_index.md
@@ -244,7 +244,7 @@ entries are skipped and surfaced as go-live actions, not emitted as per-talk
 | ant-fonts | Ant Fonts | antipattern | 13, 14 | guardrails, slides | bullet-riddled-corpse, infodeck |
 | fontaholic | Fontaholic | antipattern | 13, 14 | guardrails, slides | floodmarks |
 | floodmarks | Floodmarks | antipattern | 13, 14 | guardrails, slides | bookends, defy-defaults, unifying-visual-theme |
-| photomaniac | Photomaniac | antipattern | 10, 13, 14 | guardrails, slides | unifying-visual-theme, vacation-photos |
+| photomaniac | Photomaniac | antipattern | 13, 14 | guardrails, slides | unifying-visual-theme, vacation-photos |
 | borrowed-shoes | Borrowed Shoes | antipattern | 7, 13, 14 | guardrails | crucible, narrative-arc, carnegie-hall |
 | slideuments | Slideuments | antipattern | 13, 14 | guardrails | infodeck, charred-trail, gradual-consistency |
 | dead-demo | Dead Demo | antipattern | 11, 14 | guardrails | live-demo, a-la-carte-content |
@@ -286,7 +286,7 @@ entries are skipped and surfaced as go-live actions, not emitted as per-talk
 | negative-ignorance | Negative Ignorance | antipattern | 4, 14 | guardrails | know-your-audience, seeding-satisfaction |
 | dual-headed-monster | Dual-Headed Monster | antipattern | 4, 14 | guardrails | live-on-tape, weatherman |
 | tower-of-babble | Tower of Babble | antipattern | 7, 9, 14 | guardrails | know-your-audience, leet-grammars |
-| lipstick-on-a-pig | Lipstick on a Pig | antipattern | 8, 9, 14 | guardrails | narrative-arc |
+| lipstick-on-a-pig | Lipstick on a Pig | antipattern | 9, 14 | guardrails | narrative-arc |
 | flyover | Flyover | antipattern | 4, 14 | guardrails | know-your-audience, seeding-satisfaction, mentor |
 | nodding-room | The Nodding Room | antipattern | 4, 12, 14 | guardrails | retrieval-beat, guess-first, spaced-followup, carnegie-hall, red-yellow-green |
 
@@ -403,9 +403,9 @@ Reverse lookup: which patterns relate to each of the 14 rhetoric analysis dimens
 | 5 | Transition Techniques |  |  |
 | 6 | Closing Pattern | call-to-action, new-bliss, spaced-followup, three-part-close |  |
 | 7 | Verbal Signatures | peer-review, breathing-room, echo-chamber, master-story | hiccup-words, borrowed-shoes, tower-of-babble |
-| 8 | Slide-to-Speech Relationship | coda, second-look, crawling-credits | lipstick-on-a-pig |
+| 8 | Slide-to-Speech Relationship | coda, second-look, crawling-credits |  |
 | 9 | Persuasion Techniques | know-your-audience, required, the-big-why, proposed, display-of-high-value, emotional-state, mentor, greek-chorus, sparkline, call-to-adventure, call-to-action, new-bliss, inoculation, concrete-before-abstract, walk-around, anti-sell, delayed-self-introduction | disowning-your-topic, going-meta, tower-of-babble, lipstick-on-a-pig, golden-rule |
-| 10 | Cultural & Pop-Culture References | leet-grammars, unifying-visual-theme, meme-as-argument | alienating-artifact, photomaniac |
+| 10 | Cultural & Pop-Culture References | leet-grammars, unifying-visual-theme, meme-as-argument | alienating-artifact |
 | 11 | Technical Content Delivery | live-demo, lipsync, traveling-highlights, crawling-code, emergence, mentor, lightsaber, concrete-before-abstract, guess-first, leet-grammars | dead-demo |
 | 12 | Pacing Clues | crucible, expansion-joints, talklet, brain-breaks, lightning-talk, takahashi, carnegie-hall, breathing-room, weatherman, screen-blackout, retrieval-beat | shortchanged, disowning-your-topic, nodding-room, alienating-artifact |
 | 13 | Slide Design Patterns | unifying-visual-theme, takahashi, cave-painting, composite-animation, vacation-photos, defy-defaults, analog-noise, gradual-consistency, charred-trail, exuberant-title-top, invisibility, context-keeper, breadcrumbs, bookends, soft-transitions, intermezzi, preroll, crawling-credits, lipsync, traveling-highlights, crawling-code, emergence, screen-blackout, star-moment, second-look, coda, concurrent-creation, fourthought, infodeck, live-on-tape, meme-as-argument, peer-review, progressive-reveal | cookie-cutter, bullet-riddled-corpse, ant-fonts, fontaholic, floodmarks, photomaniac, laser-weapons, borrowed-shoes, injured-outlines, slideuments |

--- a/skills/presentation-creator/references/patterns/build/_anti_photomaniac.md
+++ b/skills/presentation-creator/references/patterns/build/_anti_photomaniac.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - guardrails
   - slides
-vault_dimensions: [10, 13, 14]
+vault_dimensions: [13, 14]
 evidence_channels: [slides, video]
 detection_signals:
   - "random stock photos"
@@ -64,7 +64,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-Dimension 10 (Visual Storytelling): Photomaniac is a direct failure of visual storytelling. The images tell no story. Dimension 13 (Slide Aesthetics): While individual Photomaniac images may be attractive, the lack of visual coherence degrades the overall aesthetic of the presentation. Dimension 14 (Overall Quality Indicators): Random stock photo selection signals a superficial approach to presentation design that prioritizes appearance over substance.
+Dimension 13 (Visual Storytelling): Photomaniac is a direct failure of visual storytelling. The images tell no story. Dimension 13 (Slide Aesthetics): While individual Photomaniac images may be attractive, the lack of visual coherence degrades the overall aesthetic of the presentation. Dimension 14 (Overall Quality Indicators): Random stock photo selection signals a superficial approach to presentation design that prioritizes appearance over substance.
 
 ## Combinatorics
 Photomaniac is the inverse of the Unifying Visual Theme pattern, which establishes a coherent visual vocabulary that guides image selection. It has a complex relationship with Vacation Photos: the Vacation Photos pattern correctly advocates for image-heavy slides, but Photomaniac is what happens when that advice is followed without the discipline of a visual theme. The solution is not fewer images but better-selected images that serve the narrative rather than decorating the slides.

--- a/skills/presentation-creator/references/patterns/deliver/_anti_lipstick-on-a-pig.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_lipstick-on-a-pig.md
@@ -5,7 +5,7 @@ type: antipattern
 part: deliver
 phase_relevance:
   - guardrails
-vault_dimensions: [8, 9, 14]
+vault_dimensions: [9, 14]
 evidence_channels: [transcript, slides, video]
 detection_signals:
   - "beautiful slides but shallow content"
@@ -68,7 +68,7 @@ Use `strong_evaluable_from`, `evidence_requirements`, and `not_evaluable_when` a
 Current catalog artifacts may support positive detection only. Because `absence_evaluable_from` is `null`, no delivery video, transcript, rendered or native deck, comparison artifact, or claim of full coverage authorizes an absence finding; when no positive signal is established, record `not_evaluable`, not `absent`.
 
 ## Relationship to Vault Dimensions
-This antipattern maps to Vault Dimension 8 (Content Depth / Value). It also maps to Vault Dimension 9 (Speaker Authority / Credibility). It also maps to Vault Dimension 14 (Speaker Craft / Professionalism).
+This antipattern maps to Vault Dimension 14 (Content Depth / Value). It also maps to Vault Dimension 9 (Speaker Authority / Credibility). It also maps to Vault Dimension 14 (Speaker Craft / Professionalism).
 
 ## Combinatorics
 Lipstick on a Pig is the inverse of Narrative Arc, which ensures content integrity before visual design. The Mentor pattern helps prevent it by orienting the talk around audience learning outcomes rather than speaker performance. Carnegie Hall rehearsal can reveal content gaps if rehearsal audiences are asked "What did you learn?" rather than "How did it look?" Know Your Audience provides the research foundation that generates substantive, audience-relevant content.


### PR DESCRIPTION
## What

Adds owner-approved aliases for the three labels the remap left unresolved, and
reruns the remap. **Closes #156.**

| Label | Was | Now | Why |
|---|---|---|---|
| `Visual Storytelling` | D10 | **D13** | `_anti_photomaniac`'s failure is in how images are chosen and composed |
| `Content Depth / Value` | D8 | **D14** | Polish outrunning substance is an overall-impression judgement |
| `Overall Quality Indicators` | D14 | **D14** | Joins `Overall Impression/Polish` in the lane it already shares; no number changes |

## Result

Two prose claims and two entries' frontmatter moved; four index rows followed.

**The catalog auditor now reports 0 errors and 0 semantic debts** — the first
time both have been clean since the dimension contract was written. Every
`Dimension N (Label)` claim in all 111 entries now resolves through the registry
and agrees with its number.

## Verification

- `audit-pattern-catalog.py`: 0 errors, 0 semantic debts
- Full suite green
- `ruff check`: clean

## Sequencing

The catalog fingerprint moves again, still ahead of the single reparse, so this
costs no extra revalidation pass.