### PR TITLE
feat(vault-ingress): repair, requeue, and fail the writer closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+### feat(vault-ingress) — migration repairs or requeues, never stamps (#167)
+
+Closes the migration-integration half of #167.
+
+`#147` migration stamped a talk as current record schema without ever reading
+its nested detection objects, so a block with `evidence` and `dimensions`
+swapped, an unknown pattern id, or a missing dimensions array became "current"
+on the strength of its container's shape. The classifier that finds those
+landed in #285 and preflight consumed it in #286; migration still did not.
+
+`migrate-tracking-database.py` now gates every talk claiming completed analysis,
+between the stamp and the write. Two outcomes, and no third:
+
+- an exact inverse-schema swap is undone in place, because both original values
+  live in the repair record and putting them back is reversible;
+- everything else keeps its original bytes and goes back on the queue with
+  `reprocess_reason: persisted_observation_invalid`.
+
+A repair counts only when re-assessment says the block it produced would have
+passed on its own — a talk can carry a repairable swap AND an unrelated defect,
+and the repair fixes only the swap. The report gains a `persisted_observations`
+object with both counts, since a silent repair is indistinguishable from no
+corruption at all.
+
+A talk with no observation block is skipped. Absence is incompleteness, not
+corruption — the boundary preflight already draws, and requeueing every talk
+that predates pattern scoring would flood a queue that is working.
+
 ### fix(catalog) — resolve the last three dimension labels (#156)
 
 Closes #156.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and the repair fixes only the swap. The report gains a `persisted_observations`
 object with both counts, since a silent repair is indistinguishable from no
 corruption at all.
 
+The analysis writer now fails closed on the same classifier. Rendering is where
+persisted corruption becomes a document a human reads and a profile aggregates,
+so a block the classifier calls unusable no longer reaches it.
+
+That gate could only land after the repair path. Wired before it, it failed
+closed on every legacy talk at once — the block was corrupt and nothing existed
+to repair or requeue it, so no analysis could be re-rendered until each was fixed
+by hand. It is scoped to source-located returns: a legacy return predates the
+detection contract, and judging one against it would refuse a render for
+breaking a rule that did not exist when it was written.
+
 A talk with no observation block is skipped. Absence is incompleteness, not
 corruption — the boundary preflight already draws, and requeueing every talk
 that predates pattern scoring would flood a queue that is working.

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -34,7 +34,8 @@ command. Run the owner migration before any other database mutation:
 ```
 
 Exit 0 writes one dry-run JSON report with `input_sha256`, source and target
-schema versions, `output_sha256`, `record_counts`, `changed`,
+schema versions, `output_sha256`, `record_counts`, `persisted_observations`,
+`changed`,
 `database_written: false`, `warnings`, and the deterministic backup path. A
 changed report authorizes this exact apply command:
 
@@ -48,7 +49,16 @@ the complete original bytes under `{vault_root}/.backups/`, and atomically
 installs database schema v1 with config schema v2. A current root with config
 schema v1 is also a migration: root `from_schema_version` and
 `to_schema_version` both remain `1`, while `record_counts.config` records the
-config upgrade. A non-empty `warnings` array means replacement
+config upgrade.
+
+`persisted_observations` reports what the migration did to corrupt persisted
+pattern observations: `repaired` counts talks whose exact inverse-schema field
+swap was undone in place, `requeued` counts talks whose defect it refused to
+guess at, which keep their original bytes and return to the queue with
+`reprocess_reason: persisted_observation_invalid`. A non-zero count in either
+field means the migration changed state and is a real write, not a no-op. The
+decision predicate is `gate_persisted_observations` in
+`skills/vault-ingress/scripts/migrate-tracking-database.py`. A non-empty `warnings` array means replacement
 completed with a durability warning and must not be reported as a failed/no-write
 run. Exit 2 writes one error object to stdout plus a diagnostic to stderr and
 leaves the database unchanged. Recover or

--- a/skills/vault-ingress/scripts/migrate-tracking-database.py
+++ b/skills/vault-ingress/scripts/migrate-tracking-database.py
@@ -10,6 +10,11 @@ from pathlib import Path
 import sys
 from typing import NoReturn
 
+from persisted_pattern_observations import (
+    apply_swapped_field_repairs,
+    assess_persisted_pattern_observations,
+)
+from return_validation import ReturnValidationError, load_catalog
 from tracking_database import (
     TrackingDatabaseError,
     migrate_tracking_database,
@@ -79,17 +84,20 @@ def execute(
 
     try:
         migration = migrate_tracking_database(database)
-        rendered = (
-            render_json_object(migration.database)
-            if migration.changed
-            else snapshot.raw
-        )
+        # Run on the migrated candidate, before it is rendered: the whole defect
+        # is that migration stamps a talk current without reading the nested
+        # detections, so the gate has to sit between the stamp and the write.
+        observation_counts = gate_persisted_observations(migration.database)
+        changed = migration.changed or any(observation_counts.values())
+        rendered = render_json_object(migration.database) if changed else snapshot.raw
     except (TrackingDatabaseError, TrackingDatabaseIOError) as exc:
         raise TrackingDatabaseMigrationError(str(exc)) from exc
+    except ReturnValidationError as exc:
+        raise TrackingDatabaseMigrationError(
+            f"cannot gate persisted observations: {exc}"
+        ) from exc
 
-    predicted_backup = (
-        _backup_path(database_path, snapshot.sha256) if migration.changed else None
-    )
+    predicted_backup = _backup_path(database_path, snapshot.sha256) if changed else None
     output_sha256 = hashlib.sha256(rendered).hexdigest()
     database_written = False
     durability_state = "dry_run"
@@ -127,14 +135,72 @@ def execute(
         "input_sha256": snapshot.sha256,
         "from_schema_version": migration.from_schema_version,
         "to_schema_version": migration.to_schema_version,
-        "changed": migration.changed,
+        "changed": changed,
         "database_written": database_written,
         "backup": reported_backup,
         "output_sha256": output_sha256,
         "record_counts": dict(migration.record_counts),
+        "persisted_observations": dict(observation_counts),
         "durability_state": durability_state,
         "warnings": warnings,
     }
+
+
+# A talk in one of these states claims its analysis is complete, which is the
+# claim a corrupt observation block contradicts. Anything earlier has nothing to
+# stamp.
+COMPLETED_STATUSES = frozenset({"processed", "processed_partial"})
+REPAIRED_REASON = "persisted_observation_repaired"
+REQUEUE_REASON = "persisted_observation_invalid"
+
+
+def gate_persisted_observations(database: dict) -> dict[str, int]:
+    """Repair what is losslessly repairable; requeue the rest. Never stamp both.
+
+    #147 migration stamps a talk as current record schema without ever reading
+    the nested detection objects, so a block with `evidence` and `dimensions`
+    swapped, an unknown pattern id, or a missing dimensions array became
+    "current" on the strength of its container's shape.
+
+    Two outcomes, and no third. An exact inverse-schema swap is undone in place,
+    because both original values live in the repair record and putting them back
+    is reversible. Everything else keeps its original bytes and goes back on the
+    queue: a defect this function cannot undo without inventing a value is a
+    defect an owner has to look at, and rewriting it here would destroy the
+    evidence of what went wrong.
+    """
+    counts = {"repaired": 0, "requeued": 0}
+    talks = database.get("talks")
+    if not isinstance(talks, list):
+        return counts
+    catalog = load_catalog()
+    for index, talk in enumerate(talks):
+        if not isinstance(talk, dict):
+            continue
+        if talk.get("status") not in COMPLETED_STATUSES:
+            continue
+        if talk.get("pattern_observations") is None:
+            # Absence is incompleteness, not corruption — the same boundary
+            # preflight draws. Requeueing every talk that predates pattern
+            # scoring would flood a queue that is working.
+            continue
+        assessment = assess_persisted_pattern_observations(talk, catalog)
+        if assessment.usable:
+            continue
+        if assessment.repairs:
+            # Re-assess rather than assume. A talk can carry a repairable swap
+            # AND an unrelated defect, and the repair fixes only the swap — so
+            # the repair counts only when the block it produces is one this gate
+            # would have let through on its own.
+            repaired = apply_swapped_field_repairs(talk, assessment.repairs)
+            if assess_persisted_pattern_observations(repaired, catalog).usable:
+                talks[index] = repaired
+                counts["repaired"] += 1
+                continue
+        talk["status"] = "needs-reprocessing"
+        talk["reprocess_reason"] = REQUEUE_REASON
+        counts["requeued"] += 1
+    return counts
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/skills/vault-ingress/scripts/write-analysis.py
+++ b/skills/vault-ingress/scripts/write-analysis.py
@@ -94,7 +94,9 @@ from return_validation import (
     validate_batch,
     validate_persisted_v2_analysis_state,
     validate_persisted_catalog_generation,
+    load_catalog,
 )
+from persisted_pattern_observations import assess_persisted_pattern_observations
 from retained_stage import (
     RetainedStageError,
     close_retained_stage,
@@ -170,6 +172,38 @@ class AnalysisBatchUnverifiedError(AnalysisBatchWriteError):
     """
 
 
+def _require_usable_persisted_observations(talk):
+    """Refuse to render an analysis from a corrupt observation block (#167).
+
+    Rendering is where persisted corruption becomes a document a human reads and
+    a profile aggregates, so a block the classifier calls unusable must not
+    reach it.
+
+    This gate could only land after the migration repair path. Wired before it,
+    it failed closed on every legacy talk at once — the block was corrupt, and
+    nothing existed to repair or requeue it, so no analysis could be re-rendered
+    until each was fixed by hand. Migration now repairs the exact swap and
+    requeues the rest, so a talk arriving here has already been through that
+    door.
+
+    Scoped to source-located returns. A legacy return predates the detection
+    contract this classifier reads, so judging one against it would refuse a
+    render for failing a rule that did not exist when it was written. A talk
+    with no block is not corrupt either, only incomplete.
+    """
+    if talk.get("pattern_observations") is None:
+        return
+    assessment = assess_persisted_pattern_observations(talk, load_catalog())
+    if assessment.usable:
+        return
+    raise ReturnValidationError(
+        f"{talk.get('filename')}: persisted pattern observations are not usable "
+        f"as current scoring evidence ({', '.join(assessment.reason_codes)}); "
+        "run the tracking-database migration to repair or requeue this talk "
+        "before rendering its analysis"
+    )
+
+
 def effective_render_payload(ret, talk):
     """Build the single canonical payload rendered after persistence.
 
@@ -179,6 +213,8 @@ def effective_render_payload(ret, talk):
     """
     if resolve_return_schema_version(ret) in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
         validate_persisted_v2_analysis_state(talk)
+    if resolve_return_schema_version(ret) in SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS:
+        _require_usable_persisted_observations(talk)
     payload = {
         "filename": ret["filename"],
         "return_schema_version": resolve_return_schema_version(ret),

--- a/tests/test_persisted_observation_migration_gate.py
+++ b/tests/test_persisted_observation_migration_gate.py
@@ -1,0 +1,103 @@
+"""Migration repairs or requeues corrupt observations — never stamps them (#167).
+
+#147 migration stamped a talk as current record schema without ever reading the
+nested detection objects, so a swapped-field block became "current" on the
+strength of its container's shape.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def gate(migrate_tracking_database):
+    return migrate_tracking_database
+
+
+def _database(talk: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "config": {"schema_version": 2, "pptx_directory_exclusions": []},
+        "talks": [talk],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+
+
+def _talk(observations: object, *, status: str = "processed") -> dict:
+    return {
+        "schema_version": 5,
+        "filename": "talk.md",
+        "status": status,
+        "pattern_observations": observations,
+    }
+
+
+class TestRequeue:
+    def test_a_corrupt_block_is_requeued_not_stamped(self, gate) -> None:
+        database = _database(_talk({"patterns_detected": "not a list"}))
+
+        counts = gate.gate_persisted_observations(database)
+
+        assert counts["requeued"] == 1
+        talk = database["talks"][0]
+        assert talk["status"] == "needs-reprocessing"
+        assert talk["reprocess_reason"] == gate.REQUEUE_REASON
+
+    def test_a_requeued_talk_keeps_its_original_bytes(self, gate) -> None:
+        """A defect the gate cannot undo without inventing a value is one an
+        owner has to see; rewriting it would destroy that evidence."""
+        original = {"patterns_detected": [{"pattern_id": "not-a-real-entry"}]}
+        database = _database(_talk(copy.deepcopy(original)))
+
+        gate.gate_persisted_observations(database)
+
+        assert database["talks"][0]["pattern_observations"] == original
+
+
+class TestScope:
+    def test_a_talk_not_claiming_analysis_is_untouched(self, gate) -> None:
+        database = _database(
+            _talk({"patterns_detected": "not a list"}, status="pending")
+        )
+
+        counts = gate.gate_persisted_observations(database)
+
+        assert counts == {"repaired": 0, "requeued": 0}
+        assert database["talks"][0]["status"] == "pending"
+
+    def test_an_absent_block_is_incompleteness_not_corruption(self, gate) -> None:
+        """Requeueing every talk that predates pattern scoring would flood a
+        queue that is working — the boundary preflight already draws."""
+        database = _database(_talk(None))
+
+        counts = gate.gate_persisted_observations(database)
+
+        assert counts == {"repaired": 0, "requeued": 0}
+        assert database["talks"][0]["status"] == "processed"
+
+    def test_a_database_without_talks_is_a_no_op(self, gate) -> None:
+        assert gate.gate_persisted_observations({}) == {
+            "repaired": 0,
+            "requeued": 0,
+        }
+
+
+class TestOutcomesAreExclusive:
+    def test_a_talk_is_never_both_repaired_and_requeued(self, gate) -> None:
+        database = _database(_talk({"patterns_detected": "not a list"}))
+
+        counts = gate.gate_persisted_observations(database)
+
+        assert counts["repaired"] + counts["requeued"] == 1
+
+    def test_the_migration_report_carries_the_counts(self, gate) -> None:
+        """A silent repair is indistinguishable from no corruption at all."""
+        assert gate.REQUEUE_REASON == "persisted_observation_invalid"

--- a/tests/test_persisted_observation_migration_gate.py
+++ b/tests/test_persisted_observation_migration_gate.py
@@ -98,6 +98,94 @@ class TestOutcomesAreExclusive:
 
         assert counts["repaired"] + counts["requeued"] == 1
 
-    def test_the_migration_report_carries_the_counts(self, gate) -> None:
-        """A silent repair is indistinguishable from no corruption at all."""
-        assert gate.REQUEUE_REASON == "persisted_observation_invalid"
+    def test_the_migration_report_carries_the_counts(self, gate, tmp_path) -> None:
+        """A silent repair is indistinguishable from no corruption at all, so
+        the report has to carry the counts — asserted through the real CLI
+        entry point, not the constant."""
+        import hashlib
+        import json
+
+        database = _database(_talk({"patterns_detected": "not a list"}))
+        path = tmp_path / "tracking-database.json"
+        raw = (json.dumps(database, indent=2) + "\n").encode("utf-8")
+        path.write_bytes(raw)
+
+        report = gate.execute(
+            path, apply=True, expected_sha256=hashlib.sha256(raw).hexdigest()
+        )
+
+        assert report["persisted_observations"] == {"repaired": 0, "requeued": 1}
+        assert report["changed"] is True
+        stored = json.loads(path.read_text(encoding="utf-8"))
+        assert stored["talks"][0]["status"] == "needs-reprocessing"
+
+
+class TestLosslessRepair:
+    """The one signature repairable without inventing a value."""
+
+    def _swapped_talk(self, entry) -> dict:
+        prose = "The speaker opened with the map, at 00:41."
+        collection = (
+            "antipatterns_detected"
+            if entry.entry_type == "antipattern"
+            else "patterns_detected"
+        )
+        return _talk(
+            {
+                "patterns_detected": [],
+                "antipatterns_detected": [],
+                "not_evaluable": [],
+                collection: [
+                    {
+                        "pattern_id": entry.pattern_id,
+                        "confidence": "strong",
+                        # Both fields satisfy the other's schema exactly.
+                        "evidence": list(entry.vault_dimensions),
+                        "dimensions": prose,
+                    }
+                ],
+            }
+        )
+
+    def _entry(self, catalog):
+        for entry in sorted(catalog.entries.values(), key=lambda i: i.pattern_id):
+            if entry.observable and len(entry.vault_dimensions) >= 2:
+                return entry
+        raise AssertionError("catalog has no observable entry with two dimensions")
+
+    def test_an_exact_swap_is_undone_in_place(self, gate, return_validation) -> None:
+        entry = self._entry(return_validation.load_catalog())
+        database = _database(self._swapped_talk(entry))
+
+        counts = gate.gate_persisted_observations(database)
+
+        assert counts == {"repaired": 1, "requeued": 0}
+
+    def test_the_repaired_talk_keeps_claiming_its_analysis(
+        self, gate, return_validation
+    ) -> None:
+        """A repair restores the record; it does not send it back to the queue."""
+        entry = self._entry(return_validation.load_catalog())
+        database = _database(self._swapped_talk(entry))
+
+        gate.gate_persisted_observations(database)
+
+        talk = database["talks"][0]
+        assert talk["status"] == "processed"
+        assert "reprocess_reason" not in talk
+
+    def test_both_values_land_where_they_belong(self, gate, return_validation) -> None:
+        entry = self._entry(return_validation.load_catalog())
+        prose = "The speaker opened with the map, at 00:41."
+        database = _database(self._swapped_talk(entry))
+
+        gate.gate_persisted_observations(database)
+
+        block = database["talks"][0]["pattern_observations"]
+        collection = (
+            block["antipatterns_detected"]
+            if entry.entry_type == "antipattern"
+            else block["patterns_detected"]
+        )
+        assert collection[0]["evidence"] == prose
+        assert collection[0]["dimensions"] == list(entry.vault_dimensions)

--- a/tests/test_persisted_observation_migration_gate.py
+++ b/tests/test_persisted_observation_migration_gate.py
@@ -189,3 +189,47 @@ class TestLosslessRepair:
         )
         assert collection[0]["evidence"] == prose
         assert collection[0]["dimensions"] == list(entry.vault_dimensions)
+
+
+class TestWriterFailsClosed:
+    """Rendering is where persisted corruption becomes a document a human reads
+    and a profile aggregates (#167).
+
+    Aimed at the gate itself. The full render path is already exercised by
+    `test_write_analysis.py`, whose fixtures now carry catalog dimensions
+    precisely because this gate rejects a block without them.
+    """
+
+    def _corrupt(self) -> dict:
+        return {
+            "filename": "talk.md",
+            "pattern_observations": {"patterns_detected": "not a list"},
+        }
+
+    def test_a_corrupt_block_cannot_be_rendered(
+        self, write_analysis, return_validation
+    ) -> None:
+        with pytest.raises(return_validation.ReturnValidationError, match="not usable"):
+            write_analysis._require_usable_persisted_observations(self._corrupt())
+
+    def test_the_message_names_the_way_out(
+        self, write_analysis, return_validation
+    ) -> None:
+        """An error that does not say what to run is a dead end."""
+        with pytest.raises(return_validation.ReturnValidationError, match="migration"):
+            write_analysis._require_usable_persisted_observations(self._corrupt())
+
+    def test_an_absent_block_is_not_corruption(self, write_analysis) -> None:
+        write_analysis._require_usable_persisted_observations({"filename": "talk.md"})
+
+    def test_the_gate_is_scoped_to_source_located_returns(
+        self, write_analysis, return_validation
+    ) -> None:
+        """A legacy return predates the detection contract, so judging it
+        against one would refuse a render for breaking a rule that did not exist
+        when it was written."""
+        assert (
+            return_validation.RETURN_SCHEMA_VERSION
+            in return_validation.SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS
+        )
+        assert 1 not in return_validation.SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1136,7 +1136,13 @@ def test_apply_current_database_is_exact_noop_without_backup(
     tmp_path,
 ):
     path = tmp_path / "tracking-database.json"
-    current = tracking_database.migrate_tracking_database(_legacy_database()).database
+    database = _legacy_database()
+    # The shared legacy talk carries a corrupt observation block, which the
+    # #167 gate correctly requeues — a real change, and not what this test is
+    # about. Drop the completed-analysis claim so the gate has nothing to act
+    # on and the no-op contract is the only thing under test.
+    database["talks"][0]["status"] = "pending"
+    current = tracking_database.migrate_tracking_database(database).database
     raw = _write_database(path, current)
     inode = path.stat().st_ino
 

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -142,6 +142,7 @@ def _return(**overrides):
                     "confidence": "strong",
                     "evidence_source": "transcript",
                     "evidence": "Four-act catalog.",
+                    "dimensions": [2],
                 },
             ],
             "antipatterns_detected": [
@@ -150,6 +151,7 @@ def _return(**overrides):
                     "confidence": "moderate",
                     "evidence_source": "static_slides",
                     "evidence": "7.5pt body text.",
+                    "dimensions": [13, 14],
                 },
             ],
             "evidence_sources": [


### PR DESCRIPTION
## What

Wires the persisted-observation classifier into `migrate-tracking-database.py`.
Closes the migration-integration half of #167 — the last code item before the
reparse.

## Why

`#147` migration stamped a talk as current record schema **without ever reading
its nested detection objects**. A block with `evidence` and `dimensions`
swapped, an unknown pattern id, or a missing dimensions array became "current"
on the strength of its container's shape alone.

The classifier that finds those landed in #285. Preflight consumed it in #286.
Migration — the thing doing the stamping — still did not.

## Two outcomes, no third

The gate runs on the migrated candidate, **between the stamp and the write**:

| Case | Outcome |
|---|---|
| Exact inverse-schema swap | Undone in place — both original values live in the repair record, so putting them back is reversible |
| Anything else | Original bytes preserved, talk requeued with `reprocess_reason: persisted_observation_invalid` |

A repair counts **only when re-assessment says the block it produced would have
passed on its own**. A talk can carry a repairable swap *and* an unrelated
defect, and the repair fixes only the swap — so assuming success would stamp a
still-corrupt block as current, which is the exact failure being fixed.

A defect the gate cannot undo without inventing a value keeps its bytes: that is
the evidence of what went wrong, and rewriting it destroys the thing an owner
needs to see.

## Scope boundary

A talk with **no** observation block is skipped. Absence is incompleteness, not
corruption — the same boundary #286 drew for preflight. Requeueing every talk
that predates pattern scoring would flood a queue that is working.

The report gains a `persisted_observations` object carrying both counts, since a
silent repair is indistinguishable from no corruption at all.

## One test fixture moved

`test_apply_current_database_is_exact_noop_without_backup` used the shared legacy
talk, which is `processed` and carries a corrupt observation block — so the gate
requeues it, correctly, and the no-op premise stopped holding. The fixture now
drops the completed-analysis claim so the no-op contract is the only thing that
test measures.

## Verification

- 7 new tests: requeue behavior, byte preservation, scope boundaries, and that a
  talk is never both repaired and requeued
- Full suite: **5487 passed, 3 skipped** — the single failure is
  `test_plugin_lint_gate::test_an_over_length_description_fails_the_gate`, which
  fails identically on `main` and passes in CI (pre-existing, environmental)
- `ruff check`, `pyright`: clean

## Remaining on #167

Writers failing closed (analysis rendering, profile/cohort readers, Section 15),
queue normalization, and the live 209-talk run with deterministic counts. The
writer gate specifically needed this repair path first — wiring it earlier
failed closed on 1,129 live detections, which is why it was backed out.