### PR TITLE
feat(vault-profile): the denominator behind a never-used claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ the test failed while the gate it covers worked correctly.
 
 Carried in three PR bodies as a pre-existing environmental failure. It was
 neither: CI passed only because its pinned tessl still emitted the old wording,
-so the next bump would have broken the gate's own test in CI. The assertion now
-names the defect — an error mentioning `description` and `1024` — instead of the
-sentence the external tool happened to phrase it with.
+so the next bump would have broken the gate's own test in CI.
+
+The assertion now names the
+outcome and the offending skill — the gate failed and the error identifies
+`demo` — instead of any sentence the external tool happened to phrase it with.
+Matching the new wording would only have swapped which CLI version it broke on;
+the two truncate the message at different points. The old wording stays covered
+by the fake-CLI classification test, which owns a captured transcript rather
+than a live tool.
 
 ### feat(vault-profile) — the denominator behind a never-used claim (#160)
 
@@ -66,6 +72,13 @@ owner run replaces it. The reason code is distinct from
 `pattern_classification_policy_unavailable`, which marks a v4 contract that never
 had a policy stamp. Occurrence rows stay readable across the boundary — they
 belong to the pattern-profile contract, not to the classification generation.
+
+The counts are checked against the active catalog, not merely against each
+other. `1 + 2 = 3` sums perfectly and describes a three-entry catalog nobody has,
+so internal consistency alone would let a fabricated denominator present as
+current coverage. The reader recomputes both halves from the installed catalog
+and rejects any payload that disagrees — including a correct total split the
+wrong way, since the split is the whole point.
 
 Presence is generation-dependent rather than optional. Classification v2 requires
 the field — the writer always emits it, and a never-used list is unreadable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,10 @@ without its denominator, so a v2 record missing it is incomplete rather than
 merely older. v1 and contract v4 forbid it.
 
 `classify-pattern-profile.py` emits it beside `never_used_patterns`, so the list
-and its denominator always travel together. The field is allowed but never
-required: a profile written before it existed is not thereby invalid, and
-demanding it would refuse to read every profile already on disk — a bigger break
-than the gap it closes.
+and its denominator always travel together. A classification-v1 profile written
+before the field existed stays readable without it — demanding it everywhere
+would refuse every profile already on disk, a bigger break than the gap it
+closes.
 
 An unobservable entry lands in neither count: it is not scored at all, so it
 belongs to no denominator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ forbidden at v1 and on the v4 contract, which carries no classification block at
 all. A v1 block that omits it stays readable — the counts are a fact about the
 catalog, not a claim the older block got anything wrong, and refusing v1 outright
 would strand every profile on disk to gain nothing. A v1 block that *carries* it
-is rejected: the stamp and the payload disagree. `speaker-profile-schema.md`
-documents the table.
+is rejected: the stamp and the payload disagree. The schema reference states the
+output contract and points at `_validate_absence_provability` for the predicate
+rather than restating it, so the two cannot drift.
 
 A v1 block is nonetheless a superseded classification generation, so a reader
 takes the no-usable-prior-state path on it — every derived domain is withheld and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ owner run replaces it. The reason code is distinct from
 had a policy stamp. Occurrence rows stay readable across the boundary — they
 belong to the pattern-profile contract, not to the classification generation.
 
+Presence is generation-dependent rather than optional. Classification v2 requires
+the field — the writer always emits it, and a never-used list is unreadable
+without its denominator, so a v2 record missing it is incomplete rather than
+merely older. v1 and contract v4 forbid it.
+
 `classify-pattern-profile.py` emits it beside `never_used_patterns`, so the list
 and its denominator always travel together. The field is allowed but never
 required: a profile written before it existed is not thereby invalid, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### test — assert the lint gate's outcome, not tessl's wording (#265)
+
+`test_an_over_length_description_fails_the_gate` matched the literal string
+`Frontmatter validation failed`. tessl 0.96.0 reports the same rejection as
+`SKILL.md frontmatter field "description" must be at most 1024 characters.`, so
+the test failed while the gate it covers worked correctly.
+
+Carried in three PR bodies as a pre-existing environmental failure. It was
+neither: CI passed only because its pinned tessl still emitted the old wording,
+so the next bump would have broken the gate's own test in CI. The assertion now
+names the defect — an error mentioning `description` and `1024` — instead of the
+sentence the external tool happened to phrase it with.
+
 ### feat(vault-profile) — the denominator behind a never-used claim (#160)
 
 Part of #160 section 3, implementing the #153 null-absence-gate decision.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,23 @@ exists to prevent.
 The classification contract bumps to **v2** to carry it, since this is a shape
 change to a persisted artifact. A v1 block stays readable: the counts are a fact
 about the catalog, not a claim the older block got something wrong, so refusing
-v1 would strand every profile already on disk to gain nothing. The field and its
-version boundary are documented in `speaker-profile-schema.md`.
+v1 would strand every profile already on disk to gain nothing. A v1 block that
+*carries* the field is a different matter and is rejected — the stamp and the
+payload disagree. The field and its version boundary are documented in
+`speaker-profile-schema.md`.
+
+The version floor reads the **classification** schema version, not the outer
+pattern-profile contract version. Review found the first revision comparing the
+contract version (4 or 5) against a classification floor of 2, so the gate
+admitted every block it existed to reject. The floor is also pinned to the
+generation that introduced the field rather than to the current one, so a later
+classification bump does not start rejecting version 2.
+
+That defect survived because the tests called the private validator and supplied
+the version by hand, which is a shape the real call path cannot produce. They now
+run through `assess_pattern_profile`, where a classification-v1 block carrying the
+field and a v4 contract carrying it are both refused. Both tests fail against the
+original code.
 
 `classify-pattern-profile.py` emits it beside `never_used_patterns`, so the list
 and its denominator always travel together. The field is allowed but never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,5 @@
 # Changelog
 
-### test — assert the lint gate's outcome, not tessl's wording (#265)
-
-`test_an_over_length_description_fails_the_gate` matched the literal string
-`Frontmatter validation failed`. tessl 0.96.0 reports the same rejection as
-`SKILL.md frontmatter field "description" must be at most 1024 characters.`, so
-the test failed while the gate it covers worked correctly.
-
-Carried in three PR bodies as a pre-existing environmental failure. It was
-neither: CI passed only because its pinned tessl still emitted the old wording,
-so the next bump would have broken the gate's own test in CI.
-
-The assertion now names the
-outcome and the offending skill — the gate failed and the error identifies
-`demo` — instead of any sentence the external tool happened to phrase it with.
-Matching the new wording would only have swapped which CLI version it broke on;
-the two truncate the message at different points. The old wording stays covered
-by the fake-CLI classification test, which owns a captured transcript rather
-than a live tool.
-
 ### feat(vault-profile) — the denominator behind a never-used claim (#160)
 
 Part of #160 section 3, implementing the #153 null-absence-gate decision.
@@ -72,6 +53,10 @@ owner run replaces it. The reason code is distinct from
 `pattern_classification_policy_unavailable`, which marks a v4 contract that never
 had a policy stamp. Occurrence rows stay readable across the boundary — they
 belong to the pattern-profile contract, not to the classification generation.
+
+The version stamp is type-checked, not just compared. Python makes `True == 1`,
+so equality alone admitted a boolean `schema_version` while every count beside it
+already rejected one.
 
 The counts are checked against the active catalog, not merely against each
 other. `1 + 2 = 3` sums perfectly and describes a three-entry catalog nobody has,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ owner run replaces it. The reason code is distinct from
 had a policy stamp. Occurrence rows stay readable across the boundary — they
 belong to the pattern-profile contract, not to the classification generation.
 
+The reader's leakage guard learned the new field. `_PATTERN_HISTORY_KEYS` in
+`validate-profile.py` is what keeps catalog-derived history inside
+`pattern_profile`, and a field the writer emits but that set never learned about
+could sit duplicated under `rhetoric_defaults` unchallenged. A regression derives
+its expectation from what the writer actually emits, so the next omission fails
+in the suite rather than in a profile.
+
 The version stamp is type-checked, not just compared. Python makes `True == 1`,
 so equality alone admitted a boolean `schema_version` while every count beside it
 already rejected one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ statement about the speaker. It is mostly a statement about coverage.
 from the catalog rather than hardcoded, so populating a gate moves the numbers
 instead of dating a constant.
 
+The reader validates it rather than merely permitting it: exact field set,
+nonnegative integer counts with booleans excluded, the sum invariant, and the
+version floor. Allowlisting a field without checking it is how a malformed
+object reaches a reader that believes the shape was verified — and a wrong count
+here misreports coverage as speaker behavior, the exact confusion the field
+exists to prevent.
+
 The classification contract bumps to **v2** to carry it, since this is a shape
 change to a persisted artifact. A v1 block stays readable: the counts are a fact
 about the catalog, not a claim the older block got something wrong, so refusing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### feat(vault-profile) — the denominator behind a never-used claim (#160)
+
+Part of #160 section 3, implementing the #153 null-absence-gate decision.
+
+`absence_evaluable_from: null` means absence is not provable for that pattern
+and never falls back to the presence gate, so never-used and underused are
+computed over the populated-gate entries only. Against the live catalog that is
+**16 of 81 observable entries** — 65 are unknowable.
+
+Without that denominator beside them, a short never-used list reads as a
+statement about the speaker. It is mostly a statement about coverage.
+`absence_provability` reports both counts plus the observable total, computed
+from the catalog rather than hardcoded, so populating a gate moves the numbers
+instead of dating a constant.
+
+An unobservable entry lands in neither count: it is not scored at all, so it
+belongs to no denominator.
+
 ### fix(catalog) — resolve the last three dimension labels (#156)
 
 Closes #156.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ statement about the speaker. It is mostly a statement about coverage.
 from the catalog rather than hardcoded, so populating a gate moves the numbers
 instead of dating a constant.
 
+The classification contract bumps to **v2** to carry it, since this is a shape
+change to a persisted artifact. A v1 block stays readable: the counts are a fact
+about the catalog, not a claim the older block got something wrong, so refusing
+v1 would strand every profile already on disk to gain nothing. The field and its
+version boundary are documented in `speaker-profile-schema.md`.
+
 `classify-pattern-profile.py` emits it beside `never_used_patterns`, so the list
 and its denominator always travel together. The field is allowed but never
 required: a profile written before it existed is not thereby invalid, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ statement about the speaker. It is mostly a statement about coverage.
 from the catalog rather than hardcoded, so populating a gate moves the numbers
 instead of dating a constant.
 
+`classify-pattern-profile.py` emits it beside `never_used_patterns`, so the list
+and its denominator always travel together. The field is allowed but never
+required: a profile written before it existed is not thereby invalid, and
+demanding it would refuse to read every profile already on disk — a bigger break
+than the gap it closes.
+
 An unobservable entry lands in neither count: it is not scored at all, so it
 belongs to no denominator.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,18 @@ That defect survived because the tests called the private validator and supplied
 the version by hand, which is a shape the real call path cannot produce. They now
 run through `assess_pattern_profile`, where a classification-v1 block carrying the
 field and a v4 contract carrying it are both refused. Both tests fail against the
-original code.
+original code. The writer's coverage moved off `inspect.getsource` and onto its
+emitted payload for the same reason: matching a call expression in source text
+passes for code that never runs and fails for a correct refactor.
+
+A version-1 block is a superseded classification generation, so a reader takes
+the no-usable-prior-state path on it — every derived domain is withheld and the
+assessment carries `pattern_classification_schema_superseded`. Nothing upgrades
+the block in place; vault-profile regenerates the profile wholesale, so the next
+owner run replaces it. The reason code is distinct from
+`pattern_classification_policy_unavailable`, which marks a v4 contract that never
+had a policy stamp. Occurrence rows stay readable across the boundary — they
+belong to the pattern-profile contract, not to the classification generation.
 
 `classify-pattern-profile.py` emits it beside `never_used_patterns`, so the list
 and its denominator always travel together. The field is allowed but never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,87 +4,66 @@
 
 Part of #160 section 3, implementing the #153 null-absence-gate decision.
 
-`absence_evaluable_from: null` means absence is not provable for that pattern
-and never falls back to the presence gate, so never-used and underused are
-computed over the populated-gate entries only. Against the live catalog that is
-**16 of 81 observable entries** — 65 are unknowable.
-
-Without that denominator beside them, a short never-used list reads as a
-statement about the speaker. It is mostly a statement about coverage.
-`absence_provability` reports both counts plus the observable total, computed
-from the catalog rather than hardcoded, so populating a gate moves the numbers
-instead of dating a constant.
-
-The reader validates it rather than merely permitting it: exact field set,
-nonnegative integer counts with booleans excluded, the sum invariant, and the
-version floor. Allowlisting a field without checking it is how a malformed
-object reaches a reader that believes the shape was verified — and a wrong count
-here misreports coverage as speaker behavior, the exact confusion the field
-exists to prevent.
-
-The classification contract bumps to **v2** to carry it, since this is a shape
-change to a persisted artifact. A v1 block stays readable: the counts are a fact
-about the catalog, not a claim the older block got something wrong, so refusing
-v1 would strand every profile already on disk to gain nothing. A v1 block that
-*carries* the field is a different matter and is rejected — the stamp and the
-payload disagree. The field and its version boundary are documented in
-`speaker-profile-schema.md`.
-
-The version floor reads the **classification** schema version, not the outer
-pattern-profile contract version. Review found the first revision comparing the
-contract version (4 or 5) against a classification floor of 2, so the gate
-admitted every block it existed to reject. The floor is also pinned to the
-generation that introduced the field rather than to the current one, so a later
-classification bump does not start rejecting version 2.
-
-That defect survived because the tests called the private validator and supplied
-the version by hand, which is a shape the real call path cannot produce. They now
-run through `assess_pattern_profile`, where a classification-v1 block carrying the
-field and a v4 contract carrying it are both refused. Both tests fail against the
-original code. The writer's coverage moved off `inspect.getsource` and onto its
-emitted payload for the same reason: matching a call expression in source text
-passes for code that never runs and fails for a correct refactor.
-
-A version-1 block is a superseded classification generation, so a reader takes
-the no-usable-prior-state path on it — every derived domain is withheld and the
-assessment carries `pattern_classification_schema_superseded`. Nothing upgrades
-the block in place; vault-profile regenerates the profile wholesale, so the next
-owner run replaces it. The reason code is distinct from
-`pattern_classification_policy_unavailable`, which marks a v4 contract that never
-had a policy stamp. Occurrence rows stay readable across the boundary — they
-belong to the pattern-profile contract, not to the classification generation.
-
-The reader's leakage guard learned the new field. `_PATTERN_HISTORY_KEYS` in
-`validate-profile.py` is what keeps catalog-derived history inside
-`pattern_profile`, and a field the writer emits but that set never learned about
-could sit duplicated under `rhetoric_defaults` unchallenged. A regression derives
-its expectation from what the writer actually emits, so the next omission fails
-in the suite rather than in a profile.
-
-The version stamp is type-checked, not just compared. Python makes `True == 1`,
-so equality alone admitted a boolean `schema_version` while every count beside it
-already rejected one.
-
-The counts are checked against the active catalog, not merely against each
-other. `1 + 2 = 3` sums perfectly and describes a three-entry catalog nobody has,
-so internal consistency alone would let a fabricated denominator present as
-current coverage. The reader recomputes both halves from the installed catalog
-and rejects any payload that disagrees — including a correct total split the
-wrong way, since the split is the whole point.
-
-Presence is generation-dependent rather than optional. Classification v2 requires
-the field — the writer always emits it, and a never-used list is unreadable
-without its denominator, so a v2 record missing it is incomplete rather than
-merely older. v1 and contract v4 forbid it.
+`absence_evaluable_from: null` means absence is not provable for that pattern and
+never falls back to the presence gate, so never-used and underused are computed
+over the populated-gate entries only. Against the live catalog that is **16 of 81
+observable entries** — 65 are unknowable. Without that denominator beside it, a
+short never-used list reads as a statement about the speaker when it is mostly a
+statement about coverage. `absence_provability` reports both counts plus the
+observable total, computed from the catalog rather than hardcoded, so populating
+a gate moves the numbers instead of dating a constant. An unobservable entry
+lands in neither count: it is not scored at all, so it belongs to no denominator.
 
 `classify-pattern-profile.py` emits it beside `never_used_patterns`, so the list
-and its denominator always travel together. A classification-v1 profile written
-before the field existed stays readable without it — demanding it everywhere
-would refuse every profile already on disk, a bigger break than the gap it
-closes.
+and its denominator always travel together.
 
-An unobservable entry lands in neither count: it is not scored at all, so it
-belongs to no denominator.
+**The version boundary.** The classification contract bumps to **v2** to carry
+the field, since this is a shape change to a persisted artifact. Presence follows
+that generation rather than the outer v5 contract: required at classification v2,
+forbidden at v1 and on the v4 contract, which carries no classification block at
+all. A v1 block that omits it stays readable — the counts are a fact about the
+catalog, not a claim the older block got anything wrong, and refusing v1 outright
+would strand every profile on disk to gain nothing. A v1 block that *carries* it
+is rejected: the stamp and the payload disagree. `speaker-profile-schema.md`
+documents the table.
+
+A v1 block is nonetheless a superseded classification generation, so a reader
+takes the no-usable-prior-state path on it — every derived domain is withheld and
+the assessment carries `pattern_classification_schema_superseded`, distinct from
+`pattern_classification_policy_unavailable`, which marks a v4 contract that never
+had a policy stamp. Nothing upgrades the block in place; vault-profile
+regenerates the profile wholesale, so the next owner run replaces it. Occurrence
+rows stay readable across the boundary — they belong to the pattern-profile
+contract, not to the classification generation.
+
+**What the reader checks.** Allowlisting a field without checking it is how a
+malformed object reaches a reader that believes the shape was verified, and a
+wrong count here misreports coverage as speaker behaviour — the exact confusion
+the field exists to prevent. So: exact field set; nonnegative integer counts with
+booleans excluded; a type-checked `schema_version`, since Python's `True == 1`
+would otherwise admit a boolean stamp; the sum invariant; and the counts
+recomputed from the active catalog. `1 + 2 = 3` sums perfectly and describes a
+three-entry catalog nobody has, so internal consistency alone would let a
+fabricated denominator present as current coverage — including a correct total
+split the wrong way, since the split is the whole point.
+
+`_PATTERN_HISTORY_KEYS` in `validate-profile.py` learned the field too. That set
+keeps catalog-derived history inside `pattern_profile`, and a field the writer
+emits but the set never learned about could sit duplicated under
+`rhetoric_defaults` unchallenged. A regression derives its expectation from what
+the writer actually emits, so the next omission fails in the suite rather than in
+a profile.
+
+**On the tests.** Review found the first revision comparing the outer contract
+version (4 or 5) against a classification floor of 2, so the gate admitted every
+block it existed to reject. That defect survived because the tests called the
+private validator and supplied the version by hand — a shape the real call path
+cannot produce. They run through `assess_pattern_profile` now, and both
+version-gate cases fail against the original code. The writer's coverage moved
+off `inspect.getsource` for the same reason: matching a call expression in source
+text passes for code that never runs and fails for a correct refactor. The floor
+is pinned to the generation that introduced the field rather than to the current
+one, so a later classification bump does not start rejecting version 2.
 
 ### test — assert the lint gate's outcome, not tessl's wording (#265)
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -668,13 +668,18 @@ of 81 observable, so a short `never_used_patterns` list is mostly a statement
 about coverage rather than about the speaker; a reader presenting the list
 without these counts misreports it.
 
-The field arrives with `classification_schema_version: 2`. A version-1 block that
-omits it stays readable — the counts are a fact about the catalog, not a claim
-the older block got anything wrong — so readers treat the field as absent rather
-than the profile as invalid. A version-1 block that *carries* it is rejected:
-the field did not exist under that generation's contract, so its presence means
-the stamp and the payload disagree. Contract v4 carries no classification block
-at all and never admits the field.
+The field arrives with `classification_schema_version: 2`, and presence is
+generation-dependent rather than optional:
+
+| Generation | `absence_provability` |
+|---|---|
+| classification v2 and later | **required** — the writer always emits it, and a never-used list is unreadable without its denominator |
+| classification v1 | **forbidden** — the field did not exist under that contract, so its presence means the stamp and the payload disagree |
+| contract v4 | **forbidden** — v4 carries no classification block at all |
+
+A version-1 block that omits it stays readable — the counts are a fact about the
+catalog, not a claim the older block got anything wrong — so readers treat the
+field as absent rather than the profile as invalid.
 
 **Migration boundary.** A version-1 block is a superseded classification
 generation, so a reader gets no usable classification state from it: every

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -393,6 +393,12 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
       }
     ],
     "never_used_patterns": [],
+    "absence_provability": {
+      "schema_version": 1,
+      "absence_provable_count": 16,
+      "absence_unknowable_count": 65,
+      "observable_count": 81
+    },
     "signature_combinations": [],
     "mastery_levels": {
       "signature": ["narrative-arc"],
@@ -650,7 +656,22 @@ policy-backed absence classification. `not_yet_observed` says that this corpus h
 positive detection while absence remains unknown. A conclusive absence that does not
 reach a named tier remains `unclassified` with observation status `confirmed_absent`.
 Only classifier-emitted `never_tried` IDs enter `never_used_patterns`; no other zero
-state may be presented as proof that the speaker has never tried the technique. The
+state may be presented as proof that the speaker has never tried the technique.
+
+`absence_provability` is the denominator that qualifies that list, emitted beside
+it by `classify-pattern-profile.py`. `absence_provable_count` is the number of
+observable catalog entries carrying a populated `absence_evaluable_from` gate —
+the only entries a never-used claim may be computed over.
+`absence_unknowable_count` is the rest, where absence is not provable at all, and
+`observable_count` is their sum. Against the current catalog that is 16 provable
+of 81 observable, so a short `never_used_patterns` list is mostly a statement
+about coverage rather than about the speaker; a reader presenting the list
+without these counts misreports it.
+
+The field arrives with `classification_schema_version: 2`. A block at version 1
+predates it and stays readable — the counts are a fact about the catalog, not a
+claim the older block got anything wrong — so readers treat the field as absent
+rather than the profile as invalid. The
 antipattern equivalent is `confirmed_none`; every other zero-detection antipattern
 remains non-recurring unless the classifier says otherwise.
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -674,7 +674,18 @@ the older block got anything wrong — so readers treat the field as absent rath
 than the profile as invalid. A version-1 block that *carries* it is rejected:
 the field did not exist under that generation's contract, so its presence means
 the stamp and the payload disagree. Contract v4 carries no classification block
-at all and never admits the field. The
+at all and never admits the field.
+
+**Migration boundary.** A version-1 block is a superseded classification
+generation, so a reader gets no usable classification state from it: every
+derived domain is withheld and the assessment carries
+`pattern_classification_schema_superseded`. Nothing upgrades the block in place
+— vault-profile regenerates the profile wholesale, so the next owner run
+replaces it. That reason code is distinct from
+`pattern_classification_policy_unavailable`, which marks a v4 contract that
+never had a policy stamp at all. Occurrence rows remain readable across the
+boundary: they belong to the pattern-profile contract, not to the classification
+generation. The
 antipattern equivalent is `confirmed_none`; every other zero-detection antipattern
 remains non-recurring unless the classifier says otherwise.
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -407,7 +407,7 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
       "rare": [],
       "never_tried": []
     },
-    "classification_schema_version": 1,
+    "classification_schema_version": 2,
     "classification_policy": {
       "schema_version": 1,
       "policy_id": "speaker-toolkit-default",
@@ -668,10 +668,13 @@ of 81 observable, so a short `never_used_patterns` list is mostly a statement
 about coverage rather than about the speaker; a reader presenting the list
 without these counts misreports it.
 
-The field arrives with `classification_schema_version: 2`. A block at version 1
-predates it and stays readable — the counts are a fact about the catalog, not a
-claim the older block got anything wrong — so readers treat the field as absent
-rather than the profile as invalid. The
+The field arrives with `classification_schema_version: 2`. A version-1 block that
+omits it stays readable — the counts are a fact about the catalog, not a claim
+the older block got anything wrong — so readers treat the field as absent rather
+than the profile as invalid. A version-1 block that *carries* it is rejected:
+the field did not exist under that generation's contract, so its presence means
+the stamp and the payload disagree. Contract v4 carries no classification block
+at all and never admits the field. The
 antipattern equivalent is `confirmed_none`; every other zero-detection antipattern
 remains non-recurring unless the classifier says otherwise.
 

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -659,7 +659,7 @@ Only classifier-emitted `never_tried` IDs enter `never_used_patterns`; no other 
 state may be presented as proof that the speaker has never tried the technique.
 
 `absence_provability` is the denominator that qualifies that list, emitted beside
-it by `classify-pattern-profile.py`. `absence_provable_count` is the number of
+it by `skills/vault-profile/scripts/classify-pattern-profile.py`. `absence_provable_count` is the number of
 observable catalog entries carrying a populated `absence_evaluable_from` gate —
 the only entries a never-used claim may be computed over.
 `absence_unknowable_count` is the rest, where absence is not provable at all, and

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -618,7 +618,10 @@ The respective stable reasons are `mixed_opportunity_coverage` and
 `no_evaluable_pattern_opportunities`; the per-pattern occurrence rows remain
 available.
 
-All `pattern_profile` fields in the schema are required in v5. If the vault has no
+All `pattern_profile` fields in the schema are required in v5, except
+`absence_provability`, whose presence follows the classification generation
+rather than the v5 contract — required at classification v2, forbidden before it
+(see the table below). If the vault has no
 `pattern-classification-policy.json`, the loader automatically applies the bundled
 `speaker-toolkit-default@1` policy; users are not asked to invent thresholds. A present
 override is strict and fail-closed: an unreadable file, duplicate key, non-finite

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -620,8 +620,8 @@ available.
 
 All `pattern_profile` fields in the schema are required in v5, except
 `absence_provability`, whose presence follows the classification generation
-rather than the v5 contract — required at classification v2, forbidden before it
-(see the table below). If the vault has no
+rather than the v5 contract (see `absence_provability` below). If the vault has
+no
 `pattern-classification-policy.json`, the loader automatically applies the bundled
 `speaker-toolkit-default@1` policy; users are not asked to invent thresholds. A present
 override is strict and fail-closed: an unreadable file, duplicate key, non-finite
@@ -662,38 +662,30 @@ Only classifier-emitted `never_tried` IDs enter `never_used_patterns`; no other 
 state may be presented as proof that the speaker has never tried the technique.
 
 `absence_provability` is the denominator that qualifies that list, emitted beside
-it by `skills/vault-profile/scripts/classify-pattern-profile.py`. `absence_provable_count` is the number of
-observable catalog entries carrying a populated `absence_evaluable_from` gate —
-the only entries a never-used claim may be computed over.
-`absence_unknowable_count` is the rest, where absence is not provable at all, and
-`observable_count` is their sum. Against the current catalog that is 16 provable
-of 81 observable, so a short `never_used_patterns` list is mostly a statement
-about coverage rather than about the speaker; a reader presenting the list
-without these counts misreports it.
+it by `skills/vault-profile/scripts/classify-pattern-profile.py`. It is an object
+of `schema_version`, `absence_provable_count`, `absence_unknowable_count`, and
+`observable_count` — the provable set being the only entries a never-used claim
+may be computed over. Most of the catalog is unprovable, so a
+`never_used_patterns` list presented without these counts misreports coverage as
+speaker behaviour. How each count is derived lives in
+`skills/vault-profile/scripts/profile_pattern_provenance.py` at
+`absence_provability()`.
 
-The field arrives with `classification_schema_version: 2`, and presence is
-generation-dependent rather than optional:
+The field arrives with `classification_schema_version: 2`. Presence is
+generation-dependent rather than optional, and the exact predicate — which
+generations require it, which forbid it, and the errors each produces — is
+`_validate_absence_provability` in the same module, keyed on
+`ABSENCE_PROVABILITY_MIN_CLASSIFICATION_SCHEMA_VERSION`. A profile that omits it
+where it is required, or carries it where it is not, fails validation.
 
-| Generation | `absence_provability` |
-|---|---|
-| classification v2 and later | **required** — the writer always emits it, and a never-used list is unreadable without its denominator |
-| classification v1 | **forbidden** — the field did not exist under that contract, so its presence means the stamp and the payload disagree |
-| contract v4 | **forbidden** — v4 carries no classification block at all |
-
-A version-1 block that omits it stays readable — the counts are a fact about the
-catalog, not a claim the older block got anything wrong — so readers treat the
-field as absent rather than the profile as invalid.
-
-**Migration boundary.** A version-1 block is a superseded classification
-generation, so a reader gets no usable classification state from it: every
-derived domain is withheld and the assessment carries
-`pattern_classification_schema_superseded`. Nothing upgrades the block in place
-— vault-profile regenerates the profile wholesale, so the next owner run
-replaces it. That reason code is distinct from
-`pattern_classification_policy_unavailable`, which marks a v4 contract that
-never had a policy stamp at all. Occurrence rows remain readable across the
-boundary: they belong to the pattern-profile contract, not to the classification
-generation. The
+**Migration boundary.** A block from a superseded classification generation
+yields no usable classification state: every derived domain is withheld and the
+assessment carries `pattern_classification_schema_superseded`, distinct from
+`pattern_classification_policy_unavailable`, which marks a contract that never
+had a policy stamp. Nothing upgrades such a block in place — vault-profile
+regenerates the profile wholesale, so the next owner run replaces it. Occurrence
+rows remain readable across the boundary: they belong to the pattern-profile
+contract, not to the classification generation. The
 antipattern equivalent is `confirmed_none`; every other zero-detection antipattern
 remains non-recurring unless the classifier says otherwise.
 

--- a/skills/vault-profile/scripts/classify-pattern-profile.py
+++ b/skills/vault-profile/scripts/classify-pattern-profile.py
@@ -64,7 +64,7 @@ from profile_pattern_provenance import absence_provability  # noqa: E402
 
 POLICY_SCHEMA_VERSION = 1
 POLICY_STAMP_SCHEMA_VERSION = 1
-CLASSIFICATION_SCHEMA_VERSION = 1
+CLASSIFICATION_SCHEMA_VERSION = 2
 CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 2
 DEFAULT_POLICY_PATH = (
     pathlib.Path(__file__).resolve().parent.parent

--- a/skills/vault-profile/scripts/classify-pattern-profile.py
+++ b/skills/vault-profile/scripts/classify-pattern-profile.py
@@ -59,6 +59,7 @@ from pattern_opportunities import (  # noqa: E402
 from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     load_catalog,
 )
+from profile_pattern_provenance import absence_provability  # noqa: E402
 
 
 POLICY_SCHEMA_VERSION = 1
@@ -1497,6 +1498,10 @@ def classify_pattern_profile(
         "strengths": strength_ids,
         "strengths_note": "Deterministic projection of regular and signature positive-pattern classifications.",
         "never_used_patterns": never_tried_ids,
+        # The denominator has to travel with the list. Absence is provable for a
+        # minority of the observable catalog, so a short never-used list is
+        # mostly a statement about coverage rather than about the speaker.
+        "absence_provability": absence_provability(resolved_catalog),
         "signature_combinations": combinations,
         "mastery_levels": mastery_levels,
     }

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -49,6 +49,10 @@ REASON_CATALOG_FINGERPRINT_MISMATCH = "pattern_catalog_fingerprint_mismatch"
 REASON_SCORING_SCHEMA_MISMATCH = "pattern_scoring_schema_mismatch"
 REASON_EMPTY_CURRENT_COHORT = "empty_current_pattern_cohort"
 REASON_CLASSIFICATION_POLICY_UNAVAILABLE = "pattern_classification_policy_unavailable"
+# A readable block from a superseded classification generation. Distinct from
+# POLICY_UNAVAILABLE (a v4 contract that never had a policy stamp): this block
+# has one, it just belongs to an older generation.
+REASON_CLASSIFICATION_SCHEMA_SUPERSEDED = "pattern_classification_schema_superseded"
 REASON_CLASSIFICATION_POLICY_INVALID = "pattern_classification_policy_invalid"
 
 LEGACY_CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 1
@@ -1585,6 +1589,7 @@ def assess_pattern_profile(
 
     domains = frozenset()
     policy_digest = None
+    superseded_classification = False
     if contract_version == 4:
         errors.extend(_validate_v4_unavailable(pattern_profile))
     elif active_catalog is not None:
@@ -1596,6 +1601,20 @@ def assess_pattern_profile(
         errors.extend(policy_errors)
         if policy_digest is None:
             _append_reason(reason_codes, REASON_CLASSIFICATION_POLICY_INVALID)
+        # A superseded classification generation is prior state, not current
+        # evidence. This module reads the block for consumers outside the owning
+        # skill and never migrates it: vault-profile regenerates the profile
+        # wholesale, so the next owner run replaces the block rather than
+        # upgrading it in place. Until then its classification-derived domains
+        # are no usable prior state. Occurrence rows survive — they belong to the
+        # pattern-profile contract, not to the classification generation.
+        superseded_classification = (
+            _is_integer(pattern_profile.get("classification_schema_version"))
+            and pattern_profile["classification_schema_version"]
+            < CLASSIFICATION_SCHEMA_VERSION
+        )
+        if superseded_classification:
+            domains = frozenset()
 
     if errors:
         _append_reason(reason_codes, REASON_INVALID_CONTRACT)
@@ -1615,6 +1634,8 @@ def assess_pattern_profile(
         _append_reason(reason_codes, REASON_EMPTY_CURRENT_COHORT)
     if contract_version == 4:
         _append_reason(reason_codes, REASON_CLASSIFICATION_POLICY_UNAVAILABLE)
+    if superseded_classification:
+        _append_reason(reason_codes, REASON_CLASSIFICATION_SCHEMA_SUPERSEDED)
     return PatternProfileAssessment(
         current_contract=True,
         catalog_fields_available=eligible_count > 0,

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -1442,6 +1442,13 @@ def assess_pattern_profile(
         set(pattern_profile) - required_fields - _OPTIONAL_PATTERN_PROFILE_FIELDS,
         key=str,
     )
+    errors.extend(
+        _validate_absence_provability(
+            pattern_profile.get("absence_provability"),
+            contract_version=contract_version,
+            present="absence_provability" in pattern_profile,
+        )
+    )
     if missing_fields:
         errors.append(
             f"pattern_profile is missing required schema-v{contract_version} fields: "
@@ -1617,6 +1624,62 @@ def assess_pattern_profile(
 
 
 ABSENCE_PROVABILITY_SCHEMA_VERSION = 1
+
+
+def _validate_absence_provability(
+    value: object, *, contract_version: int, present: bool
+) -> list[str]:
+    """Validate the denominator instead of merely permitting it.
+
+    Allowlisting a field without checking it is how a malformed object reaches a
+    reader that believes the shape was verified. These counts qualify every
+    never-used claim, so a wrong one misreports coverage as speaker behavior —
+    the exact confusion the field exists to prevent.
+    """
+    path = "pattern_profile.absence_provability"
+    if not present:
+        return []
+    if contract_version < CLASSIFICATION_SCHEMA_VERSION:
+        return [
+            f"{path} requires classification_schema_version "
+            f"{CLASSIFICATION_SCHEMA_VERSION}, not {contract_version}"
+        ]
+    if not isinstance(value, Mapping):
+        return [f"{path} must be an object"]
+    expected = {
+        "schema_version",
+        "absence_provable_count",
+        "absence_unknowable_count",
+        "observable_count",
+    }
+    if set(value) != expected:
+        return [f"{path} must contain exactly {sorted(expected)}"]
+    if value["schema_version"] != ABSENCE_PROVABILITY_SCHEMA_VERSION:
+        return [f"{path}.schema_version must be {ABSENCE_PROVABILITY_SCHEMA_VERSION}"]
+    errors: list[str] = []
+    counts: dict[str, int] = {}
+    for field in (
+        "absence_provable_count",
+        "absence_unknowable_count",
+        "observable_count",
+    ):
+        raw = value[field]
+        if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+            errors.append(f"{path}.{field} must be a nonnegative integer")
+        else:
+            counts[field] = raw
+    if len(counts) == 3:
+        total = counts["absence_provable_count"] + counts["absence_unknowable_count"]
+        if total != counts["observable_count"]:
+            # The two halves ARE the observable catalog; a mismatch means the
+            # object describes a catalog that does not exist.
+            errors.append(
+                f"{path} counts must sum to observable_count: "
+                f"{counts['absence_provable_count']} + "
+                f"{counts['absence_unknowable_count']} != "
+                f"{counts['observable_count']}"
+            )
+    return errors
 
 
 def absence_provability(catalog: object) -> dict[str, int]:

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -53,7 +53,14 @@ REASON_CLASSIFICATION_POLICY_INVALID = "pattern_classification_policy_invalid"
 
 LEGACY_CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 1
 CLASSIFICATION_AVAILABILITY_SCHEMA_VERSION = 2
-CLASSIFICATION_SCHEMA_VERSION = 1
+CLASSIFICATION_SCHEMA_VERSION = 2
+# v1 predates `absence_provability`. It stays readable: the field is a coverage
+# fact about the catalog, not a claim the older block got wrong, so refusing v1
+# would strand every profile already on disk to gain nothing.
+LEGACY_CLASSIFICATION_SCHEMA_VERSIONS = frozenset({1})
+READABLE_CLASSIFICATION_SCHEMA_VERSIONS = frozenset(
+    {*LEGACY_CLASSIFICATION_SCHEMA_VERSIONS, CLASSIFICATION_SCHEMA_VERSION}
+)
 CLASSIFICATION_POLICY_UNAVAILABLE_REASON = "owner_policy_unconfigured"
 
 _LEGACY_AVAILABILITY_FIELDS = frozenset({"schema_version", "status", "reason_codes"})
@@ -1279,9 +1286,12 @@ def _validate_v5_policy_fields(
     classification_schema_version = pattern_profile.get("classification_schema_version")
     if (
         not _is_integer(classification_schema_version)
-        or classification_schema_version != CLASSIFICATION_SCHEMA_VERSION
+        or classification_schema_version not in READABLE_CLASSIFICATION_SCHEMA_VERSIONS
     ):
-        errors.append("pattern_profile.classification_schema_version must be 1")
+        errors.append(
+            "pattern_profile.classification_schema_version must be one of "
+            f"{sorted(READABLE_CLASSIFICATION_SCHEMA_VERSIONS)}"
+        )
     try:
         stamp = validate_policy_stamp(pattern_profile.get("classification_policy"))
         digest = str(stamp["semantic_sha256"])

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -1445,7 +1445,13 @@ def assess_pattern_profile(
     errors.extend(
         _validate_absence_provability(
             pattern_profile.get("absence_provability"),
-            contract_version=contract_version,
+            # v4 carries no classification block at all, so it can never reach the
+            # generation that introduced this field.
+            classification_schema_version=(
+                pattern_profile.get("classification_schema_version")
+                if contract_version == 5
+                else None
+            ),
             present="absence_provability" in pattern_profile,
         )
     )
@@ -1624,10 +1630,14 @@ def assess_pattern_profile(
 
 
 ABSENCE_PROVABILITY_SCHEMA_VERSION = 1
+# The classification generation that introduced `absence_provability`. The floor
+# is this constant rather than the current version, so a later bump does not
+# start rejecting the generation that first carried the field.
+ABSENCE_PROVABILITY_MIN_CLASSIFICATION_SCHEMA_VERSION = 2
 
 
 def _validate_absence_provability(
-    value: object, *, contract_version: int, present: bool
+    value: object, *, classification_schema_version: object, present: bool
 ) -> list[str]:
     """Validate the denominator instead of merely permitting it.
 
@@ -1635,14 +1645,23 @@ def _validate_absence_provability(
     reader that believes the shape was verified. These counts qualify every
     never-used claim, so a wrong one misreports coverage as speaker behavior —
     the exact confusion the field exists to prevent.
+
+    The floor is the CLASSIFICATION schema version, not the outer pattern-profile
+    contract version. The outer contract is 4 or 5, so comparing it against a
+    classification floor of 2 admits every block it was meant to reject.
     """
     path = "pattern_profile.absence_provability"
     if not present:
         return []
-    if contract_version < CLASSIFICATION_SCHEMA_VERSION:
+    if (
+        not _is_integer(classification_schema_version)
+        or classification_schema_version
+        < ABSENCE_PROVABILITY_MIN_CLASSIFICATION_SCHEMA_VERSION
+    ):
         return [
             f"{path} requires classification_schema_version "
-            f"{CLASSIFICATION_SCHEMA_VERSION}, not {contract_version}"
+            f"{ABSENCE_PROVABILITY_MIN_CLASSIFICATION_SCHEMA_VERSION} or later, not "
+            f"{classification_schema_version!r}"
         ]
     if not isinstance(value, Mapping):
         return [f"{path} must be an object"]

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -101,6 +101,10 @@ _V5_PATTERN_PROFILE_FIELDS = _COMMON_PATTERN_PROFILE_FIELDS | frozenset(
         "trend_analysis",
     }
 )
+# Allowed, never required. The writer emits it, but a profile written before it
+# existed is not thereby invalid — making it required would refuse to read every
+# profile already on disk, which is a bigger break than the gap it closes.
+_OPTIONAL_PATTERN_PROFILE_FIELDS = frozenset({"absence_provability"})
 _REQUIRED_PATTERN_BREADTH_FIELDS = frozenset(
     {"avg_distinct_patterns_per_talk", "trend", "note"}
 )
@@ -1424,7 +1428,10 @@ def assess_pattern_profile(
         else _V4_PATTERN_PROFILE_FIELDS
     )
     missing_fields = sorted(required_fields - set(pattern_profile))
-    unknown_fields = sorted(set(pattern_profile) - required_fields, key=str)
+    unknown_fields = sorted(
+        set(pattern_profile) - required_fields - _OPTIONAL_PATTERN_PROFILE_FIELDS,
+        key=str,
+    )
     if missing_fields:
         errors.append(
             f"pattern_profile is missing required schema-v{contract_version} fields: "

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -1448,19 +1448,6 @@ def assess_pattern_profile(
         set(pattern_profile) - required_fields - _OPTIONAL_PATTERN_PROFILE_FIELDS,
         key=str,
     )
-    errors.extend(
-        _validate_absence_provability(
-            pattern_profile.get("absence_provability"),
-            # v4 carries no classification block at all, so it can never reach the
-            # generation that introduced this field.
-            classification_schema_version=(
-                pattern_profile.get("classification_schema_version")
-                if contract_version == 5
-                else None
-            ),
-            present="absence_provability" in pattern_profile,
-        )
-    )
     if missing_fields:
         errors.append(
             f"pattern_profile is missing required schema-v{contract_version} fields: "
@@ -1517,6 +1504,20 @@ def assess_pattern_profile(
         )
         _append_reason(reason_codes, REASON_ACTIVE_CATALOG_UNAVAILABLE)
         active_fingerprint = None
+    errors.extend(
+        _validate_absence_provability(
+            pattern_profile.get("absence_provability"),
+            # v4 carries no classification block at all, so it can never reach the
+            # generation that introduced this field.
+            classification_schema_version=(
+                pattern_profile.get("classification_schema_version")
+                if contract_version == 5
+                else None
+            ),
+            present="absence_provability" in pattern_profile,
+            active_catalog=active_catalog,
+        )
+    )
     if (
         active_fingerprint is not None
         and baseline["pattern_catalog_fingerprint"] != active_fingerprint
@@ -1660,7 +1661,11 @@ ABSENCE_PROVABILITY_MIN_CLASSIFICATION_SCHEMA_VERSION = 2
 
 
 def _validate_absence_provability(
-    value: object, *, classification_schema_version: object, present: bool
+    value: object,
+    *,
+    classification_schema_version: object,
+    present: bool,
+    active_catalog: object = None,
 ) -> list[str]:
     """Validate the denominator instead of merely permitting it.
 
@@ -1737,6 +1742,22 @@ def _validate_absence_provability(
                 f"{counts['absence_unknowable_count']} != "
                 f"{counts['observable_count']}"
             )
+        elif active_catalog is not None:
+            # Internal consistency is not correctness. `1 + 2 = 3` sums perfectly
+            # and describes a three-entry catalog that does not exist, presenting
+            # a fabricated denominator as current coverage. The counts are a
+            # function of the active catalog, so recompute them and compare.
+            expected = absence_provability(active_catalog)
+            observed = {field: counts[field] for field in counts}
+            expected_counts = {
+                field: expected[field] for field in observed if field in expected
+            }
+            if observed != expected_counts:
+                errors.append(
+                    f"{path} does not describe the active catalog: expected "
+                    f"{expected_counts}, got {observed}; regenerate the profile "
+                    "against the installed catalog"
+                )
     return errors
 
 

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -112,9 +112,11 @@ _V5_PATTERN_PROFILE_FIELDS = _COMMON_PATTERN_PROFILE_FIELDS | frozenset(
         "trend_analysis",
     }
 )
-# Allowed, never required. The writer emits it, but a profile written before it
-# existed is not thereby invalid — making it required would refuse to read every
-# profile already on disk, which is a bigger break than the gap it closes.
+# Presence is generation-dependent, so the field is neither globally required nor
+# globally optional. The v2 writer always emits it and never-used claims cannot be
+# read without it, so v2 REQUIRES it; v1 predates it and must not carry it. This
+# set only keeps it out of the unknown-field sweep — `_validate_absence_provability`
+# owns which generation must carry it.
 _OPTIONAL_PATTERN_PROFILE_FIELDS = frozenset({"absence_provability"})
 _REQUIRED_PATTERN_BREADTH_FIELDS = frozenset(
     {"avg_distinct_patterns_per_talk", "trend", "note"}
@@ -1670,9 +1672,25 @@ def _validate_absence_provability(
     The floor is the CLASSIFICATION schema version, not the outer pattern-profile
     contract version. The outer contract is 4 or 5, so comparing it against a
     classification floor of 2 admits every block it was meant to reject.
+
+    Presence is required from that generation onward and forbidden before it. The
+    v2 writer always emits the field, and a never-used list cannot be read without
+    its denominator, so a v2 record missing it is incomplete rather than merely
+    older.
     """
     path = "pattern_profile.absence_provability"
+    carries_field = (
+        _is_integer(classification_schema_version)
+        and classification_schema_version
+        >= ABSENCE_PROVABILITY_MIN_CLASSIFICATION_SCHEMA_VERSION
+    )
     if not present:
+        if carries_field:
+            return [
+                f"{path} is required at classification_schema_version "
+                f"{classification_schema_version}; a never-used list without its "
+                "denominator reads as speaker behaviour rather than coverage"
+            ]
         return []
     if (
         not _is_integer(classification_schema_version)

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -1717,7 +1717,12 @@ def _validate_absence_provability(
     }
     if set(value) != expected:
         return [f"{path} must contain exactly {sorted(expected)}"]
-    if value["schema_version"] != ABSENCE_PROVABILITY_SCHEMA_VERSION:
+    # `_is_integer` first: Python makes `True == 1`, so equality alone admits a
+    # boolean version while every count beside it explicitly rejects one.
+    if (
+        not _is_integer(value["schema_version"])
+        or value["schema_version"] != ABSENCE_PROVABILITY_SCHEMA_VERSION
+    ):
         return [f"{path}.schema_version must be {ABSENCE_PROVABILITY_SCHEMA_VERSION}"]
     errors: list[str] = []
     counts: dict[str, int] = {}

--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -1597,3 +1597,35 @@ def assess_pattern_profile(
         contract_version=contract_version,
         policy_semantic_sha256=policy_digest,
     )
+
+
+ABSENCE_PROVABILITY_SCHEMA_VERSION = 1
+
+
+def absence_provability(catalog: object) -> dict[str, int]:
+    """Split the observable catalog into what absence can and cannot be proven for.
+
+    Owner decision (#153): `absence_evaluable_from: null` means absence is not
+    provable for that pattern, and it never falls back to the presence gate. So
+    never-used and underused are computed over the populated-gate entries only —
+    currently a minority of the observable catalog.
+
+    Without the denominator beside them, a short never-used list reads as a
+    statement about the speaker. It is mostly a statement about coverage, and
+    `absence_unknowable` is what makes the difference legible.
+    """
+    provable = 0
+    unknowable = 0
+    for entry in getattr(catalog, "entries", {}).values():
+        if not getattr(entry, "observable", False):
+            continue
+        if getattr(entry, "absence_evaluable_from", None) is None:
+            unknowable += 1
+        else:
+            provable += 1
+    return {
+        "schema_version": ABSENCE_PROVABILITY_SCHEMA_VERSION,
+        "absence_provable_count": provable,
+        "absence_unknowable_count": unknowable,
+        "observable_count": provable + unknowable,
+    }

--- a/skills/vault-profile/scripts/validate-profile.py
+++ b/skills/vault-profile/scripts/validate-profile.py
@@ -128,6 +128,7 @@ _PATTERN_HISTORY_KEYS = frozenset(
         "pattern_classifications",
         "antipattern_classifications",
         "trend_analysis",
+        "absence_provability",
     }
 )
 _FORBIDDEN_NON_PATTERN_ENTRY_FIELDS = frozenset(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,15 @@ def persisted_pattern_observations():
 
 
 @pytest.fixture(scope="session")
+def profile_pattern_provenance():
+    """The profile's pattern-provenance contract (#160)."""
+    return _import_script(
+        os.path.join(SCRIPTS_VP, "profile_pattern_provenance.py"),
+        "profile_pattern_provenance",
+    )
+
+
+@pytest.fixture(scope="session")
 def pptx_talk_identity():
     """The talk-identity assessment run before catalog persistence (#176)."""
     return _import_script(

--- a/tests/test_absence_provability.py
+++ b/tests/test_absence_provability.py
@@ -119,3 +119,28 @@ class TestTheWriterEmitsIt:
             "absence_provability"
             not in profile_pattern_provenance._V5_PATTERN_PROFILE_FIELDS
         )
+
+
+class TestSchemaVersioning:
+    """A shape change to a persisted artifact bumps its governing version."""
+
+    def test_the_classification_contract_bumped(
+        self, profile_pattern_provenance
+    ) -> None:
+        assert profile_pattern_provenance.CLASSIFICATION_SCHEMA_VERSION == 2
+
+    def test_the_writer_stamps_the_new_version(
+        self, classify_pattern_profile, profile_pattern_provenance
+    ) -> None:
+        """Writer and reader share one constant, not two copies."""
+        assert (
+            classify_pattern_profile.CLASSIFICATION_SCHEMA_VERSION
+            == profile_pattern_provenance.CLASSIFICATION_SCHEMA_VERSION
+        )
+
+    def test_a_v1_block_stays_readable(self, profile_pattern_provenance) -> None:
+        """The counts are a fact about the catalog, not a claim the older block
+        got something wrong — refusing v1 would strand every profile on disk."""
+        readable = profile_pattern_provenance.READABLE_CLASSIFICATION_SCHEMA_VERSIONS
+        assert 1 in readable
+        assert profile_pattern_provenance.CLASSIFICATION_SCHEMA_VERSION in readable

--- a/tests/test_absence_provability.py
+++ b/tests/test_absence_provability.py
@@ -9,14 +9,36 @@ it is mostly a statement about coverage.
 
 from __future__ import annotations
 
+import importlib
+from pathlib import Path
+
 import pytest
 
 
-@pytest.fixture(scope="module")
-def provability(profile_pattern_provenance, return_validation):
-    return profile_pattern_provenance.absence_provability(
-        return_validation.load_catalog()
+def _no_policy_override(runtime):
+    """The bundled default policy — no on-disk override for this test run."""
+    return runtime.resolve_classification_policy(
+        Path(__file__).resolve().parent / "__no_policy_override__"
     )
+
+
+@pytest.fixture(scope="module")
+def classification_runtime(profile_pattern_provenance):
+    # Depends on profile_pattern_provenance for its import side effect: that
+    # fixture puts the vault-profile scripts directory on the path, which is what
+    # makes this plain module import resolve.
+    del profile_pattern_provenance
+    return importlib.import_module("pattern_classification_runtime")
+
+
+@pytest.fixture(scope="module")
+def pattern_catalog(return_validation):
+    return return_validation.load_catalog()
+
+
+@pytest.fixture(scope="module")
+def provability(profile_pattern_provenance, pattern_catalog):
+    return profile_pattern_provenance.absence_provability(pattern_catalog)
 
 
 class _Entry:
@@ -92,32 +114,50 @@ class TestPartition:
 
 
 class TestTheWriterEmitsIt:
-    """An unused helper is not a contract — the reason this was rejected once."""
+    """An unused helper is not a contract — the reason this was rejected once.
+
+    Asserted against the writer's emitted payload, not its source text. Matching
+    a call expression in `inspect.getsource` passes for code that is never
+    reached and fails for a correct refactor, so it measures the spelling rather
+    than the behaviour.
+    """
 
     def test_the_profile_writer_emits_the_denominator(
-        self, classify_pattern_profile
+        self, classification_runtime, pattern_catalog
     ) -> None:
-        import inspect
-
-        source = inspect.getsource(classify_pattern_profile)
-        assert '"absence_provability": absence_provability(' in source
-
-    def test_the_validator_accepts_a_profile_carrying_it(
-        self, profile_pattern_provenance
-    ) -> None:
-        assert (
-            "absence_provability"
-            in profile_pattern_provenance._OPTIONAL_PATTERN_PROFILE_FIELDS
+        emitted = classification_runtime.classify_pattern_profile(
+            [], _no_policy_override(classification_runtime), catalog=pattern_catalog
         )
 
-    def test_it_is_not_required_of_profiles_written_before_it(
-        self, profile_pattern_provenance
+        assert "absence_provability" in emitted
+        assert set(emitted["absence_provability"]) == {
+            "schema_version",
+            "absence_provable_count",
+            "absence_unknowable_count",
+            "observable_count",
+        }
+
+    def test_the_emitted_counts_match_the_live_catalog(
+        self, classification_runtime, pattern_catalog, provability
     ) -> None:
-        """Requiring it would refuse to read every profile already on disk — a
-        bigger break than the gap it closes."""
+        """The writer reports the catalog it actually ran against."""
+        emitted = classification_runtime.classify_pattern_profile(
+            [], _no_policy_override(classification_runtime), catalog=pattern_catalog
+        )
+
+        assert emitted["absence_provability"] == provability
+
+    def test_the_writer_stamps_the_generation_that_carries_it(
+        self, classification_runtime, pattern_catalog, profile_pattern_provenance
+    ) -> None:
+        """The field and its version stamp are emitted together or not at all."""
+        emitted = classification_runtime.classify_pattern_profile(
+            [], _no_policy_override(classification_runtime), catalog=pattern_catalog
+        )
+
         assert (
-            "absence_provability"
-            not in profile_pattern_provenance._V5_PATTERN_PROFILE_FIELDS
+            emitted["classification_schema_version"]
+            == profile_pattern_provenance.CLASSIFICATION_SCHEMA_VERSION
         )
 
 

--- a/tests/test_absence_provability.py
+++ b/tests/test_absence_provability.py
@@ -144,3 +144,92 @@ class TestSchemaVersioning:
         readable = profile_pattern_provenance.READABLE_CLASSIFICATION_SCHEMA_VERSIONS
         assert 1 in readable
         assert profile_pattern_provenance.CLASSIFICATION_SCHEMA_VERSION in readable
+
+
+class TestValidation:
+    """Allowlisting a field without checking it is how a malformed object
+    reaches a reader that believes the shape was verified."""
+
+    def _validate(self, ppp, value, *, version=2):
+        return ppp._validate_absence_provability(
+            value, contract_version=version, present=True
+        )
+
+    def test_a_well_formed_object_passes(self, profile_pattern_provenance) -> None:
+        good = profile_pattern_provenance.absence_provability(
+            type("C", (), {"entries": {}})()
+        )
+        assert self._validate(profile_pattern_provenance, good) == []
+
+    def test_absence_is_not_an_error(self, profile_pattern_provenance) -> None:
+        assert (
+            profile_pattern_provenance._validate_absence_provability(
+                None, contract_version=2, present=False
+            )
+            == []
+        )
+
+    def test_a_non_object_is_rejected(self, profile_pattern_provenance) -> None:
+        assert self._validate(profile_pattern_provenance, [1, 2]) != []
+
+    def test_a_missing_field_is_rejected(self, profile_pattern_provenance) -> None:
+        assert (
+            self._validate(
+                profile_pattern_provenance,
+                {"schema_version": 1, "observable_count": 0},
+            )
+            != []
+        )
+
+    def test_a_negative_count_is_rejected(self, profile_pattern_provenance) -> None:
+        assert (
+            self._validate(
+                profile_pattern_provenance,
+                {
+                    "schema_version": 1,
+                    "absence_provable_count": -1,
+                    "absence_unknowable_count": 1,
+                    "observable_count": 0,
+                },
+            )
+            != []
+        )
+
+    def test_a_boolean_count_is_rejected(self, profile_pattern_provenance) -> None:
+        """`True` is an int in Python; a count is not a flag."""
+        assert (
+            self._validate(
+                profile_pattern_provenance,
+                {
+                    "schema_version": 1,
+                    "absence_provable_count": True,
+                    "absence_unknowable_count": 0,
+                    "observable_count": 1,
+                },
+            )
+            != []
+        )
+
+    def test_counts_that_do_not_sum_are_rejected(
+        self, profile_pattern_provenance
+    ) -> None:
+        """The two halves ARE the observable catalog; a mismatch describes a
+        catalog that does not exist."""
+        assert (
+            self._validate(
+                profile_pattern_provenance,
+                {
+                    "schema_version": 1,
+                    "absence_provable_count": 16,
+                    "absence_unknowable_count": 65,
+                    "observable_count": 99,
+                },
+            )
+            != []
+        )
+
+    def test_a_v1_profile_cannot_carry_it(self, profile_pattern_provenance) -> None:
+        good = profile_pattern_provenance.absence_provability(
+            type("C", (), {"entries": {}})()
+        )
+        assert self._validate(profile_pattern_provenance, good, version=1) != []

--- a/tests/test_absence_provability.py
+++ b/tests/test_absence_provability.py
@@ -89,3 +89,33 @@ class TestPartition:
 
         assert result["observable_count"] == 0
         assert result["absence_provable_count"] == 0
+
+
+class TestTheWriterEmitsIt:
+    """An unused helper is not a contract — the reason this was rejected once."""
+
+    def test_the_profile_writer_emits_the_denominator(
+        self, classify_pattern_profile
+    ) -> None:
+        import inspect
+
+        source = inspect.getsource(classify_pattern_profile)
+        assert '"absence_provability": absence_provability(' in source
+
+    def test_the_validator_accepts_a_profile_carrying_it(
+        self, profile_pattern_provenance
+    ) -> None:
+        assert (
+            "absence_provability"
+            in profile_pattern_provenance._OPTIONAL_PATTERN_PROFILE_FIELDS
+        )
+
+    def test_it_is_not_required_of_profiles_written_before_it(
+        self, profile_pattern_provenance
+    ) -> None:
+        """Requiring it would refuse to read every profile already on disk — a
+        bigger break than the gap it closes."""
+        assert (
+            "absence_provability"
+            not in profile_pattern_provenance._V5_PATTERN_PROFILE_FIELDS
+        )

--- a/tests/test_absence_provability.py
+++ b/tests/test_absence_provability.py
@@ -1,0 +1,91 @@
+"""The provable-set denominator behind never-used claims (#160, #153).
+
+`absence_evaluable_from: null` means absence is not provable for that pattern
+and never falls back to the presence gate. Never-used and underused are computed
+over the populated-gate entries only, so the denominator has to travel with them
+— otherwise a short never-used list reads as a statement about the speaker when
+it is mostly a statement about coverage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def provability(profile_pattern_provenance, return_validation):
+    return profile_pattern_provenance.absence_provability(
+        return_validation.load_catalog()
+    )
+
+
+class _Entry:
+    def __init__(self, observable: bool, gate: object) -> None:
+        self.observable = observable
+        self.absence_evaluable_from = gate
+
+
+class _Catalog:
+    def __init__(self, entries: dict) -> None:
+        self.entries = entries
+
+
+class TestLiveCatalog:
+    def test_the_counts_partition_the_observable_catalog(self, provability) -> None:
+        assert (
+            provability["absence_provable_count"]
+            + provability["absence_unknowable_count"]
+            == provability["observable_count"]
+        )
+
+    def test_absence_is_unprovable_for_most_of_the_catalog(self, provability) -> None:
+        """The fact that makes the denominator load-bearing rather than trivia."""
+        assert (
+            provability["absence_unknowable_count"]
+            > provability["absence_provable_count"]
+        )
+
+    def test_it_is_computed_not_hardcoded(
+        self, profile_pattern_provenance, return_validation
+    ) -> None:
+        """A catalog edit that populates a gate must move these counts."""
+        catalog = return_validation.load_catalog()
+        observable = [entry for entry in catalog.entries.values() if entry.observable]
+        computed = profile_pattern_provenance.absence_provability(catalog)
+        assert computed["observable_count"] == len(observable)
+
+
+class TestPartition:
+    def test_a_null_gate_is_unknowable(self, profile_pattern_provenance) -> None:
+        catalog = _Catalog({"a": _Entry(True, None)})
+
+        result = profile_pattern_provenance.absence_provability(catalog)
+
+        assert result["absence_unknowable_count"] == 1
+        assert result["absence_provable_count"] == 0
+
+    def test_a_populated_gate_is_provable(self, profile_pattern_provenance) -> None:
+        catalog = _Catalog({"a": _Entry(True, ("static_slides",))})
+
+        result = profile_pattern_provenance.absence_provability(catalog)
+
+        assert result["absence_provable_count"] == 1
+        assert result["absence_unknowable_count"] == 0
+
+    def test_an_unobservable_entry_is_in_neither_count(
+        self, profile_pattern_provenance
+    ) -> None:
+        """It is not scored at all, so it belongs to no denominator."""
+        catalog = _Catalog(
+            {"a": _Entry(False, None), "b": _Entry(False, ("transcript",))}
+        )
+
+        result = profile_pattern_provenance.absence_provability(catalog)
+
+        assert result["observable_count"] == 0
+
+    def test_an_empty_catalog_reports_zeroes(self, profile_pattern_provenance) -> None:
+        result = profile_pattern_provenance.absence_provability(_Catalog({}))
+
+        assert result["observable_count"] == 0
+        assert result["absence_provable_count"] == 0

--- a/tests/test_absence_provability.py
+++ b/tests/test_absence_provability.py
@@ -146,90 +146,37 @@ class TestSchemaVersioning:
         assert profile_pattern_provenance.CLASSIFICATION_SCHEMA_VERSION in readable
 
 
-class TestValidation:
-    """Allowlisting a field without checking it is how a malformed object
-    reaches a reader that believes the shape was verified."""
+class TestTheEmittedObjectValidates:
+    """The writer's own output has to satisfy the reader's contract.
 
-    def _validate(self, ppp, value, *, version=2):
-        return ppp._validate_absence_provability(
-            value, contract_version=version, present=True
-        )
+    Shape and version rejection are exercised through `assess_pattern_profile` in
+    `test_profile_pattern_provenance.py` — a malformed object matters only insofar
+    as it reaches a reader, and the version gate is only observable on the real
+    call path.
+    """
 
-    def test_a_well_formed_object_passes(self, profile_pattern_provenance) -> None:
-        good = profile_pattern_provenance.absence_provability(
-            type("C", (), {"entries": {}})()
-        )
-        assert self._validate(profile_pattern_provenance, good) == []
-
-    def test_absence_is_not_an_error(self, profile_pattern_provenance) -> None:
-        assert (
-            profile_pattern_provenance._validate_absence_provability(
-                None, contract_version=2, present=False
-            )
-            == []
-        )
-
-    def test_a_non_object_is_rejected(self, profile_pattern_provenance) -> None:
-        assert self._validate(profile_pattern_provenance, [1, 2]) != []
-
-    def test_a_missing_field_is_rejected(self, profile_pattern_provenance) -> None:
-        assert (
-            self._validate(
-                profile_pattern_provenance,
-                {"schema_version": 1, "observable_count": 0},
-            )
-            != []
-        )
-
-    def test_a_negative_count_is_rejected(self, profile_pattern_provenance) -> None:
-        assert (
-            self._validate(
-                profile_pattern_provenance,
-                {
-                    "schema_version": 1,
-                    "absence_provable_count": -1,
-                    "absence_unknowable_count": 1,
-                    "observable_count": 0,
-                },
-            )
-            != []
-        )
-
-    def test_a_boolean_count_is_rejected(self, profile_pattern_provenance) -> None:
-        """`True` is an int in Python; a count is not a flag."""
-        assert (
-            self._validate(
-                profile_pattern_provenance,
-                {
-                    "schema_version": 1,
-                    "absence_provable_count": True,
-                    "absence_unknowable_count": 0,
-                    "observable_count": 1,
-                },
-            )
-            != []
-        )
-
-    def test_counts_that_do_not_sum_are_rejected(
+    def test_the_computed_object_is_a_valid_persisted_shape(
         self, profile_pattern_provenance
     ) -> None:
-        """The two halves ARE the observable catalog; a mismatch describes a
-        catalog that does not exist."""
+        computed = profile_pattern_provenance.absence_provability(_Catalog({}))
+
+        assert set(computed) == {
+            "schema_version",
+            "absence_provable_count",
+            "absence_unknowable_count",
+            "observable_count",
+        }
         assert (
-            self._validate(
-                profile_pattern_provenance,
-                {
-                    "schema_version": 1,
-                    "absence_provable_count": 16,
-                    "absence_unknowable_count": 65,
-                    "observable_count": 99,
-                },
-            )
-            != []
+            computed["schema_version"]
+            == profile_pattern_provenance.ABSENCE_PROVABILITY_SCHEMA_VERSION
         )
 
-    def test_a_v1_profile_cannot_carry_it(self, profile_pattern_provenance) -> None:
-        good = profile_pattern_provenance.absence_provability(
-            type("C", (), {"entries": {}})()
+    def test_the_version_floor_is_the_generation_that_introduced_it(
+        self, profile_pattern_provenance
+    ) -> None:
+        """Pinned to the introducing generation, not the current one — a later
+        classification bump must not start rejecting version 2."""
+        assert (
+            profile_pattern_provenance.ABSENCE_PROVABILITY_MIN_CLASSIFICATION_SCHEMA_VERSION
+            == 2
         )
-        assert self._validate(profile_pattern_provenance, good, version=1) != []

--- a/tests/test_plugin_lint_gate.py
+++ b/tests/test_plugin_lint_gate.py
@@ -179,16 +179,7 @@ def test_an_over_length_description_fails_the_gate(tmp_path: Path) -> None:
     assert result.returncode == 1
     report = json.loads(result.stdout)
     assert report["ok"] is False
-    # Assert that the gate rejected, and which skill it rejected — never the
-    # sentence tessl phrased it in. Two CLI versions word this rejection
-    # differently and truncate it at different points ("Frontmatter validation
-    # failed: [" against `SKILL.md frontmatter field "description" must be at
-    # most 1024 characters.`), so any prose match passes on one and fails on the
-    # other while the gate itself is correct on both.
-    assert report["errors"], "an over-length description must produce an error"
-    assert any("demo" in error for error in report["errors"]), (
-        f"no error named the offending skill: {report['errors']}"
-    )
+    assert any("Frontmatter validation failed" in error for error in report["errors"])
 
 
 def test_a_valid_plugin_passes_the_gate(tmp_path: Path) -> None:

--- a/tests/test_plugin_lint_gate.py
+++ b/tests/test_plugin_lint_gate.py
@@ -179,15 +179,16 @@ def test_an_over_length_description_fails_the_gate(tmp_path: Path) -> None:
     assert result.returncode == 1
     report = json.loads(result.stdout)
     assert report["ok"] is False
-    # Assert the gate rejected THIS defect, not the wording tessl rejected it in.
-    # Pinning the prose ("Frontmatter validation failed") broke on tessl 0.96.0,
-    # which reports the same rejection as `SKILL.md frontmatter field
-    # "description" must be at most 1024 characters.` — the gate was right and
-    # the assertion was reading the message instead of the outcome.
+    # Assert that the gate rejected, and which skill it rejected — never the
+    # sentence tessl phrased it in. Two CLI versions word this rejection
+    # differently and truncate it at different points ("Frontmatter validation
+    # failed: [" against `SKILL.md frontmatter field "description" must be at
+    # most 1024 characters.`), so any prose match passes on one and fails on the
+    # other while the gate itself is correct on both.
     assert report["errors"], "an over-length description must produce an error"
-    assert any(
-        "description" in error and "1024" in error for error in report["errors"]
-    ), f"no error named the over-length description: {report['errors']}"
+    assert any("demo" in error for error in report["errors"]), (
+        f"no error named the offending skill: {report['errors']}"
+    )
 
 
 def test_a_valid_plugin_passes_the_gate(tmp_path: Path) -> None:

--- a/tests/test_plugin_lint_gate.py
+++ b/tests/test_plugin_lint_gate.py
@@ -179,7 +179,15 @@ def test_an_over_length_description_fails_the_gate(tmp_path: Path) -> None:
     assert result.returncode == 1
     report = json.loads(result.stdout)
     assert report["ok"] is False
-    assert any("Frontmatter validation failed" in error for error in report["errors"])
+    # Assert the gate rejected THIS defect, not the wording tessl rejected it in.
+    # Pinning the prose ("Frontmatter validation failed") broke on tessl 0.96.0,
+    # which reports the same rejection as `SKILL.md frontmatter field
+    # "description" must be at most 1024 characters.` — the gate was right and
+    # the assertion was reading the message instead of the outcome.
+    assert report["errors"], "an over-length description must produce an error"
+    assert any(
+        "description" in error and "1024" in error for error in report["errors"]
+    ), f"no error named the over-length description: {report['errors']}"
 
 
 def test_a_valid_plugin_passes_the_gate(tmp_path: Path) -> None:

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -629,12 +629,12 @@ def test_v5_assessment_rejects_policy_digest_tampering(validate_profile):
         (
             ("classification_schema_version",),
             True,
-            "pattern_profile.classification_schema_version must be 1",
+            "pattern_profile.classification_schema_version must be one of [1, 2]",
         ),
         (
             ("classification_schema_version",),
             1.0,
-            "pattern_profile.classification_schema_version must be 1",
+            "pattern_profile.classification_schema_version must be one of [1, 2]",
         ),
         (
             ("classification_availability", "schema_version"),

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -606,6 +606,132 @@ def test_v5_assessment_enables_independent_policy_domains(validate_profile):
     )
 
 
+class TestAbsenceProvabilityThroughTheAssessor:
+    """The denominator's version gate, exercised through the public entry point.
+
+    The gate reads the CLASSIFICATION schema version, not the outer pattern-profile
+    contract version. Testing the private helper with a hand-supplied version hid
+    that: the helper was being handed a contract version of 4 or 5 and comparing it
+    against a classification floor of 2, so it admitted every block it existed to
+    reject. Only a profile that travels the real call path shows it.
+    """
+
+    def test_the_current_generation_carries_it(self, validate_profile):
+        pattern_profile = _v5_pattern_profile(validate_profile)
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert pattern_profile["classification_schema_version"] == 2
+        assert "absence_provability" in pattern_profile
+        assert assessment.current_contract is True
+
+    def test_a_classification_v1_block_cannot_carry_it(self, validate_profile):
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["classification_schema_version"] = 1
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "absence_provability requires classification_schema_version" in error
+            for error in assessment.errors
+        )
+
+    def test_a_classification_v1_block_without_it_still_reads(self, validate_profile):
+        """Refusing v1 outright would strand every profile already on disk."""
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["classification_schema_version"] = 1
+        del pattern_profile["absence_provability"]
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is True
+
+    def test_a_v4_contract_cannot_carry_it(self, validate_profile):
+        """v4 has no classification block, so it never reaches the generation
+        that introduced the field."""
+        pattern_profile = _pattern_profile(validate_profile)
+        pattern_profile["absence_provability"] = {
+            "schema_version": 1,
+            "absence_provable_count": 16,
+            "absence_unknowable_count": 65,
+            "observable_count": 81,
+        }
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=4
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "absence_provability requires classification_schema_version" in error
+            for error in assessment.errors
+        )
+
+    def test_counts_that_do_not_sum_are_rejected(self, validate_profile):
+        """The two halves ARE the observable catalog; a mismatch describes a
+        catalog that does not exist."""
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["absence_provability"]["observable_count"] = 99
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "must sum to observable_count" in error for error in assessment.errors
+        )
+
+    def test_a_non_object_is_rejected(self, validate_profile):
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["absence_provability"] = [16, 65, 81]
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "absence_provability must be an object" in error
+            for error in assessment.errors
+        )
+
+    def test_a_boolean_count_is_rejected(self, validate_profile):
+        """`True` is an int in Python; a count is not a flag."""
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["absence_provability"]["absence_provable_count"] = True
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "must be a nonnegative integer" in error for error in assessment.errors
+        )
+
+    def test_a_missing_count_is_rejected(self, validate_profile):
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        del pattern_profile["absence_provability"]["observable_count"]
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "absence_provability must contain exactly" in error
+            for error in assessment.errors
+        )
+
+
 def test_v5_assessment_rejects_policy_digest_tampering(validate_profile):
     pattern_profile = _v5_pattern_profile(validate_profile)
     pattern_profile["classification_policy"]["semantic_sha256"] = "0" * 64

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -836,6 +836,19 @@ class TestASupersededClassificationGeneration:
             for error in assessment.errors
         )
 
+    def test_a_boolean_schema_version_is_rejected(self, validate_profile):
+        """`True == 1` in Python, so equality alone admits a boolean version
+        while every count beside it explicitly rejects one."""
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["absence_provability"]["schema_version"] = True
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any("schema_version must be" in error for error in assessment.errors)
+
     def test_a_boolean_count_is_rejected(self, validate_profile):
         """`True` is an int in Python; a count is not a flag."""
         pattern_profile = _v5_pattern_profile(validate_profile)

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -627,6 +627,23 @@ class TestAbsenceProvabilityThroughTheAssessor:
         assert "absence_provability" in pattern_profile
         assert assessment.current_contract is True
 
+    def test_the_current_generation_must_carry_it(self, validate_profile):
+        """The v2 writer always emits it, and a never-used list is unreadable
+        without its denominator — so a v2 record missing it is incomplete, not
+        merely older."""
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        del pattern_profile["absence_provability"]
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "absence_provability is required at classification_schema_version" in error
+            for error in assessment.errors
+        )
+
     def test_a_classification_v1_block_cannot_carry_it(self, validate_profile):
         pattern_profile = _v5_pattern_profile(validate_profile)
         pattern_profile["classification_schema_version"] = 1

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -1868,7 +1868,10 @@ def test_pattern_baseline_rejects_unknown_fields(validate_profile, tmp_path, cap
     assert "fields are noncanonical" in report["errors"][0]
 
 
-@pytest.mark.parametrize("duplicate", ["signature_combinations", "mastery_levels"])
+@pytest.mark.parametrize(
+    "duplicate",
+    ["signature_combinations", "mastery_levels", "absence_provability"],
+)
 def test_rhetoric_defaults_cannot_duplicate_pattern_history(
     validate_profile,
     tmp_path,
@@ -1884,6 +1887,42 @@ def test_rhetoric_defaults_cannot_duplicate_pattern_history(
     assert any(
         "rhetoric_defaults duplicates catalog history" in error
         for error in report["errors"]
+    )
+
+
+# Prose the profile carries for a human reader. Not catalog-derived history, so a
+# copy elsewhere duplicates nothing.
+_PROSE_PATTERN_PROFILE_FIELDS = frozenset({"note", "strengths_note"})
+
+
+def test_every_history_field_the_writer_emits_is_guarded(
+    validate_profile, tmp_path, capsys
+):
+    """The leakage guard is a hand-maintained key set, so it drifts silently.
+
+    `absence_provability` was emitted into `pattern_profile` while the reader's
+    set still listed the fields that existed before it, which let a conflicting
+    copy sit under `rhetoric_defaults` unchallenged. Deriving the expectation
+    from what the writer actually emits makes the next omission fail here rather
+    than in a profile.
+    """
+    emitted = set(_v5_pattern_profile(validate_profile)) - _PROSE_PATTERN_PROFILE_FIELDS
+    unguarded = []
+
+    for index, field in enumerate(sorted(emitted)):
+        profile = _profile(validate_profile)
+        profile["rhetoric_defaults"][field] = [] if field.endswith("s") else {}
+        vault = tmp_path / f"case{index}"
+        vault.mkdir()
+        return_code, report = _run(validate_profile, profile, vault, capsys)
+        if return_code != 1 or not any(
+            "rhetoric_defaults duplicates catalog history" in error
+            for error in report["errors"]
+        ):
+            unguarded.append(field)
+
+    assert not unguarded, (
+        f"pattern_profile fields the leakage guard does not cover: {unguarded}"
     )
 
 

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -774,6 +774,54 @@ class TestASupersededClassificationGeneration:
             "must sum to observable_count" in error for error in assessment.errors
         )
 
+    def test_a_sum_consistent_payload_that_is_not_the_active_catalog_is_rejected(
+        self, validate_profile
+    ):
+        """Internal consistency is not correctness.
+
+        `1 + 2 = 3` sums perfectly and describes a three-entry catalog nobody
+        has. Accepted, it presents a fabricated denominator as current coverage —
+        the exact misreading the field exists to prevent.
+        """
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["absence_provability"].update(
+            {
+                "absence_provable_count": 1,
+                "absence_unknowable_count": 2,
+                "observable_count": 3,
+            }
+        )
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "does not describe the active catalog" in error
+            for error in assessment.errors
+        )
+
+    def test_shifting_the_split_within_a_correct_total_is_rejected(
+        self, validate_profile
+    ):
+        """The provable/unknowable split is the whole point — a right total with
+        a wrong split still misstates how much of the catalog is provable."""
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        block = pattern_profile["absence_provability"]
+        block["absence_provable_count"] += 1
+        block["absence_unknowable_count"] -= 1
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is False
+        assert any(
+            "does not describe the active catalog" in error
+            for error in assessment.errors
+        )
+
     def test_a_non_object_is_rejected(self, validate_profile):
         pattern_profile = _v5_pattern_profile(validate_profile)
         pattern_profile["absence_provability"] = [16, 65, 81]

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -653,6 +653,74 @@ class TestAbsenceProvabilityThroughTheAssessor:
 
         assert assessment.current_contract is True
 
+
+class TestASupersededClassificationGeneration:
+    """`stateful-artifacts` Migration Policy: a reader never treats an older
+    record as usable current state.
+
+    vault-profile regenerates the profile wholesale, so nothing upgrades a v1
+    classification block in place — the next owner run replaces it. Until then a
+    reader gets no usable classification state from it. Occurrence rows survive,
+    because they belong to the pattern-profile contract rather than to the
+    classification generation.
+    """
+
+    def test_its_classification_domains_are_withheld(self, validate_profile):
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["classification_schema_version"] = 1
+        del pattern_profile["absence_provability"]
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.classification_fields_available is False
+        assert assessment.available_classification_domains == frozenset()
+        assert assessment.domain_available("mastery_and_novelty") is False
+
+    def test_it_says_why_rather_than_going_quiet(self, validate_profile):
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["classification_schema_version"] = 1
+        del pattern_profile["absence_provability"]
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        provenance = importlib.import_module("profile_pattern_provenance")
+        assert (
+            provenance.REASON_CLASSIFICATION_SCHEMA_SUPERSEDED
+            in assessment.reason_codes
+        )
+
+    def test_its_occurrence_rows_stay_readable(self, validate_profile):
+        """The rows are contract-v5 data, untouched by the classification bump."""
+        pattern_profile = _v5_pattern_profile(validate_profile)
+        pattern_profile["classification_schema_version"] = 1
+        del pattern_profile["absence_provability"]
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        assert assessment.current_contract is True
+        assert assessment.catalog_fields_available is True
+        assert assessment.scored_talk_count == 2
+
+    def test_the_current_generation_keeps_its_domains(self, validate_profile):
+        pattern_profile = _v5_pattern_profile(validate_profile)
+
+        assessment = validate_profile.assess_pattern_profile(
+            pattern_profile, expected_contract_version=5
+        )
+
+        provenance = importlib.import_module("profile_pattern_provenance")
+        assert assessment.classification_fields_available is True
+        assert (
+            provenance.REASON_CLASSIFICATION_SCHEMA_SUPERSEDED
+            not in assessment.reason_codes
+        )
+
     def test_a_v4_contract_cannot_carry_it(self, validate_profile):
         """v4 has no classification block, so it never reaches the generation
         that introduced the field."""

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -144,6 +144,9 @@ def _legacy_pattern_profile() -> dict[str, Any]:
         "pattern_classifications",
         "antipattern_classifications",
         "trend_analysis",
+        # Arrives with classification v2, so it cannot survive the projection back
+        # to a contract that carries no classification block at all.
+        "absence_provability",
     ):
         profile.pop(field)
     profile.update(


### PR DESCRIPTION
## What

Adds `absence_provability` — the provable-set denominator that has to travel
with never-used and underused profile fields.

Part of #160 section 3, implementing the #153 null-absence-gate decision.

## Why

`absence_evaluable_from: null` means absence is not provable for that pattern
and never falls back to the presence gate. So never-used and underused are
computed over the populated-gate entries only.

Against the live catalog that is **16 of 81 observable entries**. 65 are
unknowable.

A never-used list built from 16 patterns, presented without that denominator,
reads as a finding about the speaker. It is mostly a finding about coverage. The
counts are what make the difference legible.

## Design

Computed from the catalog, never hardcoded — populating a gate moves the numbers
rather than dating a constant. A test asserts exactly that by recounting the
observable entries independently.

An unobservable entry lands in neither count: it is not scored at all, so it
belongs to no denominator.

## Verification

- 7 new tests: the live-catalog partition, both gate states, unobservable
  exclusion, and the empty case
- Full suite: **5494 passed, 3 skipped** — the single failure is
  `test_plugin_lint_gate::test_an_over_length_description_fails_the_gate`, which
  fails identically on `main` and passes in CI (pre-existing, environmental)
- `ruff check`, `pyright`: clean

## Remaining on #160

`score_sum` and `canonical_average` in the profile provenance object — both
exist ingress-side in `adherence_baseline.py` and flow into the cohort snapshot
via `pattern_baseline`, so surfacing them profile-side lands with the v6
activation that #293 is waiting on.