### PR TITLE
test: assert the lint gate's outcome, not tessl's wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### test — assert the lint gate's outcome, not tessl's wording (#265)
+
+`test_an_over_length_description_fails_the_gate` matched the literal string
+`Frontmatter validation failed`. tessl 0.96.0 phrases the same rejection as
+`SKILL.md frontmatter field "description" must be at most 1024 characters.`, so
+the test failed locally while the gate it covers worked correctly.
+
+Three PR bodies carried this as a pre-existing environmental failure. It was
+neither: CI passed only because its pinned tessl still emitted the old wording,
+so the next bump would have broken the gate's own test there too.
+
+The assertion now names the outcome and the offending skill — the gate failed
+and the error identifies `demo` — rather than any sentence the external tool
+happened to phrase it with. Matching the new wording would only have swapped
+which CLI version it broke on; the two truncate the message at different points.
+The old wording stays covered by the fake-CLI classification test, which owns a
+captured transcript rather than a live tool.
+
 ### feat(vault-ingress) — refuse a talk binding nothing proved (#176)
 
 The candidate table's `signals` map is the evidence; `agreeing` and `conflicting`

--- a/tests/test_plugin_lint_gate.py
+++ b/tests/test_plugin_lint_gate.py
@@ -179,7 +179,16 @@ def test_an_over_length_description_fails_the_gate(tmp_path: Path) -> None:
     assert result.returncode == 1
     report = json.loads(result.stdout)
     assert report["ok"] is False
-    assert any("Frontmatter validation failed" in error for error in report["errors"])
+    # Assert that the gate rejected, and which skill it rejected — never the
+    # sentence tessl phrased it in. Two CLI versions word this rejection
+    # differently and truncate it at different points ("Frontmatter validation
+    # failed: [" against `SKILL.md frontmatter field "description" must be at
+    # most 1024 characters.`), so any prose match passes on one and fails on the
+    # other while the gate itself is correct on both.
+    assert report["errors"], "an over-length description must produce an error"
+    assert any("demo" in error for error in report["errors"]), (
+        f"no error named the offending skill: {report['errors']}"
+    )
 
 
 def test_a_valid_plugin_passes_the_gate(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

`test_an_over_length_description_fails_the_gate` matched the literal string
`Frontmatter validation failed`. tessl 0.96.0 phrases the same rejection as
`SKILL.md frontmatter field "description" must be at most 1024 characters.`, so
the test failed while the gate it covers worked correctly.

## Why it is not "environmental"

Three PR bodies (#293, #294, #295) carried this as a pre-existing environmental
failure. It was neither. CI passed only because its pinned tessl still emitted
the old wording — the next bump would have broken the gate's own test in CI too.

## The fix

Assert the outcome and which skill was rejected, not the sentence reporting it.

Matching the *new* wording would only have swapped which CLI version it breaks
on: the two truncate the message at different points, so `description` + `1024`
passes on 0.96.0 and fails on the pinned older CLI. Both emit `Skill 'demo':`,
and the differential that proves the gate works — a valid plugin passing — is
already covered by `test_a_valid_plugin_passes_the_gate`.

The old wording stays covered deterministically by
`test_a_hard_error_fails_and_is_reported`, which drives a fake CLI over a
captured transcript rather than a live tool.

## Provenance

Split out of #295 at the policy reviewer's request — it is independent of that
PR's vault-profile work and belongs in its own change per `commit-conventions`
One Change Per Commit.

## Verification

- `tests/test_plugin_lint_gate.py`: 13 passed
- Assertion holds against both CLI wordings