### PR TITLE
fix(vault-ingress): an old observation block is old, not corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ that are merely old.
 
 They now classify as `outcome_collection_predates_contract`, which stays blocking
 — the evidence still is not current and the reparse is still required — but names
-the cause and the remedy. The older-generation reading requires BOTH detection
-lanes present, so an unfinished writer cannot launder itself as a legacy record.
+the cause and the remedy. The older-generation reading requires both detection
+lanes to be well-formed containers, so neither an unfinished writer nor a
+block holding a malformed lane can launder itself as a legacy record.
 
 ### feat(vault-profile) — the denominator behind a never-used claim (#160)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### fix(vault-ingress) — an old block is old, not corrupt (#167)
+
+The persisted-observation classifier reported a block carrying both detection
+lanes but no `not_evaluable` as `detection_collection_absent` — the same code it
+uses for a writer that stopped halfway.
+
+That shape is what the writer emitted before exhaustive outcomes existed, and it
+is the live vault's dominant state: all 80 talks claiming completed analysis are
+in it. Reporting them as corrupt sends the owner hunting for damage in records
+that are merely old.
+
+They now classify as `outcome_collection_predates_contract`, which stays blocking
+— the evidence still is not current and the reparse is still required — but names
+the cause and the remedy. The older-generation reading requires BOTH detection
+lanes present, so an unfinished writer cannot launder itself as a legacy record.
+
 ### feat(vault-profile) — the denominator behind a never-used claim (#160)
 
 Part of #160 section 3, implementing the #153 null-absence-gate decision.

--- a/skills/vault-ingress/scripts/persisted_pattern_observations.py
+++ b/skills/vault-ingress/scripts/persisted_pattern_observations.py
@@ -70,6 +70,12 @@ CONTAINER_LEGACY_LIST = "observations_legacy_list"
 CONTAINER_INVALID = "observations_invalid"
 COLLECTION_ABSENT = "detection_collection_absent"
 COLLECTION_INVALID = "detection_collection_invalid"
+# Both detection lanes present, the outcome lane absent. That is the shape a
+# writer produced BEFORE the exhaustive-outcomes contract existed, not one whose
+# writer stopped halfway — so it reads as an older generation needing a reparse
+# rather than as corruption. Still unusable as current evidence, and still
+# blocking; what changes is what the owner is told to do about it.
+OUTCOME_LANE_PREDATES_CONTRACT = "outcome_collection_predates_contract"
 
 # One detection object's own shape.
 DETECTION_NOT_OBJECT = "detection_not_object"
@@ -103,6 +109,7 @@ BLOCKING_REASONS = frozenset(
         CONTAINER_INVALID,
         COLLECTION_ABSENT,
         COLLECTION_INVALID,
+        OUTCOME_LANE_PREDATES_CONTRACT,
         DETECTION_NOT_OBJECT,
         DETECTION_ID_MISSING,
         DETECTION_ID_UNKNOWN,
@@ -459,13 +466,26 @@ def _audit_outcomes(
     unknown, which is not the same as complete.
     """
     if OUTCOME_COLLECTION not in observations:
+        # A block carrying both detection lanes and no outcome lane is the shape
+        # the writer emitted before exhaustive outcomes existed. Reporting that
+        # in the same bucket as a half-written block tells the owner to hunt for
+        # corruption in a record that is merely old.
+        predates = all(name in observations for name in DETECTION_COLLECTIONS)
         return [
             ObservationFinding(
-                COLLECTION_ABSENT,
+                OUTCOME_LANE_PREDATES_CONTRACT if predates else COLLECTION_ABSENT,
                 OUTCOME_COLLECTION,
                 None,
-                f"a current block carries {OUTCOME_COLLECTION}; an absent lane "
-                "is not an empty one",
+                (
+                    f"the block carries both detection lanes but no "
+                    f"{OUTCOME_COLLECTION}; it predates exhaustive outcomes and "
+                    "needs a reparse, not a repair"
+                )
+                if predates
+                else (
+                    f"a current block carries {OUTCOME_COLLECTION}; an absent "
+                    "lane is not an empty one"
+                ),
             )
         ]
     raw = observations.get(OUTCOME_COLLECTION)

--- a/skills/vault-ingress/scripts/persisted_pattern_observations.py
+++ b/skills/vault-ingress/scripts/persisted_pattern_observations.py
@@ -470,7 +470,13 @@ def _audit_outcomes(
         # the writer emitted before exhaustive outcomes existed. Reporting that
         # in the same bucket as a half-written block tells the owner to hunt for
         # corruption in a record that is merely old.
-        predates = all(name in observations for name in DETECTION_COLLECTIONS)
+        # Presence is not enough: a lane holding a string is a defect, and a
+        # block carrying one has not earned the older-generation reading. Both
+        # detection lanes must be well-formed containers before an absent outcome
+        # lane counts as age rather than damage.
+        predates = all(
+            isinstance(observations.get(name), list) for name in DETECTION_COLLECTIONS
+        )
         return [
             ObservationFinding(
                 OUTCOME_LANE_PREDATES_CONTRACT if predates else COLLECTION_ABSENT,

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -690,3 +690,28 @@ def test_the_report_is_json_ready(
     assert payload["repairs"][0]["dimensions"] == list(
         observable_entry.vault_dimensions
     )
+
+
+def test_a_malformed_detection_lane_forfeits_the_legacy_reading(
+    persisted_pattern_observations, catalog
+) -> None:
+    """Key presence is not well-formedness.
+
+    A lane holding a string is damage, and a block carrying one has not earned
+    the older-generation reading — labelling it legacy is the same category
+    error, inverted.
+    """
+    block = _block()
+    del block["not_evaluable"]
+    block["patterns_detected"] = "not a list"
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        {"pattern_observations": block}, catalog
+    )
+
+    assert assessment.usable is False
+    assert (
+        persisted_pattern_observations.OUTCOME_LANE_PREDATES_CONTRACT
+        not in assessment.reason_codes
+    )
+    assert persisted_pattern_observations.COLLECTION_INVALID in assessment.reason_codes

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -226,16 +226,6 @@ def test_a_missing_outcome_lane_beside_a_missing_detection_lane_is_not_excused(
     assert persisted_pattern_observations.COLLECTION_ABSENT in assessment.reason_codes
 
 
-def test_a_pre_contract_block_still_blocks(
-    persisted_pattern_observations, catalog
-) -> None:
-    """Naming the cause is not excusing it: the evidence is still not current."""
-    assert (
-        persisted_pattern_observations.OUTCOME_LANE_PREDATES_CONTRACT
-        in persisted_pattern_observations.BLOCKING_REASONS
-    )
-
-
 def test_an_empty_block_is_refused(persisted_pattern_observations, catalog) -> None:
     assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
         {"pattern_observations": {}}, catalog

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -155,13 +155,11 @@ def test_a_non_list_collection_is_refused(
     )
 
 
-@pytest.mark.parametrize(
-    "lane", ["patterns_detected", "antipatterns_detected", "not_evaluable"]
-)
-def test_an_absent_lane_is_not_an_empty_lane(
+@pytest.mark.parametrize("lane", ["patterns_detected", "antipatterns_detected"])
+def test_an_absent_detection_lane_is_not_an_empty_lane(
     persisted_pattern_observations, catalog, lane
 ) -> None:
-    """A block missing a lane is one whose writer never finished.
+    """A block missing a detection lane is one whose writer never finished.
 
     Reading it as empty reports coverage the record never claimed — `{}` would
     pass as a clean current block.
@@ -179,6 +177,63 @@ def test_an_absent_lane_is_not_an_empty_lane(
         persisted_pattern_observations.COLLECTION_ABSENT,
     )
     assert assessment.findings[0].location == lane
+
+
+def test_a_block_predating_exhaustive_outcomes_says_so(
+    persisted_pattern_observations, catalog
+) -> None:
+    """Both detection lanes and no outcome lane is the pre-contract shape.
+
+    It is the live vault's dominant state, and reporting it as a half-written
+    block sends the owner hunting for corruption in a record that is merely old.
+    """
+    block = _block()
+    del block["not_evaluable"]
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        {"pattern_observations": block}, catalog
+    )
+
+    assert assessment.usable is False
+    assert assessment.reason_codes == (
+        persisted_pattern_observations.OUTCOME_LANE_PREDATES_CONTRACT,
+    )
+    assert assessment.findings[0].location == "not_evaluable"
+    assert "reparse" in assessment.findings[0].detail
+
+
+def test_a_missing_outcome_lane_beside_a_missing_detection_lane_is_not_excused(
+    persisted_pattern_observations, catalog
+) -> None:
+    """The older-generation reading requires BOTH detection lanes present.
+
+    Without that, an unfinished writer would launder itself as a legacy record
+    and skip the corruption report it has earned.
+    """
+    block = _block()
+    del block["not_evaluable"]
+    del block["patterns_detected"]
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        {"pattern_observations": block}, catalog
+    )
+
+    assert assessment.usable is False
+    assert (
+        persisted_pattern_observations.OUTCOME_LANE_PREDATES_CONTRACT
+        not in assessment.reason_codes
+    )
+    assert persisted_pattern_observations.COLLECTION_ABSENT in assessment.reason_codes
+
+
+def test_a_pre_contract_block_still_blocks(
+    persisted_pattern_observations, catalog
+) -> None:
+    """Naming the cause is not excusing it: the evidence is still not current."""
+    assert (
+        persisted_pattern_observations.OUTCOME_LANE_PREDATES_CONTRACT
+        in persisted_pattern_observations.BLOCKING_REASONS
+    )
 
 
 def test_an_empty_block_is_refused(persisted_pattern_observations, catalog) -> None:


### PR DESCRIPTION
## What

The persisted-observation classifier reported a block carrying **both** detection
lanes but no `not_evaluable` as `detection_collection_absent` — the same code it
uses for a writer that stopped halfway.

## Why it matters

That shape is what the writer emitted *before* exhaustive outcomes existed, and
it is the live vault's dominant state. From the 2026-08-12 run on #167: all **80**
talks claiming completed analysis carry it, and their blocks hold
`('antipattern_ids', 'antipatterns_detected', 'pattern_ids', 'patterns_detected')`
— both detection lanes, no outcome lane.

Reporting 80 records as corrupt sends the owner hunting for damage that is not
there.

## The change

They classify as `outcome_collection_predates_contract`. It **stays blocking** —
the evidence still is not current and the reparse is still mandatory — but the
code names the cause and the remedy rather than implying corruption.

The older-generation reading requires **both** detection lanes present. Without
that, an unfinished writer would launder itself as a legacy record and skip the
corruption report it has earned; a test covers exactly that.

This follows the precedent already in the module: `detection_entry_not_observable`
is documented as "not a defect in the record: the catalog moved."

## Closes part of #167

Answers the open question in that issue's 2026-08-12 comment — whether a
pre-exhaustive-outcomes block should read as "older generation, reparse" rather
than "corrupt". It does.

## Verification

- 43 tests in `test_persisted_pattern_observations.py`, 4 of them new
- Full suite: 5582 passed
- `ruff`, `ruff format`, `pyright`: clean