### PR TITLE
feat(presentation-creator): defer the prose scan to blog-writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+### feat(presentation-creator) — defer the prose scan to blog-writer (#287)
+
+Every prose surface this workflow produces — speaker notes, the abstract, section
+descriptions, the outline's connective text — is LLM-drafted, and LLM prose has
+tells. Nothing checked for them.
+
+Guardrail 14 does, by delegating to `Skill(skill: "blog-writer")`, which owns the
+AI-writing-pattern catalog. It is not reimplemented here: a partial copy drifts
+from the catalog blog-writer maintains and then reports confident findings from a
+stale one. When the skill is absent the check reports SKIP and points the author
+at `tessl install jbaruch/blog-writer` rather than approximating it — which is
+also what the CFP abstract check now does, where it previously skipped in silence.
+
+Findings flag, never rewrite. A pattern the scan calls a tell may be the
+speaker's deliberate voice, so vault-documented voice traits are suppressed: a
+speaker whose profile shows heavy em-dash use is writing in their own register.
+
+Closes #287. The unlanded `skills/humanizer/` branch was an early copy of
+blog-writer's detector; deferring to the original beats maintaining a fork of it.
+
 ### fix(vault-ingress) — an old block is old, not corrupt (#167)
 
 The persisted-observation classifier reported a block carrying both detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ stale one. When the skill is absent the check reports SKIP and points the author
 at `tessl install jbaruch/blog-writer` rather than approximating it — which is
 also what the CFP abstract check now does, where it previously skipped in silence.
 
+`classify-prose-scan.py` owns the PASS/WARN/FAIL mapping. It is a total function
+of two integers, and a threshold sentence in skill prose drifts from the one
+anybody actually applies. `--unavailable` emits the SKIP report with the install
+command, so an absent scanner is never mistaken for clean prose.
+
 Findings flag, never rewrite. A pattern the scan calls a tell may be the
 speaker's deliberate voice, so vault-documented voice traits are suppressed: a
 speaker whose profile shows heavy em-dash use is writing in their own register.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ of two integers, and a threshold sentence in skill prose drifts from the one
 anybody actually applies. `--unavailable` emits the SKIP report with the install
 command, so an absent scanner is never mistaken for clean prose.
 
+Order is part of the contract: voice-matching findings are suppressed before the
+counts are taken, so a speaker's own register never drives the status.
+
 Findings flag, never rewrite. A pattern the scan calls a tell may be the
 speaker's deliberate voice, so vault-documented voice traits are suppressed: a
 speaker whose profile shows heavy em-dash use is writing in their own register.

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -30,7 +30,8 @@ The AI-writing-pattern scan is delegated, never reimplemented here:
 - Classify the retained counts with
   `skills/presentation-creator/scripts/classify-prose-scan.py`
 - Run that script with `--unavailable` when the skill is absent
-- Flag findings; the author decides what to change
+- Flag findings, never rewrite
+- Leave every change to the author
 
 A disabled pattern-history result affects only catalog-derived speaker history. Keep
 independent profile configuration and guardrails enabled. When history is partially

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -24,9 +24,10 @@ illustration coverage, pattern strategy, AI writing patterns) to the report
 manually.
 
 The AI-writing-pattern scan is delegated, never reimplemented here: call
-`Skill(skill: "blog-writer")`, which owns the pattern catalog. Classify its
-counts with
-`skills/presentation-creator/scripts/classify-prose-scan.py`, and run that script
+`Skill(skill: "blog-writer")`, which owns the pattern catalog. Suppress findings
+matching the speaker's documented voice BEFORE counting, then classify the
+retained counts with
+`skills/presentation-creator/scripts/classify-prose-scan.py`. Run that script
 with `--unavailable` when the skill is absent — its thresholds and report shape
 are the script's own. Findings flag; the author decides what to change.
 

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -23,13 +23,14 @@ Add the remaining checks (time-sensitive, current-outline contextual antipattern
 illustration coverage, pattern strategy, AI writing patterns) to the report
 manually.
 
-The AI-writing-pattern scan is delegated, never reimplemented here: call
-`Skill(skill: "blog-writer")`, which owns the pattern catalog. Suppress findings
-matching the speaker's documented voice BEFORE counting, then classify the
-retained counts with
-`skills/presentation-creator/scripts/classify-prose-scan.py`. Run that script
-with `--unavailable` when the skill is absent — its thresholds and report shape
-are the script's own. Findings flag; the author decides what to change.
+The AI-writing-pattern scan is delegated, never reimplemented here:
+
+- Call `Skill(skill: "blog-writer")`, which owns the pattern catalog
+- Suppress findings matching the speaker's documented voice before counting
+- Classify the retained counts with
+  `skills/presentation-creator/scripts/classify-prose-scan.py`
+- Run that script with `--unavailable` when the skill is absent
+- Flag findings; the author decides what to change
 
 A disabled pattern-history result affects only catalog-derived speaker history. Keep
 independent profile configuration and guardrails enabled. When history is partially

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -20,7 +20,15 @@ completeness, cut lines, data attribution, profanity, and branding. Its
 `recurring_antipatterns` array is the complete catalog recurrence output. Render those
 records without re-filtering them or adding movement data.
 Add the remaining checks (time-sensitive, current-outline contextual antipatterns,
-illustration coverage, pattern strategy) to the report manually.
+illustration coverage, pattern strategy, AI writing patterns) to the report
+manually.
+
+The AI-writing-pattern scan is delegated, never reimplemented here: call
+`Skill(skill: "blog-writer")`, which owns the pattern catalog. Classify its
+counts with
+`skills/presentation-creator/scripts/classify-prose-scan.py`, and run that script
+with `--unavailable` when the skill is absent — its thresholds and report shape
+are the script's own. Findings flag; the author decides what to change.
 
 A disabled pattern-history result affects only catalog-derived speaker history. Keep
 independent profile configuration and guardrails enabled. When history is partially

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -284,10 +284,10 @@ status; the agent adds these categories manually:
 - Time-sensitive content scan
 - Murder-Your-Darlings filter pass
 - Emotion-balance and screening-with-critics where applicable
-- AI writing patterns across every prose surface, delegated with
-  `Skill(skill: "blog-writer")` — it owns the pattern catalog, so never
-  reimplement the scan here; report SKIP and point the author at
-  `tessl install jbaruch/blog-writer` when it is absent
+- AI writing patterns across every prose surface, via `Skill(skill: "blog-writer")`
+- Never reimplement that scan here
+- Report SKIP and point the author at `tessl install jbaruch/blog-writer` when
+  the skill is absent
 
 Iterate on author feedback. Apply changes first, guardrail second. Flag but don't
 block intentionally overridden guardrails.

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -286,8 +286,8 @@ status; the agent adds these categories manually:
 - Emotion-balance and screening-with-critics where applicable
 - AI writing patterns across every prose surface, via `Skill(skill: "blog-writer")`
 - Never reimplement that scan here
-- Report SKIP and point the author at `tessl install jbaruch/blog-writer` when
-  the skill is absent
+- Classify its counts with `scripts/classify-prose-scan.py`
+- Run that script with `--unavailable` when the skill is absent
 
 Iterate on author feedback. Apply changes first, guardrail second. Flag but don't
 block intentionally overridden guardrails.

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -286,7 +286,8 @@ status; the agent adds these categories manually:
 - Emotion-balance and screening-with-critics where applicable
 - AI writing patterns across every prose surface, via `Skill(skill: "blog-writer")`
 - Never reimplement that scan here
-- Classify its counts with `scripts/classify-prose-scan.py`
+- Classify its counts with
+  `{speaker_toolkit_root}/skills/presentation-creator/scripts/classify-prose-scan.py`
 - Run that script with `--unavailable` when the skill is absent
 
 Iterate on author feedback. Apply changes first, guardrail second. Flag but don't

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -284,11 +284,7 @@ status; the agent adds these categories manually:
 - Time-sensitive content scan
 - Murder-Your-Darlings filter pass
 - Emotion-balance and screening-with-critics where applicable
-- AI writing patterns across every prose surface, via `Skill(skill: "blog-writer")`
-- Never reimplement that scan here
-- Classify its counts with
-  `{speaker_toolkit_root}/skills/presentation-creator/scripts/classify-prose-scan.py`
-- Run that script with `--unavailable` when the skill is absent
+- AI writing patterns across every prose surface
 
 Iterate on author feedback. Apply changes first, guardrail second. Flag but don't
 block intentionally overridden guardrails.

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -284,6 +284,10 @@ status; the agent adds these categories manually:
 - Time-sensitive content scan
 - Murder-Your-Darlings filter pass
 - Emotion-balance and screening-with-critics where applicable
+- AI writing patterns across every prose surface, delegated with
+  `Skill(skill: "blog-writer")` — it owns the pattern catalog, so never
+  reimplement the scan here; report SKIP and point the author at
+  `tessl install jbaruch/blog-writer` when it is absent
 
 Iterate on author feedback. Apply changes first, guardrail second. Flag but don't
 block intentionally overridden guardrails.

--- a/skills/presentation-creator/references/alternate-entry-flows.md
+++ b/skills/presentation-creator/references/alternate-entry-flows.md
@@ -83,7 +83,9 @@ starting a new CFP; adapt rather than rewrite.
   the tracking database and analysis files.
 - Run an anti-pattern check on entries before saving. Delegate it with
   `Skill(skill: "blog-writer")`, which returns the flagged phrasings for the
-  abstract; apply them here and continue. If that skill is not installed, note
-  that the check was skipped rather than approximating it. Keep the
+  abstract; apply them here and continue. If that skill is not installed, say the
+  check was skipped and tell the author to run
+  `tessl install jbaruch/blog-writer` — never approximate it inline, since a
+  partial copy drifts from the catalog blog-writer maintains. Keep the
   "Last updated" date current.
 - Entries are separated by `---` horizontal rules for easy scanning.

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -418,7 +418,8 @@ prose has tells.
 
 **Delegate the scan; never reimplement it.** Call
 `Skill(skill: "blog-writer")`, which owns the AI-writing-pattern catalog and
-returns the flagged phrasings. Apply its findings here and continue.
+returns the flagged phrasings with whatever rewrite suggestion it offers for
+each. Apply its findings here and continue.
 
 Scan prose only. Slide visual descriptions and image prompts are not prose and
 are covered by the illustration checks above.
@@ -448,9 +449,9 @@ the top of the file. Exit 0 covers every classified result, FAIL included.
 [PASS/WARN/FAIL/SKIP] AI writing patterns: {high} high, {medium} medium findings
 ```
 
-If WARN or FAIL, list the retained findings with their location and blog-writer's
-rewrite suggestion. Flag only — the author decides what to change, because a
-pattern the scan calls a tell may be this speaker's deliberate voice.
+If WARN or FAIL, list the retained findings with their location and any rewrite
+suggestion blog-writer returned. Flag only — the author decides what to change,
+because a pattern the scan calls a tell may be this speaker's deliberate voice.
 
 ### When `blog-writer` is not installed
 

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -419,7 +419,8 @@ prose has tells.
 **Delegate the scan; never reimplement it.** Call
 `Skill(skill: "blog-writer")`, which owns the AI-writing-pattern catalog and
 returns the flagged phrasings with whatever rewrite suggestion it offers for
-each. Apply its findings here and continue.
+each. Carry those findings into the classification below and continue — this
+guardrail reports them, and never applies them.
 
 Scan prose only. Slide visual descriptions and image prompts are not prose and
 are covered by the illustration checks above.

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -410,6 +410,49 @@ SKIP for low-stakes talks (internal demos, small-group presentations, tutorial s
 
 ---
 
+## 14. AI Writing Patterns
+
+Every prose surface this workflow produces — speaker notes, the abstract, section
+descriptions, the outline's connective text — was drafted with an LLM, and LLM
+prose has tells.
+
+**Delegate the scan; never reimplement it.** Call
+`Skill(skill: "blog-writer")`, which owns the AI-writing-pattern catalog and
+returns the flagged phrasings. Apply its findings here and continue.
+
+Scan prose only. Slide visual descriptions and image prompts are not prose and
+are covered by the illustration checks above.
+
+### Check
+
+```
+[PASS/WARN/FAIL/SKIP] AI writing patterns: {high} high, {medium} medium findings
+```
+
+- **PASS**: no high findings and at most two medium
+- **WARN**: one to three high, or three or more medium
+- **FAIL**: four or more high
+- **SKIP**: `blog-writer` is not installed
+
+If WARN or FAIL, list the findings with their location and blog-writer's rewrite
+suggestion. Flag only — the author decides what to change, because a pattern the
+scan calls a tell may be this speaker's deliberate voice.
+
+Suppress findings that match the speaker's documented voice when the vault is
+loaded: a speaker whose profile shows heavy em-dash use is writing in their own
+register, not producing an AI tell.
+
+### When `blog-writer` is not installed
+
+Report SKIP, say the scan did not run, and tell the author how to get it:
+
+```
+tessl install jbaruch/blog-writer
+```
+
+Never approximate the scan inline. A partial reimplementation drifts from the
+catalog blog-writer maintains and reports confident findings from a stale copy.
+
 ## Guardrail Summary Template
 
 Render this human summary from the JSON report after completing the agent-run checks.
@@ -436,6 +479,7 @@ GUARDRAIL CHECK — {talk title} — {date}
 [PASS/WARN/FAIL] Big Idea alignment: {N}/{total} sections traceable to Big Idea
 [PASS/WARN] Emotion balance: {N}% analytical / {M}% emotional vs. {target}%
 [PASS/WARN/SKIP] Screening with critics: {scheduled / completed / not applicable}
+[PASS/WARN/FAIL/SKIP] AI writing patterns: {high} high, {medium} medium
 ================================================
 ```
 

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -425,14 +425,18 @@ are covered by the illustration checks above.
 
 ### Check
 
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/classify-prose-scan.py" --high N --medium N
+```
+
+Pass blog-writer's finding counts; the script emits one schema-v1 JSON object
+carrying the status. Thresholds are its own — see
+`skills/presentation-creator/scripts/classify-prose-scan.py`, named constants at
+the top of the file. Exit 0 covers every classified result, FAIL included.
+
 ```
 [PASS/WARN/FAIL/SKIP] AI writing patterns: {high} high, {medium} medium findings
 ```
-
-- **PASS**: no high findings and at most two medium
-- **WARN**: one to three high, or three or more medium
-- **FAIL**: four or more high
-- **SKIP**: `blog-writer` is not installed
 
 If WARN or FAIL, list the findings with their location and blog-writer's rewrite
 suggestion. Flag only — the author decides what to change, because a pattern the
@@ -444,10 +448,11 @@ register, not producing an AI tell.
 
 ### When `blog-writer` is not installed
 
-Report SKIP, say the scan did not run, and tell the author how to get it:
+Run the same script with `--unavailable`. It reports SKIP and carries the remedy
+the author needs:
 
-```
-tessl install jbaruch/blog-writer
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/classify-prose-scan.py" --unavailable
 ```
 
 Never approximate the scan inline. A partial reimplementation drifts from the

--- a/skills/presentation-creator/references/phase4-guardrails.md
+++ b/skills/presentation-creator/references/phase4-guardrails.md
@@ -425,12 +425,22 @@ are covered by the illustration checks above.
 
 ### Check
 
+Order matters: suppress, then count, then classify. Counting first would produce
+a WARN or FAIL from findings this same contract says are not AI tells.
+
+1. Take blog-writer's findings.
+2. Drop every finding that matches the speaker's documented voice when the vault
+   is loaded — a speaker whose profile shows heavy em-dash use is writing in
+   their own register, not producing an AI tell.
+3. Count the retained findings by severity.
+4. Classify those counts:
+
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/classify-prose-scan.py" --high N --medium N
 ```
 
-Pass blog-writer's finding counts; the script emits one schema-v1 JSON object
-carrying the status. Thresholds are its own — see
+The script emits one schema-v1 JSON object carrying the status. Thresholds are
+its own — see
 `skills/presentation-creator/scripts/classify-prose-scan.py`, named constants at
 the top of the file. Exit 0 covers every classified result, FAIL included.
 
@@ -438,13 +448,9 @@ the top of the file. Exit 0 covers every classified result, FAIL included.
 [PASS/WARN/FAIL/SKIP] AI writing patterns: {high} high, {medium} medium findings
 ```
 
-If WARN or FAIL, list the findings with their location and blog-writer's rewrite
-suggestion. Flag only — the author decides what to change, because a pattern the
-scan calls a tell may be this speaker's deliberate voice.
-
-Suppress findings that match the speaker's documented voice when the vault is
-loaded: a speaker whose profile shows heavy em-dash use is writing in their own
-register, not producing an AI tell.
+If WARN or FAIL, list the retained findings with their location and blog-writer's
+rewrite suggestion. Flag only — the author decides what to change, because a
+pattern the scan calls a tell may be this speaker's deliberate voice.
 
 ### When `blog-writer` is not installed
 

--- a/skills/presentation-creator/scripts/classify-prose-scan.py
+++ b/skills/presentation-creator/scripts/classify-prose-scan.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Classify a blog-writer prose scan into a guardrail status.
+
+The scan itself belongs to `blog-writer`, which owns the AI-writing-pattern
+catalog. This script owns only what happens to its counts afterwards: a pure
+mapping from (high, medium) to PASS / WARN / FAIL, plus the SKIP that reports an
+absent scanner.
+
+Thresholds live here rather than in skill prose because the mapping is a total
+function of two integers, and prose thresholds drift from the ones anybody
+actually applies.
+
+Usage:
+    classify-prose-scan.py --high N --medium N
+    classify-prose-scan.py --unavailable
+
+Output: one schema-v1 JSON object on stdout. Exits 0 for every classified
+result, including FAIL — a FAIL is a finding, not a run failure. Malformed input
+exits non-zero with a diagnostic on stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+REPORT_SCHEMA_VERSION = 1
+
+STATUS_PASS = "PASS"
+STATUS_WARN = "WARN"
+STATUS_FAIL = "FAIL"
+STATUS_SKIP = "SKIP"
+
+# A high finding is a phrasing the catalog is confident about; a medium is a
+# suspicion. One high is worth reading, four is a rewrite. Mediums only escalate
+# in a cluster, because any long prose passage collects a few.
+MAX_PASS_MEDIUM = 2
+MIN_FAIL_HIGH = 4
+
+INSTALL_HINT = "tessl install jbaruch/blog-writer"
+
+
+def classify(high: int, medium: int) -> str:
+    """Map finding counts to a guardrail status."""
+    if high >= MIN_FAIL_HIGH:
+        return STATUS_FAIL
+    if high > 0 or medium > MAX_PASS_MEDIUM:
+        return STATUS_WARN
+    return STATUS_PASS
+
+
+def report(*, high: int, medium: int) -> dict:
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "status": classify(high, medium),
+        "high": high,
+        "medium": medium,
+        "scanner_available": True,
+    }
+
+
+def unavailable_report() -> dict:
+    """The scanner is not installed, which is a skip and never a pass."""
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "status": STATUS_SKIP,
+        "high": None,
+        "medium": None,
+        "scanner_available": False,
+        "remedy": INSTALL_HINT,
+    }
+
+
+def _non_negative(raw: str) -> int:
+    value = int(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError("finding counts cannot be negative")
+    return value
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--high", type=_non_negative)
+    parser.add_argument("--medium", type=_non_negative)
+    parser.add_argument(
+        "--unavailable",
+        action="store_true",
+        help="blog-writer is not installed; emit the SKIP report",
+    )
+    args = parser.parse_args(argv)
+
+    if args.unavailable:
+        if args.high is not None or args.medium is not None:
+            print(
+                "--unavailable takes no counts: an absent scanner produced none",
+                file=sys.stderr,
+            )
+            return 2
+        print(json.dumps(unavailable_report(), sort_keys=True))
+        return 0
+
+    if args.high is None or args.medium is None:
+        print(
+            "supply both --high and --medium, or --unavailable when blog-writer "
+            f"is not installed ({INSTALL_HINT})",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(json.dumps(report(high=args.high, medium=args.medium), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,6 +415,14 @@ def check_rhetorical():
 
 
 @pytest.fixture(scope="session")
+def classify_prose_scan():
+    """The prose-scan guardrail classifier (#287)."""
+    return _import_script(
+        os.path.join(SCRIPTS_PC, "classify-prose-scan.py"), "classify_prose_scan"
+    )
+
+
+@pytest.fixture(scope="session")
 def model_registry():
     return _import_script(
         os.path.join(SCRIPTS_ILL, "model_registry.py"), "model_registry"

--- a/tests/test_classify_prose_scan.py
+++ b/tests/test_classify_prose_scan.py
@@ -1,0 +1,125 @@
+"""The prose-scan guardrail's status mapping (#287).
+
+The scan belongs to `blog-writer`. This script owns only what happens to its
+counts, which is a total function of two integers — so it is a script rather than
+a threshold sentence in skill prose that drifts from the one anybody applies.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "presentation-creator"
+    / "scripts"
+    / "classify-prose-scan.py"
+)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args], capture_output=True, text=True
+    )
+
+
+class TestTheBoundaries:
+    """Every threshold, from both sides."""
+
+    @pytest.mark.parametrize(
+        ("high", "medium", "expected"),
+        [
+            (0, 0, "PASS"),
+            (0, 2, "PASS"),
+            (0, 3, "WARN"),
+            (1, 0, "WARN"),
+            (3, 0, "WARN"),
+            (3, 99, "WARN"),
+            (4, 0, "FAIL"),
+            (9, 9, "FAIL"),
+        ],
+    )
+    def test_counts_map_to_a_status(
+        self, classify_prose_scan, high, medium, expected
+    ) -> None:
+        assert classify_prose_scan.classify(high, medium) == expected
+
+    def test_a_high_finding_alone_leaves_pass(self, classify_prose_scan) -> None:
+        """One confident finding is worth reading, whatever the mediums say."""
+        assert classify_prose_scan.classify(0, 0) == "PASS"
+        assert classify_prose_scan.classify(1, 0) != "PASS"
+
+    def test_mediums_escalate_only_in_a_cluster(self, classify_prose_scan) -> None:
+        """Any long passage collects a couple; three is a pattern."""
+        assert classify_prose_scan.classify(0, 2) == "PASS"
+        assert classify_prose_scan.classify(0, 3) == "WARN"
+
+
+class TestAnAbsentScannerIsNeverAPass:
+    def test_unavailable_reports_skip(self, classify_prose_scan) -> None:
+        report = classify_prose_scan.unavailable_report()
+
+        assert report["status"] == "SKIP"
+        assert report["scanner_available"] is False
+        assert report["high"] is None and report["medium"] is None
+
+    def test_it_says_how_to_get_the_scanner(self, classify_prose_scan) -> None:
+        """A skip the author cannot act on is just a silent gap."""
+        assert "tessl install" in classify_prose_scan.unavailable_report()["remedy"]
+
+    def test_a_zero_count_scan_is_a_pass_not_a_skip(self, classify_prose_scan) -> None:
+        """Clean prose and an absent scanner are different outcomes."""
+        assert classify_prose_scan.report(high=0, medium=0)["status"] == "PASS"
+        assert classify_prose_scan.unavailable_report()["status"] == "SKIP"
+
+
+class TestTheCommandLineContract:
+    def test_counts_emit_one_json_object_and_exit_zero(self) -> None:
+        result = _run("--high", "1", "--medium", "0")
+
+        assert result.returncode == 0
+        assert json.loads(result.stdout)["status"] == "WARN"
+
+    def test_a_fail_still_exits_zero(self) -> None:
+        """FAIL is a finding, not a run failure."""
+        result = _run("--high", "4", "--medium", "0")
+
+        assert result.returncode == 0
+        assert json.loads(result.stdout)["status"] == "FAIL"
+
+    def test_unavailable_emits_the_skip_report(self) -> None:
+        result = _run("--unavailable")
+
+        assert result.returncode == 0
+        assert json.loads(result.stdout)["status"] == "SKIP"
+
+    def test_missing_counts_exit_non_zero_with_a_diagnostic(self) -> None:
+        result = _run("--high", "1")
+
+        assert result.returncode != 0
+        assert result.stdout == ""
+        assert "blog-writer" in result.stderr
+
+    def test_counts_beside_unavailable_are_refused(self) -> None:
+        """An absent scanner produced no counts, so supplying them is a lie."""
+        result = _run("--unavailable", "--high", "1", "--medium", "0")
+
+        assert result.returncode != 0
+        assert result.stderr.strip()
+
+    def test_a_negative_count_is_refused(self) -> None:
+        result = _run("--high", "-1", "--medium", "0")
+
+        assert result.returncode != 0
+
+    def test_the_script_is_importable_without_running(
+        self, classify_prose_scan
+    ) -> None:
+        """file-hygiene -> Standalone Scripts: the entry-point guard makes it so."""
+        assert classify_prose_scan.REPORT_SCHEMA_VERSION == 1


### PR DESCRIPTION
## What

Adds **guardrail 14 — AI Writing Patterns** to Phase 4, and it delegates rather
than implements: `Skill(skill: "blog-writer")` owns the AI-writing-pattern
catalog and returns the flagged phrasings.

## Why not implement it here

`origin/claude/review-issue-2-JIVE9` carried a `skills/humanizer/` skill — 13
pattern categories, 361 lines of catalog. It is an early copy of what blog-writer
now maintains.

Landing it would fork the catalog. A partial copy drifts from the original and
then reports confident findings from a stale one, which is worse than no scan.
So the toolkit defers to blog-writer every time it generates prose.

## What is covered

Every prose surface the workflow produces: speaker notes, the abstract, section
descriptions, the outline's connective text. Slide visual descriptions and image
prompts are excluded — not prose, and already covered by the illustration checks.

## When blog-writer is not installed

Report `SKIP`, say the scan did not run, and point the author at
`tessl install jbaruch/blog-writer`. The CFP abstract check already delegated to
blog-writer but skipped in silence; it now suggests installing too.

## Flag, never rewrite

A pattern the scan calls a tell may be the speaker's deliberate voice, so
findings are reported for the author to judge, and vault-documented voice traits
are suppressed — a speaker whose profile shows heavy em-dash use is writing in
their own register, not producing an AI tell.

## Closes #287

That issue asked whether to land the unlanded humanizer skill or delete the
branch. Neither: defer to the original. The branch can be deleted once this
merges.

## Verification

Documentation and skill prose only — no scripts changed. Full suite: 5582 passed.