### PR TITLE
docs(vault-profile): name the field the function actually returns

### DIFF
--- a/skills/vault-profile/scripts/profile_pattern_provenance.py
+++ b/skills/vault-profile/scripts/profile_pattern_provenance.py
@@ -1776,7 +1776,7 @@ def absence_provability(catalog: object) -> dict[str, int]:
 
     Without the denominator beside them, a short never-used list reads as a
     statement about the speaker. It is mostly a statement about coverage, and
-    `absence_unknowable` is what makes the difference legible.
+    `absence_unknowable_count` is what makes the difference legible.
     """
     provable = 0
     unknowable = 0


### PR DESCRIPTION
## What

`absence_provability()`'s docstring refers to `absence_unknowable`. The emitted
key is `absence_unknowable_count`, and no `absence_unknowable` key exists.

One line. Copilot raised it as an advisory on #295; per `review-severity` a lone
advisory does not earn a dedicated re-review round there, so it was deferred to
here rather than dropped.

## Verification

Docstring only. `tests/test_absence_provability.py`: 15 passed. `ruff` clean.