### PR TITLE
docs: reference the prose-scan contract instead of repeating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### docs — the guardrail rule references the contract instead of repeating it
+
+`rules/guardrail-rules.md` had grown a copy of the prose scan's invocation,
+suppression, classification, and absent-scanner steps, which
+`phase4-guardrails.md` already carries. Rules state the contract; skills carry
+the executable form, and two copies of one contract drift.
+
+Also renames `test_a_high_finding_alone_leaves_pass` — its assertion is that a
+single high finding does NOT leave PASS, so the name said the opposite of the
+test.
+
 ### feat(presentation-creator) — defer the prose scan to blog-writer (#287)
 
 Every prose surface this workflow produces — speaker notes, the abstract, section

--- a/rules/guardrail-rules.md
+++ b/rules/guardrail-rules.md
@@ -23,15 +23,10 @@ Add the remaining checks (time-sensitive, current-outline contextual antipattern
 illustration coverage, pattern strategy, AI writing patterns) to the report
 manually.
 
-The AI-writing-pattern scan is delegated, never reimplemented here:
-
-- Call `Skill(skill: "blog-writer")`, which owns the pattern catalog
-- Suppress findings matching the speaker's documented voice before counting
-- Classify the retained counts with
-  `skills/presentation-creator/scripts/classify-prose-scan.py`
-- Run that script with `--unavailable` when the skill is absent
-- Flag findings, never rewrite
-- Leave every change to the author
+The AI-writing-pattern scan is delegated to `blog-writer`, never reimplemented
+here, and it reports findings without applying them. Its execution contract —
+invocation, voice suppression, classification, and the absent-scanner path — is
+in `skills/presentation-creator/references/phase4-guardrails.md`.
 
 A disabled pattern-history result affects only catalog-derived speaker history. Keep
 independent profile configuration and guardrails enabled. When history is partially

--- a/tests/test_classify_prose_scan.py
+++ b/tests/test_classify_prose_scan.py
@@ -50,7 +50,7 @@ class TestTheBoundaries:
     ) -> None:
         assert classify_prose_scan.classify(high, medium) == expected
 
-    def test_a_high_finding_alone_leaves_pass(self, classify_prose_scan) -> None:
+    def test_a_single_high_finding_ends_pass(self, classify_prose_scan) -> None:
         """One confident finding is worth reading, whatever the mediums say."""
         assert classify_prose_scan.classify(0, 0) == "PASS"
         assert classify_prose_scan.classify(1, 0) != "PASS"


### PR DESCRIPTION
## What

Two advisories from #300, deferred there rather than burning a re-review round
on a green PR.

**1. `rules/guardrail-rules.md` duplicated the execution contract.** It had grown
a copy of the prose scan's invocation, voice suppression, classification, and
absent-scanner steps — all of which `phase4-guardrails.md` already owns.
`context-artifacts` Consistency Check: rules state the contract, skills carry the
executable form, and two copies of one contract drift. The rule now states the
policy and points at the reference.

**2. A test name said the opposite of its assertion.**
`test_a_high_finding_alone_leaves_pass` asserts that a single high finding does
**not** leave PASS. Renamed to `test_a_single_high_finding_ends_pass`; behaviour
unchanged.

## Verification

Full suite: 5643 passed. `ruff`, `ruff format`, `pyright` clean.