### PR TITLE
feat(vault-ingress): assess the bindings that predate the assessment (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ public in its owner module, so the deck reader shares one containment rule with
 the evidence classifier rather than copying it. The sweep must not be able to
 read a file the classifier would have refused.
 
+An absent or blank `config.pptx_source_dir` falls back to the vault root, as
+`schemas-db.md` documents. Passing the absent value through would report every
+deck in such a vault unreadable — a configuration default read as universal
+damage, putting every binding into `binding_unproven` on evidence nobody
+looked for.
+
 The published-PDF signal is not observed. The vault's talk-referenced PDFs live
 under the vault's own `slides/`, never beside a deck, so no deterministic
 deck-to-PDF binding exists to read — and guessing one would manufacture exactly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+### feat(vault-ingress) — assess the bindings that predate the assessment (#176)
+
+`_apply_record_pptx` refuses a new talk binding nothing proved, and preflight
+blocks a catalog row whose binding is unproven. Neither could say anything about
+the rows already stored: the live vault's 82 catalog rows are all schema v1, its
+74 bound rows carry no `identity_assessment` at all, and migration deliberately
+leaves v1 rows alone rather than inventing one. So every one of them blocks, and
+nothing in the toolkit could tell a correct binding from a wrong one.
+
+`skills/vault-ingress/scripts/sweep-pptx-talk-identity.py` is the catalog-wide
+assessment. It runs every row against every talk in the vault and reports one
+disposition each — `binding_confirmed`, `binding_contradicted`,
+`binding_review_required`, `binding_unproven`, `unbound_row`. Read-only: a
+disposition is evidence for an owner decision, never a decision.
+
+`skills/vault-ingress/scripts/pptx_deck_facts.py` is the observer it needed.
+`pptx_talk_identity` decides from facts someone else gathered, and no one
+gathered them for a deck already on disk. It reads `docProps/core.xml`,
+`docProps/app.xml`, and the title slide out of the OPC package — stdlib only,
+bounded per part, and never fatal, so a damaged deck is still assessed from its
+path rather than skipped.
+
+Only the title slide supplies rendered text, and that is load-bearing. Feeding
+in `app.xml`'s full slide-title list instead made 69 of the live vault's 74
+bound decks `identity_ambiguous_candidates`: a deck that mentions another talk's
+title on an interior slide agrees with that talk, and a deck agreeing with
+everything is indistinguishable from one carrying no evidence. Measured, not
+reasoned about.
+
+Against the live vault the sweep resolves 30 bindings, contradicts 7, and leaves
+37 for review. The 7 are real: `UberConf/2023/DevOps Reframed.pptx` was bound to
+a BaselOne talk, `Devoxx/Ukraine/2023/DPE with LLM.pptx` to a 2024 Devoxx one,
+and `DeveloperWeek/CA 2024/Sadogursky, Baruch, Fri.pptx` — same venue, same day
+as the talk it was bound to, so only the deck's own title slide could tell them
+apart — to the wrong one of two Developer Week 2024 talks.
+
+The candidate table is serialized down to material candidates. 215 talks against
+82 rows means a row's table is mostly six-`unknown` verdicts, and emitting those
+buries the handful that decided the verdict. Every candidate that could have
+contested the winner had to agree with something, so it survives the trim; a
+test asserts the trimmed assessment still satisfies `binding_refusal`.
+
+`pptx_catalog_selection._open_contained` becomes `open_contained_descriptor`,
+public in its owner module, so the deck reader shares one containment rule with
+the evidence classifier rather than copying it. The sweep must not be able to
+read a file the classifier would have refused.
+
+The published-PDF signal is not observed. The vault's talk-referenced PDFs live
+under the vault's own `slides/`, never beside a deck, so no deterministic
+deck-to-PDF binding exists to read — and guessing one would manufacture exactly
+the evidence this contract exists to require. The signal stays covered by a
+contract regression so a future producer inherits it.
+
+Carries this issue's synthetic regressions: same-title decks across venues and
+years, unrelated decks in nearby directories, master/static pairs with different
+slide counts, and a published PDF that disambiguates two candidates.
+
 ## 0.20.69 — 2026-08-13
 
 ### docs — the guardrail rule references the contract instead of repeating it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ title on an interior slide agrees with that talk, and a deck agreeing with
 everything is indistinguishable from one carrying no evidence. Measured, not
 reasoned about.
 
+Which part IS the title slide comes from `ppt/presentation.xml`'s `sldIdLst`
+resolved through the presentation's relationships — never from the part name
+`ppt/slides/slide1.xml`. OPC leaves slide order to that list, so a reordered
+deck can hold an interior slide in `slide1.xml`, and reading it would feed
+interior text in as the deck's own title: the same defect the title-slide rule
+exists to avoid, arriving by a different door. When the chain cannot be
+resolved no slide is opened at all, and `app.xml`'s slide-title list — which is
+already in presentation order — supplies the title instead. Guessing a part
+name is what this replaced.
+
 Against the live vault the sweep resolves 30 bindings, contradicts 7, and leaves
 37 for review. The 7 are real: `UberConf/2023/DevOps Reframed.pptx` was bound to
 a BaselOne talk, `Devoxx/Ukraine/2023/DPE with LLM.pptx` to a 2024 Devoxx one,

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -253,11 +253,19 @@ every one of them. Assess the whole catalog at once with:
   "{vault_root}"
 ```
 
-Read-only. It reports one disposition per row — the taxonomy and the signals it
-observes are in the script's module docstring. `binding_contradicted` names a
-deck feeding one talk's evidence to another and is owner-review work before any
-reparse; `binding_confirmed` supplies the assessment a `record_pptx` write
-carries. `--dispositions` narrows the reported rows without changing the counts.
+Read-only. Stdout is one JSON object carrying `disposition_counts`,
+`unresolved_binding_count`, and a `rows[]` entry per catalog row. Exit 0 means
+the catalog was assessed — contradictions included, since this reports rather
+than gates; preflight is the gate. Exit 2 means the database is unusable and
+writes an error object with a closed `code` to stdout plus one diagnostic line
+to stderr; stop there and repair the database, never consume a failed report as
+if the catalog were clean. The disposition taxonomy and the signals it observes
+are in the script's module docstring.
+
+`binding_contradicted` names a deck feeding one talk's evidence to another and
+is owner-review work before any reparse; `binding_confirmed` supplies the
+assessment a `record_pptx` write carries. `--dispositions` narrows the reported
+rows without changing the counts.
 Never decide from
 `visual_extracted` alone whether a deck needs extraction. Run:
 

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -244,6 +244,20 @@ The writer rejects an assessment that does not authorize the binding; the
 predicate is `binding_refusal` in
 `skills/vault-ingress/scripts/pptx_talk_identity.py`, shared with preflight. Route a rejected deck to owner review
 rather than persisting it.
+
+Rows bound before that writer existed carry no assessment, and preflight blocks
+every one of them. Assess the whole catalog at once with:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py" \
+  "{vault_root}"
+```
+
+Read-only. It reports one disposition per row — the taxonomy and the signals it
+observes are in the script's module docstring. `binding_contradicted` names a
+deck feeding one talk's evidence to another and is owner-review work before any
+reparse; `binding_confirmed` supplies the assessment a `record_pptx` write
+carries. `--dispositions` narrows the reported rows without changing the counts.
 Never decide from
 `visual_extracted` alone whether a deck needs extraction. Run:
 

--- a/skills/vault-ingress/scripts/pptx_catalog_selection.py
+++ b/skills/vault-ingress/scripts/pptx_catalog_selection.py
@@ -44,7 +44,7 @@ _READ_CHUNK_BYTES = 1024 * 1024
 _REQUIRED_OPEN_FLAGS = ("O_NOFOLLOW", "O_DIRECTORY")
 
 
-def _open_contained(root: object, parts: tuple[str, ...]) -> int | None:
+def open_contained_descriptor(root: object, parts: tuple[str, ...]) -> int | None:
     """Open a descendant of ``root``, refusing every symlink below the root.
 
     Checking a resolved path and then opening it by name are two separate
@@ -115,7 +115,7 @@ def digest_and_size(path: object, root: object) -> tuple[str, int] | None:
         parts = resolved.relative_to(Path(str(root))).parts
     except (ArtifactLocatorError, TypeError, ValueError):
         return None
-    descriptor = _open_contained(root, parts)
+    descriptor = open_contained_descriptor(root, parts)
     if descriptor is None:
         return None
     digest = hashlib.sha256()
@@ -217,4 +217,5 @@ __all__ = [
     "digest_and_size",
     "observed_artifact_digest",
     "observed_source_fingerprint",
+    "open_contained_descriptor",
 ]

--- a/skills/vault-ingress/scripts/pptx_deck_facts.py
+++ b/skills/vault-ingress/scripts/pptx_deck_facts.py
@@ -1,0 +1,401 @@
+"""Read a deck's deterministic identity facts out of its OPC package (#176).
+
+`pptx_talk_identity` decides which talk a deck belongs to from facts someone
+else observed. This module is that observer for a deck already on disk: it
+opens the package, reads two small metadata parts and the title slide, and
+returns the mapping `deck_identity_facts` accepts.
+
+Three properties shape it.
+
+* **Bounded.** Only `docProps/core.xml`, `docProps/app.xml`, and the first
+  slide are read, each under an expanded-size cap. A catalog row is persisted
+  state, and persisted state is a hint, never a licence to decompress an
+  arbitrary host file (`stateful-artifacts` -> Hints, Not Authority).
+* **Never fatal.** An unreadable, damaged, or absent deck returns the facts
+  gathered so far with a reason code. Damage must weaken the evidence, never
+  the identity requirements, so the caller still assesses the deck from its
+  path rather than skipping it.
+* **Nothing invented.** A part that is missing or malformed contributes no
+  fact. Absence is reported as absence; the identity module's `unknown`
+  verdict already means "this deck does not carry that fact".
+
+## Why the title slide and not every slide title
+
+`docProps/app.xml` lists every slide's title, and feeding that list in as
+rendered text is actively wrong. Measured against the live vault's 74 bound
+decks, passing all 95 slide titles of one deck made 69 of the 74 assessments
+`identity_ambiguous_candidates`: a deck that mentions another talk's title on
+some interior slide agrees with that talk, and agreeing with everything is
+indistinguishable from knowing nothing.
+
+The title slide cannot do that. Its runs are this deck's own title and
+subtitle, which is what the catalog's title is being compared against.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from artifact_locator import (
+    ArtifactLocatorError,
+    classify_artifact_locator,
+    materialize_artifact_locator,
+)
+from pptx_catalog_selection import open_contained_descriptor
+
+DECK_FACTS_SCHEMA_VERSION = 1
+
+# Reason codes are closed. They report why a fact is absent, never what the
+# host filesystem or the archive's bytes look like (`no-secrets` -> Logging).
+DECK_FACTS_OK = "deck_facts_read"
+DECK_FACTS_LOCATOR_INVALID = "deck_facts_locator_invalid"
+DECK_FACTS_UNREADABLE = "deck_facts_unreadable"
+DECK_FACTS_NOT_A_PACKAGE = "deck_facts_not_a_package"
+DECK_FACTS_PACKAGE_OVERSIZED = "deck_facts_package_oversized"
+DECK_FACTS_PART_UNREADABLE = "deck_facts_part_unreadable"
+DECK_FACTS_PARTS_ABSENT = "deck_facts_parts_absent"
+
+DECK_FACTS_REASON_CODES = frozenset(
+    {
+        DECK_FACTS_OK,
+        DECK_FACTS_LOCATOR_INVALID,
+        DECK_FACTS_UNREADABLE,
+        DECK_FACTS_NOT_A_PACKAGE,
+        DECK_FACTS_PACKAGE_OVERSIZED,
+        DECK_FACTS_PART_UNREADABLE,
+        DECK_FACTS_PARTS_ABSENT,
+    }
+)
+
+_CORE_PART = "docProps/core.xml"
+_APP_PART = "docProps/app.xml"
+_TITLE_SLIDE_PART = "ppt/slides/slide1.xml"
+
+# A metadata part and one slide are small. These caps bound decompression on a
+# path chosen by persisted state; a real deck's parts are orders below them.
+_MAX_PART_EXPANDED_BYTES = 8 * 1024 * 1024
+_MAX_ARCHIVE_MEMBERS = 65_536
+
+# Beyond the title, the title slide's remaining runs are the subtitle and
+# speaker/venue line. Bounded so a text-heavy first slide cannot reintroduce
+# the agree-with-everything failure the module docstring describes.
+_MAX_RENDERED_FOOTERS = 8
+_MAX_HASHTAGS = 16
+_MAX_TEXT_CHARS = 500
+
+_EXT_NS = "{http://schemas.openxmlformats.org/officeDocument/2006/extended-properties}"
+_VT_NS = "{http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes}"
+_DC_NS = "{http://purl.org/dc/elements/1.1/}"
+_DCTERMS_NS = "{http://purl.org/dc/terms/}"
+_DRAWING_NS = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+
+_SLIDE_TITLES_HEADING = "Slide Titles"
+_HASHTAG_RE = re.compile(r"#\w+", re.UNICODE)
+_YEAR_PREFIX_RE = re.compile(r"\A(?:19|20)\d{2}")
+
+
+@dataclass(frozen=True)
+class DeckFactsReading:
+    """One deck's observed identity facts plus why anything is missing.
+
+    `facts` is always a mapping `deck_identity_facts` accepts, even when the
+    package could not be opened: `pptx_path` alone is a valid observation, and
+    the path's own venue and year signals are exactly what must survive damage.
+    """
+
+    pptx_path: str
+    facts: dict[str, Any]
+    reason_code: str
+    slide_count: int | None = None
+    parts_read: tuple[str, ...] = field(default=())
+
+    @property
+    def package_read(self) -> bool:
+        return self.reason_code == DECK_FACTS_OK
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "schema_version": DECK_FACTS_SCHEMA_VERSION,
+            "pptx_path": self.pptx_path,
+            "reason_code": self.reason_code,
+            "slide_count": self.slide_count,
+            "parts_read": list(self.parts_read),
+            "facts": dict(self.facts),
+        }
+
+
+def _text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    collapsed = " ".join(value.split())
+    if not collapsed:
+        return None
+    return collapsed[:_MAX_TEXT_CHARS]
+
+
+def _slide_titles(app_xml: bytes) -> list[str]:
+    """Read `TitlesOfParts` slice that `HeadingPairs` labels as slide titles.
+
+    `TitlesOfParts` concatenates several categories — fonts, themes, then slide
+    titles — and only `HeadingPairs` says where each begins. Slicing by a fixed
+    offset would read font names as titles on any deck with a different theme
+    count.
+    """
+    root = ET.fromstring(app_xml)
+    pairs = root.find(f"{_EXT_NS}HeadingPairs")
+    parts = root.find(f"{_EXT_NS}TitlesOfParts")
+    if pairs is None or parts is None:
+        return []
+    pair_vector = pairs.find(f"{_VT_NS}vector")
+    counts: list[tuple[str, int]] = []
+    label: str | None = None
+    for variant in [] if pair_vector is None else list(pair_vector):
+        for child in variant:
+            if child.tag == f"{_VT_NS}lpstr":
+                label = child.text
+            elif child.tag == f"{_VT_NS}i4" and label is not None:
+                try:
+                    counts.append((label, int(child.text or "")))
+                except ValueError:
+                    return []
+                label = None
+    part_vector = parts.find(f"{_VT_NS}vector")
+    names = (
+        []
+        if part_vector is None
+        else [element.text or "" for element in part_vector.findall(f"{_VT_NS}lpstr")]
+    )
+    offset = 0
+    for name, count in counts:
+        if count < 0:
+            return []
+        if name == _SLIDE_TITLES_HEADING:
+            return names[offset : offset + count]
+        offset += count
+    return []
+
+
+def _slide_count(app_xml: bytes) -> int | None:
+    root = ET.fromstring(app_xml)
+    raw = root.findtext(f"{_EXT_NS}Slides")
+    try:
+        count = int((raw or "").strip())
+    except ValueError:
+        return None
+    return count if count >= 0 else None
+
+
+def _title_slide_runs(slide_xml: bytes) -> list[str]:
+    root = ET.fromstring(slide_xml)
+    runs: list[str] = []
+    for element in root.iter(f"{_DRAWING_NS}t"):
+        text = _text(element.text)
+        if text is not None:
+            runs.append(text)
+    return runs
+
+
+def _resolve_descriptor(pptx_path: str, pptx_source_dir: object) -> int | None:
+    """Open the deck under its configured root, refusing every symlink below it.
+
+    Containment is `pptx_catalog_selection`'s rule and is reused rather than
+    restated: the sweep must not be able to read a file the evidence classifier
+    would have refused.
+    """
+    if pptx_source_dir is None:
+        return None
+    try:
+        if classify_artifact_locator(pptx_path) != "relative":
+            return None
+        resolved = materialize_artifact_locator(pptx_path, pptx_source_dir)
+        parts = resolved.relative_to(Path(str(pptx_source_dir))).parts
+    except (ArtifactLocatorError, TypeError, ValueError):
+        return None
+    return open_contained_descriptor(pptx_source_dir, parts)
+
+
+def _read_part(archive: zipfile.ZipFile, name: str) -> bytes | None:
+    """Read one part, refusing a member that expands past the cap."""
+    try:
+        info = archive.getinfo(name)
+    except KeyError:
+        return None
+    if info.file_size > _MAX_PART_EXPANDED_BYTES:
+        return None
+    try:
+        with archive.open(info) as stream:
+            return stream.read(_MAX_PART_EXPANDED_BYTES + 1)
+    except (zipfile.BadZipFile, OSError, EOFError, ValueError):
+        return None
+
+
+def read_deck_identity_facts(
+    pptx_path: object,
+    pptx_source_dir: object,
+) -> DeckFactsReading:
+    """Observe one catalog deck's identity facts, or report why it could not be.
+
+    Returns a reading whose `facts` always at least names the deck, so a caller
+    can hand it straight to `assess_pptx_talk_identity` regardless of outcome.
+    """
+    path_text = _text(pptx_path)
+    if path_text is None:
+        return DeckFactsReading(
+            pptx_path="",
+            facts={"pptx_path": ""},
+            reason_code=DECK_FACTS_LOCATOR_INVALID,
+        )
+    facts: dict[str, Any] = {"pptx_path": path_text}
+    descriptor = _resolve_descriptor(path_text, pptx_source_dir)
+    if descriptor is None:
+        return DeckFactsReading(
+            pptx_path=path_text,
+            facts=facts,
+            reason_code=DECK_FACTS_UNREADABLE,
+        )
+    try:
+        with os.fdopen(descriptor, "rb", closefd=True) as handle:
+            return _read_from_stream(handle, path_text, facts)
+    except (OSError, ValueError):
+        return DeckFactsReading(
+            pptx_path=path_text,
+            facts=facts,
+            reason_code=DECK_FACTS_UNREADABLE,
+        )
+
+
+def _read_from_stream(
+    handle: Any,
+    pptx_path: str,
+    facts: dict[str, Any],
+) -> DeckFactsReading:
+    try:
+        archive = zipfile.ZipFile(handle)
+    except (zipfile.BadZipFile, OSError, EOFError, ValueError):
+        return DeckFactsReading(
+            pptx_path=pptx_path,
+            facts=facts,
+            reason_code=DECK_FACTS_NOT_A_PACKAGE,
+        )
+    with archive:
+        try:
+            members = archive.namelist()
+        except (zipfile.BadZipFile, OSError, ValueError):
+            return DeckFactsReading(
+                pptx_path=pptx_path,
+                facts=facts,
+                reason_code=DECK_FACTS_NOT_A_PACKAGE,
+            )
+        if len(members) > _MAX_ARCHIVE_MEMBERS:
+            return DeckFactsReading(
+                pptx_path=pptx_path,
+                facts=facts,
+                reason_code=DECK_FACTS_PACKAGE_OVERSIZED,
+            )
+        return _read_parts(archive, pptx_path, facts)
+
+
+def _read_parts(
+    archive: zipfile.ZipFile,
+    pptx_path: str,
+    facts: dict[str, Any],
+) -> DeckFactsReading:
+    parts_read: list[str] = []
+    malformed = False
+    slide_count: int | None = None
+    hashtag_sources: list[str] = []
+
+    core_xml = _read_part(archive, _CORE_PART)
+    if core_xml is not None:
+        try:
+            root = ET.fromstring(core_xml)
+        except ET.ParseError:
+            malformed = True
+        else:
+            parts_read.append(_CORE_PART)
+            document_title = _text(root.findtext(f"{_DC_NS}title"))
+            if document_title is not None:
+                facts["document_title"] = document_title
+            created = _text(root.findtext(f"{_DCTERMS_NS}created"))
+            if created is not None and _YEAR_PREFIX_RE.match(created):
+                facts["document_created_year"] = created[:4]
+
+    app_xml = _read_part(archive, _APP_PART)
+    titles: list[str] = []
+    if app_xml is not None:
+        try:
+            titles = [
+                text
+                for text in (_text(item) for item in _slide_titles(app_xml))
+                if text
+            ]
+            slide_count = _slide_count(app_xml)
+        except ET.ParseError:
+            malformed = True
+        else:
+            parts_read.append(_APP_PART)
+            hashtag_sources.extend(titles)
+
+    slide_xml = _read_part(archive, _TITLE_SLIDE_PART)
+    runs: list[str] = []
+    if slide_xml is not None:
+        try:
+            runs = _title_slide_runs(slide_xml)
+        except ET.ParseError:
+            malformed = True
+        else:
+            parts_read.append(_TITLE_SLIDE_PART)
+            hashtag_sources.extend(runs)
+
+    # The title slide's first run is this deck's own headline; app.xml's first
+    # slide title is the same string as PowerPoint recorded it. Either is the
+    # deck's title, and the slide is preferred because it keeps the subtitle
+    # runs that follow it in the same reading.
+    rendered_title = runs[0] if runs else (titles[0] if titles else None)
+    if rendered_title is not None:
+        facts["rendered_title"] = rendered_title
+    if len(runs) > 1:
+        facts["rendered_footers"] = runs[1 : 1 + _MAX_RENDERED_FOOTERS]
+
+    hashtags: list[str] = []
+    for text in hashtag_sources:
+        for tag in _HASHTAG_RE.findall(text):
+            if tag not in hashtags:
+                hashtags.append(tag)
+    if hashtags:
+        facts["hashtags"] = hashtags[:_MAX_HASHTAGS]
+
+    if malformed:
+        reason_code = DECK_FACTS_PART_UNREADABLE
+    elif not parts_read:
+        reason_code = DECK_FACTS_PARTS_ABSENT
+    else:
+        reason_code = DECK_FACTS_OK
+    return DeckFactsReading(
+        pptx_path=pptx_path,
+        facts=facts,
+        reason_code=reason_code,
+        slide_count=slide_count,
+        parts_read=tuple(parts_read),
+    )
+
+
+__all__ = [
+    "DECK_FACTS_LOCATOR_INVALID",
+    "DECK_FACTS_NOT_A_PACKAGE",
+    "DECK_FACTS_OK",
+    "DECK_FACTS_PACKAGE_OVERSIZED",
+    "DECK_FACTS_PARTS_ABSENT",
+    "DECK_FACTS_PART_UNREADABLE",
+    "DECK_FACTS_REASON_CODES",
+    "DECK_FACTS_SCHEMA_VERSION",
+    "DECK_FACTS_UNREADABLE",
+    "DeckFactsReading",
+    "read_deck_identity_facts",
+]

--- a/skills/vault-ingress/scripts/pptx_deck_facts.py
+++ b/skills/vault-ingress/scripts/pptx_deck_facts.py
@@ -7,10 +7,11 @@ returns the mapping `deck_identity_facts` accepts.
 
 Three properties shape it.
 
-* **Bounded.** Only `docProps/core.xml`, `docProps/app.xml`, and the first
-  slide are read, each under an expanded-size cap. A catalog row is persisted
-  state, and persisted state is a hint, never a licence to decompress an
-  arbitrary host file (`stateful-artifacts` -> Hints, Not Authority).
+* **Bounded.** Only `docProps/core.xml`, `docProps/app.xml`, the presentation
+  part and its relationships, and the first slide are read, each under an
+  expanded-size cap. A catalog row is persisted state, and persisted state is a
+  hint, never a licence to decompress an arbitrary host file
+  (`stateful-artifacts` -> Hints, Not Authority).
 * **Never fatal.** An unreadable, damaged, or absent deck returns the facts
   gathered so far with a reason code. Damage must weaken the evidence, never
   the identity requirements, so the caller still assesses the deck from its
@@ -30,11 +31,21 @@ indistinguishable from knowing nothing.
 
 The title slide cannot do that. Its runs are this deck's own title and
 subtitle, which is what the catalog's title is being compared against.
+
+## Which part IS the title slide
+
+Not `ppt/slides/slide1.xml`. That is a part name, and OPC leaves slide ORDER to
+`ppt/presentation.xml`'s `sldIdLst` resolved through the presentation's
+relationships. A deck whose slides were reordered can hold an interior slide in
+`slide1.xml`, and reading it would feed interior text in as the deck's title —
+the same defect this module's title-slide rule exists to avoid, arriving by a
+different door.
 """
 
 from __future__ import annotations
 
 import os
+import posixpath
 import re
 import zipfile
 from dataclasses import dataclass, field
@@ -75,7 +86,9 @@ DECK_FACTS_REASON_CODES = frozenset(
 
 _CORE_PART = "docProps/core.xml"
 _APP_PART = "docProps/app.xml"
-_TITLE_SLIDE_PART = "ppt/slides/slide1.xml"
+_PRESENTATION_PART = "ppt/presentation.xml"
+_PRESENTATION_RELS_PART = "ppt/_rels/presentation.xml.rels"
+_PRESENTATION_BASE = "ppt"
 
 # A metadata part and one slide are small. These caps bound decompression on a
 # path chosen by persisted state; a real deck's parts are orders below them.
@@ -94,6 +107,14 @@ _VT_NS = "{http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes}
 _DC_NS = "{http://purl.org/dc/elements/1.1/}"
 _DCTERMS_NS = "{http://purl.org/dc/terms/}"
 _DRAWING_NS = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+_PRESENTATION_NS = "{http://schemas.openxmlformats.org/presentationml/2006/main}"
+_RELATIONSHIP_ID_NS = (
+    "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+)
+_PACKAGE_RELS_NS = "{http://schemas.openxmlformats.org/package/2006/relationships}"
+_SLIDE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
+)
 
 _SLIDE_TITLES_HEADING = "Slide Titles"
 _HASHTAG_RE = re.compile(r"#\w+", re.UNICODE)
@@ -199,6 +220,66 @@ def _title_slide_runs(slide_xml: bytes) -> list[str]:
         if text is not None:
             runs.append(text)
     return runs
+
+
+def _first_slide_relationship_id(presentation_xml: bytes) -> str | None:
+    """The r:id of the first entry in the presentation's slide-id list."""
+    root = ET.fromstring(presentation_xml)
+    slide_ids = root.find(f"{_PRESENTATION_NS}sldIdLst")
+    if slide_ids is None:
+        return None
+    for slide_id in slide_ids.findall(f"{_PRESENTATION_NS}sldId"):
+        relationship_id = slide_id.get(f"{_RELATIONSHIP_ID_NS}id")
+        if isinstance(relationship_id, str) and relationship_id:
+            return relationship_id
+    return None
+
+
+def _slide_part_for_relationship(rels_xml: bytes, relationship_id: str) -> str | None:
+    """Resolve one slide relationship to its part name inside the package."""
+    root = ET.fromstring(rels_xml)
+    for relationship in root.findall(f"{_PACKAGE_RELS_NS}Relationship"):
+        if relationship.get("Id") != relationship_id:
+            continue
+        if relationship.get("Type") != _SLIDE_RELATIONSHIP_TYPE:
+            return None
+        target = relationship.get("Target")
+        if not isinstance(target, str) or not target:
+            return None
+        if target.startswith("/"):
+            return posixpath.normpath(target.lstrip("/"))
+        resolved = posixpath.normpath(posixpath.join(_PRESENTATION_BASE, target))
+        # A target that climbs out of the package is not a part of it.
+        if resolved.startswith("../") or resolved.startswith("/"):
+            return None
+        return resolved
+    return None
+
+
+def _title_slide_part(archive: zipfile.ZipFile) -> str | None:
+    """Name the part holding the deck's FIRST slide, in presentation order.
+
+    `ppt/slides/slide1.xml` is a part name, not a position. OPC leaves slide
+    order to `ppt/presentation.xml`'s `sldIdLst`, resolved through the
+    presentation's relationships, so a deck whose slides were reordered can
+    hold an interior slide in `slide1.xml` — and reading that one would feed
+    an interior slide's text in as the deck's own title.
+
+    Returns None when the chain cannot be resolved. The caller then reads no
+    slide at all rather than guessing a part name: `docProps/app.xml` already
+    lists slide titles in presentation order, so the fallback stays ordered.
+    """
+    presentation_xml = _read_part(archive, _PRESENTATION_PART)
+    rels_xml = _read_part(archive, _PRESENTATION_RELS_PART)
+    if presentation_xml is None or rels_xml is None:
+        return None
+    try:
+        relationship_id = _first_slide_relationship_id(presentation_xml)
+        if relationship_id is None:
+            return None
+        return _slide_part_for_relationship(rels_xml, relationship_id)
+    except ET.ParseError:
+        return None
 
 
 def _resolve_descriptor(pptx_path: str, pptx_source_dir: object) -> int | None:
@@ -342,7 +423,10 @@ def _read_parts(
             parts_read.append(_APP_PART)
             hashtag_sources.extend(titles)
 
-    slide_xml = _read_part(archive, _TITLE_SLIDE_PART)
+    title_slide_part = _title_slide_part(archive)
+    slide_xml = (
+        None if title_slide_part is None else _read_part(archive, title_slide_part)
+    )
     runs: list[str] = []
     if slide_xml is not None:
         try:
@@ -350,7 +434,7 @@ def _read_parts(
         except ET.ParseError:
             malformed = True
         else:
-            parts_read.append(_TITLE_SLIDE_PART)
+            parts_read.append(str(title_slide_part))
             hashtag_sources.extend(runs)
 
     # The title slide's first run is this deck's own headline; app.xml's first

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Assess every stored PPTX-to-talk binding in the catalog (#176).
+
+`_apply_record_pptx` refuses a NEW binding nothing proved, and preflight blocks
+a row whose binding is unproven. Neither assesses the rows already there: they
+were bound before any assessment existed, so they are all unproven and all
+blocking, and nothing in the toolkit could say which of them are actually
+right. This is that sweep.
+
+Every catalog row is assessed against every talk in the vault, from facts both
+sides already carry — the deck's path, document properties, and title slide
+against the catalog's title, conference, and delivery date. The result is one
+disposition per row:
+
+* `binding_confirmed` — the assessment selects the talk the row already names.
+* `binding_contradicted` — the assessment selects a DIFFERENT talk. The row is
+  feeding one talk's slide counts, OCR, and pattern observations to another.
+* `binding_review_required` — candidates are ambiguous or contradictory. Nothing
+  is proven either way, which is not the same as the binding being wrong.
+* `binding_unproven` — no signal agreed with any talk.
+* `unbound_row` — the row names no talk. Reported with its assessment so a
+  catalog-only deck is visible, never as a proposal to bind it.
+
+Read-only by construction. The sweep decides nothing and writes nothing; a
+disposition is evidence for an owner decision, and severing a binding is a
+typed owner mutation made elsewhere.
+
+Signals observed: the path's venue and delivery year, the deck's document
+properties, its title slide, and filename similarity. The published-PDF signal
+`pptx_talk_identity` accepts is NOT observed — no deterministic deck-to-PDF
+binding exists to read, and guessing one would manufacture the evidence the
+identity module exists to require.
+
+Determinism: the report depends only on the database's bytes and the decks'
+bytes. No clock is consulted, so the same inputs give the same report.
+
+Usage: sweep-pptx-talk-identity.py <vault-root-or-database-path>
+       sweep-pptx-talk-identity.py <vault-root> --dispositions binding_contradicted
+Stdout: one JSON object; `rows[]` carries the disposition, verdict, reason
+        codes, the deck facts that were readable, and the candidate table.
+Stderr: one actionable, path-neutral line when the database cannot be read.
+Exit 0 when the catalog was assessed, 2 when the database is unusable.
+Exit 0 with contradicted rows is the normal "work to do" result — this is a
+reporting tool, not a gate. Preflight is the gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+
+from pptx_deck_facts import (
+    DECK_FACTS_SCHEMA_VERSION,
+    read_deck_identity_facts,
+)
+from pptx_talk_identity import (
+    PPTX_TALK_IDENTITY_SCHEMA_VERSION,
+    SIGNAL_UNKNOWN,
+    VERDICT_MATCHED,
+    VERDICT_REVIEW_REQUIRED,
+    PptxTalkIdentityError,
+    assess_pptx_talk_identity,
+)
+from tracking_database import (
+    TrackingDatabaseError,
+    assess_tracking_database,
+)
+from tracking_database_io import (
+    DATABASE_READ_DIAGNOSTICS,
+    DATABASE_READ_FALLBACK,
+    TrackingDatabaseIOError,
+    decode_json_object,
+    snapshot_tracking_database,
+)
+
+REPORT_SCHEMA_VERSION = 1
+DATABASE_BASENAME = "tracking-database.json"
+
+DISPOSITION_CONFIRMED = "binding_confirmed"
+DISPOSITION_CONTRADICTED = "binding_contradicted"
+DISPOSITION_REVIEW_REQUIRED = "binding_review_required"
+DISPOSITION_UNPROVEN = "binding_unproven"
+DISPOSITION_UNBOUND = "unbound_row"
+DISPOSITION_UNASSESSABLE = "binding_unassessable"
+
+DISPOSITIONS = (
+    DISPOSITION_CONFIRMED,
+    DISPOSITION_CONTRADICTED,
+    DISPOSITION_REVIEW_REQUIRED,
+    DISPOSITION_UNPROVEN,
+    DISPOSITION_UNBOUND,
+    DISPOSITION_UNASSESSABLE,
+)
+
+# Every disposition but these two leaves a talk bound to a deck nothing proved
+# it belongs to. Counted separately so the report's headline is the number of
+# bindings that must be resolved before a reparse re-derives evidence through
+# them, not the number of rows.
+RESOLVED_DISPOSITIONS = frozenset({DISPOSITION_CONFIRMED, DISPOSITION_UNBOUND})
+
+
+def resolve_input(value: str | Path) -> tuple[Path, Path]:
+    """Bind a vault root to its canonical database, as preflight does."""
+    path = Path(value).expanduser().absolute()
+    if path.name.lower() == DATABASE_BASENAME:
+        return path.parent, path
+    return path, path / DATABASE_BASENAME
+
+
+def _candidate_talks(database: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Every talk carrying a filename, in stored order.
+
+    The whole vault is the candidate set on purpose. Narrowing it first — to
+    the same year, or the same conference — would decide the question the
+    assessment exists to answer, and would hide exactly the cross-talk
+    assignment this sweep looks for.
+    """
+    talks = database.get("talks")
+    if not isinstance(talks, list):
+        return []
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for talk in talks:
+        if not isinstance(talk, Mapping):
+            continue
+        filename = talk.get("filename")
+        if not isinstance(filename, str) or not filename or filename in seen:
+            continue
+        seen.add(filename)
+        candidates.append(dict(talk))
+    return candidates
+
+
+def _material_assessment(assessment: Any) -> dict[str, Any]:
+    """Serialize the assessment with only its material candidates.
+
+    The candidate set is every talk in the vault — 215 of them against 82 rows
+    — and a talk sharing no signal with the deck reads as six `unknown`
+    verdicts. Emitting those is not evidence, it is 215 rows of noise per deck
+    hiding the handful that decided the verdict.
+
+    A candidate is material when any signal reads something. That keeps
+    everything a reader needs to re-derive the verdict: the selected candidate
+    is material because it agrees, and so is every rival that could have
+    contested it, since contesting requires agreement.
+    """
+    serialized = assessment.as_json()
+    candidates = serialized.get("candidates")
+    if not isinstance(candidates, list):
+        return serialized
+    material = [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, Mapping)
+        and any(
+            verdict != SIGNAL_UNKNOWN
+            for verdict in (candidate.get("signals") or {}).values()
+        )
+    ]
+    serialized["candidates"] = material
+    serialized["candidates_assessed"] = len(candidates)
+    return serialized
+
+
+def _disposition(
+    verdict: str,
+    selected: str | None,
+    stored_talk: str | None,
+) -> str:
+    if stored_talk is None:
+        return DISPOSITION_UNBOUND
+    if verdict == VERDICT_MATCHED:
+        return (
+            DISPOSITION_CONFIRMED
+            if selected == stored_talk
+            else DISPOSITION_CONTRADICTED
+        )
+    if verdict == VERDICT_REVIEW_REQUIRED:
+        return DISPOSITION_REVIEW_REQUIRED
+    return DISPOSITION_UNPROVEN
+
+
+def sweep_catalog(
+    database: Mapping[str, Any],
+    *,
+    pptx_source_dir: object,
+) -> list[dict[str, Any]]:
+    """Assess every catalog row's stored binding, in stored order.
+
+    A row that cannot be assessed is reported as `binding_unassessable` rather
+    than dropped: a missing row would read as a binding with nothing wrong.
+    """
+    catalog = database.get("pptx_catalog")
+    if not isinstance(catalog, list):
+        return []
+    candidates = _candidate_talks(database)
+    rows: list[dict[str, Any]] = []
+    for index, record in enumerate(catalog):
+        if not isinstance(record, Mapping):
+            rows.append(
+                {
+                    "index": index,
+                    "pptx_path": None,
+                    "stored_talk_filename": None,
+                    "disposition": DISPOSITION_UNASSESSABLE,
+                    "reason_codes": ["catalog_row_not_an_object"],
+                }
+            )
+            continue
+        stored_talk = record.get("talk_filename")
+        stored_talk = stored_talk if isinstance(stored_talk, str) else None
+        reading = read_deck_identity_facts(record.get("pptx_path"), pptx_source_dir)
+        try:
+            assessment = assess_pptx_talk_identity(reading.facts, candidates)
+        except PptxTalkIdentityError as exc:
+            # The prose names the rejected value, which came out of the
+            # database (`no-secrets` -> Logging). Report the closed code.
+            rows.append(
+                {
+                    "index": index,
+                    "pptx_path": reading.pptx_path or None,
+                    "stored_talk_filename": stored_talk,
+                    "disposition": DISPOSITION_UNASSESSABLE,
+                    "reason_codes": ["identity_assessment_refused"],
+                    "deck_facts_reason_code": reading.reason_code,
+                    "error": type(exc).__name__,
+                }
+            )
+            continue
+        rows.append(
+            {
+                "index": index,
+                "pptx_path": reading.pptx_path,
+                "stored_talk_filename": stored_talk,
+                "disposition": _disposition(
+                    assessment.verdict,
+                    assessment.selected_talk_filename,
+                    stored_talk,
+                ),
+                "verdict": assessment.verdict,
+                "artifact_role": assessment.artifact_role,
+                "selected_talk_filename": assessment.selected_talk_filename,
+                "reason_codes": list(assessment.reason_codes),
+                "deck_facts_reason_code": reading.reason_code,
+                "deck_slide_count": reading.slide_count,
+                "stored_slide_count": record.get("slide_count"),
+                "observed_facts": sorted(
+                    key for key in reading.facts if key != "pptx_path"
+                ),
+                # The candidate table, not a summary. It is what makes the
+                # verdict checkable by someone who was not here when it ran.
+                "assessment": _material_assessment(assessment),
+            }
+        )
+    return rows
+
+
+def execute(
+    value: str | Path,
+    *,
+    dispositions: Sequence[str] = (),
+) -> dict[str, Any]:
+    database_path = resolve_input(value)[1]
+    snapshot = snapshot_tracking_database(database_path)
+    database = decode_json_object(snapshot)
+    try:
+        assessment = assess_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        # Reason codes are a closed vocabulary; the exception prose is not.
+        raise TrackingDatabaseIOError(
+            "tracking database owner assessment failed",
+            reason_code="owner_assessment_failed",
+        ) from exc
+    if not assessment.usable:
+        raise TrackingDatabaseIOError(
+            "tracking database has no usable legacy/current owner state",
+            reason_code="owner_state_unusable",
+        )
+    config = database.get("config")
+    pptx_source_dir = (
+        config.get("pptx_source_dir") if isinstance(config, Mapping) else None
+    )
+    rows = sweep_catalog(database, pptx_source_dir=pptx_source_dir)
+    counts = {name: 0 for name in DISPOSITIONS}
+    for row in rows:
+        counts[str(row["disposition"])] += 1
+    selected = (
+        rows
+        if not dispositions
+        else [row for row in rows if row["disposition"] in set(dispositions)]
+    )
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "identity_schema_version": PPTX_TALK_IDENTITY_SCHEMA_VERSION,
+        "deck_facts_schema_version": DECK_FACTS_SCHEMA_VERSION,
+        "ok": True,
+        "database_path": str(snapshot.path),
+        "sha256": snapshot.sha256,
+        "catalog_row_count": len(rows),
+        "disposition_counts": counts,
+        # The headline: bindings a reparse would carry forward unproven.
+        "unresolved_binding_count": sum(
+            count for name, count in counts.items() if name not in RESOLVED_DISPOSITIONS
+        ),
+        "rows": selected,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
+    parser.add_argument("vault", type=Path)
+    parser.add_argument(
+        "--dispositions",
+        nargs="+",
+        choices=DISPOSITIONS,
+        default=(),
+        help="report only rows with these dispositions; counts stay whole-catalog",
+    )
+    args = parser.parse_args(argv)
+    try:
+        report = execute(args.vault, dispositions=args.dispositions)
+    except TrackingDatabaseIOError as exc:
+        # Never echo the exception: decoder messages carry the host database
+        # path and the rejected key or value verbatim. Route the typed reason
+        # code through the shared closed vocabulary instead.
+        code, message = DATABASE_READ_DIAGNOSTICS.get(
+            exc.reason_code, DATABASE_READ_FALLBACK
+        )
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_SCHEMA_VERSION,
+                    "ok": False,
+                    "code": code,
+                    "error": message,
+                }
+            )
+        )
+        print(f"pptx talk-identity sweep failed: {message}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -306,10 +306,11 @@ def execute(
     counts = {name: 0 for name in DISPOSITIONS}
     for row in rows:
         counts[str(row["disposition"])] += 1
+    reported = frozenset(dispositions)
     selected = (
         rows
-        if not dispositions
-        else [row for row in rows if row["disposition"] in set(dispositions)]
+        if not reported
+        else [row for row in rows if row["disposition"] in reported]
     )
     return {
         "schema_version": REPORT_SCHEMA_VERSION,

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -110,6 +110,26 @@ def resolve_input(value: str | Path) -> tuple[Path, Path]:
     return path, path / DATABASE_BASENAME
 
 
+def resolve_pptx_source_dir(
+    database: Mapping[str, Any],
+    *,
+    vault_root: Path,
+) -> object:
+    """Resolve where catalog decks live, falling back to the vault root.
+
+    `config.pptx_source_dir` is optional, and `schemas-db.md` documents that a
+    null or absent value falls back to the vault root. Passing the absent value
+    straight through would report every deck in such a vault unreadable —
+    a configuration default read as universal damage, and one that would put
+    every binding into `binding_unproven` on evidence nobody looked for.
+    """
+    config = database.get("config")
+    configured = config.get("pptx_source_dir") if isinstance(config, Mapping) else None
+    if isinstance(configured, str) and configured.strip():
+        return configured
+    return vault_root
+
+
 def _candidate_talks(database: Mapping[str, Any]) -> list[dict[str, Any]]:
     """Every talk carrying a filename, in stored order.
 
@@ -263,7 +283,7 @@ def execute(
     *,
     dispositions: Sequence[str] = (),
 ) -> dict[str, Any]:
-    database_path = resolve_input(value)[1]
+    vault_root, database_path = resolve_input(value)
     snapshot = snapshot_tracking_database(database_path)
     database = decode_json_object(snapshot)
     try:
@@ -279,11 +299,10 @@ def execute(
             "tracking database has no usable legacy/current owner state",
             reason_code="owner_state_unusable",
         )
-    config = database.get("config")
-    pptx_source_dir = (
-        config.get("pptx_source_dir") if isinstance(config, Mapping) else None
+    rows = sweep_catalog(
+        database,
+        pptx_source_dir=resolve_pptx_source_dir(database, vault_root=vault_root),
     )
-    rows = sweep_catalog(database, pptx_source_dir=pptx_source_dir)
     counts = {name: 0 for name in DISPOSITIONS}
     for row in rows:
         counts[str(row["disposition"])] += 1

--- a/tests/test_pptx_deck_facts.py
+++ b/tests/test_pptx_deck_facts.py
@@ -1,0 +1,364 @@
+"""Tests for reading a deck's identity facts out of its OPC package (#176).
+
+Every package is built in-test from fixed literals — no binary fixture is
+checked in, and no test reads the clock or a live vault, so a run today and a
+run next year agree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _load(name: str):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pptx_deck_facts = _load("pptx_deck_facts")
+
+
+CORE_XML = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cp:coreProperties
+ xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+ xmlns:dc="http://purl.org/dc/elements/1.1/"
+ xmlns:dcterms="http://purl.org/dc/terms/">
+<dc:title>{title}</dc:title>
+<dcterms:created>{created}</dcterms:created>
+</cp:coreProperties>"""
+
+_APP_HEAD = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Properties
+ xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"
+ xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+<Slides>{slides}</Slides>
+<HeadingPairs><vt:vector size="4" baseType="variant">
+<vt:variant><vt:lpstr>Fonts Used</vt:lpstr></vt:variant>
+<vt:variant><vt:i4>{fonts}</vt:i4></vt:variant>
+<vt:variant><vt:lpstr>Slide Titles</vt:lpstr></vt:variant>
+<vt:variant><vt:i4>{titles}</vt:i4></vt:variant>
+</vt:vector></HeadingPairs>
+<TitlesOfParts><vt:vector size="{total}" baseType="lpstr">{parts}</vt:vector>
+</TitlesOfParts></Properties>"""
+
+SLIDE_XML = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+ xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+<p:cSld><p:spTree>{runs}</p:spTree></p:cSld></p:sld>"""
+
+
+def app_xml(*, fonts: list[str], slide_titles: list[str], slides: int) -> str:
+    """Build an app.xml whose TitlesOfParts really does concatenate categories.
+
+    The font block is not decoration: it is what makes a fixed-offset reader
+    return font names where slide titles belong.
+    """
+    parts = "".join(f"<vt:lpstr>{name}</vt:lpstr>" for name in [*fonts, *slide_titles])
+    return _APP_HEAD.format(
+        slides=slides,
+        fonts=len(fonts),
+        titles=len(slide_titles),
+        total=len(fonts) + len(slide_titles),
+        parts=parts,
+    )
+
+
+def slide_xml(runs: list[str]) -> str:
+    body = "".join(
+        f"<p:sp><p:txBody><a:p><a:r><a:t>{run}</a:t></a:r></a:p></p:txBody></p:sp>"
+        for run in runs
+    )
+    return SLIDE_XML.format(runs=body)
+
+
+def write_deck(root: Path, relative: str, members: dict[str, str]) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, text in members.items():
+            archive.writestr(name, text)
+    return path
+
+
+def full_deck_members(
+    *,
+    document_title: str = "This is your presentation title",
+    created: str = "2025-01-17T09:00:00Z",
+    slide_titles: list[str] | None = None,
+    runs: list[str] | None = None,
+    slides: int = 42,
+) -> dict[str, str]:
+    return {
+        "docProps/core.xml": CORE_XML.format(title=document_title, created=created),
+        "docProps/app.xml": app_xml(
+            fonts=["Calibri", "Bangers"],
+            slide_titles=slide_titles
+            if slide_titles is not None
+            else ["DevOps for Developers", "shownotes"],
+            slides=slides,
+        ),
+        "ppt/slides/slide1.xml": slide_xml(
+            runs
+            if runs is not None
+            else ["DevOps for Developers", "and the path beyond", "#VoxxedTicino"]
+        ),
+    }
+
+
+@pytest.fixture()
+def source_root(tmp_path: Path) -> Path:
+    root = tmp_path / "Presentations"
+    root.mkdir()
+    return root
+
+
+class TestReadingAWholeDeck:
+    def test_every_part_contributes_its_own_fact(self, source_root: Path) -> None:
+        write_deck(source_root, "Voxxed/2025/Deck.pptx", full_deck_members())
+        reading = pptx_deck_facts.read_deck_identity_facts(
+            "Voxxed/2025/Deck.pptx", source_root
+        )
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_OK
+        assert reading.facts["document_title"] == "This is your presentation title"
+        assert reading.facts["document_created_year"] == "2025"
+        assert reading.facts["rendered_title"] == "DevOps for Developers"
+        assert reading.facts["rendered_footers"] == [
+            "and the path beyond",
+            "#VoxxedTicino",
+        ]
+        assert reading.facts["hashtags"] == ["#VoxxedTicino"]
+        assert reading.slide_count == 42
+
+    def test_the_facts_are_accepted_by_the_identity_module(
+        self, source_root: Path
+    ) -> None:
+        """The two modules share one shape, and this is where that is proven."""
+        identity = _load("pptx_talk_identity")
+        write_deck(source_root, "Voxxed/2025/Deck.pptx", full_deck_members())
+        reading = pptx_deck_facts.read_deck_identity_facts(
+            "Voxxed/2025/Deck.pptx", source_root
+        )
+        facts = identity.deck_identity_facts(reading.facts)
+        assert facts.pptx_path == "Voxxed/2025/Deck.pptx"
+        assert facts.rendered_title == "DevOps for Developers"
+
+    def test_slide_titles_are_sliced_by_their_heading_pair(
+        self, source_root: Path
+    ) -> None:
+        """A fixed offset would read `Calibri` as this deck's title."""
+        write_deck(
+            source_root,
+            "Deck.pptx",
+            {
+                "docProps/app.xml": app_xml(
+                    fonts=["Calibri", "Bangers", "Sniglet"],
+                    slide_titles=["The Real Title"],
+                    slides=1,
+                )
+            },
+        )
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "The Real Title"
+
+    def test_the_title_slide_wins_over_the_recorded_slide_title(
+        self, source_root: Path
+    ) -> None:
+        """PowerPoint records a truncated title; the slide carries the whole one."""
+        write_deck(
+            source_root,
+            "Deck.pptx",
+            full_deck_members(
+                slide_titles=["Devops... reframed"],
+                runs=["Devops... reframed", "Embracing the Path"],
+            ),
+        )
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "Devops... reframed"
+        assert reading.facts["rendered_footers"] == ["Embracing the Path"]
+
+
+class TestInteriorSlidesNeverBecomeRenderedText:
+    def test_only_the_title_slide_supplies_rendered_text(
+        self, source_root: Path
+    ) -> None:
+        """The failure this bound: a deck agreeing with every talk it mentions.
+
+        Interior slide titles name other talks. Feeding them in as rendered
+        text made 69 of the live vault's 74 bound decks ambiguous, because a
+        deck that agrees with everything is indistinguishable from one that
+        carries no evidence at all.
+        """
+        write_deck(
+            source_root,
+            "Deck.pptx",
+            full_deck_members(
+                slide_titles=[
+                    "DevOps for Developers",
+                    "Securing the Software Supply Chain",
+                    "Coding Fast and Slow",
+                ],
+                runs=["DevOps for Developers"],
+            ),
+        )
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "DevOps for Developers"
+        assert "rendered_footers" not in reading.facts
+
+    def test_rendered_footers_are_bounded(self, source_root: Path) -> None:
+        write_deck(
+            source_root,
+            "Deck.pptx",
+            full_deck_members(runs=["Title", *[f"line {n}" for n in range(40)]]),
+        )
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert len(reading.facts["rendered_footers"]) == 8
+
+
+class TestHashtags:
+    def test_hashtags_are_deduplicated_in_first_seen_order(
+        self, source_root: Path
+    ) -> None:
+        write_deck(
+            source_root,
+            "Deck.pptx",
+            full_deck_members(
+                slide_titles=["#VoxxedTicino kickoff"],
+                runs=["Title", "#VoxxedTicino", "#DevOps", "#VoxxedTicino"],
+            ),
+        )
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["hashtags"] == ["#VoxxedTicino", "#DevOps"]
+
+    def test_a_deck_with_no_hashtag_reports_none(self, source_root: Path) -> None:
+        write_deck(
+            source_root,
+            "Deck.pptx",
+            full_deck_members(slide_titles=["Plain"], runs=["Plain"]),
+        )
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert "hashtags" not in reading.facts
+
+
+class TestDamageWeakensEvidenceNotRequirements:
+    def test_a_missing_deck_still_names_itself(self, source_root: Path) -> None:
+        reading = pptx_deck_facts.read_deck_identity_facts(
+            "Voxxed/2025/Absent.pptx", source_root
+        )
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_UNREADABLE
+        assert reading.facts == {"pptx_path": "Voxxed/2025/Absent.pptx"}
+
+    def test_a_file_that_is_not_a_package_reports_so(self, source_root: Path) -> None:
+        (source_root / "Deck.pptx").write_text("not a zip", encoding="utf-8")
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_NOT_A_PACKAGE
+        assert reading.facts == {"pptx_path": "Deck.pptx"}
+
+    def test_a_malformed_part_keeps_the_parts_that_parsed(
+        self, source_root: Path
+    ) -> None:
+        members = full_deck_members()
+        members["docProps/app.xml"] = "<Properties><unclosed>"
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_PART_UNREADABLE
+        assert reading.facts["document_created_year"] == "2025"
+        assert reading.facts["rendered_title"] == "DevOps for Developers"
+
+    def test_a_package_with_no_known_parts_reports_absent(
+        self, source_root: Path
+    ) -> None:
+        write_deck(source_root, "Deck.pptx", {"ppt/presentation.xml": "<p/>"})
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_PARTS_ABSENT
+        assert reading.facts == {"pptx_path": "Deck.pptx"}
+
+    def test_an_oversized_part_is_refused_rather_than_expanded(
+        self, source_root: Path
+    ) -> None:
+        members = full_deck_members()
+        members["docProps/core.xml"] = "<a>" + ("x" * (9 * 1024 * 1024)) + "</a>"
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert "document_created_year" not in reading.facts
+        assert reading.facts["rendered_title"] == "DevOps for Developers"
+
+
+class TestContainment:
+    def test_an_absolute_locator_is_refused(self, source_root: Path) -> None:
+        write_deck(source_root, "Deck.pptx", full_deck_members())
+        reading = pptx_deck_facts.read_deck_identity_facts(
+            str(source_root / "Deck.pptx"), source_root
+        )
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_UNREADABLE
+
+    def test_an_escaping_locator_is_refused(self, source_root: Path) -> None:
+        reading = pptx_deck_facts.read_deck_identity_facts(
+            "../outside.pptx", source_root
+        )
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_UNREADABLE
+
+    def test_a_symlinked_component_is_refused(self, source_root: Path) -> None:
+        outside = source_root.parent / "outside"
+        outside.mkdir()
+        write_deck(outside, "Deck.pptx", full_deck_members())
+        (source_root / "link").symlink_to(outside, target_is_directory=True)
+        reading = pptx_deck_facts.read_deck_identity_facts(
+            "link/Deck.pptx", source_root
+        )
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_UNREADABLE
+
+    def test_no_source_root_reads_nothing(self, source_root: Path) -> None:
+        write_deck(source_root, "Deck.pptx", full_deck_members())
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", None)
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_UNREADABLE
+
+
+class TestInputValidation:
+    @pytest.mark.parametrize("value", [None, "", "   ", 17, ["Deck.pptx"]])
+    def test_a_locator_that_is_not_text_reports_its_own_code(
+        self, value: object, source_root: Path
+    ) -> None:
+        reading = pptx_deck_facts.read_deck_identity_facts(value, source_root)
+        assert reading.reason_code == pptx_deck_facts.DECK_FACTS_LOCATOR_INVALID
+        assert reading.facts == {"pptx_path": ""}
+
+    def test_every_reason_code_is_in_the_closed_set(self) -> None:
+        codes = {
+            pptx_deck_facts.DECK_FACTS_OK,
+            pptx_deck_facts.DECK_FACTS_LOCATOR_INVALID,
+            pptx_deck_facts.DECK_FACTS_UNREADABLE,
+            pptx_deck_facts.DECK_FACTS_NOT_A_PACKAGE,
+            pptx_deck_facts.DECK_FACTS_PACKAGE_OVERSIZED,
+            pptx_deck_facts.DECK_FACTS_PART_UNREADABLE,
+            pptx_deck_facts.DECK_FACTS_PARTS_ABSENT,
+        }
+        assert codes == set(pptx_deck_facts.DECK_FACTS_REASON_CODES)
+
+
+class TestSerialization:
+    def test_the_reading_round_trips_as_json(self, source_root: Path) -> None:
+        write_deck(source_root, "Voxxed/2025/Deck.pptx", full_deck_members())
+        reading = pptx_deck_facts.read_deck_identity_facts(
+            "Voxxed/2025/Deck.pptx", source_root
+        )
+        payload = reading.as_json()
+        assert payload["schema_version"] == pptx_deck_facts.DECK_FACTS_SCHEMA_VERSION
+        assert payload["pptx_path"] == "Voxxed/2025/Deck.pptx"
+        assert payload["slide_count"] == 42
+        assert "docProps/app.xml" in payload["parts_read"]

--- a/tests/test_pptx_deck_facts.py
+++ b/tests/test_pptx_deck_facts.py
@@ -8,6 +8,7 @@ run next year agree.
 from __future__ import annotations
 
 import importlib.util
+import posixpath
 import sys
 import zipfile
 from pathlib import Path
@@ -62,6 +63,21 @@ SLIDE_XML = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
 <p:cSld><p:spTree>{runs}</p:spTree></p:cSld></p:sld>"""
 
+PRESENTATION_XML = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation
+ xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<p:sldIdLst>{slide_ids}</p:sldIdLst></p:presentation>"""
+
+PRESENTATION_RELS = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships
+ xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+{relationships}</Relationships>"""
+
+SLIDE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
+)
+
 
 def app_xml(*, fonts: list[str], slide_titles: list[str], slides: int) -> str:
     """Build an app.xml whose TitlesOfParts really does concatenate categories.
@@ -96,6 +112,30 @@ def write_deck(root: Path, relative: str, members: dict[str, str]) -> Path:
     return path
 
 
+def presentation_parts(slide_parts: list[str]) -> dict[str, str]:
+    """Build a presentation part plus rels declaring slide order explicitly.
+
+    Order is `sldIdLst`'s order, and the part names it reaches are whatever the
+    relationships say. Tests that care about order pass the part names in the
+    order PowerPoint would present them, which is not necessarily numeric.
+    """
+    slide_ids = "".join(
+        f'<p:sldId id="{256 + index}" r:id="rId{index + 1}"/>'
+        for index in range(len(slide_parts))
+    )
+    relationships = "".join(
+        f'<Relationship Id="rId{index + 1}" Type="{SLIDE_RELATIONSHIP_TYPE}" '
+        f'Target="{posixpath.relpath(part, "ppt")}"/>'
+        for index, part in enumerate(slide_parts)
+    )
+    return {
+        "ppt/presentation.xml": PRESENTATION_XML.format(slide_ids=slide_ids),
+        "ppt/_rels/presentation.xml.rels": PRESENTATION_RELS.format(
+            relationships=relationships
+        ),
+    }
+
+
 def full_deck_members(
     *,
     document_title: str = "This is your presentation title",
@@ -113,6 +153,7 @@ def full_deck_members(
             else ["DevOps for Developers", "shownotes"],
             slides=slides,
         ),
+        **presentation_parts(["ppt/slides/slide1.xml"]),
         "ppt/slides/slide1.xml": slide_xml(
             runs
             if runs is not None
@@ -191,6 +232,105 @@ class TestReadingAWholeDeck:
         reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
         assert reading.facts["rendered_title"] == "Devops... reframed"
         assert reading.facts["rendered_footers"] == ["Embracing the Path"]
+
+
+class TestSlideOrderComesFromThePresentationPart:
+    def test_a_reordered_deck_reads_its_real_first_slide(
+        self, source_root: Path
+    ) -> None:
+        """`slide1.xml` is a part name, not a position.
+
+        This deck presents `slide7.xml` first. A reader that assumed the part
+        name would take `slide1.xml`'s interior text as the deck's own title
+        and could confirm — or contradict — the wrong talk on it.
+        """
+        members = {
+            "docProps/app.xml": app_xml(
+                fonts=["Calibri"],
+                slide_titles=["Securing the Software Supply Chain"],
+                slides=2,
+            ),
+            **presentation_parts(["ppt/slides/slide7.xml", "ppt/slides/slide1.xml"]),
+            "ppt/slides/slide7.xml": slide_xml(
+                ["Securing the Software Supply Chain", "a subtitle"]
+            ),
+            "ppt/slides/slide1.xml": slide_xml(["DevOps for Developers"]),
+        }
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "Securing the Software Supply Chain"
+        assert reading.facts["rendered_footers"] == ["a subtitle"]
+        assert "ppt/slides/slide7.xml" in reading.parts_read
+
+    def test_an_absolute_relationship_target_resolves(self, source_root: Path) -> None:
+        members = full_deck_members()
+        members["ppt/_rels/presentation.xml.rels"] = PRESENTATION_RELS.format(
+            relationships=(
+                f'<Relationship Id="rId1" Type="{SLIDE_RELATIONSHIP_TYPE}" '
+                'Target="/ppt/slides/slide1.xml"/>'
+            )
+        )
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "DevOps for Developers"
+
+    def test_no_presentation_part_reads_no_slide_at_all(
+        self, source_root: Path
+    ) -> None:
+        """Guessing a part name is what this replaced, so it must not creep back.
+
+        `app.xml` lists slide titles in presentation order, so the fallback
+        title stays ordered — but no slide is opened, and no footers are
+        invented from one.
+        """
+        members = full_deck_members(
+            slide_titles=["The Ordered First Title"],
+            runs=["Whatever slide1 happens to hold", "and its subtitle"],
+        )
+        del members["ppt/presentation.xml"]
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "The Ordered First Title"
+        assert "rendered_footers" not in reading.facts
+        assert "ppt/slides/slide1.xml" not in reading.parts_read
+
+    def test_a_relationship_of_another_type_is_not_a_slide(
+        self, source_root: Path
+    ) -> None:
+        members = full_deck_members(slide_titles=["The Ordered First Title"])
+        members["ppt/_rels/presentation.xml.rels"] = PRESENTATION_RELS.format(
+            relationships=(
+                '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org'
+                '/officeDocument/2006/relationships/slideMaster" '
+                'Target="slideMasters/slideMaster1.xml"/>'
+            )
+        )
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "The Ordered First Title"
+        assert "rendered_footers" not in reading.facts
+
+    def test_a_target_climbing_out_of_the_package_is_refused(
+        self, source_root: Path
+    ) -> None:
+        members = full_deck_members(slide_titles=["The Ordered First Title"])
+        members["ppt/_rels/presentation.xml.rels"] = PRESENTATION_RELS.format(
+            relationships=(
+                f'<Relationship Id="rId1" Type="{SLIDE_RELATIONSHIP_TYPE}" '
+                'Target="../../outside.xml"/>'
+            )
+        )
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "The Ordered First Title"
+
+    def test_an_empty_slide_list_reads_no_slide(self, source_root: Path) -> None:
+        members = full_deck_members(slide_titles=["The Ordered First Title"])
+        members["ppt/presentation.xml"] = PRESENTATION_XML.format(slide_ids="")
+        write_deck(source_root, "Deck.pptx", members)
+        reading = pptx_deck_facts.read_deck_identity_facts("Deck.pptx", source_root)
+        assert reading.facts["rendered_title"] == "The Ordered First Title"
+        assert "rendered_footers" not in reading.facts
 
 
 class TestInteriorSlidesNeverBecomeRenderedText:

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -522,6 +522,49 @@ class TestReport:
         assert first == second
 
 
+class TestSourceDirectoryFallback:
+    def test_an_absent_source_dir_falls_back_to_the_vault_root(
+        self, tmp_path: Path
+    ) -> None:
+        """`schemas-db.md`: a null or absent `pptx_source_dir` means the vault root.
+
+        Passing the absent value through would report every deck unreadable —
+        a configuration default read as universal damage.
+        """
+        deck(tmp_path, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        payload = database(
+            [
+                catalog_row(
+                    "Voxxed Days Ticino/2025/DevOps for Developers.pptx",
+                    VOXXED_TALK["filename"],
+                )
+            ],
+            [VOXXED_TALK, DEVOXX_TALK],
+            tmp_path,
+        )
+        del payload["config"]["pptx_source_dir"]
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        report = sweep.execute(path)
+        assert report["rows"][0]["deck_facts_reason_code"] == "deck_facts_read"
+        assert report["rows"][0]["disposition"] == sweep.DISPOSITION_CONFIRMED
+
+    @pytest.mark.parametrize("configured", [None, "", "   "])
+    def test_a_blank_source_dir_falls_back_too(
+        self, tmp_path: Path, configured: object
+    ) -> None:
+        deck(tmp_path, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        payload = database([], [VOXXED_TALK], tmp_path)
+        payload["config"]["pptx_source_dir"] = configured
+        assert sweep.resolve_pptx_source_dir(payload, vault_root=tmp_path) == tmp_path
+
+    def test_a_configured_source_dir_wins(self, tmp_path: Path) -> None:
+        payload = database([], [VOXXED_TALK], tmp_path / "Presentations")
+        assert sweep.resolve_pptx_source_dir(payload, vault_root=tmp_path) == str(
+            tmp_path / "Presentations"
+        )
+
+
 class TestVaultResolution:
     def test_a_vault_root_resolves_to_its_canonical_database(
         self, tmp_path: Path

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -1,0 +1,565 @@
+"""Tests for the catalog-wide PPTX-to-talk binding sweep (#176).
+
+Carries this issue's synthetic regressions: same-title decks across venues and
+years, unrelated decks in nearby directories, master/static pairs with
+different slide counts, and a published PDF that disambiguates two candidates.
+
+Every database and every deck is built in-test from fixed literals. Nothing
+reads the clock or a live vault, so a run today and a run next year agree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from test_pptx_deck_facts import full_deck_members, write_deck
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _load_script(module_name: str, filename: str):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sweep = _load_script("sweep_pptx_talk_identity", "sweep-pptx-talk-identity.py")
+
+
+VOXXED_TALK = {
+    "filename": "2025-01-17-voxxed-ticino-devops-developers.md",
+    "title": "DevOps for Developers",
+    "conference": "Voxxed Days Ticino",
+    "date": "2025-01-17",
+}
+DEVOXX_TALK = {
+    "filename": "2024-11-05-devoxx-belgium-devops-developers.md",
+    "title": "DevOps for Developers",
+    "conference": "Devoxx Belgium",
+    "date": "2024-11-05",
+}
+KUBECON_TALK = {
+    "filename": "2025-03-02-kubecon-europe-supply-chain.md",
+    "title": "Securing the Software Supply Chain",
+    "conference": "KubeCon Europe",
+    "date": "2025-03-02",
+}
+
+
+def catalog_row(pptx_path: str, talk_filename: str | None, **overrides: Any) -> dict:
+    row: dict[str, Any] = {
+        "pptx_path": pptx_path,
+        "talk_filename": talk_filename,
+        "matched": talk_filename is not None,
+        "slide_count": 42,
+        "visual_extracted": False,
+        "schema_version": 1,
+    }
+    row.update(overrides)
+    return row
+
+
+def database(rows: list[dict], talks: list[dict], source_root: Path) -> dict:
+    """One owner-current database whose only interesting part is the catalog."""
+    return {
+        "schema_version": 1,
+        "config": {
+            "schema_version": 2,
+            "pptx_directory_exclusions": [],
+            "pptx_source_dir": str(source_root),
+        },
+        "talks": [{**talk, "schema_version": 5, "status": "pending"} for talk in talks],
+        "pptx_catalog": rows,
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+
+
+def sweep_rows(rows: list[dict], talks: list[dict], source_root: Path) -> list[dict]:
+    payload = database(rows, talks, source_root)
+    return sweep.sweep_catalog(payload, pptx_source_dir=str(source_root))
+
+
+@pytest.fixture()
+def source_root(tmp_path: Path) -> Path:
+    root = tmp_path / "Presentations"
+    root.mkdir()
+    return root
+
+
+def deck(
+    source_root: Path,
+    relative: str,
+    *,
+    title: str = "DevOps for Developers",
+    slides: int = 42,
+) -> str:
+    write_deck(
+        source_root,
+        relative,
+        full_deck_members(slide_titles=[title], runs=[title], slides=slides),
+    )
+    return relative
+
+
+class TestDispositions:
+    def test_a_binding_the_assessment_selects_is_confirmed(
+        self, source_root: Path
+    ) -> None:
+        path = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK, KUBECON_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONFIRMED
+        assert rows[0]["selected_talk_filename"] == VOXXED_TALK["filename"]
+
+    def test_a_deck_bound_to_another_talk_is_contradicted(
+        self, source_root: Path
+    ) -> None:
+        """The live vault's defect: a deck feeding evidence to someone else's talk."""
+        path = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [catalog_row(path, KUBECON_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK, KUBECON_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONTRADICTED
+        assert rows[0]["stored_talk_filename"] == KUBECON_TALK["filename"]
+        assert rows[0]["selected_talk_filename"] == VOXXED_TALK["filename"]
+
+    def test_an_unbound_row_is_never_a_proposal_to_bind_it(
+        self, source_root: Path
+    ) -> None:
+        path = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [catalog_row(path, None)],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_UNBOUND
+        assert rows[0]["stored_talk_filename"] is None
+
+    def test_a_row_that_is_not_an_object_is_reported_not_dropped(
+        self, source_root: Path
+    ) -> None:
+        """A dropped row would read as a binding with nothing wrong."""
+        rows = sweep_rows(["not a record"], [VOXXED_TALK], source_root)  # type: ignore[list-item]
+        assert rows[0]["disposition"] == sweep.DISPOSITION_UNASSESSABLE
+        assert rows[0]["reason_codes"] == ["catalog_row_not_an_object"]
+
+
+class TestSameTitleAcrossVenuesAndYears:
+    def test_two_deliveries_of_one_talk_stay_distinguishable(
+        self, source_root: Path
+    ) -> None:
+        ticino = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        belgium = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [
+                catalog_row(ticino, VOXXED_TALK["filename"]),
+                catalog_row(belgium, DEVOXX_TALK["filename"]),
+            ],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        assert [row["disposition"] for row in rows] == [
+            sweep.DISPOSITION_CONFIRMED,
+            sweep.DISPOSITION_CONFIRMED,
+        ]
+
+    def test_swapping_the_two_deliveries_contradicts_both(
+        self, source_root: Path
+    ) -> None:
+        """Identical titles must not let one delivery's deck pass as the other's."""
+        ticino = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        belgium = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [
+                catalog_row(ticino, DEVOXX_TALK["filename"]),
+                catalog_row(belgium, VOXXED_TALK["filename"]),
+            ],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        assert [row["disposition"] for row in rows] == [
+            sweep.DISPOSITION_CONTRADICTED,
+            sweep.DISPOSITION_CONTRADICTED,
+        ]
+
+    def test_the_same_venue_a_year_apart_is_not_one_delivery(
+        self, source_root: Path
+    ) -> None:
+        later = {
+            "filename": "2026-01-20-voxxed-ticino-devops-developers.md",
+            "title": "DevOps for Developers",
+            "conference": "Voxxed Days Ticino",
+            "date": "2026-01-20",
+        }
+        path = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [catalog_row(path, later["filename"])],
+            [VOXXED_TALK, later],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONTRADICTED
+        assert rows[0]["selected_talk_filename"] == VOXXED_TALK["filename"]
+
+
+class TestUnrelatedDecksInNearbyDirectories:
+    def test_a_second_talk_at_the_same_venue_makes_the_binding_ambiguous(
+        self, source_root: Path
+    ) -> None:
+        """Two talks fit the directory; the deck's title says which, and both
+        readings are corroborated, so nothing is proven."""
+        ticino_supply_chain = {
+            "filename": "2025-01-18-voxxed-ticino-supply-chain.md",
+            "title": "Securing the Software Supply Chain",
+            "conference": "Voxxed Days Ticino",
+            "date": "2025-01-18",
+        }
+        path = deck(
+            source_root,
+            "Voxxed Days Ticino/2025/Securing the Software Supply Chain.pptx",
+            title="Securing the Software Supply Chain",
+        )
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, ticino_supply_chain, KUBECON_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_REVIEW_REQUIRED
+        assert "identity_ambiguous_candidates" in rows[0]["reason_codes"]
+
+    def test_a_rival_the_directory_contradicts_does_not_unseat_the_binding(
+        self, source_root: Path
+    ) -> None:
+        """The reused-talk-family case, and why a title mismatch cannot veto.
+
+        The deck renders KubeCon's title but sits in Ticino's 2025 directory,
+        and KubeCon's venue contradicts that directory. `pptx_talk_identity`
+        treats a non-agreeing title as missing corroboration rather than as
+        contradiction — a deck legitimately carries a punchier title than its
+        catalog entry — so the venue and year decide. Asserted here because
+        the opposite rule would make every reused talk's deck unprovable.
+        """
+        path = deck(
+            source_root,
+            "Voxxed Days Ticino/2025/Securing the Software Supply Chain.pptx",
+            title="Securing the Software Supply Chain",
+        )
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, KUBECON_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONFIRMED
+        kubecon = next(
+            entry
+            for entry in rows[0]["assessment"]["candidates"]
+            if entry["talk_filename"] == KUBECON_TALK["filename"]
+        )
+        # The rival's own standing is still reported, so the owner sees the
+        # title evidence the verdict did not act on.
+        assert kubecon["agreeing"] == ["title"]
+        assert kubecon["conflicting"] == ["venue"]
+
+
+class TestMasterAndStaticPairs:
+    def test_a_master_never_confirms_a_binding(self, source_root: Path) -> None:
+        path = deck(
+            source_root,
+            "Voxxed Days Ticino/2025/master/DevOps for Developers.pptx",
+            slides=95,
+        )
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"], slide_count=95)],
+            [VOXXED_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_REVIEW_REQUIRED
+        assert rows[0]["artifact_role"] == "master"
+        assert "identity_non_delivery_artifact" in rows[0]["reason_codes"]
+
+    def test_the_pair_is_told_apart_by_role_and_slide_count(
+        self, source_root: Path
+    ) -> None:
+        """One delivery, two artifacts: only the delivery deck may be confirmed."""
+        delivery = deck(
+            source_root,
+            "Voxxed Days Ticino/2025/DevOps for Developers.pptx",
+            slides=95,
+        )
+        export = deck(
+            source_root,
+            "Voxxed Days Ticino/2025/static/DevOps for Developers.pptx",
+            slides=40,
+        )
+        rows = sweep_rows(
+            [
+                catalog_row(delivery, VOXXED_TALK["filename"], slide_count=95),
+                catalog_row(export, VOXXED_TALK["filename"], slide_count=40),
+            ],
+            [VOXXED_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONFIRMED
+        assert rows[0]["artifact_role"] == "delivery"
+        assert rows[1]["disposition"] == sweep.DISPOSITION_REVIEW_REQUIRED
+        assert rows[1]["artifact_role"] == "static_export"
+        # The counts are what tells the owner which artifact is which, so the
+        # sweep reports both the deck's own count and the row's stored claim.
+        assert [row["deck_slide_count"] for row in rows] == [95, 40]
+        assert [row["stored_slide_count"] for row in rows] == [95, 40]
+
+    def test_a_deck_whose_stored_count_no_longer_matches_is_visible(
+        self, source_root: Path
+    ) -> None:
+        path = deck(
+            source_root,
+            "Voxxed Days Ticino/2025/DevOps for Developers.pptx",
+            slides=95,
+        )
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"], slide_count=40)],
+            [VOXXED_TALK],
+            source_root,
+        )
+        assert rows[0]["deck_slide_count"] == 95
+        assert rows[0]["stored_slide_count"] == 40
+
+
+class TestPublishedPdfDisambiguates:
+    def test_the_pdf_identity_decides_between_two_equal_candidates(self) -> None:
+        """Without the PDF both deliveries agree on title; with it, one wins.
+
+        Asserted against the identity module rather than through the sweep,
+        because the sweep has no producer for this fact: the live vault's
+        talk-referenced PDFs live in the vault's own `slides/` directory and
+        never beside a deck, so no deterministic deck-to-PDF binding exists to
+        read. Inventing one would manufacture the evidence the module refuses
+        to assume. The contract is covered so a future producer inherits it.
+        """
+        identity = _load_script("pptx_talk_identity", "pptx_talk_identity.py")
+        ambiguous = identity.assess_pptx_talk_identity(
+            {
+                "pptx_path": "Decks/DevOps for Developers.pptx",
+                "rendered_title": "DevOps for Developers",
+            },
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+        assert ambiguous.verdict == "review_required"
+        decided = identity.assess_pptx_talk_identity(
+            {
+                "pptx_path": "Decks/DevOps for Developers.pptx",
+                "rendered_title": "DevOps for Developers",
+                "published_pdf_talk_filename": VOXXED_TALK["filename"],
+            },
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+        assert decided.verdict == "matched"
+        assert decided.selected_talk_filename == VOXXED_TALK["filename"]
+
+
+class TestDamagedDecks:
+    def test_damage_weakens_evidence_never_the_requirement(
+        self, source_root: Path
+    ) -> None:
+        (source_root / "Voxxed Days Ticino" / "2025").mkdir(parents=True)
+        broken = "Voxxed Days Ticino/2025/DevOps for Developers.pptx"
+        (source_root / broken).write_text("not a package", encoding="utf-8")
+        rows = sweep_rows(
+            [catalog_row(broken, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        # Venue and year still come from the path, so the binding is still
+        # assessed — with the deck's own title absent, not waived.
+        assert rows[0]["deck_facts_reason_code"] == "deck_facts_not_a_package"
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONFIRMED
+        assert rows[0]["observed_facts"] == []
+
+    def test_a_damaged_deck_cannot_confirm_the_wrong_talk(
+        self, source_root: Path
+    ) -> None:
+        (source_root / "Voxxed Days Ticino" / "2025").mkdir(parents=True)
+        broken = "Voxxed Days Ticino/2025/DevOps for Developers.pptx"
+        (source_root / broken).write_text("not a package", encoding="utf-8")
+        rows = sweep_rows(
+            [catalog_row(broken, DEVOXX_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONTRADICTED
+
+
+class TestCandidateTable:
+    def test_only_material_candidates_are_serialized(self, source_root: Path) -> None:
+        """215 rows of six `unknown` verdicts is not evidence, it is noise."""
+        path = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK, KUBECON_TALK],
+            source_root,
+        )
+        table = rows[0]["assessment"]["candidates"]
+        assert rows[0]["assessment"]["candidates_assessed"] == 3
+        assert all(
+            any(verdict != "unknown" for verdict in entry["signals"].values())
+            for entry in table
+        )
+
+    def test_the_selected_candidate_survives_the_trim(self, source_root: Path) -> None:
+        """The trim must never remove the evidence behind the verdict."""
+        path = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK, KUBECON_TALK],
+            source_root,
+        )
+        names = {
+            entry["talk_filename"] for entry in rows[0]["assessment"]["candidates"]
+        }
+        assert VOXXED_TALK["filename"] in names
+
+    def test_the_trimmed_assessment_still_authorizes_its_binding(
+        self, source_root: Path
+    ) -> None:
+        """What the sweep reports must be what the owner gate would accept."""
+        identity = _load_script("pptx_talk_identity", "pptx_talk_identity.py")
+        path = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        rows = sweep_rows(
+            [catalog_row(path, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK, KUBECON_TALK],
+            source_root,
+        )
+        assessment = dict(rows[0]["assessment"])
+        assessment.pop("candidates_assessed")
+        assert (
+            identity.binding_refusal(
+                assessment,
+                pptx_path=path,
+                talk_filename=VOXXED_TALK["filename"],
+            )
+            is None
+        )
+
+
+class TestReport:
+    def test_counts_cover_the_whole_catalog_even_when_rows_are_filtered(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        good = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        payload = database(
+            [
+                catalog_row(good, VOXXED_TALK["filename"]),
+                catalog_row(bad, VOXXED_TALK["filename"]),
+            ],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        report = sweep.execute(path, dispositions=[sweep.DISPOSITION_CONTRADICTED])
+        assert report["catalog_row_count"] == 2
+        assert report["disposition_counts"][sweep.DISPOSITION_CONFIRMED] == 1
+        assert report["disposition_counts"][sweep.DISPOSITION_CONTRADICTED] == 1
+        assert len(report["rows"]) == 1
+
+    def test_unresolved_counts_every_binding_a_reparse_would_carry_forward(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        good = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        unbound = deck(source_root, "Decks/Loose.pptx", title="Loose")
+        payload = database(
+            [
+                catalog_row(good, VOXXED_TALK["filename"]),
+                catalog_row(bad, VOXXED_TALK["filename"]),
+                catalog_row(unbound, None),
+            ],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        report = sweep.execute(path)
+        # Confirmed and unbound rows are resolved; only the contradiction is not.
+        assert report["unresolved_binding_count"] == 1
+
+    def test_the_report_is_stable_across_runs(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        path_a = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        payload = database(
+            [catalog_row(path_a, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        first = sweep.execute(path)
+        second = sweep.execute(path)
+        assert first == second
+
+
+class TestVaultResolution:
+    def test_a_vault_root_resolves_to_its_canonical_database(
+        self, tmp_path: Path
+    ) -> None:
+        root, database_path = sweep.resolve_input(tmp_path)
+        assert root == tmp_path
+        assert database_path == tmp_path / "tracking-database.json"
+
+    def test_a_database_path_resolves_to_its_parent_root(self, tmp_path: Path) -> None:
+        given = tmp_path / "tracking-database.json"
+        root, database_path = sweep.resolve_input(given)
+        assert root == tmp_path
+        assert database_path == given
+
+
+class TestCli:
+    def test_an_unreadable_database_reports_a_neutral_code(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = sweep.main([str(tmp_path)])
+        assert exit_code == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is False
+        assert "error" in payload
+
+    def test_a_swept_catalog_exits_zero_with_contradictions_present(
+        self, tmp_path: Path, source_root: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A reporting tool, not a gate: preflight is what blocks."""
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        payload = database(
+            [catalog_row(bad, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        exit_code = sweep.main([str(path)])
+        assert exit_code == 0
+        report = json.loads(capsys.readouterr().out)
+        assert report["disposition_counts"][sweep.DISPOSITION_CONTRADICTED] == 1


### PR DESCRIPTION
## What this is

#288 landed the identity assessment and #289 wired it into `record_pptx`, so a
**new** talk binding must now be proven. Neither touched the rows already in the
database.

Measured on the live vault: **82 catalog rows, all schema v1. 74 of them bind a
talk, and not one carries an `identity_assessment`.** Migration leaves v1 rows
alone by design — it carries no `visual_evidence` either, and inventing a
binding for it was already ruled out. So preflight's `_check_pptx_talk_identity`
blocks all 74, and nothing in the toolkit could tell a correct binding from a
wrong one. That is the hard blocker in front of the reparse.

## What it adds

**`sweep-pptx-talk-identity.py`** — the catalog-wide assessment. Every row
against every talk in the vault, one disposition each: `binding_confirmed`,
`binding_contradicted`, `binding_review_required`, `binding_unproven`,
`unbound_row`. Read-only; a disposition is evidence for an owner decision, never
a decision. Preflight stays the gate.

**`pptx_deck_facts.py`** — the observer it needed. `pptx_talk_identity` decides
from facts someone else gathered, and nobody gathered them for a deck already on
disk. Reads `docProps/core.xml`, `docProps/app.xml`, and the title slide out of
the OPC package: stdlib only, bounded per part, never fatal. A damaged deck is
still assessed from its path — damage weakens the evidence, not the requirement.

## The result on the live vault

| Disposition | Rows |
|---|---:|
| `binding_confirmed` | 30 |
| `binding_contradicted` | **7** |
| `binding_review_required` | 37 |
| `unbound_row` | 8 |

The 7 are real mis-assignments:

- `UberConf/2023/DevOps Reframed.pptx` → bound to a **BaselOne** talk
- `Devoxx/Ukraine/2023/DPE with LLM.pptx` → bound to a **2024** Devoxx talk
- `DeveloperWeek/CA 2024/Sadogursky, Baruch, Fri.pptx` → bound to the wrong one
  of two Developer Week 2024 talks. Same venue, same day, so venue and year
  could not discriminate; only the deck's own title slide could.

## The measurement that shaped it

Only the title slide supplies rendered text. Feeding in `app.xml`'s full
slide-title list instead made **69 of the 74** bound decks
`identity_ambiguous_candidates` — a deck mentioning another talk's title on an
interior slide agrees with that talk, and agreeing with everything is
indistinguishable from carrying no evidence. That is a test, not a comment.

## Deliberate omissions

The **published-PDF signal is not observed**. The vault's talk-referenced PDFs
live under the vault's own `slides/`, never beside a deck, so no deterministic
deck-to-PDF binding exists to read. Guessing one would manufacture the evidence
this contract exists to require. Covered by a contract regression so a future
producer inherits it.

**No writer.** Severing an unproven binding touches both sides — the catalog
row's `talk_filename` and the talk's own `pptx_path` — and no owner mutation
clears the latter. That is its own change; this PR is the evidence it acts on.

## Also

`pptx_catalog_selection._open_contained` becomes public
`open_contained_descriptor` in its owner module, so the deck reader shares one
containment rule with the evidence classifier instead of copying it. The sweep
must not be able to read a file the classifier would have refused.

## Tests

49 new, covering this issue's named synthetic regressions: same-title decks
across venues and years, unrelated decks in nearby directories, master/static
pairs with different slide counts, and a published PDF that disambiguates two
candidates. Every package is built in-test from fixed literals — no binary
fixture, no clock. Full suite: 5693 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh