### PR TITLE
feat(vault-ingress): activate weighted scoring (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,22 @@ Measured on the live vault: 6 talks restamp v5→v6; the other 209 are schema v1
 and stay v1, as they already did. No talk carries a scoring-generation stamp at
 all, so the whole corpus requeues on generation grounds regardless.
 
+The canonicalizer emits `pattern_score_basis` for a weighted return,
+recomputed from the canonical detection lanes rather than copied from the
+return. Without it a v6 return canonicalized to the v5 field set, and the
+fractional score it carries is rejected at that shape — v6 that validates and
+cannot be stored.
+
+`migrate_tracking_database`'s root-v1 branch derives `changed` from every record
+count instead of a hand-listed subset. A flag that names the collections it
+knows about goes stale the moment a migration touches one it does not, and a
+caller trusting it skips persisting a migration that already rewrote the records
+it was handed.
+
+`SKILL.md`, `schemas-db.md`, `queue-selection.md`, and
+`subagent-instructions.md` describe v6: a contract the docs still call v5 sends
+workers to emit returns that fresh v6 claims reject.
+
 Test fixtures that pinned version literals now derive them. Several had gone
 silently wrong rather than loudly stale — `_write_db` in the queue tests
 enriched only talks stamped at the literal 5, so at any other generation it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+### feat(vault-ingress) — activate weighted scoring (#299)
+
+#293 defined the weighted return contract and stopped: v6 validated but could
+not reach the database. This is the activation, and it moves as one change
+because `queue-state.py` asserts the claim, queue-claim, and return schema
+versions equal at import time — staged separately, the module does not load.
+
+Advanced together: `RETURN_SCHEMA_VERSION`, `QUEUE_CLAIM_SCHEMA_VERSION`,
+`CURRENT_QUEUE_CLAIM_SCHEMA_VERSION`, `PATTERN_SCORING_SCHEMA_VERSION`,
+`CURRENT_PATTERN_SCORING_SCHEMA_VERSION`, and `TALK_RECORD_SCHEMA_VERSION`,
+plus v6 joining `CANONICALIZABLE_RETURN_SCHEMA_VERSIONS`.
+
+**The current-version pointers are derived, not written.** `RETURN_SCHEMA_VERSION`
+is now `WEIGHTED_SCORE_RETURN_SCHEMA_VERSION` and `PATTERN_SCORING_SCHEMA_VERSION`
+is `WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION`, with
+`EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION` and
+`FLAT_PATTERN_SCORING_SCHEMA_VERSION` naming v5 for the sets that mean v5. The
+four generation sets named v5 *through the current-version pointer*, so bumping
+it would have dropped v5 out of `SUPPORTED_RETURN_SCHEMA_VERSIONS`,
+`SNAPSHOT_*`, `OUTCOME_GATE_*` and `SOURCE_LOCATED_*` — a validator that
+silently stops accepting the generation it accepted yesterday.
+
+**A production defect the bump exposed.** `queue_claim_contract` chose the
+expected adherence-baseline schema with
+`version == CURRENT_QUEUE_CLAIM_SCHEMA_VERSION`. Advancing the claim schema
+therefore demanded the *legacy* baseline of every already-stored v5 claim and
+rejected the lot. The rule now keys on
+`OPPORTUNITY_QUEUE_CLAIM_SCHEMA_VERSION`, the generation that introduced
+baseline v2, so it belongs to that generation and every later one.
+
+**The migration restamps; it never rescores.** `_restamp_talk_records` moves a
+v5 record to the v6 shape and leaves `pattern_scoring_schema_version` alone.
+Computing a basis from stored detections would recompute a score under
+arithmetic its worker never used — the reinterpretation `_validate_score`
+refuses on the way in. The talk keeps the truth about its own number, the
+cohort selector excludes it as a generation mismatch, and it requeues. That is
+the reparse, made mechanical rather than remembered. Without the restamp the
+bump alone would lock the database: the owner writer requires the exact current
+talk schema before any mutation.
+
+Measured on the live vault: 6 talks restamp v5→v6; the other 209 are schema v1
+and stay v1, as they already did. No talk carries a scoring-generation stamp at
+all, so the whole corpus requeues on generation grounds regardless.
+
+Test fixtures that pinned version literals now derive them. Several had gone
+silently wrong rather than loudly stale — `_write_db` in the queue tests
+enriched only talks stamped at the literal 5, so at any other generation it
+skipped them and they failed a later opportunity-identity check as though the
+fixture had never been valid.
+
 ## 0.20.71 — 2026-08-14
 
 ### feat(vault-ingress) — a score is only as current as the block it came from (#167)

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -122,7 +122,7 @@ Then claim each exact batch:
   --batch-id <stable-batch> --now <timezone-aware-ISO>
 ```
 
-Fresh claims are schema v6 and require return v6 — the weighted scoring generation (#299). A v6 return carries `pattern_score_basis` and may carry a fractional `pattern_score`. Use the stored claim on replay;
+Fresh claims are schema v6 and require return v6. A v6 return carries `pattern_score_basis` and may carry a fractional `pattern_score`. Use the stored claim on replay;
 recover a stranded lease and issue a new generation. Set the best verified slide
 source, use `skipped_no_sources` only when every source is unavailable, and honor
 an explicit filename/title argument as a one-talk selection.
@@ -207,8 +207,8 @@ If `{vault_root}/speaker-profile.json` exists, invoke `Skill(skill: "vault-profi
 with the updated tracking database plus the resolved `{vault_root}` and exact
 database-configured `{python_path}` as handoff context. The profile skill re-reads
 the database and rejects a missing or mismatched interpreter; never let the handoff
-fall back to `python3` on `PATH`. It writes speaker-profile schema v5 — a different axis from the return/claim/talk generations — by classifying the existing raw
-outcomes; this does not reparse talks. Report the diff of changes (added fields,
+fall back to `python3` on `PATH`. It writes speaker-profile schema v5 by classifying the existing raw
+outcomes; this does not reparse talks. Speaker-profile schema versions are independent of the return, claim, and talk schema versions. Report the diff of changes (added fields,
 changed values) so the speaker can verify.
 
 If the profile doesn't exist, skip this step silently.

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -122,7 +122,7 @@ Then claim each exact batch:
   --batch-id <stable-batch> --now <timezone-aware-ISO>
 ```
 
-Fresh claims are schema v5 and require return v5. Use the stored claim on replay;
+Fresh claims are schema v6 and require return v6 — the weighted scoring generation (#299). A v6 return carries `pattern_score_basis` and may carry a fractional `pattern_score`. Use the stored claim on replay;
 recover a stranded lease and issue a new generation. Set the best verified slide
 source, use `skipped_no_sources` only when every source is unavailable, and honor
 an explicit filename/title argument as a one-talk selection.

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -207,7 +207,7 @@ If `{vault_root}/speaker-profile.json` exists, invoke `Skill(skill: "vault-profi
 with the updated tracking database plus the resolved `{vault_root}` and exact
 database-configured `{python_path}` as handoff context. The profile skill re-reads
 the database and rejects a missing or mismatched interpreter; never let the handoff
-fall back to `python3` on `PATH`. It writes schema v5 by classifying the existing raw
+fall back to `python3` on `PATH`. It writes speaker-profile schema v5 — a different axis from the return/claim/talk generations — by classifying the existing raw
 outcomes; this does not reparse talks. Report the diff of changes (added fields,
 changed values) so the speaker can verify.
 

--- a/skills/vault-ingress/references/queue-selection.md
+++ b/skills/vault-ingress/references/queue-selection.md
@@ -6,7 +6,7 @@ and recovery rule below.
 
 Fresh queue work uses claim schema v6. Before changing any talk status,
 `queue-state.py claim` snapshots one immutable `adherence_baseline` for the
-entire selected batch, stamps `required_return_schema_version: 5`, and copies
+entire selected batch, stamps `required_return_schema_version: 6`, and copies
 that exact snapshot into every member claim. The snapshot uses the current
 catalog fingerprint and pattern-scoring schema, includes only current
 `processed`/`processed_partial` talks, and excludes every active-batch filename
@@ -43,7 +43,7 @@ before inspecting its prior score. Its `as_of` equals the claim's canonical
   --batch-id <stable-batch> --now <timezone-aware-ISO>`. The command selects
   `pending`, `needs-reprocessing`, and retryable download failures, writes an
   atomic lease, increments `reprocess_generation`, and returns the claimed talk
-  list. Every fresh claim is schema v5 and requires return schema v5. Never
+  list. Every fresh claim is schema v6 and requires return schema v6. Never
   change a record to `reprocessing-inflight` by hand.
 - Before claiming a non-YouTube talk whose transcript will be used as evidence,
   acquire the transcript and register its canonical vault-relative

--- a/skills/vault-ingress/references/queue-selection.md
+++ b/skills/vault-ingress/references/queue-selection.md
@@ -4,7 +4,7 @@ This is the complete normative Step 2 contract for `vault-ingress`. Execute
 normalization before claiming, and preserve every generation, freshness, replay,
 and recovery rule below.
 
-Fresh queue work uses claim schema v5. Before changing any talk status,
+Fresh queue work uses claim schema v6. Before changing any talk status,
 `queue-state.py claim` snapshots one immutable `adherence_baseline` for the
 entire selected batch, stamps `required_return_schema_version: 5`, and copies
 that exact snapshot into every member claim. The snapshot uses the current

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -324,7 +324,7 @@ customization, not the owner default. See the
       "not_evaluable": []
     }
   }],
-  "_comment_schema_version": "Database schema v1 is owner-migrated by vault-ingress. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, evidence ledger v2, and current scoring schema v5. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
+  "_comment_schema_version": "Database schema v1 is owner-migrated by vault-ingress. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "schema_version": 3,
@@ -784,12 +784,16 @@ The four version axes are deliberately explicit:
 | v1 or v2 | saved v1 or v2 only | migrated legacy record | never current v5 |
 | v3 | v3 only | migrated union-safe record | never current v5 |
 | v4 | v4 only | archival source-located v4 | never current v5 |
-| v5 | v5 only | v5 | v5 when canonical evidence/outcomes are fresh |
+| v5 | v5 only | v5 | never current v6 |
+| v6 | v6 only | v6 | v6 when canonical evidence/outcomes are fresh |
 
 Claim/return compatibility authorizes replay; it does not grant current scoring
-status. Only a v5 return canonicalized from current source artifacts can produce
-talk schema v5 with `pattern_scoring_schema_version: 5`, evidence ledger v2,
-exhaustive outcomes, and `pattern_scoring_generation_status: "current"`.
+status. Only a v6 return canonicalized from current source artifacts can produce
+talk schema v6 with `pattern_scoring_schema_version: 6`, evidence ledger v2,
+exhaustive outcomes, `pattern_score_basis`, and
+`pattern_scoring_generation_status: "current"`. A v5 return still validates and
+still persists, at the flat scoring generation; weighted and flat scores are not
+comparable and never share a cohort.
 V1–v3 detections retain the explicit empty-citation legacy sentinel. V4 keeps
 its source locations and evidence ledger v1 but migration never fabricates v5
 applicability assessments, outcomes, or opportunity identity.
@@ -1044,12 +1048,12 @@ classification rule including how a dominant class is selected, the provenance
 evidence used, and how unverified origins are counted as `unknown`. Both fields
 are authored-slide evidence and cannot be supplied from untrusted video context.
 
-The worker matches the active claim contract. Every fresh claim is schema v5
-with `required_return_schema_version: 5`, and only that exact claim authorizes a
-v5 return. Saved claim schemas v1/v2 authorize only return schemas v1/v2;
-schema v3 authorizes only v3; schema v4 authorizes only archival v4. Recover a
-live legacy lease and issue a new v5 generation; never mutate its claim to make
-a newer return appear compatible.
+The worker matches the active claim contract. Every fresh claim is schema v6
+with `required_return_schema_version: 6`, and only that exact claim authorizes a
+v6 return. Saved claim schemas v1/v2 authorize only return schemas v1/v2;
+schema v3 authorizes only v3; schema v4 authorizes only archival v4; schema v5
+authorizes only v5. Recover a live legacy lease and issue a new v6 generation;
+never mutate its claim to make a newer return appear compatible.
 
 For newly emitted work, `validate-returns.py` must report the processed talk's
 scoring-generation status as `current`; a valid but
@@ -1074,25 +1078,32 @@ table would restate what that worker meant rather than validate what it said. A
 v5 return carrying `pattern_score_basis` is rejected outright — the field cannot
 exist under its contract.
 
-**Writer.** No worker emits v6 yet. Every fresh claim is schema v5 with
-`required_return_schema_version: 5`, so v6 is accepted-but-unissued until the
-claim contract advances. `PATTERN_SCORING_SCHEMA_VERSION` stays at 5 for the same
-reason: bumping it before a return emits a weighted score would strand every
-persisted talk on a generation nothing has produced.
+**Writer.** Every fresh claim is schema v6 with
+`required_return_schema_version: 6`, so a worker is issued a v6 return.
+`PATTERN_SCORING_SCHEMA_VERSION` is 6; `FLAT_PATTERN_SCORING_SCHEMA_VERSION`
+names the flat generation, and `scoring_schema_version_for_return` maps a return
+to the generation its score belongs to. Weighted and flat scores are not
+comparable and never share a cohort.
 
-**Not yet persisted.** v6 validates as a return contract and nothing further: it
-is absent from `CANONICALIZABLE_RETURN_SCHEMA_VERSIONS`, so a v6 return cannot be
-canonicalized and therefore cannot reach the database. A persisted `pattern_score`
-stays an integer, and no stored `pattern_observations` carries a basis.
+**Persisted shape.** A canonicalized v6 block carries
+`pattern_score_basis` and its `pattern_score` may be fractional. The accepted
+field sets are distinct, not v5-plus-an-optional-field: a v5 record carrying a
+basis and a v6 record missing one are both malformed. The basis is recomputed
+from the persisted detection lanes on the way out of the database as well as on
+the way in — a stored basis that agrees with a stored score proves only that
+whoever wrote them agreed with themselves.
 
-Persisting a weighted score is a new talk-record shape, and
-`mutate-tracking-database` requires the exact current talk schema before any
-mutation — so admitting it alone would leave every stored talk unmutatable until
-a migration restamped it. That shape, its schema bump, the claim contract, and
-the migration advance together in one activation change.
+**Migration.** `_restamp_talk_records` moves a v5 talk record to v6 and leaves
+`pattern_scoring_schema_version` alone. It restamps; it never rescores.
+Computing a basis from stored detections would recompute a score under
+arithmetic its worker never used, which is the reinterpretation validation
+refuses on the way in. The record's shape advances, its score does not, and the
+cohort selector then excludes it as a generation mismatch and requeues it.
+Without the restamp the schema bump alone would leave every stored talk
+unmutatable, since the owner writer requires the exact current talk schema.
 
-**Migration.** None. Weights are part of the scoring schema version, so changing
-one is a scoring-generation bump, never a tuning knob.
+Weights are part of the scoring schema version, so changing one is a
+scoring-generation bump, never a tuning knob.
 
 The basis a v6 return carries has this shape:
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -262,7 +262,7 @@ customization, not the owner default. See the
       "claimed_at": "2026-07-31T18:00:00+00:00",
       "previous_status": "needs-reprocessing",
       "reprocess_generation": 1,
-      "required_return_schema_version": 5,
+      "required_return_schema_version": 6,
       "adherence_baseline": {
         "schema_version": 2,
         "as_of": "2026-07-31T18:00:00+00:00",
@@ -721,7 +721,7 @@ mutually exclusive shape and omits both `pattern_scoring_schema_version` and
 }
 ```
 
-A fresh v5 worker uses the exact empty adherence sentinel and does not author a
+A fresh v6 worker uses the exact empty adherence sentinel and does not author a
 raw-score comparison. Only an owner-side consumer that sees the canonical talk
 outcomes may compare against a baseline carrying the same
 `opportunity_coverage_identity`. Baseline schema v2 keeps all fresh-v5 talks in
@@ -753,7 +753,7 @@ manual` is provenance only and does not prove an artifact exists. Legacy
 no-video/no-transcript statuses normalize to `skipped_no_sources` only when the
 shared verified-local plus remote-acquisition capability list is empty.
 
-Every fresh queue claim is schema v5 and carries exactly the
+Every fresh queue claim is schema v6 and carries exactly the
 `required_return_schema_version` and `adherence_baseline` fields shown above.
 The queue owner builds one baseline before mutating any selected talk, copies it
 unchanged to every batch member, and requires `adherence_baseline.as_of` to equal

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -466,11 +466,12 @@ them from the preclaim artifacts and rejects false bounds or source claims.
 Return exactly the shape in [schemas-db.md](schemas-db.md). `status`,
 `slide_source`, all five catalog-feedback lanes, and the complete pattern score
 object are mandatory. Match `return_schema_version` to the active claim:
-fresh claim-schema v5 with `required_return_schema_version: 5` emits return v5.
+fresh claim-schema v6 with `required_return_schema_version: 6` emits return v6.
 Saved claim schemas v1/v2 authorize only saved return schemas v1/v2; claim
-schema v3 authorizes only return schema v3, and claim schema v4 authorizes only
-archival return schema v4.
-Recover a live legacy lease and issue a fresh v5 generation; never mutate its
+schema v3 authorizes only return schema v3, claim schema v4 authorizes only
+archival return schema v4, and claim schema v5 authorizes only return schema
+v5 — a saved legacy replay generation, never a fresh one.
+Recover a live legacy lease and issue a fresh v6 generation; never mutate its
 claim or attach a newer return to it.
 Snapshot versions 2–5 require `rhetoric_notes` and `areas_for_improvement` to
 contain substantive non-whitespace analysis. Empty strings remain valid for
@@ -484,7 +485,7 @@ never emit JSON `null`.
 Omit `processed_date`; the persistence writer owns one normalized timestamp for
 the complete queue batch and the analysis writer renders that stored value.
 
-For return v5, always return `"adherence_assessment": ""` exactly and omit
+For return v5 and v6, always return `"adherence_assessment": ""` exactly and omit
 `adherence_comparison`. The worker cannot know the canonical, engine-owned talk
 `opportunity_coverage_identity`. Only an owner-side consumer after persistence
 may compare a talk against a schema-v2 baseline, and only when the identities
@@ -523,7 +524,7 @@ nested dictionary union. Put genuinely additive experimental data under
 `structured_data.extensions.<producer_namespace>`; an undeclared top-level object
 is rejected until its replacement policy is documented and registered.
 
-Minimal processed structure for a fresh v5 claim:
+Minimal processed structure for a fresh v6 claim:
 
 ```json
 {
@@ -611,9 +612,10 @@ The array is duplicate-free, excludes the `source_comparison` marker, and must
 exactly match one qualifying catalog group.
 
 Fresh work arrives only under a claim-v5 payload that explicitly requires return
-v5. Saved claims v1/v2 remain replayable only with saved returns v1/v2; claim v3
-requires return v3 and claim v4 requires archival return v4. Recover a live
-legacy lease without rewriting it; otherwise issue a new v5 claim. Never alter a
+v6. Saved claims v1/v2 remain replayable only with saved returns v1/v2; claim v3
+requires return v3, claim v4 requires archival return v4, and claim v5 requires
+return v5. Recover a live legacy lease without rewriting it; otherwise issue a
+new v6 claim. Never alter a
 saved claim payload, invent a schema, or attach a newer return to a legacy claim.
 
 In raw v4/v5 citations, return only `source`, `channel`, and the locator you

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -6,7 +6,7 @@ returns the JSON shape in [schemas-db.md](schemas-db.md). The summary supports
 qualitative rhetoric analysis, but Section 15 is human narrative and MUST NOT be
 parsed for numeric adherence. The active claim's immutable
 `adherence_baseline` is the sole numeric authority.
-A successfully persisted v5 return is the only return generation eligible for pattern-scoring schema v5;
+A successfully persisted v6 return is the only return generation eligible for pattern-scoring schema v6;
 saved legacy claims remain replayable only with their
 same-numbered archival return generation.
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -611,7 +611,7 @@ example, `"evidence_sources_used": ["static_slides", "native_deck"]`.
 The array is duplicate-free, excludes the `source_comparison` marker, and must
 exactly match one qualifying catalog group.
 
-Fresh work arrives only under a claim-v5 payload that explicitly requires return
+Fresh work arrives only under a claim-v6 payload that explicitly requires return
 v6. Saved claims v1/v2 remain replayable only with saved returns v1/v2; claim v3
 requires return v3, claim v4 requires archival return v4, and claim v5 requires
 return v5. Recover a live legacy lease without rewriting it; otherwise issue a

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -60,14 +60,17 @@ LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION = 1
 PATTERN_EVIDENCE_SCHEMA_VERSION = 2
 SOURCE_LOCATED_RETURN_SCHEMA_VERSION = 4
 EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION = 5
-# v6 validates as a return contract but does not persist yet: admitting it here
-# would store a new record shape under talk schema v5. Persistence, the talk
-# schema bump, the claim contract, and the migration advance together in the
-# activation change, not piecemeal.
+WEIGHTED_SCORE_RETURN_SCHEMA_VERSION = 6
+# v6 canonicalizes as of the activation (#299): persistence, the talk schema
+# bump, the claim contract, and the migration moved together.
 CANONICALIZABLE_RETURN_SCHEMA_VERSIONS = frozenset(
-    {SOURCE_LOCATED_RETURN_SCHEMA_VERSION, EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION}
+    {
+        SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
+        EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
+        WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+    }
 )
-CURRENT_PATTERN_SCORING_SCHEMA_VERSION = 5
+CURRENT_PATTERN_SCORING_SCHEMA_VERSION = 6
 PATTERN_OUTCOMES = frozenset(
     {"detected", "undetected", "not_evaluable", "not_applicable"}
 )

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -29,23 +29,24 @@ when state changed.
 
 Claim schema (owned by this script; stored in ``talk._queue_claim``):
     {
-      "schema_version": 5,
+      "schema_version": 6,
       "run_id": "reparse-2026-07",
       "batch_id": "25",
       "claimed_at": "2026-07-31T18:00:00+00:00",
       "previous_status": "needs-reprocessing",
       "reprocess_generation": 2,
       "state": "claimed",
-      "required_return_schema_version": 5,
+      "required_return_schema_version": 6,
       "adherence_baseline": {"schema_version": 2, "...": "..."}
     }
 
-Fresh claims always use schema v5 and require return v5. The queue snapshots one
-baseline before mutating the selected talks, excludes the exact active batch,
-and copies the same immutable payload to every member. Schema-v1/v2 claims are
-accepted only for compatibility and authorize return v1/v2; schema-v3 claims
-authorize only return v3, and schema-v4 claims authorize only archival return
-v4. None of them authorizes v5 or is newly issued.
+Fresh claims always use schema v6 and require return v6 — the weighted scoring
+generation. The queue snapshots one baseline before mutating the selected talks,
+excludes the exact active batch, and copies the same immutable payload to every
+member. Schema-v1/v2 claims are accepted only for compatibility and authorize
+return v1/v2; schema-v3 claims authorize only return v3, schema-v4 claims
+authorize only archival return v4, and schema-v5 claims authorize only return
+v5. None of them authorizes v6 or is newly issued.
 
 Stale recovery adds ``released_at`` and ``release_reason`` and changes ``state``
 to ``stale_recovered``. A later generation moves the prior claim to

--- a/skills/vault-ingress/scripts/queue_claim_contract.py
+++ b/skills/vault-ingress/scripts/queue_claim_contract.py
@@ -27,10 +27,16 @@ from adherence_baseline import (
 )
 
 
-CURRENT_QUEUE_CLAIM_SCHEMA_VERSION = 5
+CURRENT_QUEUE_CLAIM_SCHEMA_VERSION = 6
 LEGACY_QUEUE_CLAIM_SCHEMA_VERSION = 1
 RECEIPT_QUEUE_CLAIM_SCHEMA_VERSION = 2
 ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSION = 3
+# The claim generation that introduced adherence-baseline schema v2. Named
+# because the requirement belongs to THAT generation and every later one, not
+# to whichever generation is current: keyed on "current", advancing the claim
+# schema retroactively demands the legacy baseline of every already-stored
+# claim written under the previous current, and rejects the lot.
+OPPORTUNITY_QUEUE_CLAIM_SCHEMA_VERSION = 5
 SUPPORTED_QUEUE_CLAIM_SCHEMA_VERSIONS = frozenset(
     range(
         LEGACY_QUEUE_CLAIM_SCHEMA_VERSION,
@@ -307,7 +313,7 @@ def validate_queue_claim(
             ) from exc
         expected_baseline_schema = (
             ADHERENCE_BASELINE_SCHEMA_VERSION
-            if version == CURRENT_QUEUE_CLAIM_SCHEMA_VERSION
+            if version >= OPPORTUNITY_QUEUE_CLAIM_SCHEMA_VERSION
             else LEGACY_ADHERENCE_BASELINE_SCHEMA_VERSION
         )
         if baseline.get("schema_version") != expected_baseline_schema:

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -157,6 +157,14 @@ V5_PERSISTED_PATTERN_OBSERVATION_FIELDS = PERSISTED_PATTERN_OBSERVATION_FIELDS |
     "pattern_outcomes",
     "opportunity_coverage_identity",
 }
+# The weighted generation's persisted shape. A DISTINCT accepted set, never v5
+# plus an optional field: a v5 record carrying a basis and a v6 record missing
+# one are both malformed, and an optional field cannot say that. The basis is
+# what makes a fractional score checkable, so a weighted record without one is a
+# number with no arithmetic behind it.
+V6_PERSISTED_PATTERN_OBSERVATION_FIELDS = V5_PERSISTED_PATTERN_OBSERVATION_FIELDS | {
+    "pattern_score_basis",
+}
 LEGACY_PERSISTED_PATTERN_OBSERVATION_FIELDS = PERSISTED_PATTERN_OBSERVATION_FIELDS - {
     "evidence_schema_version",
     "source_inspection",
@@ -2812,6 +2820,49 @@ def _validate_flat_score(
             )
 
 
+def validate_persisted_pattern_score_basis(observations: dict, score: object) -> None:
+    """Check a persisted weighted score against the basis stored beside it.
+
+    The return-side validator (`_validate_score`) proves the arithmetic once,
+    when the result arrives. This proves it again on the way out of the
+    database, because a persisted record is a hint and not authority
+    (`stateful-artifacts` -> Hints, Not Authority): a record edited by hand, or
+    written by an older generation of this writer, reaches readers with nobody
+    having rechecked its sum.
+
+    The basis is RECOMPUTED from the persisted detection lanes rather than
+    trusted. A stored basis that agrees with a stored score proves only that
+    whoever wrote them agreed with themselves.
+    """
+    patterns = observations.get("patterns_detected")
+    antipatterns = observations.get("antipatterns_detected")
+    not_evaluable = observations.get("not_evaluable")
+    if (
+        not isinstance(patterns, list)
+        or not isinstance(antipatterns, list)
+        or not isinstance(not_evaluable, list)
+    ):
+        raise ReturnValidationError(
+            "weighted persisted pattern snapshot requires its three detection lanes"
+        )
+    wanted = pattern_score_basis(patterns, antipatterns, not_evaluable)
+    basis = observations.get("pattern_score_basis")
+    _validate_score_basis_types(basis)
+    if basis != wanted:
+        raise ReturnValidationError(
+            "persisted pattern_score_basis does not match its detection arrays"
+        )
+    expected = expected_weighted_score(patterns, antipatterns)
+    # Exact comparison, never rounded: `expected` is already canonical to two
+    # decimals, so rounding the stored value first would accept anything within
+    # half a hundredth of a score no declared arithmetic produces.
+    if score != expected:
+        raise ReturnValidationError(
+            f"persisted pattern_score is {score}, but its weighted detection "
+            f"arrays require {expected}"
+        )
+
+
 def _validate_score(
     observations: dict,
     patterns: list[dict],
@@ -3489,6 +3540,7 @@ def validate_persisted_v2_analysis_state(talk: dict) -> None:
 
     actual_fields = set(observations)
     allowed_fields = {
+        frozenset(V6_PERSISTED_PATTERN_OBSERVATION_FIELDS),
         frozenset(V5_PERSISTED_PATTERN_OBSERVATION_FIELDS),
         PERSISTED_PATTERN_OBSERVATION_FIELDS,
         LEGACY_PERSISTED_PATTERN_OBSERVATION_FIELDS,
@@ -3496,11 +3548,13 @@ def validate_persisted_v2_analysis_state(talk: dict) -> None:
     if actual_fields not in allowed_fields:
         raise ReturnValidationError(
             "persisted pattern snapshot has noncanonical fields; expected the "
+            f"weighted v6 {sorted(V6_PERSISTED_PATTERN_OBSERVATION_FIELDS)}, "
             f"v5 {sorted(V5_PERSISTED_PATTERN_OBSERVATION_FIELDS)}, source-located "
             f"v4 {sorted(PERSISTED_PATTERN_OBSERVATION_FIELDS)}, or legacy "
             f"{sorted(LEGACY_PERSISTED_PATTERN_OBSERVATION_FIELDS)}, got "
             f"{sorted(actual_fields)}"
         )
+    weighted = actual_fields == set(V6_PERSISTED_PATTERN_OBSERVATION_FIELDS)
     evidence_schema_version = observations.get("evidence_schema_version")
     located_evidence = evidence_schema_version is not None
     if located_evidence and evidence_schema_version not in {
@@ -3511,12 +3565,12 @@ def validate_persisted_v2_analysis_state(talk: dict) -> None:
             "persisted pattern snapshot evidence_schema_version must be one of "
             f"{[LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION, PATTERN_EVIDENCE_SCHEMA_VERSION]}"
         )
-    if (
-        evidence_schema_version == PATTERN_EVIDENCE_SCHEMA_VERSION
-        and actual_fields != set(V5_PERSISTED_PATTERN_OBSERVATION_FIELDS)
+    if evidence_schema_version == PATTERN_EVIDENCE_SCHEMA_VERSION and not (
+        weighted or actual_fields == set(V5_PERSISTED_PATTERN_OBSERVATION_FIELDS)
     ):
         raise ReturnValidationError(
-            "evidence-schema v2 persisted snapshots require exhaustive v5 fields"
+            "evidence-schema v2 persisted snapshots require exhaustive v5 or "
+            "weighted v6 fields"
         )
     if (
         evidence_schema_version == LEGACY_PATTERN_EVIDENCE_SCHEMA_VERSION
@@ -3662,7 +3716,24 @@ def validate_persisted_v2_analysis_state(talk: dict) -> None:
                 "outcome ledger and generation"
             )
     score = observations["pattern_score"]
-    if isinstance(score, bool) or not isinstance(score, int):
+    if weighted:
+        # A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so it is
+        # fractional by construction. It is admitted ONLY at this generation:
+        # a flat score is count(patterns) minus count(antipatterns) and a float
+        # there means a different arithmetic produced it.
+        if isinstance(score, bool) or not isinstance(score, (int, float)):
+            raise ReturnValidationError(
+                "weighted persisted pattern snapshot pattern_score must be a number"
+            )
+        if not math.isfinite(score):
+            raise ReturnValidationError(
+                "weighted persisted pattern snapshot pattern_score must be finite"
+            )
+        # The basis is the arithmetic. Recomputed from the detection arrays
+        # rather than trusted, so a persisted score cannot claim a total its
+        # own lanes do not produce.
+        validate_persisted_pattern_score_basis(observations, score)
+    elif isinstance(score, bool) or not isinstance(score, int):
         raise ReturnValidationError(
             "persisted pattern snapshot pattern_score must be an integer"
         )

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -250,7 +250,7 @@ LANGUAGE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$")
 CONDITION_ID_RE = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
 VIDEO_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 VIDEO_EXTRACTION_SCHEMA_VERSION = 3
-QUEUE_CLAIM_SCHEMA_VERSION = 5
+QUEUE_CLAIM_SCHEMA_VERSION = 6
 SOURCE_LOCATED_QUEUE_CLAIM_SCHEMA_VERSION = 4
 BASELINE_QUEUE_CLAIM_SCHEMA_VERSION = 3
 PREVIOUS_QUEUE_CLAIM_SCHEMA_VERSION = 2
@@ -259,18 +259,24 @@ LEGACY_RETURN_SCHEMA_VERSION = 1
 PREVIOUS_RETURN_SCHEMA_VERSION = 2
 BASELINE_RETURN_SCHEMA_VERSION = 3
 SOURCE_LOCATED_RETURN_SCHEMA_VERSION = 4
-RETURN_SCHEMA_VERSION = 5
+EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION = 5
 # The first return schema whose aggregate is weighted. Below it the flat +1/-1
 # contract stands, because that is the arithmetic its worker used. v6 keeps
 # every v5 semantic and adds weighting, so it joins each set v5 belongs to.
 WEIGHTED_SCORE_RETURN_SCHEMA_VERSION = 6
+# The generation a fresh claim issues, derived rather than written. Every set
+# below names the generation it means; if they named THIS pointer instead,
+# advancing it would silently drop the generation it used to point at from
+# each of those sets — a validation set that quietly stops accepting v5 the
+# moment v6 becomes current.
+RETURN_SCHEMA_VERSION = WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
 SUPPORTED_RETURN_SCHEMA_VERSIONS = frozenset(
     {
         LEGACY_RETURN_SCHEMA_VERSION,
         PREVIOUS_RETURN_SCHEMA_VERSION,
         BASELINE_RETURN_SCHEMA_VERSION,
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
-        RETURN_SCHEMA_VERSION,
+        EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
     }
 )
@@ -279,7 +285,7 @@ SNAPSHOT_RETURN_SCHEMA_VERSIONS = frozenset(
         PREVIOUS_RETURN_SCHEMA_VERSION,
         BASELINE_RETURN_SCHEMA_VERSION,
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
-        RETURN_SCHEMA_VERSION,
+        EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
     }
 )
@@ -287,19 +293,19 @@ OUTCOME_GATE_RETURN_SCHEMA_VERSIONS = frozenset(
     {
         BASELINE_RETURN_SCHEMA_VERSION,
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
-        RETURN_SCHEMA_VERSION,
+        EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
     }
 )
 SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS = frozenset(
     {
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
-        RETURN_SCHEMA_VERSION,
+        EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
     }
 )
 EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS = frozenset(
-    {RETURN_SCHEMA_VERSION, WEIGHTED_SCORE_RETURN_SCHEMA_VERSION}
+    {EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION, WEIGHTED_SCORE_RETURN_SCHEMA_VERSION}
 )
 # The returns whose aggregate is weighted, and which therefore carry a
 # `pattern_score_basis`. Separate from the exhaustive-outcome set because the two
@@ -309,12 +315,14 @@ WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS = frozenset(
     {WEIGHTED_SCORE_RETURN_SCHEMA_VERSION}
 )
 
-# Stays at 5 until a return actually emits a weighted score. The weight table
-# below is part of the NEXT scoring generation; bumping this constant now would
-# strand every persisted talk on a generation nothing has produced yet, forcing
-# a reparse to adopt arithmetic no worker is using.
-PATTERN_SCORING_SCHEMA_VERSION = 5
+FLAT_PATTERN_SCORING_SCHEMA_VERSION = 5
 WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION = 6
+# Advanced with the activation (#299): returns now emit a weighted score, so
+# the generation persisted talks are stamped with is the weighted one. Derived
+# from the weighted constant rather than written as a literal, for the same
+# reason `RETURN_SCHEMA_VERSION` is — a reader that wants "the flat
+# generation" must name it, not reach for whatever is current.
+PATTERN_SCORING_SCHEMA_VERSION = WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
 
 
 def _persisted_scoring_schema_version(talk: Mapping[str, object]) -> int | None:
@@ -344,7 +352,7 @@ def scoring_schema_version_for_return(return_schema_version: int) -> int:
     """
     if return_schema_version in WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS:
         return WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
-    return PATTERN_SCORING_SCHEMA_VERSION
+    return FLAT_PATTERN_SCORING_SCHEMA_VERSION
 
 
 # Owner decision (#153): the aggregate stays one number, but a strong detection

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -2366,6 +2366,18 @@ def canonical_persisted_pattern_observations(
         persisted["opportunity_coverage_identity"] = observations.get(
             "opportunity_coverage_identity"
         )
+    if return_version in WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS:
+        # Recomputed from the canonical detection lanes, not copied from the
+        # return. The return's own basis was already checked against those
+        # lanes by `_validate_score`; recomputing here keeps the PERSISTED
+        # basis bound to the arrays actually being persisted, which is what
+        # `validate_persisted_pattern_score_basis` will check it against.
+        #
+        # Omitting it would persist a weighted return under the v5 field set,
+        # and the fractional score it carries is rejected at that shape.
+        persisted["pattern_score_basis"] = pattern_score_basis(
+            patterns_detected, antipatterns_detected, not_evaluable
+        )
     return persisted
 
 

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1565,7 +1565,11 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
         require_current_tracking_database(candidate)
         return TrackingDatabaseMigration(
             database=candidate,
-            changed=bool(counts["config"] or counts["pptx_catalog"]),
+            # Every record count, never a hand-listed subset: a flag that names
+            # the collections it knows about goes stale the moment a migration
+            # touches one it does not, and reports no-change over mutated
+            # records.
+            changed=any(counts.values()),
             from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
             to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
             record_counts=counts,

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -31,7 +31,10 @@ from pptx_talk_identity import unassessed_legacy_binding
 LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
 TRACKING_DATABASE_SCHEMA_VERSION = 1
 LEGACY_TALK_RECORD_SCHEMA_VERSION = 1
-TALK_RECORD_SCHEMA_VERSION = 5
+FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION = 5
+# The weighted generation's record shape (#299): `pattern_observations` may
+# carry a `pattern_score_basis` and `pattern_score` may be fractional.
+TALK_RECORD_SCHEMA_VERSION = 6
 LEGACY_CONFIG_RECORD_SCHEMA_VERSION = 1
 CONFIG_RECORD_SCHEMA_VERSION = 2
 LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION = 1
@@ -1403,6 +1406,39 @@ def _migrate_talk_record(talk: dict[str, Any]) -> bool:
     return talk_version_added
 
 
+def _restamp_talk_records(candidate: dict[str, Any]) -> int:
+    """Restamp v5 talk records to the weighted record shape (#299).
+
+    A RESTAMP, never a rescore. The v6 shape admits a `pattern_score_basis` and
+    a fractional `pattern_score`; a stored v5 record has neither, and computing
+    them here would recompute a score under arithmetic its worker never used —
+    the silent reinterpretation `stateful-artifacts` forbids and the exact thing
+    `_validate_score` refuses on the way in.
+
+    So the record's SHAPE advances and its SCORE does not. The talk keeps
+    `pattern_scoring_schema_version: 5`, which is the truth about the arithmetic
+    behind its number, and `partition_pattern_scoring_cohort` therefore excludes
+    it as a generation mismatch and requeues it. That is the reparse, and this
+    migration is what makes it mechanical rather than remembered.
+
+    Without the restamp every stored talk would be unmutatable: the owner writer
+    requires the exact current talk schema before any mutation, so the bump
+    alone would lock the database until this ran.
+    """
+    talks = candidate.get("talks")
+    if not isinstance(talks, list):
+        return 0
+    restamped = 0
+    for talk in talks:
+        if not isinstance(talk, dict):
+            continue
+        if talk.get("schema_version") != FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION:
+            continue
+        talk["schema_version"] = TALK_RECORD_SCHEMA_VERSION
+        restamped += 1
+    return restamped
+
+
 def _require_no_active_writers(talks: list[Any]) -> None:
     """Refuse to change persisted shape while a writer owns the database."""
     active = _active_claim_filenames(talks)
@@ -1475,6 +1511,7 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
         require_current_tracking_database(candidate)
         counts = _empty_record_counts()
         counts["pptx_catalog"] = _migrate_pptx_catalog_records(candidate)
+        counts["talks"] = _restamp_talk_records(candidate)
         if any(counts.values()):
             # Guarded only once state would actually change. A no-op migration
             # must stay callable while a claim is live: Step 1 migrates before
@@ -1522,6 +1559,7 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
     # config takes that return, so a record migration placed after it would be
     # skipped for exactly the databases whose config still needed upgrading.
     counts["pptx_catalog"] += _migrate_pptx_catalog_records(candidate)
+    counts["talks"] += _restamp_talk_records(candidate)
 
     if root_version == TRACKING_DATABASE_SCHEMA_VERSION:
         require_current_tracking_database(candidate)

--- a/tests/test_ingress_adherence_docs.py
+++ b/tests/test_ingress_adherence_docs.py
@@ -27,17 +27,17 @@ def test_claim_issuance_is_live_and_version_bound() -> None:
         assert "#157" not in text, f"{name} still carries the temporary issue gate"
         assert "issuance pause" not in text.lower()
 
-    assert '"schema_version": 5' in docs["queue"]
-    assert '"required_return_schema_version": 5' in docs["queue"]
+    assert '"schema_version": 6' in docs["queue"]
+    assert '"required_return_schema_version": 6' in docs["queue"]
     assert '"adherence_baseline": {"schema_version": 2' in docs["queue"]
-    assert "Fresh claims always use schema v5 and require return v5" in docs["queue"]
+    assert "Fresh claims always use schema v6 and require return v6" in docs["queue"]
     assert (
         "Saved claim schemas v1/v2 authorize only return schemas v1/v2"
         in docs["schemas"]
     )
     assert (
-        "schema v3 authorizes only v3; schema v4 authorizes only archival v4"
-        in docs["schemas"]
+        "schema v3 authorizes only v3; schema v4 authorizes only archival v4; "
+        "schema v5\nauthorizes only v5" in docs["schemas"]
     )
     assert "Recover a live legacy lease" in docs["worker"]
 
@@ -239,7 +239,7 @@ def test_source_located_worker_and_engine_evidence_ownership_is_explicit() -> No
     )
     worker_example = (
         docs["worker"]
-        .split("Minimal processed structure for a fresh v5 claim", 1)[1]
+        .split("Minimal processed structure for a fresh v6 claim", 1)[1]
         .split("```json", 1)[1]
         .split("```", 1)[0]
     )

--- a/tests/test_ingress_adherence_docs.py
+++ b/tests/test_ingress_adherence_docs.py
@@ -282,13 +282,14 @@ def test_claim_return_talk_and_scoring_axes_preserve_archival_v4() -> None:
         "| v4 | v4 only | archival source-located v4 | never current v5 |"
         in docs["schemas"]
     )
+    assert "| v5 | v5 only | v5 | never current v6 |" in docs["schemas"]
     assert (
-        "| v5 | v5 only | v5 | v5 when canonical evidence/outcomes are fresh |"
+        "| v6 | v6 only | v6 | v6 when canonical evidence/outcomes are fresh |"
         in docs["schemas"]
     )
-    assert "Fresh queue work uses claim schema v5" in docs["selection"]
+    assert "Fresh queue work uses claim schema v6" in docs["selection"]
     assert (
-        "only return generation eligible for pattern-scoring schema v5"
+        "only return generation eligible for pattern-scoring schema v6"
         in docs["worker"]
     )
 

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -10,6 +10,23 @@ from pathlib import Path
 import pytest
 
 
+import importlib as _importlib
+import sys as _sys
+
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1] / "skills" / "vault-ingress" / "scripts"
+)
+if str(_SCRIPTS_DIR) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# Talk-record fixtures track the current schema rather than pinning a literal:
+# a pin makes every fixture in this module unmutatable the moment the talk
+# record shape advances, which surfaces as "must be exact current talk schema"
+# on tests that are about something else entirely.
+CURRENT_TALK_SCHEMA = _importlib.import_module(
+    "tracking_database"
+).TALK_RECORD_SCHEMA_VERSION
+
 MISSING = {"$missing": True}
 DEFAULT_DIRECTORY_EXCLUSIONS = [
     ".venv",
@@ -45,7 +62,13 @@ def _base_database() -> dict[str, Any]:
     return {
         "schema_version": 1,
         "config": _current_config(),
-        "talks": [{"schema_version": 5, "filename": "talk.md", "status": "processed"}],
+        "talks": [
+            {
+                "schema_version": CURRENT_TALK_SCHEMA,
+                "filename": "talk.md",
+                "status": "processed",
+            }
+        ],
         "pptx_catalog": [],
         "qr_codes": [],
         "resources": [],
@@ -619,7 +642,9 @@ def test_talk_clarification_operation_accepts_only_structured_exact_fields(
         )
 
 
-@pytest.mark.parametrize("schema_version", [1, 2, 3, 4])
+# Every version below the current one, so the set widens with each bump
+# instead of quietly leaving the newest stale version untested.
+@pytest.mark.parametrize("schema_version", list(range(1, CURRENT_TALK_SCHEMA)))
 @pytest.mark.parametrize(
     ("kind", "field", "value"),
     [
@@ -644,7 +669,7 @@ def test_talk_metadata_mutations_require_exact_current_talk_schema(
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
-        match="must be exact current talk schema 5",
+        match=f"must be exact current talk schema {CURRENT_TALK_SCHEMA}",
     ):
         mutate_tracking_database.build_candidate(
             database,

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -131,7 +131,11 @@ def _return(**overrides):
 
 def _talk(**overrides):
     talk = {
-        "schema_version": 5,
+        # Tracks the current record schema; a literal here makes every fixture
+        # in this module unmutatable the moment the shape advances.
+        "schema_version": importlib.import_module(
+            "ingress_contract"
+        ).TALK_SCHEMA_VERSION,
         "filename": "talk.md",
         "status": "reprocessing-inflight",
         "reprocess_generation": 1,

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -17,6 +17,7 @@ disagree about which decks need regeneration.
 from __future__ import annotations
 
 import copy
+import importlib
 import hashlib
 import json
 import pathlib
@@ -1156,9 +1157,17 @@ def test_migration_is_idempotent(tracking_database) -> None:
 
 
 def _claimed_talk() -> dict:
-    """A talk whose queue claim is live."""
+    """A talk whose queue claim is live.
+
+    Stamped at the CURRENT record schema so the migration this fixture feeds is
+    genuinely a no-op. A stale stamp makes the migration a real restamp, and the
+    active-writer guard then fires — which would read as "the no-op path broke"
+    rather than "this fixture went out of date".
+    """
     return {
-        "schema_version": 5,
+        "schema_version": importlib.import_module(
+            "tracking_database"
+        ).TALK_RECORD_SCHEMA_VERSION,
         "filename": "2024-04-10-talk.md",
         "status": "reprocessing-inflight",
         "reprocess_generation": 1,

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -6,6 +6,7 @@ network or reads subagent returns.
 
 import copy
 import hashlib
+import importlib
 import json
 from typing import Any
 import os
@@ -32,6 +33,10 @@ SCRIPT = (
     / "scripts"
     / "queue-state.py"
 )
+if str(SCRIPT.parent) not in sys.path:
+    sys.path.insert(0, str(SCRIPT.parent))
+queue_claim_contract = importlib.import_module("queue_claim_contract")
+return_validation = importlib.import_module("return_validation")
 NOW = "2026-07-31T18:00:00+00:00"
 
 
@@ -86,7 +91,14 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
     transcripts = tmp_path / "transcripts"
     transcripts.mkdir(exist_ok=True)
     for talk in talks:
-        if talk.get("pattern_scoring_schema_version") != 5:
+        # Enrich every talk stamped at the ACTIVE scoring generation. Pinned to
+        # the literal 5, this silently stopped enriching the moment the
+        # generation advanced, and the talks it skipped then failed the
+        # opportunity-identity check as if the fixture had never been valid.
+        if (
+            talk.get("pattern_scoring_schema_version")
+            != return_validation.PATTERN_SCORING_SCHEMA_VERSION
+        ):
             continue
         observations = talk.get("pattern_observations")
         if not isinstance(observations, dict):
@@ -1483,7 +1495,7 @@ def test_claim_is_idempotent_for_an_existing_run_and_batch(tmp_path):
     assert path.read_bytes() == first_bytes
 
 
-def test_new_claim_is_v5_with_one_immutable_batch_baseline(tmp_path):
+def test_a_new_claim_is_current_with_one_immutable_batch_baseline(tmp_path):
     talks = [_talk("eg6gqvUFh6Q"), _talk("iPYc7LCH608")]
     path = _write_db(tmp_path, talks)
 
@@ -1491,8 +1503,12 @@ def test_new_claim_is_v5_with_one_immutable_batch_baseline(tmp_path):
 
     assert result.returncode == 0, result.stderr
     claims = json.loads(result.stdout)["claimed"]
-    assert {claim["schema_version"] for claim in claims} == {5}
-    assert {claim["required_return_schema_version"] for claim in claims} == {5}
+    assert {claim["schema_version"] for claim in claims} == {
+        queue_claim_contract.CURRENT_QUEUE_CLAIM_SCHEMA_VERSION
+    }
+    assert {claim["required_return_schema_version"] for claim in claims} == {
+        return_validation.RETURN_SCHEMA_VERSION
+    }
     assert claims[0]["adherence_baseline"] == claims[1]["adherence_baseline"]
     baseline: dict[str, Any] = claims[0]["adherence_baseline"]
     assert baseline["as_of"] == NOW
@@ -1528,7 +1544,7 @@ def test_inspect_dual_reads_a_schema_v3_adherence_claim(tmp_path):
     assert path.read_bytes() == before
 
 
-def test_schema_v5_claim_cannot_request_a_schema_v3_return(tmp_path):
+def test_a_current_claim_cannot_request_a_schema_v3_return(tmp_path):
     path = _write_db(tmp_path, [_talk("eg6gqvUFh6Q")])
     claimed = _claim(path)
     assert claimed.returncode == 0, claimed.stderr
@@ -1540,7 +1556,10 @@ def test_schema_v5_claim_cannot_request_a_schema_v3_return(tmp_path):
     inspected = _run(path, "inspect", "--run-id", "run-1")
 
     assert inspected.returncode == 2
-    assert "must equal its claim schema version 5" in inspected.stderr
+    assert (
+        "must equal its claim schema version "
+        f"{queue_claim_contract.CURRENT_QUEUE_CLAIM_SCHEMA_VERSION}"
+    ) in inspected.stderr
     assert path.read_bytes() == before
 
 
@@ -1615,7 +1634,9 @@ def test_same_run_and_batch_reclaims_a_stale_recovered_generation(tmp_path):
     assert talk["reprocess_generation"] == 2
     assert talk["_queue_claim"]["reprocess_generation"] == 2
     archived = talk["_queue_claim_history"][0]
-    assert archived["schema_version"] == 5
+    assert archived["schema_version"] == (
+        queue_claim_contract.CURRENT_QUEUE_CLAIM_SCHEMA_VERSION
+    )
     assert archived["adherence_baseline"] == first_claim["adherence_baseline"]
     assert archived["state"] == "stale_recovered"
     assert archived["released_at"] == "2026-07-31T18:00:00+00:00"

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -2637,7 +2637,7 @@ def test_clear_fields_is_confined_to_analysis_owned_leaves(return_validation, pa
     assert "clear_fields" in _error(return_validation, value)
 
 
-def test_validator_cli_emits_structured_report(tmp_path):
+def test_validator_cli_emits_structured_report(tmp_path, return_validation):
     batch = tmp_path / "returns.json"
     batch.write_text(json.dumps([_return()]))
     result = subprocess.run(
@@ -2649,7 +2649,9 @@ def test_validator_cli_emits_structured_report(tmp_path):
     assert report["returns"] == 1
     assert report["catalog_entries"] == 111
     assert report["return_schema_versions"] == {"2": 1}
-    assert report["pattern_scoring_schema_version"] == 5
+    assert report["pattern_scoring_schema_version"] == (
+        return_validation.PATTERN_SCORING_SCHEMA_VERSION
+    )
     assert report["pattern_scoring_generations"] == [
         {
             "filename": "talk.md",

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -28,8 +28,6 @@ CURRENT_TALK_SCHEMA = importlib.import_module(
     "tracking_database"
 ).TALK_RECORD_SCHEMA_VERSION
 
-if str(SCRIPT_DIRECTORY) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIRECTORY))
 SPEC = importlib.util.spec_from_file_location("scan_shownotes", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 scan_shownotes = importlib.util.module_from_spec(SPEC)

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -19,6 +19,17 @@ SCRIPT = REPO_ROOT / "skills" / "vault-ingress" / "scripts" / "scan-shownotes.py
 SCRIPT_DIRECTORY = SCRIPT.parent
 if str(SCRIPT_DIRECTORY) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIRECTORY))
+
+# Talk-record fixtures track the current schema rather than pinning a literal:
+# a pin makes every fixture in this module unmutatable the moment the talk
+# record shape advances, which surfaces as "must be exact current talk schema"
+# on tests that are about something else entirely.
+CURRENT_TALK_SCHEMA = importlib.import_module(
+    "tracking_database"
+).TALK_RECORD_SCHEMA_VERSION
+
+if str(SCRIPT_DIRECTORY) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIRECTORY))
 SPEC = importlib.util.spec_from_file_location("scan_shownotes", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 scan_shownotes = importlib.util.module_from_spec(SPEC)
@@ -57,7 +68,7 @@ def _database_path(
     else:
         current_talks = []
         for talk in talks or []:
-            current_talk = {**talk, "schema_version": 5}
+            current_talk = {**talk, "schema_version": CURRENT_TALK_SCHEMA}
             current_talk["source_rejections"] = [
                 {**rejection, "schema_version": 1}
                 for rejection in current_talk.get("source_rejections", [])
@@ -191,7 +202,7 @@ def test_apply_adds_only_complete_proposal_and_preserves_file_mode(
             "title": "Deterministic Ingress",
             "conference": "TestConf",
             "date": "2026-08-01",
-            "schema_version": 5,
+            "schema_version": CURRENT_TALK_SCHEMA,
             "status": "pending",
         }
     ]
@@ -217,7 +228,7 @@ def test_exact_filename_update_fills_only_empty_fields(tmp_path: Path) -> None:
         "title": "Deterministic Ingress",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(
@@ -231,7 +242,7 @@ def test_exact_filename_update_fills_only_empty_fields(tmp_path: Path) -> None:
     talk = json.loads(database_path.read_text(encoding="utf-8"))["talks"][0]
     assert talk["video_url"] == video_url
     assert talk["youtube_id"] == YOUTUBE_ID
-    assert talk["schema_version"] == 5
+    assert talk["schema_version"] == CURRENT_TALK_SCHEMA
     assert talk["status"] == "processed"
     assert report["entries"][0]["changes"] == {
         "video_url": video_url,
@@ -249,7 +260,7 @@ def test_existing_metadata_conflict_stays_a_non_mutating_review_proposal(
         "title": "Authoritative Title",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(
@@ -291,7 +302,7 @@ def test_event_qualified_shownotes_title_preserves_authored_title(
         "title": authored_title,
         "conference": conference,
         "date": talk_date,
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(
@@ -339,7 +350,7 @@ def test_event_qualified_title_requires_stored_conference_and_date(
     existing = {
         "filename": filename,
         "title": authored_title,
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
         **stored_context,
     }
@@ -378,7 +389,7 @@ def test_exact_title_still_fills_missing_stored_conference_and_date(
     existing = {
         "filename": filename,
         "title": authored_title,
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(
@@ -432,7 +443,7 @@ def test_event_qualified_title_preserves_event_type_identity(
         "title": authored_title,
         "conference": catalog_conference,
         "date": talk_date,
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(
@@ -490,7 +501,7 @@ def test_event_qualified_title_rejects_wrong_identity_and_shared_prefixes(
         "title": authored_title,
         "conference": conference,
         "date": talk_date,
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(
@@ -538,7 +549,7 @@ def test_presentation_only_metadata_differences_are_comparison_only(
         "title": "Deterministic Ingress",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     existing[field] = stored_value
@@ -583,7 +594,7 @@ def test_comparison_equivalence_does_not_rewrite_during_an_unrelated_update(
         "title": stored_title,
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(
@@ -627,7 +638,7 @@ def test_presentation_comparison_stays_narrow(
         "title": "Deterministic Ingress",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     existing[field] = stored_value
@@ -696,7 +707,7 @@ def test_rejected_source_identity_cannot_reappear_in_another_url_form(
         "title": "Deterministic Ingress",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "pending",
         "source_rejections": [
             {
@@ -767,7 +778,7 @@ def test_normalized_filename_collision_stays_a_review_proposal(
     )
     existing = {
         "filename": "Talk.md",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "pending",
     }
     database_path = _database_path(
@@ -1029,7 +1040,7 @@ def _talk_with_rejections(rejections: list[object]) -> dict[str, object]:
         "title": "Deterministic Ingress",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "pending",
         "source_rejections": rejections,
     }
@@ -1162,7 +1173,7 @@ def test_an_approved_repair_makes_the_scan_report_the_entry_unchanged(
         "title": "Authoritative Title",
         "conference": "TestConf",
         "date": "2026-08-01",
-        "schema_version": 5,
+        "schema_version": CURRENT_TALK_SCHEMA,
         "status": "processed",
     }
     database_path = _database_path(tmp_path, _local_config(site), talks=[existing])

--- a/tests/test_schema5_pattern_outcomes.py
+++ b/tests/test_schema5_pattern_outcomes.py
@@ -797,7 +797,11 @@ def test_opportunity_identity_binds_scoring_generation_independently(
     )
 
     assert v5 != v6
-    assert return_validation.RETURN_SCHEMA_VERSION == 5
+    # The identity is bound to the generation it was built at, not to
+    # whichever generation happens to be current.
+    assert return_validation.RETURN_SCHEMA_VERSION == (
+        return_validation.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
+    )
 
 
 def test_v4_source_locations_survive_root_migration_without_v5_outcomes(
@@ -835,7 +839,18 @@ def _scored_talk(
     score: int = 1,
     *,
     outcome: str = "undetected",
+    scoring_schema_version: int | None = None,
 ):
+    """Build a talk stamped at the ACTIVE scoring generation by default.
+
+    Pinning the literal 5 here made every such talk fall out of the cohort the
+    moment the generation advanced, which reads downstream as "the baseline
+    population is too small" rather than "this fixture is stale".
+    """
+    import return_validation
+
+    if scoring_schema_version is None:
+        scoring_schema_version = return_validation.PATTERN_SCORING_SCHEMA_VERSION
     return {
         "filename": filename,
         "status": "processed",
@@ -843,7 +858,7 @@ def _scored_talk(
         "pattern_scoring_generation_status": "current",
         "pattern_scoring_generation_reasons": [],
         "pattern_catalog_fingerprint": "a" * 64,
-        "pattern_scoring_schema_version": 5,
+        "pattern_scoring_schema_version": scoring_schema_version,
         "pattern_observations": {
             "pattern_score": score,
             "opportunity_coverage_identity": identity,
@@ -859,8 +874,8 @@ def test_mixed_opportunity_baseline_preserves_eligible_cohort_but_suppresses_sco
 
     baseline = adherence_baseline.build_current_cohort_baseline(
         [
-            _scored_talk("one.md", "1" * 64),
-            _scored_talk("two.md", "2" * 64),
+            _scored_talk("one.md", "1" * 64, scoring_schema_version=5),
+            _scored_talk("two.md", "2" * 64, scoring_schema_version=5),
         ],
         as_of="2026-07-31T12:00:00+00:00",
         pattern_catalog_fingerprint="a" * 64,
@@ -875,7 +890,9 @@ def test_mixed_opportunity_baseline_preserves_eligible_cohort_but_suppresses_sco
     assert baseline["opportunity_coverage_identity"] is None
     assert baseline["raw_score_comparison_status"] == "unavailable"
     assert baseline["raw_score_comparison_reason"] == "mixed_opportunity_coverage"
-    assert return_validation.PATTERN_SCORING_SCHEMA_VERSION == 5
+    assert return_validation.PATTERN_SCORING_SCHEMA_VERSION == (
+        return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+    )
 
 
 def test_all_unknown_opportunity_baseline_suppresses_zero_raw_score(
@@ -890,12 +907,14 @@ def test_all_unknown_opportunity_baseline_suppresses_zero_raw_score(
                 "1" * 64,
                 score=0,
                 outcome="not_evaluable",
+                scoring_schema_version=5,
             ),
             _scored_talk(
                 "two.md",
                 "1" * 64,
                 score=0,
                 outcome="not_evaluable",
+                scoring_schema_version=5,
             ),
         ],
         as_of="2026-07-31T12:00:00+00:00",
@@ -914,7 +933,9 @@ def test_all_unknown_opportunity_baseline_suppresses_zero_raw_score(
     assert baseline["raw_score_comparison_reason"] == (
         adherence_baseline.NO_EVALUABLE_PATTERN_OPPORTUNITIES_REASON
     )
-    assert return_validation.PATTERN_SCORING_SCHEMA_VERSION == 5
+    assert return_validation.PATTERN_SCORING_SCHEMA_VERSION == (
+        return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+    )
 
 
 def test_adherence_comparison_is_suppressed_when_opportunity_identity_differs(
@@ -923,7 +944,10 @@ def test_adherence_comparison_is_suppressed_when_opportunity_identity_differs(
     import adherence_baseline
 
     baseline = adherence_baseline.build_adherence_baseline(
-        [_scored_talk(f"talk-{index}.md", "1" * 64) for index in range(10)],
+        [
+            _scored_talk(f"talk-{index}.md", "1" * 64, scoring_schema_version=5)
+            for index in range(10)
+        ],
         selected_filenames=[],
         as_of="2026-07-31T12:00:00+00:00",
         pattern_catalog_fingerprint="a" * 64,

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -29,6 +29,7 @@ section15 = importlib.import_module("section15_pattern_history")
 cooperative_lock = importlib.import_module("cooperative_lock")
 pattern_history_status = importlib.import_module("pattern_history_status")
 provenance = importlib.import_module("profile_pattern_provenance")
+return_validation = importlib.import_module("return_validation")
 classification_runtime = importlib.import_module("pattern_classification_runtime")
 opportunities = importlib.import_module("pattern_opportunities")
 pattern_evidence = importlib.import_module("pattern_evidence")
@@ -91,7 +92,10 @@ def _transcript_projection() -> tuple[list[dict], list[dict], list[dict]]:
 
 def _pattern_profile(*, note: str = "Current exact cohort.") -> dict[str, Any]:
     fingerprint, scoring_schema = provenance.active_pattern_generation_identity()
-    assert scoring_schema == 5
+    # The fixture tracks the active generation rather than pinning a literal;
+    # a pin here fails the whole module on every scoring bump without telling
+    # the reader which behaviour actually changed.
+    assert scoring_schema == return_validation.PATTERN_SCORING_SCHEMA_VERSION
     filenames = ["example-a.md", "example-b.md"]
     outcome_talks = _outcome_talks(filenames)
     rows = opportunities.build_pattern_opportunity_rows(outcome_talks)
@@ -484,7 +488,9 @@ def test_exact_current_block_accepts_complete_scoring_v5_cohort():
         }
     )
     assert assessment.pattern_profile == profile
-    assert profile["pattern_baseline"]["pattern_scoring_schema_version"] == 5
+    assert profile["pattern_baseline"]["pattern_scoring_schema_version"] == (
+        return_validation.PATTERN_SCORING_SCHEMA_VERSION
+    )
 
 
 def test_v2_block_remains_readable_as_occurrence_only():

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1677,3 +1677,37 @@ def test_qr_v2_requires_qr_png_rel_path_to_mirror_first_artifact(tracking_databa
         match="must mirror artifacts\\[0\\].path",
     ):
         _validate_qr(tracking_database, record)
+
+
+def test_a_root_v1_database_with_only_stale_talks_reports_changed(tracking_database):
+    """The migration returns mutated records, so it must say it changed them.
+
+    A `changed` flag that names the collections it knows about goes stale the
+    moment a migration touches one it does not — and a caller that trusts it
+    skips persisting a migration that already rewrote the records it was handed.
+    """
+    database = _legacy_database()
+    database = tracking_database.migrate_tracking_database(database).database
+    database["talks"][0]["schema_version"] = (
+        _tracking_database.FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION
+    )
+
+    migration = tracking_database.migrate_tracking_database(database)
+
+    assert migration.record_counts["talks"] == 1
+    assert migration.changed is True
+    assert migration.database["talks"][0]["schema_version"] == (
+        _tracking_database.TALK_RECORD_SCHEMA_VERSION
+    )
+
+
+def test_a_database_with_nothing_stale_still_reports_no_change(tracking_database):
+    """The other half of the flag: a genuine no-op must stay a no-op, or every
+    Step 1 run writes the database for nothing."""
+    database = _legacy_database()
+    database = tracking_database.migrate_tracking_database(database).database
+
+    migration = tracking_database.migrate_tracking_database(database)
+
+    assert migration.changed is False
+    assert not any(migration.record_counts.values())

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -4,10 +4,22 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import importlib
 import json
 import os
+import sys
+from pathlib import Path
 
 import pytest
+
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+# Imported at module scope for the version CONSTANTS only — parametrize
+# decorators are evaluated at collection time, where the fixture does not
+# exist. The fixture remains the way tests reach the module's behaviour.
+_tracking_database = importlib.import_module("tracking_database")
 
 
 DEFAULT_DIRECTORY_EXCLUSIONS = [
@@ -87,7 +99,7 @@ def _legacy_talk(*, filename: str = "one.md") -> dict:
 
 def _baseline_for_claim(version: int, *, filename: str = "one.md") -> dict:
     baseline = {
-        "schema_version": 2 if version == 5 else 1,
+        "schema_version": 2 if version >= 5 else 1,
         "as_of": "2026-07-31T12:00:00+00:00",
         "scope": "global",
         "active_batch_excluded": True,
@@ -96,12 +108,12 @@ def _baseline_for_claim(version: int, *, filename: str = "one.md") -> dict:
         "pattern_scoring_generation_status": "current",
         "pattern_scoring_generation_reasons": [],
         "pattern_catalog_fingerprint": "a" * 64,
-        "pattern_scoring_schema_version": 5 if version == 5 else 4,
+        "pattern_scoring_schema_version": 5 if version >= 5 else 4,
         "scored_talk_count": 0,
         "pattern_score_sum": 0,
         "average_pattern_score": None,
     }
-    if version == 5:
+    if version >= 5:
         baseline.update(
             {
                 "eligible_talk_count": 0,
@@ -148,6 +160,18 @@ def _claim_for_version(
             }
         )
     return claim
+
+
+def _future_claim_version() -> int:
+    """One above the current claim schema, so the sentinel stays in the future.
+
+    A literal here silently stops testing anything the moment the claim schema
+    reaches it — the test keeps passing while asserting that a CURRENT claim is
+    unreadable, which is the opposite of its name.
+    """
+    import queue_claim_contract
+
+    return queue_claim_contract.CURRENT_QUEUE_CLAIM_SCHEMA_VERSION + 1
 
 
 def _legacy_database() -> dict:
@@ -289,7 +313,7 @@ def test_explicit_root_zero_is_not_implicit_legacy_state(tracking_database):
         (
             "talks",
             {
-                "schema_version": 6,
+                "schema_version": _tracking_database.TALK_RECORD_SCHEMA_VERSION + 1,
                 "talk_id": "future-talk",
                 "pattern_observations": ["future-shape"],
             },
@@ -547,7 +571,7 @@ def test_future_source_identity_receipt_does_not_poison_root_migration(
 
 
 @pytest.mark.parametrize("current_root", [False, True])
-@pytest.mark.parametrize("claim_version", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("claim_version", [1, 2, 3, 4, 5, 6])
 def test_legacy_and_current_roots_accept_supported_claim_version_boundaries(
     tracking_database,
     current_root,
@@ -632,10 +656,12 @@ def test_future_claim_is_no_usable_state_before_old_nested_validation(
     database = _legacy_database()
     if current_root:
         database = tracking_database.migrate_tracking_database(database).database
-    database["talks"][0]["schema_version"] = 5
+    database["talks"][0]["schema_version"] = (
+        _tracking_database.TALK_RECORD_SCHEMA_VERSION
+    )
     database["talks"][0]["pattern_observations"] = ["future-owned-shape"]
     future_claim = {
-        "schema_version": 6,
+        "schema_version": _future_claim_version(),
         "future_identity": "not-an-old-run-id",
         "state": {"future": True},
     }
@@ -739,7 +765,14 @@ def test_owner_migration_preserves_mixed_historical_talk_versions(
 
     migrated = tracking_database.migrate_tracking_database(database).database
 
-    assert [talk["schema_version"] for talk in migrated["talks"]] == [1, 4, 5, 1]
+    # v5 restamps to the weighted record shape (#299); the versions below it
+    # stay preserved, which is what "mixed historical" has always meant.
+    assert [talk["schema_version"] for talk in migrated["talks"]] == [
+        1,
+        4,
+        _tracking_database.TALK_RECORD_SCHEMA_VERSION,
+        1,
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tracking_database_strict_readers.py
+++ b/tests/test_tracking_database_strict_readers.py
@@ -7,6 +7,16 @@ import json
 
 import pytest
 
+import importlib as _importlib
+import sys as _sys
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(_SCRIPTS) not in _sys.path:
+    _sys.path.insert(0, str(_SCRIPTS))
+_FUTURE_TALK_SCHEMA_VERSION = (
+    _importlib.import_module("tracking_database").TALK_RECORD_SCHEMA_VERSION + 1
+)
+
 
 STRICT_INVALID_CASES = (
     pytest.param(
@@ -107,7 +117,10 @@ def test_owner_reader_accepts_implicit_legacy_after_schema_assessment(
             "config": {},
             "talks": [
                 {
-                    "schema_version": 6,
+                    # One above the current record schema: a literal stops
+                    # being "future" the moment the schema reaches it, and the
+                    # payload then exercises a different rejection path.
+                    "schema_version": _FUTURE_TALK_SCHEMA_VERSION,
                     "talk_id": "future-talk",
                 }
             ],

--- a/tests/test_weighted_pattern_score.py
+++ b/tests/test_weighted_pattern_score.py
@@ -85,16 +85,35 @@ class TestBasis:
 
 
 class TestSchemaBoundary:
-    def test_the_scoring_generation_holds_until_a_return_emits_a_weighted_score(
-        self, rv
-    ) -> None:
-        """Bumping it early would strand every persisted talk on a generation
-        nothing has produced."""
-        assert rv.PATTERN_SCORING_SCHEMA_VERSION == 5
+    def test_the_current_scoring_generation_is_the_weighted_one(self, rv) -> None:
+        """Activated in #299: returns emit a weighted score, so the generation
+        persisted talks are stamped with is the weighted one."""
+        assert rv.PATTERN_SCORING_SCHEMA_VERSION == 6
         assert rv.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION == 6
+        assert rv.FLAT_PATTERN_SCORING_SCHEMA_VERSION == 5
 
-    def test_weighting_starts_above_the_current_return_schema(self, rv) -> None:
-        assert rv.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION > rv.RETURN_SCHEMA_VERSION
+    def test_the_current_return_schema_is_the_weighted_one(self, rv) -> None:
+        assert rv.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION == rv.RETURN_SCHEMA_VERSION
+
+    def test_the_flat_generation_keeps_its_own_name(self, rv) -> None:
+        """The trap this exists to stop: the generation sets named v5 through
+        `RETURN_SCHEMA_VERSION`, so advancing that pointer would have dropped v5
+        from every one of them — a validator that silently stops accepting the
+        generation it accepted yesterday."""
+        assert (
+            rv.EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION
+            in rv.SUPPORTED_RETURN_SCHEMA_VERSIONS
+        )
+        assert (
+            rv.EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION
+            in rv.EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS
+        )
+        assert (
+            rv.scoring_schema_version_for_return(
+                rv.EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION
+            )
+            == rv.FLAT_PATTERN_SCORING_SCHEMA_VERSION
+        )
 
 
 class TestV6IsReachable:

--- a/tests/test_weighted_return_contract.py
+++ b/tests/test_weighted_return_contract.py
@@ -240,3 +240,87 @@ class TestAWeightedScoreCanBeCompared:
             return_validation.ReturnValidationError, match="must be an integer"
         ):
             return_validation.validate_return(ret, catalog)
+
+
+class TestAWeightedBlockSurvivesTheReadGate:
+    """The activation's point: a weighted block persists AND reads back.
+
+    The gate keys the weighted shape off the field SET, so a canonical block
+    that omits `pattern_score_basis` is a v5 block — and the fractional score
+    it carries is then rejected at that shape. v6 that cannot be stored.
+    """
+
+    def _talk(self, rv, block: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "structured_data": {},
+            "verbatim_examples": {},
+            "pattern_observations": block,
+            "pattern_score": block["pattern_score"],
+        }
+
+    def _weighted_block(self, rv) -> dict[str, Any]:
+        patterns = [
+            {
+                "pattern_id": "one",
+                "confidence": "moderate",
+                "evidence": "text",
+                "evidence_citations": [],
+                "dimensions": [1],
+            }
+        ]
+        block = {
+            "patterns_detected": patterns,
+            "pattern_ids": ["one"],
+            "antipatterns_detected": [],
+            "antipattern_ids": [],
+            "not_evaluable": [],
+            "not_evaluable_ids": [],
+            "evidence_sources": ["transcript"],
+            "pattern_score": rv.expected_weighted_score(patterns, []),
+            "applicability_assessments": [],
+            "pattern_outcomes": [],
+            "opportunity_coverage_identity": None,
+            "pattern_score_basis": rv.pattern_score_basis(patterns, [], []),
+        }
+        return block
+
+    def test_the_weighted_field_set_is_v5_plus_the_basis(self, return_validation):
+        assert set(return_validation.V6_PERSISTED_PATTERN_OBSERVATION_FIELDS) == (
+            set(return_validation.V5_PERSISTED_PATTERN_OBSERVATION_FIELDS)
+            | {"pattern_score_basis"}
+        )
+
+    def test_a_fractional_score_is_accepted_at_the_weighted_shape(
+        self, return_validation
+    ):
+        block = self._weighted_block(return_validation)
+        assert block["pattern_score"] != int(block["pattern_score"])
+
+        return_validation.validate_persisted_pattern_score_basis(
+            block, block["pattern_score"]
+        )
+
+    def test_the_basis_is_checked_against_the_persisted_lanes(self, return_validation):
+        """A stored basis agreeing with a stored score proves only that whoever
+        wrote them agreed with themselves."""
+        block = self._weighted_block(return_validation)
+        block["patterns_detected"].append(
+            {
+                "pattern_id": "two",
+                "confidence": "strong",
+                "evidence": "text",
+                "evidence_citations": [],
+                "dimensions": [1],
+            }
+        )
+
+        with pytest.raises(return_validation.ReturnValidationError):
+            return_validation.validate_persisted_pattern_score_basis(
+                block, block["pattern_score"]
+            )
+
+    def test_a_score_the_lanes_do_not_produce_is_refused(self, return_validation):
+        block = self._weighted_block(return_validation)
+
+        with pytest.raises(return_validation.ReturnValidationError):
+            return_validation.validate_persisted_pattern_score_basis(block, 99.0)


### PR DESCRIPTION
## What this is

#293 defined the weighted return contract and deliberately stopped — v6
validated but could not reach the database. This is the activation.

It moves as **one** change, not because that is tidier but because
`queue-state.py` asserts the claim, queue-claim, and return schema versions
equal at import time. Staged separately, the module does not load.

## Advanced together

`RETURN_SCHEMA_VERSION`, `QUEUE_CLAIM_SCHEMA_VERSION`,
`CURRENT_QUEUE_CLAIM_SCHEMA_VERSION`, `PATTERN_SCORING_SCHEMA_VERSION`,
`CURRENT_PATTERN_SCORING_SCHEMA_VERSION`, `TALK_RECORD_SCHEMA_VERSION`, and v6
joining `CANONICALIZABLE_RETURN_SCHEMA_VERSIONS`.

## The trap in the middle

The four generation sets named v5 **through the current-version pointer**:

```python
SUPPORTED_RETURN_SCHEMA_VERSIONS = frozenset({..., RETURN_SCHEMA_VERSION, WEIGHTED_...})
```

Bumping `RETURN_SCHEMA_VERSION` to 6 collapses that to `{6}` and **drops v5 out
of every validation set** — a validator that silently stops accepting the
generation it accepted yesterday, with no test naming v5 to catch it.

So the pointers are now derived and v5 has its own names:

```python
EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION = 5
WEIGHTED_SCORE_RETURN_SCHEMA_VERSION = 6
RETURN_SCHEMA_VERSION = WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
```

Same shape for `FLAT_PATTERN_SCORING_SCHEMA_VERSION` / `PATTERN_SCORING_SCHEMA_VERSION`.
Every set names the generation it means, so the next bump cannot repeat this.

## A production defect the bump exposed

`queue_claim_contract` picked the expected adherence-baseline schema with:

```python
ADHERENCE_BASELINE_SCHEMA_VERSION if version == CURRENT_QUEUE_CLAIM_SCHEMA_VERSION else LEGACY_...
```

Advancing the claim schema therefore retroactively demanded the **legacy**
baseline of every already-stored v5 claim — and rejected all of them. Now keyed
on `OPPORTUNITY_QUEUE_CLAIM_SCHEMA_VERSION`, the generation that introduced
baseline v2, so the requirement belongs to that generation and every later one.

This would have surfaced as "the vault is unreadable" after deploy, not as a
test failure.

## The migration restamps; it never rescores

`_restamp_talk_records` moves a v5 record to the v6 shape and leaves
`pattern_scoring_schema_version` alone. Computing a `pattern_score_basis` from
the stored detections would recompute a score under arithmetic its worker never
used — exactly the reinterpretation `_validate_score` refuses on the way in.

So the record's **shape** advances and its **score** does not. The talk keeps
the truth about its own number, `partition_pattern_scoring_cohort` excludes it
as a generation mismatch, and it requeues. That is the reparse, made mechanical
rather than remembered.

Without the restamp the bump alone would lock the database — the owner writer
requires the exact current talk schema before any mutation.

## Measured on the live vault

Dry-run against a copy: **6 talks restamp v5→v6**; the other **209 are schema
v1** and stay v1, exactly as they already did. No talk carries a
scoring-generation stamp at all, so the whole corpus requeues on generation
grounds regardless. The issue's "215 talks" figure was the talk count, not the
v5 count.

## Fixtures

95 tests went red on the bump. Most were version literals; several had gone
silently *wrong* rather than loudly stale — `_write_db` in the queue tests
enriched only talks stamped at the literal `5`, so at any other generation it
skipped them and they failed a later opportunity-identity check as though the
fixture had never been valid. Those now derive the version, so the next bump
reports what actually broke.

Full suite: **5720 passed**. Pyright clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh