### PR TITLE
feat(vault-ingress): sever a binding nothing proved (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ cannot see:
   assert what the other disproves, so the plan proves neither and both stay
   blocking for owner review.
 
+The talk side is cleared only when it names the deck being severed. A talk can
+carry a `pptx_path` pointing at a correctly-bound deck while some other catalog
+row wrongly claims it; clearing unconditionally destroyed that right binding
+while removing the wrong one. On the live catalog this is five talk-side clears
+that should never have happened.
+
 Each plan is exactly the `{schema_version, mutations}` envelope
 `mutate-tracking-database.py`'s `load_plan` accepts — it validates a CLOSED key
 set, so a reporting key inside the envelope makes an otherwise healthy plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ cannot see:
   assert what the other disproves, so the plan proves neither and both stay
   blocking for owner review.
 
+`binding_unassessable` is severable too: "the assessment could not run" is the
+strongest form of "not proven", and leaving those bound while the plan reads as
+complete is the failure the plan exists to prevent. Rows the plan cannot address
+are named in `unseverable[]` rather than skipped.
+
+Rows resolve to their catalog record by INDEX, never by path. A row's
+`pptx_path` is the deck-facts reading's normalized text — whitespace collapsed,
+length-capped — so a stored path with internal double spaces would not match a
+path-keyed lookup and would drop out of the plan without a word.
+
 Measured end to end on a copy of the live database — sever, re-sweep, prove,
 migrate — blocking preflight findings go **1550 → 4**: the two decks contesting
 one talk, and two unrelated `video_extraction_provenance_invalid` findings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+### feat(vault-ingress) — sever a binding nothing proved (#176)
+
+The sweep could prove a binding wrong and nothing could act on the proof. A
+binding is a pair — the catalog row's `talk_filename` and the talk's own
+`pptx_path` — and `record_pptx` writes the talk side on a match and never
+clears it.
+
+`sever_pptx_talk_binding` is that writer. Both sides move together because
+severing one is worse than severing neither: clearing only the catalog row
+leaves the talk still naming the deck, and every reader that resolves slides
+through `talks[].pptx_path` keeps drawing evidence from it, now with an audit
+trail saying it was handled.
+
+`sweep-pptx-talk-identity.py --emit-mutations` writes two plans. `mutation_plan`
+severs the unproven bindings; `proof_plan` stores the assessment behind the
+confirmed ones through `record_pptx`. Separate because keeping a binding and
+breaking one are different owner decisions, and one file carrying both invites
+applying half of what was reviewed.
+
+Both plans carry exact-old-value preconditions on both sides, and those
+preconditions found two defects in the live catalog that per-deck assessment
+cannot see:
+
+- **Two unproven rows naming one talk.** Two UberConf 2024 decks bind the same
+  delivery, so the second sever would fail a precondition the first made false.
+  The plan expects the missing marker for every sever after the first on a
+  given talk.
+- **Two confirmed rows claiming one talk.** `IJ Conference/2025/PDD.pptx` and
+  `PDD for GS.pptx` both confirm `2025-03-20-ij-2025-prompt-driven.md`. Two
+  decks cannot both be one talk's delivery deck; each is assessed alone and each
+  agrees, so the contradiction is only visible across rows. Proving either would
+  assert what the other disproves, so the plan proves neither and both stay
+  blocking for owner review.
+
+Measured end to end on a copy of the live database — sever, re-sweep, prove,
+migrate — blocking preflight findings go **1550 → 4**: the two decks contesting
+one talk, and two unrelated `video_extraction_provenance_invalid` findings.
+
 ## 0.20.72 — 2026-08-14
 
 ### feat(vault-ingress) — activate weighted scoring (#299)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ cannot see:
   assert what the other disproves, so the plan proves neither and both stay
   blocking for owner review.
 
+Each plan is exactly the `{schema_version, mutations}` envelope
+`mutate-tracking-database.py`'s `load_plan` accepts — it validates a CLOSED key
+set, so a reporting key inside the envelope makes an otherwise healthy plan
+un-applyable. `unseverable[]` sits beside the plans in the report, never inside
+one.
+
 `binding_unassessable` is severable too: "the assessment could not run" is the
 strongest form of "not proven", and leaving those bound while the plan reads as
 complete is the failure the plan exists to prevent. Rows the plan cannot address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ strongest form of "not proven", and leaving those bound while the plan reads as
 complete is the failure the plan exists to prevent. Rows the plan cannot address
 are named in `unseverable[]` rather than skipped.
 
+Every writer precondition is checked while BUILDING the plan — a nonempty
+trimmed `pptx_path`, a talk some record actually carries — so a row that
+survives is a row `mutate-tracking-database.py` accepts. A plan is a file a
+human reviews and then runs; one that looks actionable and dies partway through
+on a precondition the builder could have seen is worse than one that says up
+front what it cannot address. `proof_plan` applies the same checks, because a
+proof the owner writer would refuse is not a proof.
+
 Rows resolve to their catalog record by INDEX, never by path. A row's
 `pptx_path` is the deck-facts reading's normalized text — whitespace collapsed,
 length-capped — so a stored path with internal double spaces would not match a

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -271,8 +271,9 @@ rows without changing the counts.
 never from the `--dispositions` view. `mutation_plan` severs every binding the
 sweep could not prove, through the `sever_pptx_talk_binding` mutation, which
 clears the catalog row's `talk_filename` and the talk's own `pptx_path`
-together. `proof_plan` stores the assessment behind every confirmed binding
-through `record_pptx`.
+together; its `unseverable[]` names every row it could not address, so a
+complete-looking plan cannot hide a binding it left in place. `proof_plan`
+stores the assessment behind every confirmed binding through `record_pptx`.
 
 Apply one plan, re-run the sweep, then apply the next. Both plans carry
 exact-old-value preconditions on both sides of each binding, so a plan built

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -266,6 +266,19 @@ are in the script's module docstring.
 is owner-review work before any reparse; `binding_confirmed` supplies the
 assessment a `record_pptx` write carries. `--dispositions` narrows the reported
 rows without changing the counts.
+
+`--emit-mutations` adds two owner plans, each built from the whole catalog and
+never from the `--dispositions` view. `mutation_plan` severs every binding the
+sweep could not prove, through the `sever_pptx_talk_binding` mutation, which
+clears the catalog row's `talk_filename` and the talk's own `pptx_path`
+together. `proof_plan` stores the assessment behind every confirmed binding
+through `record_pptx`.
+
+Apply one plan, re-run the sweep, then apply the next. Both plans carry
+exact-old-value preconditions on both sides of each binding, so a plan built
+before the other was applied fails loudly rather than severing a binding nobody
+assessed. Review each plan before applying it: severing is how a wrong binding
+stops feeding a talk, and the sweep decides nothing.
 Never decide from
 `visual_extracted` alone whether a deck needs extraction. Run:
 

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -271,9 +271,15 @@ rows without changing the counts.
 never from the `--dispositions` view. `mutation_plan` severs every binding the
 sweep could not prove, through the `sever_pptx_talk_binding` mutation, which
 clears the catalog row's `talk_filename` and the talk's own `pptx_path`
-together; its `unseverable[]` names every row it could not address, so a
-complete-looking plan cannot hide a binding it left in place. `proof_plan`
-stores the assessment behind every confirmed binding through `record_pptx`.
+together. `proof_plan` stores the assessment behind every confirmed binding
+through `record_pptx`.
+
+Each plan is exactly the `{schema_version, mutations}` envelope
+`mutate-tracking-database.py` accepts, so lift one out of the report and apply
+it as-is. The report's own `unseverable[]` sits beside them, never inside:
+it names every row no plan could address, so a complete-looking plan cannot
+hide a binding it left in place. A nonempty `unseverable[]` is owner work
+before the reparse, not something to apply.
 
 Apply one plan, re-run the sweep, then apply the next. Both plans carry
 exact-old-value preconditions on both sides of each binding, so a plan built

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1071,6 +1071,106 @@ def _apply_retire_improvement_goal(
     )
 
 
+def _apply_sever_pptx_talk_binding(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    """Break a talk binding nothing proved, on BOTH sides, in one step.
+
+    A binding is a pair. The catalog row names a talk, and the talk names the
+    deck back through its own `pptx_path`. `record_pptx` writes the talk side
+    on a match and never clears it, so before this there was no way to undo
+    one: `sweep-pptx-talk-identity.py` could prove a binding wrong and nothing
+    could act on the proof.
+
+    Both sides move together because severing one is worse than severing
+    neither. Clearing only the catalog row leaves the talk still naming the
+    deck, and every reader that resolves a talk's slides through
+    `talks[].pptx_path` keeps drawing evidence from it — the exact failure
+    #176 exists to stop, now with the audit trail saying it was handled.
+
+    This does not decide anything. The assessment decides; `--emit-mutations`
+    on the sweep writes the plan; the owner reviews it. This is the writer that
+    applies a decision already made, which is why it takes exact-old-value
+    preconditions on both sides rather than a filename and a promise.
+
+    The catalog row survives, unbound: the deck still exists and the catalog
+    still knows about it. Only the claim that it belongs to this talk goes.
+    """
+    _require_keys(
+        mutation,
+        required={"kind", "pptx_path", "expect", "expect_talk_pptx_path"},
+        label=f"mutations[{index}]",
+    )
+    pptx_path = _nonempty(mutation["pptx_path"], f"mutations[{index}].pptx_path")
+    records = _collection(database, "pptx_catalog")
+    record_index, current = _find_unique_record(
+        records,
+        "pptx_path",
+        pptx_path,
+        label="pptx_catalog",
+    )
+    if current is None or record_index is None:
+        raise TrackingDatabaseMutationError(
+            f"pptx_catalog[{pptx_path!r}] does not exist; a binding that is not "
+            "stored cannot be severed"
+        )
+    _expect_value(
+        exists=True,
+        actual=current,
+        expected=mutation["expect"],
+        label=f"pptx_catalog[{pptx_path!r}]",
+    )
+    talk_filename = current.get("talk_filename")
+    if talk_filename is None:
+        raise TrackingDatabaseMutationError(
+            f"pptx_catalog[{pptx_path!r}] binds no talk; severing it would "
+            "report work that did not happen"
+        )
+    talk_filename = _nonempty(
+        talk_filename, f"pptx_catalog[{pptx_path!r}].talk_filename"
+    )
+
+    talk = _talk_by_filename(database, talk_filename)
+    _expect_value(
+        exists="pptx_path" in talk,
+        actual=talk.get("pptx_path"),
+        expected=mutation["expect_talk_pptx_path"],
+        label=f"talks[{talk_filename!r}].pptx_path",
+    )
+
+    before_record = copy.deepcopy(current)
+    replacement = copy.deepcopy(current)
+    replacement["talk_filename"] = None
+    replacement["matched"] = False
+    # Only a v3 row carries the field at all. An unbound row's assessment is
+    # null by the shape's own rule, so setting it on a v1/v2 row would add a
+    # field that generation does not have.
+    if "identity_assessment" in replacement:
+        replacement["identity_assessment"] = None
+    records[record_index] = replacement
+    _record_change(
+        changes,
+        kind="sever_pptx_talk_binding",
+        identity=pptx_path,
+        before=before_record,
+        after=replacement,
+    )
+
+    talk_before = talk.get("pptx_path", MISSING_MARKER)
+    talk.pop("pptx_path", None)
+    _record_change(
+        changes,
+        kind="clear_talk_pptx_path",
+        identity=talk_filename,
+        before=talk_before,
+        after=MISSING_MARKER,
+    )
+
+
 def _require_bound_identity_assessment(
     assessment: object,
     *,
@@ -1332,6 +1432,8 @@ def build_candidate(
             _apply_collection_upsert(candidate, mutation, changes, index=index)
         elif kind == "record_pptx":
             _apply_record_pptx(candidate, mutation, changes, index=index)
+        elif kind == "sever_pptx_talk_binding":
+            _apply_sever_pptx_talk_binding(candidate, mutation, changes, index=index)
         elif kind == "apply_reviewed_metadata":
             _apply_reviewed_metadata(candidate, mutation, changes, index=index)
         elif kind == "update_talk_publishing":

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1160,6 +1160,13 @@ def _apply_sever_pptx_talk_binding(
         after=replacement,
     )
 
+    # The talk side is cleared ONLY when it names this deck. A talk can carry a
+    # `pptx_path` pointing at a different, correctly-bound deck while some other
+    # catalog row wrongly claims it — severing that wrong row must not destroy
+    # the right binding. The precondition above still pins whatever was there;
+    # this decides whether it belongs to the deck being severed.
+    if talk.get("pptx_path") != pptx_path:
+        return
     talk_before = talk.get("pptx_path", MISSING_MARKER)
     talk.pop("pptx_path", None)
     _record_change(

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -284,15 +284,44 @@ def sweep_catalog(
     return rows
 
 
+# Every disposition that leaves a talk bound to a deck nothing proved.
+# `binding_unassessable` belongs here too: "the assessment could not run" is the
+# strongest form of "not proven", and leaving those bound while the plan reads
+# as complete is the failure the plan exists to prevent.
 SEVERABLE_DISPOSITIONS = frozenset(
-    {DISPOSITION_CONTRADICTED, DISPOSITION_REVIEW_REQUIRED, DISPOSITION_UNPROVEN}
+    {
+        DISPOSITION_CONTRADICTED,
+        DISPOSITION_REVIEW_REQUIRED,
+        DISPOSITION_UNPROVEN,
+        DISPOSITION_UNASSESSABLE,
+    }
 )
+
+
+def _catalog_record(
+    catalog: Sequence[Any],
+    row: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Resolve a report row back to the exact catalog record it describes.
+
+    By INDEX, never by path. A row's `pptx_path` is the deck-facts reading's
+    normalized text — whitespace collapsed, length-capped — so a stored path
+    carrying internal double spaces would not match the catalog key, and the
+    binding would drop out of the plan without a word.
+    """
+    index = row.get("index")
+    if not isinstance(index, int) or isinstance(index, bool):
+        return None
+    if index < 0 or index >= len(catalog):
+        return None
+    record = catalog[index]
+    return record if isinstance(record, Mapping) else None
 
 
 def sever_mutations(
     database: Mapping[str, Any],
     rows: Sequence[Mapping[str, Any]],
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Build the owner plan that breaks every binding this sweep could not prove.
 
     One mutation per unproven binding, each carrying the exact prior catalog row
@@ -304,17 +333,18 @@ def sever_mutations(
     Confirmed bindings are absent by construction. Proving a binding is
     `record_pptx`'s job — it writes the assessment alongside the receipt — and a
     sever plan that also carried proofs would be two decisions in one file.
+
+    Returns `(mutations, unseverable)`. A row whose binding cannot be turned
+    into a mutation — a malformed catalog entry, a path no stored row carries —
+    is reported rather than skipped: a plan that quietly drops what it cannot
+    handle reads as complete while leaving a binding in place.
     """
     talks = {
         talk.get("filename"): talk
         for talk in (database.get("talks") or [])
         if isinstance(talk, Mapping)
     }
-    catalog = {
-        record.get("pptx_path"): record
-        for record in (database.get("pptx_catalog") or [])
-        if isinstance(record, Mapping)
-    }
+    catalog = list(database.get("pptx_catalog") or [])
     mutations: list[dict[str, Any]] = []
     # Several unproven rows can name ONE talk — the live catalog has exactly
     # that, two UberConf 2024 decks bound to the same delivery. The talk's
@@ -323,16 +353,26 @@ def sever_mutations(
     # value for all of them makes the second mutation fail a precondition the
     # first one made false, and the whole plan aborts.
     cleared_talks: set[str] = set()
+    unseverable: list[dict[str, Any]] = []
     for row in rows:
         if row.get("disposition") not in SEVERABLE_DISPOSITIONS:
             continue
-        pptx_path = row.get("pptx_path")
-        record = catalog.get(pptx_path)
-        if not isinstance(record, Mapping):
-            continue
+        record = _catalog_record(catalog, row)
         stored_talk = row.get("stored_talk_filename")
+        pptx_path = record.get("pptx_path") if isinstance(record, Mapping) else None
+        if not isinstance(record, Mapping) or not isinstance(stored_talk, str):
+            unseverable.append(
+                {
+                    "index": row.get("index"),
+                    "pptx_path": pptx_path,
+                    "stored_talk_filename": stored_talk,
+                    "disposition": row.get("disposition"),
+                    "reason": "no stored binding this plan can address",
+                }
+            )
+            continue
         talk = talks.get(stored_talk)
-        if isinstance(stored_talk, str) and stored_talk in cleared_talks:
+        if stored_talk in cleared_talks:
             expect_talk_pptx_path: Any = MISSING_MARKER
         elif isinstance(talk, Mapping) and "pptx_path" in talk:
             expect_talk_pptx_path = talk["pptx_path"]
@@ -340,8 +380,7 @@ def sever_mutations(
             # A talk that never carried the field expects the missing marker,
             # which is a different precondition from expecting null.
             expect_talk_pptx_path = MISSING_MARKER
-        if isinstance(stored_talk, str):
-            cleared_talks.add(stored_talk)
+        cleared_talks.add(stored_talk)
         mutations.append(
             {
                 "kind": "sever_pptx_talk_binding",
@@ -350,7 +389,7 @@ def sever_mutations(
                 "expect_talk_pptx_path": expect_talk_pptx_path,
             }
         )
-    return mutations
+    return mutations, unseverable
 
 
 def proof_mutations(
@@ -378,11 +417,7 @@ def proof_mutations(
         for talk in (database.get("talks") or [])
         if isinstance(talk, Mapping)
     }
-    catalog = {
-        record.get("pptx_path"): record
-        for record in (database.get("pptx_catalog") or [])
-        if isinstance(record, Mapping)
-    }
+    catalog = list(database.get("pptx_catalog") or [])
     confirmed = [row for row in rows if row.get("disposition") == DISPOSITION_CONFIRMED]
     # Two decks cannot both be one talk's delivery deck, and the live catalog
     # has exactly that pair. The per-deck assessment cannot see it — each deck
@@ -396,8 +431,8 @@ def proof_mutations(
     )
     mutations: list[dict[str, Any]] = []
     for row in confirmed:
-        pptx_path = row.get("pptx_path")
-        record = catalog.get(pptx_path)
+        record = _catalog_record(catalog, row)
+        pptx_path = record.get("pptx_path") if isinstance(record, Mapping) else None
         assessment = row.get("assessment")
         if not isinstance(record, Mapping) or not isinstance(assessment, Mapping):
             continue
@@ -490,9 +525,13 @@ def execute(
         # Built from every row, never from the filtered view: a plan that
         # inherited `--dispositions` would silently sever only what the operator
         # happened to be reading.
+        severs, unseverable = sever_mutations(database, rows)
         report["mutation_plan"] = {
             "schema_version": MUTATION_PLAN_SCHEMA_VERSION,
-            "mutations": sever_mutations(database, rows),
+            "mutations": severs,
+            # Never empty-by-omission: a row this plan cannot address is named
+            # here so a complete-looking plan cannot hide a binding it left.
+            "unseverable": unseverable,
         }
         report["proof_plan"] = {
             "schema_version": MUTATION_PLAN_SCHEMA_VERSION,

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -47,6 +47,7 @@ reporting tool, not a gate. Preflight is the gate.
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import json
 from pathlib import Path
 import sys
@@ -65,6 +66,7 @@ from pptx_talk_identity import (
     assess_pptx_talk_identity,
 )
 from tracking_database import (
+    PPTX_CATALOG_RECORD_SCHEMA_VERSION,
     TrackingDatabaseError,
     assess_tracking_database,
 )
@@ -78,6 +80,10 @@ from tracking_database_io import (
 
 REPORT_SCHEMA_VERSION = 1
 DATABASE_BASENAME = "tracking-database.json"
+MUTATION_PLAN_SCHEMA_VERSION = 1
+# The owner writer's missing-value sentinel, restated here because the plan
+# is JSON handed to that writer rather than a Python call into it.
+MISSING_MARKER = {"$missing": True}
 
 DISPOSITION_CONFIRMED = "binding_confirmed"
 DISPOSITION_CONTRADICTED = "binding_contradicted"
@@ -278,10 +284,163 @@ def sweep_catalog(
     return rows
 
 
+SEVERABLE_DISPOSITIONS = frozenset(
+    {DISPOSITION_CONTRADICTED, DISPOSITION_REVIEW_REQUIRED, DISPOSITION_UNPROVEN}
+)
+
+
+def sever_mutations(
+    database: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build the owner plan that breaks every binding this sweep could not prove.
+
+    One mutation per unproven binding, each carrying the exact prior catalog row
+    and the talk's exact prior `pptx_path`. The preconditions are the point: the
+    plan is built from an assessment made at one moment and applied at another,
+    so anything that moved in between must make the apply fail rather than
+    silently sever a binding nobody assessed.
+
+    Confirmed bindings are absent by construction. Proving a binding is
+    `record_pptx`'s job — it writes the assessment alongside the receipt — and a
+    sever plan that also carried proofs would be two decisions in one file.
+    """
+    talks = {
+        talk.get("filename"): talk
+        for talk in (database.get("talks") or [])
+        if isinstance(talk, Mapping)
+    }
+    catalog = {
+        record.get("pptx_path"): record
+        for record in (database.get("pptx_catalog") or [])
+        if isinstance(record, Mapping)
+    }
+    mutations: list[dict[str, Any]] = []
+    # Several unproven rows can name ONE talk — the live catalog has exactly
+    # that, two UberConf 2024 decks bound to the same delivery. The talk's
+    # `pptx_path` is cleared by whichever sever reaches it first, so every later
+    # sever for that talk must expect it already gone. Snapshotting the stored
+    # value for all of them makes the second mutation fail a precondition the
+    # first one made false, and the whole plan aborts.
+    cleared_talks: set[str] = set()
+    for row in rows:
+        if row.get("disposition") not in SEVERABLE_DISPOSITIONS:
+            continue
+        pptx_path = row.get("pptx_path")
+        record = catalog.get(pptx_path)
+        if not isinstance(record, Mapping):
+            continue
+        stored_talk = row.get("stored_talk_filename")
+        talk = talks.get(stored_talk)
+        if isinstance(stored_talk, str) and stored_talk in cleared_talks:
+            expect_talk_pptx_path: Any = MISSING_MARKER
+        elif isinstance(talk, Mapping) and "pptx_path" in talk:
+            expect_talk_pptx_path = talk["pptx_path"]
+        else:
+            # A talk that never carried the field expects the missing marker,
+            # which is a different precondition from expecting null.
+            expect_talk_pptx_path = MISSING_MARKER
+        if isinstance(stored_talk, str):
+            cleared_talks.add(stored_talk)
+        mutations.append(
+            {
+                "kind": "sever_pptx_talk_binding",
+                "pptx_path": pptx_path,
+                "expect": dict(record),
+                "expect_talk_pptx_path": expect_talk_pptx_path,
+            }
+        )
+    return mutations
+
+
+def proof_mutations(
+    database: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build the owner plan that stores the proof behind every confirmed binding.
+
+    A confirmed binding is not yet a proven one. Preflight blocks a row that
+    names a talk without an assessment, so the 30 rows this sweep confirms stay
+    blocking until the assessment they earned is actually written down.
+
+    Separate from the sever plan on purpose: keeping a binding and breaking one
+    are different owner decisions, and a single file carrying both invites
+    applying half of what was reviewed.
+
+    The record advances to v3 with `visual_evidence: null`. The v1 rows being
+    replaced claim `visual_extracted: true` with no receipt behind it — which
+    `classify_pptx_visual_evidence` already reads as unknown-generation evidence,
+    never current — so nothing verifiable is discarded, and the reparse
+    re-extracts regardless.
+    """
+    talks = {
+        talk.get("filename"): talk
+        for talk in (database.get("talks") or [])
+        if isinstance(talk, Mapping)
+    }
+    catalog = {
+        record.get("pptx_path"): record
+        for record in (database.get("pptx_catalog") or [])
+        if isinstance(record, Mapping)
+    }
+    confirmed = [row for row in rows if row.get("disposition") == DISPOSITION_CONFIRMED]
+    # Two decks cannot both be one talk's delivery deck, and the live catalog
+    # has exactly that pair. The per-deck assessment cannot see it — each deck
+    # is assessed alone, and each agrees — so the contradiction is only visible
+    # here, across rows. Proving either would assert something the other
+    # disproves, so neither is proven and both stay blocking for owner review.
+    claims = Counter(
+        row.get("stored_talk_filename")
+        for row in confirmed
+        if isinstance(row.get("stored_talk_filename"), str)
+    )
+    mutations: list[dict[str, Any]] = []
+    for row in confirmed:
+        pptx_path = row.get("pptx_path")
+        record = catalog.get(pptx_path)
+        assessment = row.get("assessment")
+        if not isinstance(record, Mapping) or not isinstance(assessment, Mapping):
+            continue
+        talk_filename = row.get("stored_talk_filename")
+        if claims[talk_filename] != 1:
+            continue
+        talk = talks.get(talk_filename)
+        # `candidates_assessed` is this report's own reading aid. The owner gate
+        # validates a closed key set, so carrying it would fail the write.
+        proof = {
+            key: value
+            for key, value in assessment.items()
+            if key != "candidates_assessed"
+        }
+        mutations.append(
+            {
+                "kind": "record_pptx",
+                "expect": dict(record),
+                "expect_talk_pptx_path": (
+                    talk["pptx_path"]
+                    if isinstance(talk, Mapping) and "pptx_path" in talk
+                    else MISSING_MARKER
+                ),
+                "record": {
+                    "schema_version": PPTX_CATALOG_RECORD_SCHEMA_VERSION,
+                    "pptx_path": pptx_path,
+                    "talk_filename": talk_filename,
+                    "matched": True,
+                    "slide_count": record.get("slide_count"),
+                    "visual_extracted": False,
+                    "visual_evidence": None,
+                    "identity_assessment": proof,
+                },
+            }
+        )
+    return mutations
+
+
 def execute(
     value: str | Path,
     *,
     dispositions: Sequence[str] = (),
+    emit_mutations: bool = False,
 ) -> dict[str, Any]:
     vault_root, database_path = resolve_input(value)
     snapshot = snapshot_tracking_database(database_path)
@@ -312,7 +471,7 @@ def execute(
         if not reported
         else [row for row in rows if row["disposition"] in reported]
     )
-    return {
+    report: dict[str, Any] = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "identity_schema_version": PPTX_TALK_IDENTITY_SCHEMA_VERSION,
         "deck_facts_schema_version": DECK_FACTS_SCHEMA_VERSION,
@@ -327,11 +486,32 @@ def execute(
         ),
         "rows": selected,
     }
+    if emit_mutations:
+        # Built from every row, never from the filtered view: a plan that
+        # inherited `--dispositions` would silently sever only what the operator
+        # happened to be reading.
+        report["mutation_plan"] = {
+            "schema_version": MUTATION_PLAN_SCHEMA_VERSION,
+            "mutations": sever_mutations(database, rows),
+        }
+        report["proof_plan"] = {
+            "schema_version": MUTATION_PLAN_SCHEMA_VERSION,
+            "mutations": proof_mutations(database, rows),
+        }
+    return report
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument("vault", type=Path)
+    parser.add_argument(
+        "--emit-mutations",
+        action="store_true",
+        help=(
+            "add a mutation_plan severing every binding this sweep could not "
+            "prove; built from the whole catalog, never the --dispositions view"
+        ),
+    )
     parser.add_argument(
         "--dispositions",
         nargs="+",
@@ -341,7 +521,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     try:
-        report = execute(args.vault, dispositions=args.dispositions)
+        report = execute(
+            args.vault,
+            dispositions=args.dispositions,
+            emit_mutations=args.emit_mutations,
+        )
     except TrackingDatabaseIOError as exc:
         # Never echo the exception: decoder messages carry the host database
         # path and the rejected key or value verbatim. Route the typed reason

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -567,13 +567,17 @@ def execute(
         # inherited `--dispositions` would silently sever only what the operator
         # happened to be reading.
         severs, unseverable = sever_mutations(database, rows)
+        # The plan envelopes stay exactly what `mutate-tracking-database.py`'s
+        # `load_plan` accepts — `{schema_version, mutations}`, closed — so a
+        # plan can be lifted out of this report and applied as-is. Anything
+        # else the operator needs to know sits BESIDE them, not inside.
         report["mutation_plan"] = {
             "schema_version": MUTATION_PLAN_SCHEMA_VERSION,
             "mutations": severs,
-            # Never empty-by-omission: a row this plan cannot address is named
-            # here so a complete-looking plan cannot hide a binding it left.
-            "unseverable": unseverable,
         }
+        # Never empty-by-omission: a row no plan can address is named here so a
+        # complete-looking plan cannot hide a binding it left in place.
+        report["unseverable"] = unseverable
         report["proof_plan"] = {
             "schema_version": MUTATION_PLAN_SCHEMA_VERSION,
             "mutations": proof_mutations(database, rows),

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -417,7 +417,11 @@ def sever_mutations(
             # A talk that never carried the field expects the missing marker,
             # which is a different precondition from expecting null.
             expect_talk_pptx_path = MISSING_MARKER
-        cleared_talks.add(stored_talk)
+        # Only the sever whose deck the talk actually names will clear the talk
+        # side, so only that one makes the field missing for the severs after
+        # it. A talk pointing at some other deck keeps pointing there.
+        if expect_talk_pptx_path == pptx_path:
+            cleared_talks.add(stored_talk)
         mutations.append(
             {
                 "kind": "sever_pptx_talk_binding",

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -318,6 +318,35 @@ def _catalog_record(
     return record if isinstance(record, Mapping) else None
 
 
+def _writer_refusal(
+    record: Mapping[str, Any],
+    stored_talk: object,
+    talks: Mapping[Any, Any],
+) -> str | None:
+    """Say why the owner writer would refuse this row, or None if it would not.
+
+    Checked while BUILDING the plan, not left to the apply. A plan is a file a
+    human reviews and then runs; one that looks actionable and dies partway
+    through on a precondition the builder could have seen is worse than one that
+    says up front which rows it cannot address.
+
+    Mirrors the writer's own guards — `_nonempty` on the path, `_talk_by_filename`
+    on the talk — so a row that survives here is a row the writer accepts.
+    """
+    pptx_path = record.get("pptx_path")
+    if (
+        not isinstance(pptx_path, str)
+        or not pptx_path.strip()
+        or pptx_path != pptx_path.strip()
+    ):
+        return "catalog row has no usable pptx_path"
+    if not isinstance(stored_talk, str) or not stored_talk.strip():
+        return "no stored binding this plan can address"
+    if stored_talk not in talks:
+        return f"binds a talk no record carries ({stored_talk})"
+    return None
+
+
 def sever_mutations(
     database: Mapping[str, Any],
     rows: Sequence[Mapping[str, Any]],
@@ -359,18 +388,26 @@ def sever_mutations(
             continue
         record = _catalog_record(catalog, row)
         stored_talk = row.get("stored_talk_filename")
-        pptx_path = record.get("pptx_path") if isinstance(record, Mapping) else None
-        if not isinstance(record, Mapping) or not isinstance(stored_talk, str):
+        refusal = (
+            "no catalog row at this index"
+            if record is None
+            else _writer_refusal(record, stored_talk, talks)
+        )
+        if record is None or refusal is not None:
             unseverable.append(
                 {
                     "index": row.get("index"),
-                    "pptx_path": pptx_path,
+                    "pptx_path": (
+                        record.get("pptx_path") if isinstance(record, Mapping) else None
+                    ),
                     "stored_talk_filename": stored_talk,
                     "disposition": row.get("disposition"),
-                    "reason": "no stored binding this plan can address",
+                    "reason": refusal,
                 }
             )
             continue
+        pptx_path = record["pptx_path"]
+        assert isinstance(stored_talk, str)  # guaranteed by _writer_refusal
         talk = talks.get(stored_talk)
         if stored_talk in cleared_talks:
             expect_talk_pptx_path: Any = MISSING_MARKER
@@ -432,13 +469,17 @@ def proof_mutations(
     mutations: list[dict[str, Any]] = []
     for row in confirmed:
         record = _catalog_record(catalog, row)
-        pptx_path = record.get("pptx_path") if isinstance(record, Mapping) else None
         assessment = row.get("assessment")
-        if not isinstance(record, Mapping) or not isinstance(assessment, Mapping):
-            continue
         talk_filename = row.get("stored_talk_filename")
+        if record is None or not isinstance(assessment, Mapping):
+            continue
+        # The same writer preconditions the sever plan checks. A proof the owner
+        # writer would refuse is not a proof, and `record_pptx` reads both.
+        if _writer_refusal(record, talk_filename, talks) is not None:
+            continue
         if claims[talk_filename] != 1:
             continue
+        pptx_path = record["pptx_path"]
         talk = talks.get(talk_filename)
         # `candidates_assessed` is this report's own reading aid. The owner gate
         # validates a closed key set, so carrying it would fail the write.

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1594,3 +1594,24 @@ def test_severing_a_v1_row_does_not_invent_an_assessment_field(
     )
 
     assert "identity_assessment" not in candidate["pptx_catalog"][0]
+
+
+def test_severing_a_wrong_row_spares_a_talks_binding_to_another_deck(
+    mutate_tracking_database,
+) -> None:
+    """A talk can name a correctly-bound deck while some other catalog row
+    wrongly claims it. Severing the wrong row must not destroy the right
+    binding — the talk side is cleared only when it names THIS deck.
+    """
+    database = _bound_catalog_database()
+    # The talk's own binding points at the deck it really belongs to.
+    database["talks"][0]["pptx_path"] = "Conference/Correct.pptx"
+    plan = _sever(expect_talk_pptx_path="Conference/Correct.pptx")
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database, plan["mutations"]
+    )
+
+    assert candidate["pptx_catalog"][0]["talk_filename"] is None
+    assert candidate["talks"][0]["pptx_path"] == "Conference/Correct.pptx"
+    assert [change["kind"] for change in changes] == ["sever_pptx_talk_binding"]

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1436,3 +1436,161 @@ def test_every_writable_metadata_field_is_classified(mutate_tracking_database) -
         | mutate_tracking_database.ANALYSIS_INVALIDATING_METADATA_FIELDS
     )
     assert mutate_tracking_database.METADATA_TALK_FIELDS <= classified
+
+
+def _bound_catalog_database() -> dict[str, Any]:
+    """A stored binding, both sides written, as the live vault carries them."""
+    database = _base_database()
+    database["talks"][0]["pptx_path"] = "Conference/Talk.pptx"
+    database["pptx_catalog"] = [
+        {
+            "schema_version": 1,
+            "pptx_path": "Conference/Talk.pptx",
+            "talk_filename": "talk.md",
+            "matched": True,
+            "slide_count": 10,
+            "visual_extracted": True,
+        }
+    ]
+    return database
+
+
+def _sever(**overrides: Any) -> dict[str, Any]:
+    mutation: dict[str, Any] = {
+        "kind": "sever_pptx_talk_binding",
+        "pptx_path": "Conference/Talk.pptx",
+        "expect": {
+            "schema_version": 1,
+            "pptx_path": "Conference/Talk.pptx",
+            "talk_filename": "talk.md",
+            "matched": True,
+            "slide_count": 10,
+            "visual_extracted": True,
+        },
+        "expect_talk_pptx_path": "Conference/Talk.pptx",
+    }
+    mutation.update(overrides)
+    return {"schema_version": 1, "mutations": [mutation]}
+
+
+def test_severing_clears_both_sides_of_the_binding(
+    tmp_path: Path, mutate_tracking_database
+) -> None:
+    """Clearing only the catalog row leaves the talk still naming the deck, and
+    every reader that resolves slides through `talks[].pptx_path` keeps drawing
+    evidence from it."""
+    database = _bound_catalog_database()
+    candidate, _changes = mutate_tracking_database.build_candidate(
+        database, _sever()["mutations"]
+    )
+
+    record = candidate["pptx_catalog"][0]
+    assert record["talk_filename"] is None
+    assert record["matched"] is False
+    assert "pptx_path" not in candidate["talks"][0]
+    # The deck still exists and the catalog still knows about it.
+    assert record["pptx_path"] == "Conference/Talk.pptx"
+
+
+def test_severing_records_a_change_for_each_side(
+    tmp_path: Path, mutate_tracking_database
+) -> None:
+    _candidate, changes = mutate_tracking_database.build_candidate(
+        _bound_catalog_database(), _sever()["mutations"]
+    )
+
+    assert [change["kind"] for change in changes] == [
+        "sever_pptx_talk_binding",
+        "clear_talk_pptx_path",
+    ]
+
+
+def test_a_stale_catalog_expectation_refuses_the_sever(
+    mutate_tracking_database,
+) -> None:
+    """Assessed at one moment, applied at another."""
+    database = _bound_catalog_database()
+    plan = _sever()
+    plan["mutations"][0]["expect"]["slide_count"] = 11
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(database, plan["mutations"])
+
+
+def test_a_stale_talk_expectation_refuses_the_sever(mutate_tracking_database) -> None:
+    database = _bound_catalog_database()
+    plan = _sever(expect_talk_pptx_path="Conference/Moved.pptx")
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(database, plan["mutations"])
+
+
+def test_severing_an_unbound_row_is_refused(mutate_tracking_database) -> None:
+    """Reporting work that did not happen is worse than refusing it."""
+    database = _bound_catalog_database()
+    database["pptx_catalog"][0]["talk_filename"] = None
+    database["pptx_catalog"][0]["matched"] = False
+    plan = _sever()
+    plan["mutations"][0]["expect"]["talk_filename"] = None
+    plan["mutations"][0]["expect"]["matched"] = False
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="binds no talk",
+    ):
+        mutate_tracking_database.build_candidate(database, plan["mutations"])
+
+
+def test_severing_a_row_that_does_not_exist_is_refused(
+    mutate_tracking_database,
+) -> None:
+    database = _bound_catalog_database()
+    plan = _sever(pptx_path="Conference/Absent.pptx")
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="does not exist",
+    ):
+        mutate_tracking_database.build_candidate(database, plan["mutations"])
+
+
+def test_severing_a_v3_row_nulls_its_identity_assessment(
+    mutate_tracking_database,
+) -> None:
+    """An unbound row's assessment is null by the shape's own rule."""
+    database = _bound_catalog_database()
+    record = database["pptx_catalog"][0]
+    record.update(
+        {
+            "schema_version": 3,
+            "visual_extracted": False,
+            "visual_evidence": None,
+            "identity_assessment": {
+                "schema_version": 1,
+                "pptx_path": "Conference/Talk.pptx",
+                "verdict": "review_required",
+                "artifact_role": "delivery",
+                "selected_talk_filename": None,
+                "reason_codes": ["identity_unassessed_legacy_binding"],
+                "candidates": [],
+            },
+        }
+    )
+    plan = _sever(expect=copy.deepcopy(record))
+
+    candidate, _changes = mutate_tracking_database.build_candidate(
+        database, plan["mutations"]
+    )
+
+    assert candidate["pptx_catalog"][0]["identity_assessment"] is None
+
+
+def test_severing_a_v1_row_does_not_invent_an_assessment_field(
+    mutate_tracking_database,
+) -> None:
+    """Only a v3 row carries the field; adding it would be a shape v1 lacks."""
+    candidate, _changes = mutate_tracking_database.build_candidate(
+        _bound_catalog_database(), _sever()["mutations"]
+    )
+
+    assert "identity_assessment" not in candidate["pptx_catalog"][0]

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -1005,3 +1005,61 @@ class TestThePlanEnvelopesAreApplyableAsIs:
         for name in ("mutation_plan", "proof_plan"):
             assert set(report[name]) == {"schema_version", "mutations"}, name
         assert "unseverable" in report
+
+
+class TestOneTalkClaimedByAWrongAndARightDeck:
+    def test_severing_the_wrong_deck_spares_the_right_binding(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """One contradicted row and one confirmed row on the same talk: the
+        sever must not clear a talk-side binding that names the confirmed deck.
+        """
+        wrong = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        right = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        bound = {**VOXXED_TALK, "pptx_path": right}
+        payload = database(
+            [
+                catalog_row(wrong, VOXXED_TALK["filename"]),
+                catalog_row(right, VOXXED_TALK["filename"]),
+            ],
+            [bound, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        report = sweep.execute(path, emit_mutations=True)
+        severs = report["mutation_plan"]["mutations"]
+
+        assert [m["pptx_path"] for m in severs] == [wrong]
+        # The precondition pins what is there; the writer then leaves it,
+        # because it names a different deck.
+        assert severs[0]["expect_talk_pptx_path"] == right
+
+    def test_the_writer_leaves_that_binding_in_place(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        mutate = _load_script("mutate_tracking_database", "mutate-tracking-database.py")
+        wrong = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        right = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        bound = {**VOXXED_TALK, "pptx_path": right}
+        payload = database(
+            [
+                catalog_row(wrong, VOXXED_TALK["filename"]),
+                catalog_row(right, VOXXED_TALK["filename"]),
+            ],
+            [bound, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        severs = sweep.execute(path, emit_mutations=True)["mutation_plan"]["mutations"]
+
+        candidate, _changes = mutate.build_candidate(payload, severs)
+
+        talk = next(
+            t for t in candidate["talks"] if t["filename"] == VOXXED_TALK["filename"]
+        )
+        assert talk["pptx_path"] == right
+        assert candidate["pptx_catalog"][0]["talk_filename"] is None
+        assert candidate["pptx_catalog"][1]["talk_filename"] == VOXXED_TALK["filename"]

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -829,3 +829,78 @@ class TestProofPlan:
             "candidates_assessed"
             not in (proof["mutations"][0]["record"]["identity_assessment"])
         )
+
+
+class TestNothingIsSilentlyLeftBound:
+    def test_an_unassessable_row_is_severed_like_any_unproven_one(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """ "The assessment could not run" is the strongest form of "not
+        proven", and the plan claims to sever every binding it could not."""
+        assert sweep.DISPOSITION_UNASSESSABLE in sweep.SEVERABLE_DISPOSITIONS
+
+    def test_a_row_the_plan_cannot_address_is_named_not_dropped(
+        self, source_root: Path
+    ) -> None:
+        """A plan that quietly drops what it cannot handle reads as complete
+        while leaving a binding in place.
+
+        Exercised at the builder, because a catalog the owner reader would
+        reject never reaches `execute` — which is the right upstream behaviour
+        and the reason this safety net needs its own test.
+        """
+        payload = database([], [VOXXED_TALK], source_root)
+        orphan = {
+            "index": 7,
+            "pptx_path": "Gone.pptx",
+            "stored_talk_filename": VOXXED_TALK["filename"],
+            "disposition": sweep.DISPOSITION_UNASSESSABLE,
+        }
+
+        mutations, unseverable = sweep.sever_mutations(payload, [orphan])
+
+        assert mutations == []
+        assert len(unseverable) == 1
+        assert unseverable[0]["index"] == 7
+
+    def test_a_row_resolves_by_index_not_by_its_normalized_path(
+        self, source_root: Path
+    ) -> None:
+        """A row's `pptx_path` is the deck-facts reading's normalized text, so
+        a stored path with internal double spaces would not match a
+        path-keyed lookup and would drop out of the plan silently."""
+        stored = "Voxxed  Days/2025/Two  Spaces.pptx"
+        payload = database(
+            [catalog_row(stored, VOXXED_TALK["filename"])],
+            [VOXXED_TALK],
+            source_root,
+        )
+        row = {
+            "index": 0,
+            # Collapsed exactly as `_text` would produce it.
+            "pptx_path": "Voxxed Days/2025/Two Spaces.pptx",
+            "stored_talk_filename": VOXXED_TALK["filename"],
+            "disposition": sweep.DISPOSITION_CONTRADICTED,
+        }
+
+        mutations, unseverable = sweep.sever_mutations(payload, [row])
+
+        assert unseverable == []
+        assert mutations[0]["pptx_path"] == stored
+
+    def test_a_healthy_plan_reports_nothing_unseverable(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        payload = database(
+            [catalog_row(bad, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        plan = sweep.execute(path, emit_mutations=True)["mutation_plan"]
+
+        assert len(plan["mutations"]) == 1
+        assert plan["unseverable"] == []

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -904,3 +904,78 @@ class TestNothingIsSilentlyLeftBound:
 
         assert len(plan["mutations"]) == 1
         assert plan["unseverable"] == []
+
+
+class TestThePlanOnlyEmitsWhatTheWriterAccepts:
+    """A plan is a file a human reviews and then runs. One that looks
+    actionable and dies partway through on a precondition the builder could
+    have seen is worse than one that says up front what it cannot address.
+    """
+
+    def _row(self, **overrides: Any) -> dict[str, Any]:
+        row: dict[str, Any] = {
+            "index": 0,
+            "pptx_path": "Deck.pptx",
+            "stored_talk_filename": VOXXED_TALK["filename"],
+            "disposition": sweep.DISPOSITION_CONTRADICTED,
+        }
+        row.update(overrides)
+        return row
+
+    @pytest.mark.parametrize("bad_path", [None, "", "   ", " Deck.pptx", 17])
+    def test_a_row_with_no_usable_path_is_named_not_emitted(
+        self, source_root: Path, bad_path: object
+    ) -> None:
+        payload = database(
+            [catalog_row("Deck.pptx", VOXXED_TALK["filename"])],
+            [VOXXED_TALK],
+            source_root,
+        )
+        payload["pptx_catalog"][0]["pptx_path"] = bad_path
+
+        mutations, unseverable = sweep.sever_mutations(payload, [self._row()])
+
+        assert mutations == []
+        assert unseverable[0]["reason"] == "catalog row has no usable pptx_path"
+
+    def test_a_dangling_talk_filename_is_named_not_emitted(
+        self, source_root: Path
+    ) -> None:
+        """`_talk_by_filename` raises on a talk no record carries, so a plan
+        naming one dies at apply with nothing said about it beforehand."""
+        payload = database(
+            [catalog_row("Deck.pptx", "ghost.md")],
+            [VOXXED_TALK],
+            source_root,
+        )
+
+        mutations, unseverable = sweep.sever_mutations(
+            payload, [self._row(stored_talk_filename="ghost.md")]
+        )
+
+        assert mutations == []
+        assert "binds a talk no record carries" in unseverable[0]["reason"]
+
+    def test_a_row_pointing_past_the_catalog_is_named(self, source_root: Path) -> None:
+        payload = database([], [VOXXED_TALK], source_root)
+
+        mutations, unseverable = sweep.sever_mutations(payload, [self._row(index=9)])
+
+        assert mutations == []
+        assert unseverable[0]["reason"] == "no catalog row at this index"
+
+    def test_the_proof_plan_applies_the_same_preconditions(
+        self, source_root: Path
+    ) -> None:
+        payload = database(
+            [catalog_row("Deck.pptx", "ghost.md")],
+            [VOXXED_TALK],
+            source_root,
+        )
+        row = self._row(
+            stored_talk_filename="ghost.md",
+            disposition=sweep.DISPOSITION_CONFIRMED,
+            assessment={"verdict": "matched"},
+        )
+
+        assert sweep.proof_mutations(payload, [row]) == []

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -900,10 +900,10 @@ class TestNothingIsSilentlyLeftBound:
         path = tmp_path / "tracking-database.json"
         path.write_text(json.dumps(payload), encoding="utf-8")
 
-        plan = sweep.execute(path, emit_mutations=True)["mutation_plan"]
+        report = sweep.execute(path, emit_mutations=True)
 
-        assert len(plan["mutations"]) == 1
-        assert plan["unseverable"] == []
+        assert len(report["mutation_plan"]["mutations"]) == 1
+        assert report["unseverable"] == []
 
 
 class TestThePlanOnlyEmitsWhatTheWriterAccepts:
@@ -979,3 +979,29 @@ class TestThePlanOnlyEmitsWhatTheWriterAccepts:
         )
 
         assert sweep.proof_mutations(payload, [row]) == []
+
+
+class TestThePlanEnvelopesAreApplyableAsIs:
+    def test_each_plan_carries_only_what_load_plan_accepts(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """`load_plan` validates a CLOSED envelope, so an extra reporting key
+        makes an otherwise healthy plan un-applyable."""
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        good = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        payload = database(
+            [
+                catalog_row(bad, DEVOXX_TALK["filename"]),
+                catalog_row(good, VOXXED_TALK["filename"]),
+            ],
+            [VOXXED_TALK, DEVOXX_TALK, KUBECON_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        report = sweep.execute(path, emit_mutations=True)
+
+        for name in ("mutation_plan", "proof_plan"):
+            assert set(report[name]) == {"schema_version", "mutations"}, name
+        assert "unseverable" in report

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -606,3 +606,226 @@ class TestCli:
         assert exit_code == 0
         report = json.loads(capsys.readouterr().out)
         assert report["disposition_counts"][sweep.DISPOSITION_CONTRADICTED] == 1
+
+
+class TestSeverPlan:
+    def _plan(self, tmp_path: Path, source_root: Path, rows, talks):
+        payload = database(rows, talks, source_root)
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return sweep.execute(path, emit_mutations=True)["mutation_plan"]
+
+    def test_a_contradicted_binding_is_severed(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        plan = self._plan(
+            tmp_path,
+            source_root,
+            [catalog_row(bad, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+
+        assert [m["kind"] for m in plan["mutations"]] == ["sever_pptx_talk_binding"]
+        assert plan["mutations"][0]["pptx_path"] == bad
+
+    def test_a_confirmed_binding_is_absent_from_the_plan(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """Proving a binding is `record_pptx`'s job; a sever plan that also
+        carried proofs would be two decisions in one file."""
+        good = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        plan = self._plan(
+            tmp_path,
+            source_root,
+            [catalog_row(good, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+
+        assert plan["mutations"] == []
+
+    def test_an_unbound_row_is_never_severed(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        loose = deck(source_root, "Decks/Loose.pptx", title="Loose")
+        plan = self._plan(
+            tmp_path, source_root, [catalog_row(loose, None)], [VOXXED_TALK]
+        )
+
+        assert plan["mutations"] == []
+
+    def test_the_plan_carries_both_exact_preconditions(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """Assessed at one moment, applied at another: anything that moved in
+        between must fail the apply rather than sever silently."""
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        row = catalog_row(bad, VOXXED_TALK["filename"])
+        bound_talk = {**VOXXED_TALK, "pptx_path": bad}
+        plan = self._plan(tmp_path, source_root, [row], [bound_talk, DEVOXX_TALK])
+
+        mutation = plan["mutations"][0]
+        assert mutation["expect"] == row
+        assert mutation["expect_talk_pptx_path"] == bad
+
+    def test_a_talk_that_never_named_a_deck_expects_the_missing_marker(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """Expecting null and expecting absent are different preconditions."""
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        plan = self._plan(
+            tmp_path,
+            source_root,
+            [catalog_row(bad, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+
+        assert plan["mutations"][0]["expect_talk_pptx_path"] == {"$missing": True}
+
+    def test_the_plan_ignores_the_disposition_filter(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """A plan that inherited `--dispositions` would sever only what the
+        operator happened to be reading."""
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        payload = database(
+            [catalog_row(bad, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        report = sweep.execute(
+            path,
+            dispositions=[sweep.DISPOSITION_CONFIRMED],
+            emit_mutations=True,
+        )
+
+        assert report["rows"] == []
+        assert len(report["mutation_plan"]["mutations"]) == 1
+
+    def test_no_plan_without_the_flag(self, tmp_path: Path, source_root: Path) -> None:
+        bad = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        payload = database(
+            [catalog_row(bad, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+            source_root,
+        )
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        assert "mutation_plan" not in sweep.execute(path)
+
+    def test_two_severs_naming_one_talk_clear_its_path_once(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """The live catalog has exactly this: two UberConf 2024 decks bound to
+        one delivery. Snapshotting the stored value for both makes the second
+        mutation fail a precondition the first one made false."""
+        first = deck(source_root, "Devoxx Belgium/2024/DevOps for Developers.pptx")
+        second = deck(source_root, "Devoxx Belgium/2024/Another Deck.pptx")
+        bound = {**VOXXED_TALK, "pptx_path": first}
+        plan = self._plan(
+            tmp_path,
+            source_root,
+            [
+                catalog_row(first, VOXXED_TALK["filename"]),
+                catalog_row(second, VOXXED_TALK["filename"]),
+            ],
+            [bound, DEVOXX_TALK],
+        )
+
+        assert len(plan["mutations"]) == 2
+        assert plan["mutations"][0]["expect_talk_pptx_path"] == first
+        assert plan["mutations"][1]["expect_talk_pptx_path"] == {"$missing": True}
+
+
+class TestProofPlan:
+    def _plans(self, tmp_path: Path, source_root: Path, rows, talks):
+        payload = database(rows, talks, source_root)
+        path = tmp_path / "tracking-database.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        report = sweep.execute(path, emit_mutations=True)
+        return report["mutation_plan"], report["proof_plan"]
+
+    def test_a_confirmed_binding_gets_its_proof_written(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """A confirmed binding is not yet a proven one — preflight blocks a row
+        that names a talk without an assessment."""
+        good = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        _sever, proof = self._plans(
+            tmp_path,
+            source_root,
+            [catalog_row(good, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+
+        assert [m["kind"] for m in proof["mutations"]] == ["record_pptx"]
+        record = proof["mutations"][0]["record"]
+        assert record["talk_filename"] == VOXXED_TALK["filename"]
+        assert record["identity_assessment"]["verdict"] == "matched"
+
+    def test_the_written_proof_satisfies_the_owner_gate(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """What the plan writes must be what `record_pptx` would accept."""
+        identity = _load_script("pptx_talk_identity", "pptx_talk_identity.py")
+        good = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        _sever, proof = self._plans(
+            tmp_path,
+            source_root,
+            [catalog_row(good, VOXXED_TALK["filename"])],
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+        record = proof["mutations"][0]["record"]
+
+        assert (
+            identity.binding_refusal(
+                record["identity_assessment"],
+                pptx_path=record["pptx_path"],
+                talk_filename=record["talk_filename"],
+            )
+            is None
+        )
+
+    def test_two_decks_confirming_one_talk_prove_neither(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """Two decks cannot both be one talk's delivery deck. Each is assessed
+        alone and each agrees, so the contradiction is only visible across rows
+        — and proving either would assert what the other disproves."""
+        first = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        second = deck(
+            source_root, "Voxxed Days Ticino/2025/DevOps for Developers 2.pptx"
+        )
+        _sever, proof = self._plans(
+            tmp_path,
+            source_root,
+            [
+                catalog_row(first, VOXXED_TALK["filename"]),
+                catalog_row(second, VOXXED_TALK["filename"]),
+            ],
+            [VOXXED_TALK, DEVOXX_TALK],
+        )
+
+        assert proof["mutations"] == []
+
+    def test_the_proof_record_drops_the_reports_own_reading_aid(
+        self, tmp_path: Path, source_root: Path
+    ) -> None:
+        """`candidates_assessed` is this report's field; the owner gate
+        validates a closed key set and would refuse the write."""
+        good = deck(source_root, "Voxxed Days Ticino/2025/DevOps for Developers.pptx")
+        _sever, proof = self._plans(
+            tmp_path,
+            source_root,
+            [catalog_row(good, VOXXED_TALK["filename"])],
+            [VOXXED_TALK],
+        )
+
+        assert (
+            "candidates_assessed"
+            not in (proof["mutations"][0]["record"]["identity_assessment"])
+        )


### PR DESCRIPTION
## The gap this closes

#303 landed the sweep that proves whether a deck belongs to the talk it is bound
to. **Nothing could act on the proof.** A binding is a *pair* — the catalog
row's `talk_filename` and the talk's own `pptx_path` — and `record_pptx` writes
the talk side on a match and never clears it.

So 74 bindings sat blocking preflight, and the reparse behind them.

## What it adds

**`sever_pptx_talk_binding`** — a typed owner mutation clearing both sides in
one step. Both together because severing one is worse than severing neither:
clearing only the catalog row leaves the talk still naming the deck, and every
reader that resolves slides through `talks[].pptx_path` keeps drawing evidence
from it — now with an audit trail saying it was handled.

**`sweep-pptx-talk-identity.py --emit-mutations`** — two plans:

- `mutation_plan`: severs every binding the sweep could not prove
- `proof_plan`: stores the assessment behind every confirmed binding via
  `record_pptx`

Separate, because keeping a binding and breaking one are different owner
decisions, and one file carrying both invites applying half of what was
reviewed. Both are built from the whole catalog, never the `--dispositions`
view — a plan that inherited the filter would sever only what the operator
happened to be reading.

## The preconditions earned their keep

Both plans carry exact-old-value preconditions on both sides. Applying them
against a copy of the live database made them fail twice, and each failure was a
real defect that **per-deck assessment cannot see**:

**1. Two unproven rows naming one talk.** Two UberConf 2024 decks bind the same
delivery. The first sever clears the talk's `pptx_path`; the second then fails a
precondition the first made false. The plan now expects the missing marker for
every sever after the first on a given talk.

**2. Two *confirmed* rows claiming one talk.** `IJ Conference/2025/PDD.pptx` and
`IJ Conference/2025/PDD for GS.pptx` both confirm
`2025-03-20-ij-2025-prompt-driven.md`.

That one is sharper. Two decks cannot both be one talk's delivery deck. Each is
assessed alone and each agrees, so the contradiction exists only *across* rows —
invisible to the assessment. Proving either would assert what the other
disproves, so **the plan proves neither** and both stay blocking for owner
review.

I would not have found either by reading the code. The preconditions found them.

## Measured end to end

On a copy of the live database — sever → re-sweep → prove → migrate:

| Stage | Blocking preflight findings |
|---|---:|
| Now | 1550 |
| After migration alone | 76 |
| After sever + prove + migration | **4** |

The 4 remaining: the two decks contesting one talk (a genuine owner decision —
which is the delivery deck), and two unrelated
`video_extraction_provenance_invalid` findings.

## Tests

New coverage for the writer (both sides cleared, a change recorded per side,
stale expectation on either side refused, unbound row refused, absent row
refused, v3 assessment nulled, v1 shape not invented) and for both plans
(confirmed absent from the sever plan, unbound never severed, both preconditions
carried, missing-marker for a talk that never named a deck, filter ignored, the
two collision cases, and the written proof satisfying `binding_refusal`).

Full suite: **5746 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh