### PR TITLE
fix(vault-ingress): warn on an invalid legacy manifest, do not deadlock on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### fix(vault-ingress) — an invalid legacy manifest is warned about, not deadlocked on
+
+`_validate_video_extraction_provenance` took a `severity` from its caller and
+used it for an ABSENT manifest, then hardcoded `blocking` for an INVALID one.
+Those are the same situation on a legacy record: `_artifact_severity` already
+decides that a completed record with a usable repair lane reports actionable
+work rather than deadlocking the repair that would fix it.
+
+The asymmetry held the whole vault's reparse hostage to two pre-contract
+(`schema_version: 0`) video manifests on talks already queued for reprocessing —
+state the reparse itself regenerates. The invalid branch now uses the caller's
+severity, like the absent branch beside it.
+
+Live vault: blocking preflight findings 2 → 0.
+
 ## 0.20.73 — 2026-08-14
 
 ### feat(vault-ingress) — sever a binding nothing proved (#176)

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1544,9 +1544,16 @@ class VaultPreflight:
         try:
             state = validate_video_extraction_manifest({"video_extraction": extraction})
         except ReturnValidationError as exc:
+            # The caller's severity, not a hardcoded block. An ABSENT manifest
+            # three lines up already respects it — a legacy record queued for
+            # reprocessing reports actionable work rather than deadlocking the
+            # repair that would fix it. An invalid manifest on that same record
+            # is the same situation, and hardcoding `blocking` here held the
+            # whole vault's reparse hostage to two pre-contract manifests the
+            # reparse itself regenerates.
             self.talk_add(
                 index,
-                "blocking",
+                severity,
                 "video_extraction_provenance_invalid",
                 "video extraction manifest violates the schema-v3 artifact contract",
                 field="structured_data.video_extraction",

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4175,3 +4175,33 @@ def test_preflight_warns_when_the_extraction_artifact_was_replaced(
 
     findings = _catalog_findings(report)
     assert findings[0]["actual"]["classification"] == "stale"
+
+
+def test_an_invalid_legacy_video_manifest_on_a_requeued_talk_is_a_warning(
+    preflight_vault,
+    vault_fixture,
+):
+    """An ABSENT manifest on a requeued record already reports actionable work
+    rather than deadlocking the repair. An INVALID one on that same record is
+    the same situation: hardcoding `blocking` held the whole vault's reparse
+    hostage to pre-contract manifests the reparse itself regenerates.
+    """
+    materialize_transcript(vault_fixture)
+    write_pdf(vault_fixture["slides"] / f"{VIDEO_ID}.pdf")
+    talk = base_talk(status="needs-reprocessing", slide_source="video_extracted")
+    talk["structured_data"] = {
+        "video_extraction": {
+            # The live vault's shape: a manifest that predates the contract.
+            "schema_version": 0,
+            "output_pdf": f"slides/{VIDEO_ID}.pdf",
+            "pipeline_version": "0.4.0",
+            "slide_source": "video_extracted",
+            "unique_slides_count": 12,
+        }
+    }
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["blocking_count"] == 0
+    assert "video_extraction_provenance_invalid" in finding_codes(report, "warning")


### PR DESCRIPTION
## The asymmetry

`_validate_video_extraction_provenance` takes a `severity` from its caller and
uses it for an **absent** manifest — then hardcodes `blocking` for an
**invalid** one, three lines apart.

On a legacy record those are the same situation, and `_artifact_severity`
already decides it: a completed record with a usable verified/repair/acquisition
lane "reports actionable work without deadlocking that repair."

## What it cost

Two talks — `2015-devnexus-groovy-puzzlers-epic.md` and
`2017-devoxx-be-alexa-vs-google-vui-faceoff.md` — carry pre-contract
`video_extraction.schema_version: 0` manifests. Both are already
`needs-reprocessing`. The reparse regenerates exactly that state.

They were the **last two blocking preflight findings on the live vault**, and
they held the entire reparse hostage to state the reparse itself fixes.

```
LIVE blocking: 2 -> 0
```

## Regression

A requeued talk carrying the live vault's exact shape — a `schema_version: 0`
manifest — asserts `blocking_count == 0` and the finding present as a
**warning**. The neighbouring test for an absent manifest on a requeued talk
already asserted precisely this, which is what made the inconsistency visible.

Full suite: **5762 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh