### PR TITLE
fix(vault-ingress): a v6 return canonicalizes like a v5 one (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### fix(vault-ingress) — a v6 return canonicalizes like a v5 one (#299)
+
+The activation admitted v6 to `CANONICALIZABLE_RETURN_SCHEMA_VERSIONS` and left
+three `== EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION` tests inside
+`canonicalize_return_evidence`. A v6 return therefore reached canonicalization
+and was read as pre-v5, which rejects the `applicability_assessments` its own
+contract REQUIRES: `return schema v4 cannot carry applicability_assessments`.
+
+v6 validated on the way in and died on the way to the database. Nothing caught
+it because every canonicalization test built a v5 return — the equality tests
+were only ever exercised at the one version that satisfied them.
+
+`pattern_evidence` now carries `EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS`,
+mirroring the set of the same name in `return_validation`, and the three sites
+test membership. Found by running the reparse: the first worker produced a
+return that validated clean and could not be persisted.
+
 ## 0.20.74 — 2026-08-14
 
 ### fix(vault-ingress) — an invalid legacy manifest is warned about, not deadlocked on

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -70,6 +70,17 @@ CANONICALIZABLE_RETURN_SCHEMA_VERSIONS = frozenset(
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
     }
 )
+# Every generation carrying exhaustive outcomes and applicability assessments.
+# v6 keeps every v5 semantic and adds weighting, so canonicalization treats them
+# alike — an `== EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION` test reads a v6
+# return as pre-v5 and rejects the applicability_assessments its own contract
+# REQUIRES. Mirrors the set of the same name in `return_validation`.
+EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS = frozenset(
+    {
+        EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
+        WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+    }
+)
 CURRENT_PATTERN_SCORING_SCHEMA_VERSION = 6
 PATTERN_OUTCOMES = frozenset(
     {"detected", "undetected", "not_evaluable", "not_applicable"}
@@ -3477,7 +3488,7 @@ def canonicalize_return_evidence(
     raw_assessments = observations.get("applicability_assessments")
     assessment_entries = raw_assessments if isinstance(raw_assessments, list) else []
     assessments_by_id: dict[str, Mapping[str, object]] = {}
-    if return_schema_version == EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION:
+    if return_schema_version in EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS:
         for index, raw_assessment in enumerate(assessment_entries):
             if not isinstance(raw_assessment, Mapping):
                 raise PatternEvidenceError(
@@ -3507,7 +3518,7 @@ def canonicalize_return_evidence(
         assessment = assessments_by_id.get(pattern_id)
         applicability_gate = getattr(entry, "applicability_evaluable_from", None)
         conditions = getattr(entry, "not_applicable_when", None)
-        if return_schema_version == EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION and (
+        if return_schema_version in EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS and (
             applicability_gate is not None or conditions is not None
         ):
             if applicability_gate is None or conditions is None:
@@ -3665,7 +3676,7 @@ def canonicalize_return_evidence(
         }
         for pattern_id in sorted(expected_ids)
     ]
-    if return_schema_version == EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION:
+    if return_schema_version in EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS:
         observations["applicability_assessments"] = sorted(
             canonical_assessments,
             key=lambda item: cast(str, item["pattern_id"]),

--- a/tests/test_schema5_pattern_outcomes.py
+++ b/tests/test_schema5_pattern_outcomes.py
@@ -1048,3 +1048,65 @@ def test_a_correctly_stamped_record_still_replays_clean(
     )
 
     assert "pattern_scoring_schema_version_unusable" not in reasons
+
+
+def test_a_v6_return_canonicalizes_on_the_same_exhaustive_path_as_v5(
+    return_validation, transcript_timing, tmp_path
+):
+    """v6 keeps every v5 semantic and adds weighting, so canonicalization must
+    treat them alike.
+
+    An `== EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION` test reads a v6 return as
+    pre-v5 and rejects the `applicability_assessments` its own contract
+    REQUIRES — so a v6 return validated on the way in, then died on the way to
+    the database. Nothing caught it because every canonicalization test built a
+    v5 return.
+    """
+    import pattern_evidence
+
+    catalog = _catalog(
+        return_validation,
+        _entry(return_validation, "detected"),
+        _entry(return_validation, "conditional", applicability=True),
+        _entry(return_validation, "undetected"),
+        _entry(return_validation, "positive-only", absence_gate=None),
+    )
+    raw = _raw_return(
+        detections=[_detection()],
+        assessments=[_assessment()],
+        not_evaluable=[
+            {
+                "pattern_id": "positive-only",
+                "reason_code": "absence_not_authorized_by_catalog",
+            }
+        ],
+    )
+    raw["return_schema_version"] = (
+        return_validation.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
+    )
+    block = raw["pattern_observations"]
+    patterns = block["patterns_detected"]
+    antipatterns = block["antipatterns_detected"]
+    block["pattern_score"] = return_validation.expected_weighted_score(
+        patterns, antipatterns
+    )
+    block["pattern_score_basis"] = return_validation.pattern_score_basis(
+        patterns, antipatterns, block["not_evaluable"]
+    )
+    return_validation.validate_return(raw, catalog)
+    vault, owner = _artifact(tmp_path, transcript_timing)
+
+    canonical = pattern_evidence.canonicalize_return_evidence(
+        raw,
+        owner,
+        vault,
+        catalog,
+        pattern_scoring_schema_version=(
+            return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        ),
+    )
+
+    observations = canonical["pattern_observations"]
+    assert observations["applicability_assessments"]
+    assert observations["pattern_outcomes"]
+    assert observations["evidence_schema_version"] == 2

--- a/tests/test_schema5_pattern_outcomes.py
+++ b/tests/test_schema5_pattern_outcomes.py
@@ -1107,6 +1107,7 @@ def test_a_v6_return_canonicalizes_on_the_same_exhaustive_path_as_v5(
     )
 
     observations = canonical["pattern_observations"]
+    assert isinstance(observations, dict)
     assert observations["applicability_assessments"]
     assert observations["pattern_outcomes"]
     assert observations["evidence_schema_version"] == 2


### PR DESCRIPTION
## Found by actually running the reparse

The first reparse worker produced a v6 return that **validated clean** and then
**could not be persisted**:

```
PatternEvidenceError: return schema v4 cannot carry applicability_assessments
```

On a v6 return. Which is required by v6's own contract.

## The defect

#305 admitted v6 to `CANONICALIZABLE_RETURN_SCHEMA_VERSIONS` and left three
`== EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION` tests inside
`canonicalize_return_evidence` (`pattern_evidence.py:3480, 3510, 3668`). So a v6
return got through the door and was then read as **pre-v5**.

`return_validation` has had an `EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS` set
since #293. `pattern_evidence` never grew the plural. It has one now, and the
three sites test membership.

## Why nothing caught it

Every canonicalization test builds a **v5** return, so those equality tests were
only ever exercised at the one version that satisfies them. The new regression
drives a real v6 return — weighted score, basis, applicability assessments —
through `canonicalize_return_evidence` and asserts the canonical block comes out
with its assessments, outcomes, and `evidence_schema_version: 2`.

Verified it reproduces: with the production change reverted the new test fails
with the exact error above; with it, it passes.

## Note on scope

This is the persistence half of #299 finishing the job. The activation moved the
constants and the migration; this moves the one place that branched on the
constant instead of the set.

Full suite: **5764 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh