### PR TITLE
fix(catalog): an entry evaluable from a transcript can now cite one (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+### fix(catalog) — an entry evaluable from a transcript can now cite one
+
+Eleven observable entries declared `transcript` in `evaluable_from` — ten of
+them in `strong_evaluable_from` as well — while omitting `transcript` from
+`evidence_channels`. `call-to-action` names a transcript as an evaluable source
+three times and its `evidence_requirements` says "the spoken source must cover
+the complete closing zone", then offers only `timed_transcript` and `video` to
+cite one through.
+
+A worker holding a plain transcript therefore had no legal citation, while
+canonicalization still demanded an assessment because the applicability gate
+read as complete. The two fields contradict each other, and the contradiction is
+only visible across both, which is why nothing caught it.
+
+Affected: `call-to-action`, `call-to-adventure`, `concrete-before-abstract`,
+`delayed-self-introduction`, `guess-first`, `new-bliss`, `opening-punch`,
+`retrieval-beat`, `shortchanged`, `sparkline`, `talklet`.
+
+Only 3 of 215 talks carry a timing sidecar, so these entries were effectively
+unscorable corpus-wide — recorded as "the speaker does not do this" rather than
+"the catalog cannot see it". `guess-first` is the sharpest case: a twelve-round
+commit-then-reveal quiz recorded as not evaluable.
+
+A new catalog guard fails when any observable entry admits a transcript source
+without a transcript channel, so the pairing cannot drift apart again.
+
+Found by running the reparse (#309).
+
 ## 0.20.76 — 2026-08-14
 
 ### fix(vault-ingress) — a probe may run the interpreter the vault configures

--- a/skills/presentation-creator/references/patterns/build/call-to-action.md
+++ b/skills/presentation-creator/references/patterns/build/call-to-action.md
@@ -7,7 +7,7 @@ phase_relevance:
   - content
   - publishing
 vault_dimensions: [4, 6, 9]
-evidence_channels: [timed_transcript, video]
+evidence_channels: [transcript, timed_transcript, video]
 detection_signals:
   - "explicit imperative ask in the closing zone"
   - "asks are specific and immediately executable, not generic"

--- a/skills/presentation-creator/references/patterns/build/call-to-adventure.md
+++ b/skills/presentation-creator/references/patterns/build/call-to-adventure.md
@@ -7,7 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [1, 2, 9]
-evidence_channels: [timed_transcript, video]
+evidence_channels: [transcript, timed_transcript, video]
 detection_signals:
   - "explicit gap-reveal moment between current reality and proposed future"
   - "Big Idea stated at the structural transition from setup to body"

--- a/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
+++ b/skills/presentation-creator/references/patterns/build/concrete-before-abstract.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
 vault_dimensions: [2, 9, 11]
-evidence_channels: [timed_transcript, slide_sequence, video]
+evidence_channels: [transcript, timed_transcript, slide_sequence, video]
 detection_signals:
   - "a tangible example, object, story, or live demo precedes the named concept it illustrates"
   - "the framework/term is introduced only after the audience has experienced an instance of it"

--- a/skills/presentation-creator/references/patterns/build/guess-first.md
+++ b/skills/presentation-creator/references/patterns/build/guess-first.md
@@ -7,7 +7,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [2, 4, 11]
-evidence_channels: [timed_transcript, video]
+evidence_channels: [transcript, timed_transcript, video]
 detection_signals:
   - "audience asked to commit an answer before the reveal"
   - "prediction solicited ahead of a demo, result, or number"

--- a/skills/presentation-creator/references/patterns/build/new-bliss.md
+++ b/skills/presentation-creator/references/patterns/build/new-bliss.md
@@ -6,7 +6,7 @@ part: build
 phase_relevance:
   - content
 vault_dimensions: [2, 6, 9]
-evidence_channels: [timed_transcript, video]
+evidence_channels: [transcript, timed_transcript, video]
 detection_signals:
   - "vivid future-state description in the closing zone"
   - "talk ends on a higher emotional plane than it started"

--- a/skills/presentation-creator/references/patterns/build/retrieval-beat.md
+++ b/skills/presentation-creator/references/patterns/build/retrieval-beat.md
@@ -8,7 +8,7 @@ phase_relevance:
   - content
   - slides
 vault_dimensions: [4, 12]
-evidence_channels: [timed_transcript, video]
+evidence_channels: [transcript, timed_transcript, video]
 detection_signals:
   - "audience asked to recall earlier material from memory"
   - "speaker withholds a restatement and makes the room supply it"

--- a/skills/presentation-creator/references/patterns/build/sparkline.md
+++ b/skills/presentation-creator/references/patterns/build/sparkline.md
@@ -7,7 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [2, 9]
-evidence_channels: [timed_transcript, slides, slide_sequence, video]
+evidence_channels: [transcript, timed_transcript, slides, slide_sequence, video]
 detection_signals:
   - "establishes 'what is' baseline before introducing thesis"
   - "explicit gap-revelation moment (call to adventure)"

--- a/skills/presentation-creator/references/patterns/deliver/_anti_shortchanged.md
+++ b/skills/presentation-creator/references/patterns/deliver/_anti_shortchanged.md
@@ -6,7 +6,7 @@ part: deliver
 phase_relevance:
   - guardrails
 vault_dimensions: [12, 14]
-evidence_channels: [timed_transcript, video]
+evidence_channels: [transcript, timed_transcript, video]
 detection_signals:
   - "rushing through material"
   - "visible time pressure"

--- a/skills/presentation-creator/references/patterns/deliver/delayed-self-introduction.md
+++ b/skills/presentation-creator/references/patterns/deliver/delayed-self-introduction.md
@@ -6,7 +6,7 @@ part: deliver
 phase_relevance:
   - content
 vault_dimensions: [2, 9]
-evidence_channels: [timed_transcript, slides, video]
+evidence_channels: [transcript, timed_transcript, slides, video]
 detection_signals:
   - "speaker opens with hook/content rather than name and role"
   - "self-introduction appears after an initial slide or two"

--- a/skills/presentation-creator/references/patterns/prepare/opening-punch.md
+++ b/skills/presentation-creator/references/patterns/prepare/opening-punch.md
@@ -7,7 +7,7 @@ phase_relevance:
   - intent
   - content
 vault_dimensions: [1, 4]
-evidence_channels: [timed_transcript, slides, video]
+evidence_channels: [transcript, timed_transcript, slides, video]
 detection_signals:
   - "personal story in opening 1-2 minutes"
   - "unexpected fact or surprise as hook"

--- a/skills/presentation-creator/references/patterns/prepare/talklet.md
+++ b/skills/presentation-creator/references/patterns/prepare/talklet.md
@@ -7,7 +7,7 @@ phase_relevance:
   - architecture
   - content
 vault_dimensions: [2, 12]
-evidence_channels: [timed_transcript, slides, video]
+evidence_channels: [transcript, timed_transcript, slides, video]
 detection_signals:
   - "self-contained 20-minute modules"
   - "modular structure"

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -1576,8 +1576,8 @@ def test_metadata_channel_declares_the_fields_it_can_use():
 @pytest.mark.parametrize(
     "pattern_id,channels",
     [
-        ("opening-punch", {"timed_transcript", "slides", "video"}),
-        ("call-to-adventure", {"timed_transcript", "video"}),
+        ("opening-punch", {"transcript", "timed_transcript", "slides", "video"}),
+        ("call-to-adventure", {"transcript", "timed_transcript", "video"}),
         ("progressive-reveal", {"slide_sequence", "video"}),
         ("composite-animation", {"slides", "video"}),
         ("crawling-credits", {"slides", "video"}),
@@ -1655,3 +1655,31 @@ def test_stable_ids_retain_their_distinguishing_source_meaning(pattern_id, ancho
         assert anchor.casefold() in text, (
             f"{pattern_id}: missing source-meaning anchor {anchor!r}"
         )
+
+
+def test_every_transcript_evaluable_entry_can_cite_a_transcript():
+    """An entry evaluable from a source it cannot cite is unusable via it.
+
+    Eleven observable entries declared `transcript` in `evaluable_from` — ten of
+    them in `strong_evaluable_from` too — while omitting `transcript` from
+    `evidence_channels`. A worker with a plain transcript then had no legal
+    citation, and canonicalization still demanded an assessment because the
+    applicability gate read as complete. The contradiction is only visible
+    across the two fields, which is why nothing caught it.
+    """
+    offenders = []
+    for path in ENTRY_FILES:
+        metadata = _metadata(path)
+        if not metadata.get("observable", True):
+            continue
+        sources = {
+            source
+            for group in (metadata.get("evaluable_from") or [])
+            for source in ([group] if isinstance(group, str) else group)
+        }
+        if "transcript" not in sources:
+            continue
+        if "transcript" not in set(metadata.get("evidence_channels") or ()):
+            offenders.append(metadata.get("id"))
+
+    assert offenders == []

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -1666,20 +1666,35 @@ def test_every_transcript_evaluable_entry_can_cite_a_transcript():
     citation, and canonicalization still demanded an assessment because the
     applicability gate read as complete. The contradiction is only visible
     across the two fields, which is why nothing caught it.
+
+    Every gate field counts, not just `evaluable_from`: an entry that admits a
+    transcript for its STRONG tier, its absence proof, or its applicability
+    determination needs a transcript channel just as much, and checking one
+    field would let the same defect return through the other three.
     """
+    gate_fields = (
+        "evaluable_from",
+        "strong_evaluable_from",
+        "absence_evaluable_from",
+        "applicability_evaluable_from",
+    )
     offenders = []
     for path in ENTRY_FILES:
         metadata = _metadata(path)
         if not metadata.get("observable", True):
             continue
-        sources = {
-            source
-            for group in (metadata.get("evaluable_from") or [])
-            for source in ([group] if isinstance(group, str) else group)
-        }
-        if "transcript" not in sources:
+        admits_transcript = any(
+            "transcript"
+            in {
+                source
+                for group in (metadata.get(field) or [])
+                for source in ([group] if isinstance(group, str) else group)
+            }
+            for field in gate_fields
+        )
+        if not admits_transcript:
             continue
         if "transcript" not in set(metadata.get("evidence_channels") or ()):
-            offenders.append(metadata.get("id"))
+            offenders.append((metadata.get("id"), path))
 
-    assert offenders == []
+    assert offenders == [], [entry for entry, _ in offenders]


### PR DESCRIPTION
## The contradiction

Eleven observable entries declare `transcript` in `evaluable_from` — **ten of
them in `strong_evaluable_from` too** — and omit `transcript` from
`evidence_channels`.

`call-to-action` is the clearest:

```yaml
evidence_channels: [timed_transcript, video]        # cannot cite a transcript
evaluable_from:            [transcript, delivery_video]
strong_evaluable_from:     [transcript, delivery_video]
applicability_evaluable_from: [transcript, delivery_video]
evidence_requirements:
  - "The spoken source must cover the complete closing zone…"
```

It names a transcript as an evaluable source three times, says the *spoken
source* is what evidences it, and then provides no channel to cite one.

A worker holding a plain transcript has no legal citation — while
canonicalization still **demands** an assessment, because the applicability gate
reads as complete. The completeness that triggers the demand is what makes it
unmeetable.

## Why this is derivable, not a judgment call

I did not decide what these patterns mean. Each entry already declares that a
transcript evaluates it; the fix makes the entry self-consistent with its own
declaration. The contradiction lives *across* two fields, which is exactly why
no per-field validation caught it.

19 of the 30 transcript-evaluable entries already pair the two correctly. These
eleven were the outliers.

## Scale

```
talks total:              215
talks with a timing sidecar: 3
```

So these entries were effectively unscorable across the whole corpus, and landed
in profiles as "the speaker does not do this" rather than "the catalog cannot
see it". `guess-first` is the sharpest loss — on
`2016-qcon-sf-java-puzzlers-ng-s02.md` a twelve-round commit-then-reveal quiz
records as `not_evaluable`.

## Guard

`test_every_transcript_evaluable_entry_can_cite_a_transcript` fails when any
observable entry admits a transcript source without a transcript channel.
Verified it reproduces: revert one entry and it fails; restore it and it passes.

Two exact-channel pins (`opening-punch`, `call-to-adventure`) moved with the
change. That list already contained transcript-bearing entries, so this brings
the two into line with the rest rather than loosening anything.

## Note

The catalog fingerprint moves (`ed86f671…` → `eaf1e8d9…`), so this is a scoring
generation change — it must land **before** the reparse analyses talks, not
after, or every already-scored talk sits on a stale fingerprint.

Found by running the reparse: batch 1 stopped on
`'call-to-adventure' applicability assessment is not bound to one complete
catalog-authorized source group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh