### PR TITLE
fix(vault-ingress): persist a weighted score, and read it back (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+### fix(vault-ingress) — a weighted score can now be stored and read back (#299)
+
+#293 defined the weighted return and #308 got one through canonicalization. It
+still could not land: every writer that touched a persisted `pattern_score`
+demanded an integer, and a weighted aggregate is a sum of 1.0/0.5/0.25 terms.
+A worker's return validated clean, canonicalized clean, and died at the merge.
+
+`resolve_pattern_score` now takes the contract its generation declares.
+`merge_talk` selects it from the return schema version, so a v6 return persists
+its fraction. The cross-check moves with it: a bare weighted number is compared
+against `expected_weighted_score`, not against count-minus-count, which for a
+strong pattern and a weak antipattern is 0.75 rather than 0. The flat generation
+still refuses a float — a float there means arithmetic other than the count
+difference produced it.
+
+The same split reaches the adherence baseline, and this is where it got
+interesting. Converting only the cohort selector left `build_adherence_baseline`
+admitting a fractional score into the cohort on one line and raising on it a few
+lines later, in the same function. Every weighted baseline would have been
+unbuildable, and the symptom is a population reported as too small rather than
+a contract mismatch — the same half-converted path as #308, found this time by
+pyright rather than by a reparse. The sum, the average, and
+`validate_adherence_baseline` all key on the generation now.
+
+`_require_number` returns its value rather than widening it to float. A weighted
+score that happens to be whole is still that number, and coercing restated it as
+`5.0` in divergence messages and stored `12.0` where the flat generation stores
+`12`.
+
+Coverage in `tests/test_weighted_score_persistence.py`: the writer-side
+contract, the cohort and baseline read-back, and an end-to-end validate →
+canonicalize → `merge_talk` pass, since the last two fixes each got a different
+link in that chain wrong. Every test admitting a fraction at the weighted
+generation has a sibling proving the flat generation still refuses one.
+
 ## 0.20.77 — 2026-08-14
 
 ### fix(catalog) — an entry evaluable from a transcript can now cite one

--- a/skills/vault-ingress/scripts/adherence_baseline.py
+++ b/skills/vault-ingress/scripts/adherence_baseline.py
@@ -32,6 +32,10 @@ LEGACY_GENERATION_REASON = "legacy_generation"
 CATALOG_FINGERPRINT_MISMATCH_REASON = "catalog_fingerprint_mismatch"
 SCORING_SCHEMA_VERSION_MISMATCH_REASON = "scoring_schema_version_mismatch"
 PERSISTED_EVIDENCE_STALE_REASON = "persisted_evidence_stale"
+# The scoring generation whose aggregate is confidence-weighted, and therefore
+# fractional. Mirrors `return_validation`; restated rather than imported so this
+# module keeps performing no I/O and importing nothing that loads a catalog.
+WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION = 6
 PERSISTED_OBSERVATIONS_INVALID_REASON = "persisted_observations_invalid"
 EVIDENCE_BOUND_SCORING_SCHEMA_VERSION = 4
 OPPORTUNITY_BOUND_SCORING_SCHEMA_VERSION = 5
@@ -226,11 +230,27 @@ def _classify_generation(
     )
 
 
+def _require_number(value: object, label: str) -> float:
+    """A finite real number. `True` is an int in Python; a score is not.
+
+    Returned unchanged rather than coerced to float. A weighted score that
+    happens to be whole is still that number, and widening it here would restate
+    it as `5.0` in every message and store `12.0` where the flat generation
+    stores `12` — a difference in the record that no arithmetic asked for.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise AdherenceBaselineError(f"{label} must be a number, got {value!r}")
+    if not math.isfinite(value):
+        raise AdherenceBaselineError(f"{label} must be finite, got {value!r}")
+    return value
+
+
 def _resolved_pattern_score(
     talk: Mapping[str, object],
     *,
     filename: str,
-) -> int:
+    weighted: bool = False,
+) -> float:
     top_score = talk.get("pattern_score", _MISSING)
     observations = talk.get("pattern_observations", _MISSING)
     if top_score is _MISSING:
@@ -250,8 +270,12 @@ def _resolved_pattern_score(
             "nested pattern_observations.pattern_score"
         )
 
-    validated_top = _require_integer(top_score, f"{filename}.pattern_score")
-    validated_nested = _require_integer(
+    # A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so it is fractional
+    # by construction. The flat generation still requires an integer: a float
+    # there means arithmetic other than count-minus-count produced it.
+    require = _require_number if weighted else _require_integer
+    validated_top = require(top_score, f"{filename}.pattern_score")
+    validated_nested = require(
         nested_score,
         f"{filename}.pattern_observations.pattern_score",
     )
@@ -394,7 +418,7 @@ def _persisted_observation_reasons(
     return sorted(set(reasons))
 
 
-def _average_pattern_score(score_sum: int, talk_count: int) -> float | None:
+def _average_pattern_score(score_sum: float, talk_count: int) -> float | None:
     if talk_count == 0:
         return None
     try:
@@ -529,7 +553,11 @@ def partition_pattern_scoring_cohort(
                 }
             )
             continue
-        _resolved_pattern_score(talk, filename=filename)
+        _resolved_pattern_score(
+            talk,
+            filename=filename,
+            weighted=(exact_scoring_version >= WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION),
+        )
         if exact_scoring_version >= OPPORTUNITY_BOUND_SCORING_SCHEMA_VERSION:
             _resolved_opportunity_coverage_identity(talk, filename=filename)
         if exact_scoring_version >= EVIDENCE_BOUND_SCORING_SCHEMA_VERSION:
@@ -665,13 +693,24 @@ def _build_adherence_baseline(
             comparison_status = "unavailable"
             comparison_reason = "empty_current_cohort"
     scored_talk_count = len(comparison_talks)
+    weighted_generation = (
+        exact_scoring_version >= WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+    )
     pattern_score_sum = sum(
         _resolved_pattern_score(
             talk,
             filename=_require_filename(talk.get("filename"), "talk filename"),
+            weighted=weighted_generation,
         )
         for talk in comparison_talks
     )
+    if weighted_generation:
+        # Every weighted score is canonical to two decimals, so a sum of them is
+        # too and this rounds nothing away. It normalizes float dust instead: the
+        # cohort admits any finite number a persisted record carries, and an
+        # un-canonical sum would be stored in a snapshot other code compares
+        # exactly. Same canonicalization `expected_weighted_score` applies.
+        pattern_score_sum = round(pattern_score_sum, 2)
 
     snapshot: dict[str, object] = {
         "schema_version": (
@@ -835,7 +874,14 @@ def validate_adherence_baseline(snapshot: object) -> dict[str, object]:
         "scored_talk_count",
         minimum=0,
     )
-    score_sum = _require_integer(snapshot["pattern_score_sum"], "pattern_score_sum")
+    # The sum takes its generation's arithmetic, exactly as the per-talk score
+    # does: a weighted cohort sums fractions, so demanding an integer here would
+    # reject every baseline the weighted generation can build.
+    score_sum = (
+        _require_number(snapshot["pattern_score_sum"], "pattern_score_sum")
+        if scoring_version >= WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        else _require_integer(snapshot["pattern_score_sum"], "pattern_score_sum")
+    )
     expected_average = _average_pattern_score(score_sum, talk_count)
     raw_average = snapshot["average_pattern_score"]
     if talk_count == 0:

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -77,6 +77,7 @@ Example:
 
 import copy
 import json
+import math
 import sys
 from datetime import datetime, timezone
 
@@ -104,6 +105,8 @@ from return_validation import (
     ANALYSIS_STATUSES,
     CURRENT_PATTERN_SCORING_GENERATION_STATUS,
     EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS,
+    WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS,
+    expected_weighted_score,
     IMAGE_SOURCE_GROUP,
     LEGACY_QUEUE_CLAIM_SCHEMA_VERSION,
     LEGACY_RETURN_SCHEMA_VERSION,
@@ -462,7 +465,7 @@ def require_detections(observations, field):
     return value
 
 
-def resolve_pattern_score(observations, patterns, antipatterns):
+def resolve_pattern_score(observations, patterns, antipatterns, *, weighted=False):
     """Single source of truth for the talk's `pattern_score`.
 
     Returns (score, coerced); `score` is None when the return carries none.
@@ -485,8 +488,11 @@ def resolve_pattern_score(observations, patterns, antipatterns):
     by construction. `True` satisfies `isinstance(x, int)` in Python and a float
     looks numeric; neither is a score.
 
-    A weighted v6 return never reaches here: it does not canonicalize, so it does
-    not persist. Weighted arithmetic arrives with the activation change.
+    A weighted return DOES reach here as of the activation (#299). Its aggregate
+    is a sum of 1.0/0.5/0.25 terms, so it is fractional by construction, and the
+    count difference is not its arithmetic. `weighted` selects which contract
+    applies; the flat one still refuses a float, because a float there means
+    some other arithmetic produced it.
     """
     if "pattern_score" not in observations or observations["pattern_score"] is None:
         return None, False
@@ -507,7 +513,16 @@ def resolve_pattern_score(observations, patterns, antipatterns):
         )
 
     label = "pattern_score" if coerced else "pattern_score.score"
-    if isinstance(nested, bool) or not isinstance(nested, int):
+    if weighted:
+        if isinstance(nested, bool) or not isinstance(nested, (int, float)):
+            raise ValueError(
+                f"{label} is {nested!r} ({type(nested).__name__}). A weighted "
+                "score is a number — the confidence-weighted sum of the "
+                "detection arrays."
+            )
+        if not math.isfinite(nested):
+            raise ValueError(f"{label} must be a finite number, got {nested!r}")
+    elif isinstance(nested, bool) or not isinstance(nested, int):
         raise ValueError(
             f"{label} is {nested!r} ({type(nested).__name__}). It must be an "
             "integer — the score is count(patterns) minus count(antipatterns), "
@@ -519,13 +534,26 @@ def resolve_pattern_score(observations, patterns, antipatterns):
     # without its accompanying counts, so the arrays are the only evidence that
     # the number is right.
     if coerced:
-        used, against = len(patterns or []), len(antipatterns or [])
-        if used - against != nested:
-            raise ValueError(
-                f"pattern_score is the bare int {nested}, but patterns_detected "
-                f"({used}) minus antipatterns_detected ({against}) is "
-                f"{used - against}. Refusing to guess which is right."
-            )
+        if weighted:
+            # The weighted arithmetic, not the count difference. Compared
+            # exactly: `expected_weighted_score` is already canonical to two
+            # decimals, so rounding the untrusted value first would admit a
+            # score no declared arithmetic produces.
+            expected = expected_weighted_score(patterns or [], antipatterns or [])
+            if nested != expected:
+                raise ValueError(
+                    f"pattern_score is the bare number {nested}, but the "
+                    f"weighted detection arrays require {expected}. Refusing to "
+                    "guess which is right."
+                )
+        else:
+            used, against = len(patterns or []), len(antipatterns or [])
+            if used - against != nested:
+                raise ValueError(
+                    f"pattern_score is the bare int {nested}, but patterns_detected "
+                    f"({used}) minus antipatterns_detected ({against}) is "
+                    f"{used - against}. Refusing to guess which is right."
+                )
     return nested, coerced
 
 
@@ -666,7 +694,10 @@ def merge_talk(
     patterns = scoring_assessment.patterns_detected
     antipatterns = scoring_assessment.antipatterns_detected
     score, coerced_score = resolve_pattern_score(
-        observation_values, patterns, antipatterns
+        observation_values,
+        patterns,
+        antipatterns,
+        weighted=return_schema_version in WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS,
     )
 
     if return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:

--- a/tests/test_weighted_score_persistence.py
+++ b/tests/test_weighted_score_persistence.py
@@ -1,0 +1,564 @@
+"""The persistence half of weighted scoring (#299).
+
+#293 defined the weighted return; #308 got a v6 return through canonicalization.
+Neither could store the number it produced: both writers that read a persisted
+`pattern_score` demanded an integer, and a weighted aggregate is a sum of
+1.0/0.5/0.25 terms.
+
+These pin the two contracts that had to split by generation — `resolve_pattern_score`
+on the way into the database, and the adherence cohort on the way back out. The
+weighted allowance is an addition, so every test that admits a fraction at the
+weighted generation has a sibling proving the flat generation still refuses one.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from typing import Any
+
+import pytest
+
+from test_schema5_pattern_outcomes import (
+    _artifact,
+    _assessment,
+    _catalog,
+    _detection,
+    _entry,
+    _raw_return,
+)
+
+CATALOG = "a" * 64
+OPPORTUNITY_IDENTITY = "c" * 64
+
+
+def _arrays() -> tuple[list[dict], list[dict]]:
+    """One strong pattern against one weak antipattern: 1.0 - 0.25 = 0.75.
+
+    Deliberately not a whole number. A fixture scoring 1.0 passes the weighted
+    contract and the flat one alike, so it cannot tell them apart.
+    """
+    return (
+        [{"pattern_id": "a", "confidence": "strong"}],
+        [{"pattern_id": "b", "confidence": "weak"}],
+    )
+
+
+class TestResolveAWeightedScore:
+    """`resolve_pattern_score` — the single writer-side authority on the number."""
+
+    def test_a_bare_fraction_the_arrays_require_is_accepted(self, persist_results):
+        patterns, antipatterns = _arrays()
+
+        score, coerced = persist_results.resolve_pattern_score(
+            {"pattern_score": 0.75}, patterns, antipatterns, weighted=True
+        )
+
+        assert (score, coerced) == (0.75, True)
+
+    def test_a_bare_fraction_the_arrays_contradict_is_refused(self, persist_results):
+        """The cross-check moves to weighted arithmetic, it does not switch off."""
+        patterns, antipatterns = _arrays()
+
+        with pytest.raises(ValueError, match="weighted detection arrays require 0.75"):
+            persist_results.resolve_pattern_score(
+                {"pattern_score": 0.5}, patterns, antipatterns, weighted=True
+            )
+
+    def test_a_bare_count_difference_no_longer_satisfies_it(self, persist_results):
+        """count(1) - count(1) = 0 was the old answer; the weighted one is 0.75."""
+        patterns, antipatterns = _arrays()
+
+        with pytest.raises(ValueError, match="weighted detection arrays require"):
+            persist_results.resolve_pattern_score(
+                {"pattern_score": 0}, patterns, antipatterns, weighted=True
+            )
+
+    def test_a_bool_is_not_a_weighted_score(self, persist_results):
+        """`True` satisfies `isinstance(x, int)` in Python; a score does not."""
+        patterns, antipatterns = _arrays()
+
+        with pytest.raises(ValueError, match="A weighted score is a number"):
+            persist_results.resolve_pattern_score(
+                {"pattern_score": True}, patterns, antipatterns, weighted=True
+            )
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_a_non_finite_score_is_refused_before_any_comparison(
+        self, persist_results, value
+    ):
+        """NaN defeats the equality cross-check by never equalling anything."""
+        patterns, antipatterns = _arrays()
+
+        with pytest.raises(ValueError, match="finite"):
+            persist_results.resolve_pattern_score(
+                {"pattern_score": value}, patterns, antipatterns, weighted=True
+            )
+
+    def test_a_score_object_carries_its_own_counts_and_is_not_cross_checked(
+        self, persist_results
+    ):
+        """Only the bare form arrived without the counts that vouch for it."""
+        patterns, antipatterns = _arrays()
+
+        score, coerced = persist_results.resolve_pattern_score(
+            {
+                "pattern_score": {
+                    "patterns_used": 1,
+                    "antipatterns_detected": 1,
+                    "score": 0.75,
+                }
+            },
+            patterns,
+            antipatterns,
+            weighted=True,
+        )
+
+        assert (score, coerced) == (0.75, False)
+
+    def test_a_whole_weighted_score_stays_valid(self, persist_results):
+        """Two strong patterns against one: 2.0 - 1.0 = 1.0, weighted and integral."""
+        patterns = [
+            {"pattern_id": "a", "confidence": "strong"},
+            {"pattern_id": "b", "confidence": "strong"},
+        ]
+        antipatterns = [{"pattern_id": "c", "confidence": "strong"}]
+
+        score, _ = persist_results.resolve_pattern_score(
+            {"pattern_score": 1.0}, patterns, antipatterns, weighted=True
+        )
+
+        assert score == 1.0
+
+
+class TestTheFlatContractIsUnchanged:
+    """The weighted allowance is an addition, never a loosening."""
+
+    def test_a_float_is_still_refused_at_the_flat_generation(self, persist_results):
+        patterns, antipatterns = _arrays()
+
+        with pytest.raises(ValueError, match="must be an\n?\\s*integer"):
+            persist_results.resolve_pattern_score(
+                {"pattern_score": 0.75}, patterns, antipatterns
+            )
+
+    def test_the_count_difference_is_still_the_flat_cross_check(self, persist_results):
+        patterns, antipatterns = _arrays()
+
+        with pytest.raises(ValueError, match="minus antipatterns_detected"):
+            persist_results.resolve_pattern_score(
+                {"pattern_score": 5}, patterns, antipatterns
+            )
+
+    def test_the_flat_count_difference_still_persists(self, persist_results):
+        patterns, antipatterns = _arrays()
+
+        score, coerced = persist_results.resolve_pattern_score(
+            {"pattern_score": 0}, patterns, antipatterns
+        )
+
+        assert (score, coerced) == (0, True)
+
+    def test_weighted_defaults_off(self, persist_results):
+        """Callers that predate the split keep the flat contract by omission."""
+        patterns, antipatterns = _arrays()
+
+        with pytest.raises(ValueError, match="must be an\n?\\s*integer"):
+            persist_results.resolve_pattern_score(
+                {"pattern_score": 0.75},
+                patterns,
+                antipatterns,
+                weighted=False,
+            )
+
+
+def _cohort_talk(filename: str, score: Any, *, scoring_schema: int) -> dict[str, Any]:
+    return {
+        "filename": filename,
+        "status": "processed",
+        "pattern_catalog_fingerprint": CATALOG,
+        "pattern_scoring_schema_version": scoring_schema,
+        "pattern_scoring_generation_status": "current",
+        "pattern_scoring_generation_reasons": [],
+        "pattern_score": score,
+        "pattern_observations": {
+            "pattern_score": score,
+            "opportunity_coverage_identity": OPPORTUNITY_IDENTITY,
+            "pattern_outcomes": [{"pattern_id": "p1", "outcome": "detected"}],
+        },
+    }
+
+
+def _baseline(adherence_baseline, talks, *, scoring_schema: int):
+    return adherence_baseline.build_adherence_baseline(
+        talks,
+        selected_filenames=[],
+        as_of="2026-07-31T12:00:00+00:00",
+        pattern_catalog_fingerprint=CATALOG,
+        pattern_scoring_schema_version=scoring_schema,
+        evidence_freshness_assessor=lambda _: (),
+        persisted_observation_assessor=lambda _: (),
+    )
+
+
+def _partition(adherence_baseline, talks, *, scoring_schema: int):
+    return adherence_baseline.partition_pattern_scoring_cohort(
+        talks,
+        excluded_filenames=(),
+        pattern_catalog_fingerprint=CATALOG,
+        pattern_scoring_schema_version=scoring_schema,
+        evidence_freshness_assessor=lambda _: (),
+        persisted_observation_assessor=lambda _: (),
+    )
+
+
+@pytest.fixture(scope="module")
+def adherence_baseline():
+    import adherence_baseline as module
+
+    return module
+
+
+class TestTheWeightedCohortReadsItBack:
+    """A score the writer stored must not be unreadable to the cohort selector.
+
+    The baseline is what a talk is compared against. A weighted generation whose
+    own scores raise here has no baseline at all — every talk falls out, which
+    reads downstream as a population too small rather than a contract mismatch.
+    """
+
+    def test_a_fractional_score_stays_in_the_weighted_cohort(
+        self, adherence_baseline, return_validation
+    ):
+        talk = _cohort_talk(
+            "weighted.md",
+            0.75,
+            scoring_schema=return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION,
+        )
+
+        current, excluded, details = _partition(
+            adherence_baseline,
+            [talk],
+            scoring_schema=(return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION),
+        )
+
+        assert (current, excluded, details) == ([talk], [], [])
+
+    def test_the_flat_cohort_still_refuses_a_fraction(
+        self, adherence_baseline, return_validation
+    ):
+        flat = return_validation.FLAT_PATTERN_SCORING_SCHEMA_VERSION
+        talk = _cohort_talk("flat.md", 0.75, scoring_schema=flat)
+
+        with pytest.raises(
+            adherence_baseline.AdherenceBaselineError,
+            match="pattern_score must be an integer",
+        ):
+            _partition(adherence_baseline, [talk], scoring_schema=flat)
+
+    @pytest.mark.parametrize("score", [True, False, "1", None])
+    def test_a_non_number_is_still_refused_at_the_weighted_generation(
+        self, adherence_baseline, return_validation, score
+    ):
+        weighted = return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        talk = _cohort_talk("bad.md", score, scoring_schema=weighted)
+
+        with pytest.raises(
+            adherence_baseline.AdherenceBaselineError,
+            match="pattern_score must be a number",
+        ):
+            _partition(adherence_baseline, [talk], scoring_schema=weighted)
+
+    @pytest.mark.parametrize("score", [float("nan"), float("inf"), float("-inf")])
+    def test_a_non_finite_score_is_refused_at_the_weighted_generation(
+        self, adherence_baseline, return_validation, score
+    ):
+        """A NaN that reached the sum would make the whole average NaN."""
+        weighted = return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        talk = _cohort_talk("nonfinite.md", score, scoring_schema=weighted)
+
+        with pytest.raises(
+            adherence_baseline.AdherenceBaselineError,
+            match="pattern_score must be finite",
+        ):
+            _partition(adherence_baseline, [talk], scoring_schema=weighted)
+
+    def test_divergent_score_lanes_are_still_caught_when_both_are_fractional(
+        self, adherence_baseline, return_validation
+    ):
+        """Loosening the type must not loosen the agreement between the lanes."""
+        weighted = return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        talk = _cohort_talk("divergent.md", 0.75, scoring_schema=weighted)
+        talk["pattern_observations"]["pattern_score"] = 0.5
+
+        with pytest.raises(
+            adherence_baseline.AdherenceBaselineError,
+            match="promoted pattern_score 0.75 diverges",
+        ):
+            _partition(adherence_baseline, [talk], scoring_schema=weighted)
+
+
+class TestTheWeightedBaselineCanBeBuilt:
+    """The cohort and the sum must take the same generation's arithmetic.
+
+    Splitting only the cohort selector left `build_adherence_baseline` summing
+    on the flat contract: it admitted a fractional score into the cohort on one
+    line and raised on it a few lines later. Every weighted baseline would have
+    been unbuildable, which reads downstream as an empty population rather than
+    a contract mismatch — the same half-converted path as #308.
+    """
+
+    @staticmethod
+    def _population(score, scoring_schema):
+        """Above `MIN_ADHERENCE_BASELINE_TALKS`, so the cohort is comparable."""
+        return [
+            _cohort_talk(f"t{index}.md", score, scoring_schema=scoring_schema)
+            for index in range(12)
+        ]
+
+    def test_a_weighted_baseline_sums_and_averages_its_fractions(
+        self, adherence_baseline, return_validation
+    ):
+        weighted = return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+
+        snapshot = _baseline(
+            adherence_baseline,
+            self._population(0.75, weighted),
+            scoring_schema=weighted,
+        )
+
+        assert snapshot["scored_talk_count"] == 12
+        assert snapshot["pattern_score_sum"] == 9.0
+        assert snapshot["average_pattern_score"] == 0.75
+
+    def test_the_weighted_sum_is_canonical_to_two_places(
+        self, adherence_baseline, return_validation
+    ):
+        """A sum carrying float dust would fail an exact comparison downstream."""
+        weighted = return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+
+        snapshot = _baseline(
+            adherence_baseline,
+            self._population(0.25, weighted),
+            scoring_schema=weighted,
+        )
+
+        score_sum = snapshot["pattern_score_sum"]
+        assert isinstance(score_sum, float)
+        assert score_sum == round(score_sum, 2)
+        assert score_sum == 3.0
+
+    def test_the_flat_baseline_keeps_an_integer_sum(
+        self, adherence_baseline, return_validation
+    ):
+        """The flat generation's sum must not become a float by association."""
+        flat = return_validation.FLAT_PATTERN_SCORING_SCHEMA_VERSION
+
+        snapshot = _baseline(
+            adherence_baseline, self._population(1, flat), scoring_schema=flat
+        )
+
+        assert snapshot["pattern_score_sum"] == 12
+        assert isinstance(snapshot["pattern_score_sum"], int)
+
+    def test_the_flat_baseline_still_refuses_a_fractional_score(
+        self, adherence_baseline, return_validation
+    ):
+        flat = return_validation.FLAT_PATTERN_SCORING_SCHEMA_VERSION
+
+        with pytest.raises(
+            adherence_baseline.AdherenceBaselineError,
+            match="pattern_score must be an integer",
+        ):
+            _baseline(
+                adherence_baseline,
+                self._population(0.75, flat),
+                scoring_schema=flat,
+            )
+
+    def test_the_validator_accepts_the_weighted_snapshot_it_built(
+        self, adherence_baseline, return_validation
+    ):
+        """`build` validates on the way out, so a rejected sum would raise there."""
+        weighted = return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        snapshot = _baseline(
+            adherence_baseline,
+            self._population(0.5, weighted),
+            scoring_schema=weighted,
+        )
+
+        assert adherence_baseline.validate_adherence_baseline(snapshot) == snapshot
+
+    def test_the_validator_still_refuses_a_fractional_sum_at_the_flat_generation(
+        self, adherence_baseline, return_validation
+    ):
+        """The split is keyed on the generation, not on what the number looks like."""
+        flat = return_validation.FLAT_PATTERN_SCORING_SCHEMA_VERSION
+        snapshot = _baseline(
+            adherence_baseline, self._population(1, flat), scoring_schema=flat
+        )
+        snapshot["pattern_score_sum"] = 11.5
+
+        with pytest.raises(
+            adherence_baseline.AdherenceBaselineError,
+            match="pattern_score_sum must be an integer",
+        ):
+            adherence_baseline.validate_adherence_baseline(snapshot)
+
+
+class TestAWeightedReturnReachesTheDatabase:
+    """End to end: validate, canonicalize, merge — the path #308 died on.
+
+    The unit tests above prove the contract. This proves a return that a worker
+    actually emits reaches `resolve_pattern_score` with `weighted` set, which is
+    the wiring the previous two fixes each got wrong in a different place.
+    """
+
+    @pytest.fixture
+    def catalog(self, return_validation):
+        return _catalog(
+            return_validation,
+            _entry(return_validation, "detected"),
+            _entry(return_validation, "conditional", applicability=True),
+            _entry(return_validation, "undetected"),
+            _entry(return_validation, "positive-only", absence_gate=None),
+        )
+
+    def _v6(self, return_validation, catalog, *, bare: bool):
+        raw = _raw_return(
+            detections=[_detection()],
+            assessments=[_assessment()],
+            not_evaluable=[
+                {
+                    "pattern_id": "positive-only",
+                    "reason_code": "absence_not_authorized_by_catalog",
+                }
+            ],
+        )
+        raw["return_schema_version"] = (
+            return_validation.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
+        )
+        block = raw["pattern_observations"]
+        patterns = block["patterns_detected"]
+        antipatterns = block["antipatterns_detected"]
+        expected = return_validation.expected_weighted_score(patterns, antipatterns)
+        assert not float(expected).is_integer(), (
+            "fixture must exercise a fractional score, or it proves nothing"
+        )
+        block["pattern_score"] = (
+            expected
+            if bare
+            else {
+                "patterns_used": len(patterns),
+                "antipatterns_detected": len(antipatterns),
+                "score": expected,
+            }
+        )
+        block["pattern_score_basis"] = return_validation.pattern_score_basis(
+            patterns, antipatterns, block["not_evaluable"]
+        )
+        return_validation.validate_return(raw, catalog)
+        return raw, expected
+
+    def _merge(
+        self,
+        persist_results,
+        return_validation,
+        transcript_timing,
+        tmp_path,
+        catalog,
+        raw,
+    ):
+        import pattern_evidence
+
+        vault, owner = _artifact(tmp_path, transcript_timing)
+        canonical: dict[str, Any] = pattern_evidence.canonicalize_return_evidence(
+            raw,
+            owner,
+            vault,
+            catalog,
+            pattern_scoring_schema_version=(
+                return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+            ),
+        )
+        talk = copy.deepcopy(owner)
+        talk["schema_version"] = persist_results.TALK_SCHEMA_VERSION
+        talk["status"] = "reprocessing-inflight"
+        persist_results.merge_talk(talk, raw, catalog=catalog, canonical_ret=canonical)
+        return talk
+
+    @pytest.mark.parametrize("bare", [True, False])
+    def test_a_v6_return_persists_the_fraction_it_computed(
+        self,
+        persist_results,
+        return_validation,
+        transcript_timing,
+        tmp_path,
+        catalog,
+        bare,
+    ):
+        """Both score shapes are legal on a v6 return, so both must persist."""
+        raw, expected = self._v6(return_validation, catalog, bare=bare)
+
+        talk = self._merge(
+            persist_results,
+            return_validation,
+            transcript_timing,
+            tmp_path,
+            catalog,
+            raw,
+        )
+
+        assert talk["pattern_score"] == expected
+        assert math.isfinite(talk["pattern_score"])
+
+    def test_the_persisted_score_is_stamped_at_the_weighted_generation(
+        self,
+        persist_results,
+        return_validation,
+        transcript_timing,
+        tmp_path,
+        catalog,
+    ):
+        """A weighted number filed under the flat generation joins the wrong cohort."""
+        raw, _ = self._v6(return_validation, catalog, bare=True)
+
+        talk = self._merge(
+            persist_results,
+            return_validation,
+            transcript_timing,
+            tmp_path,
+            catalog,
+            raw,
+        )
+
+        assert talk["pattern_scoring_schema_version"] == (
+            return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        )
+
+    def test_a_v6_return_whose_score_contradicts_its_arrays_never_merges(
+        self,
+        persist_results,
+        return_validation,
+        transcript_timing,
+        tmp_path,
+        catalog,
+    ):
+        """The writer-side cross-check survives the trip through canonicalization.
+
+        Matched on the weighted message, not on any `ValueError`: the flat
+        contract also rejects this score, for the wrong reason (it is a float),
+        so a bare `pytest.raises` here would pass with the split reverted.
+        """
+        raw, expected = self._v6(return_validation, catalog, bare=True)
+        raw["pattern_observations"]["pattern_score"] = expected + 0.25
+
+        with pytest.raises(ValueError, match="weighted detection arrays require"):
+            self._merge(
+                persist_results,
+                return_validation,
+                transcript_timing,
+                tmp_path,
+                catalog,
+                raw,
+            )


### PR DESCRIPTION
Continues #299. #293 defined the weighted return; #308 got one through canonicalization. Neither could store the number it produced.

## The bug

Every writer that touched a persisted `pattern_score` demanded an integer. A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so a v6 return validated clean, canonicalized clean, and died at the merge.

## The fix

`resolve_pattern_score` takes the contract its generation declares; `merge_talk` selects it from the return schema version. The cross-check moves with it — a bare weighted number is compared against `expected_weighted_score`, not count-minus-count, which for a strong pattern and a weak antipattern is `0.75` rather than `0`. The flat generation still refuses a float, because a float there means some other arithmetic produced it.

## What the WIP had left half-converted

Converting only the cohort selector left `build_adherence_baseline` admitting a fractional score into the cohort on one line and raising on it a few lines later, in the same function:

```
weighted fractional -> RAISED: t0.md.pattern_score must be an integer, got 0.75
```

Every weighted baseline was unbuildable. The symptom downstream is a population reported as too small, not a contract mismatch — the same half-converted path as #308, found this time by pyright rather than by running the reparse. The sum, the average, and `validate_adherence_baseline` all key on the generation now.

`_require_number` returns its value rather than widening it to float. Coercion restated a whole weighted score as `5.0` in divergence messages and stored `12.0` where the flat generation stores `12`; two existing tests caught it.

## Coverage

New `tests/test_weighted_score_persistence.py` — 33 tests across the writer-side contract, the cohort and baseline read-back, and an end-to-end validate → canonicalize → `merge_talk` pass, since the last two fixes each got a different link in that chain wrong. Every test admitting a fraction at the weighted generation has a sibling proving the flat generation still refuses one.

Verified load-bearing: 23 of them fail with the production change reverted.

## Gates

- `pytest` — 5800 passed, 3 skipped
- `pyright` — 0 errors
- `ruff check` / `ruff format --check` — clean (the WIP was not format-clean; CI would have failed it)
- `check_plugin_lint.py` — valid

## Still open on #299

The talk-record schema bump and v5→v6 migration, and the claim-contract advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh