### PR TITLE
fix(packaging): ship every file past the install extension filter (#316)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,15 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 
-# Deck-driver .txt mirrors: byte-identical copies of the .bas/.applescript
-# drivers, committed so they survive tessl install's extension filter (which
-# strips .bas/.applescript). Generated from the real files by
-# skills/presentation-creator/scripts/sync-deck-drivers.py mirror — collapse the
-# diff in review; the real driver is the source of truth.
-skills/presentation-creator/scripts/*.bas.txt linguist-generated=true merge=ours
-skills/presentation-creator/scripts/*.applescript.txt linguist-generated=true merge=ours
+# Install-surviving .txt mirrors: byte-identical copies of files whose real
+# extension `tessl install` drops (it ships only .md/.py/.sh/.txt/.json).
+# Committed because the platform cannot materialize the source extension —
+# the generated-artifact exception in coding-policy: file-hygiene. The real
+# file is the source of truth; collapse the diff in review.
+#
+# Path-glob, not directory-scoped: scoping these to one skill's scripts/ dir is
+# exactly how _dimensions.yaml shipped unmarked (#316). Enforced per-file by
+# scripts/check_shipped_extensions.py, which fails when a mirror lacks both
+# attributes — so a new mirror extension cannot silently miss this list.
+skills/**/*.bas.txt linguist-generated=true merge=ours
+skills/**/*.applescript.txt linguist-generated=true merge=ours
+skills/**/*.yaml.txt linguist-generated=true merge=ours

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,13 @@ jobs:
         # unanchored "scripts/" silently stripped all 59 skills/*/scripts/
         # files from 0.18.43 through 0.18.61 while publish reported success.
         run: python3 scripts/check_package_contents.py > /dev/null
+      - name: Verify every shipped file survives the install extension filter
+        # Fails the build when a file the manifest ships carries an extension
+        # `tessl install` drops (anything outside .md/.py/.sh/.txt/.json) and
+        # has no byte-identical .txt mirror. The drop is silent at pack,
+        # publish and install, so _dimensions.yaml was absent from every clean
+        # install from 0.20.57 on and the catalog audit exited 1 (issue #316).
+        run: python3 scripts/check_shipped_extensions.py > /dev/null
       - name: Cache apt package downloads
         # Cache the downloaded .deb archives (kept in a runner-writable dir via
         # Dir::Cache::Archives below), so the slow libreoffice fetch only hits

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ __pycache__/
 *.egg-info/
 .venv/
 
+# OS metadata. `tessl plugin pack` reads the working tree, not the git index, so
+# an unignored .DS_Store under skills/ ships to consumers.
+.DS_Store
+
 # Per-developer agent / IDE state
 .agents/
 .gemini/

--- a/.tesslignore
+++ b/.tesslignore
@@ -35,3 +35,7 @@ package-lock.json
 # VCS metadata
 /.gitignore
 /.gitattributes
+
+# OS metadata. Deliberately UNANCHORED: pack reads the working tree, so a
+# .DS_Store must be stripped at every depth, not just the repo root.
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+### fix(packaging) — the dimension registry now reaches consumers (#316)
+
+`tessl install` materializes only `.md/.py/.sh/.txt/.json` and drops every
+other extension in silence. Nothing in the toolchain says so: `tessl plugin
+pack` includes the file, `tessl plugin publish` reports success, and `tessl
+install --verbose` logs not one word about what it threw away.
+
+So `_dimensions.yaml`, authored in #290, was never on a consumer's disk.
+`audit-pattern-catalog.py` exited 1 with `dimension_registry_invalid` on every
+clean install from 0.20.57 on — a hard stop in vault-ingress Step 1, which
+meant no talk could be processed or reprocessed on the released plugin.
+
+The registry now ships a byte-identical `_dimensions.yaml.txt` mirror and
+`registry_path` reads it when the real file is absent. The real file still
+wins when both exist, so a stale mirror can never shadow a dev-tree edit.
+
+The diagnosis corrects the issue's premise twice over. The drop is not at
+publish — the pack contains the file — it is at install. And it is not a
+`.yaml` rule but an extension allowlist, which is the same mechanism that ate
+`RunDeckOps.bas` and the eight `*.applescript` drivers in #85. That fix worked,
+but `sync-deck-drivers.py` only ever guarded two extensions in one directory,
+so a third extension in a different directory walked straight past it.
+
+`scripts/check_shipped_extensions.py` is the repo-wide guard that closes the
+class: every tracked file under the manifest's declared content whose extension
+is outside the allowlist must carry a current mirror. It reports missing
+mirrors, drifted mirrors, and orphan mirrors whose source was deleted, and runs
+in both `tests.yml` and `pre-publish-checks.sh`. `check_package_contents.py`
+could not have caught this — it tests `.tesslignore` stripping, which is a
+pack-stage concern, and the loss happens a stage later.
+
+Also `.DS_Store` is now ignored in both `.gitignore` and `.tesslignore`. Pack
+reads the working tree rather than the git index, so five untracked ones were
+riding along into the published package.
+
 ## 0.20.78 — 2026-08-14
 
 ### fix(vault-ingress) — a weighted score can now be stored and read back (#299)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,16 @@ so a third extension in a different directory walked straight past it.
 `scripts/check_shipped_extensions.py` is the repo-wide guard that closes the
 class: every tracked file under the manifest's declared content whose extension
 is outside the allowlist must carry a current mirror. It reports missing
-mirrors, drifted mirrors, and orphan mirrors whose source was deleted, and runs
-in both `tests.yml` and `pre-publish-checks.sh`. `check_package_contents.py`
-could not have caught this — it tests `.tesslignore` stripping, which is a
-pack-stage concern, and the loss happens a stage later.
+mirrors, drifted mirrors, orphan mirrors whose source was deleted, and mirrors
+not declared generated in `.gitattributes`, and runs in both `tests.yml` and
+`pre-publish-checks.sh`. `check_package_contents.py` could not have caught this
+— it tests `.tesslignore` stripping, which is a pack-stage concern, and the
+loss happens a stage later.
+
+The `.gitattributes` marking is enforced per file rather than trusted to a
+glob, because a directory-scoped pattern is precisely what covered the deck
+mirrors and missed `_dimensions.yaml.txt` beside them. Its patterns are now
+path-globs across `skills/**` rather than one skill's `scripts/` directory.
 
 Also `.DS_Store` is now ignored in both `.gitignore` and `.tesslignore`. Pack
 reads the working tree rather than the git index, so five untracked ones were

--- a/scripts/check_shipped_extensions.py
+++ b/scripts/check_shipped_extensions.py
@@ -41,6 +41,7 @@ from pathlib import Path
 
 from check_package_contents import (
     GateError,
+    _run_git,
     declared_content_entries,
     tracked_content,
 )
@@ -53,6 +54,13 @@ from check_package_contents import (
 SHIPPED_SUFFIXES = frozenset({".md", ".py", ".sh", ".txt", ".json"})
 
 MIRROR_SUFFIX = ".txt"
+
+# A mirror is a generated file committed only because the platform cannot
+# materialize its source extension, so file-hygiene's generated-artifact
+# exception requires it be marked in .gitattributes. Checked per file rather
+# than trusted to a glob: a directory-scoped pattern is what left
+# _dimensions.yaml.txt unmarked while the deck mirrors beside it were covered.
+GENERATED_ATTRS = {"linguist-generated": "true", "merge": "ours"}
 
 
 def mirror_of(path: str) -> str:
@@ -94,13 +102,64 @@ def needs_mirror(path: str) -> bool:
     return _is_dropped(path)
 
 
+def _read(repo_root: Path, relative: str) -> bytes:
+    """Read a tracked file, turning an unreadable one into an actionable error.
+
+    `git ls-files` lists what the index holds, which is not a promise about the
+    working tree: a file can be deleted or made unreadable between the listing
+    and the compare. Letting that OSError escape would abandon the stdout
+    contract mid-run — a traceback and no JSON, which reads to a caller as the
+    gate crashing rather than the gate refusing.
+    """
+    try:
+        return (repo_root / relative).read_bytes()
+    except OSError as error:
+        raise GateError(
+            f"ERROR: could not read tracked file {relative} to compare it with"
+            f" its mirror — {error}.\n"
+            f"  Restore the file or fix its permissions, then re-run."
+        ) from error
+
+
+def unmarked_mirrors(repo_root: Path, mirrors: list[str]) -> list[str]:
+    """Mirrors missing either generated-file attribute, sorted.
+
+    Asks git rather than parsing .gitattributes, so precedence, negation and
+    later-pattern-wins are resolved the way git itself resolves them.
+    """
+    if not mirrors:
+        return []
+    attributes = sorted(GENERATED_ATTRS)
+    result = _run_git(
+        ["-C", str(repo_root), "check-attr", *attributes, "--", *mirrors],
+        purpose="read the generated-file attributes of the .txt mirrors",
+    )
+    if result.returncode != 0:
+        raise GateError(
+            f"ERROR: git check-attr failed (exit {result.returncode}) while"
+            f" reading mirror attributes.\n  {result.stderr.strip()}"
+        )
+
+    # Each line is "<path>: <attribute>: <value>"; a path unmatched by any
+    # pattern reports "unspecified".
+    seen: dict[str, set[str]] = {path: set() for path in mirrors}
+    for line in result.stdout.splitlines():
+        path, _, rest = line.partition(": ")
+        attribute, _, value = rest.partition(": ")
+        if path in seen and GENERATED_ATTRS.get(attribute) == value:
+            seen[path].add(attribute)
+    return sorted(path for path in mirrors if seen[path] != set(attributes))
+
+
 def find_problems(repo_root: Path, tracked: list[str]) -> list[dict[str, str]]:
     """Mirror problems among the tracked content files, in report order.
 
-    Three shapes, each a distinct way a consumer ends up reading something the
+    Four shapes, each a distinct way a consumer ends up reading something the
     repo does not say: no mirror at all (the file never arrives), a mirror that
-    has drifted from its source (the consumer reads a stale copy), and a mirror
-    whose source is gone (the consumer reads a file the repo deleted).
+    has drifted from its source (the consumer reads a stale copy), a mirror
+    whose source is gone (the consumer reads a file the repo deleted), and a
+    mirror not declared generated (its diff and its merges lie about which file
+    is the source of truth).
     """
     present = set(tracked)
     problems: list[dict[str, str]] = []
@@ -112,12 +171,16 @@ def find_problems(repo_root: Path, tracked: list[str]) -> list[dict[str, str]]:
         if mirror not in present:
             problems.append({"kind": "missing", "path": path, "mirror": mirror})
             continue
-        if (repo_root / mirror).read_bytes() != (repo_root / path).read_bytes():
+        if _read(repo_root, mirror) != _read(repo_root, path):
             problems.append({"kind": "stale", "path": path, "mirror": mirror})
 
-    for path in tracked:
-        if is_mirror(path) and source_of(path) not in present:
+    mirrors = [path for path in tracked if is_mirror(path)]
+    for path in mirrors:
+        if source_of(path) not in present:
             problems.append({"kind": "orphan", "path": source_of(path), "mirror": path})
+
+    for path in unmarked_mirrors(repo_root, mirrors):
+        problems.append({"kind": "unmarked", "path": source_of(path), "mirror": path})
 
     return problems
 
@@ -141,6 +204,14 @@ def _diagnose(problems: list[dict[str, str]]) -> list[str]:
             diagnostics.append(
                 f"  stale mirror: {mirror} differs from {path}, so consumers"
                 f" read the old content — run: cp {path} {mirror}"
+            )
+        elif problem["kind"] == "unmarked":
+            attributes = " ".join(
+                f"{k}={v}" for k, v in sorted(GENERATED_ATTRS.items())
+            )
+            diagnostics.append(
+                f"  unmarked mirror: {mirror} is a generated file — add a"
+                f" .gitattributes pattern matching it with: {attributes}"
             )
         else:
             diagnostics.append(

--- a/scripts/check_shipped_extensions.py
+++ b/scripts/check_shipped_extensions.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Gate: every shipped file must reach consumers, whatever its extension.
+
+The failure this catches: `tessl install` materializes only a fixed set of
+extensions and silently drops the rest. Nothing warns — `tessl plugin pack`
+includes the file, `tessl plugin publish` reports success, `tessl install
+--verbose` logs not one word, and the file simply is not on the consumer's
+disk. It ships green and breaks on arrival.
+
+That shipped twice. The deck-ops layer lost `RunDeckOps.bas` and eight
+`*.applescript` drivers (issue #85), fixed per-file with committed `.txt`
+mirrors. Then `_dimensions.yaml` arrived in a different directory with a third
+extension and was dropped the same way, so `audit-pattern-catalog.py` exited 1
+on every clean install from 0.20.57 on — a hard stop in vault-ingress Step 1,
+which meant no talk could be processed on the released plugin (issue #316).
+
+The device is the mirror: a byte-identical `<name>.txt` beside the real file.
+`.txt` is on the allowlist, so the mirror survives install and the reader falls
+back to it. This gate is the repo-wide authority that every non-shipping file
+has one and that it has not drifted — the check the deck-driver fix only ever
+did for its own two extensions in its own one directory.
+
+Scope is the manifest's declared content (skills, rules), read through
+`git ls-files`. An untracked file is not a shipping contract, and the pack
+strips OS metadata via .tesslignore.
+
+Usage: check_shipped_extensions.py [<repo-root>]   (default: this repo)
+Stdout: one JSON object listing what was checked and every mirror problem.
+Stderr: actionable diagnostics naming the command that fixes each one.
+Exit 0 when every non-shipping file has a current mirror, 1 otherwise.
+
+Wired into CI by .github/workflows/tests.yml, and into the publish run by
+scripts/pre-publish-checks.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from check_package_contents import (
+    GateError,
+    declared_content_entries,
+    tracked_content,
+)
+
+# What `tessl install` materializes. Every other extension is dropped in
+# silence, so a file carrying one needs a mirror to reach consumers. Verified
+# empirically against an installed plugin: pack and install were diffed, and
+# .applescript, .bas and .yaml were absent from the install while .md, .py,
+# .sh, .txt and .json came through whole.
+SHIPPED_SUFFIXES = frozenset({".md", ".py", ".sh", ".txt", ".json"})
+
+MIRROR_SUFFIX = ".txt"
+
+
+def mirror_of(path: str) -> str:
+    """The mirror path that carries ``path`` past the install filter."""
+    return path + MIRROR_SUFFIX
+
+
+def source_of(mirror: str) -> str:
+    """The real file a mirror stands in for."""
+    return mirror[: -len(MIRROR_SUFFIX)]
+
+
+def _is_dropped(name: str) -> bool:
+    """Whether install drops a file with this name, judged by its extension.
+
+    An extensionless name is not treated as dropped. The filter is an extension
+    allowlist and a bare `LICENSE` carries no extension to match, so demanding a
+    mirror for one would invent a rule the evidence does not support. Both
+    predicates below read this, so "needs a mirror" and "is a mirror" can never
+    disagree about the same name — the disagreement that made `notes.txt` look
+    like a mirror of an extensionless `notes`.
+    """
+    suffix = Path(name).suffix
+    return bool(suffix) and suffix not in SHIPPED_SUFFIXES
+
+
+def is_mirror(path: str) -> bool:
+    """Whether ``path`` is a mirror rather than a plain shipped `.txt`.
+
+    A `.txt` is a mirror only when removing that suffix leaves a name whose own
+    extension would be dropped at install. `foo.applescript.txt` mirrors
+    `foo.applescript`; `release-notes.txt` mirrors nothing and is content.
+    """
+    return path.endswith(MIRROR_SUFFIX) and _is_dropped(source_of(path))
+
+
+def needs_mirror(path: str) -> bool:
+    """Whether ``path`` is dropped at install and so must carry a mirror."""
+    return _is_dropped(path)
+
+
+def find_problems(repo_root: Path, tracked: list[str]) -> list[dict[str, str]]:
+    """Mirror problems among the tracked content files, in report order.
+
+    Three shapes, each a distinct way a consumer ends up reading something the
+    repo does not say: no mirror at all (the file never arrives), a mirror that
+    has drifted from its source (the consumer reads a stale copy), and a mirror
+    whose source is gone (the consumer reads a file the repo deleted).
+    """
+    present = set(tracked)
+    problems: list[dict[str, str]] = []
+
+    for path in tracked:
+        if is_mirror(path) or not needs_mirror(path):
+            continue
+        mirror = mirror_of(path)
+        if mirror not in present:
+            problems.append({"kind": "missing", "path": path, "mirror": mirror})
+            continue
+        if (repo_root / mirror).read_bytes() != (repo_root / path).read_bytes():
+            problems.append({"kind": "stale", "path": path, "mirror": mirror})
+
+    for path in tracked:
+        if is_mirror(path) and source_of(path) not in present:
+            problems.append({"kind": "orphan", "path": source_of(path), "mirror": path})
+
+    return problems
+
+
+def _diagnose(problems: list[dict[str, str]]) -> list[str]:
+    """Actionable stderr lines: what is wrong, and the command that fixes it."""
+    diagnostics = [
+        f"ERROR: {len(problems)} file(s) would not reach consumers intact.",
+        "  `tessl install` ships only "
+        + " ".join(sorted(SHIPPED_SUFFIXES))
+        + " and drops every other extension without warning.",
+    ]
+    for problem in problems:
+        path, mirror = problem["path"], problem["mirror"]
+        if problem["kind"] == "missing":
+            diagnostics.append(
+                f"  missing mirror: {path} is dropped at install and has no"
+                f" {mirror} — run: cp {path} {mirror}"
+            )
+        elif problem["kind"] == "stale":
+            diagnostics.append(
+                f"  stale mirror: {mirror} differs from {path}, so consumers"
+                f" read the old content — run: cp {path} {mirror}"
+            )
+        else:
+            diagnostics.append(
+                f"  orphan mirror: {mirror} has no source {path} — delete the"
+                f" mirror, or restore the file it mirrors"
+            )
+    diagnostics.append(
+        "  Then teach the reader to fall back to the mirror when the real file"
+        " is absent, the way catalog_dimension_registry.registry_path does."
+    )
+    return diagnostics
+
+
+def run(repo_root: Path) -> tuple[dict[str, object], list[str]]:
+    """Check one plugin repo, returning its JSON report and stderr diagnostics."""
+    entries = declared_content_entries(repo_root)
+    tracked, _ = tracked_content(repo_root, entries)
+
+    problems = find_problems(repo_root, tracked)
+    mirrored = sorted(path for path in tracked if needs_mirror(path))
+    report: dict[str, object] = {
+        "ok": not problems,
+        "shipped_suffixes": sorted(SHIPPED_SUFFIXES),
+        "checked": len(tracked),
+        "needing_mirror": mirrored,
+        "problems": problems,
+    }
+    return report, (_diagnose(problems) if problems else [])
+
+
+def _print_failure(message: str) -> None:
+    """Emit the failure shape of the stdout contract."""
+    print(
+        json.dumps(
+            {
+                "ok": False,
+                "error": message,
+                "shipped_suffixes": sorted(SHIPPED_SUFFIXES),
+                "checked": 0,
+                "needing_mirror": [],
+                "problems": [],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def main(argv: list[str]) -> int:
+    repo_root = (
+        Path(argv[1]).resolve()
+        if len(argv) > 1
+        else Path(__file__).resolve().parent.parent
+    )
+    try:
+        report, diagnostics = run(repo_root)
+    except GateError as error:
+        # Every run emits one JSON object, including the ones that fail before
+        # any file is checked — a consumer reading stdout must never have to
+        # tell "gate said no" apart from "gate crashed" by parsing stderr.
+        _print_failure(str(error))
+        print(str(error), file=sys.stderr)
+        return 2
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    for line in diagnostics:
+        print(line, file=sys.stderr)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/pre-publish-checks.sh
+++ b/scripts/pre-publish-checks.sh
@@ -16,6 +16,7 @@ main() {
 
   python3 "$repo_root/scripts/check_tessl_pins.py" > /dev/null
   python3 "$repo_root/scripts/check_package_contents.py" > /dev/null
+  python3 "$repo_root/scripts/check_shipped_extensions.py" > /dev/null
   python3 "$repo_root/scripts/check_skill_entrypoints.py" > /dev/null
   python3 "$repo_root/scripts/check_conflict_markers.py" > /dev/null
 }

--- a/skills/presentation-creator/references/patterns/_dimensions.yaml.txt
+++ b/skills/presentation-creator/references/patterns/_dimensions.yaml.txt
@@ -1,0 +1,125 @@
+# Machine-readable authority for the 14 vault dimensions (#156).
+#
+# Entry frontmatter carries `vault_dimensions` as bare numbers, and entry prose
+# names each one as `Dimension N (Label)`. Those two drifted: the numbers were
+# assigned against a superseded taxonomy while the prose kept describing what
+# the pattern is actually about. A range check passes either way, so downstream
+# analysis attached evidence to the wrong semantic dimension.
+#
+# Owner decision (2026-08-09): the prose is the intent of record. Numbers are
+# remapped to match the label; no pattern's meaning changes.
+#
+# `aliases` is the owner-approved resolution for every label the catalog prose
+# actually uses. A label absent from every alias list does NOT resolve — the
+# auditor reports it for owner review rather than guessing, which is what keeps
+# this a reviewed migration instead of an automatic renumbering.
+#
+# Canonical names and ordinals come from
+# `skills/vault-ingress/references/rhetoric-dimensions.md` sections 1-14.
+schema_version: 1
+dimensions:
+  - id: opening-pattern
+    ordinal: 1
+    name: Opening Pattern
+    aliases:
+      - Topic and Thesis
+  - id: narrative-structure
+    ordinal: 2
+    name: Narrative Structure
+    aliases:
+      - Structure and Flow
+      - Structure/Organization
+      - Storytelling/Narrative
+      - Storytelling and Narrative
+  - id: humor-wit
+    ordinal: 3
+    name: Humor & Wit
+    aliases:
+      - Humor and Surprise Techniques
+      - Engagement / Entertainment Value
+      # Owner decision: the entertainment entry's only other claim, and a
+      # memorable beat is the wit landing rather than a cultural reference.
+      - Memorability
+  - id: audience-interaction
+    ordinal: 4
+    name: Audience Interaction
+    aliases:
+      - Audience Engagement
+  - id: transition-techniques
+    ordinal: 5
+    name: Transition Techniques
+    aliases: []
+  - id: closing-pattern
+    ordinal: 6
+    name: Closing Pattern
+    aliases:
+      - Closing Strategy
+  - id: verbal-signatures
+    ordinal: 7
+    name: Verbal Signatures
+    aliases:
+      - Clarity / Communication
+      - Language and Communication
+  - id: slide-to-speech-relationship
+    ordinal: 8
+    name: Slide-to-Speech Relationship
+    aliases:
+      # Owner decision: both uses weigh what sits on the screen against what is
+      # spoken, which is this dimension rather than a closing concern.
+      - Information Density
+  - id: persuasion-techniques
+    ordinal: 9
+    name: Persuasion Techniques
+    aliases:
+      - Speaker Authority / Credibility
+      - Speaker Credibility/Ethos
+      - Evidence and Persuasion
+      # Owner decision: positioning one's own authority is an ethos move.
+      - Self-Presentation
+  - id: cultural-pop-culture-references
+    ordinal: 10
+    name: Cultural & Pop-Culture References
+    aliases:
+      - Cultural References
+      # Owner decision: kept here, treating this as the broader
+      # creative-resonance lane the catalog actually uses it as.
+      - Creativity/Originality
+  - id: technical-content-delivery
+    ordinal: 11
+    name: Technical Content Delivery
+    aliases:
+      - Demonstrations and Tools
+      - Teaching Effectiveness
+      - Technical Depth/Accuracy
+  - id: pacing-clues
+    ordinal: 12
+    name: Pacing Clues
+    aliases:
+      - Time/Pacing
+      - Delivery Mechanics
+      # Owner decision: grouped with Delivery Mechanics, which already sits here.
+      - Delivery/Presentation Skills
+  - id: slide-design-patterns
+    ordinal: 13
+    name: Slide Design Patterns
+    aliases:
+      - Slide Design
+      - Slide Aesthetics
+      - Visual Polish and Craft
+      - Visual Aids Effectiveness
+      - Slide Design/Visual Quality
+      - Visual Design Quality
+      # Owner decision: the failure is in how the images are chosen and
+      # composed, which is slide design.
+      - Visual Storytelling
+  - id: areas-for-improvement
+    ordinal: 14
+    name: "Reflection: Areas for Improvement"
+    aliases:
+      - Areas for Improvement
+      - Overall Impression/Polish
+      - Overall Quality Indicators
+      - Speaker Craft / Professionalism
+      # Owner decision: polish outrunning substance is an overall-impression
+      # judgement, not a slide-to-speech mismatch.
+      - Content Depth / Value

--- a/skills/vault-ingress/scripts/catalog_dimension_registry.py
+++ b/skills/vault-ingress/scripts/catalog_dimension_registry.py
@@ -29,6 +29,14 @@ DIMENSION_REGISTRY_SCHEMA_VERSION = 1
 DIMENSION_COUNT = 14
 REGISTRY_FILENAME = "_dimensions.yaml"
 
+# `tessl install` materializes only .md/.py/.sh/.txt/.json and silently drops
+# everything else, so the registry never reached an installed plugin and the
+# auditor exited 1 on every consumer machine. A byte-identical `.txt` mirror
+# rides along and is read when the real file is absent. Same device as the
+# deck-ops drivers (skills/presentation-creator/scripts/sync-deck-drivers.py);
+# scripts/check_shipped_extensions.py keeps every such mirror in sync.
+MIRROR_SUFFIX = ".txt"
+
 # `Dimension 4 (Audience Engagement)` and `Vault Dimension 13 (Slide Design)`
 # are the two shapes the catalog uses.
 DIMENSION_CLAIM_RE = re.compile(r"(?:Vault )?Dimension (\d+) \(([^)]+)\)")
@@ -83,9 +91,23 @@ def _require_text(value: object, label: str) -> str:
     return value
 
 
+def registry_path(catalog_dir: Path | str) -> Path:
+    """The registry to read: the real `.yaml`, else its install-surviving mirror.
+
+    The real file wins whenever it exists, so a dev-tree edit is never shadowed
+    by a stale mirror. When neither exists the real path is returned, keeping
+    the error message pointed at the file an author is expected to create.
+    """
+    real = Path(catalog_dir) / REGISTRY_FILENAME
+    if real.exists():
+        return real
+    mirror = real.with_name(real.name + MIRROR_SUFFIX)
+    return mirror if mirror.exists() else real
+
+
 def load_dimension_registry(catalog_dir: Path | str) -> DimensionRegistry:
     """Load and validate the registry beside the catalog entries."""
-    path = Path(catalog_dir) / REGISTRY_FILENAME
+    path = registry_path(catalog_dir)
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:

--- a/tests/test_catalog_dimension_registry.py
+++ b/tests/test_catalog_dimension_registry.py
@@ -269,3 +269,61 @@ def test_the_auditor_reports_unparseable_yaml(audit_pattern_catalog, tmp_path) -
     report = audit_pattern_catalog.audit_catalog(catalog_dir=tmp_path)
 
     assert "dimension_registry_invalid" in [i["code"] for i in report["errors"]]
+
+
+class TestTheInstallSurvivingMirror:
+    """`tessl install` drops `.yaml`, so the registry ships a `.txt` mirror too.
+
+    Before this, the registry was simply absent on every consumer machine and
+    the auditor exited 1 on a clean install — a hard stop in vault-ingress
+    Step 1, so no talk could be processed on the released plugin (#316).
+    """
+
+    def test_the_mirror_is_read_when_the_real_file_is_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """The install shape: only the `.txt` survived."""
+        (tmp_path / "_dimensions.yaml.txt").write_text(
+            (CATALOG / "_dimensions.yaml").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+        loaded = registry_module.load_dimension_registry(tmp_path)
+
+        assert len(loaded.dimensions) == registry_module.DIMENSION_COUNT
+
+    def test_the_real_file_wins_when_both_exist(self, tmp_path: Path) -> None:
+        """A stale mirror must never shadow an edit in the dev tree."""
+        (tmp_path / "_dimensions.yaml").write_text(
+            (CATALOG / "_dimensions.yaml").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        (tmp_path / "_dimensions.yaml.txt").write_text(
+            "schema_version: 1\ndimensions: []\n", encoding="utf-8"
+        )
+
+        assert registry_module.registry_path(tmp_path).name == "_dimensions.yaml"
+        loaded = registry_module.load_dimension_registry(tmp_path)
+        assert len(loaded.dimensions) == registry_module.DIMENSION_COUNT
+
+    def test_neither_present_names_the_real_file(self, tmp_path: Path) -> None:
+        """The author is expected to create the `.yaml`, so the error names it."""
+        with pytest.raises(
+            registry_module.CatalogDimensionRegistryError, match="_dimensions.yaml:"
+        ):
+            registry_module.load_dimension_registry(tmp_path)
+
+    def test_the_auditor_accepts_an_install_shaped_catalog(
+        self, audit_pattern_catalog, tmp_path: Path
+    ) -> None:
+        """The #316 regression: mirror-only must not read as a missing registry."""
+        (tmp_path / "_dimensions.yaml.txt").write_text(
+            (CATALOG / "_dimensions.yaml").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+        report = audit_pattern_catalog.audit_catalog(catalog_dir=tmp_path)
+
+        assert "dimension_registry_invalid" not in [
+            issue["code"] for issue in report["errors"]
+        ]

--- a/tests/test_catalog_dimension_registry.py
+++ b/tests/test_catalog_dimension_registry.py
@@ -272,7 +272,12 @@ def test_the_auditor_reports_unparseable_yaml(audit_pattern_catalog, tmp_path) -
 
 
 class TestTheInstallSurvivingMirror:
-    """`tessl install` drops `.yaml`, so the registry ships a `.txt` mirror too.
+    """`tessl install` ships an extension allowlist, so the registry mirrors to `.txt`.
+
+    Install materializes only .md/.py/.sh/.txt/.json and drops every other
+    extension. Reading that as "it drops .yaml" is how the deck-driver fix came
+    to guard two extensions in one directory and miss this file entirely, so
+    the general shape is worth stating even in a test about one `.yaml`.
 
     Before this, the registry was simply absent on every consumer machine and
     the auditor exited 1 on a clean install — a hard stop in vault-ingress

--- a/tests/test_shipped_extensions_gate.py
+++ b/tests/test_shipped_extensions_gate.py
@@ -79,6 +79,13 @@ def plugin(tmp_path: Path) -> Path:
     _write(repo, "skills/builder/scripts/wrap.sh", "echo wrap\n")
     _write(repo, "skills/builder/references/data.json", "{}\n")
     _write(repo, "rules/house-style.md", "# House Style\n")
+    # Covers .yaml mirrors only, so a mirror of any other extension is
+    # unmarked — the shape that lets the attribute test below stay honest.
+    _write(
+        repo,
+        ".gitattributes",
+        "skills/**/*.yaml.txt linguist-generated=true merge=ours\n",
+    )
     _commit(repo)
     return repo
 
@@ -91,7 +98,8 @@ def test_all_shipped_extensions_pass(plugin: Path) -> None:
     assert report["needing_mirror"] == []
 
 
-def test_a_mirrored_file_passes(plugin: Path) -> None:
+def test_a_current_and_declared_mirror_passes(plugin: Path) -> None:
+    """The fixture's .gitattributes pattern covers .yaml mirrors."""
     _write(plugin, "skills/builder/references/dims.yaml", "a: 1\n")
     _write(plugin, "skills/builder/references/dims.yaml.txt", "a: 1\n")
     _commit(plugin)
@@ -100,6 +108,7 @@ def test_a_mirrored_file_passes(plugin: Path) -> None:
     assert result.returncode == 0, result.stderr
     report = _report(result)
     assert report["ok"] is True
+    assert report["problems"] == []
     assert report["needing_mirror"] == ["skills/builder/references/dims.yaml"]
 
 
@@ -194,6 +203,40 @@ def test_every_extension_outside_the_allowlist_needs_a_mirror(plugin: Path) -> N
         ".bas",
         ".csv",
     }
+
+
+def test_a_mirror_not_declared_generated_fails(plugin: Path) -> None:
+    """A directory-scoped .gitattributes is how _dimensions.yaml.txt went unmarked."""
+    _write(plugin, "skills/builder/scripts/driver.applescript", "beep\n")
+    _write(plugin, "skills/builder/scripts/driver.applescript.txt", "beep\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 1
+    problems = _report(result)["problems"]
+    assert [p["kind"] for p in problems] == ["unmarked"]
+    assert "linguist-generated=true merge=ours" in result.stderr
+
+
+def test_an_unreadable_tracked_file_still_emits_the_json_verdict(
+    plugin: Path,
+) -> None:
+    """`git ls-files` reports the index, which is no promise about the tree.
+
+    A traceback here would abandon the stdout contract mid-run, reading to a
+    caller as the gate crashing rather than the gate refusing.
+    """
+    _write(plugin, "skills/builder/references/dims.yaml", "a: 1\n")
+    _write(plugin, "skills/builder/references/dims.yaml.txt", "a: 1\n")
+    _commit(plugin)
+    (plugin / "skills/builder/references/dims.yaml.txt").unlink()
+
+    result = _run(plugin)
+    assert result.returncode == 2
+    report = _report(result)
+    assert report["ok"] is False
+    assert "could not read tracked file" in report["error"]
+    assert "Traceback" not in result.stderr
 
 
 def test_this_repo_ships_every_file_it_declares() -> None:

--- a/tests/test_shipped_extensions_gate.py
+++ b/tests/test_shipped_extensions_gate.py
@@ -1,0 +1,208 @@
+"""Tests for scripts/check_shipped_extensions.py.
+
+The gate answers one question: will every file the manifest ships actually be
+on the consumer's disk after `tessl install`? It exists because install
+materializes a fixed extension allowlist and drops everything else without a
+word — pack includes the file, publish reports success, and the consumer never
+sees it. `_dimensions.yaml` went missing that way from 0.20.57 on (issue #316).
+
+Its stdout is the machine-readable verdict (one JSON object, every run) and its
+stderr carries the actionable diagnostics, so the assertions below read the
+report for outcomes and the stderr for guidance.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE = REPO_ROOT / "scripts" / "check_shipped_extensions.py"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+def _write(repo: Path, rel: str, body: str) -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def _run(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(GATE), str(repo)], capture_output=True, text=True
+    )
+
+
+def _report(result: subprocess.CompletedProcess) -> dict:
+    """The gate's stdout verdict — always one JSON object, pass or fail."""
+    return json.loads(result.stdout)
+
+
+def _commit(repo: Path) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "seed")
+
+
+@pytest.fixture()
+def plugin(tmp_path: Path) -> Path:
+    """A committed plugin repo whose files all carry shipped extensions."""
+    repo = tmp_path / "plugin"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(repo)], check=True, capture_output=True
+    )
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+    _write(
+        repo,
+        ".tessl-plugin/plugin.json",
+        json.dumps(
+            {
+                "name": "acme/widget",
+                "version": "1.0.0",
+                "description": "Test plugin",
+                "skills": ["skills/builder"],
+                "rules": ["rules/house-style.md"],
+            }
+        ),
+    )
+    _write(repo, "skills/builder/SKILL.md", "# Builder\n")
+    _write(repo, "skills/builder/scripts/build.py", "print('build')\n")
+    _write(repo, "skills/builder/scripts/wrap.sh", "echo wrap\n")
+    _write(repo, "skills/builder/references/data.json", "{}\n")
+    _write(repo, "rules/house-style.md", "# House Style\n")
+    _commit(repo)
+    return repo
+
+
+def test_all_shipped_extensions_pass(plugin: Path) -> None:
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+    report = _report(result)
+    assert report["ok"] is True
+    assert report["needing_mirror"] == []
+
+
+def test_a_mirrored_file_passes(plugin: Path) -> None:
+    _write(plugin, "skills/builder/references/dims.yaml", "a: 1\n")
+    _write(plugin, "skills/builder/references/dims.yaml.txt", "a: 1\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+    report = _report(result)
+    assert report["ok"] is True
+    assert report["needing_mirror"] == ["skills/builder/references/dims.yaml"]
+
+
+def test_a_missing_mirror_fails_and_names_the_fix(plugin: Path) -> None:
+    """The #316 shape: a shipped file that install would drop, with no mirror."""
+    _write(plugin, "skills/builder/references/dims.yaml", "a: 1\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 1
+    report = _report(result)
+    assert report["ok"] is False
+    assert report["problems"] == [
+        {
+            "kind": "missing",
+            "path": "skills/builder/references/dims.yaml",
+            "mirror": "skills/builder/references/dims.yaml.txt",
+        }
+    ]
+    assert (
+        "cp skills/builder/references/dims.yaml"
+        " skills/builder/references/dims.yaml.txt" in result.stderr
+    )
+
+
+def test_a_drifted_mirror_fails(plugin: Path) -> None:
+    """A stale mirror is worse than none — the consumer silently reads old content."""
+    _write(plugin, "skills/builder/references/dims.yaml", "a: 2\n")
+    _write(plugin, "skills/builder/references/dims.yaml.txt", "a: 1\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 1
+    problems = _report(result)["problems"]
+    assert [p["kind"] for p in problems] == ["stale"]
+    assert "stale mirror" in result.stderr
+
+
+def test_an_orphan_mirror_fails(plugin: Path) -> None:
+    """A mirror whose source was deleted keeps shipping a file the repo dropped."""
+    _write(plugin, "skills/builder/references/dims.yaml.txt", "a: 1\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 1
+    problems = _report(result)["problems"]
+    assert [p["kind"] for p in problems] == ["orphan"]
+    assert "orphan mirror" in result.stderr
+
+
+def test_a_plain_txt_file_is_content_not_an_orphan_mirror(plugin: Path) -> None:
+    """`notes.txt` mirrors nothing — only `<name>.<dropped-ext>.txt` is a mirror."""
+    _write(plugin, "skills/builder/references/notes.txt", "hello\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+    assert _report(result)["problems"] == []
+
+
+def test_an_extensionless_file_is_not_flagged(plugin: Path) -> None:
+    """The filter matches extensions; a bare LICENSE has none to match."""
+    _write(plugin, "skills/builder/references/LICENSE", "MIT\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+    assert _report(result)["needing_mirror"] == []
+
+
+def test_an_untracked_file_is_not_a_shipping_contract(plugin: Path) -> None:
+    """Only committed files are checked; .tesslignore strips untracked OS junk."""
+    _write(plugin, "skills/builder/references/dims.yaml", "a: 1\n")
+
+    result = _run(plugin)
+    assert result.returncode == 0, result.stderr
+    assert _report(result)["needing_mirror"] == []
+
+
+def test_every_extension_outside_the_allowlist_needs_a_mirror(plugin: Path) -> None:
+    """Not a .yaml rule — the filter is an allowlist, so a fourth extension counts."""
+    _write(plugin, "skills/builder/scripts/driver.applescript", "beep\n")
+    _write(plugin, "skills/builder/scripts/macro.bas", "Sub Go()\n")
+    _write(plugin, "skills/builder/references/table.csv", "a,b\n")
+    _commit(plugin)
+
+    result = _run(plugin)
+    assert result.returncode == 1
+    problems = _report(result)["problems"]
+    assert {Path(p["path"]).suffix for p in problems} == {
+        ".applescript",
+        ".bas",
+        ".csv",
+    }
+
+
+def test_this_repo_ships_every_file_it_declares() -> None:
+    """The live tree stays in sync — this is the check that would have caught #316."""
+    result = _run(REPO_ROOT)
+    assert result.returncode == 0, result.stderr
+    report = _report(result)
+    assert report["ok"] is True
+    assert (
+        "skills/presentation-creator/references/patterns/_dimensions.yaml"
+        in report["needing_mirror"]
+    )


### PR DESCRIPTION
Closes #316.

## The diagnosis corrects the issue twice

#316 says the publish layer drops all `.yaml`. Both halves are wrong, and the fix depends on which.

**It is not publish.** `tessl plugin pack` produces 299 entries and `_dimensions.yaml` is one of them. Packing is fine.

**It is install, and it is not a `.yaml` rule.** Diffing the pack against a clean-room `tessl install` shows an *extension allowlist*:

| | pack | install |
|---|---|---|
| `md` / `py` / `sh` / `txt` / `json` | 176 / 84 / 12 / 9 / 3 | all through |
| `applescript` | 8 | **0** |
| `yaml` | 1 | **0** |
| `bas` | 1 | **0** |

Nothing reports it. Pack includes the file, publish reports success, and `install --verbose` logs not one word about the 14 files it discards.

## Impact

`audit-pattern-catalog.py` exited 1 with `dimension_registry_invalid` on every clean install from 0.20.57 on. That is a stop condition in vault-ingress Step 1, so no talk could be processed or reprocessed on the released plugin.

## Part 1 — unblock

`_dimensions.yaml` gets a byte-identical `.txt` mirror, and `registry_path` reads it when the real file is absent. The real file wins whenever it exists, so a stale mirror can never shadow a dev-tree edit.

Same device as the deck-ops drivers (#85), which is where this gets uncomfortable.

## Part 2 — close the class

#85 already solved this failure. Its guard just never generalized:

```python
# skills/presentation-creator/scripts/sync-deck-drivers.py:44
DRIVER_GLOBS = ("*.bas", "*.applescript")
```

Two extensions, one directory. A third extension in a different directory walked straight past it and shipped broken for twenty-one releases.

`scripts/check_shipped_extensions.py` is the repo-wide authority: every tracked file under the manifest's declared content whose extension is outside the allowlist must carry a current mirror. It reports missing mirrors, drifted mirrors (the consumer silently reads old content), and orphan mirrors whose source was deleted — each with the command that fixes it.

`check_package_contents.py` could not have caught this: it tests `.tesslignore` stripping, a pack-stage concern, and the loss happens a stage later.

## CI scope

This PR deliberately touches `.github/workflows/tests.yml` to add the gate step, and `scripts/pre-publish-checks.sh` to add it to the publish chain. Per `ci-safety`, that edit is in the PR's stated scope rather than smuggled into unrelated work.

## Also

`.DS_Store` is now ignored in `.gitignore` and `.tesslignore`. Pack reads the working tree rather than the git index, so five untracked ones were shipping.

## Verification

Packed the branch, deleted every non-allowlisted extension to simulate the install filter exactly, and ran the audit against the result:

```
EXIT=0
errors: 0
semantic_debts: 0
```

Before this branch that same command exited 1.

- 5814 passed, 3 skipped
- 11 new tests for the gate, incl. the extensionless-file and plain-`.txt` edge cases (one of which caught a real bug in the first draft of the predicate)
- 4 new tests for the mirror fallback, incl. the install-shaped catalog
- `ruff check`, `ruff format --check`, `pyright`, `pre-publish-checks.sh`, `tessl plugin lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh