### PR TITLE
chore(ci): bump the reusable publish workflow to the gated + fixed version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   publish:
-    uses: jbaruch/coding-policy/.github/workflows/publish-plugin.yml@b7eb9d08b78f72810891aa5fe7bf3e4fa6eb55f6
+    uses: jbaruch/coding-policy/.github/workflows/publish-plugin.yml@af116ebf18a7c46a672bf176064908736bc8ac28
     secrets:
       TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
     with:


### PR DESCRIPTION
**CI-scoped pin bump.** speaker-toolkit's publish run is red for the original out-of-credits reason — its pinned `publish-plugin.yml@b7eb9d0` predates the credit-outage gate (still `tesslio/patch-version-publish`, no reconciliation), so a post-publish credit exit reds the run even though the artifact landed:

```
✔ Published jbaruch/speaker-toolkit@0.20.80
✔ Uploaded 27 eval scenarios
##[error]Out of credits → exit 1
```

Bump the reusable-workflow pin `b7eb9d0 → af116eb`, which routes publishing through `smart-publish` + the `publish-landed-gate` confirm step (`jbaruch/coding-policy#292`) with the terminal-signature fix (`#293`): a landed credit-outage publish now greens (with a `::warning::`), while every non-landing or non-credit failure still reds. Dependabot would renew this weekly; bumping now to stop reding landed releases during the active credit outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186da3iE7wGaQzsqXPHPymU