### PR TITLE
fix(vault-ingress): accept a persisted weighted pattern_score (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@ the same reason `adherence_baseline` restates the scoring version. A test pins
 the two tables to each other, so a weight change landing in one file and not
 the other fails CI instead of splitting the arithmetic in half.
 
+### fix(vault-profile) — pattern trends accept a weighted cohort (#317)
+
+Unblocking the cohort exposed the next consumer to demand an integer:
+`classify-pattern-profile._talk_score` raised `pattern_score must be an
+integer` on the first weighted talk, and `Fraction(sum(values), len(values))`
+would not have averaged them anyway — the two-argument form takes integers
+only. The classifier now reads the score under the generation its talk is
+stamped with, and averages the trend window through `Fraction(str(value))`,
+which is exact for a two-decimal weighted score and for a count difference
+alike. An absent or malformed stamp still gets the flat contract: that refuses
+a fraction rather than admitting one, so nothing is filed under arithmetic it
+was not scored with.
+
 ## 0.20.80 — 2026-08-17
 
 ### fix(packaging) — the dimension registry now reaches consumers (#316)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+### fix(vault-ingress) — a persisted weighted score is no longer read as drift (#317)
+
+The #299 activation let a v6 return reach the database. Every consumer that
+read it back then rejected it, because the freshness replay in
+`pattern_evidence._v5_projection_freshness_reasons` cross-checked every
+persisted `pattern_score` against `len(patterns) - len(antipatterns)` and
+demanded an `int`. A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so five
+talks reprocessed under a fresh v6 claim validated, canonicalized, persisted
+with `pattern_scoring_generation_status: "current"` — and came back
+`pattern_score_projection_drift` plus `promoted_pattern_score_drift`, with
+every other artifact, citation, coverage and outcome check passing.
+
+That is worse than v6 never persisting. The four consumers gated on freshness
+are the renderer, the scoring cohort, `queue-state normalize`, and the
+post-batch baseline, so a full reparse wrote talks the profile could not read
+and the normalizer requeued the talks it had just processed. The database was
+never corrupt — the scores were arithmetically right under their own
+`pattern_score_basis` — and nothing downstream would take them.
+
+The replay now picks its arithmetic from the record's own
+`pattern_scoring_schema_version`, exactly as `adherence_baseline` and
+`opportunity_coverage_identity` already do. At the weighted generation it
+recomputes the aggregate from the detection lanes' confidences, admits the
+fraction, and recomputes `pattern_score_basis` from those same lanes rather
+than trusting the stored one — a stored basis agreeing with a stored score
+proves only that whoever wrote them agreed with themselves. A flat record keeps
+the count difference and the integer requirement. A record whose stamp is
+missing or malformed is replayed under neither: guessing the generation lets a
+record match by coincidence and report as fresh.
+
+Three reason codes join the set: `pattern_score_basis_projection_drift` (a
+weighted record without its basis, a basis its lanes do not produce, or a flat
+record carrying one — a v5 record with a basis and a v6 record without one are
+both malformed), `pattern_detection_confidence_invalid` (no confidence, no
+weight, no aggregate to compare against, so calling it score drift would name
+the wrong defect), and `pattern_scoring_schema_version_unusable`, reusing the
+code the wrapper already emits for the same condition.
+
+`pattern_evidence` restates `DETECTION_WEIGHTS` because it sits below
+`return_validation` in the import graph and cannot import its own consumer —
+the same reason `adherence_baseline` restates the scoring version. A test pins
+the two tables to each other, so a weight change landing in one file and not
+the other fails CI instead of splitting the arithmetic in half.
+
 ## 0.20.80 — 2026-08-17
 
 ### fix(packaging) — the dimension registry now reaches consumers (#316)

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -81,7 +81,22 @@ EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS = frozenset(
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
     }
 )
-CURRENT_PATTERN_SCORING_SCHEMA_VERSION = 6
+# The scoring generation whose aggregate is confidence-weighted, and therefore
+# fractional. `CURRENT` is derived from it rather than written as a literal: a
+# reader that wants the weighted generation must name it, exactly as
+# `return_validation` requires a reader wanting the flat one to name that.
+WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION = 6
+CURRENT_PATTERN_SCORING_SCHEMA_VERSION = WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+# Mirrors `return_validation.DETECTION_WEIGHTS`, restated because this module
+# sits BELOW that one in the import graph — the projection replay below cannot
+# import its own consumer. `tests/test_weighted_score_persistence.py` pins the
+# two tables to each other, so a weight change that lands in one file and not
+# the other fails CI rather than splitting the arithmetic in half.
+DETECTION_WEIGHTS: dict[str, float] = {
+    "strong": 1.0,
+    "moderate": 0.5,
+    "weak": 0.25,
+}
 PATTERN_OUTCOMES = frozenset(
     {"detected", "undetected", "not_evaluable", "not_applicable"}
 )
@@ -3737,6 +3752,162 @@ def detection_claim(detection: object) -> object:
     return claim
 
 
+def _persisted_generation_is_weighted(talk: Mapping[str, object]) -> bool | None:
+    """Whether the talk's own stamp names the weighted scoring generation.
+
+    None when the record carries no usable stamp. Substituting the current
+    generation for a missing one would check a flat record with weighted
+    arithmetic, or the reverse, and let it match by coincidence; the caller
+    emits a reason instead of guessing.
+    """
+    stamped = talk.get("pattern_scoring_schema_version")
+    if isinstance(stamped, bool) or not isinstance(stamped, int) or stamped < 1:
+        return None
+    return stamped >= WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+
+
+def _weighted_lane_projection(
+    detections: object,
+) -> tuple[float, dict[str, int]] | None:
+    """One lane's weighted total and its counts by confidence, or None.
+
+    None means some detection carries no usable confidence, so the lane has no
+    weight the table can produce and no aggregate to compare a stored score
+    against.
+    """
+    if not isinstance(detections, list):
+        return None
+    total = 0.0
+    counts = {level: 0 for level in sorted(DETECTION_WEIGHTS)}
+    for detection in detections:
+        confidence = (
+            detection.get("confidence") if isinstance(detection, Mapping) else None
+        )
+        if not isinstance(confidence, str) or confidence not in DETECTION_WEIGHTS:
+            return None
+        total += DETECTION_WEIGHTS[confidence]
+        counts[confidence] += 1
+    return total, counts
+
+
+def _basis_count_typed(value: object) -> bool:
+    """A count is a non-negative int. `True` is an int in Python; a count is not."""
+    return not isinstance(value, bool) and isinstance(value, int) and value >= 0
+
+
+def _basis_projection_drifted(basis: object, wanted: Mapping[str, object]) -> bool:
+    """Whether a persisted basis fails to project its own detection lanes.
+
+    Value equality alone does not settle it: Python makes `True == 1` and
+    `6.0 == 6`, so a basis carrying boolean counts or a float schema version
+    compares equal to the object the lanes require and passes every later
+    reader as verified.
+    """
+    if not isinstance(basis, Mapping) or basis != wanted:
+        return True
+    if not _basis_count_typed(basis.get("schema_version")):
+        return True
+    if not _basis_count_typed(basis.get("not_evaluable_count")):
+        return True
+    for lane in ("patterns", "antipatterns"):
+        counts = basis.get(lane)
+        if not isinstance(counts, Mapping) or not all(
+            _basis_count_typed(count) for count in counts.values()
+        ):
+            return True
+    return False
+
+
+def _score_projection_freshness_reasons(
+    talk: Mapping[str, object],
+    observations: Mapping[str, object],
+    *,
+    pattern_count: int,
+    antipattern_count: int,
+    not_evaluable_valid: bool,
+) -> set[str]:
+    """Replay the persisted score under the arithmetic its own generation declares.
+
+    A weighted aggregate sums 1.0/0.5/0.25 terms and is fractional by
+    construction; a flat one is the count difference and is an integer. They are
+    not one number computed two ways, so checking a weighted record against the
+    count difference reports every arithmetically correct score as drift — the
+    record persists and then every freshness-gated consumer refuses it (#317).
+    """
+    reasons: set[str] = set()
+    weighted = _persisted_generation_is_weighted(talk)
+    if weighted is None:
+        reasons.add("pattern_scoring_schema_version_unusable")
+        return reasons
+
+    nested_score = observations.get("pattern_score")
+    promoted_score = talk.get("pattern_score")
+    if not weighted:
+        if "pattern_score_basis" in observations:
+            # The basis is a weighted-generation field. A flat record carrying
+            # one is malformed, not a flat record with a spare field.
+            reasons.add("pattern_score_basis_projection_drift")
+        flat_expected = pattern_count - antipattern_count
+        if (
+            isinstance(nested_score, bool)
+            or not isinstance(nested_score, int)
+            or nested_score != flat_expected
+        ):
+            reasons.add("pattern_score_projection_drift")
+        if (
+            isinstance(promoted_score, bool)
+            or not isinstance(promoted_score, int)
+            or promoted_score != flat_expected
+            or promoted_score != nested_score
+        ):
+            reasons.add("promoted_pattern_score_drift")
+        return reasons
+
+    patterns = _weighted_lane_projection(observations.get("patterns_detected"))
+    antipatterns = _weighted_lane_projection(observations.get("antipatterns_detected"))
+    if patterns is None or antipatterns is None:
+        # No confidence, no weight, no expected aggregate. The score cannot be
+        # replayed at all here, so calling it drift would name the wrong defect.
+        reasons.add("pattern_detection_confidence_invalid")
+        return reasons
+    # Rounded to two places for the same reason the writer rounds: every weight
+    # is a multiple of 0.25, so every reachable total is exactly representable
+    # there, and a raw float sum emits 0.30000000000000004 for a total the
+    # arithmetic makes 0.3.
+    expected = round(patterns[0] - antipatterns[0], 2)
+    if not_evaluable_valid:
+        wanted_basis = {
+            "schema_version": WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION,
+            "weights": dict(sorted(DETECTION_WEIGHTS.items())),
+            "patterns": patterns[1],
+            "antipatterns": antipatterns[1],
+            "not_evaluable_count": len(cast(list, observations["not_evaluable"])),
+        }
+        if _basis_projection_drifted(
+            observations.get("pattern_score_basis"), wanted_basis
+        ):
+            reasons.add("pattern_score_basis_projection_drift")
+    # Compared exactly, never rounded: `expected` is already canonical to two
+    # decimals, so rounding the stored value first would accept anything within
+    # half a hundredth of a score no declared arithmetic produces.
+    if (
+        isinstance(nested_score, bool)
+        or not isinstance(nested_score, (int, float))
+        or not math.isfinite(nested_score)
+        or nested_score != expected
+    ):
+        reasons.add("pattern_score_projection_drift")
+    if (
+        isinstance(promoted_score, bool)
+        or not isinstance(promoted_score, (int, float))
+        or not math.isfinite(promoted_score)
+        or promoted_score != expected
+        or promoted_score != nested_score
+    ):
+        reasons.add("promoted_pattern_score_drift")
+    return reasons
+
+
 def _v5_projection_freshness_reasons(
     talk: Mapping[str, object],
     observations: Mapping[str, object],
@@ -3846,22 +4017,15 @@ def _v5_projection_freshness_reasons(
             reasons.add("pattern_outcomes_not_applicable_projection_drift")
 
     if patterns_valid and antipatterns_valid:
-        expected_score = len(pattern_ids) - len(antipattern_ids)
-        nested_score = observations.get("pattern_score")
-        if (
-            isinstance(nested_score, bool)
-            or not isinstance(nested_score, int)
-            or nested_score != expected_score
-        ):
-            reasons.add("pattern_score_projection_drift")
-        promoted_score = talk.get("pattern_score")
-        if (
-            isinstance(promoted_score, bool)
-            or not isinstance(promoted_score, int)
-            or promoted_score != expected_score
-            or promoted_score != nested_score
-        ):
-            reasons.add("promoted_pattern_score_drift")
+        reasons.update(
+            _score_projection_freshness_reasons(
+                talk,
+                observations,
+                pattern_count=len(pattern_ids),
+                antipattern_count=len(antipattern_ids),
+                not_evaluable_valid=not_evaluable_valid,
+            )
+        )
     return reasons
 
 

--- a/skills/vault-profile/scripts/classify-pattern-profile.py
+++ b/skills/vault-profile/scripts/classify-pattern-profile.py
@@ -57,6 +57,7 @@ from pattern_opportunities import (  # noqa: E402
 
 # Pyright cannot resolve this sibling script module added to sys.path at runtime.
 from return_validation import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION,
     load_catalog,
 )
 from profile_pattern_provenance import absence_provability  # noqa: E402
@@ -1056,12 +1057,66 @@ def _talk_filename(talk: Mapping[str, object]) -> str:
     return filename
 
 
-def _talk_score(talk: Mapping[str, object]) -> int:
+def _exact_average(values: Sequence[float]) -> Fraction:
+    """Average the window without float dust, at either generation's arithmetic.
+
+    `Fraction(numerator, denominator)` takes integers only, so a weighted window
+    cannot go through it. Reading each value from its decimal literal is exact
+    for both: every weighted score is canonical to two decimals, and an integer
+    count difference reads back as itself.
+    """
+    total = sum((Fraction(str(value)) for value in values), Fraction(0))
+    return total / len(values)
+
+
+def _is_weighted_score(value: object) -> TypeGuard[float]:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+    )
+
+
+def _weighted_generation(talk: Mapping[str, object]) -> bool:
+    """Whether the talk's own stamp names the generation whose score is weighted.
+
+    An absent or malformed stamp reads as the flat generation, which refuses a
+    fraction. That is a refusal, never a coincidence match: the alternative —
+    admitting a weighted number on a record that does not say it was scored
+    that way — files an aggregate under arithmetic nothing proved it used.
+    """
+    stamped = talk.get("pattern_scoring_schema_version")
+    if isinstance(stamped, bool) or not isinstance(stamped, int):
+        return False
+    return stamped >= WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+
+
+def _talk_score(talk: Mapping[str, object]) -> float:
+    """The talk's score, admitted under the arithmetic its generation declares.
+
+    A weighted aggregate sums 1.0/0.5/0.25 terms and is fractional by
+    construction, so demanding an integer here refuses every talk the weighted
+    generation produces (#317). A flat record still gets the integer contract:
+    its score is a count difference, and a float there means some other
+    arithmetic produced it.
+    """
     score = talk.get("pattern_score")
     observations = talk.get("pattern_observations")
     observed_score = (
         observations.get("pattern_score") if isinstance(observations, Mapping) else None
     )
+    if _weighted_generation(talk):
+        if not _is_weighted_score(score):
+            raise PatternClassificationError(
+                f"{_talk_filename(talk)}: weighted pattern_score must be a "
+                "finite number"
+            )
+        if not _is_weighted_score(observed_score) or observed_score != score:
+            raise PatternClassificationError(
+                f"{_talk_filename(talk)}: flattened and observed pattern_score "
+                "must match"
+            )
+        return score
     if not _is_integer(score):
         raise PatternClassificationError(
             f"{_talk_filename(talk)}: pattern_score must be an integer"
@@ -1262,14 +1317,14 @@ def _trend_analysis(
     ]
 
     def metric(
-        values_prior: Sequence[int],
-        values_recent: Sequence[int],
+        values_prior: Sequence[float],
+        values_recent: Sequence[float],
         threshold: float,
         improving: str,
         declining: str,
     ) -> dict[str, object]:
-        exact_prior = Fraction(sum(values_prior), len(values_prior))
-        exact_recent = Fraction(sum(values_recent), len(values_recent))
+        exact_prior = _exact_average(values_prior)
+        exact_recent = _exact_average(values_recent)
         exact_delta = exact_recent - exact_prior
         exact_threshold = Fraction(str(threshold))
         prior_average = float(exact_prior)

--- a/tests/test_classify_pattern_profile.py
+++ b/tests/test_classify_pattern_profile.py
@@ -842,3 +842,130 @@ def test_override_rejects_unknown_semantic_fields(classify_pattern_profile, tmp_
         match="fields are noncanonical",
     ):
         _policy(classify_pattern_profile, tmp_path)
+
+
+def _weighted_talk(index, *, p1, score, scoring_schema=6):
+    """A talk stamped at the weighted generation, carrying a fractional score."""
+    talk = _talk(index, p1=p1)
+    talk["pattern_scoring_schema_version"] = scoring_schema
+    talk["pattern_score"] = score
+    talk["pattern_observations"]["pattern_score"] = score
+    return talk
+
+
+def test_a_weighted_cohort_trends_on_its_fractional_scores(
+    classify_pattern_profile, tmp_path
+):
+    """#317's sibling: the classifier demanded an integer of every talk.
+
+    A weighted score is a sum of 1.0/0.5/0.25 terms, so the cohort that #317
+    unblocked reached this arithmetic and raised on the first talk.
+    """
+    talks = [
+        *[_weighted_talk(index, p1="undetected", score=0.25) for index in range(5)],
+        *[_weighted_talk(index, p1="detected", score=1.75) for index in range(5, 10)],
+    ]
+
+    result = classify_pattern_profile.classify_pattern_profile(
+        talks,
+        _policy(classify_pattern_profile, tmp_path),
+        catalog=_catalog(),
+    )
+
+    trend = result["trend_analysis"]
+    assert trend["status"] == "available"
+    assert trend["score"] == {
+        "status": "improving",
+        "prior_average": 0.25,
+        "recent_average": 1.75,
+        "delta": 1.5,
+    }
+
+
+def test_the_weighted_average_carries_no_float_dust(classify_pattern_profile, tmp_path):
+    """0.1 + 0.2 is 0.30000000000000004 in floats; the window average is exact."""
+    scores = [0.1, 0.2, 0.25, 0.25, 0.2]
+    talks = [
+        *[
+            _weighted_talk(index, p1="undetected", score=scores[index])
+            for index in range(5)
+        ],
+        *[_weighted_talk(index, p1="detected", score=0.5) for index in range(5, 10)],
+    ]
+
+    result = classify_pattern_profile.classify_pattern_profile(
+        talks,
+        _policy(classify_pattern_profile, tmp_path),
+        catalog=_catalog(),
+    )
+
+    assert result["trend_analysis"]["score"]["prior_average"] == 0.2
+
+
+def test_a_fraction_at_the_flat_generation_is_still_refused(
+    classify_pattern_profile, tmp_path
+):
+    """The weighted allowance is bound to the stamp, not to the value's shape."""
+    talks = [
+        *[
+            _weighted_talk(index, p1="undetected", score=0.25, scoring_schema=5)
+            for index in range(5)
+        ],
+        *[
+            _weighted_talk(index, p1="detected", score=1.75, scoring_schema=5)
+            for index in range(5, 10)
+        ],
+    ]
+
+    with pytest.raises(
+        classify_pattern_profile.PatternClassificationError,
+        match="pattern_score must be an integer",
+    ):
+        classify_pattern_profile.classify_pattern_profile(
+            talks,
+            _policy(classify_pattern_profile, tmp_path),
+            catalog=_catalog(),
+        )
+
+
+def test_an_unstamped_talk_keeps_the_flat_contract(classify_pattern_profile, tmp_path):
+    """A record that does not say it was scored weighted is not read as weighted."""
+    talks = [
+        *[_talk(index, p1="undetected") for index in range(5)],
+        *[_talk(index, p1="detected") for index in range(5, 10)],
+    ]
+    talks[0]["pattern_score"] = 0.25
+    talks[0]["pattern_observations"]["pattern_score"] = 0.25
+
+    with pytest.raises(
+        classify_pattern_profile.PatternClassificationError,
+        match="pattern_score must be an integer",
+    ):
+        classify_pattern_profile.classify_pattern_profile(
+            talks,
+            _policy(classify_pattern_profile, tmp_path),
+            catalog=_catalog(),
+        )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_a_non_finite_weighted_score_is_refused(
+    classify_pattern_profile, tmp_path, value
+):
+    """NaN defeats every comparison downstream by never equalling anything."""
+    talks = [
+        *[_weighted_talk(index, p1="undetected", score=0.25) for index in range(5)],
+        *[_weighted_talk(index, p1="detected", score=1.75) for index in range(5, 10)],
+    ]
+    talks[0]["pattern_score"] = value
+    talks[0]["pattern_observations"]["pattern_score"] = value
+
+    with pytest.raises(
+        classify_pattern_profile.PatternClassificationError,
+        match="weighted pattern_score must be a finite number",
+    ):
+        classify_pattern_profile.classify_pattern_profile(
+            talks,
+            _policy(classify_pattern_profile, tmp_path),
+            catalog=_catalog(),
+        )

--- a/tests/test_profile_pattern_provenance.py
+++ b/tests/test_profile_pattern_provenance.py
@@ -344,6 +344,7 @@ def _run(validate_profile, profile, tmp_path, capsys, *, extra_talks=None):
     fingerprint, scoring_schema = validate_profile.active_pattern_generation_identity()
     opportunities = importlib.import_module("pattern_opportunities")
     pattern_evidence = importlib.import_module("pattern_evidence")
+    freshness = importlib.import_module("return_validation")
     transcript_timing = importlib.import_module("transcript_timing")
     catalog = opportunities.load_catalog()
     pattern_outcomes, not_evaluable, assessments = _transcript_projection(catalog)
@@ -436,6 +437,11 @@ def _run(validate_profile, profile, tmp_path, capsys, *, extra_talks=None):
                 },
                 "pattern_observations": {
                     "pattern_score": score,
+                    # The active generation is the weighted one, so the record
+                    # carries the basis its score cannot travel without.
+                    "pattern_score_basis": freshness.pattern_score_basis(
+                        [], [], not_evaluable
+                    ),
                     "patterns_detected": [],
                     "antipatterns_detected": [],
                     "not_evaluable": copy.deepcopy(not_evaluable),
@@ -472,7 +478,6 @@ def _run(validate_profile, profile, tmp_path, capsys, *, extra_talks=None):
                 },
             }
         )
-    freshness = importlib.import_module("return_validation")
     for talk in talks:
         reasons = freshness.assess_current_persisted_pattern_evidence_freshness(
             talk,

--- a/tests/test_section15_pattern_history.py
+++ b/tests/test_section15_pattern_history.py
@@ -379,6 +379,12 @@ def _add_fresh_transcript_evidence(
         talk["pattern_observations"].update(
             {
                 "evidence_schema_version": 2,
+                # The talks are stamped at the active generation, which is the
+                # weighted one, so their block carries the basis behind the
+                # score.
+                "pattern_score_basis": return_validation.pattern_score_basis(
+                    [], [], talk["pattern_observations"]["not_evaluable"]
+                ),
                 "evidence_sources": ["transcript"],
                 "source_inspection": [
                     {

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -81,7 +81,18 @@ def _catalog_projection(source: str | None = "transcript"):
 
 def _set_projection(talk, source: str | None) -> None:
     _, outcomes, not_evaluable, assessments = _catalog_projection(source)
+    return_validation = importlib.import_module("return_validation")
     observations = talk["pattern_observations"]
+    if talk["pattern_scoring_schema_version"] >= (
+        return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+    ):
+        # A talk stamped at the weighted generation carries the basis its score
+        # was computed from; one stamped earlier cannot carry it at all.
+        observations["pattern_score_basis"] = return_validation.pattern_score_basis(
+            observations["patterns_detected"],
+            observations["antipatterns_detected"],
+            not_evaluable,
+        )
     observations.update(
         {
             "pattern_outcomes": outcomes,
@@ -544,6 +555,16 @@ def _write_vault(vault_root, talks, *, config=None):
         )
         observations.setdefault("patterns_detected", [])
         observations.setdefault("antipatterns_detected", [])
+        if scoring_version >= 6:
+            return_validation = importlib.import_module("return_validation")
+            observations.setdefault(
+                "pattern_score_basis",
+                return_validation.pattern_score_basis(
+                    observations["patterns_detected"],
+                    observations["antipatterns_detected"],
+                    observations["not_evaluable"],
+                ),
+            )
         if scoring_version >= 5:
             observations.setdefault("applicability_assessments", [])
             inspection = observations.get("source_inspection")

--- a/tests/test_weighted_score_persistence.py
+++ b/tests/test_weighted_score_persistence.py
@@ -14,6 +14,7 @@ weighted generation has a sibling proving the flat generation still refuses one.
 from __future__ import annotations
 
 import copy
+import importlib
 import math
 from typing import Any
 
@@ -406,6 +407,81 @@ class TestTheWeightedBaselineCanBeBuilt:
             adherence_baseline.validate_adherence_baseline(snapshot)
 
 
+def _weighted_catalog(return_validation):
+    return _catalog(
+        return_validation,
+        _entry(return_validation, "detected"),
+        _entry(return_validation, "conditional", applicability=True),
+        _entry(return_validation, "undetected"),
+        _entry(return_validation, "positive-only", absence_gate=None),
+    )
+
+
+def _v6_return(return_validation, catalog, *, bare: bool):
+    raw = _raw_return(
+        detections=[_detection()],
+        assessments=[_assessment()],
+        not_evaluable=[
+            {
+                "pattern_id": "positive-only",
+                "reason_code": "absence_not_authorized_by_catalog",
+            }
+        ],
+    )
+    raw["return_schema_version"] = (
+        return_validation.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
+    )
+    block = raw["pattern_observations"]
+    patterns = block["patterns_detected"]
+    antipatterns = block["antipatterns_detected"]
+    expected = return_validation.expected_weighted_score(patterns, antipatterns)
+    assert not float(expected).is_integer(), (
+        "fixture must exercise a fractional score, or it proves nothing"
+    )
+    block["pattern_score"] = (
+        expected
+        if bare
+        else {
+            "patterns_used": len(patterns),
+            "antipatterns_detected": len(antipatterns),
+            "score": expected,
+        }
+    )
+    block["pattern_score_basis"] = return_validation.pattern_score_basis(
+        patterns, antipatterns, block["not_evaluable"]
+    )
+    return_validation.validate_return(raw, catalog)
+    return raw, expected
+
+
+def _merge_v6(
+    persist_results,
+    return_validation,
+    transcript_timing,
+    tmp_path,
+    catalog,
+    raw,
+):
+    """Merge a validated v6 return, returning the stored talk and its vault."""
+    import pattern_evidence
+
+    vault, owner = _artifact(tmp_path, transcript_timing)
+    canonical: dict[str, Any] = pattern_evidence.canonicalize_return_evidence(
+        raw,
+        owner,
+        vault,
+        catalog,
+        pattern_scoring_schema_version=(
+            return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        ),
+    )
+    talk = copy.deepcopy(owner)
+    talk["schema_version"] = persist_results.TALK_SCHEMA_VERSION
+    talk["status"] = "reprocessing-inflight"
+    persist_results.merge_talk(talk, raw, catalog=catalog, canonical_ret=canonical)
+    return talk, vault
+
+
 class TestAWeightedReturnReachesTheDatabase:
     """End to end: validate, canonicalize, merge — the path #308 died on.
 
@@ -416,49 +492,10 @@ class TestAWeightedReturnReachesTheDatabase:
 
     @pytest.fixture
     def catalog(self, return_validation):
-        return _catalog(
-            return_validation,
-            _entry(return_validation, "detected"),
-            _entry(return_validation, "conditional", applicability=True),
-            _entry(return_validation, "undetected"),
-            _entry(return_validation, "positive-only", absence_gate=None),
-        )
+        return _weighted_catalog(return_validation)
 
     def _v6(self, return_validation, catalog, *, bare: bool):
-        raw = _raw_return(
-            detections=[_detection()],
-            assessments=[_assessment()],
-            not_evaluable=[
-                {
-                    "pattern_id": "positive-only",
-                    "reason_code": "absence_not_authorized_by_catalog",
-                }
-            ],
-        )
-        raw["return_schema_version"] = (
-            return_validation.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
-        )
-        block = raw["pattern_observations"]
-        patterns = block["patterns_detected"]
-        antipatterns = block["antipatterns_detected"]
-        expected = return_validation.expected_weighted_score(patterns, antipatterns)
-        assert not float(expected).is_integer(), (
-            "fixture must exercise a fractional score, or it proves nothing"
-        )
-        block["pattern_score"] = (
-            expected
-            if bare
-            else {
-                "patterns_used": len(patterns),
-                "antipatterns_detected": len(antipatterns),
-                "score": expected,
-            }
-        )
-        block["pattern_score_basis"] = return_validation.pattern_score_basis(
-            patterns, antipatterns, block["not_evaluable"]
-        )
-        return_validation.validate_return(raw, catalog)
-        return raw, expected
+        return _v6_return(return_validation, catalog, bare=bare)
 
     def _merge(
         self,
@@ -469,22 +506,14 @@ class TestAWeightedReturnReachesTheDatabase:
         catalog,
         raw,
     ):
-        import pattern_evidence
-
-        vault, owner = _artifact(tmp_path, transcript_timing)
-        canonical: dict[str, Any] = pattern_evidence.canonicalize_return_evidence(
-            raw,
-            owner,
-            vault,
+        talk, _ = _merge_v6(
+            persist_results,
+            return_validation,
+            transcript_timing,
+            tmp_path,
             catalog,
-            pattern_scoring_schema_version=(
-                return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
-            ),
+            raw,
         )
-        talk = copy.deepcopy(owner)
-        talk["schema_version"] = persist_results.TALK_SCHEMA_VERSION
-        talk["status"] = "reprocessing-inflight"
-        persist_results.merge_talk(talk, raw, catalog=catalog, canonical_ret=canonical)
         return talk
 
     @pytest.mark.parametrize("bare", [True, False])
@@ -562,3 +591,254 @@ class TestAWeightedReturnReachesTheDatabase:
                 catalog,
                 raw,
             )
+
+
+class TestTheWeightedRecordReadsBackFresh:
+    """#317: the record persisted, and then every consumer refused it.
+
+    Freshness is the gate on the renderer, the scoring cohort, the queue
+    normalizer and the post-batch baseline. Its projection replay cross-checked
+    every persisted score against the count difference, so a correct weighted
+    score — fractional by construction — read as drift on a record the writer
+    had just merged. Nothing was corrupt and nothing could converge: the queue
+    requeued the talks it had just processed.
+
+    This is the step that passes in isolation and failed in sequence, so it runs
+    the real merge first rather than hand-building a persisted block.
+    """
+
+    @pytest.fixture
+    def catalog(self, return_validation):
+        return _weighted_catalog(return_validation)
+
+    @pytest.fixture
+    def stored(
+        self,
+        persist_results,
+        return_validation,
+        transcript_timing,
+        tmp_path,
+        catalog,
+    ):
+        raw, expected = _v6_return(return_validation, catalog, bare=True)
+        talk, vault = _merge_v6(
+            persist_results,
+            return_validation,
+            transcript_timing,
+            tmp_path,
+            catalog,
+            raw,
+        )
+        return talk, vault, expected
+
+    @staticmethod
+    def _reasons(return_validation, talk, vault, catalog):
+        return return_validation.assess_current_persisted_pattern_evidence_freshness(
+            talk,
+            vault_root=vault,
+            catalog=catalog,
+        )
+
+    def test_a_merged_weighted_record_is_fresh(
+        self, return_validation, catalog, stored
+    ):
+        talk, vault, expected = stored
+
+        assert not float(expected).is_integer()
+        assert talk["pattern_score"] == expected
+        assert self._reasons(return_validation, talk, vault, catalog) == ()
+
+    def test_a_weighted_score_its_own_lanes_contradict_is_drift(
+        self, return_validation, catalog, stored
+    ):
+        """The replay still checks the arithmetic; it checks the right one."""
+        talk, vault, expected = stored
+        talk["pattern_score"] = expected + 0.25
+        talk["pattern_observations"]["pattern_score"] = expected + 0.25
+
+        assert self._reasons(return_validation, talk, vault, catalog) == (
+            "pattern_score_projection_drift",
+            "promoted_pattern_score_drift",
+        )
+
+    def test_the_count_difference_is_no_longer_the_weighted_cross_check(
+        self, return_validation, catalog, stored
+    ):
+        """The exact #317 shape, inverted: the count difference is now the drift."""
+        talk, vault, _ = stored
+        observations = talk["pattern_observations"]
+        flat = len(observations["patterns_detected"]) - len(
+            observations["antipatterns_detected"]
+        )
+        talk["pattern_score"] = flat
+        observations["pattern_score"] = flat
+
+        assert "pattern_score_projection_drift" in self._reasons(
+            return_validation, talk, vault, catalog
+        )
+
+    def test_a_weighted_record_without_its_basis_is_drift(
+        self, return_validation, catalog, stored
+    ):
+        """A fractional number with no evidence composition behind it."""
+        talk, vault, _ = stored
+        talk["pattern_observations"].pop("pattern_score_basis")
+
+        assert self._reasons(return_validation, talk, vault, catalog) == (
+            "pattern_score_basis_projection_drift",
+        )
+
+    def test_a_basis_its_lanes_do_not_produce_is_drift(
+        self, return_validation, catalog, stored
+    ):
+        """The basis is recomputed from the lanes, never trusted as stored."""
+        talk, vault, _ = stored
+        basis = talk["pattern_observations"]["pattern_score_basis"]
+        basis["not_evaluable_count"] += 1
+
+        assert self._reasons(return_validation, talk, vault, catalog) == (
+            "pattern_score_basis_projection_drift",
+        )
+
+    def test_a_boolean_count_does_not_pass_as_the_one_it_equals(
+        self, return_validation, catalog, stored
+    ):
+        """`True == 1` in Python, so value equality alone verifies nothing."""
+        talk, vault, _ = stored
+        counts = talk["pattern_observations"]["pattern_score_basis"]["patterns"]
+        level = next(level for level, count in counts.items() if count == 1)
+        counts[level] = True
+
+        assert self._reasons(return_validation, talk, vault, catalog) == (
+            "pattern_score_basis_projection_drift",
+        )
+
+    def test_an_unstamped_record_is_replayed_under_no_arithmetic_at_all(
+        self, return_validation, catalog, stored
+    ):
+        """Guessing the generation lets a record match by coincidence."""
+        talk, vault, _ = stored
+        talk.pop("pattern_scoring_schema_version")
+
+        assert "pattern_scoring_schema_version_unusable" in self._reasons(
+            return_validation, talk, vault, catalog
+        )
+
+    def test_a_detection_with_no_usable_confidence_names_that_defect(
+        self, return_validation, catalog, stored
+    ):
+        """No confidence, no weight, no aggregate to compare the score against."""
+        talk, vault, _ = stored
+        talk["pattern_observations"]["patterns_detected"][0]["confidence"] = "certain"
+
+        reasons = self._reasons(return_validation, talk, vault, catalog)
+        assert "pattern_detection_confidence_invalid" in reasons
+        assert "pattern_score_projection_drift" not in reasons
+
+
+class TestTheFlatGenerationKeepsItsArithmetic:
+    """The weighted allowance is an addition, not a replacement.
+
+    A record stamped at the flat generation was written by a worker counting
+    +1/-1. Replaying it under the weight table would restate what that worker
+    meant, which is the reinterpretation the migration refuses to do — and it is
+    why the v5→v6 migration restamps the record shape while leaving
+    `pattern_scoring_schema_version: 5` on the score.
+    """
+
+    @pytest.fixture
+    def catalog(self, return_validation):
+        return _weighted_catalog(return_validation)
+
+    @pytest.fixture
+    def flat(
+        self,
+        persist_results,
+        return_validation,
+        transcript_timing,
+        tmp_path,
+        catalog,
+    ):
+        raw, _ = _v6_return(return_validation, catalog, bare=True)
+        talk, vault = _merge_v6(
+            persist_results,
+            return_validation,
+            transcript_timing,
+            tmp_path,
+            catalog,
+            raw,
+        )
+        observations = talk["pattern_observations"]
+        flat_score = len(observations["patterns_detected"]) - len(
+            observations["antipatterns_detected"]
+        )
+        talk["pattern_scoring_schema_version"] = (
+            return_validation.FLAT_PATTERN_SCORING_SCHEMA_VERSION
+        )
+        talk["pattern_score"] = flat_score
+        observations["pattern_score"] = flat_score
+        observations["opportunity_coverage_identity"] = importlib.import_module(
+            "pattern_evidence"
+        ).opportunity_coverage_identity(
+            observations["pattern_outcomes"],
+            pattern_catalog_fingerprint=talk["pattern_catalog_fingerprint"],
+            pattern_scoring_schema_version=(
+                return_validation.FLAT_PATTERN_SCORING_SCHEMA_VERSION
+            ),
+        )
+        return talk, vault
+
+    @staticmethod
+    def _reasons(return_validation, talk, vault, catalog):
+        return return_validation.assess_current_persisted_pattern_evidence_freshness(
+            talk,
+            vault_root=vault,
+            catalog=catalog,
+        )
+
+    def test_a_flat_record_carrying_a_weighted_basis_is_drift(
+        self, return_validation, catalog, flat
+    ):
+        """The basis is a weighted-generation field; a flat record cannot hold one."""
+        talk, vault = flat
+
+        assert "pattern_score_basis_projection_drift" in self._reasons(
+            return_validation, talk, vault, catalog
+        )
+
+    def test_a_flat_record_is_still_checked_against_the_count_difference(
+        self, return_validation, catalog, flat
+    ):
+        talk, vault = flat
+        talk["pattern_observations"].pop("pattern_score_basis")
+
+        assert self._reasons(return_validation, talk, vault, catalog) == ()
+
+    def test_a_fraction_at_the_flat_generation_is_still_drift(
+        self, return_validation, catalog, flat
+    ):
+        """A float there means some other arithmetic produced the number."""
+        talk, vault = flat
+        talk["pattern_observations"].pop("pattern_score_basis")
+        talk["pattern_score"] = 0.75
+        talk["pattern_observations"]["pattern_score"] = 0.75
+
+        assert self._reasons(return_validation, talk, vault, catalog) == (
+            "pattern_score_projection_drift",
+            "promoted_pattern_score_drift",
+        )
+
+
+def test_the_mirrored_weight_table_matches_its_source(return_validation):
+    """`pattern_evidence` restates the table because it sits below its consumer.
+
+    A weight change that lands in one file and not the other splits the
+    arithmetic in half: the writer stores one number and the freshness replay
+    demands another, which is #317 with a different root cause.
+    """
+    pattern_evidence = importlib.import_module("pattern_evidence")
+
+    assert pattern_evidence.DETECTION_WEIGHTS == return_validation.DETECTION_WEIGHTS
+    assert pattern_evidence.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION == (
+        return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+    )


### PR DESCRIPTION
## Summary

- **Freshness replay is generation-aware.** `_v5_projection_freshness_reasons` cross-checked every persisted `pattern_score` against `len(patterns) - len(antipatterns)` and demanded an `int`. A weighted v6 record — which the #299 activation lets persist — was therefore reported stale by all four freshness-gated consumers (renderer, scoring cohort, `queue-state normalize`, post-batch baseline), so a reparse wrote talks the profile could never read and the normalizer requeued the talks it had just processed. The replay now reads the arithmetic from the record's own `pattern_scoring_schema_version`: weighted totals recomputed from the detection lanes' confidences at generation 6+, count difference below it, and neither when the stamp is missing or malformed.
- **`pattern_score_basis` is replayed, not trusted.** At the weighted generation the basis is recomputed from the same lanes and compared, with the count fields type-checked (`True == 1` and `6.0 == 6` in Python). New reason codes: `pattern_score_basis_projection_drift`, `pattern_detection_confidence_invalid`, and `pattern_scoring_schema_version_unusable` (reusing the code the wrapper already emits).
- **The trend window accepts a weighted cohort.** Unblocking the cohort exposed the next integer-only consumer: `classify-pattern-profile._talk_score` raised on the first weighted talk, and the two-argument `Fraction` that averages the window takes integers only. Both now read the generation the talk is stamped with; the average goes through `Fraction(str(value))`, exact for a two-decimal weighted score and a count difference alike.
- `pattern_evidence` restates `DETECTION_WEIGHTS` because it sits below `return_validation` in the import graph; a test pins the two tables to each other.

Closes #317

## Test plan

- [x] `pytest` — 5834 passed, 3 skipped
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `pyright` — no new findings (the 99 reported errors are missing optional third-party imports in the local venv, unchanged by this PR)
- [x] New tests fail against the pre-fix tree: 8 in `test_weighted_score_persistence.py` (including `test_a_merged_weighted_record_is_fresh`, which merges a real v6 return and asserts freshness returns no reasons — the exact step #317 reports as passing in isolation and failing in sequence) and 4 in `test_classify_pattern_profile.py`
- [x] Flat-generation siblings pin the unchanged contract: a fraction at generation 5, and an unstamped record, are still refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh