### PR TITLE
fix(release): resync the manifest version with the registry

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/speaker-toolkit",
-  "version": "0.20.58",
+  "version": "0.20.80",
   "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (81 observable: 62 patterns + 19 antipatterns; 30 unobservable: 21 patterns + 9 antipatterns) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [


### PR DESCRIPTION
## Summary

The #317 release (PR #321) merged clean and then failed to publish:

```
✘ Bumped version 0.20.59 also already exists. Manually set the version in the manifest.
```

The publish pipeline changed under us today. The 21:45 run used
`tesslio/patch-version-publish`, which resolves the next version from the
**registry** — which is why it published 0.20.80 from a manifest reading
0.20.58. Every run from 22:15 on uses coding-policy's `smart-publish`, which
runs `tessl plugin publish --bump patch` and commits the result back. That bump
is **manifest**-derived.

This repo's manifest had been left at 0.20.58 while the registry advanced to
0.20.80 — invisible under the old action, fatal under the new one. Two runs
have died on it now (32075194312, 32078151517); the second is the #317 release.

Setting the manifest to the registry's current latest makes the next bump
0.20.81, which is the heading the CHANGELOG stamp step already wrote on `main`
in 463e4b9. `smart-publish`'s commit-back keeps the manifest and the registry in
sync from here, so this is a one-time resync, not a recurring chore.

Closes the release path for #317.

## Test plan

- [x] Registry latest confirmed at 0.20.80 (`capture-registry-baseline.sh`)
- [x] Manifest now names that version, so `--bump patch` resolves 0.20.81
- [x] `main`'s CHANGELOG already carries the matching `## 0.20.81` heading, so no second stamp is produced
- [ ] Publish run on merge lands 0.20.81, the registry advances past 0.20.80, and moderation clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh