### PR TITLE
chore(release): land the manifest bump the credit exit skipped

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/speaker-toolkit",
-  "version": "0.20.80",
+  "version": "0.20.81",
   "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (81 observable: 62 patterns + 19 antipatterns; 30 unobservable: 21 patterns + 9 antipatterns) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [


### PR DESCRIPTION
## Summary

`0.20.81` published cleanly (run 32079681022, registry advanced, moderation
`pass`), but tessl exited non-zero on out-of-credits immediately after, so
`smart-publish` returned before committing the resolved version back to the
manifest. `main` was left at `0.20.80`.

That is the same collision PR #323 just repaired: the next merge would bump
`0.20.80 → 0.20.81`, which now exists, and the release would die. This lands the
bump by hand.

The recurring cause — the tolerated out-of-credits path skipping the
commit-back — is filed as #324, with the upstream options.

## Test plan

- [x] Registry latest is `0.20.81`; manifest now names it, so the next `--bump patch` resolves `0.20.82`
- [x] No CHANGELOG entry: this ships no user-visible change, and the stamp step no-ops with no un-headed blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh