### PR TITLE
fix(vault-ingress): type-check persisted basis weights, and clear three backlog items

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/speaker-toolkit",
-  "version": "0.20.81",
+  "version": "0.20.82",
   "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (81 observable: 62 patterns + 19 antipatterns; 30 unobservable: 21 patterns + 9 antipatterns) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+### fix(vault-ingress) — a boolean weight no longer passes the freshness replay (#322)
+
+`_basis_projection_drifted` type-checked the persisted basis's `schema_version`,
+its `not_evaluable_count`, and both lane count maps, then settled the `weights`
+map on value equality alone. `True == 1.0` in Python, so a basis carrying
+`{"strong": true, "moderate": 0.5, "weak": 0.25}` compared equal to the weight
+table the lanes require and the record reported fresh — and every reader
+afterwards believed the shape had been verified.
+
+The write side already refused it: `return_validation._validate_score_basis_types`
+loops the same map rejecting bools. This is the read-side half of that guard,
+which is the half that matters for a record already in the database, since a
+persisted record is a hint and not authority. Raised by Copilot on #321.
+
+### docs(vault-ingress) — six comments describing the flat contract as universal (#313)
+
+Two comments were reported; four more of the same shape turned up in the same
+audit. Both claims had been true of the flat generation and were left
+unqualified when the weighted split landed:
+
+- "the score is count(patterns) minus count(antipatterns), so it is an INTEGER
+  by construction" now names the flat generation, in `persist-results.py`.
+- "confidence-weighted, and therefore fractional" now reads "MAY be
+  fractional", in `adherence_baseline.py` (twice), `pattern_evidence.py`
+  (twice), `persist-results.py`, and `return_validation.py`.
+
+A weighted aggregate may be whole — two strong patterns against one strong
+antipattern is exactly `1.0`, and
+`test_weighted_score_persistence.py::TestResolveAWeightedScore::test_a_whole_weighted_score_stays_valid`
+pins that case, so the comments contradicted a test shipped in the same change.
+
+### test(vault-ingress) — name the branch that accepts a persisted weighted record (#299)
+
+The activation's last open bullet asked for integration coverage through
+`validate_persisted_v2_analysis_state`. That chain was already running:
+`merge_talk` calls `validate_effective_v2_state` before it returns, so every
+existing v6 merge test reached the validator transitively.
+
+What no test said is WHICH of its four accepted field sets took the record. The
+v6 set is the v5 set plus `pattern_score_basis`, so a weighted record that lost
+its basis validates cleanly as a v5 one and the merge still passes. The new
+class pins the persisted observation field set to v6, proves the v6 branch is a
+closed set rather than "v5 plus whatever else arrived", and runs the production
+gate `validate_effective_v2_state` directly. Removing the v6 branch from the
+validator fails all four.
+
+### chore(release) — resync the manifest to the registry (#324)
+
+Registry `0.20.82`, manifest `0.20.81`. The out-of-credits publish exits
+non-zero after the artifact lands, so `smart-publish.sh` returns on the tolerated
+credit signature before its commit-back runs and `main` keeps the old version.
+The next auto-bump then resolves a version the registry already has and the
+publish dies.
+
+The resync rides on this PR's own diff rather than getting a PR of its own: a
+bump-only PR is itself a release, so it re-arms the condition it repaired —
+which is what #325 demonstrated. Whoever opens the next PR here checks
+`capture-registry-baseline.sh` against `.tessl-plugin/plugin.json` first, until
+the upstream commit-back runs on the tolerated path or the org's credits reset.
+
 ## 0.20.81 — 2026-08-17
 
 ### fix(vault-ingress) — a persisted weighted score is no longer read as drift (#317)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,21 @@ existing v6 merge test reached the validator transitively.
 
 What no test said is WHICH of its four accepted field sets took the record. The
 v6 set is the v5 set plus `pattern_score_basis`, so a weighted record that lost
-its basis validates cleanly as a v5 one and the merge still passes. The new
-class pins the persisted observation field set to v6, proves the v6 branch is a
-closed set rather than "v5 plus whatever else arrived", and runs the production
-gate `validate_effective_v2_state` directly. Removing the v6 branch from the
-validator fails all four.
+its basis validates cleanly as a v5 one and the merge still passes.
+
+The new class states the v6 observation field set as a literal — not as a
+comparison against `V6_PERSISTED_PATTERN_OBSERVATION_FIELDS`, which is what the
+validator itself reads, so that comparison passes whenever the record and the
+validator agree, including when both drop the basis and the weighted contract
+quietly stops being required. A second test pins the constant to the literal, so
+moving it fails loudly instead of redefining what v6 means.
+
+It also proves the v6 branch is a closed set rather than "v5 plus whatever else
+arrived", runs the production gate `validate_effective_v2_state` directly, and
+pins what a basis-less v6 record actually hits: losing the basis leaves exactly
+the v5 field set, so the FLAT contract applies and the weighted fraction the
+record still carries is refused as a non-integer. Removing the basis from the v6
+constant fails the class; so does removing the v6 branch from the validator.
 
 ### chore(release) — resync the manifest to the registry (#324)
 

--- a/skills/vault-ingress/scripts/adherence_baseline.py
+++ b/skills/vault-ingress/scripts/adherence_baseline.py
@@ -32,9 +32,11 @@ LEGACY_GENERATION_REASON = "legacy_generation"
 CATALOG_FINGERPRINT_MISMATCH_REASON = "catalog_fingerprint_mismatch"
 SCORING_SCHEMA_VERSION_MISMATCH_REASON = "scoring_schema_version_mismatch"
 PERSISTED_EVIDENCE_STALE_REASON = "persisted_evidence_stale"
-# The scoring generation whose aggregate is confidence-weighted, and therefore
-# fractional. Mirrors `return_validation`; restated rather than imported so this
-# module keeps performing no I/O and importing nothing that loads a catalog.
+# The scoring generation whose aggregate is confidence-weighted, and so MAY be
+# fractional — a whole weighted score is valid (two strong patterns against one
+# strong antipattern is `1.0`). Mirrors `return_validation`; restated rather than
+# imported so this module keeps performing no I/O and importing nothing that
+# loads a catalog.
 WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION = 6
 PERSISTED_OBSERVATIONS_INVALID_REASON = "persisted_observations_invalid"
 EVIDENCE_BOUND_SCORING_SCHEMA_VERSION = 4
@@ -270,9 +272,10 @@ def _resolved_pattern_score(
             "nested pattern_observations.pattern_score"
         )
 
-    # A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so it is fractional
-    # by construction. The flat generation still requires an integer: a float
-    # there means arithmetic other than count-minus-count produced it.
+    # A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so it MAY be
+    # fractional and is admitted as any number. The flat generation still
+    # requires an integer: a float there means arithmetic other than
+    # count-minus-count produced it.
     require = _require_number if weighted else _require_integer
     validated_top = require(top_score, f"{filename}.pattern_score")
     validated_nested = require(

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -3795,19 +3795,33 @@ def _basis_count_typed(value: object) -> bool:
     return not isinstance(value, bool) and isinstance(value, int) and value >= 0
 
 
+def _basis_weight_typed(value: object) -> bool:
+    """A weight is a number. `True == 1.0`, so a bool is not one.
+
+    Mirrors the write-side check in `return_validation._validate_score_basis_types`
+    over the same `weights` map.
+    """
+    return not isinstance(value, bool) and isinstance(value, (int, float))
+
+
 def _basis_projection_drifted(basis: object, wanted: Mapping[str, object]) -> bool:
     """Whether a persisted basis fails to project its own detection lanes.
 
-    Value equality alone does not settle it: Python makes `True == 1` and
-    `6.0 == 6`, so a basis carrying boolean counts or a float schema version
-    compares equal to the object the lanes require and passes every later
-    reader as verified.
+    Value equality alone does not settle it: Python makes `True == 1`,
+    `True == 1.0` and `6.0 == 6`, so a basis carrying boolean counts, boolean
+    weights, or a float schema version compares equal to the object the lanes
+    require and passes every later reader as verified.
     """
     if not isinstance(basis, Mapping) or basis != wanted:
         return True
     if not _basis_count_typed(basis.get("schema_version")):
         return True
     if not _basis_count_typed(basis.get("not_evaluable_count")):
+        return True
+    weights = basis.get("weights")
+    if not isinstance(weights, Mapping) or not all(
+        _basis_weight_typed(weight) for weight in weights.values()
+    ):
         return True
     for lane in ("patterns", "antipatterns"):
         counts = basis.get(lane)

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -81,8 +81,10 @@ EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS = frozenset(
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
     }
 )
-# The scoring generation whose aggregate is confidence-weighted, and therefore
-# fractional. `CURRENT` is derived from it rather than written as a literal: a
+# The scoring generation whose aggregate is confidence-weighted, and so MAY be
+# fractional — a whole weighted score is valid (two strong patterns against one
+# strong antipattern is `1.0`). `CURRENT` is derived from it rather than written
+# as a literal: a
 # reader that wants the weighted generation must name it, exactly as
 # `return_validation` requires a reader wanting the flat one to name that.
 WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION = 6
@@ -3842,11 +3844,11 @@ def _score_projection_freshness_reasons(
 ) -> set[str]:
     """Replay the persisted score under the arithmetic its own generation declares.
 
-    A weighted aggregate sums 1.0/0.5/0.25 terms and is fractional by
-    construction; a flat one is the count difference and is an integer. They are
-    not one number computed two ways, so checking a weighted record against the
-    count difference reports every arithmetically correct score as drift — the
-    record persists and then every freshness-gated consumer refuses it (#317).
+    A weighted aggregate sums 1.0/0.5/0.25 terms and may land on a fraction; a
+    flat one is the count difference and is an integer. They are not one number
+    computed two ways, so checking a weighted record against the count
+    difference reports every arithmetically correct score as drift — the record
+    persists and then every freshness-gated consumer refuses it (#317).
     """
     reasons: set[str] = set()
     weighted = _persisted_generation_is_weighted(talk)

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -484,15 +484,16 @@ def resolve_pattern_score(observations, patterns, antipatterns, *, weighted=Fals
     the requirement in the brief has not moved the rate across four batches, so
     the tooling absorbs the variant — and recomputes rather than trusting it.
 
-    The score is count(patterns) minus count(antipatterns), so it is an INTEGER
-    by construction. `True` satisfies `isinstance(x, int)` in Python and a float
-    looks numeric; neither is a score.
+    At the FLAT generation the score is count(patterns) minus
+    count(antipatterns), so it is an INTEGER by construction. `True` satisfies
+    `isinstance(x, int)` in Python and a float looks numeric; neither is a score.
 
     A weighted return DOES reach here as of the activation (#299). Its aggregate
-    is a sum of 1.0/0.5/0.25 terms, so it is fractional by construction, and the
-    count difference is not its arithmetic. `weighted` selects which contract
-    applies; the flat one still refuses a float, because a float there means
-    some other arithmetic produced it.
+    is a sum of 1.0/0.5/0.25 terms, so it MAY be fractional and the count
+    difference is not its arithmetic — two strong patterns against one strong
+    antipattern is exactly `1.0`. `weighted` selects which contract applies; the
+    flat one still refuses a float, because a float there means some other
+    arithmetic produced it.
     """
     if "pattern_score" not in observations or observations["pattern_score"] is None:
         return None, False

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -3018,9 +3018,9 @@ def _validate_adherence_comparison(
         )
     comparison_score = comparison.get("talk_pattern_score")
     # The comparison restates the score the block already carries, so it takes
-    # that generation's type: fractional under weighted arithmetic, integer under
-    # a count difference. Requiring an integer of both would reject every valid
-    # weighted return that reports an adherence comparison.
+    # that generation's type: any number under weighted arithmetic, integer
+    # under a count difference. Requiring an integer of both would reject every
+    # valid weighted return that reports an adherence comparison.
     weighted = return_schema_version in WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS
     if isinstance(comparison_score, bool):
         numeric = False
@@ -3737,10 +3737,11 @@ def validate_persisted_v2_analysis_state(talk: dict) -> None:
             )
     score = observations["pattern_score"]
     if weighted:
-        # A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so it is
-        # fractional by construction. It is admitted ONLY at this generation:
-        # a flat score is count(patterns) minus count(antipatterns) and a float
-        # there means a different arithmetic produced it.
+        # A weighted aggregate is a sum of 1.0/0.5/0.25 terms, so it MAY be
+        # fractional — a whole one is valid, and `test_a_whole_weighted_score_
+        # stays_valid` pins that. A fraction is admitted ONLY at this
+        # generation: a flat score is count(patterns) minus count(antipatterns)
+        # and a float there means a different arithmetic produced it.
         if isinstance(score, bool) or not isinstance(score, (int, float)):
             raise ReturnValidationError(
                 "weighted persisted pattern snapshot pattern_score must be a number"

--- a/tests/test_weighted_score_persistence.py
+++ b/tests/test_weighted_score_persistence.py
@@ -713,6 +713,24 @@ class TestTheWeightedRecordReadsBackFresh:
             "pattern_score_basis_projection_drift",
         )
 
+    def test_a_boolean_weight_does_not_pass_as_the_one_it_equals(
+        self, return_validation, catalog, stored
+    ):
+        """`True == 1.0`, so the weight table needs the same type gate as the counts.
+
+        #322: the counts and the schema version were type-checked on the way
+        back out; the weights got value equality alone, so a basis claiming
+        `strong: true` replayed as the table the lanes require.
+        """
+        talk, vault, _ = stored
+        weights = talk["pattern_observations"]["pattern_score_basis"]["weights"]
+        level = next(level for level, weight in weights.items() if weight == 1.0)
+        weights[level] = True
+
+        assert self._reasons(return_validation, talk, vault, catalog) == (
+            "pattern_score_basis_projection_drift",
+        )
+
     def test_an_unstamped_record_is_replayed_under_no_arithmetic_at_all(
         self, return_validation, catalog, stored
     ):

--- a/tests/test_weighted_score_persistence.py
+++ b/tests/test_weighted_score_persistence.py
@@ -593,6 +593,81 @@ class TestAWeightedReturnReachesTheDatabase:
             )
 
 
+class TestTheMergedWeightedRecordValidatesAsPersistedState:
+    """#299's last bullet: the chain runs to `validate_persisted_v2_analysis_state`.
+
+    `TestAWeightedReturnReachesTheDatabase` stops at `merge_talk`, so the
+    weighted shape was never put to the validator that gates publication —
+    `persist-results.validate_effective_v2_state` and `write-analysis` both
+    call it, and it accepts a snapshot only when the observation field set is
+    one of four exact sets. A v6 record reaching it while only the v5 branch
+    was wired would read as "noncanonical fields" at the first real persist.
+    """
+
+    @pytest.fixture
+    def catalog(self, return_validation):
+        return _weighted_catalog(return_validation)
+
+    @pytest.fixture
+    def stored(
+        self,
+        persist_results,
+        return_validation,
+        transcript_timing,
+        tmp_path,
+        catalog,
+    ):
+        raw, _ = _v6_return(return_validation, catalog, bare=True)
+        talk, _ = _merge_v6(
+            persist_results,
+            return_validation,
+            transcript_timing,
+            tmp_path,
+            catalog,
+            raw,
+        )
+        return talk
+
+    def test_a_merged_weighted_record_validates_as_persisted_state(
+        self, return_validation, stored
+    ):
+        return_validation.validate_persisted_v2_analysis_state(stored)
+
+    def test_it_validated_on_the_weighted_branch_and_not_a_laxer_one(
+        self, return_validation, stored
+    ):
+        """Four field sets are accepted, so "it validated" names no branch.
+
+        The v6 set is v5 plus the basis, so a record that lost its basis
+        validates cleanly as a v5 one. Pinning the set is what distinguishes
+        the weighted shape reaching its own branch from it falling through.
+        """
+        assert set(stored["pattern_observations"]) == set(
+            return_validation.V6_PERSISTED_PATTERN_OBSERVATION_FIELDS
+        )
+
+    def test_the_weighted_shape_is_a_closed_set_at_this_validator(
+        self, return_validation, stored
+    ):
+        """Otherwise the v6 branch reads as "v5 plus whatever else you sent"."""
+        stored["pattern_observations"]["pattern_score_provenance"] = "worker"
+
+        with pytest.raises(
+            return_validation.ReturnValidationError, match="noncanonical fields"
+        ):
+            return_validation.validate_persisted_v2_analysis_state(stored)
+
+    def test_the_production_gate_accepts_it_through_the_same_call(
+        self, persist_results, return_validation, stored
+    ):
+        """`validate_effective_v2_state` is what persist-results actually runs."""
+        persist_results.validate_effective_v2_state(
+            stored,
+            stored["structured_data"],
+            pattern_snapshot_replaced=True,
+        )
+
+
 class TestTheWeightedRecordReadsBackFresh:
     """#317: the record persisted, and then every consumer refused it.
 

--- a/tests/test_weighted_score_persistence.py
+++ b/tests/test_weighted_score_persistence.py
@@ -633,18 +633,66 @@ class TestTheMergedWeightedRecordValidatesAsPersistedState:
     ):
         return_validation.validate_persisted_v2_analysis_state(stored)
 
-    def test_it_validated_on_the_weighted_branch_and_not_a_laxer_one(
-        self, return_validation, stored
-    ):
+    def test_it_validated_on_the_weighted_branch_and_not_a_laxer_one(self, stored):
         """Four field sets are accepted, so "it validated" names no branch.
 
         The v6 set is v5 plus the basis, so a record that lost its basis
         validates cleanly as a v5 one. Pinning the set is what distinguishes
         the weighted shape reaching its own branch from it falling through.
+
+        Spelled out rather than compared against
+        `V6_PERSISTED_PATTERN_OBSERVATION_FIELDS`: that constant is what the
+        validator itself reads, so comparing the record to it passes whenever
+        the record and the validator agree — including when both drop
+        `pattern_score_basis` and the weighted contract quietly stops being
+        required. The literal is the independent statement of the shape;
+        `test_the_declared_v6_shape_is_the_one_the_validator_enforces` pins the
+        constant to it, so moving the constant fails here rather than silently
+        redefining what v6 means.
         """
-        assert set(stored["pattern_observations"]) == set(
-            return_validation.V6_PERSISTED_PATTERN_OBSERVATION_FIELDS
+        assert set(stored["pattern_observations"]) == {
+            "antipattern_ids",
+            "antipatterns_detected",
+            "applicability_assessments",
+            "evidence_schema_version",
+            "evidence_sources",
+            "not_evaluable",
+            "not_evaluable_ids",
+            "opportunity_coverage_identity",
+            "pattern_ids",
+            "pattern_outcomes",
+            "pattern_score",
+            "pattern_score_basis",
+            "patterns_detected",
+            "source_inspection",
+        }
+
+    def test_the_declared_v6_shape_is_the_one_the_validator_enforces(
+        self, return_validation, stored
+    ):
+        """Ties the literal above to the constant without either defining the other."""
+        assert set(return_validation.V6_PERSISTED_PATTERN_OBSERVATION_FIELDS) == set(
+            stored["pattern_observations"]
         )
+
+    def test_a_weighted_record_that_loses_its_basis_is_refused(
+        self, return_validation, stored
+    ):
+        """The basis is not decoration on a v6 record; it is what makes it v6.
+
+        Dropping it leaves exactly the v5 field set, so the validator applies
+        the FLAT contract — and the flat contract's score is
+        count(patterns) minus count(antipatterns), an integer. The weighted
+        fraction the record still carries is what fails. A weighted number with
+        no arithmetic behind it never reaches a reader.
+        """
+        stored["pattern_observations"].pop("pattern_score_basis")
+
+        with pytest.raises(
+            return_validation.ReturnValidationError,
+            match="pattern_score must be an integer",
+        ):
+            return_validation.validate_persisted_v2_analysis_state(stored)
 
     def test_the_weighted_shape_is_a_closed_set_at_this_validator(
         self, return_validation, stored


### PR DESCRIPTION
Closes #322, #313, #299. Carries the #324 manifest resync.

## The fix — #322

`_basis_projection_drifted` type-checked the persisted basis's `schema_version`, its `not_evaluable_count`, and both lane count maps, then settled the `weights` map on value equality alone. `True == 1.0` in Python, so a basis carrying `{"strong": true, "moderate": 0.5, "weak": 0.25}` compared equal to the weight table its lanes require and the record reported fresh. Every reader afterwards believed the shape had been verified.

The write side already refuses it — `return_validation._validate_score_basis_types` loops the same map rejecting bools. This is the read-side half of that guard, which is the half that matters for a record already in the database: a persisted record is a hint, not authority.

The test fails without the fix and passes with it (verified by reverting the production change).

## The wording — #313

Two comments were reported. Four more of the same shape turned up in the audit, so six sites moved:

- `persist-results.py` — "count(patterns) minus count(antipatterns), so it is an INTEGER by construction" now names the flat generation.
- `adherence_baseline.py` (×2), `pattern_evidence.py` (×2), `return_validation.py` — "confidence-weighted, and therefore fractional" now reads "MAY be fractional".

A weighted aggregate can be whole — two strong patterns against one strong antipattern is exactly `1.0` — and `test_a_whole_weighted_score_stays_valid` pins that case, so the comments contradicted a test shipped in the same change. Comment wording only, no behavior change.

## The coverage — #299

Correcting the issue's own framing: the chain it asked for was already running. `merge_talk` calls `validate_effective_v2_state` before it returns (`persist-results.py:839`), so every existing v6 merge test reached `validate_persisted_v2_analysis_state` transitively.

What no test said is **which** of the validator's four accepted field sets took the record. The v6 set is the v5 set plus `pattern_score_basis`, so a weighted record that lost its basis validates cleanly as a v5 one and the merge still passes — "it validated" named no branch. The new class pins the persisted observation field set to v6, proves the v6 branch is a closed set rather than "v5 plus whatever else arrived", and calls the production gate directly. Removing the v6 branch from the accepted sets fails all four.

## The manifest — #324

Registry `0.20.82`, manifest was `0.20.81`. The out-of-credits publish exits non-zero after the artifact lands, so `smart-publish.sh` returns on the tolerated credit signature before its commit-back runs and `main` keeps the old version; the next auto-bump then resolves a version the registry already has and the publish dies.

The resync rides on this diff rather than getting a PR of its own, because a bump-only PR is itself a release and re-arms the condition it repaired — which is what #325 demonstrated. #324 stays open: this clears the collision for this round, it does not fix the commit-back.

## Gates

`ruff check`, `ruff format --check`, `pyright` (0 findings), `tessl plugin lint`, and 5839 passed / 3 skipped locally. Commits are split one-per-issue and each is independently green.