### PR TITLE
chore(ci): pin the publish workflow to the registry-aware bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,11 @@ permissions:
 
 jobs:
   publish:
-    uses: jbaruch/coding-policy/.github/workflows/publish-plugin.yml@af116ebf18a7c46a672bf176064908736bc8ac28
+    # Pinned to a SHA carrying smart-publish's REGISTRY-aware auto-bump
+    # (coding-policy#298). The previous pin computed the next version from the
+    # manifest alone, which collides whenever a credit-outage run skips the
+    # manifest commit-back and main falls behind the registry — the #324 chore.
+    uses: jbaruch/coding-policy/.github/workflows/publish-plugin.yml@c7d8f6395d89cf206de1570c4d882ff3e2c22dca
     secrets:
       TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
     with:

--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/speaker-toolkit",
-  "version": "0.20.82",
+  "version": "0.20.83",
   "description": "Six-skill presentation system: ingest talks into a rhetoric vault, run interactive clarification, generate a speaker profile, create presentations that match your documented patterns, produce the deck illustrations + thumbnail visual layer, and publish talk pages to a Jekyll shownotes site. Includes a 111-entry Presentation Patterns taxonomy (81 observable: 62 patterns + 19 antipatterns; 30 unobservable: 21 patterns + 9 antipatterns) for scoring, brainstorming, and go-live preparation.",
   "private": false,
   "skills": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### chore(ci) — pin the publish workflow to the registry-aware bump (#324)
+
+The publish pin was `af116eb` (2026-08-16). `smart-publish.sh` became
+REGISTRY-aware in coding-policy#298 the following day, so this repo was still
+computing the next version from the manifest alone — which collides the moment a
+credit-outage run skips the manifest commit-back and `main` falls behind the
+registry.
+
+That is the whole of the #324 chore. The manual per-release resync was working
+around a stale pin, not an unfixable pipeline: the new bump reads
+registry-empty -> manifest, manifest-strictly-ahead -> manifest, otherwise
+registry latest + one patch, so a lagging manifest stops being able to collide.
+
+Inputs are backward compatible (the new revision only adds `node-version`, with
+a default), and coding-policy publishes itself on this revision. Manifest
+resynced to `0.20.83` in the same change so the state is honest either way.
+
 ## 0.20.83 — 2026-08-18
 
 ### fix(vault-ingress) — a boolean weight no longer passes the freshness replay (#322)


### PR DESCRIPTION
**This PR is a CI configuration change and nothing else** — its stated scope is the publish workflow pin, per `rules/ci-safety.md` Hands Off CI Config.

## What this actually fixes

#324 has been treated as an unfixable-here pipeline defect, worked around by hand-resyncing `.tessl-plugin/plugin.json` on every release. It isn't. It's a stale pin.

- speaker-toolkit pinned `af116eb` — **2026-08-16**
- `smart-publish.sh` became REGISTRY-aware in coding-policy#298 — **2026-08-17**

So this repo has been running the old manifest-based `--bump patch` the whole time, which is exactly what collides once a credit-outage run skips the commit-back and `main` falls behind the registry.

## Why the new bump can't collide

`compute_target_version` (see `skills/release/smart-publish.sh`, the three rules above the function):

| condition | target |
|---|---|
| registry empty | the manifest version |
| manifest strictly ahead of registry | the manifest version |
| otherwise | **registry latest + one patch** |

Our state after merge is registry `0.20.83`, manifest `0.20.83` — not strictly ahead, so the target is `0.20.84`, always a free version. A lagging manifest becomes cosmetic instead of fatal.

The commit-back may still skip during the credit outage. That no longer matters, which is the point.

## Verified before pinning

- **Input compatibility** — the new revision only *adds* `node-version` (with a default). The three inputs this caller passes (`stamp-changelog`, `pre-publish-script`, `skill-review-credit-outage`) keep their names and semantics, and `scripts/pre-publish-checks.sh` still exists.
- **The revision works in production** — coding-policy publishes itself on it (currently `0.3.164`).
- **The earlier attempt's failure was unrelated.** Run 32075194312 ("bump the reusable publish workflow") failed at *Confirm publish landed* with `nothing landed — the registry is still at baseline 0.20.80`. That was the collision itself during the stale-manifest window, not an incompatibility with the newer workflow.
- Workflow parses; `ruff check` and `tessl plugin lint` clean.

## Manifest

Resynced `0.20.82 → 0.20.83` in the same change. Under the new pin it isn't required, but it keeps the recorded state honest and makes the merge safe under either pin.

## What to watch on merge

The publish should resolve `0.20.84`. If the commit-back still skips, `main` will read `0.20.83` against a registry at `0.20.84` — and the *next* release should then resolve `0.20.85` on its own, with no hand-resync. That is the behaviour change this PR is for, and #324 stays open until a release demonstrates it.