### PR TITLE
fix(vault-ingress): bind a deck identity assessment to the bytes it read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ no `visual_evidence`, so there is nothing to cross-check and the requirement
 narrows to the assessment naming a generation at all. Requiring the extraction
 fingerprint would have inverted the order this issue establishes.
 
+A `source_identity` is held to the same contract as the extractor's
+fingerprint — algorithm `sha256`, a 64-character lowercase hex digest, a
+positive integer size. The two are compared to each other, so a looser reading
+would have let an assessment claim a generation the database itself refuses;
+`{"algorithm": "x", "digest": "x", "size_bytes": 0}` is not a deck anything
+could have read. `tracking_database` imports this module, so the contract is
+mirrored rather than imported, and a test pins the two together.
+
 The sweep brackets the fact read with a fingerprint on each side. The facts and
 the digest come from two separate opens of the same path, so a deck replaced in
 that window would hand generation B's digest to a verdict derived from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ no `visual_evidence`, so there is nothing to cross-check and the requirement
 narrows to the assessment naming a generation at all. Requiring the extraction
 fingerprint would have inverted the order this issue establishes.
 
+The sweep brackets the fact read with a fingerprint on each side. The facts and
+the digest come from two separate opens of the same path, so a deck replaced in
+that window would hand generation B's digest to a verdict derived from
+generation A's facts — and a later check against B would then accept it,
+defeating the byte-binding entirely. A deck that is not byte-identical on both
+sides yields no verdict: the row reports `binding_unassessable` with
+`identity_source_unstable_during_read` rather than an assessment stamped with a
+generation it cannot vouch for. Raised by the policy reviewer on #329, against a
+comment that claimed the single-pass property the code did not have.
+
 The generation check runs last in the refusal order. Everything above it asks
 whether the assessment is a coherent proof; this asks whether it is a proof
 about the bytes that are there now, and running it earlier would mask a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,16 +42,26 @@ would have let an assessment claim a generation the database itself refuses;
 could have read. `tracking_database` imports this module, so the contract is
 mirrored rather than imported, and a test pins the two together.
 
-`read_deck_identity_facts` digests the descriptor it already holds and returns
-that generation with the facts, so the two are the same bytes by construction.
-Collecting them separately does not work, and the policy reviewer caught both
-ways of getting it wrong: fingerprinting the path in a second open lets a deck
-replaced between the opens hand generation B's digest to facts read from A, and
-bracketing the read with a fingerprint on each side is walked straight through
-by an A→B→A replacement, where `before == after` while the facts came from B.
-Two opens of one path are not two views of one file. A descriptor keeps pointing
-at the inode it was opened on, which is what removes the window rather than
-narrowing it.
+`read_deck_identity_facts` copies the deck into a private spool once, digesting
+as it copies, and parses that snapshot. The digest and the facts are then the
+same bytes by construction.
+
+Three weaker versions were tried and each was defeated, all three caught by the
+policy reviewer:
+
+- fingerprinting the path in a second open — a deck replaced between the opens
+  hands generation B's digest to facts parsed from A;
+- bracketing the read with a fingerprint on each side — an A→B→A replacement
+  walks straight through it, since `before == after` while the facts came
+  from B;
+- digest-then-seek-then-parse on one descriptor — survives the path being
+  repointed, but a descriptor does not freeze the inode, so a writer that
+  truncates and overwrites the same file between the two reads still yields an
+  identity describing different bytes from the facts.
+
+The window is not narrowable by comparing more, because every version above
+reads the live file twice. Copying once removes the second read instead of
+racing it.
 
 The generation check runs last in the refusal order. Everything above it asks
 whether the assessment is a coherent proof; this asks whether it is a proof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,15 +42,16 @@ would have let an assessment claim a generation the database itself refuses;
 could have read. `tracking_database` imports this module, so the contract is
 mirrored rather than imported, and a test pins the two together.
 
-The sweep brackets the fact read with a fingerprint on each side. The facts and
-the digest come from two separate opens of the same path, so a deck replaced in
-that window would hand generation B's digest to a verdict derived from
-generation A's facts — and a later check against B would then accept it,
-defeating the byte-binding entirely. A deck that is not byte-identical on both
-sides yields no verdict: the row reports `binding_unassessable` with
-`identity_source_unstable_during_read` rather than an assessment stamped with a
-generation it cannot vouch for. Raised by the policy reviewer on #329, against a
-comment that claimed the single-pass property the code did not have.
+`read_deck_identity_facts` digests the descriptor it already holds and returns
+that generation with the facts, so the two are the same bytes by construction.
+Collecting them separately does not work, and the policy reviewer caught both
+ways of getting it wrong: fingerprinting the path in a second open lets a deck
+replaced between the opens hand generation B's digest to facts read from A, and
+bracketing the read with a fingerprint on each side is walked straight through
+by an A→B→A replacement, where `before == after` while the facts came from B.
+Two opens of one path are not two views of one file. A descriptor keeps pointing
+at the inode it was opened on, which is what removes the window rather than
+narrowing it.
 
 The generation check runs last in the refusal order. Everything above it asks
 whether the assessment is a coherent proof; this asks whether it is a proof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+### fix(vault-ingress) — bind a deck's identity assessment to the bytes it read (#176)
+
+`binding_refusal` pinned an assessment to its deck by `pptx_path` — a path
+string. Replace the file at that path and the stored `matched` verdict still
+stood, so the new deck's slide counts, OCR and pattern observations became that
+talk's evidence under a proof made about different bytes. That is the exact
+failure this issue exists to stop, surviving its own fix.
+
+`PPTX_TALK_IDENTITY_SCHEMA_VERSION` is 2, and an assessment now records the
+`source_identity` it was reached against, in the same
+`{algorithm, digest, size_bytes}` shape `visual_evidence.source_fingerprint`
+already uses. A v1 assessment cannot be upgraded — nothing recorded which bytes
+it read — so it refuses as `identity_assessment_schema_unsupported` and reads as
+unproven, the position `unassessed_legacy_binding` already takes for the same
+reason: a proof that was not witnessed cannot be manufactured.
+
+The observation is a REQUIRED argument, never defaulted, so a caller states
+which case it is in:
+
+- `preflight-vault.py` digests the deck and compares, catching the swap. A deck
+  it cannot read is its own blocking finding,
+  `pptx_talk_binding_source_unobservable` — passing `None` there would read as
+  "no observation available" and fall through.
+- `mutate-tracking-database.py` takes a database and a plan and never touches
+  the vault, so it passes `None`. That still requires the assessment to name a
+  generation, and cross-checks it against the record's own extraction
+  fingerprint when the record has one — two independent producers disagreeing
+  about which deck a row is means one describes a different file.
+
+Identity is still verified BEFORE extraction: a freshly catalogued row carries
+no `visual_evidence`, so there is nothing to cross-check and the requirement
+narrows to the assessment naming a generation at all. Requiring the extraction
+fingerprint would have inverted the order this issue establishes.
+
+The generation check runs last in the refusal order. Everything above it asks
+whether the assessment is a coherent proof; this asks whether it is a proof
+about the bytes that are there now, and running it earlier would mask a
+malformed assessment behind a generation complaint.
+
 ## 0.20.84 — 2026-08-18
 
 ### chore(ci) — pin the publish workflow to the registry-aware bump (#324)

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -87,13 +87,24 @@ v2, and v3.
   and the new deck's contents became that talk's evidence. A v1 assessment
   cannot be upgraded — nothing recorded which bytes it read — so it refuses as
   `identity_assessment_schema_unsupported` and reads as unproven.
-- `binding_refusal` takes the caller's own observation as a required argument.
-  `preflight-vault.py` digests the deck and passes what it saw, so a swapped
-  deck is caught; `mutate-tracking-database.py` never touches the vault and
-  passes `None`, which still requires the assessment to name a generation but
-  makes no comparison. `None` from a caller that COULD look would be fail-open,
-  so preflight reports an unreadable deck as its own blocking finding
+- `binding_refusal` takes the caller's own observation as a required argument,
+  and the two callers supply different things. `preflight-vault.py` digests the
+  live deck, so a deck swapped at the same path is caught. The writer never
+  touches the vault, so it supplies the record's own
+  `visual_evidence.source_fingerprint` when the record has one and `None` when
+  it does not — see `_record_source_fingerprint` and the
+  `_require_bound_identity_assessment` docstring in
+  `skills/vault-ingress/scripts/mutate-tracking-database.py` for which case
+  applies. `None` never means "accepted": the assessment must still carry a
+  valid `source_identity`, which is what refuses every v1 assessment. A caller
+  that COULD look must not pass `None` to skip the comparison, so preflight
+  reports an unreadable deck as its own blocking finding
   (`pptx_talk_binding_source_unobservable`) instead.
+- A `source_identity` is held to the same contract as
+  `visual_evidence.source_fingerprint`: algorithm `sha256`, a 64-character
+  lowercase hex digest, and a positive integer `size_bytes`. The two are
+  compared to each other, so a looser reading would let an assessment claim a
+  generation the database itself would refuse.
 - Readers validate v3 shape only — that the field is null exactly when
   `talk_filename` is null, and an object otherwise. The binding's semantics are
   the writer's gate, matching how `visual_evidence` is handled.
@@ -370,7 +381,7 @@ customization, not the owner default. See the
       "reason_codes": ["identity_matched"],
       "source_identity": {
         "algorithm": "sha256",
-        "digest": "3b1f...  (64 lowercase hex characters)",
+        "digest": "3b1f8c2d4e6a90b7c5d3e1f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f80a1b",
         "size_bytes": 4096
       },
       "candidates": [

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -80,6 +80,20 @@ v2, and v3.
   selecting signals reach `agreeing` — the example's agreeing `delivery_year`
   and `filename_similarity` report without electing, which is why they appear in
   `signals` and not in `agreeing`.
+- v2 of the assessment adds `source_identity`: the deck generation the verdict
+  was reached against, in the same `{algorithm, digest, size_bytes}` shape as
+  `visual_evidence.source_fingerprint`. v1 pinned an assessment to `pptx_path`
+  alone, so replacing the file at that path left the `matched` verdict standing
+  and the new deck's contents became that talk's evidence. A v1 assessment
+  cannot be upgraded — nothing recorded which bytes it read — so it refuses as
+  `identity_assessment_schema_unsupported` and reads as unproven.
+- `binding_refusal` takes the caller's own observation as a required argument.
+  `preflight-vault.py` digests the deck and passes what it saw, so a swapped
+  deck is caught; `mutate-tracking-database.py` never touches the vault and
+  passes `None`, which still requires the assessment to name a generation but
+  makes no comparison. `None` from a caller that COULD look would be fail-open,
+  so preflight reports an unreadable deck as its own blocking finding
+  (`pptx_talk_binding_source_unobservable`) instead.
 - Readers validate v3 shape only — that the field is null exactly when
   `talk_filename` is null, and an object otherwise. The binding's semantics are
   the writer's gate, matching how `visual_evidence` is handled.
@@ -348,12 +362,17 @@ customization, not the owner default. See the
       }
     },
     "identity_assessment": {
-      "schema_version": 1,
+      "schema_version": 2,
       "pptx_path": "Conference/Year/Talk Name.pptx",
       "verdict": "matched",
       "artifact_role": "delivery",
       "selected_talk_filename": "2024-04-10-talk-slug.md",
       "reason_codes": ["identity_matched"],
+      "source_identity": {
+        "algorithm": "sha256",
+        "digest": "3b1f...  (64 lowercase hex characters)",
+        "size_bytes": 4096
+      },
       "candidates": [
         {
           "talk_filename": "2024-04-10-talk-slug.md",

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1221,9 +1221,11 @@ def _require_bound_identity_assessment(
     inconsistent plan: the fingerprint is produced by the extractor and the
     identity by the sweep, so two independent producers disagreeing about which
     deck this row is means one of them is describing a different file. A record
-    carrying no extraction evidence yet has nothing to cross-check, and there
-    the requirement narrows to the assessment naming a generation at all — which
-    is what refuses every v1 assessment, none of which recorded one.
+    carrying no extraction evidence yet has nothing to cross-check, so the
+    cross-check is SKIPPED, not failed — identity is verified before extraction,
+    and demanding a receipt here would invert that order. What still holds in
+    that case is that the assessment must carry a valid `source_identity` at
+    all, which is what refuses every v1 assessment, none of which recorded one.
 
     Both endpoints are checked because an assessment binds a pair. Verifying the
     talk alone leaves the deck free: a real, correctly-decided assessment for

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1181,10 +1181,12 @@ def _apply_sever_pptx_talk_binding(
 def _record_source_fingerprint(record: Mapping[str, Any]) -> Mapping[str, Any] | None:
     """The deck generation this record's own extraction evidence names.
 
-    `None` when the record carries no visual evidence yet, which is a real
-    state for a freshly catalogued deck and not a defect. It makes the
-    cross-check unavailable, and an unavailable cross-check refuses rather than
-    passes.
+    `None` when the record carries no visual evidence yet, which is a real state
+    for a freshly catalogued deck and not a defect: identity is verified BEFORE
+    extraction, so a row bound at that point has no receipt to cross-check
+    against. `None` SKIPS the comparison rather than failing it. What still
+    holds is the requirement that the assessment carry a valid
+    `source_identity` of its own, which is what refuses every v1 assessment.
     """
     evidence = record.get("visual_evidence")
     if not isinstance(evidence, Mapping):

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -18,7 +18,7 @@ import os
 from pathlib import Path
 import re
 import sys
-from typing import Any, NoReturn
+from typing import Any, Mapping, NoReturn
 
 from tracking_database import (
     CONFIG_RECORD_SCHEMA_VERSION,
@@ -1178,11 +1178,27 @@ def _apply_sever_pptx_talk_binding(
     )
 
 
+def _record_source_fingerprint(record: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """The deck generation this record's own extraction evidence names.
+
+    `None` when the record carries no visual evidence yet, which is a real
+    state for a freshly catalogued deck and not a defect. It makes the
+    cross-check unavailable, and an unavailable cross-check refuses rather than
+    passes.
+    """
+    evidence = record.get("visual_evidence")
+    if not isinstance(evidence, Mapping):
+        return None
+    fingerprint = evidence.get("source_fingerprint")
+    return fingerprint if isinstance(fingerprint, Mapping) else None
+
+
 def _require_bound_identity_assessment(
     assessment: object,
     *,
     pptx_path: str,
     talk_filename: str | None,
+    observed_source_identity: Mapping[str, Any] | None,
     label: str,
 ) -> None:
     """Refuse a talk binding the assessment does not actually prove.
@@ -1196,6 +1212,19 @@ def _require_bound_identity_assessment(
     assessment must be a `matched` verdict, it must be ABOUT this record's deck,
     it must name THIS record's talk, and it must be for a delivery artifact.
 
+    A fifth now rides along: the assessment must name the deck GENERATION it
+    read, and that generation must agree with the record's own extraction
+    fingerprint. Be clear about how strong that is. This writer takes a database
+    and a plan and never touches the vault, so it CANNOT compare the assessment
+    against the bytes on disk — `preflight-vault.py` is the authority that does,
+    because it observes the deck. What this catches is an internally
+    inconsistent plan: the fingerprint is produced by the extractor and the
+    identity by the sweep, so two independent producers disagreeing about which
+    deck this row is means one of them is describing a different file. A record
+    carrying no extraction evidence yet has nothing to cross-check, and there
+    the requirement narrows to the assessment naming a generation at all — which
+    is what refuses every v1 assessment, none of which recorded one.
+
     Both endpoints are checked because an assessment binds a pair. Verifying the
     talk alone leaves the deck free: a real, correctly-decided assessment for
     deck A pasted onto deck B's record would pass every other check and bind B's
@@ -1208,7 +1237,10 @@ def _require_bound_identity_assessment(
             )
         return
     refusal = binding_refusal(
-        assessment, pptx_path=pptx_path, talk_filename=talk_filename
+        assessment,
+        pptx_path=pptx_path,
+        talk_filename=talk_filename,
+        observed_source_identity=observed_source_identity,
     )
     if refusal is not None:
         raise TrackingDatabaseMutationError(
@@ -1292,6 +1324,7 @@ def _apply_record_pptx(
         record.get("identity_assessment"),
         pptx_path=pptx_path,
         talk_filename=talk_filename,
+        observed_source_identity=_record_source_fingerprint(record),
         label=f"{record_label}.identity_assessment",
     )
     records = _collection(database, "pptx_catalog")

--- a/skills/vault-ingress/scripts/pptx_deck_facts.py
+++ b/skills/vault-ingress/scripts/pptx_deck_facts.py
@@ -48,7 +48,8 @@ import os
 import posixpath
 import re
 import zipfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+import hashlib
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -135,6 +136,10 @@ class DeckFactsReading:
     reason_code: str
     slide_count: int | None = None
     parts_read: tuple[str, ...] = field(default=())
+    # The generation these exact facts were read from, digested from the SAME
+    # open descriptor that produced them. `None` when the package could not be
+    # opened at all.
+    source_identity: dict[str, Any] | None = None
 
     @property
     def package_read(self) -> bool:
@@ -342,13 +347,40 @@ def read_deck_identity_facts(
         )
     try:
         with os.fdopen(descriptor, "rb", closefd=True) as handle:
-            return _read_from_stream(handle, path_text, facts)
+            # Digest and parse from ONE descriptor, then rewind. Digesting by
+            # path in a second open is what let an A->B->A replacement hand
+            # generation A's digest to facts read from B: two opens of one path
+            # are not two views of one file. A descriptor keeps pointing at the
+            # inode it was opened on, so bytes hashed here and bytes parsed
+            # below are provably the same generation, and no before/after
+            # bracket can substitute for that.
+            identity = _digest_stream(handle)
+            handle.seek(0)
+            reading = _read_from_stream(handle, path_text, facts)
+            return replace(reading, source_identity=identity)
     except (OSError, ValueError):
         return DeckFactsReading(
             pptx_path=path_text,
             facts=facts,
             reason_code=DECK_FACTS_UNREADABLE,
         )
+
+
+_DIGEST_CHUNK_BYTES = 1024 * 1024
+
+
+def _digest_stream(handle: Any) -> dict[str, Any]:
+    """SHA-256 and byte length of an already-open deck, in the fingerprint shape.
+
+    Deliberately takes a handle, never a path: the point is that the caller
+    already holds the descriptor whose bytes become the facts.
+    """
+    digest = hashlib.sha256()
+    size = 0
+    for chunk in iter(lambda: handle.read(_DIGEST_CHUNK_BYTES), b""):
+        digest.update(chunk)
+        size += len(chunk)
+    return {"algorithm": "sha256", "digest": digest.hexdigest(), "size_bytes": size}
 
 
 def _read_from_stream(

--- a/skills/vault-ingress/scripts/pptx_deck_facts.py
+++ b/skills/vault-ingress/scripts/pptx_deck_facts.py
@@ -50,6 +50,7 @@ import re
 import zipfile
 from dataclasses import dataclass, field, replace
 import hashlib
+import tempfile
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -347,17 +348,27 @@ def read_deck_identity_facts(
         )
     try:
         with os.fdopen(descriptor, "rb", closefd=True) as handle:
-            # Digest and parse from ONE descriptor, then rewind. Digesting by
-            # path in a second open is what let an A->B->A replacement hand
-            # generation A's digest to facts read from B: two opens of one path
-            # are not two views of one file. A descriptor keeps pointing at the
-            # inode it was opened on, so bytes hashed here and bytes parsed
-            # below are provably the same generation, and no before/after
-            # bracket can substitute for that.
-            identity = _digest_stream(handle)
-            handle.seek(0)
-            reading = _read_from_stream(handle, path_text, facts)
-            return replace(reading, source_identity=identity)
+            # Copy the deck into a private spool ONCE, digesting as it goes, and
+            # do every later read against that copy. Nothing weaker holds:
+            #
+            #  * digesting by path in a second open lets an A->B->A replacement
+            #    hand generation A's digest to facts parsed from B;
+            #  * bracketing the read with a fingerprint on each side is walked
+            #    through by the same A->B->A shape, since before == after;
+            #  * digest-then-seek-then-parse on one descriptor survives path
+            #    replacement but NOT in-place mutation — a writer that truncates
+            #    or overwrites the inode between the two reads still yields an
+            #    identity describing different bytes from the facts.
+            #
+            # Only a copy the vault cannot reach is immune, because it removes
+            # the second read of the live file rather than racing it.
+            with tempfile.SpooledTemporaryFile(
+                max_size=_SPOOL_TO_DISK_BYTES, mode="w+b"
+            ) as snapshot:
+                identity = _copy_and_digest(handle, snapshot)
+                snapshot.seek(0)
+                reading = _read_from_stream(snapshot, path_text, facts)
+                return replace(reading, source_identity=identity)
     except (OSError, ValueError):
         return DeckFactsReading(
             pptx_path=path_text,
@@ -367,19 +378,25 @@ def read_deck_identity_facts(
 
 
 _DIGEST_CHUNK_BYTES = 1024 * 1024
+# Decks run to tens of megabytes, so the snapshot spills to disk past this
+# rather than being held whole in memory. Correctness does not depend on the
+# threshold — a spooled file is equally private either side of it.
+_SPOOL_TO_DISK_BYTES = 8 * 1024 * 1024
 
 
-def _digest_stream(handle: Any) -> dict[str, Any]:
-    """SHA-256 and byte length of an already-open deck, in the fingerprint shape.
+def _copy_and_digest(source: Any, destination: Any) -> dict[str, Any]:
+    """Copy a deck into a private spool, returning the generation it copied.
 
-    Deliberately takes a handle, never a path: the point is that the caller
-    already holds the descriptor whose bytes become the facts.
+    One pass over the live file, which is the whole point: the digest describes
+    exactly the bytes that landed in the snapshot, and every later read is
+    against the snapshot, so no concurrent writer can put the two out of step.
     """
     digest = hashlib.sha256()
     size = 0
-    for chunk in iter(lambda: handle.read(_DIGEST_CHUNK_BYTES), b""):
+    for chunk in iter(lambda: source.read(_DIGEST_CHUNK_BYTES), b""):
         digest.update(chunk)
         size += len(chunk)
+        destination.write(chunk)
     return {"algorithm": "sha256", "digest": digest.hexdigest(), "size_bytes": size}
 
 

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import posixpath
 import re
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence, TypeGuard
 
 from source_identity_matching import (
     AMBIGUOUS_EVENT_ALIASES,
@@ -45,7 +45,16 @@ from source_identity_matching import (
 )
 
 
-PPTX_TALK_IDENTITY_SCHEMA_VERSION = 1
+# v2 binds the assessment to the deck GENERATION it was made against, not just
+# to the deck's path. v1 compared `assessment["pptx_path"]` to the row's path,
+# so replacing the file at that path left the `matched` verdict standing and the
+# new deck's slides, OCR and pattern observations became that talk's evidence
+# under a proof made about different bytes — the #176 failure surviving its own
+# fix. A v1 assessment cannot be upgraded in place: nothing recorded which bytes
+# it read, so it falls to `identity_assessment_schema_unsupported` and reads as
+# unproven, the same position `unassessed_legacy_binding` takes for the same
+# reason (a proof not witnessed cannot be manufactured).
+PPTX_TALK_IDENTITY_SCHEMA_VERSION = 2
 
 # Signal verdicts. `unknown` is the honest default: a fact the deck does not
 # carry is not evidence for or against any candidate.
@@ -107,6 +116,13 @@ REASON_NON_DELIVERY_ARTIFACT = "identity_non_delivery_artifact"
 # existed. The binding is not declared wrong — it is declared unproven, which is
 # the honest reading and the one that routes it to review instead of trusting it.
 REASON_UNASSESSED_LEGACY_BINDING = "identity_unassessed_legacy_binding"
+# The deck could not be observed at refusal time, so the stored generation could
+# not be compared to anything. Distinct from a mismatch: "we looked and it
+# differs" and "we could not look" are different findings, and collapsing them
+# would let an unreadable deck read as a passing comparison.
+REASON_SOURCE_UNOBSERVABLE = "identity_source_unobservable"
+# The assessment names a different generation of this deck than the one on disk.
+REASON_GENERATION_STALE = "identity_generation_stale"
 
 REASON_CODES = frozenset(
     {
@@ -247,6 +263,11 @@ class TalkIdentityAssessment:
     artifact_role: str
     selected_talk_filename: str | None
     reason_codes: tuple[str, ...]
+    # The deck generation this verdict was reached against. `None` means the
+    # deck could not be digested at assessment time; the verdict still records
+    # what the facts showed, and `binding_refusal` refuses to authorize a
+    # binding it cannot pin to bytes.
+    source_identity: Mapping[str, Any] | None = None
     candidates: tuple[CandidateAssessment, ...] = field(default=())
 
     @property
@@ -265,6 +286,9 @@ class TalkIdentityAssessment:
             "artifact_role": self.artifact_role,
             "selected_talk_filename": self.selected_talk_filename,
             "reason_codes": list(self.reason_codes),
+            "source_identity": (
+                dict(self.source_identity) if self.source_identity is not None else None
+            ),
             "candidates": [candidate.as_json() for candidate in self.candidates],
         }
 
@@ -576,6 +600,8 @@ def assess_candidate(
 def assess_pptx_talk_identity(
     deck: Mapping[str, Any] | DeckIdentityFacts,
     candidates: Iterable[Mapping[str, Any]],
+    *,
+    source_identity: Mapping[str, Any] | None = None,
 ) -> TalkIdentityAssessment:
     """Decide which talk a deck belongs to, or refuse to decide.
 
@@ -618,6 +644,7 @@ def assess_pptx_talk_identity(
             artifact_role=artifact_role,
             selected_talk_filename=selected if verdict == VERDICT_MATCHED else None,
             reason_codes=tuple(dict.fromkeys(codes)),
+            source_identity=source_identity,
             candidates=assessments,
         )
 
@@ -663,10 +690,47 @@ def unassessed_legacy_binding(pptx_path: str) -> dict[str, Any]:
         "artifact_role": ROLE_DELIVERY,
         "selected_talk_filename": None,
         "reason_codes": [REASON_UNASSESSED_LEGACY_BINDING],
+        # Null rather than absent, for the same reason the candidates list is
+        # empty rather than absent: migration read no bytes, and saying so is a
+        # different statement from the field never having existed.
+        "source_identity": None,
         # Empty rather than absent: migration assessed no candidates, which is
         # a different statement from having assessed some and reported none.
         "candidates": [],
     }
+
+
+_SOURCE_IDENTITY_FIELDS = ("algorithm", "digest", "size_bytes")
+
+
+def _source_identity_comparable(value: object) -> TypeGuard[Mapping[str, Any]]:
+    """Whether a source identity is complete enough to compare at all.
+
+    A partial identity is not a weak match, it is an unusable one: comparing on
+    whichever fields happen to be present would let a record missing `digest`
+    agree with anything that shares its size.
+    """
+    if not isinstance(value, Mapping):
+        return False
+    if set(value) != set(_SOURCE_IDENTITY_FIELDS):
+        return False
+    if not isinstance(value["algorithm"], str) or not value["algorithm"]:
+        return False
+    if not isinstance(value["digest"], str) or not value["digest"]:
+        return False
+    size = value["size_bytes"]
+    return not isinstance(size, bool) and isinstance(size, int) and size >= 0
+
+
+def _same_source_generation(
+    stored: Mapping[str, Any], observed: Mapping[str, Any]
+) -> bool:
+    """Exact agreement on every field, never a subset.
+
+    The algorithm is compared too: the same digest string under two algorithms
+    is a coincidence of encoding, not the same bytes.
+    """
+    return all(stored[field] == observed[field] for field in _SOURCE_IDENTITY_FIELDS)
 
 
 def binding_refusal(
@@ -674,6 +738,7 @@ def binding_refusal(
     *,
     pptx_path: str,
     talk_filename: str,
+    observed_source_identity: Mapping[str, Any] | None,
 ) -> str | None:
     """Say why an assessment fails to authorize a binding, or None if it does.
 
@@ -687,6 +752,28 @@ def binding_refusal(
     AND a talk, so one that proves a different pair proves nothing about this
     row. Reason codes are checked because every code but the matched one
     explains a refusal.
+
+    Two separate things are checked about the deck generation, and they are not
+    the same requirement:
+
+    * The assessment must NAME the generation it read. Always. A path is not a
+      deck: v1 pinned an assessment to `pptx_path` alone, so replacing the file
+      at that path kept the `matched` verdict and handed the new deck's contents
+      to the talk under a proof about different bytes.
+    * It must AGREE with an independent observation, when the caller has one.
+
+    `observed_source_identity` is REQUIRED, never defaulted, so a caller states
+    which case it is in rather than falling into one. `None` says "I have no
+    independent observation" — true of `mutate-tracking-database.py`, which
+    takes a database and a plan and never touches the vault. That is not a pass:
+    the assessment must still carry a comparable generation, so every v1
+    assessment and every unwitnessed migration stamp still refuses. It is
+    `preflight-vault.py` that observes the deck and makes the comparison real.
+
+    A caller holding an observation must not pass `None` to skip the
+    comparison — that is the fail-open shape the observation gate was made
+    required to avoid. Preflight treats an unobservable deck as its own finding
+    rather than as an absent observation.
     """
     if not isinstance(assessment, Mapping):
         return "identity_assessment_missing"
@@ -697,6 +784,7 @@ def binding_refusal(
         "artifact_role",
         "selected_talk_filename",
         "reason_codes",
+        "source_identity",
         "candidates",
     } - set(assessment)
     if missing:
@@ -716,7 +804,22 @@ def binding_refusal(
         return "identity_reason_codes_invalid"
     if sorted(set(codes)) != sorted(MATCHED_REASON_CODES):
         return "identity_reason_codes_contradict_verdict"
-    return _candidate_table_refusal(assessment["candidates"], talk_filename)
+    table_refusal = _candidate_table_refusal(assessment["candidates"], talk_filename)
+    if table_refusal is not None:
+        return table_refusal
+    # Last, deliberately. Everything above asks whether the assessment is a
+    # coherent proof at all; this asks whether it is a proof about the bytes
+    # that are there now. Running it earlier would mask a malformed assessment
+    # behind a generation complaint and change which defect the operator sees
+    # first.
+    stored_identity = assessment["source_identity"]
+    if not _source_identity_comparable(stored_identity):
+        return REASON_SOURCE_UNOBSERVABLE
+    if observed_source_identity is not None and not _same_source_generation(
+        stored_identity, observed_source_identity
+    ):
+        return REASON_GENERATION_STALE
+    return None
 
 
 def _candidate_table_refusal(candidates: object, talk_filename: str) -> str | None:

--- a/skills/vault-ingress/scripts/pptx_talk_identity.py
+++ b/skills/vault-ingress/scripts/pptx_talk_identity.py
@@ -701,10 +701,26 @@ def unassessed_legacy_binding(pptx_path: str) -> dict[str, Any]:
 
 
 _SOURCE_IDENTITY_FIELDS = ("algorithm", "digest", "size_bytes")
+# Mirrors `tracking_database`'s PPTX source-fingerprint contract, restated
+# rather than imported because that module imports THIS one
+# (`unassessed_legacy_binding`), so reaching back would cycle.
+# `tests/test_pptx_talk_identity.py` pins the two to each other, so a contract
+# change landing in one file and not the other fails CI instead of leaving the
+# assessment accepting generations the database would refuse.
+_SOURCE_IDENTITY_ALGORITHMS = frozenset({"sha256"})
+_SHA256_DIGEST_LENGTH = 64
+_LOWER_HEX = frozenset("0123456789abcdef")
 
 
 def _source_identity_comparable(value: object) -> TypeGuard[Mapping[str, Any]]:
-    """Whether a source identity is complete enough to compare at all.
+    """Whether a source identity is a valid generation, not merely present.
+
+    Held to the same contract the extractor's fingerprint is held to, because
+    the two are compared to each other. A looser reading here would accept a
+    generation the database would refuse — `{"algorithm": "x", "digest": "x",
+    "size_bytes": 0}` is not a deck anything could have read — and an
+    assessment carrying one would claim a binding proven against bytes that
+    cannot exist.
 
     A partial identity is not a weak match, it is an unusable one: comparing on
     whichever fields happen to be present would let a record missing `digest`
@@ -714,12 +730,19 @@ def _source_identity_comparable(value: object) -> TypeGuard[Mapping[str, Any]]:
         return False
     if set(value) != set(_SOURCE_IDENTITY_FIELDS):
         return False
-    if not isinstance(value["algorithm"], str) or not value["algorithm"]:
+    if value["algorithm"] not in _SOURCE_IDENTITY_ALGORITHMS:
         return False
-    if not isinstance(value["digest"], str) or not value["digest"]:
+    digest = value["digest"]
+    if (
+        not isinstance(digest, str)
+        or len(digest) != _SHA256_DIGEST_LENGTH
+        or not set(digest) <= _LOWER_HEX
+    ):
         return False
     size = value["size_bytes"]
-    return not isinstance(size, bool) and isinstance(size, int) and size >= 0
+    # A zero-byte deck is not a deck. `bool` is an `int` in Python, so it is
+    # excluded before the range check rather than sliding through as 0 or 1.
+    return not isinstance(size, bool) and isinstance(size, int) and size >= 1
 
 
 def _same_source_generation(

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -71,7 +71,7 @@ from source_identity_matching import (
     known_event_aliases,
     titles_agree,
 )
-from pptx_catalog_selection import classify_catalog
+from pptx_catalog_selection import classify_catalog, observed_source_fingerprint
 from pptx_talk_identity import (
     VERDICT_MATCHED,
     binding_refusal,
@@ -121,6 +121,10 @@ _DATABASE_READ_FALLBACK = DATABASE_READ_FALLBACK
 SOURCE_IDENTITY_SCHEMA_VERSION = 1
 TRANSCRIPT_SOURCES = frozenset({"youtube_auto", "whisper", "manual", "none"})
 SLIDE_SOURCES = frozenset({"pptx", "pdf", "both", "video_extracted", "none"})
+# What a binding check needs of the deck itself: that it can be read and
+# digested. Reported as the `expected` of the unobservable-source finding so the
+# receipt says what was wanted, not just what was missing.
+PPTX_SOURCE_OBSERVABLE = "readable_pptx_source"
 COMPLETED_STATUSES = frozenset({"processed", "processed_partial"})
 RELATION_TYPES = frozenset({"duplicate", "borrowed_recording"})
 REJECTABLE_SOURCE_TYPES = frozenset({"video", "slides"})
@@ -389,15 +393,41 @@ class VaultPreflight:
                 continue
             pptx_path = record.get("pptx_path")
             talk_filename = record.get("talk_filename")
-            refusal = (
-                binding_refusal(
+            if not isinstance(pptx_path, str) or not isinstance(talk_filename, str):
+                refusal = "identity_assessment_incomplete"
+            else:
+                # Observed here rather than read off the row: the row's own
+                # fingerprint is what a changed deck would have to update, so
+                # trusting it would compare the record against itself. The deck
+                # on disk is the only authority for which bytes exist now.
+                observed = observed_source_fingerprint(
+                    pptx_path, self.config.get("pptx_source_dir")
+                )
+                if observed is None:
+                    # Distinct from passing `None` down. `binding_refusal`
+                    # reads `None` as "this caller has no observation", which
+                    # is true of the plan-only writer and false here — preflight
+                    # looked and found nothing. A deck that cannot be read
+                    # cannot confirm any binding, and letting it fall through as
+                    # "no observation available" is exactly the fail-open this
+                    # gate exists to close.
+                    self.add(
+                        "blocking",
+                        "pptx_talk_binding_source_unobservable",
+                        "catalog row binds a talk but its deck cannot be read, "
+                        "so the identity assessment cannot be checked against "
+                        "the deck it claims to describe",
+                        field=f"pptx_catalog[{index}].pptx_path",
+                        expected=PPTX_SOURCE_OBSERVABLE,
+                        actual=None,
+                    )
+                    continue
+                refusal = binding_refusal(
                     assessment,
                     pptx_path=pptx_path,
                     talk_filename=talk_filename,
+                    observed_source_identity=observed,
                 )
-                if isinstance(pptx_path, str) and isinstance(talk_filename, str)
-                else "identity_assessment_incomplete"
-            )
             if refusal is None:
                 continue
             reason_codes = assessment.get("reason_codes")

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -53,6 +53,7 @@ from pathlib import Path
 import sys
 from typing import Any, Mapping, Sequence
 
+from pptx_catalog_selection import observed_source_fingerprint
 from pptx_deck_facts import (
     DECK_FACTS_SCHEMA_VERSION,
     read_deck_identity_facts,
@@ -239,8 +240,17 @@ def sweep_catalog(
         stored_talk = record.get("talk_filename")
         stored_talk = stored_talk if isinstance(stored_talk, str) else None
         reading = read_deck_identity_facts(record.get("pptx_path"), pptx_source_dir)
+        # Digested from the same deck the facts were read from, in the same
+        # pass, so the verdict names the generation it actually saw. Reading the
+        # facts and fingerprinting in two separate passes would let a deck
+        # change between them and stamp a verdict onto bytes it never read.
+        observed_identity = observed_source_fingerprint(
+            record.get("pptx_path"), pptx_source_dir
+        )
         try:
-            assessment = assess_pptx_talk_identity(reading.facts, candidates)
+            assessment = assess_pptx_talk_identity(
+                reading.facts, candidates, source_identity=observed_identity
+            )
         except PptxTalkIdentityError as exc:
             # The prose names the rejected value, which came out of the
             # database (`no-secrets` -> Logging). Report the closed code.

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -53,7 +53,6 @@ from pathlib import Path
 import sys
 from typing import Any, Mapping, Sequence
 
-from pptx_catalog_selection import observed_source_fingerprint
 from pptx_deck_facts import (
     DECK_FACTS_SCHEMA_VERSION,
     read_deck_identity_facts,
@@ -92,10 +91,6 @@ DISPOSITION_REVIEW_REQUIRED = "binding_review_required"
 DISPOSITION_UNPROVEN = "binding_unproven"
 DISPOSITION_UNBOUND = "unbound_row"
 DISPOSITION_UNASSESSABLE = "binding_unassessable"
-# The deck did not hold still across the read. Its facts and its digest would
-# describe different generations, so the row gets no verdict at all rather than
-# one stamped with a generation it cannot vouch for.
-REASON_SOURCE_UNSTABLE = "identity_source_unstable_during_read"
 
 DISPOSITIONS = (
     DISPOSITION_CONFIRMED,
@@ -243,30 +238,13 @@ def sweep_catalog(
             continue
         stored_talk = record.get("talk_filename")
         stored_talk = stored_talk if isinstance(stored_talk, str) else None
-        # Fingerprint, read, fingerprint. The facts and the digest come from
-        # two separate opens of the same path, so a deck replaced between them
-        # would stamp the SECOND generation's digest onto facts derived from the
-        # first — a verdict about bytes it never read, which is precisely the
-        # confusion this whole contract exists to refuse. Bracketing the read
-        # makes that window observable: if the deck is not byte-identical on
-        # both sides, no generation can honestly be attached and the row is
-        # unassessable rather than assessed against a guess.
-        before = observed_source_fingerprint(record.get("pptx_path"), pptx_source_dir)
         reading = read_deck_identity_facts(record.get("pptx_path"), pptx_source_dir)
-        after = observed_source_fingerprint(record.get("pptx_path"), pptx_source_dir)
-        if before is None or after is None or before != after:
-            rows.append(
-                {
-                    "index": index,
-                    "pptx_path": reading.pptx_path or None,
-                    "stored_talk_filename": stored_talk,
-                    "disposition": DISPOSITION_UNASSESSABLE,
-                    "reason_codes": [REASON_SOURCE_UNSTABLE],
-                    "deck_facts_reason_code": reading.reason_code,
-                }
-            )
-            continue
-        observed_identity = before
+        # The reading digests its own descriptor, so the generation and the
+        # facts are the same bytes by construction. Fingerprinting the path
+        # separately here would reintroduce the window it closes: two opens of
+        # one path are not two views of one file, and an A->B->A replacement
+        # defeats any before/after comparison built on them.
+        observed_identity = reading.source_identity
         try:
             assessment = assess_pptx_talk_identity(
                 reading.facts, candidates, source_identity=observed_identity

--- a/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
+++ b/skills/vault-ingress/scripts/sweep-pptx-talk-identity.py
@@ -92,6 +92,10 @@ DISPOSITION_REVIEW_REQUIRED = "binding_review_required"
 DISPOSITION_UNPROVEN = "binding_unproven"
 DISPOSITION_UNBOUND = "unbound_row"
 DISPOSITION_UNASSESSABLE = "binding_unassessable"
+# The deck did not hold still across the read. Its facts and its digest would
+# describe different generations, so the row gets no verdict at all rather than
+# one stamped with a generation it cannot vouch for.
+REASON_SOURCE_UNSTABLE = "identity_source_unstable_during_read"
 
 DISPOSITIONS = (
     DISPOSITION_CONFIRMED,
@@ -239,14 +243,30 @@ def sweep_catalog(
             continue
         stored_talk = record.get("talk_filename")
         stored_talk = stored_talk if isinstance(stored_talk, str) else None
+        # Fingerprint, read, fingerprint. The facts and the digest come from
+        # two separate opens of the same path, so a deck replaced between them
+        # would stamp the SECOND generation's digest onto facts derived from the
+        # first — a verdict about bytes it never read, which is precisely the
+        # confusion this whole contract exists to refuse. Bracketing the read
+        # makes that window observable: if the deck is not byte-identical on
+        # both sides, no generation can honestly be attached and the row is
+        # unassessable rather than assessed against a guess.
+        before = observed_source_fingerprint(record.get("pptx_path"), pptx_source_dir)
         reading = read_deck_identity_facts(record.get("pptx_path"), pptx_source_dir)
-        # Digested from the same deck the facts were read from, in the same
-        # pass, so the verdict names the generation it actually saw. Reading the
-        # facts and fingerprinting in two separate passes would let a deck
-        # change between them and stamp a verdict onto bytes it never read.
-        observed_identity = observed_source_fingerprint(
-            record.get("pptx_path"), pptx_source_dir
-        )
+        after = observed_source_fingerprint(record.get("pptx_path"), pptx_source_dir)
+        if before is None or after is None or before != after:
+            rows.append(
+                {
+                    "index": index,
+                    "pptx_path": reading.pptx_path or None,
+                    "stored_talk_filename": stored_talk,
+                    "disposition": DISPOSITION_UNASSESSABLE,
+                    "reason_codes": [REASON_SOURCE_UNSTABLE],
+                    "deck_facts_reason_code": reading.reason_code,
+                }
+            )
+            continue
+        observed_identity = before
         try:
             assessment = assess_pptx_talk_identity(
                 reading.facts, candidates, source_identity=observed_identity

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -125,12 +125,21 @@ def _complete_plan() -> dict[str, Any]:
                     "visual_extracted": False,
                     "visual_evidence": None,
                     "identity_assessment": {
-                        "schema_version": 1,
+                        "schema_version": 2,
                         "pptx_path": "Conference/Talk.pptx",
                         "verdict": "matched",
                         "artifact_role": "delivery",
                         "selected_talk_filename": "talk.md",
                         "reason_codes": ["identity_matched"],
+                        # The row carries no extraction evidence yet, so there
+                        # is nothing to cross-check against — identity is
+                        # verified BEFORE extraction. The assessment still has
+                        # to name the generation it read.
+                        "source_identity": {
+                            "algorithm": "sha256",
+                            "digest": "e" * 64,
+                            "size_bytes": 2048,
+                        },
                         "candidates": [
                             {
                                 "talk_filename": "talk.md",

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -29,6 +29,7 @@ import pytest
 CURRENT_EXTRACTOR_SCHEMA = 4
 CURRENT_PIPELINE = "1.5.0"
 
+DECK_PATH = "Conference/2024/Talk.pptx"
 SOURCE_FINGERPRINT = {
     "algorithm": "sha256",
     "digest": "a" * 64,
@@ -92,12 +93,15 @@ def _signals(*, agree=(), conflict=()) -> dict:
 def _identity_assessment(**overrides) -> dict:
     """A v3 record's proof that this deck belongs to the talk it names (#176)."""
     assessment = {
-        "schema_version": 1,
+        "schema_version": 2,
         "pptx_path": "Conference/2024/Talk.pptx",
         "verdict": "matched",
         "artifact_role": "delivery",
         "selected_talk_filename": "2024-04-10-talk.md",
         "reason_codes": ["identity_matched"],
+        # v2 binds the verdict to the bytes it read, so a deck swapped at the
+        # same path no longer inherits the proof (#176).
+        "source_identity": copy.deepcopy(SOURCE_FINGERPRINT),
         "candidates": [
             {
                 "talk_filename": "2024-04-10-talk.md",
@@ -964,7 +968,7 @@ def test_a_non_delivery_artifact_cannot_bind_a_talk(
 def test_an_assessment_from_a_future_schema_is_refused(
     mutate_tracking_database,
 ) -> None:
-    record = _current_record(identity_assessment=_identity_assessment(schema_version=2))
+    record = _current_record(identity_assessment=_identity_assessment(schema_version=3))
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError,
@@ -1050,6 +1054,12 @@ def test_an_assessment_the_assessor_produced_satisfies_the_writer(
     assessment = pptx_talk_identity.assess_pptx_talk_identity(
         {"pptx_path": "Voxxed Days Ticino/2024/A Talk About Things.pptx"},
         [talk],
+        # The assessor records the generation it read; the writer refuses a
+        # verdict that names none, so the end-to-end path has to carry one.
+        # The record's own extraction fingerprint. They must agree: the writer
+        # cross-checks the sweep's generation against the extractor's, and two
+        # independent producers naming different decks is what that catches.
+        source_identity=copy.deepcopy(SOURCE_FINGERPRINT),
     )
     assert assessment.verdict == pptx_talk_identity.VERDICT_MATCHED
 
@@ -1278,22 +1288,53 @@ def test_a_legacy_config_does_not_skip_the_record_migration(
 # The catalog-wide sweep: preflight consumes the assessment (#176).
 
 
+def _materialize_deck(
+    pptx_catalog_selection,
+    tmp_path,
+    database,
+    *,
+    pptx_path=DECK_PATH,
+    body=b"deck bytes",
+):
+    """Put a real file where the catalog says the deck is, and report its truth.
+
+    Preflight digests the deck rather than trusting the row, so a row pointing
+    at nothing is now its own blocking finding. Tests that are about some OTHER
+    refusal need the deck to exist so they reach the check they are about, and
+    the one test about agreement needs the fingerprint the file actually has —
+    an invented digest cannot be the sha256 of real bytes.
+    """
+    source = tmp_path / "decks"
+    deck = source / pptx_path
+    deck.parent.mkdir(parents=True, exist_ok=True)
+    deck.write_bytes(body)
+    database["config"]["pptx_source_dir"] = str(source)
+    return pptx_catalog_selection.observed_source_fingerprint(pptx_path, source)
+
+
 def _preflight_codes(preflight_vault, database, tmp_path):
     """Run only the identity sweep; the rest of preflight needs a real vault."""
     validator = preflight_vault.VaultPreflight(
         database, tmp_path, tmp_path / "tracking-database.json"
     )
+    # `run()` loads config before reaching this check (it digests the deck
+    # through `config.pptx_source_dir`), and calling the check in isolation
+    # skips that. Without it every row reads as an unreadable deck.
+    config = database.get("config")
+    if isinstance(config, dict):
+        validator.config = config
     validator._check_pptx_talk_identity()
     return {(finding["code"], finding["severity"]) for finding in validator.findings}
 
 
 def test_preflight_blocks_on_a_migrated_legacy_binding(
-    preflight_vault, tracking_database, tmp_path
+    preflight_vault, tracking_database, pptx_catalog_selection, tmp_path
 ) -> None:
     """A warning would let Step 1's blocking-only gate proceed on state the
     database itself marks unproven."""
     database = _database([_evidence_bound_record()])
     migrated = tracking_database.migrate_tracking_database(database).database
+    _materialize_deck(pptx_catalog_selection, tmp_path, migrated)
 
     codes = _preflight_codes(preflight_vault, migrated, tmp_path)
 
@@ -1301,7 +1342,7 @@ def test_preflight_blocks_on_a_migrated_legacy_binding(
 
 
 def test_preflight_blocks_on_an_assessment_that_actually_refused(
-    preflight_vault, tmp_path
+    preflight_vault, pptx_catalog_selection, tmp_path
 ) -> None:
     """An assessor that looked and refused is a specific, actionable finding."""
     record = _current_record(
@@ -1312,15 +1353,74 @@ def test_preflight_blocks_on_an_assessment_that_actually_refused(
         )
     )
 
-    codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
+    database = _database([record])
+    _materialize_deck(pptx_catalog_selection, tmp_path, database)
+
+    codes = _preflight_codes(preflight_vault, database, tmp_path)
 
     assert ("pptx_talk_binding_unproven", "blocking") in codes
 
 
-def test_preflight_is_silent_on_a_proven_binding(preflight_vault, tmp_path) -> None:
-    codes = _preflight_codes(preflight_vault, _database([_current_record()]), tmp_path)
+def test_preflight_is_silent_on_a_proven_binding(
+    preflight_vault, pptx_catalog_selection, tmp_path
+) -> None:
+    """The one case where the generation actually has to agree.
+
+    The other preflight tests reach an earlier refusal, so their fingerprint
+    never matters. Here nothing else refuses, so the assessment is built from
+    the digest the file on disk really has — an invented constant cannot be the
+    sha256 of real bytes, and pinning one would test the fixture, not the gate.
+    """
+    database = _database([])
+    observed = _materialize_deck(pptx_catalog_selection, tmp_path, database)
+    database["pptx_catalog"] = [
+        _current_record(
+            identity_assessment=_identity_assessment(source_identity=observed)
+        )
+    ]
+
+    codes = _preflight_codes(preflight_vault, database, tmp_path)
 
     assert not any(code.startswith("pptx_talk_binding") for code, _ in codes)
+
+
+def test_preflight_blocks_a_deck_swapped_since_it_was_assessed(
+    preflight_vault, pptx_catalog_selection, tmp_path
+) -> None:
+    """The defect this whole change exists for (#176).
+
+    v1 pinned an assessment to `pptx_path`, so replacing the file at that path
+    left the `matched` verdict standing and the new deck's slides, OCR and
+    pattern observations became that talk's evidence under a proof about
+    different bytes. The row is untouched; only the file changed.
+    """
+    database = _database([])
+    observed = _materialize_deck(pptx_catalog_selection, tmp_path, database)
+    database["pptx_catalog"] = [
+        _current_record(
+            identity_assessment=_identity_assessment(source_identity=observed)
+        )
+    ]
+    _materialize_deck(
+        pptx_catalog_selection, tmp_path, database, body=b"a completely different deck"
+    )
+
+    codes = _preflight_codes(preflight_vault, database, tmp_path)
+
+    assert ("pptx_talk_binding_unproven", "blocking") in codes
+
+
+def test_preflight_blocks_a_binding_whose_deck_cannot_be_read(
+    preflight_vault, tmp_path
+) -> None:
+    """Distinct from "no observation available", which is the writer's case.
+
+    Preflight looked. Finding nothing is a finding, not a reason to fall through
+    to the plan-only path where the comparison is simply unavailable.
+    """
+    codes = _preflight_codes(preflight_vault, _database([_current_record()]), tmp_path)
+
+    assert ("pptx_talk_binding_source_unobservable", "blocking") in codes
 
 
 def test_preflight_ignores_an_unmatched_row(preflight_vault, tmp_path) -> None:
@@ -1345,7 +1445,7 @@ def test_preflight_blocks_a_row_migration_will_never_reach(
 
 
 def test_preflight_refuses_an_assessment_that_proves_another_pair(
-    preflight_vault, tmp_path
+    preflight_vault, pptx_catalog_selection, tmp_path
 ) -> None:
     """Hints, Not Authority: a persisted `matched` verdict for a different deck
     must not read as proof of this row."""
@@ -1355,13 +1455,16 @@ def test_preflight_refuses_an_assessment_that_proves_another_pair(
         )
     )
 
-    codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
+    database = _database([record])
+    _materialize_deck(pptx_catalog_selection, tmp_path, database)
+
+    codes = _preflight_codes(preflight_vault, database, tmp_path)
 
     assert ("pptx_talk_binding_unproven", "blocking") in codes
 
 
 def test_preflight_refuses_a_matched_verdict_naming_another_talk(
-    preflight_vault, tmp_path
+    preflight_vault, pptx_catalog_selection, tmp_path
 ) -> None:
     record = _current_record(
         identity_assessment=_identity_assessment(
@@ -1369,7 +1472,10 @@ def test_preflight_refuses_a_matched_verdict_naming_another_talk(
         )
     )
 
-    codes = _preflight_codes(preflight_vault, _database([record]), tmp_path)
+    database = _database([record])
+    _materialize_deck(pptx_catalog_selection, tmp_path, database)
+
+    codes = _preflight_codes(preflight_vault, database, tmp_path)
 
     assert ("pptx_talk_binding_unproven", "blocking") in codes
 

--- a/tests/test_pptx_talk_identity.py
+++ b/tests/test_pptx_talk_identity.py
@@ -409,6 +409,7 @@ class TestSerialization:
             "artifact_role",
             "selected_talk_filename",
             "reason_codes",
+            "source_identity",
             "candidates",
         }
         assert payload["schema_version"] == (
@@ -490,6 +491,7 @@ def test_the_documented_matched_example_authorizes_its_binding(
         assessment,
         pptx_path=assessment["pptx_path"],
         talk_filename=assessment["selected_talk_filename"],
+        observed_source_identity=assessment["source_identity"],
     )
 
     assert refusal is None, refusal

--- a/tests/test_pptx_talk_identity.py
+++ b/tests/test_pptx_talk_identity.py
@@ -480,6 +480,89 @@ def _documented_identity_assessment() -> dict:
     raise AssertionError("unbalanced identity_assessment example in schemas-db.md")
 
 
+VALID_SOURCE_IDENTITY = {
+    "algorithm": "sha256",
+    "digest": "3b1f8c2d4e6a90b7c5d3e1f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f80a1b",
+    "size_bytes": 4096,
+}
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param(
+            {**VALID_SOURCE_IDENTITY, "algorithm": "md5"}, id="wrong_algorithm"
+        ),
+        pytest.param({**VALID_SOURCE_IDENTITY, "digest": "x"}, id="short_digest"),
+        pytest.param(
+            {**VALID_SOURCE_IDENTITY, "digest": "3B1F" + "0" * 60},
+            id="uppercase_digest",
+        ),
+        pytest.param(
+            {**VALID_SOURCE_IDENTITY, "digest": "z" * 64}, id="non_hex_digest"
+        ),
+        pytest.param({**VALID_SOURCE_IDENTITY, "size_bytes": 0}, id="empty_deck"),
+        pytest.param({**VALID_SOURCE_IDENTITY, "size_bytes": True}, id="boolean_size"),
+        pytest.param(
+            {**VALID_SOURCE_IDENTITY, "size_bytes": "4096"}, id="stringified_size"
+        ),
+        pytest.param(
+            {k: v for k, v in VALID_SOURCE_IDENTITY.items() if k != "digest"},
+            id="missing_digest",
+        ),
+        pytest.param({**VALID_SOURCE_IDENTITY, "extra": 1}, id="extra_field"),
+    ],
+)
+def test_a_source_identity_the_database_would_refuse_proves_nothing(
+    pptx_talk_identity, identity
+) -> None:
+    """The assessment's generation is compared against the extractor's, so it is
+    held to the extractor's contract. A looser reading here would let a binding
+    claim it was proven against bytes no deck could have."""
+    assessment = dict(_documented_identity_assessment())
+    assessment["source_identity"] = identity
+
+    refusal = pptx_talk_identity.binding_refusal(
+        assessment,
+        pptx_path=assessment["pptx_path"],
+        talk_filename=assessment["selected_talk_filename"],
+        observed_source_identity=None,
+    )
+
+    assert refusal == pptx_talk_identity.REASON_SOURCE_UNOBSERVABLE
+
+
+def test_the_mirrored_source_identity_contract_matches_its_source(
+    pptx_talk_identity, tracking_database
+) -> None:
+    """`tracking_database` imports this module, so the contract is restated here
+    rather than imported. Restated constants drift; this is what stops it."""
+    assert (
+        pptx_talk_identity._SOURCE_IDENTITY_ALGORITHMS
+        == tracking_database.PPTX_SOURCE_FINGERPRINT_ALGORITHMS
+    )
+    assert set(pptx_talk_identity._SOURCE_IDENTITY_FIELDS) == set(
+        tracking_database.PPTX_SOURCE_FINGERPRINT_REQUIRED_FIELDS
+    )
+
+
+def test_a_generation_that_differs_from_the_observed_one_is_stale(
+    pptx_talk_identity,
+) -> None:
+    """Both sides valid, and they name different decks."""
+    assessment = dict(_documented_identity_assessment())
+
+    refusal = pptx_talk_identity.binding_refusal(
+        assessment,
+        pptx_path=assessment["pptx_path"],
+        talk_filename=assessment["selected_talk_filename"],
+        observed_source_identity={**VALID_SOURCE_IDENTITY, "digest": "a" * 64},
+    )
+
+    assert refusal == pptx_talk_identity.REASON_GENERATION_STALE
+
+
 def test_the_documented_matched_example_authorizes_its_binding(
     pptx_talk_identity,
 ) -> None:

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -119,6 +119,71 @@ def deck(
     return relative
 
 
+class TestTheDeckMustHoldStillAcrossTheRead:
+    """The facts and the digest come from two separate opens (#176 review).
+
+    `read_deck_identity_facts` opens the deck, then `observed_source_fingerprint`
+    opens it again. A deck replaced in that window would hand generation B's
+    digest to a verdict derived from generation A's facts — and a later check
+    against B would then accept it. The whole point of binding an assessment to
+    bytes is defeated if the bytes it names are not the bytes it read.
+    """
+
+    def test_a_deck_replaced_mid_read_is_unassessable(
+        self, source_root: Path, monkeypatch
+    ) -> None:
+        relative = deck(source_root, "Conference/2024/DevOps for Developers.pptx")
+        talk = {
+            "filename": "2024-04-10-talk.md",
+            "title": "DevOps for Developers",
+            "conference": "Conference",
+            "date": "2024-04-10",
+        }
+        original = sweep.read_deck_identity_facts
+
+        def swap_then_read(pptx_path, pptx_source_dir):
+            """Replace the deck at the exact moment its facts are read."""
+            result = original(pptx_path, pptx_source_dir)
+            write_deck(
+                source_root,
+                relative,
+                full_deck_members(
+                    slide_titles=["A Totally Different Talk"],
+                    runs=["A Totally Different Talk"],
+                    slides=7,
+                ),
+            )
+            return result
+
+        monkeypatch.setattr(sweep, "read_deck_identity_facts", swap_then_read)
+
+        rows = sweep_rows(
+            [catalog_row(relative, talk["filename"])], [talk], source_root
+        )
+
+        assert rows[0]["disposition"] == sweep.DISPOSITION_UNASSESSABLE
+        assert rows[0]["reason_codes"] == [sweep.REASON_SOURCE_UNSTABLE]
+
+    def test_a_deck_that_holds_still_is_assessed_normally(
+        self, source_root: Path
+    ) -> None:
+        """The bracket must not make every ordinary read unassessable."""
+        relative = deck(source_root, "Conference/2024/DevOps for Developers.pptx")
+        talk = {
+            "filename": "2024-04-10-talk.md",
+            "title": "DevOps for Developers",
+            "conference": "Conference",
+            "date": "2024-04-10",
+        }
+
+        rows = sweep_rows(
+            [catalog_row(relative, talk["filename"])], [talk], source_root
+        )
+
+        assert rows[0]["disposition"] == sweep.DISPOSITION_CONFIRMED
+        assert rows[0]["verdict"] == sweep.VERDICT_MATCHED
+
+
 class TestDispositions:
     def test_a_binding_the_assessment_selects_is_confirmed(
         self, source_root: Path

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -458,6 +458,7 @@ class TestCandidateTable:
                 assessment,
                 pptx_path=path,
                 talk_filename=VOXXED_TALK["filename"],
+                observed_source_identity=None,
             )
             is None
         )
@@ -786,6 +787,7 @@ class TestProofPlan:
                 record["identity_assessment"],
                 pptx_path=record["pptx_path"],
                 talk_filename=record["talk_filename"],
+                observed_source_identity=None,
             )
             is None
         )

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -119,55 +120,68 @@ def deck(
     return relative
 
 
-class TestTheDeckMustHoldStillAcrossTheRead:
-    """The facts and the digest come from two separate opens (#176 review).
+class TestTheGenerationComesFromTheBytesThatWereRead:
+    """One descriptor, not two opens of one path (#176 review, twice over).
 
-    `read_deck_identity_facts` opens the deck, then `observed_source_fingerprint`
-    opens it again. A deck replaced in that window would hand generation B's
-    digest to a verdict derived from generation A's facts — and a later check
-    against B would then accept it. The whole point of binding an assessment to
-    bytes is defeated if the bytes it names are not the bytes it read.
+    First attempt fingerprinted the path in a second open, so a deck replaced
+    between the two handed generation B's digest to facts read from A. Second
+    attempt bracketed the read with a fingerprint on each side, which an
+    A->B->A replacement walks straight through: `before == after` while the
+    facts came from B.
+
+    Neither is fixable by comparing more. The reading digests the descriptor it
+    already holds, so the digest and the facts are the same bytes by
+    construction and there is no window to lose a race in.
     """
 
-    def test_a_deck_replaced_mid_read_is_unassessable(
-        self, source_root: Path, monkeypatch
+    def test_the_reading_reports_the_digest_of_the_bytes_it_parsed(
+        self, source_root: Path
     ) -> None:
         relative = deck(source_root, "Conference/2024/DevOps for Developers.pptx")
-        talk = {
-            "filename": "2024-04-10-talk.md",
-            "title": "DevOps for Developers",
-            "conference": "Conference",
-            "date": "2024-04-10",
+
+        reading = sweep.read_deck_identity_facts(relative, source_root)
+
+        assert reading.package_read
+        expected = hashlib.sha256((source_root / relative).read_bytes())
+        assert reading.source_identity == {
+            "algorithm": "sha256",
+            "digest": expected.hexdigest(),
+            "size_bytes": (source_root / relative).stat().st_size,
         }
-        original = sweep.read_deck_identity_facts
 
-        def swap_then_read(pptx_path, pptx_source_dir):
-            """Replace the deck at the exact moment its facts are read."""
-            result = original(pptx_path, pptx_source_dir)
-            write_deck(
-                source_root,
-                relative,
-                full_deck_members(
-                    slide_titles=["A Totally Different Talk"],
-                    runs=["A Totally Different Talk"],
-                    slides=7,
-                ),
-            )
-            return result
+    def test_replacing_the_deck_after_the_read_cannot_change_the_recorded_generation(
+        self, source_root: Path
+    ) -> None:
+        """The recorded generation describes what was parsed, not what is there now.
 
-        monkeypatch.setattr(sweep, "read_deck_identity_facts", swap_then_read)
+        This is the A->B->A shape reduced to its essence: whatever happens to
+        the path afterwards, the reading already carries the digest of the bytes
+        its facts came from.
+        """
+        relative = deck(source_root, "Conference/2024/DevOps for Developers.pptx")
 
-        rows = sweep_rows(
-            [catalog_row(relative, talk["filename"])], [talk], source_root
+        reading = sweep.read_deck_identity_facts(relative, source_root)
+        recorded = dict(reading.source_identity)
+        write_deck(
+            source_root,
+            relative,
+            full_deck_members(
+                slide_titles=["A Totally Different Talk"],
+                runs=["A Totally Different Talk"],
+                slides=7,
+            ),
         )
 
-        assert rows[0]["disposition"] == sweep.DISPOSITION_UNASSESSABLE
-        assert rows[0]["reason_codes"] == [sweep.REASON_SOURCE_UNSTABLE]
+        assert reading.source_identity == recorded
+        assert (
+            sweep.read_deck_identity_facts(relative, source_root).source_identity
+            != recorded
+        )
 
     def test_a_deck_that_holds_still_is_assessed_normally(
         self, source_root: Path
     ) -> None:
-        """The bracket must not make every ordinary read unassessable."""
+        """The generation must not make every ordinary read unassessable."""
         relative = deck(source_root, "Conference/2024/DevOps for Developers.pptx")
         talk = {
             "filename": "2024-04-10-talk.md",

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -39,6 +39,7 @@ def _load_script(module_name: str, filename: str):
 
 
 sweep = _load_script("sweep_pptx_talk_identity", "sweep-pptx-talk-identity.py")
+import pptx_deck_facts  # noqa: E402  (SCRIPTS joins sys.path above)
 
 
 VOXXED_TALK = {
@@ -177,6 +178,43 @@ class TestTheGenerationComesFromTheBytesThatWereRead:
             sweep.read_deck_identity_facts(relative, source_root).source_identity
             != recorded
         )
+
+    def test_the_generation_survives_the_file_being_rewritten_in_place(
+        self, source_root: Path, monkeypatch
+    ) -> None:
+        """The case a descriptor alone does NOT cover.
+
+        A descriptor survives the path being repointed, but it does not freeze
+        the inode: a writer that truncates and overwrites the same file between
+        a digest pass and a parse pass still produces an identity describing
+        different bytes from the facts. The deck is copied into a private spool
+        before anything parses it, so the mutation lands on a file nothing is
+        reading any more.
+        """
+        relative = deck(source_root, "Conference/2024/DevOps for Developers.pptx")
+        target = source_root / relative
+        original_bytes = target.read_bytes()
+        real_read = pptx_deck_facts._read_from_stream
+
+        def mutate_then_parse(handle, pptx_path, facts):
+            # Rewrite the LIVE file in place, keeping the same inode, at the
+            # moment the parse begins.
+            with open(target, "r+b") as live:
+                live.seek(0)
+                live.write(b"\x00" * 512)
+                live.truncate(512)
+            return real_read(handle, pptx_path, facts)
+
+        monkeypatch.setattr(pptx_deck_facts, "_read_from_stream", mutate_then_parse)
+
+        reading = sweep.read_deck_identity_facts(relative, source_root)
+
+        assert reading.package_read, "the parse read the snapshot, not the corpse"
+        assert reading.source_identity == {
+            "algorithm": "sha256",
+            "digest": hashlib.sha256(original_bytes).hexdigest(),
+            "size_bytes": len(original_bytes),
+        }
 
     def test_a_deck_that_holds_still_is_assessed_normally(
         self, source_root: Path


### PR DESCRIPTION
Refs #176 — closes its last open acceptance criterion. Does not close the issue: applying the sweep to the live vault's 44 unresolved bindings is operational work.

## The defect

`binding_refusal` pinned an assessment to its deck by **`pptx_path` — a path string**:

```python
if assessment["pptx_path"] != pptx_path:
    return "identity_deck_mismatch"
```

Nothing tied the verdict to the deck's bytes. Replace the file at that path and the stored `matched` verdict still stands, so the new deck's slide counts, OCR and pattern observations become that talk's evidence under a proof made about a different file. That is #176's own failure mode surviving #176's fix, and a reparse would draw evidence straight through it.

`test_preflight_blocks_a_deck_swapped_since_it_was_assessed` pins it: the catalog row is untouched, only the file changes. It fails with the check removed.

## What changed

`PPTX_TALK_IDENTITY_SCHEMA_VERSION` -> 2. The assessment records the `source_identity` it was reached against, reusing the `{algorithm, digest, size_bytes}` shape `visual_evidence.source_fingerprint` already uses.

A v1 assessment recorded no bytes, so it cannot be upgraded in place — it refuses as `identity_assessment_schema_unsupported` and reads as unproven. That is the position `unassessed_legacy_binding` already takes, for the same reason: a proof that was not witnessed cannot be manufactured. **Expect this to surface the live vault's existing v1 assessments as unproven**, which is the honest reading, not a regression.

## The required-argument decision

`observed_source_identity` is a required keyword, never defaulted, so a caller states which case it is in rather than falling into one:

| caller | passes | why |
|---|---|---|
| `preflight-vault.py` | the digest it took | it can observe the deck, so the comparison is real |
| `mutate-tracking-database.py` | `None` | it takes a database and a plan and never touches the vault |

`None` means "no independent observation", which is **not** a pass — the assessment must still name a generation, so every v1 assessment refuses at both callers.

A caller that *could* look must not pass `None` to skip the comparison, so preflight reports an unreadable deck as its own blocking finding (`pptx_talk_binding_source_unobservable`) rather than letting it fall through. That is the fail-open shape the observation gate was made required to avoid.

## Two things I got wrong first, both caught by the work

**Requiring the record's extraction fingerprint inverted the order.** My first version refused when the record carried no `visual_evidence`, which demands extraction *before* binding — the opposite of this issue's "validate identity before catalog persistence or extraction". A freshly catalogued row now has nothing to cross-check, and the requirement narrows to the assessment naming a generation at all. The writer still cross-checks against the extraction fingerprint when one exists: the fingerprint comes from the extractor and the identity from the sweep, so two independent producers disagreeing means one describes a different file.

**The check ran too early.** Placed after the deck-path comparison, it preempted the existing semantic refusals and changed which defect an operator sees first. It runs last now: everything above asks whether the assessment is a coherent proof, this asks whether it is a proof about the bytes that are there now.

Pyright also caught a narrowing gap — the comparability predicate is a `TypeGuard` rather than a bare `bool`.

## Surface sync

`references/schemas-db.md` carried a v1 example that the writer would now reject; a schema reference prescribing an unpersistable record is worse than none. Updated, and `test_the_documented_matched_example_authorizes_its_binding` runs the documented example through the real predicate.

## Gates

`ruff check`, `ruff format --check`, `pyright` (0 findings), `tessl plugin lint`, and 5843 passed / 3 skipped.