### PR TITLE
feat(vault-ingress): add a standalone persisted-observation audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+### feat(vault-ingress) — a standalone persisted-observation audit (#167)
+
+`assess_persisted_pattern_observations` was reachable only in-flow. Seven
+consumers call it — migration, preflight, analysis rendering, queue
+normalization, persistence, the adherence baseline, the cohort snapshot — and
+every one assesses a talk to decide something about that talk, then moves on.
+None could answer what is wrong with a corpus in total, which is this issue's
+last acceptance criterion: run the validator against a copy of the live database
+and attach the deterministic counts to the repair/reparse report.
+
+`skills/vault-ingress/scripts/audit-persisted-pattern-observations.py` is that
+entry point. It emits per-reason-code counts and the filenames behind each, so a
+count can be acted on rather than only reported.
+
+Read-only, and pointing it at a copy is the intended use: the reparse decision
+wants the counts BEFORE the migration restamps anything. Exit 1 means the corpus
+has defects and the report is still on stdout — a finding, not a failure. Exit 3
+is a broken audit with empty stdout, so the two can never be confused.
+
+A talk carrying no `pattern_observations` reports `observations_absent` rather
+than being skipped: 9 of 209 live talks had no block, and silence would have read
+as nine clean talks. A talk whose own filename is unusable is named by index, so
+a malformed record is not the one entry the report cannot identify.
+
+Reports are byte-identical across runs over one database, so a diff between two
+runs is a real change rather than dict ordering.
+
 ### feat(vault-ingress) — admit `markdown` as a slide source (#318)
 
 `slide_source` accepted binary artifacts only — `pptx|pdf|both|video_extracted|none`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ a malformed record is not the one entry the report cannot identify.
 Reports are byte-identical across runs over one database, so a diff between two
 runs is a real change rather than dict ordering.
 
+Wired into `bootstrap-and-preflight.md` AHEAD of the migration command rather
+than beside the other preflight audits. That reference executes in order, so an
+audit placed with its siblings would run after `migrate-tracking-database.py`
+had already restamped and possibly repaired the observations it is meant to
+describe — a report about the repaired corpus, not the one the reparse decision
+is about.
+
 ## 0.20.86 — 2026-08-18
 
 ### feat(vault-ingress) — admit `markdown` as a slide source (#318)

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -330,6 +330,24 @@ do not auto-edit names, aliases, definitions, or graph relationships. The input,
 report, and no-write contracts are defined in
 [pattern-catalog-contract.md](pattern-catalog-contract.md).
 
+**Persisted pattern-observation audit:** Before a migration or a reparse, run the
+corpus-wide audit against a COPY of the database:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-persisted-pattern-observations.py" \
+  "{path_to_database_copy}"
+```
+
+Stdout is stable JSON carrying per-reason-code counts and the filenames behind
+each. Exit 1 means at least one talk's persisted observations are unusable —
+that is a finding about the corpus, not a failure of the audit, and the report is
+still on stdout. Exit 3 is a broken audit with empty stdout.
+
+Read-only, which is why it may be pointed at a copy. Point it at a copy: the
+reparse decision wants the counts BEFORE the migration restamps anything, and the
+same assessor runs in-flow afterwards regardless. Attach the counts to the
+repair/reparse report.
+
 **Conditional source-video runtime gate:** Use only the strict owner-read database
 payload to determine whether the upcoming source preflight may inspect any
 preserved local recording declared by

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -26,7 +26,29 @@ for the interpreter path without writing the database when that field is absent.
 Immediately re-read the same canonical path with that configured interpreter and
 require the same SHA-256; restart discovery if the generation changed. Use the
 configured interpreter for migration, queue commands, and every later toolkit
-command. Run the owner migration before any other database mutation:
+command.
+
+Before that migration runs, and only when this run is a migration or a reparse,
+capture the corpus-wide persisted-observation audit against a COPY of the
+database:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-persisted-pattern-observations.py" \
+  "{path_to_database_copy}"
+```
+
+It runs here, before the migration, because migration restamps and may repair
+the very observations the report is meant to describe — the same audit run
+afterwards describes the repaired corpus, not the one the reparse decision is
+about. Read-only, which is what makes a copy safe to point it at.
+
+Stdout is stable JSON carrying per-reason-code counts and the filenames behind
+each. Exit 1 means at least one talk's persisted observations are unusable: a
+finding about the corpus, not a failure of the audit, and the report is still on
+stdout. Exit 3 is a broken audit with empty stdout. Attach the counts to the
+repair/reparse report.
+
+Run the owner migration before any other database mutation:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
@@ -329,24 +351,6 @@ scoring. Exit 0 may include `semantic_debts`; present those for human review and
 do not auto-edit names, aliases, definitions, or graph relationships. The input,
 report, and no-write contracts are defined in
 [pattern-catalog-contract.md](pattern-catalog-contract.md).
-
-**Persisted pattern-observation audit:** Before a migration or a reparse, run the
-corpus-wide audit against a COPY of the database:
-
-```bash
-"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-persisted-pattern-observations.py" \
-  "{path_to_database_copy}"
-```
-
-Stdout is stable JSON carrying per-reason-code counts and the filenames behind
-each. Exit 1 means at least one talk's persisted observations are unusable —
-that is a finding about the corpus, not a failure of the audit, and the report is
-still on stdout. Exit 3 is a broken audit with empty stdout.
-
-Read-only, which is why it may be pointed at a copy. Point it at a copy: the
-reparse decision wants the counts BEFORE the migration restamps anything, and the
-same assessor runs in-flow afterwards regardless. Attach the counts to the
-repair/reparse report.
 
 **Conditional source-video runtime gate:** Use only the strict owner-read database
 payload to determine whether the upcoming source preflight may inspect any

--- a/skills/vault-ingress/references/entrypoint-failure-contracts.md
+++ b/skills/vault-ingress/references/entrypoint-failure-contracts.md
@@ -40,9 +40,10 @@ Every script named below lives in `skills/vault-ingress/scripts/`.
 | `validate-returns.py` | one JSON report | 2 | `validate_returns_unexpected_failure` | — read-only |
 | `audit-pattern-catalog.py` | one JSON report | 3 | `catalog_audit_unexpected_failure` | — read-only |
 | `aggregate-catalog-feedback.py` | one JSON report | 3 | `catalog_feedback_unexpected_failure` | — read-only |
+| `audit-persisted-pattern-observations.py` | one JSON report | 3 | `persisted_observation_audit_unexpected_failure` | — read-only |
 
-The two catalog gates use exit 3 because argparse already owns exit 2 there; a
-caller can still tell a malformed invocation from a broken tool.
+The three read-only audits use exit 3 because argparse already owns exit 2
+there; a caller can still tell a malformed invocation from a broken tool.
 
 `preflight-vault.py` is the one entrypoint whose failure lands on **stdout**: a
 caller gates claiming on its report, and a missing report reads as "preflight

--- a/skills/vault-ingress/scripts/audit-persisted-pattern-observations.py
+++ b/skills/vault-ingress/scripts/audit-persisted-pattern-observations.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Audit a tracking database's persisted pattern observations, read-only.
+
+`persisted_pattern_observations.assess_persisted_pattern_observations` already
+classifies one talk, and seven consumers call it in-flow — migration, preflight,
+analysis rendering, queue normalization, persistence, the adherence baseline and
+the cohort snapshot. Every one of them assesses a talk to decide something about
+that talk, then moves on. None of them can answer "what is wrong with this
+corpus, in total, before anyone touches it", which is what #167's last
+acceptance criterion asks for:
+
+    Run the validator against a copy of the live database and attach the
+    deterministic counts to the repair/reparse report.
+
+This is that entry point. It opens a database, assesses every talk, and emits
+stable JSON with per-reason-code counts and the affected filenames.
+
+Read-only on purpose. It takes a path and writes nothing, so it is safe to point
+at a copy of a live vault — and pointing it at a copy is the intended use, since
+the reparse decision wants the counts before the migration runs, not after.
+
+Exit codes follow `audit-pattern-catalog.py`, whose shape this mirrors:
+
+* 0 — every talk's observations are usable.
+* 1 — at least one talk is unusable. The report is on stdout; this is a finding
+  about the corpus, not a failure of the audit.
+* 2 — argparse owns malformed invocations.
+* 3 — unexpected failure. One JSON document on stderr, stdout left empty, so a
+  caller can tell a broken auditor from a corpus with defects.
+
+A talk carrying no `pattern_observations` at all is reported as
+`observations_absent` rather than skipped: on a corpus where 9 of 209 talks had
+no block, silence would have read as nine clean talks.
+
+Usage::
+
+    python3 skills/vault-ingress/scripts/audit-persisted-pattern-observations.py \\
+        path/to/tracking-database.json
+    python3 skills/vault-ingress/scripts/audit-persisted-pattern-observations.py \\
+        path/to/tracking-database.json --catalog path/to/patterns
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from failure_diagnostics import emit_unexpected_failure
+from persisted_pattern_observations import assess_persisted_pattern_observations
+from return_validation import load_catalog
+from tracking_database_io import decode_json_object_bytes, snapshot_tracking_database
+
+# Bumped when the emitted shape changes. A consumer that pins a version and
+# receives another must refuse the report rather than read fields positionally
+# (`rules/stateful-artifacts.md` -> Migration Policy).
+REPORT_SCHEMA_VERSION = 1
+
+
+def audit_database(
+    database_path: str | Path,
+    catalog_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Assess every talk's persisted observations and return the report.
+
+    Separate from `main` so the report can be built and asserted without a
+    process boundary, which is what the tests do.
+    """
+    snapshot = snapshot_tracking_database(database_path)
+    database = decode_json_object_bytes(snapshot.raw, snapshot.path)
+    catalog = load_catalog(catalog_path)
+
+    talks = database.get("talks")
+    if not isinstance(talks, list):
+        raise ValueError(
+            "tracking database has no talks array; point this at a tracking "
+            "database, not a talk file or a profile"
+        )
+
+    reason_counts: Counter[str] = Counter()
+    # Filenames per reason code, so a count can be acted on rather than only
+    # reported. A count alone tells an owner how bad it is and not where.
+    reason_filenames: dict[str, list[str]] = {}
+    unusable: list[str] = []
+    assessed = 0
+
+    for index, talk in enumerate(talks):
+        filename = talk.get("filename") if isinstance(talk, dict) else None
+        # Index-derived identity for a talk whose own filename is unusable —
+        # a malformed record is exactly the kind this audit exists to surface,
+        # so it must not be the one entry the report cannot name.
+        label = (
+            filename if isinstance(filename, str) and filename else f"talks[{index}]"
+        )
+        assessment = assess_persisted_pattern_observations(talk, catalog)
+        assessed += 1
+        if assessment.usable:
+            continue
+        unusable.append(label)
+        for code in sorted({finding.reason_code for finding in assessment.findings}):
+            reason_counts[code] += 1
+            reason_filenames.setdefault(code, []).append(label)
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "database": str(Path(database_path).resolve()),
+        "summary": {
+            "talks_assessed": assessed,
+            "talks_usable": assessed - len(unusable),
+            "talks_unusable": len(unusable),
+        },
+        # Sorted so two runs over one database produce byte-identical reports
+        # and a diff between two runs is a real change, not dict ordering.
+        "reason_counts": dict(sorted(reason_counts.items())),
+        "reason_filenames": {
+            code: sorted(names) for code, names in sorted(reason_filenames.items())
+        },
+        "unusable_filenames": sorted(unusable),
+        "usable": not unusable,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit persisted pattern observations in a tracking database "
+            "without modifying it."
+        ),
+    )
+    parser.add_argument(
+        "database",
+        type=Path,
+        help="tracking-database.json to audit; safe to point at a copy",
+    )
+    parser.add_argument(
+        "--catalog",
+        type=Path,
+        default=None,
+        help="pattern catalog directory; defaults to the repo's own catalog",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI and return its process status."""
+    args = _parser().parse_args(argv)
+    report = audit_database(args.database, args.catalog)
+    # Serialize before writing: a `json.dump` straight to stdout that fails
+    # partway leaves a truncated document the caller would try to parse.
+    rendered = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False)
+    sys.stdout.write(rendered + "\n")
+    if not report["usable"]:
+        print(
+            f"{report['summary']['talks_unusable']} of "
+            f"{report['summary']['talks_assessed']} talks carry unusable "
+            "persisted pattern observations; inspect JSON stdout before "
+            "migration or reparse",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def run_cli(argv: list[str] | None = None) -> int:
+    """Run the CLI behind its failure boundary. Returns the process exit code.
+
+    Importable so the boundary's contract is testable without executing the
+    module as a script.
+    """
+    try:
+        return main(argv)
+    # The reparse decision reads this report, so a non-zero exit without the
+    # stdout document must still say what happened; a traceback would leak vault
+    # paths and read an unreadable database as a corpus full of defects.
+    except Exception as exc:  # noqa: BLE001 - outer-boundary-process-contract
+        emit_unexpected_failure(
+            exc,
+            "persisted_observation_audit_unexpected_failure",
+            "The persisted pattern-observation audit failed unexpectedly. This "
+            "command is read-only, so the database is unchanged — but it is "
+            "UNAUDITED. Do not begin migration or reparse until a clean run "
+            "reports on stdout.",
+        )
+        return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli())

--- a/tests/test_audit_persisted_pattern_observations.py
+++ b/tests/test_audit_persisted_pattern_observations.py
@@ -1,0 +1,255 @@
+"""The standalone persisted-observation audit CLI (#167, last criterion).
+
+The assessor was only ever reachable in-flow: seven consumers call it to decide
+something about one talk and move on. Nothing could answer "what is wrong with
+this corpus, in total, before anyone touches it", which is what the criterion
+asks for and what the reparse decision needs BEFORE the migration runs.
+
+These tests build databases from the live catalog rather than hardcoded IDs, so
+a catalog edit that removes an entry fails them instead of quietly
+reclassifying what they assert.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "vault-ingress" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _load_script(module_name: str, filename: str):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+audit = _load_script(
+    "audit_persisted_pattern_observations",
+    "audit-persisted-pattern-observations.py",
+)
+
+
+@pytest.fixture(scope="session")
+def catalog(return_validation):
+    return return_validation.load_catalog()
+
+
+@pytest.fixture(scope="session")
+def observable_entry(catalog):
+    for entry in sorted(catalog.entries.values(), key=lambda item: item.pattern_id):
+        if entry.observable and len(entry.vault_dimensions) >= 2:
+            return entry
+    raise AssertionError("catalog has no observable entry with two dimensions")
+
+
+def _detection(entry, **overrides) -> dict[str, Any]:
+    detection = {
+        "pattern_id": entry.pattern_id,
+        "confidence": "strong",
+        "evidence": "The speaker did the thing, at 12:03.",
+        "dimensions": list(entry.vault_dimensions),
+    }
+    detection.update(overrides)
+    return detection
+
+
+def _lane(entry) -> str:
+    return (
+        "antipatterns_detected"
+        if entry.entry_type == "antipattern"
+        else "patterns_detected"
+    )
+
+
+def _talk(filename: str, entry, *detections) -> dict[str, Any]:
+    block: dict[str, Any] = {
+        "patterns_detected": [],
+        "antipatterns_detected": [],
+        "not_evaluable": [],
+    }
+    block[_lane(entry)] = list(detections)
+    return {"filename": filename, "pattern_observations": block}
+
+
+def _database(tmp_path: Path, talks: list[dict[str, Any]]) -> Path:
+    path = tmp_path / "tracking-database.json"
+    path.write_text(json.dumps({"schema_version": 1, "talks": talks}))
+    return path
+
+
+def _swapped(entry) -> dict[str, Any]:
+    """The 28-record live signature: `evidence` and `dimensions` exchanged."""
+    return _detection(
+        entry,
+        evidence=list(entry.vault_dimensions),
+        dimensions="The speaker did the thing, at 12:03.",
+    )
+
+
+class TestTheReportAnswersTheCorpusQuestion:
+    def test_a_clean_corpus_reports_usable(self, tmp_path, observable_entry) -> None:
+        path = _database(
+            tmp_path,
+            [_talk("a.md", observable_entry, _detection(observable_entry))],
+        )
+
+        report = audit.audit_database(path)
+
+        assert report["usable"] is True
+        assert report["summary"] == {
+            "talks_assessed": 1,
+            "talks_usable": 1,
+            "talks_unusable": 0,
+        }
+        assert report["reason_counts"] == {}
+
+    def test_it_counts_and_names_every_defective_talk(
+        self, tmp_path, observable_entry
+    ) -> None:
+        """A count says how bad; the filenames say where. Reporting only the
+        count leaves an owner unable to act on it."""
+        path = _database(
+            tmp_path,
+            [
+                _talk("clean.md", observable_entry, _detection(observable_entry)),
+                _talk("swapped.md", observable_entry, _swapped(observable_entry)),
+            ],
+        )
+
+        report = audit.audit_database(path)
+
+        assert report["usable"] is False
+        assert report["summary"]["talks_assessed"] == 2
+        assert report["summary"]["talks_unusable"] == 1
+        assert report["unusable_filenames"] == ["swapped.md"]
+        assert sum(report["reason_counts"].values()) >= 1
+        for names in report["reason_filenames"].values():
+            assert names == ["swapped.md"]
+
+    def test_a_talk_with_no_observations_is_reported_not_skipped(
+        self, tmp_path
+    ) -> None:
+        """9 of 209 live talks carried no block. Silence would have read as
+        nine clean talks."""
+        path = _database(tmp_path, [{"filename": "bare.md"}])
+
+        report = audit.audit_database(path)
+
+        assert report["summary"]["talks_unusable"] == 1
+        assert report["unusable_filenames"] == ["bare.md"]
+
+    def test_a_talk_whose_filename_is_unusable_is_still_named(
+        self, tmp_path, observable_entry
+    ) -> None:
+        """A malformed record is the kind this audit exists to surface, so it
+        must not be the one entry the report cannot identify."""
+        talk = _talk("ignored.md", observable_entry, _swapped(observable_entry))
+        del talk["filename"]
+        path = _database(tmp_path, [talk])
+
+        report = audit.audit_database(path)
+
+        assert report["unusable_filenames"] == ["talks[0]"]
+
+    def test_two_runs_over_one_database_are_byte_identical(
+        self, tmp_path, observable_entry
+    ) -> None:
+        """The criterion says attach deterministic counts to a report. A diff
+        between two runs has to be a real change, not dict ordering."""
+        path = _database(
+            tmp_path,
+            [
+                _talk("b.md", observable_entry, _swapped(observable_entry)),
+                _talk("a.md", observable_entry, _swapped(observable_entry)),
+            ],
+        )
+
+        first = json.dumps(audit.audit_database(path), sort_keys=True)
+        second = json.dumps(audit.audit_database(path), sort_keys=True)
+
+        assert first == second
+
+
+class TestTheProcessContract:
+    def test_a_clean_corpus_exits_zero(
+        self, tmp_path, observable_entry, capsys
+    ) -> None:
+        path = _database(
+            tmp_path,
+            [_talk("a.md", observable_entry, _detection(observable_entry))],
+        )
+
+        status = audit.run_cli([str(path)])
+
+        assert status == 0
+        assert json.loads(capsys.readouterr().out)["usable"] is True
+
+    def test_defects_exit_one_with_the_report_still_on_stdout(
+        self, tmp_path, observable_entry, capsys
+    ) -> None:
+        """Exit 1 is a finding about the corpus, not a failure of the audit, so
+        the report an owner needs must still be there."""
+        path = _database(
+            tmp_path,
+            [_talk("swapped.md", observable_entry, _swapped(observable_entry))],
+        )
+
+        status = audit.run_cli([str(path)])
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert json.loads(captured.out)["unusable_filenames"] == ["swapped.md"]
+        assert "before migration or reparse" in captured.err
+
+    def test_an_unreadable_database_exits_three_with_empty_stdout(
+        self, tmp_path, capsys
+    ) -> None:
+        """Distinct from exit 1. A broken auditor must not read as a corpus
+        full of defects."""
+        status = audit.run_cli([str(tmp_path / "absent.json")])
+
+        captured = capsys.readouterr()
+        assert status == 3
+        assert captured.out == ""
+        # stderr is one closed JSON document followed by the operator recovery
+        # note, so only the first line is the document.
+        document = json.loads(captured.err.splitlines()[0])
+        assert document["error"] == "persisted_observation_audit_unexpected_failure"
+        assert "UNAUDITED" in captured.err
+
+    def test_a_file_that_is_not_a_tracking_database_exits_three(
+        self, tmp_path, capsys
+    ) -> None:
+        path = tmp_path / "profile.json"
+        path.write_text(json.dumps({"schema_version": 1, "speaker": "someone"}))
+
+        status = audit.run_cli([str(path)])
+
+        assert status == 3
+        assert capsys.readouterr().out == ""
+
+    def test_it_never_writes_to_the_database(self, tmp_path, observable_entry) -> None:
+        """Read-only is the reason it is safe to point at a copy of a live
+        vault, so it is worth asserting rather than assuming."""
+        path = _database(
+            tmp_path,
+            [_talk("swapped.md", observable_entry, _swapped(observable_entry))],
+        )
+        before = path.read_bytes()
+
+        audit.run_cli([str(path)])
+
+        assert path.read_bytes() == before


### PR DESCRIPTION
Refs #167 — closes its last acceptance criterion. Does not close the issue: the reparse itself is vault-side work.

## The gap

> Run the validator against a copy of the live 209-talk database and attach the deterministic counts to the repair/reparse report.

`assess_persisted_pattern_observations` has seven in-flow consumers — migration, preflight, analysis rendering, queue normalization, persistence, the adherence baseline, the cohort snapshot. Every one assesses a talk to decide something about *that talk*, then moves on. None can answer "what is wrong with this corpus, in total, before anyone touches it", and no `SKILL.md` step exposed a standalone audit, so there was no way to point the validator at a database copy and get counts out.

This adds that entry point.

## Design decisions worth reviewing

**Counts *and* filenames.** A count says how bad it is; the filenames say where. Reporting only `{"detection_fields_swapped": 28}` leaves an owner unable to act on it.

**Read-only, and pointing it at a copy is the intended use** — not a caveat. The reparse decision wants the counts *before* the migration restamps anything; the same assessor runs in-flow afterwards regardless. A test asserts the database bytes are unchanged.

**Exit 1 ≠ exit 3.** Exit 1 means the corpus has defects and the report is still on stdout — a finding about the vault, not a failure of the audit. Exit 3 means the audit broke, with stdout empty and one JSON document on stderr. Collapsing them would make an unreadable database read as a corpus full of defects. This mirrors `audit-pattern-catalog.py`, whose shape and exit contract this follows.

**A talk with no observations is reported, not skipped.** 9 of the live 209 had no block. Silence would have read as nine clean talks.

**A talk whose own filename is unusable is named by index** (`talks[0]`). A malformed record is exactly what this audit exists to surface, so it must not be the one entry the report cannot identify.

**Byte-identical across runs.** Sorted throughout, so a diff between two runs is a real change rather than dict ordering — which is what "deterministic counts" in the criterion has to mean if the report is attached to anything.

## Verified end to end

Against a three-talk database (one clean, one carrying the live 28-record swapped-field signature, one with no block):

```
2 of 3 talks carry unusable persisted pattern observations; inspect JSON stdout before migration or reparse
{
  "reason_counts": {"detection_fields_swapped": 1, "observations_absent": 1},
  "reason_filenames": {"detection_fields_swapped": ["swapped.md"], "observations_absent": ["bare.md"]},
  "summary": {"talks_assessed": 3, "talks_unusable": 2, "talks_usable": 1},
  "usable": false
}
exit=1
```

## Not the abandoned branch

The issue notes an old `fix/persisted-detection-validation` branch carried a CLI at `REPORT_SCHEMA_VERSION = 2`. That branch imports `repair_exact_persisted_detection_swaps`, which no longer exists, so it will not import against current `main`. This is written against the current assessor rather than revived, and starts at `REPORT_SCHEMA_VERSION = 1` because it shares no shape with the old report.

## Surface sync

`references/bootstrap-and-preflight.md` gains the invocation and the point-it-at-a-copy instruction; `references/entrypoint-failure-contracts.md` gains its row, and the "two catalog gates" sentence becomes "three read-only audits".

## Gates

10 new tests, `ruff check`, `ruff format --check`, `pyright` (0 findings), `tessl plugin lint`, 5882 passed / 3 skipped.