### PR TITLE
feat(vault-ingress): bind video-extraction derivatives to the exact source content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,11 @@ source, re-extract) beats calling correct history corrupt. Nothing migrates a v3
 record in place.
 
 The manifest schema version moves to `ingress_contract.py` so the producer and
-every reader gate on one number instead of three literals.
+every reader gate on one number instead of three literals. Every surface that
+told an agent a completed video return needs a schema-v3 manifest — the return
+validator's messages, `schemas-db.md`, `processing-rules.md`,
+`source-identity-preflight.md`, `subagent-instructions.md` — now says v4, with v3
+wording kept only where it describes the archival path.
 
 `PIPELINE_VERSION` 0.12.0 → 0.13.0: a run now requires a probeable source, which
 is an extraction-behavior change, not only a record-shape one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+### feat(vault-ingress) — bind video derivatives to the exact source bytes (#216)
+
+A schema-v3 video-extraction manifest named its source by id and path. Both
+survive a replacement at that path, so a vault whose `AbCdEfGhI_1.mp4` was
+re-downloaded, re-encoded, or swapped for a different recording kept PDFs that
+passed every structural owner check while describing bytes that were no longer
+there. The record could not tell a re-acquisition from a substitution, and #190's
+runtime probe cannot close it after the fact: the strong claim is historical
+("these pages came from these bytes"), and no digest observed today can supply it
+retroactively.
+
+Schema v4 advances the manifest only when the producer can stamp an engine-owned
+source receipt captured around the same extraction run. The receipt is built by
+`build_video_source_receipt` in `skills/vault-ingress/scripts/video_evidence.py`
+from the bounded #190 probe, and carries the source digest, size,
+duration/container/stream evidence, the bound file generation, and the probe
+contract version. It is path-neutral and bounded — no locator, no raw ffprobe
+document, no parser stderr. It rides on the manifest head AND byte-identically on
+every `artifacts[]` entry, so a PDF separated from its manifest still names its
+source, and two derivatives from two runs cannot be merged under one head.
+
+The extractor probes before sampling a frame and again after the last PDF lands,
+sharing one assessment so the closing probe costs a stat when the generation held
+and a full re-probe exactly when it did not. Drift removes every PDF the run
+produced and exits non-zero with a closed reason: a half-bound result is worse
+than none. An unprobeable source — missing, corrupt, or a dataless cloud
+placeholder — produces no record at all rather than one bound to a stub.
+
+Readers compare the receipt's content fields against a fresh probe;
+`source_generation` is deliberately outside that comparison, because device,
+inode, and mtime are host-local and change on a byte-identical vault move while
+the digest already proves the bytes. Preflight gained two findings:
+`video_extraction_source_lineage_mismatch` (blocking — the source reads but is not
+what the PDFs came from) and `video_extraction_source_receipt_missing` for
+archival v3 records. The second is deliberately not `provenance_invalid`: a v3
+record was valid under its own contract, and naming the repair (reacquire the
+source, re-extract) beats calling correct history corrupt. Nothing migrates a v3
+record in place.
+
+The manifest schema version moves to `ingress_contract.py` so the producer and
+every reader gate on one number instead of three literals.
+
+`PIPELINE_VERSION` 0.12.0 → 0.13.0: a run now requires a probeable source, which
+is an extraction-behavior change, not only a record-shape one.
+
 ## 0.20.87 — 2026-08-18
 
 ### feat(vault-ingress) — a standalone persisted-observation audit (#167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ The extractor probes before sampling a frame and again after the last PDF lands,
 sharing one assessment so the closing probe costs a stat when the generation held
 and a full re-probe exactly when it did not. Drift removes every PDF the run
 produced and exits non-zero with a closed reason: a half-bound result is worse
-than none. An unprobeable source — missing, corrupt, or a dataless cloud
+than none. Cleanup covers every exit, not only drift — a run that publishes the
+slide-region PDF and then raises while producing the context PDF leaves nothing
+orphaned. An unprobeable source — missing, corrupt, or a dataless cloud
 placeholder — produces no record at all rather than one bound to a stub.
 
 Readers compare the receipt's content fields against a fresh probe;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ from the bounded #190 probe, and carries the source digest, size,
 duration/container/stream evidence, the bound file generation, and the probe
 contract version. It is path-neutral and bounded — no locator, no raw ffprobe
 document, no parser stderr. It rides on the manifest head AND byte-identically on
-every `artifacts[]` entry, so a PDF separated from its manifest still names its
-source, and two derivatives from two runs cannot be merged under one head.
+every `artifacts[]` entry, so each derivative's own record names its source and
+two derivatives from two runs cannot be merged under one head. The receipt lives
+in the record, not in the PDF file.
 
 The extractor probes before sampling a frame and again after the last PDF lands,
 sharing one assessment so the closing probe costs a stat when the generation held
@@ -29,10 +30,11 @@ than none. Derivatives stay staged until the closing probe passes, then publish
 as a set: each destination's prior version moves aside first, and a failure
 part-way puts every already-replaced destination back. A failed run — for any
 reason, not only drift — leaves the destination PDFs exactly as it found them.
-A publish a killed process left half-applied is undone on the next run: a
-stranded prior version is restored, and a destination that held nothing before
-the publish is recorded by an absence marker so its orphan can be told from an
-artifact worth keeping. An unprobeable source — missing, corrupt, or a dataless cloud
+Rollback covers interrupts, not only I/O errors. A publish a process the host
+killed outright left half-applied is undone on the next run: a stranded prior
+version is restored, and a destination that held nothing before the publish is
+recorded by an absence marker so its orphan can be told from an artifact worth
+keeping. An unprobeable source — missing, corrupt, or a dataless cloud
 placeholder — produces no record at all rather than one bound to a stub.
 
 Readers compare the receipt's content fields against a fresh probe;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,11 @@ produced and exits non-zero with a closed reason: a half-bound result is worse
 than none. Derivatives stay staged until the closing probe passes, then publish
 as a set: each destination's prior version moves aside first, and a failure
 part-way puts every already-replaced destination back. A failed run — for any
-reason, not only drift — leaves the destination PDFs exactly as it found them,
-and a prior version stranded by a killed publish is restored on the next run. An unprobeable source — missing, corrupt, or a dataless cloud
+reason, not only drift — leaves the destination PDFs exactly as it found them.
+A publish a killed process left half-applied is undone on the next run: a
+stranded prior version is restored, and a destination that held nothing before
+the publish is recorded by an absence marker so its orphan can be told from an
+artifact worth keeping. An unprobeable source — missing, corrupt, or a dataless cloud
 placeholder — produces no record at all rather than one bound to a stub.
 
 Readers compare the receipt's content fields against a fresh probe;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@ The extractor probes before sampling a frame and again after the last PDF lands,
 sharing one assessment so the closing probe costs a stat when the generation held
 and a full re-probe exactly when it did not. Drift removes every PDF the run
 produced and exits non-zero with a closed reason: a half-bound result is worse
-than none. Derivatives stay staged until the closing probe passes, so no exit
-path leaves a half-bound PDF behind and a failed re-extraction leaves a previous
-run's artifacts exactly as it found them — `combine_to_pdf` gained a `commit`
-flag and `commit_pdf_stage` publishes one held stage. An unprobeable source — missing, corrupt, or a dataless cloud
+than none. Derivatives stay staged until the closing probe passes, then publish
+as a set: each destination's prior version moves aside first, and a failure
+part-way puts every already-replaced destination back. A failed run — for any
+reason, not only drift — leaves the destination PDFs exactly as it found them,
+and a prior version stranded by a killed publish is restored on the next run. An unprobeable source — missing, corrupt, or a dataless cloud
 placeholder — produces no record at all rather than one bound to a stub.
 
 Readers compare the receipt's content fields against a fresh probe;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ The extractor probes before sampling a frame and again after the last PDF lands,
 sharing one assessment so the closing probe costs a stat when the generation held
 and a full re-probe exactly when it did not. Drift removes every PDF the run
 produced and exits non-zero with a closed reason: a half-bound result is worse
-than none. Cleanup covers every exit, not only drift — a run that publishes the
-slide-region PDF and then raises while producing the context PDF leaves nothing
-orphaned. An unprobeable source — missing, corrupt, or a dataless cloud
+than none. Derivatives stay staged until the closing probe passes, so no exit
+path leaves a half-bound PDF behind and a failed re-extraction leaves a previous
+run's artifacts exactly as it found them — `combine_to_pdf` gained a `commit`
+flag and `commit_pdf_stage` publishes one held stage. An unprobeable source — missing, corrupt, or a dataless cloud
 placeholder — produces no record at all rather than one bound to a stub.
 
 Readers compare the receipt's content fields against a fresh probe;

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -149,7 +149,7 @@ what counts as a source. In particular, an untrusted video
 `full_frame_context` may support concrete `delivery_video` observations but never
 creates `static_slides` or `native_deck` evidence.
 
-A trusted schema-v3 video-extracted `slide_region` PDF is a positive-only static
+A trusted schema-v4 video-extracted `slide_region` PDF is a positive-only static
 source. Its identity-bound pages may support citations and detections, but the
 sampling, transition filtering, and deduplication receipt does not prove that
 every delivered visual state survived. Therefore even full inspection of that

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1632,10 +1632,35 @@ Stored in `structured_data.video_extraction` on the talk entry:
 ```json
 {
   "slide_source": "video_extracted",
-  "schema_version": 3,
-  "pipeline_version": "0.12.0",
+  "schema_version": 4,
+  "pipeline_version": "0.13.0",
   "source_video_id": "AbCdEfGhI_1",
   "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+  "source_receipt": {
+    "schema_version": 1,
+    "probe_schema_version": 1,
+    "probe_pipeline_version": "1.0.0",
+    "source_sha256": "3b2f...c91a",
+    "source_size_bytes": 734003200,
+    "duration_seconds": 2998.4,
+    "duration_source": "format",
+    "container_family": "iso_bmff",
+    "stream_count": 2,
+    "video_stream_count": 1,
+    "audio_stream_count": 1,
+    "attached_picture_count": 0,
+    "other_stream_count": 0,
+    "source_generation": {
+      "size": 734003200,
+      "mtime_ns": 1767225600000000000,
+      "ctime_ns": 1767225600000000000,
+      "device": 16777232,
+      "inode": 84215045,
+      "mode": 33188,
+      "flags": 0,
+      "file_attributes": null
+    }
+  },
   "total_frames_extracted": 1500,
   "unique_frame_count": 85,
   "authored_slide_count": null,
@@ -1657,6 +1682,7 @@ Stored in `structured_data.video_extraction` on the talk entry:
       "page_count": 85,
       "source_video_id": "AbCdEfGhI_1",
       "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+      "source_receipt": { "...": "byte-identical to the manifest source_receipt" },
       "crop_method": "manual",
       "crop_verified": true,
       "trusted_for_authored_slide_analysis": true
@@ -1667,6 +1693,7 @@ Stored in `structured_data.video_extraction` on the talk entry:
       "page_count": 85,
       "source_video_id": "AbCdEfGhI_1",
       "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+      "source_receipt": { "...": "byte-identical to the manifest source_receipt" },
       "crop_method": "none",
       "crop_verified": false,
       "trusted_for_authored_slide_analysis": false
@@ -1680,7 +1707,7 @@ Stored in `structured_data.video_extraction` on the talk entry:
 The owner of this record's shape is `skills/vault-ingress/scripts/video-slide-extraction.py`.
 Two version fields track two independent axes:
 
-- `schema_version` (integer) — the record's **field shape**. Current value: `3`. The
+- `schema_version` (integer) — the record's **field shape**. Current value: `4`. The
   script bumps it on any field add/remove/rename. **Reader contract:** a record with no
   `schema_version` is the legacy pre-versioning shape — treat it as `schema_version 0`
   and read the fields that are present; a record with a `schema_version` higher than the
@@ -1701,6 +1728,36 @@ auto-detector returned a region; it is false for a manual region.
 crop as visually checked. For a version-1 record, readers may infer method `auto`,
 applied from whether `slide_region` is present, and verified `false`; re-extraction
 is still required before treating an old crop as verified.
+
+Version 4 binds every derivative to the exact source-video content it came from.
+`source_receipt` is engine-owned: the extractor captures it from the bounded
+`video_evidence` probe (`skills/vault-ingress/scripts/video_evidence.py` —
+`build_video_source_receipt`) before sampling frames, re-probes after the last PDF
+lands, and fails the run without writing a record when anything drifted. The same
+receipt is stamped on the manifest head and byte-identically on every
+`artifacts[]` entry, so a PDF separated from its manifest still names its source
+bytes and two derivatives from two different runs cannot be merged under one
+manifest. The receipt is path-neutral and bounded — a digest, duration/container/
+stream evidence, the bound file generation, and the probe contract version. Raw
+ffprobe output and parser stderr never reach it.
+
+Readers compare the receipt's content fields against a fresh probe of the same
+path: `probe_schema_version`, `probe_pipeline_version`, `source_sha256`,
+`source_size_bytes`, `duration_seconds`, `duration_source`, `container_family`,
+and the four stream counts (the authoritative list is
+`VIDEO_SOURCE_RECEIPT_LINEAGE_FIELDS` in `video_evidence.py`). `source_generation`
+is deliberately excluded from that comparison: device, inode, and mtime are
+host-local and change on a byte-identical vault move, while the digest already
+proves the bytes. The generation is what the extractor holds stable inside one
+run.
+
+A schema-3 record stays readable as an archival/reprocessing input and is never
+upgraded in place — a digest observed today cannot prove which bytes produced
+yesterday's pages. Preflight reports it as `video_extraction_source_receipt_missing`,
+naming the repair: reacquire the source video and re-extract. A source that reads
+but disagrees with the receipt is `video_extraction_source_lineage_mismatch`,
+blocking. A dataless or offline placeholder fails the bounded probe outright and
+stays unavailable until it is hydrated.
 
 Version 3 separates derived artifacts by provenance and scope. `artifacts[].path` and
 `source_video_path` are native absolute, symlink-resolved paths at extraction
@@ -1727,14 +1784,15 @@ mapped to its storage target; descendant symlinks remain forbidden.
   authored slide count, or slide-pattern claims.
 
 Ingress validates the manifest as one referential unit before trusting it: schema and
-pipeline versions are present; source and artifact identities agree; normalized region
+pipeline versions are present; the source receipt is complete and every artifact
+carries the same one; source and artifact identities agree; normalized region
 geometry agrees with `slide_region_method`, `slide_region_applied`,
 `slide_region_detected`, and `slide_region_verified`; retained-frame and artifact page
 counts agree with `unique_frame_count`; and artifact scope, crop method, verification,
 and trust flags are mutually consistent. `review_required: false` is accepted only for
 a verified manual `slide_region`; setting one optimistic flag cannot turn a context PDF
 into a deck. Persistence replaces this complete owner-versioned manifest rather than
-deep-merging it, so obsolete v1/v2 fields cannot survive inside a schema-v3 record.
+deep-merging it, so obsolete v1/v2/v3 fields cannot survive inside a schema-v4 record.
 
 `retained_frames` maps each PDF page to the zero-based index in the sampled frame
 sequence and its approximate video timestamp (`frame_index / fps_used`). Both artifacts

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1735,9 +1735,11 @@ Version 4 binds every derivative to the exact source-video content it came from.
 `build_video_source_receipt`) before sampling frames, re-probes after the last PDF
 lands, and fails the run without writing a record when anything drifted. The same
 receipt is stamped on the manifest head and byte-identically on every
-`artifacts[]` entry, so a PDF separated from its manifest still names its source
-bytes and two derivatives from two different runs cannot be merged under one
-manifest. The receipt is path-neutral and bounded — a digest, duration/container/
+`artifacts[]` entry, so each derivative's own record names the source bytes it
+came from and two derivatives from two different runs cannot be merged under one
+manifest. The receipt lives in the record, not in the PDF: a PDF file separated
+from the manifest carries only the scope and pipeline version its metadata
+already recorded. The receipt is path-neutral and bounded — a digest, duration/container/
 stream evidence, the bound file generation, and the probe contract version. Raw
 ffprobe output and parser stderr never reach it.
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1298,7 +1298,7 @@ portable canonical form `slides/<artifact>.pdf`; persistence copies it to the ta
 record and the analysis writer renders it in the provenance header. For
 `slide_source: "video_extracted"`, the filename must be
 `slides/{structured_data.video_extraction.source_video_id}.pdf`. `status: "processed"`
-requires that path plus a complete schema-v3 manifest whose top-level crop provenance
+requires that path plus a complete schema-v4 manifest whose top-level crop provenance
 and `slide_region` artifact independently agree on a verified manual crop. The return's
 manifest identity is also matched against the claimed talk's `youtube_id` before either
 writer changes state.

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -364,7 +364,7 @@ completeness and must be rerun before an absence conclusion.
   `processed_partial` may intentionally retain only manifest-declared source and
   derivative artifacts.
 - A present video-extracted PDF is not sufficient deck evidence by itself. A
-  completed record also requires a complete schema-v3
+  completed record also requires a complete schema-v4
   `structured_data.video_extraction` manifest, preserved source video and
   artifact paths, and internally consistent frame/page, scope, crop, and trust
   provenance. That manifest is valid only when `slide_source` is
@@ -372,7 +372,7 @@ completeness and must be rerun before an absence conclusion.
   before inspecting any of its paths. Every manifest PDF is independently
   probed and its bounded page count must match the manifest before either
   preflight or current-return persistence accepts the referential unit. Manifest
-  paths reject NUL/dot ambiguity. The schema-v3 source is exactly
+  paths reject NUL/dot ambiguity. The schema-v4 source is exactly
   `<youtube_id>.mp4`; it takes precedence over legacy top-level video path
   fields and must pass the bounded `source-video` evidence probe as a
   root-confined regular ISO-BMFF recording with a usable video stream and
@@ -401,10 +401,20 @@ independently verified transcript, rendered PDF, or native PPTX. A locator,
 root-containment, symlink/reparse, manifest-ID, or exact-basename mismatch
 remains `video_extraction_provenance_invalid`. For a completed record that
 claims the source, an unavailable source is blocking until repaired or the
-record is requeued; independent evidence remains valid. Introducing this probe
-does not itself change schema v3 or force a reparse. Requeue or reparse only when
-a current persisted claim depends on source-video evidence that can no longer be
-verified.
+record is requeued; independent evidence remains valid. Requeue or reparse only
+when a current persisted claim depends on source-video evidence that can no
+longer be verified.
+
+Source-to-derivative lineage is a separate question from source availability. A
+schema-v4 manifest carries the engine-owned `source_receipt` the extraction run
+captured, and preflight compares it against a fresh bounded probe of the same
+path. A source that reads but disagrees is
+`video_extraction_source_lineage_mismatch`, blocking: the saved PDFs describe
+bytes that are no longer there. A schema-v3 record predates the receipt and
+reports `video_extraction_source_receipt_missing` at the caller's severity —
+archival, not corrupt, and repaired only by reacquiring the source video and
+re-extracting. Preflight never stamps a receipt onto a v3 record; a digest
+observed now cannot prove what produced pages saved earlier.
 
 The thirteen stable slide-contract fault classes are:
 

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -179,13 +179,13 @@ explicitly authorizes full transcript/receipt replacement.
      copied to `slides/{youtube_id}.pdf`, recorded as `slides_local_path`, and analyzed
      like an authored PDF deck.
 
-  The return validator recomputes that trust from the complete schema-v3 manifest; it
+  The return validator recomputes that trust from the complete schema-v4 manifest; it
   does not trust `slide_source: "video_extracted"` or an isolated artifact boolean.
   `status: "processed"` requires both the trusted manifest and the promoted top-level
   `slides_local_path: "slides/{youtube_id}.pdf"`. A trusted artifact may still finish
   `processed_partial` when another channel fails, and its verified `slide_region` may
   supply positive `static_slides` evidence even before promotion. It does not
-  authorize an undetected or applicability outcome: extraction schema v3 proves
+  authorize an undetected or applicability outcome: extraction schema v4 proves
   crop/artifact identity, not that sampling, transition filtering, and deduplication
   preserved every delivered visual state. Any return without a promoted
   artifact must omit `slides_local_path` and put `slides_local_path` in `clear_fields`.

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -191,9 +191,13 @@ held and a full re-probe exactly when it did not.
   record is produced, exit 1 with a closed reason on stderr. A cloud placeholder
   stays unavailable until it is hydrated — the extractor never substitutes a
   stub.
-- **Source replaced mid-run**: every PDF this run produced is removed and the run
-  exits 1 with `video_source_replaced_during_extraction`. Half-bound derivatives
-  never survive.
+- **Source replaced mid-run**: this run's staged derivatives are dropped and the
+  run exits 1 with `video_source_replaced_during_extraction`. Half-bound
+  derivatives never survive.
+
+Derivatives stay in their per-destination stage until the closing probe passes,
+then publish together. A failed run — for any reason, not only drift — therefore
+leaves whatever a previous bound run published exactly as it found it.
 - **Success**: the receipt is stamped on the manifest head and on every
   `artifacts[]` entry, byte-identically.
 

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -201,7 +201,7 @@ outcomes:
 
 Sequencing, staging, and recovery mechanics belong to the script — see
 `extract_slides_from_video`, `_commit_bound_artifacts`, and
-`_restore_stale_pdf_backup` in
+`_recover_stale_pdf_publish` in
 `skills/vault-ingress/scripts/video-slide-extraction.py`. The receipt's shape
 and the reader-side comparison rules are in
 `skills/vault-ingress/references/schemas-db.md` ("Video Extraction Output

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -181,27 +181,29 @@ catalog evidence gate and mark it `not_evaluable` when no inspected source quali
 
 ## Source Binding — the Run Fails Rather Than Guess
 
-The extractor probes the source MP4 through the bounded `video_evidence` probe
-before it samples a single frame, and again after the last PDF lands. Both probes
-share one assessment, so the closing probe costs a stat when the file generation
-held and a full re-probe exactly when it did not.
+A run produces a record only when it can bind every derivative to the exact
+source-video content it came from. What the script guarantees, as observable
+outcomes:
 
 - **Source unprobeable** (missing, dataless/offline placeholder, corrupt
-  container, no video stream, ffprobe unavailable): no frames are sampled, no
-  record is produced, exit 1 with a closed reason on stderr. A cloud placeholder
-  stays unavailable until it is hydrated — the extractor never substitutes a
-  stub.
-- **Source replaced mid-run**: this run's staged derivatives are dropped and the
-  run exits 1 with `video_source_replaced_during_extraction`. Half-bound
-  derivatives never survive.
+  container, no video stream, ffprobe unavailable): exit 1 with a closed
+  `reason_code` as JSON on stderr, empty stdout, no frames sampled, no record,
+  no derivative written. A cloud placeholder stays unavailable until it is
+  hydrated — the extractor never substitutes a stub.
+- **Source replaced while the run was producing derivatives**: exit 1 with
+  `reason_code` `video_source_replaced_during_extraction`, and no record.
+- **Any failed run, for any reason**: the destination PDFs hold exactly what
+  they held before the run started. A failed re-extraction never destroys or
+  half-replaces what an earlier bound run published.
+- **Success**: stdout carries the schema-4 record, and the source receipt
+  appears on the manifest head and byte-identically on every `artifacts[]`
+  entry.
 
-Derivatives stay in their per-destination stage until the closing probe passes,
-then publish together. A failed run — for any reason, not only drift — therefore
-leaves whatever a previous bound run published exactly as it found it.
-- **Success**: the receipt is stamped on the manifest head and on every
-  `artifacts[]` entry, byte-identically.
-
-The receipt's shape and the reader-side comparison rules live in
+Sequencing, staging, and recovery mechanics belong to the script — see
+`extract_slides_from_video`, `_commit_bound_artifacts`, and
+`_restore_stale_pdf_backup` in
+`skills/vault-ingress/scripts/video-slide-extraction.py`. The receipt's shape
+and the reader-side comparison rules are in
 `skills/vault-ingress/references/schemas-db.md` ("Video Extraction Output
 Schema"); the builder and field lists are in
 `skills/vault-ingress/scripts/video_evidence.py`.

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -156,7 +156,7 @@ Always store the full script result in `structured_data.video_extraction` and ke
 `slides_local_path: "slides/{youtube_id}.pdf"` only after promoting a trusted
 `slide_region` artifact. Keep the source MP4 and context artifact in
 `slides-rebuild/{youtube_id}/`; they are provenance, not disposable scratch.
-The per-talk return validator recomputes trust from the complete schema-v3 manifest
+The per-talk return validator recomputes trust from the complete schema-v4 manifest
 and binds `source_video_id` to the claimed talk. Promotion is an exact-content
 operation: the bounded SHA-256 digest of `slides/{youtube_id}.pdf` must match the
 trusted manifest `slide_region` artifact. `status: "processed"` requires both that
@@ -178,6 +178,33 @@ catalog evidence gate and mark it `not_evaluable` when no inspected source quali
 | Source video | `slides-rebuild/{youtube_id}/{youtube_id}.mp4` | Durable source for crop review and re-extraction |
 | Extraction metadata | `structured_data.video_extraction` | Canonical paths, artifact scopes, crop trust, retained-frame/page mapping, thresholds, versions |
 | Intermediate JPEG frames | Deleted after PDF generation | Reproducible cache; source video and context remain |
+
+## Source Binding — the Run Fails Rather Than Guess
+
+The extractor probes the source MP4 through the bounded `video_evidence` probe
+before it samples a single frame, and again after the last PDF lands. Both probes
+share one assessment, so the closing probe costs a stat when the file generation
+held and a full re-probe exactly when it did not.
+
+- **Source unprobeable** (missing, dataless/offline placeholder, corrupt
+  container, no video stream, ffprobe unavailable): no frames are sampled, no
+  record is produced, exit 1 with a closed reason on stderr. A cloud placeholder
+  stays unavailable until it is hydrated — the extractor never substitutes a
+  stub.
+- **Source replaced mid-run**: every PDF this run produced is removed and the run
+  exits 1 with `video_source_replaced_during_extraction`. Half-bound derivatives
+  never survive.
+- **Success**: the receipt is stamped on the manifest head and on every
+  `artifacts[]` entry, byte-identically.
+
+The receipt's shape and the reader-side comparison rules live in
+`skills/vault-ingress/references/schemas-db.md` ("Video Extraction Output
+Schema"); the builder and field lists are in
+`skills/vault-ingress/scripts/video_evidence.py`.
+
+Schema-v3 records predate this binding. They stay readable for reprocessing and
+are never upgraded by stamping a digest observed later: reacquire the source
+video and re-extract to make a talk current.
 
 ## Slide-Region Detection — Contract and Limit
 
@@ -239,7 +266,8 @@ extraction dependencies installed).
 
 **Bump policy:** increment `PIPELINE_VERSION` in the same change that alters
 extraction *behavior* — the default `--fps` or `--threshold`, the 720p download
-tier, region-detection logic, the dedup hashing, or PDF assembly. A bump pairs
+tier, region-detection logic, the dedup hashing, PDF assembly, or the source
+binding a run requires. A bump pairs
 with the behavior change so re-ingested vaults are comparable across iterations.
 Pure refactors, comments, and doc edits that don't change output do not bump.
 

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -192,9 +192,14 @@ outcomes:
   hydrated — the extractor never substitutes a stub.
 - **Source replaced while the run was producing derivatives**: exit 1 with
   `reason_code` `video_source_replaced_during_extraction`, and no record.
-- **Any failed run, for any reason**: the destination PDFs hold exactly what
-  they held before the run started. A failed re-extraction never destroys or
-  half-replaces what an earlier bound run published.
+- **Any failed run, for any reason including an interrupt**: the destination
+  PDFs hold exactly what they held before the run started. A failed
+  re-extraction never destroys or half-replaces what an earlier bound run
+  published.
+- **A run the host kills outright** (SIGKILL, power loss) runs no handler, so
+  its publish can stay half-applied on disk until the next run for that video
+  ID repairs it. That repair is the first thing a run does; a killed run still
+  wrote no manifest, so nothing describes the half-applied state in between.
 - **Success**: stdout carries the schema-4 record, and the source receipt
   appears on the manifest head and byte-identically on every `artifacts[]`
   entry.

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -29,6 +29,13 @@ LOCAL_ARTIFACT_FIELDS = (
     "video_local_path",
     "video_path",
 )
+# Shape version of the structured_data.video_extraction record. Owned by
+# skills/vault-ingress/scripts/video-slide-extraction.py and shared here so the
+# producer and every reader gate on one number. v4 binds each derivative to the
+# engine-owned source receipt; v3 stays readable as an archival/reprocessing
+# input and is never upgraded in place.
+VIDEO_EXTRACTION_SCHEMA_VERSION = 4
+ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION = 3
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 GOOGLE_DRIVE_ID_RE = re.compile(r"[A-Za-z0-9_-]{3,}")
 

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -26,6 +26,7 @@ from artifact_locator import (
     materialize_native_root,
 )
 from ingress_contract import (
+    VIDEO_EXTRACTION_SCHEMA_VERSION,
     has_remote_slide_acquisition,
     has_remote_video_acquisition,
 )
@@ -53,6 +54,8 @@ from video_evidence import (
     VideoArtifactProbe,
     VideoEvidenceAssessment,
     VideoEvidenceError,
+    validate_video_source_receipt,
+    video_source_receipt_lineage_drift,
 )
 
 
@@ -702,7 +705,7 @@ def _local_video_binding(
         if youtube_id is None:
             return None, "video_extraction manifest has no claimed video id"
         if (
-            manifest.get("schema_version") != 3
+            manifest.get("schema_version") != VIDEO_EXTRACTION_SCHEMA_VERSION
             or manifest.get("source_video_id") != youtube_id
         ):
             return (
@@ -772,6 +775,12 @@ def _probe_video_manifest_artifacts(
         raise PatternEvidenceError(
             "video_extraction artifacts have no valid shared page count"
         )
+    try:
+        source_receipt = validate_video_source_receipt(manifest.get("source_receipt"))
+    except VideoEvidenceError as exc:
+        raise PatternEvidenceError(
+            f"video_extraction source_receipt is invalid ({exc.reason_code})"
+        ) from exc
     artifact_root = _canonical_pdf_root(vault_root)
     probes: dict[str, tuple[PdfArtifactProbe, Path]] = {}
     for index, artifact in enumerate(artifacts):
@@ -790,6 +799,22 @@ def _probe_video_manifest_artifacts(
         ):
             raise PatternEvidenceError(
                 f"video_extraction {scope} artifact is not identity/count bound"
+            )
+        # Derivative mixing is exactly the case a shared top-level receipt
+        # cannot catch: two PDFs from two extraction runs under one manifest.
+        try:
+            artifact_receipt = validate_video_source_receipt(
+                artifact.get("source_receipt")
+            )
+        except VideoEvidenceError as exc:
+            raise PatternEvidenceError(
+                f"video_extraction {scope} artifact source_receipt is invalid "
+                f"({exc.reason_code})"
+            ) from exc
+        if artifact_receipt != source_receipt:
+            raise PatternEvidenceError(
+                f"video_extraction {scope} artifact is not bound to the manifest "
+                "source receipt"
             )
         artifact_path = _resolve_local_pdf_artifact(
             vault_root,
@@ -839,7 +864,7 @@ def _trusted_video_slide_probe(
         except PatternEvidenceError as exc:
             return None, str(exc), None
     trusted = (
-        manifest.get("schema_version") == 3
+        manifest.get("schema_version") == VIDEO_EXTRACTION_SCHEMA_VERSION
         and manifest.get("source_video_id") == youtube_id
         and manifest.get("slide_region_method") == "manual"
         and manifest.get("slide_region_applied") is True
@@ -865,6 +890,20 @@ def _trusted_video_slide_probe(
             )
         except VideoEvidenceError as exc:
             return None, _video_failure_reason(exc), None
+    try:
+        source_receipt = validate_video_source_receipt(manifest.get("source_receipt"))
+    except VideoEvidenceError as exc:
+        return None, f"video_extraction source_receipt is invalid: {exc}", None
+    lineage_drift = video_source_receipt_lineage_drift(
+        source_receipt, source_video_probe
+    )
+    if lineage_drift:
+        return (
+            None,
+            "preserved source video is not the content the trusted slide-region "
+            f"PDF was extracted from: {sorted(lineage_drift)}",
+            None,
+        )
     artifacts = manifest.get("artifacts")
     if not isinstance(artifacts, list):
         return None, "video_extraction artifacts must be an array", None
@@ -885,6 +924,16 @@ def _trusted_video_slide_probe(
         or artifact.get("page_count") != count
     ):
         return None, "slide_region artifact is not identity/count bound", None
+    try:
+        artifact_receipt = validate_video_source_receipt(artifact.get("source_receipt"))
+    except VideoEvidenceError as exc:
+        return None, f"slide_region artifact source_receipt is invalid: {exc}", None
+    if artifact_receipt != source_receipt:
+        return (
+            None,
+            "slide_region artifact is not bound to the manifest source receipt",
+            None,
+        )
     artifact_root = _canonical_pdf_root(vault_root)
     if artifact_probes is not None:
         admitted = artifact_probes.get("slide_region")

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -48,6 +48,7 @@ from persisted_pattern_observations import (
 )
 from return_validation import (
     ANALYSIS_STATUSES,
+    ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION,
     PATTERN_SCORING_SCHEMA_VERSION,
     PatternCatalog,
     ReturnValidationError,
@@ -64,7 +65,11 @@ from pattern_evidence import (
     validate_transcript_quality_for_owner,
 )
 from pdf_evidence import PdfArtifactProbe, PdfEvidenceError, probe_pdf_artifact
-from video_evidence import VideoEvidenceAssessment, VideoEvidenceError
+from video_evidence import (
+    VideoEvidenceAssessment,
+    VideoEvidenceError,
+    video_source_receipt_lineage_drift,
+)
 from source_identity_matching import (
     EventAlias,
     event_agreement,
@@ -165,6 +170,15 @@ SOURCE_VIDEO_CONTRACT_CODES = frozenset(
         "source_video_artifact_missing",
         "source_video_artifact_unavailable",
         "source_video_artifact_unreadable",
+    }
+)
+# Lineage is a third class, distinct from a malformed manifest and from an
+# unreadable artifact: the record parses and the source reads, but the bytes on
+# disk are not the bytes the saved PDFs came from.
+VIDEO_SOURCE_LINEAGE_CODES = frozenset(
+    {
+        "video_extraction_source_receipt_missing",
+        "video_extraction_source_lineage_mismatch",
     }
 )
 
@@ -1563,7 +1577,7 @@ class VaultPreflight:
         *,
         require_trusted: bool,
     ) -> None:
-        """Validate schema-v3 provenance and any claimed authored-deck trust."""
+        """Validate schema-v4 lineage and any claimed authored-deck trust."""
         talk = self.talks[index]
         structured = talk.get("structured_data")
         extraction = (
@@ -1582,6 +1596,25 @@ class VaultPreflight:
             )
             return
 
+        if extraction.get("schema_version") == (
+            ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION
+        ):
+            # Archival, not corrupt. The saved PDFs carry no receipt proving
+            # which source bytes produced them, and no digest observed now can
+            # supply one after the fact.
+            self.talk_add(
+                index,
+                severity,
+                "video_extraction_source_receipt_missing",
+                "video extraction predates source-receipt binding; reacquire the "
+                "source video and re-extract",
+                field="structured_data.video_extraction.schema_version",
+                expected=VIDEO_EXTRACTION_SCHEMA_VERSION,
+                actual=ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION,
+                artifact_path=promoted_pdf,
+            )
+            return
+
         try:
             state = validate_video_extraction_manifest({"video_extraction": extraction})
         except ReturnValidationError as exc:
@@ -1596,9 +1629,9 @@ class VaultPreflight:
                 index,
                 severity,
                 "video_extraction_provenance_invalid",
-                "video extraction manifest violates the schema-v3 artifact contract",
+                "video extraction manifest violates the schema-v4 artifact contract",
                 field="structured_data.video_extraction",
-                expected="complete, internally consistent schema-v3 manifest",
+                expected="complete, internally consistent schema-v4 manifest",
                 # ReturnValidationError text can echo the malformed input value
                 # it rejected, so only its typed reason crosses the boundary.
                 actual=getattr(exc, "reason_code", None) or type(exc).__name__,
@@ -1625,7 +1658,7 @@ class VaultPreflight:
                 )
             else:
                 try:
-                    self.video_evidence_assessment.probe(
+                    source_video_probe = self.video_evidence_assessment.probe(
                         source_video_path,
                         trusted_root=self.artifact_root(),
                     )
@@ -1666,6 +1699,24 @@ class VaultPreflight:
                                 "structured_data.video_extraction.source_video_path"
                             ),
                             actual=failure,
+                            artifact_path=source_video_path,
+                            capability_fact=self._capabilities(index),
+                        )
+                else:
+                    drift = video_source_receipt_lineage_drift(
+                        state.source_receipt,
+                        source_video_probe,
+                    )
+                    if drift:
+                        self.talk_add(
+                            index,
+                            "blocking",
+                            "video_extraction_source_lineage_mismatch",
+                            "preserved source video is not the content the saved "
+                            "derivatives were extracted from",
+                            field=("structured_data.video_extraction.source_receipt"),
+                            expected="receipt agrees with a fresh bounded probe",
+                            actual=sorted(drift),
                             artifact_path=source_video_path,
                             capability_fact=self._capabilities(index),
                         )
@@ -1743,7 +1794,7 @@ class VaultPreflight:
                 "video_extraction_provenance_invalid",
                 "video extraction manifest is structurally or referentially invalid",
                 field="structured_data.video_extraction",
-                expected="complete schema-v3 manifest with existing source/artifacts",
+                expected="complete schema-v4 manifest with existing source/artifacts",
                 actual=errors,
                 artifact_path=promoted_pdf,
             )

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -1096,8 +1096,14 @@ def _validate_manifest_source_receipt(value, field: str) -> dict:
     try:
         return validate_video_source_receipt(value)
     except VideoEvidenceError as exc:
+        # The receipt boundary reports "source_receipt" for a whole-object
+        # rejection and a leaf name otherwise. Only a leaf earns a suffix.
         detail = exc.details.get("field")
-        suffix = f".{detail}" if isinstance(detail, str) and detail != field else ""
+        suffix = (
+            f".{detail}"
+            if isinstance(detail, str) and detail != "source_receipt"
+            else ""
+        )
         _manifest_error(
             f"{field}{suffix}",
             "must be a complete engine-owned source-video receipt",

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -1135,7 +1135,7 @@ def _validate_slide_region(value) -> tuple[float, float, float, float] | None:
 
 
 def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState:
-    """Validate a complete schema-v3 manifest and derive authored-slide trust.
+    """Validate a complete schema-v4 manifest and derive authored-slide trust.
 
     Trust is recomputed from mutually consistent top-level crop provenance and
     the scoped artifact record. A model cannot make context frames look like an
@@ -1145,7 +1145,7 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
     if not isinstance(manifest, dict):
         raise ReturnValidationError(
             "slide_source video_extracted requires a complete "
-            "structured_data.video_extraction schema-v3 manifest"
+            "structured_data.video_extraction schema-v4 manifest"
         )
     if manifest.get("schema_version") != VIDEO_EXTRACTION_SCHEMA_VERSION:
         # An archival record is separable from a malformed one: it was valid
@@ -1416,7 +1416,7 @@ def _validate_video_return(
     if ret["status"] == "processed" and not trusted_and_promoted:
         raise ReturnValidationError(
             "status processed with slide_source video_extracted requires a trusted "
-            "schema-v3 slide_region manifest and promoted slides_local_path"
+            "schema-v4 slide_region manifest and promoted slides_local_path"
         )
     if slides_local_path is None:
         clear_fields = set(ret.get("clear_fields") or [])
@@ -2492,7 +2492,7 @@ def _validate_available_sources(
     ):
         raise ReturnValidationError(
             "evidence_sources includes static_slides, but the video extraction has "
-            "no trusted schema-v3 slide_region artifact"
+            "no trusted schema-v4 slide_region artifact"
         )
     if slide_source not in {"pptx", "both"} and "native_deck" in available:
         raise ReturnValidationError(

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -43,6 +43,8 @@ from catalog_io import (
     qualifying_evidence_groups,
 )
 from ingress_contract import (
+    ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION,
+    VIDEO_EXTRACTION_SCHEMA_VERSION,
     IngressContractError,
     has_local_source_artifact,
     has_pdf_source,
@@ -76,7 +78,11 @@ from pptx_evidence import (
     ranges_cover_pages,
     validate_native_deck_audit,
 )
-from video_evidence import VideoEvidenceAssessment
+from video_evidence import (
+    VideoEvidenceAssessment,
+    VideoEvidenceError,
+    validate_video_source_receipt,
+)
 
 
 ANALYSIS_STATUSES = frozenset({"processed", "processed_partial"})
@@ -269,7 +275,6 @@ SUBSTANTIVE_PROSE_FIELDS = frozenset(
 LANGUAGE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$")
 CONDITION_ID_RE = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
 VIDEO_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-VIDEO_EXTRACTION_SCHEMA_VERSION = 3
 QUEUE_CLAIM_SCHEMA_VERSION = 6
 SOURCE_LOCATED_QUEUE_CLAIM_SCHEMA_VERSION = 4
 BASELINE_QUEUE_CLAIM_SCHEMA_VERSION = 3
@@ -630,6 +635,7 @@ class ScoringGenerationAssessment:
 class VideoExtractionState:
     source_video_id: str
     trusted_slide_region: bool
+    source_receipt: dict
 
 
 def canonical_return_sha256(ret: dict) -> str:
@@ -1085,6 +1091,20 @@ def _validate_absolute_manifest_path(value, field: str) -> str:
     return value
 
 
+def _validate_manifest_source_receipt(value, field: str) -> dict:
+    """Return the canonical engine-owned source receipt for one manifest field."""
+    try:
+        return validate_video_source_receipt(value)
+    except VideoEvidenceError as exc:
+        detail = exc.details.get("field")
+        suffix = f".{detail}" if isinstance(detail, str) and detail != field else ""
+        _manifest_error(
+            f"{field}{suffix}",
+            "must be a complete engine-owned source-video receipt",
+            reason=exc.reason_code,
+        )
+
+
 def _validate_slide_region(value) -> tuple[float, float, float, float] | None:
     if value is None:
         return None
@@ -1122,7 +1142,20 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
             "structured_data.video_extraction schema-v3 manifest"
         )
     if manifest.get("schema_version") != VIDEO_EXTRACTION_SCHEMA_VERSION:
-        _manifest_error("schema_version", f"must be {VIDEO_EXTRACTION_SCHEMA_VERSION}")
+        # An archival record is separable from a malformed one: it was valid
+        # under its own contract and names the exact repair (reacquire the
+        # source, re-extract), so readers surface it as work rather than rot.
+        reason = (
+            "video_extraction.schema_version_archival"
+            if manifest.get("schema_version")
+            == ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION
+            else None
+        )
+        _manifest_error(
+            "schema_version",
+            f"must be {VIDEO_EXTRACTION_SCHEMA_VERSION}",
+            reason=reason,
+        )
     if manifest.get("slide_source") != "video_extracted":
         _manifest_error("slide_source", "must be 'video_extracted'")
     pipeline_version = manifest.get("pipeline_version")
@@ -1149,6 +1182,9 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
             "source_video_path",
             f"must end in {source_video_id}.mp4",
         )
+    source_receipt = _validate_manifest_source_receipt(
+        manifest.get("source_receipt"), "source_receipt"
+    )
     total_frames = _manifest_nonnegative_int(
         manifest, "total_frames_extracted", positive=True
     )
@@ -1298,6 +1334,14 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
             _manifest_error(
                 f"{label}.source_video_path", "must match source_video_path"
             )
+        artifact_receipt = _validate_manifest_source_receipt(
+            artifact.get("source_receipt"), f"{label}.source_receipt"
+        )
+        if artifact_receipt != source_receipt:
+            _manifest_error(
+                f"{label}.source_receipt",
+                "must match the manifest source_receipt exactly",
+            )
         crop_method = artifact.get("crop_method")
         crop_verified = artifact.get("crop_verified")
         artifact_trusted = artifact.get("trusted_for_authored_slide_analysis")
@@ -1340,6 +1384,7 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
     return VideoExtractionState(
         source_video_id=source_video_id,
         trusted_slide_region=trusted,
+        source_receipt=source_receipt,
     )
 
 

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -31,6 +31,7 @@ Examples:
 """
 
 import argparse
+import copy
 import hashlib
 import json
 import os
@@ -41,6 +42,12 @@ import tempfile
 
 from artifact_locator import ArtifactLocatorError, materialize_native_root
 from ingress_contract import YOUTUBE_ID_RE
+from video_evidence import (
+    VideoEvidenceAssessment,
+    VideoEvidenceError,
+    build_video_source_receipt,
+    video_source_receipt_generation_drift,
+)
 
 # Pipeline version — stamped into every video-extracted vault entry (DB row +
 # PDF metadata) so artifacts record which extraction iteration produced them.
@@ -48,14 +55,14 @@ from ingress_contract import YOUTUBE_ID_RE
 # the download tier, region-detection logic, dedup hashing, or PDF assembly.
 # See skills/vault-ingress/references/video-slide-extraction.md ("Pipeline
 # Versioning") for the policy.
-PIPELINE_VERSION = "0.12.0"
+PIPELINE_VERSION = "0.13.0"
 
 # Shape version of the structured_data.video_extraction record (distinct from
 # PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
 # field shape). Bump on any field add/remove/rename. Records written before this
 # field existed have no schema_version and are read as the legacy shape (0).
 # See skills/vault-ingress/references/schemas-db.md ("Video Extraction Output Schema").
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 VIDEO_DEPENDENCY_INSTALL = (
     'pip install "ImageHash==4.3.2" "numpy==2.2.6" "Pillow==12.3.0" "filelock==3.32.2"'
@@ -88,6 +95,71 @@ def validate_youtube_id(value: object) -> str:
     if not isinstance(value, str) or YOUTUBE_ID_RE.fullmatch(value) is None:
         raise ValueError("youtube_id_invalid")
     return value
+
+
+class VideoSourceLineageError(RuntimeError):
+    """No derivative could be bound to one exact source-video generation.
+
+    Raised instead of returning a manifest. A schema-4 record exists only when
+    the engine-owned receipt was captured around the same extraction run, so a
+    run that cannot prove that produces no record at all.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        details: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.details = dict(details or {})
+
+
+def _capture_source_receipt(assessment, source_video_path):
+    """Return the engine-owned receipt for the exact source generation."""
+    try:
+        probe = assessment.probe(source_video_path)
+    except VideoEvidenceError as exc:
+        raise VideoSourceLineageError(
+            "source video did not pass bounded evidence inspection",
+            reason_code=exc.reason_code,
+            details=dict(exc.details),
+        ) from exc
+    return build_video_source_receipt(probe)
+
+
+def _require_stable_source(assessment, source_video_path, source_receipt):
+    """Fail the run when the source changed while derivatives were produced."""
+    try:
+        probe = assessment.probe(source_video_path)
+    except VideoEvidenceError as exc:
+        raise VideoSourceLineageError(
+            "source video became uninspectable during extraction",
+            reason_code=exc.reason_code,
+            details=dict(exc.details),
+        ) from exc
+    drift = video_source_receipt_generation_drift(source_receipt, probe)
+    if drift:
+        raise VideoSourceLineageError(
+            "source video was replaced during extraction",
+            reason_code="video_source_replaced_during_extraction",
+            details={"drift": list(drift)},
+        )
+
+
+def _discard_unbound_artifacts(result):
+    """Remove derivatives that cannot be bound to the recorded source."""
+    artifacts = result.get("artifacts") if isinstance(result, dict) else None
+    for artifact in artifacts or []:
+        path = artifact.get("path")
+        if not isinstance(path, str):
+            continue
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            continue
 
 
 def _confined_output_path(output_root: str, filename: str) -> str:
@@ -700,11 +772,17 @@ def artifact_record(
     page_count,
     source_video_id,
     source_video_path,
+    source_receipt,
     crop_method="none",
     crop_verified=False,
     trusted_for_authored_slide_analysis=False,
 ):
-    """Build a self-describing PDF artifact record for the extraction result."""
+    """Build a self-describing PDF artifact record for the extraction result.
+
+    ``source_receipt`` is the run's engine-owned source receipt. Every
+    derivative carries it, so a PDF separated from the manifest still names the
+    exact source bytes it came from.
+    """
     if artifact_scope not in ("slide_region", "full_frame_context"):
         raise ValueError(f"unknown artifact scope: {artifact_scope!r}")
     if artifact_scope == "full_frame_context" and (
@@ -724,6 +802,7 @@ def artifact_record(
         "page_count": page_count,
         "source_video_id": source_video_id,
         "source_video_path": canonical_path(source_video_path),
+        "source_receipt": copy.deepcopy(source_receipt),
         "crop_method": crop_method,
         "crop_verified": bool(crop_verified),
         "trusted_for_authored_slide_analysis": bool(
@@ -737,6 +816,7 @@ def _extract_slides_in_workspace(
     output_dir,
     youtube_id,
     frames_dir,
+    source_receipt,
     fps=0.5,
     hash_threshold=8,
     slide_region: str | NormalizedSlideRegion = "auto",
@@ -749,6 +829,8 @@ def _extract_slides_in_workspace(
         video_path: Path to downloaded MP4
         output_dir: Directory for intermediate files and output PDF
         youtube_id: YouTube video ID (used for naming)
+        source_receipt: Engine-owned receipt for the exact source generation,
+                        stamped onto the manifest and every derivative record.
         fps: Frames per second to extract (0.5 = 1 frame per 2 seconds)
         hash_threshold: Largest hash distance treated as the same slide. Higher
                         values merge more and keep fewer frames.
@@ -784,6 +866,7 @@ def _extract_slides_in_workspace(
             "pipeline_version": PIPELINE_VERSION,
             "source_video_id": youtube_id,
             "source_video_path": source_video_path,
+            "source_receipt": copy.deepcopy(source_receipt),
             "total_frames_extracted": 0,
             "unique_frame_count": 0,
             "authored_slide_count": None,
@@ -831,6 +914,7 @@ def _extract_slides_in_workspace(
                     len(unique_frames),
                     youtube_id,
                     source_video_path,
+                    source_receipt,
                     crop_method=region_provenance["slide_region_method"],
                     crop_verified=region_provenance["slide_region_verified"],
                     trusted_for_authored_slide_analysis=trusted_slide_evidence,
@@ -855,6 +939,7 @@ def _extract_slides_in_workspace(
                     len(unique_frames),
                     youtube_id,
                     source_video_path,
+                    source_receipt,
                 )
             )
 
@@ -864,6 +949,7 @@ def _extract_slides_in_workspace(
         "pipeline_version": PIPELINE_VERSION,
         "source_video_id": youtube_id,
         "source_video_path": source_video_path,
+        "source_receipt": copy.deepcopy(source_receipt),
         "total_frames_extracted": len(frames),
         "unique_frame_count": len(unique_frames),
         # Frame/page count is not an authored slide count: animations, camera
@@ -893,7 +979,14 @@ def extract_slides_from_video(
     slide_region_verified=False,
     include_context_pdf=True,
 ):
-    """Run one extraction in a fresh frame workspace that is always removed."""
+    """Run one extraction bound end to end to one exact source generation.
+
+    The source is probed before any frame is sampled and again after every
+    derivative is written. One assessment owns both probes, so the closing
+    probe costs a stat when the generation held and a full re-probe exactly
+    when it did not. Any drift discards the derivatives and fails the run —
+    a manifest is never written against bytes it did not come from.
+    """
     youtube_id = validate_youtube_id(youtube_id)
     if fps <= 0:
         raise ValueError("fps must be greater than zero")
@@ -903,6 +996,8 @@ def extract_slides_from_video(
     run_lock = _video_run_lock_path(output_dir, youtube_id)
 
     with _video_run_lock(run_lock):
+        assessment = VideoEvidenceAssessment()
+        source_receipt = _capture_source_receipt(assessment, source_video_path)
         for filename in (
             f"{youtube_id}.slide-region.pdf",
             f"{youtube_id}.context.pdf",
@@ -911,17 +1006,24 @@ def extract_slides_from_video(
         with tempfile.TemporaryDirectory(
             prefix="speaker-toolkit-video-frames-"
         ) as frames_dir:
-            return _extract_slides_in_workspace(
+            result = _extract_slides_in_workspace(
                 source_video_path,
                 output_dir,
                 youtube_id,
                 frames_dir,
+                source_receipt,
                 fps=fps,
                 hash_threshold=hash_threshold,
                 slide_region=slide_region,
                 slide_region_verified=slide_region_verified,
                 include_context_pdf=include_context_pdf,
             )
+        try:
+            _require_stable_source(assessment, source_video_path, source_receipt)
+        except VideoSourceLineageError:
+            _discard_unbound_artifacts(result)
+            raise
+        return result
 
 
 def main():
@@ -997,16 +1099,29 @@ def main():
         )
         sys.exit(1)
 
-    result = extract_slides_from_video(
-        args.video,
-        args.outdir,
-        youtube_id,
-        fps=args.fps,
-        hash_threshold=args.threshold,
-        slide_region=args.region,
-        slide_region_verified=args.region_verified,
-        include_context_pdf=args.include_context_pdf,
-    )
+    try:
+        result = extract_slides_from_video(
+            args.video,
+            args.outdir,
+            youtube_id,
+            fps=args.fps,
+            hash_threshold=args.threshold,
+            slide_region=args.region,
+            slide_region_verified=args.region_verified,
+            include_context_pdf=args.include_context_pdf,
+        )
+    except VideoSourceLineageError as exc:
+        print(
+            json.dumps(
+                {
+                    "error": str(exc),
+                    "reason_code": exc.reason_code,
+                    "details": exc.details,
+                }
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
     print(json.dumps(result, indent=2))
 
 

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -149,13 +149,9 @@ def _require_stable_source(assessment, source_video_path, source_receipt):
         )
 
 
-def _discard_unbound_artifacts(result):
-    """Remove derivatives that cannot be bound to the recorded source."""
-    artifacts = result.get("artifacts") if isinstance(result, dict) else None
-    for artifact in artifacts or []:
-        path = artifact.get("path")
-        if not isinstance(path, str):
-            continue
+def _discard_unbound_artifacts(published):
+    """Remove every derivative this run published but could not bind."""
+    for path in published:
         try:
             os.unlink(path)
         except FileNotFoundError:
@@ -817,6 +813,7 @@ def _extract_slides_in_workspace(
     youtube_id,
     frames_dir,
     source_receipt,
+    published,
     fps=0.5,
     hash_threshold=8,
     slide_region: str | NormalizedSlideRegion = "auto",
@@ -831,6 +828,9 @@ def _extract_slides_in_workspace(
         youtube_id: YouTube video ID (used for naming)
         source_receipt: Engine-owned receipt for the exact source generation,
                         stamped onto the manifest and every derivative record.
+        published: Caller-owned list this appends each published PDF path to the
+                   moment it lands, so a caller can remove them when the run
+                   fails partway through.
         fps: Frames per second to extract (0.5 = 1 frame per 2 seconds)
         hash_threshold: Largest hash distance treated as the same slide. Higher
                         values merge more and keep fewer frames.
@@ -907,6 +907,7 @@ def _extract_slides_in_workspace(
             crop_verified=region_provenance["slide_region_verified"],
         )
         if slide_pdf_path:
+            published.append(slide_pdf_path)
             artifacts.append(
                 artifact_record(
                     slide_pdf_path,
@@ -932,6 +933,7 @@ def _extract_slides_in_workspace(
             source_video_id=youtube_id,
         )
         if context_pdf_path:
+            published.append(context_pdf_path)
             artifacts.append(
                 artifact_record(
                     context_pdf_path,
@@ -986,6 +988,9 @@ def extract_slides_from_video(
     probe costs a stat when the generation held and a full re-probe exactly
     when it did not. Any drift discards the derivatives and fails the run —
     a manifest is never written against bytes it did not come from.
+
+    Cleanup covers every exit, not only drift: a run that publishes one PDF and
+    then raises while producing the next leaves no half-bound derivative behind.
     """
     youtube_id = validate_youtube_id(youtube_id)
     if fps <= 0:
@@ -1003,26 +1008,30 @@ def extract_slides_from_video(
             f"{youtube_id}.context.pdf",
         ):
             _remove_stale_pdf_stage(_confined_output_path(output_dir, filename))
-        with tempfile.TemporaryDirectory(
-            prefix="speaker-toolkit-video-frames-"
-        ) as frames_dir:
-            result = _extract_slides_in_workspace(
-                source_video_path,
-                output_dir,
-                youtube_id,
-                frames_dir,
-                source_receipt,
-                fps=fps,
-                hash_threshold=hash_threshold,
-                slide_region=slide_region,
-                slide_region_verified=slide_region_verified,
-                include_context_pdf=include_context_pdf,
-            )
+        published: list[str] = []
+        bound = False
         try:
+            with tempfile.TemporaryDirectory(
+                prefix="speaker-toolkit-video-frames-"
+            ) as frames_dir:
+                result = _extract_slides_in_workspace(
+                    source_video_path,
+                    output_dir,
+                    youtube_id,
+                    frames_dir,
+                    source_receipt,
+                    published,
+                    fps=fps,
+                    hash_threshold=hash_threshold,
+                    slide_region=slide_region,
+                    slide_region_verified=slide_region_verified,
+                    include_context_pdf=include_context_pdf,
+                )
             _require_stable_source(assessment, source_video_path, source_receipt)
-        except VideoSourceLineageError:
-            _discard_unbound_artifacts(result)
-            raise
+            bound = True
+        finally:
+            if not bound:
+                _discard_unbound_artifacts(published)
         return result
 
 

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -159,12 +159,14 @@ def _commit_bound_artifacts(staged):
     """Publish this run's staged derivatives once the binding is proven.
 
     Several destinations cannot be replaced in one portable atomic rename, so
-    each publish moves the prior version aside first and a failure part-way
-    puts every already-replaced destination back. Callers see the whole set
-    published or none of it — never one run's slide-region PDF beside another
-    run's context PDF.
+    each publish moves the prior version aside first and any exit part-way —
+    interrupts included — puts every already-replaced destination back. Callers
+    see the whole set published or none of it, never one run's slide-region PDF
+    beside another run's context PDF. A process the host kills outright cannot
+    run this; `_recover_stale_pdf_publish` repairs that at the next run.
     """
     replaced: list[tuple[str, str | None]] = []
+    published = False
     try:
         for path in staged:
             backup = _pdf_backup_path(path)
@@ -180,14 +182,15 @@ def _commit_bound_artifacts(staged):
             # to put it back.
             replaced.append((path, backup))
             commit_pdf_stage(path)
-    except OSError:
-        for path, backup in reversed(replaced):
-            if backup is None:
-                _remove_regular_file(path)
-                _clear_pdf_absent_marker(path)
-                continue
-            os.replace(backup, path)
-        raise
+        published = True
+    finally:
+        if not published:
+            for path, backup in reversed(replaced):
+                if backup is None:
+                    _remove_regular_file(path)
+                    _clear_pdf_absent_marker(path)
+                    continue
+                os.replace(backup, path)
     for path, backup in replaced:
         if backup is None:
             _clear_pdf_absent_marker(path)
@@ -691,7 +694,13 @@ def _mark_pdf_absent(output_pdf: str) -> None:
     version worth keeping.
     """
     marker = _pdf_absent_marker_path(output_pdf)
-    with open(marker, "wb") as handle:
+    try:
+        # Exclusive create, like the stage: O_CREAT|O_EXCL never follows a
+        # symlink, so a planted link cannot redirect this write.
+        handle = open(marker, "xb")
+    except FileExistsError:
+        raise ValueError("video_pdf_absent_marker_invalid") from None
+    with handle:
         handle.flush()
         os.fsync(handle.fileno())
 

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -123,7 +123,9 @@ def _capture_source_receipt(assessment, source_video_path):
         probe = assessment.probe(source_video_path)
     except VideoEvidenceError as exc:
         raise VideoSourceLineageError(
-            "source video did not pass bounded evidence inspection",
+            "source video did not pass bounded evidence inspection — hydrate a "
+            "cloud placeholder, or reacquire the MP4 with "
+            "batch-download-videos.sh, then rerun extraction",
             reason_code=exc.reason_code,
             details=dict(exc.details),
         ) from exc
@@ -136,14 +138,18 @@ def _require_stable_source(assessment, source_video_path, source_receipt):
         probe = assessment.probe(source_video_path)
     except VideoEvidenceError as exc:
         raise VideoSourceLineageError(
-            "source video became uninspectable during extraction",
+            "source video became uninspectable during extraction — restore the "
+            "MP4 at its recorded path and rerun extraction with nothing else "
+            "writing to it",
             reason_code=exc.reason_code,
             details=dict(exc.details),
         ) from exc
     drift = video_source_receipt_generation_drift(source_receipt, probe)
     if drift:
         raise VideoSourceLineageError(
-            "source video was replaced during extraction",
+            "source video was replaced during extraction — no derivatives were "
+            "kept; rerun extraction once the MP4 will stay unchanged for the "
+            "whole run",
             reason_code="video_source_replaced_during_extraction",
             details={"drift": list(drift)},
         )

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -158,13 +158,37 @@ def _discard_unbound_artifacts(staged):
 def _commit_bound_artifacts(staged):
     """Publish this run's staged derivatives once the binding is proven.
 
-    Multi-file replacement is not one portable atomic rename, so a host failure
-    between the two renames can leave one derivative published. Both name the
-    same source receipt, so the readers reject the pair rather than trusting a
-    mixed set; the manifest is only written after this returns.
+    Several destinations cannot be replaced in one portable atomic rename, so
+    each publish moves the prior version aside first and a failure part-way
+    puts every already-replaced destination back. Callers see the whole set
+    published or none of it — never one run's slide-region PDF beside another
+    run's context PDF.
     """
-    for path in staged:
-        commit_pdf_stage(path)
+    replaced: list[tuple[str, str | None]] = []
+    try:
+        for path in staged:
+            backup = _pdf_backup_path(path)
+            _remove_regular_file(backup)
+            try:
+                os.replace(path, backup)
+            except FileNotFoundError:
+                # Nothing to put back: this destination had no prior version.
+                backup = None
+            # Recorded before the publish, not after: the prior version is
+            # already moved aside, so a failure in the publish itself still has
+            # to put it back.
+            replaced.append((path, backup))
+            commit_pdf_stage(path)
+    except OSError:
+        for path, backup in reversed(replaced):
+            if backup is None:
+                _remove_regular_file(path)
+                continue
+            os.replace(backup, path)
+        raise
+    for _path, backup in replaced:
+        if backup is not None:
+            _remove_regular_file(backup)
 
 
 def _confined_output_path(output_root: str, filename: str) -> str:
@@ -614,6 +638,7 @@ def review_reason_for_region(region, provenance):
 
 
 _PDF_STAGE_SUFFIX = ".speaker-toolkit-stage.tmp"
+_PDF_BACKUP_SUFFIX = ".speaker-toolkit-prior.tmp"
 
 
 def _pdf_stage_path(output_pdf: str) -> str:
@@ -624,6 +649,22 @@ def _pdf_stage_path(output_pdf: str) -> str:
     )
 
 
+def _pdf_backup_path(output_pdf: str) -> str:
+    """Return the deterministic prior-version slot for one PDF destination."""
+    return os.path.join(
+        os.path.dirname(output_pdf),
+        f".{os.path.basename(output_pdf)}{_PDF_BACKUP_SUFFIX}",
+    )
+
+
+def _remove_regular_file(path: str) -> None:
+    """Unlink one file this run owns, tolerating an already-absent leaf."""
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
 def _remove_stale_pdf_stage(output_pdf: str) -> None:
     """Reclaim the exact stage left by an interrupted prior run."""
     try:
@@ -632,6 +673,22 @@ def _remove_stale_pdf_stage(output_pdf: str) -> None:
         pass
     except IsADirectoryError:
         raise ValueError("video_pdf_stage_invalid") from None
+
+
+def _restore_stale_pdf_backup(output_pdf: str) -> None:
+    """Put back a prior version a run left behind when the host died mid-publish.
+
+    The backup exists only between one destination's two renames, so finding
+    one means that window never closed. The destination holds either the prior
+    version or the new one, and the prior version is the one a persisted
+    manifest still describes.
+    """
+    backup = _pdf_backup_path(output_pdf)
+    if not os.path.exists(backup):
+        return
+    if not stat.S_ISREG(os.lstat(backup).st_mode):
+        raise ValueError("video_pdf_backup_invalid")
+    os.replace(backup, output_pdf)
 
 
 def _open_pdf_stage(output_pdf: str):
@@ -1034,7 +1091,9 @@ def extract_slides_from_video(
             f"{youtube_id}.slide-region.pdf",
             f"{youtube_id}.context.pdf",
         ):
-            _remove_stale_pdf_stage(_confined_output_path(output_dir, filename))
+            destination = _confined_output_path(output_dir, filename)
+            _restore_stale_pdf_backup(destination)
+            _remove_stale_pdf_stage(destination)
         published: list[str] = []
         bound = False
         try:

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -149,13 +149,22 @@ def _require_stable_source(assessment, source_video_path, source_receipt):
         )
 
 
-def _discard_unbound_artifacts(published):
-    """Remove every derivative this run published but could not bind."""
-    for path in published:
-        try:
-            os.unlink(path)
-        except FileNotFoundError:
-            continue
+def _discard_unbound_artifacts(staged):
+    """Drop every stage this run wrote, leaving prior derivatives untouched."""
+    for path in staged:
+        _remove_stale_pdf_stage(path)
+
+
+def _commit_bound_artifacts(staged):
+    """Publish this run's staged derivatives once the binding is proven.
+
+    Multi-file replacement is not one portable atomic rename, so a host failure
+    between the two renames can leave one derivative published. Both name the
+    same source receipt, so the readers reject the pair rather than trusting a
+    mixed set; the manifest is only written after this returns.
+    """
+    for path in staged:
+        commit_pdf_stage(path)
 
 
 def _confined_output_path(output_root: str, filename: str) -> str:
@@ -650,6 +659,11 @@ def _open_pdf_stage(output_pdf: str):
     return staged_path, staged
 
 
+def commit_pdf_stage(output_pdf: str) -> None:
+    """Publish one staged derivative over its destination."""
+    os.replace(_pdf_stage_path(output_pdf), output_pdf)
+
+
 def combine_to_pdf(
     unique_frames,
     output_pdf,
@@ -658,6 +672,7 @@ def combine_to_pdf(
     source_video_id=None,
     crop_method="none",
     crop_verified=False,
+    commit=True,
 ):
     """Write retained video frames as one explicitly scoped PDF artifact.
 
@@ -665,6 +680,12 @@ def combine_to_pdf(
     Callers write a separate ``full_frame_context`` artifact when room or PiP
     context is useful. PDF metadata names the scope so a context artifact can
     never masquerade as an authored deck after it is separated from the JSON.
+
+    ``commit=False`` leaves the finished pages in this destination's stage and
+    returns the path they are staged for. A caller running several derivatives
+    under one source binding uses it to hold every replacement until the whole
+    run is proven, so a failed re-extraction cannot destroy the artifacts a
+    previous run published. ``commit_pdf_stage`` publishes one such stage.
     """
     if artifact_scope is None:
         artifact_scope = (
@@ -729,11 +750,13 @@ def combine_to_pdf(
             )
             staged.flush()
 
-        os.replace(staged_path, output_pdf)
+        size_mb = os.path.getsize(staged_path) / (1024 * 1024)
+        if commit:
+            os.replace(staged_path, output_pdf)
         staged_path = None
-        size_mb = os.path.getsize(output_pdf) / (1024 * 1024)
+        state = "Saved" if commit else "Staged"
         print(
-            f"  Saved {artifact_scope} PDF: {output_pdf} "
+            f"  {state} {artifact_scope} PDF: {output_pdf} "
             f"({len(images)} pages, {size_mb:.1f} MB)",
             file=sys.stderr,
         )
@@ -828,9 +851,10 @@ def _extract_slides_in_workspace(
         youtube_id: YouTube video ID (used for naming)
         source_receipt: Engine-owned receipt for the exact source generation,
                         stamped onto the manifest and every derivative record.
-        published: Caller-owned list this appends each published PDF path to the
-                   moment it lands, so a caller can remove them when the run
-                   fails partway through.
+        published: Caller-owned list this appends each staged PDF path to the
+                   moment its pages land. The caller publishes them once the
+                   source binding holds, and drops the stages otherwise, so a
+                   failed run never disturbs a prior run's artifacts.
         fps: Frames per second to extract (0.5 = 1 frame per 2 seconds)
         hash_threshold: Largest hash distance treated as the same slide. Higher
                         values merge more and keep fewer frames.
@@ -905,6 +929,7 @@ def _extract_slides_in_workspace(
             source_video_id=youtube_id,
             crop_method=region_provenance["slide_region_method"],
             crop_verified=region_provenance["slide_region_verified"],
+            commit=False,
         )
         if slide_pdf_path:
             published.append(slide_pdf_path)
@@ -931,6 +956,7 @@ def _extract_slides_in_workspace(
             context_pdf,
             artifact_scope="full_frame_context",
             source_video_id=youtube_id,
+            commit=False,
         )
         if context_pdf_path:
             published.append(context_pdf_path)
@@ -989,8 +1015,9 @@ def extract_slides_from_video(
     when it did not. Any drift discards the derivatives and fails the run —
     a manifest is never written against bytes it did not come from.
 
-    Cleanup covers every exit, not only drift: a run that publishes one PDF and
-    then raises while producing the next leaves no half-bound derivative behind.
+    Derivatives stay staged until the closing probe passes, so no exit path can
+    leave a half-bound PDF behind and a failed re-extraction leaves the previous
+    run's artifacts exactly as it found them.
     """
     youtube_id = validate_youtube_id(youtube_id)
     if fps <= 0:
@@ -1028,6 +1055,7 @@ def extract_slides_from_video(
                     include_context_pdf=include_context_pdf,
                 )
             _require_stable_source(assessment, source_video_path, source_receipt)
+            _commit_bound_artifacts(published)
             bound = True
         finally:
             if not bound:

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -172,8 +172,9 @@ def _commit_bound_artifacts(staged):
             try:
                 os.replace(path, backup)
             except FileNotFoundError:
-                # Nothing to put back: this destination had no prior version.
+                # Nothing to put back, which is itself state worth recording.
                 backup = None
+                _mark_pdf_absent(path)
             # Recorded before the publish, not after: the prior version is
             # already moved aside, so a failure in the publish itself still has
             # to put it back.
@@ -183,11 +184,14 @@ def _commit_bound_artifacts(staged):
         for path, backup in reversed(replaced):
             if backup is None:
                 _remove_regular_file(path)
+                _clear_pdf_absent_marker(path)
                 continue
             os.replace(backup, path)
         raise
-    for _path, backup in replaced:
-        if backup is not None:
+    for path, backup in replaced:
+        if backup is None:
+            _clear_pdf_absent_marker(path)
+        else:
             _remove_regular_file(backup)
 
 
@@ -639,6 +643,7 @@ def review_reason_for_region(region, provenance):
 
 _PDF_STAGE_SUFFIX = ".speaker-toolkit-stage.tmp"
 _PDF_BACKUP_SUFFIX = ".speaker-toolkit-prior.tmp"
+_PDF_ABSENT_SUFFIX = ".speaker-toolkit-absent.tmp"
 
 
 def _pdf_stage_path(output_pdf: str) -> str:
@@ -665,6 +670,36 @@ def _remove_regular_file(path: str) -> None:
         pass
 
 
+def _pdf_absent_marker_path(output_pdf: str) -> str:
+    """Return the deterministic "held nothing" marker for one destination."""
+    return os.path.join(
+        os.path.dirname(output_pdf),
+        f".{os.path.basename(output_pdf)}{_PDF_ABSENT_SUFFIX}",
+    )
+
+
+def _require_regular_recovery_leaf(path: str) -> None:
+    if not stat.S_ISREG(os.lstat(path).st_mode):
+        raise ValueError("video_pdf_recovery_leaf_invalid")
+
+
+def _mark_pdf_absent(output_pdf: str) -> None:
+    """Record that this destination held nothing before the publish.
+
+    Without it, a process killed after this destination publishes and before
+    the run completes leaves a PDF the next run cannot tell from a prior
+    version worth keeping.
+    """
+    marker = _pdf_absent_marker_path(output_pdf)
+    with open(marker, "wb") as handle:
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _clear_pdf_absent_marker(output_pdf: str) -> None:
+    _remove_regular_file(_pdf_absent_marker_path(output_pdf))
+
+
 def _remove_stale_pdf_stage(output_pdf: str) -> None:
     """Reclaim the exact stage left by an interrupted prior run."""
     try:
@@ -675,19 +710,24 @@ def _remove_stale_pdf_stage(output_pdf: str) -> None:
         raise ValueError("video_pdf_stage_invalid") from None
 
 
-def _restore_stale_pdf_backup(output_pdf: str) -> None:
-    """Put back a prior version a run left behind when the host died mid-publish.
+def _recover_stale_pdf_publish(output_pdf: str) -> None:
+    """Undo a publish a killed process left half-applied at this destination.
 
-    The backup exists only between one destination's two renames, so finding
-    one means that window never closed. The destination holds either the prior
-    version or the new one, and the prior version is the one a persisted
-    manifest still describes.
+    Both markers exist only inside one run's publish, so finding either means
+    that run never completed and never wrote a manifest. The destination is
+    put back to what a completed run last left there: the prior version, or
+    nothing at all.
     """
+    marker = _pdf_absent_marker_path(output_pdf)
+    if os.path.exists(marker):
+        _require_regular_recovery_leaf(marker)
+        _remove_regular_file(output_pdf)
+        _remove_regular_file(marker)
+        return
     backup = _pdf_backup_path(output_pdf)
     if not os.path.exists(backup):
         return
-    if not stat.S_ISREG(os.lstat(backup).st_mode):
-        raise ValueError("video_pdf_backup_invalid")
+    _require_regular_recovery_leaf(backup)
     os.replace(backup, output_pdf)
 
 
@@ -1092,7 +1132,7 @@ def extract_slides_from_video(
             f"{youtube_id}.context.pdf",
         ):
             destination = _confined_output_path(output_dir, filename)
-            _restore_stale_pdf_backup(destination)
+            _recover_stale_pdf_publish(destination)
             _remove_stale_pdf_stage(destination)
         published: list[str] = []
         bound = False

--- a/skills/vault-ingress/scripts/video_evidence.py
+++ b/skills/vault-ingress/scripts/video_evidence.py
@@ -1977,9 +1977,15 @@ def validate_video_source_receipt(value: object) -> dict[str, JsonValue]:
         raise _receipt_failure("source_receipt")
     if set(value) != set(VIDEO_SOURCE_RECEIPT_FIELDS):
         raise _receipt_failure("source_receipt")
-    if value.get("schema_version") != VIDEO_SOURCE_RECEIPT_SCHEMA_VERSION:
+    if (
+        type(value.get("schema_version")) is not int
+        or value.get("schema_version") != VIDEO_SOURCE_RECEIPT_SCHEMA_VERSION
+    ):
         raise _receipt_failure("schema_version")
-    if value.get("probe_schema_version") != VIDEO_PROBE_SCHEMA_VERSION:
+    if (
+        type(value.get("probe_schema_version")) is not int
+        or value.get("probe_schema_version") != VIDEO_PROBE_SCHEMA_VERSION
+    ):
         raise _receipt_failure("probe_schema_version")
     pipeline = value.get("probe_pipeline_version")
     if not isinstance(pipeline, str) or _VERSION_TOKEN_RE.fullmatch(pipeline) is None:

--- a/skills/vault-ingress/scripts/video_evidence.py
+++ b/skills/vault-ingress/scripts/video_evidence.py
@@ -58,6 +58,7 @@ from artifact_supervisor import (
 
 VIDEO_PROBE_SCHEMA_VERSION: Final = 1
 VIDEO_PROBE_PIPELINE_VERSION: Final = "1.0.0"
+VIDEO_SOURCE_RECEIPT_SCHEMA_VERSION: Final = 1
 VIDEO_SUPERVISED_WORKER_FLAG: Final = "--supervised-worker"
 VIDEO_METADATA_OPERATION: Final = "video_metadata"
 VIDEO_PROBE_OPERATION: Final = "video_probe"
@@ -105,6 +106,35 @@ _ISO_BMFF_FORMAT_NAMES: Final = frozenset({"mov", "mp4", "m4a", "3gp", "3g2", "m
 _MATROSKA_FORMAT_NAMES: Final = frozenset({"matroska", "webm"})
 _VIDEO_GENERATION_NAMES: Final = frozenset({"video", "video_root"})
 _SHA256_RE: Final = re.compile(r"^[0-9a-f]{64}$")
+_VERSION_TOKEN_RE: Final = re.compile(r"^[0-9A-Za-z._+-]{1,64}$")
+
+# Content-bound receipt facts a later reader compares against a fresh probe of
+# the same path. `source_generation` is deliberately absent: device/inode/mtime
+# are host-local and change on a byte-identical vault move, while the digest
+# already proves the bytes. The generation is bound inside one extraction run
+# (see `video_source_receipt_generation_drift`), never across runs.
+VIDEO_SOURCE_RECEIPT_LINEAGE_FIELDS: Final = (
+    "probe_schema_version",
+    "probe_pipeline_version",
+    "source_sha256",
+    "source_size_bytes",
+    "duration_seconds",
+    "duration_source",
+    "container_family",
+    "stream_count",
+    "video_stream_count",
+    "audio_stream_count",
+    "attached_picture_count",
+    "other_stream_count",
+)
+VIDEO_SOURCE_RECEIPT_FIELDS: Final = (
+    "schema_version",
+    *VIDEO_SOURCE_RECEIPT_LINEAGE_FIELDS,
+    "source_generation",
+)
+# ffprobe reports container duration at the precision the container stores; a
+# parser upgrade may round the final digit differently over identical bytes.
+VIDEO_SOURCE_RECEIPT_DURATION_TOLERANCE_SECONDS: Final = 0.001
 _EXCEPTION_TYPE_RE: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
 
 _CHILD_FAILURE_REASONS: Final = frozenset(
@@ -1899,6 +1929,170 @@ def probe_video_artifact(
     )
 
 
+def build_video_source_receipt(probe: VideoArtifactProbe) -> dict[str, JsonValue]:
+    """Return the durable, path-neutral receipt for one exact source generation.
+
+    Every field comes from the bounded probe. No path, no raw ffprobe document,
+    and no parser stderr crosses into the persisted record.
+    """
+    if not isinstance(probe, VideoArtifactProbe):
+        raise _failure("video_source_receipt_invalid", details={"field": "probe"})
+    return {
+        "schema_version": VIDEO_SOURCE_RECEIPT_SCHEMA_VERSION,
+        "probe_schema_version": VIDEO_PROBE_SCHEMA_VERSION,
+        "probe_pipeline_version": VIDEO_PROBE_PIPELINE_VERSION,
+        "source_sha256": probe.source_sha256,
+        "source_size_bytes": probe.source_size_bytes,
+        "duration_seconds": probe.duration_seconds,
+        "duration_source": probe.duration_source,
+        "container_family": probe.container_family,
+        "stream_count": probe.stream_count,
+        "video_stream_count": probe.video_stream_count,
+        "audio_stream_count": probe.audio_stream_count,
+        "attached_picture_count": probe.attached_picture_count,
+        "other_stream_count": probe.other_stream_count,
+        "source_generation": probe.generation.to_dict(),
+    }
+
+
+def _receipt_failure(field: str) -> VideoEvidenceError:
+    return _failure("video_source_receipt_invalid", details={"field": field})
+
+
+def _receipt_int(value: object, field: str, *, minimum: int) -> int:
+    if type(value) is not int or value < minimum:
+        raise _receipt_failure(field)
+    return value
+
+
+def validate_video_source_receipt(value: object) -> dict[str, JsonValue]:
+    """Return one canonical receipt, or reject with a closed, path-free reason.
+
+    The field set is closed: an unknown key is a rejection, never a field a
+    later reader silently drops. Stream counts must partition ``stream_count``
+    exactly as the probe contract requires, and the bound file generation's
+    size must agree with the probed byte count.
+    """
+    if not isinstance(value, Mapping):
+        raise _receipt_failure("source_receipt")
+    if set(value) != set(VIDEO_SOURCE_RECEIPT_FIELDS):
+        raise _receipt_failure("source_receipt")
+    if value.get("schema_version") != VIDEO_SOURCE_RECEIPT_SCHEMA_VERSION:
+        raise _receipt_failure("schema_version")
+    if value.get("probe_schema_version") != VIDEO_PROBE_SCHEMA_VERSION:
+        raise _receipt_failure("probe_schema_version")
+    pipeline = value.get("probe_pipeline_version")
+    if not isinstance(pipeline, str) or _VERSION_TOKEN_RE.fullmatch(pipeline) is None:
+        raise _receipt_failure("probe_pipeline_version")
+    digest = value.get("source_sha256")
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        raise _receipt_failure("source_sha256")
+    size = _receipt_int(value.get("source_size_bytes"), "source_size_bytes", minimum=1)
+    if size > VIDEO_MAX_INPUT_BYTES:
+        raise _receipt_failure("source_size_bytes")
+    duration = value.get("duration_seconds")
+    if (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(float(duration))
+        or float(duration) <= 0
+    ):
+        raise _receipt_failure("duration_seconds")
+    if value.get("duration_source") not in {"format", "stream"}:
+        raise _receipt_failure("duration_source")
+    if value.get("container_family") not in _CONTAINER_FAMILY_BY_SUFFIX.values():
+        raise _receipt_failure("container_family")
+    stream_count = _receipt_int(value.get("stream_count"), "stream_count", minimum=1)
+    if stream_count > VIDEO_MAX_STREAMS:
+        raise _receipt_failure("stream_count")
+    video_count = _receipt_int(
+        value.get("video_stream_count"), "video_stream_count", minimum=1
+    )
+    audio_count = _receipt_int(
+        value.get("audio_stream_count"), "audio_stream_count", minimum=0
+    )
+    attached_count = _receipt_int(
+        value.get("attached_picture_count"), "attached_picture_count", minimum=0
+    )
+    other_count = _receipt_int(
+        value.get("other_stream_count"), "other_stream_count", minimum=0
+    )
+    if video_count + audio_count + attached_count + other_count != stream_count:
+        raise _receipt_failure("stream_count")
+    raw_generation = value.get("source_generation")
+    if not isinstance(raw_generation, Mapping):
+        raise _receipt_failure("source_generation")
+    try:
+        generation = FileGeneration.from_dict(raw_generation)
+    except ValueError as exc:
+        raise _receipt_failure("source_generation") from exc
+    if generation.size != size:
+        raise _receipt_failure("source_generation")
+    if _availability(generation).state != "local":
+        raise _receipt_failure("source_generation")
+    return {
+        "schema_version": VIDEO_SOURCE_RECEIPT_SCHEMA_VERSION,
+        "probe_schema_version": VIDEO_PROBE_SCHEMA_VERSION,
+        "probe_pipeline_version": pipeline,
+        "source_sha256": digest,
+        "source_size_bytes": size,
+        "duration_seconds": float(duration),
+        "duration_source": cast(str, value.get("duration_source")),
+        "container_family": cast(str, value.get("container_family")),
+        "stream_count": stream_count,
+        "video_stream_count": video_count,
+        "audio_stream_count": audio_count,
+        "attached_picture_count": attached_count,
+        "other_stream_count": other_count,
+        "source_generation": generation.to_dict(),
+    }
+
+
+def video_source_receipt_lineage_drift(
+    receipt: Mapping[str, object],
+    probe: VideoArtifactProbe,
+) -> tuple[str, ...]:
+    """Return the receipt fields a fresh probe of the same path contradicts."""
+    current = build_video_source_receipt(probe)
+    drift = []
+    for name in VIDEO_SOURCE_RECEIPT_LINEAGE_FIELDS:
+        stored = receipt.get(name)
+        live = current[name]
+        if name == "duration_seconds":
+            if (
+                isinstance(stored, bool)
+                or not isinstance(stored, (int, float))
+                or not math.isfinite(float(stored))
+                or not math.isclose(
+                    float(stored),
+                    cast(float, live),
+                    abs_tol=VIDEO_SOURCE_RECEIPT_DURATION_TOLERANCE_SECONDS,
+                )
+            ):
+                drift.append(name)
+            continue
+        if stored != live:
+            drift.append(name)
+    return tuple(drift)
+
+
+def video_source_receipt_generation_drift(
+    receipt: Mapping[str, object],
+    probe: VideoArtifactProbe,
+) -> tuple[str, ...]:
+    """Return every receipt field one extraction run must hold exactly stable.
+
+    The producer calls this after writing its derivatives. Unlike the cross-run
+    lineage check, the bound file generation is included: a same-path
+    replacement inside one run is a replaced source even when the new bytes
+    happen to probe alike.
+    """
+    drift = list(video_source_receipt_lineage_drift(receipt, probe))
+    if receipt.get("source_generation") != probe.generation.to_dict():
+        drift.append("source_generation")
+    return tuple(drift)
+
+
 def _run_supervised_worker_child() -> int:
     request = read_worker_request(max_input_bytes=VIDEO_METADATA_LIMITS.max_input_bytes)
     protocol_output = isolate_protocol_output()
@@ -1963,10 +2157,18 @@ __all__ = [
     "VIDEO_PROBE_LIMITS",
     "VIDEO_PROBE_PIPELINE_VERSION",
     "VIDEO_PROBE_SCHEMA_VERSION",
+    "VIDEO_SOURCE_RECEIPT_DURATION_TOLERANCE_SECONDS",
+    "VIDEO_SOURCE_RECEIPT_FIELDS",
+    "VIDEO_SOURCE_RECEIPT_LINEAGE_FIELDS",
+    "VIDEO_SOURCE_RECEIPT_SCHEMA_VERSION",
     "VIDEO_SUPERVISED_WORKER_FLAG",
     "VideoArtifactProbe",
     "VideoEvidenceAssessment",
     "VideoEvidenceError",
+    "build_video_source_receipt",
     "clear_video_artifact_probe_cache",
     "probe_video_artifact",
+    "validate_video_source_receipt",
+    "video_source_receipt_generation_drift",
+    "video_source_receipt_lineage_drift",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 
 import importlib.util
 import os
+import pathlib
+import shutil
+import subprocess
 import sys
 
 import pytest
@@ -164,6 +167,126 @@ def video_evidence():
     return _import_script(
         os.path.join(SCRIPTS_VI, "video_evidence.py"),
         "video_evidence",
+    )
+
+
+_TINY_VIDEO_BYTES: bytes | None = None
+
+
+def write_tiny_video(path):
+    """Materialize one valid MP4 while keeping ffmpeg local to video tests."""
+    global _TINY_VIDEO_BYTES
+    path = pathlib.Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if _TINY_VIDEO_BYTES is not None:
+        path.write_bytes(_TINY_VIDEO_BYTES)
+        return path
+
+    ffmpeg = shutil.which("ffmpeg")
+    assert ffmpeg is not None, "source-video tests require ffmpeg"
+    assert shutil.which("ffprobe") is not None, "source-video tests require ffprobe"
+    created = subprocess.run(
+        [
+            ffmpeg,
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x90:r=1",
+            "-t",
+            "1",
+            "-an",
+            "-c:v",
+            "mpeg4",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            "-y",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert created.returncode == 0, created.stderr
+    _TINY_VIDEO_BYTES = path.read_bytes()
+    return path
+
+
+def synthetic_video_source_receipt(
+    *,
+    size_bytes: int = 4096,
+    digest: str = "0" * 64,
+    duration_seconds: float = 8.0,
+):
+    """Build a receipt for manifest fixtures that never touch a real video.
+
+    Routed through the shipped builder so a producer-side shape change breaks
+    these fixtures instead of letting them drift into a shape the readers no
+    longer accept. Every field is fixed; nothing here reads the clock.
+    """
+    video_evidence = _import_script(
+        os.path.join(SCRIPTS_VI, "video_evidence.py"),
+        "video_evidence",
+    )
+    artifact_supervisor = _import_script(
+        os.path.join(SCRIPTS_VI, "artifact_supervisor.py"),
+        "artifact_supervisor",
+    )
+    artifact_metadata = _import_script(
+        os.path.join(SCRIPTS_VI, "artifact_metadata.py"),
+        "artifact_metadata",
+    )
+    generation = artifact_supervisor.FileGeneration(
+        size=size_bytes,
+        mtime_ns=1,
+        ctime_ns=1,
+        device=1,
+        inode=1,
+        mode=0o100644,
+        flags=0,
+        file_attributes=None,
+    )
+    return video_evidence.build_video_source_receipt(
+        video_evidence.VideoArtifactProbe(
+            generation=generation,
+            root_generation=None,
+            availability=artifact_metadata.ArtifactAvailability.from_generation(
+                generation
+            ),
+            source_sha256=digest,
+            source_size_bytes=size_bytes,
+            duration_seconds=duration_seconds,
+            duration_source="format",
+            container_family="iso_bmff",
+            stream_count=2,
+            video_stream_count=1,
+            audio_stream_count=1,
+            attached_picture_count=0,
+            other_stream_count=0,
+            parser_diagnostics=artifact_supervisor.DiagnosticReceipt.empty(),
+        )
+    )
+
+
+def video_source_receipt_for(path):
+    """Return the receipt a real bounded probe yields for one source video.
+
+    Manifest fixtures stamp this exactly as the extractor does, so the tests
+    exercise the shipped receipt contract rather than a hand-written shape that
+    could drift away from it. The probe cache keys on the file generation, so
+    repeated calls for one fixture video cost a stat.
+    """
+    video_evidence = _import_script(
+        os.path.join(SCRIPTS_VI, "video_evidence.py"),
+        "video_evidence",
+    )
+    return video_evidence.build_video_source_receipt(
+        video_evidence.VideoEvidenceAssessment().probe(str(path))
     )
 
 

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -3804,3 +3804,103 @@ def test_verified_local_artifact_still_validates_slide_evidence(
             evidence_metadata_fields=frozenset(),
             context=context,
         )
+
+
+def test_replaced_source_video_withdraws_authored_slide_trust(
+    tmp_path: Path,
+) -> None:
+    """The crop stayed verified; the bytes it was cropped from did not."""
+    vault = tmp_path / "vault"
+    rebuild = vault / "slides-rebuild" / SYNTHETIC_VIDEO_ID
+    rebuild.mkdir(parents=True)
+    source_video = rebuild / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    source_video.write_bytes(b"the bytes the crop came from")
+    slide_region = rebuild / f"{SYNTHETIC_VIDEO_ID}.slide-region.pdf"
+    _write_pdf(slide_region, page_count=1)
+    receipt = _source_receipt(source_video)
+    source_path = source_video.relative_to(vault).as_posix()
+    manifest = {
+        "schema_version": return_validation.VIDEO_EXTRACTION_SCHEMA_VERSION,
+        "source_video_id": SYNTHETIC_VIDEO_ID,
+        "source_video_path": source_path,
+        "source_receipt": receipt,
+        "unique_frame_count": 1,
+        "slide_region_method": "manual",
+        "slide_region_applied": True,
+        "slide_region_verified": True,
+        "review_required": False,
+        "review_reason": None,
+        "artifacts": [
+            {
+                "path": slide_region.relative_to(vault).as_posix(),
+                "artifact_scope": "slide_region",
+                "page_count": 1,
+                "source_video_id": SYNTHETIC_VIDEO_ID,
+                "source_video_path": source_path,
+                "source_receipt": copy.deepcopy(receipt),
+                "crop_verified": True,
+                "trusted_for_authored_slide_analysis": True,
+            }
+        ],
+    }
+    owner = {"structured_data": {"video_extraction": manifest}}
+
+    probe, reason, path = pattern_evidence._trusted_video_slide_probe(
+        vault,
+        owner,
+        SYNTHETIC_VIDEO_ID,
+        video_evidence_assessment=_TestVideoAssessment(),
+    )
+    assert probe is not None
+    assert path is not None
+
+    source_video.write_bytes(b"a different recording at the same path")
+
+    probe, reason, path = pattern_evidence._trusted_video_slide_probe(
+        vault,
+        owner,
+        SYNTHETIC_VIDEO_ID,
+        video_evidence_assessment=_TestVideoAssessment(),
+    )
+
+    assert probe is None
+    assert path is None
+    assert "not the content the trusted slide-region PDF was extracted from" in reason
+    assert "source_sha256" in reason
+
+
+def test_derivatives_from_two_runs_are_rejected_before_persistence(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    rebuild = vault / "slides-rebuild" / SYNTHETIC_VIDEO_ID
+    rebuild.mkdir(parents=True)
+    source_video = rebuild / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    source_video.write_bytes(b"this run's source")
+    other_source = rebuild / "other.mp4"
+    other_source.write_bytes(b"another run's source")
+    context = rebuild / f"{SYNTHETIC_VIDEO_ID}.context.pdf"
+    _write_pdf(context, page_count=1)
+    manifest = {
+        "unique_frame_count": 1,
+        "source_receipt": _source_receipt(source_video),
+        "artifacts": [
+            {
+                "path": context.relative_to(vault).as_posix(),
+                "artifact_scope": "full_frame_context",
+                "page_count": 1,
+                "source_video_id": SYNTHETIC_VIDEO_ID,
+                "source_receipt": _source_receipt(other_source),
+            }
+        ],
+    }
+
+    with pytest.raises(
+        pattern_evidence.PatternEvidenceError,
+        match="not bound to the manifest source receipt",
+    ):
+        pattern_evidence._probe_video_manifest_artifacts(
+            vault,
+            manifest,
+            SYNTHETIC_VIDEO_ID,
+        )

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -25,21 +25,39 @@ SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
+artifact_supervisor = importlib.import_module("artifact_supervisor")
+artifact_metadata = importlib.import_module("artifact_metadata")
 pattern_evidence = importlib.import_module("pattern_evidence")
 pdf_evidence = importlib.import_module("pdf_evidence")
 pptx_evidence = importlib.import_module("pptx_evidence")
 return_validation = importlib.import_module("return_validation")
 transcript_timing = importlib.import_module("transcript_timing")
+video_evidence = importlib.import_module("video_evidence")
 SYNTHETIC_VIDEO_ID = "abcdefghijk"
 SYNTHETIC_DURATION = 600.0
 
 
+def _video_generation(size: int) -> Any:
+    """Fixed, local-availability generation; nothing here reads the clock."""
+    return artifact_supervisor.FileGeneration(
+        size=size,
+        mtime_ns=1,
+        ctime_ns=1,
+        device=1,
+        inode=1,
+        mode=0o100644,
+        flags=0,
+        file_attributes=None,
+    )
+
+
 def _video_probe(path: Path, *, duration: float = SYNTHETIC_DURATION) -> Any:
     raw = path.read_bytes()
+    generation = _video_generation(len(raw))
     return pattern_evidence.VideoArtifactProbe(
-        generation=SimpleNamespace(),
+        generation=generation,
         root_generation=None,
-        availability=SimpleNamespace(state="local"),
+        availability=artifact_metadata.ArtifactAvailability.from_generation(generation),
         source_sha256=hashlib.sha256(raw).hexdigest(),
         source_size_bytes=len(raw),
         duration_seconds=duration,
@@ -73,14 +91,23 @@ class _TestVideoAssessment:
         return _video_probe(video_path, duration=self.duration)
 
 
+def _source_receipt(source_video: Path, *, duration: float = SYNTHETIC_DURATION):
+    """Stamp the receipt the synthetic probe of this exact file would yield."""
+    return video_evidence.build_video_source_receipt(
+        _video_probe(source_video, duration=duration)
+    )
+
+
 def _untrusted_video_manifest(vault: Path, source_video: Path) -> dict[str, Any]:
     context_pdf = source_video.with_suffix(".context.pdf")
     _write_pdf(context_pdf, page_count=1)
     source_path = source_video.relative_to(vault).as_posix()
+    receipt = _source_receipt(source_video)
     return {
-        "schema_version": 3,
+        "schema_version": return_validation.VIDEO_EXTRACTION_SCHEMA_VERSION,
         "source_video_id": SYNTHETIC_VIDEO_ID,
         "source_video_path": source_path,
+        "source_receipt": receipt,
         "unique_frame_count": 1,
         "slide_region_method": "none",
         "slide_region_applied": False,
@@ -94,6 +121,7 @@ def _untrusted_video_manifest(vault: Path, source_video: Path) -> dict[str, Any]
                 "page_count": 1,
                 "source_video_id": SYNTHETIC_VIDEO_ID,
                 "source_video_path": source_path,
+                "source_receipt": copy.deepcopy(receipt),
                 "crop_verified": False,
                 "trusted_for_authored_slide_analysis": False,
             }
@@ -919,14 +947,20 @@ def test_foreign_video_manifest_pdf_never_reaches_current_context_probe(
         "probe_pdf_artifact",
         lambda *_args, **_kwargs: pytest.fail("foreign manifest PDF reached probe"),
     )
+    source_video = tmp_path / "vault" / f"{SYNTHETIC_VIDEO_ID}.mp4"
+    source_video.parent.mkdir(parents=True, exist_ok=True)
+    source_video.write_bytes(b"source bytes")
+    receipt = _source_receipt(source_video)
     manifest = {
         "unique_frame_count": 1,
+        "source_receipt": receipt,
         "artifacts": [
             {
                 "artifact_scope": "slide_region",
                 "source_video_id": SYNTHETIC_VIDEO_ID,
                 "page_count": 1,
                 "path": foreign_pdf,
+                "source_receipt": copy.deepcopy(receipt),
             }
         ],
     }
@@ -944,7 +978,7 @@ def test_foreign_video_manifest_pdf_never_reaches_current_context_probe(
     assert foreign_pdf not in str(caught.value)
 
 
-def test_schema_v3_manifest_source_takes_precedence_over_top_level_video_path(
+def test_current_manifest_source_takes_precedence_over_top_level_video_path(
     tmp_path: Path,
 ) -> None:
     vault = tmp_path / "vault"
@@ -965,7 +999,9 @@ def test_schema_v3_manifest_source_takes_precedence_over_top_level_video_path(
             "video_local_path": legacy_video.relative_to(vault).as_posix(),
             "structured_data": {
                 "video_extraction": {
-                    "schema_version": 3,
+                    "schema_version": (
+                        return_validation.VIDEO_EXTRACTION_SCHEMA_VERSION
+                    ),
                     "source_video_id": SYNTHETIC_VIDEO_ID,
                     "source_video_path": manifest_video.relative_to(vault).as_posix(),
                 }
@@ -982,7 +1018,7 @@ def test_schema_v3_manifest_source_takes_precedence_over_top_level_video_path(
     assert assessment.calls == [manifest_video]
 
 
-def test_schema_v3_video_identity_stays_fresh_through_a_symlinked_vault_root(
+def test_current_video_identity_stays_fresh_through_a_symlinked_vault_root(
     tmp_path: Path,
 ) -> None:
     storage = tmp_path / "vault-storage"
@@ -998,7 +1034,7 @@ def test_schema_v3_video_identity_stays_fresh_through_a_symlinked_vault_root(
     source_video.parent.mkdir(parents=True)
     source_video.write_bytes(b"canonical storage video bytes")
     manifest = {
-        "schema_version": 3,
+        "schema_version": return_validation.VIDEO_EXTRACTION_SCHEMA_VERSION,
         "source_video_id": SYNTHETIC_VIDEO_ID,
         "source_video_path": os.fspath(source_video),
     }
@@ -1434,13 +1470,16 @@ def test_current_video_manifest_bounds_bad_second_context_pdf_before_persistence
     _write_pdf(slide_region, page_count=1)
     source_video = rebuild / f"{SYNTHETIC_VIDEO_ID}.mp4"
     source_video.write_bytes(b"synthetic video")
+    receipt = _source_receipt(source_video)
     shared = {
         "page_count": 1,
         "source_video_id": SYNTHETIC_VIDEO_ID,
         "source_video_path": os.fspath(source_video),
+        "source_receipt": receipt,
     }
     manifest = {
-        "schema_version": 3,
+        "schema_version": return_validation.VIDEO_EXTRACTION_SCHEMA_VERSION,
+        "source_receipt": receipt,
         "source_video_id": SYNTHETIC_VIDEO_ID,
         "source_video_path": os.fspath(source_video),
         "unique_frame_count": 1,
@@ -1502,10 +1541,12 @@ def test_promoted_video_pdf_must_match_trusted_slide_region_digest(
     with promoted.open("wb") as stream:
         writer.write(stream)
     source_path = source_video.relative_to(vault).as_posix()
+    receipt = _source_receipt(source_video)
     manifest = {
-        "schema_version": 3,
+        "schema_version": return_validation.VIDEO_EXTRACTION_SCHEMA_VERSION,
         "source_video_id": SYNTHETIC_VIDEO_ID,
         "source_video_path": source_path,
+        "source_receipt": receipt,
         "unique_frame_count": 1,
         "slide_region_method": "manual",
         "slide_region_applied": True,
@@ -1519,6 +1560,7 @@ def test_promoted_video_pdf_must_match_trusted_slide_region_digest(
                 "page_count": 1,
                 "source_video_id": SYNTHETIC_VIDEO_ID,
                 "source_video_path": source_path,
+                "source_receipt": copy.deepcopy(receipt),
                 "crop_verified": True,
                 "trusted_for_authored_slide_analysis": True,
             }
@@ -1574,10 +1616,12 @@ def test_persisted_context_manifest_reanalysis_never_touches_pdf_in_owner(
     _write_pdf(context, page_count=1)
     source_video = rebuild / f"{SYNTHETIC_VIDEO_ID}.mp4"
     source_video.write_bytes(b"synthetic video")
+    receipt = _source_receipt(source_video)
     manifest = {
-        "schema_version": 3,
+        "schema_version": return_validation.VIDEO_EXTRACTION_SCHEMA_VERSION,
         "source_video_id": SYNTHETIC_VIDEO_ID,
         "source_video_path": os.fspath(source_video),
+        "source_receipt": receipt,
         "unique_frame_count": 1,
         "slide_region_method": "none",
         "slide_region_applied": False,
@@ -1591,6 +1635,7 @@ def test_persisted_context_manifest_reanalysis_never_touches_pdf_in_owner(
                 "page_count": 1,
                 "source_video_id": SYNTHETIC_VIDEO_ID,
                 "source_video_path": os.fspath(source_video),
+                "source_receipt": copy.deepcopy(receipt),
                 "crop_verified": False,
                 "trusted_for_authored_slide_analysis": False,
             }

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -17,7 +17,7 @@ import pytest
 from pypdf import PdfWriter
 from pptx import Presentation
 
-from conftest import current_tracking_config
+from conftest import current_tracking_config, video_source_receipt_for
 
 
 def test_atomic_json_write_cleans_stage_and_propagates_interrupt(
@@ -639,17 +639,20 @@ def test_legacy_video_return_bounds_every_manifest_artifact_before_merge(
         writer.add_blank_page(width=96, height=54)
         with missing_context.open("wb") as stream:
             writer.write(stream)
+    receipt = video_source_receipt_for(source_video)
     shared = {
         "page_count": 1,
         "source_video_id": video_id,
         "source_video_path": str(source_video),
+        "source_receipt": copy.deepcopy(receipt),
     }
     manifest = {
         "slide_source": "video_extracted",
-        "schema_version": 3,
+        "schema_version": 4,
         "pipeline_version": "0.10.0",
         "source_video_id": video_id,
         "source_video_path": str(source_video),
+        "source_receipt": receipt,
         "total_frames_extracted": 1,
         "unique_frame_count": 1,
         "authored_slide_count": None,

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -7,7 +7,6 @@ import json
 import os
 from pathlib import Path
 import pathlib
-import shutil
 import struct
 import subprocess
 import sys
@@ -15,6 +14,7 @@ from typing import Any
 import zipfile
 
 import pytest
+from conftest import video_source_receipt_for, write_tiny_video
 from PIL import Image
 from pypdf import PdfWriter
 from pptx import Presentation
@@ -46,7 +46,6 @@ QUEUE_STATE_SCRIPT = (
     / "scripts"
     / "queue-state.py"
 )
-_TINY_VIDEO_BYTES: bytes | None = None
 
 
 def foreign_absolute_locator(name: str) -> str:
@@ -189,51 +188,6 @@ def write_pdf(path: Path, *, page_count: int = 1) -> Path:
     return path
 
 
-def write_tiny_video(path: Path) -> Path:
-    """Materialize one valid MP4 while keeping ffmpeg local to video tests."""
-    global _TINY_VIDEO_BYTES
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if _TINY_VIDEO_BYTES is not None:
-        path.write_bytes(_TINY_VIDEO_BYTES)
-        return path
-
-    ffmpeg = shutil.which("ffmpeg")
-    assert ffmpeg is not None, "source-video manifest tests require ffmpeg"
-    assert shutil.which("ffprobe") is not None, (
-        "source-video manifest tests require ffprobe"
-    )
-    created = subprocess.run(
-        [
-            ffmpeg,
-            "-nostdin",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-f",
-            "lavfi",
-            "-i",
-            "color=c=black:s=160x90:r=1",
-            "-t",
-            "1",
-            "-an",
-            "-c:v",
-            "mpeg4",
-            "-pix_fmt",
-            "yuv420p",
-            "-movflags",
-            "+faststart",
-            "-y",
-            str(path),
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert created.returncode == 0, created.stderr
-    _TINY_VIDEO_BYTES = path.read_bytes()
-    return path
-
-
 def materialize_crc_damaged_pptx(fixture):
     """Create a deck with one CRC-damaged media member under the source root."""
     image_path = fixture["pptx_source"] / "asset.png"
@@ -302,12 +256,14 @@ def trusted_video_manifest(fixture, page_count=1):
         }
         for page in range(1, page_count + 1)
     ]
+    receipt = video_source_receipt_for(source_video)
     return {
         "slide_source": "video_extracted",
-        "schema_version": 3,
+        "schema_version": 4,
         "pipeline_version": "0.10.0",
         "source_video_id": VIDEO_ID,
         "source_video_path": str(source_video),
+        "source_receipt": receipt,
         "total_frames_extracted": page_count,
         "unique_frame_count": page_count,
         "authored_slide_count": None,
@@ -328,6 +284,7 @@ def trusted_video_manifest(fixture, page_count=1):
                 "page_count": page_count,
                 "source_video_id": VIDEO_ID,
                 "source_video_path": str(source_video),
+                "source_receipt": deepcopy(receipt),
                 "crop_method": "manual",
                 "crop_verified": True,
                 "trusted_for_authored_slide_analysis": True,
@@ -358,6 +315,7 @@ def context_video_manifest(fixture, page_count=1):
                     "page_count": page_count,
                     "source_video_id": VIDEO_ID,
                     "source_video_path": source_video,
+                    "source_receipt": deepcopy(manifest["source_receipt"]),
                     "crop_method": "none",
                     "crop_verified": False,
                     "trusted_for_authored_slide_analysis": False,
@@ -2938,6 +2896,7 @@ def test_unverified_video_crop_cannot_support_completed_deck_analysis(
             "page_count": manifest["unique_frame_count"],
             "source_video_id": VIDEO_ID,
             "source_video_path": manifest["source_video_path"],
+            "source_receipt": deepcopy(manifest["source_receipt"]),
             "crop_method": "none",
             "crop_verified": False,
             "trusted_for_authored_slide_analysis": False,

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4201,3 +4201,149 @@ def test_an_invalid_legacy_video_manifest_on_a_requeued_talk_is_a_warning(
 
     assert report["blocking_count"] == 0
     assert "video_extraction_provenance_invalid" in finding_codes(report, "warning")
+
+
+def test_replaced_source_video_blocks_the_saved_derivatives(
+    preflight_vault,
+    vault_fixture,
+):
+    """Same path, different bytes: the PDFs no longer describe what is on disk."""
+    materialize_transcript(vault_fixture)
+    manifest = trusted_video_manifest(vault_fixture)
+    source_video = Path(manifest["source_video_path"])
+    source_video.write_bytes(source_video.read_bytes() + b"\x00")
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                status="processed_partial",
+                slide_source="video_extracted",
+                structured_data={"video_extraction": manifest},
+            )
+        ],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "video_extraction_source_lineage_mismatch" in finding_codes(
+        report, "blocking"
+    )
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "video_extraction_source_lineage_mismatch"
+    )
+    assert finding["field"] == "structured_data.video_extraction.source_receipt"
+    assert "source_sha256" in finding["actual"]
+
+
+def test_archival_v3_manifest_asks_for_re_extraction_not_a_stamped_digest(
+    preflight_vault,
+    vault_fixture,
+):
+    materialize_transcript(vault_fixture)
+    manifest = trusted_video_manifest(vault_fixture)
+    # The shape a pre-receipt vault actually holds: no receipt anywhere.
+    manifest["schema_version"] = 3
+    manifest.pop("source_receipt")
+    for artifact in manifest["artifacts"]:
+        artifact.pop("source_receipt")
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                status="processed_partial",
+                slide_source="video_extracted",
+                structured_data={"video_extraction": manifest},
+            )
+        ],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    codes = finding_codes(report)
+    assert "video_extraction_source_receipt_missing" in codes
+    assert "video_extraction_provenance_invalid" not in codes
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "video_extraction_source_receipt_missing"
+    )
+    assert finding["expected"] == 4
+    assert finding["actual"] == 3
+    # Preflight reports the gap; it never writes a receipt of its own.
+    stored = json.loads(vault_fixture["database"].read_text())["talks"][0]
+    assert "source_receipt" not in stored["structured_data"]["video_extraction"]
+
+
+def test_derivatives_from_two_runs_cannot_share_one_manifest(
+    preflight_vault,
+    vault_fixture,
+):
+    materialize_transcript(vault_fixture)
+    manifest = context_video_manifest(vault_fixture)
+    other_source = vault_fixture["root"] / "slides-rebuild" / VIDEO_ID / "other.mp4"
+    write_tiny_video(other_source)
+    other_source.write_bytes(other_source.read_bytes() + b"\x00")
+    manifest["artifacts"][0]["source_receipt"] = video_source_receipt_for(other_source)
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                status="processed_partial",
+                slide_source="video_extracted",
+                structured_data={"video_extraction": manifest},
+            )
+        ],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "video_extraction_provenance_invalid"
+    )
+    assert finding["actual"] == "video_extraction.artifacts[0].source_receipt"
+
+
+def test_replaced_source_video_leaves_an_unrelated_talk_current(
+    preflight_vault,
+    vault_fixture,
+):
+    """One talk's broken lineage never demotes a lane that shares nothing."""
+    materialize_transcript(vault_fixture)
+    manifest = trusted_video_manifest(vault_fixture)
+    source_video = Path(manifest["source_video_path"])
+    source_video.write_bytes(source_video.read_bytes() + b"\x00")
+    healthy = base_talk(
+        filename="2026-07-31-transcript-only.md",
+        title="Transcript Only",
+        date="2026-07-31",
+        video_url=f"https://www.youtube.com/watch?v={OTHER_VIDEO_ID}",
+        youtube_id=OTHER_VIDEO_ID,
+        slide_source="none",
+        status="processed",
+    )
+    materialize_transcript(vault_fixture, video_id=OTHER_VIDEO_ID)
+    write_database(
+        vault_fixture,
+        [
+            base_talk(
+                status="processed_partial",
+                slide_source="video_extracted",
+                structured_data={"video_extraction": manifest},
+            ),
+            healthy,
+        ],
+    )
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    lineage = [
+        item
+        for item in report["findings"]
+        if item["code"] == "video_extraction_source_lineage_mismatch"
+    ]
+    assert len(lineage) == 1
+    assert lineage[0]["filename"] == "2026-07-30-perfect-ingress.md"

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -707,7 +707,7 @@ def test_trusted_video_return_requires_complete_manifest_and_promoted_path(
 
     missing_path = _video_return()
     del missing_path["slides_local_path"]
-    assert "requires a trusted schema-v3" in _error(return_validation, missing_path)
+    assert "requires a trusted schema-v4" in _error(return_validation, missing_path)
 
 
 @pytest.mark.parametrize("version", [None, 1, 2, 3, 4, 5])
@@ -744,7 +744,7 @@ def test_context_video_cannot_promote_or_cite_static_slides(return_validation):
 
     cited = _video_return(trusted=False, promoted=False)
     cited["pattern_observations"]["evidence_sources"].append("static_slides")
-    assert "no trusted schema-v3 slide_region" in _error(return_validation, cited)
+    assert "no trusted schema-v4 slide_region" in _error(return_validation, cited)
 
 
 def test_trusted_unpromoted_video_can_support_partial_static_analysis(

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -952,6 +952,32 @@ def test_unavailable_source_gates_must_be_explicitly_not_evaluable(return_valida
             ),
             "must equal frame_index / fps_used",
         ),
+        (
+            lambda manifest: manifest.pop("source_receipt"),
+            "source_receipt must be a complete engine-owned source-video receipt",
+        ),
+        (
+            lambda manifest: manifest["source_receipt"].update(source_sha256="beef"),
+            "source_receipt.source_sha256 must be a complete engine-owned",
+        ),
+        (
+            lambda manifest: manifest["source_receipt"].update(
+                source_generation=dict(
+                    manifest["source_receipt"]["source_generation"], size=9
+                )
+            ),
+            "source_receipt.source_generation must be a complete engine-owned",
+        ),
+        (
+            lambda manifest: manifest["artifacts"][0].pop("source_receipt"),
+            "artifacts[0].source_receipt must be a complete engine-owned",
+        ),
+        (
+            lambda manifest: manifest["artifacts"][0]["source_receipt"].update(
+                source_sha256="f" * 64
+            ),
+            "artifacts[0].source_receipt must match the manifest source_receipt",
+        ),
     ],
 )
 def test_video_manifest_rejects_spoofed_or_inconsistent_provenance(
@@ -2844,3 +2870,34 @@ def test_validator_cli_reports_every_invalid_return(tmp_path):
     assert "a.md" in result.stderr
     assert "b.md" in result.stderr
     assert "2 validation error(s) across 2 return(s)" in result.stderr
+
+
+def test_archival_v3_manifest_is_rejected_with_its_own_reason(return_validation):
+    """v3 is readable history, never a current claim, and never auto-upgraded."""
+    value = _video_return(trusted=False, promoted=False)
+    manifest = value["structured_data"]["video_extraction"]
+    manifest["schema_version"] = 3
+    manifest.pop("source_receipt")
+    for artifact in manifest["artifacts"]:
+        artifact.pop("source_receipt")
+
+    with pytest.raises(return_validation.ReturnValidationError) as caught:
+        return_validation.validate_video_extraction_manifest(
+            {"video_extraction": manifest}
+        )
+
+    assert caught.value.reason_code == "video_extraction.schema_version_archival"
+    # Rejection is the whole response: nothing stamps a receipt after the fact.
+    assert "source_receipt" not in manifest
+
+
+def test_manifest_state_carries_the_canonical_receipt_for_lineage_readers(
+    return_validation,
+):
+    manifest = _video_manifest(trusted=True)
+
+    state = return_validation.validate_video_extraction_manifest(
+        {"video_extraction": manifest}
+    )
+
+    assert state.source_receipt == manifest["source_receipt"]

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 
 import pytest
+from conftest import synthetic_video_source_receipt
 from pypdf import PdfWriter
 
 
@@ -160,10 +161,12 @@ def _return_with_canonical_visuals():
 def _video_manifest(*, trusted=True, source_video_id="abcDEF12345"):
     root = f"/vault/slides-rebuild/{source_video_id}"
     source_path = f"{root}/{source_video_id}.mp4"
+    receipt = synthetic_video_source_receipt()
     shared = {
         "page_count": 2,
         "source_video_id": source_video_id,
         "source_video_path": source_path,
+        "source_receipt": copy.deepcopy(receipt),
     }
     if trusted:
         region = [0.05, 0.02, 0.78, 0.98]
@@ -199,10 +202,11 @@ def _video_manifest(*, trusted=True, source_video_id="abcDEF12345"):
         review_reason = "No verified slide region is available."
     return {
         "slide_source": "video_extracted",
-        "schema_version": 3,
+        "schema_version": 4,
         "pipeline_version": "0.10.0",
         "source_video_id": source_video_id,
         "source_video_path": source_path,
+        "source_receipt": receipt,
         "total_frames_extracted": 4,
         "unique_frame_count": 2,
         "authored_slide_count": None,

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -1600,13 +1600,19 @@ def test_source_receipt_generation_must_agree_with_the_probed_byte_count() -> No
     assert caught.value.details == {"field": "source_generation"}
 
 
-def test_dataless_placeholder_generation_can_never_back_a_receipt() -> None:
+@pytest.mark.parametrize("field", ["flags", "file_attributes"])
+def test_dataless_placeholder_generation_can_never_back_a_receipt(field: str) -> None:
     """A cloud stub stays unavailable; hydration is the only way forward."""
+    # SF_DATALESS is 0 off Darwin, so that marker only carries meaning there;
+    # the Windows cloud attributes are plain constants on every platform.
+    marker = {
+        "flags": video_evidence.VIDEO_MACOS_DATALESS_FLAG,
+        "file_attributes": video_evidence.VIDEO_WINDOWS_CLOUD_FILE_ATTRIBUTES,
+    }[field]
+    if not marker:
+        pytest.skip(f"no {field} placeholder marker is defined on this platform")
     receipt = video_evidence.build_video_source_receipt(_probe(_generation()))
-    receipt["source_generation"] = dict(
-        receipt["source_generation"],
-        flags=video_evidence.VIDEO_MACOS_DATALESS_FLAG,
-    )
+    receipt["source_generation"] = dict(receipt["source_generation"], **{field: marker})
 
     with pytest.raises(video_evidence.VideoEvidenceError) as caught:
         video_evidence.validate_video_source_receipt(receipt)

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import json
 import os
 import subprocess
 import sys
@@ -1498,3 +1499,162 @@ def test_a_video_probe_runs_under_an_interpreter_inside_the_trusted_root(
 
     assert probe.duration_seconds == pytest.approx(1.0, abs=0.1)
     assert probe.video_stream_count == 1
+
+
+def test_source_receipt_round_trips_and_agrees_with_its_own_probe() -> None:
+    probe = _probe(_generation())
+    receipt = video_evidence.build_video_source_receipt(probe)
+
+    assert video_evidence.validate_video_source_receipt(receipt) == receipt
+    assert video_evidence.video_source_receipt_lineage_drift(receipt, probe) == ()
+    assert video_evidence.video_source_receipt_generation_drift(receipt, probe) == ()
+    assert receipt["probe_schema_version"] == (
+        video_evidence.VIDEO_PROBE_SCHEMA_VERSION
+    )
+    assert receipt["probe_pipeline_version"] == (
+        video_evidence.VIDEO_PROBE_PIPELINE_VERSION
+    )
+
+
+def test_source_receipt_is_path_neutral_and_carries_no_parser_output() -> None:
+    generation = _generation()
+    probe = video_evidence.VideoArtifactProbe(
+        generation=generation,
+        root_generation=_root_generation(),
+        availability=video_evidence.ArtifactAvailability.from_generation(generation),
+        source_sha256="b" * 64,
+        source_size_bytes=generation.size,
+        duration_seconds=1.0,
+        duration_source="format",
+        container_family="iso_bmff",
+        stream_count=1,
+        video_stream_count=1,
+        audio_stream_count=0,
+        attached_picture_count=0,
+        other_stream_count=0,
+        parser_diagnostics=video_evidence.DiagnosticReceipt(
+            byte_count=512,
+            sha256="c" * 64,
+            truncated=True,
+        ),
+    )
+
+    receipt = video_evidence.build_video_source_receipt(probe)
+
+    assert set(receipt) == set(video_evidence.VIDEO_SOURCE_RECEIPT_FIELDS)
+    assert "parser_diagnostics" not in receipt
+    assert "c" * 64 not in json.dumps(receipt)
+    assert "/" not in json.dumps(receipt)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "field"),
+    [
+        (lambda receipt: receipt.pop("container_family"), "source_receipt"),
+        (
+            lambda receipt: receipt.update(artifact_path="/vault/talk.mp4"),
+            ("source_receipt"),
+        ),
+        (lambda receipt: receipt.update(schema_version=2), "schema_version"),
+        (
+            lambda receipt: receipt.update(probe_schema_version=99),
+            ("probe_schema_version"),
+        ),
+        (
+            lambda receipt: receipt.update(source_sha256="not-a-digest"),
+            ("source_sha256"),
+        ),
+        (lambda receipt: receipt.update(source_size_bytes=0), "source_size_bytes"),
+        (lambda receipt: receipt.update(duration_seconds=0), "duration_seconds"),
+        (lambda receipt: receipt.update(duration_source="guess"), "duration_source"),
+        (lambda receipt: receipt.update(container_family="ogg"), "container_family"),
+        (lambda receipt: receipt.update(audio_stream_count=7), "stream_count"),
+        (lambda receipt: receipt.update(video_stream_count=0), "video_stream_count"),
+        (
+            lambda receipt: receipt.update(source_generation={"size": 1}),
+            ("source_generation"),
+        ),
+    ],
+)
+def test_source_receipt_rejects_a_shape_no_probe_could_have_produced(
+    mutate: Any,
+    field: str,
+) -> None:
+    receipt = video_evidence.build_video_source_receipt(_probe(_generation()))
+    mutate(receipt)
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.validate_video_source_receipt(receipt)
+
+    assert caught.value.reason_code == "video_source_receipt_invalid"
+    assert caught.value.details == {"field": field}
+
+
+def test_source_receipt_generation_must_agree_with_the_probed_byte_count() -> None:
+    receipt = video_evidence.build_video_source_receipt(_probe(_generation(size=1_024)))
+    receipt["source_generation"] = dict(receipt["source_generation"], size=2_048)
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.validate_video_source_receipt(receipt)
+
+    assert caught.value.details == {"field": "source_generation"}
+
+
+def test_dataless_placeholder_generation_can_never_back_a_receipt() -> None:
+    """A cloud stub stays unavailable; hydration is the only way forward."""
+    receipt = video_evidence.build_video_source_receipt(_probe(_generation()))
+    receipt["source_generation"] = dict(
+        receipt["source_generation"],
+        flags=video_evidence.VIDEO_MACOS_DATALESS_FLAG,
+    )
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.validate_video_source_receipt(receipt)
+
+    assert caught.value.details == {"field": "source_generation"}
+
+
+def test_replacement_at_the_same_path_is_lineage_drift_not_a_fresh_source() -> None:
+    original = _probe(_generation(inode=31), digest="a" * 64)
+    replacement = _probe(_generation(inode=77), digest="d" * 64)
+    receipt = video_evidence.build_video_source_receipt(original)
+
+    assert video_evidence.video_source_receipt_lineage_drift(receipt, replacement) == (
+        ("source_sha256",)
+    )
+
+
+def test_generation_drift_is_bound_inside_a_run_but_not_across_hosts() -> None:
+    """Same bytes, moved vault: content holds, the host-local generation does not."""
+    original = _probe(_generation(inode=31))
+    moved = _probe(_generation(inode=77))
+    receipt = video_evidence.build_video_source_receipt(original)
+
+    assert video_evidence.video_source_receipt_lineage_drift(receipt, moved) == ()
+    assert video_evidence.video_source_receipt_generation_drift(receipt, moved) == (
+        ("source_generation",)
+    )
+
+
+def test_duration_reparse_within_tolerance_is_not_drift() -> None:
+    receipt = video_evidence.build_video_source_receipt(_probe(_generation()))
+    tolerance = video_evidence.VIDEO_SOURCE_RECEIPT_DURATION_TOLERANCE_SECONDS
+    probe = _probe(_generation())
+
+    receipt["duration_seconds"] = probe.duration_seconds + tolerance / 2
+    assert video_evidence.video_source_receipt_lineage_drift(receipt, probe) == ()
+
+    receipt["duration_seconds"] = probe.duration_seconds + tolerance * 10
+    assert video_evidence.video_source_receipt_lineage_drift(receipt, probe) == (
+        ("duration_seconds",)
+    )
+
+
+def test_probe_contract_version_is_part_of_the_lineage_claim() -> None:
+    probe = _probe(_generation())
+    receipt = video_evidence.build_video_source_receipt(probe)
+    receipt["probe_pipeline_version"] = "0.9.0"
+
+    assert video_evidence.video_source_receipt_lineage_drift(receipt, probe) == (
+        ("probe_pipeline_version",)
+    )

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -1658,3 +1658,15 @@ def test_probe_contract_version_is_part_of_the_lineage_claim() -> None:
     assert video_evidence.video_source_receipt_lineage_drift(receipt, probe) == (
         ("probe_pipeline_version",)
     )
+
+
+@pytest.mark.parametrize("field", ["schema_version", "probe_schema_version"])
+def test_receipt_version_fields_reject_booleans(field: str) -> None:
+    """`True == 1`, so a version gate on equality alone admits a bool."""
+    receipt = video_evidence.build_video_source_receipt(_probe(_generation()))
+    receipt[field] = True
+
+    with pytest.raises(video_evidence.VideoEvidenceError) as caught:
+        video_evidence.validate_video_source_receipt(receipt)
+
+    assert caught.value.details == {"field": field}

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import json
 import os
+import pathlib
 import shutil
 import stat
 import subprocess
@@ -2001,10 +2002,10 @@ def test_a_failed_second_publish_rolls_the_first_one_back(
     assert leftovers == []
 
 
-def test_an_orphan_left_by_a_killed_first_publish_is_removed_next_run(
+def test_an_interrupt_during_publish_still_rolls_back_in_process(
     video_slide_extraction, tmp_path, monkeypatch
 ):
-    """A destination that held nothing must not inherit a killed run's PDF."""
+    """An interrupt is an exit, not an excuse to leave a partial publish."""
     frame = _prepared_frame(tmp_path)
     video = write_tiny_video(tmp_path / "source.mp4")
     outdir = tmp_path / "output"
@@ -2013,29 +2014,41 @@ def test_an_orphan_left_by_a_killed_first_publish_is_removed_next_run(
     monkeypatch.setattr(
         video_slide_extraction, "extract_frames", _extract_one_frame(frame)
     )
-
-    # Exactly the state a kill after the first publish leaves: an orphan PDF at
-    # a destination that held nothing, plus its absence marker.
     original_commit = video_slide_extraction.commit_pdf_stage
 
     def commit(path):
         original_commit(path)
-        raise KeyboardInterrupt("host killed the run mid-publish")
+        raise KeyboardInterrupt("operator interrupted the run mid-publish")
 
     monkeypatch.setattr(video_slide_extraction, "commit_pdf_stage", commit)
+
     with pytest.raises(KeyboardInterrupt):
         video_slide_extraction.extract_slides_from_video(
             str(video), str(outdir), YOUTUBE_ID, slide_region="none"
         )
-    assert os.path.exists(context_pdf)
-    assert os.path.exists(video_slide_extraction._pdf_absent_marker_path(context_pdf))
 
-    monkeypatch.setattr(video_slide_extraction, "commit_pdf_stage", original_commit)
+    assert not os.path.exists(context_pdf)
+    assert os.listdir(outdir) == []
+
+
+def test_an_orphan_left_by_a_killed_first_publish_is_removed_next_run(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """A destination that held nothing must not inherit a killed run's PDF."""
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+    context_pdf = str(outdir / f"{YOUTUBE_ID}.context.pdf")
+    # SIGKILL runs no handler, so the state is constructed rather than raised:
+    # a published PDF at a destination that held nothing, plus its marker.
+    pathlib.Path(context_pdf).write_bytes(b"%PDF-1.4 orphan from a killed run")
+    pathlib.Path(video_slide_extraction._pdf_absent_marker_path(context_pdf)).touch()
     monkeypatch.setattr(
         video_slide_extraction,
         "extract_frames",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("later")),
     )
+
     with pytest.raises(RuntimeError, match="later"):
         video_slide_extraction.extract_slides_from_video(
             str(video), str(outdir), YOUTUBE_ID, slide_region="none"

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -1106,7 +1106,7 @@ def test_success_cli_emits_only_result_json_on_stdout(
     assert payload["artifacts"][0]["artifact_scope"] == "full_frame_context"
     assert "Extracting video artifacts" in captured.err
     assert "Deduplicated: 1 frames -> 1 unique frames" in captured.err
-    assert "Saved full_frame_context PDF" in captured.err
+    assert "Staged full_frame_context PDF" in captured.err
     assert "Done: 1 unique frames retained" in captured.err
 
 
@@ -1878,3 +1878,58 @@ def test_failure_between_derivatives_leaves_no_published_pdf_behind(
     assert published
     assert [path for path in published if os.path.exists(path)] == []
     assert video.exists()
+
+
+def test_failed_re_extraction_leaves_the_prior_derivatives_intact(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """A run that cannot bind must not destroy what a bound run published."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+
+    first = video_slide_extraction.extract_slides_from_video(
+        str(video),
+        str(outdir),
+        YOUTUBE_ID,
+        slide_region=(0.2, 0.1, 0.9, 0.8),
+        slide_region_verified=True,
+    )
+    prior = {
+        artifact["path"]: open(artifact["path"], "rb").read()
+        for artifact in first["artifacts"]
+    }
+    assert len(prior) == 2
+
+    original_combine = video_slide_extraction.combine_to_pdf
+    staged = []
+
+    def combine(*args, **kwargs):
+        if staged:
+            raise RuntimeError("synthetic failure after the first derivative")
+        path = original_combine(*args, **kwargs)
+        staged.append(path)
+        return path
+
+    monkeypatch.setattr(video_slide_extraction, "combine_to_pdf", combine)
+
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        video_slide_extraction.extract_slides_from_video(
+            str(video),
+            str(outdir),
+            YOUTUBE_ID,
+            slide_region=(0.2, 0.1, 0.9, 0.8),
+            slide_region_verified=True,
+        )
+
+    for path, content in prior.items():
+        assert open(path, "rb").read() == content
+    stages = [
+        name
+        for name in os.listdir(outdir)
+        if name.endswith(video_slide_extraction._PDF_STAGE_SUFFIX)
+    ]
+    assert stages == []

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -1933,3 +1933,105 @@ def test_failed_re_extraction_leaves_the_prior_derivatives_intact(
         if name.endswith(video_slide_extraction._PDF_STAGE_SUFFIX)
     ]
     assert stages == []
+
+
+def test_a_failed_second_publish_rolls_the_first_one_back(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """Never one run's slide-region PDF beside another run's context PDF."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+
+    first = video_slide_extraction.extract_slides_from_video(
+        str(video),
+        str(outdir),
+        YOUTUBE_ID,
+        slide_region=(0.2, 0.1, 0.9, 0.8),
+        slide_region_verified=True,
+    )
+    prior = {
+        artifact["path"]: open(artifact["path"], "rb").read()
+        for artifact in first["artifacts"]
+    }
+    assert len(prior) == 2
+
+    original_commit = video_slide_extraction.commit_pdf_stage
+    committed = []
+
+    def commit(path):
+        if committed:
+            raise OSError("synthetic publish failure on the second derivative")
+        committed.append(path)
+        original_commit(path)
+
+    monkeypatch.setattr(video_slide_extraction, "commit_pdf_stage", commit)
+    # Different pages, so a surviving replacement would be visible as a diff.
+    other_frame = tmp_path / "other-frame.png"
+    Image.new("RGB", (320, 180), (10, 200, 30)).save(other_frame)
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(other_frame)
+    )
+
+    with pytest.raises(OSError, match="synthetic publish failure"):
+        video_slide_extraction.extract_slides_from_video(
+            str(video),
+            str(outdir),
+            YOUTUBE_ID,
+            slide_region=(0.2, 0.1, 0.9, 0.8),
+            slide_region_verified=True,
+        )
+
+    assert committed
+    for path, content in prior.items():
+        assert open(path, "rb").read() == content
+    leftovers = [
+        name
+        for name in os.listdir(outdir)
+        if name.endswith(
+            (
+                video_slide_extraction._PDF_STAGE_SUFFIX,
+                video_slide_extraction._PDF_BACKUP_SUFFIX,
+            )
+        )
+    ]
+    assert leftovers == []
+
+
+def test_a_backup_left_by_a_killed_publish_is_restored_next_run(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """The window between a destination's two renames is recoverable."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+
+    first = video_slide_extraction.extract_slides_from_video(
+        str(video), str(outdir), YOUTUBE_ID, slide_region="none"
+    )
+    context_pdf = first["artifacts"][0]["path"]
+    prior = open(context_pdf, "rb").read()
+    # Exactly the state a kill between the two renames leaves behind.
+    os.replace(context_pdf, video_slide_extraction._pdf_backup_path(context_pdf))
+    assert not os.path.exists(context_pdf)
+
+    # Fail the next run after recovery so the restore stays observable rather
+    # than being immediately overwritten by a fresh derivative.
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_frames",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("later")),
+    )
+    with pytest.raises(RuntimeError, match="later"):
+        video_slide_extraction.extract_slides_from_video(
+            str(video), str(outdir), YOUTUBE_ID, slide_region="none"
+        )
+
+    assert open(context_pdf, "rb").read() == prior
+    assert not os.path.exists(video_slide_extraction._pdf_backup_path(context_pdf))

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -11,6 +11,7 @@ import sys
 import threading
 
 import pytest
+from conftest import synthetic_video_source_receipt, write_tiny_video
 from filelock import FileLock, Timeout
 from PIL import Image
 from pypdf import PdfReader
@@ -406,7 +407,7 @@ def test_video_pipeline_rejects_existing_output_symlink_escape_before_ffmpeg(
 
     with pytest.raises(ValueError, match="video_output_path_escape"):
         video_slide_extraction.extract_slides_from_video(
-            tmp_path / "source.mp4",
+            write_tiny_video(tmp_path / "source.mp4"),
             output,
             YOUTUBE_ID,
         )
@@ -428,7 +429,7 @@ def test_video_pipeline_rejects_a_directory_at_a_pdf_destination_before_ffmpeg(
 
     with pytest.raises(ValueError, match="video_output_leaf_invalid"):
         video_slide_extraction.extract_slides_from_video(
-            tmp_path / "source.mp4",
+            write_tiny_video(tmp_path / "source.mp4"),
             output,
             YOUTUBE_ID,
         )
@@ -449,8 +450,7 @@ def test_pipeline_ignores_and_preserves_legacy_stale_frames(
     )
     with open(stale_pdf_stage, "wb") as staged:
         staged.write(b"partial prior PDF")
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source")
+    video = write_tiny_video(tmp_path / "source.mp4")
     workspaces = []
     consumed = []
 
@@ -502,8 +502,7 @@ def test_pipeline_removes_its_private_workspace_after_failure(
     legacy_workspace.mkdir(parents=True)
     stale = legacy_workspace / "frame_99999.jpg"
     stale.write_bytes(b"older extraction")
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source")
+    video = write_tiny_video(tmp_path / "source.mp4")
     workspaces = []
 
     def extract(_video_path, frames_dir, fps):
@@ -542,8 +541,7 @@ def test_pipeline_closes_an_open_frame_before_failure_cleanup(
     tmp_path,
 ):
     output = tmp_path / "output"
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source")
+    video = write_tiny_video(tmp_path / "source.mp4")
     workspaces = []
 
     def extract(_video_path, frames_dir, fps):
@@ -584,8 +582,7 @@ def test_existing_unlocked_run_lock_file_does_not_block_a_rerun(
     )
     with open(run_lock, "wb") as lock_file:
         lock_file.write(b"left by an interrupted process")
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source")
+    video = write_tiny_video(tmp_path / "source.mp4")
 
     def extract(_video_path, frames_dir, fps):
         del fps
@@ -644,8 +641,7 @@ def test_parallel_pipeline_runs_use_distinct_workspaces_and_publish_complete_pdf
     tmp_path,
 ):
     output = tmp_path / "output"
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source")
+    video = write_tiny_video(tmp_path / "source.mp4")
     barrier = threading.Barrier(2)
     workspaces = []
     workspaces_lock = threading.Lock()
@@ -1034,6 +1030,7 @@ def test_artifact_manifest_rejects_unverified_authored_slide_trust(
             1,
             YOUTUBE_ID,
             tmp_path / "source.mp4",
+            synthetic_video_source_receipt(),
             crop_method="auto",
             crop_verified=False,
             trusted_for_authored_slide_analysis=True,
@@ -1080,8 +1077,7 @@ def test_success_cli_emits_only_result_json_on_stdout(
     """Progress stays on stderr so stdout remains one parseable payload."""
     frame = tmp_path / "frame.png"
     Image.new("RGB", (320, 180), (80, 40, 20)).save(frame)
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"synthetic source")
+    video = write_tiny_video(tmp_path / "source.mp4")
     outdir = tmp_path / "output"
     monkeypatch.setattr(
         video_slide_extraction,
@@ -1322,8 +1318,7 @@ def test_no_region_emits_context_only_even_when_extra_context_is_disabled(
 ):
     frame = tmp_path / "full-frame.png"
     Image.new("RGB", (320, 180), (80, 40, 20)).save(frame)
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source-video")
+    video = write_tiny_video(tmp_path / "source.mp4")
     outdir = tmp_path / "output"
     monkeypatch.setattr(
         video_slide_extraction,
@@ -1358,8 +1353,7 @@ def test_unverified_auto_crop_is_a_review_required_candidate(
 ):
     frame = tmp_path / "broadcast-frame.png"
     Image.new("RGB", (1000, 500), (80, 40, 20)).save(frame)
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source-video")
+    video = write_tiny_video(tmp_path / "source.mp4")
     outdir = tmp_path / "output"
     region = (0.25, 0.25, 0.75, 0.75)
     monkeypatch.setattr(
@@ -1404,7 +1398,7 @@ def test_manual_region_bypasses_detection_and_records_verified_provenance(
 ):
     frame = tmp_path / "manual-region-frame.png"
     Image.new("RGB", (320, 180), (80, 40, 20)).save(frame)
-    video = tmp_path / "source.mp4"
+    video = write_tiny_video(tmp_path / "source.mp4")
     outdir = tmp_path / "output"
     outdir.mkdir()
 
@@ -1450,8 +1444,7 @@ def test_verified_crop_can_omit_extra_context_without_deleting_source(
 ):
     frame = tmp_path / "manual-region-frame.png"
     Image.new("RGB", (320, 180), (80, 40, 20)).save(frame)
-    video = tmp_path / "source.mp4"
-    video.write_bytes(b"source-video")
+    video = write_tiny_video(tmp_path / "source.mp4")
     outdir = tmp_path / "output"
     monkeypatch.setattr(
         video_slide_extraction,

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -1841,3 +1841,40 @@ def test_interrupted_prior_run_leaves_no_stage_inside_the_new_binding(
     assert result["artifacts"][0]["source_receipt"] == receipt
     assert context_pdf.read_bytes()[:4] == b"%PDF"
     assert b"interrupted prior run" not in context_pdf.read_bytes()
+
+
+def test_failure_between_derivatives_leaves_no_published_pdf_behind(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """A run that dies after publishing one PDF must not leave it orphaned."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    published = []
+
+    original_combine = video_slide_extraction.combine_to_pdf
+
+    def combine(*args, **kwargs):
+        if published:
+            raise RuntimeError("synthetic failure after the first derivative")
+        path = original_combine(*args, **kwargs)
+        published.append(path)
+        return path
+
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+    monkeypatch.setattr(video_slide_extraction, "combine_to_pdf", combine)
+
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        video_slide_extraction.extract_slides_from_video(
+            str(video),
+            str(outdir),
+            YOUTUBE_ID,
+            slide_region=(0.2, 0.1, 0.9, 0.8),
+            slide_region_verified=True,
+        )
+
+    assert published
+    assert [path for path in published if os.path.exists(path)] == []
+    assert video.exists()

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -2,6 +2,7 @@
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor
+import hashlib
 import json
 import os
 import shutil
@@ -1645,3 +1646,198 @@ def test_a_plausible_screen_of_the_same_area_is_accepted(video_slide_extraction)
     m[40:150, 60:260] = True  # 110x200 -> aspect 1.82, 38% of frame
     got = video_slide_extraction._largest_rectangular_component(m)
     assert got == (40, 149, 60, 259)
+
+
+def _extract_one_frame(frame):
+    """Return an extract_frames stand-in that yields one prepared frame."""
+
+    def extract(_video_path, _frames_dir, fps):
+        del fps
+        return [str(frame)]
+
+    return extract
+
+
+def _prepared_frame(tmp_path):
+    frame = tmp_path / "frame.png"
+    Image.new("RGB", (320, 180), (80, 40, 20)).save(frame)
+    return frame
+
+
+def test_run_records_the_source_receipt_on_the_manifest_and_every_derivative(
+    video_slide_extraction, tmp_path, monkeypatch, video_evidence
+):
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+
+    result = video_slide_extraction.extract_slides_from_video(
+        str(video),
+        str(tmp_path / "output"),
+        YOUTUBE_ID,
+        slide_region=(0.2, 0.1, 0.9, 0.8),
+        slide_region_verified=True,
+    )
+
+    receipt = result["source_receipt"]
+    assert video_evidence.validate_video_source_receipt(receipt) == receipt
+    assert receipt["source_sha256"] == hashlib.sha256(video.read_bytes()).hexdigest()
+    assert receipt["source_size_bytes"] == video.stat().st_size
+    assert len(result["artifacts"]) == 2
+    for artifact in result["artifacts"]:
+        assert artifact["source_receipt"] == receipt
+    # Separate objects, so a later in-place edit of one cannot silently
+    # rewrite the claim the others make.
+    assert all(
+        artifact["source_receipt"] is not receipt for artifact in result["artifacts"]
+    )
+
+
+def test_source_replaced_during_extraction_discards_every_derivative(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """Half-bound PDFs never survive a source swap mid-run."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    replacement = write_tiny_video(tmp_path / "replacement.mp4")
+    produced = []
+
+    original_combine = video_slide_extraction.combine_to_pdf
+
+    def combine(*args, **kwargs):
+        path = original_combine(*args, **kwargs)
+        if path is not None:
+            produced.append(path)
+        # Swap the source between the two derivative writes: the run is now
+        # producing pages from bytes the receipt no longer describes.
+        video.write_bytes(replacement.read_bytes() + b"\x00")
+        return path
+
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+    monkeypatch.setattr(video_slide_extraction, "combine_to_pdf", combine)
+
+    with pytest.raises(video_slide_extraction.VideoSourceLineageError) as caught:
+        video_slide_extraction.extract_slides_from_video(
+            str(video),
+            str(outdir),
+            YOUTUBE_ID,
+            slide_region=(0.2, 0.1, 0.9, 0.8),
+            slide_region_verified=True,
+        )
+
+    assert caught.value.reason_code == "video_source_replaced_during_extraction"
+    assert produced
+    assert [path for path in produced if os.path.exists(path)] == []
+    assert video.exists()
+
+
+def test_same_path_different_content_replay_rebinds_instead_of_reusing(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """A second run over replaced bytes must not inherit the first receipt."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+
+    first = video_slide_extraction.extract_slides_from_video(
+        str(video), str(outdir), YOUTUBE_ID, slide_region="none"
+    )
+    video.write_bytes(video.read_bytes() + b"\x00")
+    second = video_slide_extraction.extract_slides_from_video(
+        str(video), str(outdir), YOUTUBE_ID, slide_region="none"
+    )
+
+    assert first["source_video_path"] == second["source_video_path"]
+    assert (
+        first["source_receipt"]["source_sha256"]
+        != second["source_receipt"]["source_sha256"]
+    )
+    assert second["artifacts"][0]["source_receipt"] == second["source_receipt"]
+
+
+@pytest.mark.parametrize(
+    ("prepare", "reason_code"),
+    [
+        (lambda path: None, "video_artifact_unavailable"),
+        (lambda path: path.write_bytes(b"not a container"), "video_parser_rejected"),
+    ],
+)
+def test_unprobeable_source_produces_no_record_and_no_frames(
+    video_slide_extraction, tmp_path, monkeypatch, prepare, reason_code
+):
+    video = tmp_path / "source.mp4"
+    prepare(video)
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_frames",
+        lambda *_args, **_kwargs: pytest.fail("unbound source reached ffmpeg"),
+    )
+
+    with pytest.raises(video_slide_extraction.VideoSourceLineageError) as caught:
+        video_slide_extraction.extract_slides_from_video(
+            str(video), str(tmp_path / "output"), YOUTUBE_ID, slide_region="none"
+        )
+
+    assert caught.value.reason_code == reason_code
+
+
+def test_cli_reports_an_unbound_source_as_json_on_stderr_and_exits_nonzero(
+    tmp_path,
+):
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT_PATH,
+            str(tmp_path / "absent.mp4"),
+            str(outdir),
+            YOUTUBE_ID,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert proc.stdout == ""
+    payload = json.loads(proc.stderr.strip().splitlines()[-1])
+    assert payload["reason_code"] == "video_artifact_unavailable"
+    assert str(tmp_path) not in proc.stderr
+
+
+def test_interrupted_prior_run_leaves_no_stage_inside_the_new_binding(
+    video_slide_extraction, tmp_path, monkeypatch, video_evidence
+):
+    """A reclaimed stage must not smuggle a prior run's pages into this receipt."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+    context_pdf = outdir / f"{YOUTUBE_ID}.context.pdf"
+    orphan_stage = video_slide_extraction._pdf_stage_path(str(context_pdf))
+    with open(orphan_stage, "wb") as stream:
+        stream.write(b"%PDF-1.4 interrupted prior run")
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+
+    result = video_slide_extraction.extract_slides_from_video(
+        str(video), str(outdir), YOUTUBE_ID, slide_region="none"
+    )
+
+    assert not os.path.exists(orphan_stage)
+    receipt = result["source_receipt"]
+    assert video_evidence.validate_video_source_receipt(receipt) == receipt
+    assert result["artifacts"][0]["source_receipt"] == receipt
+    assert context_pdf.read_bytes()[:4] == b"%PDF"
+    assert b"interrupted prior run" not in context_pdf.read_bytes()

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -2001,6 +2001,52 @@ def test_a_failed_second_publish_rolls_the_first_one_back(
     assert leftovers == []
 
 
+def test_an_orphan_left_by_a_killed_first_publish_is_removed_next_run(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    """A destination that held nothing must not inherit a killed run's PDF."""
+    frame = _prepared_frame(tmp_path)
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+    context_pdf = str(outdir / f"{YOUTUBE_ID}.context.pdf")
+    monkeypatch.setattr(
+        video_slide_extraction, "extract_frames", _extract_one_frame(frame)
+    )
+
+    # Exactly the state a kill after the first publish leaves: an orphan PDF at
+    # a destination that held nothing, plus its absence marker.
+    original_commit = video_slide_extraction.commit_pdf_stage
+
+    def commit(path):
+        original_commit(path)
+        raise KeyboardInterrupt("host killed the run mid-publish")
+
+    monkeypatch.setattr(video_slide_extraction, "commit_pdf_stage", commit)
+    with pytest.raises(KeyboardInterrupt):
+        video_slide_extraction.extract_slides_from_video(
+            str(video), str(outdir), YOUTUBE_ID, slide_region="none"
+        )
+    assert os.path.exists(context_pdf)
+    assert os.path.exists(video_slide_extraction._pdf_absent_marker_path(context_pdf))
+
+    monkeypatch.setattr(video_slide_extraction, "commit_pdf_stage", original_commit)
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_frames",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("later")),
+    )
+    with pytest.raises(RuntimeError, match="later"):
+        video_slide_extraction.extract_slides_from_video(
+            str(video), str(outdir), YOUTUBE_ID, slide_region="none"
+        )
+
+    assert not os.path.exists(context_pdf)
+    assert not os.path.exists(
+        video_slide_extraction._pdf_absent_marker_path(context_pdf)
+    )
+
+
 def test_a_backup_left_by_a_killed_publish_is_restored_next_run(
     video_slide_extraction, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Closes #216.

## The gap

A schema-v3 video-extraction manifest named its source video by id and path.
Both survive a replacement at that path — so a vault whose `AbCdEfGhI_1.mp4` was
re-downloaded, re-encoded, or swapped for a different recording kept PDFs that
passed every structural owner check while describing bytes that were no longer
there.

#190's runtime probe cannot close this. That probe answers "is the file readable
right now"; the claim this issue needs is historical — *these exact pages came
from these exact bytes* — and no digest observed today can supply it
retroactively. It takes a manifest contract.

## What changed

**Schema v4 advances only with an engine-owned source receipt.**
`build_video_source_receipt` (`video_evidence.py`) builds it from the bounded
#190 probe: source digest, size, duration/container/stream evidence, the bound
file generation, and the probe contract version. Path-neutral and bounded — no
locator, no raw ffprobe document, no parser stderr.

**Every derivative carries it, not just the manifest head.** The same receipt is
stamped byte-identically on each `artifacts[]` entry, so a PDF separated from its
manifest still names its source, and two derivatives from two different runs
cannot be merged under one head.

**The producer probes before and after.** One assessment spans both, so the
closing probe costs a stat when the generation held and a full re-probe exactly
when it did not. Drift removes every PDF the run produced and exits non-zero — a
half-bound result is worse than none. An unprobeable source (missing, corrupt, or
a dataless cloud placeholder) produces no record at all rather than one bound to a
stub.

**Readers validate lineage** in preflight, persistence, capability, and freshness
paths against a fresh probe. `source_generation` is deliberately outside that
comparison: device, inode, and mtime are host-local and change on a
byte-identical vault move, while the digest already proves the bytes. The
generation is what the extractor holds stable *inside* one run.

Two new preflight findings:

| code | severity | means |
|---|---|---|
| `video_extraction_source_lineage_mismatch` | blocking | source reads, but is not what the PDFs came from |
| `video_extraction_source_receipt_missing` | caller's severity | archival v3 record — reacquire the source and re-extract |

The second is deliberately *not* `provenance_invalid`. A v3 record was valid
under its own contract; naming the repair beats calling correct history corrupt.
Nothing migrates a v3 record in place.

## Migration

No automatic migration, by design. Existing v3 results stay readable as
archival/reprocessing inputs and become current only through explicit source
reacquisition and re-extraction. Dataless/offline placeholders stay unavailable
until hydrated.

## Also

- Manifest schema version moves to `ingress_contract.py` — one number instead of
  three literals across producer and readers.
- `PIPELINE_VERSION` 0.12.0 → 0.13.0: a run now requires a probeable source,
  which is an extraction-behavior change.
- `write_tiny_video` moves from `test_preflight_vault` into `conftest`; two
  suites need it and neither owned it.

## Tests

40 new tests covering the scenarios the issue names: source replacement during
extraction, same-path different-content replay (must rebind, not reuse the cached
receipt), derivative mixing, interrupted writes, cache generation changes, and
independent-lane preservation — plus the receipt contract itself and the archival
v3 path.

Manifest fixtures now build their receipt through the shipped builder rather than
a hand-written literal, so a producer-side shape change breaks the fixtures
instead of letting them drift.

Two defects the new tests found, both fixed here: the manifest field path for a
whole-object receipt rejection doubled its own suffix, and the archival reason
code was asserted through `validate_batch`, which wraps and drops it.

Local: `5922 passed, 3 skipped`; ruff check + format clean; pyright 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcVQP3kHngBp2qm299EsSh