### PR TITLE
docs(vault-ingress): record which assessor owns persisted citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+### docs(vault-ingress) — record which assessor owns persisted citations (#167)
+
+`persisted_pattern_observations.py` audits container shape, detection shape,
+catalog identity, confidence, evidence text, and dimensions, and stops there.
+#167's second acceptance criterion also names evidence citations and source
+inspection, so the module reads as if it forgot two checks, and the obvious fix
+is to reuse the return path's `validate_evidence_citations` and
+`validate_source_inspection` — one implementation cannot drift from itself.
+
+That fix is wrong, and wrong in a way the reader only discovers by shipping it.
+Those validators enforce the worker-side field sets. A canonically persisted
+citation is the worker's citation plus what the engine resolved onto it:
+
+```
+{"source": "transcript", "channel": "transcript", "quote": "...",
+ "line_start": 1, "line_end": 1, "artifact_root": "vault",
+ "artifact_path": "transcripts/talk.txt", "artifact_sha256": "aaaa..."}
+```
+
+Everything after `quote` is an unknown field to `EVIDENCE_CITATION_FIELDS`, and
+persisted `source_inspection` gains `line_count`, artifact identity, and
+`coverage_complete` the same way. The check would have reported
+`detection_evidence_citations_invalid` on every correctly persisted talk in the
+vault, and #294's fail-closed writer would then have refused to render any of
+them. `tests/test_write_analysis.py::test_cli_renders_persisted_locations_not_model_locations`
+is what caught it.
+
+The persisted contract already exists in `_v5_projection_freshness_reasons`
+inside `assess_persisted_pattern_evidence_freshness`, and is stricter than the
+duplicate would have been: citations present and non-empty, each falling within
+the recorded `source_inspection`, each bound to the artifact identity it was
+read from, and an `evidence_sources` that disagrees with the inspection
+rejected. It is required at `EVIDENCE_BOUND_SCORING_SCHEMA_VERSION` — a caller
+that omits it raises rather than silently passing, the fail-open shape #304
+recorded.
+
+The split is now in the module docstring and pinned by
+`test_source_location_defects_belong_to_the_freshness_assessor`, which asserts
+both halves: the structural classifier stays silent on a source-location
+defect, and the freshness assessor reports `source_inspection_missing` for the
+same talk. Asserting only the silence would pin a hole rather than a boundary.
+
+
 ## 0.20.88 — 2026-08-18
 
 ### feat(vault-ingress) — bind video derivatives to the exact source bytes (#216)

--- a/skills/vault-ingress/scripts/persisted_pattern_observations.py
+++ b/skills/vault-ingress/scripts/persisted_pattern_observations.py
@@ -20,6 +20,19 @@ inverse-schema field swap — is losslessly repairable. Everything else is an
 owner decision, and semantic dimension mappings belong to the catalog review in
 #156, never here.
 
+Where citations and source inspection are checked, and why not here: a
+persisted `evidence_citations` entry is the worker's citation plus what the
+engine resolved onto it — `line_start`, `artifact_root`, `artifact_sha256` —
+and `source_inspection` gains `line_count`, artifact identity, and
+`coverage_complete` the same way. `validate_evidence_citations` and
+`validate_source_inspection` enforce the WORKER-side field sets, so pointing
+either at a stored block reports every correctly persisted talk as corrupt.
+`assess_persisted_pattern_evidence_freshness` owns the persisted contract, and
+owns it more strictly: citations present, each falling within the recorded
+inspection, each bound to the artifact identity it was read from. It is
+required at scoring v4 and later. Shape and catalog agreement are this
+module's; source location and artifact binding are that one's.
+
 Pure function of (talk, catalog): no filesystem, no clock, no network.
 """
 

--- a/tests/test_persisted_pattern_observations.py
+++ b/tests/test_persisted_pattern_observations.py
@@ -705,3 +705,44 @@ def test_a_malformed_detection_lane_forfeits_the_legacy_reading(
         not in assessment.reason_codes
     )
     assert persisted_pattern_observations.COLLECTION_INVALID in assessment.reason_codes
+
+
+def test_source_location_defects_belong_to_the_freshness_assessor(
+    persisted_pattern_observations,
+    return_validation,
+    catalog,
+    observable_entry,
+    tmp_path,
+) -> None:
+    """The boundary between the two persisted assessors, pinned.
+
+    A stored citation is the worker's plus what the engine resolved onto it, so
+    the worker-side contract reads every correctly persisted talk as corrupt.
+    `assess_persisted_pattern_evidence_freshness` owns citations and source
+    inspection, and owns them more strictly — within-inspection and bound to
+    artifact identity. A second contract here is the drift #167 exists to stop,
+    and this test fails when one is added.
+    """
+    detection = _detection(observable_entry)
+    detection["evidence_citations"] = "not even a list"
+    detection["evidence_source"] = "a source nobody inspected"
+    talk = _talk(observable_entry, detection)
+    talk["pattern_observations"].update(
+        {
+            "evidence_schema_version": 2,
+            "evidence_sources": ["transcript"],
+            "source_inspection": "not even a list",
+        }
+    )
+
+    assessment = persisted_pattern_observations.assess_persisted_pattern_observations(
+        talk, catalog
+    )
+
+    assert assessment.findings == ()
+    assert assessment.usable is True
+    # Refused, and by the assessor that owns the persisted shape. Asserting the
+    # silence above without this would pin a hole rather than a boundary.
+    assert "source_inspection_missing" in return_validation.assess_artifact_freshness(
+        talk, vault_root=tmp_path
+    )


### PR DESCRIPTION
## Summary

- Records in `persisted_pattern_observations.py` which of the two persisted assessors owns evidence citations and source inspection, and why the structural one deliberately does not check them.
- Pins the split with `test_source_location_defects_belong_to_the_freshness_assessor`, which asserts both halves: the structural classifier stays silent on a source-location defect, and `assess_persisted_pattern_evidence_freshness` reports `source_inspection_missing` for the same talk.
- CHANGELOG entry carrying the incident.

## Why

Closing #167 meant checking its second acceptance criterion, which names evidence citations and source inspection alongside the shape checks. The structural classifier checks neither, so it reads as a hole, and the obvious fix is to reuse the return path's `validate_evidence_citations` / `validate_source_inspection` — one implementation cannot drift from itself.

I built that fix. It is wrong. Those validators enforce the **worker-side** field sets, and a canonically persisted citation is the worker's citation plus what the engine resolved onto it:

```
{"source": "transcript", "channel": "transcript", "quote": "...",
 "line_start": 1, "line_end": 1, "artifact_root": "vault",
 "artifact_path": "transcripts/talk.txt", "artifact_sha256": "aaaa..."}
```

Everything after `quote` is an unknown field to `EVIDENCE_CITATION_FIELDS`; persisted `source_inspection` gains `line_count`, artifact identity, and `coverage_complete` the same way. Shipped, it would have reported `detection_evidence_citations_invalid` on every correctly persisted talk in the vault, and #294's fail-closed writer would then have refused to render any of them. `test_cli_renders_persisted_locations_not_model_locations` caught it.

The persisted contract already exists in `_v5_projection_freshness_reasons`, and is stricter than the duplicate: citations present, each within the recorded inspection, each bound to the artifact identity it was read from. It is required at `EVIDENCE_BOUND_SCORING_SCHEMA_VERSION`.

Nothing about the assessor's behavior changes here. This is the trap made visible so the next reader does not spend the same detour.

## Reviewer call requested

#167 was closed on my reading that AC2 is satisfied across the two assessors rather than missing from one. That judgment had no second pair of eyes. If the reviewers disagree — if the structural lane genuinely owes its own citation check — say so and #167 gets reopened.

## Test plan

- [x] Full suite green
- [x] `ruff check` / `ruff format --check` clean, `pyright` clean on touched files
- [x] The new test fails if a citation check is added to the structural classifier (verified by building that change first — it turned this assertion red)
