### PR TITLE
fix(vault-ingress): give the catalog-date comparison one owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ function:
 
 ```python
 # audit-source-identities.py — ISO days only
-date.fromisoformat(value.strip())          # "2014" -> ValueError -> None
+date.fromisoformat(value.strip())  # "2014" -> ValueError -> None
 
 # preflight-vault.py — year-aware
-if re.fullmatch(r"\d{4}", value):           # "2014" -> (None, 2014)
+if re.fullmatch(r"\d{4}", value):  # "2014" -> (None, 2014)
     return None, int(value)
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+### fix(vault-ingress) — one owner for the catalog-date comparison (#333)
+
+Registering source identities across the live vault surfaced a number that made
+no sense: `audit-source-identities.py` reported **1** `provider_upload_predates_catalog`,
+and preflight — reading the same records, minutes later — reported **11**
+`source_identity_upload_predates_talk`. Same comparison, same facts, two
+answers, and only the preflight number gates. The operator ran the pre-check,
+read it as clean, and met the other ten at the gate.
+
+Both scripts had a function named `parse_catalog_date`. They were not the same
+function:
+
+```python
+# audit-source-identities.py — ISO days only
+date.fromisoformat(value.strip())          # "2014" -> ValueError -> None
+
+# preflight-vault.py — year-aware
+if re.fullmatch(r"\d{4}", value):           # "2014" -> (None, 2014)
+    return None, int(value)
+```
+
+Nine of the eleven withheld talks are `playlist-*` records whose `date` is a
+bare year. To the auditor every one of them read as "no catalog date", so the
+upload comparison was not failed — it was never attempted. A record too coarse
+to compare precisely is still a record that names a year, and an upload from
+the year before is still evidence of the wrong delivery.
+
+`parse_catalog_date` and `upload_predates_catalog` now live in
+`source_identity_matching.py`, alongside the `titles_agree` contract both
+scripts already shared, and both callers compare at whichever precision the
+catalog record actually carries.
+
+Worth recording, because #333 assumed otherwise: the title predicate never
+diverged. The auditor's 4 `provider_title_mismatch` against preflight's 2 is a
+population difference, not a predicate one — the two "Battle of Agents" videos
+were withheld before registration, so preflight had no stored title to compare
+and never evaluated them. Both scripts call the same `titles_agree`.
+
+`expected_duration_seconds` was also copied into both scripts. The copies agree
+today, which is precisely where the date predicate started; it moved to the
+shared module too, unchanged.
+
 ## 0.20.89 — 2026-08-18
 
 ### docs(vault-ingress) — record which assessor owns persisted citations (#167)

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -154,14 +154,18 @@ Stable finding codes:
 | `provider_title_mismatch` | Provider title lacks material full-title or explicit base-title agreement |
 | `provider_event_mismatch` | Provider title explicitly names a known event different from the catalog conference |
 | `provider_duration_mismatch` | Provider duration exceeds the audit's deterministic catalog tolerance |
-| `provider_upload_predates_catalog` | Upload date predates the cataloged delivery date |
+| `provider_upload_predates_catalog` | Upload date predates the cataloged delivery, compared at the catalog record's own precision |
 | `stored_source_identity_differs` | Fresh stable facts differ from an existing evidence block |
 | `likely_non_delivery_clip` | Conservative title/duration signals suggest a demo, teaser, excerpt, or other non-delivery artifact |
 | `same_id_cross_talk_collision` | One ID is active on records with materially different titles or delivery dates |
 
 Title and explicit-event comparison are separate: an abbreviated title cannot
 waive a delivery's event identity. Their matching contract is owned by
-`skills/vault-ingress/scripts/source_identity_matching.py`. The non-delivery
+`skills/vault-ingress/scripts/source_identity_matching.py`, which also owns the
+catalog-date reading and the upload comparison this audit and preflight share —
+see `parse_catalog_date` and `upload_predates_catalog`. A catalog record dated
+`YYYY` is compared at year precision, never skipped, so this audit and the
+preflight gate return the same verdict on the same record. The non-delivery
 finding is a review signal, never an automatic rejection. Its conservative
 signal combination is owned by
 `skills/vault-ingress/scripts/audit-source-identities.py` in

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -240,7 +240,11 @@ Offline comparison rules are intentionally deterministic:
   value, falling back to `config.speaker_name`. A full name and that same
   surname-only form agree; unrelated names do not.
 - `recorded_date` must be in the catalog year; a different day in that year is
-  a warning. `upload_date` must not precede the catalog delivery date/year.
+  a warning. `upload_date` must not precede the catalog delivery date/year. The
+  catalog reading and the upload comparison are owned by `parse_catalog_date`
+  and `upload_predates_catalog` in
+  `skills/vault-ingress/scripts/source_identity_matching.py`, so the live audit
+  reaches the same verdict this gate does.
 - When the talk has numeric `duration_seconds`, `video_duration_seconds`, or
   `talk_duration_seconds` (top-level or the documented structured variants),
   source duration may differ by at most the greater of 60 seconds or 5%.

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -26,7 +26,9 @@ from source_identity_matching import (
     event_agreement,
     known_event_aliases,
     normalized_words,
+    parse_catalog_date,
     titles_agree,
+    upload_predates_catalog,
 )
 from tracking_database import (
     TrackingDatabaseError,
@@ -192,15 +194,6 @@ def expected_duration_seconds(talk: dict[str, Any]) -> float | None:
         ):
             return float(value)
     return None
-
-
-def parse_catalog_date(value: Any) -> date | None:
-    if not isinstance(value, str):
-        return None
-    try:
-        return date.fromisoformat(value.strip())
-    except ValueError:
-        return None
 
 
 def normalize_captured_at(value: str | datetime | None = None) -> str:
@@ -1019,10 +1012,9 @@ def audit_database(
                 )
             catalog_date = parse_catalog_date(talk.get("date"))
             upload_date = _provider_date(proposal.get("upload_date"))
-            upload_predates = (
-                date.fromisoformat(upload_date) < catalog_date
-                if catalog_date is not None and upload_date is not None
-                else None
+            upload_predates = upload_predates_catalog(
+                date.fromisoformat(upload_date) if upload_date is not None else None,
+                catalog_date,
             )
             differences = _stored_identity_differences(talk, proposal)
             event_agrees, catalog_event, provider_events = event_agreement(
@@ -1101,7 +1093,7 @@ def audit_database(
                         [filename],
                         "provider upload date predates the cataloged delivery date",
                         {
-                            "catalog_date": catalog_date.isoformat(),
+                            "catalog_date": talk.get("date"),
                             "provider_upload_date": upload_date,
                         },
                     )

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -24,6 +24,7 @@ from urllib.parse import parse_qs, urlparse
 
 from source_identity_matching import (
     event_agreement,
+    expected_duration_seconds,
     known_event_aliases,
     normalized_words,
     parse_catalog_date,
@@ -168,32 +169,6 @@ def is_youtube_url(value: Any) -> bool:
         "youtube-nocookie.com",
         "www.youtube-nocookie.com",
     }
-
-
-def expected_duration_seconds(talk: dict[str, Any]) -> float | None:
-    candidates = [
-        talk.get("duration_seconds"),
-        talk.get("video_duration_seconds"),
-        talk.get("talk_duration_seconds"),
-    ]
-    structured = talk.get("structured_data")
-    if isinstance(structured, dict):
-        candidates.extend(
-            [
-                structured.get("video_duration_seconds"),
-                structured.get("recording_duration_seconds"),
-                structured.get("duration_seconds"),
-            ]
-        )
-    for value in candidates:
-        if (
-            not isinstance(value, bool)
-            and isinstance(value, (int, float))
-            and math.isfinite(value)
-            and value > 0
-        ):
-            return float(value)
-    return None
 
 
 def normalize_captured_at(value: str | datetime | None = None) -> str:

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -73,6 +73,7 @@ from video_evidence import (
 from source_identity_matching import (
     EventAlias,
     event_agreement,
+    expected_duration_seconds,
     known_event_aliases,
     parse_catalog_date,
     titles_agree,
@@ -2478,29 +2479,6 @@ def expected_speakers(talk: dict[str, Any], config: dict[str, Any]) -> list[str]
                 return [name]
     config_name = _nonempty_string(config.get("speaker_name"))
     return [config_name] if config_name else []
-
-
-def expected_duration_seconds(talk: dict[str, Any]) -> float | None:
-    candidates = [
-        talk.get("duration_seconds"),
-        talk.get("video_duration_seconds"),
-        talk.get("talk_duration_seconds"),
-    ]
-    structured = talk.get("structured_data")
-    if isinstance(structured, dict):
-        candidates.extend(
-            [
-                structured.get("video_duration_seconds"),
-                structured.get("recording_duration_seconds"),
-                structured.get("duration_seconds"),
-            ]
-        )
-    for value in candidates:
-        if isinstance(value, bool):
-            continue
-        if isinstance(value, (int, float)) and math.isfinite(value) and value > 0:
-            return float(value)
-    return None
 
 
 def relation_from(talk: dict[str, Any]) -> tuple[Any, Any] | None:

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -74,7 +74,9 @@ from source_identity_matching import (
     EventAlias,
     event_agreement,
     known_event_aliases,
+    parse_catalog_date,
     titles_agree,
+    upload_predates_catalog,
 )
 from pptx_catalog_selection import classify_catalog, observed_source_fingerprint
 from pptx_talk_identity import (
@@ -2240,12 +2242,7 @@ class VaultPreflight:
                     actual=recorded.isoformat(),
                 )
         if upload is not None:
-            predates = (
-                upload < catalog_day
-                if catalog_day is not None
-                else upload.year < catalog_year
-            )
-            if predates:
+            if upload_predates_catalog(upload, talk_date):
                 self.talk_add(
                     index,
                     "blocking",
@@ -2481,19 +2478,6 @@ def expected_speakers(talk: dict[str, Any], config: dict[str, Any]) -> list[str]
                 return [name]
     config_name = _nonempty_string(config.get("speaker_name"))
     return [config_name] if config_name else []
-
-
-def parse_catalog_date(value: Any) -> tuple[date | None, int] | None:
-    if not isinstance(value, str):
-        return None
-    value = value.strip()
-    if re.fullmatch(r"\d{4}", value):
-        return None, int(value)
-    try:
-        parsed = date.fromisoformat(value)
-    except ValueError:
-        return None
-    return parsed, parsed.year
 
 
 def expected_duration_seconds(talk: dict[str, Any]) -> float | None:

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -22,6 +22,7 @@ AT_RE = re.compile(r"\bat\b", re.IGNORECASE)
 YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
 EXPLICIT_YEAR_RE = re.compile(r"(?<!\d)\d{4}(?!\d)")
 ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+CATALOG_YEAR_RE = re.compile(r"\d{4}")
 SHOWNOTES_EVENT_QUALIFIER_RE = re.compile(
     r"\s+at\s+(?P<event>\S(?:.*\S)?)\Z",
     re.IGNORECASE,
@@ -365,3 +366,42 @@ def event_agreement(
         return None, catalog_alias, mentions
     agrees = any(_aliases_compatible(catalog_alias, mention) for mention in mentions)
     return agrees, catalog_alias, mentions
+
+
+def parse_catalog_date(value: Any) -> tuple[date | None, int] | None:
+    """Return a catalog date as its exact day (when known) and its year.
+
+    A catalog record carries either a full ISO-8601 day or a bare `YYYY`, and a
+    bare year is a real delivery whose day was never recorded — not an absent
+    date. Returning the day and the year separately lets a caller compare at
+    whichever precision the record actually supports, so a coarse record stays
+    comparable instead of dropping out of the comparison entirely.
+    """
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if CATALOG_YEAR_RE.fullmatch(value):
+        return None, int(value)
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed, parsed.year
+
+
+def upload_predates_catalog(
+    upload: date | None,
+    catalog: tuple[date | None, int] | None,
+) -> bool | None:
+    """Return whether provider upload evidence precedes the cataloged delivery.
+
+    Compares at the catalog record's own precision: against the exact day when
+    the record carries one, and against the year otherwise. `None` means the
+    comparison could not be made, which is distinct from `False`.
+    """
+    if upload is None or catalog is None:
+        return None
+    catalog_day, catalog_year = catalog
+    if catalog_day is not None:
+        return upload < catalog_day
+    return upload.year < catalog_year

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import date
+import math
 import re
 from typing import Any
 import unicodedata
@@ -405,3 +406,33 @@ def upload_predates_catalog(
     if catalog_day is not None:
         return upload < catalog_day
     return upload.year < catalog_year
+
+
+def expected_duration_seconds(talk: dict[str, Any]) -> float | None:
+    """Return the catalog's own duration for a talk, in seconds.
+
+    Reads the first positive, finite duration among the record's own fields and
+    its `structured_data` block. Booleans are rejected before the numeric test
+    because `bool` is an `int` in Python, and a `True` would otherwise read as a
+    one-second duration.
+    """
+    candidates = [
+        talk.get("duration_seconds"),
+        talk.get("video_duration_seconds"),
+        talk.get("talk_duration_seconds"),
+    ]
+    structured = talk.get("structured_data")
+    if isinstance(structured, dict):
+        candidates.extend(
+            [
+                structured.get("video_duration_seconds"),
+                structured.get("recording_duration_seconds"),
+                structured.get("duration_seconds"),
+            ]
+        )
+    for value in candidates:
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)) and math.isfinite(value) and value > 0:
+            return float(value)
+    return None

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -1048,3 +1048,55 @@ def test_a_candidate_failure_leaves_the_cli_exit_status_clean(
 
     assert "candidate_metadata_fetch_failed" in finding_codes(result)
     assert result["complete"] is True
+
+
+def test_bare_year_catalog_date_is_compared_not_skipped(audit_source_identities):
+    """A `YYYY` catalog date gates on its year instead of dropping the check.
+
+    The auditor used to parse ISO days only, so every bare-year record read as
+    "no catalog date" and its upload comparison was silently skipped — the gate
+    that preflight applied to the same record was invisible in the pre-check.
+    """
+    database = {"talks": [talk("playlist-HVy2GzbI1II.md", date="2014")]}
+
+    report = audit_source_identities.audit_database(
+        database,
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=lambda video_id: metadata(
+            video_id,
+            title="Perfect Vault Ingress — ExampleConf",
+            upload_date="20131128",
+        ),
+        captured_at=CAPTURED_AT,
+    )
+
+    assert "provider_upload_predates_catalog" in finding_codes(report)
+    comparison = report["talks"][0]["comparison"]
+    assert comparison["upload_predates_catalog_date"] is True
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "provider_upload_predates_catalog"
+    )
+    assert finding["evidence"]["catalog_date"] == "2014"
+
+
+def test_bare_year_catalog_date_accepts_an_upload_within_that_year(
+    audit_source_identities,
+):
+    """Comparing at year precision must not turn same-year uploads into faults."""
+    database = {"talks": [talk("playlist-HVy2GzbI1II.md", date="2014")]}
+
+    report = audit_source_identities.audit_database(
+        database,
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=lambda video_id: metadata(
+            video_id,
+            title="Perfect Vault Ingress — ExampleConf",
+            upload_date="20140103",
+        ),
+        captured_at=CAPTURED_AT,
+    )
+
+    assert "provider_upload_predates_catalog" not in finding_codes(report)
+    assert report["talks"][0]["comparison"]["upload_predates_catalog_date"] is False

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -196,3 +196,27 @@ def test_upload_predates_catalog_compares_at_the_records_own_precision(
     expected: bool | None,
 ) -> None:
     assert source_identity_matching.upload_predates_catalog(upload, catalog) is expected
+
+
+@pytest.mark.parametrize(
+    ("talk", "expected"),
+    [
+        ({"duration_seconds": 2700}, 2700.0),
+        ({"video_duration_seconds": 1800}, 1800.0),
+        ({"structured_data": {"recording_duration_seconds": 900}}, 900.0),
+        # A later positive value is read past an unusable earlier one.
+        ({"duration_seconds": 0, "video_duration_seconds": 1800}, 1800.0),
+        ({"duration_seconds": -5, "talk_duration_seconds": 60}, 60.0),
+        # `bool` is an `int`; `True` must not read as a one-second talk.
+        ({"duration_seconds": True}, None),
+        ({"duration_seconds": float("inf")}, None),
+        ({"duration_seconds": "2700"}, None),
+        ({"structured_data": "not-a-mapping"}, None),
+        ({}, None),
+    ],
+)
+def test_expected_duration_seconds_reads_the_first_usable_catalog_duration(
+    talk: dict[str, object],
+    expected: float | None,
+) -> None:
+    assert source_identity_matching.expected_duration_seconds(talk) == expected

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 import importlib.util
 from pathlib import Path
 
@@ -152,3 +153,46 @@ def test_shownotes_event_qualifier_requires_exact_base_event_and_year(
         )
         is expected
     )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2014", (None, 2014)),
+        (" 2014 ", (None, 2014)),
+        ("2013-11-28", (date(2013, 11, 28), 2013)),
+        ("November 2014", None),
+        ("", None),
+        (2014, None),
+        (None, None),
+    ],
+)
+def test_parse_catalog_date_keeps_a_bare_year_comparable(
+    value: object,
+    expected: tuple[date | None, int] | None,
+) -> None:
+    """A bare `YYYY` is a coarse delivery date, never an absent one."""
+    assert source_identity_matching.parse_catalog_date(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("upload", "catalog", "expected"),
+    [
+        # A bare-year catalog record still gates on the year it names.
+        (date(2013, 11, 28), (None, 2014), True),
+        (date(2014, 11, 28), (None, 2014), False),
+        (date(2015, 1, 1), (None, 2014), False),
+        # An exact catalog day gates at day precision.
+        (date(2025, 11, 1), (date(2025, 11, 2), 2025), True),
+        (date(2025, 11, 2), (date(2025, 11, 2), 2025), False),
+        # An uncomparable side is unknown, never "does not predate".
+        (None, (None, 2014), None),
+        (date(2013, 11, 28), None, None),
+    ],
+)
+def test_upload_predates_catalog_compares_at_the_records_own_precision(
+    upload: date | None,
+    catalog: tuple[date | None, int] | None,
+    expected: bool | None,
+) -> None:
+    assert source_identity_matching.upload_predates_catalog(upload, catalog) is expected


### PR DESCRIPTION
## What

`audit-source-identities.py` and `preflight-vault.py` each defined their own
`parse_catalog_date`. They were not the same function:

```python
# audit-source-identities.py — ISO days only
date.fromisoformat(value.strip())   # "2014" -> ValueError -> None

# preflight-vault.py — year-aware
if re.fullmatch(r"\d{4}", value):    # "2014" -> (None, 2014)
    return None, int(value)
```

Nine of the fifteen talks withheld in #333 are `playlist-*` records whose `date`
is a bare year. To the auditor every one read as "no catalog date", so the
upload comparison was never attempted — the pre-check reported **1**
`provider_upload_predates_catalog` where the gate reported **11**
`source_identity_upload_predates_talk`. The operator read the audit as clean and
met the other ten at the gate.

`parse_catalog_date` and `upload_predates_catalog` now live in
`source_identity_matching.py` — the module that already owned the `titles_agree`
contract both scripts share — and both callers compare at whichever precision
the catalog record actually carries.

## Also in here

`expected_duration_seconds` was copied into both scripts. The copies agree
today, which is exactly where the date predicate started before it drifted. It
moved to the shared module unchanged.

## Correcting one premise in #333

The issue reads the auditor's 4 `provider_title_mismatch` against preflight's 2
as a second diverging predicate. It isn't — both scripts call the same
`titles_agree`. The gap is population: the two "Battle of Agents" videos were
withheld before registration, so preflight had no stored title to compare and
never evaluated them. No title-predicate change was needed.

## Scope

This closes the fifth acceptance criterion of #333 (auditor and preflight share
one predicate). The other four are catalog-data corrections in the live vault,
which carry no repo diff — they are tracked on #333 and reported separately.

## Testing

- `parse_catalog_date` / `upload_predates_catalog` unit tests covering bare-year
  and exact-day precision, and the `None`-vs-`False` distinction
- Two auditor regression tests: a bare-year record now fires
  `provider_upload_predates_catalog`, and a same-year upload still does not
- Full suite: 5948 passed, 3 skipped
- `ruff check`, `ruff format --check`, `pyright` all clean

Refs #333