### PR TITLE
feat(vault-ingress): let the reviewed-metadata writer repair a delivery date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+### feat(vault-ingress) — owner-reviewed delivery-date repair (#333)
+
+Correcting the eleven catalog dates #333 measured turned out to be impossible
+with the writers that existed. `apply-source-repairs.py` owns the source lanes
+and rejects a catalog field outright. `apply_reviewed_metadata` owns catalog
+identity, but its closed field set was `{title, conference}` — so a delivery
+date the provider evidence disproves had no owner path at all, and the SKILL
+forbids editing the database directly. The measurement landed with no way to act
+on it.
+
+`date` joins that closed set, classified metadata-only alongside `title` and
+`conference`: rhetoric analysis derives from transcript and slide content, so a
+corrected delivery date cannot stale it, and the writer proves that rather than
+assuming it.
+
+One extra condition rides on `date` that the other two do not carry — the value
+must be readable by `parse_catalog_date`. Writing `"October 2013"` would trade a
+wrong date for an uncheckable one: preflight would stop comparing source
+evidence against the record and report `source_identity_date_uncheckable`
+instead of gating. A repair that silently disables the gate it was meant to
+satisfy is worse than the wrong date it replaced.
+
 ## 0.20.90 — 2026-08-18
 
 ### fix(vault-ingress) — one owner for the catalog-date comparison (#333)

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -562,7 +562,9 @@ exact-type rule. The supported mutation kinds are:
 
 `apply_reviewed_metadata` exists because `scan-shownotes.py --apply` refuses
 review-required entries by design: an approved catalog correction otherwise had
-no owner writer at all. It stays narrow — the writable field set, the
+no owner writer at all. The same writer carries an owner-reviewed delivery-date
+repair, so a cataloged date the source evidence disproves has a path that is not
+a hand edit. It stays narrow — the writable field set, the
 metadata-only versus analysis-invalidating classification, and the reprocessing
 transition it demands are named at the top of
 `skills/vault-ingress/scripts/mutate-tracking-database.py`. Deterministic scan

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -55,6 +55,7 @@ from pptx_discovery_contract import (
     validate_pptx_directory_exclusions,
 )
 from pptx_talk_identity import binding_refusal
+from source_identity_matching import parse_catalog_date
 
 
 PLAN_SCHEMA_VERSION = 1
@@ -96,13 +97,13 @@ CLARIFICATION_TALK_FIELDS = frozenset({"blind_spot_observations", "humor_postmor
 # purpose: `scan-shownotes.py --apply` refuses review-required entries, and the
 # answer is one narrow owner path, never arbitrary talk-field mutation. Source
 # lanes stay with apply-source-repairs.py.
-METADATA_TALK_FIELDS = frozenset({"title", "conference"})
+METADATA_TALK_FIELDS = frozenset({"title", "conference", "date"})
 # Whether repairing a field invalidates derived analysis. Rhetoric analysis
 # derives from transcript and slide content, so correcting a talk's catalog
 # title or conference cannot stale it — the writer proves that rather than
 # assuming it. A field that DOES invalidate belongs in the second set, and the
 # writer then requires the reprocessing transition in the same plan.
-METADATA_ONLY_FIELDS = frozenset({"title", "conference"})
+METADATA_ONLY_FIELDS = frozenset({"title", "conference", "date"})
 ANALYSIS_INVALIDATING_METADATA_FIELDS: frozenset[str] = frozenset()
 _UNCLASSIFIED_METADATA_FIELDS = METADATA_TALK_FIELDS - (
     METADATA_ONLY_FIELDS | ANALYSIS_INVALIDATING_METADATA_FIELDS
@@ -848,11 +849,21 @@ def _apply_update_talk(
 
 
 def _validate_metadata_values(values: object, label: str) -> None:
-    """Every repaired catalog value is a non-empty trimmed string."""
+    """Every repaired catalog value is a non-empty trimmed string.
+
+    `date` carries the extra requirement that the shared catalog-date parser can
+    read it. Writing an unparseable delivery date would swap a wrong date for an
+    uncheckable one: preflight would stop comparing source evidence against it
+    and report `source_identity_date_uncheckable` instead of gating.
+    """
     if not isinstance(values, dict):
         raise TrackingDatabaseMutationError(f"{label} must be an object")
     for field, value in values.items():
         _nonempty(value, f"{label}.{field}")
+        if field == "date" and parse_catalog_date(value) is None:
+            raise TrackingDatabaseMutationError(
+                f"{label}.date must be YYYY or an ISO-8601 calendar date"
+            )
 
 
 def _apply_reviewed_metadata(

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1238,7 +1238,7 @@ def test_a_reviewed_title_conflict_applies_without_opening_other_fields(
 
 @pytest.mark.parametrize(
     "field",
-    ["status", "video_url", "slides_url", "date", "transcript_source"],
+    ["status", "video_url", "slides_url", "transcript_source"],
 )
 def test_the_writer_refuses_every_field_outside_the_catalog_set(
     mutate_tracking_database, field
@@ -1624,3 +1624,68 @@ def test_severing_a_wrong_row_spares_a_talks_binding_to_another_deck(
     assert candidate["pptx_catalog"][0]["talk_filename"] is None
     assert candidate["talks"][0]["pptx_path"] == "Conference/Correct.pptx"
     assert [change["kind"] for change in changes] == ["sever_pptx_talk_binding"]
+
+
+# Reviewed delivery-date repair (#333). The identity-registration run found 11
+# talks whose cataloged year disagreed with the recording, and the reviewed
+# metadata writer covered `title` and `conference` but not `date` — so a proven
+# wrong delivery date had no owner writer at all.
+
+
+def test_a_reviewed_delivery_date_applies_with_an_exact_precondition(
+    mutate_tracking_database,
+) -> None:
+    database = _catalog_database(date="2014")
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database,
+        [_repair({"date": "2013-10-19"}, {"date": "2014"})],
+    )
+
+    assert candidate["talks"][0]["date"] == "2013-10-19"
+    assert changes[0]["kind"] == "apply_reviewed_metadata"
+    assert changes[0]["before"] == {"date": "2014"}
+    assert database["talks"][0]["date"] == "2014"
+
+
+def test_a_reviewed_delivery_date_may_be_a_bare_year(
+    mutate_tracking_database,
+) -> None:
+    """A coarse record is a real delivery date, so the writer accepts `YYYY`."""
+    database = _catalog_database(date="2019")
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database,
+        [_repair({"date": "2016"}, {"date": "2019"})],
+    )
+
+    assert candidate["talks"][0]["date"] == "2016"
+
+
+def test_a_reviewed_delivery_date_stays_readable_by_the_catalog_parser(
+    mutate_tracking_database,
+) -> None:
+    """An unparseable date would trade a wrong date for an uncheckable one."""
+    database = _catalog_database(date="2014")
+
+    for rejected in ("October 2013", "2013-13-01", "13-10-2013", "2013/10/19"):
+        with pytest.raises(
+            mutate_tracking_database.TrackingDatabaseMutationError
+        ) as excinfo:
+            mutate_tracking_database.build_candidate(
+                database,
+                [_repair({"date": rejected}, {"date": "2014"})],
+            )
+        assert "must be YYYY or an ISO-8601 calendar date" in str(excinfo.value)
+
+
+def test_a_reviewed_date_repair_does_not_open_unrelated_talk_fields(
+    mutate_tracking_database,
+) -> None:
+    database = _catalog_database(date="2014")
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database,
+            [_repair({"date": "2013", "status": "pending"}, {"date": "2014"})],
+        )


### PR DESCRIPTION
## Why

#333 measured eleven talks whose cataloged delivery date the provider evidence
disproves, and then had nowhere to write the correction:

- `apply-source-repairs.py` owns the source lanes and rejects a catalog field
  outright (`unsupported fields: ['conference', 'date']`)
- `apply_reviewed_metadata` owns catalog identity, but its closed field set was
  `{title, conference}`
- `skills/vault-ingress/SKILL.md` forbids editing the database directly

So the measurement landed with no sanctioned way to act on it. This adds the
missing path.

## What

`date` joins `METADATA_TALK_FIELDS`, classified metadata-only alongside `title`
and `conference` — rhetoric analysis derives from transcript and slide content,
so a corrected delivery date cannot stale it, and the writer's existing
classification check proves that rather than assuming it.

`date` carries one condition the other two do not: the value must parse under
the shared `parse_catalog_date`. Writing `"October 2013"` would trade a wrong
date for an uncheckable one — preflight would stop comparing source evidence
against the record and report `source_identity_date_uncheckable` instead of
gating. A repair that disables the gate it was meant to satisfy is worse than
the date it replaced.

## Contract unchanged

Still one exact talk filename, still a closed field set, still `expect` covering
exactly the same fields. The parametrized closed-set test keeps proving
`status`, `video_url`, `slides_url`, and `transcript_source` stay out; `date`
moved from that list into the supported set deliberately.

## Testing

- Exact-precondition repair, bare-year repair, and the input-object-untouched
  guarantee
- Four unparseable-date shapes rejected (`October 2013`, `2013-13-01`,
  `13-10-2013`, `2013/10/19`)
- A repair that also reaches an unrelated field still refused
- Full suite: 5961 passed, 3 skipped; `ruff check`, `ruff format --check`,
  `pyright` clean

Refs #333