### PR TITLE
feat(vault-ingress): record owner-reviewed provider-title equivalences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ current shape by being reanalysed, never by being stamped. On the live vault tha
 is 6 records restamped and 209 legacy records untouched. Migration never invents
 the field: absence means "no equivalences", which is the correct default.
 
+The writer binds each approval to what the talk actually holds when it is
+recorded: its current catalog title, its recorded provider title, and its video.
+Without that, a plan could pre-authorize an identity the talk does not have — a
+title it might be renamed to later, or another video's — and that record would
+sit dormant until the catalog drifted onto it, suppressing the gate for a pair
+no owner ever compared.
+
 When an equivalence applies the check passes silently. A warning on every run
 would be noise about a decision the owner already made and recorded, and the
 record itself carries the evidence and the timestamp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ blocking finding checks it itself. Reader and writer canonicalize the pinned
 title through one shared normalizer, so two records the reader would treat as a
 single approval cannot be stored as two.
 
+`TALK_RECORD_SCHEMA_VERSION` goes to **7**, because the ledger changes the
+persisted talk-record shape and the nested record's own version does not version
+its parent. The migration restamps v5 and v6 forward — both already hold the
+analysis v7 implies — and leaves earlier generations alone, since those reach the
+current shape by being reanalysed, never by being stamped. On the live vault that
+is 6 records restamped and 209 legacy records untouched. Migration never invents
+the field: absence means "no equivalences", which is the correct default.
+
 When an equivalence applies the check passes silently. A warning on every run
 would be noise about a decision the owner already made and recorded, and the
 record itself carries the evidence and the timestamp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,14 @@ published: Russian titles in an otherwise-English catalog, and two RoboCoders
 entries that stop matching the ten around them. That discards the speaker's own
 naming to satisfy a string comparison.
 
-`source_title_equivalence` records the judgment as data instead — the exact
-provider title reviewed, why it was accepted from a closed two-value reason set,
+`source_title_equivalence` records the judgment as data instead — both titles
+the owner read, why the pair was accepted from a closed two-value reason set,
 and when. It is consulted only after the deterministic comparison fails, and it
-pins the exact title that was read: a provider that retitles the video again no
-longer matches, and the talk re-gates rather than riding a stale approval. The
+pins BOTH sides of the pair. An approval says these two names name one talk; it
+says nothing about a name the owner never read. So a provider that retitles the
+video re-gates, and so does a catalog title edited after the review — pinning
+only the provider side would have left an edited catalog title riding an
+approval granted for a different one. The
 writer appends only and refuses a duplicate, so the ledger stays an audit trail
 rather than a mutable override.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+### feat(vault-ingress) — owner-reviewed provider-title equivalence (#333)
+
+Four talks in #333 could not register a source identity because `titles_agree`
+could not reach their provider titles. Two are Russian-language JavaDay Kiev
+2014 recordings whose catalog titles are English summaries carrying a `(Ru)`
+marker. Two are RoboCoders deliveries the uploader published as "AI-Assisted
+Engineering Applied: The Battle of Agents".
+
+Neither is a comparator bug. `битва конфигураций` is "battle of
+configurations", and no deterministic overlap test crosses that gap without also
+matching things it must not. The comparator is right to refuse, and it must stay
+right — it is the same test that catches a video from the wrong delivery.
+
+The alternative was rewriting four catalog titles to whatever the provider
+published: Russian titles in an otherwise-English catalog, and two RoboCoders
+entries that stop matching the ten around them. That discards the speaker's own
+naming to satisfy a string comparison.
+
+`source_title_equivalence` records the judgment as data instead — the exact
+provider title reviewed, why it was accepted from a closed two-value reason set,
+and when. It is consulted only after the deterministic comparison fails, and it
+pins the exact title that was read: a provider that retitles the video again no
+longer matches, and the talk re-gates rather than riding a stale approval. The
+writer appends only and refuses a duplicate, so the ledger stays an audit trail
+rather than a mutable override.
+
+When an equivalence applies the check passes silently. A warning on every run
+would be noise about a decision the owner already made and recorded, and the
+record itself carries the evidence and the timestamp.
+
 ### feat(vault-ingress) — owner-reviewed delivery-date repair (#333)
 
 Correcting the eleven catalog dates #333 measured turned out to be impossible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ longer matches, and the talk re-gates rather than riding a stale approval. The
 writer appends only and refuses a duplicate, so the ledger stays an audit trail
 rather than a mutable override.
 
+The record's own `schema_version` is validated exactly, and both the reader and
+the writer refuse a generation they cannot name — `_require_closed_shape` ignores
+that field for every record, so a ledger whose whole purpose is suppressing a
+blocking finding checks it itself. Reader and writer canonicalize the pinned
+title through one shared normalizer, so two records the reader would treat as a
+single approval cannot be stored as two.
+
 When an equivalence applies the check passes silently. A warning on every run
 would be noise about a decision the owner already made and recorded, and the
 record itself carries the evidence and the timestamp.

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -39,7 +39,7 @@ Read `tracking-database.json` through the vault path used by
 presentation-creator. Selection and composition may read legacy database schema
 0 or current schema 1 without mutation. Before copying the approved thumbnail or
 writing tracking state, require database schema 1, current independent records,
-and talk schema 5. Invoke `Skill(skill: "vault-ingress")` for schema 0 and stop
+and talk schema 7. Invoke `Skill(skill: "vault-ingress")` for schema 0 and stop
 this run. Unknown future generations are no usable prior state. Preserve every
 schema field and use the presentation-creator exact-generation atomic-write
 contract.
@@ -236,6 +236,6 @@ exact existing record for the slug or `{"$missing": true}`. In the same plan, us
 filename, expecting its current value. Dry-run the whole plan, review it, apply
 against the reported input SHA, and re-read as specified by the
 [owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
-Keep that talk at `schema_version: 5`. illustrations is an authorized writer of
+Keep that talk at `schema_version: 7`. illustrations is an authorized writer of
 current thumbnail and talk records; vault-ingress remains their schema owner.
 Never rewrite `tracking-database.json` directly.

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -16,7 +16,7 @@ Before ANY Phase 7 action, load these files. If any is missing, STOP and ask.
 
 Read the tracking database through the main presentation-creator compatibility
 gate. Thumbnail and shownotes lookup may read schema 0 or 1. Any database update
-in this phase requires current database schema 1 and talk schema 5 before the
+in this phase requires current database schema 1 and talk schema 7 before the
 thumbnail, shownotes, or video side effect paired with it. Route schema 0 through
 `Skill(skill: "vault-ingress")`; preserve all schema fields and apply the main
 skill's exact-generation atomic-write contract.
@@ -97,7 +97,7 @@ The `expect` object must cover exactly the fields being set with values from the
 latest strict read. Dry-run, review, apply against the reported input SHA, and
 re-read through the
 [owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
-Keep that talk record at `schema_version: 5`; this workflow is an authorized
+Keep that talk record at `schema_version: 7`; this workflow is an authorized
 current writer, not a schema owner or migrator.
 
 ---

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -84,7 +84,7 @@ Exit 2 writes one error object to stdout plus an `ERROR:` diagnostic to stderr;
 stop without changing session state.
 
 Every tracking write in Steps 2–8 is current-only. Preserve database schema 1,
-config schema 2, talk schema 5, and every unrelated record. Stamp confirmed
+config schema 2, talk schema 7, and every unrelated record. Stamp confirmed
 intents with schema 1 and new improvement goals with schema 2. Capture the exact
 input bytes immediately before each write, reject a changed generation, validate
 the complete current shape, and use a same-directory atomic replacement. Never

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -281,7 +281,7 @@ customization, not the owner default. See the
       "verified_at": "timezone-aware ISO-8601 timestamp"
     }],
     "pptx_path": "Conference/Year/Talk Name.pptx  (optional — highest quality slide source when available)",
-    "schema_version": 5,
+    "schema_version": 7,
     "transcript_source": "youtube_auto|whisper|manual|none  (how the transcript was obtained; MAY BE ABSENT — see below)",
     "transcript_path": "transcripts/{id}.txt  (optional vault-relative path; required for non-YouTube transcript evidence)",
     "slide_source": "pptx|pdf|both|video_extracted|markdown|none  (set in Step 2 per slide source hierarchy)",
@@ -359,7 +359,7 @@ customization, not the owner default. See the
       "not_evaluable": []
     }
   }],
-  "_comment_schema_version": "Database schema v1 is owner-migrated by vault-ingress. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
+  "_comment_schema_version": "Database schema v1 is owner-migrated by vault-ingress. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. V7 adds the optional owner-reviewed `source_title_equivalence` ledger; migration restamps a v5 or v6 record to v7 and never invents the field, because an absent ledger already means no equivalences. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "schema_version": 3,

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -182,6 +182,7 @@ no-op.
 | thumbnail | 1 |
 | confirmed intent | 1 |
 | source rejection | 1 |
+| source title equivalence | 1 |
 | improvement goal | 2 (schema 1 remains readable historical state) |
 
 | Component | Access | Contract |

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -274,6 +274,7 @@ customization, not the owner default. See the
     "source_title_equivalence": [{
       "schema_version": 1,
       "video_id": "provider video the equivalence covers",
+      "catalog_title": "the exact reviewed catalog title",
       "provider_title": "the exact reviewed provider title",
       "reason": "cross_language_title|provider_retitled",
       "evidence": "how the equivalence was reviewed",
@@ -577,8 +578,9 @@ was rewriting the catalog title to whatever the provider published. Its closed
 reason set and matching contract live in
 `skills/vault-ingress/scripts/tracking_database.py::validate_source_title_equivalence`
 and `source_identity_matching.py::title_equivalence_recorded`. An equivalence
-covers one video and one exact title, so a later provider rename re-gates rather
-than inheriting the approval. Consulted only after the deterministic comparison
+covers one video and one exact title PAIR, so either side changing re-gates
+rather than inheriting the approval — a later provider rename, and a catalog
+title edited after the review. Consulted only after the deterministic comparison
 fails; when it applies, the check passes silently and the record is the audit
 trail.
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -175,7 +175,7 @@ no-op.
 |---|---:|
 | database root | 1 |
 | config | 2 (schema 1 remains readable owner-migration input) |
-| talk | 5 |
+| talk | 7 (schemas 1-6 remain readable historical state; v5 and v6 restamp) |
 | PPTX catalog | 3 (schemas 1 and 2 remain readable legacy state) |
 | QR code | 2 (schema 1 remains readable legacy state) |
 | resource summary | 1 |
@@ -193,8 +193,8 @@ no-op.
 | vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0 and 1; gate through existing finding/error channels; never rewrite |
 | vault-clarification | current read/write | Route schema migration to vault-ingress; preserve config v2 and stamp confirmed intent v1/improvement goal v2 |
 | presentation-creator QR writer | dual reader/current writer | Read schemas 0 and 1; require schema 1 before URL creation or QR metadata persistence; stamp QR v2 |
-| presentation-creator publishing/post-event | authorized current writer | Require schema 1 before tracking writes; stamp resource v1 and preserve talk v5 |
-| illustrations thumbnail workflow | authorized current writer | Require schema 1 before tracking writes; stamp thumbnail v1 and preserve talk v5 |
+| presentation-creator publishing/post-event | authorized current writer | Require schema 1 before tracking writes; stamp resource v1 and preserve talk v7 |
+| illustrations thumbnail workflow | authorized current writer | Require schema 1 before tracking writes; stamp thumbnail v1 and preserve talk v7 |
 | vault-profile | dual reader | Parse schemas 0 and 1; treat unsupported generations as unavailable; never migrate |
 
 Current database schema 1 with config schema 2 requires all eight top-level

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -270,6 +270,14 @@ customization, not the owner default. See the
       "evidence": "how the rejection was verified",
       "verified_at": "timezone-aware ISO-8601 timestamp"
     }],
+    "source_title_equivalence": [{
+      "schema_version": 1,
+      "video_id": "provider video the equivalence covers",
+      "provider_title": "the exact reviewed provider title",
+      "reason": "cross_language_title|provider_retitled",
+      "evidence": "how the equivalence was reviewed",
+      "verified_at": "timezone-aware ISO-8601 timestamp"
+    }],
     "pptx_path": "Conference/Year/Talk Name.pptx  (optional — highest quality slide source when available)",
     "schema_version": 5,
     "transcript_source": "youtube_auto|whisper|manual|none  (how the transcript was obtained; MAY BE ABSENT — see below)",
@@ -557,8 +565,21 @@ exact-type rule. The supported mutation kinds are:
 | `upsert_resource` | Replace/add one complete schema-v1 record identified by `talk_slug` |
 | `upsert_thumbnail` | Replace/add one complete schema-v1 record identified by `talk_slug` |
 | `apply_reviewed_metadata` | Install one human-reviewed shownotes catalog-conflict decision on one exact talk filename, over a closed identity field set, with `expect` covering exactly the same fields |
+| `record_source_title_equivalence` | Append one owner-reviewed provider-title equivalence to one exact talk filename; append-only and refuses a duplicate |
 | `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
 | `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |
+
+`source_title_equivalence` records that an owner read one provider title and
+accepted it as naming the cataloged talk. The title comparator is deterministic
+and cannot cross languages or follow a provider rename, and the only alternative
+was rewriting the catalog title to whatever the provider published. Its closed
+reason set and matching contract live in
+`skills/vault-ingress/scripts/tracking_database.py::validate_source_title_equivalence`
+and `source_identity_matching.py::title_equivalence_recorded`. An equivalence
+covers one video and one exact title, so a later provider rename re-gates rather
+than inheriting the approval. Consulted only after the deterministic comparison
+fails; when it applies, the check passes silently and the record is the audit
+trail.
 
 `apply_reviewed_metadata` exists because `scan-shownotes.py --apply` refuses
 review-required entries by design: an approved catalog correction otherwise had

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -971,16 +971,15 @@ def audit_database(
                 continue
             provider_title = _nonempty(proposal.get("title"))
             catalog_title = _nonempty(talk.get("title"))
-            title_agrees = (
-                titles_agree(catalog_title, provider_title)
-                or title_equivalence_recorded(
+            title_agrees: bool | None = None
+            if catalog_title and provider_title:
+                title_agrees = titles_agree(
+                    catalog_title, provider_title
+                ) or title_equivalence_recorded(
                     talk.get("source_title_equivalence"),
                     video_id=video_id,
                     provider_title=provider_title,
                 )
-                if catalog_title and provider_title
-                else None
-            )
             expected_duration = expected_duration_seconds(talk)
             provider_duration = proposal.get("duration_seconds")
             duration_within_tolerance: bool | None = None

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -28,6 +28,7 @@ from source_identity_matching import (
     known_event_aliases,
     normalized_words,
     parse_catalog_date,
+    title_equivalence_recorded,
     titles_agree,
     upload_predates_catalog,
 )
@@ -972,6 +973,11 @@ def audit_database(
             catalog_title = _nonempty(talk.get("title"))
             title_agrees = (
                 titles_agree(catalog_title, provider_title)
+                or title_equivalence_recorded(
+                    talk.get("source_title_equivalence"),
+                    video_id=video_id,
+                    provider_title=provider_title,
+                )
                 if catalog_title and provider_title
                 else None
             )

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -978,6 +978,7 @@ def audit_database(
                 ) or title_equivalence_recorded(
                     talk.get("source_title_equivalence"),
                     video_id=video_id,
+                    catalog_title=catalog_title,
                     provider_title=provider_title,
                 )
             expected_duration = expected_duration_seconds(talk)

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -889,6 +889,34 @@ def _apply_record_title_equivalence(
     except TrackingDatabaseError as exc:
         raise TrackingDatabaseMutationError(str(exc)) from exc
 
+    # Bind the approval to what the talk actually holds right now. Without this
+    # a plan can pre-authorize an identity the talk does not have — a title it
+    # might be renamed to later, or another video's — and that record would sit
+    # dormant until the catalog drifted onto it, suppressing the wrong-delivery
+    # gate for a pair no owner ever compared.
+    identity = talk.get("source_identity")
+    if not isinstance(identity, dict):
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}] cannot approve a title for {filename!r}: the "
+            f"talk has no source_identity to compare against"
+        )
+    for field, observed, label in (
+        ("catalog_title", talk.get("title"), "catalog title"),
+        ("provider_title", identity.get("title"), "recorded provider title"),
+    ):
+        if not isinstance(observed, str) or pinned_provider_title(
+            observed
+        ) != pinned_provider_title(record[field]):
+            raise TrackingDatabaseMutationError(
+                f"mutations[{index}].equivalence.{field} does not match the "
+                f"talk's current {label} on {filename!r}"
+            )
+    if identity.get("video_id") != record["video_id"]:
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].equivalence.video_id does not match the "
+            f"recorded source identity on {filename!r}"
+        )
+
     existing = talk.get("source_title_equivalence", [])
     if not isinstance(existing, list):
         raise TrackingDatabaseMutationError(

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -894,15 +894,22 @@ def _apply_record_title_equivalence(
         raise TrackingDatabaseMutationError(
             f"talks[{filename!r}].source_title_equivalence must be an array"
         )
-    # Canonicalized on both sides with the reader's own normalizer: two titles
-    # the reader treats as one approval must not be storable as two records.
+    # The duplicate predicate is the reader's identity, canonicalized the same
+    # way: video, catalog title, and provider title together. Matching on the
+    # video and provider title alone would reject a newly reviewed approval for
+    # a retitled catalog entry as a duplicate — the reader stopped honoring the
+    # old record at that point, so refusing the new one leaves the talk gated
+    # with no owner-supported way to restore it.
     pinned = pinned_provider_title(record["provider_title"])
+    pinned_catalog = pinned_provider_title(record["catalog_title"])
     for recorded in existing:
         if (
             isinstance(recorded, dict)
             and recorded.get("video_id") == record["video_id"]
             and isinstance(recorded.get("provider_title"), str)
+            and isinstance(recorded.get("catalog_title"), str)
             and pinned_provider_title(recorded["provider_title"]) == pinned
+            and pinned_provider_title(recorded["catalog_title"]) == pinned_catalog
         ):
             raise TrackingDatabaseMutationError(
                 f"mutations[{index}] duplicates an equivalence already recorded "

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -57,7 +57,7 @@ from pptx_discovery_contract import (
     validate_pptx_directory_exclusions,
 )
 from pptx_talk_identity import binding_refusal
-from source_identity_matching import parse_catalog_date
+from source_identity_matching import parse_catalog_date, pinned_provider_title
 
 
 PLAN_SCHEMA_VERSION = 1
@@ -894,11 +894,15 @@ def _apply_record_title_equivalence(
         raise TrackingDatabaseMutationError(
             f"talks[{filename!r}].source_title_equivalence must be an array"
         )
+    # Canonicalized on both sides with the reader's own normalizer: two titles
+    # the reader treats as one approval must not be storable as two records.
+    pinned = pinned_provider_title(record["provider_title"])
     for recorded in existing:
         if (
             isinstance(recorded, dict)
             and recorded.get("video_id") == record["video_id"]
-            and recorded.get("provider_title") == record["provider_title"]
+            and isinstance(recorded.get("provider_title"), str)
+            and pinned_provider_title(recorded["provider_title"]) == pinned
         ):
             raise TrackingDatabaseMutationError(
                 f"mutations[{index}] duplicates an equivalence already recorded "

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -34,10 +34,12 @@ from tracking_database import (
     RESOURCE_REQUIRED_FIELDS as OWNER_RESOURCE_REQUIRED_FIELDS,
     THUMBNAIL_RECORD_SCHEMA_VERSION,
     THUMBNAIL_REQUIRED_FIELDS as OWNER_THUMBNAIL_REQUIRED_FIELDS,
+    SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION,
     TALK_RECORD_SCHEMA_VERSION,
     TRACKING_DATABASE_SCHEMA_VERSION,
     TrackingDatabaseError,
     require_current_tracking_database,
+    validate_source_title_equivalence,
 )
 from tracking_database_io import (
     TrackingDatabaseIOError,
@@ -848,6 +850,70 @@ def _apply_update_talk(
     )
 
 
+def _apply_record_title_equivalence(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    """Append one owner-reviewed provider-title equivalence to a talk.
+
+    The comparator cannot cross languages and cannot follow a provider rename,
+    and the alternative to recording the judgment is rewriting the catalog title
+    to match whatever the provider published. This writer keeps that judgment as
+    reviewable data: the exact provider title, why it was accepted, and when.
+    Appending only — an equivalence is never edited in place, so the ledger
+    stays an audit trail rather than a mutable override.
+    """
+    _require_keys(
+        mutation,
+        required={"kind", "filename", "equivalence"},
+        label=f"mutations[{index}]",
+    )
+    filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
+    talk = _talk_by_filename(database, filename)
+    _require_current_talk_record(talk, filename=filename)
+    equivalence = mutation["equivalence"]
+    if not isinstance(equivalence, dict):
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].equivalence must be an object"
+        )
+    record = dict(equivalence)
+    record.setdefault("schema_version", SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION)
+    try:
+        validate_source_title_equivalence(
+            record,
+            label=f"mutations[{index}].equivalence",
+        )
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
+
+    existing = talk.get("source_title_equivalence", [])
+    if not isinstance(existing, list):
+        raise TrackingDatabaseMutationError(
+            f"talks[{filename!r}].source_title_equivalence must be an array"
+        )
+    for recorded in existing:
+        if (
+            isinstance(recorded, dict)
+            and recorded.get("video_id") == record["video_id"]
+            and recorded.get("provider_title") == record["provider_title"]
+        ):
+            raise TrackingDatabaseMutationError(
+                f"mutations[{index}] duplicates an equivalence already recorded "
+                f"for video {record['video_id']!r} on {filename!r}"
+            )
+    talk["source_title_equivalence"] = [*existing, record]
+    _record_change(
+        changes,
+        kind="record_source_title_equivalence",
+        identity=filename,
+        before={"source_title_equivalence": len(existing)},
+        after={"source_title_equivalence": len(existing) + 1},
+    )
+
+
 def _validate_metadata_values(values: object, label: str) -> None:
     """Every repaired catalog value is a non-empty trimmed string.
 
@@ -1491,6 +1557,8 @@ def build_candidate(
             _apply_sever_pptx_talk_binding(candidate, mutation, changes, index=index)
         elif kind == "apply_reviewed_metadata":
             _apply_reviewed_metadata(candidate, mutation, changes, index=index)
+        elif kind == "record_source_title_equivalence":
+            _apply_record_title_equivalence(candidate, mutation, changes, index=index)
         elif kind == "update_talk_publishing":
             _apply_update_talk(candidate, mutation, changes, index=index)
         elif kind == "update_talk_clarification":

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -76,6 +76,7 @@ from source_identity_matching import (
     expected_duration_seconds,
     known_event_aliases,
     parse_catalog_date,
+    title_equivalence_recorded,
     titles_agree,
     upload_predates_catalog,
 )
@@ -2123,15 +2124,27 @@ class VaultPreflight:
             )
             return
         if not titles_agree(expected_title, observed_title):
-            self.talk_add(
-                index,
-                "blocking",
-                "source_identity_title_mismatch",
-                "recorded video title does not materially overlap the catalog title",
-                field="source_identity.title",
-                expected=expected_title,
-                actual=observed_title,
-            )
+            # An owner may have reviewed this exact provider title and recorded
+            # that it names the cataloged talk — a translation, or a provider
+            # rename the comparator cannot reach. The ledger is consulted only
+            # after the deterministic comparison fails.
+            # Silence is the pass: the persisted ledger record carries the
+            # evidence and the review timestamp, so re-reporting a decision the
+            # owner already made would warn about it on every run forever.
+            if not title_equivalence_recorded(
+                self.talks[index].get("source_title_equivalence"),
+                video_id=evidence.get("video_id"),
+                provider_title=observed_title,
+            ):
+                self.talk_add(
+                    index,
+                    "blocking",
+                    "source_identity_title_mismatch",
+                    "recorded video title does not materially overlap the catalog title",
+                    field="source_identity.title",
+                    expected=expected_title,
+                    actual=observed_title,
+                )
         event_agrees, catalog_event, provider_events = event_agreement(
             self.talks[index].get("conference"),
             observed_title,

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -2134,6 +2134,7 @@ class VaultPreflight:
             if not title_equivalence_recorded(
                 self.talks[index].get("source_title_equivalence"),
                 video_id=evidence.get("video_id"),
+                catalog_title=expected_title,
                 provider_title=observed_title,
             ):
                 self.talk_add(

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -456,22 +456,30 @@ def title_equivalence_recorded(
     equivalences: Any,
     *,
     video_id: Any,
+    catalog_title: Any,
     provider_title: Any,
 ) -> bool:
-    """Report whether an owner reviewed this exact provider title for this video.
+    """Report whether an owner reviewed this exact title pair for this video.
 
-    Comparison is on the pinned string, not the fuzzy title contract: the ledger
-    records a judgment about one observed title, so a provider that retitles the
-    video again stops matching and the talk re-gates. Whitespace and Unicode
-    composition are normalized because those vary without changing what an owner
-    read.
+    Comparison is on the pinned strings, not the fuzzy title contract: the ledger
+    records a judgment about one observed pair, so either side changing retires
+    it. A provider that retitles the video re-gates, and so does a catalog title
+    edited after the review — the approval was that THESE two name the same
+    talk, and it says nothing about a name the owner never read. Whitespace and
+    Unicode composition are normalized because those vary without changing what
+    an owner read.
     """
     if not isinstance(equivalences, list):
         return False
-    if not isinstance(video_id, str) or not isinstance(provider_title, str):
+    if (
+        not isinstance(video_id, str)
+        or not isinstance(catalog_title, str)
+        or not isinstance(provider_title, str)
+    ):
         return False
     pinned = pinned_provider_title(provider_title)
-    if not pinned:
+    pinned_catalog = pinned_provider_title(catalog_title)
+    if not pinned or not pinned_catalog:
         return False
     for equivalence in equivalences:
         if not isinstance(equivalence, dict):
@@ -488,8 +496,17 @@ def title_equivalence_recorded(
             continue
         recorded_id = equivalence.get("video_id")
         recorded_title = equivalence.get("provider_title")
-        if not isinstance(recorded_id, str) or not isinstance(recorded_title, str):
+        recorded_catalog = equivalence.get("catalog_title")
+        if (
+            not isinstance(recorded_id, str)
+            or not isinstance(recorded_title, str)
+            or not isinstance(recorded_catalog, str)
+        ):
             continue
-        if recorded_id == video_id and pinned_provider_title(recorded_title) == pinned:
+        if (
+            recorded_id == video_id
+            and pinned_provider_title(recorded_title) == pinned
+            and pinned_provider_title(recorded_catalog) == pinned_catalog
+        ):
             return True
     return False

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -438,7 +438,17 @@ def expected_duration_seconds(talk: dict[str, Any]) -> float | None:
     return None
 
 
-def _pinned_title(value: str) -> str:
+SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION = 1
+
+
+def pinned_provider_title(value: str) -> str:
+    """Canonicalize a provider title for pinned comparison.
+
+    Whitespace runs and Unicode composition vary without changing what an owner
+    read, so both are normalized. Every comparison of a pinned title — the
+    reader's match and the writer's duplicate check — goes through this, or the
+    two disagree about which records are the same approval.
+    """
     return " ".join(unicodedata.normalize("NFC", value).split())
 
 
@@ -460,16 +470,26 @@ def title_equivalence_recorded(
         return False
     if not isinstance(video_id, str) or not isinstance(provider_title, str):
         return False
-    pinned = _pinned_title(provider_title)
+    pinned = pinned_provider_title(provider_title)
     if not pinned:
         return False
     for equivalence in equivalences:
         if not isinstance(equivalence, dict):
             continue
+        # An unrecognized generation is unusable state, never an approval: a
+        # future record may mean something this reader cannot see, and the
+        # failure it would suppress is the wrong-delivery gate.
+        recorded_version = equivalence.get("schema_version")
+        if (
+            isinstance(recorded_version, bool)
+            or not isinstance(recorded_version, int)
+            or recorded_version != SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION
+        ):
+            continue
         recorded_id = equivalence.get("video_id")
         recorded_title = equivalence.get("provider_title")
         if not isinstance(recorded_id, str) or not isinstance(recorded_title, str):
             continue
-        if recorded_id == video_id and _pinned_title(recorded_title) == pinned:
+        if recorded_id == video_id and pinned_provider_title(recorded_title) == pinned:
             return True
     return False

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -436,3 +436,40 @@ def expected_duration_seconds(talk: dict[str, Any]) -> float | None:
         if isinstance(value, (int, float)) and math.isfinite(value) and value > 0:
             return float(value)
     return None
+
+
+def _pinned_title(value: str) -> str:
+    return " ".join(unicodedata.normalize("NFC", value).split())
+
+
+def title_equivalence_recorded(
+    equivalences: Any,
+    *,
+    video_id: Any,
+    provider_title: Any,
+) -> bool:
+    """Report whether an owner reviewed this exact provider title for this video.
+
+    Comparison is on the pinned string, not the fuzzy title contract: the ledger
+    records a judgment about one observed title, so a provider that retitles the
+    video again stops matching and the talk re-gates. Whitespace and Unicode
+    composition are normalized because those vary without changing what an owner
+    read.
+    """
+    if not isinstance(equivalences, list):
+        return False
+    if not isinstance(video_id, str) or not isinstance(provider_title, str):
+        return False
+    pinned = _pinned_title(provider_title)
+    if not pinned:
+        return False
+    for equivalence in equivalences:
+        if not isinstance(equivalence, dict):
+            continue
+        recorded_id = equivalence.get("video_id")
+        recorded_title = equivalence.get("provider_title")
+        if not isinstance(recorded_id, str) or not isinstance(recorded_title, str):
+            continue
+        if recorded_id == video_id and _pinned_title(recorded_title) == pinned:
+            return True
+    return False

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -46,6 +46,7 @@ RESOURCE_RECORD_SCHEMA_VERSION = 1
 THUMBNAIL_RECORD_SCHEMA_VERSION = 1
 CONFIRMED_INTENT_RECORD_SCHEMA_VERSION = 1
 SOURCE_REJECTION_RECORD_SCHEMA_VERSION = 1
+SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION = 1
 LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION = 1
 IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION = 2
 
@@ -189,6 +190,15 @@ CONFIRMED_INTENT_OPTIONAL_FIELDS = frozenset(
 )
 SOURCE_REJECTION_REQUIRED_FIELDS = frozenset(
     {"source_type", "url", "reason", "evidence", "verified_at"}
+)
+SOURCE_TITLE_EQUIVALENCE_REQUIRED_FIELDS = frozenset(
+    {"video_id", "provider_title", "reason", "evidence", "verified_at"}
+)
+# Why an owner accepted a provider title the comparator cannot reach. Closed on
+# purpose: a free-text reason would turn the ledger into a place to wave through
+# any mismatch, which is the wrong-delivery detection this ledger sits next to.
+SOURCE_TITLE_EQUIVALENCE_REASONS = frozenset(
+    {"cross_language_title", "provider_retitled"}
 )
 LEGACY_IMPROVEMENT_GOAL_REQUIRED_FIELDS = frozenset(
     {
@@ -1051,6 +1061,45 @@ def _validate_source_rejection(
         )
 
 
+def validate_source_title_equivalence(
+    equivalence: Mapping[str, object],
+    *,
+    label: str,
+) -> None:
+    """Validate one owner-reviewed title equivalence.
+
+    The record pins the exact provider title an owner reviewed. A provider that
+    retitles the video again no longer matches the pinned string, so the talk
+    re-gates instead of riding a stale approval.
+    """
+    _require_closed_shape(
+        equivalence,
+        required=SOURCE_TITLE_EQUIVALENCE_REQUIRED_FIELDS,
+        label=label,
+    )
+    for field in ("video_id", "provider_title", "evidence"):
+        _require_nonempty_string(equivalence[field], f"{label}.{field}")
+    reason = _require_nonempty_string(equivalence["reason"], f"{label}.reason")
+    if reason not in SOURCE_TITLE_EQUIVALENCE_REASONS:
+        raise TrackingDatabaseError(
+            f"{label}.reason must be one of {sorted(SOURCE_TITLE_EQUIVALENCE_REASONS)}"
+        )
+    verified_at = _require_nonempty_string(
+        equivalence["verified_at"],
+        f"{label}.verified_at",
+    )
+    try:
+        parsed = dt.datetime.fromisoformat(verified_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TrackingDatabaseError(
+            f"{label}.verified_at must be a timezone-aware ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise TrackingDatabaseError(
+            f"{label}.verified_at must be a timezone-aware ISO-8601 timestamp"
+        )
+
+
 def _validate_talk_observation_shape(
     talk: Mapping[str, object],
     index: int,
@@ -1325,6 +1374,23 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
             _validate_source_rejection(
                 rejection,
                 label=f"talks[{talk_index}].source_rejections[{rejection_index}]",
+            )
+        equivalences = talk.get("source_title_equivalence", [])
+        if not isinstance(equivalences, list):
+            raise TrackingDatabaseError(
+                f"talks[{talk_index}].source_title_equivalence must be an array"
+            )
+        for equivalence_index, equivalence in enumerate(equivalences):
+            if not isinstance(equivalence, Mapping):
+                raise TrackingDatabaseError(
+                    f"talks[{talk_index}].source_title_equivalence"
+                    f"[{equivalence_index}] must be a JSON object"
+                )
+            validate_source_title_equivalence(
+                equivalence,
+                label=(
+                    f"talks[{talk_index}].source_title_equivalence[{equivalence_index}]"
+                ),
             )
 
     try:

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1077,6 +1077,19 @@ def validate_source_title_equivalence(
         required=SOURCE_TITLE_EQUIVALENCE_REQUIRED_FIELDS,
         label=label,
     )
+    # `_require_closed_shape` ignores `schema_version` for every record, so this
+    # ledger checks it explicitly. A record whose generation this reader cannot
+    # name must never be honored: what it suppresses is the wrong-delivery gate.
+    version = equivalence.get("schema_version")
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION
+    ):
+        raise TrackingDatabaseError(
+            f"{label}.schema_version must be "
+            f"{SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION}"
+        )
     for field in ("video_id", "provider_title", "evidence"):
         _require_nonempty_string(equivalence[field], f"{label}.{field}")
     reason = _require_nonempty_string(equivalence["reason"], f"{label}.reason")

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -32,9 +32,11 @@ LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
 TRACKING_DATABASE_SCHEMA_VERSION = 1
 LEGACY_TALK_RECORD_SCHEMA_VERSION = 1
 FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION = 5
+# The generation before the owner-reviewed title-equivalence ledger (#333).
+PRE_TITLE_EQUIVALENCE_TALK_RECORD_SCHEMA_VERSION = 6
 # The weighted generation's record shape (#299): `pattern_observations` may
 # carry a `pattern_score_basis` and `pattern_score` may be fractional.
-TALK_RECORD_SCHEMA_VERSION = 6
+TALK_RECORD_SCHEMA_VERSION = 7
 LEGACY_CONFIG_RECORD_SCHEMA_VERSION = 1
 CONFIG_RECORD_SCHEMA_VERSION = 2
 LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION = 1
@@ -1494,8 +1496,16 @@ def _migrate_talk_record(talk: dict[str, Any]) -> bool:
     return talk_version_added
 
 
+_RESTAMPABLE_TALK_RECORD_SCHEMA_VERSIONS = frozenset(
+    {
+        FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION,
+        PRE_TITLE_EQUIVALENCE_TALK_RECORD_SCHEMA_VERSION,
+    }
+)
+
+
 def _restamp_talk_records(candidate: dict[str, Any]) -> int:
-    """Restamp v5 talk records to the weighted record shape (#299).
+    """Restamp analysed talk records to the current record shape (#299, #333).
 
     A RESTAMP, never a rescore. The v6 shape admits a `pattern_score_basis` and
     a fractional `pattern_score`; a stored v5 record has neither, and computing
@@ -1512,6 +1522,13 @@ def _restamp_talk_records(candidate: dict[str, Any]) -> int:
     Without the restamp every stored talk would be unmutatable: the owner writer
     requires the exact current talk schema before any mutation, so the bump
     alone would lock the database until this ran.
+
+    v6 to v7 (#333) adds the optional `source_title_equivalence` ledger. That is
+    a pure shape addition — absence means "no equivalences", the correct default
+    — so the restamp carries a v6 record forward untouched. Only records already
+    holding the analysis v7 implies are restampable; an earlier generation
+    reaches the current shape by being reanalysed, never by being stamped, which
+    is why this set is not simply "every version below current".
     """
     talks = candidate.get("talks")
     if not isinstance(talks, list):
@@ -1520,7 +1537,7 @@ def _restamp_talk_records(candidate: dict[str, Any]) -> int:
     for talk in talks:
         if not isinstance(talk, dict):
             continue
-        if talk.get("schema_version") != FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION:
+        if talk.get("schema_version") not in _RESTAMPABLE_TALK_RECORD_SCHEMA_VERSIONS:
             continue
         talk["schema_version"] = TALK_RECORD_SCHEMA_VERSION
         restamped += 1

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -192,7 +192,14 @@ SOURCE_REJECTION_REQUIRED_FIELDS = frozenset(
     {"source_type", "url", "reason", "evidence", "verified_at"}
 )
 SOURCE_TITLE_EQUIVALENCE_REQUIRED_FIELDS = frozenset(
-    {"video_id", "provider_title", "reason", "evidence", "verified_at"}
+    {
+        "video_id",
+        "catalog_title",
+        "provider_title",
+        "reason",
+        "evidence",
+        "verified_at",
+    }
 )
 # Why an owner accepted a provider title the comparator cannot reach. Closed on
 # purpose: a free-text reason would turn the ledger into a place to wave through
@@ -1068,9 +1075,11 @@ def validate_source_title_equivalence(
 ) -> None:
     """Validate one owner-reviewed title equivalence.
 
-    The record pins the exact provider title an owner reviewed. A provider that
-    retitles the video again no longer matches the pinned string, so the talk
-    re-gates instead of riding a stale approval.
+    The record pins BOTH titles the owner read — the catalog title and the
+    provider title. An equivalence is a judgment about one specific pair, so
+    either side changing retires it: a provider that retitles the video, and a
+    catalog title edited after the review, both re-gate instead of riding a
+    stale approval.
     """
     _require_closed_shape(
         equivalence,
@@ -1090,7 +1099,7 @@ def validate_source_title_equivalence(
             f"{label}.schema_version must be "
             f"{SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION}"
         )
-    for field in ("video_id", "provider_title", "evidence"):
+    for field in ("video_id", "catalog_title", "provider_title", "evidence"):
         _require_nonempty_string(equivalence[field], f"{label}.{field}")
     reason = _require_nonempty_string(equivalence["reason"], f"{label}.reason")
     if reason not in SOURCE_TITLE_EQUIVALENCE_REASONS:

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1172,6 +1172,21 @@ def test_initialization_rejects_noncurrent_config_schema_version(
 # leave a known-wrong catalog fact in place or edit the database directly.
 
 
+def _equivalence_database(**talk_fields: Any) -> dict[str, Any]:
+    """A talk whose live identity matches the equivalence fixture."""
+    return _catalog_database(
+        title="Spring config battle (Ru)",
+        source_identity={
+            "schema_version": 1,
+            "provider": "youtube",
+            "video_id": "QS-_4k7o7A4",
+            "title": "JavaDay Kiev 2014: Spring - битва конфигураций",
+            "captured_at": "2026-08-18T12:00:00Z",
+        },
+        **talk_fields,
+    )
+
+
 def _catalog_database(**talk_fields: Any) -> dict[str, Any]:
     database = _base_database()
     database["talks"][0].update(
@@ -1723,7 +1738,7 @@ def _record_equivalence(**updates: Any) -> dict[str, Any]:
 def test_a_reviewed_title_equivalence_is_appended_with_a_stamped_version(
     mutate_tracking_database,
 ) -> None:
-    database = _catalog_database()
+    database = _equivalence_database()
 
     unstamped = _equivalence()
     del unstamped["schema_version"]
@@ -1743,16 +1758,15 @@ def test_a_reviewed_title_equivalence_is_appended_with_a_stamped_version(
 def test_a_second_equivalence_appends_rather_than_replacing(
     mutate_tracking_database,
 ) -> None:
-    database = _catalog_database(source_title_equivalence=[_equivalence()])
+    """A retitled talk keeps its old approval and gains the newly reviewed one."""
+    database = _equivalence_database(source_title_equivalence=[_equivalence()])
+    database["talks"][0]["title"] = "Spring Configuration Showdown"
 
     candidate, _ = mutate_tracking_database.build_candidate(
         database,
         [
             _record_equivalence(
-                equivalence=_equivalence(
-                    video_id="wd-mXqXdfk0",
-                    provider_title="JavaDay Kiev 2014: Транcформации",
-                )
+                equivalence=_equivalence(catalog_title="Spring Configuration Showdown")
             )
         ],
     )
@@ -1761,7 +1775,7 @@ def test_a_second_equivalence_appends_rather_than_replacing(
 
 
 def test_a_duplicate_equivalence_is_refused(mutate_tracking_database) -> None:
-    database = _catalog_database(source_title_equivalence=[_equivalence()])
+    database = _equivalence_database(source_title_equivalence=[_equivalence()])
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError
@@ -1784,7 +1798,7 @@ def test_a_duplicate_equivalence_is_refused(mutate_tracking_database) -> None:
 def test_an_unreviewable_equivalence_is_refused(
     mutate_tracking_database, invalid: dict[str, Any]
 ) -> None:
-    database = _catalog_database()
+    database = _equivalence_database()
 
     with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
         mutate_tracking_database.build_candidate(
@@ -1796,7 +1810,7 @@ def test_a_whitespace_variant_duplicate_equivalence_is_refused(
     mutate_tracking_database,
 ) -> None:
     """The reader treats these as one approval, so the writer must too."""
-    database = _catalog_database(source_title_equivalence=[_equivalence()])
+    database = _equivalence_database(source_title_equivalence=[_equivalence()])
     # Trimmed (the validator rejects untrimmed outright), but carrying an
     # internal whitespace run and NFD composition — both of which the reader
     # canonicalizes away, so both name the same approval.
@@ -1820,7 +1834,7 @@ def test_a_whitespace_variant_duplicate_equivalence_is_refused(
 def test_an_equivalence_with_a_foreign_generation_is_refused(
     mutate_tracking_database, version: object
 ) -> None:
-    database = _catalog_database()
+    database = _equivalence_database()
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError
@@ -1841,7 +1855,9 @@ def test_a_retitled_catalog_entry_can_be_approved_again(
     Matching duplicates on video and provider title alone would reject the newly
     reviewed approval, leaving the talk gated with no owner-supported recovery.
     """
-    database = _catalog_database(source_title_equivalence=[_equivalence()])
+    database = _equivalence_database(source_title_equivalence=[_equivalence()])
+    # The retitle has happened: the reader already stopped honoring the old pair.
+    database["talks"][0]["title"] = "Spring Configuration Showdown"
 
     candidate, _ = mutate_tracking_database.build_candidate(
         database,
@@ -1863,7 +1879,7 @@ def test_a_retitled_catalog_entry_can_be_approved_again(
 def test_an_exact_title_pair_duplicate_is_still_refused(
     mutate_tracking_database,
 ) -> None:
-    database = _catalog_database(source_title_equivalence=[_equivalence()])
+    database = _equivalence_database(source_title_equivalence=[_equivalence()])
 
     with pytest.raises(
         mutate_tracking_database.TrackingDatabaseMutationError
@@ -1882,3 +1898,45 @@ def test_an_exact_title_pair_duplicate_is_still_refused(
         )
 
     assert "duplicates an equivalence" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "forged",
+    [
+        # A title the talk might be renamed to later.
+        {"catalog_title": "Spring Configuration Showdown"},
+        # Another video's identity.
+        {"video_id": "wd-mXqXdfk0"},
+        # A provider title the recorded identity does not carry.
+        {"provider_title": "JavaDay Kiev 2014: something else entirely"},
+    ],
+)
+def test_an_equivalence_cannot_pre_authorize_an_identity_the_talk_lacks(
+    mutate_tracking_database, forged: dict[str, Any]
+) -> None:
+    """A dormant approval would fire once the catalog drifted onto it."""
+    database = _equivalence_database()
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as excinfo:
+        mutate_tracking_database.build_candidate(
+            database, [_record_equivalence(equivalence=_equivalence(**forged))]
+        )
+
+    assert "does not match" in str(excinfo.value)
+
+
+def test_an_equivalence_needs_a_recorded_identity_to_approve(
+    mutate_tracking_database,
+) -> None:
+    """With no source_identity there is no provider title to have reviewed."""
+    database = _equivalence_database()
+    del database["talks"][0]["source_identity"]
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as excinfo:
+        mutate_tracking_database.build_candidate(database, [_record_equivalence()])
+
+    assert "no source_identity" in str(excinfo.value)

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -7,6 +7,8 @@ import json
 from typing import Any
 from pathlib import Path
 
+import unicodedata
+
 import pytest
 
 
@@ -1696,6 +1698,7 @@ def test_a_reviewed_date_repair_does_not_open_unrelated_talk_fields(
 
 def _equivalence(**updates: Any) -> dict[str, Any]:
     record = {
+        "schema_version": 1,
         "video_id": "QS-_4k7o7A4",
         "provider_title": "JavaDay Kiev 2014: Spring - битва конфигураций",
         "reason": "cross_language_title",
@@ -1721,8 +1724,11 @@ def test_a_reviewed_title_equivalence_is_appended_with_a_stamped_version(
 ) -> None:
     database = _catalog_database()
 
+    unstamped = _equivalence()
+    del unstamped["schema_version"]
+
     candidate, changes = mutate_tracking_database.build_candidate(
-        database, [_record_equivalence()]
+        database, [_record_equivalence(equivalence=unstamped)]
     )
 
     recorded = candidate["talks"][0]["source_title_equivalence"]
@@ -1782,3 +1788,44 @@ def test_an_unreviewable_equivalence_is_refused(
         mutate_tracking_database.build_candidate(
             database, [_record_equivalence(equivalence=_equivalence(**invalid))]
         )
+
+
+def test_a_whitespace_variant_duplicate_equivalence_is_refused(
+    mutate_tracking_database,
+) -> None:
+    """The reader treats these as one approval, so the writer must too."""
+    database = _catalog_database(source_title_equivalence=[_equivalence()])
+    # Trimmed (the validator rejects untrimmed outright), but carrying an
+    # internal whitespace run and NFD composition — both of which the reader
+    # canonicalizes away, so both name the same approval.
+    spaced = _equivalence(
+        provider_title=unicodedata.normalize(
+            "NFD", "JavaDay Kiev 2014: Spring -  битва конфигураций"
+        )
+    )
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as excinfo:
+        mutate_tracking_database.build_candidate(
+            database, [_record_equivalence(equivalence=spaced)]
+        )
+
+    assert "duplicates an equivalence" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("version", [2, 0, True, "1"])
+def test_an_equivalence_with_a_foreign_generation_is_refused(
+    mutate_tracking_database, version: object
+) -> None:
+    database = _catalog_database()
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as excinfo:
+        mutate_tracking_database.build_candidate(
+            database,
+            [_record_equivalence(equivalence=_equivalence(schema_version=version))],
+        )
+
+    assert "schema_version must be 1" in str(excinfo.value)

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1689,3 +1689,96 @@ def test_a_reviewed_date_repair_does_not_open_unrelated_talk_fields(
             database,
             [_repair({"date": "2013", "status": "pending"}, {"date": "2014"})],
         )
+
+
+# Owner-reviewed provider-title equivalence ledger (#333).
+
+
+def _equivalence(**updates: Any) -> dict[str, Any]:
+    record = {
+        "video_id": "QS-_4k7o7A4",
+        "provider_title": "JavaDay Kiev 2014: Spring - битва конфигураций",
+        "reason": "cross_language_title",
+        "evidence": "owner-reviewed translation of the catalog title",
+        "verified_at": "2026-08-18T12:00:00Z",
+    }
+    record.update(updates)
+    return record
+
+
+def _record_equivalence(**updates: Any) -> dict[str, Any]:
+    mutation = {
+        "kind": "record_source_title_equivalence",
+        "filename": "talk.md",
+        "equivalence": _equivalence(),
+    }
+    mutation.update(updates)
+    return mutation
+
+
+def test_a_reviewed_title_equivalence_is_appended_with_a_stamped_version(
+    mutate_tracking_database,
+) -> None:
+    database = _catalog_database()
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database, [_record_equivalence()]
+    )
+
+    recorded = candidate["talks"][0]["source_title_equivalence"]
+    assert len(recorded) == 1
+    assert recorded[0]["schema_version"] == 1
+    assert recorded[0]["reason"] == "cross_language_title"
+    assert changes[0]["kind"] == "record_source_title_equivalence"
+    assert "source_title_equivalence" not in database["talks"][0]
+
+
+def test_a_second_equivalence_appends_rather_than_replacing(
+    mutate_tracking_database,
+) -> None:
+    database = _catalog_database(source_title_equivalence=[_equivalence()])
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database,
+        [
+            _record_equivalence(
+                equivalence=_equivalence(
+                    video_id="wd-mXqXdfk0",
+                    provider_title="JavaDay Kiev 2014: Транcформации",
+                )
+            )
+        ],
+    )
+
+    assert len(candidate["talks"][0]["source_title_equivalence"]) == 2
+
+
+def test_a_duplicate_equivalence_is_refused(mutate_tracking_database) -> None:
+    database = _catalog_database(source_title_equivalence=[_equivalence()])
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as excinfo:
+        mutate_tracking_database.build_candidate(database, [_record_equivalence()])
+
+    assert "duplicates an equivalence" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        {"reason": "looked_close_enough"},
+        {"evidence": ""},
+        {"verified_at": "2026-08-18T12:00:00"},
+        {"video_id": ""},
+    ],
+)
+def test_an_unreviewable_equivalence_is_refused(
+    mutate_tracking_database, invalid: dict[str, Any]
+) -> None:
+    database = _catalog_database()
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database, [_record_equivalence(equivalence=_equivalence(**invalid))]
+        )

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1831,3 +1831,54 @@ def test_an_equivalence_with_a_foreign_generation_is_refused(
         )
 
     assert "schema_version must be 1" in str(excinfo.value)
+
+
+def test_a_retitled_catalog_entry_can_be_approved_again(
+    mutate_tracking_database,
+) -> None:
+    """The reader stopped honoring the old pair, so the writer must accept a new one.
+
+    Matching duplicates on video and provider title alone would reject the newly
+    reviewed approval, leaving the talk gated with no owner-supported recovery.
+    """
+    database = _catalog_database(source_title_equivalence=[_equivalence()])
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database,
+        [
+            _record_equivalence(
+                equivalence=_equivalence(catalog_title="Spring Configuration Showdown")
+            )
+        ],
+    )
+
+    recorded = candidate["talks"][0]["source_title_equivalence"]
+    assert len(recorded) == 2
+    assert {entry["catalog_title"] for entry in recorded} == {
+        "Spring config battle (Ru)",
+        "Spring Configuration Showdown",
+    }
+
+
+def test_an_exact_title_pair_duplicate_is_still_refused(
+    mutate_tracking_database,
+) -> None:
+    database = _catalog_database(source_title_equivalence=[_equivalence()])
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as excinfo:
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                _record_equivalence(
+                    equivalence=_equivalence(
+                        catalog_title=unicodedata.normalize(
+                            "NFD", "Spring config  battle (Ru)"
+                        )
+                    )
+                )
+            ],
+        )
+
+    assert "duplicates an equivalence" in str(excinfo.value)

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1700,6 +1700,7 @@ def _equivalence(**updates: Any) -> dict[str, Any]:
     record = {
         "schema_version": 1,
         "video_id": "QS-_4k7o7A4",
+        "catalog_title": "Spring config battle (Ru)",
         "provider_title": "JavaDay Kiev 2014: Spring - битва конфигураций",
         "reason": "cross_language_title",
         "evidence": "owner-reviewed translation of the catalog title",
@@ -1774,6 +1775,7 @@ def test_a_duplicate_equivalence_is_refused(mutate_tracking_database) -> None:
     "invalid",
     [
         {"reason": "looked_close_enough"},
+        {"catalog_title": ""},
         {"evidence": ""},
         {"verified_at": "2026-08-18T12:00:00"},
         {"video_id": ""},

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4347,3 +4347,70 @@ def test_replaced_source_video_leaves_an_unrelated_talk_current(
     ]
     assert len(lineage) == 1
     assert lineage[0]["filename"] == "2026-07-30-perfect-ingress.md"
+
+
+# Owner-reviewed provider-title equivalence (#333). The comparator cannot cross
+# languages and cannot follow a provider rename, so four talks could not
+# register a source identity without either rewriting the catalog title to
+# whatever the provider published or recording the judgment as data.
+
+
+def title_equivalence(**updates: Any) -> dict[str, Any]:
+    record = {
+        "schema_version": 1,
+        "video_id": VIDEO_ID,
+        "provider_title": "Совершенно другое название",
+        "reason": "cross_language_title",
+        "evidence": "owner-reviewed translation of the catalog title",
+        "verified_at": "2026-08-18T12:00:00Z",
+    }
+    record.update(updates)
+    return record
+
+
+def test_a_reviewed_title_equivalence_clears_the_title_gate(
+    preflight_vault, vault_fixture
+):
+    materialize_transcript(vault_fixture)
+    talk = base_talk(
+        duration_seconds=2700,
+        source_identity=source_identity(title="Совершенно другое название"),
+        source_title_equivalence=[title_equivalence()],
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["database"])
+
+    assert "source_identity_title_mismatch" not in finding_codes(report, "blocking")
+
+
+def test_an_unmatched_title_still_blocks_without_an_equivalence(
+    preflight_vault, vault_fixture
+):
+    materialize_transcript(vault_fixture)
+    talk = base_talk(
+        duration_seconds=2700,
+        source_identity=source_identity(title="Совершенно другое название"),
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["database"])
+
+    assert "source_identity_title_mismatch" in finding_codes(report, "blocking")
+
+
+def test_an_equivalence_for_another_title_does_not_clear_the_gate(
+    preflight_vault, vault_fixture
+):
+    """A provider that retitles again re-gates rather than riding the approval."""
+    materialize_transcript(vault_fixture)
+    talk = base_talk(
+        duration_seconds=2700,
+        source_identity=source_identity(title="Ещё одно новое название"),
+        source_title_equivalence=[title_equivalence()],
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["database"])
+
+    assert "source_identity_title_mismatch" in finding_codes(report, "blocking")

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4359,6 +4359,7 @@ def title_equivalence(**updates: Any) -> dict[str, Any]:
     record = {
         "schema_version": 1,
         "video_id": VIDEO_ID,
+        "catalog_title": "Perfect Vault Ingress",
         "provider_title": "Совершенно другое название",
         "reason": "cross_language_title",
         "evidence": "owner-reviewed translation of the catalog title",
@@ -4407,6 +4408,24 @@ def test_an_equivalence_for_another_title_does_not_clear_the_gate(
     talk = base_talk(
         duration_seconds=2700,
         source_identity=source_identity(title="Ещё одно новое название"),
+        source_title_equivalence=[title_equivalence()],
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["database"])
+
+    assert "source_identity_title_mismatch" in finding_codes(report, "blocking")
+
+
+def test_a_catalog_retitle_after_review_re_gates_the_talk(
+    preflight_vault, vault_fixture
+):
+    """The equivalence approved one title pair, not the catalog title's future."""
+    materialize_transcript(vault_fixture)
+    talk = base_talk(
+        title="Perfect Vault Ingress, Revised Edition",
+        duration_seconds=2700,
+        source_identity=source_identity(title="Совершенно другое название"),
         source_title_equivalence=[title_equivalence()],
     )
     write_database(vault_fixture, [talk])

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -278,3 +278,31 @@ def test_title_equivalence_treats_an_unusable_ledger_as_no_approval(
         )
         is False
     )
+
+
+@pytest.mark.parametrize("version", [2, 0, None, True, "1", 1.0])
+def test_an_unrecognized_equivalence_generation_never_suppresses_the_gate(
+    version: object,
+) -> None:
+    """Unusable state is not an approval — what it would suppress is the gate."""
+    record = dict(EQUIVALENCE[0])
+    if version is None:
+        del record["schema_version"]
+    else:
+        record["schema_version"] = version
+
+    assert (
+        source_identity_matching.title_equivalence_recorded(
+            [record],
+            video_id="QS-_4k7o7A4",
+            provider_title=EQUIVALENCE[0]["provider_title"],
+        )
+        is False
+    )
+
+
+def test_pinned_provider_title_is_the_one_canonicalizer() -> None:
+    """Reader and writer must agree on which titles are the same approval."""
+    assert source_identity_matching.pinned_provider_title(
+        "  Spring -  битва   конфигураций \n"
+    ) == source_identity_matching.pinned_provider_title("Spring - битва конфигураций")

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -220,3 +220,61 @@ def test_expected_duration_seconds_reads_the_first_usable_catalog_duration(
     expected: float | None,
 ) -> None:
     assert source_identity_matching.expected_duration_seconds(talk) == expected
+
+
+EQUIVALENCE = [
+    {
+        "schema_version": 1,
+        "video_id": "QS-_4k7o7A4",
+        "provider_title": "JavaDay Kiev 2014: Spring - битва конфигураций",
+        "reason": "cross_language_title",
+        "evidence": "owner-reviewed translation",
+        "verified_at": "2026-08-18T12:00:00Z",
+    }
+]
+
+
+@pytest.mark.parametrize(
+    ("video_id", "provider_title", "expected"),
+    [
+        # The reviewed pair, exactly as recorded.
+        ("QS-_4k7o7A4", EQUIVALENCE[0]["provider_title"], True),
+        # Whitespace and Unicode composition vary without changing what was read.
+        ("QS-_4k7o7A4", f"  {EQUIVALENCE[0]['provider_title']}  ", True),
+        # A different video must never ride another talk's approval.
+        ("wd-mXqXdfk0", EQUIVALENCE[0]["provider_title"], False),
+        # A provider that retitles again re-gates instead of staying approved.
+        ("QS-_4k7o7A4", "JavaDay Kiev 2014: Spring config showdown", False),
+        ("QS-_4k7o7A4", "", False),
+    ],
+)
+def test_title_equivalence_matches_only_the_reviewed_video_and_title(
+    video_id: str,
+    provider_title: str,
+    expected: bool,
+) -> None:
+    assert (
+        source_identity_matching.title_equivalence_recorded(
+            EQUIVALENCE,
+            video_id=video_id,
+            provider_title=provider_title,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "ledger",
+    [None, [], "not-a-list", [None], [{"video_id": "QS-_4k7o7A4"}]],
+)
+def test_title_equivalence_treats_an_unusable_ledger_as_no_approval(
+    ledger: object,
+) -> None:
+    assert (
+        source_identity_matching.title_equivalence_recorded(
+            ledger,
+            video_id="QS-_4k7o7A4",
+            provider_title=EQUIVALENCE[0]["provider_title"],
+        )
+        is False
+    )

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -226,6 +226,7 @@ EQUIVALENCE = [
     {
         "schema_version": 1,
         "video_id": "QS-_4k7o7A4",
+        "catalog_title": "Spring config battle (Ru)",
         "provider_title": "JavaDay Kiev 2014: Spring - битва конфигураций",
         "reason": "cross_language_title",
         "evidence": "owner-reviewed translation",
@@ -257,6 +258,7 @@ def test_title_equivalence_matches_only_the_reviewed_video_and_title(
         source_identity_matching.title_equivalence_recorded(
             EQUIVALENCE,
             video_id=video_id,
+            catalog_title="Spring config battle (Ru)",
             provider_title=provider_title,
         )
         is expected
@@ -274,6 +276,7 @@ def test_title_equivalence_treats_an_unusable_ledger_as_no_approval(
         source_identity_matching.title_equivalence_recorded(
             ledger,
             video_id="QS-_4k7o7A4",
+            catalog_title="Spring config battle (Ru)",
             provider_title=EQUIVALENCE[0]["provider_title"],
         )
         is False
@@ -295,6 +298,7 @@ def test_an_unrecognized_equivalence_generation_never_suppresses_the_gate(
         source_identity_matching.title_equivalence_recorded(
             [record],
             video_id="QS-_4k7o7A4",
+            catalog_title="Spring config battle (Ru)",
             provider_title=EQUIVALENCE[0]["provider_title"],
         )
         is False
@@ -306,3 +310,30 @@ def test_pinned_provider_title_is_the_one_canonicalizer() -> None:
     assert source_identity_matching.pinned_provider_title(
         "  Spring -  битва   конфигураций \n"
     ) == source_identity_matching.pinned_provider_title("Spring - битва конфигураций")
+
+
+@pytest.mark.parametrize(
+    ("catalog_title", "expected"),
+    [
+        ("Spring config battle (Ru)", True),
+        # Whitespace and composition still vary harmlessly on this side too.
+        ("  Spring config   battle (Ru) ", True),
+        # A catalog title edited after the review was never approved.
+        ("Spring Configuration Showdown", False),
+        ("", False),
+    ],
+)
+def test_a_catalog_retitle_retires_the_equivalence(
+    catalog_title: str,
+    expected: bool,
+) -> None:
+    """The approval was that THESE two names the same talk — both sides pinned."""
+    assert (
+        source_identity_matching.title_equivalence_recorded(
+            EQUIVALENCE,
+            video_id="QS-_4k7o7A4",
+            catalog_title=catalog_title,
+            provider_title=EQUIVALENCE[0]["provider_title"],
+        )
+        is expected
+    )

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1711,3 +1711,42 @@ def test_a_database_with_nothing_stale_still_reports_no_change(tracking_database
 
     assert migration.changed is False
     assert not any(migration.record_counts.values())
+
+
+def test_v6_restamps_to_the_title_equivalence_record_shape(tracking_database) -> None:
+    """#333: v7 adds the optional equivalence ledger, a pure shape addition.
+
+    A v6 record already holds the analysis v7 implies, so it carries forward
+    untouched. Generations below v5 still stay put — they reach the current
+    shape by being reanalysed, never by being stamped.
+    """
+    database = _legacy_database()
+    database["talks"] = []
+    for version in (1, 4, 5, 6):
+        talk = _legacy_talk(filename=f"v{version}.md")
+        talk["schema_version"] = version
+        database["talks"].append(talk)
+
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    current = _tracking_database.TALK_RECORD_SCHEMA_VERSION
+    assert [talk["schema_version"] for talk in migrated["talks"]] == [
+        1,
+        4,
+        current,
+        current,
+    ]
+
+
+def test_a_restamped_record_keeps_its_equivalence_ledger_absent(
+    tracking_database,
+) -> None:
+    """Absence means "no equivalences"; migration must not invent the field."""
+    database = _legacy_database()
+    talk = _legacy_talk(filename="v6.md")
+    talk["schema_version"] = 6
+    database["talks"] = [talk]
+
+    migrated = tracking_database.migrate_tracking_database(database).database
+
+    assert "source_title_equivalence" not in migrated["talks"][0]


### PR DESCRIPTION
## Why

Four talks in #333 cannot register a source identity because `titles_agree`
cannot reach their provider titles:

| talk | catalog title | provider title |
|---|---|---|
| `playlist-QS-_4k7o7A4` | Spring config battle (Ru) | JavaDay Kiev 2014: Spring - битва конфигураций |
| `playlist-wd-mXqXdfk0` | AST Transformations in Groovy (Ru) | JavaDay Kiev 2014: Транcформации Абстрактного Синтаксического Дерева в Груви |
| `2026-04-16-arcofai26-robocoders-judgment-day` | RoboCoders: Judgment Day — AI Coding Agents Face Off | AI-Assisted Engineering Applied: The Battle of Agents \| Arc Of AI 2026 |
| `2026-02-02-jfokus-2026-robocoders-...` | RoboCoders: Judgment Day – AI Coding Tools Face Off at JFokus 2026 | AI-Assisted Engineering Applied: The Battle of Agents \| Jfokus 2026 |

None of these is a comparator bug. `битва конфигураций` is "battle of
configurations"; no deterministic overlap test crosses that without also
matching things it must not. The comparator is right to refuse and must stay
right — it is the same test that catches a video from the wrong delivery.

The two RoboCoders videos were confirmed against their catalog entries before
this PR: both descriptions are the RoboCoders premise (two speakers, competing
AI coding agents, live IoT build, audience vote), not Codepocalypse, which is
consistently the LangChain4j-vs-Spring-AI framework talk.

The alternative to this change was rewriting four catalog titles to whatever the
provider published — Russian titles in an otherwise-English catalog, and two
RoboCoders entries that stop matching the ten around them.

## What

`source_title_equivalence`, a talk-level append-only ledger modelled on the
existing `source_rejections`:

```json
{"schema_version": 1, "video_id": "QS-_4k7o7A4",
 "provider_title": "JavaDay Kiev 2014: Spring - битва конфигураций",
 "reason": "cross_language_title", "evidence": "owner-reviewed translation",
 "verified_at": "2026-08-18T12:00:00Z"}
```

- Consulted **only after** the deterministic comparison fails — it can never
  loosen the comparator, only record a reviewed exception to it
- Pins the **exact** provider title reviewed, so a later provider rename
  re-gates instead of inheriting the approval
- Closed reason set (`cross_language_title`, `provider_retitled`) — free text
  would make this a place to wave through any mismatch
- New `record_source_title_equivalence` mutation: append-only, refuses a
  duplicate
- Both preflight and the auditor consult it, so the pre-check and the gate stay
  in agreement (the property #335 established)

When an equivalence applies the check passes silently: a warning on every run
would be noise about a decision already made and recorded, and the record itself
is the audit trail.

## Testing

- Predicate: exact match, whitespace/NFC variation, wrong video, retitled
  provider, empty title, and five unusable-ledger shapes
- Preflight: equivalence clears the gate; no equivalence still blocks; an
  equivalence for a different title still blocks
- Writer: stamped version on append, second equivalence appends, duplicate
  refused, four unreviewable records refused
- Full suite: 5981 passed, 3 skipped; `ruff check`, `ruff format --check`,
  `pyright` clean

Refs #333