### PR TITLE
fix(vault-ingress): let a catalog repair reach a legacy talk record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+### fix(vault-ingress) — catalog repair reaches legacy talk records (#333)
+
+#336 gave the delivery date an owner writer. Applying #333's corrections against
+the live vault then failed on all ten:
+
+```
+talks['2018-java-8-puzzlers.md'].schema_version must be exact current
+talk schema 6 before this mutation
+```
+
+**209 of the 215 live talk records are schema v1.** Six are v6. Every talk #333
+set out to correct is legacy, and so is 97% of the catalog.
+
+No migration lifts them. `_restamp_talk_records` promotes v5 to v6 and stops
+there, because the generations in between carry analysis a migration is
+forbidden to fabricate — recomputing a score under arithmetic its worker never
+used is the silent reinterpretation `stateful-artifacts` exists to prevent. A v1
+record reaches v6 by being reanalyzed, not by being restamped. That function's
+own docstring names the failure this produced:
+
+> Without the restamp every stored talk would be unmutatable: the owner writer
+> requires the exact current talk schema before any mutation, so the bump alone
+> would lock the database until this ran.
+
+Which is the state the v1 records were in: unmutatable through every sanctioned
+path, with the only route to a date correction being a full reanalysis of a talk
+whose transcript and slides were never in question.
+
+The current-generation gate is right for a writer that assumes the current
+record shape. `apply_reviewed_metadata` assumes nothing about it — it reads and
+writes `title`, `conference`, and `date`, none of which any talk-record
+generation has changed. It now accepts any generation the database assessment
+can read, and leaves the record's version alone: repairing a catalog fact must
+not claim the record was reanalyzed. Every other writer keeps the strict gate.
+
 ### feat(vault-ingress) — owner-reviewed provider-title equivalence (#333)
 
 Four talks in #333 could not register a source identity because `titles_agree`

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -586,7 +586,11 @@ trail.
 review-required entries by design: an approved catalog correction otherwise had
 no owner writer at all. The same writer carries an owner-reviewed delivery-date
 repair, so a cataloged date the source evidence disproves has a path that is not
-a hand edit. It stays narrow — the writable field set, the
+a hand edit. It is also the one talk writer that accepts any readable talk
+generation rather than the current one: a catalog-identity repair reads no
+analysis field, and a legacy record cannot be migrated forward to earn one — see
+`_require_readable_talk_record` in
+`skills/vault-ingress/scripts/mutate-tracking-database.py`. It stays narrow — the writable field set, the
 metadata-only versus analysis-invalidating classification, and the reprocessing
 transition it demands are named at the top of
 `skills/vault-ingress/scripts/mutate-tracking-database.py`. Deterministic scan

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -34,6 +34,7 @@ from tracking_database import (
     RESOURCE_REQUIRED_FIELDS as OWNER_RESOURCE_REQUIRED_FIELDS,
     THUMBNAIL_RECORD_SCHEMA_VERSION,
     THUMBNAIL_REQUIRED_FIELDS as OWNER_THUMBNAIL_REQUIRED_FIELDS,
+    LEGACY_TALK_RECORD_SCHEMA_VERSION,
     SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION,
     TALK_RECORD_SCHEMA_VERSION,
     TRACKING_DATABASE_SCHEMA_VERSION,
@@ -818,6 +819,36 @@ def _require_current_talk_record(
         )
 
 
+def _require_readable_talk_record(
+    talk: dict[str, Any],
+    *,
+    filename: str,
+) -> None:
+    """Accept any talk generation the database assessment can read.
+
+    The current-generation gate exists for mutations that assume the current
+    record shape. A catalog-identity repair assumes nothing about it: it reads
+    and writes `title`, `conference`, or `date`, none of which any talk-record
+    version has changed. Holding those repairs to the current generation locks
+    the correction out of every legacy record — and a legacy record cannot be
+    migrated forward, because the generations between carry analysis a migration
+    is forbidden to fabricate. The record would have to be reanalyzed to earn a
+    date correction it already deserves.
+    """
+    version = talk.get("schema_version", LEGACY_TALK_RECORD_SCHEMA_VERSION)
+    if (
+        type(version) is not int
+        or not LEGACY_TALK_RECORD_SCHEMA_VERSION
+        <= version
+        <= TALK_RECORD_SCHEMA_VERSION
+    ):
+        raise TrackingDatabaseMutationError(
+            f"talks[{filename!r}].schema_version must be a readable talk schema "
+            f"between {LEGACY_TALK_RECORD_SCHEMA_VERSION} and "
+            f"{TALK_RECORD_SCHEMA_VERSION} before this mutation"
+        )
+
+
 def _apply_update_talk(
     database: dict[str, Any],
     mutation: dict[str, Any],
@@ -959,7 +990,7 @@ def _apply_reviewed_metadata(
     )
     filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
     talk = _talk_by_filename(database, filename)
-    _require_current_talk_record(talk, filename=filename)
+    _require_readable_talk_record(talk, filename=filename)
     _validate_metadata_values(mutation["set"], f"mutations[{index}].set")
 
     set_values = mutation["set"]

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1303,20 +1303,31 @@ def test_a_duplicate_filename_installs_nothing(mutate_tracking_database) -> None
         )
 
 
-def test_a_legacy_talk_schema_installs_nothing(mutate_tracking_database) -> None:
+def test_a_legacy_talk_schema_still_takes_a_catalog_repair(
+    mutate_tracking_database,
+) -> None:
+    """Superseded by #333: this writer no longer requires the current generation.
+
+    It once refused a legacy record like every other writer. That locked catalog
+    corrections out of 209 of the 215 live talks, which no migration can lift —
+    the generations between carry analysis a migration must not fabricate. A
+    catalog repair reads no analysis field, so it does not need that gate.
+    """
     database = _catalog_database()
     database["talks"][0]["schema_version"] = 4
 
-    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
-        mutate_tracking_database.build_candidate(
-            database,
-            [
-                _repair(
-                    {"conference": "DevOps Days Nashville 2024"},
-                    {"conference": "DevOps Nashville 2024"},
-                )
-            ],
-        )
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database,
+        [
+            _repair(
+                {"conference": "DevOps Days Nashville 2024"},
+                {"conference": "DevOps Nashville 2024"},
+            )
+        ],
+    )
+
+    assert candidate["talks"][0]["conference"] == "DevOps Days Nashville 2024"
+    assert candidate["talks"][0]["schema_version"] == 4
 
 
 def test_a_metadata_only_change_refuses_a_reprocess_transition(
@@ -1829,3 +1840,74 @@ def test_an_equivalence_with_a_foreign_generation_is_refused(
         )
 
     assert "schema_version must be 1" in str(excinfo.value)
+
+
+# Legacy-generation catalog repair (#333). 209 of the 215 live talk records are
+# schema v1, and no migration lifts them: the generations between carry analysis
+# a migration is forbidden to fabricate. Holding a date repair to the current
+# generation locked the correction out of the whole live catalog.
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5, 6])
+def test_a_catalog_repair_reaches_every_readable_talk_generation(
+    mutate_tracking_database, version: int
+) -> None:
+    database = _catalog_database(date="2014", schema_version=version)
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database, [_repair({"date": "2013-10-19"}, {"date": "2014"})]
+    )
+
+    assert candidate["talks"][0]["date"] == "2013-10-19"
+
+
+def test_a_catalog_repair_leaves_the_records_generation_untouched(
+    mutate_tracking_database,
+) -> None:
+    """Repairing a catalog fact must not claim the record was reanalyzed."""
+    database = _catalog_database(date="2014", schema_version=1)
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database, [_repair({"date": "2013"}, {"date": "2014"})]
+    )
+
+    assert candidate["talks"][0]["schema_version"] == 1
+
+
+@pytest.mark.parametrize("version", [0, 7, "6", True])
+def test_a_catalog_repair_still_refuses_an_unreadable_generation(
+    mutate_tracking_database, version: object
+) -> None:
+    """Out-of-range generations are refused; the database assessment gets there
+    first, so this asserts the refusal rather than which layer produced it."""
+    database = _catalog_database(date="2014")
+    database["talks"][0]["schema_version"] = version
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database, [_repair({"date": "2013"}, {"date": "2014"})]
+        )
+
+
+def test_other_writers_still_require_the_current_generation(
+    mutate_tracking_database,
+) -> None:
+    """The relaxation is scoped to catalog repair, not opened to every writer."""
+    database = _catalog_database(schema_version=1)
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as excinfo:
+        mutate_tracking_database.build_candidate(
+            database,
+            [
+                {
+                    "kind": "update_talk_publishing",
+                    "filename": "talk.md",
+                    "expect": {"shownotes_published": False},
+                    "set": {"shownotes_published": True},
+                }
+            ],
+        )
+
+    assert "exact current talk schema 6" in str(excinfo.value)


### PR DESCRIPTION
> Stacked on #337 — review that first. Base retargets to `main` when #337 merges.

## The failure

#336 gave the delivery date an owner writer. Applying #333's ten corrections
against the live vault failed on every one:

```
talks['2018-java-8-puzzlers.md'].schema_version must be exact current
talk schema 6 before this mutation
```

**209 of the 215 live talk records are schema v1.** Six are v6. Every talk #333
set out to correct is legacy — and so is 97% of the catalog.

## Why no migration fixes it

`_restamp_talk_records` promotes v5→v6 and stops, because the generations in
between carry analysis a migration is forbidden to fabricate. A v1 record
reaches v6 by being *reanalyzed*, not restamped. Its own docstring names exactly
the failure this produced:

> Without the restamp every stored talk would be unmutatable: the owner writer
> requires the exact current talk schema before any mutation, so the bump alone
> would lock the database until this ran.

That is the state the v1 records are in: unmutatable through every sanctioned
path, with the only route to a date correction being a full reanalysis of a talk
whose transcript and slides were never in question.

## The change

The current-generation gate is right for a writer that assumes the current
record shape. `apply_reviewed_metadata` assumes nothing about it — it reads and
writes `title`, `conference`, and `date`, and no talk-record generation has ever
changed those. It now accepts any generation the database assessment can read
(1–6), and leaves the record's version untouched: repairing a catalog fact must
not claim the record was reanalyzed.

**Scoped to that writer only.** `update_talk_publishing`, `record_pptx`,
`update_talk_clarification` and the rest keep `_require_current_talk_record`,
and there is a test asserting that.

## Note for the reviewer

This bears on the open `TALK_RECORD_SCHEMA_VERSION` finding on #337. Bumping the
talk record to v7 would push the six currently-current records into this same
unmutatable state — widening the problem this PR narrows.

## Superseded test

`test_a_legacy_talk_schema_installs_nothing` asserted the old contract (a v4
record refusing a conference repair). It is now
`test_a_legacy_talk_schema_still_takes_a_catalog_repair`, with the reasoning in
its docstring.

## Verification

Dry-run against the live 215-talk vault now resolves all ten corrections with
their `expect` guards satisfied:

```
2018-java-8-puzzlers.md    {'date': '2018'} -> {'date': '2016'}
playlist--ApAPoxxaaw.md    {'date': '2016'} -> {'date': '2015'}
playlist-pUA83-e82qI.md    {'date': '2018'} -> {'date': '2017'}
... 7 more
```

Tests: generations 1–6 all accept a repair; version left untouched; out-of-range
generations still refused; other writers still require v6. Full suite 6005
passed, 3 skipped; `ruff`, `pyright` clean.

Refs #333