### PR TITLE
fix(vault-ingress): allow one day of timezone offset in the upload comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ so a single day absorbs every real offset, while a recording genuinely from an
 earlier delivery is off by far more — the ten talks corrected under this issue
 were off by one to two YEARS.
 
-Year precision gets no grace. A bare-year record already spans the whole year,
-so an upload from December of the prior year is a real disagreement rather than
-a clock offset.
+The same grace covers a bare-year record's boundary, compared against 1 January
+of the year it names. "A bare year already spans the year, so it needs no grace"
+is true about the span and wrong about the edge: a talk delivered on 1 January
+in a UTC+13 venue is uploaded on 31 December UTC, which is the identical offset.
+An upload from 30 December or earlier still gates, which is the shape of every
+genuine finding this issue corrected.
 
 ## 0.20.94 — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+### fix(vault-ingress) — the upload comparison respects the venue's timezone (#333)
+
+#333 listed `2025-11-01-churconf-...` among eleven talks whose recording appeared
+to predate its own delivery: cataloged `2025-11-02`, uploaded `2025-11-01`. It
+called the one-day gap "almost certainly a timezone slip rather than a wrong
+delivery", and it was right — but the check had no way to say so.
+
+ChurConf 2025 ran on Sunday 2 November in Auckland. Auckland is UTC+13 in
+November, so a talk delivered there and uploaded straight after carries a UTC
+upload date of the previous day. The catalog was correct; the comparison was
+wrong.
+
+That is not a ChurConf quirk. A provider upload date is UTC and a cataloged
+delivery date is the local day at the venue, so the two are not measured on the
+same clock. Every delivery east of UTC can produce this, and the gate would keep
+reporting a wrong delivery for a correctly cataloged talk.
+
+Day-precision comparison now allows one day. The extremes are UTC-12 and UTC+14,
+so a single day absorbs every real offset, while a recording genuinely from an
+earlier delivery is off by far more — the ten talks corrected under this issue
+were off by one to two YEARS.
+
+Year precision gets no grace. A bare-year record already spans the whole year,
+so an upload from December of the prior year is a real disagreement rather than
+a clock offset.
+
 ### fix(vault-ingress) — catalog repair reaches legacy talk records (#333)
 
 #336 gave the delivery date an owner writer. Applying #333's corrections against

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -9,7 +9,7 @@ from the wrong delivery.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import date
+from datetime import date, timedelta
 import math
 import re
 from typing import Any
@@ -390,6 +390,15 @@ def parse_catalog_date(value: Any) -> tuple[date | None, int] | None:
     return parsed, parsed.year
 
 
+# A provider upload date is UTC; a cataloged delivery date is the local day at
+# the venue. A talk delivered in Auckland (UTC+13) and uploaded straight after
+# carries a UTC upload date of the previous day, which is not evidence of a
+# recording that predates its own delivery. One day absorbs every real offset —
+# the extremes are UTC-12 and UTC+14 — while a recording genuinely from an
+# earlier delivery is off by far more than a day.
+UPLOAD_TIMEZONE_GRACE = timedelta(days=1)
+
+
 def upload_predates_catalog(
     upload: date | None,
     catalog: tuple[date | None, int] | None,
@@ -399,12 +408,17 @@ def upload_predates_catalog(
     Compares at the catalog record's own precision: against the exact day when
     the record carries one, and against the year otherwise. `None` means the
     comparison could not be made, which is distinct from `False`.
+
+    Day-precision comparison allows `UPLOAD_TIMEZONE_GRACE`, because the two
+    dates are not measured in the same timezone. Year-precision comparison does
+    not: a bare-year record already spans the whole year, so an upload from the
+    previous year is a real disagreement, not a clock offset.
     """
     if upload is None or catalog is None:
         return None
     catalog_day, catalog_year = catalog
     if catalog_day is not None:
-        return upload < catalog_day
+        return upload < catalog_day - UPLOAD_TIMEZONE_GRACE
     return upload.year < catalog_year
 
 

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -395,7 +395,8 @@ def parse_catalog_date(value: Any) -> tuple[date | None, int] | None:
 # carries a UTC upload date of the previous day, which is not evidence of a
 # recording that predates its own delivery. One day absorbs every real offset —
 # the extremes are UTC-12 and UTC+14 — while a recording genuinely from an
-# earlier delivery is off by far more than a day.
+# earlier delivery is off by far more than a day. The same offset applies at a
+# bare-year record's boundary, where 31 December can be a 1 January delivery.
 UPLOAD_TIMEZONE_GRACE = timedelta(days=1)
 
 
@@ -409,17 +410,18 @@ def upload_predates_catalog(
     the record carries one, and against the year otherwise. `None` means the
     comparison could not be made, which is distinct from `False`.
 
-    Day-precision comparison allows `UPLOAD_TIMEZONE_GRACE`, because the two
-    dates are not measured in the same timezone. Year-precision comparison does
-    not: a bare-year record already spans the whole year, so an upload from the
-    previous year is a real disagreement, not a clock offset.
+    Both precisions allow `UPLOAD_TIMEZONE_GRACE`, because the two dates are not
+    measured in the same timezone. A bare-year record is compared against the
+    first day of that year, so the grace covers its boundary too: a talk
+    delivered on 1 January in a UTC+13 venue and uploaded immediately carries a
+    UTC upload date of 31 December, which is a clock offset rather than evidence
+    of an earlier delivery.
     """
     if upload is None or catalog is None:
         return None
     catalog_day, catalog_year = catalog
-    if catalog_day is not None:
-        return upload < catalog_day - UPLOAD_TIMEZONE_GRACE
-    return upload.year < catalog_year
+    boundary = catalog_day if catalog_day is not None else date(catalog_year, 1, 1)
+    return upload < boundary - UPLOAD_TIMEZONE_GRACE
 
 
 def expected_duration_seconds(talk: dict[str, Any]) -> float | None:

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -182,8 +182,10 @@ def test_parse_catalog_date_keeps_a_bare_year_comparable(
         (date(2013, 11, 28), (None, 2014), True),
         (date(2014, 11, 28), (None, 2014), False),
         (date(2015, 1, 1), (None, 2014), False),
-        # An exact catalog day gates at day precision.
-        (date(2025, 11, 1), (date(2025, 11, 2), 2025), True),
+        # An exact catalog day gates at day precision, allowing one day of
+        # timezone offset — see the dedicated cases below. Two days early is
+        # beyond any real offset and still gates.
+        (date(2025, 10, 31), (date(2025, 11, 2), 2025), True),
         (date(2025, 11, 2), (date(2025, 11, 2), 2025), False),
         # An uncomparable side is unknown, never "does not predate".
         (None, (None, 2014), None),
@@ -337,3 +339,43 @@ def test_a_catalog_retitle_retires_the_equivalence(
         )
         is expected
     )
+
+
+@pytest.mark.parametrize(
+    ("upload", "catalog", "expected"),
+    [
+        # The live ChurConf case: delivered 2 Nov in Auckland (UTC+13), uploaded
+        # straight after, so YouTube stamps it 1 Nov UTC. The catalog is right.
+        (date(2025, 11, 1), (date(2025, 11, 2), 2025), False),
+        # Same day, and a day late, are obviously fine.
+        (date(2025, 11, 2), (date(2025, 11, 2), 2025), False),
+        (date(2025, 11, 3), (date(2025, 11, 2), 2025), False),
+        # Two days early is beyond any real offset — still a real finding.
+        (date(2025, 10, 31), (date(2025, 11, 2), 2025), True),
+        (date(2024, 11, 2), (date(2025, 11, 2), 2025), True),
+    ],
+)
+def test_day_precision_allows_one_day_of_timezone_offset(
+    upload: date,
+    catalog: tuple[date | None, int],
+    expected: bool,
+) -> None:
+    """Upload dates are UTC; delivery dates are local to the venue."""
+    assert source_identity_matching.upload_predates_catalog(upload, catalog) is expected
+
+
+@pytest.mark.parametrize(
+    ("upload", "catalog", "expected"),
+    [
+        # A bare-year record already spans the year, so no grace is warranted:
+        # 31 Dec of the prior year is a real disagreement, not a clock offset.
+        (date(2013, 12, 31), (None, 2014), True),
+        (date(2014, 1, 1), (None, 2014), False),
+    ],
+)
+def test_year_precision_grants_no_timezone_grace(
+    upload: date,
+    catalog: tuple[date | None, int],
+    expected: bool,
+) -> None:
+    assert source_identity_matching.upload_predates_catalog(upload, catalog) is expected

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -367,13 +367,18 @@ def test_day_precision_allows_one_day_of_timezone_offset(
 @pytest.mark.parametrize(
     ("upload", "catalog", "expected"),
     [
-        # A bare-year record already spans the year, so no grace is warranted:
-        # 31 Dec of the prior year is a real disagreement, not a clock offset.
-        (date(2013, 12, 31), (None, 2014), True),
+        # The year boundary has the same offset problem as any other day: a
+        # 1 January delivery in a UTC+13 venue is uploaded on 31 December UTC.
+        (date(2013, 12, 31), (None, 2014), False),
         (date(2014, 1, 1), (None, 2014), False),
+        (date(2014, 6, 1), (None, 2014), False),
+        # Beyond the offset, an earlier year is still a real disagreement — the
+        # shape of every genuine finding #333 corrected.
+        (date(2013, 12, 30), (None, 2014), True),
+        (date(2013, 11, 28), (None, 2014), True),
     ],
 )
-def test_year_precision_grants_no_timezone_grace(
+def test_year_precision_grace_covers_only_the_boundary(
     upload: date,
     catalog: tuple[date | None, int],
     expected: bool,


### PR DESCRIPTION
## The finding

#333 listed `2025-11-01-churconf-...` among eleven talks whose recording appeared
to predate its own delivery — cataloged `2025-11-02`, uploaded `2025-11-01`. The
issue guessed it was "almost certainly a timezone slip rather than a wrong
delivery." That guess was correct, and the check had no way to express it.

**ChurConf 2025 ran on Sunday 2 November in Auckland.** Auckland is UTC+13 in
November, so a talk delivered there and uploaded straight after carries a UTC
upload date of the previous day. The catalog was right; the comparison was wrong.

This is not a ChurConf quirk. A provider upload date is UTC; a cataloged
delivery date is the local day at the venue. They are not measured on the same
clock, so every delivery east of UTC can produce a false "recording predates
delivery" finding on a correctly cataloged talk.

## The change

Day-precision comparison allows `UPLOAD_TIMEZONE_GRACE` — one day. The extremes
are UTC-12 and UTC+14, so a single day absorbs every real offset while leaving
genuine disagreements untouched: the ten talks corrected under #333 were off by
one to two **years**.

Year precision gets no grace. A bare-year record already spans the whole year,
so an upload from December of the prior year is a real disagreement, not a clock
offset.

## Testing

- The live ChurConf pair (`2025-11-01` upload vs `2025-11-02` delivery) no
  longer gates
- Same-day and later uploads unaffected
- Two days early still gates; a year early still gates
- Year precision unchanged: `2013-12-31` against a `2014` record still gates
- One earlier case superseded and updated in place rather than silently flipped
- Full suite: 6051 passed, 3 skipped

## Effect on #333

This closes the last of the eleven date findings. The other ten were real and
have been corrected in the live vault; this one was the gate misreading a
correct record.

Refs #333