### PR TITLE
fix(ci): install system deps from the cache instead of a mirror

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,140 +101,35 @@ jobs:
         # publish and install, so _dimensions.yaml was absent from every clean
         # install from 0.20.57 on and the catalog audit exited 1 (issue #316).
         run: python3 scripts/check_shipped_extensions.py > /dev/null
-      - name: Cache apt package downloads
-        # Cache the downloaded .deb archives (kept in a runner-writable dir via
-        # Dir::Cache::Archives below), so the slow libreoffice fetch only hits
-        # the network on a cache miss. Bump the key suffix to invalidate.
-        #
-        # `APT::Keep-Downloaded-Packages "true"` below is what makes this cache
-        # exist at all: apt has discarded downloaded .debs after a successful
-        # install since 1.6, so the archive dir was empty when the post-step ran
-        # and no cache was ever written — every run re-fetched all of it.
+      - name: Compute the apt cache week
+        id: apt-cache-week
+        # The key rotates weekly so the cached archives and indices are renewed
+        # instead of pinned forever (`dependency-management` Freshness), and the
+        # installer's own hash rotates it whenever the package set or the install
+        # logic changes — the old `-v1` suffix relied on someone remembering to
+        # bump it by hand.
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+      - name: Cache apt package downloads and package indices
+        # Both halves, and the second is the point. Caching only the .deb
+        # archives left `apt-get update` fetching the indices from a mirror on
+        # every run, so a cache that restored 185 MiB still paid a full network
+        # round-trip — and that fetch, not the download, is what stalled the job
+        # for 20 minutes. With the indices here too, a hit installs offline.
         uses: actions/cache@v4
         with:
-          path: /tmp/apt-cache
-          key: apt-${{ runner.os }}-ffmpeg-libreoffice-tesseract-v1
+          path: |
+            /tmp/apt-cache
+            /tmp/apt-lists
+          key: apt-${{ runner.os }}-${{ hashFiles('scripts/install_system_deps.py') }}-${{ steps.apt-cache-week.outputs.week }}
       - name: Install system dependencies (ffmpeg, libreoffice-impress, tesseract)
-        # ffmpeg drives the video-slide-extraction tests; libreoffice-impress
-        # drives the PPTX->PDF export tests; tesseract drives OCR of baked-in
-        # picture text in pptx-extraction. Source-video evidence tests require
-        # ffmpeg/ffprobe and fail if either is absent. OCR unit tests inject a
-        # fake engine; integration tests skipif tesseract is missing.
-        #
-        # Why this is verbose instead of a plain `apt-get install`: the plain
-        # form intermittently wedged for the full 6h job limit (the identical
-        # install completes in ~2-3 min in a clean Ubuntu container locally, so
-        # it is a flaky-mirror infra issue, not a debconf prompt). The fixes:
-        #   - Acquire::*::Timeout + Acquire::Retries bound each mirror
-        #     connection (apt has effectively no default cap → the actual hang).
-        #   - `timeout` per command turns a stall into a fast, visible failure.
-        #   - Timestamped, line-by-line output (`set -x` + the stamp filter)
-        #     shows exactly which package/URL it is on if it stalls again.
-        #   - A degraded mirror is retried against the next official host rather
-        #     than failing the run: one archive being slow is the observed
-        #     failure, and waiting longer on the same host does not fix it.
-        #     Both hosts are Canonical-operated; no third-party mirror is added.
+        # Offline from the cache when it can, else through the mirror list with a
+        # reachability probe ahead of each host. The package set, mirror list,
+        # timeouts and fallback order are the script's — see
+        # scripts/install_system_deps.py (module docstring and top-of-file
+        # constants), covered by tests/test_install_system_deps.py.
         env:
           DEBIAN_FRONTEND: noninteractive
-        run: |
-          set -euxo pipefail
-          sudo mkdir -p /tmp/apt-cache/partial
-          sudo chmod -R 777 /tmp/apt-cache
-          sudo tee /etc/apt/apt.conf.d/99ci >/dev/null <<'CONF'
-          Dir::Cache::Archives "/tmp/apt-cache";
-          APT::Keep-Downloaded-Packages "true";
-          Acquire::Retries "3";
-          Acquire::http::Timeout "30";
-          Acquire::https::Timeout "30";
-          CONF
-          stamp() { while IFS= read -r line; do printf '%s %s\n' "$(date -u +%H:%M:%S)" "$line"; done; }
-
-          # Keep a pristine copy of the source lists. Each attempt restores it
-          # before rewriting, so no rewrite ever reads already-rewritten state.
-          apt_src_backup=/tmp/apt-src-orig
-          sudo rm -rf "$apt_src_backup"
-          sudo mkdir -p "$apt_src_backup"
-          if [ -f /etc/apt/sources.list ]; then
-            sudo cp /etc/apt/sources.list "$apt_src_backup/sources.list"
-          fi
-          if [ -d /etc/apt/sources.list.d ]; then
-            sudo cp -r /etc/apt/sources.list.d "$apt_src_backup/sources.list.d"
-          fi
-
-          # The rewrite is suite-aware and lives in scripts/apt_set_mirror.py
-          # with its own tests: a line-based rewrite cannot do it correctly,
-          # because Azure runners serve BOTH pockets from one host and deb822
-          # binds a `URIs:` to the `Suites:` in its own stanza.
-          set_mirror() {
-            local archive="$1" security="$2"
-            if [ -f "$apt_src_backup/sources.list" ]; then
-              sudo cp "$apt_src_backup/sources.list" /etc/apt/sources.list
-            fi
-            if [ -d "$apt_src_backup/sources.list.d" ]; then
-              sudo rm -rf /etc/apt/sources.list.d
-              sudo cp -r "$apt_src_backup/sources.list.d" /etc/apt/sources.list.d
-            fi
-            sudo python3 "${GITHUB_WORKSPACE}/scripts/apt_set_mirror.py" \
-              "$archive" "$security" \
-              /etc/apt/sources.list /etc/apt/sources.list.d/*.list \
-              /etc/apt/sources.list.d/*.sources
-          }
-
-          # Called as an `if` condition, which disables errexit for the whole
-          # function — so each pipeline is checked explicitly. Without this a
-          # failed `apt-get update` would be swallowed whenever the install then
-          # succeeded from the apt cache, and the job would go green on a
-          # half-broken mirror.
-          fetch_deps() {
-            if ! timeout 300 sudo -E apt-get update 2>&1 | stamp; then
-              return 1
-            fi
-            if ! timeout 600 sudo -E apt-get install -y ffmpeg libreoffice-impress \
-              tesseract-ocr=5.3.4-1build5 2>&1 | stamp; then
-              return 1
-            fi
-            return 0
-          }
-
-          # Ordered fastest-first, then genuinely independent. The first two are
-          # Canonical's own infrastructure and fail together when Canonical is
-          # degraded — which is not a fallback at all, so the list continues onto
-          # mirrors run by other organisations entirely.
-          #
-          # A third-party mirror cannot serve tampered packages: apt verifies
-          # each Release against the ubuntu-archive-keyring signature, so
-          # integrity comes from the signature, not from who hosts the bytes.
-          # Full Ubuntu mirrors carry the `-security` suites too, so one host
-          # serves both pockets.
-          installed=""
-          for pair in "http://azure.archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu" \
-                      "http://archive.ubuntu.com/ubuntu|http://security.ubuntu.com/ubuntu" \
-                      "http://mirrors.edge.kernel.org/ubuntu|http://mirrors.edge.kernel.org/ubuntu" \
-                      "http://ubuntu.osuosl.org/ubuntu|http://ubuntu.osuosl.org/ubuntu"; do
-            archive="${pair%%|*}"
-            security="${pair##*|}"
-            set_mirror "$archive" "$security"
-            if fetch_deps; then
-              installed="$archive"
-              break
-            fi
-            echo "apt failed against ${archive} / ${security}; trying the next mirror" >&2
-          done
-          if [ -z "$installed" ]; then
-            echo "every configured Ubuntu mirror failed, Canonical's and independent alike — re-run the job" >&2
-            exit 1
-          fi
-          echo "system dependencies installed from ${installed}"
-
-          # actions/cache tars as the runner user, and apt leaves behind a
-          # root-owned `lock` and `partial/`. tar cannot read them, the save
-          # aborts, and it reports a WARNING — so the step goes green having
-          # cached nothing, which is how this stayed invisible. Drop the
-          # transient entries and hand the archives to the runner.
-          sudo rm -f /tmp/apt-cache/lock
-          sudo rm -rf /tmp/apt-cache/partial
-          sudo chown -R "$(id -u):$(id -g)" /tmp/apt-cache
-          echo "cached $(find /tmp/apt-cache -name '*.deb' | wc -l) .deb archives"
+        run: python3 scripts/install_system_deps.py "$GITHUB_WORKSPACE"
       - run: pip install ".[test]"
       - run: pytest -v --tb=short
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,14 +101,16 @@ jobs:
         # publish and install, so _dimensions.yaml was absent from every clean
         # install from 0.20.57 on and the catalog audit exited 1 (issue #316).
         run: python3 scripts/check_shipped_extensions.py > /dev/null
-      - name: Compute the apt cache week
-        id: apt-cache-week
-        # The key rotates weekly so the cached archives and indices are renewed
-        # instead of pinned forever (`dependency-management` Freshness), and the
-        # installer's own hash rotates it whenever the package set or the install
-        # logic changes — the old `-v1` suffix relied on someone remembering to
-        # bump it by hand.
-        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+      - name: Resolve the apt cache key
+        id: apt-cache-key
+        # The key binds to the pinned package set, not to the installer file: a
+        # renewed pin must invalidate the cache, and an edited comment or a
+        # reordered fallback must not throw away 185 MiB of archives. The week
+        # stamp is the renewal cadence — a set nobody touches is still refetched
+        # rather than pinned forever (`dependency-management` Freshness).
+        run: |
+          echo "packages=$(python3 scripts/install_system_deps.py --package-digest)" >> "$GITHUB_OUTPUT"
+          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
       - name: Cache apt package downloads and package indices
         # Both halves, and the second is the point. Caching only the .deb
         # archives left `apt-get update` fetching the indices from a mirror on
@@ -120,7 +122,7 @@ jobs:
           path: |
             /tmp/apt-cache
             /tmp/apt-lists
-          key: apt-${{ runner.os }}-${{ hashFiles('scripts/install_system_deps.py') }}-${{ steps.apt-cache-week.outputs.week }}
+          key: apt-${{ runner.os }}-${{ steps.apt-cache-key.outputs.packages }}-${{ steps.apt-cache-key.outputs.week }}
       - name: Install system dependencies (ffmpeg, libreoffice-impress, tesseract)
         # Offline from the cache when it can, else through the mirror list with a
         # reachability probe ahead of each host. The package set, mirror list,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+### fix(ci) — the apt cache stops being decorative
+
+The dependency install cached apt's `.deb` archives and hit that cache every
+run — 185 MiB restored, logged as `Cache restored successfully` — and then went
+to a mirror anyway. Nothing in the step consulted what it had just restored:
+`fetch_deps()` ran `apt-get update` unconditionally, and the archives only ever
+save work inside `apt-get install`, which the run never reached. The bytes were
+cached, the package indices were not, and fetching the indices is what hung.
+
+So the network trip was not a cache miss. It was unconditional by construction,
+and a perfect cache would not have avoided one second of it.
+
+The indices are cached beside the archives now, and a restored pair installs
+with `--no-download` — no probe, no `apt-get update`, no mirror. Both halves are
+checked rather than the cache-hit flag, because an entry saved before this
+change holds only the archives and cannot resolve anything offline. A cached set
+that cannot satisfy the install — a runner image that gained or lost a
+preinstalled library — falls through to the mirror path instead of failing.
+
+The second failure is what the 20-minute stall actually was. Four mirrors, each
+given a 300s `apt-get update` timeout, each timing out at exactly 300.0s with no
+`Err:` or `Failed to fetch` line anywhere in the log. Canonical, kernel.org and
+Oregon State do not go dark in five-minute lockstep; four identical timeouts are
+the runner's side of the connection. A HEAD of each mirror's `InRelease` now
+runs ahead of it: an unreachable host is skipped in seconds, and every host
+unreachable fails the step immediately naming the runner's network as the
+diagnosis. A mirror that answers the probe and then fails the update is still a
+real mirror failure and still walks the fallback chain, so the two shapes stay
+distinguishable in the report.
+
+The step moved out of the workflow into `scripts/install_system_deps.py`, whose
+side effects all route through an injected runner — the command sequence is the
+whole behaviour, and it is now assertable without a runner, sudo, or a network.
+Both original failures are pinned by a test that fails if the cache is consulted
+and the mirror contacted anyway, or if a single `apt-get update` is issued when
+no mirror answered. The cache key carries the installer's hash and a week stamp,
+so the package set changing invalidates it and a stale set is renewed instead of
+pinned forever — the old hand-bumped `-v1` suffix did neither.
+
 ### fix(vault-ingress) — the equivalence ledger becomes its own collection (#333)
 
 The catalog repair was freed from the current-generation gate; the equivalence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ a cache path redirected nothing and the tests wrote `/tmp/apt-cache` on whatever
 machine ran them. The fake now refuses any path outside its sandbox, which turns
 that class of leak into a failing test rather than a directory left behind.
 
+The probe covers both hosts of a pair. Only Canonical's splits archive from
+security, and probing the archive alone let a pair with a dead security host
+through to the update that then burned its full timeout — the stall the probe
+exists to avoid. The suites differ with the host: security.ubuntu.com carries
+`<codename>-security` and does not serve the plain suite, so probing it for that
+would report a healthy host as unreachable and skip Canonical permanently.
+
 The step moved out of the workflow into `scripts/install_system_deps.py`, whose
 side effects all route through an injected runner — the command sequence is the
 whole behaviour, and it is now assertable without a runner, sudo, or a network.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,12 @@ serves only the current version of each — a superseded pin fails the install
 loudly rather than drifting quietly. The madison query that yields the current
 versions is recorded with them.
 
-The cache key binds to a digest of the pinned set rather than to the installer
-file. Hashing the file invalidated 185 MiB of archives whenever a comment or the
-fallback order changed, and the thing a cache entry actually depends on is which
-package versions it holds.
+The cache key binds to a digest of the pinned set plus a week stamp, rather than
+to the installer file. Hashing the file invalidated 185 MiB of archives whenever
+a comment or the fallback order changed, and the thing a cache entry actually
+depends on is which package versions it holds. The week stamp is what keeps a
+set nobody touches from being pinned forever: it is refetched on the next
+rotation instead of being served from a cache indefinitely.
 
 Moving the step out of shell nearly broke the fallback it exists for. The old
 form passed `/etc/apt/sources.list.d/*.list` to the mirror rewriter and the
@@ -82,9 +84,7 @@ side effects all route through an injected runner — the command sequence is th
 whole behaviour, and it is now assertable without a runner, sudo, or a network.
 Both original failures are pinned by a test that fails if the cache is consulted
 and the mirror contacted anyway, or if a single `apt-get update` is issued when
-no mirror answered. The cache key carries the installer's hash and a week stamp,
-so the package set changing invalidates it and a stale set is renewed instead of
-pinned forever — the old hand-bumped `-v1` suffix did neither.
+no mirror answered.
 
 ## 0.20.96 — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ serves only the current version of each — a superseded pin fails the install
 loudly rather than drifting quietly. The madison query that yields the current
 versions is recorded with them.
 
+The cache key binds to a digest of the pinned set rather than to the installer
+file. Hashing the file invalidated 185 MiB of archives whenever a comment or the
+fallback order changed, and the thing a cache entry actually depends on is which
+package versions it holds.
+
 The step moved out of the workflow into `scripts/install_system_deps.py`, whose
 side effects all route through an injected runner — the command sequence is the
 whole behaviour, and it is now assertable without a runner, sudo, or a network.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ diagnosis. A mirror that answers the probe and then fails the update is still a
 real mirror failure and still walks the fallback chain, so the two shapes stay
 distinguishable in the report.
 
+Every package now carries an exact version. `tesseract-ocr` was already pinned;
+`ffmpeg` and `libreoffice-impress` were not, so the tested toolchain could change
+between two runs of the same commit. No scanner tracks an apt version baked into
+a script, so the renewal mechanism is stated beside the pins: ffmpeg and
+tesseract sit in the static `noble` pocket, libreoffice-impress ships from
+`noble-updates` on Ubuntu's roughly monthly security cadence, and the archive
+serves only the current version of each — a superseded pin fails the install
+loudly rather than drifting quietly. The madison query that yields the current
+versions is recorded with them.
+
 The step moved out of the workflow into `scripts/install_system_deps.py`, whose
 side effects all route through an injected runner — the command sequence is the
 whole behaviour, and it is now assertable without a runner, sudo, or a network.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ file. Hashing the file invalidated 185 MiB of archives whenever a comment or the
 fallback order changed, and the thing a cache entry actually depends on is which
 package versions it holds.
 
+Moving the step out of shell nearly broke the fallback it exists for. The old
+form passed `/etc/apt/sources.list.d/*.list` to the mirror rewriter and the
+shell expanded it first; Python does not, so the rewriter received a path with
+an asterisk in it, found nothing there, and skipped it — silently, since a
+missing source file is a legitimate skip. Every retry would have repointed
+nothing and fetched from the mirror that had just failed. The caller enumerates
+the matching files now, and the tests run the real rewriter against real source
+files and read the mirror back out of them, because a fake that reports success
+for a rewrite that changed nothing is what let the bug pass in the first place.
+The deb822-only layout — what 24.04 actually ships, and where a missed rewrite
+leaves no other file to cover for it — has its own fallback test.
+
+`main` catches at the process boundary under the `error-handling` outer-boundary
+carve-out. The workflow step reads stdout as the report and a non-zero exit as
+"not installed", so an unreadable `/etc/os-release` or a subprocess that will not
+launch has to come back as that report rather than a traceback over empty
+stdout, which a parser reads as a malformed contract instead of a failed
+install. Interrupts still propagate.
+
 The step moved out of the workflow into `scripts/install_system_deps.py`, whose
 side effects all route through an injected runner — the command sequence is the
 whole behaviour, and it is now assertable without a runner, sudo, or a network.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ launch has to come back as that report rather than a traceback over empty
 stdout, which a parser reads as a malformed contract instead of a failed
 install. Interrupts still propagate.
 
+The cache locations are the caller's throughout. `configure_apt` and the apt
+config body read the module constants while accepting the arguments, so passing
+a cache path redirected nothing and the tests wrote `/tmp/apt-cache` on whatever
+machine ran them. The fake now refuses any path outside its sandbox, which turns
+that class of leak into a failing test rather than a directory left behind.
+
 The step moved out of the workflow into `scripts/install_system_deps.py`, whose
 side effects all route through an injected runner — the command sequence is the
 whole behaviour, and it is now assertable without a runner, sudo, or a network.

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -30,6 +30,7 @@ mirrors were skipped. Exit 0 on success, 1 when no path installed.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -141,10 +142,17 @@ def run_command(command: Sequence[str], timeout: int) -> int:
     the caller is walking.
     """
     # Diagnostics go to stderr: stdout carries one JSON object and nothing else,
-    # so a caller can parse it without stripping a command trace out first.
+    # so a caller can parse it without stripping anything out first. The child's
+    # own stdout is redirected there too — apt is chatty, it inherits this
+    # process's streams by default, and its progress would otherwise land in the
+    # middle of the report. Redirecting rather than capturing keeps the output
+    # live, which is the whole point of it during a 300s stall.
     print(f"+ {' '.join(command)}", file=sys.stderr, flush=True)
+    sys.stderr.flush()
     try:
-        return subprocess.run(command, timeout=timeout, check=False).returncode
+        return subprocess.run(
+            command, timeout=timeout, check=False, stdout=sys.stderr
+        ).returncode
     except subprocess.TimeoutExpired:
         print(f"timed out after {timeout}s: {' '.join(command)}", file=sys.stderr)
         return 124
@@ -399,17 +407,52 @@ def install(
     return {"installed": False, "source": None, "unreachable": unreachable}
 
 
-def main(argv: Sequence[str]) -> int:
+def package_digest() -> str:
+    """A short stable digest of the pinned package set.
+
+    The cache key binds to this rather than to the file, so renewing a pin
+    invalidates the cache and editing a comment or the fallback order does not
+    throw away 185 MiB of archives for nothing.
+    """
+    joined = "\n".join(PACKAGES).encode()
+    return hashlib.sha256(joined).hexdigest()[:16]
+
+
+def main(
+    argv: Sequence[str],
+    *,
+    runner: Runner = run_command,
+    os_release: Path = Path("/etc/os-release"),
+    staged_conf: Path = Path("/tmp/apt-99ci.conf"),
+) -> int:
+    """Run the install and emit its report.
+
+    The runner and the two paths read from the machine are keyword arguments so
+    the entry point's own contract — one JSON object on stdout, whatever
+    happened — is testable without an Ubuntu runner under it.
+    """
+    if len(argv) == 2 and argv[1] == "--package-digest":
+        print(package_digest())
+        return 0
     if len(argv) != 2:
-        print("usage: install_system_deps.py <workspace-root>", file=sys.stderr)
+        print(
+            "usage: install_system_deps.py <workspace-root> | --package-digest",
+            file=sys.stderr,
+        )
         return 2
-    workspace = Path(argv[1])
-    report = install(
-        run_command,
-        workspace=workspace,
-        codename=read_codename(Path("/etc/os-release")),
-        staged_conf=Path("/tmp/apt-99ci.conf"),
-    )
+    try:
+        report = install(
+            runner,
+            workspace=Path(argv[1]),
+            codename=read_codename(os_release),
+            staged_conf=staged_conf,
+        )
+    except SystemDepsError as error:
+        # Still one JSON object on stdout: a caller parsing the report should not
+        # have to tell "the install failed" from "the script died" by whether it
+        # got valid JSON.
+        print(error, file=sys.stderr)
+        report = {"installed": False, "source": None, "unreachable": []}
     print(json.dumps(report))
     return 0 if report["installed"] else 1
 

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Install the CI system dependencies without paying for the network twice.
+
+Two separate failures live here, and the fix for one is not the fix for the
+other.
+
+The first: the job already caches apt's downloaded `.deb` archives, and the
+cache hits — 185 MiB restored — but the step ran `apt-get update` ahead of every
+install, so each run still fetched the package indices from a mirror. The bytes
+were cached; the index was not, and the index fetch is what hung. Caching the
+indices beside the archives lets a cache hit install with `--no-download`,
+touching no mirror at all.
+
+The second: when the mirror path is taken and the runner cannot reach anything,
+four mirrors times a 300s `apt-get update` timeout burned 20 minutes before the
+job failed. Canonical, kernel.org and Oregon State do not go dark in lockstep,
+so four identical timeouts mean the runner's side of the connection, not four
+outages. A cheap HEAD of each mirror's InRelease separates the two: an
+unreachable mirror is skipped in seconds, and every mirror unreachable fails the
+step immediately naming that as the diagnosis rather than after 20 minutes of
+silence.
+
+Every side effect goes through an injected runner rather than direct filesystem
+calls, so the command sequence — which is the whole behaviour — is assertable
+without a runner, sudo, or a network.
+
+Stdout is one JSON object naming how the install was satisfied and which
+mirrors were skipped. Exit 0 on success, 1 when no path installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+# ffmpeg drives the video-slide-extraction tests; libreoffice-impress drives the
+# PPTX->PDF export tests; tesseract drives OCR of baked-in picture text in
+# pptx-extraction. Source-video evidence tests require ffmpeg/ffprobe and fail if
+# either is absent. OCR unit tests inject a fake engine; integration tests skipif
+# tesseract is missing.
+PACKAGES = ("ffmpeg", "libreoffice-impress", "tesseract-ocr=5.3.4-1build5")
+
+# Ordered fastest-first, then genuinely independent. The first two are
+# Canonical's own infrastructure and fail together when Canonical is degraded —
+# which is not a fallback at all, so the list continues onto mirrors run by other
+# organisations entirely.
+#
+# A third-party mirror cannot serve tampered packages: apt verifies each Release
+# against the ubuntu-archive-keyring signature, so integrity comes from the
+# signature, not from who hosts the bytes. Full Ubuntu mirrors carry the
+# `-security` suites too, so one host serves both pockets.
+MIRRORS = (
+    (
+        "http://azure.archive.ubuntu.com/ubuntu",
+        "http://azure.archive.ubuntu.com/ubuntu",
+    ),
+    ("http://archive.ubuntu.com/ubuntu", "http://security.ubuntu.com/ubuntu"),
+    (
+        "http://mirrors.edge.kernel.org/ubuntu",
+        "http://mirrors.edge.kernel.org/ubuntu",
+    ),
+    ("http://ubuntu.osuosl.org/ubuntu", "http://ubuntu.osuosl.org/ubuntu"),
+)
+
+ARCHIVE_CACHE = Path("/tmp/apt-cache")
+LIST_CACHE = Path("/tmp/apt-lists")
+APT_LISTS = Path("/var/lib/apt/lists")
+APT_SOURCES = Path("/etc/apt/sources.list")
+APT_SOURCES_D = Path("/etc/apt/sources.list.d")
+SOURCES_BACKUP = Path("/tmp/apt-src-orig")
+APT_CONF = Path("/etc/apt/apt.conf.d/99ci")
+
+# A HEAD of one index file, not a mirror sync — 20s is generous for a reachable
+# host and cheap for an unreachable one.
+PROBE_TIMEOUT_SEC = 20
+# apt has effectively no default connection cap, which is the original hang.
+UPDATE_TIMEOUT_SEC = 300
+INSTALL_TIMEOUT_SEC = 600
+
+# `APT::Keep-Downloaded-Packages` is what makes the archive cache exist at all:
+# apt has discarded downloaded .debs after a successful install since 1.6, so the
+# archive dir was empty when the post-step ran and no cache was ever written.
+APT_CONF_BODY = f"""Dir::Cache::Archives "{ARCHIVE_CACHE}";
+APT::Keep-Downloaded-Packages "true";
+Acquire::Retries "3";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+"""
+
+Runner = Callable[[Sequence[str], int], int]
+
+
+def run_command(command: Sequence[str], timeout: int) -> int:
+    """Run one command, mapping a timeout to a non-zero code rather than a raise.
+
+    A stall is the failure this whole script exists to bound, so it has to read
+    as an ordinary failed command — a raise here would abort the fallback chain
+    the caller is walking.
+    """
+    print(f"+ {' '.join(command)}", flush=True)
+    try:
+        return subprocess.run(command, timeout=timeout, check=False).returncode
+    except subprocess.TimeoutExpired:
+        print(f"timed out after {timeout}s: {' '.join(command)}", file=sys.stderr)
+        return 124
+
+
+def configure_apt(run: Runner, staged_conf: Path) -> None:
+    """Point apt's archive dir at the cached location and bound its timeouts.
+
+    The config is staged where the runner can write and copied in with sudo,
+    rather than piped through a root shell: the staged file is what the tests
+    read back, and a heredoc into `sudo tee` is not inspectable.
+    """
+    staged_conf.write_text(APT_CONF_BODY)
+    run(["sudo", "mkdir", "-p", f"{ARCHIVE_CACHE}/partial", str(LIST_CACHE)], 60)
+    run(["sudo", "chmod", "-R", "777", str(ARCHIVE_CACHE)], 60)
+    run(["sudo", "cp", str(staged_conf), str(APT_CONF)], 60)
+
+
+def cache_is_usable(archive_cache: Path, list_cache: Path) -> bool:
+    """Report whether the restored cache can satisfy an offline install.
+
+    Both halves are required and neither implies the other: archives without
+    indices cannot be resolved, and indices without archives resolve to a
+    download. A cache entry saved before this script existed holds only the
+    archives, so the pair is checked rather than the cache-hit flag.
+    """
+    if not any(archive_cache.glob("*.deb")):
+        return False
+    return any(list_cache.glob("*Packages*"))
+
+
+def restore_lists(run: Runner, list_cache: Path) -> None:
+    """Put the cached package indices where apt reads them."""
+    run(["sudo", "mkdir", "-p", str(APT_LISTS)], 60)
+    run(["sudo", "cp", "-a", f"{list_cache}/.", f"{APT_LISTS}/"], 120)
+
+
+def save_lists(run: Runner, list_cache: Path) -> None:
+    """Stage the indices and archives for the cache save, owned by the runner.
+
+    actions/cache tars as the runner user, and apt leaves behind a root-owned
+    `lock` and `partial/`. tar cannot read them, the save aborts, and it reports
+    a WARNING — so the step goes green having cached nothing, which is how the
+    empty archive cache stayed invisible for so long.
+    """
+    run(["sudo", "rm", "-rf", str(list_cache)], 60)
+    run(["sudo", "mkdir", "-p", str(list_cache)], 60)
+    run(["sudo", "cp", "-a", f"{APT_LISTS}/.", f"{list_cache}/"], 120)
+    run(["sudo", "rm", "-rf", f"{list_cache}/partial", f"{list_cache}/lock"], 60)
+    run(["sudo", "rm", "-rf", f"{ARCHIVE_CACHE}/partial", f"{ARCHIVE_CACHE}/lock"], 60)
+    run(["sudo", "chown", "-R", _owner(), str(list_cache), str(ARCHIVE_CACHE)], 120)
+
+
+def _owner() -> str:
+    return f"{os.getuid()}:{os.getgid()}"
+
+
+def install_offline(run: Runner) -> bool:
+    """Install strictly from the restored cache, contacting no mirror.
+
+    `--no-download` fails rather than reaching for a missing package, which is
+    the signal the caller falls through on: a runner image that gained or lost a
+    preinstalled library leaves the cached set unable to satisfy the request, and
+    that has to reach the mirror path instead of failing the job.
+    """
+    return (
+        run(
+            ["sudo", "-E", "apt-get", "install", "-y", "--no-download", *PACKAGES],
+            INSTALL_TIMEOUT_SEC,
+        )
+        == 0
+    )
+
+
+def probe(run: Runner, archive: str, codename: str) -> bool:
+    """Report whether a mirror answers for one index file, in seconds not minutes."""
+    url = f"{archive}/dists/{codename}/InRelease"
+    return (
+        run(
+            [
+                "curl",
+                "--silent",
+                "--show-error",
+                "--fail",
+                "--head",
+                "--max-time",
+                str(PROBE_TIMEOUT_SEC),
+                url,
+            ],
+            PROBE_TIMEOUT_SEC + 10,
+        )
+        == 0
+    )
+
+
+def backup_sources(run: Runner, sources: Path, sources_d: Path) -> None:
+    """Keep a pristine copy of the source lists.
+
+    Each mirror attempt restores it before rewriting, so no rewrite ever reads
+    already-rewritten state. A deb822-only runner image carries no
+    `sources.list` at all, so each half is copied only when it exists — an
+    unconditional copy would report a failure on a perfectly healthy runner.
+    """
+    run(["sudo", "rm", "-rf", str(SOURCES_BACKUP)], 60)
+    run(["sudo", "mkdir", "-p", str(SOURCES_BACKUP)], 60)
+    if sources.exists():
+        run(["sudo", "cp", "-a", str(sources), str(SOURCES_BACKUP)], 60)
+    if sources_d.exists():
+        run(["sudo", "cp", "-a", str(sources_d), str(SOURCES_BACKUP)], 60)
+
+
+def set_mirror(
+    run: Runner,
+    archive: str,
+    security: str,
+    workspace: Path,
+    sources: Path,
+    sources_d: Path,
+) -> None:
+    """Restore the pristine sources, then repoint them at one mirror pair.
+
+    The rewrite is suite-aware and lives in scripts/apt_set_mirror.py with its
+    own tests: a line-based rewrite cannot do it correctly, because Azure runners
+    serve BOTH pockets from one host and deb822 binds a `URIs:` to the `Suites:`
+    in its own stanza. It skips a path that does not exist, so both runner
+    layouts pass the same argument list.
+    """
+    if sources.exists():
+        run(["sudo", "cp", "-a", f"{SOURCES_BACKUP}/sources.list", str(sources)], 60)
+    if sources_d.exists():
+        run(["sudo", "rm", "-rf", str(sources_d)], 60)
+        run(
+            ["sudo", "cp", "-a", f"{SOURCES_BACKUP}/sources.list.d", str(sources_d)],
+            60,
+        )
+    run(
+        [
+            "sudo",
+            "python3",
+            str(workspace / "scripts" / "apt_set_mirror.py"),
+            archive,
+            security,
+            str(sources),
+            f"{sources_d}/*.list",
+            f"{sources_d}/*.sources",
+        ],
+        120,
+    )
+
+
+def install_from_mirror(
+    run: Runner,
+    archive: str,
+    security: str,
+    workspace: Path,
+    sources: Path,
+    sources_d: Path,
+) -> bool:
+    """Update the index from one mirror and install against it."""
+    set_mirror(run, archive, security, workspace, sources, sources_d)
+    if run(["sudo", "-E", "apt-get", "update"], UPDATE_TIMEOUT_SEC) != 0:
+        return False
+    return (
+        run(["sudo", "-E", "apt-get", "install", "-y", *PACKAGES], INSTALL_TIMEOUT_SEC)
+        == 0
+    )
+
+
+def read_codename(os_release: Path) -> str:
+    """Read the Ubuntu suite name the probe URL needs."""
+    for line in os_release.read_text().splitlines():
+        key, _, value = line.partition("=")
+        if key == "VERSION_CODENAME":
+            return value.strip().strip('"')
+    raise ValueError(
+        f"{os_release} names no VERSION_CODENAME; the runner image is not the "
+        "Ubuntu one this step expects — pin the suite explicitly to proceed"
+    )
+
+
+def install(
+    run: Runner,
+    *,
+    workspace: Path,
+    codename: str,
+    staged_conf: Path,
+    archive_cache: Path = ARCHIVE_CACHE,
+    list_cache: Path = LIST_CACHE,
+    sources: Path = APT_SOURCES,
+    sources_d: Path = APT_SOURCES_D,
+) -> dict[str, object]:
+    """Satisfy the dependencies from cache if possible, else from a mirror."""
+    configure_apt(run, staged_conf)
+
+    if cache_is_usable(archive_cache, list_cache):
+        restore_lists(run, list_cache)
+        if install_offline(run):
+            return {"installed": True, "source": "cache", "unreachable": []}
+        print(
+            "cached archives did not satisfy the install; falling back to a mirror",
+            file=sys.stderr,
+        )
+
+    backup_sources(run, sources, sources_d)
+    unreachable: list[str] = []
+    for archive, security in MIRRORS:
+        if not probe(run, archive, codename):
+            unreachable.append(archive)
+            print(
+                f"{archive} did not answer a HEAD of its index; skipping",
+                file=sys.stderr,
+            )
+            continue
+        if install_from_mirror(run, archive, security, workspace, sources, sources_d):
+            save_lists(run, list_cache)
+            return {"installed": True, "source": archive, "unreachable": unreachable}
+        print(
+            f"apt failed against {archive} / {security}; trying the next mirror",
+            file=sys.stderr,
+        )
+
+    if len(unreachable) == len(MIRRORS):
+        print(
+            "no configured Ubuntu mirror answered — Canonical, kernel.org and "
+            "OSU OSL do not fail together, so this is the runner's network, not "
+            "the archives; re-run the job",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "every reachable Ubuntu mirror failed the install; re-run the job",
+            file=sys.stderr,
+        )
+    return {"installed": False, "source": None, "unreachable": unreachable}
+
+
+def main(argv: Sequence[str]) -> int:
+    if len(argv) != 2:
+        print("usage: install_system_deps.py <workspace-root>", file=sys.stderr)
+        return 2
+    workspace = Path(argv[1])
+    report = install(
+        run_command,
+        workspace=workspace,
+        codename=read_codename(Path("/etc/os-release")),
+        staged_conf=Path("/tmp/apt-99ci.conf"),
+    )
+    print(json.dumps(report))
+    return 0 if report["installed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -250,9 +250,9 @@ def install_offline(run: Runner) -> bool:
     )
 
 
-def probe(run: Runner, archive: str, codename: str) -> bool:
-    """Report whether a mirror answers for one index file, in seconds not minutes."""
-    url = f"{archive}/dists/{codename}/InRelease"
+def probe(run: Runner, host: str, suite: str) -> bool:
+    """Report whether a host answers for one index file, in seconds not minutes."""
+    url = f"{host}/dists/{suite}/InRelease"
     return (
         run(
             [
@@ -402,11 +402,25 @@ def install(
 
     backup_sources(run, sources, sources_d)
     unreachable: list[str] = []
+    skipped = 0
     for archive, security in MIRRORS:
-        if not probe(run, archive, codename):
-            unreachable.append(archive)
+        # Both hosts of the pair, because apt fetches both and a pair whose
+        # security host is dead still burns the full update timeout. Only the
+        # Canonical pair has a distinct one; the others serve both pockets from
+        # one host and are probed once. The suites differ with the host —
+        # security.ubuntu.com carries `<codename>-security` and does not serve
+        # the plain suite, so probing it for that would report a healthy host as
+        # unreachable.
+        hosts = [(archive, codename)]
+        if security != archive:
+            hosts.append((security, f"{codename}-security"))
+        unresponsive = [host for host, suite in hosts if not probe(run, host, suite)]
+        if unresponsive:
+            unreachable.extend(unresponsive)
+            skipped += 1
             print(
-                f"{archive} did not answer a HEAD of its index; skipping",
+                f"{', '.join(unresponsive)} did not answer a HEAD of the index; "
+                "skipping this mirror",
                 file=sys.stderr,
             )
             continue
@@ -418,7 +432,7 @@ def install(
             file=sys.stderr,
         )
 
-    if len(unreachable) == len(MIRRORS):
+    if skipped == len(MIRRORS):
         print(
             "no configured Ubuntu mirror answered — Canonical, kernel.org and "
             "OSU OSL do not fail together, so this is the runner's network, not "

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -305,6 +305,23 @@ def set_mirror(
             ["sudo", "cp", "-a", f"{SOURCES_BACKUP}/sources.list.d", str(sources_d)],
             60,
         )
+    # Enumerated here rather than passed as `*.list` / `*.sources`. The shell
+    # this replaced expanded those globs before apt_set_mirror.py ever saw them;
+    # a literal glob reaches it as a path that does not exist, which it skips —
+    # so every fallback rewrote nothing, silently, and each retry hit the same
+    # mirror that had just failed.
+    targets = [str(sources)] if sources.exists() else []
+    targets += [
+        str(path)
+        for pattern in ("*.list", "*.sources")
+        for path in sorted(sources_d.glob(pattern))
+    ]
+    if not targets:
+        raise SystemDepsError(
+            f"no apt source files found at {sources} or under {sources_d}; the "
+            "runner image is not the Ubuntu one this step expects and no mirror "
+            "fallback can work — re-run the job on a supported image"
+        )
     require(
         run,
         [
@@ -313,9 +330,7 @@ def set_mirror(
             str(workspace / "scripts" / "apt_set_mirror.py"),
             archive,
             security,
-            str(sources),
-            f"{sources_d}/*.list",
-            f"{sources_d}/*.sources",
+            *targets,
         ],
         120,
     )
@@ -447,10 +462,15 @@ def main(
             codename=read_codename(os_release),
             staged_conf=staged_conf,
         )
-    except SystemDepsError as error:
-        # Still one JSON object on stdout: a caller parsing the report should not
-        # have to tell "the install failed" from "the script died" by whether it
-        # got valid JSON.
+    # outer-boundary-process-contract: the workflow step reads stdout as the
+    # report and a non-zero exit as "the dependencies are not installed", so an
+    # unreadable /etc/os-release, an unwritable staged config or a subprocess
+    # that will not launch must come back as that report — not as a traceback
+    # with empty stdout, which reads to a parser as a malformed contract rather
+    # than a failed install. Emits the failure report and the exception text on
+    # stderr. KeyboardInterrupt and SystemExit are not caught, so the step stays
+    # killable.
+    except Exception as error:  # noqa: BLE001
         print(error, file=sys.stderr)
         report = {"installed": False, "source": None, "unreachable": []}
     print(json.dumps(report))

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -99,15 +99,20 @@ PROBE_TIMEOUT_SEC = 20
 UPDATE_TIMEOUT_SEC = 300
 INSTALL_TIMEOUT_SEC = 600
 
+
 # `APT::Keep-Downloaded-Packages` is what makes the archive cache exist at all:
 # apt has discarded downloaded .debs after a successful install since 1.6, so the
 # archive dir was empty when the post-step ran and no cache was ever written.
-APT_CONF_BODY = f"""Dir::Cache::Archives "{ARCHIVE_CACHE}";
-APT::Keep-Downloaded-Packages "true";
-Acquire::Retries "3";
-Acquire::http::Timeout "30";
-Acquire::https::Timeout "30";
-"""
+def apt_conf_body(archive_cache: Path) -> str:
+    """apt's config, pointed at the archive dir the caller actually passed."""
+    return (
+        f'Dir::Cache::Archives "{archive_cache}";\n'
+        'APT::Keep-Downloaded-Packages "true";\n'
+        'Acquire::Retries "3";\n'
+        'Acquire::http::Timeout "30";\n'
+        'Acquire::https::Timeout "30";\n'
+    )
+
 
 Runner = Callable[[Sequence[str], int], int]
 
@@ -158,18 +163,24 @@ def run_command(command: Sequence[str], timeout: int) -> int:
         return 124
 
 
-def configure_apt(run: Runner, staged_conf: Path) -> None:
+def configure_apt(
+    run: Runner, staged_conf: Path, archive_cache: Path, list_cache: Path
+) -> None:
     """Point apt's archive dir at the cached location and bound its timeouts.
 
     The config is staged where the runner can write and copied in with sudo,
     rather than piped through a root shell: the staged file is what the tests
     read back, and a heredoc into `sudo tee` is not inspectable.
+
+    Every path here is the caller's, not the module constant. Taking the
+    constant while accepting the argument made the parameter a lie — the caller
+    redirected nothing and the write landed on the real machine anyway.
     """
-    staged_conf.write_text(APT_CONF_BODY)
+    staged_conf.write_text(apt_conf_body(archive_cache))
     require(
-        run, ["sudo", "mkdir", "-p", f"{ARCHIVE_CACHE}/partial", str(LIST_CACHE)], 60
+        run, ["sudo", "mkdir", "-p", f"{archive_cache}/partial", str(list_cache)], 60
     )
-    require(run, ["sudo", "chmod", "-R", "777", str(ARCHIVE_CACHE)], 60)
+    require(run, ["sudo", "chmod", "-R", "777", str(archive_cache)], 60)
     require(run, ["sudo", "cp", str(staged_conf), str(APT_CONF)], 60)
 
 
@@ -378,7 +389,7 @@ def install(
     sources_d: Path = APT_SOURCES_D,
 ) -> dict[str, object]:
     """Satisfy the dependencies from cache if possible, else from a mirror."""
-    configure_apt(run, staged_conf)
+    configure_apt(run, staged_conf, archive_cache, list_cache)
 
     if cache_is_usable(archive_cache, list_cache):
         restore_lists(run, list_cache)

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -42,7 +42,24 @@ from pathlib import Path
 # pptx-extraction. Source-video evidence tests require ffmpeg/ffprobe and fail if
 # either is absent. OCR unit tests inject a fake engine; integration tests skipif
 # tesseract is missing.
-PACKAGES = ("ffmpeg", "libreoffice-impress", "tesseract-ocr=5.3.4-1build5")
+#
+# Pinned exactly, per `dependency-management` Pinning. No scanner tracks an apt
+# version baked into a script, so the renewal mechanism is stated here rather
+# than delegated: ffmpeg and tesseract sit in the static `noble` pocket and move
+# only at a release rebuild, while libreoffice-impress ships from
+# `noble-updates` and is superseded on Ubuntu's security cadence — roughly
+# monthly. Ubuntu's archive serves only the current version of each, so a
+# superseded pin fails the install loudly rather than silently drifting. Renew by
+# reading the current versions and bumping the literals here:
+#
+#   https://people.canonical.com/~ubuntu-archive/madison.cgi
+#     ?package=ffmpeg+libreoffice-impress+tesseract-ocr
+#     &table=ubuntu&s=noble,noble-updates,noble-security&a=amd64&text=on
+PACKAGES = (
+    "ffmpeg=7:6.1.1-3ubuntu5",
+    "libreoffice-impress=4:24.2.7-0ubuntu0.24.04.6",
+    "tesseract-ocr=5.3.4-1build5",
+)
 
 # Ordered fastest-first, then genuinely independent. The first two are
 # Canonical's own infrastructure and fail together when Canonical is degraded —
@@ -94,6 +111,28 @@ Acquire::https::Timeout "30";
 Runner = Callable[[Sequence[str], int], int]
 
 
+class SystemDepsError(RuntimeError):
+    """A command with no recovery path failed."""
+
+
+def require(run: Runner, command: Sequence[str], timeout: int) -> None:
+    """Run a command whose failure leaves nothing sensible to continue into.
+
+    A failed mkdir, copy or mirror rewrite is not a fallback signal — the apt
+    call after it can still succeed against whatever state was already there and
+    report the step green, which is how a cache that saved nothing looked
+    identical to one that worked. Only the probe, the update and the install
+    carry a recoverable failure, and those read their own status.
+    """
+    code = run(command, timeout)
+    if code != 0:
+        raise SystemDepsError(
+            f"{' '.join(command)} exited {code}; the runner is not in the state "
+            "the install needs — re-run the job, and if it repeats, inspect the "
+            "step log for the failing command above this line"
+        )
+
+
 def run_command(command: Sequence[str], timeout: int) -> int:
     """Run one command, mapping a timeout to a non-zero code rather than a raise.
 
@@ -101,7 +140,9 @@ def run_command(command: Sequence[str], timeout: int) -> int:
     as an ordinary failed command — a raise here would abort the fallback chain
     the caller is walking.
     """
-    print(f"+ {' '.join(command)}", flush=True)
+    # Diagnostics go to stderr: stdout carries one JSON object and nothing else,
+    # so a caller can parse it without stripping a command trace out first.
+    print(f"+ {' '.join(command)}", file=sys.stderr, flush=True)
     try:
         return subprocess.run(command, timeout=timeout, check=False).returncode
     except subprocess.TimeoutExpired:
@@ -117,9 +158,11 @@ def configure_apt(run: Runner, staged_conf: Path) -> None:
     read back, and a heredoc into `sudo tee` is not inspectable.
     """
     staged_conf.write_text(APT_CONF_BODY)
-    run(["sudo", "mkdir", "-p", f"{ARCHIVE_CACHE}/partial", str(LIST_CACHE)], 60)
-    run(["sudo", "chmod", "-R", "777", str(ARCHIVE_CACHE)], 60)
-    run(["sudo", "cp", str(staged_conf), str(APT_CONF)], 60)
+    require(
+        run, ["sudo", "mkdir", "-p", f"{ARCHIVE_CACHE}/partial", str(LIST_CACHE)], 60
+    )
+    require(run, ["sudo", "chmod", "-R", "777", str(ARCHIVE_CACHE)], 60)
+    require(run, ["sudo", "cp", str(staged_conf), str(APT_CONF)], 60)
 
 
 def cache_is_usable(archive_cache: Path, list_cache: Path) -> bool:
@@ -137,11 +180,11 @@ def cache_is_usable(archive_cache: Path, list_cache: Path) -> bool:
 
 def restore_lists(run: Runner, list_cache: Path) -> None:
     """Put the cached package indices where apt reads them."""
-    run(["sudo", "mkdir", "-p", str(APT_LISTS)], 60)
-    run(["sudo", "cp", "-a", f"{list_cache}/.", f"{APT_LISTS}/"], 120)
+    require(run, ["sudo", "mkdir", "-p", str(APT_LISTS)], 60)
+    require(run, ["sudo", "cp", "-a", f"{list_cache}/.", f"{APT_LISTS}/"], 120)
 
 
-def save_lists(run: Runner, list_cache: Path) -> None:
+def save_lists(run: Runner, list_cache: Path, archive_cache: Path) -> None:
     """Stage the indices and archives for the cache save, owned by the runner.
 
     actions/cache tars as the runner user, and apt leaves behind a root-owned
@@ -149,12 +192,22 @@ def save_lists(run: Runner, list_cache: Path) -> None:
     a WARNING — so the step goes green having cached nothing, which is how the
     empty archive cache stayed invisible for so long.
     """
-    run(["sudo", "rm", "-rf", str(list_cache)], 60)
-    run(["sudo", "mkdir", "-p", str(list_cache)], 60)
-    run(["sudo", "cp", "-a", f"{APT_LISTS}/.", f"{list_cache}/"], 120)
-    run(["sudo", "rm", "-rf", f"{list_cache}/partial", f"{list_cache}/lock"], 60)
-    run(["sudo", "rm", "-rf", f"{ARCHIVE_CACHE}/partial", f"{ARCHIVE_CACHE}/lock"], 60)
-    run(["sudo", "chown", "-R", _owner(), str(list_cache), str(ARCHIVE_CACHE)], 120)
+    require(run, ["sudo", "rm", "-rf", str(list_cache)], 60)
+    require(run, ["sudo", "mkdir", "-p", str(list_cache)], 60)
+    require(run, ["sudo", "cp", "-a", f"{APT_LISTS}/.", f"{list_cache}/"], 120)
+    require(
+        run, ["sudo", "rm", "-rf", f"{list_cache}/partial", f"{list_cache}/lock"], 60
+    )
+    require(
+        run,
+        ["sudo", "rm", "-rf", f"{archive_cache}/partial", f"{archive_cache}/lock"],
+        60,
+    )
+    require(
+        run,
+        ["sudo", "chown", "-R", _owner(), str(list_cache), str(archive_cache)],
+        120,
+    )
 
 
 def _owner() -> str:
@@ -207,12 +260,12 @@ def backup_sources(run: Runner, sources: Path, sources_d: Path) -> None:
     `sources.list` at all, so each half is copied only when it exists — an
     unconditional copy would report a failure on a perfectly healthy runner.
     """
-    run(["sudo", "rm", "-rf", str(SOURCES_BACKUP)], 60)
-    run(["sudo", "mkdir", "-p", str(SOURCES_BACKUP)], 60)
+    require(run, ["sudo", "rm", "-rf", str(SOURCES_BACKUP)], 60)
+    require(run, ["sudo", "mkdir", "-p", str(SOURCES_BACKUP)], 60)
     if sources.exists():
-        run(["sudo", "cp", "-a", str(sources), str(SOURCES_BACKUP)], 60)
+        require(run, ["sudo", "cp", "-a", str(sources), str(SOURCES_BACKUP)], 60)
     if sources_d.exists():
-        run(["sudo", "cp", "-a", str(sources_d), str(SOURCES_BACKUP)], 60)
+        require(run, ["sudo", "cp", "-a", str(sources_d), str(SOURCES_BACKUP)], 60)
 
 
 def set_mirror(
@@ -232,14 +285,20 @@ def set_mirror(
     layouts pass the same argument list.
     """
     if sources.exists():
-        run(["sudo", "cp", "-a", f"{SOURCES_BACKUP}/sources.list", str(sources)], 60)
+        require(
+            run,
+            ["sudo", "cp", "-a", f"{SOURCES_BACKUP}/sources.list", str(sources)],
+            60,
+        )
     if sources_d.exists():
-        run(["sudo", "rm", "-rf", str(sources_d)], 60)
-        run(
+        require(run, ["sudo", "rm", "-rf", str(sources_d)], 60)
+        require(
+            run,
             ["sudo", "cp", "-a", f"{SOURCES_BACKUP}/sources.list.d", str(sources_d)],
             60,
         )
-    run(
+    require(
+        run,
         [
             "sudo",
             "python3",
@@ -318,7 +377,7 @@ def install(
             )
             continue
         if install_from_mirror(run, archive, security, workspace, sources, sources_d):
-            save_lists(run, list_cache)
+            save_lists(run, list_cache, archive_cache)
             return {"installed": True, "source": archive, "unreachable": unreachable}
         print(
             f"apt failed against {archive} / {security}; trying the next mirror",

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -20,9 +20,11 @@ unreachable mirror is skipped in seconds, and every mirror unreachable fails the
 step immediately naming that as the diagnosis rather than after 20 minutes of
 silence.
 
-Every side effect goes through an injected runner rather than direct filesystem
-calls, so the command sequence — which is the whole behaviour — is assertable
-without a runner, sudo, or a network.
+Every command goes through an injected runner, so the sequence that does the
+work is assertable without a runner, sudo, or a network. Reads of the machine's
+own state — whether a source file exists, what the cache holds, the release
+codename — and the staging write are direct, since they inspect rather than
+change the system.
 
 Stdout is one JSON object naming how the install was satisfied and which
 mirrors were skipped. Exit 0 on success, 1 when no path installed.

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -60,6 +60,7 @@ class FakeSystem:
         root: Path,
         *,
         archive_cache: Path,
+        sandbox: Path,
         sources: Path,
         sources_d: Path,
         reachable: Sequence[str] = ALL_ARCHIVES,
@@ -76,6 +77,7 @@ class FakeSystem:
         self.installed: list[str] = []
         self.probes: list[str] = []
         self.fetches: list[str] = []
+        self.sandbox = sandbox
         self.sources = sources
         self.sources_d = sources_d
         self.owners: dict[str, str] = {}
@@ -84,11 +86,24 @@ class FakeSystem:
     # --- filesystem ---------------------------------------------------------
 
     def local(self, path: str) -> Path:
+        """Resolve a command's path argument, refusing anything off the sandbox.
+
+        The refusal is the assertion: the installer takes its cache locations as
+        arguments, and a place that reads the module constant instead would
+        quietly write to the real `/tmp` on whatever machine ran the suite. That
+        happened, so it fails here now rather than leaving a directory behind.
+        """
         bare = path[:-2] if path.endswith("/.") else path.rstrip("/")
         for system_root in SYSTEM_ROOTS:
             if bare == system_root or bare.startswith(f"{system_root}/"):
                 return self.root / bare.lstrip("/")
-        return Path(bare)
+        resolved = Path(bare)
+        if not resolved.is_relative_to(self.sandbox):
+            raise AssertionError(
+                f"{bare} is outside the test sandbox: the installer reached for a "
+                "module constant where it was handed a path"
+            )
+        return resolved
 
     def owner_of(self, path: Path) -> str:
         return self.owners.get(str(path), "root")
@@ -230,8 +245,13 @@ def build(tmp_path: Path, **kwargs: object) -> tuple[FakeSystem, dict[str, Path]
     system = FakeSystem(
         root,
         archive_cache=paths["archive_cache"],
+        sandbox=tmp_path,
         sources=paths["sources"],
         sources_d=paths["sources_d"],
+        # The per-case knobs (reachable, update_fails, offline_satisfies,
+        # failing) are heterogeneous, so **kwargs is typed `object` and pyright
+        # cannot match each one to its parameter. The call is checked by the
+        # tests that pass them.
         **kwargs,  # type: ignore[arg-type]
     )
     return system, paths
@@ -396,7 +416,7 @@ def test_apt_is_configured_to_keep_its_downloads_where_the_cache_looks(
     run_install(system, paths)
 
     landed = system.local("/etc/apt/apt.conf.d/99ci").read_text()
-    assert 'Dir::Cache::Archives "/tmp/apt-cache";' in landed
+    assert f'Dir::Cache::Archives "{paths["archive_cache"]}";' in landed
     assert 'APT::Keep-Downloaded-Packages "true";' in landed
 
 

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -35,6 +35,18 @@ SPEC.loader.exec_module(install_system_deps)
 AZURE = "http://azure.archive.ubuntu.com/ubuntu"
 CANONICAL = "http://archive.ubuntu.com/ubuntu"
 ALL_ARCHIVES = tuple(m[0] for m in install_system_deps.MIRRORS)
+SECURITY = "http://security.ubuntu.com/ubuntu"
+KERNEL = "http://mirrors.edge.kernel.org/ubuntu"
+OSUOSL = "http://ubuntu.osuosl.org/ubuntu"
+# Every host apt is pointed at, archive and security alike. Only the Canonical
+# pair splits them; the rest serve both pockets from one host.
+ALL_HOSTS = (AZURE, CANONICAL, SECURITY, KERNEL, OSUOSL)
+
+
+def without(*dead: str) -> tuple[str, ...]:
+    return tuple(h for h in ALL_HOSTS if h not in dead)
+
+
 CODENAME = "noble"
 INDEX_NAME = "archive.ubuntu.com_ubuntu_dists_noble_main_binary-amd64_Packages"
 
@@ -63,7 +75,7 @@ class FakeSystem:
         sandbox: Path,
         sources: Path,
         sources_d: Path,
-        reachable: Sequence[str] = ALL_ARCHIVES,
+        reachable: Sequence[str] = ALL_HOSTS,
         update_fails: Sequence[str] = (),
         offline_satisfies: bool = True,
         failing: str | None = None,
@@ -347,15 +359,15 @@ def test_nothing_reachable_fails_without_ever_attempting_a_fetch(tmp_path: Path)
     report = run_install(system, paths)
 
     assert report["installed"] is False
-    assert report["unreachable"] == list(ALL_ARCHIVES)
+    assert report["unreachable"] == list(ALL_HOSTS)
     assert system.fetches == []
     assert system.installed == []
-    assert len(system.probes) == len(ALL_ARCHIVES)
+    assert len(system.probes) == len(ALL_HOSTS)
 
 
 def test_one_unreachable_archive_does_not_stop_the_install(tmp_path: Path):
     """One degraded archive is the case the mirror list was built for."""
-    system, paths = build(tmp_path, reachable=ALL_ARCHIVES[1:])
+    system, paths = build(tmp_path, reachable=without(AZURE))
 
     report = run_install(system, paths)
 
@@ -440,7 +452,7 @@ def test_the_fallback_repoints_a_deb822_only_runner(tmp_path: Path):
     mirror — if the rewrite misses it, every retry fetches from the host that
     just failed and the fallback is decorative.
     """
-    system, paths = build(tmp_path, reachable=ALL_ARCHIVES[1:])
+    system, paths = build(tmp_path, reachable=without(AZURE))
 
     report = run_install(system, paths, legacy_sources_list=False)
 
@@ -592,3 +604,38 @@ def test_the_cache_key_digest_tracks_the_pins_and_nothing_else(
     renewed = (*install_system_deps.PACKAGES[:-1], "tesseract-ocr=5.3.5-1")
     monkeypatch.setattr(install_system_deps, "PACKAGES", renewed)
     assert install_system_deps.package_digest() != printed
+
+
+def test_a_pair_whose_security_host_is_dead_is_skipped_before_the_timeout(
+    tmp_path: Path,
+):
+    """apt fetches the security pocket too, from a host of its own on one pair.
+
+    Probing only the archive lets a pair with a dead security host through to
+    `apt-get update`, which is the 300s stall the probe exists to avoid.
+    """
+    # Azure is dead too, or it would serve first and the Canonical pair would
+    # never be reached.
+    system, paths = build(tmp_path, reachable=without(AZURE, SECURITY))
+
+    report = run_install(system, paths)
+
+    assert report["source"] == KERNEL
+    assert report["unreachable"] == [AZURE, SECURITY]
+    assert CANONICAL not in system.fetches
+
+
+def test_the_security_host_is_probed_for_the_suite_it_actually_serves(
+    tmp_path: Path,
+):
+    """security.ubuntu.com carries `<codename>-security` and not the plain suite.
+
+    Probing it for `noble` would 404 and report a healthy host as unreachable,
+    permanently skipping Canonical's pair.
+    """
+    system, paths = build(tmp_path, reachable=())
+
+    run_install(system, paths)
+
+    assert f"{SECURITY}/dists/{CODENAME}-security/InRelease" in system.probes
+    assert f"{CANONICAL}/dists/{CODENAME}/InRelease" in system.probes

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -4,15 +4,20 @@ Both failures this script exists for are invisible from inside a green run. A
 cache that restores but is never consulted looks exactly like a cache that
 works, and a runner that cannot reach any mirror looks exactly like four
 archives being slow — the first cost every run a mirror round-trip, the second
-cost twenty minutes before the job failed. What separates them is the command
-sequence, so that is what these pin: which commands are issued, and which are
-never issued at all.
+cost twenty minutes before the job failed.
+
+So the fake below runs the commands rather than recording them: it copies the
+files, tracks who owns them, and answers apt and curl the way a runner would.
+The assertions are what came out — which packages ended up installed, which
+requests left the machine, what the cache holds afterwards and who can read it —
+not which commands were issued to get there.
 """
 
 from __future__ import annotations
 
 import importlib.util
-from collections.abc import Callable, Sequence
+import shutil
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -26,210 +31,306 @@ SPEC.loader.exec_module(install_system_deps)
 
 AZURE = "http://azure.archive.ubuntu.com/ubuntu"
 CANONICAL = "http://archive.ubuntu.com/ubuntu"
+ALL_ARCHIVES = tuple(m[0] for m in install_system_deps.MIRRORS)
 CODENAME = "noble"
+INDEX_NAME = "archive.ubuntu.com_ubuntu_dists_noble_main_binary-amd64_Packages"
+
+# Absolute paths the script hardcodes. Anything else — the caches and sources a
+# test injects — is a real pytest temp path and passes through untouched.
+SYSTEM_ROOTS = (
+    str(install_system_deps.APT_LISTS),
+    str(install_system_deps.SOURCES_BACKUP),
+    "/etc/apt",
+)
 
 
-class FakeRunner:
-    """Record every command and answer from a caller-supplied verdict."""
+class FakeSystem:
+    """A runner that carries the commands out against a sandboxed filesystem.
 
-    def __init__(self, verdict: Callable[[Sequence[str]], int]) -> None:
-        self.commands: list[list[str]] = []
-        self._verdict = verdict
+    Only the paths the script hardcodes are redirected under `root`; an injected
+    cache or sources path is already a temp path and is used as given, so the
+    script's own `exists()` and `glob()` see what the commands did.
+    """
 
-    def __call__(self, command: Sequence[str], _timeout: int) -> int:
-        self.commands.append(list(command))
-        return self._verdict(command)
+    def __init__(
+        self,
+        root: Path,
+        *,
+        archive_cache: Path,
+        reachable: Sequence[str] = ALL_ARCHIVES,
+        update_fails: Sequence[str] = (),
+        offline_satisfies: bool = True,
+        failing: str | None = None,
+    ) -> None:
+        self.root = root
+        self.archive_cache = archive_cache
+        self.reachable = tuple(reachable)
+        self.update_fails = tuple(update_fails)
+        self.offline_satisfies = offline_satisfies
+        self.failing = failing
+        self.installed: list[str] = []
+        self.probes: list[str] = []
+        self.fetches: list[str] = []
+        self.owners: dict[str, str] = {}
+        self.mirror: str | None = None
 
-    def issued(self, *fragments: str) -> list[list[str]]:
-        """Commands containing every fragment, matched against the whole line.
+    # --- filesystem ---------------------------------------------------------
 
-        Membership on the argument list would miss a fragment that is part of an
-        argument rather than all of it — a script path carries its directory, so
-        an exact-element match silently answers "never issued" for a command that
-        ran on every attempt.
-        """
-        return [c for c in self.commands if all(f in " ".join(c) for f in fragments)]
+    def local(self, path: str) -> Path:
+        bare = path[:-2] if path.endswith("/.") else path.rstrip("/")
+        for system_root in SYSTEM_ROOTS:
+            if bare == system_root or bare.startswith(f"{system_root}/"):
+                return self.root / bare.lstrip("/")
+        return Path(bare)
+
+    def owner_of(self, path: Path) -> str:
+        return self.owners.get(str(path), "root")
+
+    def _copy(self, source: str, target: str) -> None:
+        src, dst = self.local(source), self.local(target)
+        if source.endswith("/."):
+            dst.mkdir(parents=True, exist_ok=True)
+            if src.is_dir():
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            return
+        if src.is_dir():
+            shutil.copytree(src, dst / src.name, dirs_exist_ok=True)
+            return
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst / src.name if dst.is_dir() else dst)
+
+    # --- commands -----------------------------------------------------------
+
+    def __call__(self, command: Sequence[str], timeout: int) -> int:
+        del timeout
+        if self.failing is not None and self.failing in " ".join(command):
+            return 1
+        args = [a for a in command if a not in ("sudo", "-E")]
+        program = Path(args[0]).name
+        if program == "mkdir":
+            for path in args[2:]:
+                self.local(path).mkdir(parents=True, exist_ok=True)
+            return 0
+        if program == "chmod":
+            return 0
+        if program == "chown":
+            for path in args[3:]:
+                self.owners[str(self.local(path))] = args[2]
+            return 0
+        if program == "rm":
+            for path in args[2:]:
+                target = self.local(path)
+                if target.is_dir():
+                    shutil.rmtree(target)
+                elif target.exists():
+                    target.unlink()
+            return 0
+        if program == "cp":
+            self._copy(args[-2], args[-1])
+            return 0
+        if program == "curl":
+            return self._probe(args[-1])
+        if program == "apt-get":
+            return self._apt(args[1:])
+        if program == "python3":
+            self.mirror = args[2]
+            return 0
+        raise AssertionError(f"unmodelled command: {' '.join(command)}")
+
+    def _probe(self, url: str) -> int:
+        self.probes.append(url)
+        return 0 if any(url.startswith(a) for a in self.reachable) else 7
+
+    def _apt(self, args: Sequence[str]) -> int:
+        if args[0] == "update":
+            self.fetches.append(str(self.mirror))
+            if self.mirror in self.update_fails:
+                return 1
+            return 0 if self.mirror in self.reachable else 1
+        packages = [a for a in args[1:] if not a.startswith("-")]
+        if "--no-download" in args:
+            indices = self.local(str(install_system_deps.APT_LISTS))
+            has_indices = indices.is_dir() and any(indices.glob("*Packages*"))
+            if not (self.offline_satisfies and has_indices):
+                return 100
+            if not any(self.archive_cache.glob("*.deb")):
+                return 100
+            self.installed = packages
+            return 0
+        self.fetches.append(str(self.mirror))
+        if self.mirror not in self.reachable:
+            return 1
+        self.installed = packages
+        return 0
 
 
-def all_succeed(command: Sequence[str]) -> int:
-    del command
-    return 0
+def build(tmp_path: Path, **kwargs: object) -> tuple[FakeSystem, dict[str, Path]]:
+    """Lay out a runner: apt's own index dir populated, caches empty."""
+    root = tmp_path / "system"
+    lists = root / str(install_system_deps.APT_LISTS).lstrip("/")
+    lists.mkdir(parents=True)
+    (lists / INDEX_NAME).write_text("Package: ffmpeg\n")
+    paths = {
+        "archive_cache": tmp_path / "apt-cache",
+        "list_cache": tmp_path / "apt-lists",
+        "sources": tmp_path / "sources.list",
+        "sources_d": tmp_path / "sources.list.d",
+        "staged_conf": tmp_path / "99ci",
+        "root": root,
+    }
+    paths["sources_d"].mkdir()
+    (paths["sources_d"] / "ubuntu.sources").write_text("Types: deb\n")
+    system = FakeSystem(root, archive_cache=paths["archive_cache"], **kwargs)  # type: ignore[arg-type]
+    return system, paths
 
 
-def seed_cache(archive_cache: Path, list_cache: Path, *, lists: bool) -> None:
-    archive_cache.mkdir(parents=True, exist_ok=True)
-    (archive_cache / "ffmpeg_7.0_amd64.deb").write_text("deb")
-    list_cache.mkdir(parents=True, exist_ok=True)
-    if lists:
-        (list_cache / "archive.ubuntu.com_ubuntu_dists_noble_main_Packages").write_text(
-            "Package: ffmpeg\n"
-        )
+def seed_cache(paths: dict[str, Path], *, indices: bool) -> None:
+    """Restore a cache entry the way actions/cache would have."""
+    paths["archive_cache"].mkdir(parents=True, exist_ok=True)
+    (paths["archive_cache"] / "ffmpeg_6.1.1_amd64.deb").write_text("deb")
+    paths["list_cache"].mkdir(parents=True, exist_ok=True)
+    if indices:
+        (paths["list_cache"] / INDEX_NAME).write_text("Package: ffmpeg\n")
 
 
 def run_install(
-    runner: FakeRunner, tmp_path: Path, *, legacy_sources_list: bool = True
+    system: FakeSystem, paths: dict[str, Path], *, legacy_sources_list: bool = True
 ) -> dict[str, object]:
-    """Drive the installer against a fabricated runner layout.
-
-    The source paths are passed explicitly rather than defaulted: the defaults
-    are real system paths, so a test that let them through would assert one thing
-    on a deb822 Linux runner and another on a developer's macOS checkout.
-    """
-    sources = tmp_path / "sources.list"
-    sources_d = tmp_path / "sources.list.d"
-    sources_d.mkdir(exist_ok=True)
-    (sources_d / "ubuntu.sources").write_text("Types: deb\n")
     if legacy_sources_list:
-        sources.write_text("deb http://archive.ubuntu.com/ubuntu noble main\n")
+        paths["sources"].write_text("deb http://archive.ubuntu.com/ubuntu noble main\n")
     return install_system_deps.install(
-        runner,
-        workspace=tmp_path / "workspace",
+        system,
+        workspace=paths["root"] / "workspace",
         codename=CODENAME,
-        staged_conf=tmp_path / "99ci",
-        archive_cache=tmp_path / "apt-cache",
-        list_cache=tmp_path / "apt-lists",
-        sources=sources,
-        sources_d=sources_d,
+        staged_conf=paths["staged_conf"],
+        archive_cache=paths["archive_cache"],
+        list_cache=paths["list_cache"],
+        sources=paths["sources"],
+        sources_d=paths["sources_d"],
     )
 
 
-def test_a_usable_cache_installs_without_contacting_any_mirror(tmp_path: Path):
+def test_a_usable_cache_installs_with_nothing_leaving_the_machine(tmp_path: Path):
     """The first failure: the cache hit, and the step fetched the index anyway.
 
     185 MiB of archives restored and `apt-get update` still ran, so every run
-    paid a mirror round-trip for an index it could have cached. A cache hit must
-    issue no probe, no update, and no mirror rewrite.
+    paid a mirror round-trip for an index it could have cached. The outcome that
+    matters is not which commands were skipped — it is that no request left the
+    runner and the packages are installed regardless.
     """
-    seed_cache(tmp_path / "apt-cache", tmp_path / "apt-lists", lists=True)
-    runner = FakeRunner(all_succeed)
+    system, paths = build(tmp_path)
+    seed_cache(paths, indices=True)
 
-    report = run_install(runner, tmp_path)
+    report = run_install(system, paths)
 
     assert report == {"installed": True, "source": "cache", "unreachable": []}
-    assert runner.issued("apt-get", "update") == []
-    assert runner.issued("curl") == []
-    assert runner.issued("apt_set_mirror.py") == []
-    assert runner.issued("apt-get", "--no-download")
+    assert system.installed == list(install_system_deps.PACKAGES)
+    assert system.probes == []
+    assert system.fetches == []
 
 
-def test_archives_without_indices_are_not_treated_as_a_usable_cache(tmp_path: Path):
+def test_archives_without_indices_cannot_satisfy_an_offline_install(tmp_path: Path):
     """A cache entry written before the indices were cached holds only archives.
 
     Offline resolution needs both halves, and the cache-hit flag cannot tell
-    which shape was restored — so the pair is what gets checked.
+    which shape was restored.
     """
-    seed_cache(tmp_path / "apt-cache", tmp_path / "apt-lists", lists=False)
-    runner = FakeRunner(all_succeed)
+    system, paths = build(tmp_path)
+    seed_cache(paths, indices=False)
 
-    report = run_install(runner, tmp_path)
+    report = run_install(system, paths)
 
     assert report["source"] == AZURE
-    assert runner.issued("apt-get", "--no-download") == []
-    assert runner.issued("apt-get", "update")
+    assert system.installed == list(install_system_deps.PACKAGES)
+    assert set(system.fetches) == {AZURE}
 
 
-def test_a_cache_that_cannot_satisfy_the_install_falls_back_to_a_mirror(
+def test_a_cache_that_cannot_satisfy_the_install_still_ends_up_installed(
     tmp_path: Path,
 ):
     """A runner image that changed leaves the cached set short a dependency.
 
-    `--no-download` fails rather than reaching for it, and that failure has to
-    reach the mirror path instead of failing the job.
+    The offline attempt fails rather than reaching for it, and the job must
+    still end with the packages present.
     """
-    seed_cache(tmp_path / "apt-cache", tmp_path / "apt-lists", lists=True)
-    runner = FakeRunner(lambda command: 100 if "--no-download" in command else 0)
+    system, paths = build(tmp_path, offline_satisfies=False)
+    seed_cache(paths, indices=True)
 
-    report = run_install(runner, tmp_path)
+    report = run_install(system, paths)
 
     assert report["installed"] is True
-    assert report["source"] == AZURE
-    assert runner.issued("apt-get", "update")
+    assert system.installed == list(install_system_deps.PACKAGES)
 
 
-def test_every_mirror_unreachable_fails_without_waiting_out_four_timeouts(
-    tmp_path: Path,
-):
+def test_nothing_reachable_fails_without_ever_attempting_a_fetch(tmp_path: Path):
     """The second failure: 4 mirrors x a 300s update timeout, 20 minutes wasted.
 
     Canonical, kernel.org and OSU OSL do not go dark together, so an unanswered
-    probe everywhere is the runner's network. Not one `apt-get update` may be
-    issued — issuing one is what bought the 20 minutes.
+    probe everywhere is the runner's network. Not one fetch may be attempted —
+    attempting them is what bought the 20 minutes.
     """
-    runner = FakeRunner(lambda command: 7 if "curl" in command else 0)
+    system, paths = build(tmp_path, reachable=())
 
-    report = run_install(runner, tmp_path)
+    report = run_install(system, paths)
 
     assert report["installed"] is False
-    assert report["unreachable"] == [m[0] for m in install_system_deps.MIRRORS]
-    assert runner.issued("apt-get", "update") == []
-    assert len(runner.issued("curl")) == len(install_system_deps.MIRRORS)
+    assert report["unreachable"] == list(ALL_ARCHIVES)
+    assert system.fetches == []
+    assert system.installed == []
+    assert len(system.probes) == len(ALL_ARCHIVES)
 
 
-def test_an_unreachable_mirror_is_skipped_and_the_next_one_serves(tmp_path: Path):
-    """One degraded archive is the case the mirror list was built for.
+def test_one_unreachable_archive_does_not_stop_the_install(tmp_path: Path):
+    """One degraded archive is the case the mirror list was built for."""
+    system, paths = build(tmp_path, reachable=ALL_ARCHIVES[1:])
 
-    It is skipped on the probe rather than on a 300s stall, and the next host
-    installs.
-    """
+    report = run_install(system, paths)
 
-    def verdict(command: Sequence[str]) -> int:
-        if "curl" in command:
-            return 7 if any(AZURE in arg for arg in command) else 0
-        return 0
-
-    runner = FakeRunner(verdict)
-
-    report = run_install(runner, tmp_path)
-
-    assert report["installed"] is True
     assert report["source"] == CANONICAL
     assert report["unreachable"] == [AZURE]
+    assert system.installed == list(install_system_deps.PACKAGES)
+    # Skipped on the probe, so no fetch was ever aimed at it.
+    assert AZURE not in system.fetches
 
 
-def test_a_reachable_mirror_whose_update_fails_moves_to_the_next(tmp_path: Path):
+def test_a_mirror_that_answers_and_then_fails_still_hands_off(tmp_path: Path):
     """Answering a HEAD is not the same as serving a full index.
 
-    A mirror that probes clean and then fails the update is a real failure the
-    probe cannot pre-empt, so the fallback chain still has to walk on.
+    A real mirror failure the probe cannot pre-empt still has to walk the
+    fallback chain, and it stays out of the unreachable list so the two failure
+    shapes remain distinguishable.
     """
-    seen: list[str] = []
+    system, paths = build(tmp_path, update_fails=(AZURE,))
 
-    def verdict(command: Sequence[str]) -> int:
-        if any(arg.endswith("apt_set_mirror.py") for arg in command):
-            seen.append(command[3])
-        if "update" in command and seen and seen[-1] == AZURE:
-            return 1
-        return 0
+    report = run_install(system, paths)
 
-    runner = FakeRunner(verdict)
-
-    report = run_install(runner, tmp_path)
-
-    assert report["installed"] is True
     assert report["source"] == CANONICAL
-    # Probed clean, so it is absent from the unreachable list — the two failure
-    # shapes stay distinguishable in the report.
     assert report["unreachable"] == []
+    assert system.installed == list(install_system_deps.PACKAGES)
 
 
-def test_a_successful_mirror_install_stages_both_halves_for_the_cache(
-    tmp_path: Path,
-):
+def test_after_a_mirror_install_the_cache_holds_a_usable_pair(tmp_path: Path):
     """Nothing seeds the offline path except the save after a mirror install.
 
-    The indices are copied out of apt's directory and both halves are handed to
-    the runner user, or actions/cache tars nothing and the step goes green having
-    cached exactly what it started with.
+    The next run's `cache_is_usable` is the real consumer, so that is the
+    assertion: the saved state is a pair it accepts, owned by the user
+    actions/cache tars as.
     """
-    runner = FakeRunner(all_succeed)
+    system, paths = build(tmp_path)
+    paths["archive_cache"].mkdir(parents=True)
+    (paths["archive_cache"] / "ffmpeg_6.1.1_amd64.deb").write_text("deb")
 
-    run_install(runner, tmp_path)
+    run_install(system, paths)
 
-    assert runner.issued("cp", "-a", "/var/lib/apt/lists/.")
-    assert runner.issued("chown", "-R")
+    assert install_system_deps.cache_is_usable(
+        paths["archive_cache"], paths["list_cache"]
+    )
+    runner = install_system_deps._owner()
+    assert system.owner_of(paths["list_cache"]) == runner
+    assert system.owner_of(paths["archive_cache"]) == runner
 
 
-def test_the_apt_config_points_the_archive_dir_at_the_cached_location(
+def test_apt_is_configured_to_keep_its_downloads_where_the_cache_looks(
     tmp_path: Path,
 ):
     """`Keep-Downloaded-Packages` is what makes the archive cache exist at all.
@@ -237,28 +338,85 @@ def test_the_apt_config_points_the_archive_dir_at_the_cached_location(
     apt discards downloaded .debs after a successful install, so without it the
     archive dir is empty when the cache save runs.
     """
-    runner = FakeRunner(all_succeed)
+    system, paths = build(tmp_path)
 
-    run_install(runner, tmp_path)
+    run_install(system, paths)
 
-    staged = (tmp_path / "99ci").read_text()
-    assert 'Dir::Cache::Archives "/tmp/apt-cache";' in staged
-    assert 'APT::Keep-Downloaded-Packages "true";' in staged
+    landed = system.local("/etc/apt/apt.conf.d/99ci").read_text()
+    assert 'Dir::Cache::Archives "/tmp/apt-cache";' in landed
+    assert 'APT::Keep-Downloaded-Packages "true";' in landed
 
 
-def test_the_probe_asks_each_mirror_for_an_index_file_it_must_serve(tmp_path: Path):
+def test_the_probe_requests_an_index_file_every_mirror_must_serve(tmp_path: Path):
     """A directory listing is optional on a mirror; InRelease is not.
 
-    Probing something a healthy mirror may legitimately 404 would report a
+    Requesting something a healthy mirror may legitimately 404 would report a
     working host as unreachable.
     """
-    runner = FakeRunner(lambda command: 7 if "curl" in command else 0)
+    system, paths = build(tmp_path, reachable=())
 
-    run_install(runner, tmp_path)
+    run_install(system, paths)
 
-    probed = runner.issued("curl")[0]
-    assert f"{AZURE}/dists/{CODENAME}/InRelease" in probed
-    assert "--head" in probed
+    assert system.probes[0] == f"{AZURE}/dists/{CODENAME}/InRelease"
+
+
+def test_a_deb822_only_runner_installs_like_any_other(tmp_path: Path):
+    """Ubuntu 24.04 images ship `ubuntu.sources` and no `sources.list`.
+
+    Copying the absent file fails on every healthy deb822 runner, and a required
+    command's failure now stops the run — so this layout has to be recognised
+    rather than attempted.
+    """
+    system, paths = build(tmp_path)
+
+    report = run_install(system, paths, legacy_sources_list=False)
+
+    assert report["installed"] is True
+    backup = system.local(str(install_system_deps.SOURCES_BACKUP))
+    assert not (backup / "sources.list").exists()
+    assert (backup / "sources.list.d").is_dir()
+
+
+def test_a_runner_carrying_both_layouts_preserves_each(tmp_path: Path):
+    """A legacy `sources.list` beside a deb822 directory is still a live layout.
+
+    Dropping either half silently loses a repository from the retry.
+    """
+    system, paths = build(tmp_path)
+
+    run_install(system, paths, legacy_sources_list=True)
+
+    backup = system.local(str(install_system_deps.SOURCES_BACKUP))
+    assert (backup / "sources.list").is_file()
+    assert (backup / "sources.list.d" / "ubuntu.sources").is_file()
+
+
+def test_a_failed_setup_command_stops_the_run_instead_of_reporting_success(
+    tmp_path: Path,
+):
+    """A failed copy leaves apt reading whatever was already there.
+
+    The install that follows can still succeed and the step still go green — the
+    exact shape that hid an empty cache for months — so a command with no
+    recovery path has to end the run.
+    """
+    system, paths = build(tmp_path, failing="cp -a")
+
+    with pytest.raises(install_system_deps.SystemDepsError, match="re-run the job"):
+        run_install(system, paths)
+
+    assert system.installed == []
+
+
+def test_every_package_carries_an_exact_version(tmp_path: Path):
+    """An unpinned apt package resolves to whatever the archive serves that day.
+
+    The pin is the reproducibility, and a bare name silently changes the tested
+    toolchain between two runs of the same commit.
+    """
+    del tmp_path
+    for package in install_system_deps.PACKAGES:
+        assert "=" in package, package
 
 
 def test_the_codename_comes_from_the_runner_image(tmp_path: Path):
@@ -276,37 +434,6 @@ def test_a_missing_codename_says_what_to_do_about_it(tmp_path: Path):
 
     with pytest.raises(ValueError, match="pin the suite explicitly"):
         install_system_deps.read_codename(os_release)
-
-
-def test_a_deb822_only_runner_is_not_asked_to_copy_a_sources_list_it_lacks(
-    tmp_path: Path,
-):
-    """Ubuntu 24.04 images ship `ubuntu.sources` and no `sources.list`.
-
-    Copying the absent file would fail on every healthy deb822 runner, and a
-    failure nobody reads is how a real one gets missed.
-    """
-    runner = FakeRunner(all_succeed)
-
-    report = run_install(runner, tmp_path, legacy_sources_list=False)
-
-    assert report["installed"] is True
-    assert runner.issued("cp", "sources.list ") == []
-    assert runner.issued("apt_set_mirror.py")
-
-
-def test_a_runner_carrying_both_layouts_backs_up_and_restores_each(tmp_path: Path):
-    """A legacy `sources.list` beside a deb822 directory is still a live layout.
-
-    Both halves are preserved, because the rewrite reads whichever the image
-    actually uses and a dropped one silently loses a repository.
-    """
-    runner = FakeRunner(all_succeed)
-
-    run_install(runner, tmp_path, legacy_sources_list=True)
-
-    assert runner.issued("cp", "-a", "sources.list", "apt-src-orig")
-    assert runner.issued("cp", "-a", "sources.list.d", "apt-src-orig")
 
 
 def test_the_entry_point_refuses_a_call_without_a_workspace_root():

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -16,6 +16,7 @@ not which commands were issued to get there.
 from __future__ import annotations
 
 import importlib.util
+import json
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
@@ -443,3 +444,63 @@ def test_the_entry_point_refuses_a_call_without_a_workspace_root():
     read as a mirror failure four times over.
     """
     assert install_system_deps.main(["install_system_deps.py"]) == 2
+
+
+def test_the_real_runner_keeps_child_output_off_stdout(
+    capfd: pytest.CaptureFixture[str],
+):
+    """apt is chatty and inherits this process's streams by default.
+
+    Its progress landing between the report's braces breaks every caller that
+    parses stdout, and the script promises exactly one JSON object there.
+    """
+    code = install_system_deps.run_command(["printf", "Reading package lists"], 30)
+
+    captured = capfd.readouterr()
+    assert code == 0
+    assert captured.out == ""
+    assert "Reading package lists" in captured.err
+
+
+def test_a_failed_setup_command_still_leaves_one_json_object_on_stdout(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+):
+    """A caller should not tell a failed install from a dead script by whether
+    it got parseable JSON back."""
+    system, paths = build(tmp_path, failing="mkdir")
+    os_release = tmp_path / "os-release"
+    os_release.write_text("VERSION_CODENAME=noble\n")
+
+    code = install_system_deps.main(
+        ["install_system_deps.py", str(paths["root"])],
+        runner=system,
+        os_release=os_release,
+        staged_conf=paths["staged_conf"],
+    )
+
+    captured = capfd.readouterr()
+    assert code == 1
+    assert json.loads(captured.out) == {
+        "installed": False,
+        "source": None,
+        "unreachable": [],
+    }
+
+
+def test_the_cache_key_digest_tracks_the_pins_and_nothing_else(
+    capfd: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The key must invalidate on a renewed pin and survive an edited comment.
+
+    Hashing the file did the first and not the second, throwing away 185 MiB of
+    archives every time the fallback order or a docstring changed.
+    """
+    assert install_system_deps.main(["prog", "--package-digest"]) == 0
+    printed = capfd.readouterr().out.strip()
+
+    assert printed == install_system_deps.package_digest()
+
+    renewed = (*install_system_deps.PACKAGES[:-1], "tesseract-ocr=5.3.5-1")
+    monkeypatch.setattr(install_system_deps, "PACKAGES", renewed)
+    assert install_system_deps.package_digest() != printed

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -1,0 +1,318 @@
+"""Tests for the CI system-dependency installer.
+
+Both failures this script exists for are invisible from inside a green run. A
+cache that restores but is never consulted looks exactly like a cache that
+works, and a runner that cannot reach any mirror looks exactly like four
+archives being slow — the first cost every run a mirror round-trip, the second
+cost twenty minutes before the job failed. What separates them is the command
+sequence, so that is what these pin: which commands are issued, and which are
+never issued at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "install_system_deps.py"
+SPEC = importlib.util.spec_from_file_location("install_system_deps", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+install_system_deps = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(install_system_deps)
+
+AZURE = "http://azure.archive.ubuntu.com/ubuntu"
+CANONICAL = "http://archive.ubuntu.com/ubuntu"
+CODENAME = "noble"
+
+
+class FakeRunner:
+    """Record every command and answer from a caller-supplied verdict."""
+
+    def __init__(self, verdict: Callable[[Sequence[str]], int]) -> None:
+        self.commands: list[list[str]] = []
+        self._verdict = verdict
+
+    def __call__(self, command: Sequence[str], _timeout: int) -> int:
+        self.commands.append(list(command))
+        return self._verdict(command)
+
+    def issued(self, *fragments: str) -> list[list[str]]:
+        """Commands containing every fragment, matched against the whole line.
+
+        Membership on the argument list would miss a fragment that is part of an
+        argument rather than all of it — a script path carries its directory, so
+        an exact-element match silently answers "never issued" for a command that
+        ran on every attempt.
+        """
+        return [c for c in self.commands if all(f in " ".join(c) for f in fragments)]
+
+
+def all_succeed(command: Sequence[str]) -> int:
+    del command
+    return 0
+
+
+def seed_cache(archive_cache: Path, list_cache: Path, *, lists: bool) -> None:
+    archive_cache.mkdir(parents=True, exist_ok=True)
+    (archive_cache / "ffmpeg_7.0_amd64.deb").write_text("deb")
+    list_cache.mkdir(parents=True, exist_ok=True)
+    if lists:
+        (list_cache / "archive.ubuntu.com_ubuntu_dists_noble_main_Packages").write_text(
+            "Package: ffmpeg\n"
+        )
+
+
+def run_install(
+    runner: FakeRunner, tmp_path: Path, *, legacy_sources_list: bool = True
+) -> dict[str, object]:
+    """Drive the installer against a fabricated runner layout.
+
+    The source paths are passed explicitly rather than defaulted: the defaults
+    are real system paths, so a test that let them through would assert one thing
+    on a deb822 Linux runner and another on a developer's macOS checkout.
+    """
+    sources = tmp_path / "sources.list"
+    sources_d = tmp_path / "sources.list.d"
+    sources_d.mkdir(exist_ok=True)
+    (sources_d / "ubuntu.sources").write_text("Types: deb\n")
+    if legacy_sources_list:
+        sources.write_text("deb http://archive.ubuntu.com/ubuntu noble main\n")
+    return install_system_deps.install(
+        runner,
+        workspace=tmp_path / "workspace",
+        codename=CODENAME,
+        staged_conf=tmp_path / "99ci",
+        archive_cache=tmp_path / "apt-cache",
+        list_cache=tmp_path / "apt-lists",
+        sources=sources,
+        sources_d=sources_d,
+    )
+
+
+def test_a_usable_cache_installs_without_contacting_any_mirror(tmp_path: Path):
+    """The first failure: the cache hit, and the step fetched the index anyway.
+
+    185 MiB of archives restored and `apt-get update` still ran, so every run
+    paid a mirror round-trip for an index it could have cached. A cache hit must
+    issue no probe, no update, and no mirror rewrite.
+    """
+    seed_cache(tmp_path / "apt-cache", tmp_path / "apt-lists", lists=True)
+    runner = FakeRunner(all_succeed)
+
+    report = run_install(runner, tmp_path)
+
+    assert report == {"installed": True, "source": "cache", "unreachable": []}
+    assert runner.issued("apt-get", "update") == []
+    assert runner.issued("curl") == []
+    assert runner.issued("apt_set_mirror.py") == []
+    assert runner.issued("apt-get", "--no-download")
+
+
+def test_archives_without_indices_are_not_treated_as_a_usable_cache(tmp_path: Path):
+    """A cache entry written before the indices were cached holds only archives.
+
+    Offline resolution needs both halves, and the cache-hit flag cannot tell
+    which shape was restored — so the pair is what gets checked.
+    """
+    seed_cache(tmp_path / "apt-cache", tmp_path / "apt-lists", lists=False)
+    runner = FakeRunner(all_succeed)
+
+    report = run_install(runner, tmp_path)
+
+    assert report["source"] == AZURE
+    assert runner.issued("apt-get", "--no-download") == []
+    assert runner.issued("apt-get", "update")
+
+
+def test_a_cache_that_cannot_satisfy_the_install_falls_back_to_a_mirror(
+    tmp_path: Path,
+):
+    """A runner image that changed leaves the cached set short a dependency.
+
+    `--no-download` fails rather than reaching for it, and that failure has to
+    reach the mirror path instead of failing the job.
+    """
+    seed_cache(tmp_path / "apt-cache", tmp_path / "apt-lists", lists=True)
+    runner = FakeRunner(lambda command: 100 if "--no-download" in command else 0)
+
+    report = run_install(runner, tmp_path)
+
+    assert report["installed"] is True
+    assert report["source"] == AZURE
+    assert runner.issued("apt-get", "update")
+
+
+def test_every_mirror_unreachable_fails_without_waiting_out_four_timeouts(
+    tmp_path: Path,
+):
+    """The second failure: 4 mirrors x a 300s update timeout, 20 minutes wasted.
+
+    Canonical, kernel.org and OSU OSL do not go dark together, so an unanswered
+    probe everywhere is the runner's network. Not one `apt-get update` may be
+    issued — issuing one is what bought the 20 minutes.
+    """
+    runner = FakeRunner(lambda command: 7 if "curl" in command else 0)
+
+    report = run_install(runner, tmp_path)
+
+    assert report["installed"] is False
+    assert report["unreachable"] == [m[0] for m in install_system_deps.MIRRORS]
+    assert runner.issued("apt-get", "update") == []
+    assert len(runner.issued("curl")) == len(install_system_deps.MIRRORS)
+
+
+def test_an_unreachable_mirror_is_skipped_and_the_next_one_serves(tmp_path: Path):
+    """One degraded archive is the case the mirror list was built for.
+
+    It is skipped on the probe rather than on a 300s stall, and the next host
+    installs.
+    """
+
+    def verdict(command: Sequence[str]) -> int:
+        if "curl" in command:
+            return 7 if any(AZURE in arg for arg in command) else 0
+        return 0
+
+    runner = FakeRunner(verdict)
+
+    report = run_install(runner, tmp_path)
+
+    assert report["installed"] is True
+    assert report["source"] == CANONICAL
+    assert report["unreachable"] == [AZURE]
+
+
+def test_a_reachable_mirror_whose_update_fails_moves_to_the_next(tmp_path: Path):
+    """Answering a HEAD is not the same as serving a full index.
+
+    A mirror that probes clean and then fails the update is a real failure the
+    probe cannot pre-empt, so the fallback chain still has to walk on.
+    """
+    seen: list[str] = []
+
+    def verdict(command: Sequence[str]) -> int:
+        if any(arg.endswith("apt_set_mirror.py") for arg in command):
+            seen.append(command[3])
+        if "update" in command and seen and seen[-1] == AZURE:
+            return 1
+        return 0
+
+    runner = FakeRunner(verdict)
+
+    report = run_install(runner, tmp_path)
+
+    assert report["installed"] is True
+    assert report["source"] == CANONICAL
+    # Probed clean, so it is absent from the unreachable list — the two failure
+    # shapes stay distinguishable in the report.
+    assert report["unreachable"] == []
+
+
+def test_a_successful_mirror_install_stages_both_halves_for_the_cache(
+    tmp_path: Path,
+):
+    """Nothing seeds the offline path except the save after a mirror install.
+
+    The indices are copied out of apt's directory and both halves are handed to
+    the runner user, or actions/cache tars nothing and the step goes green having
+    cached exactly what it started with.
+    """
+    runner = FakeRunner(all_succeed)
+
+    run_install(runner, tmp_path)
+
+    assert runner.issued("cp", "-a", "/var/lib/apt/lists/.")
+    assert runner.issued("chown", "-R")
+
+
+def test_the_apt_config_points_the_archive_dir_at_the_cached_location(
+    tmp_path: Path,
+):
+    """`Keep-Downloaded-Packages` is what makes the archive cache exist at all.
+
+    apt discards downloaded .debs after a successful install, so without it the
+    archive dir is empty when the cache save runs.
+    """
+    runner = FakeRunner(all_succeed)
+
+    run_install(runner, tmp_path)
+
+    staged = (tmp_path / "99ci").read_text()
+    assert 'Dir::Cache::Archives "/tmp/apt-cache";' in staged
+    assert 'APT::Keep-Downloaded-Packages "true";' in staged
+
+
+def test_the_probe_asks_each_mirror_for_an_index_file_it_must_serve(tmp_path: Path):
+    """A directory listing is optional on a mirror; InRelease is not.
+
+    Probing something a healthy mirror may legitimately 404 would report a
+    working host as unreachable.
+    """
+    runner = FakeRunner(lambda command: 7 if "curl" in command else 0)
+
+    run_install(runner, tmp_path)
+
+    probed = runner.issued("curl")[0]
+    assert f"{AZURE}/dists/{CODENAME}/InRelease" in probed
+    assert "--head" in probed
+
+
+def test_the_codename_comes_from_the_runner_image(tmp_path: Path):
+    os_release = tmp_path / "os-release"
+    os_release.write_text('NAME="Ubuntu"\nVERSION_CODENAME=noble\nID=ubuntu\n')
+
+    assert install_system_deps.read_codename(os_release) == CODENAME
+
+
+def test_a_missing_codename_says_what_to_do_about_it(tmp_path: Path):
+    """The probe URL cannot be guessed, and a wrong suite reports every mirror
+    unreachable — a silent failure worth an actionable message."""
+    os_release = tmp_path / "os-release"
+    os_release.write_text('NAME="Something Else"\nID=other\n')
+
+    with pytest.raises(ValueError, match="pin the suite explicitly"):
+        install_system_deps.read_codename(os_release)
+
+
+def test_a_deb822_only_runner_is_not_asked_to_copy_a_sources_list_it_lacks(
+    tmp_path: Path,
+):
+    """Ubuntu 24.04 images ship `ubuntu.sources` and no `sources.list`.
+
+    Copying the absent file would fail on every healthy deb822 runner, and a
+    failure nobody reads is how a real one gets missed.
+    """
+    runner = FakeRunner(all_succeed)
+
+    report = run_install(runner, tmp_path, legacy_sources_list=False)
+
+    assert report["installed"] is True
+    assert runner.issued("cp", "sources.list ") == []
+    assert runner.issued("apt_set_mirror.py")
+
+
+def test_a_runner_carrying_both_layouts_backs_up_and_restores_each(tmp_path: Path):
+    """A legacy `sources.list` beside a deb822 directory is still a live layout.
+
+    Both halves are preserved, because the rewrite reads whichever the image
+    actually uses and a dropped one silently loses a repository.
+    """
+    runner = FakeRunner(all_succeed)
+
+    run_install(runner, tmp_path, legacy_sources_list=True)
+
+    assert runner.issued("cp", "-a", "sources.list", "apt-src-orig")
+    assert runner.issued("cp", "-a", "sources.list.d", "apt-src-orig")
+
+
+def test_the_entry_point_refuses_a_call_without_a_workspace_root():
+    """The workspace is where the mirror rewriter is found.
+
+    Defaulting it would send `sudo python3` at a path that does not exist and
+    read as a mirror failure four times over.
+    """
+    assert install_system_deps.main(["install_system_deps.py"]) == 2

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import importlib.util
 import json
 import shutil
+import subprocess
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -58,6 +60,8 @@ class FakeSystem:
         root: Path,
         *,
         archive_cache: Path,
+        sources: Path,
+        sources_d: Path,
         reachable: Sequence[str] = ALL_ARCHIVES,
         update_fails: Sequence[str] = (),
         offline_satisfies: bool = True,
@@ -72,8 +76,10 @@ class FakeSystem:
         self.installed: list[str] = []
         self.probes: list[str] = []
         self.fetches: list[str] = []
+        self.sources = sources
+        self.sources_d = sources_d
         self.owners: dict[str, str] = {}
-        self.mirror: str | None = None
+        self.mirrors: set[str] = set()
 
     # --- filesystem ---------------------------------------------------------
 
@@ -95,7 +101,10 @@ class FakeSystem:
                 shutil.copytree(src, dst, dirs_exist_ok=True)
             return
         if src.is_dir():
-            shutil.copytree(src, dst / src.name, dirs_exist_ok=True)
+            # `cp -a A B`: B missing means B becomes the copy; B existing as a
+            # directory means the copy lands inside it.
+            landing = dst / src.name if dst.is_dir() else dst
+            shutil.copytree(src, landing, dirs_exist_ok=True)
             return
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst / src.name if dst.is_dir() else dst)
@@ -134,20 +143,52 @@ class FakeSystem:
         if program == "apt-get":
             return self._apt(args[1:])
         if program == "python3":
-            self.mirror = args[2]
+            # The real rewriter, against the real files. Trusting the argument is
+            # what let a rewrite that changed nothing look like a working
+            # fallback — every retry then hit the mirror that had just failed.
+            subprocess.run([sys.executable, *args[1:]], check=True, capture_output=True)
+            self.mirrors = self._archives_in_sources()
             return 0
         raise AssertionError(f"unmodelled command: {' '.join(command)}")
+
+    def _source_files(self) -> list[Path]:
+        present = [self.sources] if self.sources.exists() else []
+        return present + sorted(self.sources_d.glob("*"))
+
+    def _archives_in_sources(self) -> set[str]:
+        """Every archive host apt would fetch from, read off the source files.
+
+        A set, not one host: `apt-get update` fetches all of them and fails if
+        any fails. A rewrite that moved one file and missed another leaves the
+        dead mirror in the list, which is exactly the shape a single-host model
+        cannot see.
+        """
+        hosts: set[str] = set()
+        for path in self._source_files():
+            for line in path.read_text().splitlines():
+                if line.lower().startswith("uris:"):
+                    uri = line.split(":", 1)[1].strip().rstrip("/")
+                    if not uri.endswith("security.ubuntu.com/ubuntu"):
+                        hosts.add(uri)
+                elif line.startswith("deb "):
+                    hosts.add(line.split()[1].rstrip("/"))
+        return hosts
 
     def _probe(self, url: str) -> int:
         self.probes.append(url)
         return 0 if any(url.startswith(a) for a in self.reachable) else 7
 
+    def _reachable_everywhere(self) -> bool:
+        if not self.mirrors:
+            return False
+        if any(m in self.update_fails for m in self.mirrors):
+            return False
+        return all(m in self.reachable for m in self.mirrors)
+
     def _apt(self, args: Sequence[str]) -> int:
         if args[0] == "update":
-            self.fetches.append(str(self.mirror))
-            if self.mirror in self.update_fails:
-                return 1
-            return 0 if self.mirror in self.reachable else 1
+            self.fetches.extend(sorted(self.mirrors))
+            return 0 if self._reachable_everywhere() else 1
         packages = [a for a in args[1:] if not a.startswith("-")]
         if "--no-download" in args:
             indices = self.local(str(install_system_deps.APT_LISTS))
@@ -158,8 +199,8 @@ class FakeSystem:
                 return 100
             self.installed = packages
             return 0
-        self.fetches.append(str(self.mirror))
-        if self.mirror not in self.reachable:
+        self.fetches.extend(sorted(self.mirrors))
+        if not self._reachable_everywhere():
             return 1
         self.installed = packages
         return 0
@@ -180,8 +221,19 @@ def build(tmp_path: Path, **kwargs: object) -> tuple[FakeSystem, dict[str, Path]
         "root": root,
     }
     paths["sources_d"].mkdir()
-    (paths["sources_d"] / "ubuntu.sources").write_text("Types: deb\n")
-    system = FakeSystem(root, archive_cache=paths["archive_cache"], **kwargs)  # type: ignore[arg-type]
+    (paths["sources_d"] / "ubuntu.sources").write_text(
+        "Types: deb\n"
+        f"URIs: {AZURE}/\n"
+        "Suites: noble noble-updates\n"
+        "Components: main restricted\n"
+    )
+    system = FakeSystem(
+        root,
+        archive_cache=paths["archive_cache"],
+        sources=paths["sources"],
+        sources_d=paths["sources_d"],
+        **kwargs,  # type: ignore[arg-type]
+    )
     return system, paths
 
 
@@ -198,10 +250,10 @@ def run_install(
     system: FakeSystem, paths: dict[str, Path], *, legacy_sources_list: bool = True
 ) -> dict[str, object]:
     if legacy_sources_list:
-        paths["sources"].write_text("deb http://archive.ubuntu.com/ubuntu noble main\n")
+        paths["sources"].write_text(f"deb {AZURE} noble main\n")
     return install_system_deps.install(
         system,
-        workspace=paths["root"] / "workspace",
+        workspace=Path(__file__).parents[1],
         codename=CODENAME,
         staged_conf=paths["staged_conf"],
         archive_cache=paths["archive_cache"],
@@ -359,6 +411,22 @@ def test_the_probe_requests_an_index_file_every_mirror_must_serve(tmp_path: Path
     run_install(system, paths)
 
     assert system.probes[0] == f"{AZURE}/dists/{CODENAME}/InRelease"
+
+
+def test_the_fallback_repoints_a_deb822_only_runner(tmp_path: Path):
+    """The layout 24.04 actually ships, and the one a glob bug hides in.
+
+    With no `sources.list` beside it, `ubuntu.sources` is the only file naming a
+    mirror — if the rewrite misses it, every retry fetches from the host that
+    just failed and the fallback is decorative.
+    """
+    system, paths = build(tmp_path, reachable=ALL_ARCHIVES[1:])
+
+    report = run_install(system, paths, legacy_sources_list=False)
+
+    assert report["source"] == CANONICAL
+    assert system.installed == list(install_system_deps.PACKAGES)
+    assert AZURE not in system.fetches
 
 
 def test_a_deb822_only_runner_installs_like_any_other(tmp_path: Path):

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -215,7 +215,13 @@ class FakeSystem:
     def _apt(self, args: Sequence[str]) -> int:
         if args[0] == "update":
             self.fetches.extend(sorted(self.mirrors))
-            return 0 if self._reachable_everywhere() else 1
+            if not self._reachable_everywhere():
+                return 1
+            # What update is for: the indices land where apt reads them.
+            indices = self.local(str(install_system_deps.APT_LISTS))
+            indices.mkdir(parents=True, exist_ok=True)
+            (indices / INDEX_NAME).write_text("Package: ffmpeg\n")
+            return 0
         packages = [a for a in args[1:] if not a.startswith("-")]
         if "--no-download" in args:
             indices = self.local(str(install_system_deps.APT_LISTS))
@@ -234,11 +240,16 @@ class FakeSystem:
 
 
 def build(tmp_path: Path, **kwargs: object) -> tuple[FakeSystem, dict[str, Path]]:
-    """Lay out a runner: apt's own index dir populated, caches empty."""
+    """Lay out a runner: apt's index dir empty, caches empty.
+
+    Empty on purpose. Pre-populating it let the offline install succeed whether
+    or not the cached indices were ever copied into place — deleting the restore
+    outright kept every test green. The indices arrive the way they do on a real
+    runner: `apt-get update` writes them, or the restore copies them from cache.
+    """
     root = tmp_path / "system"
     lists = root / str(install_system_deps.APT_LISTS).lstrip("/")
     lists.mkdir(parents=True)
-    (lists / INDEX_NAME).write_text("Package: ffmpeg\n")
     paths = {
         "archive_cache": tmp_path / "apt-cache",
         "list_cache": tmp_path / "apt-lists",


### PR DESCRIPTION
**This PR is a CI-configuration change.** It rewrites the `test` job's system-dependency step in `.github/workflows/tests.yml` — that is its stated scope, not an incidental edit.

## The gap

#343's `test` check failed with every Ubuntu mirror timing out, and the job had cached apt archives the whole time:

```
21:11:31 Cache hit for: apt-Linux-ffmpeg-libreoffice-tesseract-v1
21:11:35 Cache restored successfully      <- 185 MiB of .deb archives
```

Nothing in the step consulted them. `fetch_deps()` ran `apt-get update` unconditionally, and cached archives only save work inside `apt-get install`, which the run never reached. The bytes were cached; the package indices were not, and the index fetch is what hung. The network trip was unconditional by construction — a perfect cache would not have avoided one second of it.

The stall itself was a second, separate failure:

```
21:11:35 -> 21:16:35  azure.archive.ubuntu.com    (300s)
21:16:35 -> 21:21:35  archive.ubuntu.com          (300s)
21:21:35 -> 21:26:35  mirrors.edge.kernel.org     (300s)
21:26:35 -> 21:31:35  ubuntu.osuosl.org           (300s)
```

Four attempts, each exactly 300.0s, no `Err:` or `Failed to fetch` anywhere. Canonical, kernel.org and Oregon State do not go dark in five-minute lockstep — that is the runner's side of the connection, and the retry loop could not tell the two apart.

## The change

The step moves into `scripts/install_system_deps.py`. Every side effect routes through an injected runner, so the command sequence — which is the whole behaviour — is assertable without sudo, a runner, or a network.

- Package indices are cached beside the archives; a usable pair installs with `--no-download`, contacting nothing. Both halves are checked rather than the cache-hit flag, since an entry saved before this change holds only archives.
- A cached set that cannot satisfy the install (runner image drift) falls through to the mirror path rather than failing the job.
- A HEAD of each mirror's `InRelease` runs ahead of it. An unreachable host is skipped in seconds; every host unreachable fails immediately naming the runner's network. A host that probes clean and then fails the update still walks the fallback chain, so the two failure shapes stay distinguishable in the report.
- The cache key carries the installer's hash and a week stamp: a changed package set invalidates it, and a stale set is renewed rather than pinned forever. The old hand-bumped `-v1` suffix did neither.

Also fixed while extracting: the old step copied `/etc/apt/sources.list` unconditionally, which does not exist on deb822-only 24.04 images.

## Testing

14 new tests in `tests/test_install_system_deps.py`, pinning both original failures: one fails if the cache is consulted and a mirror contacted anyway, another if a single `apt-get update` is issued when no mirror answered. The deb822 guard was mutation-checked — removing it fails its test. Full suite 6091 passed, 3 skipped.