### PR TITLE
fix(ci): key the apt cache on the runner's Ubuntu suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,9 +108,22 @@ jobs:
         # reordered fallback must not throw away 185 MiB of archives. The week
         # stamp is the renewal cadence — a set nobody touches is still refetched
         # rather than pinned forever (`dependency-management` Freshness).
+        #
+        # The suite name is in the key too. `ubuntu-latest` moves to the next
+        # LTS on GitHub's schedule, and an entry saved under the previous one
+        # holds indices and archives the new suite's apt cannot install from —
+        # and `actions/cache` does not save on an exact key hit, so the new
+        # suite would go without an entry of its own until the week rolled.
         run: |
-          echo "packages=$(python3 scripts/install_system_deps.py --package-digest)" >> "$GITHUB_OUTPUT"
-          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          packages="$(python3 scripts/install_system_deps.py --package-digest)"
+          codename="$(python3 scripts/install_system_deps.py --codename)"
+          week="$(date -u +%G-%V)"
+          {
+            echo "packages=$packages"
+            echo "codename=$codename"
+            echo "week=$week"
+          } >> "$GITHUB_OUTPUT"
       - name: Cache apt package downloads and package indices
         # Both halves, and the second is the point. Caching only the .deb
         # archives left `apt-get update` fetching the indices from a mirror on
@@ -122,7 +135,7 @@ jobs:
           path: |
             /tmp/apt-cache
             /tmp/apt-lists
-          key: apt-${{ runner.os }}-${{ steps.apt-cache-key.outputs.packages }}-${{ steps.apt-cache-key.outputs.week }}
+          key: apt-${{ runner.os }}-${{ steps.apt-cache-key.outputs.codename }}-${{ steps.apt-cache-key.outputs.packages }}-${{ steps.apt-cache-key.outputs.week }}
       - name: Install system dependencies (ffmpeg, libreoffice-impress, tesseract)
         # Offline from the cache when it can, else through the mirror list with a
         # reachability probe ahead of each host. The package set, mirror list,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+### fix(ci) — the apt cache key names the suite it was built for
+
+The key was `apt-<os>-<package-digest>-<week>`, and `runner.os` is `Linux` for
+every Ubuntu image GitHub has ever shipped. So when `ubuntu-latest` rolls to the
+next LTS, the first run on the new image computes a key identical to one the old
+image saved, restores that entry, and gets indices and `.deb` archives for the
+suite it is no longer on. `actions/cache` does not save on an exact key hit, so
+the new suite would not get an entry of its own until the week stamp rotated.
+
+Narrow and self-limiting, which is why #344 deferred it rather than folding it
+in: the pins in `PACKAGES` are suite-specific (`4:24.2.7-0ubuntu0.24.04.6` is a
+noble build), so the same image move makes them unresolvable and the install
+fails loudly on the pin long before anyone wonders about the cache. Two failure
+modes, one trigger, and the loud one lands first.
+
+`VERSION_CODENAME` from `/etc/os-release` is in the key now, read through the
+`--codename` mode of `scripts/install_system_deps.py` rather than a second
+parse in shell — `read_codename` already existed for the mirror probe URL and
+already had tests. That mode sits outside the entry point's report contract on
+purpose: the install path answers an unreadable `/etc/os-release` with a failure
+report, but a cache key has nothing to fall back on, and a swallowed error there
+keys every run on the empty string, which is one shared entry across every
+suite. It raises instead.
+
+The step's shell went with it. `echo "k=$(cmd)" >> "$GITHUB_OUTPUT"` discards
+`cmd`'s exit status — `echo` succeeds, the output is written empty, and the
+`set -e` the runner gives the block never sees a thing. The three values are
+assigned first and echoed after, so a failing resolver takes the step down.
+
+Closes #345.
+
 ## 0.20.97 — 2026-08-19
 
 ### fix(ci) — the apt cache stops being decorative

--- a/scripts/install_system_deps.py
+++ b/scripts/install_system_deps.py
@@ -476,9 +476,18 @@ def main(
     if len(argv) == 2 and argv[1] == "--package-digest":
         print(package_digest())
         return 0
+    if len(argv) == 2 and argv[1] == "--codename":
+        # The other half of the cache key. A suite name absent from the key
+        # lets a run restore the previous LTS's indices and archives, so this
+        # is deliberately outside the report contract below: an unreadable
+        # /etc/os-release fails the step loudly rather than keying the cache on
+        # an empty string.
+        print(read_codename(os_release))
+        return 0
     if len(argv) != 2:
         print(
-            "usage: install_system_deps.py <workspace-root> | --package-digest",
+            "usage: install_system_deps.py <workspace-root> | --package-digest"
+            " | --codename",
             file=sys.stderr,
         )
         return 2

--- a/tests/test_install_system_deps.py
+++ b/tests/test_install_system_deps.py
@@ -617,6 +617,36 @@ def test_the_cache_key_digest_tracks_the_pins_and_nothing_else(
     assert install_system_deps.package_digest() != printed
 
 
+def test_the_cache_key_carries_the_suite_the_runner_image_is_on(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+):
+    """`ubuntu-latest` moves between LTS releases without the workflow changing.
+
+    A key without the suite lets the first run on the new image restore the old
+    one's indices and archives, which its apt cannot install from.
+    """
+    os_release = tmp_path / "os-release"
+    os_release.write_text('NAME="Ubuntu"\nVERSION_CODENAME=noble\nID=ubuntu\n')
+
+    assert install_system_deps.main(["prog", "--codename"], os_release=os_release) == 0
+    assert capfd.readouterr().out.strip() == CODENAME
+
+
+def test_an_unreadable_suite_fails_the_cache_key_rather_than_emptying_it(
+    tmp_path: Path,
+):
+    """The install path answers a bad /etc/os-release with a failure report.
+
+    The cache key has no report to fall back on: a swallowed error keys every
+    run on an empty string, which is one shared entry across every suite.
+    """
+    os_release = tmp_path / "os-release"
+    os_release.write_text('NAME="Something Else"\nID=other\n')
+
+    with pytest.raises(ValueError, match="pin the suite explicitly"):
+        install_system_deps.main(["prog", "--codename"], os_release=os_release)
+
+
 def test_a_pair_whose_security_host_is_dead_is_skipped_before_the_timeout(
     tmp_path: Path,
 ):


### PR DESCRIPTION
Closes #345 — the follow-up Copilot raised on #344 and that PR deferred.

## The gap

The apt cache key was `apt-${{ runner.os }}-<package-digest>-<week>`, and `runner.os` is `Linux` for every Ubuntu image GitHub ships. Nothing in the key distinguishes one LTS from the next, so the first run after `ubuntu-latest` rolls computes a key the previous suite already saved, restores its indices and `.deb` archives, and hands the new suite's apt a set it cannot install from. `actions/cache` does not save on an exact key hit, so the new suite would go without an entry of its own until the week stamp rotated.

Self-limiting, as #345 notes: the pins in `PACKAGES` are suite-specific (`libreoffice-impress=4:24.2.7-0ubuntu0.24.04.6` is a noble build), so the same image move makes them unresolvable and the install fails loudly on the pin first. Two failure modes, one trigger — this closes the quiet one.

## The change

- `scripts/install_system_deps.py` gains a `--codename` mode that prints `read_codename(os_release)`. Reuses the parser the mirror probe URL already needed instead of a second parse in shell, per the issue.
- That mode sits outside the entry point's report contract deliberately. The install path answers an unreadable `/etc/os-release` with a failure report; a cache key has nothing to fall back on, and a swallowed error keys every run on the empty string — one shared entry across every suite. It raises.
- `.github/workflows/tests.yml` emits `codename` and puts it in the key: `apt-<os>-<codename>-<packages>-<week>`.
- The resolver step's shell went with it. `echo "k=$(cmd)" >> "$GITHUB_OUTPUT"` throws away `cmd`'s exit status — `echo` succeeds, the output is written empty, and the runner's `set -e` never sees it. The three values are assigned first and echoed after, under an explicit `set -euo pipefail`.

## Verification

- Two new tests in `tests/test_install_system_deps.py`: the mode prints the suite from the image's `/etc/os-release`, and a non-Ubuntu one raises rather than emitting an empty key.
- The step's shell block was driven locally against both a good and a `VERSION_CODENAME`-less `os-release`: the good path writes all three outputs, the bad path exits 1 with the actionable message and leaves `$GITHUB_OUTPUT` empty.
- `ruff check`, `ruff format --check`, `pyright` clean on the changed files.

Not folded in: the suite-specific pin renewal #345 suggests pairing this with. That is triggered by the image move, not by this key, and belongs with the version bump it needs.