### PR TITLE
feat(vault-ingress): name the new-source requeue reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+### feat(vault-ingress) — `source_added` is its own requeue reason
+
+Issue #318 found the workaround at the end of a real 21-talk reparse: after
+exporting a Slidev deck to PDF and registering it on an already-`processed`
+talk, there was no supported way to get the talk back into the queue.
+`apply-source-repairs.py` refused the status change with `completed claim
+result_status 'processed_partial' disagrees with talk status
+'needs-reprocessing'`, and `queue-state.py normalize` reported `changed: 0`
+because normalization requeues evidence that *drifted*, and evidence that
+newly *arrived* has not drifted.
+
+The path that worked was `reprocess_reason: "source_identity_correction"` — a
+`LEGACY_REPROCESS_REASONS` member, so `is_deliberate_reprocess_reason` accepted
+it and the claim/status disagreement was allowed. It worked for the wrong
+reason. Nothing about the talk's identity was corrected: the video is the same
+video, the deck is the same deck, and the only thing that changed is that one
+of them became readable. A vault audited a year from now would show a run of
+identity corrections that never happened.
+
+`source_added` now says what actually happened, and
+`DELIBERATE_REPROCESS_REASONS` is the set `is_deliberate_reprocess_reason`
+checks — `LEGACY_REPROCESS_REASONS` keeps its own meaning as the two reasons
+that predate the structured `pattern_scoring_generation:` form rather than
+quietly growing a third member that is not legacy at all.
+
+`references/bootstrap-and-preflight.md` documents the register-then-requeue
+plan next to the source-repair commands, which is where the reparse looked for
+it and did not find it.
+
 ## 0.20.98 — 2026-08-20
 
 ### fix(ci) — the apt cache key names the suite it was built for

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -418,6 +418,17 @@ claims, writes a byte-for-byte backup under `{vault_root}/.backups/`, and replac
 the DB atomically. Re-run the preflight after applying; do not claim work until
 blocking findings reach zero.
 
+Registering a source that did not exist at analysis time — a markdown-authored
+deck exported to PDF, a recording that finally published, a hand-recovered
+transcript — is the same plan plus a deliberate requeue. One repair sets the
+new source fields, `status: "needs-reprocessing"`, and
+`reprocess_reason: "source_added"`. `queue-state.py normalize` will not do it:
+normalization requeues drifted evidence, and a source that arrived is not
+drift. The reasons that let a completed claim's `result_status` disagree with
+the talk status are named in
+`skills/vault-ingress/scripts/queue_claim_contract.py`
+(`DELIBERATE_REPROCESS_REASONS`).
+
 The summary's status block is owner-generated, never hand-edited. Refresh it at
 safe checkpoints — after migration or recovery, after normalization, and after a
 batch persists — with:

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -279,7 +279,7 @@ customization, not the owner default. See the
     "slides_local_path": "slides/<artifact>.pdf  (optional explicit local PDF; legacy readers also accept slides_pdf_path/pdf_path)",
     "pptx_visual_status": "pending|extracted|no_pptx",
     "status": "pending|needs-reprocessing|reprocessing-inflight|processed|processed_partial|skipped_no_sources|skipped_download_failed|skipped_duplicate",
-    "reprocess_reason": "machine-readable reason for needs-reprocessing, or null",
+    "reprocess_reason": "machine-readable reason for needs-reprocessing, or null (owner-set values: DELIBERATE_REPROCESS_REASONS in queue_claim_contract.py)",
     "reprocess_generation": 1,
     "_queue_claim": {
       "schema_version": 5,

--- a/skills/vault-ingress/scripts/queue_claim_contract.py
+++ b/skills/vault-ingress/scripts/queue_claim_contract.py
@@ -111,9 +111,11 @@ LEGACY_REPROCESS_REASONS = frozenset(
 # finally published, a hand-recovered transcript. The evidence changed, the
 # recorded identity did not, so this is not a `source_identity_correction`.
 SOURCE_ADDED_REPROCESS_REASON = "source_added"
-# Reasons an owner may set to move a talk with a completed claim back to
-# `needs-reprocessing`. A claim's `result_status` is allowed to disagree with
-# the talk status only under one of these; every other disagreement is drift.
+# Reasons an owner sets by hand to move a talk with a completed claim back to
+# `needs-reprocessing`. `is_deliberate_reprocess_reason` accepts these plus the
+# structured `pattern_scoring_generation:` form the normalizer writes; a claim's
+# `result_status` may disagree with the talk status under any of them, and every
+# other disagreement is drift.
 DELIBERATE_REPROCESS_REASONS = LEGACY_REPROCESS_REASONS | frozenset(
     {SOURCE_ADDED_REPROCESS_REASON}
 )

--- a/skills/vault-ingress/scripts/queue_claim_contract.py
+++ b/skills/vault-ingress/scripts/queue_claim_contract.py
@@ -106,6 +106,17 @@ PATTERN_SCORING_REPROCESS_REASON_SEQUENCES = frozenset(
 LEGACY_REPROCESS_REASONS = frozenset(
     {"pattern_scoring_added", "source_identity_correction"}
 )
+# A source that did not exist when the talk was analysed became available: a
+# markdown-authored deck exported to PDF and registered, a recording that
+# finally published, a hand-recovered transcript. The evidence changed, the
+# recorded identity did not, so this is not a `source_identity_correction`.
+SOURCE_ADDED_REPROCESS_REASON = "source_added"
+# Reasons an owner may set to move a talk with a completed claim back to
+# `needs-reprocessing`. A claim's `result_status` is allowed to disagree with
+# the talk status only under one of these; every other disagreement is drift.
+DELIBERATE_REPROCESS_REASONS = LEGACY_REPROCESS_REASONS | frozenset(
+    {SOURCE_ADDED_REPROCESS_REASON}
+)
 
 QUEUE_CLAIM_SCHEMA_UNSUPPORTED_REASON = "queue_claim_schema_version_unsupported"
 ADHERENCE_BASELINE_SCHEMA_UNSUPPORTED_REASON = (
@@ -155,7 +166,7 @@ def require_queue_identifier(value: object, label: str) -> str:
 def is_deliberate_reprocess_reason(value: object) -> bool:
     if not isinstance(value, str):
         return False
-    if value in LEGACY_REPROCESS_REASONS:
+    if value in DELIBERATE_REPROCESS_REASONS:
         return True
     if not value.startswith(PATTERN_SCORING_REPROCESS_REASON_PREFIX):
         return False

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -2212,3 +2212,59 @@ def test_cli_requires_timezone_aware_now(tmp_path):
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
     assert "has no timezone" in payload["error"]
+
+
+def _completed_claim(result_status: str = "processed") -> dict[str, Any]:
+    """A closed schema-v2 claim: no adherence baseline, receipt required."""
+    return {
+        "schema_version": 2,
+        "run_id": "reparse-2026-07",
+        "batch_id": "25",
+        "claimed_at": NOW,
+        "previous_status": "pending",
+        "reprocess_generation": 1,
+        "state": "completed",
+        "released_at": NOW,
+        "release_reason": "batch persisted",
+        "result_status": result_status,
+        "result_payload_sha256": "0" * 64,
+    }
+
+
+def test_source_added_requeues_a_talk_whose_claim_completed():
+    talk = {
+        "schema_version": 5,
+        "filename": "talk.md",
+        "status": "needs-reprocessing",
+        "reprocess_generation": 1,
+        "reprocess_reason": queue_claim_contract.SOURCE_ADDED_REPROCESS_REASON,
+        "_queue_claim": _completed_claim(),
+    }
+
+    queue_claim_contract.validate_talk_queue_claim_state(talk, 0)
+
+
+def test_a_requeue_reason_outside_the_deliberate_set_is_drift():
+    talk = {
+        "schema_version": 5,
+        "filename": "talk.md",
+        "status": "needs-reprocessing",
+        "reprocess_generation": 1,
+        "reprocess_reason": "operator_hunch",
+        "_queue_claim": _completed_claim(),
+    }
+
+    with pytest.raises(queue_claim_contract.QueueClaimContractError) as excinfo:
+        queue_claim_contract.validate_talk_queue_claim_state(talk, 0)
+
+    assert "disagrees with talk status" in str(excinfo.value)
+
+
+def test_deliberate_reprocess_reasons_extend_the_legacy_set():
+    assert queue_claim_contract.DELIBERATE_REPROCESS_REASONS == (
+        queue_claim_contract.LEGACY_REPROCESS_REASONS
+        | {queue_claim_contract.SOURCE_ADDED_REPROCESS_REASON}
+    )
+    assert queue_claim_contract.is_deliberate_reprocess_reason(
+        queue_claim_contract.SOURCE_ADDED_REPROCESS_REASON
+    )


### PR DESCRIPTION
## Summary

- Adds `source_added` as a deliberate reprocess reason, so registering a source that did not exist at analysis time (a markdown deck exported to PDF, a recording that finally published) has an honest requeue path instead of borrowing `source_identity_correction`.
- `is_deliberate_reprocess_reason` now checks `DELIBERATE_REPROCESS_REASONS`; `LEGACY_REPROCESS_REASONS` keeps its own meaning as the two reasons predating the structured `pattern_scoring_generation:` form.
- Documents the register-then-requeue plan in `references/bootstrap-and-preflight.md`, next to the `apply-source-repairs.py` commands where the original reparse looked for it.

Closes the "Related friction" section of #318 (the remaining items 2–4 stay open there).

## Test plan

- [x] `tests/test_queue_state.py` — new cases: `source_added` requeues a talk with a completed claim, a reason outside the deliberate set is still drift, and the set relationship is pinned
- [x] `.venv/bin/python -m pytest tests/test_queue_state.py tests/test_tracking_database_schema.py tests/test_apply_source_repairs.py tests/test_persist_results.py` — 453 passed
- [x] `ruff check .`, `ruff format --check .`, `pyright` (only the known local unresolved-third-party-import noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2oVxH1XMvSRyXsjf5BZ1U