### PR TITLE
fix(ci): renew the Chocolatey ffmpeg pin to 9.0.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,8 +191,9 @@ jobs:
       - name: Install Windows media evidence dependencies
         if: runner.os == 'Windows'
         shell: pwsh
-        # Chocolatey package pin, renewed from 8.1.2 to 9.0.0 after the feed
-        # withdrew 8.1.2 and took `main` red with no source change. No
+        # Chocolatey package pin, renewed 8.1.2 -> 9.0.0 -> 9.0.1, each time
+        # after the feed withdrew the previous one and took `main` red with no
+        # source change. No
         # Dependabot ecosystem covers Chocolatey, so RENEWAL IS MANUAL: check
         # the feed's current version whenever this step fails to resolve, or
         # quarterly, whichever comes first. Chocolatey serves only the current
@@ -206,7 +207,7 @@ jobs:
         # ffprobe child.
         run: |
           $ErrorActionPreference = 'Stop'
-          choco install ffmpeg --version=9.0.0 --no-progress -y
+          choco install ffmpeg --version=9.0.1 --no-progress -y
           # Locate the real binary rather than assuming a layout. The package
           # moved ffprobe.exe out of tools\ffmpeg\bin between versions, so a
           # hardcoded path fails on exactly the upgrade that unpinning invites.
@@ -225,7 +226,7 @@ jobs:
             throw "cannot read the Chocolatey ffmpeg package tree: $($_.Exception.Message)"
           }
           if (-not $probe) {
-            throw "Chocolatey installed ffmpeg 9.0.0 but no ffprobe.exe is in its package tree — check the package layout and update this step's search root"
+            throw "Chocolatey installed ffmpeg 9.0.1 but no ffprobe.exe is in its package tree — check the package layout and update this step's search root"
           }
           $ffmpegBin = $probe.DirectoryName
           if (-not (Test-Path (Join-Path $ffmpegBin 'ffmpeg.exe') -PathType Leaf)) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### fix(ci) — renew the Chocolatey ffmpeg pin to 9.0.1
+
+Third time, same mechanism, and the step's own comment called it: "Chocolatey
+serves only the current version of a package, so expect this pin to need
+renewing again." The feed withdrew 9.0.0, `choco install ffmpeg
+--version=9.0.0` stopped resolving, and the Windows platform-contracts job went
+red on every branch with no source change behind it.
+
+Its own bump rather than a ride-along on whatever PR happened to notice, per
+`dependency-management` Freshness. Nothing but the three version literals
+moved.
+
+The renewal stays manual because no Dependabot ecosystem covers Chocolatey. The
+current version is one query away, and the comment already carries it:
+
+    https://community.chocolatey.org/api/v2/Packages()?$filter=Id eq 'ffmpeg' and IsLatestVersion
+
 ## 0.20.99 — 2026-08-20
 
 ### feat(vault-ingress) — `source_added` is its own requeue reason


### PR DESCRIPTION
## Summary

The Chocolatey feed withdrew ffmpeg 9.0.0, so `choco install ffmpeg --version=9.0.0` no longer resolves and the Windows platform-contracts job reds on every branch with no source change behind it. Third time this mechanism has fired (8.1.2 → 9.0.0 → 9.0.1), and the step's own comment predicted it: "Chocolatey serves only the current version of a package, so expect this pin to need renewing again."

Its own bump rather than a ride-along on whatever PR happened to notice, per `dependency-management` Freshness. Nothing but the three version literals moved.

Unblocks #349, which is otherwise green.

## Test plan

- [x] Current feed version confirmed as 9.0.1 via `https://community.chocolatey.org/api/v2/Packages()?$filter=Id eq 'ffmpeg' and IsLatestVersion`
- [ ] The Windows `Artifact platform contracts` job resolves the pin and goes green — this PR's own run is the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2oVxH1XMvSRyXsjf5BZ1U