### PR TITLE
feat(vault-ingress): name the deck a rendered PDF came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ the v0 path stamps — so v1 needs no branch of its own; what it did need was fo
 the tail to stop reporting a hardcoded `from_schema_version: 0`, which would
 have misnamed what was migrated.
 
+The collection is gated on the root generation, not merely versioned alongside
+it. Validating `markdown_decks` on any root would let a v0 or v1 database carry
+the new shape while still claiming the old generation — the version would stop
+describing the bytes, which is the whole reason the bump exists. A pre-v2 root
+carrying the key is refused, naming the migration that stamps it.
+
 Two holes the review caught in this PR's own new code. An absolute locator may
 carry a trailing slash — `classify_artifact_locator` accepts it and
 `PurePosixPath(value).name` then strips it — so `/repos/slides.md/` reached the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ the v0 path stamps — so v1 needs no branch of its own; what it did need was fo
 the tail to stop reporting a hardcoded `from_schema_version: 0`, which would
 have misnamed what was migrated.
 
+`record_markdown_deck` takes an `expect`, the same optimistic precondition every
+other talk-touching mutation carries: the plan states the `deck_source_path` it
+believes is registered, or `{"$missing": true}` when nothing is, and a
+registration that moved under the plan fails the write instead of being
+overwritten without anyone noticing.
+
 The writer/reader contract moved with it. `references/schemas-db.md` carries the
 schema-version table and one access-contract row per consumer, and a root bump
 that leaves those rows saying "require database schema 1" documents a flow that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ The collection is optional, absent means no registered deck, and no migration
 owns it — it is deliberately absent from `_RECORD_COUNT_KEYS`, since a deck is
 registered by an owner who knows where the file is and is never inferred.
 
+**The root schema goes to v2.** A top-level key is part of the ROOT record's
+shape, and a version on each nested deck record does not version its parent
+database — the same principle #333 stated one level down. So
+`TRACKING_DATABASE_SCHEMA_VERSION` moves 1 → 2, root v1 becomes
+`PRE_MARKDOWN_DECKS_TRACKING_DATABASE_SCHEMA_VERSION`, and a v0 or v1 database
+reaches v2 through the migration tail that already existed. Every step in that
+tail is idempotent for a v1 database — its records already carry the versions
+the v0 path stamps — so v1 needs no branch of its own; what it did need was for
+the tail to stop reporting a hardcoded `from_schema_version: 0`, which would
+have misnamed what was migrated.
+
+Fixture fallout worth naming, because it is the argument for the shared
+constant now in `tests/conftest.py`: seventeen fixtures pinned the root
+generation by literal, and each one failed as `assert 2 == 1` with nothing in
+the message naming a generation. Three tests turned out to read
+`~/.claude/rhetoric-knowledge-vault` — the developer's real vault — because
+they passed no `--vault`, so the argument-validation they assert was being
+decided by whatever generation that machine happened to be at. They now pass a
+`tmp_path`. And a strict-reader case pinned a "future" root of literal 2, which
+this bump turned into the current one; it is derived now, the same way the
+talk-record case beside it already warned it should be.
+
 `deck_source_path` goes through `classify_artifact_locator`, the same lexical
 contract every other persisted artifact path uses, so a NUL byte (which used to
 reach `Path.stat()` and raise outside the renderer's `OSError` diagnostic), a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+### feat(vault-ingress) — name the deck a rendered PDF came from
+
+Issue #318, item (1)'s second half, and the last piece of it. `slide_source:
+"markdown"` (0.20.86) made a markdown-authored talk a valid record, and
+`render-markdown-deck.py` (0.20.101) made its deck readable. Between them sat a
+quiet data loss: registering the render sets `slide_source` to `"pdf"`, which is
+correct — the talk now has real slides — and in doing so erases the only field
+that said the deck was ever markdown. Nothing on the record named the file. The
+second render, after the speaker added three slides, started with a hunt.
+
+`deck_source_path` is that name. It goes on the talk record through
+`apply-source-repairs.py`, holds an absolute path (the ordinary case: these
+decks live one git repo per talk, so no configured directory locates them the
+way `config.pptx_source_dir` locates a deck library) or a vault-root-relative
+one like `pptx_path`, and it is deliberately independent of `slide_source` so it
+survives the `"markdown"` → `"pdf"` rewrite that motivated it.
+
+**It does not bump `TALK_RECORD_SCHEMA_VERSION`, and that is the whole design
+decision.** The obvious move was 7 → 8 with 7 added to
+`_RESTAMPABLE_TALK_RECORD_SCHEMA_VERSIONS`; the machinery is built for exactly
+that additive shape and no test references the literal. Three things argued
+against it, all of them already written down in this file:
+
+The constant means analysis generation, not record shape — the #333 entry says
+so outright: "the contradiction is real, and it comes from
+`TALK_RECORD_SCHEMA_VERSION` carrying two meanings at once: the analysis
+generation, which is why a v1 record can never migrate forward, and the record
+shape." That is why v7 is today a bump for a field that no longer lives on the
+talk record at all; `_restamp_talk_records` says "v7 adds no field a v6 record
+lacks." Adding a second such bump would compound the confusion, not resolve it.
+
+The stamp would not reach the records that need the field. 209 of the 215 live
+talk records are schema v1, non-restampable by design, and they are precisely
+the transcript-only markdown talks #318 is about. A v8 stamp lifts six modern
+records and leaves the other 209 exactly where they were — the same wall #333
+hit, then reversed by moving its field off the talk record entirely.
+
+And the stamp is not free. Talk versions are accepted as `range(1, CURRENT + 1)`,
+so a v8-stamped database read by any older toolkit is not one unreadable record:
+it is `talks_schema_version_unsupported`, `usable: false`, the whole vault. That
+is a real downgrade cliff, paid for a marker that reaches 3% of the corpus.
+
+So the field lands additively at v7. The talk record has never been closed-shape
+— `_require_closed_shape` guards catalog records, QR artifacts, and
+equivalences, never talks — and `apply-source-repairs.py` carries no
+record-version gate at all, which is why #318's documented manual workaround
+already worked on v1 records. Absence means no registered deck, which is the
+correct reading of every database written before today. An older toolkit ignores
+the field rather than misreading it, because no version ever defined it
+differently. This is `stateful-artifacts`' additive backward-compatible case:
+the new reader reads old records via the field's default, and the default is the
+truth.
+
+`validate_deck_source_path` refuses a directory, a `..` segment, a backslash
+separator, a non-canonical spelling, and any suffix outside `.md` / `.markdown`,
+naming the canonical form in the diagnostic rather than the first check that
+fired. It does not check existence — the deck's repo need not be on this
+machine, so a missing file is the renderer's loud failure, not a plan's silent
+precondition.
+
+Not done here, deliberately: a return claiming `slide_source: "markdown"` is not
+required to have a registered deck path, though the symmetry with `"pdf"`
+requiring `has_pdf` is tempting. Workers analyse; they do not discover decks.
+Making it a return precondition would block reprocessing a known-markdown talk
+whose path nobody has registered yet, which is the state every such talk starts
+in.
+
 ## 0.20.101 — 2026-08-20
 
 ### feat(vault-ingress) — render markdown-authored decks as slide evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,16 @@ the v0 path stamps — so v1 needs no branch of its own; what it did need was fo
 the tail to stop reporting a hardcoded `from_schema_version: 0`, which would
 have misnamed what was migrated.
 
+The writer/reader contract moved with it. `references/schemas-db.md` carries the
+schema-version table and one access-contract row per consumer, and a root bump
+that leaves those rows saying "require database schema 1" documents a flow that
+rejects the state the owner now writes. Every row is updated, along with the
+five consumer pages outside vault-ingress that state the same requirement —
+`illustrations/references/thumbnails.md`,
+`vault-ingress/references/bootstrap-and-preflight.md`,
+`presentation-creator/references/phase6-publishing.md` and `phase7-post-event.md`,
+and `vault-clarification/SKILL.md`.
+
 Fixture fallout worth naming, because it is the argument for the shared
 constant now in `tests/conftest.py`: seventeen fixtures pinned the root
 generation by literal, and each one failed as `assert 2 == 1` with nothing in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,11 +63,14 @@ the v0 path stamps — so v1 needs no branch of its own; what it did need was fo
 the tail to stop reporting a hardcoded `from_schema_version: 0`, which would
 have misnamed what was migrated.
 
-The collection is gated on the root generation, not merely versioned alongside
-it. Validating `markdown_decks` on any root would let a v0 or v1 database carry
-the new shape while still claiming the old generation — the version would stop
-describing the bytes, which is the whole reason the bump exists. A pre-v2 root
-carrying the key is refused, naming the migration that stamps it.
+The collection is not usable on a pre-v2 root, and the way that is enforced
+matters. The first attempt raised from the assessment — which turned out to be a
+dead end, because `migrate_tracking_database` assesses before it stamps, so the
+diagnostic sent an owner at the one command that would refuse them. Usability is
+gated one level up instead: a pre-v2 root is never `current`, so every reader
+and writer requiring current state refuses it, and the migration advances the
+root while preserving the records. Which is what a preservation migration is
+for.
 
 Two holes the review caught in this PR's own new code. An absolute locator may
 carry a trailing slash — `classify_artifact_locator` accepts it and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ the v0 path stamps — so v1 needs no branch of its own; what it did need was fo
 the tail to stop reporting a hardcoded `from_schema_version: 0`, which would
 have misnamed what was migrated.
 
+Two holes the review caught in this PR's own new code. An absolute locator may
+carry a trailing slash — `classify_artifact_locator` accepts it and
+`PurePosixPath(value).name` then strips it — so `/repos/slides.md/` reached the
+suffix check looking like a file and passed, and the renderer would have been
+handed a directory. And the malformed-owner-state diagnostic hardcoded "schema
+v1", so after the bump it sent readers at the wrong generation. Both now carry
+regression tests.
+
 `record_markdown_deck` takes an `expect`, the same optimistic precondition every
 other talk-touching mutation carries: the plan states the `deck_source_path` it
 believes is registered, or `{"$missing": true}` when nothing is, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,20 @@ correct — the talk now has real slides — and in doing so erases the only fie
 that said the deck was ever markdown. Nothing on the record named the file. The
 second render, after the speaker added three slides, started with a hunt.
 
-`deck_source_path` is that name. It goes on the talk record through
-`apply-source-repairs.py`, holds an absolute path (the ordinary case: these
-decks live one git repo per talk, so no configured directory locates them the
-way `config.pptx_source_dir` locates a deck library) or a vault-root-relative
-one like `pptx_path`, and it is deliberately independent of `slide_source` so it
-survives the `"markdown"` → `"pdf"` rewrite that motivated it.
+`markdown_decks` is a new top-level collection at record v1, one record per
+talk, holding `talk_filename` and `deck_source_path`. It is written by a new
+`record_markdown_deck` mutation kind, which upserts rather than appends — the
+equivalence ledger beside it is an audit trail of owner judgments and only ever
+grows, while a deck registration is current state and a repo that moves
+re-points it.
 
-**It does not bump `TALK_RECORD_SCHEMA_VERSION`, and that is the whole design
-decision.** The obvious move was 7 → 8 with 7 added to
-`_RESTAMPABLE_TALK_RECORD_SCHEMA_VERSIONS`; the machinery is built for exactly
-that additive shape and no test references the literal. Three things argued
-against it, all of them already written down in this file:
+**Why a collection and not a field on the talk record.** The first attempt added
+`deck_source_path` as an optional talk field and left
+`TALK_RECORD_SCHEMA_VERSION` alone, on the reasoning that a never-before-defined
+optional field cannot be misread by an older reader. `stateful-artifacts`
+requires a version bump for any persisted shape change, additive included, and
+the policy review blocked it. The rule is right and the bump was still wrong,
+which is the whole reason this landed where it did:
 
 The constant means analysis generation, not record shape — the #333 entry says
 so outright: "the contradiction is real, and it comes from
@@ -29,43 +31,53 @@ so outright: "the contradiction is real, and it comes from
 generation, which is why a v1 record can never migrate forward, and the record
 shape." That is why v7 is today a bump for a field that no longer lives on the
 talk record at all; `_restamp_talk_records` says "v7 adds no field a v6 record
-lacks." Adding a second such bump would compound the confusion, not resolve it.
+lacks."
 
-The stamp would not reach the records that need the field. 209 of the 215 live
-talk records are schema v1, non-restampable by design, and they are precisely
-the transcript-only markdown talks #318 is about. A v8 stamp lifts six modern
-records and leaves the other 209 exactly where they were — the same wall #333
-hit, then reversed by moving its field off the talk record entirely.
+A bump would not have reached the records that need the field. 209 of the 215
+live talk records are schema v1, non-restampable by design, and they are
+precisely the transcript-only markdown talks #318 is about. A v8 stamp lifts the
+six modern records and leaves the other 209 where they were.
 
-And the stamp is not free. Talk versions are accepted as `range(1, CURRENT + 1)`,
+And the bump is not free. Talk versions are accepted as `range(1, CURRENT + 1)`,
 so a v8-stamped database read by any older toolkit is not one unreadable record:
-it is `talks_schema_version_unsupported`, `usable: false`, the whole vault. That
-is a real downgrade cliff, paid for a marker that reaches 3% of the corpus.
+it is `talks_schema_version_unsupported`, `usable: false`, the whole vault.
 
-So the field lands additively at v7. The talk record has never been closed-shape
-— `_require_closed_shape` guards catalog records, QR artifacts, and
-equivalences, never talks — and `apply-source-repairs.py` carries no
-record-version gate at all, which is why #318's documented manual workaround
-already worked on v1 records. Absence means no registered deck, which is the
-correct reading of every database written before today. An older toolkit ignores
-the field rather than misreading it, because no version ever defined it
-differently. This is `stateful-artifacts`' additive backward-compatible case:
-the new reader reads old records via the field's default, and the default is the
-truth.
+#333 hit this exact wall — an owner ledger bound to the analysis generation,
+unreachable for 97% of the corpus — and resolved it by moving the field off the
+talk into its own versioned collection. Same wall, same resolution. The nested
+alternative is closed for the same reason #333 closed it: "the nested record's
+own version does not version its parent."
 
-`validate_deck_source_path` refuses a directory, a `..` segment, a backslash
-separator, a non-canonical spelling, and any suffix outside `.md` / `.markdown`,
-naming the canonical form in the diagnostic rather than the first check that
-fired. It does not check existence — the deck's repo need not be on this
-machine, so a missing file is the renderer's loud failure, not a plan's silent
-precondition.
+The collection is optional, absent means no registered deck, and no migration
+owns it — it is deliberately absent from `_RECORD_COUNT_KEYS`, since a deck is
+registered by an owner who knows where the file is and is never inferred.
+
+`deck_source_path` goes through `classify_artifact_locator`, the same lexical
+contract every other persisted artifact path uses, so a NUL byte (which used to
+reach `Path.stat()` and raise outside the renderer's `OSError` diagnostic), a
+`~`, a `..` segment, an ambiguous `//server/share`, and a Windows reserved name
+are refused by one shared reader rather than by a private opinion about paths. A
+markdown-suffix check sits on top. Existence is never checked: the deck's repo
+need not be on this machine, so an absent file is the renderer's loud failure at
+render time.
+
+Two documentation faults fixed in the same pass. The register-the-render plan in
+`references/markdown-decks.md` set `status` and `reprocess_reason` without
+declaring them in `expect`, and `validate_plan` refuses a repair that changes a
+field it did not declare — so the recipe could never be applied by a reader
+following it. Both documented plans are now executed verbatim by a test. And the
+page now says that a vault-relative deck path must be resolved against the vault
+root before it reaches a renderer, which resolves a relative CLI path from its
+own working directory and would otherwise report a missing deck for a good
+locator.
 
 Not done here, deliberately: a return claiming `slide_source: "markdown"` is not
-required to have a registered deck path, though the symmetry with `"pdf"`
-requiring `has_pdf` is tempting. Workers analyse; they do not discover decks.
-Making it a return precondition would block reprocessing a known-markdown talk
-whose path nobody has registered yet, which is the state every such talk starts
-in.
+required to have a registered deck, though the symmetry with `"pdf"` requiring
+`has_pdf` is tempting. Workers analyse; they do not discover decks. Making it a
+return precondition would block reprocessing a known-markdown talk whose deck
+nobody has registered yet, which is the state every such talk starts in. There
+is also no unregister mutation — a deck that moves is re-pointed, which is the
+case that actually occurs.
 
 ## 0.20.101 — 2026-08-20
 

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -38,8 +38,8 @@ never fall back to a PATH interpreter.
 Read `tracking-database.json` through the vault path used by
 presentation-creator. Selection and composition may read legacy database schema
 0 or current schema 1 without mutation. Before copying the approved thumbnail or
-writing tracking state, require database schema 1, current independent records,
-and talk schema 7. Invoke `Skill(skill: "vault-ingress")` for schema 0 and stop
+writing tracking state, require database schema 2, current independent records,
+and talk schema 7. Invoke `Skill(skill: "vault-ingress")` for schema 0 or 1 and stop
 this run. Unknown future generations are no usable prior state. Preserve every
 schema field and use the presentation-creator exact-generation atomic-write
 contract.

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -37,7 +37,7 @@ never fall back to a PATH interpreter.
 
 Read `tracking-database.json` through the vault path used by
 presentation-creator. Selection and composition may read legacy database schema
-0 or current schema 1 without mutation. Before copying the approved thumbnail or
+0 or 1, or current schema 2, without mutation. Before copying the approved thumbnail or
 writing tracking state, require database schema 2, current independent records,
 and talk schema 7. Invoke `Skill(skill: "vault-ingress")` for schema 0 or 1 and stop
 this run. Unknown future generations are no usable prior state. Preserve every

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -44,7 +44,7 @@ location). Load `tracking-database.json` with the strict owner reader at
 `{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py` to
 get `config.vault_root`; never parse it directly. The stdlib-only reader may use
 the host interpreter for this one bootstrap read. It accepts legacy database
-schema 0 and current schema 1 without rewriting either. Stop on unsupported root
+schemas 0 and 1 and current schema 2 without rewriting any of them. Stop on unsupported root
 or owner-record generations and route migration to `Skill(skill: "vault-ingress")`.
 
 Discover the exact non-empty `config.python_path`, then immediately re-read the

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -52,10 +52,10 @@ same canonical database path with that interpreter and require the same SHA-256;
 restart discovery if the generation changed. Use only that configured interpreter
 for every later toolkit command. Missing or unusable configuration stops this flow
 and invokes `Skill(skill: "vault-ingress")` with Step 1 as the handoff context.
-Read-only phases may continue on schema 0, but publishing and post-event writes
-require schema 1 before their paired network, deck, image, or tracking side
-effects. For schema 0, invoke `Skill(skill: "vault-ingress")` with a Step 1
-migration handoff before continuing.
+Read-only phases may continue on schema 0 or 1, but publishing and post-event
+writes require schema 2 before their paired network, deck, image, or tracking
+side effects. For schema 0 or 1, invoke `Skill(skill: "vault-ingress")` with a
+Step 1 migration handoff before continuing.
 
 Load from vault root: `rhetoric-style-summary.md` (constitution — all patterns),
 `slide-design-spec.md` (visual rules), `speaker-profile.json` (structured data).

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -186,8 +186,9 @@ path make the check before resolving the link.
    ```
 
    The script is a non-owner dual reader and a current-schema writer. Dry-run
-   accepts legacy database schema 0 or current schema 1 without changing either.
-   A real run requires database schema 1 before URL-shortener calls, deck edits,
+   accepts any readable database schema — legacy 0, pre-`markdown_decks` 1, or
+   current 2 — without changing any of them.
+   A real run requires database schema 2 before URL-shortener calls, deck edits,
    or tracking persistence. Route a legacy database through vault-ingress Step 1.
    An unsupported future database or record version is no usable prior state.
 

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -16,8 +16,8 @@ Before ANY Phase 7 action, load these files. If any is missing, STOP and ask.
 
 Read the tracking database through the main presentation-creator compatibility
 gate. Thumbnail and shownotes lookup may read schema 0 or 1. Any database update
-in this phase requires current database schema 1 and talk schema 7 before the
-thumbnail, shownotes, or video side effect paired with it. Route schema 0 through
+in this phase requires current database schema 2 and talk schema 7 before the
+thumbnail, shownotes, or video side effect paired with it. Route schema 0 or 1 through
 `Skill(skill: "vault-ingress")`; preserve all schema fields and apply the main
 skill's exact-generation atomic-write contract.
 

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -76,7 +76,7 @@ state:
 
 Exit 0 writes one JSON object with `from_schema_version`,
 `to_schema_version`, `changed`, `database_written: false`, `input_sha256`, and
-`record_counts`. Continue only for `changed: false` at database schema v1 with
+`record_counts`. Continue only for `changed: false` at database schema v2 with
 config schema v2. A legacy root or config report requires the owner workflow;
 invoke `Skill(skill: "vault-ingress")`
 with the migration report as handoff context, then finish this clarification run.

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -83,7 +83,7 @@ with the migration report as handoff context, then finish this clarification run
 Exit 2 writes one error object to stdout plus an `ERROR:` diagnostic to stderr;
 stop without changing session state.
 
-Every tracking write in Steps 2–8 is current-only. Preserve database schema 1,
+Every tracking write in Steps 2–8 is current-only. Preserve database schema 2,
 config schema 2, talk schema 7, and every unrelated record. Stamp confirmed
 intents with schema 1 and new improvement goals with schema 2. Capture the exact
 input bytes immediately before each write, reject a changed generation, validate

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -89,7 +89,9 @@ in order of preference:
 The `slide_source` field tracks which path: `"pptx"`, `"pdf"`, `"both"`,
 `"video_extracted"`, `"markdown"` (a Slidev/presenterm/Marp deck — provenance
 only, it yields no slide evidence until rendered to PDF and re-registered as
-`"pdf"`), or `"none"`. The `pptx_catalog` array fuzzy-matches `.pptx`
+`"pdf"`), or `"none"`. `deck_source_path` names the markdown file that deck was
+authored in and outlives the re-registration, so a changed deck re-renders
+without being located again. The `pptx_catalog` array fuzzy-matches `.pptx`
 files to shownotes entries.
 
 ## Step 1 — Bootstrap Vault State

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -89,10 +89,10 @@ in order of preference:
 The `slide_source` field tracks which path: `"pptx"`, `"pdf"`, `"both"`,
 `"video_extracted"`, `"markdown"` (a Slidev/presenterm/Marp deck — provenance
 only, it yields no slide evidence until rendered to PDF and re-registered as
-`"pdf"`), or `"none"`. `deck_source_path` names the markdown file that deck was
-authored in and outlives the re-registration, so a changed deck re-renders
-without being located again. The `pptx_catalog` array fuzzy-matches `.pptx`
-files to shownotes entries.
+`"pdf"`), or `"none"`. The top-level `markdown_decks` collection names the file
+that deck was authored in and outlives the re-registration, so a changed deck
+re-renders without being located again. The `pptx_catalog` array fuzzy-matches
+`.pptx` files to shownotes entries.
 
 ## Step 1 — Bootstrap Vault State
 

--- a/skills/vault-ingress/references/batch-persistence.md
+++ b/skills/vault-ingress/references/batch-persistence.md
@@ -43,7 +43,7 @@ whether to run the gate.
   `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/persist-results.py" {vault_root}/tracking-database.json batch-returns.json`.
   The script first requires the return filenames to equal every live member of one
   run/batch claim; partial, extra, mixed-identity, duplicate, closed, or stranded
-  batches fail before merge. The script requires database schema v1 and current
+  batches fail before merge. The script requires database schema v2 and current
   independent record versions; Step 1 is the sole migration path. It then merges each return into its matching
   talk entry, promotes the declared queryable scalars to the talk top level, and
   rewrites the DB in place. Do NOT hand-copy fields one at a time — that is what

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -92,7 +92,7 @@ database or talk record. The existing queue transition may advance a recovered
 legacy claim receipt from schema v1 to v2 while adding its release fields. Rerun
 migration dry-run, then apply its new exact digest. Do not copy a digest across
 runs. `queue-state.py ... normalize` and `queue-state.py ... claim` require
-database schema 1.
+database schema 2.
 
 **Config bootstrapping** — ask once per missing user-owned field and persist to the tracking
 database with expectation-bound `set_config` mutations. Re-read after every
@@ -123,7 +123,7 @@ before another config write.
   --lanes core,pdf,pptx
 ```
 
-All owner-authored tracking writes below require database schema 1 and config
+All owner-authored tracking writes below require database schema 2 and config
 schema 2 after this
 gate. Preserve every independent record version and validate the complete
 candidate before installing it. Only `migrate-tracking-database.py` may move

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -10,7 +10,7 @@ each section in order; later sections assume every earlier gate succeeded.
    [schemas-db.md](schemas-db.md#owner-read-and-mutation-contract).
 2. **Path missing** — first-time setup: ask preferred location via `AskUserQuestion`,
    create the directory (and symlink if a custom path was chosen), then use a sole
-   `initialize_database` mutation. Include database `schema_version: 1`, config
+   `initialize_database` mutation. Include database `schema_version: 2`, config
    `schema_version: 2`, and empty `talks`, `pptx_catalog`, `qr_codes`, `resources`,
    `thumbnails`, `confirmed_intents`, and `improvement_goals` arrays. The plan may
    omit `pptx_directory_exclusions`; the initializer supplies the canonical default
@@ -70,7 +70,7 @@ Exit 0 from apply writes one JSON report with `database_written: true`, preserve
 the complete original bytes under `{vault_root}/.backups/`, and atomically
 installs database schema v2 with config schema v2. A current root with config
 schema v1 is also a migration: root `from_schema_version` and
-`to_schema_version` both remain `1`, while `record_counts.config` records the
+`to_schema_version` both remain `2`, while `record_counts.config` records the
 config upgrade.
 
 `persisted_observations` reports what the migration did to corrupt persisted

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -68,7 +68,7 @@ changed report authorizes this exact apply command:
 
 Exit 0 from apply writes one JSON report with `database_written: true`, preserves
 the complete original bytes under `{vault_root}/.backups/`, and atomically
-installs database schema v1 with config schema v2. A current root with config
+installs database schema v2 with config schema v2. A current root with config
 schema v1 is also a migration: root `from_schema_version` and
 `to_schema_version` both remain `1`, while `record_counts.config` records the
 config upgrade.

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -127,7 +127,7 @@ All owner-authored tracking writes below require database schema 2 and config
 schema 2 after this
 gate. Preserve every independent record version and validate the complete
 candidate before installing it. Only `migrate-tracking-database.py` may move
-schema 0 to schema 1; its hash precondition binds replacement to the exact input
+schema 0 or schema 1 to schema 2; its hash precondition binds replacement to the exact input
 bytes as documented above.
 
 Core requires Python 3.10+ and PyYAML and is blocking. The PDF lane requires

--- a/skills/vault-ingress/references/markdown-decks.md
+++ b/skills/vault-ingress/references/markdown-decks.md
@@ -41,6 +41,10 @@ optional lane, an absent renderer degrades that one deck, not the run.
 
 ## Render, then register
 
+`{deck_path}` below is the talk's `deck_source_path` when one is registered,
+and the file you located by hand when it is not — registering it is the last
+step of this page.
+
 Read the deck without touching a renderer — this reports the detected flavor,
 the lane, and what is missing from it:
 
@@ -74,8 +78,11 @@ the `apply-source-repairs.py` dry-run/apply pair):
 {"schema_version": 1, "repairs": [{
   "filename": "spring-rag-jcon.md",
   "reason": "Slidev deck rendered to PDF and registered as slide evidence",
-  "expect": {"slides_local_path": {"$missing": true}, "slide_source": "markdown"},
+  "expect": {"slides_local_path": {"$missing": true},
+             "deck_source_path": {"$missing": true},
+             "slide_source": "markdown"},
   "set": {"slides_local_path": "slides/spring-rag-jcon.pdf",
+          "deck_source_path": "/repos/spring-rag/slides.md",
           "slide_source": "pdf",
           "status": "needs-reprocessing",
           "reprocess_reason": "source_added"}}]}
@@ -83,6 +90,19 @@ the `apply-source-repairs.py` dry-run/apply pair):
 
 The talk then binds as a normal `static_slides` artifact. Nothing about the
 evidence path is special-cased for a deck that started as markdown.
+
+`deck_source_path` is the one thing that does not follow that rule, and it is
+why the repair sets it in the same plan. The rest of this registration is a
+one-way door: `slide_source` goes from `"markdown"` to `"pdf"` because the talk
+now genuinely has readable slides, and after that no field on the record says
+the deck was ever markdown or where it lives. Set the deck path here and a
+later render — the deck gained three slides, the speaker reworked the demo —
+reads its source off the talk instead of asking whoever remembers. Leave it out
+and the second render starts by hunting for the file.
+
+The path may be absolute (the usual case; these decks live one git repo per
+talk) or vault-root-relative. It is not checked for existence, so a deck repo
+that is not on this machine registers fine and fails, loudly, at the render.
 
 Nothing reaches the output path until the bounded PDF probe has accepted the
 render. A renderer that exits 0 over a corrupt file leaves an earlier valid

--- a/skills/vault-ingress/references/markdown-decks.md
+++ b/skills/vault-ingress/references/markdown-decks.md
@@ -41,9 +41,12 @@ optional lane, an absent renderer degrades that one deck, not the run.
 
 ## Render, then register
 
-`{deck_path}` below is the talk's `deck_source_path` when one is registered,
-and the file you located by hand when it is not — registering it is the last
-step of this page.
+`{deck_path}` below is the talk's registered `deck_source_path` when it has one,
+and the file you located by hand when it does not — registering it is the last
+step of this page. A registered value that is not absolute is vault-root
+relative: resolve it against `{vault_root}` before passing it, because the
+renderer resolves a relative path from its own working directory and would
+report a missing deck for a locator that is fine.
 
 Read the deck without touching a renderer — this reports the detected flavor,
 the lane, and what is missing from it:
@@ -79,30 +82,44 @@ the `apply-source-repairs.py` dry-run/apply pair):
   "filename": "spring-rag-jcon.md",
   "reason": "Slidev deck rendered to PDF and registered as slide evidence",
   "expect": {"slides_local_path": {"$missing": true},
-             "deck_source_path": {"$missing": true},
-             "slide_source": "markdown"},
+             "slide_source": "markdown",
+             "status": "processed_partial",
+             "reprocess_reason": {"$missing": true}},
   "set": {"slides_local_path": "slides/spring-rag-jcon.pdf",
-          "deck_source_path": "/repos/spring-rag/slides.md",
           "slide_source": "pdf",
           "status": "needs-reprocessing",
           "reprocess_reason": "source_added"}}]}
 ```
 
+`expect` covers every field `set` touches, `status` and `reprocess_reason`
+included — `validate_plan` refuses a repair that changes a field it did not
+declare, so a plan missing those two is rejected before anything is written.
+Use the talk's actual current `status`, not the one above.
+
 The talk then binds as a normal `static_slides` artifact. Nothing about the
 evidence path is special-cased for a deck that started as markdown.
 
-`deck_source_path` is the one thing that does not follow that rule, and it is
-why the repair sets it in the same plan. The rest of this registration is a
-one-way door: `slide_source` goes from `"markdown"` to `"pdf"` because the talk
-now genuinely has readable slides, and after that no field on the record says
-the deck was ever markdown or where it lives. Set the deck path here and a
-later render — the deck gained three slides, the speaker reworked the demo —
-reads its source off the talk instead of asking whoever remembers. Leave it out
-and the second render starts by hunting for the file.
+## Register the deck itself
 
-The path may be absolute (the usual case; these decks live one git repo per
-talk) or vault-root-relative. It is not checked for existence, so a deck repo
-that is not on this machine registers fine and fails, loudly, at the render.
+That repair is a one-way door: `slide_source` becomes `"pdf"` because the talk
+now genuinely has readable slides, and after it nothing on the record says the
+deck was ever markdown or where it lives. Record the deck separately, in its own
+collection, so a later render — the deck gained three slides, the speaker
+reworked the demo — reads its source instead of asking whoever remembers:
+
+```json
+{"schema_version": 1, "mutations": [{
+  "kind": "record_markdown_deck",
+  "filename": "spring-rag-jcon.md",
+  "deck_source_path": "/repos/spring-rag/slides.md"}]}
+```
+
+It is an upsert keyed on the talk, so a deck repo that moves is re-pointed by
+running it again; a second record for one talk is refused. It does not touch the
+talk record — deliberately, because a talk's `schema_version` is its analysis
+generation, and the transcript-only talks this whole page is about are legacy
+records that can never advance to a shape gate. Field contract and accepted path
+spellings: [schemas-db.md](schemas-db.md#owner-read-and-mutation-contract).
 
 Nothing reaches the output path until the bounded PDF probe has accepted the
 render. A renderer that exits 0 over a corrupt file leaves an earlier valid

--- a/skills/vault-ingress/references/markdown-decks.md
+++ b/skills/vault-ingress/references/markdown-decks.md
@@ -111,11 +111,16 @@ reworked the demo — reads its source instead of asking whoever remembers:
 {"schema_version": 1, "mutations": [{
   "kind": "record_markdown_deck",
   "filename": "spring-rag-jcon.md",
+  "expect": {"deck_source_path": {"$missing": true}},
   "deck_source_path": "/repos/spring-rag/slides.md"}]}
 ```
 
-It is an upsert keyed on the talk, so a deck repo that moves is re-pointed by
-running it again; a second record for one talk is refused. It does not touch the
+`expect` is the same optimistic precondition every other talk-touching mutation
+carries: state what you believe is registered, and `{"$missing": true}` when
+nothing is. A registration that moved under the plan fails the write instead of
+being silently overwritten. Re-pointing a deck repo that moved names the old
+path there and runs the same mutation again; a second record for one talk is
+refused. It does not touch the
 talk record — deliberately, because a talk's `schema_version` is its analysis
 generation, and the transcript-only talks this whole page is about are legacy
 records that can never advance to a shape gate. Field contract and accepted path

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -152,9 +152,10 @@ v1 and v2 for the rollout window.
   legacy record has no `artifacts` and cannot satisfy the v2 shape. Only the QR
   writer produces v2 records, and it writes them complete.
 
-A schema-v1 database with config v2 is an idempotent no-op. A schema-v1 database
-with config v1 receives only the config-v2 migration; the root generation and
-every other record remain unchanged. Before migration, queue `inspect` may read
+A schema-v2 database with config v2 is an idempotent no-op. A schema-v1 database
+is not: its root advances to v2, and a config v1 is upgraded in the same pass.
+A schema-v2 database with config v1 receives only the config-v2 migration; the
+root generation and every other record remain unchanged. Before migration, queue `inspect` may read
 schema 0 and queue `recover` may close an active schema-0 lease in place.
 Recovery changes only queue lease/status state and never stamps database or talk
 schema fields; the established queue transition may advance a recovered claim
@@ -162,9 +163,8 @@ receipt from v1 to v2 while adding its release fields.
 
 The owner migration is a preservation migration. Its only allowed semantic
 changes are advancing the root to schema v2, adding the validated historical
-version to an
-unversioned owner record, creating absent owned arrays as empty arrays, and
-upgrading config v1 to v2. A missing exclusion list receives the canonical
+version to an unversioned owner record, creating absent owned arrays as empty
+arrays, and upgrading config v1 to v2. A missing exclusion list receives the canonical
 defaults; a valid owner-supplied list is preserved exactly. It
 preserves every other JSON value and missing-vs-present distinction, including
 legacy-v1 `pattern_observations` objects, arrays, or nulls and every historical
@@ -631,10 +631,12 @@ every other persisted artifact path uses, plus a markdown-suffix check; the
 accepted and refused spellings are
 `skills/vault-ingress/scripts/tracking_database.py::validate_markdown_deck`.
 
-The collection is the root v2 shape, so it cannot ride an older root: a database
-at root 0 or 1 carrying a `markdown_decks` key is refused, naming the migration
-that stamps the root before the collection is usable. Otherwise the root version
-would stop describing the bytes, which is what the generation exists to record.
+The collection is the root v2 shape, so it is not usable on an older root. A
+database at root 0 or 1 carrying a `markdown_decks` key is never `current`, so
+every reader and writer that requires current state refuses it; the migration
+advances the root and preserves the records, which is what a preservation
+migration is for. Refusing such a database outright would be a dead end — the
+migration assesses before it stamps.
 
 Existence is never checked. The deck's repo need not be on this machine, so an
 absent file is the renderer's loud failure at render time rather than a silent

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -672,7 +672,7 @@ review its `changes`, then bind apply to that report's exact input hash:
 ```
 
 Initialization uses a sole `initialize_database` mutation, stamps database
-schema version 1 and config schema version 2, supplies the canonical
+schema version 2 and config schema version 2, supplies the canonical
 `pptx_directory_exclusions` when the plan omits that field, defaults to dry-run,
 and applies with the literal
 `--expected-sha256 missing`. All other applies

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -563,7 +563,7 @@ exact-type rule. The supported mutation kinds are:
 | `upsert_thumbnail` | Replace/add one complete schema-v1 record identified by `talk_slug` |
 | `apply_reviewed_metadata` | Install one human-reviewed shownotes catalog-conflict decision on one exact talk filename, over a closed identity field set, with `expect` covering exactly the same fields |
 | `record_source_title_equivalence` | Append one owner-reviewed provider-title equivalence to one exact talk filename; append-only and refuses a duplicate |
-| `record_markdown_deck` | Register (or re-point) the markdown file one exact talk's deck was authored in; upsert, one deck per talk |
+| `record_markdown_deck` | Register (or re-point) the markdown file one exact talk's deck was authored in, with `expect` naming the currently registered `deck_source_path` or the missing marker; upsert, one deck per talk |
 | `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
 | `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -277,7 +277,6 @@ customization, not the owner default. See the
     "transcript_path": "transcripts/{id}.txt  (optional vault-relative path; required for non-YouTube transcript evidence)",
     "slide_source": "pptx|pdf|both|video_extracted|markdown|none  (set in Step 2 per slide source hierarchy)",
     "slides_local_path": "slides/<artifact>.pdf  (optional explicit local PDF; legacy readers also accept slides_pdf_path/pdf_path)",
-    "deck_source_path": "/decks/<talk>/slides.md  (optional; the markdown file the deck was authored in \u2014 see below)",
     "pptx_visual_status": "pending|extracted|no_pptx",
     "status": "pending|needs-reprocessing|reprocessing-inflight|processed|processed_partial|skipped_no_sources|skipped_download_failed|skipped_duplicate",
     "reprocess_reason": "machine-readable reason for needs-reprocessing, or null (owner-set values: DELIBERATE_REPROCESS_REASONS in queue_claim_contract.py)",
@@ -560,6 +559,7 @@ exact-type rule. The supported mutation kinds are:
 | `upsert_thumbnail` | Replace/add one complete schema-v1 record identified by `talk_slug` |
 | `apply_reviewed_metadata` | Install one human-reviewed shownotes catalog-conflict decision on one exact talk filename, over a closed identity field set, with `expect` covering exactly the same fields |
 | `record_source_title_equivalence` | Append one owner-reviewed provider-title equivalence to one exact talk filename; append-only and refuses a duplicate |
+| `record_markdown_deck` | Register (or re-point) the markdown file one exact talk's deck was authored in; upsert, one deck per talk |
 | `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
 | `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |
 
@@ -596,6 +596,43 @@ rather than inheriting the approval — a later provider rename, and a catalog
 title edited after the review. Consulted only after the deterministic comparison
 fails; when it applies, the check passes silently and the record is the audit
 trail.
+
+`markdown_decks` is a top-level collection for the same reason, and it is the
+newer half of the same lesson:
+
+```json
+"markdown_decks": [{
+  "schema_version": 1,
+  "talk_filename": "spring-rag-jcon.md",
+  "deck_source_path": "/repos/spring-rag/slides.md"
+}]
+```
+
+It names the markdown file a talk's deck was authored in — Slidev, presenterm,
+Marp, reveal-md. It is kept because registering a render destroys the only other
+trace: the repair that binds `slides/<talk>.pdf` moves `slide_source` from
+`"markdown"` to `"pdf"`, correctly, since the talk now has readable slides, and
+after that nothing says the deck was ever markdown. The next render, after the
+deck gained three slides, would begin by hunting for the file.
+
+`deck_source_path` is a native absolute path in the ordinary case — these decks
+live one git repo per talk, so no configured directory locates them the way
+`config.pptx_source_dir` locates a deck library — or a vault-root-relative one
+like `pptx_path`. **A relative value is resolved by the caller against the vault
+root before it reaches a renderer**, which resolves a relative CLI path from its
+own working directory and would otherwise report a missing deck for a perfectly
+good locator. Its shape goes through `classify_artifact_locator`
+(`skills/vault-ingress/scripts/artifact_locator.py`), the same lexical contract
+every other persisted artifact path uses, plus a markdown-suffix check; the
+accepted and refused spellings are
+`skills/vault-ingress/scripts/tracking_database.py::validate_markdown_deck`.
+
+Existence is never checked. The deck's repo need not be on this machine, so an
+absent file is the renderer's loud failure at render time rather than a silent
+reason to refuse the whole database. The collection is optional — absent means
+no registered deck, which is the correct reading of every database written
+before it existed — and no migration owns it: a deck is registered by an owner
+who knows where the file is, never inferred.
 
 `apply_reviewed_metadata` exists because `scan-shownotes.py --apply` refuses
 review-required entries by design: an approved catalog correction otherwise had
@@ -1354,21 +1391,6 @@ to a `processed_partial` return. An untrusted manifest is context-only: do not l
 `full_frame_context` artifact may still qualify as `delivery_video` evidence for room,
 speaker, PiP, and delivery/timing phenomena that it actually establishes; its scope can
 never be promoted into authored-slide evidence.
-
-`deck_source_path` names the markdown file a talk's deck was authored in
-(Slidev, presenterm, Marp, reveal-md). It is owner-set through
-`apply-source-repairs.py`, never returned by a worker, and it is deliberately
-independent of `slide_source`: registering a render moves `slide_source` from
-`"markdown"` to `"pdf"`, and the deck path has to outlive that rewrite or
-nothing names the file to re-render when the deck changes. Absolute values are
-the ordinary case, since these decks live one git repo per talk rather than in
-a configured library; a relative value resolves from the vault root like
-`pptx_path`. Absence means no authored markdown deck is registered — the
-correct reading for every record written before the field existed. Existence is
-not a precondition of any repair: the deck's repo need not be in this checkout,
-so a missing file surfaces as the renderer's diagnostic rather than a plan
-rejection. The accepted spellings are `validate_deck_source_path` in
-`skills/vault-ingress/scripts/apply-source-repairs.py`.
 
 `clear_fields` explicitly deletes prior analysis before the return is applied. Allowed paths
 are top-level analysis prose/provenance scalars or leaves under

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -277,6 +277,7 @@ customization, not the owner default. See the
     "transcript_path": "transcripts/{id}.txt  (optional vault-relative path; required for non-YouTube transcript evidence)",
     "slide_source": "pptx|pdf|both|video_extracted|markdown|none  (set in Step 2 per slide source hierarchy)",
     "slides_local_path": "slides/<artifact>.pdf  (optional explicit local PDF; legacy readers also accept slides_pdf_path/pdf_path)",
+    "deck_source_path": "/decks/<talk>/slides.md  (optional; the markdown file the deck was authored in \u2014 see below)",
     "pptx_visual_status": "pending|extracted|no_pptx",
     "status": "pending|needs-reprocessing|reprocessing-inflight|processed|processed_partial|skipped_no_sources|skipped_download_failed|skipped_duplicate",
     "reprocess_reason": "machine-readable reason for needs-reprocessing, or null (owner-set values: DELIBERATE_REPROCESS_REASONS in queue_claim_contract.py)",
@@ -1353,6 +1354,21 @@ to a `processed_partial` return. An untrusted manifest is context-only: do not l
 `full_frame_context` artifact may still qualify as `delivery_video` evidence for room,
 speaker, PiP, and delivery/timing phenomena that it actually establishes; its scope can
 never be promoted into authored-slide evidence.
+
+`deck_source_path` names the markdown file a talk's deck was authored in
+(Slidev, presenterm, Marp, reveal-md). It is owner-set through
+`apply-source-repairs.py`, never returned by a worker, and it is deliberately
+independent of `slide_source`: registering a render moves `slide_source` from
+`"markdown"` to `"pdf"`, and the deck path has to outlive that rewrite or
+nothing names the file to re-render when the deck changes. Absolute values are
+the ordinary case, since these decks live one git repo per talk rather than in
+a configured library; a relative value resolves from the vault root like
+`pptx_path`. Absence means no authored markdown deck is registered — the
+correct reading for every record written before the field existed. Existence is
+not a precondition of any repair: the deck's repo need not be in this checkout,
+so a missing file surfaces as the renderer's diagnostic rather than a plan
+rejection. The accepted spellings are `validate_deck_source_path` in
+`skills/vault-ingress/scripts/apply-source-repairs.py`.
 
 `clear_fields` explicitly deletes prior analysis before the return is applied. Allowed paths
 are top-level analysis prose/provenance scalars or leaves under

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -9,9 +9,10 @@ Canonical path: `~/.claude/rhetoric-knowledge-vault/tracking-database.json`.
 shape, and all migrations. vault-clarification may write current config,
 confirmed-intent, and improvement-goal records. presentation-creator may write
 current QR records. vault-profile and the remaining presentation consumers are
-read-only. Non-owner readers accept legacy database schema 0 and current schema
-1 during rollout. They never rewrite legacy state. An unsupported future
-database or record version is no usable prior state.
+read-only. Non-owner readers accept every readable database generation during
+rollout — legacy 0, pre-`markdown_decks` 1, and current 2. They never rewrite
+legacy state. An unsupported future database or record version is no usable
+prior state.
 
 The independently versioned records are the database root, `config`, each
 `talks[]`, `pptx_catalog[]`, `qr_codes[]`, `resources[]`, `thumbnails[]`,
@@ -160,7 +161,8 @@ schema fields; the established queue transition may advance a recovered claim
 receipt from v1 to v2 while adding its release fields.
 
 The owner migration is a preservation migration. Its only allowed semantic
-changes are adding root schema v1, adding the validated historical version to an
+changes are advancing the root to schema v2, adding the validated historical
+version to an
 unversioned owner record, creating absent owned arrays as empty arrays, and
 upgrading config v1 to v2. A missing exclusion list receives the canonical
 defaults; a valid owner-supplied list is preserved exactly. It
@@ -173,7 +175,7 @@ no-op.
 
 | Independent record | Current schema |
 |---|---:|
-| database root | 1 |
+| database root | 2 (schema 1, the generation before `markdown_decks`, remains readable) |
 | config | 2 (schema 1 remains readable owner-migration input) |
 | talk | 7 (schemas 1-6 remain readable historical state; v5 and v6 restamp) |
 | PPTX catalog | 3 (schemas 1 and 2 remain readable legacy state) |
@@ -187,18 +189,20 @@ no-op.
 
 | Component | Access | Contract |
 |---|---|---|
-| vault-ingress migration | owner read/write | Accept root schema 0/1 and config schema 1/2; migrate to root v1/config v2; never downgrade future state |
-| vault-ingress queue inspection/recovery | owner compatibility transition | Inspect schema 0/1; recover active leases in schema 0/1; never stamp artifact or talk schema versions |
-| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 1, config schema 2, and supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
-| vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0 and 1; gate through existing finding/error channels; never rewrite |
+| vault-ingress migration | owner read/write | Accept root schema 0/1/2 and config schema 1/2; migrate to root v2/config v2; never downgrade future state |
+| vault-ingress queue inspection/recovery | owner compatibility transition | Inspect schema 0/1/2; recover active leases in schema 0/1/2; never stamp artifact or talk schema versions |
+| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 2, config schema 2, and supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
+| vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0, 1, and 2; gate through existing finding/error channels; never rewrite |
 | vault-clarification | current read/write | Route schema migration to vault-ingress; preserve config v2 and stamp confirmed intent v1/improvement goal v2 |
-| presentation-creator QR writer | dual reader/current writer | Read schemas 0 and 1; require schema 1 before URL creation or QR metadata persistence; stamp QR v2 |
-| presentation-creator publishing/post-event | authorized current writer | Require schema 1 before tracking writes; stamp resource v1 and preserve talk v7 |
-| illustrations thumbnail workflow | authorized current writer | Require schema 1 before tracking writes; stamp thumbnail v1 and preserve talk v7 |
-| vault-profile | dual reader | Parse schemas 0 and 1; treat unsupported generations as unavailable; never migrate |
+| presentation-creator QR writer | dual reader/current writer | Read schemas 0, 1, and 2; require schema 2 before URL creation or QR metadata persistence; stamp QR v2 |
+| presentation-creator publishing/post-event | authorized current writer | Require schema 2 before tracking writes; stamp resource v1 and preserve talk v7 |
+| illustrations thumbnail workflow | authorized current writer | Require schema 2 before tracking writes; stamp thumbnail v1 and preserve talk v7 |
+| vault-profile | dual reader | Parse schemas 0, 1, and 2; treat unsupported generations as unavailable; never migrate |
 
-Current database schema 1 with config schema 2 requires all eight top-level
-state fields shown below.
+Current database schema 2 with config schema 2 requires all eight top-level
+state fields shown below. `markdown_decks` is the ninth key and is optional:
+absent means no talk has a registered markdown deck, which is what every
+database written before root v2 says.
 Missing legacy arrays become empty during owner migration. Current writers do
 not create them opportunistically. A schema-v1 improvement goal remains valid
 historical state; migration never fabricates the schema-v2 baseline provenance
@@ -2165,7 +2169,7 @@ bounded PDF ceiling, complete page-tree walk, and repair-diagnostic rejection to
 render receipts produced inside the already-contained PPTX extraction worker.
 
 Extractor schema v4 is independent of persisted pattern-evidence schema v2,
-return schema v5, queue-claim schema v5, and tracking-database schema v1. Those
+return schema v5, queue-claim schema v5, and tracking-database schema v2. Those
 downstream generations do not advance here; their current readers bind or
 validate the new nested records inside their existing contracts.
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -223,7 +223,7 @@ customization, not the owner default. See the
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "config": {
     "schema_version": 2,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
@@ -350,7 +350,7 @@ customization, not the owner default. See the
       "not_evaluable": []
     }
   }],
-  "_comment_schema_version": "Database schema v1 is owner-migrated by vault-ingress. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level `source_title_equivalences` collection at record v2, so v7 adds no field a v6 record lacks; migration restamps a v5 or v6 record to v7 untouched and lifts a nested v1 ledger out of the talk into that collection. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
+  "_comment_schema_version": "Database root schema v2 is owner-migrated by vault-ingress; root v1 is the generation before the top-level `markdown_decks` collection, and migration moves a v0 or v1 database to v2 without touching any record it already carries. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level `source_title_equivalences` collection at record v2, so v7 adds no field a v6 record lacks; migration restamps a v5 or v6 record to v7 untouched and lifts a nested v1 ledger out of the talk into that collection. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "schema_version": 3,

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -631,6 +631,11 @@ every other persisted artifact path uses, plus a markdown-suffix check; the
 accepted and refused spellings are
 `skills/vault-ingress/scripts/tracking_database.py::validate_markdown_deck`.
 
+The collection is the root v2 shape, so it cannot ride an older root: a database
+at root 0 or 1 carrying a `markdown_decks` key is refused, naming the migration
+that stamps the root before the collection is usable. Otherwise the root version
+would stop describing the bytes, which is what the generation exists to record.
+
 Existence is never checked. The deck's repo need not be on this machine, so an
 absent file is the renderer's loud failure at render time rather than a silent
 reason to refuse the whole database. The collection is optional — absent means

--- a/skills/vault-ingress/scripts/apply-source-repairs.py
+++ b/skills/vault-ingress/scripts/apply-source-repairs.py
@@ -30,7 +30,7 @@ import argparse
 import copy
 import hashlib
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import sys
 from typing import Any
 
@@ -63,6 +63,7 @@ ALLOWED_FIELDS = frozenset(
         "slides_local_path",
         "slides_pdf_path",
         "pdf_path",
+        "deck_source_path",
         "transcript_path",
         "transcript_source",
         "slide_source",
@@ -73,6 +74,10 @@ ALLOWED_FIELDS = frozenset(
         "reprocess_reason",
     }
 )
+# Suffixes a markdown-authored deck source is written with. Every flavor this
+# toolkit renders — Slidev, presenterm, Marp, reveal-md — authors markdown, so a
+# `deck_source_path` naming anything else is a mistyped path rather than a deck.
+DECK_SOURCE_SUFFIXES = frozenset({".md", ".markdown"})
 ALLOWED_REPAIR_STATUSES = frozenset(
     {
         "pending",
@@ -203,8 +208,66 @@ def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
             raise SourceRepairError(
                 f"{label}.set.status must be one of {sorted(ALLOWED_REPAIR_STATUSES)}"
             )
+        if "deck_source_path" in set_values:
+            validate_deck_source_path(
+                set_values["deck_source_path"], f"{label}.set.deck_source_path"
+            )
         normalized.append(repair)
     return normalized
+
+
+def validate_deck_source_path(value: Any, label: str) -> None:
+    """Check a `deck_source_path` before it is written onto a talk.
+
+    The field names the markdown file a talk's deck was authored in. It exists
+    as its own field rather than being read back off `slide_source` because
+    registering a render overwrites that: the repair that binds
+    `slides/<talk>.pdf` moves `slide_source` from "markdown" to "pdf", and the
+    only record that the deck was ever markdown goes with it. A talk whose deck
+    later changes then has nothing naming the file to re-render.
+
+    Absolute values are the ordinary case. The decks in #318 live in a git repo
+    per talk beside the vault, so no single configured directory locates them
+    the way `config.pptx_source_dir` locates a deck library; a relative value
+    resolves from the vault root, which is `pptx_path`'s own fallback.
+
+    Rejected: a non-string, a directory, a traversal segment, a backslash
+    separator, and any suffix outside DECK_SOURCE_SUFFIXES. Existence is NOT
+    checked here — the deck lives outside the vault and may legitimately be
+    absent from this checkout, so a missing file is the renderer's diagnostic
+    to give, not this plan's precondition to fail.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise SourceRepairError(f"{label} must be a nonempty string")
+    if value != value.strip():
+        raise SourceRepairError(
+            f"{label} has leading or trailing whitespace; write it as {value.strip()!r}"
+        )
+    if "\\" in value:
+        raise SourceRepairError(
+            f"{label} must separate path segments with '/', not a backslash"
+        )
+    path = PurePosixPath(value)
+    if ".." in path.parts:
+        raise SourceRepairError(
+            f"{label} must not contain a '..' segment; give the resolved path"
+        )
+    # Each rejected form has one canonical spelling, so the diagnostic can name
+    # it rather than leaving the operator to guess which character offended.
+    if path.as_posix() != value:
+        raise SourceRepairError(
+            f"{label} is not canonical (a doubled, trailing, or './' separator); "
+            f"write it as {path.as_posix()!r}"
+        )
+    if path.name in {".", ".."} or not path.suffix:
+        raise SourceRepairError(
+            f"{label} must name a deck file, not a directory: {value!r}"
+        )
+    if path.suffix.lower() not in DECK_SOURCE_SUFFIXES:
+        raise SourceRepairError(
+            f"{label} must name a markdown deck source "
+            f"({', '.join(sorted(DECK_SOURCE_SUFFIXES))}), not {path.name!r}"
+        )
 
 
 def _matches_expected(talk: dict[str, Any], field: str, expected: Any) -> bool:

--- a/skills/vault-ingress/scripts/apply-source-repairs.py
+++ b/skills/vault-ingress/scripts/apply-source-repairs.py
@@ -30,7 +30,7 @@ import argparse
 import copy
 import hashlib
 import json
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 import sys
 from typing import Any
 
@@ -63,7 +63,6 @@ ALLOWED_FIELDS = frozenset(
         "slides_local_path",
         "slides_pdf_path",
         "pdf_path",
-        "deck_source_path",
         "transcript_path",
         "transcript_source",
         "slide_source",
@@ -74,10 +73,6 @@ ALLOWED_FIELDS = frozenset(
         "reprocess_reason",
     }
 )
-# Suffixes a markdown-authored deck source is written with. Every flavor this
-# toolkit renders — Slidev, presenterm, Marp, reveal-md — authors markdown, so a
-# `deck_source_path` naming anything else is a mistyped path rather than a deck.
-DECK_SOURCE_SUFFIXES = frozenset({".md", ".markdown"})
 ALLOWED_REPAIR_STATUSES = frozenset(
     {
         "pending",
@@ -208,66 +203,8 @@ def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
             raise SourceRepairError(
                 f"{label}.set.status must be one of {sorted(ALLOWED_REPAIR_STATUSES)}"
             )
-        if "deck_source_path" in set_values:
-            validate_deck_source_path(
-                set_values["deck_source_path"], f"{label}.set.deck_source_path"
-            )
         normalized.append(repair)
     return normalized
-
-
-def validate_deck_source_path(value: Any, label: str) -> None:
-    """Check a `deck_source_path` before it is written onto a talk.
-
-    The field names the markdown file a talk's deck was authored in. It exists
-    as its own field rather than being read back off `slide_source` because
-    registering a render overwrites that: the repair that binds
-    `slides/<talk>.pdf` moves `slide_source` from "markdown" to "pdf", and the
-    only record that the deck was ever markdown goes with it. A talk whose deck
-    later changes then has nothing naming the file to re-render.
-
-    Absolute values are the ordinary case. The decks in #318 live in a git repo
-    per talk beside the vault, so no single configured directory locates them
-    the way `config.pptx_source_dir` locates a deck library; a relative value
-    resolves from the vault root, which is `pptx_path`'s own fallback.
-
-    Rejected: a non-string, a directory, a traversal segment, a backslash
-    separator, and any suffix outside DECK_SOURCE_SUFFIXES. Existence is NOT
-    checked here — the deck lives outside the vault and may legitimately be
-    absent from this checkout, so a missing file is the renderer's diagnostic
-    to give, not this plan's precondition to fail.
-    """
-    if not isinstance(value, str) or not value.strip():
-        raise SourceRepairError(f"{label} must be a nonempty string")
-    if value != value.strip():
-        raise SourceRepairError(
-            f"{label} has leading or trailing whitespace; write it as {value.strip()!r}"
-        )
-    if "\\" in value:
-        raise SourceRepairError(
-            f"{label} must separate path segments with '/', not a backslash"
-        )
-    path = PurePosixPath(value)
-    if ".." in path.parts:
-        raise SourceRepairError(
-            f"{label} must not contain a '..' segment; give the resolved path"
-        )
-    # Each rejected form has one canonical spelling, so the diagnostic can name
-    # it rather than leaving the operator to guess which character offended.
-    if path.as_posix() != value:
-        raise SourceRepairError(
-            f"{label} is not canonical (a doubled, trailing, or './' separator); "
-            f"write it as {path.as_posix()!r}"
-        )
-    if path.name in {".", ".."} or not path.suffix:
-        raise SourceRepairError(
-            f"{label} must name a deck file, not a directory: {value!r}"
-        )
-    if path.suffix.lower() not in DECK_SOURCE_SUFFIXES:
-        raise SourceRepairError(
-            f"{label} must name a markdown deck source "
-            f"({', '.join(sorted(DECK_SOURCE_SUFFIXES))}), not {path.name!r}"
-        )
 
 
 def _matches_expected(talk: dict[str, Any], field: str, expected: Any) -> bool:

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -35,11 +35,13 @@ from tracking_database import (
     THUMBNAIL_RECORD_SCHEMA_VERSION,
     THUMBNAIL_REQUIRED_FIELDS as OWNER_THUMBNAIL_REQUIRED_FIELDS,
     LEGACY_TALK_RECORD_SCHEMA_VERSION,
+    MARKDOWN_DECK_RECORD_SCHEMA_VERSION,
     SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION,
     TALK_RECORD_SCHEMA_VERSION,
     TRACKING_DATABASE_SCHEMA_VERSION,
     TrackingDatabaseError,
     require_current_tracking_database,
+    validate_markdown_deck,
     validate_source_title_equivalence,
 )
 from tracking_database_io import (
@@ -994,6 +996,67 @@ def _apply_record_title_equivalence(
     )
 
 
+def _apply_record_markdown_deck(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    """Register, or re-point, the markdown deck a talk's slides come from.
+
+    Upsert rather than append. The equivalence ledger beside it is an audit
+    trail of owner judgments, so it only ever grows; a deck registration is
+    current state — the repo moved, the deck was renamed — and the assessment
+    refuses a second record for one talk, so appending would write a database
+    no reader could resolve.
+
+    The talk is read for existence only. Nothing here touches the talk record,
+    which is the point: `TALK_RECORD_SCHEMA_VERSION` is the analysis
+    generation, and the talks that need a deck registered are the legacy ones
+    that can never migrate forward to a shape gate (#333). The readable-record
+    check accepts every generation the assessment can read.
+    """
+    _require_keys(
+        mutation,
+        required={"kind", "filename", "deck_source_path"},
+        label=f"mutations[{index}]",
+    )
+    filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
+    talk = _talk_by_filename(database, filename)
+    _require_readable_talk_record(talk, filename=filename)
+    record = {
+        "schema_version": MARKDOWN_DECK_RECORD_SCHEMA_VERSION,
+        "talk_filename": filename,
+        "deck_source_path": mutation["deck_source_path"],
+    }
+    try:
+        validate_markdown_deck(record, label=f"mutations[{index}]")
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
+
+    existing = database.get("markdown_decks", [])
+    if not isinstance(existing, list):
+        raise TrackingDatabaseMutationError("markdown_decks must be an array")
+    replaced: object = MISSING_MARKER
+    remaining: list[Any] = []
+    for recorded in existing:
+        if isinstance(recorded, dict) and recorded.get("talk_filename") == filename:
+            replaced = recorded.get("deck_source_path")
+            continue
+        remaining.append(recorded)
+    if replaced == record["deck_source_path"]:
+        return
+    database["markdown_decks"] = [*remaining, record]
+    _record_change(
+        changes,
+        kind="record_markdown_deck",
+        identity=filename,
+        before={"deck_source_path": replaced},
+        after={"deck_source_path": record["deck_source_path"]},
+    )
+
+
 def _validate_metadata_values(values: object, label: str) -> None:
     """Every repaired catalog value is a non-empty trimmed string.
 
@@ -1639,6 +1702,8 @@ def build_candidate(
             _apply_reviewed_metadata(candidate, mutation, changes, index=index)
         elif kind == "record_source_title_equivalence":
             _apply_record_title_equivalence(candidate, mutation, changes, index=index)
+        elif kind == "record_markdown_deck":
+            _apply_record_markdown_deck(candidate, mutation, changes, index=index)
         elif kind == "update_talk_publishing":
             _apply_update_talk(candidate, mutation, changes, index=index)
         elif kind == "update_talk_clarification":

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1019,12 +1019,18 @@ def _apply_record_markdown_deck(
     """
     _require_keys(
         mutation,
-        required={"kind", "filename", "deck_source_path"},
+        required={"kind", "filename", "expect", "deck_source_path"},
         label=f"mutations[{index}]",
     )
     filename = _nonempty(mutation["filename"], f"mutations[{index}].filename")
     talk = _talk_by_filename(database, filename)
     _require_readable_talk_record(talk, filename=filename)
+    expect = mutation["expect"]
+    if not isinstance(expect, dict) or set(expect) != {"deck_source_path"}:
+        raise TrackingDatabaseMutationError(
+            f"mutations[{index}].expect must be an object naming exactly "
+            "deck_source_path"
+        )
     record = {
         "schema_version": MARKDOWN_DECK_RECORD_SCHEMA_VERSION,
         "talk_filename": filename,
@@ -1039,13 +1045,25 @@ def _apply_record_markdown_deck(
     if not isinstance(existing, list):
         raise TrackingDatabaseMutationError("markdown_decks must be an array")
     replaced: object = MISSING_MARKER
+    registered = False
     remaining: list[Any] = []
     for recorded in existing:
         if isinstance(recorded, dict) and recorded.get("talk_filename") == filename:
-            replaced = recorded.get("deck_source_path")
+            replaced = recorded.get("deck_source_path", MISSING_MARKER)
+            registered = True
             continue
         remaining.append(recorded)
-    if replaced == record["deck_source_path"]:
+    # Same optimistic precondition every other talk-touching mutation carries:
+    # the plan states what it believes is registered, and a registration that
+    # moved under it fails instead of being silently overwritten. `$missing`
+    # is how a plan says "no deck is registered yet".
+    _expect_value(
+        exists=registered,
+        actual=replaced,
+        expected=expect["deck_source_path"],
+        label=f"mutations[{index}].expect.deck_source_path",
+    )
+    if registered and json_values_equal(replaced, record["deck_source_path"]):
         return
     database["markdown_decks"] = [*remaining, record]
     _record_change(

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1570,6 +1570,20 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
     # Validated in the assessment, like the equivalences above: a deck record
     # names the file a re-render reads, so a malformed or orphaned one must
     # refuse the database rather than send a renderer at a path no owner wrote.
+    #
+    # Gated on the root generation first. The collection IS the root v2 shape,
+    # so accepting it on a v0 or v1 root would let a database carry the new
+    # shape while still claiming the old generation — the version stops
+    # describing the bytes, which is the entire thing the bump exists to
+    # prevent (`stateful-artifacts` Migration Policy).
+    if not current and "markdown_decks" in database:
+        raise TrackingDatabaseError(
+            f"tracking database at root schema v{root_version} carries a "
+            "'markdown_decks' collection, which is the root schema "
+            f"v{TRACKING_DATABASE_SCHEMA_VERSION} shape; run "
+            "migrate-tracking-database.py to stamp the root before the "
+            "collection is usable"
+        )
     decks = database.get("markdown_decks", [])
     if not isinstance(decks, list):
         raise TrackingDatabaseError("markdown_decks must be an array")

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -12,9 +12,11 @@ from contextlib import contextmanager
 import copy
 from dataclasses import dataclass
 import datetime as dt
+from pathlib import PurePosixPath
 import re
 from typing import Any, Mapping
 
+from artifact_locator import ArtifactLocatorError, classify_artifact_locator
 from queue_claim_contract import (
     QueueClaimContractError,
     classify_queue_claim_versions,
@@ -55,6 +57,15 @@ LEGACY_SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION = 1
 SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION = 2
 LEGACY_IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION = 1
 IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION = 2
+# The authored markdown deck a talk's slides were rendered from (#318). Its own
+# top-level collection rather than a talk field: `TALK_RECORD_SCHEMA_VERSION`
+# means the analysis generation, so a shape change there is unreachable for the
+# legacy records this is for, and a nested record's version does not version its
+# parent (#333). The collection is optional — absent means no registered deck —
+# so every database written before it existed stays valid, and no migration
+# owns it (it is absent from `_RECORD_COUNT_KEYS` for that reason): a deck is
+# registered by an owner who knows where the file is, never inferred.
+MARKDOWN_DECK_RECORD_SCHEMA_VERSION = 1
 
 READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS = frozenset(
     {
@@ -209,6 +220,11 @@ LEGACY_SOURCE_TITLE_EQUIVALENCE_REQUIRED_FIELDS = frozenset(
         "verified_at",
     }
 )
+MARKDOWN_DECK_REQUIRED_FIELDS = frozenset({"talk_filename", "deck_source_path"})
+# Every flavor this toolkit renders — Slidev, presenterm, Marp, reveal-md —
+# authors markdown, so a deck source named with any other suffix is a mistyped
+# path rather than a deck.
+MARKDOWN_DECK_SOURCE_SUFFIXES = frozenset({".md", ".markdown"})
 SOURCE_TITLE_EQUIVALENCE_REQUIRED_FIELDS = frozenset(
     {
         "talk_filename",
@@ -1130,6 +1146,74 @@ def _validate_title_equivalence_shape(
         )
 
 
+def validate_markdown_deck(
+    record: Mapping[str, object],
+    *,
+    label: str,
+) -> None:
+    """Validate one registered markdown deck source.
+
+    The record names the markdown file a talk's deck was authored in. It is
+    kept because registering a render destroys the only other trace of it: the
+    repair that binds `slides/<talk>.pdf` moves `slide_source` from "markdown"
+    to "pdf", correctly — the talk now has readable slides — and after that no
+    field says the deck was ever markdown. The next render, after the deck
+    gained slides, would begin by hunting for the file.
+
+    The locator goes through `classify_artifact_locator`, the same lexical
+    contract every other persisted artifact path uses, so a NUL byte, a `~`,
+    a `..` segment, an ambiguous `//`, and a Windows reserved name are refused
+    here by one shared reader rather than by a private opinion about paths.
+    A native absolute value is the ordinary case, since these decks live one
+    git repo per talk; a relative one is vault-root-relative, like `pptx_path`.
+
+    Existence is not checked. The deck's repo need not be on this machine, so
+    an absent file is the renderer's loud failure at render time, never a
+    silent reason to refuse the whole database.
+    """
+    _require_closed_shape(
+        record,
+        required=MARKDOWN_DECK_REQUIRED_FIELDS,
+        label=label,
+    )
+    # `_require_closed_shape` ignores `schema_version` for every record, so the
+    # generation is checked explicitly. A record this reader cannot name must
+    # refuse rather than be coerced into the current shape.
+    recorded = record.get("schema_version")
+    if (
+        isinstance(recorded, bool)
+        or not isinstance(recorded, int)
+        or recorded != MARKDOWN_DECK_RECORD_SCHEMA_VERSION
+    ):
+        raise TrackingDatabaseError(
+            f"{label}.schema_version must be {MARKDOWN_DECK_RECORD_SCHEMA_VERSION}"
+        )
+    _require_nonempty_string(record["talk_filename"], f"{label}.talk_filename")
+    value = _require_nonempty_string(
+        record["deck_source_path"],
+        f"{label}.deck_source_path",
+    )
+    try:
+        classify_artifact_locator(value)
+    except ArtifactLocatorError as exc:
+        raise TrackingDatabaseError(
+            f"{label}.deck_source_path is not a usable artifact locator "
+            f"({exc.reason_code}): {value!r}"
+        ) from exc
+    name = PurePosixPath(value).name
+    suffix = PurePosixPath(name).suffix
+    if not suffix or name == suffix:
+        raise TrackingDatabaseError(
+            f"{label}.deck_source_path must name a deck file, not a directory: "
+            f"{value!r}"
+        )
+    if suffix.lower() not in MARKDOWN_DECK_SOURCE_SUFFIXES:
+        raise TrackingDatabaseError(
+            f"{label}.deck_source_path must name a markdown deck source "
+            f"({', '.join(sorted(MARKDOWN_DECK_SOURCE_SUFFIXES))}), not {name!r}"
+        )
+
+
 def validate_source_title_equivalence(
     equivalence: Mapping[str, object],
     *,
@@ -1472,6 +1556,34 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
                 f"source_title_equivalences[{index}].talk_filename names no talk: "
                 f"{equivalence['talk_filename']!r}"
             )
+
+    # Validated in the assessment, like the equivalences above: a deck record
+    # names the file a re-render reads, so a malformed or orphaned one must
+    # refuse the database rather than send a renderer at a path no owner wrote.
+    decks = database.get("markdown_decks", [])
+    if not isinstance(decks, list):
+        raise TrackingDatabaseError("markdown_decks must be an array")
+    claimed_by_talk: set[object] = set()
+    for index, record in enumerate(decks):
+        if not isinstance(record, Mapping):
+            raise TrackingDatabaseError(
+                f"markdown_decks[{index}] must be a JSON object"
+            )
+        validate_markdown_deck(record, label=f"markdown_decks[{index}]")
+        talk_filename = record["talk_filename"]
+        if talk_filename not in known_filenames:
+            raise TrackingDatabaseError(
+                f"markdown_decks[{index}].talk_filename names no talk: "
+                f"{talk_filename!r}"
+            )
+        # One deck per talk. A second record would leave every reader picking
+        # between two paths with nothing in the data saying which is current.
+        if talk_filename in claimed_by_talk:
+            raise TrackingDatabaseError(
+                f"markdown_decks[{index}] is a second deck for "
+                f"{talk_filename!r}; a talk has one authored deck source"
+            )
+        claimed_by_talk.add(talk_filename)
 
     try:
         # Assessment intentionally admits claim/status drift so schema-0 queue

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1571,19 +1571,15 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
     # names the file a re-render reads, so a malformed or orphaned one must
     # refuse the database rather than send a renderer at a path no owner wrote.
     #
-    # Gated on the root generation first. The collection IS the root v2 shape,
-    # so accepting it on a v0 or v1 root would let a database carry the new
-    # shape while still claiming the old generation — the version stops
-    # describing the bytes, which is the entire thing the bump exists to
-    # prevent (`stateful-artifacts` Migration Policy).
-    if not current and "markdown_decks" in database:
-        raise TrackingDatabaseError(
-            f"tracking database at root schema v{root_version} carries a "
-            "'markdown_decks' collection, which is the root schema "
-            f"v{TRACKING_DATABASE_SCHEMA_VERSION} shape; run "
-            "migrate-tracking-database.py to stamp the root before the "
-            "collection is usable"
-        )
+    # The collection IS the root v2 shape, so a pre-v2 root carrying it is not
+    # usable AS current — but the fix is the migration, not a refusal. Raising
+    # here would have been a dead end: `migrate_tracking_database` assesses
+    # before it stamps, so the diagnostic told an owner to run the one command
+    # that would refuse them. Usability is already gated correctly one level
+    # up — a pre-v2 root is `legacy`, and `require_current_tracking_database`
+    # refuses every generation but the current one — so the migration advances
+    # the root and preserves the records, which is what a preservation
+    # migration is for.
     decks = database.get("markdown_decks", [])
     if not isinstance(decks, list):
         raise TrackingDatabaseError("markdown_decks must be an array")
@@ -1852,7 +1848,7 @@ def _migrate_pptx_catalog_records(candidate: dict[str, Any]) -> int:
 
 
 def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
-    """Build the deterministic owner migration to root v1/config v2."""
+    """Build the deterministic owner migration to root v2/config v2."""
     assessment = assess_tracking_database(database)
     if not assessment.usable:
         raise TrackingDatabaseError(

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1206,6 +1206,10 @@ def validate_markdown_deck(
             f"{label}.deck_source_path is not a usable artifact locator "
             f"({exc.reason_code}): {value!r}"
         ) from exc
+    if value.endswith("/"):
+        raise TrackingDatabaseError(
+            f"{label}.deck_source_path ends in '/', which names a directory: {value!r}"
+        )
     name = PurePosixPath(value).name
     suffix = PurePosixPath(name).suffix
     if not suffix or name == suffix:
@@ -1622,7 +1626,8 @@ def require_current_tracking_database(database: object) -> dict[str, Any]:
     except TrackingDatabaseError as exc:
         if version == TRACKING_DATABASE_SCHEMA_VERSION:
             raise TrackingDatabaseError(
-                "tracking database schema v1 has malformed owner-managed state; "
+                f"tracking database schema v{TRACKING_DATABASE_SCHEMA_VERSION} "
+                "has malformed owner-managed state; "
                 "update speaker-toolkit or repair the owner-managed state. Schema "
                 f"migration will refuse this state ({exc})"
             ) from exc

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -31,7 +31,12 @@ from pptx_talk_identity import unassessed_legacy_binding
 
 
 LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
-TRACKING_DATABASE_SCHEMA_VERSION = 1
+# The root shape before the `markdown_decks` collection (#318). A top-level key
+# is part of the ROOT record's shape, and a version on each nested deck record
+# does not version its parent database, so admitting the collection moves the
+# root generation (`stateful-artifacts` Migration Policy).
+PRE_MARKDOWN_DECKS_TRACKING_DATABASE_SCHEMA_VERSION = 1
+TRACKING_DATABASE_SCHEMA_VERSION = 2
 LEGACY_TALK_RECORD_SCHEMA_VERSION = 1
 FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION = 5
 # The generation before the owner-reviewed title-equivalence ledger (#333).
@@ -70,6 +75,7 @@ MARKDOWN_DECK_RECORD_SCHEMA_VERSION = 1
 READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS = frozenset(
     {
         LEGACY_TRACKING_DATABASE_SCHEMA_VERSION,
+        PRE_MARKDOWN_DECKS_TRACKING_DATABASE_SCHEMA_VERSION,
         TRACKING_DATABASE_SCHEMA_VERSION,
     }
 )
@@ -1975,7 +1981,12 @@ def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
     return TrackingDatabaseMigration(
         database=candidate,
         changed=True,
-        from_schema_version=LEGACY_TRACKING_DATABASE_SCHEMA_VERSION,
+        # The generation actually read, not a hardcoded legacy 0. Every step
+        # above is idempotent for a root v1 database — its records already carry
+        # the versions the v0 path stamps — so v1 reaches v2 through the same
+        # tail, and reporting it as having come from v0 would misname what was
+        # migrated.
+        from_schema_version=root_version,
         to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
         record_counts=counts,
     )

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -43,7 +43,7 @@ repair any field in that stamp during profile assembly.
 extractor cohort for pacing-sensitive analysis. Instrumentation membership never
 confers pattern-baseline eligibility.
 
-Legacy database schema 0 and current schema 1 are read-only inputs. An unsupported
+Legacy database schemas 0 and 1 and current schema 2 are read-only inputs. An unsupported
 future database or record schema has no usable prior state. Compatibility stays
 internal, adds no payload fields, and never migrates the database.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,12 @@ DEFAULT_PPTX_DIRECTORY_EXCLUSIONS = [
 ]
 
 
+# The owner-current root generation, in one place. A fixture that pins it by
+# literal has to be hunted down on every root bump, and the ones that were
+# missed failed as "assert 2 == 1" with nothing naming the generation.
+CURRENT_ROOT_SCHEMA_VERSION = 2
+
+
 def current_tracking_config(**updates: object) -> dict[str, object]:
     """Return the owner-current config generation for writer fixtures."""
     config: dict[str, object] = {

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -403,134 +403,46 @@ def test_malformed_missing_marker_is_an_exact_object_not_absence(
         apply_source_repairs.build_repaired_database(database, [repair])
 
 
-def deck_database():
-    """A markdown-authored talk in the state #318 describes: deck, no evidence."""
-    database = base_database()
-    database["talks"][0]["slide_source"] = "markdown"
-    return database
-
-
-def deck_repair(**overrides):
-    repair = {
-        "filename": "talk.md",
-        "reason": "Slidev deck rendered to PDF and registered as slide evidence",
-        "expect": {
-            "slide_source": "markdown",
-            "slides_local_path": {"$missing": True},
-            "deck_source_path": {"$missing": True},
-        },
-        "set": {
-            "slide_source": "pdf",
-            "slides_local_path": "slides/talk.pdf",
-            "deck_source_path": "/decks/spring-rag/slides.md",
-        },
-    }
-    repair.update(overrides)
-    return {"schema_version": 1, "repairs": [repair]}
-
-
-def test_registering_a_render_keeps_the_deck_it_was_rendered_from(
+def test_the_documented_render_registration_plan_applies(
     apply_source_repairs,
 ) -> None:
-    """`slide_source` alone loses the provenance the moment the PDF is bound.
+    """The register-the-render plan in references/markdown-decks.md, verbatim.
 
-    Registering the render moves `slide_source` from "markdown" to "pdf", which
-    is correct — the talk now has readable slide evidence. Before this field
-    existed that rewrite also erased the only trace that the deck was authored
-    in markdown, leaving nothing to re-render when the deck changed.
+    `validate_plan` refuses a repair that changes a field it did not declare in
+    `expect`, so the page's earlier recipe — which set `status` and
+    `reprocess_reason` while expecting neither — could never be applied by the
+    reader following it.
     """
-    repaired, changes = apply_source_repairs.build_repaired_database(
-        deck_database(),
-        deck_repair()["repairs"],
-    )
+    database = base_database()
+    database["talks"][0]["slide_source"] = "markdown"
+    database["talks"][0]["status"] = "processed_partial"
+    plan = {
+        "schema_version": 1,
+        "repairs": [
+            {
+                "filename": "talk.md",
+                "reason": "Slidev deck rendered to PDF and registered as evidence",
+                "expect": {
+                    "slides_local_path": {"$missing": True},
+                    "slide_source": "markdown",
+                    "status": "processed_partial",
+                    "reprocess_reason": {"$missing": True},
+                },
+                "set": {
+                    "slides_local_path": "slides/talk.pdf",
+                    "slide_source": "pdf",
+                    "status": "needs-reprocessing",
+                    "reprocess_reason": "source_added",
+                },
+            }
+        ],
+    }
+
+    repairs = apply_source_repairs.validate_plan(plan)
+    repaired, changes = apply_source_repairs.build_repaired_database(database, repairs)
 
     talk = repaired["talks"][0]
     assert talk["slide_source"] == "pdf"
     assert talk["slides_local_path"] == "slides/talk.pdf"
-    assert talk["deck_source_path"] == "/decks/spring-rag/slides.md"
-    assert changes
-
-
-@pytest.mark.parametrize(
-    "path",
-    [
-        "/decks/spring-rag/slides.md",
-        "decks/spring-rag/slides.md",
-        "slides.MD",
-        "deck.markdown",
-    ],
-)
-def test_deck_source_path_accepts_absolute_and_vault_relative_decks(
-    apply_source_repairs,
-    path,
-) -> None:
-    """Decks live one git repo per talk, so no configured directory locates them.
-
-    An absolute path is the ordinary case and a relative one resolves from the
-    vault root, matching `pptx_path`. Both are accepted here; neither is
-    checked for existence, because the deck's repo need not be in this
-    checkout.
-    """
-    apply_source_repairs.validate_plan(
-        deck_repair(
-            set={
-                "slide_source": "pdf",
-                "slides_local_path": "slides/talk.pdf",
-                "deck_source_path": path,
-            }
-        )
-    )
-
-
-@pytest.mark.parametrize(
-    ("path", "message"),
-    [
-        ("deck.pptx", "must name a markdown deck source"),
-        ("decks/spring-rag", "must name a deck file, not a directory"),
-        ("decks//slides.md", "write it as 'decks/slides.md'"),
-        ("./slides.md", "write it as 'slides.md'"),
-        ("../slides.md", "must not contain a '..' segment"),
-        (" slides.md", "write it as 'slides.md'"),
-        ("decks\\slides.md", "must separate path segments with '/'"),
-        ("", "must be a nonempty string"),
-        (42, "must be a nonempty string"),
-    ],
-)
-def test_deck_source_path_rejects_a_value_that_is_not_a_deck(
-    apply_source_repairs,
-    path,
-    message,
-) -> None:
-    """Each rejection names the defect it found, not the first check to fire."""
-    plan = deck_repair(
-        set={
-            "slide_source": "pdf",
-            "slides_local_path": "slides/talk.pdf",
-            "deck_source_path": path,
-        }
-    )
-
-    with pytest.raises(apply_source_repairs.SourceRepairError, match=message):
-        apply_source_repairs.validate_plan(plan)
-
-
-def test_deck_source_path_can_be_cleared_when_a_deck_moves_away(
-    apply_source_repairs,
-) -> None:
-    """A registered deck that is no longer the talk's source is unregisterable."""
-    database = deck_database()
-    database["talks"][0]["deck_source_path"] = "/decks/old/slides.md"
-    repaired, changes = apply_source_repairs.build_repaired_database(
-        database,
-        [
-            {
-                "filename": "talk.md",
-                "reason": "deck repo retired; the render is now the only source",
-                "expect": {"deck_source_path": "/decks/old/slides.md"},
-                "clear": ["deck_source_path"],
-            }
-        ],
-    )
-
-    assert "deck_source_path" not in repaired["talks"][0]
+    assert talk["status"] == "needs-reprocessing"
     assert changes

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -15,7 +15,7 @@ def write_json(path, value):
 
 def base_database():
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": current_tracking_config(),
         "talks": [
             {

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -401,3 +401,136 @@ def test_malformed_missing_marker_is_an_exact_object_not_absence(
         match="preconditions failed",
     ):
         apply_source_repairs.build_repaired_database(database, [repair])
+
+
+def deck_database():
+    """A markdown-authored talk in the state #318 describes: deck, no evidence."""
+    database = base_database()
+    database["talks"][0]["slide_source"] = "markdown"
+    return database
+
+
+def deck_repair(**overrides):
+    repair = {
+        "filename": "talk.md",
+        "reason": "Slidev deck rendered to PDF and registered as slide evidence",
+        "expect": {
+            "slide_source": "markdown",
+            "slides_local_path": {"$missing": True},
+            "deck_source_path": {"$missing": True},
+        },
+        "set": {
+            "slide_source": "pdf",
+            "slides_local_path": "slides/talk.pdf",
+            "deck_source_path": "/decks/spring-rag/slides.md",
+        },
+    }
+    repair.update(overrides)
+    return {"schema_version": 1, "repairs": [repair]}
+
+
+def test_registering_a_render_keeps_the_deck_it_was_rendered_from(
+    apply_source_repairs,
+) -> None:
+    """`slide_source` alone loses the provenance the moment the PDF is bound.
+
+    Registering the render moves `slide_source` from "markdown" to "pdf", which
+    is correct — the talk now has readable slide evidence. Before this field
+    existed that rewrite also erased the only trace that the deck was authored
+    in markdown, leaving nothing to re-render when the deck changed.
+    """
+    repaired, changes = apply_source_repairs.build_repaired_database(
+        deck_database(),
+        deck_repair()["repairs"],
+    )
+
+    talk = repaired["talks"][0]
+    assert talk["slide_source"] == "pdf"
+    assert talk["slides_local_path"] == "slides/talk.pdf"
+    assert talk["deck_source_path"] == "/decks/spring-rag/slides.md"
+    assert changes
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/decks/spring-rag/slides.md",
+        "decks/spring-rag/slides.md",
+        "slides.MD",
+        "deck.markdown",
+    ],
+)
+def test_deck_source_path_accepts_absolute_and_vault_relative_decks(
+    apply_source_repairs,
+    path,
+) -> None:
+    """Decks live one git repo per talk, so no configured directory locates them.
+
+    An absolute path is the ordinary case and a relative one resolves from the
+    vault root, matching `pptx_path`. Both are accepted here; neither is
+    checked for existence, because the deck's repo need not be in this
+    checkout.
+    """
+    apply_source_repairs.validate_plan(
+        deck_repair(
+            set={
+                "slide_source": "pdf",
+                "slides_local_path": "slides/talk.pdf",
+                "deck_source_path": path,
+            }
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "message"),
+    [
+        ("deck.pptx", "must name a markdown deck source"),
+        ("decks/spring-rag", "must name a deck file, not a directory"),
+        ("decks//slides.md", "write it as 'decks/slides.md'"),
+        ("./slides.md", "write it as 'slides.md'"),
+        ("../slides.md", "must not contain a '..' segment"),
+        (" slides.md", "write it as 'slides.md'"),
+        ("decks\\slides.md", "must separate path segments with '/'"),
+        ("", "must be a nonempty string"),
+        (42, "must be a nonempty string"),
+    ],
+)
+def test_deck_source_path_rejects_a_value_that_is_not_a_deck(
+    apply_source_repairs,
+    path,
+    message,
+) -> None:
+    """Each rejection names the defect it found, not the first check to fire."""
+    plan = deck_repair(
+        set={
+            "slide_source": "pdf",
+            "slides_local_path": "slides/talk.pdf",
+            "deck_source_path": path,
+        }
+    )
+
+    with pytest.raises(apply_source_repairs.SourceRepairError, match=message):
+        apply_source_repairs.validate_plan(plan)
+
+
+def test_deck_source_path_can_be_cleared_when_a_deck_moves_away(
+    apply_source_repairs,
+) -> None:
+    """A registered deck that is no longer the talk's source is unregisterable."""
+    database = deck_database()
+    database["talks"][0]["deck_source_path"] = "/decks/old/slides.md"
+    repaired, changes = apply_source_repairs.build_repaired_database(
+        database,
+        [
+            {
+                "filename": "talk.md",
+                "reason": "deck repo retired; the render is now the only source",
+                "expect": {"deck_source_path": "/decks/old/slides.md"},
+                "clear": ["deck_source_path"],
+            }
+        ],
+    )
+
+    assert "deck_source_path" not in repaired["talks"][0]
+    assert changes

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -1019,7 +1019,7 @@ def test_a_candidate_failure_leaves_the_cli_exit_status_clean(
 ):
     """`complete` drives the CLI exit code; a lane-local failure must not fail it."""
     database = {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": {"schema_version": 2, "pptx_directory_exclusions": []},
         "talks": [dict(talk(), schema_version=5)],
         "pptx_catalog": [],

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -13,12 +13,16 @@ from PIL import Image
 from pptx import Presentation
 from pptx.util import Inches
 
-from conftest import current_tracking_config, make_deck
+from conftest import (
+    CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT,
+    current_tracking_config,
+    make_deck,
+)
 
 
 def _current_tracking_database():
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],
@@ -874,7 +878,7 @@ def test_main_current_database_stamps_qr_record_and_writes_atomically(
     generate_qr.main()
 
     written = json.loads(path.read_text(encoding="utf-8"))
-    assert written["schema_version"] == 1
+    assert written["schema_version"] == CURRENT_ROOT
     record = written["qr_codes"][0]
     assert written["qr_codes"] == [
         {
@@ -906,7 +910,7 @@ def test_main_current_database_stamps_qr_record_and_writes_atomically(
 def test_main_rejects_future_database_without_side_effect(
     generate_qr, monkeypatch, tmp_path
 ):
-    database = _current_tracking_database() | {"schema_version": 2}
+    database = _current_tracking_database() | {"schema_version": CURRENT_ROOT + 1}
     path = tmp_path / "tracking-database.json"
     path.write_text(json.dumps(database), encoding="utf-8")
     before = path.read_bytes()
@@ -1346,6 +1350,8 @@ def test_mcp_non_slug_back_half_exits_before_any_side_effect(
             "https://bit.ly/a3xK9f",
             "--output",
             str(output),
+            "--vault",
+            str(tmp_path),
         ],
     )
     with pytest.raises(SystemExit) as excinfo:
@@ -1354,7 +1360,7 @@ def test_mcp_non_slug_back_half_exits_before_any_side_effect(
     assert not output.exists()
 
 
-def test_provider_flags_require_short_url(generate_qr, monkeypatch):
+def test_provider_flags_require_short_url(generate_qr, monkeypatch, tmp_path):
     """Provider identity without --short-url would be silently dropped."""
     monkeypatch.setattr(
         sys,
@@ -1370,6 +1376,8 @@ def test_provider_flags_require_short_url(generate_qr, monkeypatch):
             "bitly",
             "--short-link-id",
             "bit.ly/abc",
+            "--vault",
+            str(tmp_path),
         ],
     )
     with pytest.raises(SystemExit):
@@ -1403,6 +1411,8 @@ def test_provider_identity_is_all_or_neither(
             value,
             "--output",
             str(tmp_path / "qr.png"),
+            "--vault",
+            str(tmp_path),
         ],
     )
     with pytest.raises(SystemExit):

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -2060,6 +2060,7 @@ def _record_deck(**updates: Any) -> dict[str, Any]:
     mutation = {
         "kind": "record_markdown_deck",
         "filename": "talk.md",
+        "expect": {"deck_source_path": {"$missing": True}},
         "deck_source_path": "/repos/spring-rag/slides.md",
     }
     mutation.update(updates)
@@ -2113,7 +2114,13 @@ def test_re_registering_a_moved_deck_repoints_rather_than_appends(
     database = _base_database()
     candidate, _ = mutate_tracking_database.build_candidate(database, [_record_deck()])
     candidate, changes = mutate_tracking_database.build_candidate(
-        candidate, [_record_deck(deck_source_path="/repos/moved/slides.md")]
+        candidate,
+        [
+            _record_deck(
+                expect={"deck_source_path": "/repos/spring-rag/slides.md"},
+                deck_source_path="/repos/moved/slides.md",
+            )
+        ],
     )
 
     assert len(candidate["markdown_decks"]) == 1
@@ -2128,7 +2135,10 @@ def test_registering_the_same_deck_twice_changes_nothing(
 ) -> None:
     database = _base_database()
     once, _ = mutate_tracking_database.build_candidate(database, [_record_deck()])
-    twice, changes = mutate_tracking_database.build_candidate(once, [_record_deck()])
+    twice, changes = mutate_tracking_database.build_candidate(
+        once,
+        [_record_deck(expect={"deck_source_path": "/repos/spring-rag/slides.md"})],
+    )
 
     assert twice["markdown_decks"] == once["markdown_decks"]
     assert changes == []
@@ -2192,6 +2202,7 @@ def test_the_documented_deck_registration_plan_applies(
         {"schema_version": 1, "mutations": [{
           "kind": "record_markdown_deck",
           "filename": "talk.md",
+          "expect": {"deck_source_path": {"$missing": true}},
           "deck_source_path": "/repos/spring-rag/slides.md"}]}
         """
     )
@@ -2204,3 +2215,58 @@ def test_the_documented_deck_registration_plan_applies(
         "/repos/spring-rag/slides.md"
     )
     assert changes
+
+
+def test_a_deck_registration_that_moved_under_the_plan_is_refused(
+    mutate_tracking_database,
+) -> None:
+    """Optimistic, like every other talk-touching mutation.
+
+    A plan that believes nothing is registered must not silently overwrite a
+    registration someone added in between; the write fails and the operator
+    re-reads instead of losing the other path.
+    """
+    database = _base_database()
+    registered, _ = mutate_tracking_database.build_candidate(database, [_record_deck()])
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            registered, [_record_deck(deck_source_path="/repos/other/slides.md")]
+        )
+
+
+def test_a_deck_registration_expecting_the_wrong_path_is_refused(
+    mutate_tracking_database,
+) -> None:
+    database = _base_database()
+    registered, _ = mutate_tracking_database.build_candidate(database, [_record_deck()])
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            registered,
+            [
+                _record_deck(
+                    expect={"deck_source_path": "/repos/never-registered.md"},
+                    deck_source_path="/repos/other/slides.md",
+                )
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "expect",
+    [
+        None,
+        {},
+        {"deck_source_path": "/a.md", "talk_filename": "talk.md"},
+        {"talk_filename": "talk.md"},
+    ],
+)
+def test_a_deck_registration_without_a_usable_expectation_is_refused(
+    mutate_tracking_database,
+    expect,
+) -> None:
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            _base_database(), [_record_deck(expect=expect)]
+        )

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -2049,3 +2049,156 @@ def test_an_equivalence_reaches_every_readable_talk_generation(
 
     assert len(candidate["source_title_equivalences"]) == 1
     assert candidate["talks"][0]["schema_version"] == version
+
+
+# Registered markdown deck sources (#318).
+
+
+def _record_deck(**updates: Any) -> dict[str, Any]:
+    mutation = {
+        "kind": "record_markdown_deck",
+        "filename": "talk.md",
+        "deck_source_path": "/repos/spring-rag/slides.md",
+    }
+    mutation.update(updates)
+    return mutation
+
+
+def test_a_registered_deck_lands_in_its_own_versioned_collection(
+    mutate_tracking_database,
+) -> None:
+    """The deck record carries its own generation; the talk record is untouched.
+
+    That separation is the design: `TALK_RECORD_SCHEMA_VERSION` means the
+    analysis generation, so putting the deck path on the talk would gate it
+    behind a shape the legacy records this serves can never reach.
+    """
+    database = _base_database()
+    before = copy.deepcopy(database["talks"][0])
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database, [_record_deck()]
+    )
+
+    recorded = candidate["markdown_decks"]
+    assert len(recorded) == 1
+    assert recorded[0]["schema_version"] == 1
+    assert recorded[0]["talk_filename"] == "talk.md"
+    assert recorded[0]["deck_source_path"] == "/repos/spring-rag/slides.md"
+    assert candidate["talks"][0] == before
+    assert changes[0]["kind"] == "record_markdown_deck"
+    assert "markdown_decks" not in database
+
+
+def test_a_legacy_talk_record_can_still_register_a_deck(
+    mutate_tracking_database,
+) -> None:
+    """The 209-of-215 case: a v1 record is exactly who this field is for."""
+    database = _base_database()
+    database["talks"][0]["schema_version"] = 1
+
+    candidate, _ = mutate_tracking_database.build_candidate(database, [_record_deck()])
+
+    assert candidate["markdown_decks"][0]["deck_source_path"] == (
+        "/repos/spring-rag/slides.md"
+    )
+
+
+def test_re_registering_a_moved_deck_repoints_rather_than_appends(
+    mutate_tracking_database,
+) -> None:
+    """One deck per talk: a second record would leave readers picking a path."""
+    database = _base_database()
+    candidate, _ = mutate_tracking_database.build_candidate(database, [_record_deck()])
+    candidate, changes = mutate_tracking_database.build_candidate(
+        candidate, [_record_deck(deck_source_path="/repos/moved/slides.md")]
+    )
+
+    assert len(candidate["markdown_decks"]) == 1
+    assert candidate["markdown_decks"][0]["deck_source_path"] == (
+        "/repos/moved/slides.md"
+    )
+    assert changes[0]["before"] == {"deck_source_path": "/repos/spring-rag/slides.md"}
+
+
+def test_registering_the_same_deck_twice_changes_nothing(
+    mutate_tracking_database,
+) -> None:
+    database = _base_database()
+    once, _ = mutate_tracking_database.build_candidate(database, [_record_deck()])
+    twice, changes = mutate_tracking_database.build_candidate(once, [_record_deck()])
+
+    assert twice["markdown_decks"] == once["markdown_decks"]
+    assert changes == []
+
+
+def test_a_deck_cannot_be_registered_for_a_talk_that_does_not_exist(
+    mutate_tracking_database,
+) -> None:
+    database = _base_database()
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database, [_record_deck(filename="absent.md")]
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "deck.pptx",
+        "decks/spring-rag",
+        "../slides.md",
+        "~/slides.md",
+        "//server/share/slides.md",
+        "slides\x00.md",
+        "",
+        42,
+    ],
+)
+def test_a_deck_source_path_that_is_not_a_usable_locator_is_refused(
+    mutate_tracking_database,
+    path,
+) -> None:
+    """Locator shape goes through the shared artifact-locator contract.
+
+    A NUL byte reached `Path.stat()` and raised outside the renderer's OSError
+    diagnostic; an ambiguous `//server/share` is not a canonical locator. Both
+    are the shared reader's rejections, not a private opinion about paths.
+    """
+    database = _base_database()
+
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database, [_record_deck(deck_source_path=path)]
+        )
+
+
+def test_the_documented_deck_registration_plan_applies(
+    mutate_tracking_database,
+) -> None:
+    """The plan in references/markdown-decks.md, verbatim.
+
+    A documented plan that `validate_plan` refuses is worse than no
+    documentation: the reader follows it and gets a rejection naming a
+    contract they cannot see. The previous registration recipe on that page
+    changed `status` and `reprocess_reason` without declaring them in
+    `expect`, which the repair validator refuses.
+    """
+    plan = json.loads(
+        """
+        {"schema_version": 1, "mutations": [{
+          "kind": "record_markdown_deck",
+          "filename": "talk.md",
+          "deck_source_path": "/repos/spring-rag/slides.md"}]}
+        """
+    )
+
+    candidate, changes = mutate_tracking_database.build_candidate(
+        _base_database(), plan["mutations"]
+    )
+
+    assert candidate["markdown_decks"][0]["deck_source_path"] == (
+        "/repos/spring-rag/slides.md"
+    )
+    assert changes

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -11,6 +11,8 @@ import unicodedata
 
 import pytest
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
+
 
 import importlib as _importlib
 import sys as _sys
@@ -62,7 +64,7 @@ def _write_json(path: Path, value: object) -> None:
 
 def _base_database() -> dict[str, Any]:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": _current_config(),
         "talks": [
             {
@@ -427,7 +429,7 @@ def test_initialization_dry_run_and_missing_precondition(
     )
     assert applied["database_written"] is True
     initialized = json.loads(database_path.read_text(encoding="utf-8"))
-    assert initialized["schema_version"] == 1
+    assert initialized["schema_version"] == CURRENT_ROOT
     assert initialized["config"]["schema_version"] == 2
     assert (
         initialized["config"]["pptx_directory_exclusions"]

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -199,7 +199,7 @@ def _write_tiny_mp4(path):
 
 def _db_json(database):
     """Render a current tracking database around one test's talk fixtures."""
-    database["schema_version"] = 1
+    database["schema_version"] = 2
     config = database.setdefault("config", {})
     if isinstance(config, dict):
         existing = dict(config)

--- a/tests/test_persisted_observation_migration_gate.py
+++ b/tests/test_persisted_observation_migration_gate.py
@@ -19,7 +19,7 @@ def gate(migrate_tracking_database):
 
 def _database(talk: dict) -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": {"schema_version": 2, "pptx_directory_exclusions": []},
         "talks": [talk],
         "pptx_catalog": [],

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -379,7 +379,7 @@ def test_a_non_integer_record_version_is_rejected(tracking_database) -> None:
 
 def _database(records: list[dict]) -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": {"schema_version": 2, "pptx_directory_exclusions": []},
         "talks": [],
         "pptx_catalog": records,

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -142,7 +142,7 @@ def write_database(fixture, talks, config=None, *, current=False, equivalences=N
     if current:
         database.update(
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "pptx_catalog": [],
                 "qr_codes": [],
                 "resources": [],

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -241,7 +241,7 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
         "improvement_goals": [],
     }
     if current:
-        database["schema_version"] = 1
+        database["schema_version"] = 2
         database["config"] = current_tracking_config(**database["config"])
     else:
         for talk in talks:

--- a/tests/test_render_vault_status.py
+++ b/tests/test_render_vault_status.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
+
 GENERATED_AT = "2026-08-10T12:00:00Z"
 
 
@@ -67,7 +69,7 @@ def _database(talks: list[dict], **config_extra) -> dict:
     config = {"schema_version": 2, "pptx_directory_exclusions": []}
     config.update(config_extra)
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": config,
         "talks": talks,
         "pptx_catalog": [],
@@ -185,7 +187,7 @@ def test_the_block_binds_the_exact_database_generation(
 
     status = report["status"]
     assert status["database_sha256"] == hashlib.sha256(raw).hexdigest()
-    assert status["database_schema_version"] == 1
+    assert status["database_schema_version"] == CURRENT_ROOT
     assert status["scoring_generation"] == {
         "pattern_scoring_schema_version": 5,
         "pattern_catalog_fingerprint": "a" * 64,

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -73,7 +73,7 @@ def _database_path(
             ]
             current_talks.append(current_talk)
         database = {
-            "schema_version": 1,
+            "schema_version": 2,
             "config": current_tracking_config(**config),
             "talks": current_talks,
             "pptx_catalog": [],

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -78,7 +78,7 @@ def catalog_row(pptx_path: str, talk_filename: str | None, **overrides: Any) -> 
 def database(rows: list[dict], talks: list[dict], source_root: Path) -> dict:
     """One owner-current database whose only interesting part is the catalog."""
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": {
             "schema_version": 2,
             "pptx_directory_exclusions": [],

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -2024,3 +2024,34 @@ def test_a_deck_that_is_not_a_markdown_file_is_refused(tracking_database):
         tracking_database.TrackingDatabaseError, match="markdown deck source"
     ):
         tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/repos/spring-rag/slides.md/", "/repos/spring-rag/"],
+)
+def test_a_deck_path_ending_in_a_separator_is_refused(tracking_database, path):
+    """An absolute locator may carry a trailing slash and still classify.
+
+    `PurePosixPath(value).name` then strips it, so `/repos/slides.md/` reached
+    the suffix check looking like a file and passed — the renderer would have
+    been handed a directory.
+    """
+    database = _database_with_decks(tracking_database, [_deck(deck_source_path=path)])
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="names a directory"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_malformed_current_database_names_its_own_generation(tracking_database):
+    """The diagnostic read v1 after the root moved, sending readers at the wrong
+    generation."""
+    database = tracking_database.migrate_tracking_database(_legacy_database()).database
+    database["talks"] = [{"filename": "broken.md", "schema_version": "not-an-int"}]
+
+    with pytest.raises(tracking_database.TrackingDatabaseError) as excinfo:
+        tracking_database.require_current_tracking_database(database)
+
+    assert f"schema v{CURRENT_ROOT}" in str(excinfo.value)

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -2058,23 +2058,45 @@ def test_a_malformed_current_database_names_its_own_generation(tracking_database
 
 
 @pytest.mark.parametrize("root", [None, 1])
-def test_a_pre_v2_root_carrying_the_deck_collection_is_refused(
+def test_a_pre_v2_root_carrying_the_deck_collection_is_not_current(
     tracking_database,
     root,
 ):
-    """The collection IS the root v2 shape, so it cannot ride an older root.
+    """The collection IS the root v2 shape, so it is not usable on an older root.
 
-    Accepting it on a v0 or v1 root would let a database carry the new shape
-    while still claiming the old generation, and the version would stop
-    describing the bytes — the exact auditability the bump exists to give.
+    Refusing it outright in the assessment was a dead end: the migration
+    assesses before it stamps, so the diagnostic sent an owner at the one
+    command that would refuse them. Usability is gated one level up instead —
+    a pre-v2 root is never `current`, so nothing requiring current state takes
+    it, and the migration is the way forward rather than a wall.
     """
     database = _legacy_database()
     if root is not None:
         database["schema_version"] = root
     database["markdown_decks"] = [_deck(talk_filename=database["talks"][0]["filename"])]
 
-    with pytest.raises(tracking_database.TrackingDatabaseError, match="markdown_decks"):
-        tracking_database.assess_tracking_database(database)
+    assert tracking_database.assess_tracking_database(database).state != "current"
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.require_current_tracking_database(database)
+
+
+@pytest.mark.parametrize("root", [None, 1])
+def test_migrating_a_pre_v2_root_stamps_it_and_keeps_the_deck_collection(
+    tracking_database,
+    root,
+):
+    """A preservation migration: the root advances, the records survive."""
+    database = _legacy_database()
+    if root is not None:
+        database["schema_version"] = root
+    deck = _deck(talk_filename=database["talks"][0]["filename"])
+    database["markdown_decks"] = [deck]
+
+    result = tracking_database.migrate_tracking_database(database)
+
+    assert result.to_schema_version == CURRENT_ROOT
+    assert result.database["markdown_decks"] == [deck]
+    tracking_database.require_current_tracking_database(result.database)
 
 
 def test_migrating_a_pre_v2_root_without_the_collection_reaches_v2(

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -39,6 +39,9 @@ DEFAULT_DIRECTORY_EXCLUSIONS = [
 ]
 
 
+CURRENT_ROOT = _tracking_database.TRACKING_DATABASE_SCHEMA_VERSION
+
+
 def _legacy_goal(*, goal_id: str = "legacy") -> dict:
     return {
         "id": goal_id,
@@ -237,7 +240,7 @@ def _legacy_database() -> dict:
 
 def _expected_migration(database: dict) -> dict:
     expected = copy.deepcopy(database)
-    expected["schema_version"] = 1
+    expected["schema_version"] = CURRENT_ROOT
     expected["config"]["schema_version"] = 2
     expected["config"]["pptx_directory_exclusions"] = DEFAULT_DIRECTORY_EXCLUSIONS
     for talk in expected["talks"]:
@@ -278,7 +281,9 @@ def test_legacy_reader_accepts_without_mutating(tracking_database):
         "usable": True,
         "state": "legacy",
         "schema_version": 0,
-        "accepted_schema_versions": [0, 1],
+        "accepted_schema_versions": sorted(
+            _tracking_database.READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS
+        ),
         "reason_codes": [],
     }
     assert database == original
@@ -286,7 +291,8 @@ def test_legacy_reader_accepts_without_mutating(tracking_database):
 
 def test_future_root_is_no_usable_prior_state(tracking_database):
     assessment = tracking_database.assess_tracking_database(
-        _legacy_database() | {"schema_version": 2}
+        _legacy_database()
+        | {"schema_version": tracking_database.TRACKING_DATABASE_SCHEMA_VERSION + 1}
     )
 
     assert assessment.usable is False
@@ -475,7 +481,9 @@ def test_owner_migration_only_adds_owned_version_keys(tracking_database):
 
     assert result.changed is True
     assert result.from_schema_version == 0
-    assert result.to_schema_version == 1
+    assert (
+        result.to_schema_version == tracking_database.TRACKING_DATABASE_SCHEMA_VERSION
+    )
     assert database == original
     assert result.database == _expected_migration(original)
     assert result.database["talks"][0]["schema_version"] == 1
@@ -750,7 +758,10 @@ def test_owner_migration_adds_absent_owned_collections(tracking_database):
         "improvement_goals",
     ):
         assert result.database[collection] == []
-    assert result.database["schema_version"] == 1
+    assert (
+        result.database["schema_version"]
+        == tracking_database.TRACKING_DATABASE_SCHEMA_VERSION
+    )
 
 
 def test_owner_migration_preserves_mixed_historical_talk_versions(
@@ -852,8 +863,8 @@ def test_current_root_config_v1_migrates_only_config(tracking_database):
     assert assessment.usable is True
     assert assessment.state == "legacy"
     assert migration.changed is True
-    assert migration.from_schema_version == 1
-    assert migration.to_schema_version == 1
+    assert migration.from_schema_version == CURRENT_ROOT
+    assert migration.to_schema_version == CURRENT_ROOT
     assert migration.record_counts["config"] == 1
     assert migration.database["config"] == {
         "schema_version": 2,
@@ -866,8 +877,8 @@ def test_current_root_config_v1_migrates_only_config(tracking_database):
 
     second = tracking_database.migrate_tracking_database(migration.database)
     assert second.changed is False
-    assert second.from_schema_version == 1
-    assert second.to_schema_version == 1
+    assert second.from_schema_version == CURRENT_ROOT
+    assert second.to_schema_version == CURRENT_ROOT
     assert second.database == migration.database
     assert all(count == 0 for count in second.record_counts.values())
 
@@ -924,7 +935,7 @@ def test_future_config_generation_fails_closed_without_poisoning_root_version(
     assessment = tracking_database.assess_tracking_database(current)
 
     assert assessment.usable is False
-    assert assessment.schema_version == 1
+    assert assessment.schema_version == CURRENT_ROOT
     assert assessment.reason_codes == ("config_schema_version_unsupported",)
     with pytest.raises(
         tracking_database.TrackingDatabaseError,
@@ -1084,8 +1095,8 @@ def test_config_only_migration_uses_generation_neutral_backup_name(
     backup = tmp_path / ".backups" / f"{path.name}.owner-migration-{digest}.bak"
     assert backup.read_bytes() == raw
     assert report["backup"] == str(backup)
-    assert report["from_schema_version"] == 1
-    assert report["to_schema_version"] == 1
+    assert report["from_schema_version"] == CURRENT_ROOT
+    assert report["to_schema_version"] == CURRENT_ROOT
     assert report["record_counts"]["config"] == 1
 
 
@@ -1359,7 +1370,7 @@ def test_legacy_queue_recovery_unblocks_migration_without_schema_stamping(
     )
     assert report["changed"] is True
     assert report["from_schema_version"] == 0
-    assert report["to_schema_version"] == 1
+    assert report["to_schema_version"] == CURRENT_ROOT
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -2055,3 +2055,40 @@ def test_a_malformed_current_database_names_its_own_generation(tracking_database
         tracking_database.require_current_tracking_database(database)
 
     assert f"schema v{CURRENT_ROOT}" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("root", [None, 1])
+def test_a_pre_v2_root_carrying_the_deck_collection_is_refused(
+    tracking_database,
+    root,
+):
+    """The collection IS the root v2 shape, so it cannot ride an older root.
+
+    Accepting it on a v0 or v1 root would let a database carry the new shape
+    while still claiming the old generation, and the version would stop
+    describing the bytes — the exact auditability the bump exists to give.
+    """
+    database = _legacy_database()
+    if root is not None:
+        database["schema_version"] = root
+    database["markdown_decks"] = [_deck(talk_filename=database["talks"][0]["filename"])]
+
+    with pytest.raises(tracking_database.TrackingDatabaseError, match="markdown_decks"):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_migrating_a_pre_v2_root_without_the_collection_reaches_v2(
+    tracking_database,
+):
+    """The ordinary path: nothing carries the new shape until an owner adds it."""
+    database = _legacy_database()
+    database["schema_version"] = 1
+
+    result = tracking_database.migrate_tracking_database(database)
+
+    assert result.from_schema_version == 1
+    assert result.to_schema_version == CURRENT_ROOT
+    assert "markdown_decks" not in result.database
+    assert tracking_database.assess_tracking_database(result.database).state == (
+        "current"
+    )

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1926,3 +1926,90 @@ def test_a_v1_entry_already_naming_a_talk_is_refused(tracking_database):
 
     with pytest.raises(tracking_database.TrackingDatabaseError, match="unknown fields"):
         tracking_database.migrate_tracking_database(database)
+
+
+# Registered markdown deck sources (#318).
+
+
+def _deck(**updates):
+    record = {
+        "schema_version": 1,
+        "talk_filename": "one.md",
+        "deck_source_path": "/repos/spring-rag/slides.md",
+    }
+    record.update(updates)
+    return record
+
+
+def _database_with_decks(tracking_database, decks):
+    migrated = tracking_database.migrate_tracking_database(_legacy_database()).database
+    migrated["markdown_decks"] = decks
+    return migrated
+
+
+def test_a_registered_deck_leaves_the_database_current(tracking_database):
+    """The collection is optional and additive: no talk record changes shape."""
+    database = _database_with_decks(tracking_database, [_deck()])
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.state == "current"
+    assert assessment.usable is True
+
+
+def test_a_database_without_the_collection_stays_current(tracking_database):
+    """Absent means no registered deck — every database written before today."""
+    database = tracking_database.migrate_tracking_database(_legacy_database()).database
+
+    assert "markdown_decks" not in database
+    assert tracking_database.assess_tracking_database(database).state == "current"
+
+
+def test_a_deck_naming_no_talk_refuses_the_database(tracking_database):
+    """An orphaned record would send a renderer at a path no reader can place."""
+    database = _database_with_decks(
+        tracking_database, [_deck(talk_filename="absent.md")]
+    )
+
+    with pytest.raises(tracking_database.TrackingDatabaseError, match="names no talk"):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_second_deck_for_one_talk_refuses_the_database(tracking_database):
+    database = _database_with_decks(
+        tracking_database,
+        [_deck(), _deck(deck_source_path="/repos/other/slides.md")],
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="a talk has one authored deck"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("version", [2, 0, True, "1"])
+def test_a_foreign_deck_generation_is_refused(tracking_database, version):
+    database = _database_with_decks(tracking_database, [_deck(schema_version=version)])
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="schema_version must be 1"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_deck_record_carrying_an_unknown_field_is_refused(tracking_database):
+    database = _database_with_decks(tracking_database, [_deck(flavor="slidev")])
+
+    with pytest.raises(tracking_database.TrackingDatabaseError, match="unknown fields"):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_deck_that_is_not_a_markdown_file_is_refused(tracking_database):
+    database = _database_with_decks(
+        tracking_database, [_deck(deck_source_path="/repos/x/deck.pptx")]
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="markdown deck source"
+    ):
+        tracking_database.assess_tracking_database(database)

--- a/tests/test_tracking_database_strict_readers.py
+++ b/tests/test_tracking_database_strict_readers.py
@@ -16,6 +16,9 @@ if str(_SCRIPTS) not in _sys.path:
 _FUTURE_TALK_SCHEMA_VERSION = (
     _importlib.import_module("tracking_database").TALK_RECORD_SCHEMA_VERSION + 1
 )
+_FUTURE_ROOT_SCHEMA_VERSION = (
+    _importlib.import_module("tracking_database").TRACKING_DATABASE_SCHEMA_VERSION + 1
+)
 
 
 STRICT_INVALID_CASES = (
@@ -110,7 +113,11 @@ def test_owner_reader_accepts_implicit_legacy_after_schema_assessment(
     "payload",
     [
         {
-            "schema_version": 2,
+            # Derived, never a literal — the same hazard the talk-record case
+            # below names: a pinned number stops being "future" the moment the
+            # schema reaches it, and the payload then exercises a different
+            # rejection path while still reading as a future-root test.
+            "schema_version": _FUTURE_ROOT_SCHEMA_VERSION,
             "future_config": ["no old config/talks shape"],
         },
         {

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -21,7 +21,7 @@ def _write(path: Path, value: object) -> bytes:
 
 def _current_database() -> dict[str, object]:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],

--- a/tests/test_validate_profile.py
+++ b/tests/test_validate_profile.py
@@ -811,7 +811,7 @@ def test_load_vault_projects_confirmed_intents_without_storage_metadata(
     _write_vault(tmp_path, [])
     database_path = tmp_path / "tracking-database.json"
     database = {
-        "schema_version": 1,
+        "schema_version": 2,
         "config": {"schema_version": 1, "synthetic": True},
         "talks": [],
         "pptx_catalog": [],

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -330,7 +330,7 @@ def _write_tracking_db(
     path.write_text(
         json.dumps(
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "config": current_tracking_config(),
                 "talks": talks,
                 "pptx_catalog": [],


### PR DESCRIPTION
Closes the last piece of #318 — item (1)'s second half, "with the talk record naming the deck source path".

> **Design changed after review.** The first push put `deck_source_path` on the talk record as an optional field at v7. The policy reviewer blocked it under `stateful-artifacts` (a bump is required for any persisted shape change, additive included) and was right to. It now lands as its own top-level versioned collection, which satisfies the rule without the costs a talk-record bump carries. The reasoning is below and in the CHANGELOG.

## The gap

`slide_source: "markdown"` made a markdown-authored talk a valid record. `render-markdown-deck.py` made its deck readable. Between them sat a quiet data loss: the repair that registers the render sets `slide_source` to `"pdf"` — correct, the talk now has real slides — and in doing so erases the only field that said the deck was ever markdown. Nothing on the record named the file, so the second render, after the speaker added three slides, started with a hunt.

## What lands

`markdown_decks`, a top-level collection at record v1, one record per talk:

```json
"markdown_decks": [{
  "schema_version": 1,
  "talk_filename": "spring-rag-jcon.md",
  "deck_source_path": "/repos/spring-rag/slides.md"
}]
```

Written by a new `record_markdown_deck` mutation kind. It upserts rather than appends — the equivalence ledger beside it is an audit trail of owner judgments and only ever grows, while a deck registration is current state and a repo that moves re-points it. The assessment refuses a second record for one talk and an orphaned `talk_filename`.

## Why a collection and not a bumped talk record

The reviewer asked for `TALK_RECORD_SCHEMA_VERSION` 7 → 8 plus a migration. Three reasons that is the wrong bump, all already recorded in this repo:

1. **The constant means analysis generation, not record shape.** The #333 CHANGELOG entry says so outright: "the contradiction is real, and it comes from `TALK_RECORD_SCHEMA_VERSION` carrying two meanings at once: the analysis generation, which is why a v1 record can never migrate forward, and the record shape." Which is why v7 today is a bump for a field that no longer lives on the talk record — `_restamp_talk_records` states "v7 adds no field a v6 record lacks."

2. **It would not reach the records that need it.** 209 of 215 live talk records are schema v1, non-restampable by design, and they are precisely the transcript-only markdown talks #318 is about. A v8 stamp lifts 6 modern records and leaves the other 209 where they were.

3. **It is not free.** Talk versions are accepted as `range(1, CURRENT + 1)`, so a v8-stamped database read by any older toolkit is not one unreadable record — it is `talks_schema_version_unsupported`, `usable: false`, the whole vault.

#333 hit this exact wall — an owner ledger bound to the analysis generation, unreachable for 97% of the corpus — and resolved it by moving the field off the talk into its own versioned collection. Same wall, same resolution. The nested-record alternative is closed for the reason #333 closed it: "the nested record's own version does not version its parent."

The collection is optional (absent means no registered deck, correct for every database written before today) and no migration owns it — deliberately absent from `_RECORD_COUNT_KEYS`, since a deck is registered by an owner who knows where the file is and is never inferred.

## Copilot's advisories, all three folded in

- **Locator validation** — `deck_source_path` goes through `classify_artifact_locator`, the shared lexical contract every other persisted artifact path uses, instead of a hand-rolled `PurePosixPath` check. That closes the NUL byte (which reached `Path.stat()` and raised outside the renderer's `OSError` diagnostic), `//server/share`, `~`, and `..`, each as a named reason code, plus Windows reserved names for free. A markdown-suffix check sits on top.
- **The documented registration plan could not be applied** — it set `status` and `reprocess_reason` without declaring them in `expect`, which `validate_plan` refuses. Fixed, and both documented plans are now executed verbatim by tests so the page cannot drift from the validator again.
- **Relative path resolution** — `references/markdown-decks.md` now states that a vault-relative deck path is resolved against the vault root by the caller before it reaches a renderer, which resolves a relative CLI path from its own working directory.

## Deliberate non-goals

A return claiming `slide_source: "markdown"` is **not** required to carry a registered deck. Workers analyse; they do not discover decks. Making it a return precondition would block reprocessing a known-markdown talk whose deck nobody has registered yet — the state every such talk starts in. There is also no unregister mutation: a deck that moves is re-pointed, which is the case that actually occurs.

## Verification

- `pytest tests/` — 6232 passed, 8 skipped. The three `tests/test_plugin_lint_gate.py` failures reproduce on a clean checkout of `main`: CI pins `tesslio/setup-tessl@v2` to `0.95.0` and the newer local CLI words its rejections differently. CI's `test` job is green on those.
- `ruff check .`, `ruff format --check .` — clean.
- `pyright --pythonpath .venv/bin/python` — 0 errors across the repo.
- New tests cover the collection's assessment rules (orphan, duplicate, foreign generation, unknown field, non-markdown suffix), the mutation (registration on a legacy v1 record, re-point, idempotent re-register, missing talk, eight rejected locator shapes), and both documented plans end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2oVxH1XMvSRyXsjf5BZ1U
