### PR TITLE
fix(vault-ingress): close a code fence only with one long enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+### fix(vault-ingress) — close a code fence only with one long enough to close it
+
+Issue #351, both advisories from #349's review, deferred at the time because the
+PR was green and `review-severity` says not to burn a re-review round on a lone
+advisory.
+
+`_fence_mask` tracked which character opened a fence and not how many of them
+there were. CommonMark closes a fence only with the same character, at least as
+long — which is the entire reason four backticks exist, since that is how a deck
+quotes markdown that itself contains a three-backtick block. Matching on the
+character alone closed the outer block on the inner one, and everything after
+that point read as deck source: the `---` inside the quoted sample became a
+slide break, a quoted `<!-- pause -->` became a reveal. Measured on the test
+deck, a three-slide deck read as five and one reveal read as two.
+
+The render's page count was never wrong — it does not consult this reader. The
+symptom was `source_slide_count` disagreeing with it, which flips
+`slide_count_agrees_with_source` to `false` and tells the operator the deck uses
+a construct the source reader does not model. It did not. It used four
+backticks.
+
+The same pass takes the adjacent CommonMark rule, for the same reason: a closing
+fence carries no info string, so a ```` ```yaml ```` line inside a quoted block is
+content rather than a close.
+
+Second advisory, presentation only: a half-installed lane told the operator to
+install the whole lane. With presenterm on PATH and weasyprint missing, "Install
+presenterm and weasyprint" sends them to check a box that is already checked.
+The install clause now names what is absent, which is what the clause before it
+already said.
+
 ## 0.20.101 — 2026-08-20
 
 ### feat(vault-ingress) — render markdown-authored decks as slide evidence

--- a/skills/vault-ingress/scripts/markdown_deck.py
+++ b/skills/vault-ingress/scripts/markdown_deck.py
@@ -116,7 +116,10 @@ _IMPLICIT_REVEAL_SWITCHES: dict[str, tuple[tuple[str, ...], ...]] = {
 # reads as one and renders as however many the imported file holds.
 _SLIDEV_IMPORT_KEY = re.compile(r"^src\s*:\s*(\S.*?)\s*$")
 
-_FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
+# Group 1 is the fence run itself, group 2 everything after it. Both are
+# load-bearing: CommonMark closes a fence only with the same character, at
+# least as long, and carrying no info string (#351).
+_FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})(.*)$")
 _YAML_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_.\-]*\s*:(\s|$)")
 _HORIZONTAL_RULE = re.compile(r"^-{3,}\s*$")
 _VERTICAL_RULE = re.compile(r"^--\s*$")
@@ -200,19 +203,43 @@ class DeckStructure:
 
 
 def _fence_mask(lines: Sequence[str]) -> list[bool]:
-    """Return, per line, whether it sits inside a fenced code block."""
+    """Return, per line, whether it sits inside a fenced code block.
+
+    Fence LENGTH is tracked, not just the character. A four-backtick fence is
+    how a deck quotes markdown that itself contains a three-backtick block, and
+    matching on the character alone closed the outer fence on the inner one:
+    everything from there to the real close read as deck source, so a `---` or
+    a `<!-- pause -->` in the quoted sample counted as a slide break or a
+    reveal. The symptom was `source_slide_count` disagreeing with the render
+    for a reason the receipt could not explain.
+
+    An info string disqualifies a closing fence for the same reason — ```` ```py ````
+    inside a quoted block is content, not a close.
+    """
     inside = [False] * len(lines)
     open_fence: str | None = None
+    open_length = 0
     for number, line in enumerate(lines):
         match = _FENCE.match(line)
         if open_fence is None:
             if match is not None:
+                # A backtick fence's info string may not itself contain a
+                # backtick, so a line like ```` ```a`b ```` opens nothing.
+                if match.group(1)[0] == "`" and "`" in match.group(2):
+                    continue
                 open_fence = match.group(1)[0]
+                open_length = len(match.group(1))
                 inside[number] = True
             continue
         inside[number] = True
-        if match is not None and match.group(1)[0] == open_fence:
+        if (
+            match is not None
+            and match.group(1)[0] == open_fence
+            and len(match.group(1)) >= open_length
+            and not match.group(2).strip()
+        ):
             open_fence = None
+            open_length = 0
     return inside
 
 

--- a/skills/vault-ingress/scripts/render-markdown-deck.py
+++ b/skills/vault-ingress/scripts/render-markdown-deck.py
@@ -351,7 +351,7 @@ def render(
     if absent:
         raise RenderError(
             f"the {spec.lane} lane is unavailable: {', '.join(absent)} not on "
-            f"PATH. Install {' and '.join(spec.commands)}, or export the deck "
+            f"PATH. Install {' and '.join(absent)}, or export the deck "
             "by hand and register the PDF"
         )
     # An unwritable or missing output directory is an operator mistake with an

--- a/tests/test_markdown_deck.py
+++ b/tests/test_markdown_deck.py
@@ -363,3 +363,67 @@ def test_a_deck_ending_on_a_separator_invents_no_slide():
 
 def test_an_empty_source_declares_no_slides():
     assert markdown_deck.read_deck("", markdown_deck.MARP).slide_count == 0
+
+
+def test_a_longer_fence_is_not_closed_by_a_shorter_one_inside_it():
+    """Quoting markdown that contains a code block is what four backticks are for.
+
+    Matching on the fence character alone closed the outer block on the inner
+    one, and everything after it — the `---` in the quoted sample included —
+    read as deck source. The symptom was a slide count that disagreed with the
+    render for a reason the receipt could not explain (#351).
+    """
+    quoted = MARP_DECK.replace(
+        "# Two",
+        "# Two\n\n````markdown\n```yaml\n---\nnot: a slide break\n---\n```\n````",
+    )
+
+    structure = markdown_deck.read_deck(quoted, markdown_deck.MARP)
+
+    assert structure.slide_count == 3
+
+
+def test_a_longer_fence_still_closes_on_a_fence_at_least_as_long():
+    """The length rule is a floor, not an equality: five backticks close four."""
+    quoted = MARP_DECK.replace(
+        "# Two",
+        "# Two\n\n````text\nquoted\n`````\n\n---\n\n# Three",
+    )
+
+    structure = markdown_deck.read_deck(quoted, markdown_deck.MARP)
+
+    assert structure.slide_count == 4
+
+
+def test_a_reveal_marker_inside_a_longer_fence_is_not_a_reveal():
+    quoted = PRESENTERM_DECK.replace(
+        "# Close",
+        "# Close\n\n````markdown\n```\n<!-- pause -->\n```\n````",
+    )
+
+    structure = markdown_deck.read_deck(quoted, markdown_deck.PRESENTERM)
+
+    assert structure.to_dict()["reveal_marker_total"] == 1
+
+
+def test_a_fence_carrying_an_info_string_does_not_close_a_block():
+    """A closing fence carries no info string, so ```py inside a block is content."""
+    quoted = MARP_DECK.replace(
+        "# Two",
+        "# Two\n\n````\n```yaml\n---\nnot: a slide break\n---\n```yaml\n````",
+    )
+
+    structure = markdown_deck.read_deck(quoted, markdown_deck.MARP)
+
+    assert structure.slide_count == 3
+
+
+def test_a_tilde_fence_is_not_closed_by_a_backtick_one():
+    quoted = MARP_DECK.replace(
+        "# Two",
+        "# Two\n\n~~~markdown\n```\n---\nnot: a slide break\n---\n```\n~~~",
+    )
+
+    structure = markdown_deck.read_deck(quoted, markdown_deck.MARP)
+
+    assert structure.slide_count == 3

--- a/tests/test_render_markdown_deck.py
+++ b/tests/test_render_markdown_deck.py
@@ -132,7 +132,13 @@ def test_a_half_installed_lane_names_only_what_is_missing(tmp_path, fake_path):
             timeout_seconds=30,
         )
 
-    assert "weasyprint not on PATH" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "weasyprint not on PATH" in message
+    # The install clause is built from what is absent, not from the whole
+    # spec: telling an operator with presenterm already installed to install
+    # presenterm sends them to check a box that is checked (#351).
+    assert "Install weasyprint," in message
+    assert "Install presenterm" not in message
 
 
 def test_presenterm_is_handed_a_sized_terminal(tmp_path, fake_path):


### PR DESCRIPTION
Closes #351 — both advisories from #349's review, deferred at the time because that PR was green and `review-severity` says not to burn a re-review round on a lone advisory.

## 1. Fence length (correctness)

`_fence_mask` recorded which character opened a fence and not how many of them there were. CommonMark closes a fence only with the same character **at least as long** — which is the entire reason four backticks exist, since that is how a deck quotes markdown that itself contains a three-backtick block.

Matching on the character alone closed the outer block on the inner one, and everything after that point read as deck source. Measured on the test deck, before the fix:

```
test_a_longer_fence_is_not_closed_by_a_shorter_one_inside_it   assert 5 == 3
test_a_reveal_marker_inside_a_longer_fence_is_not_a_reveal     assert 2 == 1
test_a_fence_carrying_an_info_string_does_not_close_a_block    assert 5 == 3
```

A three-slide deck read as five; one reveal read as two.

The render's page count was never wrong — it does not consult this reader. The symptom was `source_slide_count` disagreeing with it, which flips `slide_count_agrees_with_source` to `false` and tells the operator the deck uses a construct the source reader does not model. It did not. It used four backticks.

The same pass takes the adjacent CommonMark rule for the same reason: a closing fence carries no info string, so a ```` ```yaml ```` line inside a quoted block is content, not a close. That one is reachable only from inside a longer fence, which is exactly the case being fixed — leaving it would have been an inline patch on a gap this change is already standing in front of.

Two of the five new tests pass on the old code by design: they pin behavior that must *not* change — a five-backtick fence still closes a four-backtick one (the rule is a floor, not an equality), and a backtick fence still cannot close a tilde one.

## 2. Lane diagnostic (presentation)

With presenterm on PATH and weasyprint missing, the error said "Install presenterm and weasyprint" — sending the operator to check a box that is already checked. The install clause is now built from `absent`, which is what the clause before it already said. The existing `test_a_half_installed_lane_names_only_what_is_missing` is extended to assert the install clause, not just the diagnostic clause.

## Verification

- `pytest tests/` — 6212 passed, 8 skipped. The three `tests/test_plugin_lint_gate.py` failures reproduce on a clean checkout of `main`: CI pins `tesslio/setup-tessl@v2` to `0.95.0` and the newer local CLI words its rejections differently. CI's `test` job is green on those.
- `ruff check .`, `ruff format --check .` — clean.
- `pyright --pythonpath .venv/bin/python` — 0 errors across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2oVxH1XMvSRyXsjf5BZ1U
