### PR TITLE
fix(vault-ingress): bound transcript word rate from above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+### fix(vault-ingress) — bound the transcript word rate from above, and stop the bound erasing itself
+
+The first talk of a full-vault reparse returned `ok: true`, exit 0, and a
+transcript holding two speakers. `Kl6tLcQ5hGI` is a 5.3-minute DevOpsDays
+segment; YouTube served it the whole session block's caption track. The text
+opens as the right talk ("my name is Baruch Sadogursky") and closes inside
+somebody else's ("how can we break Brooks' law?"). Rhetoric analysis reads
+verbatim examples, hiccup words, pacing and closing type straight off that
+text, so the wrong speaker's delivery would have been scored as this one's.
+
+Three defects stacked to let it through, and each hid the next.
+
+**The policy had a floor and no ceiling.** `min_words` is derived from
+`duration_seconds`, and the receipt carried both numbers while only ever
+comparing them upward. 1609 words over 318s is 304 wpm. Every genuine receipt
+in the vault sits at 110-132 wpm, so the separation is not marginal.
+`MAX_WORDS_PER_MINUTE` is deliberately loose at 240 — it exists to catch a
+track belonging to a different recording, never to police a fast talker.
+
+**The duration was modelled as a floor-relaxation input, so the bound could
+only be reached from below.** `needs_duration_probe` fired when a transcript
+looked too *short*; a long one never got a duration, and the new ceiling would
+have been inert on exactly the path a reparse takes most — the transcript is
+already on disk. The probe stays off the offline fast path: a stored receipt
+whose own duration cannot hold the words now buys a probe, and the verdict
+still comes from the probed value, never the stored one.
+
+**A re-validation that declined to probe wrote the weaker receipt back.** The
+run that found no duration replaced `{youtube_duration, 318.0}` with
+`{fixed_default, null}`, destroying the evidence the next run needed — and
+defeating the screening above. A receipt claiming a source-owned duration now
+triggers a probe, and a probe that cannot reach the provider leaves the
+stronger receipt alone.
+
+Found by #355 during the reparse of a 250-talk vault where
+`transcript_quality_receipt_unverified` fires on 193 talks — nearly every
+receipt in that vault was about to be written for the first time.
+
+The ceiling catches gross contamination, not subtle: a caption track only
+moderately longer than its talk still lands under 240 wpm. Promoting the
+timing-overrun rejection ("timed segments extend beyond the source-owned
+duration bound") from a dropped `timed_path` to a transcript-level verdict is
+the precise detector and stays open on #355.
+
 ## 0.20.103 — 2026-08-21
 
 ### feat(vault-ingress) — name the deck a rendered PDF came from

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -190,7 +190,7 @@ Treat the readable transcript and its two receipts as three separate artifacts:
 - `transcripts/<id>.segments.json` schema v2 owns owner-bound acquisition
   source and optional timing.
 - `transcripts/<id>.quality.json` owns the exact validation policy and the
-  source of any duration that lowered the fixed short-artifact floor.
+  source of any duration that bounded the transcript word rate.
 
 Both receipts carry SHA-256 of the exact `.txt` bytes. Verify against raw bytes,
 not newline-normalized text: replacing CRLF with LF invalidates both even when
@@ -207,6 +207,22 @@ YouTube ID or `ffprobe` over exact local media, whose digest is stored in the
 provenance. `--duration-seconds` is an expected value that must match that
 source-owned probe; it is not authority itself. Return fields, analysis prose,
 and unbound talk metadata never lower the floor.
+
+A trusted duration bounds the word rate in both directions. Below
+`MIN_WORDS_PER_MINUTE` the transcript covers only part of the talk; above
+`MAX_WORDS_PER_MINUTE` the caption track covers more than the recording, which
+is a track belonging to a different video rather than a fast talker. Both
+rejections are validation failures, so an existing transcript that breaches
+either bound is refused with exit 1 until `--force` authorizes replacement.
+Bound values are the script's constants (see
+`skills/vault-ingress/scripts/transcript_quality.py` — named constants at the
+top of the file), never restated here.
+
+Because the ceiling needs a duration to fire, a stored receipt that already
+records one is itself a reason to re-probe: a receipt whose own duration cannot
+hold the transcript's words buys a provider probe, and only the probed duration
+decides. A probe that cannot reach the provider leaves a stronger stored
+receipt in place rather than overwriting it with the fixed default.
 
 Current v5 persistence requires a hash-current receipt with exact provenance.
 For `youtube_duration`, the receipt video ID must equal the owning talk's

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1634,7 +1634,11 @@ source-owned duration beyond the reader's one-second measurement tolerance.
 existing output bundle is preserved unless `--force` authorizes replacement.
 
 `fetch-transcript.py` separately writes `transcripts/{id}.quality.json`. This
-closed receipt owns quality authority even when no timed segments exist:
+closed receipt owns quality authority even when no timed segments exist. Its
+`duration_seconds` bounds the transcript word rate in both directions — a floor
+below which the text covers only part of the talk, and a ceiling above which
+the caption track covers more than the recording (see
+`references/processing-rules.md`):
 
 ```json
 {

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -99,6 +99,8 @@ from transcript_quality import (
     build_quality_policy,
     count_words,
     normalize_duration,
+    receipt_claims_source_duration,
+    receipt_duration_cannot_hold,
     validate_transcript,
 )
 
@@ -1196,11 +1198,21 @@ def main(argv: list[str] | None = None) -> NoReturn:
         existing_words = count_words(existing)
         receipt, _receipt_reason = load_verified_quality_receipt(out, existing)
         # Stored duration authority is never trusted as its own proof. Re-probe
-        # the current provider owner before a duration can lower the safe floor.
+        # the current provider owner before a duration can bound the floor.
+        #
+        # The stored duration is also read here, but only to decide whether to
+        # spend a probe. Gating the probe on the transcript looking too short
+        # made the duration bound reachable only from below, so a caption track
+        # covering a whole session block was never measured against the
+        # recording it claims to describe. A receipt whose own duration cannot
+        # hold this many words is grounds to go ask the provider — never
+        # grounds to reject, which still requires the probe.
         needs_duration_probe = (
             args.duration_seconds is not None
             or existing_words < DEFAULT_MIN_WORDS
             or sidecar_path(out).exists()
+            or receipt_claims_source_duration(receipt)
+            or receipt_duration_cannot_hold(receipt, existing_words)
             or (
                 args.existing_source == "youtube_auto"
                 and args.method in {"auto", "captions"}
@@ -1280,7 +1292,16 @@ def main(argv: list[str] | None = None) -> NoReturn:
             "policy": quality_policy,
             "provenance": quality_provenance,
         }
-        if receipt != expected_receipt:
+        # A probe that could not reach the provider leaves the fixed default in
+        # hand. Writing that over a receipt that already records a source-owned
+        # duration trades evidence for the absence of evidence, and the next
+        # run inherits a transcript nothing can bound. Keep the stronger
+        # receipt and let a run that reaches the provider refresh it.
+        would_discard_source_duration = (
+            trusted_duration is None
+            and receipt_claims_source_duration(receipt)
+        )
+        if receipt != expected_receipt and not would_discard_source_duration:
             try:
                 write_quality_receipt(
                     out,

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -1298,8 +1298,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
         # run inherits a transcript nothing can bound. Keep the stronger
         # receipt and let a run that reaches the provider refresh it.
         would_discard_source_duration = (
-            trusted_duration is None
-            and receipt_claims_source_duration(receipt)
+            trusted_duration is None and receipt_claims_source_duration(receipt)
         )
         if receipt != expected_receipt and not would_discard_source_duration:
             try:

--- a/skills/vault-ingress/scripts/transcript_quality.py
+++ b/skills/vault-ingress/scripts/transcript_quality.py
@@ -26,6 +26,15 @@ NON_SPEECH_MARKERS = ("[Music]", "[Applause]", "[Laughter]", "[музыка]")
 WORD = re.compile(r"[^\W\d_]+", re.UNICODE)
 DEFAULT_MIN_WORDS = 400
 MIN_WORDS_PER_MINUTE = 30
+# A caption track that covers more than this talk — a venue's whole session
+# block, a livestream spanning several speakers — parses as clean speech and
+# clears every floor, so only its rate against the source-owned duration
+# gives it away. Sustained human delivery does not reach this: observed
+# vault transcripts run 110-132 wpm, and the fastest plausible speaker sits
+# far below the ceiling. The bound is deliberately loose — it exists to
+# catch a track belonging to a different recording, never to police a fast
+# talker.
+MAX_WORDS_PER_MINUTE = 240
 QUALITY_POLICY_SCHEMA_VERSION = 1
 QUALITY_POLICY_FIELDS = frozenset({"schema_version", "min_words", "duration_seconds"})
 
@@ -143,6 +152,51 @@ def validate_quality_policy(policy: object) -> tuple[bool, str]:
     return True, "canonical transcript quality policy"
 
 
+def receipt_claims_source_duration(receipt: object) -> bool:
+    """Return whether a stored receipt records a source-owned duration.
+
+    A receipt that already carries a probed duration is a standing claim that
+    this recording's length is knowable. Re-deriving without asking the
+    provider replaces that claim with the fixed default and writes the weaker
+    receipt back, so the evidence a later run needs is destroyed by the run
+    that declined to gather it. Treat the claim as a reason to probe again.
+    """
+    if not isinstance(receipt, dict):
+        return False
+    policy = receipt.get("policy")
+    if not isinstance(policy, dict):
+        return False
+    return policy.get("duration_seconds") is not None
+
+
+def receipt_duration_cannot_hold(receipt: object, words: int) -> bool:
+    """Return whether a receipt's own duration is too short to hold this speech.
+
+    Screening only, and deliberately so. The stored duration is not trusted
+    authority: a value larger than the truth would hide a foreign caption
+    track, and one smaller would accuse a sound transcript. So a True here buys
+    a provider probe and nothing else — the verdict still comes from the probed
+    duration. A receipt that is absent, malformed, or carries no duration
+    screens nothing and returns False, leaving the caller's other probe
+    triggers untouched.
+    """
+    if not isinstance(receipt, dict):
+        return False
+    policy = receipt.get("policy")
+    if not isinstance(policy, dict):
+        return False
+    duration = policy.get("duration_seconds")
+    if (
+        duration is None
+        or isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(float(duration))
+        or float(duration) <= 0
+    ):
+        return False
+    return words / (float(duration) / 60.0) > MAX_WORDS_PER_MINUTE
+
+
 def validate_transcript(
     text: str,
     *,
@@ -199,5 +253,13 @@ def validate_transcript(
                 f"({words_per_minute:.0f} wpm), below the "
                 f"{MIN_WORDS_PER_MINUTE} wpm floor — it likely covers only "
                 "part of the talk"
+            )
+        if words_per_minute > MAX_WORDS_PER_MINUTE:
+            return False, (
+                f"transcript has {words} words for {minutes:.0f} minutes "
+                f"({words_per_minute:.0f} wpm), above the "
+                f"{MAX_WORDS_PER_MINUTE} wpm ceiling — the caption track "
+                "covers more than this recording; confirm it belongs to this "
+                "video before use"
             )
     return True, f"{words} words"

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -171,9 +171,7 @@ def test_caption_track_covering_more_than_the_recording_is_rejected(
     Reproduces Kl6tLcQ5hGI — 1568 words against a provider-probed 318s, which
     opened as the right talk and closed inside a different speaker's.
     """
-    ok, reason = fetch_transcript.validate_transcript(
-        _talk(1568), duration_seconds=318
-    )
+    ok, reason = fetch_transcript.validate_transcript(_talk(1568), duration_seconds=318)
     assert not ok
     assert "wpm" in reason
     assert "ceiling" in reason

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -163,6 +163,89 @@ def test_transcript_far_too_short_for_runtime_is_rejected(fetch_transcript):
     assert "wpm" in reason
 
 
+def test_caption_track_covering_more_than_the_recording_is_rejected(
+    fetch_transcript,
+):
+    """The real shape: a 5-minute segment served the session block's captions.
+
+    Reproduces Kl6tLcQ5hGI — 1568 words against a provider-probed 318s, which
+    opened as the right talk and closed inside a different speaker's.
+    """
+    ok, reason = fetch_transcript.validate_transcript(
+        _talk(1568), duration_seconds=318
+    )
+    assert not ok
+    assert "wpm" in reason
+    assert "ceiling" in reason
+
+
+def test_a_fast_talker_is_not_mistaken_for_a_foreign_caption_track(
+    fetch_transcript,
+):
+    """The ceiling catches a wrong recording, never a brisk delivery."""
+    ok, _reason = fetch_transcript.validate_transcript(
+        _talk(200 * 30), duration_seconds=30 * 60
+    )
+    assert ok
+
+
+def test_the_observed_vault_word_rates_all_clear_the_ceiling(fetch_transcript):
+    """Every genuine receipt in the vault sat at 110-132 wpm."""
+    for words, seconds in ((2389, 18 * 60), (1067, 492), (6626, 53 * 60)):
+        ok, reason = fetch_transcript.validate_transcript(
+            _talk(words), duration_seconds=seconds
+        )
+        assert ok, reason
+
+
+def test_receipt_whose_duration_cannot_hold_the_words_asks_for_a_probe(
+    fetch_transcript,
+):
+    """The Kl6tLcQ5hGI receipt: 318s recorded, 1609 words on disk."""
+    receipt = {"policy": {"duration_seconds": 318.0}}
+    assert fetch_transcript.receipt_duration_cannot_hold(receipt, 1609) is True
+
+
+def test_a_receipt_that_comfortably_holds_its_words_asks_for_nothing(
+    fetch_transcript,
+):
+    receipt = {"policy": {"duration_seconds": 53 * 60}}
+    assert fetch_transcript.receipt_duration_cannot_hold(receipt, 6626) is False
+
+
+def test_an_absent_or_unusable_receipt_screens_nothing(fetch_transcript):
+    """Screening must never manufacture a probe from a missing duration."""
+    for receipt in (
+        None,
+        {},
+        {"policy": {}},
+        {"policy": {"duration_seconds": None}},
+        {"policy": {"duration_seconds": 0}},
+        {"policy": {"duration_seconds": -5}},
+        {"policy": {"duration_seconds": True}},
+        {"policy": {"duration_seconds": float("inf")}},
+        {"policy": "not-an-object"},
+    ):
+        assert fetch_transcript.receipt_duration_cannot_hold(receipt, 99999) is False
+
+
+def test_a_receipt_with_a_probed_duration_asks_to_be_reprobed(fetch_transcript):
+    """Re-deriving without asking the provider would write the weaker receipt."""
+    receipt = {"policy": {"duration_seconds": 318.0}}
+    assert fetch_transcript.receipt_claims_source_duration(receipt) is True
+
+
+def test_a_receipt_without_a_duration_claims_nothing(fetch_transcript):
+    for receipt in (
+        None,
+        {},
+        {"policy": {}},
+        {"policy": {"duration_seconds": None}},
+        {"policy": "not-an-object"},
+    ):
+        assert fetch_transcript.receipt_claims_source_duration(receipt) is False
+
+
 def test_plausible_transcript_passes(fetch_transcript):
     ok, reason = fetch_transcript.validate_transcript(
         _talk(7000), duration_seconds=50 * 60


### PR DESCRIPTION
Fixes #355.

## What happened

First talk of the full-vault reparse. `fetch-transcript.py` returned `ok: true`, exit 0, and wrote a transcript containing **two different speakers**.

[`Kl6tLcQ5hGI`](https://www.youtube.com/watch?v=Kl6tLcQ5hGI) is a 5.3-minute DevOpsDays Silicon Valley segment. YouTube served it the caption track for the venue's whole session block. The text opens as the right talk:

> "Let's talk about Docker, my name is Baruch Sadogursky..."

and closes inside somebody else's:

> "...how can we break **Brooks' law**? Really it comes down to DevOps culture. Thanks. [Applause]"

Rhetoric analysis reads verbatim examples, hiccup words, pacing and closing type straight off the transcript, so another speaker's delivery would have been scored as this one's.

## Three defects, each hiding the next

**1. The policy had a floor and no ceiling.** `min_words` is derived from `duration_seconds`; the receipt carried both numbers and only ever compared them upward. 1609 words over 318s is 304 wpm. Every genuine receipt in the vault:

| wpm | words / min | video |
|---|---|---|
| **304** | 1609 / 5.3 | `Kl6tLcQ5hGI` ← contaminated |
| 132 | 2389 / 18.0 | `xJLI6httbKU` |
| 130 | 1067 / 8.2 | `ledOM8izI7Q` |
| 125 | 6626 / 53.0 | `5RCnt53R3s8` |
| 110 | 7315 / 66.8 | `9MV-zginASY` |

`MAX_WORDS_PER_MINUTE = 240` is deliberately loose — it catches a track belonging to a different recording, not a fast talker.

**2. The duration was modelled as a floor-relaxation input.** `needs_duration_probe` fired when a transcript looked too *short*, so a long one never obtained a duration and the ceiling would have been **inert on the `existing` path** — the path a reparse takes most, since those transcripts are already on disk. Shipping the ceiling alone would have shipped a no-op for the actual run.

The offline fast path is preserved. A stored receipt whose own duration cannot hold the words buys a probe; the verdict still comes from the probed value, never the stored one. False negatives are possible, false positives are not.

**3. A re-validation that declined to probe wrote the weaker receipt back.** Observed live: `{youtube_duration, 318.0}` was replaced by `{fixed_default, null}`, destroying the evidence — and defeating fix 2, which depends on the receipt keeping its duration. A receipt claiming a source-owned duration now triggers a probe, and a probe that cannot reach the provider leaves the stronger receipt intact.

## Verification

End-to-end against the real file, via the `existing` path:

```
exit=1
"existing transcript is not usable: transcript has 1609 words for 5 minutes
 (304 wpm), above the 240 wpm ceiling — the caption track covers more than
 this recording; confirm it belongs to this video before use"
```

Exit 1 is `processed_partial` territory per the contract table — an honest degraded result instead of silent contamination.

8 tests added: the real contaminated case, a fast-talker false-positive guard, all four genuine vault word rates, and the screening/claim helpers against absent, empty, zero, negative, boolean and infinite durations.

Full suite: **6259 passed**. The 3 failures in `test_plugin_lint_gate.py` are the pre-existing tessl-CLI drift tracked in #347 (local 0.98.0 vs CI pin 0.95.0) and are unrelated.

## Scope

The ceiling catches gross contamination, not subtle — a track only moderately longer than its talk still lands under 240 wpm. Promoting the timing-overrun rejection (`timed segments extend beyond the source-owned duration bound`) from a dropped `timed_path` to a transcript-level verdict is the precise detector; it is a larger contract change and stays open on #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2oVxH1XMvSRyXsjf5BZ1U