### PR TITLE
fix(vault-ingress): try every YouTube player client before giving up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+### fix(vault-ingress) — try every YouTube player client before declaring a talk untranscribable
+
+The Whisper fallback was dead and said the wrong thing about why. `yt-dlp`
+media download returned `HTTP 403: Forbidden`, the script reported
+`whisper: unavailable`, and mlx-whisper was installed and working the whole
+time. What failed was the download, not the transcriber.
+
+YouTube blocks its player clients unevenly. Measured against
+`Kl6tLcQ5hGI`: the default chain, `web_safari`, `ios` and `tv` all 403, while
+`mweb` downloads fine. The script passed no `--extractor-args` at all, so it
+took whatever default the installed yt-dlp picked and stopped at the first
+refusal. One working client existed and it was never reached.
+
+`fetch_whisper` now walks `YOUTUBE_PLAYER_CLIENTS`, starting with `None` so a
+healthy environment runs yt-dlp's own default chain and pays nothing for the
+fallbacks. On exhaustion the error names every client tried and its reason,
+rather than blaming the transcriber.
+
+This mattered immediately: #359 made a contaminated caption track fail closed,
+and the intended recovery from a rejected track is Whisper. Between the two,
+a talk with bad captions had no path to a transcript at all.
+
+The same run also carried the local-audio half of the receipt-preservation fix
+that #359 landed for YouTube only. In `_handle_local_audio` a failed
+`probe_local_media_duration` still overwrote a valid `local_media_duration`
+receipt with the fixed default, destroying the duration a later run needs for
+either word-rate bound. The guard now applies there too, with one condition the
+YouTube branch does not need: a stored receipt is the stronger one only while
+its `media_sha256` still names the bytes in hand. A receipt describing other
+media is stale, not strong.
+
+Found by Copilot on #359 and tracked as #360; the 403 is #361, which stays open
+for the dependency half — `yt-dlp` is not declared in `pyproject.toml` at all,
+resolves from `PATH`, and has no renewal mechanism, which is the
+adversarial-freshness case in `rules/dependency-management.md`.
+
 ## 0.20.104 — 2026-08-22
 
 ### fix(vault-ingress) — bound the transcript word rate from above, and stop the bound erasing itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,50 @@
 # Changelog
 
-### fix(vault-ingress) — try every YouTube player client before declaring a talk untranscribable
+### fix(vault-ingress) — declare yt-dlp, and stop one refusal ending the Whisper lane
 
-The Whisper fallback was dead and said the wrong thing about why. `yt-dlp`
-media download returned `HTTP 403: Forbidden`, the script reported
-`whisper: unavailable`, and mlx-whisper was installed and working the whole
-time. What failed was the download, not the transcriber.
+The Whisper fallback was dead and blamed the wrong component. `yt-dlp` returned
+`HTTP 403: Forbidden`, the script reported `whisper: unavailable`, and
+mlx-whisper was installed and working the whole time. What failed was the
+download.
 
-YouTube blocks its player clients unevenly. Measured against
-`Kl6tLcQ5hGI`: the default chain, `web_safari`, `ios` and `tv` all 403, while
-`mweb` downloads fine. The script passed no `--extractor-args` at all, so it
-took whatever default the installed yt-dlp picked and stopped at the first
-refusal. One working client existed and it was never reached.
+**The root cause was staleness, not YouTube.** `yt-dlp` was never declared in
+`pyproject.toml`. It resolved from `PATH` — a Homebrew binary at 2026.06.09,
+two and a half months old — with no floor, no pin, and no renewal path.
+Nothing broke when it rotted, which is the whole problem: a stale yt-dlp does
+not fail the build, it quietly removes the ability to transcribe. Declaring
+`yt-dlp==2026.8.19` puts it under the `pip` Dependabot ecosystem the repo
+already runs weekly, so the renewal that was missing now happens on its own.
+Verified: 2026.8.19 downloads on the default player client, where 2026.06.09
+403s.
 
-`fetch_whisper` now walks `YOUTUBE_PLAYER_CLIENTS`, starting with `None` so a
-healthy environment runs yt-dlp's own default chain and pays nothing for the
-fallbacks. On exhaustion the error names every client tried and its reason,
-rather than blaming the transcriber.
+That makes the second change defense in depth rather than the fix. YouTube
+blocks its player clients unevenly and a pin will always lag the adversary by
+up to a renewal cycle, so a single refusal should not end the lane. Measured
+against `Kl6tLcQ5hGI` on the stale version: default, `web_safari`, `ios` and
+`tv` all 403, `mweb` served it. `fetch_whisper` now walks
+`YOUTUBE_PLAYER_CLIENTS`, `None` first so a healthy environment runs yt-dlp's
+own default chain and pays nothing, and on exhaustion names every client tried.
 
-This mattered immediately: #359 made a contaminated caption track fail closed,
-and the intended recovery from a rejected track is Whisper. Between the two,
-a talk with bad captions had no path to a transcript at all.
+Each attempt downloads into its own directory. Sharing one output path let a
+refused attempt leave a partial file behind, and the next attempt's
+existence check would accept those bytes as its own success — the chain would
+stop early and transcribe the failure's leftovers. A zero-byte artifact is
+likewise a failed extraction wearing a filename, not a download.
 
-The same run also carried the local-audio half of the receipt-preservation fix
-that #359 landed for YouTube only. In `_handle_local_audio` a failed
+This blocked recovery from the previous entry: a contaminated caption track now
+fails closed, and Whisper is the intended fallback. Between the two, a talk with
+bad captions had no path to a transcript at all.
+
+The same change carries the local-audio half of the receipt-preservation guard,
+which landed for YouTube only. In `_handle_local_audio` a failed
 `probe_local_media_duration` still overwrote a valid `local_media_duration`
 receipt with the fixed default, destroying the duration a later run needs for
-either word-rate bound. The guard now applies there too, with one condition the
-YouTube branch does not need: a stored receipt is the stronger one only while
-its `media_sha256` still names the bytes in hand. A receipt describing other
-media is stale, not strong.
+either word-rate bound. That branch adds one condition the YouTube branch does
+not need: a stored receipt is the stronger one only while its `media_sha256`
+still names the bytes in hand. A receipt describing other media is stale, not
+strong.
 
-Found by Copilot on #359 and tracked as #360; the 403 is #361, which stays open
-for the dependency half — `yt-dlp` is not declared in `pyproject.toml` at all,
-resolves from `PATH`, and has no renewal mechanism, which is the
-adversarial-freshness case in `rules/dependency-management.md`.
-
-## 0.20.104 — 2026-08-22
+Found during the reparse of a 250-talk vault; #360 and #361.
 
 ### fix(vault-ingress) — bound the transcript word rate from above, and stop the bound erasing itself
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     # in .github/dependabot.yml (weekly), so the next break lands as a reviewed
     # bump rather than as corrupt data.
     "youtube-transcript-api==1.2.4",
+    "yt-dlp==2026.8.19",
 ]
 
 [project.optional-dependencies]

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -648,9 +648,16 @@ def fetch_whisper(
 ) -> tuple[str | None, str | None, Iterable[object] | None]:
     """Download audio and return Whisper text, language, and timed segments."""
     url = f"https://www.youtube.com/watch?v={video_id}"
-    audio = Path(work_dir) / "audio.mp3"
+    audio: Path | None = None
     failures: list[str] = []
-    for client in YOUTUBE_PLAYER_CLIENTS:
+    # Each attempt downloads into its own directory. Sharing one path let a
+    # refused attempt leave a partial file behind, and the next attempt's
+    # "did the audio appear" check would accept those bytes as its own success
+    # — the retry chain would stop early and transcribe whatever the failure
+    # left. Isolation makes the check answer only for the attempt that ran.
+    for index, client in enumerate(YOUTUBE_PLAYER_CLIENTS):
+        attempt_dir = Path(work_dir) / f"download-{index}"
+        attempt_dir.mkdir(parents=True, exist_ok=True)
         command = [
             "yt-dlp",
             "-x",
@@ -658,7 +665,7 @@ def fetch_whisper(
             "mp3",
             "--no-playlist",
             "-o",
-            str(Path(work_dir) / "audio.%(ext)s"),
+            str(attempt_dir / "audio.%(ext)s"),
         ]
         if client is not None:
             command += ["--extractor-args", f"youtube:player_client={client}"]
@@ -676,7 +683,14 @@ def fetch_whisper(
                 file=sys.stderr,
             )
             return None, None, None
-        if download.returncode == 0 and audio.exists():
+        candidate = attempt_dir / "audio.mp3"
+        # A zero-byte artifact is a failed extraction wearing a filename.
+        if (
+            download.returncode == 0
+            and candidate.exists()
+            and candidate.stat().st_size > 0
+        ):
+            audio = candidate
             break
         failures.append(f"{client or 'default'}: {download.stderr.strip()[:200]}")
     else:

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -101,10 +101,28 @@ from transcript_quality import (
     normalize_duration,
     receipt_claims_source_duration,
     receipt_duration_cannot_hold,
+    receipt_matches_media_digest,
     validate_transcript,
 )
 
 __all__ = ["VTT_TIMING_TAG", "write_atomically"]
+
+
+# YouTube serves media per player client, and it blocks them unevenly: a client
+# that 403s today may work tomorrow and the reverse. Trying one client and
+# giving up turns a transient block into "this talk has no transcript", which
+# is how the Whisper fallback went silently dead while mlx-whisper sat
+# installed and working. `None` runs yt-dlp's own default chain first, so a
+# healthy environment pays nothing; the named clients are only reached after it
+# fails. Order is cheapest-first, not preference — every entry produces the
+# same audio when it works.
+YOUTUBE_PLAYER_CLIENTS: tuple[str | None, ...] = (
+    None,
+    "mweb",
+    "web_safari",
+    "ios",
+    "tv",
+)
 
 
 VIDEO_ID = re.compile(r"(?:v=|youtu\.be/|/embed/|/shorts/)([A-Za-z0-9_-]{11})")
@@ -631,35 +649,40 @@ def fetch_whisper(
     """Download audio and return Whisper text, language, and timed segments."""
     url = f"https://www.youtube.com/watch?v={video_id}"
     audio = Path(work_dir) / "audio.mp3"
-    try:
-        download = subprocess.run(
-            [
-                "yt-dlp",
-                "-x",
-                "--audio-format",
-                "mp3",
-                "--no-playlist",
-                "-o",
-                str(Path(work_dir) / "audio.%(ext)s"),
-                url,
-            ],
-            capture_output=True,
-            text=True,
-        )
-    except (FileNotFoundError, OSError) as exc:
-        # A missing yt-dlp must not escape as a traceback: this script's callers
-        # parse its stdout JSON, and a script that dies without emitting it is
-        # the same silent-failure shape the whole file exists to prevent.
+    failures: list[str] = []
+    for client in YOUTUBE_PLAYER_CLIENTS:
+        command = [
+            "yt-dlp",
+            "-x",
+            "--audio-format",
+            "mp3",
+            "--no-playlist",
+            "-o",
+            str(Path(work_dir) / "audio.%(ext)s"),
+        ]
+        if client is not None:
+            command += ["--extractor-args", f"youtube:player_client={client}"]
+        command.append(url)
+        try:
+            download = subprocess.run(command, capture_output=True, text=True)
+        except (FileNotFoundError, OSError) as exc:
+            # A missing yt-dlp must not escape as a traceback: this script's
+            # callers parse its stdout JSON, and a script that dies without
+            # emitting it is the same silent-failure shape the whole file
+            # exists to prevent.
+            print(
+                f"cannot run yt-dlp ({exc}) — install it with "
+                "`brew install yt-dlp` or `pip install yt-dlp`",
+                file=sys.stderr,
+            )
+            return None, None, None
+        if download.returncode == 0 and audio.exists():
+            break
+        failures.append(f"{client or 'default'}: {download.stderr.strip()[:200]}")
+    else:
         print(
-            f"cannot run yt-dlp ({exc}) — install it with "
-            "`brew install yt-dlp` or `pip install yt-dlp`",
-            file=sys.stderr,
-        )
-        return None, None, None
-    if download.returncode != 0 or not audio.exists():
-        print(
-            f"yt-dlp could not download audio for {video_id}: "
-            f"{download.stderr.strip()[:400]}",
+            f"yt-dlp could not download audio for {video_id} under any player "
+            f"client — {'; '.join(failures)}",
             file=sys.stderr,
         )
         return None, None, None
@@ -877,7 +900,19 @@ def _handle_local_audio(
                 "policy": quality_policy,
                 "provenance": quality_provenance,
             }
-            if receipt != expected_receipt:
+            # Same rule as the YouTube branch: a probe that could not read the
+            # media leaves the fixed default in hand, and writing that over a
+            # receipt already recording a source-owned duration trades evidence
+            # for its absence. One condition this branch adds — the stored
+            # receipt is only the stronger one while it still describes these
+            # bytes. A receipt for different media is stale, not strong, so the
+            # digest must match before it is preserved.
+            would_discard_source_duration = (
+                trusted_duration is None
+                and receipt_claims_source_duration(receipt)
+                and receipt_matches_media_digest(receipt, media.sha256)
+            )
+            if receipt != expected_receipt and not would_discard_source_duration:
                 media.assert_unchanged(verify_source_digest=True)
                 try:
                     write_quality_receipt(

--- a/skills/vault-ingress/scripts/transcript_quality.py
+++ b/skills/vault-ingress/scripts/transcript_quality.py
@@ -169,6 +169,24 @@ def receipt_claims_source_duration(receipt: object) -> bool:
     return policy.get("duration_seconds") is not None
 
 
+def receipt_matches_media_digest(receipt: object, media_sha256: object) -> bool:
+    """Return whether a receipt's provenance names exactly these media bytes.
+
+    A stored receipt is only stronger evidence while it still describes the
+    file in hand. One that names different bytes is stale, and preserving it
+    would pin a duration to media nobody is reading. A receipt with no media
+    digest — the YouTube provenance forms — never matches, because this asks a
+    local-media question.
+    """
+    if not isinstance(receipt, dict) or not isinstance(media_sha256, str):
+        return False
+    provenance = receipt.get("provenance")
+    if not isinstance(provenance, dict):
+        return False
+    stored = provenance.get("media_sha256")
+    return isinstance(stored, str) and stored == media_sha256
+
+
 def receipt_duration_cannot_hold(receipt: object, words: int) -> bool:
     """Return whether a receipt's own duration is too short to hold this speech.
 

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -244,6 +244,44 @@ def test_a_receipt_without_a_duration_claims_nothing(fetch_transcript):
         assert fetch_transcript.receipt_claims_source_duration(receipt) is False
 
 
+def test_a_receipt_for_these_exact_media_bytes_is_preservable(fetch_transcript):
+    receipt = {"provenance": {"media_sha256": "a" * 64}}
+    assert fetch_transcript.receipt_matches_media_digest(receipt, "a" * 64) is True
+
+
+def test_a_receipt_for_other_media_is_stale_not_strong(fetch_transcript):
+    """Preserving it would pin a duration to bytes nobody is reading."""
+    receipt = {"provenance": {"media_sha256": "a" * 64}}
+    assert fetch_transcript.receipt_matches_media_digest(receipt, "b" * 64) is False
+
+
+def test_a_receipt_with_no_media_digest_never_matches(fetch_transcript):
+    """The YouTube provenance forms answer a different question."""
+    for receipt in (
+        None,
+        {},
+        {"provenance": {}},
+        {"provenance": {"video_id": "Kl6tLcQ5hGI"}},
+        {"provenance": {"media_sha256": None}},
+        {"provenance": "not-an-object"},
+    ):
+        assert fetch_transcript.receipt_matches_media_digest(receipt, "a" * 64) is False
+    assert (
+        fetch_transcript.receipt_matches_media_digest(
+            {"provenance": {"media_sha256": "a" * 64}}, None
+        )
+        is False
+    )
+
+
+def test_the_player_client_chain_tries_the_default_first(fetch_transcript):
+    """A healthy environment must not pay for the fallbacks."""
+    clients = fetch_transcript.YOUTUBE_PLAYER_CLIENTS
+    assert clients[0] is None
+    assert "mweb" in clients
+    assert len(set(clients)) == len(clients)
+
+
 def test_plausible_transcript_passes(fetch_transcript):
     ok, reason = fetch_transcript.validate_transcript(
         _talk(7000), duration_seconds=50 * 60

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -12,8 +12,8 @@ in CI without a network, without YouTube, and without Apple-Silicon Whisper.
 
 import hashlib
 import json
-import pathlib
 import os
+import pathlib
 import subprocess
 import sys
 from pathlib import Path
@@ -296,6 +296,76 @@ def _blocking_yt_dlp(fetch_transcript, monkeypatch, serving_client, attempts):
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
     monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
+
+
+def test_a_refused_attempt_that_left_bytes_behind_is_not_reused(
+    fetch_transcript, monkeypatch, tmp_path
+):
+    """A partial file from a failed client must not end the retry chain.
+
+    yt-dlp can exit nonzero having already written something. If every attempt
+    shared one output path, the next attempt's existence check would accept
+    those bytes as its own success and transcribe the failure's leftovers.
+    """
+    attempts: list[str | None] = []
+
+    def run(command, **_kwargs):
+        client = None
+        if "--extractor-args" in command:
+            client = command[command.index("--extractor-args") + 1].split("=")[-1]
+        attempts.append(client)
+        target = pathlib.Path(
+            command[command.index("-o") + 1].replace("%(ext)s", "mp3")
+        )
+        if client != "mweb":
+            # the failure leaves a truncated artifact behind
+            target.write_bytes(b"partial-garbage")
+            return subprocess.CompletedProcess(
+                command, 1, stdout="", stderr="HTTP Error 403: Forbidden"
+            )
+        target.write_bytes(b"real-audio")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
+    transcribed: list[bytes] = []
+
+    def transcribe(audio_path, *_a, **_k):
+        transcribed.append(pathlib.Path(audio_path).read_bytes())
+        return "spoken words here", "en", None
+
+    monkeypatch.setattr(fetch_transcript, "transcribe_audio", transcribe)
+
+    text, _language, _segments = fetch_transcript.fetch_whisper(
+        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
+    )
+
+    assert text == "spoken words here"
+    assert "mweb" in attempts, "a leftover file must not end the chain early"
+    assert transcribed == [b"real-audio"], "the failure's bytes must never be read"
+
+
+def test_a_zero_byte_download_is_not_a_success(fetch_transcript, monkeypatch, tmp_path):
+    """An empty artifact is a failed extraction wearing a filename."""
+    attempts: list[str | None] = []
+
+    def run(command, **_kwargs):
+        client = None
+        if "--extractor-args" in command:
+            client = command[command.index("--extractor-args") + 1].split("=")[-1]
+        attempts.append(client)
+        pathlib.Path(
+            command[command.index("-o") + 1].replace("%(ext)s", "mp3")
+        ).write_bytes(b"")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
+
+    text, language, segments = fetch_transcript.fetch_whisper(
+        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
+    )
+
+    assert (text, language, segments) == (None, None, None)
+    assert len(attempts) == len(fetch_transcript.YOUTUBE_PLAYER_CLIENTS)
 
 
 def test_a_refused_player_client_advances_to_the_next(

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -12,6 +12,7 @@ in CI without a network, without YouTube, and without Apple-Silicon Whisper.
 
 import hashlib
 import json
+import pathlib
 import os
 import subprocess
 import sys
@@ -274,12 +275,86 @@ def test_a_receipt_with_no_media_digest_never_matches(fetch_transcript):
     )
 
 
-def test_the_player_client_chain_tries_the_default_first(fetch_transcript):
-    """A healthy environment must not pay for the fallbacks."""
-    clients = fetch_transcript.YOUTUBE_PLAYER_CLIENTS
-    assert clients[0] is None
-    assert "mweb" in clients
-    assert len(set(clients)) == len(clients)
+def _blocking_yt_dlp(fetch_transcript, monkeypatch, serving_client, attempts):
+    """Mock yt-dlp as YouTube currently behaves: one client works, others 403.
+
+    Writes the audio file only for `serving_client`, exactly as a real download
+    does, so the caller's "did a file appear" check decides the outcome.
+    """
+
+    def run(command, **_kwargs):
+        client = None
+        if "--extractor-args" in command:
+            client = command[command.index("--extractor-args") + 1].split("=")[-1]
+        attempts.append(client)
+        if client != serving_client:
+            return subprocess.CompletedProcess(
+                command, 1, stdout="", stderr="HTTP Error 403: Forbidden"
+            )
+        target = command[command.index("-o") + 1]
+        pathlib.Path(target.replace("%(ext)s", "mp3")).write_bytes(b"audio")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
+
+
+def test_a_refused_player_client_advances_to_the_next(
+    fetch_transcript, monkeypatch, tmp_path
+):
+    """The 403 that killed the fallback: a later client must still be tried."""
+    attempts: list[str | None] = []
+    _blocking_yt_dlp(fetch_transcript, monkeypatch, "mweb", attempts)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "transcribe_audio",
+        lambda *a, **k: ("spoken words here", "en", None),
+    )
+
+    text, language, _segments = fetch_transcript.fetch_whisper(
+        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
+    )
+
+    assert text == "spoken words here"
+    assert language == "en"
+    assert attempts[0] is None, "the default chain must be tried first"
+    assert "mweb" in attempts, "the serving client must be reached"
+
+
+def test_a_working_default_client_never_pays_for_the_fallbacks(
+    fetch_transcript, monkeypatch, tmp_path
+):
+    attempts: list[str | None] = []
+    _blocking_yt_dlp(fetch_transcript, monkeypatch, None, attempts)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "transcribe_audio",
+        lambda *a, **k: ("spoken words here", "en", None),
+    )
+
+    text, _language, _segments = fetch_transcript.fetch_whisper(
+        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
+    )
+
+    assert text == "spoken words here"
+    assert attempts == [None], "a healthy environment must make exactly one attempt"
+
+
+def test_every_player_client_refusing_reports_failure(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """Exhaustion is a failure that names what was tried, not a traceback."""
+    attempts: list[str | None] = []
+    _blocking_yt_dlp(fetch_transcript, monkeypatch, "no-such-client", attempts)
+
+    text, language, segments = fetch_transcript.fetch_whisper(
+        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
+    )
+
+    assert (text, language, segments) == (None, None, None)
+    assert len(attempts) == len(fetch_transcript.YOUTUBE_PLAYER_CLIENTS)
+    stderr = capsys.readouterr().err
+    assert "under any player client" in stderr
+    assert "403" in stderr
 
 
 def test_plausible_transcript_passes(fetch_transcript):

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -809,6 +809,76 @@ def test_local_duration_provenance_hashes_the_exact_media(
     }
 
 
+def _existing_local_audio_bundle(fetch_transcript, tmp_path, receipt_digest):
+    """An on-disk transcript plus a local-media receipt naming `receipt_digest`."""
+    media = tmp_path / "recording.mp4"
+    media.write_bytes(b"stable local media bytes")
+    out = tmp_path / "local-talk.txt"
+    text = _talk(600)
+    out.write_text(text, encoding="utf-8")
+    policy = fetch_transcript.build_quality_policy(None, trusted_duration_seconds=600.0)
+    out.with_suffix(".quality.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "transcript_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                "policy": policy,
+                "provenance": {
+                    "kind": "local_media_duration",
+                    "media_sha256": receipt_digest,
+                    "duration_seconds": 600.0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return media, out
+
+
+def test_a_failed_probe_keeps_a_receipt_that_still_names_these_media_bytes(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """ffprobe unavailable must not cost the duration a later bound needs."""
+    digest = hashlib.sha256(b"stable local media bytes").hexdigest()
+    media, out = _existing_local_audio_bundle(fetch_transcript, tmp_path, digest)
+    before = out.with_suffix(".quality.json").read_text(encoding="utf-8")
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_local_media_duration",
+        lambda _path: (None, "ffprobe unavailable"),
+    )
+
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["local-talk", "--audio", str(media), "--out", str(out)])
+
+    assert exited.value.code == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+    after = json.loads(out.with_suffix(".quality.json").read_text(encoding="utf-8"))
+    assert after == json.loads(before), "the source-owned receipt must survive"
+    assert after["provenance"]["kind"] == "local_media_duration"
+    assert after["policy"]["duration_seconds"] == 600.0
+
+
+def test_a_failed_probe_replaces_a_receipt_describing_other_media(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """A receipt for bytes nobody is reading is stale, not strong."""
+    media, out = _existing_local_audio_bundle(fetch_transcript, tmp_path, "f" * 64)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_local_media_duration",
+        lambda _path: (None, "ffprobe unavailable"),
+    )
+
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["local-talk", "--audio", str(media), "--out", str(out)])
+
+    assert exited.value.code == 0
+    after = json.loads(out.with_suffix(".quality.json").read_text(encoding="utf-8"))
+    assert after["provenance"] == {"kind": "fixed_default"}
+    assert after["policy"]["duration_seconds"] is None
+
+
 def test_local_audio_probe_transcription_and_receipts_share_one_snapshot(
     fetch_transcript, monkeypatch, tmp_path, capsys
 ):


### PR DESCRIPTION
Closes #360. Refs #361 (the dependency half stays open — see below).

## The Whisper fallback was dead, and blamed the wrong component

```
$ fetch-transcript.py Kl6tLcQ5hGI --method whisper --force
{"ok": false, "method": "none", "reason": "no source produced a valid transcript — whisper: unavailable"}
yt-dlp could not download audio: ERROR: unable to download video data: HTTP Error 403: Forbidden
```

mlx-whisper was installed and working the whole time. What failed was the download.

YouTube blocks its player clients unevenly. Measured against this video:

| `player_client` | result |
|---|---|
| default (`android_vr`) | 403 |
| `web_safari` | 403 |
| `ios` | 403 |
| `tv` | 403 |
| **`mweb`** | **downloads fine** |

The script passed no `--extractor-args`, so it took whatever default the installed yt-dlp picked and stopped at the first refusal. A working client existed and was never reached.

`fetch_whisper` now walks `YOUTUBE_PLAYER_CLIENTS`. `None` is first, so a healthy environment runs yt-dlp's own default chain and pays nothing for the fallbacks; the named clients are only reached after it fails. On exhaustion the error names every client tried and its reason instead of blaming the transcriber.

**Why this was blocking.** #359 made a contaminated caption track fail closed, which is right — and the intended recovery from a rejected track is Whisper. Between the two changes, a talk with bad captions had *no* path to a transcript.

## Verification

End-to-end, unattended, on the video that could not be downloaded at all before:

```
{"ok": true, "method": "whisper", "words": 798}
```

Same talk, transcribed from its own audio: 798 words over 318s = 155 wpm, against the contaminated caption track's 1568 words at 296 wpm. The transcript opens and closes as the right speaker.

## Also: #360, the local-audio half of #359

#359 landed keep-the-stronger-receipt for YouTube only. Copilot caught that `_handle_local_audio` still overwrote a valid `local_media_duration` receipt with the fixed default when its probe failed, destroying the duration a later run needs for either word-rate bound.

The guard now applies there too, with one condition the YouTube branch does not need: a stored receipt is the stronger one **only while its `media_sha256` still names the bytes in hand**. A receipt describing other media is stale, not strong, and preserving it would pin a duration to a file nobody is reading.

This branch is no longer hypothetical — with YouTube media download blocked it was, until this PR, the only working route to a transcript.

## Tests

4 added (72 total in the file, all passing): the digest helper against matching bytes, differing bytes, and absent/malformed/`None` provenance; plus the client chain's shape — default first, `mweb` present, no duplicates.

`ruff format` clean across 412 files; pyright clean on the changed module.

## Still open on #361

`yt-dlp` is not declared in `pyproject.toml` at all. It resolves from `PATH` — here a Homebrew binary, version 2026.06.09, about two and a half months stale — with no floor, no pin, and no renewal cadence. That is the **Adversarial-Freshness Dependency Carve-Out** case in `rules/dependency-management.md`: its whole value is tracking an adversary, and staleness surfaces as silent capability loss rather than a build break. Declaring it and bringing it under that carve-out needs an authority-of-record rule and a deploy-time check, which is its own change and does not block the reparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2oVxH1XMvSRyXsjf5BZ1U