### PR TITLE
feat(vault-ingress): catch a caption track that belongs to a longer recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+### feat(vault-ingress) — catch a caption track that belongs to a longer recording
+
+Timed cues running far past the source-owned duration mean the track describes
+a different recording. The signal was already computed on every fetch and then
+thrown away: it dropped `timed_path`, wrote a prose reason, and let the text
+through. `timing_extent_is_foreign` now measures the overrun as a ratio, and
+the caption lane falls through to Whisper when it fires — so a rejected track
+becomes a real transcript instead of nothing.
+
+**It does not catch the track that motivated it, and that is worth recording.**
+`Kl6tLcQ5hGI`'s contaminated captions overrun by 1.213x — under the threshold —
+and were caught by the word-rate ceiling at 296 wpm instead. The assumption
+behind this work, that a session-block track shows up as a long timeline, was
+wrong: that track's cues barely overrun while its *text* is roughly double.
+The contamination was dense, not long.
+
+The two detectors cover different shapes, which is why this still ships:
+
+| contamination | ceiling | extent |
+|---|---|---|
+| dense text, short cues (observed) | catches at 296 wpm | misses at 1.21x |
+| long cues, dense text | catches — a 3000s block's words over a 318s divisor reads ~1400 wpm | catches |
+| long cues, sparse text | misses — 800 words over 5.3 min reads a normal 151 wpm | catches at 11x |
+
+The third row is the whole justification. The ceiling divides words by the
+*video's* duration, so it can never learn that the track disagrees about how
+long the recording is. That shape has not been seen in this vault.
+
+The threshold is loose on purpose — its verdict discards a transcript, and a
+cue trailing an hour-long talk by three seconds reads 1.0008.
+
 ### fix(vault-ingress) — declare yt-dlp, and stop one refusal ending the Whisper lane
 
 The Whisper fallback was dead and blamed the wrong component. `yt-dlp` returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ The third row is the whole justification. The ceiling divides words by the
 *video's* duration, so it can never learn that the track disagrees about how
 long the recording is. That shape has not been seen in this vault.
 
+The check runs on the caption lane only. Whisper cannot be foreign — it
+transcribes the audio in hand — and its timestamps are merely sometimes sloppy;
+this same talk produced `malformed or zero-duration segments` from that lane.
+Applying the guard to the final fallback would discard a sound transcript over
+bad timing and leave the talk with nothing.
+
+Segments are materialized before the check, because the timing bundle reads
+them again and a lane returning a one-shot iterable would hand the second
+reader an exhausted iterator — disabling the guard and the timing both.
+
 The threshold is loose on purpose — its verdict discards a transcript, and a
 cue trailing an hour-long talk by three seconds reads 1.0008.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,15 @@ this same talk produced `malformed or zero-duration segments` from that lane.
 Applying the guard to the final fallback would discard a sound transcript over
 bad timing and leave the talk with nothing.
 
-Segments are materialized before the check, because the timing bundle reads
-them again and a lane returning a one-shot iterable would hand the second
-reader an exhausted iterator — disabling the guard and the timing both.
+Segments are materialized inside the caption lane, not at the call site. Two
+readers consume them — the extent check and the timing bundle — so a one-shot
+track would hand the second an exhausted iterator, disabling the guard and the
+timing both. `segments_to_text` is a third reader and runs first, so the lane
+was already returning a spent iterable to anyone who received a lazy track.
+Consuming it inside the lane also keeps the consumption within the caller's
+expected-error boundary: a track that raises mid-read is a caption-lane
+failure that falls through to Whisper, where materializing at the call site
+would have let the same exception reach the process boundary and end the run.
 
 The threshold is loose on purpose — its verdict discards a transcript, and a
 cue trailing an hour-long talk by three seconds reads 1.0008.

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -542,9 +542,19 @@ def _fetch_captions_from_api(
             file=sys.stderr,
         )
         return None, None, None
+    # The track's own language, read before materializing — `list()` keeps the
+    # segments and drops the object's attributes.
     raw_language = getattr(segments, "language_code", None)
     language = raw_language if isinstance(raw_language, str) else None
-    return segments_to_text(segments), language, segments
+    # Materialize here, inside the lane the caller wrapped in its expected-error
+    # boundary. A lazy track that raises mid-consumption must read as a caption
+    # lane failure and fall through to Whisper; consumed outside this function
+    # the same exception reaches the process boundary and ends the run. Doing it
+    # once also means the text and the returned segments are the same data —
+    # `segments_to_text` would otherwise exhaust a one-shot track and hand the
+    # caller an empty one.
+    materialized = list(segments)
+    return segments_to_text(materialized), language, materialized
 
 
 def enrich_existing_caption_timing(
@@ -1498,12 +1508,6 @@ def main(argv: list[str] | None = None) -> NoReturn:
         # "malformed or zero-duration segments" from that lane. Applying the
         # check there would discard a sound transcript over bad timing, and
         # since Whisper is the last fallback the talk would end with nothing.
-        # A lane may hand back a one-shot iterable. The extent check reads the
-        # segments and so does the timing bundle below, and the second reader
-        # would get an exhausted iterator — disabling the guard and the timing
-        # both, silently. Materialize once so every reader sees the same data.
-        if segments is not None and not isinstance(segments, (list, tuple)):
-            segments = list(segments)
         if name == "captions" and timing_extent_is_foreign(segments, trusted_duration):
             overrun = timing_extent_overrun_ratio(segments, trusted_duration) or 0.0
             failures.append(

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -92,6 +92,8 @@ from transcript_timing import (
     write_timing_receipt,
     write_transcript_bundle,
     youtube_timing_provenance,
+    timing_extent_is_foreign,
+    timing_extent_overrun_ratio,
 )
 from transcript_quality import (
     DEFAULT_MIN_WORDS,
@@ -1487,6 +1489,20 @@ def main(argv: list[str] | None = None) -> NoReturn:
         text, language, segments = lane_result
         if text is None:
             failures.append(f"{name}: unavailable")
+            continue
+        # The strongest contamination signal available, and it is free: cues
+        # that run far past the recording mean this track describes a longer
+        # one — a venue's session block served to a single talk's video. The
+        # word-rate ceiling infers the same thing from text alone and only
+        # catches gross cases; this measures it directly. Falling through
+        # rather than failing hands the talk to Whisper, which transcribes the
+        # actual audio and cannot overrun it.
+        overrun = timing_extent_overrun_ratio(segments, trusted_duration)
+        if overrun is not None and timing_extent_is_foreign(segments, trusted_duration):
+            failures.append(
+                f"{name}: caption track covers {overrun:.1f}x this recording's "
+                "duration — it belongs to a longer video"
+            )
             continue
         policy_min_words = quality_policy["min_words"]
         if not isinstance(policy_min_words, int):

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -1490,20 +1490,21 @@ def main(argv: list[str] | None = None) -> NoReturn:
         if text is None:
             failures.append(f"{name}: unavailable")
             continue
-        # The strongest contamination signal available, and it is free: cues
-        # that run far past the recording mean this track describes a longer
-        # one — a venue's session block served to a single talk's video. The
-        # word-rate ceiling infers the same thing from text alone and only
-        # catches gross cases; this measures it directly. Falling through
-        # rather than failing hands the talk to Whisper, which transcribes the
-        # actual audio and cannot overrun it.
+        # Captions only. A caption track can belong to a different recording —
+        # a venue's session block served to one talk's video — and cues running
+        # far past the duration are the direct evidence of it. Whisper cannot
+        # be foreign: it transcribes the audio in hand. Its timestamps are
+        # merely sometimes sloppy, and this same talk has already produced
+        # "malformed or zero-duration segments" from that lane. Applying the
+        # check there would discard a sound transcript over bad timing, and
+        # since Whisper is the last fallback the talk would end with nothing.
         # A lane may hand back a one-shot iterable. The extent check reads the
         # segments and so does the timing bundle below, and the second reader
         # would get an exhausted iterator — disabling the guard and the timing
         # both, silently. Materialize once so every reader sees the same data.
         if segments is not None and not isinstance(segments, (list, tuple)):
             segments = list(segments)
-        if timing_extent_is_foreign(segments, trusted_duration):
+        if name == "captions" and timing_extent_is_foreign(segments, trusted_duration):
             overrun = timing_extent_overrun_ratio(segments, trusted_duration) or 0.0
             failures.append(
                 f"{name}: caption track covers {overrun:.1f}x this recording's "

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -1497,8 +1497,14 @@ def main(argv: list[str] | None = None) -> NoReturn:
         # catches gross cases; this measures it directly. Falling through
         # rather than failing hands the talk to Whisper, which transcribes the
         # actual audio and cannot overrun it.
-        overrun = timing_extent_overrun_ratio(segments, trusted_duration)
-        if overrun is not None and timing_extent_is_foreign(segments, trusted_duration):
+        # A lane may hand back a one-shot iterable. The extent check reads the
+        # segments and so does the timing bundle below, and the second reader
+        # would get an exhausted iterator — disabling the guard and the timing
+        # both, silently. Materialize once so every reader sees the same data.
+        if segments is not None and not isinstance(segments, (list, tuple)):
+            segments = list(segments)
+        if timing_extent_is_foreign(segments, trusted_duration):
+            overrun = timing_extent_overrun_ratio(segments, trusted_duration) or 0.0
             failures.append(
                 f"{name}: caption track covers {overrun:.1f}x this recording's "
                 "duration — it belongs to a longer video"

--- a/skills/vault-ingress/scripts/transcript_timing.py
+++ b/skills/vault-ingress/scripts/transcript_timing.py
@@ -77,6 +77,56 @@ TIMING_OWNER_SOURCES = frozenset(
     {"youtube_auto", "whisper", "manual", "unknown", "vtt"}
 )
 TIMING_BOUND_TOLERANCE_SECONDS = 1.0
+# Past the tolerance above, timing is merely untrustworthy — a caption track
+# routinely trails its video by a rounding artifact. Past this ratio it is not
+# this recording's track at all: the segments describe more speech than the
+# recording can physically hold, which is what a venue's whole session block
+# looks like when YouTube serves it to one talk's video. The two thresholds
+# answer different questions, so they are separate constants; this one is
+# deliberately loose because its verdict throws the transcript away.
+FOREIGN_TIMING_EXTENT_RATIO = 1.25
+
+
+def timing_extent_overrun_ratio(
+    segments: object, duration_seconds: object
+) -> float | None:
+    """Return how far timed segments run past a source-owned duration.
+
+    `None` when the question cannot be asked — no usable duration, or no
+    segment carrying a readable end. A ratio of 1.0 means the final cue lands
+    exactly on the end of the recording. Normalization is shared with the rest
+    of this module, so a raw caption object and a stored segment dict are read
+    the same way.
+    """
+    if (
+        not isinstance(duration_seconds, (int, float))
+        or isinstance(duration_seconds, bool)
+        or not math.isfinite(float(duration_seconds))
+        or float(duration_seconds) <= 0
+    ):
+        return None
+    if segments is None or isinstance(segments, (str, bytes)):
+        return None
+    if not isinstance(segments, Iterable):
+        return None
+    normalized = normalize_segments(segments)
+    ends = [
+        float(end)
+        for item in normalized
+        for end in (item.get("end_seconds"),)
+        if isinstance(end, (int, float)) and not isinstance(end, bool)
+    ]
+    if not ends:
+        return None
+    return max(ends) / float(duration_seconds)
+
+
+def timing_extent_is_foreign(segments: object, duration_seconds: object) -> bool:
+    """Return whether timed segments describe a different recording."""
+    ratio = timing_extent_overrun_ratio(segments, duration_seconds)
+    return ratio is not None and ratio > FOREIGN_TIMING_EXTENT_RATIO
+
+
 QUALITY_RECEIPT_SCHEMA_VERSION = 1
 QUALITY_RECEIPT_FIELDS = frozenset(
     {"schema_version", "transcript_sha256", "policy", "provenance"}

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -964,6 +964,45 @@ def test_a_one_shot_segment_iterable_does_not_bypass_the_guard(
     assert out.read_text(encoding="utf-8") == whisper_text
 
 
+def test_overlong_whisper_timestamps_do_not_discard_the_transcript(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """Whisper cannot be a foreign track — it transcribed the audio in hand.
+
+    Its timestamps are merely sometimes sloppy. Applying the caption guard to
+    the final fallback would leave a talk with nothing despite having valid
+    transcript text.
+    """
+    whisper_text = _talk(800)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_youtube_duration",
+        lambda _v: (318.0, "trusted synthetic duration"),
+    )
+    monkeypatch.setattr(
+        fetch_transcript, "fetch_captions", lambda *_a, **_k: (None, None, None)
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_whisper",
+        lambda *_a, **_k: (
+            whisper_text,
+            "en",
+            [{"text": "drifted cue", "start": 2990.0, "duration": 10.0}],
+        ),
+    )
+    out = tmp_path / "Kl6tLcQ5hGI.txt"
+
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["Kl6tLcQ5hGI", "--out", str(out)])
+
+    assert exited.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["method"] == "whisper"
+    assert out.read_text(encoding="utf-8") == whisper_text
+
+
 def test_a_caption_track_within_its_recording_is_kept(
     fetch_transcript, monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -879,6 +879,83 @@ def test_a_failed_probe_replaces_a_receipt_describing_other_media(
     assert after["policy"]["duration_seconds"] is None
 
 
+def test_a_foreign_caption_track_falls_through_to_whisper(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """The Kl6tLcQ5hGI shape, handled end to end.
+
+    A 318-second video served a caption track whose cues run to 3000 seconds.
+    That track must not become the transcript, and rejecting it must hand the
+    talk to Whisper rather than leaving it with nothing.
+    """
+    caption_text = _talk(1600)
+    whisper_text = _talk(800)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_youtube_duration",
+        lambda _v: (318.0, "trusted synthetic duration"),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_captions",
+        lambda *_a, **_k: (
+            caption_text,
+            "en",
+            [{"text": "a later talk", "start": 2990.0, "duration": 10.0}],
+        ),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_whisper",
+        lambda *_a, **_k: (whisper_text, "en", None),
+    )
+    out = tmp_path / "Kl6tLcQ5hGI.txt"
+
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["Kl6tLcQ5hGI", "--out", str(out)])
+
+    assert exited.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["method"] == "whisper"
+    assert out.read_text(encoding="utf-8") == whisper_text, (
+        "the session-block caption track must never reach the corpus"
+    )
+
+
+def test_a_caption_track_within_its_recording_is_kept(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """The guard must not push ordinary captions into the Whisper lane."""
+    caption_text = _talk(800)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_youtube_duration",
+        lambda _v: (318.0, "trusted synthetic duration"),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_captions",
+        lambda *_a, **_k: (
+            caption_text,
+            "en",
+            [{"text": "closing", "start": 300.0, "duration": 18.0}],
+        ),
+    )
+
+    def unreachable(*_a, **_k):  # pragma: no cover - asserted by not running
+        raise AssertionError("a sound caption track must not reach Whisper")
+
+    monkeypatch.setattr(fetch_transcript, "fetch_whisper", unreachable)
+    out = tmp_path / "Kl6tLcQ5hGI.txt"
+
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["Kl6tLcQ5hGI", "--out", str(out)])
+
+    assert exited.value.code == 0
+    assert json.loads(capsys.readouterr().out)["method"] == "captions"
+
+
 def test_local_audio_probe_transcription_and_receipts_share_one_snapshot(
     fetch_transcript, monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -923,6 +923,47 @@ def test_a_foreign_caption_track_falls_through_to_whisper(
     )
 
 
+def test_a_one_shot_segment_iterable_does_not_bypass_the_guard(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """A generator must not disable the check by being read twice.
+
+    The extent check reads the segments and the timing bundle reads them
+    again. If the lane hands back a one-shot iterable and nothing materializes
+    it, the second reader gets an exhausted iterator and the guard silently
+    passes a foreign track.
+    """
+    caption_text = _talk(1600)
+    whisper_text = _talk(800)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_youtube_duration",
+        lambda _v: (318.0, "trusted synthetic duration"),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_captions",
+        lambda *_a, **_k: (
+            caption_text,
+            "en",
+            (s for s in [{"text": "a later talk", "start": 2990.0, "duration": 10.0}]),
+        ),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_whisper",
+        lambda *_a, **_k: (whisper_text, "en", None),
+    )
+    out = tmp_path / "Kl6tLcQ5hGI.txt"
+
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["Kl6tLcQ5hGI", "--out", str(out)])
+
+    assert exited.value.code == 0
+    assert json.loads(capsys.readouterr().out)["method"] == "whisper"
+    assert out.read_text(encoding="utf-8") == whisper_text
+
+
 def test_a_caption_track_within_its_recording_is_kept(
     fetch_transcript, monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -504,6 +504,75 @@ def test_caption_errors_fall_through_instead_of_propagating(
     )
 
 
+def test_a_one_shot_caption_track_is_materialized_by_the_lane(
+    fetch_transcript, monkeypatch
+):
+    """Text and segments must be the same data, both readable.
+
+    `segments_to_text` consumes the track. Returning the consumed iterable
+    would hand the caller an empty one, and materializing later — outside this
+    lane — would put the consumption beyond the caller's expected-error
+    boundary.
+    """
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    cues = [
+        {"text": "first cue", "start": 0.0, "duration": 2.0},
+        {"text": "second cue", "start": 2.0, "duration": 2.0},
+    ]
+
+    def one_shot(self, *_args, **_kwargs):
+        return (cue for cue in cues)
+
+    monkeypatch.setattr(YouTubeTranscriptApi, "fetch", one_shot, raising=False)
+
+    text, _language, segments = fetch_transcript.fetch_captions("eg6gqvUFh6Q", ["en"])
+
+    assert text and "first cue" in text and "second cue" in text
+    assert isinstance(segments, list)
+    assert len(list(segments)) == 2, "the segments must survive a second read"
+    assert len(list(segments)) == 2
+
+
+def test_a_caption_track_raising_mid_read_degrades_to_the_next_lane(
+    fetch_transcript, monkeypatch, tmp_path, capsys
+):
+    """Consumption happens inside the lane, so a failure is not fatal.
+
+    Materialized outside the caller's expected-error boundary, this exception
+    would reach the process boundary and end the run instead of recording a
+    caption-lane failure and trying Whisper.
+    """
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    def exploding(self, *_args, **_kwargs):
+        def cues():
+            yield {"text": "first cue", "start": 0.0, "duration": 2.0}
+            raise ValueError("synthetic mid-read caption failure")
+
+        return cues()
+
+    monkeypatch.setattr(YouTubeTranscriptApi, "fetch", exploding, raising=False)
+    whisper_text = _talk(800)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_youtube_duration",
+        lambda _v: (318.0, "trusted synthetic duration"),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_whisper",
+        lambda *_a, **_k: (whisper_text, "en", None),
+    )
+    out = tmp_path / "eg6gqvUFh6Q.txt"
+
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["eg6gqvUFh6Q", "--out", str(out)])
+
+    assert exited.value.code == 0
+    assert json.loads(capsys.readouterr().out)["method"] == "whisper"
+
+
 def test_broken_caption_constructor_degrades_only_caption_lane(
     fetch_transcript, monkeypatch
 ):

--- a/tests/test_transcript_timing.py
+++ b/tests/test_transcript_timing.py
@@ -799,3 +799,42 @@ def test_overlapping_caption_text_does_not_invalidate_line_location(
     )
 
     assert resolved == {"line_start": 1, "line_end": 1}
+
+
+def test_a_session_block_caption_track_is_foreign(transcript_timing):
+    """Kl6tLcQ5hGI: a 5.3-minute video served the venue's whole block."""
+    segments = [{"text": "later talk", "start": 2990.0, "duration": 10.0}]
+    assert transcript_timing.timing_extent_is_foreign(segments, 318.0) is True
+    ratio = transcript_timing.timing_extent_overrun_ratio(segments, 318.0)
+    assert round(ratio, 1) == 9.4
+
+
+def test_a_cue_trailing_its_video_by_seconds_is_not_foreign(transcript_timing):
+    """Rounding at the end of an hour-long talk must not throw it away."""
+    segments = [{"text": "closing", "start": 3600.0, "duration": 3.0}]
+    assert transcript_timing.timing_extent_is_foreign(segments, 3600.0) is False
+
+
+def test_a_cue_landing_exactly_on_the_end_is_not_foreign(transcript_timing):
+    segments = [{"text": "closing", "start": 300.0, "duration": 18.0}]
+    assert transcript_timing.timing_extent_is_foreign(segments, 318.0) is False
+
+
+def test_the_foreign_question_is_unanswerable_without_both_sides(
+    transcript_timing,
+):
+    """No duration, no segments, or unreadable timing must not accuse anyone."""
+    good = [{"text": "x", "start": 0.0, "duration": 1.0}]
+    for segments, duration in (
+        (good, None),
+        (good, 0),
+        (good, -1),
+        (good, float("nan")),
+        (good, True),
+        (None, 318.0),
+        ([], 318.0),
+        ("not-segments", 318.0),
+        ([{"text": "x"}], 318.0),
+    ):
+        assert transcript_timing.timing_extent_overrun_ratio(segments, duration) is None
+        assert transcript_timing.timing_extent_is_foreign(segments, duration) is False


### PR DESCRIPTION
Closes #355.

## What this adds

Timed cues running far past the source-owned duration mean the caption track describes a *different, longer* recording. That signal was already computed on every fetch and then discarded — it dropped `timed_path`, wrote a prose reason, and let the text through as valid.

`timing_extent_is_foreign` measures the overrun as a ratio. When it fires, the caption lane **falls through to Whisper** rather than hard-failing, so a rejected track becomes a real transcript instead of nothing.

## It does not catch the track that motivated it

Stating this plainly because it changes what the change is worth, and it inverts the premise in #355.

`Kl6tLcQ5hGI`'s contaminated captions overrun by **1.213×** — max cue 385.8s against a 318s video — which is under the 1.25 threshold. They were caught by the word-rate ceiling from #359 at 296 wpm.

The assumption behind #355, and behind my first cut at this, was that a session-block caption track shows up as a long timeline. It doesn't. That track's cues barely overrun while its *text* is roughly double the recording. The contamination was **dense, not long**.

## Why it ships anyway

The two detectors cover different shapes:

| contamination | wpm ceiling | extent detector |
|---|---|---|
| dense text, short cues (**observed**) | **catches** — 296 wpm | misses — 1.21× |
| long cues, dense text | **catches easily** — a 3000s block's words over a 318s divisor reads ~1400 wpm | catches |
| long cues, **sparse** text | **misses** — 800 words over 5.3 min reads a normal 151 wpm | **catches** — 11× |

The third row is the entire justification. The ceiling divides words by the *video's* duration, so it can never learn that the track disagrees about how long the recording is. A talk whose captions came from a much longer, word-sparse recording passes the ceiling looking completely ordinary.

That shape has **not been observed in this vault**. This is a real hole, closed speculatively.

## Threshold

`FOREIGN_TIMING_EXTENT_RATIO = 1.25`, deliberately loose — the verdict discards a transcript. Kept separate from the existing `TIMING_BOUND_TOLERANCE_SECONDS = 1.0`, which answers a different question ("is this timing trustworthy") and keeps its current behaviour unchanged.

Measured: a cue trailing an hour-long talk by three seconds reads 1.0008. A session-block cue at 3000s on a 318s video reads 9.4.

## Tests

6 added. Extent detector: the session-block shape, a seconds-long trailing cue, a cue landing exactly on the end, and the unanswerable cases (no duration, zero, negative, NaN, boolean, no segments, non-list, segments with no readable end — all must return `None`/`False` rather than accuse anyone).

Two end-to-end through `main()`: a foreign track falls through and Whisper's text is what lands on disk, and a sound caption track is kept with `fetch_whisper` monkeypatched to raise if reached.

Full suite **6275 passed**. The 3 failures in `test_plugin_lint_gate.py` are the pre-existing tessl CLI drift tracked in #347 (local 0.98.0 vs CI pin 0.95.0), unrelated.

Normalization is shared with the rest of `transcript_timing` via `normalize_segments`, so a raw caption object and a stored segment dict are read identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2oVxH1XMvSRyXsjf5BZ1U