### PR TITLE
fix(vault-ingress): normalize evidence_sources_used order in the claim projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+### fix(vault-ingress) — a source group's order no longer reads as model drift
+
+`detection_claim` projects a detection down to what the model actually claimed,
+and `write-analysis.py` compares that projection of the raw return against the
+same projection of the persisted overlay. A mismatch means the engine rewrote
+something the model authored, which is a hard refusal of the whole batch.
+
+`evidence_sources_used` names a source GROUP. The engine compares it as a
+frozenset everywhere else, and persistence may store it in a different order
+than the worker wrote it. The projection compared it as a list, so a batch that
+merged cleanly could never render. A worker returned
+`["native_deck", "static_slides"]`, persistence stored
+`["static_slides", "native_deck"]`, and rendering failed with
+"canonicalization changed model-authored return fields" — with no way forward
+that did not involve editing an already-receipted return.
+
+The projection now sorts a plain list of strings, matching how the engine reads
+the field. A list holding anything else passes through untouched, so a malformed
+value still reaches the validator that owns the failure.
+
 ### fix(vault-ingress) — a failed video download is now visible, and uses the pinned yt-dlp
 
 `batch-download-videos.sh` discarded yt-dlp's stderr and never checked its exit

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -3775,6 +3775,16 @@ def detection_claim(detection: object) -> object:
     # Dimensions are catalog authority, not model authority. Raw returns may
     # omit them; return validation rejects any supplied value that differs.
     claim.pop("dimensions", None)
+    # `evidence_sources_used` names a source GROUP, which the engine itself
+    # compares as a frozenset. Persistence may store it in a different order
+    # than the worker wrote, so normalize here; otherwise a batch that merged
+    # cleanly can never render, the raw/canonical projection reporting drift
+    # over ordering alone.
+    sources_used = claim.get("evidence_sources_used")
+    if isinstance(sources_used, list) and all(
+        isinstance(item, str) for item in sources_used
+    ):
+        claim["evidence_sources_used"] = sorted(sources_used)
     citations = claim.get("evidence_citations")
     if isinstance(citations, list):
         stripped = []

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -3904,3 +3904,34 @@ def test_derivatives_from_two_runs_are_rejected_before_persistence(
             manifest,
             SYNTHETIC_VIDEO_ID,
         )
+
+
+def test_detection_claim_normalizes_evidence_sources_used_order() -> None:
+    """A comparison group is a set, so its order must not read as model drift.
+
+    persist-results.py may store `evidence_sources_used` in a different order than
+    the worker wrote it. write-analysis.py then compares the raw return against the
+    persisted overlay through this projection, so an order-sensitive comparison
+    made a batch that merged cleanly impossible to render.
+    """
+    worker = {
+        "pattern_id": "gradual-consistency",
+        "confidence": "moderate",
+        "evidence_source": "source_comparison",
+        "evidence_sources_used": ["native_deck", "static_slides"],
+    }
+    persisted = dict(worker, evidence_sources_used=["static_slides", "native_deck"])
+
+    assert pattern_evidence.detection_claim(worker) == pattern_evidence.detection_claim(
+        persisted
+    )
+
+
+def test_detection_claim_leaves_non_string_sources_used_untouched() -> None:
+    """Only a list of plain strings is a source group; anything else passes through."""
+    detection = {"pattern_id": "x", "evidence_sources_used": [{"source": "a"}, 2]}
+
+    assert pattern_evidence.detection_claim(detection)["evidence_sources_used"] == [
+        {"source": "a"},
+        2,
+    ]


### PR DESCRIPTION
## Summary

- `detection_claim` compared `evidence_sources_used` order-sensitively. That field names a source GROUP, which the engine itself compares as a frozenset, so persistence may store it in a different order than the worker wrote it.
- `write-analysis.py` compares the raw return against the persisted overlay through that projection, so a batch that merged cleanly could never render: the projection reported drift over ordering alone and refused the whole batch.
- Found during the 250-talk reparse. A worker returned `["native_deck", "static_slides"]`; persistence stored `["static_slides", "native_deck"]`; rendering failed with "canonicalization changed model-authored return fields" and no way forward that did not involve editing an already-receipted return.

## Test plan

- [x] `tests/test_pattern_evidence.py::test_detection_claim_normalizes_evidence_sources_used_order` — fails without the projection change
- [x] `tests/test_pattern_evidence.py::test_detection_claim_leaves_non_string_sources_used_untouched` — a non-string list passes through untouched
- [x] `pytest tests/test_pattern_evidence.py` — 154 passed
- [x] `ruff check .`, `ruff format --check .`, `pyright` — clean
- [x] Exercised end to end on reparse batch-017: 5 returns persisted and rendered
