### PR TITLE
fix(vault-ingress): let an owner register a preserved local recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+### fix(vault-ingress) — an owner can register a preserved local recording
+
+`pattern_evidence._local_video_binding` trusts local media through exactly two
+doors: a `structured_data.video_extraction` manifest already stored on the talk,
+or a `video_local_path` / `video_path` on the talk. No owner path could open
+either. `video_local_path` was absent from `apply-source-repairs.py`'s
+`ALLOWED_FIELDS` and from `mutate-tracking-database.py`'s
+`PUBLISHING_TALK_FIELDS`, and the manifest only reaches a talk through the merge
+that the missing binding blocks — a closed loop.
+
+The talk that surfaced it had its YouTube source deleted upstream. The recording
+was preserved locally, `fetch-transcript.py --audio` transcribed it, and the
+quality receipt recorded `provenance.kind = local_media_duration` plus the
+media's SHA-256 (which matches the file byte for byte). Persistence then refused
+the transcript source outright with `receipt_owner_mismatch`, because nothing on
+the talk said that mp4 was this talk's media. The analysis scored 14.0 across
+four evidence lanes and could not be persisted at all.
+
+`video_local_path` and `video_path` now pass `apply-source-repairs.py`'s field
+allowlist, so the owner registers the preserved file the same guarded way every
+other source is registered: an exact `expect` precondition, a dry run, a
+byte-for-byte backup, and a refusal while the talk carries an active queue
+claim. Nothing about validation moves — `_resolve_local_video_artifact` still
+bounds the path inside the vault and to a video suffix, and the binding still
+requires the filename stem to equal the `youtube_id`, so a wrong path fails
+closed at evidence time rather than registering a lie.
+
+This does not reach the second known instance, an InfoQ talk Whispered from an
+`.mp3`: `_VIDEO_SUFFIXES` admits no audio, so that one still needs its own
+decision about whether duration-only binding may cite an audio file.
+
 ## 0.20.109 — 2026-08-28
 
 ### fix(vault-ingress) — a failed video download is now visible, and uses the pinned yt-dlp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ This does not reach the second known instance, an InfoQ talk Whispered from an
 `.mp3`: `_VIDEO_SUFFIXES` admits no audio, so that one still needs its own
 decision about whether duration-only binding may cite an audio file.
 
+The writer now also enforces the requeue that `references/bootstrap-and-preflight.md`
+has always required in prose. A source that appears after an analysis ran
+invalidates that analysis — the talk was scored without it — so a repair that
+registers a previously absent source on a `processed` or `processed_partial`
+talk must also set `status: "needs-reprocessing"` and
+`reprocess_reason: "source_added"`, or the whole plan is refused. What counts as
+a source is `ingress_contract`'s own `REMOTE_ACQUISITION_FIELDS` and
+`LOCAL_ARTIFACT_FIELDS` rather than a second list that can drift from them.
+`youtube_id` is deliberately outside it: the id identifies a `video_url` the
+talk already carries, so backfilling it adds no evidence and drags no requeue
+behind it. A talk already `pending` or `needs-reprocessing` has no analysis to
+invalidate and needs nothing extra.
+
 ## 0.20.109 — 2026-08-28
 
 ### fix(vault-ingress) — a failed video download is now visible, and uses the pinned yt-dlp

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -425,7 +425,9 @@ Registering a source that did not exist at analysis time — a markdown-authored
 deck exported to PDF, a recording that finally published, a hand-recovered
 transcript — is the same plan plus a deliberate requeue. One repair sets the
 new source fields, `status: "needs-reprocessing"`, and
-`reprocess_reason: "source_added"`. `queue-state.py normalize` will not do it:
+`reprocess_reason: "source_added"`. `apply-source-repairs.py` refuses a plan
+that adds a source to an already-analyzed talk without that pair.
+`queue-state.py normalize` will not do it:
 normalization requeues drifted evidence, and a source that arrived is not
 drift. The reasons that let a completed claim's `result_status` disagree with
 the talk status are named in

--- a/skills/vault-ingress/scripts/apply-source-repairs.py
+++ b/skills/vault-ingress/scripts/apply-source-repairs.py
@@ -34,6 +34,10 @@ from pathlib import Path
 import sys
 from typing import Any
 
+from ingress_contract import (
+    LOCAL_ARTIFACT_FIELDS,
+    REMOTE_ACQUISITION_FIELDS,
+)
 from tracking_database import (
     TrackingDatabaseError,
     require_current_tracking_database,
@@ -75,6 +79,19 @@ ALLOWED_FIELDS = frozenset(
         "reprocess_reason",
     }
 )
+# A source that appears after an analysis ran invalidates that analysis: the
+# talk was scored without it. references/bootstrap-and-preflight.md states the
+# contract in prose ("the same plan plus a deliberate requeue"); these constants
+# make the writer refuse a registration that omits it. What counts as a source
+# is the ingress contract's own answer, not a second list that can drift from
+# it. `youtube_id` is deliberately absent: it is the identifier of a `video_url`
+# already on the talk, so backfilling it adds no evidence.
+SOURCE_REGISTRATION_FIELDS = frozenset(REMOTE_ACQUISITION_FIELDS) | frozenset(
+    LOCAL_ARTIFACT_FIELDS
+)
+ANALYZED_STATUSES = frozenset({"processed", "processed_partial"})
+REQUEUE_STATUS = "needs-reprocessing"
+SOURCE_ADDED_REPROCESS_REASON = "source_added"
 ALLOWED_REPAIR_STATUSES = frozenset(
     {
         "pending",
@@ -209,6 +226,18 @@ def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
     return normalized
 
 
+def _newly_registered_sources(repair: dict[str, Any]) -> set[str]:
+    """Name the source fields this repair adds where none was recorded."""
+    set_values = repair.get("set", {})
+    expect = repair["expect"]
+    return {
+        field
+        for field in set_values
+        if field in SOURCE_REGISTRATION_FIELDS
+        and json_values_equal(expect.get(field), MISSING_MARKER)
+    }
+
+
 def _matches_expected(talk: dict[str, Any], field: str, expected: Any) -> bool:
     if json_values_equal(expected, MISSING_MARKER):
         return field not in talk
@@ -254,6 +283,20 @@ def build_repaired_database(
                 actual = current[field] if field in current else MISSING_MARKER
                 errors.append(
                     f"{filename}.{field}: expected {expected!r}, found {actual!r}"
+                )
+        registered = _newly_registered_sources(repair)
+        if registered and current.get("status") in ANALYZED_STATUSES:
+            set_values = repair.get("set", {})
+            if (
+                set_values.get("status") != REQUEUE_STATUS
+                or set_values.get("reprocess_reason") != SOURCE_ADDED_REPROCESS_REASON
+            ):
+                errors.append(
+                    f"{filename}: registering {sorted(registered)} on a "
+                    f"{current.get('status')!r} talk must also set status "
+                    f"{REQUEUE_STATUS!r} and reprocess_reason "
+                    f"{SOURCE_ADDED_REPROCESS_REASON!r}; the stored analysis ran "
+                    "without that source"
                 )
 
     if errors:

--- a/skills/vault-ingress/scripts/apply-source-repairs.py
+++ b/skills/vault-ingress/scripts/apply-source-repairs.py
@@ -64,6 +64,8 @@ ALLOWED_FIELDS = frozenset(
         "slides_pdf_path",
         "pdf_path",
         "transcript_path",
+        "video_local_path",
+        "video_path",
         "transcript_source",
         "slide_source",
         "source_identity",

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -446,3 +446,65 @@ def test_the_documented_render_registration_plan_applies(
     assert talk["slides_local_path"] == "slides/talk.pdf"
     assert talk["status"] == "needs-reprocessing"
     assert changes
+
+
+def test_preserved_local_media_can_be_registered(apply_source_repairs) -> None:
+    """Register a preserved recording whose remote source is gone.
+
+    `pattern_evidence._local_video_binding` trusts local media only through a
+    stored `structured_data.video_extraction` manifest or a `video_local_path` /
+    `video_path` on the talk. The manifest reaches the talk through the merge,
+    and a transcript Whispered from that media fails its receipt owner check
+    until something marks the file as the talk's. Registering the path is the
+    owner's way in.
+    """
+    database = base_database()
+    database["talks"][0]["transcript_source"] = "whisper"
+    plan = {
+        "schema_version": 1,
+        "repairs": [
+            {
+                "filename": "talk.md",
+                "reason": "YouTube source deleted upstream; preserved recording is the media",
+                "expect": {
+                    "video_local_path": {"$missing": True},
+                    "transcript_source": "whisper",
+                },
+                "set": {
+                    "video_local_path": "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+                    "transcript_source": "whisper",
+                },
+            }
+        ],
+    }
+
+    repairs = apply_source_repairs.validate_plan(plan)
+    repaired, changes = apply_source_repairs.build_repaired_database(database, repairs)
+
+    talk = repaired["talks"][0]
+    assert talk["video_local_path"] == "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4"
+    assert changes
+
+
+def test_legacy_video_path_alias_can_be_cleared(apply_source_repairs) -> None:
+    """`video_path` is the legacy alias of the same locator and clears the same way."""
+    database = base_database()
+    database["talks"][0]["video_path"] = "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4"
+    plan = {
+        "schema_version": 1,
+        "repairs": [
+            {
+                "filename": "talk.md",
+                "reason": "preserved recording was removed from the vault",
+                "expect": {
+                    "video_path": "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+                },
+                "clear": ["video_path"],
+            }
+        ],
+    }
+
+    repairs = apply_source_repairs.validate_plan(plan)
+    repaired, _ = apply_source_repairs.build_repaired_database(database, repairs)
+
+    assert "video_path" not in repaired["talks"][0]

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -448,6 +448,26 @@ def test_the_documented_render_registration_plan_applies(
     assert changes
 
 
+def preserved_media_repair(**overrides):
+    """The documented registration plan for a preserved local recording."""
+    repair = {
+        "filename": "talk.md",
+        "reason": "YouTube source deleted upstream; preserved recording is the media",
+        "expect": {
+            "video_local_path": {"$missing": True},
+            "status": "processed",
+            "reprocess_reason": {"$missing": True},
+        },
+        "set": {
+            "video_local_path": "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+            "status": "needs-reprocessing",
+            "reprocess_reason": "source_added",
+        },
+    }
+    repair.update(overrides)
+    return {"schema_version": 1, "repairs": [repair]}
+
+
 def test_preserved_local_media_can_be_registered(apply_source_repairs) -> None:
     """Register a preserved recording whose remote source is gone.
 
@@ -460,30 +480,91 @@ def test_preserved_local_media_can_be_registered(apply_source_repairs) -> None:
     """
     database = base_database()
     database["talks"][0]["transcript_source"] = "whisper"
+
+    repairs = apply_source_repairs.validate_plan(preserved_media_repair())
+    repaired, changes = apply_source_repairs.build_repaired_database(database, repairs)
+
+    talk = repaired["talks"][0]
+    assert talk["video_local_path"] == "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4"
+    assert talk["status"] == "needs-reprocessing"
+    assert talk["reprocess_reason"] == "source_added"
+    assert changes
+
+
+def test_registering_a_source_without_the_requeue_is_refused(
+    apply_source_repairs,
+) -> None:
+    """A source that appears after the analysis ran must requeue the talk.
+
+    The stored analysis was scored without it, so leaving the talk `processed`
+    publishes a score that silently ignores evidence the vault now holds.
+    """
+    database = base_database()
+    plan = preserved_media_repair(
+        expect={
+            "video_local_path": {"$missing": True},
+            "transcript_source": "youtube_auto",
+        },
+        set={
+            "video_local_path": "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+            "transcript_source": "whisper",
+        },
+    )
+    repairs = apply_source_repairs.validate_plan(plan)
+
+    with pytest.raises(
+        apply_source_repairs.SourceRepairError, match="must also set status"
+    ):
+        apply_source_repairs.build_repaired_database(database, repairs)
+
+
+def test_registering_a_source_on_a_queued_talk_needs_no_requeue(
+    apply_source_repairs,
+) -> None:
+    """A talk already awaiting reprocessing has nothing to invalidate."""
+    database = base_database()
+    database["talks"][0]["status"] = "pending"
+    plan = preserved_media_repair(
+        expect={
+            "video_local_path": {"$missing": True},
+            "transcript_source": "youtube_auto",
+        },
+        set={
+            "video_local_path": "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
+            "transcript_source": "whisper",
+        },
+    )
+    repairs = apply_source_repairs.validate_plan(plan)
+    repaired, _ = apply_source_repairs.build_repaired_database(database, repairs)
+
+    assert repaired["talks"][0]["status"] == "pending"
+
+
+def test_correcting_an_existing_source_is_not_a_registration(
+    apply_source_repairs,
+) -> None:
+    """Replacing a recorded locator is an identity correction, not an addition.
+
+    The requeue rule fires on a source the analysis could not have seen. A
+    locator that was already there keeps its own repair flow.
+    """
+    database = base_database()
     plan = {
         "schema_version": 1,
         "repairs": [
             {
                 "filename": "talk.md",
-                "reason": "YouTube source deleted upstream; preserved recording is the media",
-                "expect": {
-                    "video_local_path": {"$missing": True},
-                    "transcript_source": "whisper",
-                },
-                "set": {
-                    "video_local_path": "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
-                    "transcript_source": "whisper",
-                },
+                "reason": "provider metadata identifies the correct recording",
+                "expect": {"video_url": "https://youtu.be/AbCdEfGhI_1"},
+                "set": {"video_url": "https://youtu.be/AbCdEfGhI_2"},
             }
         ],
     }
-
     repairs = apply_source_repairs.validate_plan(plan)
-    repaired, changes = apply_source_repairs.build_repaired_database(database, repairs)
+    repaired, _ = apply_source_repairs.build_repaired_database(database, repairs)
 
-    talk = repaired["talks"][0]
-    assert talk["video_local_path"] == "slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4"
-    assert changes
+    assert repaired["talks"][0]["video_url"] == "https://youtu.be/AbCdEfGhI_2"
+    assert repaired["talks"][0]["status"] == "processed"
 
 
 def test_legacy_video_path_alias_can_be_cleared(apply_source_repairs) -> None:
@@ -508,3 +589,31 @@ def test_legacy_video_path_alias_can_be_cleared(apply_source_repairs) -> None:
     repaired, _ = apply_source_repairs.build_repaired_database(database, repairs)
 
     assert "video_path" not in repaired["talks"][0]
+
+
+def test_backfilling_youtube_id_is_not_a_source_registration(
+    apply_source_repairs,
+) -> None:
+    """`youtube_id` identifies a `video_url` the talk already carries.
+
+    Recording the derived id adds no evidence the stored analysis lacked, so it
+    does not drag a requeue behind it.
+    """
+    database = base_database()
+    database["talks"][0].pop("youtube_id")
+    plan = {
+        "schema_version": 1,
+        "repairs": [
+            {
+                "filename": "talk.md",
+                "reason": "backfill the identifier of the recorded video_url",
+                "expect": {"youtube_id": {"$missing": True}},
+                "set": {"youtube_id": "AbCdEfGhI_1"},
+            }
+        ],
+    }
+    repairs = apply_source_repairs.validate_plan(plan)
+    repaired, _ = apply_source_repairs.build_repaired_database(database, repairs)
+
+    assert repaired["talks"][0]["youtube_id"] == "AbCdEfGhI_1"
+    assert repaired["talks"][0]["status"] == "processed"


### PR DESCRIPTION
## Summary

- `pattern_evidence._local_video_binding` trusts local media only through a stored `structured_data.video_extraction` manifest or a `video_local_path` / `video_path` on the talk — and no owner path could set either. The field was missing from `apply-source-repairs.py`'s `ALLOWED_FIELDS`, and the manifest only reaches a talk through the merge the missing binding blocks.
- Found during the 250-talk reparse on a talk whose YouTube source was deleted upstream. The recording was preserved locally, `fetch-transcript.py --audio` transcribed it, and the receipt cites `local_media_duration` with the media's SHA-256 (verified to match the file). Persistence refused the transcript source with `receipt_owner_mismatch`; a four-lane analysis scoring 14.0 could not persist at all.
- Adds `video_local_path` and `video_path` to the repair allowlist. Validation is untouched: `_resolve_local_video_artifact` still bounds the path inside the vault and to a video suffix, the binding still requires the filename stem to equal the `youtube_id`, and the repair still refuses a talk under an active queue claim.
- Does not reach the second known instance — an InfoQ talk Whispered from an `.mp3`. `_VIDEO_SUFFIXES` admits no audio, and whether duration-only binding may cite an audio file is its own decision.

## Test plan

- [x] `test_preserved_local_media_can_be_registered` — registers the path through a full `expect`-bound plan
- [x] `test_legacy_video_path_alias_can_be_cleared` — the legacy alias clears the same way
- [x] Both new tests fail on the unpatched allowlist with `contains unsupported fields`
- [x] `pytest tests/test_apply_source_repairs.py` — 18 passed
- [x] `ruff check .`, `ruff format --check .` — clean
