### PR TITLE
fix(vault-ingress): harden runtime and ingress contracts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
           # Tessl CLI pin. No Dependabot ecosystem tracks the CLI version an
           # action input names; renew quarterly, or when the publish workflow's
           # own lint disagrees with this gate. Keep both jobs on one version.
-          version: "0.95.0"
+          version: "0.105.0"
       - name: Verify no conflict marker was committed
         # Fails the build on any of the four merge markers in a tracked text
         # file. A diff3 base marker (|||||||) survived a resolution and shipped
@@ -81,7 +81,7 @@ jobs:
           # Tessl CLI pin. No Dependabot ecosystem tracks the CLI version an
           # action input names; renew quarterly, or when the publish workflow's
           # own lint disagrees with this gate. Keep both jobs on one version.
-          version: "0.95.0"
+          version: "0.105.0"
       - name: Enforce tessl-version-floating carve-out
         # See rules/tessl-version-floating.md. Fails the build if any
         # dependency in a covered manifest uses a specifier other than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+### fix(vault-ingress) — every yt-dlp caller uses the pinned runtime (#371)
+
+Provider metadata, transcript duration probes, Whisper audio fallback, video
+downloads, and the runtime check now share one executable resolver. It prefers
+an explicit `YT_DLP`, then the console script beside the configured Python
+interpreter and the toolkit environments, with PATH retained only as a
+compatibility fallback. A stale system yt-dlp can no longer shadow the pinned
+project dependency during one of the previously bare invocations.
+
+Runtime report schema v3 also checks the resolved yt-dlp version against the
+exact `pyproject.toml` pin. A mismatch makes only the `youtube-download` lane
+unavailable and reports both versions in the structured command failure.
+
+### fix(vault-ingress) — preserve non-YouTube automatic-caption provenance (#386)
+
+Fresh queue claims and returns advance to schema v7, and persisted talk records
+advance to schema v8. The new `provider_auto` transcript source distinguishes a
+non-YouTube provider's automatic captions from both YouTube captions and human
+transcription without changing weighted scoring schema v6.
+
+Validation, preflight, evidence canonicalization, VTT timing ownership,
+fetcher enrichment, migrations, and downstream current-record writers all read
+the new generation. Saved v6 returns and pre-v8 talk records keep their closed
+historical enums; migration restamps eligible v5-v7 records without relabeling
+their source and refuses an impossible legacy `provider_auto` claim.
+
+### fix(ci) — renew both Tessl CLI gates together (#347)
+
+The lint and test jobs now install Tessl CLI 0.105.0, matching the current local
+tool used by the plugin-lint regression suite instead of the expired 0.95.0 CI
+pin. The four reported local regressions—including an ambient `FORCE_COLOR`
+run—now pass under the pinned toolchain.
+
+### docs(vault-ingress) — keep one video-downloader outcome contract (#376)
+
+The video-extraction reference now links to the canonical per-talk worker
+instructions before invoking the extractor. It no longer duplicates the
+downloader result and exit-code predicate, so future contract changes have one
+owner.
+
 ## 0.20.111 — 2026-09-01
 
 ### fix(vault-ingress) — a source group's order no longer reads as model drift

--- a/README.md
+++ b/README.md
@@ -370,8 +370,9 @@ notes which named patterns and antipatterns are detected per talk.
   native-deck evidence. Preserved source-video evidence uses the separate
   `source-video` runtime lane with exactly `psutil==7.2.2` plus `ffprobe`
 - Lane-specific runtime: importable `gdown` for Google Drive acquisition,
-  `youtube-transcript-api` for captions, `yt-dlp` for provider probing/audio
-  download, `pdftoppm` for rendered-PDF inspection, Pillow + `imagehash` +
+  `youtube-transcript-api` for captions, exactly `yt-dlp==2026.8.19` for
+  provider probing/audio download, `pdftoppm` for rendered-PDF inspection,
+  Pillow + `imagehash` +
   `ffmpeg`/`ffprobe` for video extraction, and optional `mlx-whisper` for local
   Whisper fallback
 - Markdown-authored decks (Slidev, presenterm, Marp, reveal-md) render through
@@ -386,9 +387,12 @@ dependency absence is isolated: missing pypdf cannot erase transcript/PPTX
 capability, and missing python-pptx cannot erase transcript/PDF capability.
 Dependency initializer exceptions, native crashes, timeouts, and invalid child
 results remain lane-local and carry machine-readable failure reasons.
-The checker emits report schema v2; each lane's `required_module_versions`
-declares exact runtime pins, and an incompatible installed version is unavailable
-rather than silently accepted.
+The checker emits report schema v3; each lane's `required_module_versions`
+declares exact Python pins, while `required_command_versions` declares the
+`youtube-download` lane's yt-dlp pin. An incompatible installed version is
+unavailable rather than silently accepted. The yt-dlp probe and every ingress
+caller resolve the configured interpreter's console script before falling back
+to PATH, so a stale system installation cannot shadow the project dependency.
 
 ## Generation & Publishing Skills Details
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ declares exact Python pins, while `required_command_versions` declares the
 `youtube-download` lane's yt-dlp pin. An incompatible installed version is
 unavailable rather than silently accepted. The yt-dlp probe and every ingress
 caller resolve the configured interpreter's console script before falling back
-to PATH, so a stale system installation cannot shadow the project dependency.
+to PATH.
 
 ## Generation & Publishing Skills Details
 

--- a/rules/transcript-fetch-authority.md
+++ b/rules/transcript-fetch-authority.md
@@ -73,8 +73,8 @@ description: Authority of record for the Whisper transcription layer's Platform-
   `ffprobe` duration for the exact local-media digest. Worker-returned or talk
   analysis metadata can never lower a threshold.
 - Missing timing does not invalidate a current quality receipt. Missing or
-  stale quality authority does make a transcript ineligible for current v5
-  scoring until the fetcher validates it and writes a receipt.
+  stale quality authority does make a transcript ineligible for the current
+  pattern-scoring generation until the fetcher validates it and writes a receipt.
 - Both receipt readers hash raw transcript bytes. Any byte replacement,
   including CRLF→LF with identical decoded words, invalidates both receipts.
 - The talk's recorded `transcript_source` is canonical. A sidecar may confirm
@@ -110,7 +110,12 @@ Run against a talk whose caption track is disabled, on Apple Silicon with the
 4. `test "$(jq -r .transcript_sha256 /tmp/{youtube_id}.segments.json)" = "$(shasum -a 256 /tmp/{youtube_id}.txt | awk '{print $1}')"` exits 0.
 5. `jq -e '.schema_version == 1 and (.transcript_sha256 | length == 64) and .policy.schema_version == 1 and (.policy.min_words >= 1) and ((.policy.duration_seconds == null and .provenance == {"kind":"fixed_default"}) or (.policy.duration_seconds == .provenance.duration_seconds))' /tmp/{youtube_id}.quality.json` exits 0, and its `transcript_sha256` equals `shasum -a 256 /tmp/{youtube_id}.txt`.
 6. Confirm `/tmp/{youtube_id}.txt` holds prose, not `[Music]` markers or a traceback.
-7. Re-run with `yt-dlp` removed from `PATH` and a fresh output path. Expect exit 1, a stderr line naming the install command, one JSON object with `"ok": false`, and no transcript or receipt at that output path.
+7. Re-run with `YT_DLP` set to a nonexistent absolute path and a fresh output
+   path. Expect exit 1, a stderr line explaining how to correct or unset the
+   override, one JSON object with `"ok": false`, and no transcript or receipt
+   at that output path. Removing only `yt-dlp` from `PATH` is insufficient: the
+   fetcher deliberately resolves the configured interpreter's console script
+   before the compatibility PATH fallback.
 8. `"{python_path}" skills/vault-ingress/scripts/fetch-transcript.py local-talk-label --audio <local-file> --out /tmp/a.txt --existing-source unknown` on a non-YouTube recording: exit 0, `"method": "whisper"`, `"timed_path": "/tmp/a.segments.json"`, `"quality_path": "/tmp/a.quality.json"`, prose at the output path, timing schema v2 with `local_media_whisper` provenance, and timing plus quality provenance whose `media_sha256` equals the exact input-media digest.
 
 A pass requires all eight checks.

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -39,7 +39,7 @@ Read `tracking-database.json` through the vault path used by
 presentation-creator. Selection and composition may read legacy database schema
 0 or 1, or current schema 2, without mutation. Before copying the approved thumbnail or
 writing tracking state, require database schema 2, current independent records,
-and talk schema 7. Invoke `Skill(skill: "vault-ingress")` for schema 0 or 1 and stop
+and talk schema 8. Invoke `Skill(skill: "vault-ingress")` for schema 0 or 1 and stop
 this run. Unknown future generations are no usable prior state. Preserve every
 schema field and use the presentation-creator exact-generation atomic-write
 contract.
@@ -236,6 +236,6 @@ exact existing record for the slug or `{"$missing": true}`. In the same plan, us
 filename, expecting its current value. Dry-run the whole plan, review it, apply
 against the reported input SHA, and re-read as specified by the
 [owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
-Keep that talk at `schema_version: 7`. illustrations is an authorized writer of
+Keep that talk at `schema_version: 8`. illustrations is an authorized writer of
 current thumbnail and talk records; vault-ingress remains their schema owner.
 Never rewrite `tracking-database.json` directly.

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -16,7 +16,7 @@ Before ANY Phase 7 action, load these files. If any is missing, STOP and ask.
 
 Read the tracking database through the main presentation-creator compatibility
 gate. Thumbnail and shownotes lookup may read schema 0 or 1. Any database update
-in this phase requires current database schema 2 and talk schema 7 before the
+in this phase requires current database schema 2 and talk schema 8 before the
 thumbnail, shownotes, or video side effect paired with it. Route schema 0 or 1 through
 `Skill(skill: "vault-ingress")`; preserve all schema fields and apply the main
 skill's exact-generation atomic-write contract.
@@ -97,7 +97,7 @@ The `expect` object must cover exactly the fields being set with values from the
 latest strict read. Dry-run, review, apply against the reported input SHA, and
 re-read through the
 [owner mutation contract](../../vault-ingress/references/schemas-db.md#owner-read-and-mutation-contract).
-Keep that talk record at `schema_version: 7`; this workflow is an authorized
+Keep that talk record at `schema_version: 8`; this workflow is an authorized
 current writer, not a schema owner or migrator.
 
 ---

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -84,7 +84,7 @@ Exit 2 writes one error object to stdout plus an `ERROR:` diagnostic to stderr;
 stop without changing session state.
 
 Every tracking write in Steps 2–8 is current-only. Preserve database schema 2,
-config schema 2, talk schema 7, and every unrelated record. Stamp confirmed
+config schema 2, talk schema 8, and every unrelated record. Stamp confirmed
 intents with schema 1 and new improvement goals with schema 2. Capture the exact
 input bytes immediately before each write, reject a changed generation, validate
 the complete current shape, and use a same-directory atomic replacement. Never

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -130,7 +130,8 @@ Then claim each exact batch:
   --batch-id <stable-batch> --now <timezone-aware-ISO>
 ```
 
-Fresh claims are schema v6 and require return v6. A v6 return carries `pattern_score_basis` and may carry a fractional `pattern_score`. Use the stored claim on replay;
+Fresh claims are schema v7 and require return v7. A v7 return carries the v6
+weighted score contract plus `provider_auto` transcript provenance. Use the stored claim on replay;
 recover a stranded lease and issue a new generation. Set the best verified slide
 source, use `skipped_no_sources` only when every source is unavailable, and honor
 an explicit filename/title argument as a one-talk selection.

--- a/skills/vault-ingress/references/batch-persistence.md
+++ b/skills/vault-ingress/references/batch-persistence.md
@@ -61,7 +61,7 @@ whether to run the gate.
   resolves every `evidence_citations` source location and refuses the whole
   batch when proof is absent or unverifiable. Comparison detections must locate
   proof from every underlying member of `evidence_sources_used`.
-  Version-2 through version-5 returns snapshot-replace every supplied declared
+  Version-2 through version-7 returns snapshot-replace every supplied declared
   field, including empty values where that field contract permits emptiness,
   and complete structured maps; omission preserves a field. Saved returns with
   missing/version-1 metadata retain their legacy
@@ -72,8 +72,9 @@ whether to run the gate.
   authored-slide evidence. The script
   persists that path when a trusted artifact is promoted, replaces a complete
   video-extraction manifest atomically, and clears matching promoted scalars.
-  Returns satisfying the current evidence contract receive the exact catalog
-  fingerprint and scoring-schema version 5. Replayable v1–v4 returns that cannot
+  Weighted v6/v7 returns satisfying the current evidence contract receive the
+  exact catalog fingerprint and scoring-schema version 6. Replayable v1–v5
+  returns that cannot
   prove it are retained with
   `pattern_scoring_generation_status: legacy_unbaselineable`, exact machine reasons, and no current fingerprint or
   scoring version. The DB write remains atomic.
@@ -89,8 +90,8 @@ whether to run the gate.
   timestamp is treated as an explicit identity assertion and must normalize to
   the same batch stamp or the entire write fails.
   A successful merge closes the matching queue lease as `completed`; it never
-  deletes claim history. Claims v2 through v5 close at their own versions, and
-  an active v1 lease upgrades to v2. Every completed v2–v5 claim stores a canonical
+  deletes claim history. Claims v2 through v7 close at their own versions, and
+  an active v1 lease upgrades to v2. Every completed v2–v7 claim stores a canonical
   SHA-256 receipt of the exact return payload; a receiptless completed v1 claim
   cannot authorize analysis replacement. Unknown future claim versions fail
   closed. An

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -143,8 +143,10 @@ boundary maps that trusted root to storage while still rejecting every
 descendant symlink/reparse redirect. Trusted-root bindings retain the directory
 object's stable identity and policy attributes, not mutable child-content size or
 timestamps; PDF and PPTX leaf generations remain exact. The checker emits report
-schema v2 and records exact pins under
-each lane's `required_module_versions`; a mismatched version is unavailable. A
+schema v3 and records exact Python pins under each lane's
+`required_module_versions`. The `youtube-download` lane also resolves `yt-dlp`
+from the configured interpreter before PATH, records its exact pin under
+`required_command_versions`, and makes a mismatched version unavailable. A
 missing optional lane is reported as degraded and must not erase a healthy
 transcript or alternate slide lane.
 Require a lane before using it, for example `--require-lanes core,pdf`. Remote

--- a/skills/vault-ingress/references/processing-rules.md
+++ b/skills/vault-ingress/references/processing-rules.md
@@ -67,7 +67,7 @@ or antipattern must record concrete `evidence` and the qualifying
 duplicate-free `evidence_sources_used` array. It must exactly equal one
 qualifying all-of group, while the prose evidence names what was compared.
 
-Return v4/v5 makes "inspected" an artifact-bound statement. Alongside the exact
+Returns v4-v7 make "inspected" an artifact-bound statement. Alongside the exact
 `evidence_sources` set, return one closed raw `source_inspection` record per
 underlying source:
 
@@ -101,14 +101,14 @@ clarification notes, not the score.
 
 For an entry with no positive detection, use `absence_evaluable_from`
 (defaulting to `evaluable_from`) to decide whether completely inspected sources
-can support an undetected outcome. Return v4/v5 uses no prose waiver: every
+can support an undetected outcome. Returns v4-v7 use no prose waiver: every
 `not_evaluable` item contains exactly `pattern_id` and `reason_code`. Use
 `missing_required_source_coverage` when no effective absence group has complete
 coverage. Use `absence_not_authorized_by_catalog` when an explicit
 `absence_evaluable_from: null` makes the entry positive-only; this is intentional
 catalog policy, not unfinished owner work. Use `source_gate_pending_owner_review`
 only when the observable catalog entry has no owner-approved positive gate.
-That pending entry fails closed: it cannot be detected by a v4/v5 return and
+That pending entry fails closed: it cannot be detected by a v4-v7 return and
 cannot be silently counted as absent. A
 valid positive detection takes precedence for a gated entry; never add the same
 ID to `not_evaluable`. Do not guess and do not interpret `not_evaluable` as
@@ -116,7 +116,7 @@ absence. Exclude not-evaluable entries from the score. Persistence recomputes
 the exhaustive expected ID→reason map and rejects missing, extra, duplicate,
 prose-bearing, or blanket waivers.
 
-Return v5 additionally makes applicability exhaustive. For every nondetected
+Returns v5-v7 additionally make applicability exhaustive. For every nondetected
 entry with `not_applicable_when`, first evaluate the complete
 `applicability_evaluable_from` gate. Without complete canonical coverage, an
 assessment is forbidden and the outcome is `not_evaluable` with
@@ -128,7 +128,7 @@ catalog-authorized `condition_id` only for `not_applicable`. An `applicable`
 assessment forbids `condition_id` and then proceeds through the ordinary
 absence gate; there is no implicit applicable default.
 
-Persistence owns the exhaustive v5 projection. It writes exactly one sorted
+Persistence owns the exhaustive v5-v7 projection. It writes exactly one sorted
 `pattern_outcomes` row per observable entry using precedence: detection;
 validated applicability assessment; incomplete applicability/absence gate as
 `not_evaluable`; applicable plus complete absence gate as `undetected`.

--- a/skills/vault-ingress/references/queue-selection.md
+++ b/skills/vault-ingress/references/queue-selection.md
@@ -4,9 +4,9 @@ This is the complete normative Step 2 contract for `vault-ingress`. Execute
 normalization before claiming, and preserve every generation, freshness, replay,
 and recovery rule below.
 
-Fresh queue work uses claim schema v6. Before changing any talk status,
+Fresh queue work uses claim schema v7. Before changing any talk status,
 `queue-state.py claim` snapshots one immutable `adherence_baseline` for the
-entire selected batch, stamps `required_return_schema_version: 6`, and copies
+entire selected batch, stamps `required_return_schema_version: 7`, and copies
 that exact snapshot into every member claim. The snapshot uses the current
 catalog fingerprint and pattern-scoring schema, includes only current
 `processed`/`processed_partial` talks, and excludes every active-batch filename
@@ -43,7 +43,7 @@ before inspecting its prior score. Its `as_of` equals the claim's canonical
   --batch-id <stable-batch> --now <timezone-aware-ISO>`. The command selects
   `pending`, `needs-reprocessing`, and retryable download failures, writes an
   atomic lease, increments `reprocess_generation`, and returns the claimed talk
-  list. Every fresh claim is schema v6 and requires return schema v6. Never
+  list. Every fresh claim is schema v7 and requires return schema v7. Never
   change a record to `reprocessing-inflight` by hand.
 - Before claiming a non-YouTube talk whose transcript will be used as evidence,
   acquire the transcript and register its canonical vault-relative

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -177,7 +177,7 @@ no-op.
 |---|---:|
 | database root | 2 (schema 1, the generation before `markdown_decks`, remains readable) |
 | config | 2 (schema 1 remains readable owner-migration input) |
-| talk | 7 (schemas 1-6 remain readable historical state; v5 and v6 restamp) |
+| talk | 8 (schemas 1-7 remain readable historical state; v5-v7 restamp) |
 | PPTX catalog | 3 (schemas 1 and 2 remain readable legacy state) |
 | QR code | 2 (schema 1 remains readable legacy state) |
 | resource summary | 1 |
@@ -276,8 +276,8 @@ customization, not the owner default. See the
       "verified_at": "timezone-aware ISO-8601 timestamp"
     }],
     "pptx_path": "Conference/Year/Talk Name.pptx  (optional — highest quality slide source when available)",
-    "schema_version": 7,
-    "transcript_source": "youtube_auto|whisper|manual|none  (how the transcript was obtained; MAY BE ABSENT — see below)",
+    "schema_version": 8,
+    "transcript_source": "youtube_auto|provider_auto|whisper|manual|none  (how the transcript was obtained; MAY BE ABSENT — see below)",
     "transcript_path": "transcripts/{id}.txt  (optional vault-relative path; required for non-YouTube transcript evidence)",
     "slide_source": "pptx|pdf|both|video_extracted|markdown|none  (set in Step 2 per slide source hierarchy)",
     "slides_local_path": "slides/<artifact>.pdf  (optional explicit local PDF; legacy readers also accept slides_pdf_path/pdf_path)",
@@ -286,13 +286,13 @@ customization, not the owner default. See the
     "reprocess_reason": "machine-readable reason for needs-reprocessing, or null (owner-set values: DELIBERATE_REPROCESS_REASONS in queue_claim_contract.py)",
     "reprocess_generation": 1,
     "_queue_claim": {
-      "schema_version": 5,
+      "schema_version": 7,
       "run_id": "reparse-2026-07",
       "batch_id": "25",
       "claimed_at": "2026-07-31T18:00:00+00:00",
       "previous_status": "needs-reprocessing",
       "reprocess_generation": 1,
-      "required_return_schema_version": 6,
+      "required_return_schema_version": 7,
       "adherence_baseline": {
         "schema_version": 2,
         "as_of": "2026-07-31T18:00:00+00:00",
@@ -354,7 +354,7 @@ customization, not the owner default. See the
       "not_evaluable": []
     }
   }],
-  "_comment_schema_version": "Database root schema v2 is owner-migrated by vault-ingress; root v1 is the generation before the top-level `markdown_decks` collection, and migration moves a v0 or v1 database to v2 without touching any record it already carries. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level `source_title_equivalences` collection at record v2, so v7 adds no field a v6 record lacks; migration restamps a v5 or v6 record to v7 untouched and lifts a nested v1 ledger out of the talk into that collection. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
+  "_comment_schema_version": "Database root schema v2 is owner-migrated by vault-ingress; root v1 is the generation before the top-level `markdown_decks` collection, and migration moves a v0 or v1 database to v2 without touching any record it already carries. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level `source_title_equivalences` collection at record v2, so v7 adds no field a v6 record lacks. V8 adds `provider_auto` to the transcript-source enum. Migration restamps v5-v7 records to v8 without relabeling their source and lifts a nested v1 title ledger into the top-level collection. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "schema_version": 3,
@@ -842,7 +842,7 @@ mutually exclusive shape and omits both `pattern_scoring_schema_version` and
 }
 ```
 
-A fresh v6 worker uses the exact empty adherence sentinel and does not author a
+A fresh v7 worker uses the exact empty adherence sentinel and does not author a
 raw-score comparison. Only an owner-side consumer that sees the canonical talk
 outcomes may compare against a baseline carrying the same
 `opportunity_coverage_identity`. Baseline schema v2 keeps all fresh-v5 talks in
@@ -874,7 +874,7 @@ manual` is provenance only and does not prove an artifact exists. Legacy
 no-video/no-transcript statuses normalize to `skipped_no_sources` only when the
 shared verified-local plus remote-acquisition capability list is empty.
 
-Every fresh queue claim is schema v6 and carries exactly the
+Every fresh queue claim is schema v7 and carries exactly the
 `required_return_schema_version` and `adherence_baseline` fields shown above.
 The queue owner builds one baseline before mutating any selected talk, copies it
 unchanged to every batch member, and requires `adherence_baseline.as_of` to equal
@@ -905,12 +905,13 @@ The four version axes are deliberately explicit:
 | v1 or v2 | saved v1 or v2 only | migrated legacy record | never current v5 |
 | v3 | v3 only | migrated union-safe record | never current v5 |
 | v4 | v4 only | archival source-located v4 | never current v5 |
-| v5 | v5 only | v5 | never current v6 |
-| v6 | v6 only | v6 | v6 when canonical evidence/outcomes are fresh |
+| v5 | v5 only | migrated v8 | never current v6 |
+| v6 | v6 only | migrated v8 | v6 when canonical evidence/outcomes are fresh |
+| v7 | v7 only | v8 | v6 when canonical evidence/outcomes are fresh |
 
 Claim/return compatibility authorizes replay; it does not grant current scoring
-status. Only a v6 return canonicalized from current source artifacts can produce
-talk schema v6 with `pattern_scoring_schema_version: 6`, evidence ledger v2,
+status. A v6 or v7 return canonicalized from current source artifacts can produce
+talk schema v8 with `pattern_scoring_schema_version: 6`, evidence ledger v2,
 exhaustive outcomes, `pattern_score_basis`, and
 `pattern_scoring_generation_status: "current"`. A v5 return still validates and
 still persists, at the flat scoring generation; weighted and flat scores are not
@@ -934,7 +935,7 @@ Each subagent returns this JSON after processing one talk:
 ```json
 {
   "filename": "the .md filename",
-  "return_schema_version": 5,
+  "return_schema_version": 7,
   "queue_claim": {
     "run_id": "copied from talk._queue_claim.run_id",
     "batch_id": "copied from talk._queue_claim.batch_id",
@@ -948,7 +949,7 @@ Each subagent returns this JSON after processing one talk:
   ],
   "rhetoric_notes": "500-1000 words: qualitative observations across dimensions 1-13",
   "areas_for_improvement": "100-300 words: honest critical reflection (Dimension 14); name the related antipattern ID + severity per issue where a Dimension 14 antipattern applies",
-  "transcript_source": "youtube_auto|whisper|manual  (how the transcript was obtained; OMIT the key entirely when provenance is unknown — see Absent transcript_source in the DB schema above)",
+  "transcript_source": "youtube_auto|provider_auto|whisper|manual  (how the transcript was obtained; OMIT the key entirely when provenance is unknown — see Absent transcript_source in the DB schema above)",
   "transcript_path": "transcripts/{id}.txt  (optional exact repeat of a pre-registered non-YouTube path; cannot introduce citation authority)",
   "structured_data": {
     "delivery_language": "en|de|ru|etc  (primary language of the talk)",
@@ -1169,11 +1170,11 @@ classification rule including how a dominant class is selected, the provenance
 evidence used, and how unverified origins are counted as `unknown`. Both fields
 are authored-slide evidence and cannot be supplied from untrusted video context.
 
-The worker matches the active claim contract. Every fresh claim is schema v6
-with `required_return_schema_version: 6`, and only that exact claim authorizes a
-v6 return. Saved claim schemas v1/v2 authorize only return schemas v1/v2;
+The worker matches the active claim contract. Every fresh claim is schema v7
+with `required_return_schema_version: 7`, and only that exact claim authorizes a
+v7 return. Saved claim schemas v1/v2 authorize only return schemas v1/v2;
 schema v3 authorizes only v3; schema v4 authorizes only archival v4; schema v5
-authorizes only v5. Recover a live legacy lease and issue a new v6 generation;
+authorizes only v5; schema v6 authorizes only v6. Recover a live legacy lease and issue a new v7 generation;
 never mutate its claim to make a newer return appear compatible.
 
 For newly emitted work, `validate-returns.py` must report the processed talk's
@@ -1199,8 +1200,8 @@ table would restate what that worker meant rather than validate what it said. A
 v5 return carrying `pattern_score_basis` is rejected outright — the field cannot
 exist under its contract.
 
-**Writer.** Every fresh claim is schema v6 with
-`required_return_schema_version: 6`, so a worker is issued a v6 return.
+**Writer.** Saved claim schema v6 carries
+`required_return_schema_version: 6`, so its worker replays a v6 return.
 `PATTERN_SCORING_SCHEMA_VERSION` is 6; `FLAT_PATTERN_SCORING_SCHEMA_VERSION`
 names the flat generation, and `scoring_schema_version_for_return` maps a return
 to the generation its score belongs to. Weighted and flat scores are not
@@ -1226,6 +1227,15 @@ unmutatable, since the owner writer requires the exact current talk schema.
 Weights are part of the scoring schema version, so changing one is a
 scoring-generation bump, never a tuning knob.
 
+### Return schema v7 — provider automatic captions
+
+v7 keeps the complete v6 evidence and weighted-score contract and adds
+`provider_auto` to `transcript_source`. The value means a non-YouTube
+provider's automatic caption track. It has the same machine-ASR reliability as
+`youtube_auto`, but it never enters YouTube caption-timing enrichment. Fresh
+claims require v7; saved v6 claims and returns remain replayable and reject the
+new value.
+
 The basis a v6 return carries has this shape:
 
 ```json
@@ -1246,7 +1256,7 @@ recompute the score without consulting the engine. The per-lane counts cover eve
 confidence level the catalog admits; a level added without a weight fails the
 table's own exhaustiveness test rather than silently scoring as zero.
 
-Versions 2–6 share the complete-snapshot merge contract: supplied declared
+Versions 2–7 share the complete-snapshot merge contract: supplied declared
 scalar and list fields replace prior values, including empties only where the
 field contract permits emptiness; complete structured maps and each verbatim
 lane replace their prior snapshots; omitted fields remain untouched. The
@@ -1309,7 +1319,7 @@ batch in `claimed` state and closes it as `completed`; `write-analysis.py`
 requires that same whole batch in `completed` state. A genuinely one-member
 batch is complete and remains supported. A partially closed or stranded batch
 must be recovered into a fresh queue generation rather than finished piecemeal.
-For claim v3–v5, every live batch member must also share one canonical
+For claim v3–v7, every live batch member must also share one canonical
 `claimed_at`, one identical baseline, and an `excluded_filenames` array equal to
 the exact sorted batch. Persistence validates all of those conditions before
 the first candidate merge; one mismatch leaves both DB and analysis artifacts
@@ -1318,11 +1328,12 @@ unchanged.
 Queue-claim schema v2 adds `result_payload_sha256` to completed claims; schema
 v3 adds the required-return version and immutable adherence snapshot. Schema v4
 freezes those fields to the source-located return-v4/scoring-v4 contract. Schema
-v5 carries the v5 return/scoring contract and schema-v2 baseline. The
+v5 carries the v5 return/scoring contract and schema-v2 baseline, v6 introduces
+weighted scoring, and v7 adds provider-auto transcript provenance. The
 receipt hashes the exact return payload after stable JSON key/whitespace
-canonicalization. `persist-results.py` closes v1 as v2 and closes v2–v5 at
-their own versions, storing the receipt for every completed v2–v5 claim. The analysis writer
-recomputes it and rejects a substituted payload. `queue-state.py` reads v1–v5
+canonicalization. `persist-results.py` closes v1 as v2 and closes v2–v7 at
+their own versions, storing the receipt for every completed v2–v7 claim. The analysis writer
+recomputes it and rejects a substituted payload. `queue-state.py` reads v1–v7
 without mutating `inspect` or idempotent replay. An already completed v1 claim
 has no reconstructable receipt and therefore cannot authorize an analysis
 replacement until a fresh generation is processed. Unknown future claim
@@ -1330,7 +1341,7 @@ versions fail closed.
 
 Recovery never rewrites a claim snapshot. It marks the generation closed and
 restores its prior claimable status; reclaiming creates a new generation with a
-fresh pre-mutation baseline. A historical v3/v4/v5 batch may therefore be split across
+fresh pre-mutation baseline. A historical v3-v7 batch may therefore be split across
 current and history storage locations, but the combined `(run_id, batch_id,
 claimed_at)` epoch must still have exact membership and one baseline.
 
@@ -1408,14 +1419,14 @@ are top-level analysis prose/provenance scalars or leaves under
 `structured_data`, `verbatim_examples`, and `pattern_observations`. It cannot
 clear queue identity, source URLs, catalog metadata, or the talk record itself.
 Clearing a promoted structured scalar clears its top-level copy too. A supplied
-v2–v5 replacement wins after a clear; permitted empty values are real snapshots,
+v2–v7 replacement wins after a clear; permitted empty values are real snapshots,
 not no-ops. Legacy v1 empty values retain their historical additive no-op behavior.
 
 `evidence_source` uses the enum defined by the pattern index's Evidence-Source Contract.
 Detected entries must name a qualifying source. Strong detections use
 `strong_evaluable_from` (defaulting to `evaluable_from`); moderate/weak
 detections use the base gate. A `source_comparison` detection must name both
-sources in its evidence. Every v4/v5 return carries a
+sources in its evidence. Every v4-v7 return carries a
 duplicate-free `evidence_sources_used` array exactly equal to one qualifying
 underlying group. Saved v1–v3 replay may omit that array; persistence infers it
 only when exactly one pair qualifies. Zero or multiple qualifying groups remain
@@ -1452,7 +1463,7 @@ schema and aggregation contract are in
 
 ### Source Inspection Receipt Schema
 
-Every return v4/v5 carries `pattern_observations.source_inspection`. Its source-name
+Every return v4-v7 carries `pattern_observations.source_inspection`. Its source-name
 set exactly equals `evidence_sources`; comparison records may repeat the
 `source_comparison` name only for distinct underlying groups. Worker-authored
 records are closed objects:
@@ -1497,7 +1508,7 @@ must not return either absence-capability field.
 
 Workers never return canonical receipt enrichment. Persistence adds
 `artifact_root`, vault/root-relative `artifact_path`, `artifact_sha256`, optional
-timing-artifact identity, required quality-artifact identity for current v4/v5
+timing-artifact identity, required quality-artifact identity for current v4-v7
 transcript evidence, derived `line_count`/`page_count`/`duration_seconds`, and
 `coverage_complete`; comparison records add `artifact_identities`. Current
 cohort readers re-hash these identities and fail stale, missing, symlinked,
@@ -1550,7 +1561,7 @@ transcript `start_seconds`/`end_seconds`, artifact root/path/hash fields,
 timing/quality-artifact fields, metadata `value`/`owner_value_after_return`, or
 any other canonical enrichment from an earlier analysis. Unknown raw citation fields are
 rejected. Catalog dimensions are likewise engine-owned; workers should omit
-them, although a supplied v4/v5 `dimensions` array is accepted only when it exactly
+them, although a supplied v4-v7 `dimensions` array is accepted only when it exactly
 matches catalog order.
 
 For transcript citations, `quote` is always the exact source-language text needed
@@ -1579,7 +1590,7 @@ itself, and an irrelevant metadata field cannot stand in for pattern evidence.
 
 Historical v1–v3 records may contain `evidence_citations: []`. That is a deliberate
 legacy marker: readers may render the old `evidence` prose, but must not present
-it as source-verified. The v4/v5 writer never accepts an empty array for a new
+it as source-verified. The v4-v7 writer never accepts an empty array for a new
 detection. `evidence_schema_version` is writer-owned persisted state; workers
 must not return it, and legacy detections never acquire it by migration.
 

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1100,12 +1100,7 @@ Each subagent returns this JSON after processing one talk:
         "pattern_id": "conditional-pattern-with-incomplete-coverage",
         "reason_code": "missing_applicability_source_coverage"
       }
-    ],
-    "pattern_score": {
-      "patterns_used": 8,
-      "antipatterns_detected": 2,
-      "score": 6
-    }
+    ]
   },
   "catalog_feedback": {
     "unmatched_observations": [{
@@ -1135,6 +1130,12 @@ Each subagent returns this JSON after processing one talk:
   }
 }
 ```
+
+This is the raw worker shape. Before validation, pass it through
+`skills/vault-ingress/scripts/build-score-basis.py`; that canonical completion
+step inserts `pattern_score` and `pattern_score_basis` through the scoring
+owner. Do not calculate, author, or merge either field by hand. See
+[subagent-instructions.md](subagent-instructions.md) for the invocation.
 
 A `source_comparison` detection or applicability assessment adds
 `"evidence_sources_used": ["static_slides", "native_deck"]` (or another

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -13,11 +13,10 @@ plan:
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-source-identities.py" {vault_root}
 ```
 
-The audit requires the pinned `yt-dlp` executable and network access. It uses
-the shared ingress resolver: `YT_DLP` when explicitly set, the configured
-Python interpreter's console script, the active/toolkit virtual environment,
-then PATH only as a compatibility fallback. An **active talk** for this helper
-is a record with a nonempty `video_url`. Only supported YouTube
+The audit requires the pinned `yt-dlp` executable and network access. Executable
+selection belongs to
+`skills/vault-ingress/scripts/ytdlp_runtime.py` — `resolve_ytdlp`. An **active
+talk** for this helper is a record with a nonempty `video_url`. Only supported YouTube
 URL forms are fetched. The helper parses their 11-character IDs, groups every
 record naming the same ID, and makes exactly one metadata request per group.
 Records with a stored `youtube_id` but no active URL are not resurrected or

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -13,8 +13,11 @@ plan:
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/audit-source-identities.py" {vault_root}
 ```
 
-The audit requires the `yt-dlp` executable and network access. An **active talk**
-for this helper is a record with a nonempty `video_url`. Only supported YouTube
+The audit requires the pinned `yt-dlp` executable and network access. It uses
+the shared ingress resolver: `YT_DLP` when explicitly set, the configured
+Python interpreter's console script, the active/toolkit virtual environment,
+then PATH only as a compatibility fallback. An **active talk** for this helper
+is a record with a nonempty `video_url`. Only supported YouTube
 URL forms are fetched. The helper parses their 11-character IDs, groups every
 record naming the same ID, and makes exactly one metadata request per group.
 Records with a stored `youtube_id` but no active URL are not resurrected or

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -329,8 +329,8 @@ return, but budget, availability, change, placeholder, probe, or extraction
 reasons leave coverage incomplete. Legacy unversioned batch output has unknown
 completeness and must be rerun before an absence conclusion.
 
-- Transcript source enum: `youtube_auto`, `whisper`, `manual`, `none`. Absence
-  remains valid “unknown provenance.” Unless the value is `none`, the expected
+- Transcript source enum: `youtube_auto`, `provider_auto`, `whisper`, `manual`,
+  `none`. Absence remains valid “unknown provenance.” Unless the value is `none`, the expected
   file is `transcripts/{youtube_id}.txt`; an explicit relative
   `transcript_path` is resolved from the vault root.
 - Slide source enum: `pptx`, `pdf`, `both`, `video_extracted`, `markdown`, `none`.

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -6,7 +6,7 @@ returns the JSON shape in [schemas-db.md](schemas-db.md). The summary supports
 qualitative rhetoric analysis, but Section 15 is human narrative and MUST NOT be
 parsed for numeric adherence. The active claim's immutable
 `adherence_baseline` is the sole numeric authority.
-A successfully persisted v6 return is the only return generation eligible for pattern-scoring schema v6;
+A successfully persisted v7 return is the fresh return generation eligible for pattern-scoring schema v6;
 saved legacy claims remain replayable only with their
 same-numbered archival return generation.
 
@@ -50,6 +50,10 @@ Map the returned `method` to `transcript_source`:
 | `whisper` | `whisper` |
 | `existing` | leave the talk's current `transcript_source` unchanged; when the field is absent, leave it absent |
 
+An automatic caption track imported from a non-YouTube provider records
+`provider_auto`; it does not map from the fetcher's YouTube-only `captions`
+method.
+
 `existing` means a valid transcript was already on disk and no fetch ran, so the
 script learned nothing about where it came from — overwriting the recorded source
 would replace a known value with a guess, and inventing one where the field is
@@ -72,7 +76,8 @@ floor but cannot lower it; a short-talk floor comes only from the trusted probe.
 Treat `timed_path: null` literally. A hash-current `quality_path` still permits
 an ordinary `transcript` quote, but no opening/closing position, pause, or other
 timing-dependent claim. Missing or stale quality is unverified legacy input and
-cannot enter current v5 scoring; requeue it through this script. Never invent a
+cannot enter the current pattern-scoring generation; requeue it through this
+script. Never invent a
 timestamp, reuse an unverified receipt, or copy receipt fields into a return;
 persistence owns and verifies both artifacts.
 
@@ -134,6 +139,10 @@ The input must be a non-symlink regular file within the output transcript
 directory. The schema-v2 timing receipt binds its safe relative path, exact
 digest, and final cue extent. An existing output is preserved unless `--force`
 explicitly authorizes full transcript/receipt replacement.
+Record `transcript_source: provider_auto` when the imported VTT is known to be
+the provider's automatic caption track. A VTT authored by a human remains
+`manual`; the artifact receipt proves the file identity, not who produced its
+text.
 
 ### Slide acquisition (per `slide_source`)
 
@@ -227,9 +236,10 @@ explicitly authorizes full transcript/receipt replacement.
 
 ### `transcript_source` records known provenance
 
-Set `transcript_source` on the talk entry: `youtube_auto` (caption track),
-`whisper` (local transcription), or `manual`. Downstream tools use it to gauge
-transcript reliability.
+Set `transcript_source` on the talk entry: `youtube_auto` (YouTube caption
+track), `provider_auto` (another provider's automatic caption track), `whisper`
+(local transcription), or `manual`. Downstream tools use it to gauge transcript
+reliability.
 
 **One exception, and only one:** `method: "existing"` from the fetcher. No fetch
 ran, so provenance is unknown — leave the recorded value alone, and leave the
@@ -415,8 +425,10 @@ verified timed transcript or direct video review; sequence claims require the
 actual consecutive slides. Native-deck structure can support motion/build
 claims only when the entry's gate permits `native_deck`; observed playback and
 delivery claims require direct video review.
-Do not cite a video interval unless you inspected that interval. Compute per-talk score:
-`count(patterns) − count(antipatterns)`. Store in `pattern_observations`.
+Do not cite a video interval unless you inspected that interval. Compute the
+per-talk score with the owner-approved confidence weights: strong ±1.0,
+moderate ±0.5, and weak ±0.25. Store it in `pattern_observations`; the
+`build-score-basis.py` step below derives the matching evidence basis.
 See [processing-rules.md](processing-rules.md) for full tagging rules.
 
 Use `evaluable_from` for moderate/weak detections,
@@ -431,7 +443,7 @@ cannot replace its qualifying source/outcome gate.
 
 ### Record exact source inspection coverage
 
-Return v4/v5 requires a receipt for the material you actually inspected, not just
+Return v4-v7 requires a receipt for the material you actually inspected, not just
 a list of artifacts that happened to exist. `pattern_observations.evidence_sources`
 must be the exact source-name set represented by `source_inspection`:
 
@@ -481,14 +493,15 @@ them from the preclaim artifacts and rejects false bounds or source claims.
 Return exactly the shape in [schemas-db.md](schemas-db.md). `status`,
 `slide_source`, all five catalog-feedback lanes, and the complete pattern score
 object are mandatory. Match `return_schema_version` to the active claim:
-fresh claim-schema v6 with `required_return_schema_version: 6` emits return v6.
+fresh claim-schema v7 with `required_return_schema_version: 7` emits return v7.
 Saved claim schemas v1/v2 authorize only saved return schemas v1/v2; claim
 schema v3 authorizes only return schema v3, claim schema v4 authorizes only
-archival return schema v4, and claim schema v5 authorizes only return schema
-v5 — a saved legacy replay generation, never a fresh one.
-Recover a live legacy lease and issue a fresh v6 generation; never mutate its
+archival return schema v4, claim schema v5 authorizes only return schema v5,
+and claim schema v6 authorizes only return schema v6. These are saved legacy
+replay generations, never fresh ones.
+Recover a live legacy lease and issue a fresh v7 generation; never mutate its
 claim or attach a newer return to it.
-Snapshot versions 2–5 require `rhetoric_notes` and `areas_for_improvement` to
+Snapshot versions 2–7 require `rhetoric_notes` and `areas_for_improvement` to
 contain substantive non-whitespace analysis. Empty strings remain valid for
 `adherence_assessment`, `new_patterns`, and
 `summary_updates` where documented; the adherence no-assessment sentinel must be
@@ -500,7 +513,7 @@ never emit JSON `null`.
 Omit `processed_date`; the persistence writer owns one normalized timestamp for
 the complete queue batch and the analysis writer renders that stored value.
 
-For return v5 and v6, always return `"adherence_assessment": ""` exactly and omit
+For returns v5-v7, always return `"adherence_assessment": ""` exactly and omit
 `adherence_comparison`. The worker cannot know the canonical, engine-owned talk
 `opportunity_coverage_identity`. Only an owner-side consumer after persistence
 may compare a talk against a schema-v2 baseline, and only when the identities
@@ -523,7 +536,7 @@ slide, page, or asset; how one class wins when multiple images or sources occur;
 which provenance evidence supports the classes; and how unverified origins enter
 the `unknown` count.
 
-Version-2 through version-5 supplied fields are snapshots: an empty string, array,
+Version-2 through version-7 supplied fields are snapshots: an empty string, array,
 or declared map
 replaces an older value when that field permits emptiness, while an omitted field
 preserves it. Use `clear_fields`
@@ -539,12 +552,12 @@ nested dictionary union. Put genuinely additive experimental data under
 `structured_data.extensions.<producer_namespace>`; an undeclared top-level object
 is rejected until its replacement policy is documented and registered.
 
-Minimal processed structure for a fresh v6 claim:
+Minimal processed structure for a fresh v7 claim:
 
 ```json
 {
   "filename": "2026-01-01-example.md",
-  "return_schema_version": 6,
+  "return_schema_version": 7,
   "queue_claim": {
     "run_id": "reparse-2026-07",
     "batch_id": "25",
@@ -643,14 +656,14 @@ example, `"evidence_sources_used": ["static_slides", "native_deck"]`.
 The array is duplicate-free, excludes the `source_comparison` marker, and must
 exactly match one qualifying catalog group.
 
-Fresh work arrives only under a claim-v6 payload that explicitly requires return
-v6. Saved claims v1/v2 remain replayable only with saved returns v1/v2; claim v3
-requires return v3, claim v4 requires archival return v4, and claim v5 requires
-return v5. Recover a live legacy lease without rewriting it; otherwise issue a
-new v6 claim. Never alter a
+Fresh work arrives only under a claim-v7 payload that explicitly requires return
+v7. Saved claims v1/v2 remain replayable only with saved returns v1/v2; claim v3
+requires return v3, claim v4 requires archival return v4, claim v5 requires
+return v5, and claim v6 requires return v6. Recover a live legacy lease without
+rewriting it; otherwise issue a new v7 claim. Never alter a
 saved claim payload, invent a schema, or attach a newer return to a legacy claim.
 
-In raw v4/v5 citations, return only `source`, `channel`, and the locator you
+In raw v4-v7 citations, return only `source`, `channel`, and the locator you
 actually observed: transcript `quote` (plus optional `translation`), slide
 `slide_numbers`, video `start_seconds`/`end_seconds`, or metadata `field`.
 Never return transcript line/timestamp matches, artifact root/path/hash fields,

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -426,9 +426,10 @@ actual consecutive slides. Native-deck structure can support motion/build
 claims only when the entry's gate permits `native_deck`; observed playback and
 delivery claims require direct video review.
 Do not cite a video interval unless you inspected that interval. Compute the
-per-talk score with the owner-approved confidence weights: strong ±1.0,
-moderate ±0.5, and weak ±0.25. Store it in `pattern_observations`; the
-`build-score-basis.py` step below derives the matching evidence basis.
+per-talk score only through the `build-score-basis.py` step below. Record each
+detection's confidence, but do not calculate or write `pattern_score` or
+`pattern_score_basis` yourself; the script derives both through the scoring
+owner.
 See [processing-rules.md](processing-rules.md) for full tagging rules.
 
 Use `evaluable_from` for moderate/weak detections,
@@ -608,12 +609,7 @@ Minimal processed structure for a fresh v7 claim:
     ],
     "antipatterns_detected": [],
     "applicability_assessments": [],
-    "not_evaluable": [],
-    "pattern_score": {
-      "patterns_used": 1,
-      "antipatterns_detected": 0,
-      "score": 1
-    }
+    "not_evaluable": []
   },
   "catalog_feedback": {
     "unmatched_observations": [],
@@ -625,8 +621,9 @@ Minimal processed structure for a fresh v7 claim:
 }
 ```
 
-This block is complete except for `pattern_observations.pattern_score_basis`,
-which a script fills in. Do not write or merge it by hand:
+This block is complete except for `pattern_observations.pattern_score` and
+`pattern_observations.pattern_score_basis`, which a script fills in. Do not
+write, calculate, or merge either field by hand:
 
 ```bash
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/build-score-basis.py" \
@@ -634,11 +631,12 @@ which a script fills in. Do not write or merge it by hand:
 ```
 
 Input is one return object or an array of them; output is those same returns
-with the field set, ready for `validate-returns.py`. Exit `0` means the batch
+with both fields set, ready for `validate-returns.py`. Exit `0` means the batch
 is complete. Exit `2` means unreadable, malformed, or duplicate-filename input:
 a diagnostic goes to stderr, stdout stays empty, and you must stop rather than
-validate a partial batch. The weight table and the object's shape belong to
-`skills/vault-ingress/scripts/return_validation.py`; nothing here restates them.
+validate a partial batch. The arithmetic, weight table, and basis shape belong
+to `skills/vault-ingress/scripts/return_validation.py`; nothing here restates
+them.
 
 The example claims one inspected source. Add a source only with the audit
 behind it: `native_deck` requires the current

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -119,6 +119,10 @@ device/current-drive, foreign absolute, raw-dot-segment, and dual-flavor `//`
 forms fail closed; paths are never translated between operating-system
 grammars.
 
+The downloader result and exit-code contract lives in
+[subagent-instructions.md](subagent-instructions.md#slide-acquisition-per-slide_source),
+under `video_extracted`. Follow it before invoking the extractor.
+
 `youtube_id` must match the shared ingress grammar exactly:
 `[A-Za-z0-9_-]{11}`. It is validated before any filesystem or process boundary,
 is never normalized, and is the only component used to derive the frame
@@ -129,15 +133,11 @@ shell interpolation, so shell metacharacters in valid native POSIX filenames do
 not become commands.
 
 ```bash
-# Download video at 720p. Read the report before going further: extraction runs
-# only when this id's `results` entry is `ok` or `skip`. A `fail` entry, or a
-# report with no `results` at all (exits 2 and 3), means there is no video to
-# extract — stop here rather than running the extractor against an absent or
-# stale MP4.
+# Download video at 720p under the prerequisite above.
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/batch-download-videos.py" \
   "{vault_root}" "{youtube_id}"
 
-# Extract slides — only for an `ok` or `skip` entry
+# Extract slides after the prerequisite confirms this video's artifact.
 "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/video-slide-extraction.py" \
   "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \
   "{vault_root}/slides-rebuild/{youtube_id}" \
@@ -345,9 +345,7 @@ In Step 3 of the skill (per-talk subagent):
 
 ```
 if slide_source == "video_extracted":
-    1. Download video: skills/vault-ingress/scripts/batch-download-videos.py
-       "{vault_root}" "{youtube_id}" — and stop unless this id's `results`
-       entry is `ok` or `skip`
+    1. Run the downloader under the Usage prerequisite above
     2. Run extract_slides_from_video()
     3. Store the complete artifact manifest in structured_data
     4. If review_required, inspect source + context + candidate and rerun with a

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -43,6 +43,7 @@ from tracking_database_io import (
     decode_json_object,
     snapshot_tracking_database,
 )
+from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
 
 
 REPORT_SCHEMA_VERSION = 2
@@ -195,12 +196,18 @@ def normalize_captured_at(value: str | datetime | None = None) -> str:
 def fetch_youtube_metadata(
     video_id: str,
     runner: Callable[..., Any] = subprocess.run,
+    *,
+    ytdlp: str | Path | None = None,
 ) -> dict[str, Any]:
     """Fetch one video's metadata through the yt-dlp CLI without downloading it."""
     if not YOUTUBE_ID_RE.fullmatch(video_id):
         raise MetadataFetchError(f"invalid YouTube ID: {video_id!r}")
+    try:
+        executable = Path(ytdlp) if ytdlp is not None else resolve_ytdlp()
+    except YtDlpResolutionError as exc:
+        raise MetadataFetchError(str(exc)) from exc
     command = [
-        "yt-dlp",
+        str(executable),
         "--ignore-config",
         "--no-playlist",
         "--skip-download",

--- a/skills/vault-ingress/scripts/batch-download-videos.py
+++ b/skills/vault-ingress/scripts/batch-download-videos.py
@@ -54,16 +54,15 @@ the resolved path and version are announced before the first download.
 from __future__ import annotations
 
 import json
-import os
 import re
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-import shutil
 import subprocess
 import sys
 
 from failure_diagnostics import sanitized_frames
 from ingress_contract import YOUTUBE_ID_RE
+from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
 
 USAGE = "usage: batch-download-videos.py <vault_root> ID1 [ID2 ...]"
 
@@ -113,55 +112,6 @@ VIDEO_FORMAT = (
     "/best[height<=720][ext=mp4]"
     "/best[height<=720]"
 )
-
-
-class YtDlpResolutionError(RuntimeError):
-    """No usable yt-dlp executable, reported with what to do about it."""
-
-    def __init__(self, code: str, message: str) -> None:
-        if code not in FAILURE_CODES:
-            raise ValueError("invalid yt-dlp resolution failure code")
-        super().__init__(message)
-        self.code = code
-
-
-def resolve_ytdlp() -> Path:
-    """Find the pinned yt-dlp, falling back to PATH only as a last resort.
-
-    An explicit override wins; then the console script beside the running
-    interpreter, which is the pinned one whenever the toolkit runs from the
-    environment that declares it; then the toolkit's own virtualenv, for a run
-    driven by a system interpreter; then PATH.
-    """
-    override = os.environ.get("YT_DLP")
-    if override:
-        candidate = Path(override)
-        if os.access(candidate, os.X_OK) and candidate.is_file():
-            return candidate
-        raise YtDlpResolutionError(
-            "ytdlp_override_invalid",
-            f"YT_DLP is set to {override!r}, which is not an executable file — "
-            "point it at a yt-dlp binary or unset it",
-        )
-
-    candidates = [Path(sys.executable).parent / "yt-dlp"]
-    virtual_env = os.environ.get("VIRTUAL_ENV")
-    if virtual_env:
-        candidates.append(Path(virtual_env) / "bin" / "yt-dlp")
-    toolkit_root = Path(__file__).resolve().parents[3]
-    candidates.append(toolkit_root / ".venv" / "bin" / "yt-dlp")
-    for candidate in candidates:
-        if os.access(candidate, os.X_OK) and candidate.is_file():
-            return candidate
-
-    found = shutil.which("yt-dlp")
-    if found:
-        return Path(found)
-    raise YtDlpResolutionError(
-        "ytdlp_not_found",
-        "cannot find yt-dlp — install the pinned version with `pip install .` "
-        "into the toolkit environment, or set YT_DLP to its path",
-    )
 
 
 def probe_version(ytdlp: Path) -> str:

--- a/skills/vault-ingress/scripts/build-score-basis.py
+++ b/skills/vault-ingress/scripts/build-score-basis.py
@@ -42,15 +42,23 @@ def _observations(ret: object, label: str) -> dict:
     return observations
 
 
-def basis_for(ret: object, label: str) -> dict:
-    """Return the exact basis this return's own lanes require."""
+def _required_lanes(ret: object, label: str) -> dict[str, list]:
+    """Return every required detection lane, rejecting omissions as malformed."""
     observations = _observations(ret, label)
-    lanes = {}
+    lanes: dict[str, list] = {}
     for name in ("patterns_detected", "antipatterns_detected", "not_evaluable"):
-        value = observations.get(name, [])
+        if name not in observations:
+            raise ValueError(f"{label} pattern_observations.{name} is required")
+        value = observations[name]
         if not isinstance(value, list):
             raise ValueError(f"{label} pattern_observations.{name} must be an array")
         lanes[name] = value
+    return lanes
+
+
+def basis_for(ret: object, label: str) -> dict:
+    """Return the exact basis this return's own lanes require."""
+    lanes = _required_lanes(ret, label)
     try:
         return pattern_score_basis(
             lanes["patterns_detected"],
@@ -69,13 +77,7 @@ def basis_for(ret: object, label: str) -> dict:
 
 def score_for(ret: object, label: str) -> float:
     """Return the exact weighted score this return's own lanes require."""
-    observations = _observations(ret, label)
-    lanes = {}
-    for name in ("patterns_detected", "antipatterns_detected"):
-        value = observations.get(name, [])
-        if not isinstance(value, list):
-            raise ValueError(f"{label} pattern_observations.{name} must be an array")
-        lanes[name] = value
+    lanes = _required_lanes(ret, label)
     try:
         return expected_weighted_score(
             lanes["patterns_detected"], lanes["antipatterns_detected"]

--- a/skills/vault-ingress/scripts/build-score-basis.py
+++ b/skills/vault-ingress/scripts/build-score-basis.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Complete v6 returns by filling in the pattern_score_basis they require.
+"""Complete weighted returns by filling in the pattern_score_basis they require.
 
 The basis is a pure function of a return's detection lanes and its
 not-evaluable ledger, and inserting it is a mechanical JSON edit, so both steps
@@ -7,7 +7,8 @@ belong in a script rather than in a worker's reasoning. `return_validation`
 owns the weight table and the object's shape; this is a thin entry point onto
 that owner, so no caller reproduces either or decides where the field goes.
 
-Usage:
+Return schemas v6 and v7 share scoring schema v6 and therefore require the same
+basis. Usage:
     build-score-basis.py <return.json> [...]
 
 Each input is one return object or an array of return objects. The output is

--- a/skills/vault-ingress/scripts/build-score-basis.py
+++ b/skills/vault-ingress/scripts/build-score-basis.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
-"""Complete weighted returns by filling in the pattern_score_basis they require.
+"""Complete weighted returns by filling in their score and score basis.
 
-The basis is a pure function of a return's detection lanes and its
-not-evaluable ledger, and inserting it is a mechanical JSON edit, so both steps
-belong in a script rather than in a worker's reasoning. `return_validation`
-owns the weight table and the object's shape; this is a thin entry point onto
-that owner, so no caller reproduces either or decides where the field goes.
+The score and basis are pure functions of a return's detection lanes and its
+not-evaluable ledger, and inserting them is a mechanical JSON edit, so every
+step belongs in a script rather than in a worker's reasoning.
+`return_validation` owns the arithmetic, weight table, and basis shape; this is
+a thin entry point onto that owner, so no caller reproduces them or decides
+where the fields go.
 
 Return schemas v6 and v7 share scoring schema v6 and therefore require the same
 basis. Usage:
     build-score-basis.py <return.json> [...]
 
 Each input is one return object or an array of return objects. The output is
-those same returns with `pattern_observations.pattern_score_basis` set — one
-object for a single return, an array for several — ready to pass straight to
-`validate-returns.py`.
+those same returns with `pattern_observations.pattern_score` and
+`pattern_observations.pattern_score_basis` set — one object for a single
+return, an array for several — ready to pass straight to `validate-returns.py`.
 
 Exit 0 on success. Exit 2 on unreadable, malformed, or duplicate-filename
 input, with a diagnostic on stderr and nothing on stdout; callers must stop on
@@ -29,7 +30,7 @@ import json
 import sys
 from pathlib import Path
 
-from return_validation import pattern_score_basis
+from return_validation import expected_weighted_score, pattern_score_basis
 
 
 def _observations(ret: object, label: str) -> dict:
@@ -66,10 +67,31 @@ def basis_for(ret: object, label: str) -> dict:
         ) from exc
 
 
+def score_for(ret: object, label: str) -> float:
+    """Return the exact weighted score this return's own lanes require."""
+    observations = _observations(ret, label)
+    lanes = {}
+    for name in ("patterns_detected", "antipatterns_detected"):
+        value = observations.get(name, [])
+        if not isinstance(value, list):
+            raise ValueError(f"{label} pattern_observations.{name} must be an array")
+        lanes[name] = value
+    try:
+        return expected_weighted_score(
+            lanes["patterns_detected"], lanes["antipatterns_detected"]
+        )
+    except (TypeError, KeyError) as exc:
+        raise ValueError(
+            f"{label} has a malformed detection entry ({exc}); every detection "
+            "needs an object with a confidence of strong, moderate, or weak"
+        ) from exc
+
+
 def completed(ret: object, label: str) -> dict:
-    """Return a copy of this return with its required basis filled in."""
+    """Return a copy with its owner-computed score and basis filled in."""
     filled = copy.deepcopy(ret)
     assert isinstance(filled, dict)
+    filled["pattern_observations"]["pattern_score"] = score_for(ret, label)
     filled["pattern_observations"]["pattern_score_basis"] = basis_for(ret, label)
     return filled
 

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -23,8 +23,15 @@ import tempfile
 from pathlib import Path
 from typing import Any, BinaryIO, Callable, TypedDict
 
+from ytdlp_runtime import (
+    YTDLP_REQUIRED_VERSION,
+    YtDlpResolutionError,
+    normalized_ytdlp_version,
+    resolve_ytdlp,
+)
 
-REPORT_SCHEMA_VERSION = 2
+
+REPORT_SCHEMA_VERSION = 3
 MODULE_PROBE_SCHEMA_VERSION = 1
 MODULE_PROBE_TIMEOUT_SECONDS = 30
 MODULE_PROBE_MAX_OUTPUT_BYTES = 4096
@@ -120,6 +127,13 @@ DEFAULT_REQUIRED_LANES = ("core",)
 
 class ModuleProbeResult(TypedDict):
     """Parent-side result for one isolated dependency import."""
+
+    available: bool
+    failure: dict[str, object] | None
+
+
+class CommandProbeResult(TypedDict):
+    """Result for one executable dependency probe."""
 
     available: bool
     failure: dict[str, object] | None
@@ -361,6 +375,78 @@ def _command_available(command: str) -> bool:
     return shutil.which(command) is not None
 
 
+def _probe_command(
+    label: str,
+    command: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> CommandProbeResult:
+    """Probe presence, plus the pinned version for versioned commands."""
+    if label != "yt-dlp":
+        available = _command_available(command)
+        return {
+            "available": available,
+            "failure": None if available else {"reason": "not_found"},
+        }
+
+    try:
+        executable = resolve_ytdlp()
+    except YtDlpResolutionError as exc:
+        return {
+            "available": False,
+            "failure": {"reason": exc.code},
+        }
+
+    run = subprocess.run if runner is None else runner
+    try:
+        completed = run(
+            [str(executable), "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=MODULE_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "available": False,
+            "failure": {
+                "reason": "timeout",
+                "timeout_seconds": MODULE_PROBE_TIMEOUT_SECONDS,
+            },
+        }
+    except OSError as exc:
+        return {
+            "available": False,
+            "failure": {
+                "reason": "probe_start_failure",
+                "exception_type": type(exc).__name__,
+            },
+        }
+
+    raw_version = completed.stdout.strip()
+    actual_version = raw_version if raw_version and len(raw_version) <= 64 else None
+    if completed.returncode != 0 or actual_version is None:
+        return {
+            "available": False,
+            "failure": {
+                "reason": "version_unavailable",
+                "exit_code": completed.returncode,
+            },
+        }
+    if normalized_ytdlp_version(actual_version) != normalized_ytdlp_version(
+        YTDLP_REQUIRED_VERSION
+    ):
+        return {
+            "available": False,
+            "failure": {
+                "reason": "incompatible_version",
+                "required_version": YTDLP_REQUIRED_VERSION,
+                "actual_version": actual_version,
+            },
+        }
+    return {"available": True, "failure": None}
+
+
 def _parse_lanes(value: str) -> tuple[str, ...]:
     lanes = tuple(dict.fromkeys(part.strip() for part in value.split(",")))
     if not lanes or any(not lane for lane in lanes):
@@ -399,9 +485,17 @@ def build_report(
             for distribution, probe in module_probes.items()
             if probe["failure"] is not None
         }
-        commands = {
-            label: _command_available(command)
+        command_probes = {
+            label: _probe_command(label, command)
             for label, command in requirements["commands"].items()
+        }
+        commands = {
+            label: probe["available"] for label, probe in command_probes.items()
+        }
+        command_failures = {
+            label: probe["failure"]
+            for label, probe in command_probes.items()
+            if probe["failure"] is not None
         }
         missing_modules = sorted(
             name for name, available in modules.items() if not available
@@ -423,6 +517,12 @@ def build_report(
                 if import_name in REQUIRED_MODULE_VERSIONS
             },
             "commands": commands,
+            "command_failures": command_failures,
+            "required_command_versions": (
+                {"yt-dlp": YTDLP_REQUIRED_VERSION}
+                if "yt-dlp" in requirements["commands"]
+                else {}
+            ),
             "missing_modules": missing_modules,
             "missing_commands": missing_commands,
         }

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -25,7 +25,7 @@ Sources, in order:
 Usage:
     fetch-transcript.py <video-id-or-url> --out <path> [--languages en,ru,he]
                         [--method auto|captions|whisper] [--force]
-                        [--existing-source youtube_auto|whisper|manual|unknown]
+                        [--existing-source youtube_auto|provider_auto|whisper|manual|unknown]
                         [--duration-seconds N] [--min-words N]
     fetch-transcript.py <label> --audio <file> --out <path>   # non-YouTube talk
 
@@ -106,6 +106,7 @@ from transcript_quality import (
     receipt_matches_media_digest,
     validate_transcript,
 )
+from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
 
 __all__ = ["VTT_TIMING_TAG", "write_atomically"]
 
@@ -340,13 +341,16 @@ def _positive_duration(value: object) -> float | None:
     return normalize_duration(value)
 
 
-def probe_youtube_duration(video_id: str) -> tuple[float | None, str]:
+def probe_youtube_duration(
+    video_id: str, *, ytdlp: str | Path | None = None
+) -> tuple[float | None, str]:
     """Read source-owned duration for one exact YouTube identity via yt-dlp."""
     url = f"https://www.youtube.com/watch?v={video_id}"
     try:
+        executable = Path(ytdlp) if ytdlp is not None else resolve_ytdlp()
         completed = subprocess.run(
             [
-                "yt-dlp",
+                str(executable),
                 "--dump-single-json",
                 "--skip-download",
                 "--no-playlist",
@@ -355,10 +359,10 @@ def probe_youtube_duration(video_id: str) -> tuple[float | None, str]:
             capture_output=True,
             text=True,
         )
-    except (FileNotFoundError, OSError) as exc:
+    except (YtDlpResolutionError, OSError) as exc:
         return None, (
-            f"cannot probe trusted YouTube duration ({exc}) — install yt-dlp "
-            "with `brew install yt-dlp` or `pip install yt-dlp`"
+            f"cannot probe trusted YouTube duration ({exc}) — install the pinned "
+            "yt-dlp with `pip install .` or set YT_DLP to its path"
         )
     if completed.returncode != 0:
         detail = completed.stderr.strip()[:400] or "provider metadata unavailable"
@@ -656,12 +660,21 @@ def _transcribe_audio_with_mlx(
 
 
 def fetch_whisper(
-    video_id: str, work_dir: str, model: str
+    video_id: str,
+    work_dir: str,
+    model: str,
+    *,
+    ytdlp: str | Path | None = None,
 ) -> tuple[str | None, str | None, Iterable[object] | None]:
     """Download audio and return Whisper text, language, and timed segments."""
     url = f"https://www.youtube.com/watch?v={video_id}"
     audio: Path | None = None
     failures: list[str] = []
+    try:
+        executable = Path(ytdlp) if ytdlp is not None else resolve_ytdlp()
+    except YtDlpResolutionError as exc:
+        print(str(exc), file=sys.stderr)
+        return None, None, None
     # Each attempt downloads into its own directory. Sharing one path let a
     # refused attempt leave a partial file behind, and the next attempt's
     # "did the audio appear" check would accept those bytes as its own success
@@ -671,7 +684,7 @@ def fetch_whisper(
         attempt_dir = Path(work_dir) / f"download-{index}"
         attempt_dir.mkdir(parents=True, exist_ok=True)
         command = [
-            "yt-dlp",
+            str(executable),
             "-x",
             "--audio-format",
             "mp3",
@@ -690,8 +703,8 @@ def fetch_whisper(
             # emitting it is the same silent-failure shape the whole file
             # exists to prevent.
             print(
-                f"cannot run yt-dlp ({exc}) — install it with "
-                "`brew install yt-dlp` or `pip install yt-dlp`",
+                f"cannot run yt-dlp ({exc}) — install the pinned version with "
+                "`pip install .` or set YT_DLP to its path",
                 file=sys.stderr,
             )
             return None, None, None
@@ -1105,7 +1118,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
     )
     parser.add_argument(
         "--existing-source",
-        choices=("youtube_auto", "whisper", "manual", "unknown"),
+        choices=("youtube_auto", "provider_auto", "whisper", "manual", "unknown"),
         default="unknown",
         help=(
             "owner-recorded provenance of an existing transcript; only "

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -64,13 +64,15 @@ PATTERN_EVIDENCE_SCHEMA_VERSION = 2
 SOURCE_LOCATED_RETURN_SCHEMA_VERSION = 4
 EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION = 5
 WEIGHTED_SCORE_RETURN_SCHEMA_VERSION = 6
-# v6 canonicalizes as of the activation (#299): persistence, the talk schema
-# bump, the claim contract, and the migration moved together.
+PROVIDER_AUTO_RETURN_SCHEMA_VERSION = 7
+# v6 canonicalizes as of the activation (#299), and v7 keeps that evidence
+# contract while widening transcript provenance.
 CANONICALIZABLE_RETURN_SCHEMA_VERSIONS = frozenset(
     {
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
         EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+        PROVIDER_AUTO_RETURN_SCHEMA_VERSION,
     }
 )
 # Every generation carrying exhaustive outcomes and applicability assessments.
@@ -82,6 +84,7 @@ EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS = frozenset(
     {
         EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+        PROVIDER_AUTO_RETURN_SCHEMA_VERSION,
     }
 )
 # The scoring generation whose aggregate is confidence-weighted, and so MAY be
@@ -1615,7 +1618,12 @@ def build_evidence_context(
     transcript_policy_bound = False
     canonical_transcript_source: str | None = None
     recorded_transcript_source = talk.get("transcript_source")
-    if recorded_transcript_source in {"youtube_auto", "whisper", "manual"}:
+    if recorded_transcript_source in {
+        "youtube_auto",
+        "provider_auto",
+        "whisper",
+        "manual",
+    }:
         canonical_transcript_source = cast(str, recorded_transcript_source)
     timing_owner_source = canonical_transcript_source or "unknown"
     timing_owner_duration = _catalog_duration(talk)
@@ -3374,7 +3382,7 @@ def canonicalize_return_evidence(
     pattern_scoring_schema_version: int = CURRENT_PATTERN_SCORING_SCHEMA_VERSION,
     video_evidence_assessment: VideoEvidenceAssessment | None = None,
 ) -> dict[str, object]:
-    """Return a v4/v5 payload with source claims canonically located."""
+    """Return a source-located payload with source claims canonicalized."""
     canonical = copy.deepcopy(dict(ret))
     return_schema_version = canonical.get("return_schema_version")
     if return_schema_version not in CANONICALIZABLE_RETURN_SCHEMA_VERSIONS:
@@ -3396,7 +3404,12 @@ def canonicalize_return_evidence(
     )
     if context.get("transcript_text") is not None:
         canonical_transcript_source = context.get("canonical_transcript_source")
-        if canonical_transcript_source not in {"youtube_auto", "whisper", "manual"}:
+        if canonical_transcript_source not in {
+            "youtube_auto",
+            "provider_auto",
+            "whisper",
+            "manual",
+        }:
             raise PatternEvidenceError(
                 "validated transcript has no machine receipt or pre-registered "
                 "transcript_source provenance"

--- a/skills/vault-ingress/scripts/persist-results.py
+++ b/skills/vault-ingress/scripts/persist-results.py
@@ -183,7 +183,9 @@ def normalize_stamp(value):
 # clear semantics. Existing readers ignore the new metadata; older records stay
 # readable and acquire generation identity on their next validated analysis. The
 # two historical v3 lineages are unified by v4's source-located evidence ledger.
-# V5 adds exhaustive applicability/outcome state and opportunity identity. The
+# V5 adds exhaustive applicability/outcome state and opportunity identity. V6
+# adds weighted scoring, v7 the title-equivalence generation, and v8 the
+# provider-auto transcript-source value. The
 # shared constant lives in ingress_contract.py so readers reject future records
 # against the same boundary this owner migrates.
 
@@ -306,7 +308,7 @@ def merge_structured_v2(existing, incoming):
 
 
 def merge_verbatim_v2(existing, incoming):
-    """Snapshot-replace each supplied v2–v5 verbatim lane, including []."""
+    """Snapshot-replace each supplied v2–v7 verbatim lane, including []."""
     validate_verbatim_examples(incoming, reject_unknown=True)
     merged = copy.deepcopy(existing)
     for field, value in incoming.items():
@@ -341,7 +343,7 @@ def _sync_v2_promotions(talk, incoming_structured):
 def validate_effective_v2_state(
     talk, incoming_structured, *, pattern_snapshot_replaced
 ):
-    """Validate a post-v2–v5 snapshot candidate before publication."""
+    """Validate a post-v2–v7 snapshot candidate before publication."""
     validate_talk_record_schemas([talk])
     try:
         validate_persisted_v2_analysis_state(talk)
@@ -704,7 +706,7 @@ def merge_talk(
     if return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS:
         # Validate persisted block types before a clear could conceal malformed
         # structured state, then apply every operation to the isolated candidate.
-        # Verbatim and pattern blocks are supplied snapshots in every valid v2–v5
+        # Verbatim and pattern blocks are supplied snapshots in every valid v2–v7
         # analysis, so they may repair legacy array containers atomically.
         require_stored_mapping(candidate, "structured_data")
 

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -93,6 +93,7 @@ from tracking_database import (
     CONFIG_RECORD_SCHEMA_VERSION,
     LEGACY_CONFIG_RECORD_SCHEMA_VERSION,
     PPTX_EVIDENCE_CURRENT,
+    TALK_RECORD_SCHEMA_VERSION,
     TrackingDatabaseConfigExclusionsError,
     TrackingDatabaseError,
     assess_tracking_database,
@@ -128,7 +129,12 @@ _DATABASE_READ_FALLBACK = DATABASE_READ_FALLBACK
 
 
 SOURCE_IDENTITY_SCHEMA_VERSION = 1
-TRANSCRIPT_SOURCES = frozenset({"youtube_auto", "whisper", "manual", "none"})
+PRE_PROVIDER_AUTO_TRANSCRIPT_SOURCES = frozenset(
+    {"youtube_auto", "whisper", "manual", "none"}
+)
+TRANSCRIPT_SOURCES = frozenset(
+    {"youtube_auto", "provider_auto", "whisper", "manual", "none"}
+)
 # A markdown-authored deck (Slidev, presenterm, Marp, reveal-md, remark).
 # Admitted as PROVENANCE, deliberately absent from USABLE_SLIDE_SOURCES: the
 # deck exists and the record says so, but nothing here renders markdown, so it
@@ -777,9 +783,14 @@ class VaultPreflight:
     def _validate_sources(self, index: int) -> None:
         talk = self.talks[index]
         transcript_source = talk.get("transcript_source")
+        allowed_transcript_sources = (
+            TRANSCRIPT_SOURCES
+            if talk.get("schema_version") == TALK_RECORD_SCHEMA_VERSION
+            else PRE_PROVIDER_AUTO_TRANSCRIPT_SOURCES
+        )
         if transcript_source is not None and (
             not isinstance(transcript_source, str)
-            or transcript_source not in TRANSCRIPT_SOURCES
+            or transcript_source not in allowed_transcript_sources
         ):
             self.talk_add(
                 index,
@@ -787,7 +798,7 @@ class VaultPreflight:
                 "transcript_source_unsupported",
                 "transcript_source is outside the supported enum",
                 field="transcript_source",
-                expected=sorted(TRANSCRIPT_SOURCES),
+                expected=sorted(allowed_transcript_sources),
                 actual=transcript_source,
             )
 

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -29,24 +29,26 @@ when state changed.
 
 Claim schema (owned by this script; stored in ``talk._queue_claim``):
     {
-      "schema_version": 6,
+      "schema_version": 7,
       "run_id": "reparse-2026-07",
       "batch_id": "25",
       "claimed_at": "2026-07-31T18:00:00+00:00",
       "previous_status": "needs-reprocessing",
       "reprocess_generation": 2,
       "state": "claimed",
-      "required_return_schema_version": 6,
+      "required_return_schema_version": 7,
       "adherence_baseline": {"schema_version": 2, "...": "..."}
     }
 
-Fresh claims always use schema v6 and require return v6 — the weighted scoring
-generation. The queue snapshots one baseline before mutating the selected talks,
+Fresh claims always use schema v7 and require return v7. Return v7 keeps the
+weighted scoring generation and adds provider-auto transcript provenance. The
+queue snapshots one baseline before mutating the selected talks,
 excludes the exact active batch, and copies the same immutable payload to every
 member. Schema-v1/v2 claims are accepted only for compatibility and authorize
 return v1/v2; schema-v3 claims authorize only return v3, schema-v4 claims
-authorize only archival return v4, and schema-v5 claims authorize only return
-v5. None of them authorizes v6 or is newly issued.
+authorize only archival return v4, schema-v5 claims authorize only return v5,
+and schema-v6 claims authorize only return v6. None of them authorizes v7
+or is newly issued.
 
 Stale recovery adds ``released_at`` and ``release_reason`` and changes ``state``
 to ``stale_recovered``. A later generation moves the prior claim to

--- a/skills/vault-ingress/scripts/queue_claim_contract.py
+++ b/skills/vault-ingress/scripts/queue_claim_contract.py
@@ -27,7 +27,7 @@ from adherence_baseline import (
 )
 
 
-CURRENT_QUEUE_CLAIM_SCHEMA_VERSION = 6
+CURRENT_QUEUE_CLAIM_SCHEMA_VERSION = 7
 LEGACY_QUEUE_CLAIM_SCHEMA_VERSION = 1
 RECEIPT_QUEUE_CLAIM_SCHEMA_VERSION = 2
 ADHERENCE_QUEUE_CLAIM_SCHEMA_VERSION = 3
@@ -538,7 +538,7 @@ def validate_queue_claim_database(
 def _validate_adherence_claim_batches(
     talks: Sequence[Mapping[str, object]],
 ) -> None:
-    """Require every stored v3/v4/v5 batch snapshot to be exact and shared."""
+    """Require every stored v3-v7 batch snapshot to be exact and shared."""
     current_batches: dict[
         tuple[object, object], list[tuple[str, Mapping[str, object]]]
     ] = {}

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -115,7 +115,10 @@ SLIDE_SOURCES = frozenset(
 # The complement of `pattern_evidence.USABLE_SLIDE_SOURCES` within
 # SLIDE_SOURCES, pinned by a test so the two cannot drift apart.
 SLIDE_SOURCES_WITHOUT_READABLE_SLIDES = frozenset({"none", "markdown"})
-TRANSCRIPT_SOURCES = frozenset({"youtube_auto", "whisper", "manual", "none"})
+PRE_PROVIDER_AUTO_TRANSCRIPT_SOURCES = frozenset(
+    {"youtube_auto", "whisper", "manual", "none"}
+)
+TRANSCRIPT_SOURCES = PRE_PROVIDER_AUTO_TRANSCRIPT_SOURCES | {"provider_auto"}
 CONFIDENCE_LEVELS = frozenset({"strong", "moderate", "weak"})
 EVIDENCE_SOURCE_ORDER = (
     "static_slides",
@@ -275,7 +278,7 @@ SUBSTANTIVE_PROSE_FIELDS = frozenset(
 LANGUAGE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$")
 CONDITION_ID_RE = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
 VIDEO_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-QUEUE_CLAIM_SCHEMA_VERSION = 6
+QUEUE_CLAIM_SCHEMA_VERSION = 7
 SOURCE_LOCATED_QUEUE_CLAIM_SCHEMA_VERSION = 4
 BASELINE_QUEUE_CLAIM_SCHEMA_VERSION = 3
 PREVIOUS_QUEUE_CLAIM_SCHEMA_VERSION = 2
@@ -289,12 +292,13 @@ EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION = 5
 # contract stands, because that is the arithmetic its worker used. v6 keeps
 # every v5 semantic and adds weighting, so it joins each set v5 belongs to.
 WEIGHTED_SCORE_RETURN_SCHEMA_VERSION = 6
+PROVIDER_AUTO_RETURN_SCHEMA_VERSION = 7
 # The generation a fresh claim issues, derived rather than written. Every set
 # below names the generation it means; if they named THIS pointer instead,
 # advancing it would silently drop the generation it used to point at from
 # each of those sets — a validation set that quietly stops accepting v5 the
 # moment v6 becomes current.
-RETURN_SCHEMA_VERSION = WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
+RETURN_SCHEMA_VERSION = PROVIDER_AUTO_RETURN_SCHEMA_VERSION
 SUPPORTED_RETURN_SCHEMA_VERSIONS = frozenset(
     {
         LEGACY_RETURN_SCHEMA_VERSION,
@@ -303,6 +307,7 @@ SUPPORTED_RETURN_SCHEMA_VERSIONS = frozenset(
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
         EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+        PROVIDER_AUTO_RETURN_SCHEMA_VERSION,
     }
 )
 SNAPSHOT_RETURN_SCHEMA_VERSIONS = frozenset(
@@ -312,6 +317,7 @@ SNAPSHOT_RETURN_SCHEMA_VERSIONS = frozenset(
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
         EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+        PROVIDER_AUTO_RETURN_SCHEMA_VERSION,
     }
 )
 OUTCOME_GATE_RETURN_SCHEMA_VERSIONS = frozenset(
@@ -320,6 +326,7 @@ OUTCOME_GATE_RETURN_SCHEMA_VERSIONS = frozenset(
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
         EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+        PROVIDER_AUTO_RETURN_SCHEMA_VERSION,
     }
 )
 SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS = frozenset(
@@ -327,17 +334,22 @@ SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS = frozenset(
         SOURCE_LOCATED_RETURN_SCHEMA_VERSION,
         EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
         WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+        PROVIDER_AUTO_RETURN_SCHEMA_VERSION,
     }
 )
 EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSIONS = frozenset(
-    {EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION, WEIGHTED_SCORE_RETURN_SCHEMA_VERSION}
+    {
+        EXHAUSTIVE_OUTCOME_RETURN_SCHEMA_VERSION,
+        WEIGHTED_SCORE_RETURN_SCHEMA_VERSION,
+        PROVIDER_AUTO_RETURN_SCHEMA_VERSION,
+    }
 )
 # The returns whose aggregate is weighted, and which therefore carry a
 # `pattern_score_basis`. Separate from the exhaustive-outcome set because the two
 # properties are independent: v5 is exhaustive and flat, v6 is exhaustive and
 # weighted, and a later schema could be one without the other.
 WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS = frozenset(
-    {WEIGHTED_SCORE_RETURN_SCHEMA_VERSION}
+    {WEIGHTED_SCORE_RETURN_SCHEMA_VERSION, PROVIDER_AUTO_RETURN_SCHEMA_VERSION}
 )
 
 FLAT_PATTERN_SCORING_SCHEMA_VERSION = 5
@@ -2522,7 +2534,8 @@ def _validate_source_inspection(
     if return_schema_version not in SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS:
         if inspection is not None:
             raise ReturnValidationError(
-                "source_inspection is supported only by return schemas v4/v5"
+                "source_inspection is supported only by return schemas "
+                f"{sorted(SOURCE_LOCATED_RETURN_SCHEMA_VERSIONS)}"
             )
         return
     if not isinstance(inspection, list) or not inspection:
@@ -3046,7 +3059,8 @@ def _validate_adherence_comparison(
     if return_schema_version not in OUTCOME_GATE_RETURN_SCHEMA_VERSIONS:
         if "adherence_comparison" in ret:
             raise ReturnValidationError(
-                "adherence_comparison is supported only by return schemas v3/v4/v5"
+                "adherence_comparison is supported only by return schemas "
+                f"{sorted(OUTCOME_GATE_RETURN_SCHEMA_VERSIONS)}"
             )
         return
     if comparison is None:
@@ -4869,6 +4883,11 @@ def validate_return(ret, catalog: PatternCatalog | None = None) -> None:
     slides_local_path = _validate_slides_local_path(ret)
 
     transcript_source = ret.get("transcript_source")
+    allowed_transcript_sources = (
+        TRANSCRIPT_SOURCES
+        if return_schema_version == PROVIDER_AUTO_RETURN_SCHEMA_VERSION
+        else PRE_PROVIDER_AUTO_TRANSCRIPT_SOURCES
+    )
     if "transcript_path" in ret:
         try:
             validate_transcript_path(ret["transcript_path"])
@@ -4877,20 +4896,21 @@ def validate_return(ret, catalog: PatternCatalog | None = None) -> None:
     if (
         return_schema_version in SNAPSHOT_RETURN_SCHEMA_VERSIONS
         and "transcript_source" in ret
-        and transcript_source not in TRANSCRIPT_SOURCES
+        and transcript_source not in allowed_transcript_sources
     ):
         raise ReturnValidationError(
             "snapshot return transcript_source must be omitted when provenance "
-            f"is unknown or be one of {sorted(TRANSCRIPT_SOURCES)}, got "
+            f"is unknown or be one of {sorted(allowed_transcript_sources)}, got "
             f"{transcript_source!r}"
         )
     if (
         return_schema_version not in SNAPSHOT_RETURN_SCHEMA_VERSIONS
         and transcript_source is not None
-        and transcript_source not in TRANSCRIPT_SOURCES
+        and transcript_source not in allowed_transcript_sources
     ):
         raise ReturnValidationError(
-            f"transcript_source must be one of {sorted(TRANSCRIPT_SOURCES)}, "
+            "transcript_source must be one of "
+            f"{sorted(allowed_transcript_sources)}, "
             f"got {transcript_source!r}"
         )
 

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -43,7 +43,10 @@ FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION = 5
 PRE_TITLE_EQUIVALENCE_TALK_RECORD_SCHEMA_VERSION = 6
 # The weighted generation's record shape (#299): `pattern_observations` may
 # carry a `pattern_score_basis` and `pattern_score` may be fractional.
-TALK_RECORD_SCHEMA_VERSION = 7
+PRE_PROVIDER_AUTO_TALK_RECORD_SCHEMA_VERSION = 7
+# The provider-auto generation adds the non-YouTube automatic-caption
+# provenance value. Older record generations retain their closed enum.
+TALK_RECORD_SCHEMA_VERSION = 8
 LEGACY_CONFIG_RECORD_SCHEMA_VERSION = 1
 CONFIG_RECORD_SCHEMA_VERSION = 2
 LEGACY_PPTX_CATALOG_RECORD_SCHEMA_VERSION = 1
@@ -1689,6 +1692,7 @@ _RESTAMPABLE_TALK_RECORD_SCHEMA_VERSIONS = frozenset(
     {
         FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION,
         PRE_TITLE_EQUIVALENCE_TALK_RECORD_SCHEMA_VERSION,
+        PRE_PROVIDER_AUTO_TALK_RECORD_SCHEMA_VERSION,
     }
 )
 
@@ -1779,10 +1783,11 @@ def _restamp_talk_records(candidate: dict[str, Any]) -> int:
 
     v6 to v7 (#333) was introduced for an owner ledger that has since moved to
     its own top-level collection, so v7 adds no field a v6 record lacks and the
-    restamp carries it forward untouched. Only records already holding the
-    analysis v7 implies are restampable; an earlier generation reaches the
-    current shape by being reanalysed, never by being stamped, which is why this
-    set is not simply "every version below current".
+    restamp carries it forward untouched. V8 widens only transcript provenance,
+    so a v7 record carries forward without relabeling its source. Only records
+    already holding the analysis v7 implies are restampable; an earlier
+    generation reaches the current shape by being reanalysed, never by being
+    stamped, which is why this set is not simply "every version below current".
     """
     talks = candidate.get("talks")
     if not isinstance(talks, list):
@@ -1793,6 +1798,11 @@ def _restamp_talk_records(candidate: dict[str, Any]) -> int:
             continue
         if talk.get("schema_version") not in _RESTAMPABLE_TALK_RECORD_SCHEMA_VERSIONS:
             continue
+        if talk.get("transcript_source") == "provider_auto":
+            raise TrackingDatabaseError(
+                "provider_auto transcript provenance requires talk schema v8; "
+                "correct the legacy record source before rerunning migration"
+            )
         talk["schema_version"] = TALK_RECORD_SCHEMA_VERSION
         restamped += 1
     return restamped

--- a/skills/vault-ingress/scripts/transcript_timing.py
+++ b/skills/vault-ingress/scripts/transcript_timing.py
@@ -74,7 +74,7 @@ TIMING_PROVENANCE_KINDS = frozenset(
     {"youtube_captions", "youtube_whisper", "local_media_whisper", "vtt_artifact"}
 )
 TIMING_OWNER_SOURCES = frozenset(
-    {"youtube_auto", "whisper", "manual", "unknown", "vtt"}
+    {"youtube_auto", "provider_auto", "whisper", "manual", "unknown", "vtt"}
 )
 # A caption cue carries display time, not speech time, so the final cue
 # routinely outlives the recording by a second or two. Measured across a

--- a/skills/vault-ingress/scripts/ytdlp_runtime.py
+++ b/skills/vault-ingress/scripts/ytdlp_runtime.py
@@ -1,0 +1,82 @@
+"""Resolve the yt-dlp console script declared by the toolkit runtime.
+
+The project pins yt-dlp as a Python dependency. A bare ``yt-dlp`` subprocess
+still resolves through ``PATH``, where an older system installation can shadow
+that pin. Keep every caller on one resolution order: explicit override, the
+running interpreter, its active virtual environment, the toolkit virtual
+environment, then ``PATH`` as a compatibility fallback.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import sys
+
+
+YTDLP_REQUIRED_VERSION = "2026.8.19"
+YTDLP_RESOLUTION_FAILURE_CODES = frozenset(
+    {
+        "ytdlp_override_invalid",
+        "ytdlp_not_found",
+        "ytdlp_version_unavailable",
+    }
+)
+
+
+class YtDlpResolutionError(RuntimeError):
+    """No usable yt-dlp executable, with a typed recovery code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        if code not in YTDLP_RESOLUTION_FAILURE_CODES:
+            raise ValueError("invalid yt-dlp resolution failure code")
+        super().__init__(message)
+        self.code = code
+
+
+def resolve_ytdlp() -> Path:
+    """Return the pinned yt-dlp console script before consulting ``PATH``."""
+    override = os.environ.get("YT_DLP")
+    if override:
+        candidate = Path(override)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+        raise YtDlpResolutionError(
+            "ytdlp_override_invalid",
+            f"YT_DLP is set to {override!r}, which is not an executable file — "
+            "point it at a yt-dlp binary or unset it",
+        )
+
+    candidates = [Path(sys.executable).parent / "yt-dlp"]
+    virtual_env = os.environ.get("VIRTUAL_ENV")
+    if virtual_env:
+        candidates.append(Path(virtual_env) / "bin" / "yt-dlp")
+    toolkit_root = Path(__file__).resolve().parents[3]
+    candidates.append(toolkit_root / ".venv" / "bin" / "yt-dlp")
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+
+    found = shutil.which("yt-dlp")
+    if found:
+        return Path(found)
+    raise YtDlpResolutionError(
+        "ytdlp_not_found",
+        "cannot find yt-dlp — install the pinned version with `pip install .` "
+        "into the toolkit environment, or set YT_DLP to its path",
+    )
+
+
+def normalized_ytdlp_version(value: str) -> tuple[int, int, int] | None:
+    """Normalize yt-dlp's calendar version without an external parser."""
+    parts = value.strip().split(".")
+    if len(parts) != 3 or any(not part.isdecimal() for part in parts):
+        return None
+    year, month, day = (int(part) for part in parts)
+    return year, month, day

--- a/skills/vault-ingress/scripts/ytdlp_runtime.py
+++ b/skills/vault-ingress/scripts/ytdlp_runtime.py
@@ -15,6 +15,10 @@ import shutil
 import sys
 
 
+# Dependabot renews the pyproject.toml pin weekly. Every such manifest update
+# must renew this runtime mirror in the same PR;
+# tests/test_check_runtime.py::test_ytdlp_version_authority_is_synchronized
+# enforces that the two pins stay identical.
 YTDLP_REQUIRED_VERSION = "2026.8.19"
 YTDLP_RESOLUTION_FAILURE_CODES = frozenset(
     {

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -498,11 +499,12 @@ def test_yt_dlp_fetch_is_dependency_injected_and_download_free(audit_source_iden
     result = audit_source_identities.fetch_youtube_metadata(
         VIDEO_ID,
         runner=runner,
+        ytdlp=Path("/runtime/bin/yt-dlp"),
     )
 
     assert result["id"] == VIDEO_ID
     command, kwargs = calls[0]
-    assert command[0] == "yt-dlp"
+    assert command[0] == "/runtime/bin/yt-dlp"
     assert "--skip-download" in command
     assert "--no-playlist" in command
     assert command[-1].endswith(VIDEO_ID)

--- a/tests/test_build_score_basis.py
+++ b/tests/test_build_score_basis.py
@@ -97,6 +97,19 @@ def test_a_non_array_lane_is_rejected(build_score_basis):
         build_score_basis.basis_for(broken, "talk.md")
 
 
+def test_a_missing_required_lane_is_rejected(build_score_basis, tmp_path, capsys):
+    for missing in ("patterns_detected", "antipatterns_detected", "not_evaluable"):
+        broken = _return()
+        del broken["pattern_observations"][missing]
+        path = tmp_path / f"missing-{missing}.json"
+        path.write_text(json.dumps(broken), encoding="utf-8")
+
+        assert build_score_basis.main([str(path)]) == 2
+        captured = capsys.readouterr()
+        assert f"pattern_observations.{missing} is required" in captured.err
+        assert captured.out == ""
+
+
 def test_cli_emits_the_completed_return(build_score_basis, tmp_path, capsys):
     """Output is the return itself, so no caller computes or places either field."""
     path = tmp_path / "r.json"

--- a/tests/test_build_score_basis.py
+++ b/tests/test_build_score_basis.py
@@ -98,7 +98,7 @@ def test_a_non_array_lane_is_rejected(build_score_basis):
 
 
 def test_cli_emits_the_completed_return(build_score_basis, tmp_path, capsys):
-    """Output is the return itself, so no caller decides where the field goes."""
+    """Output is the return itself, so no caller computes or places either field."""
     path = tmp_path / "r.json"
     path.write_text(
         json.dumps(_return(patterns=[_detection("moderate")])), encoding="utf-8"
@@ -106,6 +106,7 @@ def test_cli_emits_the_completed_return(build_score_basis, tmp_path, capsys):
     assert build_score_basis.main([str(path)]) == 0
     printed = json.loads(capsys.readouterr().out)
     assert printed["filename"] == "talk.md"
+    assert printed["pattern_observations"]["pattern_score"] == 0.5
     assert (
         printed["pattern_observations"]["pattern_score_basis"]["patterns"]["moderate"]
         == 1
@@ -123,10 +124,25 @@ def test_cli_emits_an_array_for_several_returns(build_score_basis, tmp_path, cap
 
 
 def test_the_input_return_is_not_mutated(build_score_basis):
-    """A caller reusing its own object must not find a field it did not add."""
+    """A caller reusing its own object must not find fields it did not add."""
     original = _return(patterns=[_detection("strong")])
     build_score_basis.completed(original, "talk.md")
+    assert "pattern_score" not in original["pattern_observations"]
     assert "pattern_score_basis" not in original["pattern_observations"]
+
+
+def test_completed_overwrites_a_worker_supplied_score_from_owner_math(
+    build_score_basis,
+):
+    ret = _return(
+        patterns=[_detection("strong"), _detection("moderate")],
+        antipatterns=[_detection("weak")],
+    )
+    ret["pattern_observations"]["pattern_score"] = 999
+
+    completed = build_score_basis.completed(ret, "talk.md")
+
+    assert completed["pattern_observations"]["pattern_score"] == 1.25
 
 
 def test_a_malformed_detection_exits_two_without_a_traceback(

--- a/tests/test_check_runtime.py
+++ b/tests/test_check_runtime.py
@@ -24,6 +24,8 @@ SCRIPT = (
     / "scripts"
     / "check-runtime.py"
 )
+if str(SCRIPT.parent) not in sys.path:
+    sys.path.insert(0, str(SCRIPT.parent))
 SPEC = importlib.util.spec_from_file_location("check_runtime", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 check_runtime = importlib.util.module_from_spec(SPEC)
@@ -1080,13 +1082,14 @@ def test_outer_boundary_emits_one_json_failure_for_unexpected_probe_fault(
 def test_lane_requirements_match_the_configured_interpreter_contract() -> None:
     requirements = check_runtime.LANE_REQUIREMENTS
 
-    assert check_runtime.REPORT_SCHEMA_VERSION == 2
+    assert check_runtime.REPORT_SCHEMA_VERSION == 3
     assert check_runtime.MODULE_PROBE_SCHEMA_VERSION == 1
     assert check_runtime.PSUTIL_REQUIRED_VERSION == "7.2.2"
     assert check_runtime.FILELOCK_REQUIRED_VERSION == "3.32.2"
     assert check_runtime.IMAGEHASH_REQUIRED_VERSION == "4.3.2"
     assert check_runtime.NUMPY_REQUIRED_VERSION == "2.2.6"
     assert check_runtime.PILLOW_REQUIRED_VERSION == "12.3.0"
+    assert check_runtime.YTDLP_REQUIRED_VERSION == "2026.8.19"
     assert check_runtime.REQUIRED_MODULE_VERSIONS == {
         "PIL": "12.3.0",
         "filelock": "3.32.2",
@@ -1163,6 +1166,71 @@ def test_psutil_version_authorities_are_synchronized() -> None:
         artifact_supervisor.PSUTIL_REQUIRED_VERSION
         == check_runtime.PSUTIL_REQUIRED_VERSION
     )
+
+
+def test_ytdlp_version_authority_is_synchronized() -> None:
+    manifest = PYPROJECT.read_text(encoding="utf-8")
+    manifest_versions = re.findall(
+        r'^\s*"yt-dlp==([^"\s]+)",\s*$',
+        manifest,
+        flags=re.MULTILINE,
+    )
+
+    assert manifest_versions == [check_runtime.YTDLP_REQUIRED_VERSION]
+
+
+def test_ytdlp_probe_accepts_the_pinned_zero_padded_version(monkeypatch) -> None:
+    monkeypatch.setattr(
+        check_runtime, "resolve_ytdlp", lambda: Path("/runtime/bin/yt-dlp")
+    )
+
+    probe = check_runtime._probe_command(
+        "yt-dlp",
+        "yt-dlp",
+        runner=lambda command, **kwargs: subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="2026.08.19\n",
+            stderr="",
+        ),
+    )
+
+    assert probe == {"available": True, "failure": None}
+
+
+def test_stale_ytdlp_version_degrades_the_download_lane(monkeypatch) -> None:
+    monkeypatch.setattr(
+        check_runtime, "_probe_module", lambda _name: _available_probe()
+    )
+    monkeypatch.setattr(
+        check_runtime, "resolve_ytdlp", lambda: Path("/runtime/bin/yt-dlp")
+    )
+    monkeypatch.setattr(
+        check_runtime.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="2026.06.09\n",
+            stderr="",
+        ),
+    )
+
+    report = check_runtime.build_report(("youtube-download",), ("core",))
+    lane = report["lanes"]["youtube-download"]
+
+    assert lane["available"] is False
+    assert lane["commands"] == {"yt-dlp": False}
+    assert lane["missing_commands"] == ["yt-dlp"]
+    assert lane["required_command_versions"] == {"yt-dlp": "2026.8.19"}
+    assert lane["command_failures"] == {
+        "yt-dlp": {
+            "reason": "incompatible_version",
+            "required_version": "2026.8.19",
+            "actual_version": "2026.06.09",
+        }
+    }
+    assert report["degraded_lanes"] == ["youtube-download"]
 
 
 def test_video_dependency_version_authorities_are_synchronized() -> None:

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -344,6 +344,38 @@ def test_a_refused_attempt_that_left_bytes_behind_is_not_reused(
     assert transcribed == [b"real-audio"], "the failure's bytes must never be read"
 
 
+def test_whisper_download_uses_the_resolved_executable(
+    fetch_transcript, monkeypatch, tmp_path
+):
+    commands: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        target = pathlib.Path(
+            command[command.index("-o") + 1].replace("%(ext)s", "mp3")
+        )
+        target.write_bytes(b"audio")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "transcribe_audio",
+        lambda *_args: ("spoken words here", "en", None),
+    )
+
+    executable = tmp_path / "runtime" / "yt-dlp"
+    text, _language, _segments = fetch_transcript.fetch_whisper(
+        "Kl6tLcQ5hGI",
+        str(tmp_path),
+        "tiny",
+        ytdlp=executable,
+    )
+
+    assert text == "spoken words here"
+    assert commands[0][0] == str(executable)
+
+
 def test_a_zero_byte_download_is_not_a_success(fetch_transcript, monkeypatch, tmp_path):
     """An empty artifact is a failed extraction wearing a filename."""
     attempts: list[str | None] = []
@@ -799,14 +831,17 @@ def test_youtube_duration_probe_is_bound_to_the_exact_video_id(
 
     monkeypatch.setattr(fetch_transcript.subprocess, "run", completed)
 
-    duration, reason = fetch_transcript.probe_youtube_duration("eg6gqvUFh6Q")
+    ytdlp = Path("/runtime/bin/yt-dlp")
+    duration, reason = fetch_transcript.probe_youtube_duration(
+        "eg6gqvUFh6Q", ytdlp=ytdlp
+    )
 
     assert duration == 179.625
     assert "trusted yt-dlp duration" in reason
     assert seen == [
         (
             [
-                "yt-dlp",
+                str(ytdlp),
                 "--dump-single-json",
                 "--skip-download",
                 "--no-playlist",
@@ -1903,6 +1938,32 @@ def test_manual_existing_transcript_is_never_relabelled_as_captions(
         "eg6gqvUFh6Q",
         ["en"],
         existing_source="manual",
+    )
+
+    assert timed_path is None
+    assert "not 'youtube_auto'" in reason
+    assert not out.with_suffix(".segments.json").exists()
+
+
+def test_provider_auto_existing_transcript_never_fetches_youtube_captions(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+):
+    out = tmp_path / "provider.txt"
+    existing = _talk(450)
+    out.write_text(existing, encoding="utf-8")
+
+    def must_not_fetch(_video_id, _languages):
+        raise AssertionError("provider captions must not enter the YouTube lane")
+
+    monkeypatch.setattr(fetch_transcript, "fetch_captions", must_not_fetch)
+    timed_path, reason = fetch_transcript.enrich_existing_caption_timing(
+        out,
+        existing,
+        "eg6gqvUFh6Q",
+        ["en"],
+        existing_source="provider_auto",
     )
 
     assert timed_path is None

--- a/tests/test_ingress_adherence_docs.py
+++ b/tests/test_ingress_adherence_docs.py
@@ -1,4 +1,4 @@
-"""Documentation guards for live claim-v5 and archival-v4 adherence."""
+"""Documentation guards for current and archival claim generations."""
 
 import json
 from pathlib import Path
@@ -29,17 +29,17 @@ def test_claim_issuance_is_live_and_version_bound() -> None:
         assert "#157" not in text, f"{name} still carries the temporary issue gate"
         assert "issuance pause" not in text.lower()
 
-    assert '"schema_version": 6' in docs["queue"]
-    assert '"required_return_schema_version": 6' in docs["queue"]
+    assert '"schema_version": 7' in docs["queue"]
+    assert '"required_return_schema_version": 7' in docs["queue"]
     assert '"adherence_baseline": {"schema_version": 2' in docs["queue"]
-    assert "Fresh claims always use schema v6 and require return v6" in docs["queue"]
+    assert "Fresh claims always use schema v7 and require return v7" in docs["queue"]
     assert (
         "Saved claim schemas v1/v2 authorize only return schemas v1/v2"
         in docs["schemas"]
     )
     assert (
         "schema v3 authorizes only v3; schema v4 authorizes only archival v4; "
-        "schema v5\nauthorizes only v5" in docs["schemas"]
+        "schema v5\nauthorizes only v5; schema v6 authorizes only v6" in docs["schemas"]
     )
     assert "Recover a live legacy lease" in docs["worker"]
 
@@ -111,10 +111,7 @@ def test_threshold_and_structured_comparison_contract_is_documented() -> None:
     assert "2–4 punctuation-terminated sentences" in docs["processing"]
     assert "Validators deliberately do not parse prose" in docs["processing"]
     assert "renderer generates this anchor mechanically" in docs["processing"]
-    # schemas-db documents the v5 shape deliberately: the compatibility table
-    # above that example states a v5 return "still validates and still
-    # persists, at the flat scoring generation".
-    assert '"return_schema_version": 5' in docs["schemas"]
+    assert '"return_schema_version": 7' in docs["schemas"]
 
 
 def test_native_picture_render_threshold_is_script_owned() -> None:
@@ -148,7 +145,7 @@ def test_claim_replay_recovery_and_closure_matrix_are_documented() -> None:
         in docs["schemas"]
     )
     assert "Recovery never rewrites a claim snapshot" in docs["schemas"]
-    assert "closes v1 as v2 and closes v2–v5 at\ntheir own versions" in docs["schemas"]
+    assert "closes v1 as v2 and closes v2–v7 at\ntheir own versions" in docs["schemas"]
     assert "receiptless completed v1 claim" in docs["persistence"]
     assert "takes a fresh pre-mutation snapshot" in docs["selection"]
 
@@ -243,7 +240,7 @@ def test_source_located_worker_and_engine_evidence_ownership_is_explicit() -> No
     )
     worker_example = (
         docs["worker"]
-        .split("Minimal processed structure for a fresh v6 claim", 1)[1]
+        .split("Minimal processed structure for a fresh v7 claim", 1)[1]
         .split("```json", 1)[1]
         .split("```", 1)[0]
     )
@@ -286,14 +283,18 @@ def test_claim_return_talk_and_scoring_axes_preserve_archival_v4() -> None:
         "| v4 | v4 only | archival source-located v4 | never current v5 |"
         in docs["schemas"]
     )
-    assert "| v5 | v5 only | v5 | never current v6 |" in docs["schemas"]
+    assert "| v5 | v5 only | migrated v8 | never current v6 |" in docs["schemas"]
     assert (
-        "| v6 | v6 only | v6 | v6 when canonical evidence/outcomes are fresh |"
+        "| v6 | v6 only | migrated v8 | v6 when canonical evidence/outcomes are fresh |"
         in docs["schemas"]
     )
-    assert "Fresh queue work uses claim schema v6" in docs["selection"]
     assert (
-        "only return generation eligible for pattern-scoring schema v6"
+        "| v7 | v7 only | v8 | v6 when canonical evidence/outcomes are fresh |"
+        in docs["schemas"]
+    )
+    assert "Fresh queue work uses claim schema v7" in docs["selection"]
+    assert (
+        "fresh return generation eligible for pattern-scoring schema v6"
         in docs["worker"]
     )
 
@@ -307,7 +308,7 @@ def test_transcript_freshness_revalidates_quality_provenance() -> None:
     assert "transcript_quality_context_drift" in docs["schemas"]
 
 
-def _worker_v6_example() -> dict:
+def _worker_current_example() -> dict:
     """Parse the fenced return example the per-talk workers copy."""
     doc = DOC_PATHS["worker"].read_text(encoding="utf-8")
     marker = '{\n  "filename": "2026-01-01-example.md"'
@@ -318,22 +319,19 @@ def _worker_v6_example() -> dict:
 def test_worker_example_declares_the_version_its_heading_claims(
     return_validation,
 ) -> None:
-    """The block every subagent copies is headed "fresh v6 claim".
+    """The block every subagent copies is headed with the current claim.
 
     It previously declared version 5, which a v6 claim rejects outright, and the
     rejection read as the worker analysing badly rather than the instruction
     being wrong.
     """
-    example = _worker_v6_example()
-    assert (
-        example["return_schema_version"]
-        == return_validation.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
-    )
+    example = _worker_current_example()
+    assert example["return_schema_version"] == return_validation.RETURN_SCHEMA_VERSION
 
 
 def test_worker_example_uses_only_declared_verbatim_lanes(return_validation) -> None:
     """Invented lane names are rejected as unknown snapshot lanes."""
-    example = _worker_v6_example()
+    example = _worker_current_example()
     assert (
         set(example.get("verbatim_examples", {}))
         <= return_validation.VERBATIM_EXAMPLE_FIELDS
@@ -352,7 +350,7 @@ def test_the_documented_flow_turns_the_example_into_a_valid_return() -> None:
     import sys
     import tempfile
 
-    example = _worker_v6_example()
+    example = _worker_current_example()
     assert "pattern_score_basis" not in example["pattern_observations"], (
         "the example must not restate script-owned output"
     )

--- a/tests/test_ingress_adherence_docs.py
+++ b/tests/test_ingress_adherence_docs.py
@@ -23,6 +23,13 @@ def _docs() -> dict[str, str]:
     return {name: path.read_text(encoding="utf-8") for name, path in DOC_PATHS.items()}
 
 
+def _schema_current_return_example() -> dict:
+    text = DOC_PATHS["schemas"].read_text(encoding="utf-8")
+    section = text.split("## Per-Talk Subagent Return Schema", 1)[1]
+    payload = section.split("```json", 1)[1].split("```", 1)[0]
+    return json.loads(payload)
+
+
 def test_claim_issuance_is_live_and_version_bound() -> None:
     docs = _docs()
     for name, text in docs.items():
@@ -112,6 +119,16 @@ def test_threshold_and_structured_comparison_contract_is_documented() -> None:
     assert "Validators deliberately do not parse prose" in docs["processing"]
     assert "renderer generates this anchor mechanically" in docs["processing"]
     assert '"return_schema_version": 7' in docs["schemas"]
+
+
+def test_schema_worker_example_delegates_weighted_score_completion() -> None:
+    schemas = _docs()["schemas"]
+    example = _schema_current_return_example()
+
+    assert "pattern_score" not in example["pattern_observations"]
+    assert "pattern_score_basis" not in example["pattern_observations"]
+    assert "scripts/build-score-basis.py" in schemas
+    assert "inserts `pattern_score` and `pattern_score_basis`" in schemas
 
 
 def test_native_picture_render_threshold_is_script_owned() -> None:

--- a/tests/test_ingress_adherence_docs.py
+++ b/tests/test_ingress_adherence_docs.py
@@ -341,16 +341,19 @@ def test_worker_example_uses_only_declared_verbatim_lanes(return_validation) -> 
 def test_the_documented_flow_turns_the_example_into_a_valid_return() -> None:
     """Example plus basis builder must equal something the validator accepts.
 
-    The block deliberately omits `pattern_score_basis`; the reference tells the
-    worker to generate it. This exercises that sequence end to end, so the
-    documented flow is what is under test rather than a copy of the script's
-    output pasted into the page.
+    The block deliberately omits `pattern_score` and `pattern_score_basis`; the
+    reference tells the worker to generate both. This exercises that sequence
+    end to end, so the documented flow is what is under test rather than a copy
+    of the script's output pasted into the page.
     """
     import subprocess
     import sys
     import tempfile
 
     example = _worker_current_example()
+    assert "pattern_score" not in example["pattern_observations"], (
+        "the example must not restate script-owned arithmetic"
+    )
     assert "pattern_score_basis" not in example["pattern_observations"], (
         "the example must not restate script-owned output"
     )

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1870,7 +1870,7 @@ def test_an_equivalence_with_a_foreign_generation_is_refused(
 # generation locked the correction out of the whole live catalog.
 
 
-@pytest.mark.parametrize("version", [1, 2, 3, 4, 5, 6, 7])
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5, 6, 7, 8])
 def test_a_catalog_repair_reaches_every_readable_talk_generation(
     mutate_tracking_database, version: int
 ) -> None:
@@ -1896,7 +1896,7 @@ def test_a_catalog_repair_leaves_the_records_generation_untouched(
     assert candidate["talks"][0]["schema_version"] == 1
 
 
-@pytest.mark.parametrize("version", [0, 8, "7", True])
+@pytest.mark.parametrize("version", [0, 9, "8", True])
 def test_a_catalog_repair_still_refuses_an_unreadable_generation(
     mutate_tracking_database, version: object
 ) -> None:
@@ -1932,7 +1932,7 @@ def test_other_writers_still_require_the_current_generation(
             ],
         )
 
-    assert "exact current talk schema 7" in str(excinfo.value)
+    assert "exact current talk schema 8" in str(excinfo.value)
 
 
 def test_a_retitled_catalog_entry_can_be_approved_again(

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -379,6 +379,31 @@ def _canonical_transcript_talk(
     return vault, raw, persisted
 
 
+def test_provider_auto_transcript_is_canonical_evidence(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    transcript, lines = _write_transcript(vault, timed=False)
+    talk = {
+        "filename": "synthetic-talk.md",
+        "title": "Synthetic Talk",
+        "transcript_path": transcript.relative_to(vault).as_posix(),
+        "transcript_source": "provider_auto",
+        "slide_source": "none",
+    }
+    raw = _raw_transcript_return(len(lines), timed=False)
+    raw["return_schema_version"] = pattern_evidence.PROVIDER_AUTO_RETURN_SCHEMA_VERSION
+    raw["transcript_source"] = "provider_auto"
+
+    canonical = pattern_evidence.canonicalize_return_evidence(
+        raw,
+        talk,
+        vault,
+        _catalog(_entry()),
+    )
+
+    assert canonical["transcript_source"] == "provider_auto"
+    assert canonical["pattern_observations"]["evidence_schema_version"] == 2
+
+
 def test_artifact_root_kinds_are_canonical_and_owner_bound(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     source_root = tmp_path / "pptx-source"

--- a/tests/test_policy_delegation_docs.py
+++ b/tests/test_policy_delegation_docs.py
@@ -44,6 +44,16 @@ def test_ingress_delegates_section15_assessment_and_replacement() -> None:
         assert classifier_owned_predicate not in rules
 
 
+def test_video_extractor_delegates_downloader_outcomes_to_the_worker_contract() -> None:
+    extractor = _read("skills/vault-ingress/references/video-slide-extraction.md")
+    worker = _read("skills/vault-ingress/references/subagent-instructions.md")
+
+    assert "subagent-instructions.md#slide-acquisition-per-slide_source" in extractor
+    assert "Branch on this id's `results` entry" in worker
+    assert "only for an `ok` or `skip` entry" not in extractor
+    assert "report with no `results` at all" not in extractor
+
+
 def test_speaker_profile_eval_requires_opaque_loader_outputs() -> None:
     task = _read("evals/speaker-profile-from-vault/task.md")
     criteria = json.loads(_read("evals/speaker-profile-from-vault/criteria.json"))

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -3254,6 +3254,30 @@ def test_source_enums_are_closed(
     assert code in finding_codes(report, "blocking")
 
 
+def test_provider_auto_is_valid_only_on_the_current_talk_schema(
+    preflight_vault,
+    tracking_database,
+    vault_fixture,
+):
+    materialize_transcript(vault_fixture)
+    talk = base_talk(
+        schema_version=tracking_database.TALK_RECORD_SCHEMA_VERSION,
+        video_url=None,
+        youtube_id=None,
+        transcript_path=f"transcripts/{VIDEO_ID}.txt",
+        transcript_source="provider_auto",
+    )
+    write_database(vault_fixture, [talk])
+
+    current = preflight_vault.run_preflight(vault_fixture["root"])
+    assert "transcript_source_unsupported" not in finding_codes(current, "blocking")
+
+    talk["schema_version"] = tracking_database.TALK_RECORD_SCHEMA_VERSION - 1
+    write_database(vault_fixture, [talk])
+    legacy = preflight_vault.run_preflight(vault_fixture["root"])
+    assert "transcript_source_unsupported" in finding_codes(legacy, "blocking")
+
+
 @pytest.mark.parametrize("status", ["skipped_no_sources", "skipped_no_video"])
 def test_source_less_skip_status_cannot_hide_pdf_source(
     preflight_vault,

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -465,7 +465,7 @@ def test_return_schema_reads_every_supported_version(return_validation, version)
     return_validation.validate_batch([value])
 
 
-@pytest.mark.parametrize("version", [0, 7, True, "5"])
+@pytest.mark.parametrize("version", [0, 8, True, "5"])
 def test_return_schema_rejects_unknown_or_wrong_typed_versions(
     return_validation, version
 ):

--- a/tests/test_schema5_pattern_outcomes.py
+++ b/tests/test_schema5_pattern_outcomes.py
@@ -797,11 +797,11 @@ def test_opportunity_identity_binds_scoring_generation_independently(
     )
 
     assert v5 != v6
-    # The identity is bound to the generation it was built at, not to
-    # whichever generation happens to be current.
-    assert return_validation.RETURN_SCHEMA_VERSION == (
-        return_validation.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION
-    )
+    # The identity is bound to the scoring generation it was built at, not to
+    # whichever return generation happens to be current.
+    assert return_validation.scoring_schema_version_for_return(
+        return_validation.RETURN_SCHEMA_VERSION
+    ) == (return_validation.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION)
 
 
 def test_v4_source_locations_survive_root_migration_without_v5_outcomes(

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1726,16 +1726,15 @@ def test_a_database_with_nothing_stale_still_reports_no_change(tracking_database
     assert not any(migration.record_counts.values())
 
 
-def test_v6_restamps_to_the_title_equivalence_record_shape(tracking_database) -> None:
-    """#333: v7 adds the optional equivalence ledger, a pure shape addition.
+def test_restampable_talk_generations_advance_to_current(tracking_database) -> None:
+    """The additive v7 and v8 generations preserve existing analysis.
 
-    A v6 record already holds the analysis v7 implies, so it carries forward
-    untouched. Generations below v5 still stay put — they reach the current
-    shape by being reanalysed, never by being stamped.
+    Records at v5-v7 already hold the analysis the current record implies, so
+    they carry forward untouched. Earlier generations still stay put.
     """
     database = _legacy_database()
     database["talks"] = []
-    for version in (1, 4, 5, 6):
+    for version in (1, 4, 5, 6, 7):
         talk = _legacy_talk(filename=f"v{version}.md")
         talk["schema_version"] = version
         database["talks"].append(talk)
@@ -1748,7 +1747,24 @@ def test_v6_restamps_to_the_title_equivalence_record_shape(tracking_database) ->
         4,
         current,
         current,
+        current,
     ]
+
+
+def test_migration_rejects_provider_auto_on_a_pre_v8_record(
+    tracking_database,
+) -> None:
+    database = _legacy_database()
+    talk = _legacy_talk(filename="invalid-v7.md")
+    talk["schema_version"] = 7
+    talk["transcript_source"] = "provider_auto"
+    database["talks"] = [talk]
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match="provider_auto transcript provenance requires talk schema v8",
+    ):
+        tracking_database.migrate_tracking_database(database)
 
 
 def test_a_restamped_record_keeps_its_equivalence_ledger_absent(

--- a/tests/test_transcript_timing.py
+++ b/tests/test_transcript_timing.py
@@ -657,6 +657,35 @@ def test_vtt_provenance_is_portable_and_rejects_unsafe_paths(
         )
 
 
+def test_provider_auto_owns_a_matching_vtt_timing_receipt(transcript_timing, tmp_path):
+    transcript = tmp_path / "talk.txt"
+    source = tmp_path / "talk.en-x-autogen.vtt"
+    source.write_bytes(b"WEBVTT synthetic")
+    text = "Provider caption text."
+    provenance = transcript_timing.vtt_timing_provenance(
+        transcript,
+        source,
+        transcript_timing.hashlib.sha256(source.read_bytes()).hexdigest(),
+        4.0,
+    )
+    transcript_timing.write_transcript_bundle(
+        transcript,
+        text,
+        [{"text": text, "start": 0.0, "end": 4.0}],
+        source="vtt",
+        timing_provenance=provenance,
+    )
+
+    segments, reason = transcript_timing.load_verified_segments(
+        transcript,
+        text,
+        owner_source="provider_auto",
+    )
+
+    assert len(segments) == 1
+    assert "verified owner-bound timed segments" in reason
+
+
 def test_bundle_failure_rolls_back_exact_transcript_and_receipts(
     transcript_timing, tmp_path, monkeypatch
 ):

--- a/tests/test_weighted_pattern_score.py
+++ b/tests/test_weighted_pattern_score.py
@@ -92,8 +92,13 @@ class TestSchemaBoundary:
         assert rv.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION == 6
         assert rv.FLAT_PATTERN_SCORING_SCHEMA_VERSION == 5
 
-    def test_the_current_return_schema_is_the_weighted_one(self, rv) -> None:
-        assert rv.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION == rv.RETURN_SCHEMA_VERSION
+    def test_the_current_return_keeps_the_weighted_scoring_contract(self, rv) -> None:
+        assert rv.WEIGHTED_SCORE_RETURN_SCHEMA_VERSION < rv.RETURN_SCHEMA_VERSION
+        assert rv.RETURN_SCHEMA_VERSION in rv.WEIGHTED_SCORE_RETURN_SCHEMA_VERSIONS
+        assert (
+            rv.scoring_schema_version_for_return(rv.RETURN_SCHEMA_VERSION)
+            == rv.WEIGHTED_PATTERN_SCORING_SCHEMA_VERSION
+        )
 
     def test_the_flat_generation_keeps_its_own_name(self, rv) -> None:
         """The trap this exists to stop: the generation sets named v5 through

--- a/tests/test_weighted_return_contract.py
+++ b/tests/test_weighted_return_contract.py
@@ -1,4 +1,4 @@
-"""The v5/v6 scoring boundary, asserted through the public validator (#153).
+"""The v5/weighted scoring boundary, asserted through the public validator.
 
 These drive `validate_return`, the entry point that owns schema resolution — a
 test calling the private score helper proves the arithmetic but not that any
@@ -118,6 +118,29 @@ class TestV6IsAcceptedEndToEnd:
             return_validation.validate_return(
                 _v6(return_validation, basis=basis), catalog
             )
+
+
+class TestV7AddsProviderAutoProvenance:
+    def test_provider_auto_validates_at_the_new_generation(
+        self, return_validation, catalog
+    ) -> None:
+        ret = _v6(return_validation)
+        ret["return_schema_version"] = return_validation.RETURN_SCHEMA_VERSION
+        ret["transcript_source"] = "provider_auto"
+
+        return_validation.validate_return(ret, catalog)
+
+    def test_provider_auto_is_not_backported_to_v6(
+        self, return_validation, catalog
+    ) -> None:
+        ret = _v6(return_validation)
+        ret["transcript_source"] = "provider_auto"
+
+        with pytest.raises(
+            return_validation.ReturnValidationError,
+            match="snapshot return transcript_source",
+        ):
+            return_validation.validate_return(ret, catalog)
 
 
 class TestTheBasisIsRequiredByTheScoreNotItsShape:

--- a/tests/test_ytdlp_runtime.py
+++ b/tests/test_ytdlp_runtime.py
@@ -1,0 +1,106 @@
+"""Tests for shared yt-dlp executable resolution."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import stat
+import sys
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "skills"
+    / "vault-ingress"
+    / "scripts"
+    / "ytdlp_runtime.py"
+)
+SPEC = importlib.util.spec_from_file_location("ytdlp_runtime", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+ytdlp_runtime = importlib.util.module_from_spec(SPEC)
+sys.modules.setdefault("ytdlp_runtime", ytdlp_runtime)
+SPEC.loader.exec_module(ytdlp_runtime)
+
+
+def _executable(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return path
+
+
+def test_interpreter_console_script_wins_over_path(monkeypatch, tmp_path: Path) -> None:
+    pinned = _executable(tmp_path / "runtime" / "yt-dlp")
+    stale = _executable(tmp_path / "path" / "yt-dlp")
+    monkeypatch.delenv("YT_DLP", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setenv("PATH", f"{stale.parent}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setattr(ytdlp_runtime.sys, "executable", str(pinned.parent / "python"))
+
+    assert ytdlp_runtime.resolve_ytdlp() == pinned
+
+
+def test_explicit_override_wins_over_interpreter(monkeypatch, tmp_path: Path) -> None:
+    override = _executable(tmp_path / "override" / "yt-dlp")
+    pinned = _executable(tmp_path / "runtime" / "yt-dlp")
+    monkeypatch.setenv("YT_DLP", str(override))
+    monkeypatch.setattr(ytdlp_runtime.sys, "executable", str(pinned.parent / "python"))
+
+    assert ytdlp_runtime.resolve_ytdlp() == override
+
+
+def test_invalid_override_fails_instead_of_falling_back(
+    monkeypatch, tmp_path: Path
+) -> None:
+    pinned = _executable(tmp_path / "runtime" / "yt-dlp")
+    monkeypatch.setenv("YT_DLP", str(tmp_path / "missing"))
+    monkeypatch.setattr(ytdlp_runtime.sys, "executable", str(pinned.parent / "python"))
+
+    try:
+        ytdlp_runtime.resolve_ytdlp()
+    except ytdlp_runtime.YtDlpResolutionError as exc:
+        assert exc.code == "ytdlp_override_invalid"
+    else:  # pragma: no cover - assertion branch
+        raise AssertionError("invalid YT_DLP override unexpectedly fell back")
+
+
+def test_path_is_only_a_compatibility_fallback(monkeypatch, tmp_path: Path) -> None:
+    fallback = _executable(tmp_path / "path" / "yt-dlp")
+    monkeypatch.delenv("YT_DLP", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setenv("PATH", str(fallback.parent))
+    monkeypatch.setattr(ytdlp_runtime.sys, "executable", "/missing/bin/python")
+    monkeypatch.setattr(
+        ytdlp_runtime,
+        "__file__",
+        str(tmp_path / "isolated" / "a" / "b" / "c" / "ytdlp_runtime.py"),
+    )
+
+    assert ytdlp_runtime.resolve_ytdlp() == fallback
+
+
+def test_missing_binary_has_a_typed_failure(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("YT_DLP", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    monkeypatch.setattr(ytdlp_runtime.sys, "executable", "/missing/bin/python")
+    monkeypatch.setattr(
+        ytdlp_runtime,
+        "__file__",
+        str(tmp_path / "isolated" / "a" / "b" / "c" / "ytdlp_runtime.py"),
+    )
+
+    with pytest.raises(ytdlp_runtime.YtDlpResolutionError) as excinfo:
+        ytdlp_runtime.resolve_ytdlp()
+
+    assert excinfo.value.code == "ytdlp_not_found"
+
+
+def test_calendar_versions_ignore_zero_padding_only() -> None:
+    assert ytdlp_runtime.normalized_ytdlp_version("2026.08.19") == (2026, 8, 19)
+    assert ytdlp_runtime.normalized_ytdlp_version("2026.8.19") == (2026, 8, 19)
+    assert ytdlp_runtime.normalized_ytdlp_version("latest") is None
+    assert ytdlp_runtime.normalized_ytdlp_version("2026.8.19.1") is None


### PR DESCRIPTION
## Summary
- centralize pinned yt-dlp runtime discovery and report exact-version readiness
- advance ingress return and talk provenance schemas for provider_auto transcripts
- centralize the per-video downloader outcome contract in the canonical subagent instructions
- renew the Tessl CLI CI pin to 0.105.0

Fixes #371
Fixes #347
Fixes #386
Fixes #376

## Verification
- full pytest suite: 6357 passed, 8 skipped
- Ruff check and formatting check
- Pyright: 0 errors, 0 warnings
- package content, conflict-marker, shipped-extension, Tessl-pin, and plugin-lint gates
- Tessl reviews: vault-ingress 97%, illustrations 98%, presentation-creator 90%, vault-clarification 85%