### PR TITLE
fix(vault-ingress): gate cloud-placeholder claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### fix(vault-ingress) — block claims on cloud-placeholder evidence (#354)
+
+Pending and legacy talks no longer enter a fresh batch while their declared
+slide or recording artifacts are cloud placeholders. Preflight reports a blocking
+`artifact_dataless` finding and a distinct-file download inventory with apparent
+bytes and affected talks. Missing files retain their separate diagnosis.
+
+The inventory uses existing metadata receipts without opening or hydrating a
+placeholder. An owner can download the listed files through the cloud provider
+and rerun preflight. The queue rechecks at the lease boundary, preserves
+cloud-only legacy statuses, and reports files withheld from automatic selection.
+An independent transcript or fallback deck remains available evidence without
+silently making the declared cloud artifact disappear from the readiness gate.
+
 ## 0.20.112 — 2026-09-04
 
 ### fix(vault-ingress) — every yt-dlp caller uses the pinned runtime (#371)

--- a/skills/vault-ingress/references/queue-selection.md
+++ b/skills/vault-ingress/references/queue-selection.md
@@ -4,6 +4,15 @@ This is the complete normative Step 2 contract for `vault-ingress`. Execute
 normalization before claiming, and preserve every generation, freshness, replay,
 and recovery rule below.
 
+Declared cloud-placeholder evidence blocks a fresh claim even when another
+source is usable. Follow the download inventory and owner hydration procedure in
+[Source Identity Preflight](source-identity-preflight.md#cloud-files-and-download-cost).
+Automatic selection leaves affected talks unclaimed and reports `cloud_artifacts`;
+an explicitly named affected talk rejects the batch without changing the database.
+Legacy cloud-only talks keep their prior status during normalization instead of
+becoming `skipped_no_sources`. The final claim reassesses readiness before writing
+the lease. Replaying an existing claim does not create fresh evidence authority.
+
 Fresh queue work uses claim schema v7. Before changing any talk status,
 `queue-state.py claim` snapshots one immutable `adherence_baseline` for the
 entire selected batch, stamps `required_return_schema_version: 7`, and copies

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -16,6 +16,34 @@ blocking. Invocation errors use argparse's exit `2` and still emit a blocking
 JSON report. A missing, unreadable, malformed, or structurally invalid tracking
 database is itself a blocking integrity finding.
 
+## Cloud files and download cost
+
+A declared PDF, PPTX, or preserved recording that is an offline cloud
+placeholder produces a blocking `artifact_dataless` finding, including for
+pending and legacy talks that have an independent transcript. Missing files
+retain their existing findings; a cloud placeholder is evidence awaiting download.
+
+The report's `cloud_artifacts` object is the download inventory. It contains
+`artifact_count`, `talk_count`, `total_bytes`, `unknown_size_count`, and
+`artifacts`. Each artifact names its path, apparent byte size, affected talk
+filenames, and source lanes. Shared paths count once. `total_bytes` sums known
+sizes; any nonzero `unknown_size_count` makes that sum a lower bound.
+The inventory reuses the evidence probes' metadata receipts and never opens a
+placeholder. Its schema and projection are owned by `scripts/cloud_artifacts.py`.
+
+To hydrate, run the preflight command above and present the inventory's file
+count and byte total. The owner chooses when to download that set. In Finder
+or Explorer, select the listed paths and use the cloud provider's **Download
+Now**, **Available offline**, or equivalent command. Wait for the provider to
+finish, then rerun preflight. Proceed only after the placeholder findings are
+gone and no other blocking finding remains. Do not change `slide_source`, erase
+paths, or mark sources absent to bypass this gate. Downloading the file does
+not itself authorize a manifest, crop, or source-identity claim.
+
+No automatic hydration occurs during preflight, queue normalization, or claims.
+Queue commands report the same inventory when a batch leaves cloud files waiting;
+explicitly claiming an affected talk exits `2` with `reason_code: artifact_dataless`.
+
 ## Trusted vault-root authority
 
 Every ingress reader derives the same artifact root before it assesses,

--- a/skills/vault-ingress/scripts/cloud_artifacts.py
+++ b/skills/vault-ingress/scripts/cloud_artifacts.py
@@ -1,0 +1,112 @@
+"""Project metadata-only cloud-placeholder receipts into queue/preflight reports.
+
+The evidence probes own platform flags and generation checks. This module never
+opens, stats, hashes, or hydrates an artifact. Sizes are apparent download bytes,
+not allocated disk blocks. Repeated references to one path count once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+CLOUD_PLACEHOLDER_REASONS = frozenset(
+    {
+        "pdf_cloud_placeholder_unavailable",
+        "pptx_cloud_placeholder_unavailable",
+        "video_cloud_placeholder_unavailable",
+    }
+)
+ARTIFACT_DATALESS = "artifact_dataless"
+
+
+def unavailable_cloud_artifacts(sources: object) -> list[dict[str, Any]]:
+    """Retain only closed placeholder failures, including unknown-size facts."""
+    if not isinstance(sources, Mapping):
+        return []
+    result = []
+    for source, record in sorted(sources.items()):
+        if not isinstance(record, Mapping):
+            continue
+        if record.get("reason_code") not in CLOUD_PLACEHOLDER_REASONS:
+            continue
+        details = record.get("details")
+        size = details.get("size_bytes") if isinstance(details, Mapping) else None
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            size = None
+        result.append(
+            {
+                "source": source,
+                "artifact_path": record.get("artifact_path"),
+                "size_bytes": size,
+                "reason_code": record["reason_code"],
+            }
+        )
+    return result
+
+
+def cloud_artifacts(assessment: Mapping[str, object]) -> list[dict[str, Any]]:
+    """Read retained declarations, including sources superseded by a fallback."""
+    retained = assessment.get("cloud_artifacts")
+    result = [dict(item) for item in retained] if isinstance(retained, list) else []
+    result.extend(
+        unavailable_cloud_artifacts(assessment.get("unavailable_evidence_sources"))
+    )
+    unique = {(item["source"], item["artifact_path"]): item for item in result}
+    return sorted(
+        unique.values(), key=lambda item: (item["source"], str(item["artifact_path"]))
+    )
+
+
+def cloud_artifact_blocking_reason(assessment: Mapping[str, object]) -> str | None:
+    """Explain the owner action needed before any fresh claim can proceed."""
+    if not cloud_artifacts(assessment):
+        return None
+    return (
+        f"{ARTIFACT_DATALESS}: declared local evidence is not downloaded; "
+        "review preflight's cloud_artifacts count, total_bytes, and paths, "
+        "download those files with the cloud provider, then rerun preflight"
+    )
+
+
+def summarize_cloud_artifacts(
+    records: Iterable[tuple[str, Mapping[str, object]]],
+) -> dict[str, Any]:
+    """Report distinct paths, affected talks, and explicitly incomplete costs."""
+    artifacts: dict[object, dict[str, Any]] = {}
+    for filename, assessment in records:
+        for item in cloud_artifacts(assessment):
+            path = item["artifact_path"]
+            key = path if path is not None else (filename, item["source"])
+            if key not in artifacts:
+                artifacts[key] = {
+                    "artifact_path": path,
+                    "size_bytes": item["size_bytes"],
+                    "filenames": set(),
+                    "sources": set(),
+                }
+            entry = artifacts[key]
+            # A path observed with different sizes changed during this report;
+            # do not turn either generation into a confident cost estimate.
+            if entry["size_bytes"] != item["size_bytes"]:
+                entry["size_bytes"] = None
+            entry["filenames"].add(filename)
+            entry["sources"].add(item["source"])
+    rows = [
+        {
+            **entry,
+            "filenames": sorted(entry["filenames"]),
+            "sources": sorted(entry["sources"]),
+        }
+        for entry in artifacts.values()
+    ]
+    rows.sort(key=lambda row: (str(row["artifact_path"]), row["filenames"]))
+    return {
+        "schema_version": 1,
+        "artifact_count": len(rows),
+        "talk_count": len({name for row in rows for name in row["filenames"]}),
+        "total_bytes": sum(row["size_bytes"] or 0 for row in rows),
+        "unknown_size_count": sum(row["size_bytes"] is None for row in rows),
+        "artifacts": rows,
+    }

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -31,6 +31,7 @@ from ingress_contract import (
     has_remote_video_acquisition,
 )
 from artifact_metadata import canonicalize_trusted_artifact_locator
+from cloud_artifacts import unavailable_cloud_artifacts
 from pdf_evidence import PdfArtifactProbe, PdfEvidenceError, probe_pdf_artifact
 from transcript_quality import validate_transcript
 from transcript_timing import (
@@ -1618,7 +1619,7 @@ def build_evidence_context(
     transcript_policy_bound = False
     canonical_transcript_source: str | None = None
     recorded_transcript_source = talk.get("transcript_source")
-    if recorded_transcript_source in {
+    if isinstance(recorded_transcript_source, str) and recorded_transcript_source in {
         "youtube_auto",
         "provider_auto",
         "whisper",
@@ -1825,6 +1826,9 @@ def build_evidence_context(
         except PatternEvidenceError as exc:
             source_reasons["static_slides"] = str(exc)
 
+    # Preserve declared cloud files even if a different manifest-selected PDF
+    # later supplies the same source lane. A fallback does not hydrate them.
+    declared_cloud_artifacts = unavailable_cloud_artifacts(source_unavailable)
     slide_source = talk.get("slide_source")
     if slide_source == "video_extracted":
         # A predeclared PDF is not interchangeable with the manifest-selected
@@ -2157,6 +2161,7 @@ def build_evidence_context(
         "source_reasons": source_reasons,
         "degraded_evidence_sources": source_degradations,
         "unavailable_evidence_sources": source_unavailable,
+        "cloud_artifacts": declared_cloud_artifacts,
         "metadata": metadata,
         "delivery_language": delivery_language,
     }
@@ -2313,6 +2318,7 @@ def assess_talk_artifact_capabilities(
         "source_reasons": source_reasons,
         "degraded_evidence_sources": degraded_sources,
         "unavailable_evidence_sources": unavailable_sources,
+        "cloud_artifacts": context.get("cloud_artifacts", []) if context else [],
     }
 
 

--- a/skills/vault-ingress/scripts/pdf_evidence.py
+++ b/skills/vault-ingress/scripts/pdf_evidence.py
@@ -1748,6 +1748,7 @@ def probe_pdf_artifact(
             details={
                 "availability": _availability(receipt.generation).to_dict(),
                 "reparse_tag": receipt.reparse_tag,
+                "size_bytes": receipt.generation.size,
             },
         )
         _cache_result(key, _cached_failure(error))

--- a/skills/vault-ingress/scripts/pptx_evidence.py
+++ b/skills/vault-ingress/scripts/pptx_evidence.py
@@ -1924,7 +1924,7 @@ def _cloud_placeholder_failure(
     if details is not None:
         return _probe_failure(
             "pptx_cloud_placeholder_unavailable",
-            details=details,
+            details={**details, "size_bytes": key[3]},
         )
     return None
 

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -33,6 +33,11 @@ from artifact_locator import (
     materialize_native_root,
 )
 from artifact_metadata import canonicalize_trusted_artifact_locator
+from cloud_artifacts import (
+    ARTIFACT_DATALESS,
+    cloud_artifacts,
+    summarize_cloud_artifacts,
+)
 from ingress_contract import (
     YOUTUBE_ID_RE,
     is_youtube_url,
@@ -669,6 +674,17 @@ class VaultPreflight:
             self._validate_source_status_reachability(index)
             self._validate_source_rejections(index)
             self._validate_artifacts(index)
+            for artifact in cloud_artifacts(self._capabilities(index)):
+                self.talk_add(
+                    index,
+                    "blocking",
+                    ARTIFACT_DATALESS,
+                    "declared local evidence is not downloaded; review "
+                    "cloud_artifacts and download the listed files with the "
+                    "cloud provider, then rerun preflight before claiming",
+                    actual=artifact,
+                    artifact_path=artifact["artifact_path"],
+                )
             self._validate_source_identity(index)
             self._validate_persisted_observations(index)
         self._validate_relations()
@@ -2464,6 +2480,10 @@ class VaultPreflight:
             "talk_count": talk_count,
             "blocking_count": blocking,
             "warning_count": warnings,
+            "cloud_artifacts": summarize_cloud_artifacts(
+                (str(self.talks[index].get("filename", "")), assessment)
+                for index, assessment in self.artifact_capabilities.items()
+            ),
             "summary": {
                 "by_severity": {
                     "blocking": blocking,
@@ -2656,6 +2676,7 @@ def run_cli() -> int:
                     "talk_count": 0,
                     "blocking_count": 1,
                     "warning_count": 0,
+                    "cloud_artifacts": summarize_cloud_artifacts(()),
                     "summary": {
                         "by_severity": {"blocking": 1, "warning": 0},
                         "by_code": {"preflight_unexpected_failure": 1},

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -105,6 +105,12 @@ from pattern_evidence import (
     required_pptx_evidence_blocking_reason,
 )
 from video_evidence import VideoEvidenceAssessment
+from cloud_artifacts import (
+    ARTIFACT_DATALESS,
+    cloud_artifacts,
+    cloud_artifact_blocking_reason,
+    summarize_cloud_artifacts,
+)
 from return_validation import (
     PATTERN_SCORING_SCHEMA_VERSION,
     QUEUE_CLAIM_SCHEMA_VERSION,
@@ -149,6 +155,10 @@ CAPABILITY_ORDER = ("video", "slides", "transcript")
 
 class QueueStateError(ValueError):
     """A deterministic input or state-contract failure."""
+
+    def __init__(self, message, *, reason_code=None):
+        super().__init__(message)
+        self.reason_code = reason_code
 
 
 class JsonArgumentParser(argparse.ArgumentParser):
@@ -323,7 +333,9 @@ def claim_blocking_artifact_reason(talk, *, capability_assessor):
             f"{talk.get('filename')}: artifact capability assessor returned "
             "a non-object result"
         )
-    return required_pptx_evidence_blocking_reason(talk, assessment)
+    return cloud_artifact_blocking_reason(
+        assessment
+    ) or required_pptx_evidence_blocking_reason(talk, assessment)
 
 
 def has_claimable_source(talk, *, capability_assessor):
@@ -511,9 +523,12 @@ def normalize_legacy_statuses(database, *, capability_assessor):
         previous = talk["status"]
         if previous not in LEGACY_STATUSES:
             continue
+        assessment = capability_assessor(talk)
+        if cloud_artifact_blocking_reason(assessment) is not None:
+            continue
         capabilities = processable_capabilities(
             talk,
-            capability_assessor=capability_assessor,
+            capability_assessor=lambda _talk: assessment,
         )
         current = "pending" if capabilities else "skipped_no_sources"
         talk["status"] = current
@@ -661,7 +676,12 @@ def claim_talk(
         capability_assessor=final_capability_assessor,
     )
     if blocking_reason is not None:
-        raise QueueStateError(f"{talk['filename']}: cannot claim: {blocking_reason}")
+        raise QueueStateError(
+            f"{talk['filename']}: cannot claim: {blocking_reason}",
+            reason_code=ARTIFACT_DATALESS
+            if cloud_artifacts(final_assessment)
+            else None,
+        )
     if not has_processable_source(
         talk,
         capability_assessor=final_capability_assessor,
@@ -833,7 +853,10 @@ def command_claim(
             )
             if blocking_reason is not None:
                 raise QueueStateError(
-                    f"{talk['filename']}: cannot claim: {blocking_reason}"
+                    f"{talk['filename']}: cannot claim: {blocking_reason}",
+                    reason_code=ARTIFACT_DATALESS
+                    if cloud_artifacts(provisional_assessment)
+                    else None,
                 )
             if not has_processable_source(
                 talk,
@@ -894,6 +917,11 @@ def command_claim(
         )
         for talk in candidate["talks"]
     )
+    cloud_report = summarize_cloud_artifacts(
+        (talk["filename"], capability_assessor(talk))
+        for talk in candidate["talks"]
+        if talk["status"] in CLAIMABLE_STATUSES | LEGACY_STATUSES
+    )
     if normalizations or claimed:
         validate_database(candidate)
         write_result = write_database_atomically(
@@ -914,6 +942,7 @@ def command_claim(
         "normalizations": normalizations,
         "claimed": claimed,
         "remaining_eligible": remaining,
+        "cloud_artifacts": cloud_report,
         **write_result_fields(write_result),
     }
 
@@ -1083,6 +1112,8 @@ def main(argv=None):
             )
     except (QueueStateError, VaultRootAuthorityError) as exc:
         payload = {"ok": False, "error": str(exc)}
+        if isinstance(exc, QueueStateError) and exc.reason_code is not None:
+            payload["reason_code"] = exc.reason_code
         print(str(exc), file=sys.stderr)
         print(json.dumps(payload, ensure_ascii=False))
         return 2

--- a/skills/vault-ingress/scripts/queue-state.py
+++ b/skills/vault-ingress/scripts/queue-state.py
@@ -838,10 +838,6 @@ def command_claim(
             )
         selected = [by_filename[filename] for filename in sorted(requested)]
         for talk in selected:
-            if talk["status"] not in CLAIMABLE_STATUSES:
-                raise QueueStateError(
-                    f"{talk['filename']}: cannot claim status {talk['status']!r}"
-                )
             provisional_assessment = capability_assessor(talk)
 
             def provisional_assessor(_talk):
@@ -857,6 +853,10 @@ def command_claim(
                     reason_code=ARTIFACT_DATALESS
                     if cloud_artifacts(provisional_assessment)
                     else None,
+                )
+            if talk["status"] not in CLAIMABLE_STATUSES:
+                raise QueueStateError(
+                    f"{talk['filename']}: cannot claim status {talk['status']!r}"
                 )
             if not has_processable_source(
                 talk,

--- a/skills/vault-ingress/scripts/video_evidence.py
+++ b/skills/vault-ingress/scripts/video_evidence.py
@@ -828,6 +828,7 @@ def _compute_generation_outcome(
             details={
                 "availability": availability.to_dict(),
                 "reparse_tag": receipt.reparse_tag,
+                "size_bytes": receipt.generation.size,
             },
         )
     if receipt.generation.size == 0:

--- a/tests/test_cloud_artifacts.py
+++ b/tests/test_cloud_artifacts.py
@@ -1,0 +1,109 @@
+"""Cloud readiness and cost reports use probe facts, never artifact byte I/O."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "skills/vault-ingress/scripts"))
+
+from cloud_artifacts import (  # noqa: E402
+    cloud_artifact_blocking_reason,
+    cloud_artifacts,
+    summarize_cloud_artifacts,
+)
+
+
+def assessment(
+    source="static_slides",
+    *,
+    reason="pdf_cloud_placeholder_unavailable",
+    size=1200,
+    path="/vault/slides/deck.pdf",
+):
+    return {
+        "verified_capabilities": ("transcript",),
+        "acquisition_capabilities": ("slides",),
+        "unavailable_evidence_sources": {
+            source: {
+                "reason_code": reason,
+                "artifact_path": path,
+                "details": {"size_bytes": size},
+            }
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("source", "reason"),
+    [
+        ("static_slides", "pdf_cloud_placeholder_unavailable"),
+        ("native_deck", "pptx_cloud_placeholder_unavailable"),
+        ("delivery_video", "video_cloud_placeholder_unavailable"),
+    ],
+)
+def test_independent_sources_do_not_hide_pending_cloud_evidence(source, reason):
+    report = assessment(source, reason=reason)
+    assert cloud_artifacts(report)[0]["size_bytes"] == 1200
+    message = cloud_artifact_blocking_reason(report)
+    assert message is not None
+    assert "artifact_dataless" in message
+    assert "download" in message
+
+
+@pytest.mark.parametrize(
+    "reason", ["pdf_artifact_unavailable", "pdf_probe_timeout", "pdf_invalid_container"]
+)
+def test_absent_or_invalid_evidence_is_not_reported_as_cloud(reason):
+    assert cloud_artifact_blocking_reason(assessment(reason=reason)) is None
+
+
+def test_cost_counts_one_file_shared_by_two_talks_once():
+    report = summarize_cloud_artifacts(
+        [
+            ("first.md", assessment()),
+            ("second.md", assessment()),
+            (
+                "second.md",
+                assessment(
+                    "native_deck",
+                    reason="pptx_cloud_placeholder_unavailable",
+                    size=800,
+                    path="/vault/source.pptx",
+                ),
+            ),
+        ]
+    )
+    assert report["artifact_count"] == 2
+    assert report["talk_count"] == 2
+    assert report["total_bytes"] == 2000
+    assert report["unknown_size_count"] == 0
+    assert report["artifacts"][0]["filenames"] == ["first.md", "second.md"]
+
+
+@pytest.mark.parametrize("size", [None, True, -1, "1200"])
+def test_unknown_cost_stays_explicit(size):
+    report = summarize_cloud_artifacts([("talk.md", assessment(size=size))])
+    assert report["artifact_count"] == 1
+    assert report["total_bytes"] == 0
+    assert report["unknown_size_count"] == 1
+
+
+def test_changed_size_cannot_be_reported_as_a_confident_total():
+    report = summarize_cloud_artifacts(
+        [
+            ("one.md", assessment(size=1200)),
+            ("two.md", assessment(size=1400)),
+        ]
+    )
+    assert report["unknown_size_count"] == 1
+    assert report["total_bytes"] == 0
+
+
+def test_available_fallback_does_not_erase_declared_cloud_artifact():
+    retained = cloud_artifacts(assessment())
+    report = {"cloud_artifacts": retained, "unavailable_evidence_sources": {}}
+    assert cloud_artifact_blocking_reason(report) is not None
+    assert summarize_cloud_artifacts([("talk.md", report)])["total_bytes"] == 1200

--- a/tests/test_pdf_evidence.py
+++ b/tests/test_pdf_evidence.py
@@ -314,6 +314,7 @@ def test_platform_offline_facts_reject_before_probe_open(
     assert isinstance(availability, dict)
     assert availability["state"] == "unavailable"
     assert availability[expected_flag] is True
+    assert caught.value.details["size_bytes"] == generation.size
 
 
 def test_success_with_any_parser_diagnostic_is_a_cached_repair_fact(

--- a/tests/test_pptx_evidence_recovery.py
+++ b/tests/test_pptx_evidence_recovery.py
@@ -1308,6 +1308,7 @@ def test_dataless_cloud_placeholder_never_starts_worker_io(
     with pytest.raises(pptx_evidence.PptxEvidenceError) as caught:
         pptx_evidence.probe_pptx_artifact(deck)
     assert caught.value.reason_code == "pptx_cloud_placeholder_unavailable"
+    assert caught.value.details["size_bytes"] == actual.st_size
 
 
 def test_dataless_flag_uses_explicit_darwin_fallback(pptx_evidence) -> None:

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -163,6 +163,62 @@ def write_database(fixture, talks, config=None, *, current=False, equivalences=N
     return fixture["database"]
 
 
+def test_cloud_placeholder_blocks_preflight_with_cost_and_preserves_transcript(
+    preflight_vault,
+    vault_fixture,
+    monkeypatch,
+):
+    from dataclasses import replace
+
+    materialize_transcript(vault_fixture)
+    artifact = write_pdf(vault_fixture["slides"] / "cloud.pdf")
+    path = write_database(
+        vault_fixture,
+        [
+            base_talk(
+                slide_source="pdf",
+                slides_local_path="slides/cloud.pdf",
+                status="pending",
+            )
+        ],
+    )
+    pdf = importlib.import_module("pdf_evidence")
+    original = pdf._run_bounded_metadata_worker
+
+    def metadata(*args, **kwargs):
+        receipt = original(*args, **kwargs)
+        return replace(
+            receipt, generation=replace(receipt.generation, file_attributes=0x1000)
+        )
+
+    monkeypatch.setattr(pdf, "_run_bounded_metadata_worker", metadata)
+    monkeypatch.setattr(
+        pdf,
+        "_invoke_probe_worker",
+        lambda *_args, **_kwargs: pytest.fail("cloud PDF was opened"),
+    )
+    before = path.read_bytes()
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+    assert report["ok"] is False
+    findings = [
+        item for item in report["findings"] if item["code"] == "artifact_dataless"
+    ]
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "blocking"
+    cost = report["cloud_artifacts"]
+    assert cost["artifact_count"] == 1
+    assert cost["total_bytes"] == artifact.stat().st_size
+    assert cost["unknown_size_count"] == 0
+    assert cost["artifacts"][0]["artifact_path"] == str(artifact)
+    warning = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "slide_pdf_artifact_unavailable"
+    )
+    assert "transcript" in warning["capability_fact"]["verified_evidence_sources"]
+    assert path.read_bytes() == before
+
+
 def materialize_transcript(fixture, video_id=VIDEO_ID):
     path = fixture["transcripts"] / f"{video_id}.txt"
     # Long enough to remain plausible for the 45-minute provider-duration

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from pathlib import Path
 import zipfile
+from dataclasses import replace
 
 import pytest
 from PIL import Image
@@ -38,6 +39,119 @@ if str(SCRIPT.parent) not in sys.path:
 queue_claim_contract = importlib.import_module("queue_claim_contract")
 return_validation = importlib.import_module("return_validation")
 NOW = "2026-07-31T18:00:00+00:00"
+
+
+def test_cloud_pdf_blocks_claim_without_byte_io_then_hydration_allows_it(
+    queue_state,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    talk = _talk("abcdefghijk")
+    talk.update({"slide_source": "pdf", "slides_local_path": "slides/cloud.pdf"})
+    path = _write_db(tmp_path, [talk])
+    slides = tmp_path / "slides"
+    slides.mkdir()
+    artifact = slides / "cloud.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=640, height=480)
+    with artifact.open("wb") as stream:
+        writer.write(stream)
+    pdf = importlib.import_module("pdf_evidence")
+    metadata_worker = pdf._run_bounded_metadata_worker
+    probe_worker = pdf._invoke_probe_worker
+    hydrated = False
+
+    def metadata(*args, **kwargs):
+        receipt = metadata_worker(*args, **kwargs)
+        if not hydrated:
+            return replace(
+                receipt, generation=replace(receipt.generation, flags=0x40000000)
+            )
+        return receipt
+
+    def probe(*args, **kwargs):
+        assert hydrated, "cloud PDF reached byte-reading worker"
+        return probe_worker(*args, **kwargs)
+
+    monkeypatch.setattr(pdf, "PDF_MACOS_DATALESS_FLAG", 0x40000000)
+    monkeypatch.setattr(pdf, "_run_bounded_metadata_worker", metadata)
+    monkeypatch.setattr(pdf, "_invoke_probe_worker", probe)
+    before = path.read_bytes()
+    command = [
+        str(path),
+        "claim",
+        "--run-id",
+        "cloud",
+        "--batch-id",
+        "one",
+        "--now",
+        NOW,
+    ]
+    assert queue_state.main(command + ["--filename", str(talk["filename"])]) == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["reason_code"] == "artifact_dataless"
+    assert path.read_bytes() == before
+    assert queue_state.main(command) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["claimed"] == []
+    assert report["cloud_artifacts"]["artifact_count"] == 1
+    assert report["cloud_artifacts"]["total_bytes"] == artifact.stat().st_size
+    assert path.read_bytes() == before
+    hydrated = True
+    assert queue_state.main(command) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert [item["filename"] for item in report["claimed"]] == [talk["filename"]]
+    assert report["cloud_artifacts"]["artifact_count"] == 0
+
+
+def test_cloud_only_legacy_talk_is_never_normalized_to_no_sources(queue_state):
+    talk = _talk("abcdefghijk", status="skipped_no_transcript")
+    database = {"talks": [talk]}
+    before = copy.deepcopy(database)
+    assessment = {
+        "verified_capabilities": (),
+        "acquisition_capabilities": (),
+        "unavailable_evidence_sources": {
+            "static_slides": {
+                "reason_code": "pdf_cloud_placeholder_unavailable",
+                "artifact_path": "/vault/slides/cloud.pdf",
+            }
+        },
+    }
+    assert (
+        queue_state.normalize_legacy_statuses(
+            database, capability_assessor=lambda _talk: assessment
+        )
+        == []
+    )
+    assert database == before
+
+
+def test_cloud_eviction_between_selection_and_claim_cannot_write_a_lease(queue_state):
+    talk = _talk("abcdefghijk")
+    clean = {"verified_capabilities": ("slides",), "acquisition_capabilities": ()}
+    unavailable = {
+        **clean,
+        "unavailable_evidence_sources": {
+            "static_slides": {
+                "reason_code": "pdf_cloud_placeholder_unavailable",
+                "artifact_path": "/vault/slides/cloud.pdf",
+            }
+        },
+    }
+    snapshots = iter([clean, unavailable])
+
+    def assessor(_talk):
+        return next(snapshots)
+
+    assert queue_state.has_claimable_source(talk, capability_assessor=assessor)
+    before = copy.deepcopy(talk)
+    with pytest.raises(queue_state.QueueStateError, match="artifact_dataless"):
+        queue_state.claim_talk(
+            talk, "cloud", "one", NOW, {}, capability_assessor=assessor
+        )
+    assert talk == before
 
 
 def _talk(

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -41,13 +41,17 @@ return_validation = importlib.import_module("return_validation")
 NOW = "2026-07-31T18:00:00+00:00"
 
 
+@pytest.mark.parametrize(
+    "status", ["pending", "skipped_no_transcript", "skipped_no_video"]
+)
 def test_cloud_pdf_blocks_claim_without_byte_io_then_hydration_allows_it(
     queue_state,
     tmp_path,
     monkeypatch,
     capsys,
+    status,
 ):
-    talk = _talk("abcdefghijk")
+    talk = _talk("abcdefghijk", status=status)
     talk.update({"slide_source": "pdf", "slides_local_path": "slides/cloud.pdf"})
     path = _write_db(tmp_path, [talk])
     slides = tmp_path / "slides"
@@ -91,6 +95,7 @@ def test_cloud_pdf_blocks_claim_without_byte_io_then_hydration_allows_it(
     assert queue_state.main(command + ["--filename", str(talk["filename"])]) == 2
     report = json.loads(capsys.readouterr().out)
     assert report["reason_code"] == "artifact_dataless"
+    assert "download those files with the cloud provider" in report["error"]
     assert path.read_bytes() == before
     assert queue_state.main(command) == 0
     report = json.loads(capsys.readouterr().out)

--- a/tests/test_video_evidence.py
+++ b/tests/test_video_evidence.py
@@ -473,6 +473,7 @@ def test_placeholder_short_circuits_before_probe_or_digest(
     assert caught.value.reason_code == "video_cloud_placeholder_unavailable"
     assert caught.value.details["availability"]["state"] == "unavailable"
     assert caught.value.details["reparse_tag"] is None
+    assert caught.value.details["size_bytes"] == generation.size
 
 
 def test_windows_cloud_reparse_placeholder_stops_before_probe_or_digest(


### PR DESCRIPTION
## Summary

- Block fresh queue claims for declared cloud-placeholder PDFs, PPTX files, and recordings, including talks with other usable evidence; preserve legacy cloud-only queue state.
- Add metadata-only preflight and queue download inventories with deduplicated paths, apparent byte totals, and explicit unknown-size counts. Retain placeholder declarations across alternate slide-source fallbacks.
- Document owner-triggered cloud-provider downloads and fresh preflight verification; never hydrate implicitly. Closes #354.

## Test plan

- [x] Full pytest suite: 6,377 passed, 8 skipped.
- [x] Ruff lint and formatting, Pyright with the project virtualenv: clean.
- [x] Package contents, shipped extensions, conflict markers, and plugin lint checks: clean.
- [x] Vault-ingress skill quality review: 100/100.
- [x] Regression coverage: no byte-worker invocation for offline files, exact size receipts, shared-file cost deduplication, independent transcripts, atomic explicit rejection, automatic skipping, late readiness changes, and successful claiming after hydration.

Patch release; version stamping is owned by the publish workflow.
