### PR TITLE
fix(vault-ingress): Decode complete recordings before accepting downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### fix(vault-ingress) — decode recordings before accepting downloads (#381)
+
+The former corruption scan could miss H.264 NAL damage and describe a truncated
+recording as clean. `video_integrity.py` now decodes each non-cover audio/video
+stream with strict error handling and compares terminal decode timestamps with
+the declared stream and container extents. Healthy audio cannot mask damaged
+video, and unfamiliar decoder diagnostics cannot escape a keyword list.
+
+The gate runs in the shared supervised worker boundary against an immutable
+snapshot and binds its receipt to the original digest and file generation.
+Timeouts, process/resource limits, missing tools, parser failures, and changing
+files fail visibly without promoting evidence. The downloader verifies both
+new staging files and existing resume candidates; damaged existing recordings
+are preserved for the owner to inspect or move aside. Synthetic fixtures cover
+late NAL corruption that passes metadata inspection, duration gaps, and the
+download promotion and retry boundaries.
+
 ## 0.20.113 — 2026-09-04
 
 ### fix(vault-ingress) — block claims on cloud-placeholder evidence (#354)

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -8,7 +8,7 @@ This is the fourth slide acquisition path — used when a talk has `video_url` b
 
 - `yt-dlp` (video download) — invoked only through
   `skills/vault-ingress/scripts/batch-download-videos.py`, never by bare name
-- `ffmpeg` (frame extraction)
+- `ffmpeg` and `ffprobe` (full decode verification and frame extraction)
 - Python packages: `imagehash`, NumPy, `Pillow` (perceptual deduplication), and
   `filelock` (same-video run coordination)
 
@@ -57,6 +57,30 @@ owns are in `references/subagent-instructions.md` under `video_extracted` and in
 the script's own docstring — not restated here.
 
 For talks where 720p is unavailable, yt-dlp will fall back to the best available.
+
+### Integrity of preserved recordings
+
+The downloader fully decodes new files before promotion and existing files
+before reporting a resume skip. Its `integrity` receipt comes from
+`scripts/video_integrity.py`; use that script for a recording acquired outside
+the downloader or for an explicit corruption audit:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/video_integrity.py" \
+  "{recording_path}"
+```
+
+Read its JSON report and require `ok: true` before declaring the recording
+verified. The script owns exit codes, resource limits, stream-duration
+tolerances, and receipt fields; see its docstring. A timeout is not proof of
+corruption or completeness. Inspect the runtime, then explicitly increase
+`--timeout-seconds` when needed. A failed existing download remains untouched;
+move a damaged file aside before downloading a replacement. Failed new files
+remain staging files and never satisfy the resume gate.
+
+Do not substitute stream-copy scans, stderr keyword counts, successful seeks,
+or a few extracted frames for decode verification. A clean integrity receipt
+does not establish speaker identity, delivery identity, or the slide crop.
 
 ## Step 2: Extract Frames
 

--- a/skills/vault-ingress/scripts/batch-download-videos.py
+++ b/skills/vault-ingress/scripts/batch-download-videos.py
@@ -11,8 +11,9 @@ beginning with `-` needs no escaping; a `--` separator is accepted and ignored.
 Each video lands at `<vault_root>/slides-rebuild/<youtube_id>/<youtube_id>.mp4`
 at 720p, with yt-dlp's combined output kept beside it as `<youtube_id>.yt-dlp.log`.
 
-An id already carrying a non-empty video is skipped, so a large batch resumes
-rather than restarting.
+An id already carrying a complete, decode-verified video is skipped, so a large
+batch resumes rather than restarting. Non-empty but damaged files fail visibly;
+the owner can move them aside and retry. They are never silently overwritten.
 
 Stdout: one JSON object.
 
@@ -23,8 +24,9 @@ Stdout: one JSON object.
 
 `results` holds one entry per requested id, in the order given; an id repeated
 in one invocation is rejected rather than downloaded twice. An `ok` or `skip`
-entry carries `path` and `bytes`; a `fail` entry carries `exit_code`, `reason`,
-and `log`. An `ok` requires both a zero exit and a non-empty file — a run that
+entry carries `path`, `bytes`, and `integrity`; a `fail` entry carries `exit_code`,
+`reason`, and `log`. An `ok` requires a zero exit, a non-empty file, and full
+decode verification by video_integrity.py before promotion — a run that
 exits non-zero having left a truncated file behind fails, and its partial output
 is discarded so the next run retries rather than skipping it.
 
@@ -56,12 +58,16 @@ from __future__ import annotations
 import json
 import re
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from pathlib import Path
 import subprocess
 import sys
 
 from failure_diagnostics import sanitized_frames
+from artifact_supervisor import FileGeneration, SupervisorError
 from ingress_contract import YOUTUBE_ID_RE
+from video_evidence import VideoEvidenceError, probe_video_artifact
+from video_integrity import VideoIntegrityError, verify_video_integrity
 from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
 
 USAGE = "usage: batch-download-videos.py <vault_root> ID1 [ID2 ...]"
@@ -163,6 +169,44 @@ def failure_reason(output: str) -> str:
     return "no output file and no yt-dlp diagnostic"
 
 
+def _verify_download(path: Path) -> dict[str, object]:
+    try:
+        receipt = verify_video_integrity(path)
+        if (
+            FileGeneration.from_stat(path.lstat()).to_dict()
+            != receipt["source_generation"]
+        ):
+            raise VideoIntegrityError("integrity_source_changed")
+        return receipt
+    except (SupervisorError, VideoEvidenceError) as exc:
+        raise VideoIntegrityError(exc.reason_code, exc.details) from exc
+    except OSError as exc:
+        raise VideoIntegrityError("integrity_source_unavailable") from exc
+
+
+def _bind_promoted_integrity(path: Path, receipt: dict[str, object]) -> None:
+    """A rename changes ctime, not the verified object, bytes, or other metadata."""
+    raw = receipt["source_generation"]
+    if not isinstance(raw, dict):
+        raise VideoIntegrityError("integrity_source_changed")
+    expected = FileGeneration.from_dict(raw)
+    try:
+        observed = FileGeneration.from_stat(path.lstat())
+    except OSError as exc:
+        raise VideoIntegrityError("integrity_source_changed") from exc
+    if replace(observed, ctime_ns=expected.ctime_ns) != expected:
+        raise VideoIntegrityError("integrity_source_changed")
+    # A rename and an in-place write both change ctime. Re-probe the promoted
+    # bytes so a same-size write with restored mtime cannot hide in that carve-out.
+    try:
+        probe = probe_video_artifact(path)
+    except (VideoEvidenceError, SupervisorError) as exc:
+        raise VideoIntegrityError(exc.reason_code, exc.details) from exc
+    if probe.generation != observed or probe.source_sha256 != receipt["source_sha256"]:
+        raise VideoIntegrityError("integrity_source_changed")
+    receipt["source_generation"] = probe.generation.to_dict()
+
+
 def download_one(ytdlp: Path, vault_root: Path, youtube_id: str) -> dict[str, object]:
     """Download one video, returning its outcome rather than raising."""
     target_dir = vault_root / "slides-rebuild" / youtube_id
@@ -175,11 +219,25 @@ def download_one(ytdlp: Path, vault_root: Path, youtube_id: str) -> dict[str, ob
     log_path = target_dir / f"{youtube_id}.yt-dlp.log"
 
     if target.is_file() and target.stat().st_size > 0:
+        try:
+            integrity = _verify_download(target)
+        except VideoIntegrityError as exc:
+            return {
+                "youtube_id": youtube_id,
+                "outcome": "fail",
+                "exit_code": None,
+                "reason_code": exc.code,
+                "reason": f"existing recording failed integrity verification ({exc.code}) — "
+                "check the runtime or move the damaged file aside, then rerun this id",
+                "log": None,
+                "integrity_details": exc.details,
+            }
         return {
             "youtube_id": youtube_id,
             "outcome": "skip",
             "path": str(target),
             "bytes": target.stat().st_size,
+            "integrity": integrity,
         }
 
     try:
@@ -273,7 +331,20 @@ def download_one(ytdlp: Path, vault_root: Path, youtube_id: str) -> dict[str, ob
     # truncated file behind.
     written = staging.is_file() and staging.stat().st_size > 0
     if exit_code == 0 and written:
-        size = staging.stat().st_size
+        try:
+            integrity = _verify_download(staging)
+        except VideoIntegrityError as exc:
+            return {
+                "youtube_id": youtube_id,
+                "outcome": "fail",
+                "exit_code": exit_code,
+                "reason_code": exc.code,
+                "reason": f"download failed integrity verification ({exc.code}) — "
+                "check the runtime and retry; unverified staging output was not promoted",
+                "integrity_details": exc.details,
+                **log_fields,
+            }
+        size = integrity["source_size_bytes"]
         try:
             staging.replace(target)
         except OSError as exc:
@@ -289,11 +360,24 @@ def download_one(ytdlp: Path, vault_root: Path, youtube_id: str) -> dict[str, ob
                 ),
                 **log_fields,
             }
+        try:
+            _bind_promoted_integrity(target, integrity)
+        except VideoIntegrityError as exc:
+            return {
+                "youtube_id": youtube_id,
+                "outcome": "fail",
+                "exit_code": exit_code,
+                "reason_code": exc.code,
+                "reason": "recording changed during promotion — inspect the target and "
+                "rerun verification before using it as evidence",
+                **log_fields,
+            }
         return {
             "youtube_id": youtube_id,
             "outcome": "ok",
             "path": str(target),
             "bytes": size,
+            "integrity": integrity,
             **log_fields,
         }
 

--- a/skills/vault-ingress/scripts/video_integrity.py
+++ b/skills/vault-ingress/scripts/video_integrity.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Decode-verify one recording; never infer integrity from stderr vocabulary.
+
+Usage: video_integrity.py VIDEO [--timeout-seconds 1800]
+Stdout is one JSON report. Exit 0 means every non-cover audio/video stream
+decoded without an error and reached its declared extent. Exit 1 rejects the
+recording; exit 2 reports invalid usage. No file is modified. Reports bind the
+verification to a source digest/generation, not merely a pathname. Verification
+is not speaker, delivery, crop, or transcript authority.
+
+ffprobe supplies declared stream durations (format duration is the fallback).
+ffmpeg decodes streams individually to null with strict error detection and
+machine-readable progress. Per-stream comparisons prevent healthy audio from
+masking truncated video. No stream copy, frame sampling, or error-text regex
+can satisfy this gate. Short timestamp rounding differences are allowed by
+the documented tolerance in stream_specs().
+
+The existing video probe owns metadata-only placeholder checks and immutable
+source preparation. Its shared supervisor bounds the decode worker's process
+tree, memory, wall time, and output. Tool stderr is never copied into reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from dataclasses import replace
+import json
+import math
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any, BinaryIO, NoReturn, cast
+
+from artifact_supervisor import (
+    JsonValue,
+    SupervisorError,
+    SupervisorLimits,
+    _PipeDrainer,
+    isolate_protocol_output,
+    read_worker_request,
+    run_authenticated_worker,
+    write_worker_response,
+)
+import video_evidence as video
+
+
+SCHEMA_VERSION = 1
+PIPELINE_VERSION = "video-integrity-v1"
+LIMITS = SupervisorLimits(
+    profile_id=PIPELINE_VERSION,
+    wall_seconds=1800,
+    max_memory_bytes=2 * 1024**3,
+    max_output_bytes=256 * 1024,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=8,
+)
+TOOL_OUTPUT_BYTES = 1024 * 1024
+WORKER_FLAG = "--supervised-worker"
+USAGE = "video_integrity.py VIDEO [--timeout-seconds 1800]"
+
+
+class VideoIntegrityError(ValueError):
+    """Closed diagnostic with caller-actionable recovery, never parser text."""
+
+    def __init__(self, code: str, details: Mapping[str, object] | None = None):
+        self.code = code
+        self.details = dict(details or {})
+        super().__init__(
+            f"{code}: do not use this recording as verified evidence; check the "
+            "reported dependency or limit, or obtain a complete recording and retry"
+        )
+
+
+class IntegrityArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        print(f"invalid integrity command; usage: {USAGE}", file=sys.stderr)
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "ok": False,
+                    "code": "integrity_usage_invalid",
+                    "usage": USAGE,
+                }
+            )
+        )
+        raise SystemExit(2)
+
+
+def _positive(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        return None
+    try:
+        number = float(value)
+    except (ValueError, OverflowError):
+        return None
+    return number if math.isfinite(number) and number > 0 else None
+
+
+def _timestamp(value: object) -> float:
+    if value is None or value == "N/A":
+        return 0.0
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise VideoIntegrityError("integrity_metadata_invalid")
+    try:
+        number = float(value)
+    except (ValueError, OverflowError) as exc:
+        raise VideoIntegrityError("integrity_metadata_invalid") from exc
+    if not math.isfinite(number):
+        raise VideoIntegrityError("integrity_metadata_invalid")
+    return number
+
+
+def stream_specs(document: object) -> tuple[list[dict[str, Any]], float]:
+    """Project strict stream identities, declared extents, and rounding margins.
+
+    Margin is 100 ms or two video frames, whichever is larger, capped at 1 s.
+    """
+    if not isinstance(document, Mapping):
+        raise VideoIntegrityError("integrity_metadata_invalid")
+    fmt = document.get("format")
+    if not isinstance(fmt, Mapping):
+        raise VideoIntegrityError("integrity_metadata_invalid")
+    duration = _positive(fmt.get("duration"))
+    streams = document.get("streams")
+    if duration is None or not isinstance(streams, list) or not streams:
+        raise VideoIntegrityError("integrity_metadata_invalid")
+    format_start = _timestamp(fmt.get("start_time"))
+    if len(streams) > video.VIDEO_MAX_STREAMS:
+        raise VideoIntegrityError("integrity_stream_limit")
+    result = []
+    seen = set()
+    for stream in streams:
+        if not isinstance(stream, Mapping):
+            raise VideoIntegrityError("integrity_metadata_invalid")
+        index = stream.get("index")
+        if type(index) is not int or index < 0 or index in seen:
+            raise VideoIntegrityError("integrity_metadata_invalid")
+        seen.add(index)
+        kind = stream.get("codec_type")
+        if not isinstance(kind, str):
+            raise VideoIntegrityError("integrity_metadata_invalid")
+        disposition = stream.get("disposition", {})
+        if not isinstance(disposition, Mapping):
+            raise VideoIntegrityError("integrity_metadata_invalid")
+        if kind not in {"video", "audio"} or disposition.get("attached_pic") == 1:
+            continue
+        offset = max(0.0, _timestamp(stream.get("start_time")) - format_start)
+        expected = _positive(stream.get("duration")) or (duration - offset)
+        if expected <= 0:
+            raise VideoIntegrityError("integrity_metadata_invalid")
+        margin = 0.1
+        if kind == "video":
+            rate = stream.get("avg_frame_rate")
+            if isinstance(rate, str) and rate.count("/") == 1:
+                numerator, denominator = map(_positive, rate.split("/"))
+                if numerator is not None and denominator is not None:
+                    margin = min(1.0, max(margin, 2 * denominator / numerator))
+        result.append(
+            {
+                "index": index,
+                "kind": kind,
+                "declared_seconds": expected,
+                "tolerance_seconds": margin,
+                "start_offset_seconds": offset,
+            }
+        )
+    if not any(item["kind"] == "video" for item in result):
+        raise VideoIntegrityError("integrity_no_video_stream")
+    return result, duration
+
+
+def decoded_extent(output: bytes) -> float:
+    """Read terminal progress, rejecting missing/invalid timestamps or frames."""
+    try:
+        lines = output.decode("ascii").splitlines()
+    except UnicodeError as exc:
+        raise VideoIntegrityError("integrity_progress_invalid") from exc
+    current: dict[str, str] = {}
+    terminal: dict[str, str] | None = None
+    for line in lines:
+        key, separator, value = line.partition("=")
+        if not separator:
+            raise VideoIntegrityError("integrity_progress_invalid")
+        current[key.strip()] = value.strip()
+        if key == "progress":
+            if value not in {"continue", "end"} or terminal is not None:
+                raise VideoIntegrityError("integrity_progress_invalid")
+            if value == "end":
+                terminal = current
+            current = {}
+    if current or terminal is None:
+        raise VideoIntegrityError("integrity_progress_incomplete")
+    micros = _positive(terminal.get("out_time_us"))
+    if micros is None:
+        raise VideoIntegrityError("integrity_progress_invalid")
+    return micros / 1_000_000
+
+
+def _run_tool(command: list[str]) -> bytes:
+    """Drain bounded pipes inside the already-supervised worker process tree."""
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            close_fds=True,
+        )
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        raise VideoIntegrityError("integrity_tool_unavailable") from exc
+    if process.stdout is None or process.stderr is None:
+        video._stop_process(process)
+        raise VideoIntegrityError("integrity_pipe_failure")
+    stdout = _PipeDrainer(cast(BinaryIO, process.stdout), TOOL_OUTPUT_BYTES)
+    stderr = _PipeDrainer(cast(BinaryIO, process.stderr), LIMITS.max_diagnostic_bytes)
+    stdout.start()
+    stderr.start()
+    try:
+        while process.poll() is None:
+            if stdout.overflowed or stderr.overflowed:
+                video._stop_process(process)
+                break
+            time.sleep(0.01)
+        code = process.wait()
+        stdout.join(1)
+        stderr.join(1)
+        if stdout.alive or stderr.alive or stdout.failed or stderr.failed:
+            raise VideoIntegrityError("integrity_pipe_failure")
+        if stdout.overflowed or stderr.overflowed:
+            raise VideoIntegrityError("integrity_output_limit")
+        if code != 0 or stderr.receipt.byte_count:
+            raise VideoIntegrityError(
+                "integrity_decode_failed",
+                {"exit_code": code, "diagnostics": stderr.receipt.to_dict()},
+            )
+        return stdout.data
+    finally:
+        video._stop_process(process)
+        stdout.close()
+        stderr.close()
+
+
+def decode_recording(path: Path) -> dict[str, object]:
+    """Decode each declared audio/video stream; called only in the worker."""
+    binaries = {name: shutil.which(name) for name in ("ffmpeg", "ffprobe")}
+    for name, binary in binaries.items():
+        if binary is None:
+            raise VideoIntegrityError(
+                "integrity_dependency_missing", {"dependency": name}
+            )
+    raw = _run_tool(
+        [
+            str(binaries["ffprobe"]),
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration,start_time:stream=index,codec_type,duration,start_time,avg_frame_rate:stream_disposition=attached_pic",
+            "-of",
+            "json",
+            os.fspath(path),
+        ]
+    )
+    try:
+        document = json.loads(raw)
+    except (ValueError, UnicodeError) as exc:
+        raise VideoIntegrityError("integrity_metadata_invalid") from exc
+    specs, container_duration = stream_specs(document)
+    reports = []
+    for spec in specs:
+        command = [
+            str(binaries["ffmpeg"]),
+            "-hide_banner",
+            "-nostdin",
+            "-nostats",
+            "-v",
+            "error",
+            "-xerror",
+            "-max_error_rate",
+            "0",
+            "-err_detect",
+            "explode",
+            "-threads",
+            "2",
+            "-i",
+            os.fspath(path),
+            "-map",
+            f"0:{spec['index']}",
+            "-progress",
+            "pipe:1",
+            "-stats_period",
+            "5",
+        ]
+        if spec["kind"] == "video":
+            command.extend(["-vf", "setpts=PTS-STARTPTS", "-fps_mode", "passthrough"])
+        else:
+            command.extend(["-af", "asetpts=PTS-STARTPTS"])
+        command.extend(["-filter_threads", "1", "-f", "null", "-"])
+        extent = decoded_extent(_run_tool(command))
+        gap = spec["declared_seconds"] - extent
+        report = {**spec, "decoded_seconds": extent, "gap_seconds": max(0.0, gap)}
+        if gap > spec["tolerance_seconds"]:
+            raise VideoIntegrityError("integrity_duration_gap", report)
+        if -gap > spec["tolerance_seconds"]:
+            raise VideoIntegrityError("integrity_duration_mismatch", report)
+        reports.append(report)
+    container_extent = max(
+        item["start_offset_seconds"] + item["decoded_seconds"] for item in reports
+    )
+    if abs(container_duration - container_extent) > max(
+        item["tolerance_seconds"] for item in reports
+    ):
+        raise VideoIntegrityError(
+            "integrity_container_duration_gap",
+            {
+                "declared_seconds": container_duration,
+                "decoded_seconds": container_extent,
+            },
+        )
+    return {"container_duration_seconds": container_duration, "streams": reports}
+
+
+def verify_video_integrity(
+    path: str | os.PathLike[str], *, timeout_seconds: float = LIMITS.wall_seconds
+) -> dict[str, object]:
+    """Return a generation-bound receipt, or fail without altering the input."""
+    if (
+        isinstance(timeout_seconds, bool)
+        or not isinstance(timeout_seconds, (int, float))
+        or _positive(timeout_seconds) is None
+        or timeout_seconds > 21600
+    ):
+        raise VideoIntegrityError("integrity_timeout_invalid")
+    artifact = Path(os.path.abspath(path))
+    probe = video.probe_video_artifact(artifact)
+    command = [sys.executable, os.fspath(Path(__file__).resolve()), WORKER_FLAG]
+    result = run_authenticated_worker(
+        command,
+        "video_integrity",
+        {"video": probe.generation},
+        {"path": os.fspath(artifact), "sha256": probe.source_sha256},
+        replace(LIMITS, wall_seconds=timeout_seconds),
+        immutable_process_identity=command[:2],
+        sensitive_values=(artifact,),
+        pipeline_generation=PIPELINE_VERSION,
+    )
+    if result.diagnostics.byte_count or not isinstance(result.payload, dict):
+        raise VideoIntegrityError("integrity_result_invalid")
+    if set(result.payload) != {"container_duration_seconds", "streams"}:
+        raise VideoIntegrityError("integrity_result_invalid")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "source_sha256": probe.source_sha256,
+        "source_size_bytes": probe.source_size_bytes,
+        "source_generation": probe.generation.to_dict(),
+        "pipeline_version": PIPELINE_VERSION,
+        **result.payload,
+    }
+
+
+def _worker() -> int:
+    request = read_worker_request(max_input_bytes=LIMITS.max_input_bytes)
+    output = isolate_protocol_output()
+    try:
+        try:
+            if (
+                request.operation != "video_integrity"
+                or request.pipeline_generation != PIPELINE_VERSION
+                or request.schema_generation != SCHEMA_VERSION
+                or request.limit_profile_id != LIMITS.profile_id
+                or set(request.expected_generations) != {"video"}
+                or not isinstance(request.payload, dict)
+                or set(request.payload) != {"path", "sha256"}
+                or not isinstance(request.payload["path"], str)
+                or not isinstance(request.payload["sha256"], str)
+            ):
+                raise SupervisorError("invalid_worker_request")
+            artifact = Path(request.payload["path"])
+            expected = request.expected_generations["video"]
+            before = video._metadata_receipt_in_probe_worker(artifact, None)
+            if (
+                before.generation != expected
+                or video._availability(expected).state != "local"
+            ):
+                raise SupervisorError("worker_generation_changed")
+            with video._prepared_video_source(artifact, expected) as prepared:
+                report = decode_recording(prepared.probe_artifact)
+                digest = video._digest_open_descriptor(
+                    prepared.source_descriptor, expected
+                )
+                snapshot_digest = video._digest_open_descriptor(
+                    prepared.probe_descriptor, prepared.probe_generation
+                )
+                if digest != request.payload["sha256"] or snapshot_digest != digest:
+                    raise SupervisorError("worker_generation_changed")
+            after = video._metadata_receipt_in_probe_worker(artifact, None)
+            if after.generation != expected:
+                raise SupervisorError("worker_generation_changed")
+            write_worker_response(
+                request,
+                payload=cast(JsonValue, report),
+                observed_generations={"video": after.generation},
+                stream=output,
+                max_output_bytes=LIMITS.max_output_bytes,
+            )
+        except (SupervisorError, VideoIntegrityError, video.VideoEvidenceError) as exc:
+            code = exc.code if isinstance(exc, VideoIntegrityError) else exc.reason_code
+            write_worker_response(
+                request,
+                error=SupervisorError(code, cast(Mapping[str, JsonValue], exc.details)),
+                observed_generations=request.expected_generations,
+                stream=output,
+                max_output_bytes=LIMITS.max_output_bytes,
+            )
+    finally:
+        output.close()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if arguments in (["--help"], ["-h"]):
+        print(
+            json.dumps({"schema_version": SCHEMA_VERSION, "ok": True, "usage": USAGE})
+        )
+        return 0
+    parser = IntegrityArgumentParser(add_help=False)
+    parser.add_argument("video", type=Path)
+    parser.add_argument("--timeout-seconds", type=float, default=LIMITS.wall_seconds)
+    args = parser.parse_args(arguments)
+    try:
+        report = verify_video_integrity(
+            args.video, timeout_seconds=args.timeout_seconds
+        )
+    except (VideoIntegrityError, video.VideoEvidenceError, SupervisorError) as exc:
+        code = exc.code if isinstance(exc, VideoIntegrityError) else exc.reason_code
+        error = VideoIntegrityError(code, exc.details)
+        print(str(error), file=sys.stderr)
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "ok": False,
+                    "code": code,
+                    "error": str(error),
+                    "details": error.details,
+                }
+            )
+        )
+        return 1
+    print(json.dumps(report))
+    return 0
+
+
+def run_cli() -> int:
+    try:
+        return _worker() if sys.argv[1:] == [WORKER_FLAG] else main()
+    # Agent callers need one failure report; a traceback would drop the JSON
+    # contract and could expose parser paths. Emit a closed failure instead.
+    # outer-boundary-process-contract
+    except Exception:  # noqa: BLE001
+        print(
+            "integrity check failed unexpectedly; repair the runtime and retry",
+            file=sys.stderr,
+        )
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "ok": False,
+                    "code": "integrity_unexpected_failure",
+                }
+            )
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli())

--- a/tests/test_batch_download.py
+++ b/tests/test_batch_download.py
@@ -3,6 +3,7 @@
 import importlib.util
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -28,13 +29,13 @@ PRESENT_ID = "EfGhIjKlMn4"
 STUB_ID = "OpQrStUvWx5"
 DASH_ID = "-YzAbCdEfG6"
 
-# Writes a non-empty file at the -o path, so the script sees a usable download.
+# Copies a locally generated complete recording to the requested output path.
 FAKE_OK = """\
 #!/usr/bin/env bash
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version) echo "9999.12.31"; exit 0 ;;
-        -o) shift; printf 'video-bytes' > "$1" ;;
+        -o) shift; cp "$FAKE_VIDEO_SOURCE" "$1" ;;
         *) ;;
     esac
     shift
@@ -151,8 +152,44 @@ def _fake_ytdlp(tmp_path, body, name="yt-dlp"):
     return fake
 
 
+def _video_fixture(path):
+    ffmpeg = shutil.which("ffmpeg")
+    assert ffmpeg, "install ffmpeg; download integrity tests must not skip decoding"
+    subprocess.run(
+        [
+            ffmpeg,
+            "-v",
+            "error",
+            "-nostdin",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:size=64x48:rate=10",
+            "-t",
+            "1",
+            "-c:v",
+            "libx264",
+            "-threads",
+            "1",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    return path.read_bytes()
+
+
 def _run(vault, ids, ytdlp=None, path_dir=None):
     env = os.environ.copy()
+    source = vault.parent / "fixture-video.mp4"
+    if not source.exists():
+        _video_fixture(source)
+    env["FAKE_VIDEO_SOURCE"] = str(source)
     env.pop("VIRTUAL_ENV", None)
     if ytdlp is not None:
         env["YT_DLP"] = str(ytdlp)
@@ -161,7 +198,7 @@ def _run(vault, ids, ytdlp=None, path_dir=None):
     if path_dir is not None:
         env["PATH"] = f"{path_dir}:{env['PATH']}"
     return subprocess.run(
-        [SCRIPT, str(vault), *ids],
+        [sys.executable, SCRIPT, str(vault), *ids],
         capture_output=True,
         text=True,
         env=env,
@@ -185,11 +222,16 @@ def test_downloads_to_correct_path(tmp_path):
 
     assert result.returncode == 0, result.stderr
     target = vault / "slides-rebuild" / OK_ID / f"{OK_ID}.mp4"
-    assert target.read_text() == "video-bytes"
+    assert target.read_bytes() == (tmp_path / "fixture-video.mp4").read_bytes()
     entry = _by_id(result)[OK_ID]
     assert entry["outcome"] == "ok"
     assert entry["path"] == str(target)
-    assert entry["bytes"] == len("video-bytes")
+    assert entry["bytes"] == target.stat().st_size
+    assert entry["integrity"]["ok"] is True
+    assert (
+        entry["integrity"]["source_generation"]
+        == downloader.FileGeneration.from_stat(target.stat()).to_dict()
+    )
 
 
 def test_creates_directory_structure(tmp_path):
@@ -252,7 +294,7 @@ def test_one_failure_does_not_stop_the_others(tmp_path):
     vault = tmp_path / "vault"
     present = vault / "slides-rebuild" / PRESENT_ID
     present.mkdir(parents=True)
-    (present / f"{PRESENT_ID}.mp4").write_text("prior-bytes")
+    _video_fixture(present / f"{PRESENT_ID}.mp4")
 
     result = _run(
         vault, [PRESENT_ID, BLOCKED_ID], ytdlp=_fake_ytdlp(tmp_path, FAKE_403, "403")
@@ -271,13 +313,80 @@ def test_existing_video_is_skipped_not_redownloaded(tmp_path):
     target_dir = vault / "slides-rebuild" / PRESENT_ID
     target_dir.mkdir(parents=True)
     target = target_dir / f"{PRESENT_ID}.mp4"
-    target.write_text("prior-bytes")
+    before = _video_fixture(target)
 
     result = _run(vault, [PRESENT_ID], ytdlp=_fake_ytdlp(tmp_path, FAKE_OK))
 
     assert result.returncode == 0, result.stderr
-    assert target.read_text() == "prior-bytes"
+    assert target.read_bytes() == before
     assert _by_id(result)[PRESENT_ID]["outcome"] == "skip"
+
+
+def test_nonempty_corrupt_existing_video_never_counts_as_verified(tmp_path):
+    vault = tmp_path / "vault"
+    target = vault / "slides-rebuild" / PRESENT_ID / f"{PRESENT_ID}.mp4"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"damaged prior recording")
+    result = _run(vault, [PRESENT_ID], ytdlp=_fake_ytdlp(tmp_path, FAKE_OK))
+    assert result.returncode == 1
+    entry = _by_id(result)[PRESENT_ID]
+    assert entry["outcome"] == "fail"
+    assert "reason_code" in entry
+    assert "move the damaged file aside" in entry["reason"]
+    assert target.read_bytes() == b"damaged prior recording"
+
+
+def test_zero_exit_with_corrupt_file_is_not_promoted(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    corrupt = FAKE_OK.replace('cp "$FAKE_VIDEO_SOURCE" "$1"', 'printf damaged > "$1"')
+    result = _run(vault, [OK_ID], ytdlp=_fake_ytdlp(tmp_path, corrupt))
+    assert result.returncode == 1
+    entry = _by_id(result)[OK_ID]
+    assert entry["outcome"] == "fail"
+    assert entry["exit_code"] == 0
+    assert "integrity verification" in entry["reason"]
+    assert not (vault / "slides-rebuild" / OK_ID / f"{OK_ID}.mp4").exists()
+    staging = vault / "slides-rebuild" / OK_ID / f"{OK_ID}.incomplete.mp4"
+    assert staging.read_bytes() == b"damaged"
+    retried = _run(vault, [OK_ID], ytdlp=_fake_ytdlp(tmp_path, FAKE_OK))
+    assert _by_id(retried)[OK_ID]["outcome"] == "ok"
+
+
+def test_decode_failure_cannot_promote_a_nonempty_download(tmp_path, monkeypatch):
+    def reject(_path):
+        raise downloader.VideoIntegrityError("integrity_decode_failed")
+
+    monkeypatch.setattr(downloader, "_verify_download", reject)
+    source = tmp_path / "source.mp4"
+    _video_fixture(source)
+    monkeypatch.setenv("FAKE_VIDEO_SOURCE", str(source))
+    result = downloader.download_one(_fake_ytdlp(tmp_path, FAKE_OK), tmp_path, OK_ID)
+    assert result["outcome"] == "fail"
+    assert result["reason_code"] == "integrity_decode_failed"
+    assert not (tmp_path / "slides-rebuild" / OK_ID / f"{OK_ID}.mp4").exists()
+
+
+def test_changed_promoted_object_cannot_reuse_verified_receipt(tmp_path):
+    source = tmp_path / "source.mp4"
+    _video_fixture(source)
+    receipt = downloader._verify_download(source)
+    source.write_bytes(source.read_bytes() + b"changed")
+    with pytest.raises(downloader.VideoIntegrityError, match="source_changed"):
+        downloader._bind_promoted_integrity(source, receipt)
+
+
+def test_same_size_change_with_restored_mtime_cannot_hide_as_rename(tmp_path):
+    source = tmp_path / "source.mp4"
+    _video_fixture(source)
+    receipt = downloader._verify_download(source)
+    before = source.stat()
+    data = bytearray(source.read_bytes())
+    data[-1] ^= 1
+    source.write_bytes(data)
+    os.utime(source, ns=(before.st_atime_ns, before.st_mtime_ns))
+    with pytest.raises(downloader.VideoIntegrityError):
+        downloader._bind_promoted_integrity(source, receipt)
 
 
 def test_empty_existing_file_is_redownloaded(tmp_path):
@@ -290,7 +399,9 @@ def test_empty_existing_file_is_redownloaded(tmp_path):
     result = _run(vault, [STUB_ID], ytdlp=_fake_ytdlp(tmp_path, FAKE_OK))
 
     assert result.returncode == 0, result.stderr
-    assert (target_dir / f"{STUB_ID}.mp4").read_text() == "video-bytes"
+    assert (target_dir / f"{STUB_ID}.mp4").read_bytes() == (
+        tmp_path / "fixture-video.mp4"
+    ).read_bytes()
     assert _by_id(result)[STUB_ID]["outcome"] == "ok"
 
 
@@ -487,7 +598,7 @@ def test_a_partial_download_never_lands_on_the_target_path(tmp_path):
 
     retried = _run(vault, [OK_ID], ytdlp=_fake_ytdlp(tmp_path, FAKE_OK))
     assert _by_id(retried)[OK_ID]["outcome"] == "ok"
-    assert target.read_text() == "video-bytes"
+    assert target.read_bytes() == (tmp_path / "fixture-video.mp4").read_bytes()
 
 
 def test_a_signed_url_never_reaches_the_report_or_the_log(tmp_path):

--- a/tests/test_video_integrity.py
+++ b/tests/test_video_integrity.py
@@ -1,0 +1,366 @@
+"""Full-decode integrity, independent stream extents, and failure boundaries."""
+
+import copy
+import hashlib
+import importlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+integrity = importlib.import_module("video_integrity")
+
+
+def _metadata(*, duration="10", video_duration="10", audio_duration="10"):
+    return {
+        "format": {"duration": duration, "start_time": "0"},
+        "streams": [
+            {
+                "index": 0,
+                "codec_type": "video",
+                "duration": video_duration,
+                "avg_frame_rate": "30/1",
+                "disposition": {"attached_pic": 0},
+            },
+            {"index": 1, "codec_type": "audio", "duration": audio_duration},
+        ],
+    }
+
+
+def _progress(seconds):
+    return f"out_time_us={int(seconds * 1_000_000)}\nprogress=end\n".encode()
+
+
+@pytest.fixture
+def recording(tmp_path):
+    ffmpeg = shutil.which("ffmpeg")
+    assert ffmpeg, "install ffmpeg; real integrity tests may not be skipped"
+    output = tmp_path / "recording.mp4"
+    subprocess.run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-nostdin",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=320x240:rate=10",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:sample_rate=16000",
+            "-t",
+            "10",
+            "-c:v",
+            "libx264",
+            "-threads",
+            "1",
+            "-preset",
+            "ultrafast",
+            "-c:a",
+            "aac",
+            "-movflags",
+            "+faststart",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    return output
+
+
+def test_complete_recording_has_independent_decoded_stream_receipts(recording):
+    before = recording.read_bytes()
+    result = integrity.verify_video_integrity(recording)
+    assert result["ok"] is True
+    assert result["source_sha256"] == hashlib.sha256(before).hexdigest()
+    assert result["source_size_bytes"] == len(before)
+    assert {stream["kind"] for stream in result["streams"]} == {"video", "audio"}
+    assert all(stream["decoded_seconds"] >= 9.9 for stream in result["streams"])
+    assert recording.read_bytes() == before
+
+
+def test_late_nal_damage_passes_metadata_but_fails_full_decode(recording):
+    ffprobe = shutil.which("ffprobe")
+    assert ffprobe, "install ffprobe; corruption regression must run"
+    result = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_packets",
+            "-show_entries",
+            "packet=pts_time,pos,size",
+            "-of",
+            "json",
+            str(recording),
+        ],
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+    packets = json.loads(result.stdout)["packets"]
+    packet = next(item for item in packets if float(item["pts_time"]) >= 8)
+    data = bytearray(recording.read_bytes())
+    position = int(packet["pos"])
+    data[position : position + 4] = b"\xff\xff\xff\xf0"
+    recording.write_bytes(data)
+    # Header/container inspection is not decode verification: the prior gate
+    # accepts this file even though an interior H.264 packet is damaged.
+    assert integrity.video.probe_video_artifact(recording).duration_seconds == 10
+    with pytest.raises(integrity.SupervisorError, match="integrity_decode_failed"):
+        integrity.verify_video_integrity(recording)
+    assert recording.read_bytes() == data
+
+
+def _fake_tools(monkeypatch, metadata, extents):
+    outputs = iter([json.dumps(metadata).encode(), *map(_progress, extents)])
+    monkeypatch.setattr(integrity.shutil, "which", lambda name: f"/tools/{name}")
+    monkeypatch.setattr(integrity, "_run_tool", lambda command: next(outputs))
+
+
+def test_intact_audio_cannot_hide_short_video(monkeypatch):
+    _fake_tools(monkeypatch, _metadata(), [4, 10])
+    with pytest.raises(integrity.VideoIntegrityError) as caught:
+        integrity.decode_recording(Path("recording.mp4"))
+    assert caught.value.code == "integrity_duration_gap"
+    assert caught.value.details["kind"] == "video"
+    assert caught.value.details["decoded_seconds"] == 4
+
+
+def test_decoded_extent_beyond_declared_stream_is_rejected(monkeypatch):
+    _fake_tools(monkeypatch, _metadata(), [14, 10])
+    with pytest.raises(integrity.VideoIntegrityError, match="duration_mismatch"):
+        integrity.decode_recording(Path("recording.mp4"))
+
+
+def test_intact_video_cannot_hide_short_audio(monkeypatch):
+    _fake_tools(monkeypatch, _metadata(), [10, 4])
+    with pytest.raises(integrity.VideoIntegrityError) as caught:
+        integrity.decode_recording(Path("recording.mp4"))
+    assert caught.value.code == "integrity_duration_gap"
+    assert caught.value.details["kind"] == "audio"
+
+
+def test_short_declared_streams_cannot_hide_container_gap(monkeypatch):
+    _fake_tools(monkeypatch, _metadata(video_duration="4", audio_duration="4"), [4, 4])
+    with pytest.raises(
+        integrity.VideoIntegrityError, match="integrity_container_duration_gap"
+    ):
+        integrity.decode_recording(Path("recording.mp4"))
+
+
+def test_intentionally_shorter_video_and_audio_outro_are_valid(monkeypatch):
+    _fake_tools(monkeypatch, _metadata(video_duration="8"), [8, 10])
+    assert len(integrity.decode_recording(Path("recording.mp4"))["streams"]) == 2
+
+
+def test_nonzero_start_time_and_rounding_are_valid(monkeypatch):
+    metadata = _metadata()
+    metadata["format"]["start_time"] = "20"
+    metadata["streams"][0].update({"start_time": "22", "duration": "8"})
+    metadata["streams"][1]["start_time"] = "20"
+    _fake_tools(monkeypatch, metadata, [7.967, 10])
+    result = integrity.decode_recording(Path("recording.mp4"))
+    assert result["streams"][0]["start_offset_seconds"] == 2
+
+
+@pytest.mark.parametrize("value", [None, {}, [], True, "NaN", "inf", "-2", "0"])
+def test_invalid_container_duration_is_not_verified(value):
+    with pytest.raises(integrity.VideoIntegrityError, match="metadata_invalid"):
+        integrity.stream_specs(_metadata(duration=value))
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"index": True},
+        {"index": -1},
+        {"codec_type": []},
+        {"disposition": []},
+        {"start_time": "nan"},
+    ],
+)
+def test_invalid_stream_metadata_fails_closed(change):
+    metadata = _metadata()
+    metadata["streams"][0].update(change)
+    with pytest.raises(integrity.VideoIntegrityError):
+        integrity.stream_specs(metadata)
+
+
+def test_cover_art_and_subtitles_are_not_treated_as_video():
+    metadata = _metadata()
+    metadata["streams"][0]["disposition"]["attached_pic"] = 1
+    metadata["streams"].append({"index": 2, "codec_type": "subtitle"})
+    with pytest.raises(integrity.VideoIntegrityError, match="no_video_stream"):
+        integrity.stream_specs(metadata)
+
+
+def test_duplicate_stream_ids_are_rejected():
+    metadata = _metadata()
+    metadata["streams"].append(copy.deepcopy(metadata["streams"][0]))
+    with pytest.raises(integrity.VideoIntegrityError, match="metadata_invalid"):
+        integrity.stream_specs(metadata)
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        b"",
+        b"out_time_us=10000000\nprogress=continue\n",
+        b"out_time_us=N/A\nprogress=end\n",
+        b"out_time_us=NaN\nprogress=end\n",
+        b"out_time_us=-1\nprogress=end\n",
+        b"out_time_us=0\nprogress=end\n",
+        b"out_time_us=10000000\nprogress=end\ngarbage",
+        b"\xff",
+        b"out_time_us=10000000\nprogress=end\nprogress=end\n",
+    ],
+)
+def test_incomplete_or_invalid_progress_never_proves_integrity(output):
+    with pytest.raises(integrity.VideoIntegrityError):
+        integrity.decoded_extent(output)
+
+
+def test_only_final_extent_is_authoritative():
+    assert (
+        integrity.decoded_extent(
+            b"out_time_us=1000000\nprogress=continue\nout_time_us=2000000\nprogress=end\n"
+        )
+        == 2
+    )
+
+
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        "Invalid NAL unit size",
+        "Error splitting the input into NAL units",
+        "missing picture",
+        "a future decoder error never seen before",
+    ],
+)
+def test_any_error_diagnostic_rejects_even_with_zero_exit(diagnostic):
+    with pytest.raises(integrity.VideoIntegrityError) as caught:
+        integrity._run_tool(
+            [sys.executable, "-c", f"import sys; sys.stderr.write({diagnostic!r})"]
+        )
+    assert caught.value.code == "integrity_decode_failed"
+    assert diagnostic not in json.dumps(caught.value.details)
+    assert caught.value.details["diagnostics"]["byte_count"] == len(diagnostic)
+
+
+def test_nonzero_exit_without_stderr_is_rejected():
+    with pytest.raises(integrity.VideoIntegrityError, match="decode_failed"):
+        integrity._run_tool([sys.executable, "-c", "raise SystemExit(7)"])
+
+
+def test_tool_output_is_bounded():
+    with pytest.raises(integrity.VideoIntegrityError, match="output_limit"):
+        integrity._run_tool(
+            [
+                sys.executable,
+                "-c",
+                f"import sys; sys.stdout.write('x' * {integrity.TOOL_OUTPUT_BYTES + 1})",
+            ]
+        )
+
+
+def test_missing_tool_is_actionable(monkeypatch):
+    monkeypatch.setattr(integrity.shutil, "which", lambda name: None)
+    with pytest.raises(integrity.VideoIntegrityError) as caught:
+        integrity.decode_recording(Path("recording.mp4"))
+    assert caught.value.details == {"dependency": "ffmpeg"}
+    assert "retry" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "timeout", [True, "10", 0, -1, float("nan"), float("inf"), 21601]
+)
+def test_invalid_deadline_rejected_before_reading(timeout, monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("invalid timeout read the recording")
+
+    monkeypatch.setattr(integrity.video, "probe_video_artifact", forbidden)
+    with pytest.raises(integrity.VideoIntegrityError, match="timeout_invalid"):
+        integrity.verify_video_integrity("missing.mp4", timeout_seconds=timeout)
+
+
+def test_generation_change_between_probe_and_decode_is_rejected(recording, monkeypatch):
+    run = integrity.run_authenticated_worker
+
+    def replaced(*args, **kwargs):
+        recording.write_bytes(recording.read_bytes() + b"changed")
+        return run(*args, **kwargs)
+
+    monkeypatch.setattr(integrity, "run_authenticated_worker", replaced)
+    with pytest.raises(integrity.SupervisorError, match="generation_changed"):
+        integrity.verify_video_integrity(recording)
+
+
+def test_decode_deadline_is_enforced(recording):
+    with pytest.raises(integrity.SupervisorError, match="worker_timeout"):
+        integrity.verify_video_integrity(recording, timeout_seconds=0.001)
+
+
+def test_cli_reports_missing_input_as_one_json_object(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS / "video_integrity.py"),
+            str(tmp_path / "missing.mp4"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["ok"] is False
+    assert "do not use this recording" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "arguments,code", [([], 2), (["--help"], 0), (["--unknown"], 2)]
+)
+def test_usage_and_help_are_structured(arguments, code):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS / "video_integrity.py"), *arguments],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == code
+    assert json.loads(result.stdout)["usage"] == integrity.USAGE
+
+
+def test_unexpected_failure_reports_json_without_exception_text(monkeypatch, capsys):
+    def explode():
+        raise RuntimeError("private parser output")
+
+    monkeypatch.setattr(integrity, "main", explode)
+    monkeypatch.setattr(sys, "argv", ["video_integrity.py"])
+    assert integrity.run_cli() == 1
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["code"] == "integrity_unexpected_failure"
+    assert "private parser output" not in captured.out + captured.err
+
+
+def test_interrupt_is_not_swallowed(monkeypatch):
+    def interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(integrity, "main", interrupt)
+    monkeypatch.setattr(sys, "argv", ["video_integrity.py"])
+    with pytest.raises(KeyboardInterrupt):
+        integrity.run_cli()


### PR DESCRIPTION
## Summary
- Decode every non-cover audio/video stream before accepting a new recording or an existing resume candidate. Strict decoder failures and per-stream/container duration gaps reject the recording without keyword matching.
- Run verification in the shared bounded worker against an immutable snapshot, bind receipts to the verified bytes and generation, and recheck promotion. Preserve failed existing files and keep failed new output in staging.
- Document the standalone integrity command. Closes #381. Patch release; the publish workflow owns the version bump.

## Test plan
- [x] Full suite: 6,439 passed, 8 existing platform skips.
- [x] 89 focused video-integrity/downloader tests, including a real late H.264 NAL corruption that passes metadata inspection, independent audio/video extents, bounded failures, mutation races, and retry behavior.
- [x] Ruff lint and format; Pyright: no errors or warnings.
- [x] Package contents, shipped extensions, conflict-marker check, and plugin lint.
- [x] Vault-ingress skill review: 97/100.
- [ ] Policy and Copilot reviews, hosted CI, registry publication, and moderation verification.
