### PR TITLE
fix(vault-ingress): Repair missing legacy QR versions through the owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### fix(vault-ingress) — repair unstamped legacy QR records through the owner
+
+An explicit `--repair-missing-qr-versions` migration mode recovers valid legacy
+QR records accidentally left unversioned under a current root. Ordinary reads
+and migration still refuse that state. The repair validates the exact legacy
+shape, stamps only missing QR versions, and validates the complete candidate.
+It refuses unknown generations, ambiguous artifact receipts, other schema
+defects, and active writers without changing the database.
+
+The dry run exposes the configured interpreter only after candidate validation.
+Apply requires its exact digest, preserves an exact backup through the shared
+transaction, and leaves talks, observations, and queue status untouched. This
+unblocks catalog-only operations without forcing a reparse or running the
+normal migration's observation repairs.
+
 ## 0.20.115 — 2026-09-04
 
 ### fix(vault-ingress) — count unnamed cloud-blocked talks separately (#389)

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -28,6 +28,10 @@ require the same SHA-256; restart discovery if the generation changed. Use the
 configured interpreter for migration, queue commands, and every later toolkit
 command.
 
+If an unusable QR schema blocks that initial read, follow the speaker-authorized
+[explicit QR-version recovery](schemas-db.md#explicit-qr-version-recovery)
+contract. Stop on refusal; never lower the root version to force a migration.
+
 Before that migration runs, and only when this run is a migration or a reparse,
 capture the corpus-wide persisted-observation audit against a COPY of the
 database:

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -523,8 +523,9 @@ Repeat the same dry run with that configured interpreter and require matching
 ```
 
 The repair's exact eligibility and preservation contract lives in
-`scripts/tracking_database.py::repair_missing_qr_schema_versions`; its CLI report
-and failure contract is in `scripts/migrate-tracking-database.py`'s docstring.
+`skills/vault-ingress/scripts/tracking_database.py::repair_missing_qr_schema_versions`;
+its CLI report and failure contract is in
+`skills/vault-ingress/scripts/migrate-tracking-database.py`'s docstring.
 It does not run the normal migration or its persisted-observation changes.
 Its exact backup and digest-bound replacement use the existing migration
 transaction. After success, repeat the ordinary strict owner read with the

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -500,6 +500,38 @@ interpreter and require the same SHA-256; restart if the generation changed. Use
 the configured interpreter for initialization, migration, queue recovery, typed
 mutation, and every later toolkit command.
 
+### Explicit QR-version recovery
+
+When the strict reader refuses the database and the speaker authorizes QR-version
+recovery, use the owner's separate preservation-only repair mode:
+
+```bash
+"{bootstrap_python}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" --repair-missing-qr-versions
+```
+
+This dry run is the only additional host-interpreter bootstrap operation. It
+returns no database payload. On success, read `repair.python_path` from the
+fully validated candidate; if absent, ask the speaker for the interpreter.
+Repeat the same dry run with that configured interpreter and require matching
+`input_sha256` and `output_sha256`. Review `record_counts` before applying:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" --repair-missing-qr-versions \
+  --apply --expected-sha256 "{input_sha256}"
+```
+
+The repair's exact eligibility and preservation contract lives in
+`scripts/tracking_database.py::repair_missing_qr_schema_versions`; its CLI report
+and failure contract is in `scripts/migrate-tracking-database.py`'s docstring.
+It does not run the normal migration or its persisted-observation changes.
+Its exact backup and digest-bound replacement use the existing migration
+transaction. After success, repeat the ordinary strict owner read with the
+configured interpreter and require the repair's `output_sha256`. Resume the
+normal bootstrap gates only then. A refusal authorizes no manual restamping,
+raw database read, or bypass of another schema gate.
+
 Agent-owned config and catalog changes use a typed plan:
 
 ```json

--- a/skills/vault-ingress/scripts/migrate-tracking-database.py
+++ b/skills/vault-ingress/scripts/migrate-tracking-database.py
@@ -246,8 +246,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--expected-sha256")
     parser.add_argument("--repair-missing-qr-versions", action="store_true")
+    repair_requested = False
     try:
         args = parser.parse_args(argv)
+        repair_requested = args.repair_missing_qr_versions
         report = execute(
             args.database,
             apply=args.apply,
@@ -257,7 +259,7 @@ def main(argv: list[str] | None = None) -> int:
     except TrackingDatabaseMigrationError as exc:
         # Repair is a bootstrap boundary over an unreadable database; neither
         # decoder nor schema errors may echo rejected values or host paths.
-        repair_requested = "--repair-missing-qr-versions" in (
+        repair_requested = repair_requested or "--repair-missing-qr-versions" in (
             sys.argv[1:] if argv is None else argv
         )
         message = (

--- a/skills/vault-ingress/scripts/migrate-tracking-database.py
+++ b/skills/vault-ingress/scripts/migrate-tracking-database.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Migrate one tracking database with a hash precondition and exact backup."""
+"""Migrate one tracking database with a hash precondition and exact backup.
+
+--repair-missing-qr-versions selects a separate preservation-only owner repair,
+not the normal migration: see tracking_database.repair_missing_qr_schema_versions.
+It never restamps talks, repairs observations, or requeues work. A successful
+repair report adds repair.kind and repair.python_path from the fully validated
+candidate, so a blocked bootstrap reader can discover its configured interpreter.
+Repeat the dry run with that interpreter and require the same input/output
+digests before --apply --expected-sha256. Refusals expose no database values.
+"""
 
 from __future__ import annotations
 
@@ -17,7 +26,9 @@ from persisted_pattern_observations import (
 from return_validation import ReturnValidationError, load_catalog
 from tracking_database import (
     TrackingDatabaseError,
+    TrackingDatabaseRepairError,
     migrate_tracking_database,
+    repair_missing_qr_schema_versions,
 )
 from tracking_database_io import (
     BackupRequest,
@@ -34,6 +45,13 @@ REPORT_SCHEMA_VERSION = 1
 
 class TrackingDatabaseMigrationError(ValueError):
     """Migration input or filesystem state failed a precondition."""
+
+    def __init__(
+        self, message: str, *, code: str | None = None, details: dict | None = None
+    ):
+        super().__init__(message)
+        self.code = code
+        self.details = details or {}
 
 
 class JsonArgumentParser(argparse.ArgumentParser):
@@ -61,6 +79,7 @@ def execute(
     *,
     apply: bool,
     expected_sha256: str | None,
+    repair_missing_qr_versions: bool = False,
 ) -> dict[str, object]:
     database_path = path.expanduser().absolute()
     if expected_sha256 is not None:
@@ -83,13 +102,25 @@ def execute(
         )
 
     try:
-        migration = migrate_tracking_database(database)
+        migration = (
+            repair_missing_qr_schema_versions(database)
+            if repair_missing_qr_versions
+            else migrate_tracking_database(database)
+        )
         # Run on the migrated candidate, before it is rendered: the whole defect
         # is that migration stamps a talk current without reading the nested
         # detections, so the gate has to sit between the stamp and the write.
-        observation_counts = gate_persisted_observations(migration.database)
+        observation_counts = (
+            {"repaired": 0, "requeued": 0}
+            if repair_missing_qr_versions
+            else gate_persisted_observations(migration.database)
+        )
         changed = migration.changed or any(observation_counts.values())
         rendered = render_json_object(migration.database) if changed else snapshot.raw
+    except TrackingDatabaseRepairError as exc:
+        raise TrackingDatabaseMigrationError(
+            str(exc), code=exc.reason_code, details=exc.details
+        ) from exc
     except (TrackingDatabaseError, TrackingDatabaseIOError) as exc:
         raise TrackingDatabaseMigrationError(str(exc)) from exc
     except ReturnValidationError as exc:
@@ -127,7 +158,7 @@ def execute(
         warnings = list(result.warnings)
         reported_backup = result.backup
 
-    return {
+    report: dict[str, object] = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "ok": True,
         "mode": "apply" if apply else "dry-run",
@@ -144,6 +175,12 @@ def execute(
         "durability_state": durability_state,
         "warnings": warnings,
     }
+    if repair_missing_qr_versions:
+        report["repair"] = {
+            "kind": "missing_qr_schema_versions",
+            "python_path": migration.database["config"].get("python_path"),
+        }
+    return report
 
 
 # A talk in one of these states claims its analysis is complete, which is the
@@ -208,24 +245,39 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("database", type=Path)
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--expected-sha256")
+    parser.add_argument("--repair-missing-qr-versions", action="store_true")
     try:
         args = parser.parse_args(argv)
         report = execute(
             args.database,
             apply=args.apply,
             expected_sha256=args.expected_sha256,
+            repair_missing_qr_versions=args.repair_missing_qr_versions,
         )
     except TrackingDatabaseMigrationError as exc:
+        # Repair is a bootstrap boundary over an unreadable database; neither
+        # decoder nor schema errors may echo rejected values or host paths.
+        repair_requested = "--repair-missing-qr-versions" in (
+            sys.argv[1:] if argv is None else argv
+        )
+        message = (
+            "QR schema repair refused; verify the path and exact dry-run digest, "
+            "resolve active claims and other owner-state defects, and retry. "
+            "Only valid unstamped legacy QR records are repairable."
+            if repair_requested
+            else str(exc)
+        )
         print(
             json.dumps(
                 {
                     "schema_version": REPORT_SCHEMA_VERSION,
                     "ok": False,
-                    "error": str(exc),
+                    "error": message,
+                    **({"code": exc.code, "details": exc.details} if exc.code else {}),
                 }
             )
         )
-        print(f"tracking-database migration failed: {exc}", file=sys.stderr)
+        print(f"tracking-database migration failed: {message}", file=sys.stderr)
         return 2
     print(json.dumps(report, indent=2, sort_keys=True))
     return 0

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -287,6 +287,17 @@ class TrackingDatabaseConfigExclusionsError(TrackingDatabaseError):
     """The config-owned PPTX directory-exclusion field is invalid."""
 
 
+class TrackingDatabaseRepairError(TrackingDatabaseError):
+    """Closed repair diagnostic; details contain no rejected database values."""
+
+    def __init__(self, reason_code: str, details: dict[str, object]):
+        self.reason_code = reason_code
+        self.details = details
+        super().__init__(
+            "owner QR repair refused; resolve the reported defect and retry"
+        )
+
+
 class PptxVisualEvidenceError(TrackingDatabaseError):
     """A persisted extraction receipt is malformed.
 
@@ -1855,6 +1866,80 @@ def _migrate_pptx_catalog_records(candidate: dict[str, Any]) -> int:
         )
         migrated += 1
     return migrated
+
+
+def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigration:
+    """Explicit, preservation-only repair of unstamped legacy QR records.
+
+    Ordinary readers/migration remain closed on missing child versions. This
+    opt-in owner operation accepts only a current root/config whose sole version
+    defect is a missing QR stamp. Every unstamped record must satisfy the exact
+    legacy-v1 shape before stamping; v2 artifact receipts are never invented or
+    inferred. The complete candidate must validate before it is returned. No
+    talk, evidence, queue, config, or other record migration runs here.
+    """
+    try:
+        assessment = assess_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseRepairError(
+            "qr_repair_input_invalid", {"stage": "initial_owner_validation"}
+        ) from exc
+    if (
+        not isinstance(database, dict)
+        or assessment.schema_version != TRACKING_DATABASE_SCHEMA_VERSION
+        or (
+            not assessment.usable
+            and assessment.reason_codes != ("qr_codes_schema_version_missing",)
+        )
+    ):
+        raise TrackingDatabaseRepairError(
+            "qr_repair_input_unsupported",
+            {"reason_codes": list(assessment.reason_codes)},
+        )
+    candidate = copy.deepcopy(database)
+    records = _object_collection(candidate, "qr_codes", required=True)
+    counts = _empty_record_counts()
+    for index, record in enumerate(records):
+        if "schema_version" in record:
+            continue
+        try:
+            _validate_collection_record("qr_codes", record, label=f"qr_codes[{index}]")
+        except TrackingDatabaseError as exc:
+            raise TrackingDatabaseRepairError(
+                "qr_repair_record_invalid",
+                {
+                    "record_index": index,
+                    "missing_fields": sorted(QR_CODE_REQUIRED_FIELDS - set(record)),
+                    "unexpected_field_count": len(
+                        set(record) - QR_CODE_REQUIRED_FIELDS
+                    ),
+                    "has_artifacts": "artifacts" in record,
+                },
+            ) from exc
+        record["schema_version"] = LEGACY_QR_CODE_RECORD_SCHEMA_VERSION
+        counts["qr_codes"] += 1
+    try:
+        require_current_tracking_database(candidate)
+    except TrackingDatabaseError as exc:
+        raise TrackingDatabaseRepairError(
+            "qr_repair_candidate_invalid", {"stage": "complete_owner_validation"}
+        ) from exc
+    if counts["qr_codes"]:
+        talks = _object_collection(candidate, "talks", required=True)
+        try:
+            _require_no_active_writers(talks)
+        except TrackingDatabaseError as exc:
+            raise TrackingDatabaseRepairError(
+                "qr_repair_active_writers",
+                {"active_talk_count": len(_active_claim_filenames(talks))},
+            ) from exc
+    return TrackingDatabaseMigration(
+        database=candidate,
+        changed=bool(counts["qr_codes"]),
+        from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+        to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+        record_counts=counts,
+    )
 
 
 def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1631,6 +1631,161 @@ def test_qr_v1_records_still_validate(tracking_database):
     _validate_qr(tracking_database, _qr_v1_record())
 
 
+def _missing_qr_version_database(tracking_database):
+    database = tracking_database.migrate_tracking_database(_legacy_database()).database
+    database["qr_codes"][0].pop("schema_version")
+    return database
+
+
+def test_qr_repair_is_opt_in_and_preserves_every_other_record(tracking_database):
+    database = _missing_qr_version_database(tracking_database)
+    database["qr_codes"].append(_qr_v2_record())
+    before = copy.deepcopy(database)
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.migrate_tracking_database(database)
+    assert tracking_database.assess_tracking_database(database).usable is False
+
+    repaired = tracking_database.repair_missing_qr_schema_versions(database)
+
+    expected = copy.deepcopy(before)
+    expected["qr_codes"][0]["schema_version"] = 1
+    assert database == before
+    assert repaired.database == expected
+    assert repaired.changed is True
+    assert repaired.record_counts["qr_codes"] == 1
+    assert sum(repaired.record_counts.values()) == 1
+    assert (
+        tracking_database.assess_tracking_database(repaired.database).state == "current"
+    )
+    repeated = tracking_database.repair_missing_qr_schema_versions(repaired.database)
+    assert repeated.database == repaired.database
+    assert repeated.changed is False
+    assert sum(repeated.record_counts.values()) == 0
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "future_root",
+        "legacy_root",
+        "legacy_config",
+        "future_qr",
+        "null_qr",
+        "bool_qr",
+        "unstamped_v2",
+        "unknown_field",
+        "missing_field",
+        "invalid_date",
+        "duplicate_identity",
+        "missing_talk_version",
+        "active_writer",
+    ],
+)
+def test_qr_repair_refuses_ambiguous_or_unrelated_state(tracking_database, change):
+    database = _missing_qr_version_database(tracking_database)
+    if change == "future_root":
+        database["schema_version"] = CURRENT_ROOT + 1
+    elif change == "legacy_root":
+        database.pop("schema_version")
+    elif change == "legacy_config":
+        database["config"]["schema_version"] = 1
+    elif change in {"future_qr", "null_qr", "bool_qr"}:
+        extra = _qr_v1_record()
+        extra["schema_version"] = {"future_qr": 99, "null_qr": None, "bool_qr": True}[
+            change
+        ]
+        database["qr_codes"].append(extra)
+    elif change == "unstamped_v2":
+        database["qr_codes"][0] = _qr_v2_record()
+        database["qr_codes"][0].pop("schema_version")
+    elif change == "unknown_field":
+        database["qr_codes"][0]["unknown"] = "never discard me"
+    elif change == "missing_field":
+        database["qr_codes"][0].pop("target_url")
+    elif change == "invalid_date":
+        database["qr_codes"][0]["created_at"] = "not-a-date"
+    elif change == "duplicate_identity":
+        database["qr_codes"].append(copy.deepcopy(database["qr_codes"][0]))
+    elif change == "missing_talk_version":
+        database["talks"][0].pop("schema_version")
+    elif change == "active_writer":
+        database["talks"][0]["status"] = "reprocessing-inflight"
+    before = copy.deepcopy(database)
+
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.repair_missing_qr_schema_versions(database)
+    assert database == before
+
+
+def test_qr_repair_dry_run_apply_and_backup_preserve_talk_evidence(
+    tracking_database, migrate_tracking_database, tmp_path, monkeypatch
+):
+    path = tmp_path / "tracking-database.json"
+    original = _missing_qr_version_database(tracking_database)
+    raw = _write_database(path, original)
+    monkeypatch.setattr(
+        migrate_tracking_database,
+        "gate_persisted_observations",
+        lambda *_: pytest.fail("QR repair must not migrate or requeue observations"),
+    )
+    options = {"repair_missing_qr_versions": True}
+    dry = migrate_tracking_database.execute(
+        path, apply=False, expected_sha256=None, **options
+    )
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+    assert dry["repair"] == {
+        "kind": "missing_qr_schema_versions",
+        "python_path": "/opt/python",
+    }
+    assert dry["persisted_observations"] == {"repaired": 0, "requeued": 0}
+
+    for digest in (None, "0" * 64):
+        with pytest.raises(migrate_tracking_database.TrackingDatabaseMigrationError):
+            migrate_tracking_database.execute(
+                path, apply=True, expected_sha256=digest, **options
+            )
+        assert path.read_bytes() == raw
+        assert not (tmp_path / ".backups").exists()
+    applied = migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=dry["input_sha256"], **options
+    )
+    assert Path(applied["backup"]).read_bytes() == raw
+    assert applied["database_written"] is True
+    assert applied["output_sha256"] == dry["output_sha256"]
+    expected = copy.deepcopy(original)
+    expected["qr_codes"][0]["schema_version"] = 1
+    assert json.loads(path.read_bytes()) == expected
+    installed = path.read_bytes()
+    replay = migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=applied["output_sha256"], **options
+    )
+    assert replay["changed"] is False
+    assert replay["backup"] is None
+    assert path.read_bytes() == installed
+
+
+@pytest.mark.parametrize("invalid", [False, True])
+def test_qr_repair_cli_reports_json_without_rejected_values(
+    tracking_database, migrate_tracking_database, tmp_path, capsys, invalid
+):
+    path = tmp_path / "private-catalog.json"
+    database = _missing_qr_version_database(tracking_database)
+    if invalid:
+        database["qr_codes"][0]["created_at"] = "secret-rejected-value"
+    raw = _write_database(path, database)
+    code = migrate_tracking_database.main([str(path), "--repair-missing-qr-versions"])
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert code == (2 if invalid else 0)
+    assert report["ok"] is not invalid
+    assert "secret-rejected-value" not in captured.out + captured.err
+    if invalid:
+        assert str(path) not in captured.out + captured.err
+        assert "retry" in report["error"]
+    assert path.read_bytes() == raw
+
+
 def test_qr_v2_record_validates(tracking_database):
     _validate_qr(tracking_database, _qr_v2_record())
 

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1770,15 +1770,16 @@ def test_qr_repair_dry_run_apply_and_backup_preserve_talk_evidence(
 
 
 @pytest.mark.parametrize("invalid", [False, True])
+@pytest.mark.parametrize("flag", ["--repair-missing-qr-versions", "--repair-missing"])
 def test_qr_repair_cli_reports_json_without_rejected_values(
-    tracking_database, migrate_tracking_database, tmp_path, capsys, invalid
+    tracking_database, migrate_tracking_database, tmp_path, capsys, invalid, flag
 ):
     path = tmp_path / "private-catalog.json"
     database = _missing_qr_version_database(tracking_database)
     if invalid:
         database["qr_codes"][0]["created_at"] = "secret-rejected-value"
     raw = _write_database(path, database)
-    code = migrate_tracking_database.main([str(path), "--repair-missing-qr-versions"])
+    code = migrate_tracking_database.main([str(path), flag])
     captured = capsys.readouterr()
     report = json.loads(captured.out)
     assert code == (2 if invalid else 0)

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1710,6 +1710,10 @@ def test_qr_repair_refuses_ambiguous_or_unrelated_state(tracking_database, chang
         database["talks"][0].pop("schema_version")
     elif change == "active_writer":
         database["talks"][0]["status"] = "reprocessing-inflight"
+        database["talks"][0]["reprocess_generation"] = 1
+        database["talks"][0]["_queue_claim"] = _claim_for_version(
+            1, generation=1, state="claimed", batch_id="active"
+        )
     before = copy.deepcopy(database)
 
     with pytest.raises(tracking_database.TrackingDatabaseError):
@@ -1783,7 +1787,38 @@ def test_qr_repair_cli_reports_json_without_rejected_values(
     if invalid:
         assert str(path) not in captured.out + captured.err
         assert "retry" in report["error"]
+        assert report["code"] == "qr_repair_record_invalid"
+        assert report["details"] == {
+            "record_index": 0,
+            "missing_fields": [],
+            "unexpected_field_count": 0,
+            "has_artifacts": False,
+        }
     assert path.read_bytes() == raw
+
+
+def test_qr_repair_active_writer_diagnostic_has_no_database_values(
+    tracking_database, migrate_tracking_database, tmp_path, capsys
+):
+    path = tmp_path / "private.json"
+    database = _missing_qr_version_database(tracking_database)
+    database["talks"][0]["status"] = "reprocessing-inflight"
+    database["talks"][0]["reprocess_generation"] = 1
+    database["talks"][0]["_queue_claim"] = _claim_for_version(
+        1, generation=1, state="claimed", batch_id="active"
+    )
+    raw = _write_database(path, database)
+    assert (
+        migrate_tracking_database.main([str(path), "--repair-missing-qr-versions"]) == 2
+    )
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["code"] == "qr_repair_active_writers"
+    assert report["details"] == {"active_talk_count": 1}
+    assert "one.md" not in captured.out + captured.err
+    assert str(path) not in captured.out + captured.err
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
 
 
 def test_qr_v2_record_validates(tracking_database):


### PR DESCRIPTION
## Summary
- Add an explicit owner-only `--repair-missing-qr-versions` mode for valid unstamped legacy QR records under a current database root. Ordinary reads and migration remain fail-closed.
- Reuse the exact-byte backup, hash precondition, and shared transaction; validate the complete candidate and refuse active writers. Preserve talks, observations, statuses, claims, and every unrelated record without running normal migration or reparsing.
- Document the authorized bootstrap recovery path and emit closed, value-redacted refusal diagnostics. This is the user-approved prerequisite repair for catalog issues #333 and #339, not a claim that those issues are complete. Patch release with automatic version bump.

## Test plan
- [x] Schema tests cover exact preservation, dry-run/apply/replay, digest refusal, backup bytes, malformed/future schemas, active claims, and error redaction including abbreviated CLI flags.
- [x] Full suite: 6,459 passed, 8 existing platform skips. Ruff lint/format, Pyright, packaging, conflict-marker and plugin lint gates passed.
- [x] Vault-ingress skill review: 97/100.
- [x] Live read-only preview validates the candidate but reports five active claims; no database bytes changed and no claims were canceled.
- [ ] Policy/Copilot reviews, hosted CI, publication, and moderation verification.
- [ ] Apply the reviewed repair after active claims finish or an explicitly approved recovery resolves them.
