### PR TITLE
feat(vault-ingress): add bounded crop review tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,8 @@
 skills/**/*.bas.txt linguist-generated=true merge=ours
 skills/**/*.applescript.txt linguist-generated=true merge=ours
 skills/**/*.yaml.txt linguist-generated=true merge=ours
+skills/**/*.html.txt linguist-generated=true merge=ours
+skills/**/*.js.txt linguist-generated=true merge=ours
 
 # Renderer dependency lock. Committed under the generated-artifact exception in
 # coding-policy: file-hygiene — pinning four top-level versions leaves the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### feat(vault-ingress) — package source-bound crop review (#382)
+
+The formerly scratch-only contact-sheet and crop-review workflow now ships as
+bounded scripts and an offline reviewer shell. Sampling preserves individual
+frames alongside a separate classification sheet, binds them to the recording,
+and rejects incomplete or changed inputs without replacing existing outputs.
+
+The TSV builder validates every talk's frames and reports their counts. The
+reviewer keeps the supplied photographic proofing layout, exposes every sampled
+timestamp, isolates saved decisions by batch/source/proposal identity, and
+clears approval after edits. Proposed no-slides decisions remain unapproved.
+Copying produces shell-quoted commands or no-slides comments and never runs them.
+
+Extraction pipeline 0.14.0 adds an optional reviewed-source digest guard, used
+by exported commands, to reject a replacement recording before sampling or
+changing prior derivatives. No database change or reparse is part of building
+the reviewer. HTML/JavaScript mirrors preserve installation compatibility.
+
 ## 0.20.116 — 2026-09-04
 
 ### fix(vault-ingress) — repair unstamped legacy QR records through the owner

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -59,6 +59,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/rhetoric-dimensions.md](references/rhetoric-dimensions.md) | 14 analysis dimensions |
 | [references/subagent-instructions.md](references/subagent-instructions.md) | Step 3 per-talk procedure — transcript download, slide acquisition, fallback chains, return-JSON shape |
 | [references/video-slide-extraction.md](references/video-slide-extraction.md) | Video-to-slides pipeline — layout heuristics, tuning, limitations |
+| [references/crop-review.md](references/crop-review.md) | Reproducible contact sheets, individual-frame proposals, and owner crop approval |
 | [references/markdown-decks.md](references/markdown-decks.md) | Slidev/presenterm/Marp/reveal-md decks — render lanes, register-and-requeue, reveal structure |
 | [references/source-identity-preflight.md](references/source-identity-preflight.md) | Offline identity, duplicate-source, enum, and artifact integrity contracts |
 | [references/source-identity-audit.md](references/source-identity-audit.md) | Networked, read-only capture of live provider identity evidence and review findings |

--- a/skills/vault-ingress/references/crop-review.md
+++ b/skills/vault-ingress/references/crop-review.md
@@ -1,0 +1,134 @@
+# Reproducible Crop Review
+
+Use this workflow to classify a recording and obtain the owner's slide-region
+decision. It does not parse talks, change the tracking database, or approve a
+proposal on the owner's behalf. A contact sheet is classification context, not
+a crop canvas or proof that the entire video is intact.
+
+## Build the Samples
+
+Use the configured `{python_path}` and a local recording. Create the output's
+parent directory first, then select a new bundle name:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/build-contact-sheet.py" \
+  "{recording_path}" "{sample_bundle_path}"
+```
+
+Read the JSON report's `manifest`, `frames`, and `reused` fields. `--frames` and
+`--timeout-seconds` are optional. The sampling range, image dimensions,
+resource limits, and interior timestamp schedule belong to
+`skills/vault-ingress/scripts/crop_frames.py` (`sample_times` and top-level
+constants). Both a classification sheet and independently extracted frame
+images are retained. Never substitute a sheet for an individual frame.
+
+The operation rejects unavailable cloud files without hydrating them. Decoding
+uses an immutable private snapshot inside the bounded supervisor. A complete
+bundle is published after source and snapshot verification. An identical
+existing bundle is reusable; a changed or incomplete bundle needs a fresh
+output directory. Existing content is not repaired or overwritten.
+
+## Propose, Then Ask the Owner
+
+Inspect the classification sheet and individual frames. Use reasoning to
+propose the slide rectangle or a full-frame/no-slides classification. A sampled
+demo segment alone does not establish that the entire talk has no slides;
+increase sampling or inspect the recording when ambiguous.
+
+The UTF-8 TSV column contract is in the docstring of
+`skills/vault-ingress/scripts/build-crop-reviewer.py`. Write rows carrying the talk
+ID, display metadata, native absolute recording/output/manifest paths, and the
+proposed mode and normalized rectangle. The header is:
+
+```text
+id	title	conference	date	video_path	output_dir	manifest	mode	region
+```
+
+Build the offline reviewer:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/build-crop-reviewer.py" \
+  "{proposals_tsv_path}" "{reviewer_html_path}" \
+  --batch-id "{review_batch_id}" --python "{python_path}"
+```
+
+Read `frames_per_talk` in the JSON report. Every talk must have validated
+individual frame images, including proposed no-slides talks. The builder also
+checks the current recording against the sampled content. Missing frames,
+changed digests, unsupported manifests, and stale recordings stop the build.
+An identical existing HTML file is reusable; changed proposals need a new
+filename. Both scripts emit one JSON object, use exit 0 for success, 1 for an
+input/operational failure, and 2 for invalid command usage. Read the failure
+code and stderr recovery message; never interpret missing output as success.
+
+Open the generated HTML locally and have the owner check every timestamp.
+The supplied reviewer shell retains the frame-first proofing layout. Numeric
+coordinates and focus-scoped arrow keys supplement pointer dragging. Each
+proposal begins unapproved. Editing, resetting, or choosing full frame clears
+approval. Confirming no slides is an explicit owner decision, not a consequence
+of a proposed classification.
+
+The HTML embeds its frames and makes no external font or image requests. It
+contains recording images and local command paths; keep it in the authorized
+local review workspace, outside the public repository. Browser storage failure
+is visible; copy decisions before closing when storage is unavailable.
+
+## Approval Round-Trip
+
+The reviewer exports POSIX-shell commands only for explicitly approved crops
+or full frames. Commands carry the reviewed source digest and
+`--region-verified`. No-slides decisions export comments, not extraction or
+database commands. Copying commands never executes them. Execute only when
+the owner has authorized extraction; this tooling does not authorize a reparse.
+
+The extractor's source-mismatch behavior is documented in
+[video-slide-extraction.md](video-slide-extraction.md#source-binding--the-run-fails-rather-than-guess).
+Retain the normal acquisition, integrity, promotion, and persistence gates in
+that workflow. Crop approval does not establish speaker identity, delivery
+identity, full-recording integrity, or a trusted authored-slide count.
+
+## Owned State Contracts
+
+Owner: `vault-ingress`. The sampler alone writes and reads frame manifests;
+the reviewer builder consumes them without migration. Unknown schemas fail
+closed. Regenerate an unsupported sample bundle through its owner into a fresh
+directory; never restamp it.
+
+Manifest root fields:
+
+- `schema_version`: 1.
+- `pipeline_version`: the sampling implementation generation.
+- `source`: the existing versioned video-source receipt, including content
+  digest, exact file generation, duration, and stream facts. Its schema remains
+  owned by the video-evidence contract in `schemas-db.md`.
+- `frames`: ordered individual-image records.
+- `contact_sheet`: a separate classification-image record.
+
+Every image record carries `schema_version: 1`, literal `file`, `sha256`,
+`size_bytes`, `width`, and `height`. Individual frames also carry `index` and
+`timestamp_seconds`; timestamps are requested seek positions, not measured
+word/caption alignment. The closed field sets and filename/dimension checks
+are enforced by `validate_manifest` in the sampling module referenced above. Duplicate-looking frames
+can represent static content and are not silently deduplicated.
+
+The generated HTML embeds versioned talk records (`id`, `title`, `conference`,
+`date`, proposed `region`/`mode`, `frames`, and shell-quoted `command_prefix`).
+Embedded frames carry `schema_version: 1`, requested `timestamp` in seconds,
+and a JPEG data URL in `image`. Batch metadata has `schema_version: 1`, `id`,
+and `fingerprint`. The batch
+fingerprint binds proposals, source/frame manifests, and generated command
+arguments. A changed identity cannot inherit old approvals. The browser's
+localStorage key combines that fingerprint with the explicit batch ID.
+
+The reviewer is the sole writer/reader of its saved-decision envelope:
+`schema_version: 1`, `fingerprint`, and `entries` keyed by talk ID. Every entry
+has `schema_version: 1`, `mode`, normalized `region`, and `verdict`. Unsupported
+or malformed state is discarded visibly; missing state is unapproved. This is
+local review continuity, not a catalog mutation receipt or a source of approval
+for other skills. Exact validation and state transitions live in
+`skills/vault-ingress/scripts/crop-reviewer.js` (`restore`, `edit`, `approve`).
+
+The HTML and JavaScript templates have byte-identical `.txt` mirrors for the
+plugin install filter. The builder reads those mirrors when source extensions
+are absent. No generated reviewer, sampled image, or live proposal TSV belongs
+in the shipped package.

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1773,7 +1773,7 @@ Stored in `structured_data.video_extraction` on the talk entry:
 {
   "slide_source": "video_extracted",
   "schema_version": 4,
-  "pipeline_version": "0.13.0",
+  "pipeline_version": "0.14.0",
   "source_video_id": "AbCdEfGhI_1",
   "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
   "source_receipt": {

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -103,6 +103,11 @@ Conference videos have varying layouts — slides may occupy the full frame, or
 share space with a speaker camera (PiP), conference branding bars, or lower-third
 titles. The script auto-detects the slide region.
 
+For reproducible human review of proposed regions, follow
+[crop-review.md](crop-review.md). That workflow preserves individual sample
+frames, separates classification sheets from crop inputs, and exports commands
+only for owner-approved decisions. Building a reviewer does not run extraction.
+
 ## Step 4: Deduplicate by Perceptual Hash
 
 Adjacent frames showing the same slide produce near-identical perceptual hashes.
@@ -225,6 +230,10 @@ outcomes:
   hydrated — the extractor never substitutes a stub.
 - **Source replaced while the run was producing derivatives**: exit 1 with
   `reason_code` `video_source_replaced_during_extraction`, and no record.
+- **Source differs from `--expected-source-sha256`**: exit 1 with
+  `reason_code` `video_review_source_mismatch`; no frames are sampled or prior
+  derivatives changed. Rebuild the reviewer for the current recording and
+  obtain a new approval.
 - **Any failed run, for any reason including an interrupt**: the destination
   PDFs hold exactly what they held before the run started. A failed
   re-extraction never destroys or half-replaces what an earlier bound run

--- a/skills/vault-ingress/scripts/build-contact-sheet.py
+++ b/skills/vault-ingress/scripts/build-contact-sheet.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Sample VIDEO into OUTPUT_DIR without approving crops or touching the vault DB.
+
+Usage: build-contact-sheet.py VIDEO OUTPUT_DIR [--frames N] [--timeout-seconds N]
+Stdout: one JSON report (manifest path, frame count, reuse status).
+Exit 0: complete validated bundle; 1: operational failure; 2: invalid usage.
+Output includes individual frames and a separate classification contact sheet.
+The sampling constants and failure codes live in crop_frames.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import NoReturn
+
+from artifact_supervisor import SupervisorError
+from crop_frames import CropFramesError, DEFAULT_FRAMES, LIMITS, sample_video
+from video_evidence import VideoEvidenceError
+
+
+USAGE = "build-contact-sheet.py VIDEO OUTPUT_DIR [--frames N] [--timeout-seconds N]"
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        print(json.dumps({"ok": False, "code": "crop_usage_invalid", "usage": USAGE}))
+        print(f"invalid sampling command; usage: {USAGE}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if arguments in (["--help"], ["-h"]):
+        print(json.dumps({"ok": True, "usage": USAGE}))
+        return 0
+    parser = ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("video", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--frames", type=int, default=DEFAULT_FRAMES)
+    parser.add_argument("--timeout-seconds", type=float, default=LIMITS.wall_seconds)
+    args = parser.parse_args(arguments)
+    try:
+        report = sample_video(
+            args.video,
+            args.output_dir,
+            count=args.frames,
+            timeout_seconds=args.timeout_seconds,
+        )
+    except (CropFramesError, VideoEvidenceError, SupervisorError, OSError) as exc:
+        code = (
+            exc.code
+            if isinstance(exc, CropFramesError)
+            else exc.reason_code
+            if isinstance(exc, (VideoEvidenceError, SupervisorError))
+            else "crop_io_failure"
+        )
+        print(json.dumps({"ok": False, "code": code}))
+        print(str(CropFramesError(code)), file=sys.stderr)
+        return 1
+    print(json.dumps(report))
+    return 0
+
+
+def run_cli() -> int:
+    try:
+        return main()
+    # Agent callers interpret absent JSON as a lost process contract. Emit a
+    # closed failure; a traceback would drop that contract and expose paths.
+    # outer-boundary-process-contract
+    except Exception:  # noqa: BLE001
+        print(json.dumps({"ok": False, "code": "crop_unexpected_failure"}))
+        print(
+            "sampling failed unexpectedly; repair the runtime and retry",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli())

--- a/skills/vault-ingress/scripts/build-crop-reviewer.py
+++ b/skills/vault-ingress/scripts/build-crop-reviewer.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Build an offline, human-approved crop reviewer from a proposals TSV.
+
+Usage: build-crop-reviewer.py PROPOSALS OUTPUT_HTML --batch-id ID [--python PATH]
+TSV columns: id, title, conference, date, video_path, output_dir, manifest,
+mode, region. Modes: crop, full-frame, no-slides. Region: normalized L,T,R,B
+for crop, blank otherwise. Paths are native absolute paths, not shell fragments.
+
+Every talk requires a validated individual-frame bundle from build-contact-sheet.py.
+The builder verifies current recording content against the sampled source. It
+never approves a proposal, runs extraction, reparses, or reads/writes the vault DB.
+Stdout: one JSON report with frames_per_talk and the output path. Exit 0 succeeds,
+1 reports an operational/input rejection, 2 reports invalid CLI usage. Existing
+identical HTML is reusable; changed HTML requires a fresh output filename.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import sys
+import tempfile
+from typing import NoReturn
+
+from artifact_supervisor import SupervisorError
+from crop_frames import CropFramesError, load_frame_bundle
+from ingress_contract import YOUTUBE_ID_RE
+from video_evidence import VideoEvidenceError, probe_video_artifact
+
+
+SCHEMA_VERSION = 1
+MAX_TALKS = 500
+MAX_TSV_BYTES = 2 * 1024**2
+MAX_HTML_BYTES = 256 * 1024**2
+COLUMNS = (
+    "id",
+    "title",
+    "conference",
+    "date",
+    "video_path",
+    "output_dir",
+    "manifest",
+    "mode",
+    "region",
+)
+USAGE = "build-crop-reviewer.py PROPOSALS OUTPUT_HTML --batch-id ID [--python PATH]"
+
+
+class ReviewerError(ValueError):
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(
+            f"{code}: check the proposals and frame manifests; regenerate stale samples or choose a fresh reviewer filename and retry"
+        )
+
+
+def _text(value: object, *, required: bool = False) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > 4096
+        or any(ord(char) < 32 or ord(char) == 127 for char in value)
+        or (required and not value.strip())
+    ):
+        raise ReviewerError("crop_proposal_text_invalid")
+    return value
+
+
+def _path(value: str) -> str:
+    _text(value, required=True)
+    if not Path(value).is_absolute():
+        raise ReviewerError("crop_proposal_path_invalid")
+    return value
+
+
+def parse_proposals(text: str) -> list[dict]:
+    try:
+        reader = csv.DictReader(io.StringIO(text), delimiter="\t", strict=True)
+        if reader.fieldnames != list(COLUMNS):
+            raise ReviewerError("crop_proposal_columns_invalid")
+        result = []
+        seen = set()
+        for row in reader:
+            if len(result) >= MAX_TALKS or set(row) != set(COLUMNS):
+                raise ReviewerError("crop_proposal_rows_invalid")
+            for key, value in row.items():
+                _text(value, required=key not in {"conference", "date", "region"})
+            if not YOUTUBE_ID_RE.fullmatch(row["id"]) or row["id"] in seen:
+                raise ReviewerError("crop_proposal_id_invalid")
+            seen.add(row["id"])
+            for key in ("video_path", "output_dir", "manifest"):
+                _path(row[key])
+            mode = row["mode"]
+            if mode not in {"crop", "full-frame", "no-slides"}:
+                raise ReviewerError("crop_proposal_mode_invalid")
+            if mode == "crop":
+                try:
+                    region = [float(number) for number in row["region"].split(",")]
+                except ValueError as exc:
+                    raise ReviewerError("crop_proposal_region_invalid") from exc
+                if len(region) != 4 or not (
+                    0 <= region[0] < region[2] <= 1 and 0 <= region[1] < region[3] <= 1
+                ):
+                    raise ReviewerError("crop_proposal_region_invalid")
+            else:
+                if row["region"]:
+                    raise ReviewerError("crop_proposal_region_invalid")
+                region = [0, 0, 1, 1]
+            result.append({**row, "region": region})
+        if not result:
+            raise ReviewerError("crop_proposal_empty")
+        return result
+    except csv.Error as exc:
+        raise ReviewerError("crop_proposal_tsv_invalid") from exc
+
+
+def script_json(value: object) -> str:
+    return (
+        json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+def _read_template(name: str) -> str:
+    path = Path(__file__).with_name(name)
+    if not path.exists():
+        path = path.with_name(path.name + ".txt")
+    return path.read_text(encoding="utf-8")
+
+
+def build_reviewer(
+    proposals: Path, output: Path, *, batch_id: str, python_path: str = sys.executable
+) -> dict:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", batch_id):
+        raise ReviewerError("crop_batch_id_invalid")
+    _path(python_path)
+    with proposals.open("rb") as stream:
+        raw = stream.read(MAX_TSV_BYTES + 1)
+    if len(raw) > MAX_TSV_BYTES:
+        raise ReviewerError("crop_proposal_size_limit")
+    try:
+        rows = parse_proposals(raw.decode("utf-8-sig"))
+    except UnicodeError as exc:
+        raise ReviewerError("crop_proposal_encoding_invalid") from exc
+    talks = []
+    identities = []
+    total = 0
+    extractor = str(Path(__file__).with_name("video-slide-extraction.py").resolve())
+    for row in rows:
+        bundle = load_frame_bundle(row["manifest"])
+        manifest = bundle["manifest"]
+        source = probe_video_artifact(row["video_path"])
+        if (
+            source.source_sha256 != manifest["source"]["source_sha256"]
+            or source.source_size_bytes != manifest["source"]["source_size_bytes"]
+        ):
+            raise ReviewerError("crop_proposal_source_mismatch")
+        frames = [
+            {
+                "schema_version": SCHEMA_VERSION,
+                "timestamp": item["timestamp_seconds"],
+                "image": "data:image/jpeg;base64," + bundle["artifacts"][item["file"]],
+            }
+            for item in manifest["frames"]
+        ]
+        total += sum(len(frame["image"]) for frame in frames)
+        if total > MAX_HTML_BYTES:
+            raise ReviewerError("crop_reviewer_size_limit")
+        command_prefix = shlex.join(
+            [
+                python_path,
+                extractor,
+                row["video_path"],
+                row["output_dir"],
+                "--expected-source-sha256",
+                source.source_sha256,
+            ]
+        )
+        identity = {
+            "schema_version": SCHEMA_VERSION,
+            **row,
+            "manifest_sha256": bundle["manifest_sha256"],
+            "command_prefix": command_prefix,
+        }
+        identities.append(identity)
+        talks.append(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "id": row["id"],
+                "title": row["title"],
+                "conference": row["conference"],
+                "date": row["date"],
+                "region": row["region"],
+                "mode": row["mode"],
+                "frames": frames,
+                "command_prefix": command_prefix,
+            }
+        )
+    fingerprint = hashlib.sha256(script_json(identities).encode()).hexdigest()
+    template = _read_template("crop-reviewer-shell.html")
+    javascript = _read_template("crop-reviewer.js")
+    if (
+        template.count("__TALKS_JSON__") != 1
+        or template.count("__BATCH_JSON__") != 1
+        or template.count("__REVIEWER_JS__") != 1
+    ):
+        raise ReviewerError("crop_reviewer_template_invalid")
+    replacements = {
+        "__REVIEWER_JS__": javascript,
+        "__BATCH_JSON__": script_json(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "id": batch_id,
+                "fingerprint": fingerprint,
+            }
+        ),
+        "__TALKS_JSON__": script_json(talks),
+    }
+    # One substitution pass: data containing another marker remains literal.
+    html = re.sub(
+        r"__REVIEWER_JS__|__BATCH_JSON__|__TALKS_JSON__",
+        lambda match: replacements[match.group()],
+        template,
+    )
+    encoded = html.encode("utf-8")
+    if len(encoded) > MAX_HTML_BYTES:
+        raise ReviewerError("crop_reviewer_size_limit")
+    output = output.absolute()
+    if output.is_symlink():
+        raise ReviewerError("crop_reviewer_output_conflict")
+    if output.exists():
+        with output.open("rb") as stream:
+            prior = stream.read(MAX_HTML_BYTES + 1)
+        if prior != encoded:
+            raise ReviewerError("crop_reviewer_output_conflict")
+        reused = True
+    else:
+        with tempfile.TemporaryDirectory(
+            prefix=".crop-review-stage-", dir=output.parent
+        ) as directory:
+            staged = Path(directory) / "review.html"
+            staged.write_bytes(encoded)
+            staged.chmod(0o600)
+            os.link(staged, output)
+        reused = False
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "output": str(output),
+        "reused": reused,
+        "batch_fingerprint": fingerprint,
+        "frames_per_talk": {talk["id"]: len(talk["frames"]) for talk in talks},
+    }
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        print(
+            json.dumps(
+                {"ok": False, "code": "crop_reviewer_usage_invalid", "usage": USAGE}
+            )
+        )
+        print(f"invalid reviewer command; usage: {USAGE}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if arguments in (["--help"], ["-h"]):
+        print(json.dumps({"ok": True, "usage": USAGE}))
+        return 0
+    parser = ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("proposals", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--batch-id", required=True)
+    parser.add_argument("--python", default=sys.executable)
+    args = parser.parse_args(arguments)
+    try:
+        report = build_reviewer(
+            args.proposals, args.output, batch_id=args.batch_id, python_path=args.python
+        )
+    except (
+        ReviewerError,
+        CropFramesError,
+        SupervisorError,
+        VideoEvidenceError,
+        OSError,
+    ) as exc:
+        code = (
+            exc.code
+            if isinstance(exc, (ReviewerError, CropFramesError))
+            else exc.reason_code
+            if isinstance(exc, (SupervisorError, VideoEvidenceError))
+            else "crop_reviewer_io_failure"
+        )
+        print(json.dumps({"ok": False, "code": code}))
+        print(str(ReviewerError(code)), file=sys.stderr)
+        return 1
+    print(json.dumps(report))
+    return 0
+
+
+def run_cli() -> int:
+    try:
+        return main()
+    # Agent callers treat absent JSON as a broken process contract. Emit one
+    # closed failure; propagation would lose the contract and expose paths.
+    # outer-boundary-process-contract
+    except Exception:  # noqa: BLE001
+        print(json.dumps({"ok": False, "code": "crop_reviewer_unexpected_failure"}))
+        print(
+            "reviewer build failed unexpectedly; repair the runtime and retry",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli())

--- a/skills/vault-ingress/scripts/crop-reviewer-shell.html
+++ b/skills/vault-ingress/scripts/crop-reviewer-shell.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Slide Region Review</title>
+<style>
+:root{
+  --ground:#F2F3F5; --panel:#FFFFFF; --sunk:#E7E9ED; --line:#D3D7DE;
+  --text:#16181C; --muted:#5D646E; --accent:#B5731A; --accent-soft:#F0E0C6;
+  --good:#2F7D53; --warn:#9A5B12; --stop:#A33A3A;
+  --shadow:0 1px 2px rgba(20,22,26,.08),0 8px 24px rgba(20,22,26,.06);
+}
+@media (prefers-color-scheme:dark){:root:not([data-theme="light"]){
+  --ground:#14161A; --panel:#1D2026; --sunk:#101216; --line:#2C3038;
+  --text:#E6E8EC; --muted:#8A9099; --accent:#E8A33D; --accent-soft:#3A2E1B;
+  --good:#5BC08C; --warn:#E8A33D; --stop:#E06C6C;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+}}
+:root[data-theme="dark"]{
+  --ground:#14161A; --panel:#1D2026; --sunk:#101216; --line:#2C3038;
+  --text:#E6E8EC; --muted:#8A9099; --accent:#E8A33D; --accent-soft:#3A2E1B;
+  --good:#5BC08C; --warn:#E8A33D; --stop:#E06C6C;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--ground);color:var(--text);
+  font-family:Aptos,"Segoe UI",sans-serif;font-size:15px;line-height:1.5}
+h1,h2,h3,.lbl{font-family:"Arial Narrow","Aptos Display",Aptos,sans-serif}
+.mono{font-family:Aptos,"Segoe UI",sans-serif;
+  font-variant-numeric:tabular-nums}
+.lbl{font-size:13px;font-weight:600;color:var(--muted)}
+header{display:flex;flex-wrap:wrap;gap:16px;align-items:baseline;
+  padding:18px 22px;border-bottom:1px solid var(--line);background:var(--panel)}
+header h1{margin:0;font-size:21px;font-weight:700;letter-spacing:-.01em}
+header .sub{color:var(--muted);font-size:14px;max-width:62ch}
+.counts{margin-left:auto;display:flex;gap:14px;align-items:center}
+.count{display:flex;gap:6px;align-items:baseline}
+.count b{font-size:19px;font-weight:600}
+.wrap{display:grid;grid-template-columns:290px minmax(0,1fr);gap:0;min-height:calc(100vh - 74px)}
+@media (max-width:900px){.wrap{grid-template-columns:1fr}}
+aside{border-right:1px solid var(--line);background:var(--panel);overflow-y:auto;max-height:calc(100vh - 74px)}
+@media (max-width:900px){aside{max-height:none;border-right:0;border-bottom:1px solid var(--line)}}
+.row{display:flex;gap:10px;align-items:center;width:100%;text-align:left;
+  padding:10px 14px;background:none;border:0;border-bottom:1px solid var(--line);
+  color:inherit;font:inherit;cursor:pointer}
+.row:hover{background:var(--sunk)}
+.row[aria-current="true"]{background:var(--sunk);box-shadow:inset 3px 0 0 var(--accent)}
+.row .nm{flex:1;min-width:0}
+.row .t{display:block;font-weight:500;font-size:13.5px;overflow:hidden;
+  text-overflow:ellipsis;white-space:nowrap}
+.row .c{display:block;color:var(--muted);font-size:11.5px;overflow:hidden;
+  text-overflow:ellipsis;white-space:nowrap}
+.chip{flex:none;width:9px;height:9px;border-radius:50%;background:var(--line)}
+.chip.ok{background:var(--good)} .chip.no{background:var(--stop)} .chip.ed{background:var(--accent)}
+main{padding:20px 22px;display:flex;flex-direction:column;gap:16px;min-width:0}
+.stage{background:var(--sunk);border:1px solid var(--line);border-radius:6px;padding:14px}
+.frame{position:relative;width:100%;max-width:940px;margin:0 auto;user-select:none;
+  touch-action:none;line-height:0}
+.frame img{width:100%;height:auto;display:block;border-radius:3px}
+.veil{position:absolute;inset:0;background:rgba(10,11,14,.62);pointer-events:none;border-radius:3px}
+.crop{position:absolute;border:1.5px solid var(--accent);cursor:move;
+  box-shadow:0 0 0 9999px rgba(0,0,0,0);}
+.crop::after{content:"";position:absolute;inset:0;
+  background:linear-gradient(var(--accent),var(--accent)) no-repeat,
+             linear-gradient(var(--accent),var(--accent)) no-repeat;
+  background-size:100% 1px,1px 100%;background-position:0 33.3%,33.3% 0;opacity:.18}
+.h{position:absolute;width:13px;height:13px;background:var(--accent);border-radius:2px}
+.h[data-h="nw"]{left:-7px;top:-7px;cursor:nwse-resize}
+.h[data-h="ne"]{right:-7px;top:-7px;cursor:nesw-resize}
+.h[data-h="sw"]{left:-7px;bottom:-7px;cursor:nesw-resize}
+.h[data-h="se"]{right:-7px;bottom:-7px;cursor:nwse-resize}
+.h[data-h="n"]{left:50%;top:-7px;margin-left:-6px;cursor:ns-resize}
+.h[data-h="s"]{left:50%;bottom:-7px;margin-left:-6px;cursor:ns-resize}
+.h[data-h="w"]{left:-7px;top:50%;margin-top:-6px;cursor:ew-resize}
+.h[data-h="e"]{right:-7px;top:50%;margin-top:-6px;cursor:ew-resize}
+.tabs{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;margin-top:12px}
+.tab{padding:5px 13px;border:1px solid var(--line);background:var(--panel);color:var(--muted);
+  border-radius:999px;cursor:pointer;font:inherit;font-size:12.5px}
+.tab[aria-pressed="true"]{border-color:var(--accent);color:var(--text);background:var(--accent-soft)}
+.hint{text-align:center;color:var(--muted);font-size:12.5px;margin-top:8px}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:14px 16px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:12px}
+.fld{display:flex;flex-direction:column;gap:5px}
+input[type=number]{width:100%;padding:7px 9px;border:1px solid var(--line);border-radius:4px;
+  background:var(--sunk);color:var(--text);font-family:Aptos,"Segoe UI",sans-serif;font-size:13px;
+  font-variant-numeric:tabular-nums}
+input[type=number]:focus-visible,button:focus-visible,.row:focus-visible,.frame:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.acts{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+button.b{padding:8px 15px;border-radius:5px;border:1px solid var(--line);background:var(--panel);
+  color:var(--text);font:inherit;font-weight:500;cursor:pointer}
+button.b:hover{border-color:var(--muted)}
+button.b.pri{background:var(--accent);border-color:var(--accent);color:#14161A;font-weight:600}
+button.b.danger{color:var(--stop)}
+.meta{display:flex;flex-wrap:wrap;gap:18px;color:var(--muted);font-size:12.5px}
+pre{margin:0;padding:12px;background:var(--sunk);border:1px solid var(--line);border-radius:5px;
+  overflow-x:auto;font-family:Aptos,"Segoe UI",sans-serif;font-size:12.5px;line-height:1.7}
+.note{color:var(--muted);font-size:13px;max-width:70ch}
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+</style></head><body>
+<header>
+  <div>
+    <h1>Slide Region Review</h1>
+    <div class="sub">Check the proposed region against every sampled timestamp. Drag the box to include only the slide. A proposal is not an approval; editing any decision clears its approval.</div>
+  </div>
+  <div class="counts">
+    <div class="count"><b id="cOk">0</b><span class="lbl">approved</span></div>
+    <div class="count"><b id="cNo">0</b><span class="lbl">no slides</span></div>
+    <div class="count"><b id="cLeft">0</b><span class="lbl">left</span></div>
+  </div>
+</header>
+<div class="wrap">
+  <aside id="list" aria-label="Talks to review"></aside>
+  <main>
+    <p id="notice" role="status" hidden></p>
+    <div>
+      <h2 id="tTitle" style="margin:0 0 2px;font-size:18px"></h2>
+      <div class="meta">
+        <span id="tConf"></span>
+        <span class="mono" id="tId"></span>
+        <span id="tFrames"></span>
+        <span id="tRatio"></span>
+      </div>
+    </div>
+
+    <div class="stage">
+      <div class="frame" id="frame" tabindex="0" aria-label="Crop canvas. Arrow keys move the crop; Shift moves faster.">
+        <img id="img" alt="Individual video frame for slide crop review">
+        <div class="veil" id="veil"></div>
+        <div class="crop" id="crop">
+          <span class="h" data-h="nw"></span><span class="h" data-h="n"></span><span class="h" data-h="ne"></span>
+          <span class="h" data-h="w"></span><span class="h" data-h="e"></span>
+          <span class="h" data-h="sw"></span><span class="h" data-h="s"></span><span class="h" data-h="se"></span>
+        </div>
+      </div>
+      <div class="tabs" id="tabs"></div>
+      <div class="hint">Drag inside the box to move it, the handles to resize. Focus the frame to nudge with arrow keys; Shift+Arrow moves faster.</div>
+    </div>
+
+    <div class="panel">
+      <div class="grid">
+        <label class="fld"><span class="lbl">Left</span><input type="number" id="iL" step="0.001" min="0" max="1"></label>
+        <label class="fld"><span class="lbl">Top</span><input type="number" id="iT" step="0.001" min="0" max="1"></label>
+        <label class="fld"><span class="lbl">Right</span><input type="number" id="iR" step="0.001" min="0" max="1"></label>
+        <label class="fld"><span class="lbl">Bottom</span><input type="number" id="iB" step="0.001" min="0" max="1"></label>
+      </div>
+      <div class="acts" style="margin-top:14px">
+        <button class="b pri" id="bOk">Approve crop</button>
+        <button class="b" id="bReset">Reset to proposal</button>
+        <button class="b" id="bFull">Use full frame</button>
+        <button class="b danger" id="bNo">Confirm no slides</button>
+        <span class="mono" id="stateNote" role="status" style="color:var(--muted);font-size:12.5px"></span>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="lbl" style="margin-bottom:8px">Commands for approved talks</div>
+      <p class="note" style="margin:0 0 10px">These commands use your explicitly approved region and require the exact sampled recording. Copying does not execute them. They are POSIX-shell commands; run only when you intend to re-extract.</p>
+      <pre id="out">Approve a crop to see its command.</pre>
+      <div class="acts" style="margin-top:10px">
+        <button class="b" id="bCopy">Copy commands</button>
+        <button class="b" id="bClear">Clear all decisions</button>
+      </div>
+    </div>
+  </main>
+</div>
+<script>
+const TALKS = __TALKS_JSON__;
+const BATCH = __BATCH_JSON__;
+__REVIEWER_JS__
+</script>
+</body></html>

--- a/skills/vault-ingress/scripts/crop-reviewer-shell.html.txt
+++ b/skills/vault-ingress/scripts/crop-reviewer-shell.html.txt
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Slide Region Review</title>
+<style>
+:root{
+  --ground:#F2F3F5; --panel:#FFFFFF; --sunk:#E7E9ED; --line:#D3D7DE;
+  --text:#16181C; --muted:#5D646E; --accent:#B5731A; --accent-soft:#F0E0C6;
+  --good:#2F7D53; --warn:#9A5B12; --stop:#A33A3A;
+  --shadow:0 1px 2px rgba(20,22,26,.08),0 8px 24px rgba(20,22,26,.06);
+}
+@media (prefers-color-scheme:dark){:root:not([data-theme="light"]){
+  --ground:#14161A; --panel:#1D2026; --sunk:#101216; --line:#2C3038;
+  --text:#E6E8EC; --muted:#8A9099; --accent:#E8A33D; --accent-soft:#3A2E1B;
+  --good:#5BC08C; --warn:#E8A33D; --stop:#E06C6C;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+}}
+:root[data-theme="dark"]{
+  --ground:#14161A; --panel:#1D2026; --sunk:#101216; --line:#2C3038;
+  --text:#E6E8EC; --muted:#8A9099; --accent:#E8A33D; --accent-soft:#3A2E1B;
+  --good:#5BC08C; --warn:#E8A33D; --stop:#E06C6C;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 10px 30px rgba(0,0,0,.35);
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--ground);color:var(--text);
+  font-family:Aptos,"Segoe UI",sans-serif;font-size:15px;line-height:1.5}
+h1,h2,h3,.lbl{font-family:"Arial Narrow","Aptos Display",Aptos,sans-serif}
+.mono{font-family:Aptos,"Segoe UI",sans-serif;
+  font-variant-numeric:tabular-nums}
+.lbl{font-size:13px;font-weight:600;color:var(--muted)}
+header{display:flex;flex-wrap:wrap;gap:16px;align-items:baseline;
+  padding:18px 22px;border-bottom:1px solid var(--line);background:var(--panel)}
+header h1{margin:0;font-size:21px;font-weight:700;letter-spacing:-.01em}
+header .sub{color:var(--muted);font-size:14px;max-width:62ch}
+.counts{margin-left:auto;display:flex;gap:14px;align-items:center}
+.count{display:flex;gap:6px;align-items:baseline}
+.count b{font-size:19px;font-weight:600}
+.wrap{display:grid;grid-template-columns:290px minmax(0,1fr);gap:0;min-height:calc(100vh - 74px)}
+@media (max-width:900px){.wrap{grid-template-columns:1fr}}
+aside{border-right:1px solid var(--line);background:var(--panel);overflow-y:auto;max-height:calc(100vh - 74px)}
+@media (max-width:900px){aside{max-height:none;border-right:0;border-bottom:1px solid var(--line)}}
+.row{display:flex;gap:10px;align-items:center;width:100%;text-align:left;
+  padding:10px 14px;background:none;border:0;border-bottom:1px solid var(--line);
+  color:inherit;font:inherit;cursor:pointer}
+.row:hover{background:var(--sunk)}
+.row[aria-current="true"]{background:var(--sunk);box-shadow:inset 3px 0 0 var(--accent)}
+.row .nm{flex:1;min-width:0}
+.row .t{display:block;font-weight:500;font-size:13.5px;overflow:hidden;
+  text-overflow:ellipsis;white-space:nowrap}
+.row .c{display:block;color:var(--muted);font-size:11.5px;overflow:hidden;
+  text-overflow:ellipsis;white-space:nowrap}
+.chip{flex:none;width:9px;height:9px;border-radius:50%;background:var(--line)}
+.chip.ok{background:var(--good)} .chip.no{background:var(--stop)} .chip.ed{background:var(--accent)}
+main{padding:20px 22px;display:flex;flex-direction:column;gap:16px;min-width:0}
+.stage{background:var(--sunk);border:1px solid var(--line);border-radius:6px;padding:14px}
+.frame{position:relative;width:100%;max-width:940px;margin:0 auto;user-select:none;
+  touch-action:none;line-height:0}
+.frame img{width:100%;height:auto;display:block;border-radius:3px}
+.veil{position:absolute;inset:0;background:rgba(10,11,14,.62);pointer-events:none;border-radius:3px}
+.crop{position:absolute;border:1.5px solid var(--accent);cursor:move;
+  box-shadow:0 0 0 9999px rgba(0,0,0,0);}
+.crop::after{content:"";position:absolute;inset:0;
+  background:linear-gradient(var(--accent),var(--accent)) no-repeat,
+             linear-gradient(var(--accent),var(--accent)) no-repeat;
+  background-size:100% 1px,1px 100%;background-position:0 33.3%,33.3% 0;opacity:.18}
+.h{position:absolute;width:13px;height:13px;background:var(--accent);border-radius:2px}
+.h[data-h="nw"]{left:-7px;top:-7px;cursor:nwse-resize}
+.h[data-h="ne"]{right:-7px;top:-7px;cursor:nesw-resize}
+.h[data-h="sw"]{left:-7px;bottom:-7px;cursor:nesw-resize}
+.h[data-h="se"]{right:-7px;bottom:-7px;cursor:nwse-resize}
+.h[data-h="n"]{left:50%;top:-7px;margin-left:-6px;cursor:ns-resize}
+.h[data-h="s"]{left:50%;bottom:-7px;margin-left:-6px;cursor:ns-resize}
+.h[data-h="w"]{left:-7px;top:50%;margin-top:-6px;cursor:ew-resize}
+.h[data-h="e"]{right:-7px;top:50%;margin-top:-6px;cursor:ew-resize}
+.tabs{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;margin-top:12px}
+.tab{padding:5px 13px;border:1px solid var(--line);background:var(--panel);color:var(--muted);
+  border-radius:999px;cursor:pointer;font:inherit;font-size:12.5px}
+.tab[aria-pressed="true"]{border-color:var(--accent);color:var(--text);background:var(--accent-soft)}
+.hint{text-align:center;color:var(--muted);font-size:12.5px;margin-top:8px}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:14px 16px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(128px,1fr));gap:12px}
+.fld{display:flex;flex-direction:column;gap:5px}
+input[type=number]{width:100%;padding:7px 9px;border:1px solid var(--line);border-radius:4px;
+  background:var(--sunk);color:var(--text);font-family:Aptos,"Segoe UI",sans-serif;font-size:13px;
+  font-variant-numeric:tabular-nums}
+input[type=number]:focus-visible,button:focus-visible,.row:focus-visible,.frame:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.acts{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+button.b{padding:8px 15px;border-radius:5px;border:1px solid var(--line);background:var(--panel);
+  color:var(--text);font:inherit;font-weight:500;cursor:pointer}
+button.b:hover{border-color:var(--muted)}
+button.b.pri{background:var(--accent);border-color:var(--accent);color:#14161A;font-weight:600}
+button.b.danger{color:var(--stop)}
+.meta{display:flex;flex-wrap:wrap;gap:18px;color:var(--muted);font-size:12.5px}
+pre{margin:0;padding:12px;background:var(--sunk);border:1px solid var(--line);border-radius:5px;
+  overflow-x:auto;font-family:Aptos,"Segoe UI",sans-serif;font-size:12.5px;line-height:1.7}
+.note{color:var(--muted);font-size:13px;max-width:70ch}
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+</style></head><body>
+<header>
+  <div>
+    <h1>Slide Region Review</h1>
+    <div class="sub">Check the proposed region against every sampled timestamp. Drag the box to include only the slide. A proposal is not an approval; editing any decision clears its approval.</div>
+  </div>
+  <div class="counts">
+    <div class="count"><b id="cOk">0</b><span class="lbl">approved</span></div>
+    <div class="count"><b id="cNo">0</b><span class="lbl">no slides</span></div>
+    <div class="count"><b id="cLeft">0</b><span class="lbl">left</span></div>
+  </div>
+</header>
+<div class="wrap">
+  <aside id="list" aria-label="Talks to review"></aside>
+  <main>
+    <p id="notice" role="status" hidden></p>
+    <div>
+      <h2 id="tTitle" style="margin:0 0 2px;font-size:18px"></h2>
+      <div class="meta">
+        <span id="tConf"></span>
+        <span class="mono" id="tId"></span>
+        <span id="tFrames"></span>
+        <span id="tRatio"></span>
+      </div>
+    </div>
+
+    <div class="stage">
+      <div class="frame" id="frame" tabindex="0" aria-label="Crop canvas. Arrow keys move the crop; Shift moves faster.">
+        <img id="img" alt="Individual video frame for slide crop review">
+        <div class="veil" id="veil"></div>
+        <div class="crop" id="crop">
+          <span class="h" data-h="nw"></span><span class="h" data-h="n"></span><span class="h" data-h="ne"></span>
+          <span class="h" data-h="w"></span><span class="h" data-h="e"></span>
+          <span class="h" data-h="sw"></span><span class="h" data-h="s"></span><span class="h" data-h="se"></span>
+        </div>
+      </div>
+      <div class="tabs" id="tabs"></div>
+      <div class="hint">Drag inside the box to move it, the handles to resize. Focus the frame to nudge with arrow keys; Shift+Arrow moves faster.</div>
+    </div>
+
+    <div class="panel">
+      <div class="grid">
+        <label class="fld"><span class="lbl">Left</span><input type="number" id="iL" step="0.001" min="0" max="1"></label>
+        <label class="fld"><span class="lbl">Top</span><input type="number" id="iT" step="0.001" min="0" max="1"></label>
+        <label class="fld"><span class="lbl">Right</span><input type="number" id="iR" step="0.001" min="0" max="1"></label>
+        <label class="fld"><span class="lbl">Bottom</span><input type="number" id="iB" step="0.001" min="0" max="1"></label>
+      </div>
+      <div class="acts" style="margin-top:14px">
+        <button class="b pri" id="bOk">Approve crop</button>
+        <button class="b" id="bReset">Reset to proposal</button>
+        <button class="b" id="bFull">Use full frame</button>
+        <button class="b danger" id="bNo">Confirm no slides</button>
+        <span class="mono" id="stateNote" role="status" style="color:var(--muted);font-size:12.5px"></span>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="lbl" style="margin-bottom:8px">Commands for approved talks</div>
+      <p class="note" style="margin:0 0 10px">These commands use your explicitly approved region and require the exact sampled recording. Copying does not execute them. They are POSIX-shell commands; run only when you intend to re-extract.</p>
+      <pre id="out">Approve a crop to see its command.</pre>
+      <div class="acts" style="margin-top:10px">
+        <button class="b" id="bCopy">Copy commands</button>
+        <button class="b" id="bClear">Clear all decisions</button>
+      </div>
+    </div>
+  </main>
+</div>
+<script>
+const TALKS = __TALKS_JSON__;
+const BATCH = __BATCH_JSON__;
+__REVIEWER_JS__
+</script>
+</body></html>

--- a/skills/vault-ingress/scripts/crop-reviewer.js
+++ b/skills/vault-ingress/scripts/crop-reviewer.js
@@ -1,0 +1,248 @@
+/* Offline crop review. Pure decision rules are exported for CI tests. */
+"use strict";
+
+const CropReview = (() => {
+  const full = () => [0, 0, 1, 1];
+  const validRegion = r => Array.isArray(r) && r.length === 4 &&
+    r.every(v => typeof v === "number" && Number.isFinite(v)) &&
+    0 <= r[0] && r[0] < r[2] && r[2] <= 1 &&
+    0 <= r[1] && r[1] < r[3] && r[3] <= 1;
+  const initial = talk => ({schema_version: 1, mode: talk.mode,
+    region: talk.region.slice(), verdict: null});
+  const key = batch => `crop-review-v1:${batch.id}:${batch.fingerprint}`;
+
+  function validEntry(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry) ||
+        Object.keys(entry).sort().join(",") !== "mode,region,schema_version,verdict" ||
+        entry.schema_version !== 1 || !validRegion(entry.region) ||
+        !["crop", "full-frame", "no-slides"].includes(entry.mode)) return false;
+    if (entry.mode !== "crop" && entry.region.some((v, i) => v !== full()[i])) return false;
+    return entry.verdict === null ||
+      (entry.verdict === "approved" && entry.mode !== "no-slides") ||
+      (entry.verdict === "no-slides" && entry.mode === "no-slides");
+  }
+
+  function restore(talks, batch, raw) {
+    const entries = Object.fromEntries(talks.map(t => [t.id, initial(t)]));
+    if (raw === null) return entries;
+    const saved = JSON.parse(raw);
+    if (!saved || typeof saved !== "object" || saved.schema_version !== 1 ||
+        Object.keys(saved).sort().join(",") !== "entries,fingerprint,schema_version" ||
+        saved.fingerprint !== batch.fingerprint || !saved.entries ||
+        typeof saved.entries !== "object" || Array.isArray(saved.entries) ||
+        Object.keys(saved.entries).some(id => !Object.hasOwn(entries, id)) ||
+        Object.values(saved.entries).some(e => !validEntry(e))) {
+      throw new SyntaxError("Saved crop decisions do not match this reviewer");
+    }
+    for (const talk of talks) {
+      if (Object.hasOwn(saved.entries, talk.id)) entries[talk.id] = saved.entries[talk.id];
+    }
+    return entries;
+  }
+
+  function edit(entry, region, mode = "crop") {
+    const updated = {...entry, region: region.slice(), mode, verdict: null};
+    if (!validEntry(updated)) throw new RangeError("Enter a rectangle inside the frame");
+    return updated;
+  }
+
+  function approve(entry) {
+    const updated = {...entry, region: entry.region.slice(),
+      verdict: entry.mode === "no-slides" ? "no-slides" : "approved"};
+    if (!validEntry(updated)) throw new RangeError("Review a valid region before approving");
+    return updated;
+  }
+
+  function commands(talks, entries) {
+    const lines = [];
+    for (const talk of talks) {
+      const entry = entries[talk.id];
+      if (!validEntry(entry)) continue;
+      if (entry.verdict === "approved") {
+        lines.push(`${talk.command_prefix} --region ${entry.region.join(",")} --region-verified -- ${talk.id}`);
+      } else if (entry.verdict === "no-slides") {
+        // IDs are a closed alphabet; display titles never enter shell comments.
+        lines.push(`# ${talk.id}: owner confirmed no slides; no extraction command`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  function storageFailure(error) {
+    return error instanceof SyntaxError ||
+      (error instanceof DOMException && ["SecurityError", "QuotaExceededError"].includes(error.name));
+  }
+
+  function start(talks, batch) {
+    const $ = id => document.getElementById(id);
+    const announce = message => { $("notice").hidden = !message; $("notice").textContent = message; };
+    let entries = restore(talks, batch, null);
+    try { entries = restore(talks, batch, localStorage.getItem(key(batch))); }
+    catch (error) {
+      if (!storageFailure(error)) throw error;
+      announce("Saved decisions could not be loaded. All proposals need approval again; copy your commands before closing this page.");
+    }
+    function save() {
+      try { localStorage.setItem(key(batch), JSON.stringify({schema_version: 1,
+        fingerprint: batch.fingerprint, entries})); }
+      catch (error) {
+        if (!storageFailure(error)) throw error;
+        announce("Decisions are only in this open page. Browser storage is unavailable; copy the commands before closing.");
+      }
+    }
+
+    let current = 0, frameIndex = 0, drag = null;
+    const talk = () => talks[current];
+    const entry = () => entries[talk().id];
+    const clamp = (value, lo, hi) => Math.min(hi, Math.max(lo, value));
+    const label = e => e.verdict === "approved" ? "Approved" :
+      e.verdict === "no-slides" ? "Confirmed no slides" :
+      e.mode === "no-slides" ? "Proposed no slides; not approved" : "Not approved";
+
+    function renderList() {
+      $("list").replaceChildren();
+      for (const [index, item] of talks.entries()) {
+        const button = document.createElement("button");
+        button.className = "row";
+        button.setAttribute("aria-current", index === current ? "true" : "false");
+        const chip = document.createElement("span");
+        chip.className = "chip " + (entries[item.id].verdict === "approved" ? "ok" : entries[item.id].verdict === "no-slides" ? "no" : "ed");
+        chip.setAttribute("aria-hidden", "true");
+        const name = document.createElement("span"); name.className = "nm";
+        const title = document.createElement("span"); title.className = "t"; title.textContent = item.title;
+        const detail = document.createElement("span"); detail.className = "c";
+        detail.textContent = `${label(entries[item.id])} — ${item.conference || item.id}`;
+        name.append(title, detail); button.append(chip, name);
+        button.onclick = () => { current = index; frameIndex = 0; renderAll(); };
+        $("list").append(button);
+      }
+      const approved = Object.values(entries).filter(e => e.verdict === "approved").length;
+      const none = Object.values(entries).filter(e => e.verdict === "no-slides").length;
+      $("cOk").textContent = approved; $("cNo").textContent = none;
+      $("cLeft").textContent = talks.length - approved - none;
+    }
+
+    function renderCrop() {
+      const [l, t, r, b] = entry().region;
+      const crop = $("crop");
+      crop.style.left = `${l * 100}%`; crop.style.top = `${t * 100}%`;
+      crop.style.width = `${(r - l) * 100}%`; crop.style.height = `${(b - t) * 100}%`;
+      crop.hidden = entry().mode === "no-slides";
+      $("veil").hidden = crop.hidden;
+      $("veil").style.clipPath = `polygon(0 0,100% 0,100% 100%,0 100%,0 0,${l*100}% ${t*100}%,${l*100}% ${b*100}%,${r*100}% ${b*100}%,${r*100}% ${t*100}%,${l*100}% ${t*100}%)`;
+      ["iL", "iT", "iR", "iB"].forEach((id, i) => { $(id).value = entry().region[i]; });
+      $("stateNote").textContent = label(entry());
+      $("bOk").textContent = entry().mode === "no-slides" ? "Confirm no slides" : entry().mode === "full-frame" ? "Approve full frame" : "Approve crop";
+    }
+
+    function renderOut() {
+      const output = commands(talks, entries);
+      $("out").textContent = output || "Approve a decision to see its command or note.";
+      $("bCopy").disabled = !output;
+    }
+
+    function renderAll() {
+      const item = talk();
+      $("tTitle").textContent = item.title;
+      $("tConf").textContent = [item.conference, item.date].filter(Boolean).join(" / ");
+      $("tId").textContent = item.id;
+      $("tFrames").textContent = `${item.frames.length} individual sample frames`;
+      $("tRatio").textContent = `Proposal: ${item.mode}`;
+      $("img").src = item.frames[frameIndex].image;
+      $("img").alt = `Frame at ${item.frames[frameIndex].timestamp.toFixed(2)} seconds: ${item.title}`;
+      $("tabs").replaceChildren();
+      item.frames.forEach((frame, index) => {
+        const button = document.createElement("button"); button.className = "tab";
+        button.textContent = `${frame.timestamp.toFixed(2)}s`;
+        button.setAttribute("aria-pressed", index === frameIndex ? "true" : "false");
+        button.onclick = () => { frameIndex = index; renderAll(); };
+        $("tabs").append(button);
+      });
+      renderCrop(); renderList(); renderOut();
+    }
+
+    function setRegion(region, mode = "crop") {
+      entries[talk().id] = edit(entry(), region, mode);
+      save(); renderCrop(); renderList(); renderOut();
+    }
+
+    $("frame").addEventListener("pointerdown", event => {
+      const handle = event.target.closest(".h");
+      if (!handle && !event.target.closest(".crop")) return;
+      event.preventDefault(); $("frame").focus();
+      const rect = $("frame").getBoundingClientRect();
+      drag = {mode: handle ? handle.dataset.h : "move", rect,
+        x: event.clientX, y: event.clientY, start: entry().region.slice()};
+      $("frame").setPointerCapture(event.pointerId);
+    });
+    $("frame").addEventListener("pointermove", event => {
+      if (!drag) return;
+      const dx = (event.clientX - drag.x) / drag.rect.width;
+      const dy = (event.clientY - drag.y) / drag.rect.height;
+      let [l, t, r, b] = drag.start;
+      if (drag.mode === "move") {
+        const w = r - l, h = b - t;
+        l = clamp(l + dx, 0, 1 - w); t = clamp(t + dy, 0, 1 - h); r = l + w; b = t + h;
+      } else {
+        if (drag.mode.includes("w")) l = clamp(l + dx, 0, r - .001);
+        if (drag.mode.includes("e")) r = clamp(r + dx, l + .001, 1);
+        if (drag.mode.includes("n")) t = clamp(t + dy, 0, b - .001);
+        if (drag.mode.includes("s")) b = clamp(b + dy, t + .001, 1);
+      }
+      if (validRegion([l, t, r, b])) setRegion([l, t, r, b]);
+    });
+    for (const event of ["pointerup", "pointercancel", "lostpointercapture"]) {
+      $("frame").addEventListener(event, () => { drag = null; });
+    }
+
+    ["iL", "iT", "iR", "iB"].forEach((id, index) => {
+      $(id).addEventListener("change", () => {
+        const region = entry().region.slice();
+        region[index] = $(id).value === "" ? NaN : Number($(id).value);
+        if (!validRegion(region)) {
+          announce("Enter coordinates from 0 to 1, with left before right and top before bottom.");
+          renderCrop(); return;
+        }
+        setRegion(region);
+      });
+    });
+    $("frame").addEventListener("keydown", event => {
+      const directions = {ArrowLeft: [-1, 0], ArrowRight: [1, 0], ArrowUp: [0, -1], ArrowDown: [0, 1]};
+      const direction = directions[event.key];
+      if (!direction || entry().mode === "no-slides") return;
+      event.preventDefault();
+      const step = event.shiftKey ? .02 : .004;
+      let [l, t, r, b] = entry().region;
+      const w = r - l, h = b - t;
+      l = clamp(l + direction[0] * step, 0, 1 - w);
+      t = clamp(t + direction[1] * step, 0, 1 - h);
+      setRegion([l, t, l + w, t + h]);
+    });
+
+    $("bOk").onclick = () => { entries[talk().id] = approve(entry()); save(); renderAll(); };
+    $("bNo").onclick = () => { entries[talk().id] = approve(edit(entry(), full(), "no-slides")); save(); renderAll(); };
+    $("bFull").onclick = () => setRegion(full(), "full-frame");
+    $("bReset").onclick = () => { entries[talk().id] = initial(talk()); save(); renderAll(); };
+    $("bClear").onclick = () => {
+      if (confirm("Clear every decision in this reviewer?")) {
+        entries = restore(talks, batch, null); save(); renderAll();
+      }
+    };
+    $("bCopy").onclick = async () => {
+      if (!navigator.clipboard) { announce("Clipboard access is unavailable. Select and copy the command text below."); return; }
+      try {
+        await navigator.clipboard.writeText(commands(talks, entries));
+        announce("Commands copied. Nothing has been executed.");
+      } catch (error) {
+        if (!(error instanceof DOMException)) throw error;
+        announce("Clipboard access was refused. Select and copy the command text below.");
+      }
+    };
+    renderAll();
+  }
+
+  return {validRegion, initial, key, validEntry, restore, edit, approve, commands, start};
+})();
+
+if (typeof module !== "undefined" && module.exports) module.exports = CropReview;
+if (typeof document !== "undefined") CropReview.start(TALKS, BATCH);

--- a/skills/vault-ingress/scripts/crop-reviewer.js.txt
+++ b/skills/vault-ingress/scripts/crop-reviewer.js.txt
@@ -1,0 +1,248 @@
+/* Offline crop review. Pure decision rules are exported for CI tests. */
+"use strict";
+
+const CropReview = (() => {
+  const full = () => [0, 0, 1, 1];
+  const validRegion = r => Array.isArray(r) && r.length === 4 &&
+    r.every(v => typeof v === "number" && Number.isFinite(v)) &&
+    0 <= r[0] && r[0] < r[2] && r[2] <= 1 &&
+    0 <= r[1] && r[1] < r[3] && r[3] <= 1;
+  const initial = talk => ({schema_version: 1, mode: talk.mode,
+    region: talk.region.slice(), verdict: null});
+  const key = batch => `crop-review-v1:${batch.id}:${batch.fingerprint}`;
+
+  function validEntry(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry) ||
+        Object.keys(entry).sort().join(",") !== "mode,region,schema_version,verdict" ||
+        entry.schema_version !== 1 || !validRegion(entry.region) ||
+        !["crop", "full-frame", "no-slides"].includes(entry.mode)) return false;
+    if (entry.mode !== "crop" && entry.region.some((v, i) => v !== full()[i])) return false;
+    return entry.verdict === null ||
+      (entry.verdict === "approved" && entry.mode !== "no-slides") ||
+      (entry.verdict === "no-slides" && entry.mode === "no-slides");
+  }
+
+  function restore(talks, batch, raw) {
+    const entries = Object.fromEntries(talks.map(t => [t.id, initial(t)]));
+    if (raw === null) return entries;
+    const saved = JSON.parse(raw);
+    if (!saved || typeof saved !== "object" || saved.schema_version !== 1 ||
+        Object.keys(saved).sort().join(",") !== "entries,fingerprint,schema_version" ||
+        saved.fingerprint !== batch.fingerprint || !saved.entries ||
+        typeof saved.entries !== "object" || Array.isArray(saved.entries) ||
+        Object.keys(saved.entries).some(id => !Object.hasOwn(entries, id)) ||
+        Object.values(saved.entries).some(e => !validEntry(e))) {
+      throw new SyntaxError("Saved crop decisions do not match this reviewer");
+    }
+    for (const talk of talks) {
+      if (Object.hasOwn(saved.entries, talk.id)) entries[talk.id] = saved.entries[talk.id];
+    }
+    return entries;
+  }
+
+  function edit(entry, region, mode = "crop") {
+    const updated = {...entry, region: region.slice(), mode, verdict: null};
+    if (!validEntry(updated)) throw new RangeError("Enter a rectangle inside the frame");
+    return updated;
+  }
+
+  function approve(entry) {
+    const updated = {...entry, region: entry.region.slice(),
+      verdict: entry.mode === "no-slides" ? "no-slides" : "approved"};
+    if (!validEntry(updated)) throw new RangeError("Review a valid region before approving");
+    return updated;
+  }
+
+  function commands(talks, entries) {
+    const lines = [];
+    for (const talk of talks) {
+      const entry = entries[talk.id];
+      if (!validEntry(entry)) continue;
+      if (entry.verdict === "approved") {
+        lines.push(`${talk.command_prefix} --region ${entry.region.join(",")} --region-verified -- ${talk.id}`);
+      } else if (entry.verdict === "no-slides") {
+        // IDs are a closed alphabet; display titles never enter shell comments.
+        lines.push(`# ${talk.id}: owner confirmed no slides; no extraction command`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  function storageFailure(error) {
+    return error instanceof SyntaxError ||
+      (error instanceof DOMException && ["SecurityError", "QuotaExceededError"].includes(error.name));
+  }
+
+  function start(talks, batch) {
+    const $ = id => document.getElementById(id);
+    const announce = message => { $("notice").hidden = !message; $("notice").textContent = message; };
+    let entries = restore(talks, batch, null);
+    try { entries = restore(talks, batch, localStorage.getItem(key(batch))); }
+    catch (error) {
+      if (!storageFailure(error)) throw error;
+      announce("Saved decisions could not be loaded. All proposals need approval again; copy your commands before closing this page.");
+    }
+    function save() {
+      try { localStorage.setItem(key(batch), JSON.stringify({schema_version: 1,
+        fingerprint: batch.fingerprint, entries})); }
+      catch (error) {
+        if (!storageFailure(error)) throw error;
+        announce("Decisions are only in this open page. Browser storage is unavailable; copy the commands before closing.");
+      }
+    }
+
+    let current = 0, frameIndex = 0, drag = null;
+    const talk = () => talks[current];
+    const entry = () => entries[talk().id];
+    const clamp = (value, lo, hi) => Math.min(hi, Math.max(lo, value));
+    const label = e => e.verdict === "approved" ? "Approved" :
+      e.verdict === "no-slides" ? "Confirmed no slides" :
+      e.mode === "no-slides" ? "Proposed no slides; not approved" : "Not approved";
+
+    function renderList() {
+      $("list").replaceChildren();
+      for (const [index, item] of talks.entries()) {
+        const button = document.createElement("button");
+        button.className = "row";
+        button.setAttribute("aria-current", index === current ? "true" : "false");
+        const chip = document.createElement("span");
+        chip.className = "chip " + (entries[item.id].verdict === "approved" ? "ok" : entries[item.id].verdict === "no-slides" ? "no" : "ed");
+        chip.setAttribute("aria-hidden", "true");
+        const name = document.createElement("span"); name.className = "nm";
+        const title = document.createElement("span"); title.className = "t"; title.textContent = item.title;
+        const detail = document.createElement("span"); detail.className = "c";
+        detail.textContent = `${label(entries[item.id])} — ${item.conference || item.id}`;
+        name.append(title, detail); button.append(chip, name);
+        button.onclick = () => { current = index; frameIndex = 0; renderAll(); };
+        $("list").append(button);
+      }
+      const approved = Object.values(entries).filter(e => e.verdict === "approved").length;
+      const none = Object.values(entries).filter(e => e.verdict === "no-slides").length;
+      $("cOk").textContent = approved; $("cNo").textContent = none;
+      $("cLeft").textContent = talks.length - approved - none;
+    }
+
+    function renderCrop() {
+      const [l, t, r, b] = entry().region;
+      const crop = $("crop");
+      crop.style.left = `${l * 100}%`; crop.style.top = `${t * 100}%`;
+      crop.style.width = `${(r - l) * 100}%`; crop.style.height = `${(b - t) * 100}%`;
+      crop.hidden = entry().mode === "no-slides";
+      $("veil").hidden = crop.hidden;
+      $("veil").style.clipPath = `polygon(0 0,100% 0,100% 100%,0 100%,0 0,${l*100}% ${t*100}%,${l*100}% ${b*100}%,${r*100}% ${b*100}%,${r*100}% ${t*100}%,${l*100}% ${t*100}%)`;
+      ["iL", "iT", "iR", "iB"].forEach((id, i) => { $(id).value = entry().region[i]; });
+      $("stateNote").textContent = label(entry());
+      $("bOk").textContent = entry().mode === "no-slides" ? "Confirm no slides" : entry().mode === "full-frame" ? "Approve full frame" : "Approve crop";
+    }
+
+    function renderOut() {
+      const output = commands(talks, entries);
+      $("out").textContent = output || "Approve a decision to see its command or note.";
+      $("bCopy").disabled = !output;
+    }
+
+    function renderAll() {
+      const item = talk();
+      $("tTitle").textContent = item.title;
+      $("tConf").textContent = [item.conference, item.date].filter(Boolean).join(" / ");
+      $("tId").textContent = item.id;
+      $("tFrames").textContent = `${item.frames.length} individual sample frames`;
+      $("tRatio").textContent = `Proposal: ${item.mode}`;
+      $("img").src = item.frames[frameIndex].image;
+      $("img").alt = `Frame at ${item.frames[frameIndex].timestamp.toFixed(2)} seconds: ${item.title}`;
+      $("tabs").replaceChildren();
+      item.frames.forEach((frame, index) => {
+        const button = document.createElement("button"); button.className = "tab";
+        button.textContent = `${frame.timestamp.toFixed(2)}s`;
+        button.setAttribute("aria-pressed", index === frameIndex ? "true" : "false");
+        button.onclick = () => { frameIndex = index; renderAll(); };
+        $("tabs").append(button);
+      });
+      renderCrop(); renderList(); renderOut();
+    }
+
+    function setRegion(region, mode = "crop") {
+      entries[talk().id] = edit(entry(), region, mode);
+      save(); renderCrop(); renderList(); renderOut();
+    }
+
+    $("frame").addEventListener("pointerdown", event => {
+      const handle = event.target.closest(".h");
+      if (!handle && !event.target.closest(".crop")) return;
+      event.preventDefault(); $("frame").focus();
+      const rect = $("frame").getBoundingClientRect();
+      drag = {mode: handle ? handle.dataset.h : "move", rect,
+        x: event.clientX, y: event.clientY, start: entry().region.slice()};
+      $("frame").setPointerCapture(event.pointerId);
+    });
+    $("frame").addEventListener("pointermove", event => {
+      if (!drag) return;
+      const dx = (event.clientX - drag.x) / drag.rect.width;
+      const dy = (event.clientY - drag.y) / drag.rect.height;
+      let [l, t, r, b] = drag.start;
+      if (drag.mode === "move") {
+        const w = r - l, h = b - t;
+        l = clamp(l + dx, 0, 1 - w); t = clamp(t + dy, 0, 1 - h); r = l + w; b = t + h;
+      } else {
+        if (drag.mode.includes("w")) l = clamp(l + dx, 0, r - .001);
+        if (drag.mode.includes("e")) r = clamp(r + dx, l + .001, 1);
+        if (drag.mode.includes("n")) t = clamp(t + dy, 0, b - .001);
+        if (drag.mode.includes("s")) b = clamp(b + dy, t + .001, 1);
+      }
+      if (validRegion([l, t, r, b])) setRegion([l, t, r, b]);
+    });
+    for (const event of ["pointerup", "pointercancel", "lostpointercapture"]) {
+      $("frame").addEventListener(event, () => { drag = null; });
+    }
+
+    ["iL", "iT", "iR", "iB"].forEach((id, index) => {
+      $(id).addEventListener("change", () => {
+        const region = entry().region.slice();
+        region[index] = $(id).value === "" ? NaN : Number($(id).value);
+        if (!validRegion(region)) {
+          announce("Enter coordinates from 0 to 1, with left before right and top before bottom.");
+          renderCrop(); return;
+        }
+        setRegion(region);
+      });
+    });
+    $("frame").addEventListener("keydown", event => {
+      const directions = {ArrowLeft: [-1, 0], ArrowRight: [1, 0], ArrowUp: [0, -1], ArrowDown: [0, 1]};
+      const direction = directions[event.key];
+      if (!direction || entry().mode === "no-slides") return;
+      event.preventDefault();
+      const step = event.shiftKey ? .02 : .004;
+      let [l, t, r, b] = entry().region;
+      const w = r - l, h = b - t;
+      l = clamp(l + direction[0] * step, 0, 1 - w);
+      t = clamp(t + direction[1] * step, 0, 1 - h);
+      setRegion([l, t, l + w, t + h]);
+    });
+
+    $("bOk").onclick = () => { entries[talk().id] = approve(entry()); save(); renderAll(); };
+    $("bNo").onclick = () => { entries[talk().id] = approve(edit(entry(), full(), "no-slides")); save(); renderAll(); };
+    $("bFull").onclick = () => setRegion(full(), "full-frame");
+    $("bReset").onclick = () => { entries[talk().id] = initial(talk()); save(); renderAll(); };
+    $("bClear").onclick = () => {
+      if (confirm("Clear every decision in this reviewer?")) {
+        entries = restore(talks, batch, null); save(); renderAll();
+      }
+    };
+    $("bCopy").onclick = async () => {
+      if (!navigator.clipboard) { announce("Clipboard access is unavailable. Select and copy the command text below."); return; }
+      try {
+        await navigator.clipboard.writeText(commands(talks, entries));
+        announce("Commands copied. Nothing has been executed.");
+      } catch (error) {
+        if (!(error instanceof DOMException)) throw error;
+        announce("Clipboard access was refused. Select and copy the command text below.");
+      }
+    };
+    renderAll();
+  }
+
+  return {validRegion, initial, key, validEntry, restore, edit, approve, commands, start};
+})();
+
+if (typeof module !== "undefined" && module.exports) module.exports = CropReview;
+if (typeof document !== "undefined") CropReview.start(TALKS, BATCH);

--- a/skills/vault-ingress/scripts/crop_frames.py
+++ b/skills/vault-ingress/scripts/crop_frames.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Bounded, source-bound frame sampling for human crop review.
+
+The sampler emits individual JPEGs, a separate classification sheet, and a
+versioned manifest. Samples never establish full-video integrity or approval.
+All media decoding, snapshot reads, and image validation run in the shared
+authenticated supervisor. A complete bundle is published to a fresh directory;
+an identical existing bundle is reusable, and conflicting outputs are preserved.
+
+This module owns the manifest contract; see references/crop-review.md.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Mapping
+from dataclasses import replace
+import hashlib
+import io
+import json
+import math
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from typing import Any, cast
+
+from artifact_metadata import ArtifactAvailability, inspect_metadata_generation
+from artifact_supervisor import (
+    JsonValue,
+    SupervisorError,
+    SupervisorLimits,
+    isolate_protocol_output,
+    read_worker_request,
+    run_authenticated_worker,
+    write_worker_response,
+)
+import video_evidence as video
+from video_integrity import VideoIntegrityError, _run_tool
+
+
+SCHEMA_VERSION = 1
+PIPELINE_VERSION = "crop-frames-v1"
+DEFAULT_FRAMES = 12
+MIN_FRAMES = 6
+MAX_FRAMES = 48
+FRAME_EDGE = 960
+FRAME_BYTES = 1024 * 1024
+SHEET_BYTES = 8 * 1024 * 1024
+MANIFEST_BYTES = 128 * 1024
+SHEET_COLUMNS = 3
+SHEET_CELL = 480
+LIMITS = SupervisorLimits(
+    profile_id=PIPELINE_VERSION,
+    wall_seconds=300,
+    max_memory_bytes=2 * 1024**3,
+    max_output_bytes=96 * 1024**2,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=8,
+)
+WORKER_FLAG = "--supervised-worker"
+
+
+class CropFramesError(ValueError):
+    """Closed failure code; inputs and parser diagnostics stay private."""
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(
+            f"{code}: check the local inputs, dependencies, and sampling limits; "
+            "use a fresh output directory for changed inputs and retry"
+        )
+
+
+def sample_times(duration: float, count: int) -> list[float]:
+    if type(count) is not int or not MIN_FRAMES <= count <= MAX_FRAMES:
+        raise CropFramesError("crop_frame_count_invalid")
+    if (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration <= 0
+    ):
+        raise CropFramesError("crop_duration_invalid")
+    return [duration * index / (count + 1) for index in range(1, count + 1)]
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_path(path: str | os.PathLike[str]) -> Path:
+    # Configured parent roots may be symlinks; the artifact leaf is never resolved.
+    target = Path(os.path.abspath(path))
+    return target.parent.resolve(strict=True) / target.name
+
+
+def _read_local(path: Path, limit: int) -> bytes:
+    """Snapshot one bounded, regular, available file inside a worker only."""
+    before = inspect_metadata_generation(path, trusted_root=path.parent)
+    if ArtifactAvailability.from_generation(before.generation).state != "local":
+        raise CropFramesError("crop_artifact_unavailable")
+    if not 0 < before.generation.size <= limit:
+        raise CropFramesError("crop_artifact_size_invalid")
+    with video._prepared_video_source(path, before.generation) as prepared:
+        os.lseek(prepared.probe_descriptor, 0, os.SEEK_SET)
+        with os.fdopen(os.dup(prepared.probe_descriptor), "rb") as stream:
+            data = stream.read(limit + 1)
+        digest = video._digest_open_descriptor(
+            prepared.source_descriptor, before.generation
+        )
+        if len(data) != before.generation.size or _digest(data) != digest:
+            raise CropFramesError("crop_artifact_changed")
+    after = inspect_metadata_generation(path, trusted_root=path.parent)
+    if after != before:
+        raise CropFramesError("crop_artifact_changed")
+    return data
+
+
+def _image(data: bytes, *, max_edge: int):
+    """Decode a bounded JPEG only in the supervised worker."""
+    from PIL import Image, UnidentifiedImageError
+
+    try:
+        picture = Image.open(io.BytesIO(data))
+        if picture.format != "JPEG" or not all(
+            0 < dimension <= max_edge for dimension in picture.size
+        ):
+            raise CropFramesError("crop_image_invalid")
+        picture.load()
+        return picture.convert("RGB")
+    except (
+        OSError,
+        ValueError,
+        UnidentifiedImageError,
+        Image.DecompressionBombError,
+    ) as exc:
+        raise CropFramesError("crop_image_invalid") from exc
+
+
+def _image_record(name: str, data: bytes, size: tuple[int, int]) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "file": name,
+        "sha256": _digest(data),
+        "size_bytes": len(data),
+        "width": size[0],
+        "height": size[1],
+    }
+
+
+def _sample_snapshot(path: Path, duration: float, count: int) -> dict[str, Any]:
+    """Sample an immutable private recording, not a live pathname."""
+    from PIL import Image, ImageDraw, ImageOps
+
+    binary = shutil.which("ffmpeg")
+    if binary is None:
+        raise CropFramesError("crop_ffmpeg_missing")
+    times = sample_times(duration, count)
+    pictures = []
+    records = []
+    artifacts = {}
+    for index, timestamp in enumerate(times, 1):
+        data = _run_tool(
+            [
+                binary,
+                "-hide_banner",
+                "-nostdin",
+                "-v",
+                "error",
+                "-xerror",
+                "-threads",
+                "2",
+                "-ss",
+                f"{timestamp:.9f}",
+                "-i",
+                str(path),
+                "-map",
+                "0:V:0",
+                "-frames:v",
+                "1",
+                "-an",
+                "-sn",
+                "-dn",
+                "-vf",
+                f"scale={FRAME_EDGE}:{FRAME_EDGE}:force_original_aspect_ratio=decrease:force_divisible_by=2,setsar=1",
+                "-filter_threads",
+                "1",
+                "-threads",
+                "2",
+                "-q:v",
+                "3",
+                "-f",
+                "image2pipe",
+                "-c:v",
+                "mjpeg",
+                "pipe:1",
+            ]
+        )
+        picture = _image(data, max_edge=FRAME_EDGE)
+        name = f"frame-{index:03d}.jpg"
+        records.append(
+            {
+                **_image_record(name, data, picture.size),
+                "index": index,
+                "timestamp_seconds": timestamp,
+            }
+        )
+        artifacts[name] = base64.b64encode(data).decode("ascii")
+        pictures.append(picture)
+    rows = math.ceil(count / SHEET_COLUMNS)
+    sheet = Image.new(
+        "RGB", (SHEET_CELL * SHEET_COLUMNS, (SHEET_CELL + 28) * rows), "#16181c"
+    )
+    draw = ImageDraw.Draw(sheet)
+    for index, picture in enumerate(pictures):
+        thumb = ImageOps.contain(picture, (SHEET_CELL, SHEET_CELL))
+        x = index % SHEET_COLUMNS * SHEET_CELL
+        y = index // SHEET_COLUMNS * (SHEET_CELL + 28)
+        sheet.paste(thumb, (x + (SHEET_CELL - thumb.width) // 2, y))
+        draw.text((x + 8, y + SHEET_CELL + 5), f"{times[index]:.2f}s", fill="white")
+    output = io.BytesIO()
+    sheet.save(output, format="JPEG", quality=85)
+    data = output.getvalue()
+    if len(data) > SHEET_BYTES:
+        raise CropFramesError("crop_sheet_size_invalid")
+    name = "contact-sheet.jpg"
+    artifacts[name] = base64.b64encode(data).decode("ascii")
+    return {
+        "frames": records,
+        "contact_sheet": _image_record(name, data, sheet.size),
+        "artifacts": artifacts,
+    }
+
+
+def _strict_json(data: bytes) -> Any:
+    def pairs(values):
+        result = {}
+        for key, value in values:
+            if key in result:
+                raise CropFramesError("crop_manifest_invalid")
+            result[key] = value
+        return result
+
+    def constant(value):
+        raise CropFramesError("crop_manifest_invalid")
+
+    try:
+        return json.loads(data, object_pairs_hook=pairs, parse_constant=constant)
+    except (ValueError, UnicodeError, RecursionError) as exc:
+        raise CropFramesError("crop_manifest_invalid") from exc
+
+
+def validate_manifest(document: object) -> dict[str, Any]:
+    """Validate the closed owner schema before touching any named frame."""
+    if not isinstance(document, dict) or set(document) != {
+        "schema_version",
+        "pipeline_version",
+        "source",
+        "frames",
+        "contact_sheet",
+    }:
+        raise CropFramesError("crop_manifest_invalid")
+    if (
+        type(document["schema_version"]) is not int
+        or document["schema_version"] != SCHEMA_VERSION
+        or document["pipeline_version"] != PIPELINE_VERSION
+    ):
+        raise CropFramesError("crop_manifest_unsupported")
+    source = video.validate_video_source_receipt(document["source"])
+    frames = document["frames"]
+    if not isinstance(frames, list):
+        raise CropFramesError("crop_manifest_invalid")
+    times = sample_times(cast(float, source["duration_seconds"]), len(frames))
+    sheet = document["contact_sheet"]
+    base_fields = {"schema_version", "file", "sha256", "size_bytes", "width", "height"}
+    for index, item in enumerate([*frames, sheet]):
+        is_frame = index < len(frames)
+        expected_fields = base_fields | (
+            {"index", "timestamp_seconds"} if is_frame else set()
+        )
+        if not isinstance(item, dict) or set(item) != expected_fields:
+            raise CropFramesError("crop_manifest_invalid")
+        name = f"frame-{index + 1:03d}.jpg" if is_frame else "contact-sheet.jpg"
+        limit = FRAME_BYTES if is_frame else SHEET_BYTES
+        edge = (
+            FRAME_EDGE
+            if is_frame
+            else (SHEET_CELL + 28) * math.ceil(MAX_FRAMES / SHEET_COLUMNS)
+        )
+        if (
+            type(item["schema_version"]) is not int
+            or item["schema_version"] != SCHEMA_VERSION
+            or item["file"] != name
+            or not isinstance(item["sha256"], str)
+            or len(item["sha256"]) != 64
+            or any(c not in "0123456789abcdef" for c in item["sha256"])
+            or type(item["size_bytes"]) is not int
+            or not 0 < item["size_bytes"] <= limit
+            or any(
+                type(item[key]) is not int or not 0 < item[key] <= edge
+                for key in ("width", "height")
+            )
+        ):
+            raise CropFramesError("crop_manifest_invalid")
+        if is_frame and (
+            type(item["index"]) is not int
+            or item["index"] != index + 1
+            or type(item["timestamp_seconds"]) not in (float, int)
+            or item["timestamp_seconds"] != times[index]
+        ):
+            raise CropFramesError("crop_manifest_invalid")
+    if sheet["width"] != SHEET_COLUMNS * SHEET_CELL or sheet["height"] != math.ceil(
+        len(frames) / SHEET_COLUMNS
+    ) * (SHEET_CELL + 28):
+        raise CropFramesError("crop_manifest_invalid")
+    if any(frame["sha256"] == sheet["sha256"] for frame in frames):
+        raise CropFramesError("crop_tiled_frame_rejected")
+    return document
+
+
+def _load_bundle(path: Path) -> dict[str, Any]:
+    raw = _read_local(path, MANIFEST_BYTES)
+    manifest = validate_manifest(_strict_json(raw))
+    artifacts = {}
+    for item in [*manifest["frames"], manifest["contact_sheet"]]:
+        data = _read_local(path.parent / item["file"], item["size_bytes"])
+        if _digest(data) != item["sha256"] or len(data) != item["size_bytes"]:
+            raise CropFramesError("crop_frame_digest_mismatch")
+        edge = max(item["width"], item["height"])
+        picture = _image(data, max_edge=edge)
+        if picture.size != (item["width"], item["height"]):
+            raise CropFramesError("crop_frame_dimensions_mismatch")
+        artifacts[item["file"]] = base64.b64encode(data).decode("ascii")
+    if _read_local(path, MANIFEST_BYTES) != raw:
+        raise CropFramesError("crop_artifact_changed")
+    return {
+        "manifest": manifest,
+        "manifest_sha256": _digest(raw),
+        "artifacts": artifacts,
+    }
+
+
+def _validated_timeout(timeout_seconds: object) -> float:
+    if (
+        type(timeout_seconds) not in (int, float)
+        or not math.isfinite(cast(float, timeout_seconds))
+        or not 0 < cast(float, timeout_seconds) <= 3600
+    ):
+        raise CropFramesError("crop_timeout_invalid")
+    return float(cast(float, timeout_seconds))
+
+
+def _invoke(
+    operation: str,
+    payload: dict,
+    generations: Mapping | None = None,
+    *,
+    timeout_seconds: float = LIMITS.wall_seconds,
+):
+    timeout_seconds = _validated_timeout(timeout_seconds)
+    command = [sys.executable, str(Path(__file__).resolve()), WORKER_FLAG]
+    result = run_authenticated_worker(
+        command,
+        operation,
+        generations or {},
+        cast(JsonValue, payload),
+        replace(LIMITS, wall_seconds=timeout_seconds),
+        immutable_process_identity=command[:2],
+        pipeline_generation=PIPELINE_VERSION,
+    )
+    if result.diagnostics.byte_count or not isinstance(result.payload, dict):
+        raise CropFramesError("crop_worker_result_invalid")
+    return result.payload
+
+
+def load_frame_bundle(path: str | os.PathLike[str]) -> dict[str, Any]:
+    return _invoke("crop_load", {"path": str(_canonical_path(path))})
+
+
+def sample_video(
+    path: str | os.PathLike[str],
+    output: str | os.PathLike[str],
+    *,
+    count: int = DEFAULT_FRAMES,
+    timeout_seconds: float = LIMITS.wall_seconds,
+) -> dict[str, Any]:
+    sample_times(1, count)
+    timeout_seconds = _validated_timeout(timeout_seconds)
+    artifact = _canonical_path(path)
+    destination = _canonical_path(output)
+    probe = video.probe_video_artifact(artifact)
+    source = video.build_video_source_receipt(probe)
+    if destination.exists() or destination.is_symlink():
+        if destination.is_symlink() or not destination.is_dir():
+            raise CropFramesError("crop_output_conflict")
+        prior = load_frame_bundle(destination / "manifest.json")
+        if (
+            prior["manifest"]["source"] != source
+            or len(prior["manifest"]["frames"]) != count
+        ):
+            raise CropFramesError("crop_output_conflict")
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "ok": True,
+            "reused": True,
+            "manifest": str(destination / "manifest.json"),
+            "frames": count,
+        }
+    report = _invoke(
+        "crop_sample",
+        {"path": str(artifact), "source": source, "count": count},
+        {"video": probe.generation},
+        timeout_seconds=timeout_seconds,
+    )
+    manifest = validate_manifest(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "pipeline_version": PIPELINE_VERSION,
+            "source": source,
+            "frames": report.get("frames"),
+            "contact_sheet": report.get("contact_sheet"),
+        }
+    )
+    artifacts = report.get("artifacts")
+    if not isinstance(artifacts, dict) or set(artifacts) != {
+        item["file"] for item in [*manifest["frames"], manifest["contact_sheet"]]
+    }:
+        raise CropFramesError("crop_worker_result_invalid")
+    with tempfile.TemporaryDirectory(
+        prefix=".crop-stage-", dir=destination.parent
+    ) as temporary:
+        stage = Path(temporary) / "bundle"
+        stage.mkdir(mode=0o700)
+        for item in [*manifest["frames"], manifest["contact_sheet"]]:
+            try:
+                encoded = artifacts[item["file"]]
+                if not isinstance(encoded, str):
+                    raise CropFramesError("crop_worker_result_invalid")
+                data = base64.b64decode(encoded, validate=True)
+            except (TypeError, ValueError, binascii.Error) as exc:
+                raise CropFramesError("crop_worker_result_invalid") from exc
+            if _digest(data) != item["sha256"] or len(data) != item["size_bytes"]:
+                raise CropFramesError("crop_worker_result_invalid")
+            (stage / item["file"]).write_bytes(data)
+        (stage / "manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+        try:
+            from filelock import FileLock
+        except ImportError as exc:
+            raise CropFramesError("crop_lock_dependency_missing") from exc
+        lock_name = _digest(os.fsencode(destination)) + ".crop.lock"
+        with FileLock(str(Path(tempfile.gettempdir()) / lock_name), timeout=10):
+            if destination.exists() or destination.is_symlink():
+                raise CropFramesError("crop_output_conflict")
+            stage.rename(destination)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "reused": False,
+        "manifest": str(destination / "manifest.json"),
+        "frames": count,
+    }
+
+
+def _worker() -> int:
+    request = read_worker_request(max_input_bytes=LIMITS.max_input_bytes)
+    output = isolate_protocol_output()
+    try:
+        try:
+            if (
+                request.schema_generation != SCHEMA_VERSION
+                or request.pipeline_generation != PIPELINE_VERSION
+                or request.limit_profile_id != LIMITS.profile_id
+                or not isinstance(request.payload, dict)
+            ):
+                raise SupervisorError("invalid_worker_request")
+            payload = request.payload
+            if (
+                request.operation == "crop_load"
+                and set(payload) == {"path"}
+                and not request.expected_generations
+                and isinstance(payload["path"], str)
+            ):
+                report = _load_bundle(Path(payload["path"]))
+            elif (
+                request.operation == "crop_sample"
+                and set(payload) == {"path", "source", "count"}
+                and set(request.expected_generations) == {"video"}
+                and isinstance(payload["path"], str)
+            ):
+                artifact = Path(payload["path"])
+                source = video.validate_video_source_receipt(payload["source"])
+                expected = request.expected_generations["video"]
+                before = video._metadata_receipt_in_probe_worker(artifact, None)
+                if (
+                    before.generation != expected
+                    or video._availability(expected).state != "local"
+                    or source["source_generation"] != expected.to_dict()
+                ):
+                    raise SupervisorError("worker_generation_changed")
+                with video._prepared_video_source(artifact, expected) as prepared:
+                    report = _sample_snapshot(
+                        prepared.probe_artifact,
+                        cast(float, source["duration_seconds"]),
+                        cast(int, payload["count"]),
+                    )
+                    digest = video._digest_open_descriptor(
+                        prepared.source_descriptor, expected
+                    )
+                    snapshot = video._digest_open_descriptor(
+                        prepared.probe_descriptor, prepared.probe_generation
+                    )
+                    if digest != source["source_sha256"] or snapshot != digest:
+                        raise SupervisorError("worker_generation_changed")
+                if (
+                    video._metadata_receipt_in_probe_worker(artifact, None).generation
+                    != expected
+                ):
+                    raise SupervisorError("worker_generation_changed")
+            else:
+                raise SupervisorError("invalid_worker_request")
+            write_worker_response(
+                request,
+                payload=cast(JsonValue, report),
+                observed_generations=request.expected_generations,
+                stream=output,
+                max_output_bytes=LIMITS.max_output_bytes,
+            )
+        except (
+            CropFramesError,
+            SupervisorError,
+            video.VideoEvidenceError,
+            VideoIntegrityError,
+            OSError,
+            ValueError,
+        ) as exc:
+            code = (
+                exc.code
+                if isinstance(exc, (CropFramesError, VideoIntegrityError))
+                else exc.reason_code
+                if isinstance(exc, (SupervisorError, video.VideoEvidenceError))
+                else "crop_input_unavailable"
+            )
+            write_worker_response(
+                request,
+                error=SupervisorError(code),
+                observed_generations=request.expected_generations,
+                stream=output,
+                max_output_bytes=LIMITS.max_output_bytes,
+            )
+    finally:
+        output.close()
+    return 0
+
+
+def run_worker() -> int:
+    try:
+        return _worker()
+    # The supervisor reads a missing authenticated response plus nonzero exit
+    # as a worker crash. Emit a closed diagnostic; a traceback would leak paths.
+    # outer-boundary-process-contract
+    except Exception:  # noqa: BLE001
+        print("crop worker failed; check the runtime and retry", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != [WORKER_FLAG]:
+        print(json.dumps({"ok": False, "code": "crop_worker_only"}))
+        print("run build-contact-sheet.py or build-crop-reviewer.py", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(run_worker())

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -55,7 +55,7 @@ from video_evidence import (
 # the download tier, region-detection logic, dedup hashing, or PDF assembly.
 # See skills/vault-ingress/references/video-slide-extraction.md ("Pipeline
 # Versioning") for the policy.
-PIPELINE_VERSION = "0.13.0"
+PIPELINE_VERSION = "0.14.0"
 
 # Shape version of the structured_data.video_extraction record (distinct from
 # PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
@@ -1119,6 +1119,7 @@ def extract_slides_from_video(
     slide_region: str | NormalizedSlideRegion = "auto",
     slide_region_verified=False,
     include_context_pdf=True,
+    expected_source_sha256=None,
 ):
     """Run one extraction bound end to end to one exact source generation.
 
@@ -1133,6 +1134,14 @@ def extract_slides_from_video(
     run's artifacts exactly as it found them.
     """
     youtube_id = validate_youtube_id(youtube_id)
+    if expected_source_sha256 is not None and (
+        not isinstance(expected_source_sha256, str)
+        or len(expected_source_sha256) != 64
+        or any(char not in "0123456789abcdef" for char in expected_source_sha256)
+    ):
+        raise ValueError(
+            "invalid expected source digest — supply the review manifest's SHA-256"
+        )
     if fps <= 0:
         raise ValueError("fps must be greater than zero")
     output_dir = canonical_path(output_dir)
@@ -1143,6 +1152,14 @@ def extract_slides_from_video(
     with _video_run_lock(run_lock):
         assessment = VideoEvidenceAssessment()
         source_receipt = _capture_source_receipt(assessment, source_video_path)
+        if (
+            expected_source_sha256 is not None
+            and source_receipt["source_sha256"] != expected_source_sha256
+        ):
+            raise VideoSourceLineageError(
+                "recording differs from the reviewed frames — rebuild the crop reviewer and obtain a new approval",
+                reason_code="video_review_source_mismatch",
+            )
         for filename in (
             f"{youtube_id}.slide-region.pdf",
             f"{youtube_id}.context.pdf",
@@ -1220,6 +1237,10 @@ def main():
         help="mark a manually supplied --region as visually verified",
     )
     parser.add_argument(
+        "--expected-source-sha256",
+        help="require the exact recording whose frames were reviewed before extraction",
+    )
+    parser.add_argument(
         "--no-context-pdf",
         action="store_false",
         dest="include_context_pdf",
@@ -1261,6 +1282,7 @@ def main():
             slide_region=args.region,
             slide_region_verified=args.region_verified,
             include_context_pdf=args.include_context_pdf,
+            expected_source_sha256=args.expected_source_sha256,
         )
     except VideoSourceLineageError as exc:
         print(

--- a/tests/test_crop_frames.py
+++ b/tests/test_crop_frames.py
@@ -1,0 +1,285 @@
+"""Real media sampling, bounded failure paths, and closed frame manifests."""
+
+import copy
+from dataclasses import replace
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts")
+)
+import crop_frames as crops
+
+
+@pytest.fixture
+def recording(tmp_path):
+    binary = shutil.which("ffmpeg")
+    assert binary, "install ffmpeg; crop sampling tests require the real decoder"
+    output = tmp_path / "talk.mp4"
+    subprocess.run(
+        [
+            binary,
+            "-hide_banner",
+            "-nostdin",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=320x180:rate=10",
+            "-t",
+            "3",
+            "-c:v",
+            "libx264",
+            "-threads",
+            "1",
+            "-preset",
+            "ultrafast",
+            "-pix_fmt",
+            "yuv420p",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    return output
+
+
+@pytest.fixture
+def bundle(recording):
+    directory = recording.parent / "frames"
+    crops.sample_video(recording, directory, count=6)
+    return directory
+
+
+def test_real_sample_has_individual_frames_and_separate_sheet(recording):
+    from PIL import Image
+
+    before = recording.read_bytes()
+    target = recording.parent / "frames"
+    result = crops.sample_video(recording, target)
+    loaded = crops.load_frame_bundle(result["manifest"])
+    manifest = loaded["manifest"]
+    assert result["frames"] == 12
+    assert not result["reused"]
+    assert manifest["source"]["source_sha256"] == hashlib.sha256(before).hexdigest()
+    assert [
+        frame["timestamp_seconds"] for frame in manifest["frames"]
+    ] == crops.sample_times(3, 12)
+    assert len({frame["sha256"] for frame in manifest["frames"]}) == 12
+    for frame in manifest["frames"]:
+        with Image.open(target / frame["file"]) as picture:
+            assert picture.size == (960, 540)
+        assert (
+            frame["sha256"]
+            == hashlib.sha256((target / frame["file"]).read_bytes()).hexdigest()
+        )
+    with Image.open(target / "contact-sheet.jpg") as picture:
+        assert picture.size == (1440, 2032)
+    assert recording.read_bytes() == before
+    snapshots = {path.name: path.read_bytes() for path in target.iterdir()}
+    replay = crops.sample_video(recording, target)
+    assert replay["reused"]
+    assert snapshots == {path.name: path.read_bytes() for path in target.iterdir()}
+
+
+@pytest.mark.parametrize("count", [0, 4, 5, 49, True, 6.0, "12"])
+def test_invalid_count_never_reads_media(count, monkeypatch):
+    monkeypatch.setattr(
+        crops.video, "probe_video_artifact", lambda *args: pytest.fail("read media")
+    )
+    with pytest.raises(crops.CropFramesError, match="count_invalid"):
+        crops.sample_video("absent.mp4", "output", count=count)
+
+
+@pytest.mark.parametrize(
+    "timeout", [0, -1, float("nan"), float("inf"), 3601, True, "10"]
+)
+def test_invalid_timeout_fails_before_input_io(timeout, monkeypatch):
+    monkeypatch.setattr(
+        crops.video, "probe_video_artifact", lambda *args: pytest.fail("read media")
+    )
+    with pytest.raises(crops.CropFramesError, match="timeout_invalid"):
+        crops.sample_video("absent.mp4", "output", timeout_seconds=timeout)
+
+
+def test_unexpected_worker_failure_is_closed_and_interruptible(monkeypatch, capsys):
+    def fail():
+        raise RuntimeError("private parser state")
+
+    monkeypatch.setattr(crops, "_worker", fail)
+    assert crops.run_worker() == 2
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert "private parser state" not in output.err
+
+    def interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(crops, "_worker", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        crops.run_worker()
+
+
+@pytest.mark.parametrize("duration", [0, -1, float("inf"), float("nan"), True, "3"])
+def test_invalid_duration_rejected(duration):
+    with pytest.raises(crops.CropFramesError, match="duration_invalid"):
+        crops.sample_times(duration, 6)
+
+
+def test_new_count_preserves_existing_bundle(recording, bundle):
+    before = {path.name: path.read_bytes() for path in bundle.iterdir()}
+    with pytest.raises(crops.CropFramesError, match="output_conflict"):
+        crops.sample_video(recording, bundle, count=12)
+    assert before == {path.name: path.read_bytes() for path in bundle.iterdir()}
+
+
+def test_timeout_publishes_nothing(recording):
+    output = recording.parent / "frames"
+    with pytest.raises(crops.SupervisorError, match="worker_timeout"):
+        crops.sample_video(recording, output, count=6, timeout_seconds=0.001)
+    assert not output.exists()
+    assert not list(recording.parent.glob(".crop-stage-*"))
+
+
+def test_changed_source_never_publishes(recording, monkeypatch):
+    invoke = crops._invoke
+
+    def changed(operation, *args, **kwargs):
+        recording.write_bytes(recording.read_bytes() + b"changed")
+        return invoke(operation, *args, **kwargs)
+
+    monkeypatch.setattr(crops, "_invoke", changed)
+    with pytest.raises(crops.SupervisorError, match="generation_changed"):
+        crops.sample_video(recording, recording.parent / "frames", count=6)
+    assert not (recording.parent / "frames").exists()
+
+
+def test_dataless_frame_fails_before_byte_reads(tmp_path, monkeypatch):
+    source = tmp_path / "frame.jpg"
+    source.write_bytes(b"not opened")
+    receipt = crops.inspect_metadata_generation(source, trusted_root=tmp_path)
+    receipt = replace(
+        receipt, generation=replace(receipt.generation, file_attributes=0x001000)
+    )
+    monkeypatch.setattr(
+        crops, "inspect_metadata_generation", lambda *args, **kwargs: receipt
+    )
+    monkeypatch.setattr(
+        crops.video,
+        "_prepared_video_source",
+        lambda *args: pytest.fail("opened placeholder"),
+    )
+    with pytest.raises(crops.CropFramesError, match="artifact_unavailable"):
+        crops._read_local(source, 1024)
+
+
+@pytest.mark.parametrize("change", ["missing", "damaged", "sheet", "symlink"])
+def test_bad_individual_frame_prevents_reviewer_input(bundle, change):
+    frame = bundle / "frame-001.jpg"
+    if change == "missing":
+        frame.unlink()
+    elif change == "damaged":
+        frame.write_bytes(b"corrupt")
+    elif change == "sheet":
+        frame.write_bytes((bundle / "contact-sheet.jpg").read_bytes())
+    else:
+        frame.unlink()
+        frame.symlink_to(bundle / "frame-002.jpg")
+    with pytest.raises(crops.SupervisorError):
+        crops.load_frame_bundle(bundle / "manifest.json")
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "future",
+        "unknown",
+        "path",
+        "timestamp",
+        "index",
+        "bool",
+        "sheet_digest",
+        "sheet_shape",
+    ],
+)
+def test_manifest_is_closed_before_frame_io(bundle, change):
+    document = json.loads((bundle / "manifest.json").read_text())
+    document = copy.deepcopy(document)
+    if change == "future":
+        document["schema_version"] = 2
+    elif change == "unknown":
+        document["unexpected"] = "field"
+    elif change == "path":
+        document["frames"][0]["file"] = "../secret.jpg"
+    elif change == "timestamp":
+        document["frames"][0]["timestamp_seconds"] = float("nan")
+    elif change == "index":
+        document["frames"][0]["index"] = 2
+    elif change == "bool":
+        document["frames"][0]["width"] = True
+    elif change == "sheet_digest":
+        document["frames"][0]["sha256"] = document["contact_sheet"]["sha256"]
+    else:
+        document["contact_sheet"]["width"] = 1
+    with pytest.raises(crops.CropFramesError):
+        crops.validate_manifest(document)
+
+
+@pytest.mark.parametrize(
+    "raw", [b'{"schema_version":1,"schema_version":1}', b'{"value":NaN}', b"\xff"]
+)
+def test_ambiguous_json_is_rejected(raw):
+    with pytest.raises(crops.CropFramesError):
+        crops._strict_json(raw)
+
+
+@pytest.mark.parametrize(
+    "arguments,code",
+    [([], 2), (["--help"], 0), (["--unknown"], 2), (["absent.mp4", "output"], 1)],
+)
+def test_cli_reports_one_json_object(arguments, code):
+    script = Path(crops.__file__).with_name("build-contact-sheet.py")
+    result = subprocess.run(
+        [sys.executable, str(script), *arguments],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == code
+    assert isinstance(json.loads(result.stdout), dict)
+    if code:
+        assert result.stderr
+
+
+def test_unexpected_cli_error_is_redacted_and_interrupts_propagate(monkeypatch, capsys):
+    spec = importlib.util.spec_from_file_location(
+        "contact_cli", Path(crops.__file__).with_name("build-contact-sheet.py")
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def fail():
+        raise RuntimeError("private token")
+
+    monkeypatch.setattr(module, "main", fail)
+    assert module.run_cli() == 1
+    output = capsys.readouterr()
+    assert json.loads(output.out)["code"] == "crop_unexpected_failure"
+    assert "private token" not in output.out + output.err
+
+    def interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(module, "main", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        module.run_cli()

--- a/tests/test_crop_reviewer.py
+++ b/tests/test_crop_reviewer.py
@@ -1,0 +1,359 @@
+"""TSV-to-offline-reviewer integration and executable JavaScript decisions."""
+
+import csv
+import importlib.util
+import io
+import json
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from test_crop_frames import bundle as bundle, recording as recording
+
+
+SCRIPTS = Path(__file__).parents[1] / "skills" / "vault-ingress" / "scripts"
+
+
+@pytest.fixture
+def reviewer():
+    spec = importlib.util.spec_from_file_location(
+        "crop_reviewer_builder", SCRIPTS / "build-crop-reviewer.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def proposal(reviewer, recording, bundle, **changes):
+    row = dict(
+        zip(
+            reviewer.COLUMNS,
+            [
+                "dQw4w9WgXcQ",
+                "A diagram worth keeping",
+                "ExampleConf",
+                "2025-01-01",
+                str(recording),
+                str(recording.parent / "extracted"),
+                str(bundle / "manifest.json"),
+                "crop",
+                "0.1,0.1,0.8,0.9",
+            ],
+        )
+    )
+    row.update(changes)
+    return row
+
+
+def tsv(reviewer, rows):
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=reviewer.COLUMNS, delimiter="\t")
+    writer.writeheader()
+    writer.writerows(rows)
+    return buffer.getvalue()
+
+
+def build(reviewer, recording, bundle, **changes):
+    row = proposal(reviewer, recording, bundle, **changes)
+    proposals = recording.parent / "proposals.tsv"
+    proposals.write_text(tsv(reviewer, [row]), encoding="utf-8")
+    output = recording.parent / "review.html"
+    result = reviewer.build_reviewer(proposals, output, batch_id="test-batch")
+    return row, proposals, output, result
+
+
+def embedded(output):
+    html = output.read_text(encoding="utf-8")
+    talks = re.search(r"const TALKS = (.*);\nconst BATCH", html)
+    batch = re.search(r"const BATCH = (.*);\n", html)
+    assert talks and batch
+    return html, json.loads(talks.group(1)), json.loads(batch.group(1))
+
+
+def test_real_bundle_build_is_offline_and_idempotent(reviewer, recording, bundle):
+    row, proposals, output, result = build(reviewer, recording, bundle)
+    html, talks, batch = embedded(output)
+    assert result["frames_per_talk"] == {row["id"]: 6}
+    assert len(talks[0]["frames"]) == 6
+    assert all(
+        frame["image"].startswith("data:image/jpeg;base64,")
+        for frame in talks[0]["frames"]
+    )
+    assert "fonts.googleapis" not in html
+    assert 'src="http' not in html
+    assert "__TALKS_JSON__" not in html
+    assert talks[0]["mode"] == "crop"
+    assert "verdict" not in talks[0]
+    assert batch["fingerprint"] == result["batch_fingerprint"]
+    assert "--expected-source-sha256" in talks[0]["command_prefix"]
+    before = output.read_bytes()
+    assert reviewer.build_reviewer(proposals, output, batch_id="test-batch")["reused"]
+    assert output.read_bytes() == before
+
+
+def test_talks_with_different_frame_counts_are_reported(reviewer, recording, bundle):
+    import crop_frames
+
+    second = recording.parent / "twelve-frames"
+    crop_frames.sample_video(recording, second)
+    rows = [
+        proposal(reviewer, recording, bundle),
+        proposal(
+            reviewer,
+            recording,
+            second,
+            id="abcdefghijk",
+            title="A second delivery",
+            mode="no-slides",
+            region="",
+        ),
+    ]
+    proposals = recording.parent / "two.tsv"
+    proposals.write_text(tsv(reviewer, rows), encoding="utf-8")
+    output = recording.parent / "two.html"
+    result = reviewer.build_reviewer(proposals, output, batch_id="mixed-counts")
+    assert result["frames_per_talk"] == {"dQw4w9WgXcQ": 6, "abcdefghijk": 12}
+    assert embedded(output)[1][1]["mode"] == "no-slides"
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"id": "../../escape"},
+        {"id": "too-short"},
+        {"mode": "approved"},
+        {"region": "nan,0,1,1"},
+        {"region": "0,0,inf,1"},
+        {"region": "0,0,0,1"},
+        {"region": "0,0,2,1"},
+        {"region": "0,0,1"},
+        {"mode": "full-frame", "region": "0,0,1,1"},
+        {"title": "first\nsecond"},
+        {"video_path": "$V/talk.mp4"},
+        {"title": ""},
+    ],
+)
+def test_bad_proposals_fail_before_media_io(reviewer, tmp_path, changes):
+    row = proposal(reviewer, tmp_path / "talk.mp4", tmp_path, **changes)
+    with pytest.raises(reviewer.ReviewerError):
+        reviewer.parse_proposals(tsv(reviewer, [row]))
+
+
+def test_duplicate_ids_empty_or_wrong_header_fail(reviewer, tmp_path):
+    row = proposal(reviewer, tmp_path / "talk.mp4", tmp_path)
+    for text in [
+        tsv(reviewer, [row, row]),
+        tsv(reviewer, []),
+        "id\ttitle\nabc\ttalk\n",
+    ]:
+        with pytest.raises(reviewer.ReviewerError):
+            reviewer.parse_proposals(text)
+
+
+def test_script_embedding_and_command_arguments_cannot_inject(
+    reviewer, recording, bundle
+):
+    attack = "</script><script>alert('x')</script> __BATCH_JSON__ __TALKS_JSON__"
+    target = str(recording.parent / "output ' $(touch /tmp/injected) ; #")
+    _, proposals, output, _ = build(
+        reviewer, recording, bundle, title=attack, output_dir=target
+    )
+    html, talks, _ = embedded(output)
+    assert attack not in html
+    assert talks[0]["title"] == attack
+    assert html.count("</script>") == 1
+    args = shlex.split(talks[0]["command_prefix"])
+    assert args[3] == target
+    assert args[2] == str(recording)
+    alternative = recording.parent / "marker-batch.html"
+    reviewer.build_reviewer(proposals, alternative, batch_id="batch__TALKS_JSON__")
+    assert embedded(alternative)[2]["id"] == "batch__TALKS_JSON__"
+
+
+def test_changed_proposal_requires_fresh_output_and_new_approval_identity(
+    reviewer, recording, bundle
+):
+    row, proposals, output, first = build(reviewer, recording, bundle)
+    before = output.read_bytes()
+    row["region"] = "0.2,0.2,0.7,0.8"
+    proposals.write_text(tsv(reviewer, [row]), encoding="utf-8")
+    with pytest.raises(reviewer.ReviewerError, match="output_conflict"):
+        reviewer.build_reviewer(proposals, output, batch_id="test-batch")
+    assert output.read_bytes() == before
+    second = reviewer.build_reviewer(
+        proposals, recording.parent / "changed.html", batch_id="test-batch"
+    )
+    assert first["batch_fingerprint"] != second["batch_fingerprint"]
+
+
+def test_exported_command_runs_for_dash_prefixed_video_id(reviewer, recording, bundle):
+    _, _, output, _ = build(
+        reviewer, recording, bundle, id="-abcdefghij", mode="full-frame", region=""
+    )
+    talk = {
+        key: value for key, value in embedded(output)[1][0].items() if key != "frames"
+    }
+    command = run_javascript(
+        "const talk = "
+        + json.dumps(talk)
+        + "; process.stdout.write(review.commands([talk], {[talk.id]:review.approve(review.initial(talk))}));"
+    )
+    args = shlex.split(command)
+    assert args[-2:] == ["--", "-abcdefghij"]
+    result = subprocess.run(args, capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["source_video_id"] == "-abcdefghij"
+    assert report["review_required"] is False
+    assert (
+        report["source_receipt"]["source_sha256"]
+        == args[args.index("--expected-source-sha256") + 1]
+    )
+
+
+def test_missing_frames_never_builds_even_for_proposed_no_slides(
+    reviewer, recording, bundle
+):
+    (bundle / "frame-001.jpg").unlink()
+    with pytest.raises(reviewer.SupervisorError):
+        build(reviewer, recording, bundle, mode="no-slides", region="")
+    assert not (recording.parent / "review.html").exists()
+
+
+def test_replaced_recording_rejects_stale_samples(reviewer, recording, bundle):
+    recording.write_bytes(recording.read_bytes() + b"changed")
+    with pytest.raises(reviewer.ReviewerError, match="source_mismatch"):
+        build(reviewer, recording, bundle)
+    assert not (recording.parent / "review.html").exists()
+
+
+def test_installed_template_falls_back_to_txt_mirror(reviewer, tmp_path, monkeypatch):
+    monkeypatch.setattr(reviewer, "__file__", str(tmp_path / "build-crop-reviewer.py"))
+    for name in ("crop-reviewer.js", "crop-reviewer-shell.html"):
+        (tmp_path / (name + ".txt")).write_text("installed mirror", encoding="utf-8")
+        assert reviewer._read_template(name) == "installed mirror"
+
+
+def run_javascript(script):
+    node = shutil.which("node")
+    assert node, "install the project's Node runtime; decision tests may not be skipped"
+    result = subprocess.run(
+        [
+            node,
+            "-e",
+            "const assert = require('node:assert/strict'); const review = require("
+            + json.dumps(str(SCRIPTS / "crop-reviewer.js"))
+            + ");\n"
+            + script,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_reviewer_ui_event_contracts():
+    node = shutil.which("node")
+    assert node, "install Node to run the reviewer UI event tests"
+    result = subprocess.run(
+        [node, "--test", str(Path(__file__).with_name("test_crop_reviewer_ui.js"))],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_executable_decisions_require_explicit_approval_and_edit_invalidates():
+    run_javascript("""
+const talk = {id:'dQw4w9WgXcQ', mode:'crop', region:[.1,.2,.8,.9], command_prefix:'python extract.py'};
+let entry = review.initial(talk);
+assert.equal(review.commands([talk], {[talk.id]:entry}), '');
+entry = review.approve(entry);
+assert.match(review.commands([talk], {[talk.id]:entry}), /--region 0.1,0.2,0.8,0.9 --region-verified -- dQw4w9WgXcQ$/);
+entry = review.edit(entry, [.2,.2,.8,.9]);
+assert.equal(entry.verdict, null);
+assert.equal(review.commands([talk], {[talk.id]:entry}), '');
+entry = review.edit(review.approve(entry), [0,0,1,1], 'full-frame');
+assert.equal(entry.verdict, null);
+assert.match(review.commands([talk], {[talk.id]:review.approve(entry)}), /--region 0,0,1,1 --region-verified -- dQw4w9WgXcQ$/);
+const no = {...talk, mode:'no-slides', region:[0,0,1,1]};
+entry = review.initial(no);
+assert.equal(review.commands([no], {[no.id]:entry}), '');
+entry = review.approve(entry);
+assert.match(review.commands([no], {[no.id]:entry}), /^# dQw4w9WgXcQ: owner confirmed no slides/);
+assert(!review.commands([no], {[no.id]:entry}).includes('--region-verified'));
+assert.equal(review.edit(entry, [.1,.2,.8,.9]).verdict, null);
+assert.equal(review.initial(talk).verdict, null);
+""")
+
+
+def test_saved_approvals_are_isolated_and_malformed_state_fails_closed():
+    run_javascript("""
+const talk = {id:'dQw4w9WgXcQ', mode:'crop', region:[.1,.2,.8,.9]};
+const batch = {id:'one',fingerprint:'a'.repeat(64)};
+const entry = review.approve(review.initial(talk));
+const saved = {schema_version:1,fingerprint:batch.fingerprint,entries:{[talk.id]:entry}};
+assert.equal(review.restore([talk], batch, JSON.stringify(saved))[talk.id].verdict, 'approved');
+assert.notEqual(review.key(batch), review.key({...batch,id:'two'}));
+assert.notEqual(review.key(batch), review.key({...batch,fingerprint:'b'.repeat(64)}));
+assert.throws(() => review.restore([talk], {...batch,fingerprint:'b'.repeat(64)}, JSON.stringify(saved)), SyntaxError);
+for (const changed of [{...saved,schema_version:2}, {...saved,entries:{unknown:entry}}, {...saved,entries:{[talk.id]:{...entry,region:[0,0,2,1]}}}, {...saved,entries:{[talk.id]:{...entry,mode:'no-slides'}}}]) {
+  assert.throws(() => review.restore([talk], batch, JSON.stringify(changed)), SyntaxError);
+}
+for (const region of [[0,0,NaN,1],[0,0,Infinity,1],[0,0,0,1],[0,0,1,1,1],[false,0,1,1]]) {
+  assert.equal(review.validRegion(region), false);
+  assert.throws(() => review.edit(entry, region), RangeError);
+}
+assert.equal(review.commands([talk], {[talk.id]:{...entry,region:[0,0,2,1]}}), '');
+""")
+
+
+@pytest.mark.parametrize(
+    "args,code",
+    [
+        ([], 2),
+        (["--help"], 0),
+        (["--unknown"], 2),
+        (["absent.tsv", "output.html", "--batch-id", "test"], 1),
+    ],
+)
+def test_reviewer_cli_json_contract(args, code):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS / "build-crop-reviewer.py"), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == code
+    assert isinstance(json.loads(result.stdout), dict)
+    if code:
+        assert result.stderr
+
+
+def test_reviewer_boundary_redacts_unexpected_failure_and_keeps_interrupts(
+    reviewer, monkeypatch, capsys
+):
+    def fail():
+        raise RuntimeError("private details")
+
+    monkeypatch.setattr(reviewer, "main", fail)
+    assert reviewer.run_cli() == 1
+    output = capsys.readouterr()
+    assert json.loads(output.out)["code"] == "crop_reviewer_unexpected_failure"
+    assert "private details" not in output.out + output.err
+
+    def interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(reviewer, "main", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        reviewer.run_cli()

--- a/tests/test_crop_reviewer_ui.js
+++ b/tests/test_crop_reviewer_ui.js
@@ -1,0 +1,126 @@
+/* Exercise browser event wiring with deterministic DOM/storage/clipboard ports. */
+"use strict";
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const test = require("node:test");
+const source = fs.readFileSync(path.join(__dirname, "../skills/vault-ingress/scripts/crop-reviewer.js"), "utf8");
+
+function fixture({storageError = false, clipboardError = false, saved = null} = {}) {
+  const nodes = new Map();
+  class Element {
+    constructor() { this.children = []; this.style = {}; this.handlers = {}; this.attributes = {}; this.value = ""; }
+    append(...children) { this.children.push(...children); }
+    replaceChildren(...children) { this.children = children; }
+    setAttribute(name, value) { this.attributes[name] = value; }
+    addEventListener(name, handler) { this.handlers[name] = handler; }
+    focus() { document.activeElement = this; }
+    getBoundingClientRect() { return {width: 1000, height: 500}; }
+    setPointerCapture() {}
+  }
+  const document = {activeElement: null,
+    getElementById(id) { if (!nodes.has(id)) nodes.set(id, new Element()); return nodes.get(id); },
+    createElement() { return new Element(); }};
+  const talks = [
+    {schema_version: 1, id: "dQw4w9WgXcQ", title: "Diagram talk", conference: "ExampleConf", date: "2025-01-01", region: [.1,.2,.8,.9], mode: "crop", command_prefix: "python extract.py",
+      frames: Array.from({length: 12}, (_, index) => ({schema_version: 1, timestamp: index + 1, image: `data:image/jpeg;base64,frame${index}`}))},
+    {schema_version: 1, id: "abcdefghijk", title: "Discussion", conference: "ExampleConf", date: "2025-01-01", region: [0,0,1,1], mode: "no-slides", command_prefix: "python other.py",
+      frames: Array.from({length: 6}, (_, index) => ({schema_version: 1, timestamp: index + 1, image: `data:image/jpeg;base64,other${index}`}))},
+  ];
+  const batch = {schema_version: 1, id: "fixture", fingerprint: "a".repeat(64)};
+  let stored = saved, copied = null;
+  const localStorage = {getItem() { if (storageError) throw new DOMException("denied", "SecurityError"); return stored; },
+    setItem(key, value) { if (storageError) throw new DOMException("full", "QuotaExceededError"); stored = value; }};
+  const navigator = {clipboard: {async writeText(value) { if (clipboardError) throw new DOMException("denied", "NotAllowedError"); copied = value; }}};
+  const sandbox = {document, localStorage, navigator, DOMException, TALKS: talks, BATCH: batch, confirm: () => true};
+  vm.runInNewContext(source, sandbox);
+  return {get: id => nodes.get(id), stored: () => stored, copied: () => copied};
+}
+
+test("every timestamp is reachable; edits clear approval and output immediately", async () => {
+  const ui = fixture();
+  assert.equal(ui.get("tabs").children.length, 12);
+  assert.equal(ui.get("cLeft").textContent, 2);
+  assert.equal(ui.get("bCopy").disabled, true);
+  ui.get("tabs").children[11].onclick();
+  assert.equal(ui.get("img").src, "data:image/jpeg;base64,frame11");
+  ui.get("bOk").onclick();
+  assert.equal(ui.get("cOk").textContent, 1);
+  assert.match(ui.get("out").textContent, /--region-verified/);
+  await ui.get("bCopy").onclick();
+  assert.equal(ui.copied(), ui.get("out").textContent);
+  assert.match(ui.get("notice").textContent, /Nothing has been executed/);
+  ui.get("iL").value = ".2";
+  ui.get("iL").handlers.change();
+  assert.equal(ui.get("cOk").textContent, 0);
+  assert.equal(ui.get("stateNote").textContent, "Not approved");
+  assert(!ui.get("out").textContent.includes("--region-verified"));
+  ui.get("bOk").onclick();
+  const persisted = fixture({saved: ui.stored()});
+  assert.equal(persisted.get("cOk").textContent, 1);
+  ui.get("bFull").onclick();
+  assert.equal(ui.get("cOk").textContent, 0);
+  assert.equal(ui.get("bOk").textContent, "Approve full frame");
+  ui.get("bOk").onclick();
+  assert.match(ui.get("out").textContent, /--region 0,0,1,1 --region-verified/);
+  ui.get("bReset").onclick();
+  assert.equal(ui.get("cOk").textContent, 0);
+});
+
+test("no-slides proposal needs confirmation and never emits extraction", () => {
+  const ui = fixture();
+  ui.get("list").children[1].onclick();
+  assert.equal(ui.get("tabs").children.length, 6);
+  assert.equal(ui.get("cNo").textContent, 0);
+  assert.equal(ui.get("crop").hidden, true);
+  ui.get("bOk").onclick();
+  assert.equal(ui.get("cNo").textContent, 1);
+  assert.match(ui.get("out").textContent, /^# abcdefghijk:/);
+  assert(!ui.get("out").textContent.includes("extract.py"));
+  ui.get("bFull").onclick();
+  assert.equal(ui.get("cNo").textContent, 0);
+  assert.equal(ui.get("crop").hidden, false);
+  ui.get("bNo").onclick();
+  assert.equal(ui.get("cNo").textContent, 1);
+  ui.get("bClear").onclick();
+  assert.equal(ui.get("cNo").textContent, 0);
+  assert.equal(ui.get("cLeft").textContent, 2);
+});
+
+test("pointer and focused-keyboard changes invalidate the command", () => {
+  const ui = fixture();
+  ui.get("bOk").onclick();
+  let prevented = false;
+  ui.get("frame").handlers.keydown({key: "ArrowRight", shiftKey: false, preventDefault() { prevented = true; }});
+  assert(prevented);
+  assert.equal(ui.get("cOk").textContent, 0);
+  assert.equal(ui.get("iL").value, .10400000000000001);
+  ui.get("bOk").onclick();
+  const target = {closest(selector) { return selector === ".crop" ? {} : null; }};
+  ui.get("frame").handlers.pointerdown({target, clientX: 100, clientY: 100, pointerId: 1, preventDefault() {}});
+  ui.get("frame").handlers.pointermove({clientX: 150, clientY: 100});
+  assert.equal(ui.get("cOk").textContent, 0);
+  assert(ui.get("iL").value > .15);
+  ui.get("frame").handlers.pointercancel();
+  const value = ui.get("iL").value;
+  ui.get("frame").handlers.pointermove({clientX: 900, clientY: 100});
+  assert.equal(ui.get("iL").value, value);
+});
+
+test("invalid input, inaccessible storage, and refused clipboard are visible", async () => {
+  const ui = fixture({storageError: true, clipboardError: true});
+  assert.match(ui.get("notice").textContent, /could not be loaded/);
+  ui.get("iL").value = "2";
+  ui.get("iL").handlers.change();
+  assert.match(ui.get("notice").textContent, /Enter coordinates/);
+  assert.equal(ui.get("iL").value, .1);
+  ui.get("bOk").onclick();
+  assert.match(ui.get("notice").textContent, /only in this open page/);
+  await ui.get("bCopy").onclick();
+  assert.match(ui.get("notice").textContent, /Clipboard access was refused/);
+  assert.equal(ui.copied(), null);
+  const malformed = fixture({saved: "{broken"});
+  assert.equal(malformed.get("cOk").textContent, 0);
+  assert.match(malformed.get("notice").textContent, /could not be loaded/);
+});

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -1680,6 +1680,7 @@ def test_run_records_the_source_receipt_on_the_manifest_and_every_derivative(
         YOUTUBE_ID,
         slide_region=(0.2, 0.1, 0.9, 0.8),
         slide_region_verified=True,
+        expected_source_sha256=hashlib.sha256(video.read_bytes()).hexdigest(),
     )
 
     receipt = result["source_receipt"]
@@ -1694,6 +1695,46 @@ def test_run_records_the_source_receipt_on_the_manifest_and_every_derivative(
     assert all(
         artifact["source_receipt"] is not receipt for artifact in result["artifacts"]
     )
+
+
+def test_reviewed_source_digest_rejects_replacement_before_extraction(
+    video_slide_extraction, tmp_path, monkeypatch
+):
+    video = write_tiny_video(tmp_path / "source.mp4")
+    outdir = tmp_path / "output"
+    outdir.mkdir()
+    prior = outdir / f"{YOUTUBE_ID}.slide-region.pdf"
+    prior.write_bytes(b"previous verified output")
+    monkeypatch.setattr(
+        video_slide_extraction,
+        "extract_frames",
+        lambda *a, **k: pytest.fail("sampled replacement"),
+    )
+    with pytest.raises(video_slide_extraction.VideoSourceLineageError) as caught:
+        video_slide_extraction.extract_slides_from_video(
+            str(video),
+            str(outdir),
+            YOUTUBE_ID,
+            slide_region=(0, 0, 1, 1),
+            slide_region_verified=True,
+            expected_source_sha256="0" * 64,
+        )
+    assert caught.value.reason_code == "video_review_source_mismatch"
+    assert prior.read_bytes() == b"previous verified output"
+
+
+@pytest.mark.parametrize("digest", ["", "abc", "A" * 64, True, 1, "0" * 63])
+def test_invalid_review_source_digest_fails_before_io(
+    video_slide_extraction, tmp_path, digest
+):
+    with pytest.raises(ValueError, match="invalid expected source digest"):
+        video_slide_extraction.extract_slides_from_video(
+            str(tmp_path / "absent.mp4"),
+            str(tmp_path / "output"),
+            YOUTUBE_ID,
+            expected_source_sha256=digest,
+        )
+    assert not (tmp_path / "output").exists()
 
 
 def test_source_replaced_during_extraction_discards_every_derivative(


### PR DESCRIPTION
## Summary

- Make the crop workflow reproducible with bounded video sampling, versioned individual-frame manifests, and a separate classification sheet.
- Build an offline reviewer from TSV proposals, retain the supplied shell's layout, and require explicit human approval with batch/source-bound persistence.
- Export source-digest-guarded extraction commands, including dash-prefixed video IDs; preserve no-slides decisions as comments and keep all vault writes/reparsing outside this workflow.

Closes #382.

## Test plan

- [x] Real-video sampler, manifest, cloud-availability, mutation, and output-preservation tests.
- [x] Reviewer TSV/embedding/quoting tests and a real extraction command round-trip for a dash-prefixed ID.
- [x] Executable JavaScript decision and UI-event tests: all frame tabs, explicit approvals, reset/edit invalidation, pointer/keyboard changes, persistence, and visible storage/clipboard failures.
- [x] Ruff lint/format and Pyright; package, extension-mirror, conflict-marker, and plugin-lint gates.
- [x] Skill quality review: 97/100, threshold 85.
- [x] Final full suite: 6,548 passed, 8 skipped (243.80 seconds).

Visual browser verification was attempted but the browser control connection timed out. Its extension/native-host diagnostics pass; opening a fresh browser window is awaiting user approval. No screenshot verification is claimed. Automated UI-event tests cover the interaction contracts, and the existing frame-first shell is retained.
