### PR TITLE
feat(illustrations): add public and personal style catalogs

### DIFF
--- a/.github/ISSUE_TEMPLATE/style-contribution.yml
+++ b/.github/ISSUE_TEMPLATE/style-contribution.yml
@@ -1,0 +1,42 @@
+name: Style contribution
+description: Propose a reusable, style-only entry for the public catalog.
+title: "style: "
+labels: [style-contribution]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is a public proposal, not automatic catalog admission. Do not share
+        private vault paths, unapproved talk content, or credentials. A maintainer
+        will review the style-only anchors, evidence, and sharing permissions.
+  - type: textarea
+    id: entry
+    attributes:
+      label: Complete catalog entry
+      description: Paste one schema-v1 entry including slug, name, FULL/IMG+TXT anchors, text_treatment, conventions, composition, tags, sample, and provenance.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Representative sample
+      description: Attach a consented image or public image link. Identify the source slide and explain what style features it demonstrates. An unbundled reference must be stated explicitly.
+    validations:
+      required: true
+  - type: textarea
+    id: provenance
+    attributes:
+      label: Source attribution and reuse
+      description: Name the originating talk, exploration, or contributor and link the public source. Explain why this is reusable rather than a private signature or a per-slide scene.
+    validations:
+      required: true
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Sharing consent
+      options:
+        - label: I am authorized to publish this entry, sample, and provenance for review in this public repository.
+          required: true
+        - label: I reviewed the anchors and conventions as style-only; they do not require scene content or recurring page furniture on every slide.
+          required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Reusable public and personal style catalogs
+
+Add versioned packaged and vault-local style catalogs with personal-over-public
+shadowing by slug, digest-bound owner writes, and exact prior-byte backups. Seed
+the three owner-supplied Berglund exploration styles with explicitly unbundled
+sample references. Catalog-backed exploration preserves conventions, composition,
+and text treatment while continuing to read legacy candidate files. Add an opt-in
+public contribution form and a separate end-of-ingress offer. The delivered-talk
+visual-evidence seeding pass in #92 remains separate; these exploration seeds do
+not claim that pass is complete.
+
 ## 0.20.118 — 2026-09-04
 
 ### Clean usage errors for malformed reviewed-source digests

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -54,6 +54,7 @@ Do not restate them here — apply them.
 | [skills/illustrations/references/thumbnails.md](references/thumbnails.md) | Phase 7 thumbnail composition + slide selection |
 | [skills/illustrations/references/style-explore-candidates-schema.md](references/style-explore-candidates-schema.md) | `--style-explore` contract — `candidates.json` input + `rendered.json` output |
 | `skills/illustrations/scripts/model_registry.py` | Model roster, aliases, attributes; `--check-freshness` + `--shortlist` |
+| [skills/illustrations/references/style-catalog.md](references/style-catalog.md) | Packaged/public + personal style catalog, selection, owner writes, and opt-in contributions |
 | `skills/illustrations/scripts/generate-illustrations.py` | Deck illustrations, edits, fixes, builds, model comparison, style exploration |
 | `skills/illustrations/scripts/apply-illustrations-to-deck.py` | Insert illustrations + builds into a .pptx |
 | `skills/illustrations/scripts/generate-thumbnail.py` | YouTube thumbnail composition |
@@ -179,6 +180,11 @@ Proceed immediately to Step 7.
 
 ## Step 7 — Propose Styles Across the Checked Sources
 
+Read the merged catalog using
+[skills/illustrations/references/style-catalog.md](references/style-catalog.md).
+Use its reusable entries across the checked sources; personal styles shadow
+public styles by slug. Surface unavailable catalog layers before proposing.
+
 Propose 3-4 style options spanning the Step 3 sources, grounded in concept fit +
 vault context (the speaker's `visual_style_history`, `rhetoric-style-summary.md`
 Section 13). These are candidates for the render, not a commitment — the speaker
@@ -189,8 +195,10 @@ Proceed immediately to Step 8.
 
 ## Step 8 — Render the Exploration Grid
 
-Write `style-explore/candidates.json` (styles × shortlist × formats per the
-schema), then render:
+For catalog styles, generate `style-explore/candidates.json` with the catalog
+owner's selection command in
+[skills/illustrations/references/style-catalog.md](references/style-catalog.md).
+Use the Step 6 shortlist and representative slides, then render:
 
 ```bash
 python3 "{speaker_toolkit_root}/skills/illustrations/scripts/generate-illustrations.py" \
@@ -242,8 +250,9 @@ model cannot generate.
 Full protocol — the option template, continuity options, the gate contract:
 [skills/illustrations/references/strategy.md](references/strategy.md).
 
-Proceed immediately to Step 10 if generation was also requested; otherwise finish
-here.
+For a newly discovered reusable style, follow the separate opt-in contribution
+offer in [skills/illustrations/references/style-catalog.md](references/style-catalog.md).
+Proceed immediately to Step 10 if generation was also requested; otherwise finish here.
 
 ## Step 10 — Generate Deck Illustrations
 

--- a/skills/illustrations/catalog/styles.json
+++ b/skills/illustrations/catalog/styles.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "styles": [
+    {
+      "schema_version": 1,
+      "slug": "comic-book-hero",
+      "name": "Comic Book Hero",
+      "anchors": {
+        "FULL": "A bold modern comic-book / graphic-novel illustration: heavy black ink outlines, dramatic Ben-Day halftone dot shading, high-contrast cel coloring, dynamic foreshortened perspective, saturated punchy colors, and printed-comic paper grain.",
+        "IMG+TXT": "A bold modern comic-book / graphic-novel illustration: heavy black ink outlines, dramatic Ben-Day halftone dot shading, high-contrast cel coloring, dynamic foreshortened perspective, saturated punchy colors, and printed-comic paper grain."
+      },
+      "text_treatment": "Render title and footer lettering as a thick blockbuster comic logo: heavy brush/slab capitals with a bold black outline and a thin contrasting inner outline.",
+      "conventions": "Color is semantic, never decorative. When the scene names opposing roles, use ominous crimson-and-black with jagged edges for the old/brittle role and confident electric blue with warm highlights for the clean/hopeful role. Apply motion-line styling only to movement named in the scene.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "narrative",
+        "comic",
+        "high-contrast"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://github.com/jbaruch/speaker-toolkit/issues/92",
+        "description": "The issue identifies slide 2, “WHEN I HEAR \"MCP\"…”, from the Tim Berglund re-talk exploration. The representative image is not bundled or claimed as inspected."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "exploration",
+        "reference": "https://github.com/jbaruch/speaker-toolkit/issues/92",
+        "note": "Owner-supplied anchor from the Building Agents with MCP and Data Streams exploration. Style detail is retained; lettering is separated and scene/page-furniture instructions are conditional under #87."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "isometric-systems-3d",
+      "name": "Isometric Systems 3D",
+      "anchors": {
+        "FULL": "A clean isometric 3D systems illustration at a fixed approximately 30-degree angle: crisp toy-like low-poly forms with soft ambient occlusion, smooth matte-plastic surfaces, gentle studio lighting and long soft shadows on a pale neutral ground. Precise geometric, infographic-grade rendering with generous clean negative space.",
+        "IMG+TXT": "A clean isometric 3D systems illustration at a fixed approximately 30-degree angle: crisp toy-like low-poly forms with soft ambient occlusion, smooth matte-plastic surfaces, gentle studio lighting and long soft shadows on a pale neutral ground. Precise geometric, infographic-grade rendering with generous clean negative space."
+      },
+      "text_treatment": "Render title and footer lettering as tidy modern geometric sans-serif, crisp and flat like a UI label.",
+      "conventions": "Use cool indigo and slate with vivid semantic accents: alarm orange-red for any brittle/problem role named in the scene and fresh teal-green for any clean/hopeful role. Color is semantic, not decorative.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "systems",
+        "diagram",
+        "isometric"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://github.com/jbaruch/speaker-toolkit/issues/92",
+        "description": "The issue identifies slide 2, “WHEN I HEAR \"MCP\"…”, from the Tim Berglund re-talk exploration. The representative image is not bundled or claimed as inspected."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "exploration",
+        "reference": "https://github.com/jbaruch/speaker-toolkit/issues/92",
+        "note": "Owner-supplied anchor from the Building Agents with MCP and Data Streams exploration. Style detail is retained; lettering is separated and scene/page-furniture instructions are conditional under #87."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "illuminated-manuscript",
+      "name": "Illuminated Manuscript",
+      "anchors": {
+        "FULL": "A medieval illuminated-manuscript aesthetic: hand-inked on aged vellum with a warm parchment tone, ornate gold-leaf accents, egg-tempera mineral pigments (lapis blue, vermilion red, verdigris green, burnished gold), flattened Gothic perspective, gilt highlights, and cracked hand-illuminated texture with scribal authority.",
+        "IMG+TXT": "A medieval illuminated-manuscript aesthetic: hand-inked on aged vellum with a warm parchment tone, ornate gold-leaf accents, egg-tempera mineral pigments (lapis blue, vermilion red, verdigris green, burnished gold), flattened Gothic perspective, gilt highlights, and cracked hand-illuminated texture with scribal authority."
+      },
+      "text_treatment": "Render title and footer lettering as ornate gold-leaf Gothic blackletter with decorated illuminated initials, like a manuscript rubric.",
+      "conventions": "Color is semantic. When the scene names opposing roles, treat the problem role with vermilion-and-ink and the hopeful role with lapis-and-gold. Use foliate ornament, grotesque marginalia, beasts, halos, and borders only when the individual scene explicitly requests those elements.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "historical",
+        "narrative",
+        "manuscript"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://github.com/jbaruch/speaker-toolkit/issues/92",
+        "description": "The issue identifies slide 2, “WHEN I HEAR \"MCP\"…”, from the Tim Berglund re-talk exploration. The representative image is not bundled or claimed as inspected."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "exploration",
+        "reference": "https://github.com/jbaruch/speaker-toolkit/issues/92",
+        "note": "Owner-supplied anchor from the Building Agents with MCP and Data Streams exploration. Style detail is retained; lettering is separated and scene/page-furniture instructions are conditional under #87."
+      }
+    }
+  ]
+}

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -141,6 +141,12 @@ table.
 
 ## Step 7: Propose Styles Across the Checked Sources
 
+Read the public/personal merged catalog through the owner command in
+[skills/illustrations/references/style-catalog.md](style-catalog.md). Choose
+reusable entries by slug across the selected idea sources. Catalog membership
+does not establish concept fit, personal history, or rendered approval. A novel
+style can be added to the personal layer through the owner preview/apply flow.
+
 Present 3-4 style options spanning the Step 3 sources, each informed by **three
 inputs**:
 
@@ -191,7 +197,9 @@ Models produce meaningfully different aesthetics from the same prompt, and so do
 styles. The decision is visual — made from rendered output, not prose — and style
 and model are picked together.
 
-1. **Write `style-explore/candidates.json`** — the shortlisted models, the
+1. **Build `style-explore/candidates.json`** through the catalog owner's selection
+   command for catalog styles. Legacy hand-authored v1 inputs remain readable.
+   Include the shortlisted models, the
    candidate styles with their per-format anchor paragraphs, and one
    representative slide per format (central to the deck's concept, not the title
    slide, not an edge case; each slide must already have a complete `[STYLE

--- a/skills/illustrations/references/style-catalog.md
+++ b/skills/illustrations/references/style-catalog.md
@@ -95,6 +95,8 @@ Kinds: `exploration`, `delivered-talk`, `contribution`, or `personal`.
 Public provenance must be a credential-free public HTTPS reference. Personal
 provenance may refer to local evidence. Plain-text fields are bounded to 16,000
 characters; do not include credentials or private source text in a public entry.
+URL user information is forbidden in every sample/provenance reference, including
+personal local-image fields and personal provenance.
 
 The merged view is a read-only v1 envelope with `public_sha256`,
 `personal_sha256` (or `missing`), and `styles`. Each style retains its entry fields

--- a/skills/illustrations/references/style-catalog.md
+++ b/skills/illustrations/references/style-catalog.md
@@ -1,0 +1,159 @@
+# Reusable Style Catalog
+
+The illustrations skill owns these schemas. The packaged public layer lives at
+`skills/illustrations/catalog/styles.json`; the optional personal layer is
+`{vault_root}/style-catalog.json`, separate from the tracking database and
+descriptive `visual_style_history`. No tracking schema change or talk reparse is
+needed. Never infer a reusable anchor from a talk title or transcript alone.
+
+## Read and select
+
+Resolve `{speaker_toolkit_root}` from the loaded skill. With a known vault:
+
+```bash
+python3 "{speaker_toolkit_root}/skills/illustrations/scripts/style_catalog.py" list \
+  --vault "{vault_root}"
+```
+
+Omit `--vault` for public-only selection. A missing personal file means an empty
+overlay. A present invalid, unavailable, or unsupported-version personal file
+stops selection; it must not silently expose the shadowed public defaults.
+Personal entries replace entire public entries of the same slug, not individual
+fields. Distinct slugs form the union; output is sorted by slug. Neither layer is
+modified by a read, and no image or remote sample is fetched.
+
+Use the merged entries in Step 7's source/fit judgment. A catalog entry is a
+candidate, not a speaker's approval or a substitute for inspecting a rendered
+sample. Existing personal history still informs which entries fit. New styles
+can be proposed when the selected idea sources need them; record them through
+the owner tool instead of maintaining another ad hoc reusable library.
+
+After the speaker chooses the exploration candidates, author a selection JSON:
+
+```json
+{
+  "schema_version": 1,
+  "slugs": ["comic-book-hero", "isometric-systems-3d"],
+  "slides": {"FULL": 7},
+  "models": ["gemini-3-pro-image"]
+}
+```
+
+Use the live Step 6 shortlist, not the illustrative model ID above. `slides`
+maps FULL and/or IMG+TXT to positive outline slide numbers. Select one to twenty
+distinct slugs and one to twenty distinct model IDs. Explore a single
+composition per grid; poster-theatrical requires FULL only. Selected display
+names must have distinct exploration-directory slugs. Unknown fields and
+unsupported selection versions are refused.
+
+```bash
+python3 "{speaker_toolkit_root}/skills/illustrations/scripts/style_catalog.py" candidates \
+  --vault "{vault_root}" --selection selection.json \
+  --output "{talk_dir}/style-explore/candidates.json"
+```
+
+Create the output parent directory first. An identical output is reused;
+different existing bytes are preserved and require a fresh filename. The owner
+emits candidate schema v2 with complete style entries and layer/digest receipts.
+The generator reads v1 and v2 without rewriting either. Its v2 path applies each
+style's conventions and, for posters, text treatment to the representative
+slide's actual `text_overlay` and the outline's footer. A poster representative
+must have text and no safe zone. Follow Step 8's normal render and Step 9's
+human-choice/render-before-bake gates; copy the selected entry's anchor,
+conventions, composition, and text treatment when baking. Receipts identify the
+snapshot used, not a promise that a later catalog read is unchanged.
+
+## Catalog schema v1
+
+Root: exactly `schema_version: 1` and `styles: []`, with at most 200 entries.
+Every entry has exactly the fields below; entry, sample, and provenance versions
+are independently explicit integers, not booleans. Unknown fields, duplicate
+JSON keys, nonfinite numbers, duplicate layer slugs, and future versions fail
+closed. UTF-8 inputs and outputs are bounded to 2 MiB.
+
+| Field | Contract |
+|---|---|
+| `schema_version` | Integer 1 |
+| `slug` | Stable lowercase hyphenated identifier, at most 100 characters |
+| `name` | Nonempty single-line display name, at most 160 characters |
+| `anchors` | Exactly FULL and IMG+TXT, both nonempty style-only text |
+| `text_treatment` | Text-rendering style; nonempty for poster-theatrical |
+| `conventions` | Style-only continuity/color conventions; empty allowed |
+| `composition` | `poster-theatrical` or `overlay` |
+| `tags` | One to twenty distinct slug-shaped concept-fit hints |
+| `sample` | Versioned reference described below |
+| `provenance` | Versioned origin described below |
+
+Sample has exactly `schema_version: 1`, `kind`, `location`, `description`.
+Kinds: `local-image` (personal only), `remote-image` (HTTPS), or `reference`
+(HTTPS source describing an unbundled sample). A reference is not an inspected
+image; keep that limitation visible. Local sample paths are resolved by the
+speaker relative to the vault unless absolute. Readers do not open them.
+
+Provenance has exactly `schema_version: 1`, `kind`, `reference`, `note`.
+Kinds: `exploration`, `delivered-talk`, `contribution`, or `personal`.
+Public provenance must be a credential-free public HTTPS reference. Personal
+provenance may refer to local evidence. Plain-text fields are bounded to 16,000
+characters; do not include credentials or private source text in a public entry.
+
+The merged view is a read-only v1 envelope with `public_sha256`,
+`personal_sha256` (or `missing`), and `styles`. Each style retains its entry fields
+and adds `catalog_source`: exactly `schema_version: 1`, `layer` (`public` or
+`personal`), and the source layer's `sha256`. Candidate v2 preserves these styles;
+its other root fields remain `slides` and `models`. See
+[skills/illustrations/references/style-explore-candidates-schema.md](style-explore-candidates-schema.md).
+
+## Personal owner writes
+
+Only the `put` action of
+[skills/illustrations/scripts/style_catalog.py](../scripts/style_catalog.py)
+writes the personal layer. Author one complete entry JSON, then preview against `personal_sha256`
+from a fresh list. For an absent file, use `missing`:
+
+```bash
+python3 "{speaker_toolkit_root}/skills/illustrations/scripts/style_catalog.py" put \
+  --vault "{vault_root}" --entry personal-entry.json --expected-sha256 missing
+```
+
+Review the entry and preview. To authorize the same operation, repeat with
+`--apply` and the same `--expected-sha256`. The configured environment must have
+the project's `filelock` dependency. All owner writers share a canonical-path
+lock. A stale digest fails before mutation. Replacement backs up exact prior
+bytes as `style-catalog.json.backup-<sha256>`, then atomically publishes the whole
+validated catalog. Existing other entries retain their values; a semantic no-op
+preserves the complete original bytes. Keep backups private with the catalog.
+Use verified backups as evidence when restoring reviewed entries through `put`;
+never copy a backup over live state or add a reader-side reset.
+
+There are no legacy versions of this new artifact. Readers never migrate or
+restamp unsupported records. A future shape change must increment its owner's
+version and ship the relevant reader/migration work before writing that shape.
+No catalog write requeues talks, changes active claims, or edits the public file.
+
+## Discoveries and opt-in contribution
+
+After ingress or exploration yields a genuinely new, visually evidenced style,
+compare it with the merged catalog. The anchor discipline in
+[rules/illustration-rules.md](../../../rules/illustration-rules.md) applies; semantic style-only review remains human/
+agent judgment, not a regex classifier. Keep signature/private styles personal.
+
+Offer one separate question: “Would you like to contribute this reusable style
+to the public catalog?” Never submit automatically or bundle this with a
+clarification question. A decline ends this flow without a write or upload.
+
+On acceptance, show the exact proposed entry, sample, and provenance; remove
+private paths, talk content, and identifying material the speaker has not agreed
+to share. Obtain approval for that exact public payload. Use the
+`style-contribution` issue form at
+[New style contribution](https://github.com/jbaruch/speaker-toolkit/issues/new?template=style-contribution.yml).
+The form requests the complete catalog entry, a representative image/link,
+source attribution, and sharing consent. A maintainer validates and reviews it
+before adding it to the public catalog. An issue is a proposal, not automatic
+catalog admission, rendered-sample approval, or permission to publish a vault.
+
+The initial three Berglund exploration entries cite their owner-supplied issue
+anchors; their images are unbundled references. Seeding from delivered talks
+dated April 2026 onward is a separate evidence pass after this format lands:
+verify the delivery/source identity, inspect actual slides, extract style-only
+features, and retain a consented sample with exact provenance. Do not label the
+three exploration seeds as that completed delivered-talk pass.

--- a/skills/illustrations/references/style-explore-candidates-schema.md
+++ b/skills/illustrations/references/style-explore-candidates-schema.md
@@ -8,11 +8,12 @@ and `rendered.json` (output the script writes). One doc owns both.
 
 ## candidates.json — input
 
-- **Writer**: the agent, after proposing candidate styles (Step 7) and computing
-  the model shortlist (Step 6)
+- **Writers**: the catalog owner script emits v2 from selected catalog entries;
+  legacy agent-authored v1 files remain readable. Both follow Step 7 proposals
+  and the Step 6 model shortlist.
 - **Reader**: `generate-illustrations.py --style-explore`
 
-## Schema (schema_version 1)
+## Legacy schema (schema_version 1)
 
 ```json
 {
@@ -44,10 +45,26 @@ and `rendered.json` (output the script writes). One doc owns both.
 - `styles` — candidate styles. Each needs a `name` and an `anchors` map of
   format → anchor text. A style that omits a format is skipped for that format.
 
-Only `schema_version` 1 is accepted today — the reader rejects any other value.
+The reader accepts legacy v1 and catalog-backed v2 — other versions are refused.
 `candidates.json` is a transient per-talk input, not a persisted record, so
 there is no on-read migration. A future schema change bumps the version and
 teaches the reader to handle the new shape.
+
+## Catalog-backed schema (schema_version 2)
+
+The root has exactly `schema_version: 2`, `slides`, `models`, and `styles`.
+Every style is a complete closed catalog-v1 entry plus its versioned
+`catalog_source` receipt. The entry retains both anchors, conventions,
+composition, text treatment, tags, sample, and provenance; none is dropped
+during projection. The exact shape, bounds, and selection command are owned by
+[skills/illustrations/references/style-catalog.md](style-catalog.md).
+
+The generator validates the v2 shape before loading credentials or rendering.
+One grid uses one composition; posters use FULL only, require an actual
+representative-slide `text_overlay`, and reject safe zones. Poster prompts use
+the candidate's text treatment, not a previously baked style's lettering. The
+normal compose-only guard and render-before-bake gate still apply. Reads of
+either version do not migrate or rewrite the input.
 
 ## rendered.json — output
 

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -1807,7 +1807,7 @@ def run_style_explore(outline_path, candidates_path):
         safe_zone = slide.get("safe_zone")
         if poster and (safe_zone or not slide.get("text")):
             print(
-                "ERROR: poster catalog exploration requires a FULL representative "
+                f"ERROR: poster catalog exploration slide {slide_num} requires a FULL representative "
                 "slide with text_overlay and no safe zone. Update the outline and retry.",
                 file=sys.stderr,
             )

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -51,6 +51,7 @@ import urllib.error
 import urllib.request
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 from model_registry import (
     COMPARE_MODELS,
@@ -58,6 +59,12 @@ from model_registry import (
     OPENAI_API_BASE,
     is_supported_model,
     resolve_model_id,
+)
+from style_catalog import (
+    CatalogError,
+    decode as decode_catalog_json,
+    read_bytes as read_catalog_bytes,
+    validate_candidates as validate_catalog_candidates,
 )
 
 # outline.yaml is the single source of truth; its pydantic schema + loader live
@@ -1623,22 +1630,27 @@ def _format_slug(fmt):
 def parse_candidates(path):
     """Parse + validate a style-explore candidates.json file.
 
-    Schema (schema_version 1) is documented in
+    Schemas (legacy version 1 and catalog-backed version 2) are documented in
     skills/illustrations/references/style-explore-candidates-schema.md.
 
     Returns the parsed dict. Raises ValueError with an actionable message on a
     malformed file.
     """
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    except json.JSONDecodeError as e:
-        raise ValueError(f"{path} is not valid JSON ({e}).")
+        data = decode_catalog_json(read_catalog_bytes(Path(path)))
+    except CatalogError as exc:
+        if exc.code == "catalog_file_missing":
+            raise FileNotFoundError(path) from exc
+        raise
 
-    if data.get("schema_version") != 1:
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: candidates must be a JSON object.")
+    if type(data.get("schema_version")) is int and data["schema_version"] == 2:
+        return validate_catalog_candidates(data)
+    if type(data.get("schema_version")) is not int or data["schema_version"] != 1:
         raise ValueError(
             f"{path}: unsupported schema_version {data.get('schema_version')!r}; "
-            "expected 1."
+            "expected legacy version 1 or catalog-backed version 2."
         )
     slides = data.get("slides")
     if not isinstance(slides, dict) or not slides:
@@ -1776,6 +1788,10 @@ def run_style_explore(outline_path, candidates_path):
         os.path.dirname(os.path.abspath(outline_path)), "style-explore"
     )
     os.makedirs(base_dir, exist_ok=True)
+    catalog_backed = candidates["schema_version"] == 2
+    poster = (
+        catalog_backed and candidates["styles"][0]["composition"] == "poster-theatrical"
+    )
 
     # Resolve each format's representative scene prompt from the outline.
     targets = []
@@ -1789,6 +1805,13 @@ def run_style_explore(outline_path, candidates_path):
             )
             continue
         safe_zone = slide.get("safe_zone")
+        if poster and (safe_zone or not slide.get("text")):
+            print(
+                "ERROR: poster catalog exploration requires a FULL representative "
+                "slide with text_overlay and no safe zone. Update the outline and retry.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         # A safe zone forces FULL sizing/anchor downstream; if that disagrees
         # with the format being explored, the cell would render at the wrong
         # geometry. Skip it so every rendered cell keys consistently on `fmt`.
@@ -1800,7 +1823,7 @@ def run_style_explore(outline_path, candidates_path):
                 file=sys.stderr,
             )
             continue
-        targets.append((fmt, slide["prompt"], safe_zone))
+        targets.append((fmt, slide["prompt"], safe_zone, slide.get("text")))
 
     if not targets:
         print(
@@ -1814,7 +1837,7 @@ def run_style_explore(outline_path, candidates_path):
     # Build the full render plan up front so the progress count is exact.
     plan = []
     for style in candidates["styles"]:
-        for fmt, scene_prompt, safe_zone in targets:
+        for fmt, scene_prompt, safe_zone, title_text in targets:
             eff_format = effective_slide_format(fmt, safe_zone)
             # When a safe zone forces FULL, prefer the style's eff_format anchor
             # so anchor text, substitution, and sizing all agree; fall back to
@@ -1822,9 +1845,19 @@ def run_style_explore(outline_path, candidates_path):
             anchor = style["anchors"].get(eff_format) or style["anchors"].get(fmt)
             if not anchor:
                 continue
+            if catalog_backed:
+                anchor = f"{anchor} {style['conventions']}".strip()
+            prompt = resolve_prompt(scene_prompt, eff_format, {eff_format: anchor})
+            if poster:
+                prompt = apply_poster_embed_directive(
+                    prompt,
+                    title_text,
+                    outline.get("embedded_footer"),
+                    style["text_treatment"],
+                )
             prompt = apply_compose_only_directive(
                 apply_safe_zone_directive(
-                    resolve_prompt(scene_prompt, eff_format, {eff_format: anchor}),
+                    prompt,
                     safe_zone,
                 )
             )

--- a/skills/illustrations/scripts/style_catalog.py
+++ b/skills/illustrations/scripts/style_catalog.py
@@ -87,7 +87,12 @@ def _slug(value: Any) -> str:
 def _https(value: str) -> None:
     try:
         parts = urlsplit(value)
-        valid = parts.scheme == "https" and bool(parts.hostname) and not parts.username
+        valid = (
+            parts.scheme == "https"
+            and bool(parts.hostname)
+            and parts.username is None
+            and parts.password is None
+        )
     except ValueError:
         valid = False
     if not valid or any(c.isspace() for c in value):
@@ -237,7 +242,13 @@ def _file_ok(info: os.stat_result) -> None:
 def read_bytes(path: Path, *, missing: bool = False) -> bytes | None:
     try:
         _file_ok(path.lstat())
-        fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK | getattr(os, "O_NOFOLLOW", 0))
+        fd = os.open(
+            path,
+            os.O_RDONLY
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_BINARY", 0),
+        )
     except FileNotFoundError:
         if missing:
             return None
@@ -271,7 +282,10 @@ def read_bytes(path: Path, *, missing: bool = False) -> bytes | None:
 
 
 def personal_path(vault: Path) -> Path:
-    resolved = vault.resolve(strict=True)
+    try:
+        resolved = vault.resolve(strict=True)
+    except (FileNotFoundError, NotADirectoryError):
+        _fail("catalog_vault_invalid", "Select an existing vault directory.")
     if not resolved.is_dir():
         _fail("catalog_vault_invalid", "Select an existing vault directory.")
     return resolved / PERSONAL_NAME

--- a/skills/illustrations/scripts/style_catalog.py
+++ b/skills/illustrations/scripts/style_catalog.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""Own the versioned public/personal style catalog and exploration projection.
+
+CLI: style_catalog.py list [--vault VAULT]
+     style_catalog.py candidates --selection JSON --output JSON [--vault VAULT]
+     style_catalog.py put --vault VAULT --entry JSON --expected-sha256 SHA|missing
+                         [--apply]
+
+All commands emit one JSON object; failures also emit a closed diagnostic on
+stderr. Exit 0 success, 1 expected operational/validation failure, 2 usage or
+unexpected process-boundary failure. Reads never migrate or write. Put defaults
+to a digest-bound preview, preserves other entries, and backs up replaced bytes.
+Selection and artifact schemas: skills/illustrations/references/style-catalog.md.
+No image generation, network access, tracking-DB access, or public submission.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+from typing import Any, NoReturn
+from urllib.parse import urlsplit
+
+
+VERSION = 1
+CANDIDATES_VERSION = 2
+MAX_BYTES = 2 * 1024 * 1024
+MAX_ENTRIES = 200
+PERSONAL_NAME = "style-catalog.json"
+PUBLIC_PATH = Path(__file__).resolve().parent.parent / "catalog" / "styles.json"
+SLUG = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+FORMATS = {"FULL", "IMG+TXT"}
+
+
+class CatalogError(ValueError):
+    """Closed error code and safe, actionable diagnostic."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise CatalogError(code, message)
+
+
+def _shape(value: Any, fields: set[str]) -> dict:
+    if not isinstance(value, dict) or set(value) != fields:
+        _fail("catalog_shape_invalid", "Use the documented closed catalog schema.")
+    return value
+
+
+def _version(value: Any, expected: int = VERSION) -> None:
+    if type(value) is not int or value != expected:
+        _fail(
+            "catalog_version_unsupported",
+            "Update the owner tool; do not restamp records.",
+        )
+
+
+def _text(value: Any, *, empty: bool = False) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > 16000
+        or (not empty and not value.strip())
+        or any(ord(c) < 32 and c not in "\n\t" for c in value)
+    ):
+        _fail("catalog_text_invalid", "Supply bounded plain-text catalog fields.")
+    return value
+
+
+def _slug(value: Any) -> str:
+    if not isinstance(value, str) or len(value) > 100 or not SLUG.fullmatch(value):
+        _fail("catalog_slug_invalid", "Use a lowercase, hyphen-separated style slug.")
+    return value
+
+
+def _https(value: str) -> None:
+    try:
+        parts = urlsplit(value)
+        valid = parts.scheme == "https" and bool(parts.hostname) and not parts.username
+    except ValueError:
+        valid = False
+    if not valid or any(c.isspace() for c in value):
+        _fail(
+            "catalog_reference_invalid",
+            "Use a public HTTPS reference without credentials.",
+        )
+
+
+def validate_entry(value: Any, *, public: bool = False) -> dict:
+    entry = _shape(
+        value,
+        {
+            "schema_version",
+            "slug",
+            "name",
+            "anchors",
+            "text_treatment",
+            "conventions",
+            "composition",
+            "tags",
+            "sample",
+            "provenance",
+        },
+    )
+    _version(entry["schema_version"])
+    _slug(entry["slug"])
+    name = _text(entry["name"])
+    if len(name) > 160 or "\n" in name or "\t" in name:
+        _fail("catalog_name_invalid", "Use a single-line style display name.")
+    anchors = _shape(entry["anchors"], FORMATS)
+    for anchor in anchors.values():
+        _text(anchor)
+    _text(entry["conventions"], empty=True)
+    if entry["composition"] not in ("overlay", "poster-theatrical"):
+        _fail("catalog_composition_invalid", "Choose overlay or poster-theatrical.")
+    _text(entry["text_treatment"], empty=entry["composition"] == "overlay")
+    tags = entry["tags"]
+    if not isinstance(tags, list) or not 1 <= len(tags) <= 20:
+        _fail("catalog_tags_invalid", "Supply one to twenty distinct tag slugs.")
+    for tag in tags:
+        _slug(tag)
+    if len(set(tags)) != len(tags):
+        _fail("catalog_tags_invalid", "Remove duplicate tag slugs.")
+    sample = _shape(
+        entry["sample"], {"schema_version", "kind", "location", "description"}
+    )
+    _version(sample["schema_version"])
+    if sample["kind"] not in ("local-image", "remote-image", "reference"):
+        _fail(
+            "catalog_sample_invalid",
+            "Declare an image or an explicitly unbundled reference.",
+        )
+    _text(sample["location"])
+    _text(sample["description"])
+    if public or sample["kind"] != "local-image":
+        if sample["kind"] == "local-image":
+            _fail(
+                "catalog_sample_private",
+                "Publish a consented public sample, not a local path.",
+            )
+        _https(sample["location"])
+    provenance = _shape(
+        entry["provenance"], {"schema_version", "kind", "reference", "note"}
+    )
+    _version(provenance["schema_version"])
+    if provenance["kind"] not in (
+        "exploration",
+        "delivered-talk",
+        "contribution",
+        "personal",
+    ):
+        _fail("catalog_provenance_invalid", "Use a documented provenance kind.")
+    _text(provenance["reference"])
+    _text(provenance["note"])
+    if public:
+        _https(provenance["reference"])
+    return entry
+
+
+def validate_catalog(value: Any, *, public: bool = False) -> dict:
+    catalog = _shape(value, {"schema_version", "styles"})
+    _version(catalog["schema_version"])
+    entries = catalog["styles"]
+    if not isinstance(entries, list) or len(entries) > MAX_ENTRIES:
+        _fail("catalog_entries_invalid", "Use at most 200 style entries per layer.")
+    slugs = set()
+    for entry in entries:
+        validate_entry(entry, public=public)
+        if entry["slug"] in slugs:
+            _fail(
+                "catalog_slug_duplicate",
+                "Keep each slug unique within its catalog layer.",
+            )
+        slugs.add(entry["slug"])
+    return catalog
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            _fail("catalog_json_duplicate", "Remove duplicate JSON object keys.")
+        result[key] = value
+    return result
+
+
+def _constant(_: str) -> None:
+    _fail("catalog_json_invalid", "Use finite, standard JSON values.")
+
+
+def decode(raw: bytes | None) -> Any:
+    if raw is None:
+        _fail("catalog_file_missing", "Locate the required input file and retry.")
+    try:
+        return json.loads(raw, object_pairs_hook=_pairs, parse_constant=_constant)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _fail("catalog_json_invalid", "Supply valid JSON encoded as UTF-8.")
+
+
+def encode(value: Any) -> bytes:
+    raw = (
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False)
+        + "\n"
+    ).encode()
+    if len(raw) > MAX_BYTES:
+        _fail(
+            "catalog_too_large", "Keep each catalog or selection document within 2 MiB."
+        )
+    return raw
+
+
+def digest(raw: bytes | None) -> str:
+    return "missing" if raw is None else hashlib.sha256(raw).hexdigest()
+
+
+def _file_ok(info: os.stat_result) -> None:
+    if not stat.S_ISREG(info.st_mode) or info.st_size > MAX_BYTES:
+        _fail("catalog_file_invalid", "Use a regular local JSON file within 2 MiB.")
+    if getattr(info, "st_flags", 0) & getattr(stat, "UF_DATALESS", 0x40000000):
+        _fail(
+            "catalog_file_unavailable",
+            "Make the catalog available locally, then retry.",
+        )
+
+
+def read_bytes(path: Path, *, missing: bool = False) -> bytes | None:
+    try:
+        _file_ok(path.lstat())
+        fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK | getattr(os, "O_NOFOLLOW", 0))
+    except FileNotFoundError:
+        if missing:
+            return None
+        _fail("catalog_file_missing", "Locate the required input file and retry.")
+    with os.fdopen(fd, "rb") as stream:
+        before = os.fstat(stream.fileno())
+        _file_ok(before)
+        raw = stream.read(MAX_BYTES + 1)
+        after = os.fstat(stream.fileno())
+    current = path.lstat()
+
+    def identity(info):
+        return (
+            info.st_dev,
+            info.st_ino,
+            info.st_size,
+            info.st_mtime_ns,
+            info.st_ctime_ns,
+        )
+
+    if (
+        len(raw) > MAX_BYTES
+        or identity(before) != identity(after)
+        or identity(after) != identity(current)
+    ):
+        _fail(
+            "catalog_input_changed",
+            "Input changed during the read; retry from a fresh preview.",
+        )
+    return raw
+
+
+def personal_path(vault: Path) -> Path:
+    resolved = vault.resolve(strict=True)
+    if not resolved.is_dir():
+        _fail("catalog_vault_invalid", "Select an existing vault directory.")
+    return resolved / PERSONAL_NAME
+
+
+def load_merged(vault: Path | None = None, *, public_path: Path = PUBLIC_PATH) -> dict:
+    public_raw = read_bytes(public_path)
+    public = validate_catalog(decode(public_raw), public=True)
+    personal_raw = read_bytes(personal_path(vault), missing=True) if vault else None
+    personal = (
+        validate_catalog(decode(personal_raw))
+        if personal_raw is not None
+        else {"schema_version": 1, "styles": []}
+    )
+    merged = {}
+    for layer, catalog, raw in (
+        ("public", public, public_raw),
+        ("personal", personal, personal_raw),
+    ):
+        for entry in catalog["styles"]:
+            merged[entry["slug"]] = {
+                **copy.deepcopy(entry),
+                "catalog_source": {
+                    "schema_version": 1,
+                    "layer": layer,
+                    "sha256": digest(raw),
+                },
+            }
+    return {
+        "schema_version": 1,
+        "public_sha256": digest(public_raw),
+        "personal_sha256": digest(personal_raw),
+        "styles": [merged[slug] for slug in sorted(merged)],
+    }
+
+
+def validate_candidate_style(style: Any) -> dict:
+    if not isinstance(style, dict) or "catalog_source" not in style:
+        _fail(
+            "catalog_candidate_invalid",
+            "Rebuild catalog candidates with the owner tool.",
+        )
+    validate_entry(
+        {key: value for key, value in style.items() if key != "catalog_source"}
+    )
+    source = _shape(style["catalog_source"], {"schema_version", "layer", "sha256"})
+    _version(source["schema_version"])
+    if (
+        source["layer"] not in ("public", "personal")
+        or not isinstance(source["sha256"], str)
+        or not SHA256.fullmatch(source["sha256"])
+    ):
+        _fail(
+            "catalog_candidate_invalid",
+            "Rebuild candidates from the current catalog layers.",
+        )
+    return style
+
+
+def seed_candidates(merged: dict, selection: Any) -> dict:
+    selection = _shape(selection, {"schema_version", "slugs", "slides", "models"})
+    _version(selection["schema_version"])
+    slugs = selection["slugs"]
+    if not isinstance(slugs, list) or not 1 <= len(slugs) <= 20:
+        _fail("catalog_selection_invalid", "Select one to twenty style slugs.")
+    for slug in slugs:
+        _slug(slug)
+    if len(set(slugs)) != len(slugs):
+        _fail("catalog_selection_invalid", "Select each style slug only once.")
+    entries = {entry["slug"]: entry for entry in merged["styles"]}
+    if any(slug not in entries for slug in slugs):
+        _fail(
+            "catalog_selection_missing",
+            "List the current merged catalog and select known slugs.",
+        )
+    styles = [copy.deepcopy(entries[slug]) for slug in slugs]
+    compositions = {entry["composition"] for entry in styles}
+    slides = selection["slides"]
+    if (
+        not isinstance(slides, dict)
+        or not slides
+        or set(slides) - FORMATS
+        or any(type(n) is not int or n < 1 for n in slides.values())
+    ):
+        _fail(
+            "catalog_selection_slides_invalid",
+            "Map FULL and/or IMG+TXT to positive slide numbers.",
+        )
+    if len(compositions) != 1 or (
+        "poster-theatrical" in compositions and set(slides) != {"FULL"}
+    ):
+        _fail(
+            "catalog_selection_composition",
+            "Explore one composition at a time; posters require FULL only.",
+        )
+    names = [
+        re.sub(r"[^a-z0-9]+", "-", entry["name"].lower()).strip("-") or "style"
+        for entry in styles
+    ]
+    if len(set(names)) != len(names):
+        _fail(
+            "catalog_selection_name_collision",
+            "Choose distinct display names for exploration output directories.",
+        )
+    models = selection["models"]
+    if not isinstance(models, list) or not 1 <= len(models) <= 20:
+        _fail(
+            "catalog_selection_models_invalid",
+            "Supply one to twenty shortlisted model IDs.",
+        )
+    for model in models:
+        _text(model)
+        if any(c.isspace() for c in model):
+            _fail(
+                "catalog_selection_models_invalid", "Use model IDs without whitespace."
+            )
+    if len(set(models)) != len(models):
+        _fail("catalog_selection_models_invalid", "Select each model ID only once.")
+    return {
+        "schema_version": CANDIDATES_VERSION,
+        "slides": copy.deepcopy(slides),
+        "models": list(models),
+        "styles": styles,
+    }
+
+
+def validate_candidates(value: Any) -> dict:
+    candidate = _shape(value, {"schema_version", "slides", "models", "styles"})
+    _version(candidate["schema_version"], CANDIDATES_VERSION)
+    if not isinstance(candidate["styles"], list):
+        _fail(
+            "catalog_candidate_invalid",
+            "Rebuild candidates with the catalog owner tool.",
+        )
+    for style in candidate["styles"]:
+        validate_candidate_style(style)
+    seed_candidates(
+        {"styles": candidate["styles"]},
+        {
+            "schema_version": 1,
+            "slugs": [style["slug"] for style in candidate["styles"]],
+            "slides": candidate["slides"],
+            "models": candidate["models"],
+        },
+    )
+    return candidate
+
+
+def _publish_new(path: Path, raw: bytes) -> bool:
+    existing = read_bytes(path, missing=True)
+    if existing is not None:
+        if existing == raw:
+            return False
+        _fail(
+            "catalog_output_exists",
+            "Preserve the existing output; choose a fresh filename.",
+        )
+    with tempfile.TemporaryDirectory(
+        prefix=".style-catalog-", dir=path.parent
+    ) as temporary:
+        stage = Path(temporary) / "candidate.json"
+        with stage.open("xb") as stream:
+            os.chmod(stage, 0o600)
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(stage, path)
+        except FileExistsError:
+            if read_bytes(path) != raw:
+                _fail(
+                    "catalog_output_changed",
+                    "Output appeared during publication; choose a fresh filename.",
+                )
+            return False
+    return True
+
+
+def put_entry(vault: Path, entry: Any, expected: str, *, apply: bool = False) -> dict:
+    validate_entry(entry)
+    if expected != "missing" and (
+        not isinstance(expected, str) or not SHA256.fullmatch(expected)
+    ):
+        _fail(
+            "catalog_expected_invalid",
+            "Pass the preview's SHA-256, or missing for a new catalog.",
+        )
+    target = personal_path(vault)
+    # All owner writes use one canonical-path lock; no tracking-database lease is involved.
+    from filelock import FileLock, Timeout
+
+    lock_path = Path(tempfile.gettempdir()) / (
+        "speaker-style-" + hashlib.sha256(str(target).encode()).hexdigest() + ".lock"
+    )
+    try:
+        with FileLock(str(lock_path), timeout=10):
+            raw = read_bytes(target, missing=True)
+            if digest(raw) != expected:
+                _fail(
+                    "catalog_expected_mismatch",
+                    "Catalog changed; preview again before applying.",
+                )
+            prior = (
+                validate_catalog(decode(raw))
+                if raw is not None
+                else {"schema_version": 1, "styles": []}
+            )
+            entries = {item["slug"]: item for item in prior["styles"]}
+            changed = entries.get(entry["slug"]) != entry
+            entries[entry["slug"]] = copy.deepcopy(entry)
+            candidate = {
+                "schema_version": 1,
+                "styles": [entries[slug] for slug in sorted(entries)],
+            }
+            validate_catalog(candidate)
+            output = raw if not changed and raw is not None else encode(candidate)
+            result = {
+                "schema_version": 1,
+                "ok": True,
+                "changed": changed,
+                "applied": False,
+                "input_sha256": digest(raw),
+                "output_sha256": digest(output),
+                "backup": None,
+            }
+            if not apply or not changed:
+                return result
+            if raw is not None:
+                backup = target.with_name(PERSONAL_NAME + ".backup-" + digest(raw))
+                _publish_new(backup, raw)
+                result["backup"] = str(backup)
+            with tempfile.TemporaryDirectory(
+                prefix=".style-catalog-", dir=target.parent
+            ) as temporary:
+                stage = Path(temporary) / "catalog.json"
+                _publish_new(stage, output)
+                if read_bytes(target, missing=True) != raw:
+                    _fail(
+                        "catalog_expected_mismatch",
+                        "Catalog changed; preview again before applying.",
+                    )
+                os.replace(stage, target)
+            result["applied"] = True
+            return result
+    except Timeout:
+        _fail(
+            "catalog_writer_busy",
+            "Wait for the current catalog writer, then preview again.",
+        )
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        _fail("catalog_usage_invalid", "Use --help for the catalog command contract.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        parser = _Parser(description=__doc__, allow_abbrev=False, add_help=False)
+        parser.add_argument("action", nargs="?", choices=("list", "candidates", "put"))
+        parser.add_argument("--help", action="store_true")
+        parser.add_argument("--vault", type=Path)
+        parser.add_argument("--selection", type=Path)
+        parser.add_argument("--output", type=Path)
+        parser.add_argument("--entry", type=Path)
+        parser.add_argument("--expected-sha256")
+        parser.add_argument("--apply", action="store_true")
+        args = parser.parse_args(argv)
+        if args.help:
+            result = {"schema_version": 1, "ok": True, "help": __doc__}
+        elif args.action == "list" and not any(
+            (args.selection, args.output, args.entry, args.expected_sha256, args.apply)
+        ):
+            result = {"ok": True, **load_merged(args.vault)}
+        elif (
+            args.action == "candidates"
+            and args.selection
+            and args.output
+            and not any((args.entry, args.expected_sha256, args.apply))
+        ):
+            candidate = seed_candidates(
+                load_merged(args.vault), decode(read_bytes(args.selection))
+            )
+            created = _publish_new(args.output, encode(candidate))
+            result = {
+                "schema_version": 1,
+                "ok": True,
+                "created": created,
+                "output": str(args.output),
+                "styles": len(candidate["styles"]),
+            }
+        elif (
+            args.action == "put"
+            and args.vault
+            and args.entry
+            and args.expected_sha256
+            and not any((args.selection, args.output))
+        ):
+            result = put_entry(
+                args.vault,
+                decode(read_bytes(args.entry)),
+                args.expected_sha256,
+                apply=args.apply,
+            )
+        else:
+            _fail(
+                "catalog_usage_invalid", "Use --help for the catalog command contract."
+            )
+        print(json.dumps(result, ensure_ascii=True, allow_nan=False))
+        return 0
+    except CatalogError as exc:
+        code, message = exc.code, str(exc)
+        status = 2 if code == "catalog_usage_invalid" else 1
+    except (OSError, ImportError):
+        code, message, status = (
+            "catalog_io_failed",
+            "Check local file access and the configured Python dependencies, then retry.",
+            1,
+        )
+    # Callers treat missing/invalid stdout as a silent contract failure. Emit one
+    # closed JSON failure; a traceback would replace the promised JSON envelope.
+    except Exception:  # noqa: BLE001 — outer-boundary-process-contract
+        code, message, status = (
+            "catalog_unexpected_failure",
+            "Unexpected owner failure; preserve inputs and report this code.",
+            2,
+        )
+    result = {
+        "schema_version": 1,
+        "ok": False,
+        "error": {"code": code, "message": message},
+    }
+    print(json.dumps(result))
+    print(message, file=sys.stderr)
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/illustrations/scripts/style_catalog.py
+++ b/skills/illustrations/scripts/style_catalog.py
@@ -84,17 +84,21 @@ def _slug(value: Any) -> str:
     return value
 
 
-def _https(value: str) -> None:
+def _reject_url_credentials(value: str) -> None:
+    """Reference fields may hold local paths, but never URL user information."""
     try:
         parts = urlsplit(value)
-        valid = (
-            parts.scheme == "https"
-            and bool(parts.hostname)
-            and parts.username is None
-            and parts.password is None
-        )
+        credential_free = parts.username is None and parts.password is None
     except ValueError:
-        valid = False
+        credential_free = False
+    if not credential_free:
+        _fail("catalog_reference_invalid", "Remove URL credentials from the reference.")
+
+
+def _https(value: str) -> None:
+    _reject_url_credentials(value)
+    parts = urlsplit(value)
+    valid = parts.scheme == "https" and bool(parts.hostname)
     if not valid or any(c.isspace() for c in value):
         _fail(
             "catalog_reference_invalid",
@@ -147,6 +151,7 @@ def validate_entry(value: Any, *, public: bool = False) -> dict:
             "Declare an image or an explicitly unbundled reference.",
         )
     _text(sample["location"])
+    _reject_url_credentials(sample["location"])
     _text(sample["description"])
     if public or sample["kind"] != "local-image":
         if sample["kind"] == "local-image":
@@ -167,6 +172,7 @@ def validate_entry(value: Any, *, public: bool = False) -> dict:
     ):
         _fail("catalog_provenance_invalid", "Use a documented provenance kind.")
     _text(provenance["reference"])
+    _reject_url_credentials(provenance["reference"])
     _text(provenance["note"])
     if public:
         _https(provenance["reference"])
@@ -447,8 +453,12 @@ def _publish_new(path: Path, raw: bytes) -> bool:
         prefix=".style-catalog-", dir=path.parent
     ) as temporary:
         stage = Path(temporary) / "candidate.json"
-        with stage.open("xb") as stream:
-            os.chmod(stage, 0o600)
+        descriptor = os.open(
+            stage,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as stream:
             stream.write(raw)
             stream.flush()
             os.fsync(stream.fileno())

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -42,6 +42,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | 7 | Regenerate an existing speaker profile |
 | 8 | Verify active improvement goals against current provenance |
 | 9 | Hand fresh findings to clarification using the delivery-recency policy |
+| 10 | Offer opt-in contribution of new visually evidenced styles |
 
 ## Key Files & References
 
@@ -249,6 +250,16 @@ If no talk was processed, finish. Otherwise compute candidate topics and follow
   acceptance, invoke it with the candidate topics as handoff context.
 - **7–30 days:** recommend the full session with topics; do not auto-invoke.
 - **30+ days:** recommend the compressed session; do not auto-invoke.
+
+After any clarification interaction finishes, proceed immediately to Step 10.
+
+## Step 10 — Offer Style Contribution
+
+For a newly discovered, visually evidenced reusable style, follow
+[skills/illustrations/references/style-catalog.md](../illustrations/references/style-catalog.md#discoveries-and-opt-in-contribution).
+Offer contribution as one separate question; never upload automatically.
+If no new reusable style was observed, finish silently. Otherwise finish after
+the contribution decision and any explicitly approved submission.
 
 ## Error Handling
 

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -897,7 +897,7 @@ def test_parse_candidates_valid(generate_illustrations, tmp_path):
 def test_parse_candidates_bad_version(generate_illustrations, tmp_path):
     import pytest
 
-    path = _write_candidates(tmp_path, _candidates(schema_version=2))
+    path = _write_candidates(tmp_path, _candidates(schema_version=3))
     with pytest.raises(ValueError) as exc:
         generate_illustrations.parse_candidates(path)
     assert "schema_version" in str(exc.value)
@@ -1003,7 +1003,7 @@ def test_run_style_explore_bad_candidates_exits_cleanly(
     # A malformed candidates file surfaces the ValueError as a clean stderr
     # message + non-zero exit, not a traceback.
     p = tmp_path / "candidates.json"
-    p.write_text(json.dumps({"schema_version": 2}))
+    p.write_text(json.dumps({"schema_version": 3}))
     with pytest.raises(SystemExit) as exc:
         generate_illustrations.run_style_explore(str(tmp_path / "outline.yaml"), str(p))
     assert exc.value.code == 1

--- a/tests/test_style_catalog.py
+++ b/tests/test_style_catalog.py
@@ -150,7 +150,7 @@ def test_private_sample_not_accepted_as_public(catalog):
     entry["sample"].update(
         kind="remote-image", location="https://user:password@example.test/image.png"
     )
-    with pytest.raises(catalog.CatalogError, match="without credentials"):
+    with pytest.raises(catalog.CatalogError, match="credentials"):
         catalog.validate_entry(entry)
 
 
@@ -163,7 +163,7 @@ def test_public_url_userinfo_is_always_refused(catalog, userinfo, field):
     entry = personal_entry(catalog)
     location = "location" if field == "sample" else "reference"
     entry[field][location] = f"https://{userinfo}@example.test/image.png"
-    with pytest.raises(catalog.CatalogError, match="without credentials"):
+    with pytest.raises(catalog.CatalogError, match="credentials"):
         catalog.validate_entry(entry, public=True)
 
 
@@ -184,6 +184,59 @@ def test_cli_does_not_echo_password_with_empty_username(catalog, tmp_path):
     assert json.loads(result.stdout)["error"]["code"] == "catalog_reference_invalid"
     assert "synthetic-password" not in result.stdout + result.stderr
     assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("field", ["provenance", "local-sample"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:synthetic-password@example.test/entry",
+        "https://:synthetic-password@example.test/entry",
+        "http://user:synthetic-password@example.test/entry",
+        "//user:synthetic-password@example.test/entry",
+        "ftp://user:synthetic-password@example.test/entry",
+    ],
+)
+def test_personal_reference_credentials_never_reach_cli_output(
+    catalog, tmp_path, field, url
+):
+    entry = personal_entry(catalog)
+    if field == "provenance":
+        entry["provenance"]["reference"] = url
+    else:
+        entry["sample"].update(kind="local-image", location=url)
+    path = write_json(
+        tmp_path / catalog.PERSONAL_NAME, {"schema_version": 1, "styles": [entry]}
+    )
+    original = path.read_bytes()
+    result = subprocess.run(
+        [sys.executable, catalog.__file__, "list", "--vault", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["error"]["code"] == "catalog_reference_invalid"
+    assert "synthetic-password" not in result.stdout + result.stderr
+    assert path.read_bytes() == original
+    with pytest.raises(catalog.CatalogError, match="credentials"):
+        catalog.put_entry(tmp_path, entry, catalog.digest(original), apply=True)
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "slides/sample.png",
+        "/speaker/slides/sample.png",
+        r"C:\speaker\slides\sample.png",
+    ],
+)
+def test_personal_local_references_remain_valid(catalog, path):
+    entry = personal_entry(catalog)
+    entry["sample"].update(kind="local-image", location=path)
+    entry["provenance"].update(kind="personal", reference=path)
+    assert catalog.validate_entry(entry) == entry
 
 
 def test_preview_apply_backup_and_exact_idempotence(catalog, tmp_path):
@@ -449,7 +502,8 @@ def test_poster_missing_title_refuses_before_render(
     with pytest.raises(SystemExit) as error:
         generate_illustrations.run_style_explore(str(outline), str(candidate))
     assert error.value.code == 1
-    assert "text_overlay" in capsys.readouterr().err
+    diagnostic = capsys.readouterr().err
+    assert "text_overlay" in diagnostic and "slide 3" in diagnostic
 
 
 def test_cli_candidates_round_trip_and_preserves_changed_output(catalog, tmp_path):
@@ -578,6 +632,30 @@ def test_owner_lock_failure_preserves_absent_catalog(catalog, tmp_path, monkeypa
     with pytest.raises(catalog.CatalogError, match="current catalog writer"):
         catalog.put_entry(tmp_path, personal_entry(catalog), "missing", apply=True)
     assert not (tmp_path / catalog.PERSONAL_NAME).exists()
+
+
+def test_personal_bytes_are_created_private_before_writing(
+    catalog, tmp_path, monkeypatch
+):
+    import stat
+
+    original_open = catalog.os.open
+    creation_modes = []
+
+    def open_private(path, flags, mode=0o777, **kwargs):
+        descriptor = original_open(path, flags, mode, **kwargs)
+        if flags & catalog.os.O_CREAT and Path(path).is_relative_to(tmp_path):
+            creation_modes.append(
+                (mode, stat.S_IMODE(catalog.os.fstat(descriptor).st_mode))
+            )
+        return descriptor
+
+    monkeypatch.setattr(catalog.os, "open", open_private)
+    catalog.put_entry(tmp_path, personal_entry(catalog), "missing", apply=True)
+    assert creation_modes
+    assert all(mode == 0o600 for mode, _ in creation_modes)
+    if catalog.os.name == "posix":
+        assert all(actual & 0o077 == 0 for _, actual in creation_modes)
 
 
 def test_contribution_form_requires_complete_payload_and_consent():

--- a/tests/test_style_catalog.py
+++ b/tests/test_style_catalog.py
@@ -154,6 +154,38 @@ def test_private_sample_not_accepted_as_public(catalog):
         catalog.validate_entry(entry)
 
 
+@pytest.mark.parametrize(
+    "userinfo",
+    ["user:synthetic-password", ":synthetic-password", "user:", ":", "user", ""],
+)
+@pytest.mark.parametrize("field", ["sample", "provenance"])
+def test_public_url_userinfo_is_always_refused(catalog, userinfo, field):
+    entry = personal_entry(catalog)
+    location = "location" if field == "sample" else "reference"
+    entry[field][location] = f"https://{userinfo}@example.test/image.png"
+    with pytest.raises(catalog.CatalogError, match="without credentials"):
+        catalog.validate_entry(entry, public=True)
+
+
+def test_cli_does_not_echo_password_with_empty_username(catalog, tmp_path):
+    entry = personal_entry(catalog)
+    entry["sample"]["location"] = "https://:synthetic-password@example.test/image.png"
+    path = write_json(
+        tmp_path / catalog.PERSONAL_NAME, {"schema_version": 1, "styles": [entry]}
+    )
+    original = path.read_bytes()
+    result = subprocess.run(
+        [sys.executable, catalog.__file__, "list", "--vault", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["error"]["code"] == "catalog_reference_invalid"
+    assert "synthetic-password" not in result.stdout + result.stderr
+    assert path.read_bytes() == original
+
+
 def test_preview_apply_backup_and_exact_idempotence(catalog, tmp_path):
     entry = personal_entry(catalog)
     preview = catalog.put_entry(tmp_path, entry, "missing")
@@ -248,6 +280,51 @@ def test_input_change_detected(catalog, tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "lstat", changed)
     with pytest.raises(catalog.CatalogError, match="changed during"):
         catalog.read_bytes(path)
+
+
+def test_regular_catalog_read_without_posix_open_flags(catalog, tmp_path, monkeypatch):
+    path = tmp_path / "catalog.json"
+    raw = b'{\r\n  "schema_version": 1, "styles": []\r\n}\r\n'
+    path.write_bytes(raw)
+    monkeypatch.delattr(catalog.os, "O_NONBLOCK", raising=False)
+    monkeypatch.delattr(catalog.os, "O_NOFOLLOW", raising=False)
+    assert catalog.read_bytes(path) == raw
+
+
+def test_binary_flag_is_used_where_available(catalog, tmp_path, monkeypatch):
+    path = tmp_path / "catalog.json"
+    path.write_bytes(b"{}\r\n")
+    original_open = catalog.os.open
+    binary_flag = getattr(catalog.os, "O_BINARY", 1 << 27)
+    monkeypatch.setattr(catalog.os, "O_BINARY", binary_flag, raising=False)
+    seen = []
+
+    def open_binary(candidate, flags):
+        seen.append(flags)
+        # Simulate a platform with O_BINARY while executing the byte read locally.
+        return original_open(candidate, catalog.os.O_RDONLY)
+
+    monkeypatch.setattr(catalog.os, "open", open_binary)
+    assert catalog.read_bytes(path) == b"{}\r\n"
+    assert seen[0] & binary_flag
+
+
+@pytest.mark.parametrize("kind", ["missing", "file", "below-file"])
+def test_invalid_vault_has_specific_closed_cli_diagnostic(catalog, tmp_path, kind):
+    path = tmp_path / "vault"
+    if kind in ("file", "below-file"):
+        path.write_text("not a vault")
+    if kind == "below-file":
+        path = path / "nested"
+    result = subprocess.run(
+        [sys.executable, catalog.__file__, "list", "--vault", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["error"]["code"] == "catalog_vault_invalid"
+    assert "Select an existing vault directory" in result.stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_style_catalog.py
+++ b/tests/test_style_catalog.py
@@ -1,0 +1,525 @@
+"""Catalog ownership, overlay, publication, and real exploration adapter contracts."""
+
+import copy
+import json
+from pathlib import Path
+import stat
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from conftest import SCRIPTS_ILL, _import_script
+from test_generate_illustrations import _write_outline
+
+
+@pytest.fixture
+def catalog():
+    return _import_script(str(Path(SCRIPTS_ILL) / "style_catalog.py"), "style_catalog")
+
+
+def personal_entry(catalog, slug="personal-ink"):
+    entry = copy.deepcopy(catalog.load_merged()["styles"][0])
+    entry.pop("catalog_source")
+    entry["slug"] = slug
+    entry["name"] = "Personal Ink"
+    return entry
+
+
+def selection(slugs=None, **updates):
+    return {
+        "schema_version": 1,
+        "slugs": slugs or ["comic-book-hero"],
+        "slides": {"FULL": 3},
+        "models": ["gemini-3-pro-image"],
+        **updates,
+    }
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def test_packaged_seeds_are_closed_versioned_references(catalog):
+    merged = catalog.load_merged()
+    assert {style["slug"] for style in merged["styles"]} == {
+        "comic-book-hero",
+        "isometric-systems-3d",
+        "illuminated-manuscript",
+    }
+    for style in merged["styles"]:
+        catalog.validate_candidate_style(style)
+        assert style["catalog_source"]["layer"] == "public"
+        assert style["sample"]["kind"] == "reference"
+        assert "not bundled" in style["sample"]["description"]
+        assert "EMBEDDED TITLE" not in style["anchors"]["FULL"]
+    assert merged["personal_sha256"] == "missing"
+
+
+def test_personal_shadow_and_union_leave_public_untouched(catalog, tmp_path):
+    original = catalog.PUBLIC_PATH.read_bytes()
+    entry = personal_entry(catalog, "comic-book-hero")
+    custom = personal_entry(catalog)
+    write_json(
+        tmp_path / catalog.PERSONAL_NAME,
+        {"schema_version": 1, "styles": [entry, custom]},
+    )
+    merged = catalog.load_merged(tmp_path)
+    assert len(merged["styles"]) == 4
+    shadow = next(
+        style for style in merged["styles"] if style["slug"] == "comic-book-hero"
+    )
+    assert shadow["name"] == "Personal Ink"
+    assert shadow["catalog_source"]["layer"] == "personal"
+    assert catalog.PUBLIC_PATH.read_bytes() == original
+
+
+@pytest.mark.parametrize("version", [None, True, 0, 2, "1"])
+def test_unknown_personal_generations_never_fall_back_or_rewrite(
+    catalog, tmp_path, version
+):
+    path = write_json(
+        tmp_path / catalog.PERSONAL_NAME, {"schema_version": version, "styles": []}
+    )
+    original = path.read_bytes()
+    with pytest.raises(catalog.CatalogError, match="Update the owner"):
+        catalog.load_merged(tmp_path)
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 2),
+        ("slug", "../../bad"),
+        ("name", "two\nlines"),
+        ("name", ""),
+        ("anchors", {"FULL": "x"}),
+        ("anchors", {"FULL": "", "IMG+TXT": "x"}),
+        ("composition", "anything"),
+        ("composition", []),
+        ("text_treatment", ""),
+        ("tags", ["same", "same"]),
+        ("tags", ["bad tag"]),
+        ("tags", []),
+        ("conventions", 2),
+        ("sample", {"schema_version": 2}),
+        ("provenance", {"schema_version": 1}),
+    ],
+)
+def test_invalid_records_refused_before_publication(catalog, tmp_path, field, value):
+    entry = personal_entry(catalog)
+    entry[field] = value
+    with pytest.raises(catalog.CatalogError):
+        catalog.put_entry(tmp_path, entry, "missing", apply=True)
+    assert not (tmp_path / catalog.PERSONAL_NAME).exists()
+
+
+def test_duplicate_slug_and_unknown_field_refused(catalog):
+    entry = personal_entry(catalog)
+    with pytest.raises(catalog.CatalogError, match="unique"):
+        catalog.validate_catalog({"schema_version": 1, "styles": [entry, entry]})
+    with pytest.raises(catalog.CatalogError, match="closed"):
+        catalog.validate_entry({**entry, "future": True})
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b'{"schema_version":1,"schema_version":1}',
+        b'{"x":NaN}',
+        b'{"x":Infinity}',
+        b"\xff",
+        b"{bad",
+    ],
+)
+def test_strict_json(catalog, raw):
+    with pytest.raises(catalog.CatalogError):
+        catalog.decode(raw)
+
+
+def test_private_sample_not_accepted_as_public(catalog):
+    entry = personal_entry(catalog)
+    entry["sample"].update(kind="local-image", location="private.png")
+    catalog.validate_entry(entry)
+    with pytest.raises(catalog.CatalogError, match="consented public"):
+        catalog.validate_entry(entry, public=True)
+    entry["sample"].update(
+        kind="remote-image", location="https://user:password@example.test/image.png"
+    )
+    with pytest.raises(catalog.CatalogError, match="without credentials"):
+        catalog.validate_entry(entry)
+
+
+def test_preview_apply_backup_and_exact_idempotence(catalog, tmp_path):
+    entry = personal_entry(catalog)
+    preview = catalog.put_entry(tmp_path, entry, "missing")
+    target = tmp_path / catalog.PERSONAL_NAME
+    assert preview["changed"] and not preview["applied"]
+    assert not target.exists()
+    applied = catalog.put_entry(tmp_path, entry, "missing", apply=True)
+    assert applied["output_sha256"] == preview["output_sha256"]
+    assert applied["applied"] and applied["backup"] is None
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    # Keep unusual input whitespace byte-for-byte on a semantic no-op.
+    original = b"  " + target.read_bytes() + b"\n"
+    target.write_bytes(original)
+    unchanged = catalog.put_entry(tmp_path, entry, catalog.digest(original), apply=True)
+    assert not unchanged["changed"] and not unchanged["applied"]
+    assert target.read_bytes() == original
+    second = personal_entry(catalog, "second-style")
+    changed = catalog.put_entry(tmp_path, second, catalog.digest(original), apply=True)
+    assert Path(changed["backup"]).read_bytes() == original
+    assert len(catalog.load_merged(tmp_path)["styles"]) == 5
+    assert (
+        next(
+            item
+            for item in json.loads(target.read_bytes())["styles"]
+            if item["slug"] == entry["slug"]
+        )
+        == entry
+    )
+
+
+def test_stale_digest_and_commit_failure_preserve_catalog(
+    catalog, tmp_path, monkeypatch
+):
+    entry = personal_entry(catalog)
+    catalog.put_entry(tmp_path, entry, "missing", apply=True)
+    target = tmp_path / catalog.PERSONAL_NAME
+    original = target.read_bytes()
+    entry["name"] = "Changed"
+    with pytest.raises(catalog.CatalogError, match="preview again"):
+        catalog.put_entry(tmp_path, entry, "missing", apply=True)
+
+    def fail_replace(*args):
+        raise OSError("synthetic commit failure")
+
+    monkeypatch.setattr(catalog.os, "replace", fail_replace)
+    with pytest.raises(OSError):
+        catalog.put_entry(tmp_path, entry, catalog.digest(original), apply=True)
+    assert target.read_bytes() == original
+    assert next(tmp_path.glob("*.backup-*")).read_bytes() == original
+    assert not list(tmp_path.glob(".style-catalog-*"))
+
+
+def test_symlink_and_large_catalog_never_opened(catalog, tmp_path, monkeypatch):
+    real = tmp_path / "real.json"
+    real.write_text("{}")
+    link = tmp_path / "link.json"
+    link.symlink_to(real)
+    with pytest.raises(catalog.CatalogError, match="regular local"):
+        catalog.read_bytes(link)
+    monkeypatch.setattr(catalog, "MAX_BYTES", 1)
+    with pytest.raises(catalog.CatalogError, match="regular local"):
+        catalog.read_bytes(real)
+
+
+def test_cloud_placeholder_is_metadata_only(catalog, tmp_path, monkeypatch):
+    path = tmp_path / "placeholder.json"
+    info = SimpleNamespace(
+        st_mode=stat.S_IFREG | 0o600, st_size=10, st_flags=0x40000000
+    )
+    monkeypatch.setattr(Path, "lstat", lambda self: info)
+
+    def forbidden(*args):
+        pytest.fail("placeholder was opened")
+
+    monkeypatch.setattr(catalog.os, "open", forbidden)
+    with pytest.raises(catalog.CatalogError, match="available locally"):
+        catalog.read_bytes(path)
+
+
+def test_input_change_detected(catalog, tmp_path, monkeypatch):
+    path = tmp_path / "catalog.json"
+    path.write_text("{}")
+    original = Path.lstat
+    calls = []
+
+    def changed(self):
+        calls.append(self)
+        if len(calls) == 2:
+            self.write_text('{"changed":true}')
+        return original(self)
+
+    monkeypatch.setattr(Path, "lstat", changed)
+    with pytest.raises(catalog.CatalogError, match="changed during"):
+        catalog.read_bytes(path)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"schema_version": 2},
+        {"slugs": ["missing"]},
+        {"slugs": ["comic-book-hero", "comic-book-hero"]},
+        {"slides": {"FULL": True}},
+        {"slides": {"FULL": 0}},
+        {"slides": {"IMG+TXT": 3}},
+        {"slides": {"other": 3}},
+        {"models": []},
+        {"models": ["has space"]},
+        {"models": ["same", "same"]},
+    ],
+)
+def test_bad_selection_refused(catalog, updates):
+    with pytest.raises(catalog.CatalogError):
+        catalog.seed_candidates(catalog.load_merged(), selection(**updates))
+
+
+def test_candidate_projection_preserves_style_and_source(
+    catalog, generate_illustrations, tmp_path
+):
+    merged = catalog.load_merged()
+    projected = catalog.seed_candidates(merged, selection())
+    path = write_json(tmp_path / "candidates.json", projected)
+    parsed = generate_illustrations.parse_candidates(str(path))
+    assert parsed == projected
+    assert parsed["schema_version"] == 2
+    assert parsed["styles"][0] == merged["styles"][0]
+    assert "text_treatment" in parsed["styles"][0]
+
+
+def test_mixed_composition_and_output_name_collision_refused(catalog):
+    merged = catalog.load_merged()
+    styles = merged["styles"]
+    styles[1]["composition"] = "overlay"
+    selected = selection([style["slug"] for style in styles[:2]])
+    with pytest.raises(catalog.CatalogError, match="one composition"):
+        catalog.seed_candidates(merged, selected)
+    styles[1]["composition"] = styles[0]["composition"]
+    styles[1]["name"] = styles[0]["name"].upper()
+    with pytest.raises(catalog.CatalogError, match="distinct display"):
+        catalog.seed_candidates(merged, selected)
+
+
+@pytest.mark.parametrize("poster", [True, False])
+def test_real_exploration_adapter_uses_catalog_prompt(
+    catalog, generate_illustrations, tmp_path, monkeypatch, poster
+):
+    gi = generate_illustrations
+    merged = catalog.load_merged()
+    style = merged["styles"][0]
+    if not poster:
+        style["composition"] = "overlay"
+        style["text_treatment"] = ""
+    projected = catalog.seed_candidates(merged, selection())
+    cpath = write_json(tmp_path / "candidates.json", projected)
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 3,
+                "chapter": "c",
+                "title": "A choice",
+                "format": "FULL",
+                "text_overlay": "ACTUAL SLIDE TITLE",
+                "image_prompt": "[STYLE ANCHOR] A single ladder.",
+            }
+        ],
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "synthetic-key")
+    prompts = []
+
+    def generate(prompt, model, keys, fmt):
+        prompts.append((prompt, fmt))
+        return b"synthetic image transport", "image/png"
+
+    monkeypatch.setattr(gi, "generate_image", generate)
+    gi.run_style_explore(str(outline), str(cpath))
+    assert len(prompts) == 1
+    prompt, fmt = prompts[0]
+    assert fmt == "FULL"
+    assert style["anchors"]["FULL"] in prompt and style["conventions"] in prompt
+    assert "A single ladder." in prompt and gi.COMPOSE_ONLY_DIRECTIVE in prompt
+    assert ("ACTUAL SLIDE TITLE" in prompt) is poster
+    assert ("EMBEDDED TEXT" in prompt) is poster
+    assert (style["text_treatment"] in prompt) if poster else True
+    manifest = json.loads((tmp_path / "style-explore" / "rendered.json").read_text())
+    assert manifest["cells"][0]["status"] == "OK"
+
+
+def test_poster_missing_title_refuses_before_render(
+    catalog, generate_illustrations, tmp_path, monkeypatch, capsys
+):
+    candidate = write_json(
+        tmp_path / "candidates.json",
+        catalog.seed_candidates(catalog.load_merged(), selection()),
+    )
+    outline = _write_outline(
+        tmp_path,
+        model="gemini-3-pro-image",
+        slides=[
+            {
+                "n": 3,
+                "chapter": "c",
+                "title": "No text",
+                "format": "FULL",
+                "image_prompt": "[STYLE ANCHOR] Ladder.",
+            }
+        ],
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "synthetic-key")
+
+    def forbidden(*args):
+        pytest.fail("invalid poster was rendered")
+
+    monkeypatch.setattr(generate_illustrations, "generate_image", forbidden)
+    with pytest.raises(SystemExit) as error:
+        generate_illustrations.run_style_explore(str(outline), str(candidate))
+    assert error.value.code == 1
+    assert "text_overlay" in capsys.readouterr().err
+
+
+def test_cli_candidates_round_trip_and_preserves_changed_output(catalog, tmp_path):
+    source = write_json(tmp_path / "selection.json", selection())
+    output = tmp_path / "candidates.json"
+    command = [
+        sys.executable,
+        catalog.__file__,
+        "candidates",
+        "--selection",
+        str(source),
+        "--output",
+        str(output),
+    ]
+    first = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert first.returncode == 0 and json.loads(first.stdout)["created"]
+    second = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert second.returncode == 0 and not json.loads(second.stdout)["created"]
+    output.write_text("keep me")
+    refused = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert (
+        refused.returncode == 1
+        and json.loads(refused.stdout)["error"]["code"] == "catalog_output_exists"
+    )
+    assert output.read_text() == "keep me"
+
+
+@pytest.mark.parametrize(
+    "args,status",
+    [(["--help"], 0), (["list"], 0), (["put"], 2), (["list", "--app"], 2)],
+)
+def test_cli_json_contract(catalog, args, status):
+    result = subprocess.run(
+        [sys.executable, catalog.__file__, *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == status
+    assert json.loads(result.stdout)["ok"] is (status == 0)
+    assert bool(result.stderr) is (status != 0)
+
+
+def test_outer_boundary_redacts_unexpected_and_preserves_interrupts(
+    catalog, monkeypatch, capsys
+):
+    def unexpected(*args):
+        raise RuntimeError("private secret input")
+
+    monkeypatch.setattr(catalog, "load_merged", unexpected)
+    assert catalog.main(["list"]) == 2
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["error"]["code"] == "catalog_unexpected_failure"
+    assert "private secret" not in captured.out + captured.err
+
+    def interrupted(*args):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(catalog, "load_merged", interrupted)
+    with pytest.raises(KeyboardInterrupt):
+        catalog.main(["list"])
+
+
+@pytest.mark.parametrize(
+    "damage",
+    ["root-bool", "style-future", "missing-source", "extra-field", "duplicate-key"],
+)
+def test_malformed_v2_candidates_are_not_legacy_fallback(
+    catalog, generate_illustrations, tmp_path, damage
+):
+    candidate = catalog.seed_candidates(catalog.load_merged(), selection())
+    if damage == "root-bool":
+        candidate["schema_version"] = True
+    elif damage == "style-future":
+        candidate["styles"][0]["schema_version"] = 2
+    elif damage == "missing-source":
+        candidate["styles"][0].pop("catalog_source")
+    elif damage == "extra-field":
+        candidate["styles"][0]["future"] = "refuse"
+    path = write_json(tmp_path / "candidates.json", candidate)
+    if damage == "duplicate-key":
+        path.write_text(
+            path.read_text().replace(
+                '"schema_version": 2', '"schema_version": 1, "schema_version": 2', 1
+            )
+        )
+    original = path.read_bytes()
+    with pytest.raises(ValueError):
+        generate_illustrations.parse_candidates(str(path))
+    assert path.read_bytes() == original
+
+
+def test_cli_put_requires_explicit_apply(catalog, tmp_path):
+    entry_path = write_json(tmp_path / "entry.json", personal_entry(catalog))
+    command = [
+        sys.executable,
+        catalog.__file__,
+        "put",
+        "--vault",
+        str(tmp_path),
+        "--entry",
+        str(entry_path),
+        "--expected-sha256",
+        "missing",
+    ]
+    preview = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert preview.returncode == 0 and not json.loads(preview.stdout)["applied"]
+    assert not (tmp_path / catalog.PERSONAL_NAME).exists()
+    applied = subprocess.run(
+        [*command, "--apply"], capture_output=True, text=True, check=False
+    )
+    assert applied.returncode == 0 and json.loads(applied.stdout)["applied"]
+    assert (
+        json.loads(preview.stdout)["output_sha256"]
+        == json.loads(applied.stdout)["output_sha256"]
+    )
+
+
+def test_owner_lock_failure_preserves_absent_catalog(catalog, tmp_path, monkeypatch):
+    import filelock
+
+    def busy(*args, **kwargs):
+        raise filelock.Timeout("synthetic-lock")
+
+    monkeypatch.setattr(filelock, "FileLock", busy)
+    with pytest.raises(catalog.CatalogError, match="current catalog writer"):
+        catalog.put_entry(tmp_path, personal_entry(catalog), "missing", apply=True)
+    assert not (tmp_path / catalog.PERSONAL_NAME).exists()
+
+
+def test_contribution_form_requires_complete_payload_and_consent():
+    import yaml
+
+    path = (
+        Path(__file__).resolve().parents[1]
+        / ".github"
+        / "ISSUE_TEMPLATE"
+        / "style-contribution.yml"
+    )
+    form = yaml.safe_load(path.read_text())
+    assert form["labels"] == ["style-contribution"]
+    inputs = {item["id"]: item for item in form["body"] if "id" in item}
+    assert set(inputs) == {"entry", "sample", "provenance", "consent"}
+    assert all(
+        inputs[key]["validations"]["required"]
+        for key in ("entry", "sample", "provenance")
+    )
+    assert all(
+        option["required"] for option in inputs["consent"]["attributes"]["options"]
+    )


### PR DESCRIPTION
## Summary

- Add a closed, versioned public style catalog and separate personal vault overlay, with slug-based shadowing, digest-bound owner preview/apply writes, and exact-byte backups.
- Seed the three owner-supplied Berglund exploration styles and project selected catalog entries into backward-compatible exploration rendering that preserves conventions, composition, and text treatment.
- Add the opt-in contribution form and end-of-ingress offer; the required `style-contribution` label has been created and verified.

Refs #92. This implements the format, three exploration seeds, selection integration, and contribution workflow. The remaining scope of #92 is unfinished: the delivered-talk visual-evidence seeding pass remains outstanding. The supplied sample images are explicitly unbundled references, not claimed as inspected renders. No tracking-database writes or reparsing are part of this PR.

## Test plan

- [x] 289 focused catalog, exploration, and installed-path tests, including public/personal URL-userinfo rejection without secret echo, private-at-creation staging, portable open flags, and specific missing-vault diagnostics.
- [x] Ruff lint/format, Pyright, package/mirror/conflict gates, and plugin lint.
- [x] Skill quality review: illustrations 94/100 after the final review fixes; ingress 94/100. The ingress link warning refers to a cross-skill reference verified present in the complete package.
- [x] Full integrated suite after the final fixes and rebase onto published 0.20.118: 6,652 passed, 8 skipped (262.14 seconds).
