### PR TITLE
fix(vault-ingress): validate reviewed-source digests at CLI parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Clean usage errors for malformed reviewed-source digests
+
+Validate `--expected-source-sha256` at argument parsing as well as at the
+library boundary. Malformed direct CLI input now exits with a usage diagnostic
+before extraction, without a traceback or any source/output pipeline work.
+The exact lowercase SHA-256 contract and valid extraction behavior are unchanged
+(#394, follow-up to PR #393).
+
 ## 0.20.117 — 2026-09-04
 
 ### feat(vault-ingress) — package source-bound crop review (#382)

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -293,6 +293,27 @@ def parse_slide_region(value: str) -> str | NormalizedSlideRegion:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
+def validate_expected_source_sha256(value: object) -> str:
+    """Validate an exact reviewed-source digest without normalizing caller input."""
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        raise ValueError(
+            "invalid expected source digest — supply the review manifest's SHA-256"
+        )
+    return value
+
+
+def parse_expected_source_sha256(value: str) -> str:
+    """Keep malformed CLI digests in argparse's usage-error contract."""
+    try:
+        return validate_expected_source_sha256(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def extract_frames(video_path, frames_dir, fps=0.5):
     """Extract frames into one empty workspace and enumerate them literally."""
     video_path = canonical_path(video_path)
@@ -1134,14 +1155,8 @@ def extract_slides_from_video(
     run's artifacts exactly as it found them.
     """
     youtube_id = validate_youtube_id(youtube_id)
-    if expected_source_sha256 is not None and (
-        not isinstance(expected_source_sha256, str)
-        or len(expected_source_sha256) != 64
-        or any(char not in "0123456789abcdef" for char in expected_source_sha256)
-    ):
-        raise ValueError(
-            "invalid expected source digest — supply the review manifest's SHA-256"
-        )
+    if expected_source_sha256 is not None:
+        validate_expected_source_sha256(expected_source_sha256)
     if fps <= 0:
         raise ValueError("fps must be greater than zero")
     output_dir = canonical_path(output_dir)
@@ -1238,6 +1253,7 @@ def main():
     )
     parser.add_argument(
         "--expected-source-sha256",
+        type=parse_expected_source_sha256,
         help="require the exact recording whose frames were reviewed before extraction",
     )
     parser.add_argument(

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -1737,6 +1737,68 @@ def test_invalid_review_source_digest_fails_before_io(
     assert not (tmp_path / "output").exists()
 
 
+@pytest.mark.parametrize(
+    "digest", ["", "abc", "A" * 64, "0" * 63, "0" * 65, " " + "0" * 64]
+)
+def test_invalid_review_digest_cli_is_clean_usage_error(tmp_path, digest):
+    output = tmp_path / "existing-output"
+    output.mkdir()
+    prior = output / "keep.pdf"
+    prior.write_bytes(b"prior verified artifact")
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT_PATH,
+            str(tmp_path / "absent.mp4"),
+            str(output),
+            YOUTUBE_ID,
+            "--expected-source-sha256",
+            digest,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert not result.stdout
+    assert "--expected-source-sha256" in result.stderr
+    assert "invalid expected source digest" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert prior.read_bytes() == b"prior verified artifact"
+    assert list(output.iterdir()) == [prior]
+
+
+def test_invalid_digest_cli_never_enters_extraction(
+    video_slide_extraction, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            SCRIPT_PATH,
+            "source.mp4",
+            "output",
+            YOUTUBE_ID,
+            "--expected-source-sha256",
+            "malformed",
+        ],
+    )
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("invalid CLI input entered the source/output pipeline")
+
+    monkeypatch.setattr(video_slide_extraction, "extract_slides_from_video", forbidden)
+    with pytest.raises(SystemExit) as error:
+        video_slide_extraction.main()
+    assert error.value.code == 2
+    assert "invalid expected source digest" in capsys.readouterr().err
+
+
+def test_valid_cli_digest_preserves_exact_value(video_slide_extraction):
+    digest = "0123456789abcdef" * 4
+    assert video_slide_extraction.parse_expected_source_sha256(digest) == digest
+
+
 def test_source_replaced_during_extraction_discards_every_derivative(
     video_slide_extraction, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- Validate reviewed-source digests at argparse and library boundaries through one exact-value validator.
- Reject malformed CLI values with a clean usage diagnostic before source/output work, without normalizing the requested digest.

Closes #394. Follow-up to the advisory in PR #393.

## Test plan

- [x] Full suite: 6,556 passed, 8 skipped (246.03 seconds).
- [x] 148 focused extraction/reviewer tests, including actual CLI failures, no pipeline entry on invalid input, preserved prior outputs, and real dash-prefixed-ID extraction.
- [x] Ruff lint/format, Pyright, package/mirror/conflict gates, and plugin lint.
- [x] Mandatory ingress skill review: 97/100.
