### PR TITLE
fix(pacing): separate recorded speech rates from planning assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### Separate recorded speech rates from narration-planning assumptions
+
+Issue #367 exposed a circular timing check that treated articulation WPM as
+elapsed narration, then verified its own prediction. The new word-timing owner
+preserves timeline, narration, short-phrase, and thresholded articulation rates
+with explicit units, pause definitions, sample provenance, and observed ranges.
+Measured profiles retain their evidence and are recomputed on validation;
+long-form plans require narration and prefer measured data over assumptions.
+Full-recording duration verification has no planning-WPM input.
+
+New outlines use a versioned typed narration rate, while legacy ranges remain
+readable as explicitly unverified narration assumptions. Script reports expose
+the distinction. The independent speech profile leaves tracking state, pattern
+history, and slide-budget pacing unchanged. This ships the deterministic
+contract, not the live calibration pass in #368 or media acquisition in #219.
+
 ## 0.20.119 — 2026-09-05
 
 ### Reusable public and personal style catalogs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,11 @@ executionEnvironments = [
         "skills/illustrations/scripts",
         "skills/presentation-creator/scripts",
     ] },
-    { root = "skills/presentation-creator/scripts", extraPaths = ["skills/presentation-creator/scripts"] },
+    # The outline reader consumes the vault-profile-owned speech-rate contract.
+    { root = "skills/presentation-creator/scripts", extraPaths = [
+        "skills/presentation-creator/scripts",
+        "skills/vault-profile/scripts",
+    ] },
     # clarification and profile splice the vault-ingress scripts onto sys.path
     # at import time to share its validators.
     { root = "skills/vault-clarification/scripts", extraPaths = [

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -238,6 +238,12 @@ voice calibration, placeholder definitions, and meme-brief format.
 
 Fill `slides[]` and `interludes[]` in `outline.yaml`.
 
+Use the typed narration-planning contract in
+[speech-rates.md](../vault-profile/references/speech-rates.md). Prefer a current
+owner-validated measured profile; label uncalibrated rates as assumptions.
+Author `talk.pacing_rate` and root `schema_version: 1`; never use articulation
+WPM to plan elapsed narration or predicted timing to verify a recording.
+
 Placeholders use typed, independent numbering (each type starts at 01):
 `AUTHOR-01`, `DEMO-01`, `DATA-01`, `SCREENSHOT-01`, `IMAGE-01`, `MEME-01`. Every
 placeholder requiring author input MUST use one of these typed tags — never

--- a/skills/presentation-creator/references/phase3-content.md
+++ b/skills/presentation-creator/references/phase3-content.md
@@ -8,6 +8,11 @@ regenerate deterministically — never hand-edit them.
 
 A complete worked example lives at `tests/fixtures/outline-example.yaml`.
 
+New outlines declare root `schema_version: 1`. Previously unversioned outlines
+remain read-only-compatible; the creator adds the stamp on the next authoring
+pass. Explicit unsupported root versions fail closed. This does not rewrite
+an existing file during loading.
+
 ## Writing the Outline
 
 The outline needs to be:
@@ -32,7 +37,8 @@ Authored in Phase 1; never re-edited carelessly. Field reference (see
 | `audience_spread` | yes | `heterogeneous` (cover all four registers) or `homogeneous` (match one). Set at intake — see `phase0-intake.md` Step 0.4 and `patterns/prepare/walk-around.md` |
 | `dominant_register` | conditional | `A` \| `B` \| `C` \| `D`. Required iff `audience_spread: homogeneous`; rejected otherwise |
 | `slide_budget` | yes | Integer; expanded build count is validated against this |
-| `pacing_wpm` | yes | `[low, high]` integer tuple |
+| `pacing_rate` | yes for new outlines | Complete typed narration rate from owner planning output; see `skills/vault-profile/references/speech-rates.md` |
+| `pacing_wpm` | legacy only | Ordered positive `[low, high]` integer tuple; an unverified narration assumption retaining internal gaps ≤2 s, never a measurement. Cannot coexist with `pacing_rate` |
 | `architecture` | yes | One of: `narrative-arc`, `sparkline`, `fourthought`, `triad`, `talklet`, `expansion-joints`, `lightning-talk`, `takahashi`, `cave-painting`. Filled in Phase 2 — leave a placeholder at Phase 1 |
 | `engine` | yes | `pptx` \| `presenterm`. Filled in Phase 2 Decision #2 |
 | `deck_theme` | yes | Free-string theme/template pointer. Phase 2 Decision #2 |
@@ -45,6 +51,17 @@ Authored in Phase 1; never re-edited carelessly. Field reference (see
 | `must_include`, `must_avoid` | optional | Lists of strings |
 | `catalog_reference` | optional | Pointer to sessions-catalog entry |
 | `delivery_count`, `delivery_date` | optional | First delivery = 1; date in ISO YYYY-MM-DD |
+
+For long-form duration planning, use
+`"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/speech_rates.py"` with `intended_metric: narration`.
+Keep a measured profile's complete rate and provenance when copying it into
+`talk.pacing_rate`. Use an explicit assumption only when no measured profile
+exists; a present invalid profile is an owner error, not a fallback trigger.
+The full contract and command shapes are in
+`skills/vault-profile/references/speech-rates.md`. Recording verification uses
+actual complete-recording duration and aligned words, independently of the
+planning estimate. Keep timeline, narration, short-phrase, and articulation
+values labeled in reports.
 
 ## The `chapters:` block
 

--- a/skills/presentation-creator/scripts/extract-script.py
+++ b/skills/presentation-creator/scripts/extract-script.py
@@ -110,12 +110,29 @@ def render(outline: _os.Outline) -> str:
     """Render the full script.md content."""
     lines: list[str] = []
     speakers_csv = " · ".join(outline.talk.speakers)
+    rate = outline.talk.narration_rate
+    low, high = rate["range"]
+    provenance = rate["provenance"]
+    if rate["basis"] == "measured":
+        rate_source = (
+            f"measured; {provenance['sample_count']} samples, "
+            f"{provenance['analyzed_duration_seconds']:g} s analyzed; "
+            f"cohort {provenance['cohort']}; {provenance['method_version']}; "
+            "observed sample range, not a confidence interval"
+        )
+    else:
+        rate_source = f"assumption, not verified: {provenance['reason']}"
     lines.append(f"# {outline.talk.title} — Script")
     lines.append("")
     lines.append(
         f"**{outline.talk.venue}** · {outline.talk.duration_min:g} min "
-        f"· {speakers_csv} · pacing {outline.talk.pacing_wpm[0]}–"
-        f"{outline.talk.pacing_wpm[1]} WPM",
+        f"· {speakers_csv} · pacing {low:g}–{high:g} WPM narration "
+        f"(internal gaps ≤{rate['pause_threshold_seconds']:g} s; {rate_source})",
+    )
+    lines.append("")
+    lines.append(
+        "> Narration pace supports planning only. Recording verification requires "
+        "actual word timestamps and actual duration; predicted timing is not evidence."
     )
     lines.append("")
     lines.append(

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -38,7 +38,7 @@ if str(_PROFILE_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_PROFILE_SCRIPTS))
 
 # The installed sibling skill owns speech-rate schemas; readers do not migrate them.
-from speech_rates import assumed_narration, validate_rate  # noqa: E402  # pyright: ignore[reportMissingImports]
+from speech_rates import assumed_narration, validate_rate  # noqa: E402
 
 
 class _StrictModel(BaseModel):

--- a/skills/presentation-creator/scripts/outline_schema.py
+++ b/skills/presentation-creator/scripts/outline_schema.py
@@ -16,6 +16,7 @@ checklist concern, not a schema concern; the schema accepts any non-antipattern.
 from __future__ import annotations
 
 import json
+import copy
 import re
 import sys
 from enum import Enum
@@ -31,6 +32,13 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+
+_PROFILE_SCRIPTS = Path(__file__).resolve().parents[2] / "vault-profile" / "scripts"
+if str(_PROFILE_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PROFILE_SCRIPTS))
+
+# The installed sibling skill owns speech-rate schemas; readers do not migrate them.
+from speech_rates import assumed_narration, validate_rate  # noqa: E402  # pyright: ignore[reportMissingImports]
 
 
 class _StrictModel(BaseModel):
@@ -425,9 +433,57 @@ class TalkMetadata(_StrictModel):
     mode: str
     venue: str
     slide_budget: int = Field(gt=0)
-    pacing_wpm: tuple[int, int]
+    # Legacy read-only compatibility: unverified narration planning assumption,
+    # never a measured rate. New outlines select one typed pacing_rate instead.
+    pacing_wpm: tuple[int, int] | None = None
+    pacing_rate: dict | None = None
     architecture: str
     applied_patterns: list[AppliedPattern] = Field(default_factory=list)
+
+    @field_validator("pacing_wpm", mode="before")
+    @classmethod
+    def _legacy_pacing_is_an_ordered_integer_range(cls, value):
+        if value is None:
+            return value
+        if (
+            not isinstance(value, (list, tuple))
+            or len(value) != 2
+            or any(type(n) is not int for n in value)
+            or not 0 < value[0] <= value[1]
+        ):
+            raise ValueError(
+                "pacing_wpm requires an ordered positive integer range; use pacing_rate for measured narration"
+            )
+        return value
+
+    @field_validator("pacing_rate")
+    @classmethod
+    def _typed_pacing_is_narration(cls, value):
+        if value is None:
+            return value
+        validate_rate(value)
+        if value["metric"] != "narration":
+            raise ValueError("pacing_rate must name narration for long-form planning")
+        return value
+
+    @model_validator(mode="after")
+    def _one_pacing_source(self) -> "TalkMetadata":
+        if (self.pacing_wpm is None) == (self.pacing_rate is None):
+            raise ValueError(
+                "select exactly one pacing_rate or legacy pacing_wpm assumption"
+            )
+        return self
+
+    @property
+    def narration_rate(self) -> dict:
+        """Read a typed rate without rewriting the source outline."""
+        if self.pacing_rate is not None:
+            return copy.deepcopy(self.pacing_rate)
+        assert self.pacing_wpm is not None  # Required by _one_pacing_source.
+        return assumed_narration(
+            *self.pacing_wpm,
+            reason="legacy pacing_wpm; unverified narration assumption",
+        )
 
     @model_validator(mode="after")
     def _walk_around_is_per_claim(self) -> "TalkMetadata":
@@ -630,6 +686,9 @@ def _check_beat_slide_refs(
 
 
 class Outline(_StrictModel):
+    # Missing root stamp is the legacy read-only view. The owner writes v1 on
+    # its next authoring pass; no loader rewrites an existing outline.
+    schema_version: int = Field(default=1, strict=True, ge=1, le=1)
     talk: TalkMetadata
     style_anchor: StyleAnchor | None = None
     chapters: list[Chapter] = Field(min_length=1)
@@ -795,6 +854,7 @@ class PartialOutline(_StrictModel):
     stays the Phase 3+ source-of-truth contract.
     """
 
+    schema_version: int = Field(default=1, strict=True, ge=1, le=1)
     talk: TalkMetadata
     style_anchor: StyleAnchor | None = None
     chapters: list[Chapter] = Field(default_factory=list)

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -61,6 +61,8 @@ configuration. Never fall back to whichever `python3` happens to be on `PATH`.
 - Use [speaker-profile-schema.md](references/speaker-profile-schema.md) for the full
   JSON shape and [schemas-config.md](references/schemas-config.md) for config and
   confirmed intents.
+- Read [speech-rates.md](references/speech-rates.md) before speech calibration or
+  narration planning. Keep measured word-timing profiles separate from slide pacing.
 - Treat `tracking-database.json` as source of truth and `speaker-profile.json` as the
   output. Toolkit scripts, not prose, own cohort, opportunity, classification, pacing,
   and validation arithmetic.
@@ -163,6 +165,12 @@ classification, empty-cohort, and non-pattern provenance rules there. Use
 schema. Copy deterministic baseline, opportunity, policy stamp, availability, and
 derived classification data; do not infer or recalculate catalog history. Regenerating
 these profile fields reads existing tracking rows and does not reparse any talk.
+
+Apply the independent speaking-rate contract in
+[speech-rates.md](references/speech-rates.md) when measured word evidence is
+available. Preserve `speech-rate-profile.json` separately; missing evidence
+does not authorize a reparse. Legacy `pacing.wpm_range` is an unverified
+narration assumption, never a measured speaker rate.
 
 Compute `pacing.adherence` by running `"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/compute-pacing-adherence.py"`. The
 deterministic arithmetic — duration parsing, slides-per-minute, budget-band

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -157,6 +157,12 @@ generation, or an instrumentation cohort.
 
 ## Pacing and Section 15
 
+`pacing.wpm_range` is a legacy unverified narration assumption with the
+2-second internal-gap definition, not a measured speaking-rate profile.
+Keep measured word-timing calibration in the separate owner artifact described
+in [speech-rates.md](speech-rates.md); do not collapse its four rate types into
+the legacy range or infer speech speed from slides per minute.
+
 Pacing is quantitative but approximate. Treat marginal slide-budget overages softly;
 the result complements, rather than replaces, Dimension 14's transcript-evident
 "rushing" assessment.

--- a/skills/vault-profile/references/speaker-profile-schema.md
+++ b/skills/vault-profile/references/speaker-profile-schema.md
@@ -58,6 +58,14 @@ Current `schema_version`: **5**. The validator (`scripts/validate-profile.py`,
 
 ## Schema
 
+`pacing.wpm_range` retains one explicit legacy meaning: an unverified narration
+planning assumption that retains internal gaps up to 2 seconds. Its values do
+not establish a measured speaker rate. Measured timeline, narration,
+short-phrase, and articulation rates live in the separate schema-v1
+`speech-rate-profile.json` owned by vault-profile; see
+[speech-rates.md](speech-rates.md). That artifact does not change this profile's
+v5 shape, pattern provenance, or slide-budget `pacing.adherence` lane.
+
 ```json
 {
   "schema_version": 5,
@@ -753,7 +761,7 @@ automatically picks up changes when the profile is regenerated.
 | `design_rules` | Phase 5 (slide generation) | Background colors, footer specs, shape vocabulary |
 | `rhetoric_defaults` | Phase 1-3 (spec, architecture, content) | Voice calibration, opening/closing defaults |
 | `confirmed_intents` | Phase 2-4 (architecture, guardrails) | Hard rules that override pattern inference |
-| `pacing` | Phase 3-4 (content, guardrails) | Slide budget tables, WPM targets |
+| `pacing` | Phase 3-4 (content, guardrails) | Slide budget tables and legacy unverified narration assumptions; measured speech rates use the separate owner artifact |
 | `guardrail_sources` | Phase 4 (guardrails) | All guardrail checks with thresholds |
 | `instrument_catalog` | Phase 2 (architecture) | Complete instrument menu by dimension |
 | `visual_style_history` | Phase 2 (architecture — illustration strategy) | Default aesthetic, mode-specific departures, style proposals |

--- a/skills/vault-profile/references/speech-rates.md
+++ b/skills/vault-profile/references/speech-rates.md
@@ -1,0 +1,188 @@
+# Speaking-Rate Contracts
+
+Owner: `vault-profile`. Executable owner:
+`skills/vault-profile/scripts/speech_rates.py`. This is an independent
+schema-v1 artifact lane, not a change to `speaker-profile.json` schema v5 or
+the tracking database. No operation here acquires media, runs Whisper, or
+reparses talks. Acquisition and source-generation verification remain the
+ingress owner's responsibility.
+
+## Four Different Metrics
+
+Every rate uses `unit: "words_per_minute"` and a named `metric`. Method
+`word-gaps-v1` has these closed definitions:
+
+| Metric | Denominator | `pause_threshold_seconds` | Use |
+|---|---|---|---|
+| `timeline` | Complete sample duration, including leading/trailing silence and all interruptions | `null` | Describe the finished recording |
+| `narration` | Word spans plus complete internal gaps of at most 2 seconds | `2.0` | Long-form narration planning |
+| `short_phrase` | Word spans plus complete internal gaps of at most 1 second | `1.0` | Describe phrase/beat pace |
+| `articulation` | Word spans plus complete internal gaps of at most 250 milliseconds | `0.25` | Describe thresholded articulation, not end-to-end duration |
+
+Gaps above a threshold contribute nothing; they are not clipped to the
+threshold. Articulation is an operational word-alignment metric, not a
+phonetic voice-activity detector. Do not relabel it as narration or use it
+to size a long-form script. A threshold change requires a new method version.
+
+## Recorded Word Evidence
+
+`measure` consumes this exact schema-v1 record. Every key is required:
+
+```json
+{
+  "schema_version": 1,
+  "timing_kind": "recorded_words",
+  "source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "source_duration_seconds": 50,
+  "sample_start_seconds": 0,
+  "sample_duration_seconds": 50,
+  "aligner": "synthetic-example-v1",
+  "words": [["Example", 1.0, 1.4], ["words", 1.6, 2.0]]
+}
+```
+
+The example is synthetic, not a speaker calibration. Word times are relative
+to the sample. Each tuple contains one nonempty whitespace-free lexical token
+and its actual start/end seconds. Spans must be positive, ordered,
+non-overlapping, and inside the sample; the sample must fit inside the
+source's actual duration. A punctuation-only tuple is not a word. Preserve
+the aligner's word-tokenization convention and record its name/version.
+
+Use word timestamps and duration from the same unchanged recording generation.
+The source digest must come from the acquisition owner's receipt. This tool
+validates and carries that binding; it does not open the media or authenticate
+a supplied digest. Recheck freshness through the acquisition owner before
+acting on a stored snapshot. Do not substitute evenly divided segment times,
+script estimates, or a predicted duration. Existing transcript timing sidecar
+v2 contains segments, not word evidence, and is not accepted by this contract.
+
+Bounds and diagnostic codes belong to the script's header and validators.
+Missing/unknown fields, future or type-confused versions, duplicate JSON keys,
+non-finite numbers, and invalid timing fail closed without echoing input data.
+
+## Measured Profile and Persistence
+
+`calibrate` consumes `{schema_version: 1, cohort: string, samples: [evidence, ...]}`.
+Choose a cohort deliberately: speaker, delivery mode, language, and sample
+selection should match the intended use. A sample count is not a count of
+independent talks. Duplicate or overlapping windows from one source digest are
+rejected; disjoint windows remain distinct samples. Do not present them as
+independent deliveries. One source digest cannot declare two source durations.
+
+The result is a closed profile:
+
+```text
+{schema_version: 1, calibration: <exact calibration request>, rates: [<rate>, ...]}
+```
+
+All four rates are retained. Each rate has exactly:
+
+```text
+{schema_version: 1, metric, unit, pause_threshold_seconds, value,
+ range: [low, high], basis: "measured", provenance}
+```
+
+`value` is the equally weighted sample mean. `range` is the observed minimum
+and maximum across sample rates, not a population interval. Provenance has:
+
+```text
+{schema_version: 1, sample_count, analyzed_duration_seconds, cohort,
+ method_version: "word-gaps-v1", evidence_sha256: [digest, ...],
+ range_kind: "observed_sample_range_not_confidence_interval"}
+```
+
+The evidence digest is SHA-256 of the owner's canonical JSON for the complete
+word-evidence record. Consumers treat it as opaque, not an algorithm to
+reimplement. The profile retains the source evidence for reproducibility;
+keep it private with the vault, not in the public plugin or a public issue.
+Small or biased cohorts remain small or biased even when validation succeeds.
+
+Vault-profile alone creates or replaces `speech-rate-profile.json`. Run
+`calibrate`, require exit 0 and `ok: true`, then store only its `data` object
+unchanged in a fresh candidate file. Preserve the prior file until the new
+candidate has validated; do not redirect a failing command over the prior
+profile. Repeated identical calibration produces identical bytes with
+`encode()`. No automatic migration is performed: regenerate legacy or unknown
+profiles through this owner from recorded word evidence. Non-owner readers
+call `validate_profile()`, which recomputes all derived rates/provenance from
+the retained evidence and rejects any inconsistent present profile. They
+never repair, restamp, or silently replace invalid state with a default.
+
+## Planning and Verification
+
+`plan_duration(word_count, *, intended_metric, profile=None, assumption=None)`
+requires `intended_metric: "narration"`. Other named metrics and unqualified
+numeric WPM are rejected. If a valid measured profile is supplied, its
+narration rate wins over an assumption. A present invalid profile fails
+instead of falling back. If no profile exists, explicitly supply an assumption;
+there is no hidden universal speaker-rate default.
+
+An assumed rate has the same rate keys, with `basis: "assumption"` and
+`provenance: {schema_version: 1, reason: string}`. Its positive ordered range
+must contain its point value. Library callers can construct one through
+`assumed_narration(low, high, reason=...)`. Never attach measured provenance
+to an assumption. `plan_duration` emits a schema-v1 prediction containing the
+selected complete rate, intended metric, word count, point duration, and
+inverted duration range, labeled `kind: "prediction_not_verification"`.
+
+`verify_recording(evidence, *, maximum_duration_seconds)` has no planning-rate
+input. It requires word evidence covering the complete recording, not an
+interior calibration window. Its schema-v1 result carries
+`kind: "recorded_duration_check"`, the explicit maximum duration,
+`fits_duration`, and the actual measurement with all four rates. The comparison
+uses actual recording duration, including pauses; changing a planning WPM
+cannot change the verdict. This is a duration check, not proof of script
+completeness, alignment accuracy, or delivery quality.
+
+`measure` returns a schema-v1 record with `method_version`, `evidence_sha256`,
+`source_sha256`, `word_count`, `actual_duration_seconds`, and four rate records.
+Each measurement rate has `schema_version`, `metric`, `unit`,
+`pause_threshold_seconds`, `denominator_seconds`, and `value`.
+
+## Command Contract
+
+Use the configured vault interpreter resolved by the parent skill. Each action
+reads one JSON document from stdin and emits one JSON envelope. The executable
+does not write files or mutate the vault.
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/speech_rates.py" measure < word-evidence.json
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/speech_rates.py" calibrate < calibration-request.json
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/speech_rates.py" plan < planning-request.json
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/speech_rates.py" verify < verification-request.json
+```
+
+Plan request: `{schema_version: 1, word_count, intended_metric: "narration",
+profile: <complete validated profile or null>, assumption: <assumed rate or null>}`.
+Verification request: `{schema_version: 1, evidence: <complete recording word
+evidence>, maximum_duration_seconds}`. Extra fields, including a planning WPM
+in a verification request, are rejected. Success is
+`{schema_version: 1, ok: true, data: <action result>}` with exit 0. Failures
+have `ok: false` and `error: {code, message}` plus a redacted stderr diagnostic;
+exit 1 rejects input and exit 2 reports usage/tool failure. `--help` emits a
+JSON help envelope without reading stdin. Interrupts propagate.
+
+## Creator and Legacy Compatibility
+
+New outlines carry root `schema_version: 1` and exactly one
+`talk.pacing_rate`: the complete typed narration rate from planning output.
+Both complete and partial outline readers reject unsupported explicit root
+versions and validate the embedded rate. The creator never recalculates or
+edits measured provenance. Use a fresh owner-validated measured profile when
+available. A stale or invalid present profile requires owner attention.
+
+Previously unversioned outlines remain read-only-compatible. The loader does
+not rewrite them; the next creator authoring pass adds the v1 root stamp.
+Legacy `talk.pacing_wpm: [low, high]` has one compatibility meaning: an
+unverified narration planning assumption with the v1 2-second gap definition.
+It cannot coexist with `pacing_rate`; the owner replaces it with a typed
+record on the next authoring pass. `extract-script.py` explicitly reports the
+metric, threshold, assumption/measured basis, and measured provenance/range.
+It never labels predicted timing as verification.
+
+Legacy `speaker-profile.json.pacing.wpm_range` has the same unverified
+narration-assumption meaning; it is not a measured profile and cannot be fed
+directly into the typed planning API. Its `comfortable` value is not an
+independent observation. Leave schema-v5 slide-budget `pacing.adherence`
+unchanged: slides per minute is a different quantity. Keep calibrated speech
+data in this separate owner artifact and preserve all four metric labels.

--- a/skills/vault-profile/references/speech-rates.md
+++ b/skills/vault-profile/references/speech-rates.md
@@ -9,20 +9,24 @@ ingress owner's responsibility.
 
 ## Four Different Metrics
 
-Every rate uses `unit: "words_per_minute"` and a named `metric`. Method
-`word-gaps-v1` has these closed definitions:
+Every rate uses `unit: "words_per_minute"` and a named `metric`. Each emitted
+record preserves its applied `pause_threshold_seconds`; measurement records
+also expose `denominator_seconds`. The complete timeline/pause definitions
+for `word-gaps-v1` are documented in the owner's module docstring and implemented
+by `THRESHOLDS` and `_denominators` in
+`skills/vault-profile/scripts/speech_rates.py`. Execute the owner rather than
+recreating those calculations in prose or reader code.
 
-| Metric | Denominator | `pause_threshold_seconds` | Use |
-|---|---|---|---|
-| `timeline` | Complete sample duration, including leading/trailing silence and all interruptions | `null` | Describe the finished recording |
-| `narration` | Word spans plus complete internal gaps of at most 2 seconds | `2.0` | Long-form narration planning |
-| `short_phrase` | Word spans plus complete internal gaps of at most 1 second | `1.0` | Describe phrase/beat pace |
-| `articulation` | Word spans plus complete internal gaps of at most 250 milliseconds | `0.25` | Describe thresholded articulation, not end-to-end duration |
+| Metric label | Reporting and planning role |
+|---|---|
+| `timeline` | Describe the finished recording's complete timeline |
+| `narration` | Plan long-form narration |
+| `short_phrase` | Describe phrase/beat pace |
+| `articulation` | Describe thresholded articulation, not end-to-end duration |
 
-Gaps above a threshold contribute nothing; they are not clipped to the
-threshold. Articulation is an operational word-alignment metric, not a
-phonetic voice-activity detector. Do not relabel it as narration or use it
-to size a long-form script. A threshold change requires a new method version.
+Articulation is an operational word-alignment metric, not a phonetic
+voice-activity detector. Do not relabel it as narration. Preserve the method
+version and applied threshold with every copied rate.
 
 ## Recorded Word Evidence
 

--- a/skills/vault-profile/scripts/speech_rates.py
+++ b/skills/vault-profile/scripts/speech_rates.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+"""Typed speaking-rate analysis and planning; no media acquisition or vault writes.
+
+Owner: vault-profile. Schema/method v1 uses recorded, non-overlapping word
+intervals, never evenly distributed segment timestamps. ``measure``,
+``calibrate``, ``plan``, and ``verify`` read one JSON document on stdin and emit
+one {schema_version, ok, data|error} envelope. Exit 0 succeeds, 1 rejects input,
+2 reports usage/tool failure. Diagnostics never echo input values.
+
+Input/output shapes, persistence, and reader compatibility are documented in
+skills/vault-profile/references/speech-rates.md. Library entry points return
+JSON-compatible objects and raise SpeechRateError on invalid contracts.
+
+Bounds: 16 MiB JSON per request/result; 64 samples, 50,000 words per sample,
+four hours per sample/source; one whitespace-free lexical token per word tuple
+[text, start_seconds, end_seconds]. Times are relative to the sample. Recording
+duration and word alignment must come from the same source generation. The
+source SHA-256 is a provenance binding supplied by the acquisition owner, not
+a claim that this arithmetic tool opened or authenticated the media.
+
+Method word-gaps-v1: include each word span and each complete internal gap at
+or below the metric's threshold (not a clipped portion of a longer gap).
+Timeline includes the complete sample, including leading/trailing silence.
+Narration retains gaps <=2 s, short_phrase <=1 s, articulation <=0.25 s.
+Articulation is the explicitly thresholded operational metric, not a phonetic
+voice-activity measurement. Profiles use equally weighted sample means and
+observed sample ranges, not confidence intervals or population guarantees.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import re
+import statistics
+import sys
+from typing import Any, NoReturn
+
+
+MAX_JSON_BYTES = 16 * 1024 * 1024
+MAX_SAMPLES = 64
+MAX_WORDS = 50_000
+MAX_DURATION_SECONDS = 4 * 60 * 60
+METHOD_VERSION = "word-gaps-v1"
+THRESHOLDS = {
+    "timeline": None,
+    "narration": 2.0,
+    "short_phrase": 1.0,
+    "articulation": 0.25,
+}
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class SpeechRateError(ValueError):
+    """Closed diagnostic; user-controlled words, paths, and values are omitted."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpeechRateError(code, message)
+
+
+def _record(value: Any, keys: set[str]) -> dict:
+    if not isinstance(value, dict) or set(value) != keys | {"schema_version"}:
+        _fail("speech_shape_invalid", "Use the documented closed speech-rate shape.")
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        _fail(
+            "speech_schema_unsupported",
+            "Use schema version 1; update the owner for other versions.",
+        )
+    return value
+
+
+def _number(value: Any, *, positive: bool = False) -> float:
+    if type(value) not in (int, float):
+        _fail(
+            "speech_number_invalid", "Use finite JSON numbers, not strings or booleans."
+        )
+    try:
+        finite = math.isfinite(value)
+    except OverflowError:
+        finite = False
+    if not finite:
+        _fail(
+            "speech_number_invalid",
+            "Use finite numbers within the supported arithmetic range.",
+        )
+    if value < 0 or (positive and value == 0):
+        _fail(
+            "speech_number_invalid",
+            "Use positive durations and rates and nonnegative timestamps.",
+        )
+    return float(value)
+
+
+def _text(value: Any, *, limit: int = 200) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > limit:
+        _fail(
+            "speech_text_invalid",
+            "Supply a nonempty bounded cohort or provenance label.",
+        )
+    return value
+
+
+def _sha(value: Any) -> str:
+    if not isinstance(value, str) or not _SHA256.fullmatch(value):
+        _fail(
+            "speech_digest_invalid",
+            "Supply the exact lowercase source SHA-256 from acquisition.",
+        )
+    return value
+
+
+def _metric(value: Any) -> str:
+    if not isinstance(value, str) or value not in THRESHOLDS:
+        _fail(
+            "speech_metric_invalid",
+            "Name timeline, narration, short_phrase, or articulation.",
+        )
+    return value
+
+
+def encode(value: Any) -> bytes:
+    raw = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode()
+    if len(raw) > MAX_JSON_BYTES:
+        _fail(
+            "speech_json_too_large", "Reduce the calibration batch to at most 16 MiB."
+        )
+    return raw
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(encode(value)).hexdigest()
+
+
+def validate_evidence(value: Any) -> dict:
+    evidence = _record(
+        value,
+        {
+            "timing_kind",
+            "source_sha256",
+            "source_duration_seconds",
+            "sample_start_seconds",
+            "sample_duration_seconds",
+            "aligner",
+            "words",
+        },
+    )
+    if evidence["timing_kind"] != "recorded_words":
+        _fail(
+            "speech_recording_required",
+            "Acquire actual recording word timestamps; predictions and segment timing are not evidence.",
+        )
+    _sha(evidence["source_sha256"])
+    source_duration = _number(evidence["source_duration_seconds"], positive=True)
+    duration = _number(evidence["sample_duration_seconds"], positive=True)
+    start = _number(evidence["sample_start_seconds"])
+    if source_duration > MAX_DURATION_SECONDS or start + duration > source_duration:
+        _fail(
+            "speech_window_invalid",
+            "Choose a sample within the actual source duration and four-hour ceiling.",
+        )
+    _text(evidence["aligner"])
+    words = evidence["words"]
+    if not isinstance(words, list) or not 1 <= len(words) <= MAX_WORDS:
+        _fail("speech_words_invalid", "Supply one to 50,000 actual aligned words.")
+    previous_end = 0.0
+    for word in words:
+        if not isinstance(word, (list, tuple)) or len(word) != 3:
+            _fail(
+                "speech_word_invalid",
+                "Use [word, start_seconds, end_seconds] for every aligned word.",
+            )
+        text, word_start, word_end = word
+        _text(text)
+        if any(c.isspace() for c in text) or not any(c.isalnum() for c in text):
+            _fail(
+                "speech_word_invalid",
+                "Use one lexical token per aligned word; do not pass segments or punctuation-only tokens.",
+            )
+        word_start = _number(word_start)
+        word_end = _number(word_end, positive=True)
+        if word_start < previous_end or word_end <= word_start or word_end > duration:
+            _fail(
+                "speech_word_timing_invalid",
+                "Supply ordered, non-overlapping positive word spans within the actual sample duration.",
+            )
+        previous_end = word_end
+    return evidence
+
+
+def _denominators(evidence: dict) -> dict[str, float]:
+    words = evidence["words"]
+    active = math.fsum(end - start for _, start, end in words)
+    gaps = [right[1] - left[2] for left, right in zip(words, words[1:])]
+    return {
+        metric: evidence["sample_duration_seconds"]
+        if threshold is None
+        else active + math.fsum(gap for gap in gaps if gap <= threshold)
+        for metric, threshold in THRESHOLDS.items()
+    }
+
+
+def measure(evidence: Any) -> dict:
+    evidence = validate_evidence(evidence)
+    denominators = _denominators(evidence)
+    count = len(evidence["words"])
+    return {
+        "schema_version": 1,
+        "method_version": METHOD_VERSION,
+        "evidence_sha256": _digest(evidence),
+        "source_sha256": evidence["source_sha256"],
+        "word_count": count,
+        "actual_duration_seconds": evidence["sample_duration_seconds"],
+        "rates": [
+            {
+                "schema_version": 1,
+                "metric": metric,
+                "unit": "words_per_minute",
+                "pause_threshold_seconds": THRESHOLDS[metric],
+                "denominator_seconds": seconds,
+                "value": _number(count * 60 / seconds, positive=True),
+            }
+            for metric, seconds in denominators.items()
+        ],
+    }
+
+
+def calibrate(request: Any) -> dict:
+    request = _record(request, {"cohort", "samples"})
+    _text(request["cohort"])
+    samples = request["samples"]
+    if not isinstance(samples, list) or not 1 <= len(samples) <= MAX_SAMPLES:
+        _fail(
+            "speech_samples_invalid",
+            "Supply one to 64 explicitly selected calibration samples.",
+        )
+    windows: dict[str, list[tuple[float, float]]] = {}
+    source_durations = {}
+    measurements = []
+    for sample in samples:
+        validate_evidence(sample)
+        source = sample["source_sha256"]
+        source_duration = sample["source_duration_seconds"]
+        if source in source_durations and source_durations[source] != source_duration:
+            _fail(
+                "speech_source_inconsistent",
+                "Use one actual duration for each unchanged recording generation.",
+            )
+        source_durations[source] = source_duration
+        start = sample["sample_start_seconds"]
+        end = start + sample["sample_duration_seconds"]
+        prior = windows.setdefault(sample["source_sha256"], [])
+        if any(start < old_end and end > old_start for old_start, old_end in prior):
+            _fail(
+                "speech_samples_overlap",
+                "Select non-overlapping samples; do not count a recording window twice.",
+            )
+        prior.append((start, end))
+        measurements.append(measure(sample))
+    provenance = {
+        "schema_version": 1,
+        "sample_count": len(samples),
+        "analyzed_duration_seconds": math.fsum(
+            sample["sample_duration_seconds"] for sample in samples
+        ),
+        "cohort": request["cohort"],
+        "method_version": METHOD_VERSION,
+        "evidence_sha256": [
+            measurement["evidence_sha256"] for measurement in measurements
+        ],
+        "range_kind": "observed_sample_range_not_confidence_interval",
+    }
+    rates = []
+    for index, metric in enumerate(THRESHOLDS):
+        values = [measurement["rates"][index]["value"] for measurement in measurements]
+        rates.append(
+            {
+                "schema_version": 1,
+                "metric": metric,
+                "unit": "words_per_minute",
+                "pause_threshold_seconds": THRESHOLDS[metric],
+                "value": statistics.mean(values),
+                "range": [min(values), max(values)],
+                "basis": "measured",
+                "provenance": copy.deepcopy(provenance),
+            }
+        )
+    result = {
+        "schema_version": 1,
+        "calibration": copy.deepcopy(request),
+        "rates": rates,
+    }
+    encode(result)
+    return result
+
+
+def validate_profile(value: Any) -> dict:
+    profile = _record(value, {"calibration", "rates"})
+    expected = calibrate(profile["calibration"])
+    # Canonical JSON equality also rejects bool/int and int/float substitutions.
+    if encode(profile) != encode(expected):
+        _fail(
+            "speech_profile_inconsistent",
+            "Regenerate the speech profile from its recorded word evidence; do not edit derived rates.",
+        )
+    return profile
+
+
+def validate_rate(value: Any) -> dict:
+    rate = _record(
+        value,
+        {
+            "metric",
+            "unit",
+            "pause_threshold_seconds",
+            "value",
+            "range",
+            "basis",
+            "provenance",
+        },
+    )
+    metric = _metric(rate["metric"])
+    threshold = rate["pause_threshold_seconds"]
+    if threshold is not None:
+        _number(threshold)
+    if rate["unit"] != "words_per_minute" or threshold != THRESHOLDS[metric]:
+        _fail(
+            "speech_definition_invalid",
+            "Use the named metric's v1 pause threshold and words_per_minute units.",
+        )
+    point = _number(rate["value"], positive=True)
+    limits = rate["range"]
+    if not isinstance(limits, (list, tuple)) or len(limits) != 2:
+        _fail(
+            "speech_range_invalid",
+            "Supply an ordered [low, high] rate range containing the point estimate.",
+        )
+    low, high = (_number(n, positive=True) for n in limits)
+    if not low <= point <= high:
+        _fail(
+            "speech_range_invalid",
+            "Supply an ordered [low, high] rate range containing the point estimate.",
+        )
+    if rate["basis"] == "assumption":
+        provenance = _record(rate["provenance"], {"reason"})
+        _text(provenance["reason"])
+    elif rate["basis"] == "measured":
+        provenance = _record(
+            rate["provenance"],
+            {
+                "sample_count",
+                "analyzed_duration_seconds",
+                "cohort",
+                "method_version",
+                "evidence_sha256",
+                "range_kind",
+            },
+        )
+        count = provenance["sample_count"]
+        if type(count) is not int or not 1 <= count <= MAX_SAMPLES:
+            _fail(
+                "speech_provenance_invalid",
+                "Preserve the measured profile's sample count and evidence provenance.",
+            )
+        _number(provenance["analyzed_duration_seconds"], positive=True)
+        _text(provenance["cohort"])
+        digests = provenance["evidence_sha256"]
+        if (
+            not isinstance(digests, list)
+            or len(digests) != count
+            or len(set(map(str, digests))) != count
+        ):
+            _fail(
+                "speech_provenance_invalid",
+                "Preserve one distinct evidence digest per measured sample.",
+            )
+        for digest in digests:
+            _sha(digest)
+        if (
+            provenance["method_version"] != METHOD_VERSION
+            or provenance["range_kind"]
+            != "observed_sample_range_not_confidence_interval"
+        ):
+            _fail(
+                "speech_provenance_invalid",
+                "Use the current method and explicitly label observed ranges, not confidence intervals.",
+            )
+    else:
+        _fail(
+            "speech_basis_invalid",
+            "Identify a rate as measured or an explicit assumption.",
+        )
+    return rate
+
+
+def assumed_narration(low: float, high: float, *, reason: str) -> dict:
+    low, high = _number(low, positive=True), _number(high, positive=True)
+    return validate_rate(
+        {
+            "schema_version": 1,
+            "metric": "narration",
+            "unit": "words_per_minute",
+            "pause_threshold_seconds": 2.0,
+            "value": (low + high) / 2,
+            "range": [low, high],
+            "basis": "assumption",
+            "provenance": {"schema_version": 1, "reason": reason},
+        }
+    )
+
+
+def plan_duration(
+    word_count: int,
+    *,
+    intended_metric: str,
+    profile: Any = None,
+    assumption: Any = None,
+) -> dict:
+    if _metric(intended_metric) != "narration":
+        _fail(
+            "speech_planning_metric_invalid",
+            "Use narration for long-form duration planning; articulation is not elapsed narration.",
+        )
+    if type(word_count) is not int or not 1 <= word_count <= MAX_WORDS:
+        _fail(
+            "speech_word_count_invalid",
+            "Supply a positive script word count within 50,000 words.",
+        )
+    if profile is not None:
+        profile = validate_profile(profile)
+        rate = next(
+            rate for rate in profile["rates"] if rate["metric"] == intended_metric
+        )
+    elif assumption is not None:
+        rate = validate_rate(assumption)
+        if rate["metric"] != intended_metric or rate["basis"] != "assumption":
+            _fail(
+                "speech_assumption_invalid",
+                "Supply an explicitly assumed narration rate, or the complete measured profile.",
+            )
+    else:
+        _fail(
+            "speech_rate_required",
+            "Provide a measured narration profile or an explicitly labeled assumption.",
+        )
+    low, high = rate["range"]
+    return {
+        "schema_version": 1,
+        "kind": "prediction_not_verification",
+        "word_count": word_count,
+        "intended_metric": intended_metric,
+        "rate": copy.deepcopy(rate),
+        "estimated_seconds": _number(word_count * 60 / rate["value"], positive=True),
+        "estimated_range_seconds": [
+            _number(word_count * 60 / high, positive=True),
+            _number(word_count * 60 / low, positive=True),
+        ],
+    }
+
+
+def verify_recording(evidence: Any, *, maximum_duration_seconds: float) -> dict:
+    maximum = _number(maximum_duration_seconds, positive=True)
+    measurement = measure(evidence)
+    if (
+        evidence["sample_start_seconds"] != 0
+        or evidence["sample_duration_seconds"] != evidence["source_duration_seconds"]
+    ):
+        _fail(
+            "speech_full_recording_required",
+            "Verify the complete recording, not an interior calibration sample.",
+        )
+    return {
+        "schema_version": 1,
+        "kind": "recorded_duration_check",
+        "maximum_duration_seconds": maximum,
+        "fits_duration": measurement["actual_duration_seconds"] <= maximum,
+        "measurement": measurement,
+    }
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            _fail("speech_json_invalid", "Remove duplicate JSON keys.")
+        result[key] = value
+    return result
+
+
+def _constant(_: str) -> NoReturn:
+    _fail("speech_json_invalid", "Use finite standard JSON values.")
+
+
+def decode(raw: bytes) -> Any:
+    if len(raw) > MAX_JSON_BYTES:
+        _fail(
+            "speech_json_too_large", "Reduce the calibration batch to at most 16 MiB."
+        )
+    try:
+        return json.loads(raw, object_pairs_hook=_pairs, parse_constant=_constant)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        _fail(
+            "speech_json_invalid",
+            "Supply one UTF-8 JSON document matching the owner schema.",
+        )
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        _fail(
+            "speech_usage_invalid", "Use --help for the speech-rate command contract."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        parser = _Parser(description=__doc__, allow_abbrev=False, add_help=False)
+        parser.add_argument(
+            "action", nargs="?", choices=("measure", "calibrate", "plan", "verify")
+        )
+        parser.add_argument("--help", action="store_true")
+        args = parser.parse_args(argv)
+        if args.help:
+            result = {"help": __doc__}
+        elif args.action:
+            request = decode(sys.stdin.buffer.read(MAX_JSON_BYTES + 1))
+            if args.action == "measure":
+                result = measure(request)
+            elif args.action == "calibrate":
+                result = calibrate(request)
+            elif args.action == "plan":
+                request = _record(
+                    request, {"word_count", "intended_metric", "profile", "assumption"}
+                )
+                result = plan_duration(
+                    request["word_count"],
+                    intended_metric=request["intended_metric"],
+                    profile=request["profile"],
+                    assumption=request["assumption"],
+                )
+            else:
+                request = _record(request, {"evidence", "maximum_duration_seconds"})
+                result = verify_recording(
+                    request["evidence"],
+                    maximum_duration_seconds=request["maximum_duration_seconds"],
+                )
+        else:
+            _fail(
+                "speech_usage_invalid",
+                "Choose measure, calibrate, plan, or verify; use --help.",
+            )
+        print(encode({"schema_version": 1, "ok": True, "data": result}).decode())
+        return 0
+    except SpeechRateError as exc:
+        code, message = exc.code, str(exc)
+        status = 2 if code == "speech_usage_invalid" else 1
+    except OSError:
+        code, message, status = (
+            "speech_io_failed",
+            "Check access to the input/output streams and retry.",
+            2,
+        )
+    # Consumers treat absent/invalid JSON as a silent contract failure. Emit a
+    # closed error envelope; a traceback would replace their required JSON.
+    except Exception:  # noqa: BLE001 — outer-boundary-process-contract
+        code, message, status = (
+            "speech_unexpected_failure",
+            "Preserve the input and report this owner failure code.",
+            2,
+        )
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "ok": False,
+                "error": {"code": code, "message": message},
+            }
+        )
+    )
+    print(message, file=sys.stderr)
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/vault-profile/scripts/speech_rates.py
+++ b/skills/vault-profile/scripts/speech_rates.py
@@ -506,8 +506,12 @@ def decode(raw: bytes) -> Any:
             "speech_json_too_large", "Reduce the calibration batch to at most 16 MiB."
         )
     try:
-        return json.loads(raw, object_pairs_hook=_pairs, parse_constant=_constant)
-    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        return json.loads(
+            raw.decode("utf-8"), object_pairs_hook=_pairs, parse_constant=_constant
+        )
+    except SpeechRateError:
+        raise
+    except (UnicodeDecodeError, ValueError, RecursionError):
         _fail(
             "speech_json_invalid",
             "Supply one UTF-8 JSON document matching the owner schema.",

--- a/tests/test_speech_rates.py
+++ b/tests/test_speech_rates.py
@@ -404,13 +404,19 @@ def test_unrepresentable_arithmetic_is_rejected(rates, evidence):
         rates.plan_duration(100, intended_metric="narration", assumption=assumption)
 
 
-def test_decoder_recursion_failure_is_typed(rates, monkeypatch):
+@pytest.mark.parametrize("failure", [ValueError, RecursionError])
+def test_decoder_value_or_recursion_failure_is_typed(rates, monkeypatch, failure):
     def reject_deep_input(*args, **kwargs):
-        raise RecursionError
+        raise failure
 
     monkeypatch.setattr(rates.json, "loads", reject_deep_input)
     with pytest.raises(rates.SpeechRateError):
         rates.decode(b"[]")
+
+
+def test_utf16_is_not_accepted_as_utf8_json(rates):
+    with pytest.raises(rates.SpeechRateError):
+        rates.decode('{"schema_version":1}'.encode("utf-16le"))
 
 
 def test_outline_legacy_range_is_explicitly_unverified(outline, extract_script):

--- a/tests/test_speech_rates.py
+++ b/tests/test_speech_rates.py
@@ -1,0 +1,502 @@
+"""Recorded word timing stays distinct from assumed narration planning."""
+
+import copy
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from conftest import SCRIPTS_VP, _import_script
+
+
+@pytest.fixture
+def rates():
+    return _import_script(Path(SCRIPTS_VP) / "speech_rates.py", "speech_rates")
+
+
+@pytest.fixture
+def outline(outline_schema):
+    return outline_schema.load_outline(
+        Path(__file__).parent / "fixtures" / "outline-example.yaml"
+    )
+
+
+@pytest.fixture
+def evidence():
+    # 40 s word spans, 4 s natural phrase gaps, 50 s complete timeline.
+    # One 1.2 s gap and seven 0.4 s gaps distinguish all four metrics.
+    words = []
+    cursor = 1.0
+    for index in range(100):
+        if index == 8:
+            cursor += 1.2
+        elif index in (20, 30, 40, 50, 60, 70, 80):
+            cursor += 0.4
+        words.append(["word", round(cursor, 6), round(cursor + 0.4, 6)])
+        cursor += 0.4
+    return {
+        "schema_version": 1,
+        "timing_kind": "recorded_words",
+        "source_sha256": "a" * 64,
+        "source_duration_seconds": 50,
+        "sample_start_seconds": 0,
+        "sample_duration_seconds": 50,
+        "aligner": "synthetic-fixed-fixture-v1",
+        "words": words,
+    }
+
+
+def _profile(rates, evidence):
+    return rates.calibrate(
+        {
+            "schema_version": 1,
+            "cohort": "synthetic-demo-fixtures",
+            "samples": [evidence],
+        }
+    )
+
+
+def test_four_metrics_remain_distinct(rates, evidence):
+    measured = rates.measure(evidence)
+    rows = {rate["metric"]: rate for rate in measured["rates"]}
+    assert rows["timeline"]["value"] == 120
+    assert rows["narration"]["value"] == pytest.approx(136.363636)
+    assert rows["short_phrase"]["value"] == pytest.approx(140.186916)
+    assert rows["articulation"]["value"] == pytest.approx(150)
+    assert [row["denominator_seconds"] for row in rows.values()] == pytest.approx(
+        [50, 44, 42.8, 40]
+    )
+    assert [row["pause_threshold_seconds"] for row in rows.values()] == [
+        None,
+        2.0,
+        1.0,
+        0.25,
+    ]
+    assert all(row["unit"] == "words_per_minute" for row in rows.values())
+    assert measured["source_sha256"] == "a" * 64
+    assert measured["word_count"] == 100
+
+
+def test_profile_persistence_keeps_provenance_and_metric_identity(
+    rates, evidence, tmp_path
+):
+    profile = _profile(rates, evidence)
+    target = tmp_path / "speech-rate-profile.json"
+    target.write_bytes(rates.encode(profile))
+    restored = rates.validate_profile(rates.decode(target.read_bytes()))
+    assert restored == profile
+    for row in restored["rates"]:
+        rates.validate_rate(row)
+        assert row["basis"] == "measured"
+        assert row["range"] == [row["value"], row["value"]]
+        provenance = row["provenance"]
+        assert provenance["sample_count"] == 1
+        assert provenance["analyzed_duration_seconds"] == 50
+        assert provenance["cohort"] == "synthetic-demo-fixtures"
+        assert provenance["method_version"] == "word-gaps-v1"
+        assert (
+            provenance["range_kind"] == "observed_sample_range_not_confidence_interval"
+        )
+        assert provenance["evidence_sha256"] == [
+            rates.measure(evidence)["evidence_sha256"]
+        ]
+
+
+def test_long_form_prefers_measured_narration_over_assumption(rates, evidence):
+    profile = _profile(rates, evidence)
+    assumption = rates.assumed_narration(150, 150, reason="uncalibrated fixture")
+    result = rates.plan_duration(
+        100, intended_metric="narration", profile=profile, assumption=assumption
+    )
+    assert result["estimated_seconds"] == pytest.approx(44)
+    assert result["rate"]["metric"] == "narration"
+    assert result["rate"]["basis"] == "measured"
+    assert result["kind"] == "prediction_not_verification"
+
+
+def test_assumptions_cannot_change_recording_verdict(rates, evidence):
+    slow = rates.plan_duration(
+        100,
+        intended_metric="narration",
+        assumption=rates.assumed_narration(100, 100, reason="slow assumption"),
+    )
+    before = rates.verify_recording(evidence, maximum_duration_seconds=45)
+    fast = rates.plan_duration(
+        100,
+        intended_metric="narration",
+        assumption=rates.assumed_narration(200, 200, reason="fast assumption"),
+    )
+    after = rates.verify_recording(evidence, maximum_duration_seconds=45)
+    assert slow["estimated_seconds"] == 60
+    assert fast["estimated_seconds"] == 30
+    assert before == after
+    assert before["fits_duration"] is False
+    assert before["measurement"]["actual_duration_seconds"] == 50
+    assert (
+        rates.verify_recording(evidence, maximum_duration_seconds=50)["fits_duration"]
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "metric", ["timeline", "short_phrase", "articulation", "wpm", None, True]
+)
+def test_long_form_rejects_non_narration_or_unqualified_rates(rates, metric):
+    with pytest.raises(rates.SpeechRateError):
+        rates.plan_duration(100, intended_metric=metric, assumption=150)
+
+
+def test_planning_requires_explicit_intent_and_basis(rates):
+    with pytest.raises(TypeError):
+        rates.plan_duration(100)
+    with pytest.raises(rates.SpeechRateError, match="measured narration profile"):
+        rates.plan_duration(100, intended_metric="narration")
+    with pytest.raises(rates.SpeechRateError):
+        rates.plan_duration(100, intended_metric="narration", assumption=150)
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 2),
+        ("schema_version", 1.0),
+        ("timing_kind", "predicted"),
+        ("timing_kind", "segments"),
+        ("source_sha256", "A" * 64),
+        ("source_sha256", "bad"),
+        ("source_duration_seconds", 49),
+        ("source_duration_seconds", 14401),
+        ("sample_duration_seconds", 0),
+        ("sample_start_seconds", 1),
+        ("aligner", ""),
+        ("words", []),
+        ("words", [["two words", 0, 1]]),
+        ("words", [["...", 0, 1]]),
+        ("words", [["word", 0, 0]]),
+        ("words", [["word", 0, 51]]),
+        ("words", [["word", True, 1]]),
+        ("words", [["word", 0, float("inf")]]),
+        ("words", [["word", 0, 2], ["second", 1, 3]]),
+    ],
+)
+def test_bad_recording_evidence_fails_closed(rates, evidence, key, value):
+    evidence[key] = value
+    with pytest.raises(rates.SpeechRateError):
+        rates.measure(evidence)
+
+
+def test_unknown_fields_and_absent_versions_are_not_silently_accepted(rates, evidence):
+    evidence["wpm"] = 150
+    with pytest.raises(rates.SpeechRateError):
+        rates.measure(evidence)
+    del evidence["wpm"]
+    del evidence["schema_version"]
+    with pytest.raises(rates.SpeechRateError):
+        rates.measure(evidence)
+
+
+def test_pause_threshold_boundary_keeps_whole_eligible_gaps(rates, evidence):
+    evidence["words"] = [
+        ["one", 1, 2],
+        ["two", 2.25, 3.25],
+        ["three", 4.25, 5.25],
+        ["four", 7.25, 8.25],
+        ["five", 11.25, 12.25],
+    ]
+    rows = rates.measure(evidence)["rates"]
+    assert [row["denominator_seconds"] for row in rows] == [50, 8.25, 6.25, 5.25]
+
+
+def test_overlapping_samples_rejected_but_disjoint_windows_allowed(rates, evidence):
+    second = copy.deepcopy(evidence)
+    request = {
+        "schema_version": 1,
+        "cohort": "synthetic",
+        "samples": [evidence, second],
+    }
+    with pytest.raises(rates.SpeechRateError, match="non-overlapping"):
+        rates.calibrate(request)
+    evidence["source_duration_seconds"] = 100
+    second["source_duration_seconds"] = 100
+    second["sample_start_seconds"] = 50
+    profile = rates.calibrate(request)
+    assert profile["rates"][0]["provenance"]["sample_count"] == 2
+    assert profile["rates"][0]["provenance"]["analyzed_duration_seconds"] == 100
+
+
+@pytest.mark.parametrize("mutation", ["value", "threshold", "cohort", "word", "schema"])
+def test_persisted_profile_tampering_is_rejected(rates, evidence, mutation):
+    profile = _profile(rates, evidence)
+    if mutation == "value":
+        profile["rates"][1]["value"] = 150
+    elif mutation == "threshold":
+        profile["rates"][1]["pause_threshold_seconds"] = 0.25
+    elif mutation == "cohort":
+        profile["calibration"]["cohort"] = "different"
+    elif mutation == "word":
+        profile["calibration"]["samples"][0]["words"][0][0] = "changed"
+    else:
+        profile["schema_version"] = 2
+    with pytest.raises(rates.SpeechRateError):
+        rates.validate_profile(profile)
+
+
+def test_invalid_present_profile_does_not_fall_back_to_assumption(rates, evidence):
+    profile = _profile(rates, evidence)
+    profile["schema_version"] = 99
+    with pytest.raises(rates.SpeechRateError):
+        rates.plan_duration(
+            100,
+            intended_metric="narration",
+            profile=profile,
+            assumption=rates.assumed_narration(150, 150, reason="default"),
+        )
+
+
+def test_sample_mean_does_not_overflow_when_each_rate_is_finite(rates, evidence):
+    samples = []
+    for digest in ("a", "b", "c", "d"):
+        sample = copy.deepcopy(evidence)
+        sample["source_sha256"] = digest * 64
+        sample["words"] = [["word", 0, 1e-306]]
+        samples.append(sample)
+    profile = rates.calibrate(
+        {"schema_version": 1, "cohort": "synthetic-extreme", "samples": samples}
+    )
+    assert profile["rates"][1]["value"] == pytest.approx(6e307)
+    rates.validate_profile(profile)
+
+
+def test_predicted_result_is_not_recording_evidence(rates):
+    prediction = rates.plan_duration(
+        100,
+        intended_metric="narration",
+        assumption=rates.assumed_narration(150, 150, reason="default"),
+    )
+    with pytest.raises(rates.SpeechRateError):
+        rates.verify_recording(prediction, maximum_duration_seconds=60)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b'{"schema_version":1,"schema_version":1}',
+        b'{"x":NaN}',
+        b'{"x":Infinity}',
+        b"\xff",
+        b"{",
+    ],
+)
+def test_strict_json_decode(rates, raw):
+    with pytest.raises(rates.SpeechRateError):
+        rates.decode(raw)
+
+
+def test_json_size_limit(rates):
+    with pytest.raises(rates.SpeechRateError):
+        rates.decode(b" " * (rates.MAX_JSON_BYTES + 1))
+    with pytest.raises(rates.SpeechRateError):
+        rates.encode("x" * rates.MAX_JSON_BYTES)
+
+
+@pytest.mark.parametrize("action", ["measure", "calibrate", "plan", "verify"])
+def test_real_cli_emits_one_json_and_does_not_mutate_inputs(
+    rates, evidence, tmp_path, action
+):
+    requests = {
+        "measure": evidence,
+        "calibrate": {
+            "schema_version": 1,
+            "cohort": "synthetic",
+            "samples": [evidence],
+        },
+        "plan": {
+            "schema_version": 1,
+            "word_count": 100,
+            "intended_metric": "narration",
+            "profile": _profile(rates, evidence),
+            "assumption": None,
+        },
+        "verify": {
+            "schema_version": 1,
+            "evidence": evidence,
+            "maximum_duration_seconds": 45,
+        },
+    }
+    original = rates.encode(requests[action])
+    source = tmp_path / "request.json"
+    source.write_bytes(original)
+    result = subprocess.run(
+        [sys.executable, str(Path(SCRIPTS_VP) / "speech_rates.py"), action],
+        input=original,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == b""
+    assert len(result.stdout.splitlines()) == 1
+    assert json.loads(result.stdout)["ok"] is True
+    assert source.read_bytes() == original
+
+
+def test_cli_invalid_input_never_echoes_words_or_credentials(
+    rates, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        sys, "stdin", io.TextIOWrapper(io.BytesIO(b'{"private":"synthetic-secret"}'))
+    )
+    assert rates.main(["measure"]) == 1
+    result = capsys.readouterr()
+    assert json.loads(result.out)["ok"] is False
+    assert "synthetic-secret" not in result.out + result.err
+
+
+@pytest.mark.parametrize("argv", [[], ["bogus"], ["--unknown", "synthetic-secret"]])
+def test_cli_usage_is_structured_and_redacted(rates, capsys, argv):
+    assert rates.main(argv) == 2
+    result = capsys.readouterr()
+    assert json.loads(result.out)["error"]["code"] == "speech_usage_invalid"
+    assert "synthetic-secret" not in result.out + result.err
+
+
+def test_help_does_not_read_stdin(rates, capsys):
+    assert rates.main(["--help"]) == 0
+    assert "word-gaps-v1" in json.loads(capsys.readouterr().out)["data"]["help"]
+
+
+def test_interior_window_cannot_verify_full_recording(rates, evidence):
+    evidence["source_duration_seconds"] = 100
+    evidence["sample_start_seconds"] = 20
+    assert rates.measure(evidence)["actual_duration_seconds"] == 50
+    with pytest.raises(rates.SpeechRateError, match="complete recording"):
+        rates.verify_recording(evidence, maximum_duration_seconds=60)
+
+
+def test_inconsistent_duration_for_same_source_rejected(rates, evidence):
+    other = copy.deepcopy(evidence)
+    other["sample_start_seconds"] = 50
+    other["source_duration_seconds"] = 100
+    with pytest.raises(rates.SpeechRateError, match="one actual duration"):
+        rates.calibrate(
+            {"schema_version": 1, "cohort": "synthetic", "samples": [evidence, other]}
+        )
+
+
+@pytest.mark.parametrize(
+    "value", [True, "150", -1, 0, float("nan"), float("inf"), 10**400]
+)
+def test_invalid_assumption_numbers_are_typed_failures(rates, value):
+    with pytest.raises(rates.SpeechRateError):
+        rates.assumed_narration(value, value, reason="synthetic")
+
+
+def test_unrepresentable_arithmetic_is_rejected(rates, evidence):
+    evidence["words"] = [["word", 0, 1e-320]]
+    with pytest.raises(rates.SpeechRateError):
+        rates.measure(evidence)
+    assumption = rates.assumed_narration(1e-320, 1e-320, reason="synthetic")
+    with pytest.raises(rates.SpeechRateError):
+        rates.plan_duration(100, intended_metric="narration", assumption=assumption)
+
+
+def test_decoder_recursion_failure_is_typed(rates, monkeypatch):
+    def reject_deep_input(*args, **kwargs):
+        raise RecursionError
+
+    monkeypatch.setattr(rates.json, "loads", reject_deep_input)
+    with pytest.raises(rates.SpeechRateError):
+        rates.decode(b"[]")
+
+
+def test_outline_legacy_range_is_explicitly_unverified(outline, extract_script):
+    rate = outline.talk.narration_rate
+    assert rate["basis"] == "assumption"
+    assert rate["metric"] == "narration"
+    assert rate["pause_threshold_seconds"] == 2
+    rendered = extract_script.render(outline)
+    assert "140–160 WPM narration" in rendered
+    assert "assumption, not verified" in rendered
+    assert "actual word timestamps and actual duration" in rendered
+
+
+def test_typed_measured_narration_survives_outline_and_script(
+    rates, evidence, outline, outline_schema, extract_script
+):
+    data = outline.model_dump(mode="json")
+    data["talk"]["pacing_wpm"] = None
+    data["talk"]["pacing_rate"] = _profile(rates, evidence)["rates"][1]
+    parsed = outline_schema.Outline.model_validate(data)
+    restored = outline_schema.Outline.model_validate_json(parsed.model_dump_json())
+    assert restored.talk.narration_rate["value"] == pytest.approx(136.363636)
+    rendered = extract_script.render(restored)
+    assert "136.364–136.364 WPM narration" in rendered
+    assert "measured; 1 samples, 50 s analyzed" in rendered
+    assert "synthetic-demo-fixtures" in rendered
+    assert "word-gaps-v1" in rendered
+    assert "not a confidence interval" in rendered
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["ambiguous", "articulation", "version", "no_pace", "bool_range", "reversed"],
+)
+def test_outline_rejects_ambiguous_or_wrong_pacing(
+    rates, evidence, outline, outline_schema, mutation
+):
+    from pydantic import ValidationError
+
+    data = outline.model_dump(mode="json")
+    if mutation == "ambiguous":
+        data["talk"]["pacing_rate"] = _profile(rates, evidence)["rates"][1]
+    elif mutation == "articulation":
+        data["talk"]["pacing_wpm"] = None
+        data["talk"]["pacing_rate"] = _profile(rates, evidence)["rates"][3]
+    elif mutation == "version":
+        data["schema_version"] = 2
+    elif mutation == "no_pace":
+        data["talk"]["pacing_wpm"] = None
+    elif mutation == "bool_range":
+        data["talk"]["pacing_wpm"] = [True, 160]
+    else:
+        data["talk"]["pacing_wpm"] = [160, 140]
+    with pytest.raises(ValidationError):
+        outline_schema.Outline.model_validate(data)
+
+
+def test_partial_outline_accepts_typed_pacing(rates, evidence, outline, outline_schema):
+    talk = outline.model_dump(mode="json")["talk"]
+    talk["pacing_wpm"] = None
+    talk["pacing_rate"] = _profile(rates, evidence)["rates"][1]
+    partial = outline_schema.PartialOutline.model_validate(
+        {"schema_version": 1, "talk": talk}
+    )
+    assert partial.talk.narration_rate["basis"] == "measured"
+
+
+def test_outer_boundary_emits_closed_failure_and_preserves_interrupts(
+    rates, monkeypatch, capsys
+):
+    class BrokenInput:
+        @property
+        def buffer(self):
+            raise RuntimeError("synthetic-secret")
+
+    monkeypatch.setattr(sys, "stdin", BrokenInput())
+    assert rates.main(["measure"]) == 2
+    result = capsys.readouterr()
+    assert json.loads(result.out)["error"]["code"] == "speech_unexpected_failure"
+    assert "synthetic-secret" not in result.out + result.err
+
+    class InterruptedInput:
+        @property
+        def buffer(self):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(sys, "stdin", InterruptedInput())
+    with pytest.raises(KeyboardInterrupt):
+        rates.main(["measure"])


### PR DESCRIPTION
## Summary

- Separate timeline, narration, short-phrase, and thresholded articulation WPM in a closed, versioned word-timing owner contract. Preserve sample count, analyzed duration, cohort, method, evidence digests, and explicitly observed ranges.
- Require a named narration metric for long-form planning, prefer a validated measured profile, and label all uncalibrated rates as assumptions. Verify complete recordings from actual duration and word timestamps with no planning-WPM input.
- Persist reproducible speech profiles independently of tracking/pattern state and add typed outline pacing with explicit legacy compatibility and provenance-aware script reports.

Closes #367. This implements the deterministic contract using synthetic fixtures; it does not claim the live speaker calibration in #368 is complete or acquire/transcribe media from #219. Supplied recording digests and word alignments remain acquisition-owner inputs, not media authentication performed by this arithmetic tool. No tracking-database writes or reparsing are part of this PR.

## Test plan

- [x] 201 focused speech-rate, outline, report, and installed-path tests. The fixed fixture remains about 136 narration WPM and 150 articulation WPM through analysis, persistence, planning, and reporting.
- [x] Verify changing assumed WPM cannot change a recording verdict; interior windows, predictions, edited derived profiles, overlap, inconsistent source durations, malformed schemas, non-finite arithmetic, and secret-echo errors are rejected.
- [x] Ruff, formatting, Pyright, tracked-package/mirror/conflict gates, and plugin lint.
- [x] Final changed-skill quality reviews: presentation-creator 90/100; vault-profile 90/100. Cross-skill/global-rule references flagged by the single-skill reviewer were verified present in the complete plugin; required step-continuity statements are retained.
- [x] Final full integrated suite on published 0.20.119: 6,732 passed, 8 skipped (240.20 seconds).
- [x] Review round: configure the sibling owner in Pyright without a missing-import suppression; keep threshold arithmetic in the owner; reject non-UTF-8 and decoder-limit failures through closed errors.
