### PR TITLE
fix(vault-ingress): preserve active claims during QR-only repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Preserve active claims during the QR-version-only owner repair
+
+Allow the explicit missing-QR-version repair to preserve valid active queue
+claims and their histories unchanged. Keep normal migration's inactive-writer
+requirement. The shared locked transaction rejects stale repair or writer
+snapshots, retaining exact backups and all talk evidence; owner readers can
+resume after repair without cancelling claims or reparsing talks.
+
 ## 0.20.120 — 2026-09-05
 
 ### Separate recorded speech rates from narration-planning assumptions

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -533,6 +533,12 @@ configured interpreter and require the repair's `output_sha256`. Resume the
 normal bootstrap gates only then. A refusal authorizes no manual restamping,
 raw database read, or bypass of another schema gate.
 
+Valid active queue claims do not require recovery for this QR-only repair.
+The owner preserves them unchanged; shape-changing normal migration still
+refuses active writers. If a concurrent writer reports a generation conflict, reload through
+that writer's owner and retry the intended operation. Do not cancel a claim to
+clear a generation conflict.
+
 Agent-owned config and catalog changes use a typed plan:
 
 ```json

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1877,6 +1877,13 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
     legacy-v1 shape before stamping; v2 artifact receipts are never invented or
     inferred. The complete candidate must validate before it is returned. No
     talk, evidence, queue, config, or other record migration runs here.
+
+    Supported active claims are preserved unchanged. Unlike a normal migration,
+    this operation changes no claim/return contract, talk generation, or analysis
+    state. The CLI commits through the shared locked generation transaction: a
+    competing writer invalidates this repair's snapshot, and this repair
+    invalidates a pre-repair writer's snapshot. That writer must reload and
+    retry its ordinary owner operation, not recover or cancel the claim.
     """
     try:
         assessment = assess_tracking_database(database)
@@ -1924,15 +1931,6 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
         raise TrackingDatabaseRepairError(
             "qr_repair_candidate_invalid", {"stage": "complete_owner_validation"}
         ) from exc
-    if counts["qr_codes"]:
-        talks = _object_collection(candidate, "talks", required=True)
-        try:
-            _require_no_active_writers(talks)
-        except TrackingDatabaseError as exc:
-            raise TrackingDatabaseRepairError(
-                "qr_repair_active_writers",
-                {"active_talk_count": len(_active_claim_filenames(talks))},
-            ) from exc
     return TrackingDatabaseMigration(
         database=candidate,
         changed=bool(counts["qr_codes"]),

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -1637,6 +1637,38 @@ def _missing_qr_version_database(tracking_database):
     return database
 
 
+def _qr_repair_with_active_claim(tracking_database, version):
+    database = _missing_qr_version_database(tracking_database)
+    talk = database["talks"][0]
+    talk["status"] = "reprocessing-inflight"
+    talk["reprocess_generation"] = 2
+    talk["_queue_claim"] = _claim_for_version(
+        version, generation=2, state="claimed", batch_id="active"
+    )
+    talk["_queue_claim_history"] = [
+        _claim_for_version(
+            version, generation=1, state="stale_recovered", batch_id="previous"
+        )
+    ]
+    return database
+
+
+@pytest.mark.parametrize("version", range(1, 8))
+def test_qr_repair_preserves_supported_active_claims_and_history(
+    tracking_database, version
+):
+    database = _qr_repair_with_active_claim(tracking_database, version)
+    before = copy.deepcopy(database)
+
+    repaired = tracking_database.repair_missing_qr_schema_versions(database)
+
+    expected = copy.deepcopy(before)
+    expected["qr_codes"][0]["schema_version"] = 1
+    assert repaired.database == expected
+    assert database == before
+    tracking_database.require_current_tracking_database(repaired.database)
+
+
 def test_qr_repair_is_opt_in_and_preserves_every_other_record(tracking_database):
     database = _missing_qr_version_database(tracking_database)
     database["qr_codes"].append(_qr_v2_record())
@@ -1678,7 +1710,8 @@ def test_qr_repair_is_opt_in_and_preserves_every_other_record(tracking_database)
         "invalid_date",
         "duplicate_identity",
         "missing_talk_version",
-        "active_writer",
+        "future_active_claim",
+        "invalid_active_claim",
     ],
 )
 def test_qr_repair_refuses_ambiguous_or_unrelated_state(tracking_database, change):
@@ -1708,12 +1741,13 @@ def test_qr_repair_refuses_ambiguous_or_unrelated_state(tracking_database, chang
         database["qr_codes"].append(copy.deepcopy(database["qr_codes"][0]))
     elif change == "missing_talk_version":
         database["talks"][0].pop("schema_version")
-    elif change == "active_writer":
-        database["talks"][0]["status"] = "reprocessing-inflight"
-        database["talks"][0]["reprocess_generation"] = 1
-        database["talks"][0]["_queue_claim"] = _claim_for_version(
-            1, generation=1, state="claimed", batch_id="active"
-        )
+    elif change in {"future_active_claim", "invalid_active_claim"}:
+        database = _qr_repair_with_active_claim(tracking_database, 7)
+        claim = database["talks"][0]["_queue_claim"]
+        if change == "future_active_claim":
+            claim["schema_version"] = _future_claim_version()
+        else:
+            claim["released_at"] = "2026-07-31T13:00:00+00:00"
     before = copy.deepcopy(database)
 
     with pytest.raises(tracking_database.TrackingDatabaseError):
@@ -1721,11 +1755,16 @@ def test_qr_repair_refuses_ambiguous_or_unrelated_state(tracking_database, chang
     assert database == before
 
 
+@pytest.mark.parametrize("active_version", [None, 1, 7])
 def test_qr_repair_dry_run_apply_and_backup_preserve_talk_evidence(
-    tracking_database, migrate_tracking_database, tmp_path, monkeypatch
+    tracking_database, migrate_tracking_database, tmp_path, monkeypatch, active_version
 ):
     path = tmp_path / "tracking-database.json"
-    original = _missing_qr_version_database(tracking_database)
+    original = (
+        _missing_qr_version_database(tracking_database)
+        if active_version is None
+        else _qr_repair_with_active_claim(tracking_database, active_version)
+    )
     raw = _write_database(path, original)
     monkeypatch.setattr(
         migrate_tracking_database,
@@ -1798,27 +1837,111 @@ def test_qr_repair_cli_reports_json_without_rejected_values(
     assert path.read_bytes() == raw
 
 
-def test_qr_repair_active_writer_diagnostic_has_no_database_values(
+def test_qr_repair_active_writer_preview_does_not_mutate_claims(
     tracking_database, migrate_tracking_database, tmp_path, capsys
 ):
     path = tmp_path / "private.json"
-    database = _missing_qr_version_database(tracking_database)
-    database["talks"][0]["status"] = "reprocessing-inflight"
-    database["talks"][0]["reprocess_generation"] = 1
-    database["talks"][0]["_queue_claim"] = _claim_for_version(
-        1, generation=1, state="claimed", batch_id="active"
-    )
+    database = _qr_repair_with_active_claim(tracking_database, 7)
     raw = _write_database(path, database)
     assert (
-        migrate_tracking_database.main([str(path), "--repair-missing-qr-versions"]) == 2
+        migrate_tracking_database.main([str(path), "--repair-missing-qr-versions"]) == 0
     )
     captured = capsys.readouterr()
     report = json.loads(captured.out)
-    assert report["code"] == "qr_repair_active_writers"
-    assert report["details"] == {"active_talk_count": 1}
+    assert report["ok"] is True
+    assert report["database_written"] is False
+    assert report["record_counts"]["qr_codes"] == 1
     assert "one.md" not in captured.out + captured.err
-    assert str(path) not in captured.out + captured.err
     assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+
+
+@pytest.mark.parametrize("writer", ["queue", "results"])
+def test_qr_repair_rejects_stale_writers_and_allows_owner_reload(
+    tracking_database,
+    tracking_database_io,
+    migrate_tracking_database,
+    queue_state,
+    persist_results,
+    tmp_path,
+    writer,
+):
+    path = tmp_path / "tracking-database.json"
+    original = _qr_repair_with_active_claim(tracking_database, 7)
+    raw = _write_database(path, original)
+    stale = tracking_database_io.snapshot_tracking_database(path)
+    options = {"repair_missing_qr_versions": True}
+    dry = migrate_tracking_database.execute(
+        path, apply=False, expected_sha256=None, **options
+    )
+    applied = migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=dry["input_sha256"], **options
+    )
+    repaired_raw = path.read_bytes()
+    if writer == "queue":
+        write = queue_state.write_database_atomically
+        load = queue_state.load_database_snapshot
+        error = queue_state.QueueStateError
+    else:
+        write = persist_results.atomic_write_json
+        load = persist_results.load_tracking_database
+        error = ValueError
+
+    with pytest.raises(error, match="generation changed"):
+        write(path, original, expected_snapshot=stale)
+    assert path.read_bytes() == repaired_raw
+    assert Path(applied["backup"]).read_bytes() == raw
+
+    current, fresh = load(path)
+    assert current["talks"] == original["talks"]
+    assert current["qr_codes"][0]["schema_version"] == 1
+    # A subsequent owner transaction can proceed without recovering a claim.
+    current["config"]["speaker_name"] = "Synthetic speaker"
+    result = write(path, current, expected_snapshot=fresh)
+    assert result.installed is True
+    reloaded, _ = load(path)
+    assert reloaded["talks"] == original["talks"]
+    assert reloaded["qr_codes"] == current["qr_codes"]
+    assert reloaded["config"]["speaker_name"] == "Synthetic speaker"
+
+
+def test_qr_repair_preserves_a_concurrent_final_window_writer(
+    tracking_database,
+    tracking_database_io,
+    migrate_tracking_database,
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "tracking-database.json"
+    original = _qr_repair_with_active_claim(tracking_database, 7)
+    _write_database(path, original)
+    options = {"repair_missing_qr_versions": True}
+    dry = migrate_tracking_database.execute(
+        path, apply=False, expected_sha256=None, **options
+    )
+    competing = copy.deepcopy(original)
+    competing["config"]["speaker_name"] = "Concurrent writer"
+    original_stage = tracking_database_io._stage_candidate
+    concurrent_raw = b""
+
+    def stage_and_replace(target, candidate, mode):
+        nonlocal concurrent_raw
+        stage = original_stage(target, candidate, mode)
+        replacement = tmp_path / "competing.json"
+        concurrent_raw = _write_database(replacement, competing)
+        os.replace(replacement, path)
+        return stage
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", stage_and_replace)
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="generation changed",
+    ):
+        migrate_tracking_database.execute(
+            path, apply=True, expected_sha256=dry["input_sha256"], **options
+        )
+    assert path.read_bytes() == concurrent_raw
+    assert json.loads(concurrent_raw)["talks"] == original["talks"]
     assert not (tmp_path / ".backups").exists()
 
 


### PR DESCRIPTION
## Summary

- Allow the explicit, preservation-only missing-QR-version repair to retain supported active claims and their histories unchanged. No root/config migration, talk restamping, observation repair, requeue, or claim recovery runs in this mode.
- Keep the shared locked generation transaction and exact-byte backup: stale queue/result writers cannot overwrite a repair, and a competing database generation prevents the repair from installing. Normal shape-changing migration retains its inactive-writer gate.
- Document owner reload/retry after a generation conflict. Strict schema validation still rejects unsupported or invalid claims and ambiguous QR records.

Follow-up to #392 for the user-requested schema repair. This PR does not claim the remaining live catalog work is complete or authorize bypassing another owner gate. All committed fixtures are synthetic.

## Test plan

- [x] 285 focused schema, database I/O, and writer-race tests, including preservation across all seven supported claim versions, histories, exact backups, idempotence, stale writer refusal, successful owner reload, and a final-window competing writer.
- [x] Full integrated suite after the speaking-rate release: 6,745 passed, 8 skipped (239.61 seconds). The publisher's subsequent version-only manifest stamp was incorporated with package and lint rechecks.
- [x] Ruff, formatting, Pyright, package/mirror/entrypoint/conflict gates, and plugin lint.
- [x] Final vault-ingress skill quality review: 96/100 (threshold 85). The single-skill cross-reference warning resolves in the complete plugin; broader prose-density suggestions are outside this narrow repair.
- [x] Read-only operational preview repeated with the database-configured interpreter: identical input/output digests; exactly one missing QR version proposed; zero talk or observation changes; no database write. No private database content is included in this PR.

The live repair will be freshly previewed, hash-bound, backed up, and verified through the strict owner reader only after release review and publication succeed.
