### PR TITLE
fix(speech-rates): return typed serialization failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Typed failures for invalid speech-rate serialization inputs
+
+Make the speech-rate owner's direct-library serializer reject non-JSON values,
+non-finite numbers, circular structures, and encoder recursion failures with a
+closed, redacted error. Preserve canonical output bytes, size-bound errors, and
+interrupt propagation (#402).
+
 ## 0.20.121 — 2026-09-05
 
 ### Preserve active claims during the QR-version-only owner repair

--- a/skills/vault-profile/scripts/speech_rates.py
+++ b/skills/vault-profile/scripts/speech_rates.py
@@ -127,9 +127,19 @@ def _metric(value: Any) -> str:
 
 
 def encode(value: Any) -> bytes:
-    raw = json.dumps(
-        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
-    ).encode()
+    try:
+        raw = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode()
+    except (TypeError, ValueError, RecursionError):
+        raise SpeechRateError(
+            "speech_json_invalid",
+            "Supply finite JSON-compatible values without circular or excessive nesting.",
+        ) from None
     if len(raw) > MAX_JSON_BYTES:
         _fail(
             "speech_json_too_large", "Reduce the calibration batch to at most 16 MiB."

--- a/tests/test_speech_rates.py
+++ b/tests/test_speech_rates.py
@@ -419,6 +419,60 @@ def test_utf16_is_not_accepted_as_utf8_json(rates):
         rates.decode('{"schema_version":1}'.encode("utf-16le"))
 
 
+@pytest.mark.parametrize("value", [object(), float("nan"), float("inf"), -float("inf")])
+def test_encoder_rejects_non_json_values_with_typed_errors(rates, value):
+    with pytest.raises(rates.SpeechRateError) as caught:
+        rates.encode({"private-label": value})
+    assert caught.value.code == "speech_json_invalid"
+    assert "private-label" not in str(caught.value)
+    assert caught.value.__suppress_context__ is True
+
+
+def test_encoder_rejects_circular_structures(rates):
+    value = []
+    value.append(value)
+    with pytest.raises(rates.SpeechRateError) as caught:
+        rates.encode(value)
+    assert caught.value.code == "speech_json_invalid"
+
+
+@pytest.mark.parametrize("failure", [TypeError, ValueError, RecursionError])
+def test_encoder_failure_is_redacted_and_unchained(rates, monkeypatch, failure):
+    import traceback
+
+    def reject_input(*args, **kwargs):
+        raise failure("private input value")
+
+    monkeypatch.setattr(rates.json, "dumps", reject_input)
+    with pytest.raises(rates.SpeechRateError) as caught:
+        rates.encode({})
+    assert caught.value.code == "speech_json_invalid"
+    assert "private input value" not in "".join(
+        traceback.format_exception(caught.value)
+    )
+
+
+@pytest.mark.parametrize("interrupt", [KeyboardInterrupt, SystemExit])
+def test_encoder_does_not_swallow_interrupts(rates, monkeypatch, interrupt):
+    def stop(*args, **kwargs):
+        raise interrupt
+
+    monkeypatch.setattr(rates.json, "dumps", stop)
+    with pytest.raises(interrupt):
+        rates.encode({})
+
+
+def test_encoder_preserves_canonical_bytes_and_size_failure(rates, monkeypatch):
+    value = {"schema_version": 1, "a": [1, True, None, "text"]}
+    encoded = rates.encode(value)
+    assert encoded == b'{"a":[1,true,null,"text"],"schema_version":1}'
+    assert rates.decode(encoded) == value
+    monkeypatch.setattr(rates, "MAX_JSON_BYTES", len(encoded) - 1)
+    with pytest.raises(rates.SpeechRateError) as caught:
+        rates.encode(value)
+    assert caught.value.code == "speech_json_too_large"
+
+
 def test_outline_legacy_range_is_explicitly_unverified(outline, extract_script):
     rate = outline.talk.narration_rate
     assert rate["basis"] == "assumption"


### PR DESCRIPTION
## Summary

- Convert JSON serialization type, value, and recursion failures into the speech-rate owner's closed `SpeechRateError`, suppressing the raw exception context.
- Preserve canonical JSON bytes, the existing size-limit error, and interrupt propagation.
- Add direct-library regressions for non-JSON values, non-finite numbers, circular structures, decoder-independent encoder failures, redaction, size bounds, and successful round trips.

Closes #402, the advisory follow-up from #397. This is a narrow library error-contract change; it does not alter timing arithmetic, profile schemas, media acquisition, or the tracking database. Fixtures are synthetic.

## Test plan

- [x] 91 focused speech-rate tests; rerun successfully after final formatting.
- [x] Full integrated suite on published 0.20.121 after the changelog-only rebase: 6,756 passed, 8 skipped (244.22 seconds).
- [x] Ruff, formatting, Pyright, package/mirror/entrypoint/conflict checks, and plugin lint.
- [x] Vault-profile skill quality review: 90/100, no validation warnings.
