### PR TITLE
feat(ingress): retain reviewed inactive source aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Preserve reviewed inactive recording aliases
+
+Add an owner-reviewed YouTube alias ledger outside talk analysis generations,
+with independent delivery evidence, provider facts, comparison hashes, reviewer,
+and verification time. Bind append to both the reviewed database and candidate
+digests. Shownotes reconciliation preserves the canonical URL/ID and treats an
+accepted alternate as resolved. Reject conflicting ownership, rejected-source
+overlap, cycles, and unknown schemas. Root v3 introduces the optional collection;
+older roots remain readable, and QR-only recovery preserves v2/v3 roots and
+active claims. Atomic canonical promotion remains separate work in #175.
+
 ## 0.20.122 — 2026-09-05
 
 ### Typed failures for invalid speech-rate serialization inputs

--- a/skills/illustrations/references/thumbnails.md
+++ b/skills/illustrations/references/thumbnails.md
@@ -36,10 +36,11 @@ owner-reader invocation. Every command below uses the configured interpreter;
 never fall back to a PATH interpreter.
 
 Read `tracking-database.json` through the vault path used by
-presentation-creator. Selection and composition may read legacy database schema
-0 or 1, or current schema 2, without mutation. Before copying the approved thumbnail or
-writing tracking state, require database schema 2, current independent records,
-and talk schema 8. Invoke `Skill(skill: "vault-ingress")` for schema 0 or 1 and stop
+presentation-creator. Selection and composition may read the generations in the
+[owner compatibility contract](../../vault-ingress/references/schemas-db.md#schema-versioning)
+without mutation. Before copying the approved thumbnail or writing tracking
+state, require the owner-current database, current independent records, and talk
+schema 8. Invoke `Skill(skill: "vault-ingress")` for legacy generations and stop
 this run. Unknown future generations are no usable prior state. Preserve every
 schema field and use the presentation-creator exact-generation atomic-write
 contract.

--- a/skills/presentation-creator/SKILL.md
+++ b/skills/presentation-creator/SKILL.md
@@ -43,8 +43,9 @@ The vault lives at `~/.claude/rhetoric-knowledge-vault/` (may be a symlink to a 
 location). Load `tracking-database.json` with the strict owner reader at
 `{speaker_toolkit_root}/skills/vault-ingress/scripts/read-tracking-database.py` to
 get `config.vault_root`; never parse it directly. The stdlib-only reader may use
-the host interpreter for this one bootstrap read. It accepts legacy database
-schemas 0 and 1 and current schema 2 without rewriting any of them. Stop on unsupported root
+the host interpreter for this one bootstrap read. It accepts the readable database
+generations in the [owner compatibility contract](../vault-ingress/references/schemas-db.md#schema-versioning)
+without rewriting them. Stop on unsupported root
 or owner-record generations and route migration to `Skill(skill: "vault-ingress")`.
 
 Discover the exact non-empty `config.python_path`, then immediately re-read the
@@ -52,9 +53,10 @@ same canonical database path with that interpreter and require the same SHA-256;
 restart discovery if the generation changed. Use only that configured interpreter
 for every later toolkit command. Missing or unusable configuration stops this flow
 and invokes `Skill(skill: "vault-ingress")` with Step 1 as the handoff context.
-Read-only phases may continue on schema 0 or 1, but publishing and post-event
-writes require schema 2 before their paired network, deck, image, or tracking
-side effects. For schema 0 or 1, invoke `Skill(skill: "vault-ingress")` with a
+Read-only phases may continue on readable legacy generations, but publishing and
+post-event writes require the owner-current schema before their paired network,
+deck, image, or tracking side effects. For a legacy generation, invoke
+`Skill(skill: "vault-ingress")` with a
 Step 1 migration handoff before continuing.
 
 Load from vault root: `rhetoric-style-summary.md` (constitution — all patterns),

--- a/skills/presentation-creator/references/phase6-publishing.md
+++ b/skills/presentation-creator/references/phase6-publishing.md
@@ -186,9 +186,9 @@ path make the check before resolving the link.
    ```
 
    The script is a non-owner dual reader and a current-schema writer. Dry-run
-   accepts any readable database schema — legacy 0, pre-`markdown_decks` 1, or
-   current 2 — without changing any of them.
-   A real run requires database schema 2 before URL-shortener calls, deck edits,
+   accepts every readable database generation without changing it; the generations
+   are defined by the [owner schema](../../vault-ingress/references/schemas-db.md).
+   A real run requires the current database schema before URL-shortener calls, deck edits,
    or tracking persistence. Route a legacy database through vault-ingress Step 1.
    An unsupported future database or record version is no usable prior state.
 

--- a/skills/presentation-creator/references/phase7-post-event.md
+++ b/skills/presentation-creator/references/phase7-post-event.md
@@ -15,9 +15,11 @@ Before ANY Phase 7 action, load these files. If any is missing, STOP and ask.
 4. **YouTube video URL** — provided by the speaker at trigger time
 
 Read the tracking database through the main presentation-creator compatibility
-gate. Thumbnail and shownotes lookup may read schema 0 or 1. Any database update
-in this phase requires current database schema 2 and talk schema 8 before the
-thumbnail, shownotes, or video side effect paired with it. Route schema 0 or 1 through
+gate and the [owner compatibility contract](../../vault-ingress/references/schemas-db.md#schema-versioning).
+Thumbnail and shownotes lookup may read the owner's readable generations. Any
+database update in this phase requires the owner-current database and talk
+schema 8 before the thumbnail, shownotes, or video side effect paired with it.
+Route legacy generations through
 `Skill(skill: "vault-ingress")`; preserve all schema fields and apply the main
 skill's exact-generation atomic-write contract.
 

--- a/skills/vault-clarification/SKILL.md
+++ b/skills/vault-clarification/SKILL.md
@@ -76,14 +76,15 @@ state:
 
 Exit 0 writes one JSON object with `from_schema_version`,
 `to_schema_version`, `changed`, `database_written: false`, `input_sha256`, and
-`record_counts`. Continue only for `changed: false` at database schema v2 with
-config schema v2. A legacy root or config report requires the owner workflow;
+`record_counts`. Continue only for `changed: false` at the current database
+generation in the [owner compatibility contract](../vault-ingress/references/schemas-db.md#schema-versioning)
+with config schema v2. A legacy root or config report requires the owner workflow;
 invoke `Skill(skill: "vault-ingress")`
 with the migration report as handoff context, then finish this clarification run.
 Exit 2 writes one error object to stdout plus an `ERROR:` diagnostic to stderr;
 stop without changing session state.
 
-Every tracking write in Steps 2–8 is current-only. Preserve database schema 2,
+Every tracking write in Steps 2–8 is current-only. Preserve the owner-current root,
 config schema 2, talk schema 8, and every unrelated record. Stamp confirmed
 intents with schema 1 and new improvement goals with schema 2. Capture the exact
 input bytes immediately before each write, reject a changed generation, validate

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -64,6 +64,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/markdown-decks.md](references/markdown-decks.md) | Slidev/presenterm/Marp/reveal-md decks — render lanes, register-and-requeue, reveal structure |
 | [references/source-identity-preflight.md](references/source-identity-preflight.md) | Offline identity, duplicate-source, enum, and artifact integrity contracts |
 | [references/source-identity-audit.md](references/source-identity-audit.md) | Networked, read-only capture of live provider identity evidence and review findings |
+| [references/source-aliases.md](references/source-aliases.md) | Owner-reviewed inactive recording aliases; evidence review, hash-bound append, and scan verification |
 | [references/catalog-feedback-intake.md](references/catalog-feedback-intake.md) | Five-lane catalog-feedback schema, polarity, recurrence, and review contract |
 | [references/pattern-catalog-contract.md](references/pattern-catalog-contract.md) | Read-only catalog graph, polarity, source-gate, and semantic-debt contract |
 | [references/processing-rules.md](references/processing-rules.md) | Language policy, pattern migration logic, structured field rules |

--- a/skills/vault-ingress/references/batch-persistence.md
+++ b/skills/vault-ingress/references/batch-persistence.md
@@ -43,7 +43,8 @@ whether to run the gate.
   `"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/persist-results.py" {vault_root}/tracking-database.json batch-returns.json`.
   The script first requires the return filenames to equal every live member of one
   run/batch claim; partial, extra, mixed-identity, duplicate, closed, or stranded
-  batches fail before merge. The script requires database schema v2 and current
+  batches fail before merge. The script requires the current database generation
+  from the [owner compatibility contract](schemas-db.md#schema-versioning) and current
   independent record versions; Step 1 is the sole migration path. It then merges each return into its matching
   talk entry, promotes the declared queryable scalars to the talk top level, and
   rewrites the DB in place. Do NOT hand-copy fields one at a time — that is what

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -10,7 +10,7 @@ each section in order; later sections assume every earlier gate succeeded.
    [schemas-db.md](schemas-db.md#owner-read-and-mutation-contract).
 2. **Path missing** — first-time setup: ask preferred location via `AskUserQuestion`,
    create the directory (and symlink if a custom path was chosen), then use a sole
-   `initialize_database` mutation. Include database `schema_version: 2`, config
+   `initialize_database` mutation. Include database `schema_version: 3`, config
    `schema_version: 2`, and empty `talks`, `pptx_catalog`, `qr_codes`, `resources`,
    `thumbnails`, `confirmed_intents`, and `improvement_goals` arrays. The plan may
    omit `pptx_directory_exclusions`; the initializer supplies the canonical default
@@ -72,9 +72,10 @@ changed report authorizes this exact apply command:
 
 Exit 0 from apply writes one JSON report with `database_written: true`, preserves
 the complete original bytes under `{vault_root}/.backups/`, and atomically
-installs database schema v2 with config schema v2. A current root with config
+installs the current root from the [owner compatibility contract](schemas-db.md#schema-versioning)
+with config schema v2. A current root with config
 schema v1 is also a migration: root `from_schema_version` and
-`to_schema_version` both remain `2`, while `record_counts.config` records the
+`to_schema_version` both remain at that current root, while `record_counts.config` records the
 config upgrade.
 
 `persisted_observations` reports what the migration did to corrupt persisted
@@ -96,7 +97,7 @@ database or talk record. The existing queue transition may advance a recovered
 legacy claim receipt from schema v1 to v2 while adding its release fields. Rerun
 migration dry-run, then apply its new exact digest. Do not copy a digest across
 runs. `queue-state.py ... normalize` and `queue-state.py ... claim` require
-database schema 2.
+the owner-current database schema.
 
 **Config bootstrapping** — ask once per missing user-owned field and persist to the tracking
 database with expectation-bound `set_config` mutations. Re-read after every
@@ -127,11 +128,11 @@ before another config write.
   --lanes core,pdf,pptx
 ```
 
-All owner-authored tracking writes below require database schema 2 and config
+All owner-authored tracking writes below require the owner-current database and config
 schema 2 after this
 gate. Preserve every independent record version and validate the complete
 candidate before installing it. Only `migrate-tracking-database.py` may move
-schema 0 or schema 1 to schema 2; its hash precondition binds replacement to the exact input
+readable legacy roots to the current schema; its hash precondition binds replacement to the exact input
 bytes as documented above.
 
 Core requires Python 3.10+ and PyYAML and is blocking. The PDF lane requires

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -152,6 +152,8 @@ v1 and v2 for the rollout window.
   legacy record has no `artifacts` and cannot satisfy the v2 shape. Only the QR
   writer produces v2 records, and it writes them complete.
 
+### Schema versioning
+
 A schema-v3 database with current child records is an idempotent no-op.
 Earlier roots advance to v3; config v1 advances to v2 in the same pass.
 The root-only v2-to-v3 transition preserves every child value and does not
@@ -2233,9 +2235,9 @@ receipt behavior changes; current is `1.5.0`. Pipeline 1.5 applies the shared
 bounded PDF ceiling, complete page-tree walk, and repair-diagnostic rejection to
 render receipts produced inside the already-contained PPTX extraction worker.
 
-Extractor schema v4 is independent of persisted pattern-evidence schema v2,
-return schema v5, queue-claim schema v5, and tracking-database schema v2. Those
-downstream generations do not advance here; their current readers bind or
+Extractor schema v4 is independent of persisted pattern-evidence, return,
+queue-claim, and tracking-database generations. Those downstream generations
+do not advance with the extractor; their current readers bind or
 validate the new nested records inside their existing contracts.
 
 These records are transient per-invocation output, not a persisted artifact with

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -10,7 +10,7 @@ shape, and all migrations. vault-clarification may write current config,
 confirmed-intent, and improvement-goal records. presentation-creator may write
 current QR records. vault-profile and the remaining presentation consumers are
 read-only. Non-owner readers accept every readable database generation during
-rollout — legacy 0, pre-`markdown_decks` 1, and current 2. They never rewrite
+rollout — legacy 0, pre-`markdown_decks` 1, pre-`source_aliases` 2, and current 3. They never rewrite
 legacy state. An unsupported future database or record version is no usable
 prior state.
 
@@ -152,17 +152,17 @@ v1 and v2 for the rollout window.
   legacy record has no `artifacts` and cannot satisfy the v2 shape. Only the QR
   writer produces v2 records, and it writes them complete.
 
-A schema-v2 database with config v2 is an idempotent no-op. A schema-v1 database
-is not: its root advances to v2, and a config v1 is upgraded in the same pass.
-A schema-v2 database with config v1 receives only the config-v2 migration; the
-root generation and every other record remain unchanged. Before migration, queue `inspect` may read
+A schema-v3 database with current child records is an idempotent no-op.
+Earlier roots advance to v3; config v1 advances to v2 in the same pass.
+The root-only v2-to-v3 transition preserves every child value and does not
+create or infer any source alias. Before migration, queue `inspect` may read
 schema 0 and queue `recover` may close an active schema-0 lease in place.
 Recovery changes only queue lease/status state and never stamps database or talk
 schema fields; the established queue transition may advance a recovered claim
 receipt from v1 to v2 while adding its release fields.
 
 The owner migration is a preservation migration. Its only allowed semantic
-changes are advancing the root to schema v2, adding the validated historical
+changes are advancing the root to schema v3, adding the validated historical
 version to an unversioned owner record, creating absent owned arrays as empty
 arrays, and upgrading config v1 to v2. A missing exclusion list receives the canonical
 defaults; a valid owner-supplied list is preserved exactly. It
@@ -175,7 +175,7 @@ no-op.
 
 | Independent record | Current schema |
 |---|---:|
-| database root | 2 (schema 1, the generation before `markdown_decks`, remains readable) |
+| database root | 3 (schemas 0-2 remain readable migration inputs) |
 | config | 2 (schema 1 remains readable owner-migration input) |
 | talk | 8 (schemas 1-7 remain readable historical state; v5-v7 restamp) |
 | PPTX catalog | 3 (schemas 1 and 2 remain readable legacy state) |
@@ -185,22 +185,24 @@ no-op.
 | confirmed intent | 1 |
 | source rejection | 1 |
 | source title equivalence | 2 (own top-level collection; v1 nested entries are migrated) |
+| accepted source alias | 1 (optional top-level collection; never inferred by migration) |
 | improvement goal | 2 (schema 1 remains readable historical state) |
 
 | Component | Access | Contract |
 |---|---|---|
-| vault-ingress migration | owner read/write | Accept root schema 0/1/2 and config schema 1/2; migrate to root v2/config v2; never downgrade future state |
-| vault-ingress queue inspection/recovery | owner compatibility transition | Inspect schema 0/1/2; recover active leases in schema 0/1/2; never stamp artifact or talk schema versions |
-| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 2, config schema 2, and supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
-| vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0, 1, and 2; gate through existing finding/error channels; never rewrite |
+| vault-ingress migration | owner read/write | Accept root schema 0/1/2/3 and config schema 1/2; migrate to root v3/config v2; never downgrade future state |
+| vault-ingress queue inspection/recovery | owner compatibility transition | Inspect schema 0/1/2/3; recover active leases in readable roots; never stamp artifact or talk schema versions |
+| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 3, config schema 2, and supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
+| vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0-3; gate through existing finding/error channels; never rewrite |
 | vault-clarification | current read/write | Route schema migration to vault-ingress; preserve config v2 and stamp confirmed intent v1/improvement goal v2 |
-| presentation-creator QR writer | dual reader/current writer | Read schemas 0, 1, and 2; require schema 2 before URL creation or QR metadata persistence; stamp QR v2 |
-| presentation-creator publishing/post-event | authorized current writer | Require schema 2 before tracking writes; stamp resource v1 and preserve talk v7 |
-| illustrations thumbnail workflow | authorized current writer | Require schema 2 before tracking writes; stamp thumbnail v1 and preserve talk v7 |
-| vault-profile | dual reader | Parse schemas 0, 1, and 2; treat unsupported generations as unavailable; never migrate |
+| presentation-creator QR writer | dual reader/current writer | Read schemas 0-3; require schema 3 before URL creation or QR metadata persistence; stamp QR v2 |
+| presentation-creator publishing/post-event | authorized current writer | Require schema 3 before tracking writes; stamp resource v1 and preserve talk v8 |
+| illustrations thumbnail workflow | authorized current writer | Require schema 3 before tracking writes; stamp thumbnail v1 and preserve talk v8 |
+| vault-profile | dual reader | Parse schemas 0-3; treat unsupported generations as unavailable; never migrate |
 
-Current database schema 2 with config schema 2 requires all eight top-level
-state fields shown below. `markdown_decks` is the ninth key and is optional:
+Current database schema 3 with config schema 2 requires all eight top-level
+state fields shown below. `source_title_equivalences`, `source_aliases`, and
+`markdown_decks` are optional owner collections. For `markdown_decks`,
 absent means no talk has a registered markdown deck, which is what every
 database written before root v2 says.
 Missing legacy arrays become empty during owner migration. Current writers do
@@ -227,7 +229,7 @@ customization, not the owner default. See the
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "config": {
     "schema_version": 2,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",
@@ -354,7 +356,7 @@ customization, not the owner default. See the
       "not_evaluable": []
     }
   }],
-  "_comment_schema_version": "Database root schema v2 is owner-migrated by vault-ingress; root v1 is the generation before the top-level `markdown_decks` collection, and migration moves a v0 or v1 database to v2 without touching any record it already carries. A missing talk record version is the historical implicit-v1 lineage. v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds `pattern_score_basis` and a possibly-fractional `pattern_score` at the weighted scoring generation; migration restamps a v5 record to v6 without rescoring it, because recomputing a score under arithmetic its worker never used would restate what the worker meant. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level `source_title_equivalences` collection at record v2, so v7 adds no field a v6 record lacks. V8 adds `provider_auto` to the transcript-source enum. Migration restamps v5-v7 records to v8 without relabeling their source and lifts a nested v1 title ledger into the top-level collection. Root migration preserves all historical evidence and never synthesizes v5 outcomes.",
+  "_comment_schema_version": "Database root schema v3 is owner-migrated by vault-ingress and introduces the optional top-level source_aliases collection. Root v2 introduced markdown_decks. Root migration infers neither deck registrations nor aliases. A missing talk record version is the historical implicit-v1 lineage. Talk v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds pattern_score_basis and a possibly-fractional pattern_score at the weighted scoring generation. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level source_title_equivalences collection at record v2, so v7 adds no field a v6 record lacks. V8 adds provider_auto to the transcript-source enum. Migration restamps v5-v7 records to v8 without rescoring or relabeling their source and lifts a nested v1 title ledger into the top-level collection. It preserves historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "schema_version": 3,
@@ -602,6 +604,7 @@ exact-type rule. The supported mutation kinds are:
 | `upsert_thumbnail` | Replace/add one complete schema-v1 record identified by `talk_slug` |
 | `apply_reviewed_metadata` | Install one human-reviewed shownotes catalog-conflict decision on one exact talk filename, over a closed identity field set, with `expect` covering exactly the same fields |
 | `record_source_title_equivalence` | Append one owner-reviewed provider-title equivalence to one exact talk filename; append-only and refuses a duplicate |
+| `record_source_alias` | Append a reviewed inactive YouTube identity; exact canonical/ledger expectations and both input/output hashes bind apply; see [source-aliases.md](source-aliases.md) |
 | `record_markdown_deck` | Register (or re-point) the markdown file one exact talk's deck was authored in, with `expect` naming the currently registered `deck_source_path` or the missing marker; upsert, one deck per talk |
 | `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
 | `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |

--- a/skills/vault-ingress/references/source-aliases.md
+++ b/skills/vault-ingress/references/source-aliases.md
@@ -1,0 +1,117 @@
+# Reviewed Inactive Source Aliases
+
+An accepted alias is a second verified upload of the same delivery. Keep it
+separate from wrong-delivery `source_rejections` and from the active source used
+for acquisition, queueing, artifact lineage, and profile freshness.
+
+## Read and review
+
+Use the owner read/bootstrap procedure in
+[schemas-db.md](schemas-db.md#owner-read-and-mutation-contract). The optional
+top-level `source_aliases` collection belongs to root schema v3; its records
+have their own schema version. Migration creates no alias and infers no
+equivalence. Older roots remain read-only until owner migration; root v2 keeps
+its existing strict child-version checks. Normal migration still refuses
+active claims. The explicit QR-only repair continues to support root v2
+without advancing it or cancelling claims.
+
+For an unresolved shownotes recording, run the
+[candidate identity audit](source-identity-audit.md#candidate-mode-230). Read
+both provider-fact blocks and all findings. Verify the delivery independently
+against an event program or authoritative event page, including speakers and
+delivery date. Upload dates and uploader accounts are not delivery facts.
+Compare recording content, transcripts, or artifacts when available; retain
+the compared artifact hashes. Title similarity alone is not equivalence.
+
+The current record accepts the YouTube video lane. Unsupported providers or
+lanes fail closed; do not relabel them as YouTube. The auditor supplies provider
+facts, not an automatic alias decision or transcript comparison. An owner must
+review and approve the independent evidence before writing the plan.
+
+## Persisted shape
+
+`skills/vault-ingress/scripts/source_alias_contract.py` owns the closed record
+shape, provider identity checks, relationship/comparison enums, and lineage
+validation. Every record contains:
+
+- `schema_version`, `talk_filename`, and the reviewed `catalog_title`.
+- `source_type`, `alias`, and `canonical`. Each provider block carries
+  `provider`, `video_id`, `url`, `title`, `uploader`, `upload_date`,
+  `duration_seconds`, and timezone-aware `captured_at`.
+- `relationship` and nullable `canonical_choice_reason`; the reason explains
+  the canonical choice without calling the alternate invalid.
+- `event`: independent `url`, `conference`, delivery `date`, and `speakers`.
+- `comparison`: `method`, `summary`, `canonical_sha256`, `alias_sha256`, and
+  nullable integer `agreement_basis_points`. Recording review may leave hashes
+  null; transcript/artifact comparisons require both reviewed byte identities.
+- `reviewer` and timezone-aware `verified_at`.
+
+Provider facts and comparison hashes are recorded evidence, not independently
+authenticated by the offline writer. Review the actual sources; never invent
+missing values to satisfy the schema. A record does not grant its artifacts
+analysis trust.
+
+The ledger rejects canonical/alias overlap, duplicate alias ownership, overlap
+with the owning talk's rejection ledger, dangling canonical targets, and cycles.
+Historical edges may terminate through another same-talk alias at the current
+canonical source. Unknown record versions are unusable owner state. Existing
+canonical duplicate-talk relationships retain their separate preflight contract.
+
+## Hash-bound owner append
+
+Construct a strict JSON mutation plan using the reviewed record:
+
+```json
+{
+  "schema_version": 1,
+  "mutations": [{
+    "kind": "record_source_alias",
+    "record": "replace this placeholder with the complete reviewed record",
+    "expect": {
+      "video_url": "exact current canonical URL",
+      "youtube_id": "exact current stored ID or the missing marker",
+      "source_rejections": {"$missing": true},
+      "source_aliases": {"$missing": true}
+    }
+  }]
+}
+```
+
+The placeholders are not executable values. Replace every expectation with the
+exact owner-read value, preserving absence versus null; existing ledgers require
+their complete arrays. The writer binds the reviewed catalog/event identity and
+canonical ID, refuses an active claim on the target talk, and changes only the
+top-level alias collection. An exact already-recorded entry with current
+expectations is a no-op. A stale plan is refused, not silently rebased.
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/mutate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" alias-plan.json
+```
+
+Review `changes`, `input_sha256`, and `output_sha256`. Both hashes are mandatory
+for alias apply; a modified candidate requires a fresh dry run and review:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/mutate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" alias-plan.json --apply \
+  --expected-sha256 "{input_sha256}" --expected-output-sha256 "{output_sha256}"
+```
+
+The shared locked transaction rejects competing database generations. Re-read
+through the owner and verify the reported output digest, then repeat the scan
+and preflight. `scan-shownotes.py` reports a reviewed alternate as `unchanged`
+when no independent metadata conflict remains. It preserves the canonical URL
+and stored ID, including an absent ID, and never promotes the alias.
+
+## Canonical replacement boundary
+
+This append operation does not replace the canonical source, rewrite old ledger
+entries, invalidate analysis, or perform reparsing. Do not compose a canonical
+replacement from separate source-repair and alias-append writes: a partial
+transition can lose provenance or leave invalid lineage. The atomic reviewed
+promotion/superseded-history transition remains follow-up work in #175.
+
+Unrelated source repair, scan/import, queue, persistence, and profile operations
+must preserve the ledger. A mutation that would make its ownership inconsistent
+fails the owner-schema gate; removing the ledger is not a repair.

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -112,6 +112,11 @@ keeps its blocking code and fails the run.
 promoted or persisted here — reviewing this evidence and applying a decision are
 separate steps.
 
+When both identities are valid uploads of the same delivery, review the two
+provider-fact blocks with independent event evidence and a recording/transcript
+comparison. Follow [source-aliases.md](source-aliases.md) to retain the inactive
+identity without rejecting it or replacing the canonical recording.
+
 ## Report contract (v2)
 
 ```json

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -310,6 +310,12 @@ compare against this ledger before importing an upstream link.
 
 ## YouTube identity and duplicate relation
 
+Accepted inactive uploads live in the owner's top-level `source_aliases` ledger,
+not `source_rejections`. The shared schema assessment rejects malformed/future
+aliases, conflicting ownership, canonical/rejection overlap, and invalid lineage
+before evidence access. See [source-aliases.md](source-aliases.md) for the record
+and reviewed-write contract. Aliases supply no artifact or acquisition capability.
+
 The parser accepts these URL identities:
 
 - `youtube.com/watch?v={id}`

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1831,14 +1831,14 @@ def build_candidate(
     return candidate, changes
 
 
-def _validate_digest(value: str) -> None:
+def _validate_digest(value: str, *, flag: str = "--expected-sha256") -> None:
     if value == "missing":
         return
     if len(value) != 64 or any(
         character not in "0123456789abcdef" for character in value
     ):
         raise TrackingDatabaseMutationError(
-            "--expected-sha256 must be `missing` or 64 lowercase hexadecimal characters"
+            f"{flag} must be `missing` or 64 lowercase hexadecimal characters"
         )
 
 
@@ -1862,7 +1862,7 @@ def execute(
         mutation.get("kind") == "record_source_alias" for mutation in mutations
     )
     if expected_output_sha256 is not None:
-        _validate_digest(expected_output_sha256)
+        _validate_digest(expected_output_sha256, flag="--expected-output-sha256")
         if expected_output_sha256 == "missing":
             raise TrackingDatabaseMutationError(
                 "--expected-output-sha256 must be a candidate digest, not missing"

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -61,6 +61,11 @@ from pptx_discovery_contract import (
 )
 from pptx_talk_identity import binding_refusal
 from source_identity_matching import parse_catalog_date, pinned_provider_title
+from source_alias_contract import (
+    SourceAliasError,
+    active_identity,
+    validate_alias_record,
+)
 
 
 PLAN_SCHEMA_VERSION = 1
@@ -996,6 +1001,81 @@ def _apply_record_title_equivalence(
     )
 
 
+def _apply_record_source_alias(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    """Append a reviewed inactive identity without changing talk evidence."""
+    label = f"mutations[{index}]"
+    _require_keys(mutation, required={"kind", "record", "expect"}, label=label)
+    record = mutation["record"]
+    try:
+        validate_alias_record(record, label=f"{label}.record")
+    except SourceAliasError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
+    filename = record["talk_filename"]
+    talk = _talk_by_filename(database, filename)
+    _require_readable_talk_record(talk, filename=filename)
+    claim = talk.get("_queue_claim")
+    if talk.get("status") == "reprocessing-inflight" or (
+        isinstance(claim, dict) and claim.get("state") == "claimed"
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label}: cannot change an active claim's identity ledger"
+        )
+    expected = mutation["expect"]
+    if not isinstance(expected, dict):
+        raise TrackingDatabaseMutationError(f"{label}.expect must be an object")
+    _require_keys(
+        expected,
+        required={"video_url", "youtube_id", "source_rejections", "source_aliases"},
+        label=f"{label}.expect",
+    )
+    for field in ("video_url", "youtube_id", "source_rejections", "source_aliases"):
+        container = database if field == "source_aliases" else talk
+        _expect_value(
+            exists=field in container,
+            actual=container.get(field),
+            expected=expected[field],
+            label=f"{label}.expect.{field}",
+        )
+    if active_identity(talk) != record["canonical"]["video_id"]:
+        raise TrackingDatabaseMutationError(
+            f"{label}: canonical evidence is not the talk's current source"
+        )
+    if (
+        talk.get("title") != record["catalog_title"]
+        or talk.get("conference") != record["event"]["conference"]
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label}: reviewed catalog identity disagrees with this talk"
+        )
+    catalog_date = talk.get("date")
+    event_date = record["event"]["date"]
+    if not isinstance(catalog_date, str) or catalog_date not in {
+        event_date,
+        event_date[:4],
+    }:
+        raise TrackingDatabaseMutationError(
+            f"{label}: independent event date disagrees with this delivery"
+        )
+    before = database.get("source_aliases", MISSING_MARKER)
+    existing = database.get("source_aliases", [])
+    if any(json_values_equal(item, record) for item in existing):
+        return
+    database["source_aliases"] = [*existing, copy.deepcopy(record)]
+    _record_change(
+        changes,
+        kind="record_source_alias",
+        identity=filename,
+        before=before,
+        after=database["source_aliases"],
+    )
+
+
 def _apply_record_markdown_deck(
     database: dict[str, Any],
     mutation: dict[str, Any],
@@ -1720,6 +1800,8 @@ def build_candidate(
             _apply_reviewed_metadata(candidate, mutation, changes, index=index)
         elif kind == "record_source_title_equivalence":
             _apply_record_title_equivalence(candidate, mutation, changes, index=index)
+        elif kind == "record_source_alias":
+            _apply_record_source_alias(candidate, mutation, changes, index=index)
         elif kind == "record_markdown_deck":
             _apply_record_markdown_deck(candidate, mutation, changes, index=index)
         elif kind == "update_talk_publishing":
@@ -1766,6 +1848,7 @@ def execute(
     *,
     apply: bool,
     expected_sha256: str | None,
+    expected_output_sha256: str | None = None,
 ) -> dict[str, Any]:
     plan = load_plan(plan_path)
     mutations = plan["mutations"]
@@ -1774,6 +1857,19 @@ def execute(
     if apply and expected_sha256 is None:
         raise TrackingDatabaseMutationError(
             "--apply requires --expected-sha256 from the reviewed dry-run report"
+        )
+    alias_plan = any(
+        mutation.get("kind") == "record_source_alias" for mutation in mutations
+    )
+    if expected_output_sha256 is not None:
+        _validate_digest(expected_output_sha256)
+        if expected_output_sha256 == "missing":
+            raise TrackingDatabaseMutationError(
+                "--expected-output-sha256 must be a candidate digest, not missing"
+            )
+    if apply and alias_plan and expected_output_sha256 is None:
+        raise TrackingDatabaseMutationError(
+            "alias --apply requires --expected-output-sha256 from the reviewed dry run"
         )
 
     initialize = (
@@ -1806,6 +1902,13 @@ def execute(
             ) from exc
         rendered = render_json_object(candidate)
         output_sha256 = hashlib.sha256(rendered).hexdigest()
+        if (
+            expected_output_sha256 is not None
+            and expected_output_sha256 != output_sha256
+        ):
+            raise TrackingDatabaseMutationError(
+                "reviewed candidate output sha256 precondition failed; repeat the dry run and review"
+            )
         if apply:
             try:
                 result = initialize_tracking_database(database_path, candidate)
@@ -1857,6 +1960,10 @@ def execute(
     candidate, changes = build_candidate(database, mutations)
     rendered = render_json_object(candidate) if changes else snapshot.raw
     output_sha256 = hashlib.sha256(rendered).hexdigest()
+    if expected_output_sha256 is not None and expected_output_sha256 != output_sha256:
+        raise TrackingDatabaseMutationError(
+            "reviewed candidate output sha256 precondition failed; repeat the dry run and review"
+        )
     if apply:
         try:
             result = commit_tracking_database(snapshot, rendered)
@@ -1892,6 +1999,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("plan", type=Path)
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--expected-sha256")
+    parser.add_argument("--expected-output-sha256")
     try:
         args = parser.parse_args(argv)
         report = execute(
@@ -1899,6 +2007,7 @@ def main(argv: list[str] | None = None) -> int:
             args.plan,
             apply=args.apply,
             expected_sha256=args.expected_sha256,
+            expected_output_sha256=args.expected_output_sha256,
         )
     except TrackingDatabaseMutationError as exc:
         print(json.dumps({"schema_version": 1, "ok": False, "error": str(exc)}))

--- a/skills/vault-ingress/scripts/scan-shownotes.py
+++ b/skills/vault-ingress/scripts/scan-shownotes.py
@@ -37,6 +37,7 @@ from ingress_contract import (
     validate_talk_record_schemas,
 )
 from source_identity_matching import shownotes_titles_agree
+from source_alias_contract import matched_alias
 from tracking_database import (
     TrackingDatabaseError,
     assess_tracking_database,
@@ -799,6 +800,8 @@ def _existing_entry(
     talk: dict[str, Any],
     proposal: dict[str, Any],
     parse_issues: list[dict[str, Any]],
+    *,
+    accepted_alias: dict[str, Any] | None = None,
 ) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
     issues = list(parse_issues)
     patch: dict[str, Any] = {}
@@ -806,6 +809,11 @@ def _existing_entry(
     stored_date = talk.get("date")
     for field in TRACKED_FIELDS:
         if field not in proposal:
+            continue
+        # The URL and derived ID are one source claim. Suppressing only the URL
+        # conflict would either reopen the ID conflict or backfill the alias ID
+        # into a canonical record whose redundant ID is absent.
+        if accepted_alias is not None and field in {"video_url", "youtube_id"}:
             continue
         candidate = proposal[field]
         if field in {"video_url", "slides_url"}:
@@ -935,7 +943,13 @@ def build_scan_report(
         patch: dict[str, Any] = {}
         if filename in exact:
             index, talk = exact[filename]
-            disposition, patch, issues = _existing_entry(talk, proposal, parse_issues)
+            alias = matched_alias(database, talk, proposal.get("video_url"))
+            disposition, patch, issues = _existing_entry(
+                talk,
+                proposal,
+                parse_issues,
+                accepted_alias=dict(alias) if alias is not None else None,
+            )
             if disposition == "update":
                 updates.append((index, patch))
         else:
@@ -1038,6 +1052,12 @@ def execute(database_path: Path, *, apply_requested: bool) -> dict[str, Any]:
         apply_requested=apply_requested,
     )
     if apply_requested:
+        try:
+            require_current_tracking_database(candidate)
+        except TrackingDatabaseError as exc:
+            raise ShownotesScanError(
+                f"scan candidate violates the owner schema: {exc}"
+            ) from exc
         if report["mutation_count"]:
             write_result = _atomic_write_database(
                 database_path,

--- a/skills/vault-ingress/scripts/source_alias_contract.py
+++ b/skills/vault-ingress/scripts/source_alias_contract.py
@@ -1,0 +1,327 @@
+"""Owner-reviewed, inactive same-delivery YouTube identities.
+
+An alias is an identity judgment, never an acquisition capability or analysis
+receipt. Edges retain the identity actually compared by the reviewer; a later
+official-source promotion may extend that chain, but every edge must end at the
+talk's one current source. No title heuristic creates an edge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime
+import math
+import re
+from typing import Any, NoReturn
+from urllib.parse import parse_qs, urlparse
+
+
+SOURCE_ALIAS_SCHEMA_VERSION = 1
+RELATIONSHIPS = frozenset(
+    {"valid_duplicate", "mirror", "superseded_by_official_upload"}
+)
+COMPARISON_METHODS = frozenset({"recording_review", "transcript", "artifact"})
+MAX_ALIASES = 10000
+MAX_TEXT_LENGTH = 16384
+RECORD_FIELDS = frozenset(
+    {
+        "schema_version",
+        "talk_filename",
+        "catalog_title",
+        "source_type",
+        "alias",
+        "canonical",
+        "relationship",
+        "event",
+        "comparison",
+        "reviewer",
+        "verified_at",
+        "canonical_choice_reason",
+    }
+)
+PROVIDER_FIELDS = frozenset(
+    {
+        "provider",
+        "video_id",
+        "url",
+        "title",
+        "uploader",
+        "upload_date",
+        "duration_seconds",
+        "captured_at",
+    }
+)
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+
+
+class SourceAliasError(ValueError):
+    """A closed alias record or its owner binding is invalid."""
+
+
+def _refuse(label: str, detail: str) -> NoReturn:
+    raise SourceAliasError(
+        f"{label}: {detail}; review and repair through the alias owner"
+    )
+
+
+def _shape(value: Any, fields: frozenset[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != fields:
+        _refuse(label, "unsupported record shape")
+    return value
+
+
+def _text(value: Any, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value != value.strip()
+        or len(value) > MAX_TEXT_LENGTH
+    ):
+        _refuse(label, "expected bounded nonempty trimmed text")
+    return value
+
+
+def _timestamp(value: Any, label: str) -> None:
+    text = _text(value, label)
+    _date(text[:10], label)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise SourceAliasError(
+            f"{label}: supply a timezone-aware ISO timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        _refuse(label, "timestamp has no timezone")
+
+
+def _date(value: Any, label: str) -> None:
+    # Pin the portable calendar-date spelling instead of inheriting additional
+    # basic/week-date forms from newer Python fromisoformat implementations.
+    text = _text(value, label)
+    if DATE_RE.fullmatch(text) is None:
+        _refuse(label, "expected YYYY-MM-DD calendar date")
+    try:
+        date.fromisoformat(text)
+    except ValueError as exc:
+        raise SourceAliasError(f"{label}: supply a valid calendar date") from exc
+
+
+def _url(value: Any, label: str) -> str:
+    text = _text(value, label)
+    try:
+        parsed = urlparse(text)
+        port = parsed.port
+    except ValueError as exc:
+        raise SourceAliasError(f"{label}: supply a valid HTTP(S) evidence URL") from exc
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 80, 443}
+        or any(char.isspace() or ord(char) < 32 or ord(char) == 127 for char in text)
+    ):
+        _refuse(label, "invalid HTTP(S) evidence URL")
+    return text
+
+
+def youtube_identity(value: Any) -> str | None:
+    # Resolve lazily: tracking_database owns this contract and ingress_contract
+    # re-exports the talk schema from tracking_database. No parsing runs during
+    # import, so both import orders use the existing provider parser safely.
+    from ingress_contract import parse_youtube_id
+
+    try:
+        return parse_youtube_id(value)
+    except ValueError:
+        return None
+
+
+def _provider(value: Any, label: str) -> Mapping[str, Any]:
+    record = _shape(value, PROVIDER_FIELDS, label)
+    url = _url(record["url"], f"{label}.url")
+    identity = youtube_identity(url)
+    parsed = urlparse(url)
+    if (
+        record["provider"] != "youtube"
+        or identity is None
+        or record["video_id"] != identity
+        or (parsed.path == "/watch" and len(parse_qs(parsed.query).get("v", [])) != 1)
+    ):
+        _refuse(label, "unsupported provider or URL/ID disagreement")
+    for field in ("title", "uploader"):
+        _text(record[field], f"{label}.{field}")
+    _date(record["upload_date"], f"{label}.upload_date")
+    duration = record["duration_seconds"]
+    if (
+        type(duration) not in {int, float}
+        or not 0 < duration <= 100000000
+        or not math.isfinite(duration)
+    ):
+        _refuse(label, "provider duration must be positive and finite")
+    _timestamp(record["captured_at"], f"{label}.captured_at")
+    return record
+
+
+def validate_alias_record(value: Any, *, label: str = "source_alias") -> None:
+    record = _shape(value, RECORD_FIELDS, label)
+    if (
+        type(record["schema_version"]) is not int
+        or record["schema_version"] != SOURCE_ALIAS_SCHEMA_VERSION
+    ):
+        _refuse(label, "unsupported source-alias schema version")
+    for field in ("talk_filename", "catalog_title", "reviewer"):
+        _text(record[field], f"{label}.{field}")
+    if (
+        record["source_type"] != "video"
+        or not isinstance(record["relationship"], str)
+        or record["relationship"] not in RELATIONSHIPS
+    ):
+        _refuse(label, "unsupported source lane or relationship")
+    if record["canonical_choice_reason"] is not None:
+        _text(record["canonical_choice_reason"], f"{label}.canonical_choice_reason")
+    _timestamp(record["verified_at"], f"{label}.verified_at")
+    alias = _provider(record["alias"], f"{label}.alias")
+    canonical = _provider(record["canonical"], f"{label}.canonical")
+    if alias["video_id"] == canonical["video_id"]:
+        _refuse(label, "an alias cannot name its own canonical identity")
+    event = _shape(
+        record["event"],
+        frozenset({"url", "conference", "date", "speakers"}),
+        f"{label}.event",
+    )
+    event_url = _url(event["url"], f"{label}.event.url")
+    if youtube_identity(event_url) in {alias["video_id"], canonical["video_id"]}:
+        _refuse(label, "event evidence must be independent of the two provider pages")
+    _text(event["conference"], f"{label}.event.conference")
+    _date(event["date"], f"{label}.event.date")
+    speakers = event["speakers"]
+    if not isinstance(speakers, list) or not speakers:
+        _refuse(label, "independent event evidence must identify the speakers")
+    for speaker in speakers:
+        _text(speaker, f"{label}.event.speakers")
+    if len(speakers) != len(set(speakers)):
+        _refuse(label, "event speakers must be unique")
+    comparison = _shape(
+        record["comparison"],
+        frozenset(
+            {
+                "method",
+                "summary",
+                "canonical_sha256",
+                "alias_sha256",
+                "agreement_basis_points",
+            }
+        ),
+        f"{label}.comparison",
+    )
+    if (
+        not isinstance(comparison["method"], str)
+        or comparison["method"] not in COMPARISON_METHODS
+    ):
+        _refuse(label, "equivalence requires recording, transcript, or artifact review")
+    _text(comparison["summary"], f"{label}.comparison.summary")
+    for field in ("canonical_sha256", "alias_sha256"):
+        digest = comparison[field]
+        if digest is None and comparison["method"] == "recording_review":
+            continue
+        if not isinstance(digest, str) or SHA256_RE.fullmatch(digest) is None:
+            _refuse(
+                label, "comparison artifact hashes must identify the reviewed bytes"
+            )
+    agreement = comparison["agreement_basis_points"]
+    if agreement is not None and (
+        type(agreement) is not int or not 0 <= agreement <= 10000
+    ):
+        _refuse(label, "agreement must be null or integer basis points")
+
+
+def active_identity(talk: Mapping[str, Any]) -> str | None:
+    identity = youtube_identity(talk.get("video_url"))
+    stored = talk.get("youtube_id")
+    if stored is not None and (
+        not isinstance(stored, str) or stored not in {"", identity}
+    ):
+        return None
+    return identity
+
+
+def validate_alias_database(database: Mapping[str, Any]) -> None:
+    """Validate shape, ownership, rejected overlap, and bounded acyclic lineage."""
+    records = database.get("source_aliases", [])
+    if not isinstance(records, list) or len(records) > MAX_ALIASES:
+        _refuse("source_aliases", "expected a bounded array")
+    if not records:
+        return
+    talks = {talk["filename"]: talk for talk in database["talks"]}
+    active_ids = {
+        identity
+        for talk in talks.values()
+        for identity in (
+            youtube_identity(talk.get("video_url")),
+            talk.get("youtube_id"),
+        )
+        if isinstance(identity, str) and identity
+    }
+    edges: dict[str, Mapping[str, Any]] = {}
+    for index, record in enumerate(records):
+        label = f"source_aliases[{index}]"
+        validate_alias_record(record, label=label)
+        filename = record["talk_filename"]
+        if filename not in talks:
+            _refuse(label, "alias names no canonical talk")
+        identity = _text(record["alias"]["video_id"], f"{label}.alias.video_id")
+        if identity in active_ids:
+            _refuse(label, "accepted alias overlaps an active canonical source")
+        if identity in edges:
+            _refuse(label, "duplicate alias ownership")
+        rejected = {
+            youtube_identity(rejection["url"])
+            for rejection in talks[filename].get("source_rejections", [])
+            if rejection["source_type"] == "video"
+        }
+        if identity in rejected or record["canonical"]["video_id"] in rejected:
+            _refuse(label, "accepted source overlaps the talk's rejection ledger")
+        edges[identity] = record
+    resolved: dict[str, str] = {}
+    for identity, record in edges.items():
+        filename = record["talk_filename"]
+        terminal = active_identity(talks[filename])
+        if terminal is None:
+            _refuse("source_aliases", "talk has no agreeing canonical URL/ID")
+        visited = {identity}
+        target = record["canonical"]["video_id"]
+        while target != terminal:
+            if resolved.get(target) == filename:
+                break
+            if target in visited:
+                _refuse("source_aliases", "alias lineage contains a cycle")
+            visited.add(target)
+            parent = edges.get(target)
+            if parent is None or parent["talk_filename"] != filename:
+                _refuse(
+                    "source_aliases",
+                    "alias lineage does not end at its talk's canonical source",
+                )
+            target = parent["canonical"]["video_id"]
+        for visited_identity in visited:
+            resolved[visited_identity] = filename
+
+
+def matched_alias(
+    database: Mapping[str, Any], talk: Mapping[str, Any], url: Any
+) -> Mapping[str, Any] | None:
+    """Look up only a reviewed identity; callers first validate the database."""
+    identity = youtube_identity(url)
+    if identity is None:
+        return None
+    return next(
+        (
+            record
+            for record in database.get("source_aliases", [])
+            if record["talk_filename"] == talk.get("filename")
+            and record["alias"]["video_id"] == identity
+        ),
+        None,
+    )

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -28,6 +28,7 @@ from pptx_discovery_contract import (
     validate_pptx_directory_exclusions,
 )
 from pptx_talk_identity import unassessed_legacy_binding
+from source_alias_contract import SourceAliasError, validate_alias_database
 
 
 LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
@@ -36,7 +37,8 @@ LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
 # does not version its parent database, so admitting the collection moves the
 # root generation (`stateful-artifacts` Migration Policy).
 PRE_MARKDOWN_DECKS_TRACKING_DATABASE_SCHEMA_VERSION = 1
-TRACKING_DATABASE_SCHEMA_VERSION = 2
+PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION = 2
+TRACKING_DATABASE_SCHEMA_VERSION = 3
 LEGACY_TALK_RECORD_SCHEMA_VERSION = 1
 FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION = 5
 # The generation before the owner-reviewed title-equivalence ledger (#333).
@@ -79,6 +81,7 @@ READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS = frozenset(
     {
         LEGACY_TRACKING_DATABASE_SCHEMA_VERSION,
         PRE_MARKDOWN_DECKS_TRACKING_DATABASE_SCHEMA_VERSION,
+        PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
         TRACKING_DATABASE_SCHEMA_VERSION,
     }
 )
@@ -1348,7 +1351,12 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
         )
 
     current = root_version == TRACKING_DATABASE_SCHEMA_VERSION
-    if current and "config" not in database:
+    # Root v2 already required explicit child versions and complete collections.
+    # Admitting it as a rollout reader must not loosen those existing gates.
+    explicit_records = (
+        root_version >= PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION
+    )
+    if explicit_records and "config" not in database:
         raise TrackingDatabaseError(
             f"tracking database schema v{TRACKING_DATABASE_SCHEMA_VERSION} "
             "requires a 'config' object"
@@ -1357,12 +1365,14 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
     if not isinstance(config, Mapping):
         raise TrackingDatabaseError("tracking database 'config' must be an object")
     collections = {
-        key: _object_collection(database, key, required=current or key == "talks")
+        key: _object_collection(
+            database, key, required=explicit_records or key == "talks"
+        )
         for key in _TOP_LEVEL_COLLECTIONS
     }
 
     reasons: list[str] = []
-    if current and "schema_version" not in config:
+    if explicit_records and "schema_version" not in config:
         reasons.append("config_schema_version_missing")
     config_version = _record_version(
         config,
@@ -1409,7 +1419,7 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
             records,
             label=key,
             accepted_versions=accepted_versions_by_collection[key],
-            require_explicit=current,
+            require_explicit=explicit_records,
             missing_version=(
                 LEGACY_TALK_RECORD_SCHEMA_VERSION
                 if key == "talks"
@@ -1469,7 +1479,7 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
         for rejection_index, rejection in enumerate(rejections):
             if not isinstance(rejection, Mapping):
                 continue
-            if current and "schema_version" not in rejection:
+            if explicit_records and "schema_version" not in rejection:
                 reasons.append("source_rejections_schema_version_missing")
                 break
             rejection_version = _record_version(
@@ -1618,6 +1628,11 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
                 f"{talk_filename!r}; a talk has one authored deck source"
             )
         claimed_by_talk.add(talk_filename)
+
+    try:
+        validate_alias_database(database)
+    except SourceAliasError as exc:
+        raise TrackingDatabaseError(str(exc)) from exc
 
     try:
         # Assessment intentionally admits claim/status drift so schema-0 queue
@@ -1872,7 +1887,7 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
     """Explicit, preservation-only repair of unstamped legacy QR records.
 
     Ordinary readers/migration remain closed on missing child versions. This
-    opt-in owner operation accepts only a current root/config whose sole version
+    opt-in owner operation accepts root v2/v3 with current config whose sole version
     defect is a missing QR stamp. Every unstamped record must satisfy the exact
     legacy-v1 shape before stamping; v2 artifact receipts are never invented or
     inferred. The complete candidate must validate before it is returned. No
@@ -1893,7 +1908,11 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
         ) from exc
     if (
         not isinstance(database, dict)
-        or assessment.schema_version != TRACKING_DATABASE_SCHEMA_VERSION
+        or assessment.schema_version
+        not in {
+            PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
+            TRACKING_DATABASE_SCHEMA_VERSION,
+        }
         or (
             not assessment.usable
             and assessment.reason_codes != ("qr_codes_schema_version_missing",)
@@ -1926,7 +1945,14 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
         record["schema_version"] = LEGACY_QR_CODE_RECORD_SCHEMA_VERSION
         counts["qr_codes"] += 1
     try:
-        require_current_tracking_database(candidate)
+        repaired = assess_tracking_database(candidate)
+        if (
+            not repaired.usable
+            or candidate["config"]["schema_version"] != CONFIG_RECORD_SCHEMA_VERSION
+        ):
+            raise TrackingDatabaseError(
+                "QR repair candidate must retain validated current config"
+            )
     except TrackingDatabaseError as exc:
         raise TrackingDatabaseRepairError(
             "qr_repair_candidate_invalid", {"stage": "complete_owner_validation"}
@@ -1934,14 +1960,14 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
     return TrackingDatabaseMigration(
         database=candidate,
         changed=bool(counts["qr_codes"]),
-        from_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
-        to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+        from_schema_version=assessment.schema_version,
+        to_schema_version=assessment.schema_version,
         record_counts=counts,
     )
 
 
 def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
-    """Build the deterministic owner migration to root v2/config v2."""
+    """Build the deterministic owner migration to root v3/config v2."""
     assessment = assess_tracking_database(database)
     if not assessment.usable:
         raise TrackingDatabaseError(

--- a/skills/vault-profile/references/profile-construction-rules.md
+++ b/skills/vault-profile/references/profile-construction-rules.md
@@ -43,7 +43,9 @@ repair any field in that stamp during profile assembly.
 extractor cohort for pacing-sensitive analysis. Instrumentation membership never
 confers pattern-baseline eligibility.
 
-Legacy database schemas 0 and 1 and current schema 2 are read-only inputs. An unsupported
+The readable database generations in the
+[owner compatibility contract](../../vault-ingress/references/schemas-db.md#schema-versioning)
+are read-only inputs. An unsupported
 future database or record schema has no usable prior state. Compatibility stays
 internal, adds no payload fields, and never migrates the database.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ DEFAULT_PPTX_DIRECTORY_EXCLUSIONS = [
 # The owner-current root generation, in one place. A fixture that pins it by
 # literal has to be hunted down on every root bump, and the ones that were
 # missed failed as "assert 2 == 1" with nothing naming the generation.
-CURRENT_ROOT_SCHEMA_VERSION = 2
+CURRENT_ROOT_SCHEMA_VERSION = 3
 
 
 def current_tracking_config(**updates: object) -> dict[str, object]:

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -15,7 +15,7 @@ def write_json(path, value):
 
 def base_database():
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "config": current_tracking_config(),
         "talks": [
             {

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -22,7 +22,7 @@ from conftest import (
 
 def _current_tracking_database():
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -64,7 +64,7 @@ def _write_json(path: Path, value: object) -> None:
 
 def _base_database() -> dict[str, Any]:
     return {
-        "schema_version": 2,
+        "schema_version": CURRENT_ROOT,
         "config": _current_config(),
         "talks": [
             {

--- a/tests/test_persist_results.py
+++ b/tests/test_persist_results.py
@@ -17,7 +17,11 @@ import pytest
 from pypdf import PdfWriter
 from pptx import Presentation
 
-from conftest import current_tracking_config, video_source_receipt_for
+from conftest import (
+    CURRENT_ROOT_SCHEMA_VERSION,
+    current_tracking_config,
+    video_source_receipt_for,
+)
 
 
 def test_atomic_json_write_cleans_stage_and_propagates_interrupt(
@@ -199,7 +203,7 @@ def _write_tiny_mp4(path):
 
 def _db_json(database):
     """Render a current tracking database around one test's talk fixtures."""
-    database["schema_version"] = 2
+    database["schema_version"] = CURRENT_ROOT_SCHEMA_VERSION
     config = database.setdefault("config", {})
     if isinstance(config, dict):
         existing = dict(config)

--- a/tests/test_persisted_observation_migration_gate.py
+++ b/tests/test_persisted_observation_migration_gate.py
@@ -19,7 +19,7 @@ def gate(migrate_tracking_database):
 
 def _database(talk: dict) -> dict:
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "config": {"schema_version": 2, "pptx_directory_exclusions": []},
         "talks": [talk],
         "pptx_catalog": [],

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -379,7 +379,7 @@ def test_a_non_integer_record_version_is_rejected(tracking_database) -> None:
 
 def _database(records: list[dict]) -> dict:
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "config": {"schema_version": 2, "pptx_directory_exclusions": []},
         "talks": [],
         "pptx_catalog": records,

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -142,7 +142,7 @@ def write_database(fixture, talks, config=None, *, current=False, equivalences=N
     if current:
         database.update(
             {
-                "schema_version": 2,
+                "schema_version": 3,
                 "pptx_catalog": [],
                 "qr_codes": [],
                 "resources": [],

--- a/tests/test_queue_state.py
+++ b/tests/test_queue_state.py
@@ -24,7 +24,7 @@ from pptx import Presentation
 from pptx.util import Inches
 from pypdf import PdfWriter
 
-from conftest import current_tracking_config
+from conftest import CURRENT_ROOT_SCHEMA_VERSION, current_tracking_config
 
 
 SCRIPT = (
@@ -360,7 +360,7 @@ def _write_db(tmp_path, talks, *, config=None, current=True):
         "improvement_goals": [],
     }
     if current:
-        database["schema_version"] = 2
+        database["schema_version"] = CURRENT_ROOT_SCHEMA_VERSION
         database["config"] = current_tracking_config(**database["config"])
     else:
         for talk in talks:

--- a/tests/test_render_vault_status.py
+++ b/tests/test_render_vault_status.py
@@ -69,7 +69,7 @@ def _database(talks: list[dict], **config_extra) -> dict:
     config = {"schema_version": 2, "pptx_directory_exclusions": []}
     config.update(config_extra)
     return {
-        "schema_version": 2,
+        "schema_version": CURRENT_ROOT,
         "config": config,
         "talks": talks,
         "pptx_catalog": [],

--- a/tests/test_scan_shownotes.py
+++ b/tests/test_scan_shownotes.py
@@ -11,7 +11,7 @@ import sys
 
 import pytest
 
-from conftest import current_tracking_config
+from conftest import CURRENT_ROOT_SCHEMA_VERSION, current_tracking_config
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -73,7 +73,7 @@ def _database_path(
             ]
             current_talks.append(current_talk)
         database = {
-            "schema_version": 2,
+            "schema_version": CURRENT_ROOT_SCHEMA_VERSION,
             "config": current_tracking_config(**config),
             "talks": current_talks,
             "pptx_catalog": [],

--- a/tests/test_source_alias_contract.py
+++ b/tests/test_source_alias_contract.py
@@ -1,0 +1,558 @@
+"""Synthetic owner, scanner, and read-only regressions for source aliases."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib
+import json
+
+import pytest
+
+from conftest import CURRENT_ROOT_SCHEMA_VERSION, current_tracking_config
+
+
+# Public identity pairs from #231; all metadata and comparison hashes below are
+# synthetic fixtures, not a claim that this suite fetched or verified a video.
+PAIRS = [
+    ("76NjQxjKCAQ", "FzDYQ3SIKEc", 9750),
+    ("SNMrlOxbI7k", "WKWFKEmfpmc", 9760),
+    ("blLFf6iY2IA", "TYLVt9ZAI2M", 9870),
+    ("P34QBbvLXjU", "sGZRDP533Nc", 9180),
+]
+MISSING = {"$missing": True}
+
+
+def _provider(identity):
+    return {
+        "provider": "youtube",
+        "video_id": identity,
+        "url": f"https://youtu.be/{identity}",
+        "title": "Synthetic delivery",
+        "uploader": "Synthetic event channel",
+        "upload_date": "2026-01-02",
+        "duration_seconds": 2700,
+        "captured_at": "2026-02-01T12:00:00Z",
+    }
+
+
+def _record(pair=PAIRS[0], **updates):
+    canonical, alias, agreement = pair
+    record = {
+        "schema_version": 1,
+        "talk_filename": "talk.md",
+        "catalog_title": "Synthetic delivery",
+        "source_type": "video",
+        "alias": _provider(alias),
+        "canonical": _provider(canonical),
+        "relationship": "valid_duplicate",
+        "event": {
+            "url": "https://event.example/program/session",
+            "conference": "TestConf",
+            "date": "2026-01-01",
+            "speakers": ["Synthetic Speaker"],
+        },
+        "comparison": {
+            "method": "transcript",
+            "summary": "Synthetic matching interior recording sequence",
+            "canonical_sha256": "a" * 64,
+            "alias_sha256": "b" * 64,
+            "agreement_basis_points": agreement,
+        },
+        "reviewer": "Synthetic owner",
+        "verified_at": "2026-02-01T14:00:00+01:00",
+        "canonical_choice_reason": "The event upload retains the complete Q&A",
+    }
+    record.update(updates)
+    return record
+
+
+def _database(record=None):
+    record = record or _record()
+    return {
+        "schema_version": CURRENT_ROOT_SCHEMA_VERSION,
+        "config": current_tracking_config(),
+        "talks": [
+            {
+                "schema_version": 1,
+                "filename": "talk.md",
+                "title": record["catalog_title"],
+                "conference": record["event"]["conference"],
+                "date": record["event"]["date"],
+                "status": "pending",
+                "video_url": record["canonical"]["url"],
+                "youtube_id": record["canonical"]["video_id"],
+            }
+        ],
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+
+
+def _mutation(database, record):
+    talk = database["talks"][0]
+    return {
+        "kind": "record_source_alias",
+        "record": record,
+        "expect": {
+            "video_url": talk.get("video_url", MISSING),
+            "youtube_id": talk.get("youtube_id", MISSING),
+            "source_rejections": talk.get("source_rejections", MISSING),
+            "source_aliases": database.get("source_aliases", MISSING),
+        },
+    }
+
+
+def _write(path, value):
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize("pair", PAIRS)
+def test_owner_acceptance_preserves_canonical_and_all_talk_state(
+    mutate_tracking_database, tracking_database, pair
+):
+    record = _record(pair)
+    database = _database(record)
+    before = copy.deepcopy(database)
+    candidate, changes = mutate_tracking_database.build_candidate(
+        database, [_mutation(database, record)]
+    )
+    assert candidate == {**before, "source_aliases": [record]}
+    assert database == before
+    assert len(changes) == 1
+    assert tracking_database.assess_tracking_database(candidate).state == "current"
+    again, changes = mutate_tracking_database.build_candidate(
+        candidate, [_mutation(candidate, record)]
+    )
+    assert again == candidate
+    assert changes == []
+
+
+@pytest.mark.parametrize("pair", PAIRS)
+@pytest.mark.parametrize("stored_id", [True, False])
+def test_scanner_resolves_alias_url_and_id_without_any_write(
+    mutate_tracking_database, scan_shownotes_module, tmp_path, pair, stored_id
+):
+    record = _record(pair)
+    database = _database(record)
+    if not stored_id:
+        database["talks"][0].pop("youtube_id")
+    site = tmp_path / "shownotes"
+    notes = site / "_talks"
+    notes.mkdir(parents=True)
+    database["config"]["shownotes"] = {
+        "enabled": True,
+        "source": {
+            "type": "local_jekyll",
+            "path_or_url": str(site),
+            "talks_subdir": "_talks",
+        },
+    }
+    database, _ = mutate_tracking_database.build_candidate(
+        database, [_mutation(database, record)]
+    )
+    (notes / "talk.md").write_text(
+        "---\nlayout: talk\n---\n# Synthetic delivery\n**Conference:** TestConf\n"
+        f"**Date:** 2026-01-01\n**Video:** [Watch](https://www.youtube.com/watch?v={record['alias']['video_id']})\n",
+        encoding="utf-8",
+    )
+    path = tmp_path / "tracking-database.json"
+    _write(path, database)
+    original = path.read_bytes()
+    report = scan_shownotes_module.execute(path, apply_requested=True)
+    assert report["entries"][0]["disposition"] == "unchanged"
+    assert report["entries"][0]["issues"] == []
+    assert report["mutation_count"] == 0
+    assert not report["database_written"]
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 2),
+        ("schema_version", 1.0),
+        ("relationship", "wrong_delivery"),
+        ("relationship", []),
+        ("source_type", "slides"),
+        ("reviewer", ""),
+        ("verified_at", "2026-02-01T14:00:00"),
+        ("verified_at", "20260201T14:00:00Z"),
+        ("verified_at", "2026-W05-7T14:00:00Z"),
+        ("comparison", {}),
+        ("event", {}),
+        ("canonical_choice_reason", ""),
+    ],
+)
+def test_closed_record_failures_never_modify_input(tracking_database, field, value):
+    record = _record(**{field: value})
+    database = _database()
+    database["source_aliases"] = [record]
+    before = copy.deepcopy(database)
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+    assert database == before
+
+
+@pytest.mark.parametrize(
+    "side,field,value",
+    [
+        ("alias", "video_id", "WrongVideo1"),
+        ("canonical", "provider", "unknown"),
+        ("alias", "url", "https://youtube.com/watch?v=FzDYQ3SIKEc&v=WrongVideo1"),
+        ("alias", "duration_seconds", True),
+        ("canonical", "duration_seconds", 10**400),
+        ("comparison", "method", "title_similarity"),
+        ("comparison", "method", []),
+        ("comparison", "alias_sha256", None),
+        ("comparison", "agreement_basis_points", True),
+        ("event", "url", "https://youtu.be/FzDYQ3SIKEc"),
+        ("event", "speakers", []),
+    ],
+)
+def test_provider_and_independent_evidence_are_required(
+    tracking_database, side, field, value
+):
+    database = _database()
+    record = _record()
+    record[side][field] = value
+    database["source_aliases"] = [record]
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "canonical",
+        "date",
+        "title",
+        "rejected",
+        "cross_talk",
+        "active_overlap",
+        "cycle",
+        "future",
+    ],
+)
+def test_conflicts_fail_closed_before_owner_write(mutate_tracking_database, change):
+    record = _record()
+    database = _database(record)
+    if change == "canonical":
+        record["canonical"] = _provider(PAIRS[1][0])
+    elif change == "date":
+        record["event"]["date"] = "2025-01-01"
+    elif change == "title":
+        record["catalog_title"] = "A different delivery"
+    elif change == "rejected":
+        database["talks"][0]["source_rejections"] = [
+            {
+                "schema_version": 1,
+                "source_type": "video",
+                "url": record["alias"]["url"],
+                "reason": "wrong_delivery",
+                "evidence": "Independent program identifies a different talk",
+                "verified_at": "2026-02-01T12:00:00Z",
+            }
+        ]
+    elif change in {"cross_talk", "active_overlap"}:
+        other = copy.deepcopy(database["talks"][0])
+        other["filename"] = "unrelated.md"
+        other["youtube_id"] = (
+            record["alias"]["video_id"] if change == "active_overlap" else PAIRS[1][0]
+        )
+        other["video_url"] = f"https://youtu.be/{other['youtube_id']}"
+        database["talks"].append(other)
+        if change == "cross_talk":
+            prior = copy.deepcopy(record)
+            prior["talk_filename"] = "unrelated.md"
+            prior["canonical"] = _provider(PAIRS[1][0])
+            database["source_aliases"] = [prior]
+    elif change == "cycle":
+        first = _record()
+        second = _record(PAIRS[1])
+        first["canonical"] = copy.deepcopy(second["alias"])
+        second["canonical"] = copy.deepcopy(first["alias"])
+        database["source_aliases"] = [first, second]
+    else:
+        database["source_aliases"] = [_record(schema_version=999)]
+    before = copy.deepcopy(database)
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database, [_mutation(database, record)]
+        )
+    assert database == before
+
+
+def test_alias_apply_binds_input_and_reviewed_candidate(
+    mutate_tracking_database, tmp_path
+):
+    record = _record()
+    database = _database(record)
+    path = tmp_path / "tracking-database.json"
+    plan = tmp_path / "alias-plan.json"
+    _write(path, database)
+    original = path.read_bytes()
+    payload = {"schema_version": 1, "mutations": [_mutation(database, record)]}
+    _write(plan, payload)
+    preview = mutate_tracking_database.execute(
+        path, plan, apply=False, expected_sha256=None
+    )
+    assert path.read_bytes() == original
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="expected-output-sha256",
+    ):
+        mutate_tracking_database.execute(
+            path, plan, apply=True, expected_sha256=preview["input_sha256"]
+        )
+    payload["mutations"][0]["record"]["reviewer"] = "Different reviewer after review"
+    _write(plan, payload)
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="candidate output"
+    ):
+        mutate_tracking_database.execute(
+            path,
+            plan,
+            apply=True,
+            expected_sha256=preview["input_sha256"],
+            expected_output_sha256=preview["output_sha256"],
+        )
+    assert path.read_bytes() == original
+    payload["mutations"][0]["record"]["reviewer"] = _record()["reviewer"]
+    _write(plan, payload)
+    result = mutate_tracking_database.execute(
+        path,
+        plan,
+        apply=True,
+        expected_sha256=preview["input_sha256"],
+        expected_output_sha256=preview["output_sha256"],
+    )
+    assert result["database_written"]
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == preview["output_sha256"]
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="input sha256"
+    ):
+        mutate_tracking_database.execute(
+            path,
+            plan,
+            apply=True,
+            expected_sha256=preview["input_sha256"],
+            expected_output_sha256=preview["output_sha256"],
+        )
+
+
+def test_v2_rollout_read_and_owner_migration_preserve_values(tracking_database):
+    database = _database()
+    database["schema_version"] = 2
+    before = copy.deepcopy(database)
+    assert tracking_database.assess_tracking_database(database).state == "legacy"
+    result = tracking_database.migrate_tracking_database(database)
+    assert result.database == {**before, "schema_version": CURRENT_ROOT_SCHEMA_VERSION}
+    assert result.from_schema_version == 2
+    assert not any(result.record_counts.values())
+    assert database == before
+
+
+@pytest.mark.parametrize("root", [2, 3])
+def test_qr_only_repair_retains_root_and_active_claims(tracking_database, root):
+    from test_tracking_database_schema import _qr_repair_with_active_claim
+
+    database = _qr_repair_with_active_claim(tracking_database, 7)
+    database["schema_version"] = root
+    before = copy.deepcopy(database)
+    assert not tracking_database.assess_tracking_database(database).usable
+    result = tracking_database.repair_missing_qr_schema_versions(database)
+    expected = copy.deepcopy(before)
+    expected["qr_codes"][0]["schema_version"] = 1
+    assert result.database == expected
+    assert result.from_schema_version == result.to_schema_version == root
+    assert database == before
+
+
+def test_preflight_and_reader_refuse_future_alias_without_rewrite(
+    preflight_vault, read_tracking_database, tmp_path, capsys
+):
+    database = _database()
+    database["source_aliases"] = [_record(schema_version=999)]
+    path = tmp_path / "tracking-database.json"
+    _write(path, database)
+    original = path.read_bytes()
+    assert preflight_vault.main([str(tmp_path)]) == 1
+    assert json.loads(capsys.readouterr().out)["blocking_count"] >= 1
+    assert read_tracking_database.main([str(path)]) == 2
+    assert "database" not in json.loads(capsys.readouterr().out)
+    assert path.read_bytes() == original
+
+
+def test_alias_record_is_not_a_source_capability(tracking_database):
+    database = _database()
+    contract = importlib.import_module("ingress_contract")
+    assert not contract.has_video_source({"source_aliases": [_record()]})
+    database["talks"][0].pop("video_url")
+    database["talks"][0].pop("youtube_id")
+    database["source_aliases"] = [_record()]
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="no agreeing canonical"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize(
+    "relationship", ["valid_duplicate", "mirror", "superseded_by_official_upload"]
+)
+def test_closed_relationships_preserve_valid_alternates(
+    mutate_tracking_database, relationship
+):
+    record = _record(relationship=relationship)
+    database = _database(record)
+    result, _ = mutate_tracking_database.build_candidate(
+        database, [_mutation(database, record)]
+    )
+    assert result["source_aliases"] == [record]
+    assert result["talks"] == database["talks"]
+
+
+def test_alias_approval_refuses_an_active_claim(
+    mutate_tracking_database, tracking_database
+):
+    from test_tracking_database_schema import _qr_repair_with_active_claim
+
+    database = tracking_database.repair_missing_qr_schema_versions(
+        _qr_repair_with_active_claim(tracking_database, 7)
+    ).database
+    record = _record(talk_filename=database["talks"][0]["filename"])
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="active claim"
+    ):
+        mutate_tracking_database.build_candidate(
+            database, [_mutation(database, record)]
+        )
+
+
+def test_unrelated_writers_and_profile_preserve_alias_values(
+    mutate_tracking_database,
+    apply_source_repairs,
+    queue_state,
+    persist_results,
+    tracking_database_io,
+    validate_profile,
+    tmp_path,
+):
+    record = _record()
+    database = _database(record)
+    database["talks"][0]["status"] = "processed_partial"
+    database["talks"][0]["processed_date"] = "2026-01-03"
+    database["talks"][0]["rhetoric_notes"] = "Historical delivery notes"
+    path = tmp_path / "tracking-database.json"
+    _write(path, database)
+    profile = {
+        "pattern_profile": {"pattern_baseline": {"as_of": "2026-02-02T12:00:00Z"}}
+    }
+    before = validate_profile._load_live_pattern_snapshot(tmp_path, profile)
+    database, _ = mutate_tracking_database.build_candidate(
+        database, [_mutation(database, record)]
+    )
+    _write(path, database)
+    assert validate_profile._load_live_pattern_snapshot(tmp_path, profile) == before
+    ledger_bytes = json.dumps(database["source_aliases"], ensure_ascii=False).encode()
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database,
+        [
+            {
+                "kind": "set_config",
+                "path": ["speaker_name"],
+                "expect": MISSING,
+                "value": "Synthetic Speaker",
+            }
+        ],
+    )
+    candidate, _ = apply_source_repairs.build_repaired_database(
+        candidate,
+        [
+            {
+                "filename": "talk.md",
+                "reason": "Explicit queue transition unrelated to alias identity",
+                "expect": {"status": "processed_partial"},
+                "set": {"status": "needs-reprocessing"},
+            }
+        ],
+    )
+    snapshot = tracking_database_io.snapshot_tracking_database(path)
+    queue_state.write_database_atomically(path, candidate, expected_snapshot=snapshot)
+    loaded, snapshot = persist_results.load_tracking_database(path)
+    assert (
+        json.dumps(loaded["source_aliases"], ensure_ascii=False).encode()
+        == ledger_bytes
+    )
+    loaded["talks"][0]["rhetoric_notes"] = "Updated synthetic analysis"
+    persist_results.atomic_write_json(path, loaded, expected_snapshot=snapshot)
+    stored = tracking_database_io.decode_json_object(
+        tracking_database_io.snapshot_tracking_database(path)
+    )
+    assert (
+        json.dumps(stored["source_aliases"], ensure_ascii=False).encode()
+        == ledger_bytes
+    )
+
+
+def test_scanner_cannot_import_another_talk_with_an_accepted_alias(
+    mutate_tracking_database,
+    scan_shownotes_module,
+    tmp_path,
+):
+    record = _record()
+    database = _database(record)
+    site = tmp_path / "notes"
+    talks = site / "_talks"
+    talks.mkdir(parents=True)
+    (talks / "unrelated.md").write_text(
+        "---\nlayout: talk\n---\n# Unrelated delivery\n**Conference:** ElseConf\n"
+        f"**Date:** 2026-01-02\n**Video:** [Watch]({record['alias']['url']})\n",
+        encoding="utf-8",
+    )
+    database["config"]["shownotes"] = {
+        "enabled": True,
+        "source": {
+            "type": "local_jekyll",
+            "path_or_url": str(site),
+            "talks_subdir": "_talks",
+        },
+    }
+    database, _ = mutate_tracking_database.build_candidate(
+        database, [_mutation(database, record)]
+    )
+    path = tmp_path / "tracking-database.json"
+    _write(path, database)
+    original = path.read_bytes()
+    with pytest.raises(
+        scan_shownotes_module.ShownotesScanError, match="overlaps an active canonical"
+    ):
+        scan_shownotes_module.execute(path, apply_requested=True)
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("expected", [None, [], {"video_url": None}])
+def test_incomplete_expectations_are_closed(mutate_tracking_database, expected):
+    database = _database()
+    mutation = _mutation(database, _record())
+    mutation["expect"] = expected
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(database, [mutation])
+
+
+@pytest.mark.parametrize("value", ["20260101", "2026-W01-4", "2026-02-30"])
+@pytest.mark.parametrize("side,field", [("event", "date"), ("alias", "upload_date")])
+def test_calendar_dates_have_one_portable_valid_spelling(
+    tracking_database, value, side, field
+):
+    record = _record()
+    record[side][field] = value
+    database = _database()
+    database["source_aliases"] = [record]
+    with pytest.raises(tracking_database.TrackingDatabaseError, match="calendar date"):
+        tracking_database.assess_tracking_database(database)

--- a/tests/test_source_alias_contract.py
+++ b/tests/test_source_alias_contract.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import importlib
 import json
+from pathlib import Path
 
 import pytest
 
@@ -556,3 +557,59 @@ def test_calendar_dates_have_one_portable_valid_spelling(
     database["source_aliases"] = [record]
     with pytest.raises(tracking_database.TrackingDatabaseError, match="calendar date"):
         tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("value", ["typo", "A" * 64, "f" * 63, "missing"])
+def test_invalid_candidate_digest_names_its_own_flag(
+    mutate_tracking_database, tmp_path, value
+):
+    database = _database()
+    path = tmp_path / "tracking-database.json"
+    plan = tmp_path / "alias-plan.json"
+    _write(path, database)
+    original = path.read_bytes()
+    _write(plan, {"schema_version": 1, "mutations": [_mutation(database, _record())]})
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="--expected-output-sha256",
+    ) as error:
+        mutate_tracking_database.execute(
+            path,
+            plan,
+            apply=True,
+            expected_sha256=hashlib.sha256(original).hexdigest(),
+            expected_output_sha256=value,
+        )
+    assert "--expected-sha256" not in str(error.value)
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "vault-clarification/SKILL.md",
+        "presentation-creator/SKILL.md",
+        "presentation-creator/references/phase7-post-event.md",
+        "illustrations/references/thumbnails.md",
+        "vault-ingress/references/bootstrap-and-preflight.md",
+        "vault-ingress/references/batch-persistence.md",
+        "vault-profile/references/profile-construction-rules.md",
+    ],
+)
+def test_catalog_rollout_consumers_reference_owner_schema(relative):
+    root = Path(__file__).resolve().parents[1]
+    document = (root / "skills" / relative).read_text(encoding="utf-8")
+    assert "schemas-db.md#schema-versioning" in document
+    for obsolete in (
+        "database schema 2",
+        "database schema v2",
+        "current schema 2",
+        "writes require schema 2",
+        "schemas 0 and 1",
+        "schema 0 or 1",
+    ):
+        assert obsolete not in document
+    owner = (root / "skills/vault-ingress/references/schemas-db.md").read_text(
+        encoding="utf-8"
+    )
+    assert "### Schema versioning" in owner

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -78,7 +78,7 @@ def catalog_row(pptx_path: str, talk_filename: str | None, **overrides: Any) -> 
 def database(rows: list[dict], talks: list[dict], source_root: Path) -> dict:
     """One owner-current database whose only interesting part is the catalog."""
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "config": {
             "schema_version": 2,
             "pptx_directory_exclusions": [],

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -21,7 +21,7 @@ def _write(path: Path, value: object) -> bytes:
 
 def _current_database() -> dict[str, object]:
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -330,7 +330,7 @@ def _write_tracking_db(
     path.write_text(
         json.dumps(
             {
-                "schema_version": 2,
+                "schema_version": 3,
                 "config": current_tracking_config(),
                 "talks": talks,
                 "pptx_catalog": [],


### PR DESCRIPTION
## Summary

- Add a closed, independently versioned owner ledger for reviewed inactive YouTube uploads. Retain canonical identity, independent event evidence, provider facts, comparison hashes, reviewer, timestamp, and canonical-choice rationale without granting analysis trust.
- Bind the append to exact canonical/ledger expectations and both input and candidate SHA-256 values. Reject future schemas, rejection/canonical overlap, cross-talk alias ownership, cycles, and dangling lineage. Preserve the canonical URL and ID during shownotes reconciliation, and validate scan candidates before import.
- Advance the database root to v3 with read-only rollout support for roots 0–2 and preserved v2 strictness. Keep the QR-only repair available on roots v2 and v3 with active claims untouched. Existing talk schemas do not advance for alias registration.

This is the inactive-alias foundation for #175. The atomic canonical-promotion/superseded-history transition remains tracked there. This PR changes no live vault data and runs no reparse or claim recovery. Normal live root migration remains gated on active writers finishing.

## Test plan

- [x] 65 synthetic alias regressions, including all four public identity pairs documented in #231, exact scanner non-mutation, absent canonical-ID preservation, closed schemas, portable calendar-date/timestamp forms, independent evidence requirements, stale plan/input refusal, active-claim refusal, cross-talk import refusal, QR v2/v3 recovery, profile freshness, and writer preservation.
- [x] Complete regression suite: 6,821 passed, 8 skipped in 237.68 seconds.
- [x] Ruff lint/format (436 files), Pyright, package contents (315 files), shipped-extension mirrors, entrypoints, conflict markers (568 files), floating-policy pins, and plugin lint.
- [x] Required final skill quality review: vault-ingress 96; presentation-creator 95. Complete review bodies read; cross-skill/deeper-link warnings checked against the full package. Existing schema/claim gate prose remains intact; optional editorial shortening is outside this alias change.
- [x] Self-audit: shared transactional boundary; strict version ownership and legacy read-only rollout; no guessed equivalence or analysis evidence; no CI edits or dependency changes; no new catch-all exception boundary.

Patch version is assigned by the publish workflow. The unheaded changelog entry is intentionally stamped by its `stamp-changelog: true` contract.
