### PR TITLE
feat(vault-ingress): Preserve superseded source history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Preserve superseded sources during reviewed official-upload promotion
+
+Complete the canonical replacement path in #175 with a single hash-bound owner
+transition. Preserve the original identity, provider evidence, and any earlier
+alias judgment in versioned inactive history; keep unrelated edges and artifacts
+unchanged. Requeue the talk without relabeling old analysis or receipts as the new
+upload's evidence. Reject active claims, stale plans, cross-talk ownership,
+rejection collisions, future history schemas, and excessive history depth.
+Also correct the readable-root missing-config diagnostic identified in PR #404.
+
 ## 0.20.123 — 2026-09-05
 
 ### Preserve reviewed inactive recording aliases

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -64,7 +64,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/markdown-decks.md](references/markdown-decks.md) | Slidev/presenterm/Marp/reveal-md decks — render lanes, register-and-requeue, reveal structure |
 | [references/source-identity-preflight.md](references/source-identity-preflight.md) | Offline identity, duplicate-source, enum, and artifact integrity contracts |
 | [references/source-identity-audit.md](references/source-identity-audit.md) | Networked, read-only capture of live provider identity evidence and review findings |
-| [references/source-aliases.md](references/source-aliases.md) | Owner-reviewed inactive recording aliases; evidence review, hash-bound append, and scan verification |
+| [references/source-aliases.md](references/source-aliases.md) | Owner-reviewed recording aliases; hash-bound append, official-upload promotion, superseded history, and scan verification |
 | [references/catalog-feedback-intake.md](references/catalog-feedback-intake.md) | Five-lane catalog-feedback schema, polarity, recurrence, and review contract |
 | [references/pattern-catalog-contract.md](references/pattern-catalog-contract.md) | Read-only catalog graph, polarity, source-gate, and semantic-debt contract |
 | [references/processing-rules.md](references/processing-rules.md) | Language policy, pattern migration logic, structured field rules |

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -187,7 +187,7 @@ no-op.
 | confirmed intent | 1 |
 | source rejection | 1 |
 | source title equivalence | 2 (own top-level collection; v1 nested entries are migrated) |
-| accepted source alias | 1 (optional top-level collection; never inferred by migration) |
+| accepted source alias | 1 (inactive decision), 2 (owner-built promotion history); never inferred by migration |
 | improvement goal | 2 (schema 1 remains readable historical state) |
 
 | Component | Access | Contract |
@@ -607,6 +607,7 @@ exact-type rule. The supported mutation kinds are:
 | `apply_reviewed_metadata` | Install one human-reviewed shownotes catalog-conflict decision on one exact talk filename, over a closed identity field set, with `expect` covering exactly the same fields |
 | `record_source_title_equivalence` | Append one owner-reviewed provider-title equivalence to one exact talk filename; append-only and refuses a duplicate |
 | `record_source_alias` | Append a reviewed inactive YouTube identity; exact canonical/ledger expectations and both input/output hashes bind apply; see [source-aliases.md](source-aliases.md) |
+| `promote_source_alias` | Sole mutation for an owner-reviewed official-upload switch; expect the complete talk and alias ledger, require both hashes, preserve superseded identity/history, and requeue without relabeling existing evidence; see [source-aliases.md](source-aliases.md#atomic-official-upload-promotion) |
 | `record_markdown_deck` | Register (or re-point) the markdown file one exact talk's deck was authored in, with `expect` naming the currently registered `deck_source_path` or the missing marker; upsert, one deck per talk |
 | `update_talk_publishing` | Set supported publishing fields on one exact talk filename, with `expect` covering exactly the same fields |
 | `update_talk_clarification` | Set complete object/array `blind_spot_observations` or `humor_postmortem` values on one exact talk, with matching field expectations |

--- a/skills/vault-ingress/references/source-aliases.md
+++ b/skills/vault-ingress/references/source-aliases.md
@@ -104,13 +104,58 @@ and preflight. `scan-shownotes.py` reports a reviewed alternate as `unchanged`
 when no independent metadata conflict remains. It preserves the canonical URL
 and stored ID, including an absent ID, and never promotes the alias.
 
-## Canonical replacement boundary
+## Atomic official-upload promotion
 
-This append operation does not replace the canonical source, rewrite old ledger
-entries, invalidate analysis, or perform reparsing. Do not compose a canonical
-replacement from separate source-repair and alias-append writes: a partial
-transition can lose provenance or leave invalid lineage. The atomic reviewed
-promotion/superseded-history transition remains follow-up work in #175.
+Appending an alias does not change acquisition. For an owner-approved switch to
+a verified official upload, use `promote_source_alias` as the plan's sole
+mutation. Review independent event identity and recording comparison again;
+an existing alias decision alone does not authorize changing the canonical.
+
+Supply a complete **v1** decision with the old current upload in `alias`, the
+new official upload in `canonical`, relationship
+`superseded_by_official_upload`, and a non-null `canonical_choice_reason` that
+records the owner's official-source judgment. The writer does not infer an
+official channel from its name, title, or upload date. `expect` names exactly:
+
+- `talk`: the complete owner-read talk record, including any completed lease,
+  artifact declarations, analysis, and absent-versus-null fields.
+- `source_aliases`: the complete current top-level array, or the missing marker.
+
+Use the same dry-run command and review both hashes before apply. The writer
+refuses active claims, competing ownership, stale talk/ledger values, rejected
+identities, or a composed multi-operation plan. The locked commit installs the
+source switch and its history together; do not substitute separate repair and
+append writes.
+
+The writer sets `video_url` and `youtube_id` to the reviewed new identity,
+removes the old upload's top-level `source_identity`, and sets status
+`needs-reprocessing` with reason `source_added`. It leaves all other talk fields,
+analysis, transcript/video declarations, receipts, and external artifacts
+untouched. The source switch performs no acquisition or reparsing. Old receipts
+do not become proof for the new upload: existing owner/provenance checks still
+apply, and preflight may remain blocking until separately authorized evidence
+repair or reprocessing. Never clear or relabel those receipts to bypass a gate.
+
+The resulting alias is **v2**, with the v1 decision fields plus:
+
+- `prior_state`: closed schema-v1 snapshot of the exact overwritten or removed
+  `video_url`, `youtube_id`, `source_identity`, `status`, and `reprocess_reason`.
+  An absent field uses `{"$missing": true}`. Historical provider evidence is
+  preserved as an inactive object, never interpreted as current evidence.
+- `retired_alias`: null, or the complete earlier same-talk alias record for the
+  identity that is now canonical. It retains its original version, reviewer,
+  comparison, and any prior history. Only this edge moves into history; other
+  edges retain their compared targets and resolve through the superseded source.
+
+Readers accept v1 and v2 without restamping old judgments. Only the promotion
+writer constructs v2 history; caller-supplied history is refused. Historical
+records must name the promoted identity and same talk. The contract's bounded
+history limit fails closed without dropping old decisions. Retired records are
+neither live aliases nor acquisition capabilities. Root schema remains v3.
+
+Re-read the committed database and verify its output digest. Repeat shownotes
+scan and preflight; shownotes for the superseded recording now resolves as an
+accepted alias, while independent metadata conflicts stay visible.
 
 Unrelated source repair, scan/import, queue, persistence, and profile operations
 must preserve the ledger. A mutation that would make its ownership inconsistent

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -116,6 +116,8 @@ When both identities are valid uploads of the same delivery, review the two
 provider-fact blocks with independent event evidence and a recording/transcript
 comparison. Follow [source-aliases.md](source-aliases.md) to retain the inactive
 identity without rejecting it or replacing the canonical recording.
+An owner-approved official-upload switch uses the separate atomic promotion
+contract in that reference, not a repair followed by an alias append.
 
 ## Report contract (v2)
 

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -62,9 +62,13 @@ from pptx_discovery_contract import (
 from pptx_talk_identity import binding_refusal
 from source_identity_matching import parse_catalog_date, pinned_provider_title
 from source_alias_contract import (
+    PRIOR_SOURCE_FIELDS,
+    PROMOTED_SOURCE_ALIAS_SCHEMA_VERSION,
+    SOURCE_ALIAS_SCHEMA_VERSION,
     SourceAliasError,
     active_identity,
     validate_alias_record,
+    youtube_identity,
 )
 
 
@@ -1001,6 +1005,50 @@ def _apply_record_title_equivalence(
     )
 
 
+def _require_alias_delivery(
+    talk: dict[str, Any], record: dict[str, Any], *, label: str
+) -> None:
+    if (
+        talk.get("title") != record["catalog_title"]
+        or talk.get("conference") != record["event"]["conference"]
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label}: reviewed catalog identity disagrees with this talk"
+        )
+    catalog_date = talk.get("date")
+    event_date = record["event"]["date"]
+    if not isinstance(catalog_date, str) or catalog_date not in {
+        event_date,
+        event_date[:4],
+    }:
+        raise TrackingDatabaseMutationError(
+            f"{label}: independent event date disagrees with this delivery"
+        )
+
+
+def _require_inactive_alias_owner(talk: dict[str, Any], *, label: str) -> None:
+    claim = talk.get("_queue_claim")
+    if talk.get("status") == "reprocessing-inflight" or (
+        isinstance(claim, dict) and claim.get("state") == "claimed"
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label}: cannot change an active claim's identity ledger"
+        )
+
+
+def _reviewed_alias_record(mutation: dict[str, Any], *, label: str) -> dict[str, Any]:
+    record = mutation["record"]
+    try:
+        validate_alias_record(record, label=f"{label}.record")
+    except SourceAliasError as exc:
+        raise TrackingDatabaseMutationError(str(exc)) from exc
+    if record["schema_version"] != SOURCE_ALIAS_SCHEMA_VERSION:
+        raise TrackingDatabaseMutationError(
+            f"{label}: submit a reviewed v1 decision; only promotion constructs history"
+        )
+    return record
+
+
 def _apply_record_source_alias(
     database: dict[str, Any],
     mutation: dict[str, Any],
@@ -1011,21 +1059,11 @@ def _apply_record_source_alias(
     """Append a reviewed inactive identity without changing talk evidence."""
     label = f"mutations[{index}]"
     _require_keys(mutation, required={"kind", "record", "expect"}, label=label)
-    record = mutation["record"]
-    try:
-        validate_alias_record(record, label=f"{label}.record")
-    except SourceAliasError as exc:
-        raise TrackingDatabaseMutationError(str(exc)) from exc
+    record = _reviewed_alias_record(mutation, label=label)
     filename = record["talk_filename"]
     talk = _talk_by_filename(database, filename)
     _require_readable_talk_record(talk, filename=filename)
-    claim = talk.get("_queue_claim")
-    if talk.get("status") == "reprocessing-inflight" or (
-        isinstance(claim, dict) and claim.get("state") == "claimed"
-    ):
-        raise TrackingDatabaseMutationError(
-            f"{label}: cannot change an active claim's identity ledger"
-        )
+    _require_inactive_alias_owner(talk, label=label)
     expected = mutation["expect"]
     if not isinstance(expected, dict):
         raise TrackingDatabaseMutationError(f"{label}.expect must be an object")
@@ -1046,22 +1084,7 @@ def _apply_record_source_alias(
         raise TrackingDatabaseMutationError(
             f"{label}: canonical evidence is not the talk's current source"
         )
-    if (
-        talk.get("title") != record["catalog_title"]
-        or talk.get("conference") != record["event"]["conference"]
-    ):
-        raise TrackingDatabaseMutationError(
-            f"{label}: reviewed catalog identity disagrees with this talk"
-        )
-    catalog_date = talk.get("date")
-    event_date = record["event"]["date"]
-    if not isinstance(catalog_date, str) or catalog_date not in {
-        event_date,
-        event_date[:4],
-    }:
-        raise TrackingDatabaseMutationError(
-            f"{label}: independent event date disagrees with this delivery"
-        )
+    _require_alias_delivery(talk, record, label=label)
     before = database.get("source_aliases", MISSING_MARKER)
     existing = database.get("source_aliases", [])
     if any(json_values_equal(item, record) for item in existing):
@@ -1073,6 +1096,101 @@ def _apply_record_source_alias(
         identity=filename,
         before=before,
         after=database["source_aliases"],
+    )
+
+
+def _apply_promote_source_alias(
+    database: dict[str, Any],
+    mutation: dict[str, Any],
+    changes: list[dict[str, Any]],
+    *,
+    index: int,
+) -> None:
+    """Replace one acquisition identity and retain its exact superseded state."""
+    label = f"mutations[{index}]"
+    _require_keys(mutation, required={"kind", "record", "expect"}, label=label)
+    record = _reviewed_alias_record(mutation, label=label)
+    filename = record["talk_filename"]
+    talk = _talk_by_filename(database, filename)
+    _require_readable_talk_record(talk, filename=filename)
+    _require_inactive_alias_owner(talk, label=label)
+    expected = mutation["expect"]
+    if not isinstance(expected, dict):
+        raise TrackingDatabaseMutationError(f"{label}.expect must be an object")
+    _require_keys(
+        expected, required={"talk", "source_aliases"}, label=f"{label}.expect"
+    )
+    _expect_value(
+        exists=True,
+        actual=talk,
+        expected=expected["talk"],
+        label=f"{label}.expect.talk",
+    )
+    _expect_value(
+        exists="source_aliases" in database,
+        actual=database.get("source_aliases"),
+        expected=expected["source_aliases"],
+        label=f"{label}.expect.source_aliases",
+    )
+    if (
+        record["relationship"] != "superseded_by_official_upload"
+        or record["canonical_choice_reason"] is None
+        or active_identity(talk) != record["alias"]["video_id"]
+    ):
+        raise TrackingDatabaseMutationError(
+            f"{label}: promotion requires the current source as alias, an official-upload relationship, and a reviewed reason"
+        )
+    _require_alias_delivery(talk, record, label=label)
+    promoted_id = record["canonical"]["video_id"]
+    for other in database["talks"]:
+        if other["filename"] != filename and promoted_id in (
+            youtube_identity(other.get("video_url")),
+            other.get("youtube_id"),
+        ):
+            raise TrackingDatabaseMutationError(
+                f"{label}: promoted source is already active on another talk; resolve ownership first"
+            )
+    existing = database.get("source_aliases", [])
+    retired = next(
+        (item for item in existing if item["alias"]["video_id"] == promoted_id), None
+    )
+    if retired is not None and retired["talk_filename"] != filename:
+        raise TrackingDatabaseMutationError(
+            f"{label}: promoted alias belongs to another talk; resolve ownership first"
+        )
+    prior_talk = copy.deepcopy(talk)
+    promoted_record = {
+        **copy.deepcopy(record),
+        "schema_version": PROMOTED_SOURCE_ALIAS_SCHEMA_VERSION,
+        "prior_state": {
+            "schema_version": 1,
+            **{
+                field: copy.deepcopy(talk.get(field, MISSING_MARKER))
+                for field in sorted(PRIOR_SOURCE_FIELDS)
+            },
+        },
+        "retired_alias": copy.deepcopy(retired),
+    }
+    # Move only the newly active identity's earlier judgment into inactive
+    # history. Other edges keep their compared target and resolve through the
+    # old canonical's new edge, preserving the original evidence.
+    database["source_aliases"] = [item for item in existing if item is not retired] + [
+        promoted_record
+    ]
+    talk["video_url"] = record["canonical"]["url"]
+    talk["youtube_id"] = promoted_id
+    talk.pop("source_identity", None)
+    talk["status"] = "needs-reprocessing"
+    talk["reprocess_reason"] = "source_added"
+    _record_change(
+        changes,
+        kind="promote_source_alias",
+        identity=filename,
+        before={"talk": prior_talk, "source_aliases": existing},
+        after={
+            "talk": copy.deepcopy(talk),
+            "source_aliases": database["source_aliases"],
+        },
     )
 
 
@@ -1780,6 +1898,12 @@ def build_candidate(
         raise TrackingDatabaseMutationError(str(exc)) from exc
     candidate = copy.deepcopy(database)
     _validate_database_shape(candidate)
+    if len(mutations) != 1 and any(
+        mutation.get("kind") == "promote_source_alias" for mutation in mutations
+    ):
+        raise TrackingDatabaseMutationError(
+            "promote_source_alias must be the plan's sole mutation; review its complete transition"
+        )
     changes: list[dict[str, Any]] = []
     for index, mutation in enumerate(mutations):
         kind = mutation.get("kind")
@@ -1802,6 +1926,8 @@ def build_candidate(
             _apply_record_title_equivalence(candidate, mutation, changes, index=index)
         elif kind == "record_source_alias":
             _apply_record_source_alias(candidate, mutation, changes, index=index)
+        elif kind == "promote_source_alias":
+            _apply_promote_source_alias(candidate, mutation, changes, index=index)
         elif kind == "record_markdown_deck":
             _apply_record_markdown_deck(candidate, mutation, changes, index=index)
         elif kind == "update_talk_publishing":
@@ -1859,7 +1985,8 @@ def execute(
             "--apply requires --expected-sha256 from the reviewed dry-run report"
         )
     alias_plan = any(
-        mutation.get("kind") == "record_source_alias" for mutation in mutations
+        mutation.get("kind") in {"record_source_alias", "promote_source_alias"}
+        for mutation in mutations
     )
     if expected_output_sha256 is not None:
         _validate_digest(expected_output_sha256, flag="--expected-output-sha256")

--- a/skills/vault-ingress/scripts/source_alias_contract.py
+++ b/skills/vault-ingress/scripts/source_alias_contract.py
@@ -17,6 +17,11 @@ from urllib.parse import parse_qs, urlparse
 
 
 SOURCE_ALIAS_SCHEMA_VERSION = 1
+PROMOTED_SOURCE_ALIAS_SCHEMA_VERSION = 2
+MAX_RETIRED_ALIAS_DEPTH = 32
+PRIOR_SOURCE_FIELDS = frozenset(
+    {"video_url", "youtube_id", "source_identity", "status", "reprocess_reason"}
+)
 RELATIONSHIPS = frozenset(
     {"valid_duplicate", "mirror", "superseded_by_official_upload"}
 )
@@ -80,6 +85,14 @@ def _text(value: Any, label: str) -> str:
     ):
         _refuse(label, "expected bounded nonempty trimmed text")
     return value
+
+
+def _missing(value: Any) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and set(value) == {"$missing"}
+        and value["$missing"] is True
+    )
 
 
 def _timestamp(value: Any, label: str) -> None:
@@ -164,13 +177,19 @@ def _provider(value: Any, label: str) -> Mapping[str, Any]:
     return record
 
 
-def validate_alias_record(value: Any, *, label: str = "source_alias") -> None:
-    record = _shape(value, RECORD_FIELDS, label)
-    if (
-        type(record["schema_version"]) is not int
-        or record["schema_version"] != SOURCE_ALIAS_SCHEMA_VERSION
-    ):
+def _validate_alias_record(value: Any, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        _refuse(label, "unsupported record shape")
+    version = value.get("schema_version")
+    if type(version) is not int or version not in {
+        SOURCE_ALIAS_SCHEMA_VERSION,
+        PROMOTED_SOURCE_ALIAS_SCHEMA_VERSION,
+    }:
         _refuse(label, "unsupported source-alias schema version")
+    fields = RECORD_FIELDS
+    if version == PROMOTED_SOURCE_ALIAS_SCHEMA_VERSION:
+        fields = fields | {"prior_state", "retired_alias"}
+    record = _shape(value, fields, label)
     for field in ("talk_filename", "catalog_title", "reviewer"):
         _text(record[field], f"{label}.{field}")
     if (
@@ -235,6 +254,57 @@ def validate_alias_record(value: Any, *, label: str = "source_alias") -> None:
         type(agreement) is not int or not 0 <= agreement <= 10000
     ):
         _refuse(label, "agreement must be null or integer basis points")
+    if version == PROMOTED_SOURCE_ALIAS_SCHEMA_VERSION:
+        if (
+            record["relationship"] != "superseded_by_official_upload"
+            or record["canonical_choice_reason"] is None
+        ):
+            _refuse(
+                label, "promotion requires the official-upload relationship and reason"
+            )
+        prior = _shape(
+            record["prior_state"],
+            PRIOR_SOURCE_FIELDS | {"schema_version"},
+            f"{label}.prior_state",
+        )
+        if type(prior["schema_version"]) is not int or prior["schema_version"] != 1:
+            _refuse(label, "unsupported prior-source-state schema version")
+        old_url = _url(prior["video_url"], f"{label}.prior_state.video_url")
+        old_id = prior["youtube_id"]
+        if youtube_identity(old_url) != alias["video_id"] or (
+            not _missing(old_id) and old_id not in (None, "", alias["video_id"])
+        ):
+            _refuse(
+                label, "superseded state disagrees with the prior canonical identity"
+            )
+        for field in ("status", "reprocess_reason"):
+            old = prior[field]
+            if old is not None and not _missing(old):
+                _text(old, f"{label}.prior_state.{field}")
+        identity = prior["source_identity"]
+        if identity is not None and not isinstance(identity, Mapping):
+            _refuse(label, "historical source identity must be an object or null")
+    return record
+
+
+def validate_alias_record(value: Any, *, label: str = "source_alias") -> None:
+    """Read both generations and bounded, inactive retired-decision history."""
+    record = _validate_alias_record(value, label=label)
+    depth = 0
+    while record["schema_version"] == PROMOTED_SOURCE_ALIAS_SCHEMA_VERSION:
+        retired = record["retired_alias"]
+        if retired is None:
+            return
+        depth += 1
+        if depth > MAX_RETIRED_ALIAS_DEPTH:
+            _refuse(label, "retired alias history exceeds the supported depth")
+        parent = _validate_alias_record(retired, label=f"{label}.retired_alias")
+        if (
+            parent["talk_filename"] != record["talk_filename"]
+            or parent["alias"]["video_id"] != record["canonical"]["video_id"]
+        ):
+            _refuse(label, "retired decision does not belong to the promoted identity")
+        record = parent
 
 
 def active_identity(talk: Mapping[str, Any]) -> str | None:

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1358,8 +1358,7 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
     )
     if explicit_records and "config" not in database:
         raise TrackingDatabaseError(
-            f"tracking database schema v{TRACKING_DATABASE_SCHEMA_VERSION} "
-            "requires a 'config' object"
+            f"tracking database schema v{root_version} requires a 'config' object"
         )
     config = database.get("config", {})
     if not isinstance(config, Mapping):

--- a/tests/test_source_alias_promotion.py
+++ b/tests/test_source_alias_promotion.py
@@ -1,0 +1,509 @@
+"""Synthetic official-upload transitions; no live equivalence judgments."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from test_source_alias_contract import (
+    MISSING,
+    PAIRS,
+    _database,
+    _provider,
+    _record,
+    _write,
+)
+
+
+def _promotion(database, identity=PAIRS[0][1]):
+    talk = database["talks"][0]
+    record = _record(
+        alias=_provider(talk["youtube_id"]),
+        canonical=_provider(identity),
+        relationship="superseded_by_official_upload",
+        canonical_choice_reason="Owner verified the event's official full upload",
+    )
+    return {
+        "kind": "promote_source_alias",
+        "record": record,
+        "expect": {
+            "talk": copy.deepcopy(talk),
+            "source_aliases": copy.deepcopy(database.get("source_aliases", MISSING)),
+        },
+    }
+
+
+@pytest.mark.parametrize("existing_alias", [False, True])
+@pytest.mark.parametrize(
+    "status", ["pending", "processed", "processed_partial", "needs-reprocessing"]
+)
+def test_promotion_preserves_evidence_and_moves_only_reviewed_source_state(
+    mutate_tracking_database, tracking_database, existing_alias, status
+):
+    database = _database()
+    talk = database["talks"][0]
+    talk.update(
+        status=status,
+        source_identity={"schema_version": 1, "video_id": talk["youtube_id"]},
+        transcript_path="transcripts/original.txt",
+        video_local_path="videos/original.mp4",
+        rhetoric_notes="Observations of the original recording",
+        structured_data={
+            "video_extraction": {
+                "schema_version": 3,
+                "source_video_path": "videos/original.mp4",
+            }
+        },
+    )
+    if existing_alias:
+        database["source_aliases"] = [_record()]
+    original = copy.deepcopy(database)
+    mutation = _promotion(database)
+    candidate, changes = mutate_tracking_database.build_candidate(database, [mutation])
+    expected_talk = copy.deepcopy(talk)
+    expected_talk.update(
+        video_url=mutation["record"]["canonical"]["url"],
+        youtube_id=mutation["record"]["canonical"]["video_id"],
+        status="needs-reprocessing",
+        reprocess_reason="source_added",
+    )
+    expected_talk.pop("source_identity")
+    assert candidate["talks"] == [expected_talk]
+    assert database == original
+    assert len(changes) == 1
+    assert tracking_database.assess_tracking_database(candidate).state == "current"
+    history = candidate["source_aliases"][0]
+    assert history["schema_version"] == 2
+    assert history["prior_state"] == {
+        "schema_version": 1,
+        **{
+            field: talk.get(field, MISSING)
+            for field in (
+                "video_url",
+                "youtube_id",
+                "source_identity",
+                "status",
+                "reprocess_reason",
+            )
+        },
+    }
+    assert history["retired_alias"] == (_record() if existing_alias else None)
+    assert history["alias"]["video_id"] == talk["youtube_id"]
+    assert "source_rejections" not in candidate["talks"][0]
+
+
+def test_repeated_promotions_preserve_prior_decisions_and_resolve_all_edges(
+    mutate_tracking_database, tracking_database
+):
+    contract = importlib.import_module("source_alias_contract")
+    database = _database()
+    database["source_aliases"] = [_record(), _record(alias=_provider(PAIRS[1][1]))]
+    original = copy.deepcopy(database)
+    for identity in (PAIRS[0][1], PAIRS[1][1], PAIRS[0][0], PAIRS[0][1]):
+        previous = copy.deepcopy(database)
+        database, _ = mutate_tracking_database.build_candidate(
+            database, [_promotion(database, identity)]
+        )
+        assert tracking_database.assess_tracking_database(database).state == "current"
+        for source in (PAIRS[0][0], PAIRS[0][1], PAIRS[1][1]):
+            match = contract.matched_alias(
+                database, database["talks"][0], _provider(source)["url"]
+            )
+            assert (match is None) == (source == identity)
+        latest = database["source_aliases"][-1]
+        prior = next(
+            (
+                item
+                for item in previous["source_aliases"]
+                if item["alias"]["video_id"] == identity
+            ),
+            None,
+        )
+        assert latest["retired_alias"] == prior
+        for item in previous["source_aliases"]:
+            if item != prior:
+                assert item in database["source_aliases"]
+    assert original["source_aliases"][0] == _record()
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "wrong_delivery",
+        "stale_talk",
+        "stale_ledger",
+        "wrong_old_source",
+        "no_reason",
+        "not_official",
+        "rejected",
+        "other_active",
+        "other_alias",
+        "active_claim",
+        "inflight",
+        "composed_plan",
+        "forged_history",
+    ],
+)
+def test_promotion_refuses_conflicts_without_mutation(mutate_tracking_database, fault):
+    database = _database()
+    if fault == "rejected":
+        database["talks"][0]["source_rejections"] = [
+            {
+                "schema_version": 1,
+                "source_type": "video",
+                "url": _provider(PAIRS[0][1])["url"],
+                "reason": "wrong_delivery",
+                "evidence": "Synthetic rejected delivery",
+                "verified_at": "2026-02-01T12:00:00Z",
+            }
+        ]
+    elif fault in {"other_active", "other_alias"}:
+        other = copy.deepcopy(database["talks"][0])
+        other.update(
+            filename="other.md",
+            video_url=_provider(PAIRS[1][0])["url"],
+            youtube_id=PAIRS[1][0],
+        )
+        if fault == "other_active":
+            other.update(
+                video_url=_provider(PAIRS[0][1])["url"], youtube_id=PAIRS[0][1]
+            )
+        else:
+            database["source_aliases"] = [
+                _record(talk_filename="other.md", canonical=_provider(PAIRS[1][0]))
+            ]
+        database["talks"].append(other)
+    elif fault == "inflight":
+        database["talks"][0]["status"] = "reprocessing-inflight"
+    elif fault == "active_claim":
+        # The owner rejects this malformed lease before a promotion may edit it.
+        database["talks"][0]["_queue_claim"] = {
+            "schema_version": 999,
+            "state": "claimed",
+        }
+    mutation = _promotion(database)
+    if fault == "wrong_delivery":
+        mutation["record"]["event"]["date"] = "2025-01-01"
+    elif fault == "stale_talk":
+        mutation["expect"]["talk"]["rhetoric_notes"] = "Stale reviewed observations"
+    elif fault == "stale_ledger":
+        mutation["expect"]["source_aliases"] = []
+    elif fault == "wrong_old_source":
+        mutation["record"]["alias"] = _provider(PAIRS[1][1])
+    elif fault == "no_reason":
+        mutation["record"]["canonical_choice_reason"] = None
+    elif fault == "not_official":
+        mutation["record"]["relationship"] = "mirror"
+    elif fault == "forged_history":
+        mutation["record"]["schema_version"] = 2
+    plan = (
+        [mutation, copy.deepcopy(mutation)] if fault == "composed_plan" else [mutation]
+    )
+    before = copy.deepcopy(database)
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(database, plan)
+    assert database == before
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", 999),
+        ("schema_version", True),
+        ("video_url", "https://youtu.be/WrongVideo1"),
+        ("youtube_id", "WrongVideo1"),
+        ("status", []),
+        ("source_identity", "invalid"),
+        ("youtube_id", {"$missing": 1}),
+        ("status", {"$missing": 1.0}),
+    ],
+)
+def test_malformed_history_is_not_usable(
+    mutate_tracking_database, tracking_database, field, value
+):
+    database = _database()
+    database, _ = mutate_tracking_database.build_candidate(
+        database, [_promotion(database)]
+    )
+    database["source_aliases"][0]["prior_state"][field] = value
+    before = copy.deepcopy(database)
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+    assert database == before
+
+
+@pytest.mark.parametrize("fault", ["future", "wrong_identity", "wrong_talk", "depth"])
+def test_retired_alias_history_fails_closed(
+    mutate_tracking_database, tracking_database, fault
+):
+    database = _database()
+    database["source_aliases"] = [_record()]
+    database, _ = mutate_tracking_database.build_candidate(
+        database, [_promotion(database)]
+    )
+    retired = database["source_aliases"][0]["retired_alias"]
+    if fault == "future":
+        retired["schema_version"] = 999
+    elif fault == "wrong_identity":
+        retired["alias"] = _provider(PAIRS[1][1])
+    elif fault == "wrong_talk":
+        retired["talk_filename"] = "other.md"
+    else:
+        # A cyclic in-memory input must reach the explicit depth refusal, not recursion.
+        parent = database["source_aliases"][0]
+        child = copy.deepcopy(parent)
+        child["alias"], child["canonical"] = parent["canonical"], parent["alias"]
+        child["prior_state"]["video_url"] = child["alias"]["url"]
+        child["prior_state"]["youtube_id"] = child["alias"]["video_id"]
+        parent["retired_alias"] = child
+        child["retired_alias"] = parent
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_promotion_hash_review_survives_separate_processes(
+    mutate_tracking_database, tmp_path
+):
+    database = _database()
+    path = tmp_path / "tracking-database.json"
+    plan = tmp_path / "promotion.json"
+    _write(path, database)
+    _write(plan, {"schema_version": 1, "mutations": [_promotion(database)]})
+    original = path.read_bytes()
+    script = mutate_tracking_database.__file__
+    result = subprocess.run(
+        [sys.executable, script, str(path), str(plan)],
+        env={**os.environ, "PYTHONHASHSEED": "1"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    preview = json.loads(result.stdout)
+    assert path.read_bytes() == original
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError,
+        match="expected-output-sha256",
+    ):
+        mutate_tracking_database.execute(
+            path, plan, apply=True, expected_sha256=preview["input_sha256"]
+        )
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="candidate output"
+    ):
+        mutate_tracking_database.execute(
+            path,
+            plan,
+            apply=True,
+            expected_sha256=preview["input_sha256"],
+            expected_output_sha256="0" * 64,
+        )
+    assert path.read_bytes() == original
+    result = subprocess.run(
+        [
+            sys.executable,
+            script,
+            str(path),
+            str(plan),
+            "--apply",
+            "--expected-sha256",
+            preview["input_sha256"],
+            "--expected-output-sha256",
+            preview["output_sha256"],
+        ],
+        env={**os.environ, "PYTHONHASHSEED": "2"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(result.stdout)["database_written"]
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == preview["output_sha256"]
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="input sha256"
+    ):
+        mutate_tracking_database.execute(
+            path,
+            plan,
+            apply=True,
+            expected_sha256=preview["input_sha256"],
+            expected_output_sha256=preview["output_sha256"],
+        )
+
+
+def test_promotion_cas_keeps_competing_write(
+    mutate_tracking_database, tmp_path, monkeypatch
+):
+    database = _database()
+    path = tmp_path / "tracking-database.json"
+    plan = tmp_path / "promotion.json"
+    _write(path, database)
+    _write(plan, {"schema_version": 1, "mutations": [_promotion(database)]})
+    preview = mutate_tracking_database.execute(
+        path, plan, apply=False, expected_sha256=None
+    )
+    commit = mutate_tracking_database.commit_tracking_database
+    competitor = copy.deepcopy(database)
+    competitor["talks"][0]["rhetoric_notes"] = "Concurrent owner write"
+
+    def competing_commit(snapshot, rendered):
+        _write(path, competitor)
+        return commit(snapshot, rendered)
+
+    monkeypatch.setattr(
+        mutate_tracking_database, "commit_tracking_database", competing_commit
+    )
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.execute(
+            path,
+            plan,
+            apply=True,
+            expected_sha256=preview["input_sha256"],
+            expected_output_sha256=preview["output_sha256"],
+        )
+    assert json.loads(path.read_bytes()) == competitor
+
+
+@pytest.mark.parametrize("version", [2, 3])
+def test_missing_config_diagnostic_names_observed_readable_root(
+    tracking_database, version
+):
+    database = _database()
+    database["schema_version"] = version
+    database.pop("config")
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError,
+        match=f"schema v{version} requires a 'config' object",
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("claim_version", range(1, 8))
+def test_promotion_refuses_valid_active_claim_generations(
+    mutate_tracking_database, tracking_database, claim_version
+):
+    from test_tracking_database_schema import _qr_repair_with_active_claim
+
+    database = tracking_database.repair_missing_qr_schema_versions(
+        _qr_repair_with_active_claim(tracking_database, claim_version)
+    ).database
+    talk = database["talks"][0]
+    mutation = {
+        "kind": "promote_source_alias",
+        "record": _record(talk_filename=talk["filename"]),
+        "expect": {"talk": copy.deepcopy(talk), "source_aliases": MISSING},
+    }
+    before = copy.deepcopy(database)
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError, match="active claim"
+    ):
+        mutate_tracking_database.build_candidate(database, [mutation])
+    assert database == before
+
+
+@pytest.mark.parametrize("source", [PAIRS[0][0], PAIRS[0][1], PAIRS[1][1]])
+def test_shownotes_resolves_superseded_and_other_aliases_after_promotion(
+    mutate_tracking_database, scan_shownotes_module, tmp_path, source
+):
+    database = _database()
+    database["source_aliases"] = [_record(), _record(alias=_provider(PAIRS[1][1]))]
+    site = tmp_path / "notes"
+    notes = site / "_talks"
+    notes.mkdir(parents=True)
+    database["config"]["shownotes"] = {
+        "enabled": True,
+        "source": {
+            "type": "local_jekyll",
+            "path_or_url": str(site),
+            "talks_subdir": "_talks",
+        },
+    }
+    (notes / "talk.md").write_text(
+        "---\nlayout: talk\n---\n# Synthetic delivery\n**Conference:** TestConf\n"
+        f"**Date:** 2026-01-01\n**Video:** [Watch](https://youtu.be/{source})\n",
+        encoding="utf-8",
+    )
+    database, _ = mutate_tracking_database.build_candidate(
+        database, [_promotion(database)]
+    )
+    path = tmp_path / "tracking-database.json"
+    _write(path, database)
+    before = path.read_bytes()
+    report = scan_shownotes_module.execute(path, apply_requested=True)
+    assert report["entries"][0]["disposition"] == "unchanged"
+    assert report["mutation_count"] == 0
+    assert not report["database_written"]
+    assert path.read_bytes() == before
+
+
+def test_unrelated_writers_and_owner_reads_preserve_promotion_history(
+    mutate_tracking_database,
+    apply_source_repairs,
+    queue_state,
+    persist_results,
+    tracking_database_io,
+    read_tracking_database,
+    tmp_path,
+    capsys,
+):
+    database = _database()
+    database["source_aliases"] = [_record()]
+    database, _ = mutate_tracking_database.build_candidate(
+        database, [_promotion(database)]
+    )
+    history = json.dumps(database["source_aliases"]).encode()
+    path = tmp_path / "tracking-database.json"
+    _write(path, database)
+    original = path.read_bytes()
+    assert read_tracking_database.main([str(path)]) == 0
+    assert json.loads(capsys.readouterr().out)["ok"]
+    assert path.read_bytes() == original
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database,
+        [
+            {
+                "kind": "set_config",
+                "path": ["speaker_name"],
+                "expect": MISSING,
+                "value": "Synthetic Speaker",
+            }
+        ],
+    )
+    candidate, _ = apply_source_repairs.build_repaired_database(
+        candidate,
+        [
+            {
+                "filename": "talk.md",
+                "reason": "Unrelated PDF registration",
+                "expect": {"slides_url": MISSING},
+                "set": {"slides_url": "https://slides.example/slides.pdf"},
+            }
+        ],
+    )
+    snapshot = tracking_database_io.snapshot_tracking_database(path)
+    queue_state.write_database_atomically(path, candidate, expected_snapshot=snapshot)
+    loaded, snapshot = persist_results.load_tracking_database(path)
+    loaded["talks"][0]["rhetoric_notes"] = "New synthetic notes"
+    persist_results.atomic_write_json(path, loaded, expected_snapshot=snapshot)
+    stored = tracking_database_io.decode_json_object(
+        tracking_database_io.snapshot_tracking_database(path)
+    )
+    assert json.dumps(stored["source_aliases"]).encode() == history
+
+
+def test_promotion_contract_documents_history_and_evidence_boundary():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    reference = (root / "skills/vault-ingress/references/source-aliases.md").read_text(
+        encoding="utf-8"
+    )
+    assert "`promote_source_alias` as the plan's sole" in reference
+    for field in ("prior_state", "retired_alias", "source_added"):
+        assert f"`{field}`" in reference
+    assert "Never clear or relabel those receipts to bypass a gate" in reference


### PR DESCRIPTION
## Summary

- Complete #175 with a single owner-reviewed, input/output-hash-bound official-upload promotion, preserving superseded identities and earlier alias judgments in bounded versioned history.
- Preserve all other talk evidence and artifacts, requeue without relabeling receipts, and reject active claims, stale plans, rejection collisions, and cross-talk ownership. No live promotions or reparsing are performed by this change.
- Correct the observed-root diagnostic deferred from PR #404.

Closes #175.

## Test plan

- [x] Full suite: 6,882 passed, 8 skipped (240.49s).
- [x] Focused owner/alias/schema suite: 484 passed, including separate-process digest stability, CAS races, all seven active-claim generations, history preservation, and shownotes reconciliation.
- [x] Ruff lint and formatting (437 files); Pyright: zero errors or warnings.
- [x] Package contents, shipped mirrors, entrypoints, conflict markers, dependency pins, plugin lint, and diff hygiene.
- [x] Manual code/doc/test self-audit and policy-marker scans.
- [ ] Tessl skill quality review: **UNREVIEWED due to the exact out-of-credits billing failure**, not a below-threshold score. Existing `.github/workflows/publish.yml` opts into `skill-review-credit-outage: skip`, as permitted by coding-policy's Credit-Outage Review Carve-Out. No workflow, threshold, or policy change is included. The publish action must retry review and explicitly warn/name `vault-ingress` if the outage persists.

GitHub CI, both automated PR reviews, exact merge-bound publication, registry advancement, moderation, and branch cleanup remain required release gates.
