### PR TITLE
feat(vault-ingress): Supervise transcript media acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### Bound transcript media acquisition to supervised source generations
+
+Address #219's acquisition boundary with authenticated metadata, generic-media
+probe, yt-dlp, and Whisper workers. Reject cloud placeholders and unsupported
+sources before byte I/O; bound copy, parsing, provider output, download disk
+usage, wall time, memory, and descendant processes. Reuse established media or
+video facts during transcription, then check the source generation after bundle
+staging and before commit. Download attempts use one literal private artifact
+and clean it on success, refusal, consumer failure, and worker termination.
+
+Keep prior transcript and receipt bytes on failed local acquisition, including
+stale quality receipts previously eligible for a fixed-default downgrade. Bind
+downloaded Whisper quality to verified provider duration and reject duration
+drift. Narrow the platform-bound test exemption to the actual MLX import/call;
+exercise orchestration and failure paths with synthetic providers and generated
+media. This changes no stored receipt schema and does not establish a missing
+catalog-to-recording identity or perform live calibration/reparsing.
+
 ## 0.20.124 — 2026-09-05
 
 ### Preserve superseded sources during reviewed official-upload promotion

--- a/rules/transcript-fetch-authority.md
+++ b/rules/transcript-fetch-authority.md
@@ -1,6 +1,6 @@
 ---
 alwaysApply: false
-applyTo: "skills/vault-ingress/scripts/fetch-transcript.py, skills/vault-ingress/scripts/transcript_quality.py, skills/vault-ingress/scripts/transcript_timing.py, skills/vault-ingress/scripts/vtt-cleanup.py, pyproject.toml — when changing transcript acquisition, VTT import, quality/timing receipts, or the mlx-whisper dependency"
+applyTo: "skills/vault-ingress/scripts/fetch-transcript.py, skills/vault-ingress/scripts/local_media_*.py, skills/vault-ingress/scripts/transcript_quality.py, skills/vault-ingress/scripts/transcript_timing.py, skills/vault-ingress/scripts/vtt-cleanup.py, pyproject.toml — when changing transcript acquisition, VTT import, quality/timing receipts, or the mlx-whisper dependency"
 description: Authority of record for the Whisper transcription layer's Platform-Bound Untestable Carve-Out
 ---
 
@@ -14,9 +14,15 @@ description: Authority of record for the Whisper transcription layer's Platform-
 
 ## Covered Artifact
 
-- `transcribe_audio()` in `skills/vault-ingress/scripts/fetch-transcript.py` — the `mlx_whisper.transcribe()` call — and `fetch_whisper()`, which downloads audio and delegates to it. Both the YouTube `--method whisper` path and the non-YouTube `--audio` path reach the exemption through `transcribe_audio()`; nothing else in the file is exempt.
+- The `mlx_whisper` import and actual `provider.transcribe()` call inside
+  `_transcribe_with_mlx()` in
+  `skills/vault-ingress/scripts/local_media_transcription.py` are exempt.
+- Both YouTube `--method whisper` and non-YouTube `--audio` delegate to that
+  worker. Their orchestration, media admission, resource supervision, download,
+  result validation, cleanup, and receipt writes are not exempt.
 - `mlx-whisper` is declared as the optional `whisper` extra in `pyproject.toml`, never a base dependency. The caption path and every validator work without it.
-- Non-YouTube talks route through `--audio` on this same script. Transcription is deterministic script work per `jbaruch/coding-policy: script-delegation`, so no skill prose may call `mlx_whisper.transcribe()` directly — a hand-rolled call carries none of the validation, atomic write, or JSON contract, which is the defect class this script was written to end.
+- Route non-YouTube talks through `fetch-transcript.py --audio`. Never call
+  `mlx_whisper.transcribe()` from skill prose.
 
 ## Precondition 1 — CI-Runnable Pieces Are Extracted and Tested
 
@@ -24,16 +30,19 @@ description: Authority of record for the Whisper transcription layer's Platform-
   `resolve_video_id()`, `segments_to_text()`, receipt validation, and atomic
   writers are deterministic and carry tests in `tests/test_fetch_transcript.py`
   and `tests/test_transcript_timing.py`.
-- Duration probes are subprocess wrappers with synthetic CI tests. YouTube
-  duration comes from provider metadata returned by `yt-dlp`; local-media
-  duration comes from `ffprobe` over the exact file and is bound to its SHA-256.
+- `local_media_contract.py`, `local_media_evidence.py`, `local_media_process.py`,
+  `local_media_download.py`, and `local_media_transcription.py` each have a
+  corresponding `tests/test_local_media_*.py` suite. Native synthetic workers
+  exercise authenticated framing, process limits, capped pipes, container
+  inspection, source-generation changes, and cleanup without provider access.
+- YouTube duration comes from identity-bound `yt-dlp` metadata. Local duration
+  comes from supervised `ffprobe` and binds the exact source SHA-256.
 - Tests cover empty/error/VTT/non-speech artifacts, the fixed and WPM floors,
   low-`--min-words` bypass attempts, source-duration matching, Unicode word
   counting, both segment shapes, invalid UTF-8, exact provenance, no-segment
   quality receipts, CRLF/LF byte drift, transactional rollback, enumerated
   optional-library failures, malformed-timing downgrade, media
   snapshot mutation, destination symlinks, VTT path safety, and caption fall-through.
-- Only the audio-download-and-transcribe wrapper is exempt.
 - Caption and Whisper imports, constructors, API calls, and provider result
   objects are optional-lane boundaries. `ImportError`, `OSError`,
   `RuntimeError`, `AttributeError`, `TypeError`, `ValueError`, and `KeyError`
@@ -85,12 +94,16 @@ description: Authority of record for the Whisper transcription layer's Platform-
   bundle-write failure restores the prior transcript and both receipts exactly.
   Missing, malformed, mismatched, or over-bound optional timing removes stale
   timing while valid transcript text and its quality receipt still commit.
-- Local `--audio` acquisition copies one twice-verified regular source into a
-  private read-only snapshot. Hashing, `ffprobe`, Whisper, quality provenance,
-  and timing provenance all use that snapshot. The original pathname identity
-  and open-descriptor digest are revalidated immediately before commit.
-  Original-source replacement, in-place mutation, or snapshot drift fails with
-  no bundle write.
+- Local `--audio` admission rejects unavailable or unsupported source metadata
+  before byte I/O. A bounded worker copies and hashes one admitted generation
+  into an owner-cleaned private read-only snapshot for `ffprobe`.
+- Whisper reuses established media or video probe facts without another copy,
+  hash, or probe. Its bounded worker checks the original source's pathname and
+  open-descriptor generation before and after transcription.
+- The fetcher checks source generation after staging and before replacing a
+  transcript bundle or refreshing existing quality. Source drift or worker
+  failure leaves prior artifacts untouched. Failed local probing never replaces
+  an existing quality receipt with fixed-default provenance.
 - Transcript, timing, and quality final-component symlinks are forbidden,
   including dangling links. VTT imports require lexical and resolved
   containment below the transcript directory, no symlink components below that
@@ -99,7 +112,11 @@ description: Authority of record for the Whisper transcription layer's Platform-
 ## Precondition 2 — Manual Validation Procedure
 
 Run against a talk whose caption track is disabled, on Apple Silicon with the
-`whisper` extra installed:
+`whisper` extra installed. First require the configured runtime:
+
+```bash
+"{python_path}" skills/vault-ingress/scripts/check-runtime.py --lanes core,whisper,youtube-download --require-lanes core,whisper,youtube-download
+```
 
 1. `"{python_path}" skills/vault-ingress/scripts/fetch-transcript.py {youtube_id} --out /tmp/{youtube_id}.txt --method whisper --existing-source unknown`
 2. Observe: exit 0, one JSON object on stdout with `"method": "whisper"`,
@@ -111,8 +128,8 @@ Run against a talk whose caption track is disabled, on Apple Silicon with the
 5. `jq -e '.schema_version == 1 and (.transcript_sha256 | length == 64) and .policy.schema_version == 1 and (.policy.min_words >= 1) and ((.policy.duration_seconds == null and .provenance == {"kind":"fixed_default"}) or (.policy.duration_seconds == .provenance.duration_seconds))' /tmp/{youtube_id}.quality.json` exits 0, and its `transcript_sha256` equals `shasum -a 256 /tmp/{youtube_id}.txt`.
 6. Confirm `/tmp/{youtube_id}.txt` holds prose, not `[Music]` markers or a traceback.
 7. Re-run with `YT_DLP` set to a nonexistent absolute path and a fresh output
-   path. Expect exit 1, a stderr line explaining how to correct or unset the
-   override, one JSON object with `"ok": false`, and no transcript or receipt
+   path. Expect exit 1, a path-neutral stderr failure with the
+   `ytdlp_dependency_unavailable` reason, one JSON object with `"ok": false`, and no transcript or receipt
    at that output path. Removing only `yt-dlp` from `PATH` is insufficient: the
    fetcher deliberately resolves the configured interpreter's console script
    before the compatibility PATH fallback.
@@ -122,6 +139,7 @@ A pass requires all eight checks.
 
 ## Scope Limits
 
-- The carve-out covers this one wrapper. It does not extend to another script, another dependency, or the caption path.
+- The carve-out covers only the named Apple-Silicon import and provider call.
+  It does not extend to another script, dependency, or the caption path.
 - Adding a second exempt artifact requires naming it here AND documenting its own validation procedure. Adding one without both invalidates the precondition.
 - "Hard to install in CI" does not qualify — see `jbaruch/coding-policy: ci-safety` Install, Don't Skip. `mlx-whisper` cannot run on the runner's architecture and qualifies for the carve-out.

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -59,6 +59,7 @@ symlink to a custom location). All paths are relative to this **vault root**.
 | [references/clarification-handoff.md](references/clarification-handoff.md) | Step 9 topic selection and recency-bucket handoff contract |
 | [references/rhetoric-dimensions.md](references/rhetoric-dimensions.md) | 14 analysis dimensions |
 | [references/subagent-instructions.md](references/subagent-instructions.md) | Step 3 per-talk procedure — transcript download, slide acquisition, fallback chains, return-JSON shape |
+| [references/local-media-acquisition.md](references/local-media-acquisition.md) | Bounded audio/video acquisition, runtime gates, fact reuse, and failure preservation |
 | [references/video-slide-extraction.md](references/video-slide-extraction.md) | Video-to-slides pipeline — layout heuristics, tuning, limitations |
 | [references/crop-review.md](references/crop-review.md) | Reproducible contact sheets, individual-frame proposals, and owner crop approval |
 | [references/markdown-decks.md](references/markdown-decks.md) | Slidev/presenterm/Marp/reveal-md decks — render lanes, register-and-requeue, reveal structure |

--- a/skills/vault-ingress/references/bootstrap-and-preflight.md
+++ b/skills/vault-ingress/references/bootstrap-and-preflight.md
@@ -149,7 +149,10 @@ descendant symlink/reparse redirect. Trusted-root bindings retain the directory
 object's stable identity and policy attributes, not mutable child-content size or
 timestamps; PDF and PPTX leaf generations remain exact. The checker emits report
 schema v3 and records exact Python pins under each lane's
-`required_module_versions`. The `youtube-download` lane also resolves `yt-dlp`
+`required_module_versions`. Generic audio/video acquisition uses `source-media`;
+its runtime and owner boundaries are documented in
+[Bounded Local-Media Acquisition](local-media-acquisition.md).
+The `youtube-download` lane also requires psutil and resolves `yt-dlp`
 from the configured interpreter before PATH, records its exact pin under
 `required_command_versions`, and makes a mismatched version unavailable. A
 missing optional lane is reported as degraded and must not erase a healthy
@@ -159,7 +162,7 @@ Drive acquisition additionally needs the `gdown` module; captions need
 `youtube-transcript-api`; audio download fallback needs `yt-dlp`; rendered PDF
 inspection needs `pdftoppm`; video extraction needs exactly `Pillow==12.3.0`,
 `ImageHash==4.3.2`, `numpy==2.2.6`, and `filelock==3.32.2`, plus `ffmpeg` and
-`ffprobe`; local Whisper needs `mlx-whisper` and `ffprobe`; rendering a
+`ffprobe`; local Whisper needs `mlx-whisper`, psutil, `ffmpeg`, and `ffprobe`; rendering a
 markdown-authored deck needs that deck's own tool, one lane per flavor (see
 [markdown-decks.md](markdown-decks.md)).
 Inspect those with the checker's `google-drive`, `captions`,

--- a/skills/vault-ingress/references/entrypoint-failure-contracts.md
+++ b/skills/vault-ingress/references/entrypoint-failure-contracts.md
@@ -77,7 +77,9 @@ Never infer commit position from the exit code; read the field.
 
 ## Worker Protocol Boundaries
 
-`pptx_evidence.py`, `pptx-extraction.py`, and `pdf_evidence.py` — same
+`pptx_evidence.py`, `pptx-extraction.py`, `pdf_evidence.py`,
+`local_media_evidence.py`, `local_media_download.py`, and
+`local_media_transcription.py` — same
 directory — run supervised worker children whose stdout is reserved for one
 authenticated frame. Their boundaries emit a path-neutral
 `<kind> worker failed: <reason>` line on stderr and exit 2; the supervisor

--- a/skills/vault-ingress/references/local-media-acquisition.md
+++ b/skills/vault-ingress/references/local-media-acquisition.md
@@ -1,0 +1,53 @@
+# Bounded Local-Media Acquisition
+
+Read before using local audio/video or the YouTube Whisper fallback. The public
+entrypoint remains `fetch-transcript.py`; its module docstring owns arguments,
+JSON output, exit codes, and transcript-replacement authorization.
+
+## Runtime Gate
+
+Require the database-configured interpreter's lanes before using them:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
+  --lanes core,source-media,whisper --require-lanes core,source-media,whisper
+```
+
+For the YouTube download fallback, include `youtube-download` in both lists.
+For probe-only library work, require `core,source-media` without Whisper.
+`check-runtime.py`'s `LANE_REQUIREMENTS` and version maps own dependencies and
+pins. A failed optional lane does not invalidate independent captions or slides.
+
+## Acquisition Ownership
+
+- Pass the original local locator to `fetch-transcript.py --audio`; never
+  pre-open, hash, hydrate, copy, or invoke `ffprobe` on the source yourself.
+- `local_media_evidence.py`'s `probe_local_media` owns availability, generation
+  binding, snapshot hashing, probe facts, and private-workspace cleanup.
+- `local_media_contract.py`'s named `MEDIA_*` constants, admission helpers, and
+  `bounded_whisper_result` own supported containers and resource ceilings.
+- `local_media_transcription.py`'s `transcribe_local_media` accepts a current
+  in-memory media/video probe from its owner. It reuses those facts and rechecks
+  source generation. A serialized or hand-constructed receipt is not authority
+  to skip acquisition.
+- `local_media_download.py`'s `download_youtube_audio` yields a private local
+  artifact plus provider duration and removes the workspace when its consumer
+  exits. It does not register or preserve a recording in the vault.
+- Worker arguments contain no source locator or model path. Authenticated
+  private request payloads carry them; diagnostics remain bounded and redacted.
+
+## Refusal and Recovery
+
+The fetcher reports worker refusal through its existing failure JSON and stderr.
+Use `LocalMediaError.reason_code` for library callers. Repair unavailable runtime
+lanes, restore a locally available supported source, or retry after source edits
+finish. Never bypass worker admission or increase a threshold from skill prose.
+
+A failed local probe, transcription, resource check, cleanup, or precommit
+generation check leaves prior transcript, quality, and timing artifacts intact.
+This includes a stale quality receipt: failure does not authorize weakening its
+provenance. `--force` authorizes transcript replacement, not bypassing validation.
+
+Acquisition proves source bytes and duration, not that a recording belongs to a
+catalog talk. Keep the separate owner-binding preflight gate; do not patch a
+receipt, infer a missing recording, or relabel old analysis to clear it.

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -14,6 +14,10 @@ same-numbered archival return generation.
 
 ### Transcript download
 
+Before local-media acquisition or the YouTube Whisper fallback, follow
+[Bounded Local-Media Acquisition](local-media-acquisition.md). Require its
+runtime lanes and pass the source locator to the owner; do not pre-read media.
+
 One command. Do NOT hand-roll a fetch — an inline `python3 -c` fetch here is
 what wrote four Python tracebacks into `transcripts/` when the upstream library
 renamed a method, and nothing noticed because nothing validated the output.
@@ -126,6 +130,9 @@ reclaim after source registration if the path was missing. YouTube talks may
 omit the field because `youtube_id` remains the canonical fallback.
 The local-media quality receipt binds trusted duration to SHA-256 of the exact
 input media; moving a policy to another recording does not authorize it.
+An acquisition failure preserves prior transcript and receipt bytes, including
+stale quality. Do not weaken provenance or bypass the owner-binding preflight
+gate to make an existing transcript eligible.
 
 For an existing WebVTT artifact, provide an explicit collision-free output:
 

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -73,11 +73,15 @@ LANE_REQUIREMENTS: dict[str, dict[str, dict[str, str]]] = {
         "commands": {},
     },
     "youtube-download": {
-        "modules": {},
+        "modules": {"psutil": "psutil"},
         "commands": {"yt-dlp": "yt-dlp"},
     },
     "whisper": {
-        "modules": {"mlx-whisper": "mlx_whisper"},
+        "modules": {"mlx-whisper": "mlx_whisper", "psutil": "psutil"},
+        "commands": {"ffmpeg": "ffmpeg", "ffprobe": "ffprobe"},
+    },
+    "source-media": {
+        "modules": {"psutil": "psutil"},
         "commands": {"ffprobe": "ffprobe"},
     },
     "source-video": {

--- a/skills/vault-ingress/scripts/fetch-transcript.py
+++ b/skills/vault-ingress/scripts/fetch-transcript.py
@@ -58,24 +58,31 @@ receipts hash exact transcript bytes, so replacement invalidates both.
 ``--duration-seconds`` is only an expected value: it must match a YouTube
 provider probe or ``ffprobe`` of the exact local media before it can authorize a
 short-talk threshold.
+
+Local-media admission, snapshot hashing/ffprobe, yt-dlp and Whisper run in
+authenticated resource-bounded workers. Source paths travel in private payloads,
+not worker command lines. A probe's exact generation and digest are reused for
+transcription, then checked again after staging and before bundle replacement.
+A failed local probe preserves even a stale prior quality receipt; it never
+substitutes weaker fixed-default provenance. See local_media_contract.py for
+media admission and resource profiles, and local_media_evidence.py for cleanup.
 """
 
 import argparse
-import hashlib
-import importlib
 import json
-import math
 import os
 import re
-import stat
-import subprocess
 import sys
-import tempfile
 from collections.abc import Callable, Iterable, Iterator
-from contextlib import contextmanager, redirect_stdout
+from contextlib import redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NoReturn, TypeVar
+
+from local_media_contract import LocalMediaError, MediaArtifactProbe
+from local_media_download import download_youtube_audio, probe_youtube_media_duration
+from local_media_evidence import check_media_generation, probe_local_media
+from local_media_transcription import transcribe_local_media
 
 from transcript_timing import (
     ensure_bundle_destinations_are_not_symlinks,
@@ -103,29 +110,11 @@ from transcript_quality import (
     normalize_duration,
     receipt_claims_source_duration,
     receipt_duration_cannot_hold,
-    receipt_matches_media_digest,
+    receipt_matches_media_digest as receipt_matches_media_digest,
     validate_transcript,
 )
-from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
 
 __all__ = ["VTT_TIMING_TAG", "write_atomically"]
-
-
-# YouTube serves media per player client, and it blocks them unevenly: a client
-# that 403s today may work tomorrow and the reverse. Trying one client and
-# giving up turns a transient block into "this talk has no transcript", which
-# is how the Whisper fallback went silently dead while mlx-whisper sat
-# installed and working. `None` runs yt-dlp's own default chain first, so a
-# healthy environment pays nothing; the named clients are only reached after it
-# fails. Order is cheapest-first, not preference — every entry produces the
-# same audio when it works.
-YOUTUBE_PLAYER_CLIENTS: tuple[str | None, ...] = (
-    None,
-    "mweb",
-    "web_safari",
-    "ios",
-    "tv",
-)
 
 
 VIDEO_ID = re.compile(r"(?:v=|youtu\.be/|/embed/|/shorts/)([A-Za-z0-9_-]{11})")
@@ -158,125 +147,35 @@ TIMING_PAYLOAD_ERRORS = (
 )
 
 
-def _stat_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
-    return (
-        value.st_dev,
-        value.st_ino,
-        value.st_size,
-        value.st_mtime_ns,
-        value.st_ctime_ns,
-    )
+@dataclass(frozen=True)
+class AssessedMediaSource:
+    """One source generation whose byte facts came from the bounded owner."""
+
+    path: Path
+    probe: MediaArtifactProbe
+
+    @property
+    def sha256(self) -> str:
+        return self.probe.source_sha256
+
+    def assert_unchanged(self) -> None:
+        check_media_generation(self.path, self.probe)
 
 
 @dataclass(frozen=True)
-class MediaSnapshot:
-    """One private local-media snapshot used by every acquisition step."""
+class WhisperAcquisition:
+    """Speech plus the provider duration verified against its downloaded media."""
 
-    source_path: Path
-    source_descriptor: int
-    source_identity: tuple[int, int, int, int, int]
-    path: Path
-    sha256: str
-    identity: tuple[int, int, int, int, int]
+    text: str
+    language: str | None
+    segments: list[dict[str, Any]] | None
+    duration_seconds: float
 
-    def assert_unchanged(self, *, verify_source_digest: bool = False) -> None:
-        """Fail before a write when the source binding or snapshot drifted."""
-        try:
-            source_entry = self.source_path.lstat()
-            source_descriptor_state = os.fstat(self.source_descriptor)
-            current = self.path.lstat()
-        except OSError as exc:
-            raise ValueError(
-                f"local-media source or snapshot became unavailable: {exc}; "
-                "no transcript bundle was written"
-            ) from exc
-        if (
-            not stat.S_ISREG(source_entry.st_mode)
-            or _stat_identity(source_entry) != self.source_identity
-            or _stat_identity(source_descriptor_state) != self.source_identity
-        ):
-            raise ValueError(
-                "local-media source changed or was replaced during acquisition; "
-                "no transcript bundle was written"
-            )
-        if verify_source_digest:
-            os.lseek(self.source_descriptor, 0, os.SEEK_SET)
-            source_digest = hashlib.sha256()
-            while chunk := os.read(self.source_descriptor, 1024 * 1024):
-                source_digest.update(chunk)
-            source_after_hash = os.fstat(self.source_descriptor)
-            if (
-                _stat_identity(source_after_hash) != self.source_identity
-                or source_digest.hexdigest() != self.sha256
-            ):
-                raise ValueError(
-                    "local-media source changed during acquisition; no transcript "
-                    "bundle was written"
-                )
-        if (
-            not stat.S_ISREG(current.st_mode)
-            or _stat_identity(current) != self.identity
-            or media_sha256(self.path) != self.sha256
-        ):
-            raise ValueError(
-                "local-media snapshot changed during probe or transcription; "
-                "no transcript bundle was written"
-            )
-
-
-@contextmanager
-def immutable_media_snapshot(source: Path) -> Iterator[MediaSnapshot]:
-    """Copy a stable regular source twice-verified through one open descriptor."""
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    try:
-        descriptor = os.open(source, flags)
-    except OSError as exc:
-        raise ValueError(
-            f"cannot open --audio media as a non-symlink regular file: {exc}"
-        ) from exc
-    try:
-        before = os.fstat(descriptor)
-        if not stat.S_ISREG(before.st_mode):
-            raise ValueError("--audio media must be a regular file")
-        with tempfile.TemporaryDirectory(prefix="speaker-toolkit-media-") as work_dir:
-            snapshot_path = Path(work_dir) / source.name
-            first_digest = hashlib.sha256()
-            with snapshot_path.open("xb") as snapshot_stream:
-                while chunk := os.read(descriptor, 1024 * 1024):
-                    first_digest.update(chunk)
-                    snapshot_stream.write(chunk)
-                snapshot_stream.flush()
-                os.fsync(snapshot_stream.fileno())
-            after_copy = os.fstat(descriptor)
-            os.lseek(descriptor, 0, os.SEEK_SET)
-            second_digest = hashlib.sha256()
-            while chunk := os.read(descriptor, 1024 * 1024):
-                second_digest.update(chunk)
-            after_verify = os.fstat(descriptor)
-            if (
-                _stat_identity(before) != _stat_identity(after_copy)
-                or _stat_identity(before) != _stat_identity(after_verify)
-                or first_digest.digest() != second_digest.digest()
-            ):
-                raise ValueError(
-                    "--audio media changed while its immutable snapshot was being "
-                    "created; no transcript bundle was written"
-                )
-            snapshot_path.chmod(stat.S_IRUSR)
-            snapshot_stat = snapshot_path.lstat()
-            snapshot = MediaSnapshot(
-                source_path=source,
-                source_descriptor=descriptor,
-                source_identity=_stat_identity(after_verify),
-                path=snapshot_path,
-                sha256=first_digest.hexdigest(),
-                identity=_stat_identity(snapshot_stat),
-            )
-            snapshot.assert_unchanged()
-            yield snapshot
-    finally:
-        os.close(descriptor)
+    def __iter__(self) -> Iterator[Any]:
+        # Keep the historical three-value programmatic unpacking contract.
+        yield self.text
+        yield self.language
+        yield self.segments
 
 
 def _call_with_provider_stdout_isolated(
@@ -321,104 +220,15 @@ def resolve_video_id(value):
     return match.group(1) if match else None
 
 
-def media_sha256(path: Path) -> str:
-    """Hash the exact local media bytes that owned a duration probe."""
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        while chunk := stream.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _positive_duration(value: object) -> float | None:
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, (int, float))
-        or not math.isfinite(float(value))
-        or float(value) <= 0
-    ):
-        return None
-    return normalize_duration(value)
-
-
 def probe_youtube_duration(
     video_id: str, *, ytdlp: str | Path | None = None
 ) -> tuple[float | None, str]:
-    """Read source-owned duration for one exact YouTube identity via yt-dlp."""
-    url = f"https://www.youtube.com/watch?v={video_id}"
+    """Read identity-bound duration through the bounded provider worker."""
     try:
-        executable = Path(ytdlp) if ytdlp is not None else resolve_ytdlp()
-        completed = subprocess.run(
-            [
-                str(executable),
-                "--dump-single-json",
-                "--skip-download",
-                "--no-playlist",
-                url,
-            ],
-            capture_output=True,
-            text=True,
-        )
-    except (YtDlpResolutionError, OSError) as exc:
-        return None, (
-            f"cannot probe trusted YouTube duration ({exc}) — install the pinned "
-            "yt-dlp with `pip install .` or set YT_DLP to its path"
-        )
-    if completed.returncode != 0:
-        detail = completed.stderr.strip()[:400] or "provider metadata unavailable"
-        return None, f"yt-dlp could not probe duration for {video_id}: {detail}"
-    try:
-        payload = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
-        return None, f"yt-dlp returned invalid duration metadata for {video_id}: {exc}"
-    if not isinstance(payload, dict) or payload.get("id") != video_id:
-        returned_id = payload.get("id") if isinstance(payload, dict) else None
-        return None, (
-            "yt-dlp duration metadata identity mismatch: requested "
-            f"{video_id}, received {returned_id!r}"
-        )
-    duration = _positive_duration(payload.get("duration"))
-    if duration is None:
-        return None, (
-            f"yt-dlp metadata for {video_id} has no positive finite duration; "
-            "cannot authorize a short-talk threshold"
-        )
-    return duration, f"trusted yt-dlp duration for YouTube video {video_id}"
-
-
-def probe_local_media_duration(path: Path) -> tuple[float | None, str]:
-    """Read duration from the exact local media bytes via ffprobe."""
-    try:
-        completed = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "default=noprint_wrappers=1:nokey=1",
-                str(path),
-            ],
-            capture_output=True,
-            text=True,
-        )
-    except (FileNotFoundError, OSError) as exc:
-        return None, (
-            f"cannot probe trusted local-media duration ({exc}) — install "
-            "ffprobe with `brew install ffmpeg`"
-        )
-    if completed.returncode != 0:
-        detail = completed.stderr.strip()[:400] or "media duration unavailable"
-        return None, f"ffprobe could not read duration from {path}: {detail}"
-    try:
-        raw_duration = float(completed.stdout.strip())
-    except ValueError:
-        return None, f"ffprobe returned an invalid duration for {path}"
-    duration = _positive_duration(raw_duration)
-    if duration is None:
-        return None, f"ffprobe returned no positive finite duration for {path}"
-    return duration, f"trusted ffprobe duration for local media {path}"
+        duration = probe_youtube_media_duration(video_id, ytdlp=ytdlp)
+    except LocalMediaError as exc:
+        return None, str(exc)
+    return duration, f"trusted bounded yt-dlp duration for YouTube video {video_id}"
 
 
 def duration_matches_expected(expected: int, trusted: float) -> bool:
@@ -614,49 +424,21 @@ def enrich_existing_caption_timing(
 
 
 def transcribe_audio(
-    audio_path: Path, video_id: str, model: str
-) -> tuple[str | None, str | None, Iterable[object] | None]:
-    """Call local Whisper; the caller owns enumerated lane isolation."""
-    return _transcribe_audio_with_mlx(audio_path, video_id, model)
-
-
-def _transcribe_audio_with_mlx(
-    audio_path: Path, video_id: str, model: str
-) -> tuple[str | None, str | None, Iterable[object] | None]:
-    """Return ``(text, language, timed segments)`` from local Whisper."""
-    try:
-        mlx_whisper = importlib.import_module("mlx_whisper")
-    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
-        print(
-            "mlx-whisper lane is unavailable "
-            f"({type(exc).__name__}: {exc}) (Apple Silicon only) — "
-            "`pip install 'speaker-toolkit[whisper]'`, or supply the transcript "
-            "by hand. On other platforms use a caption track or an external "
-            "transcription service.",
-            file=sys.stderr,
-        )
-        return None, None, None
-
-    try:
-        result = mlx_whisper.transcribe(str(audio_path), path_or_hf_repo=model)
-    except (AttributeError, OSError, TypeError, ValueError, RuntimeError) as exc:
-        # Model download failure, unreadable audio, or an unsupported runtime.
-        # Must not escape as a traceback — callers parse this script's stdout.
-        print(
-            f"mlx_whisper could not transcribe {video_id}: {type(exc).__name__}: {exc}",
-            file=sys.stderr,
-        )
-        return None, None, None
-    text = result.get("text") if isinstance(result, dict) else None
-    if not isinstance(text, str) or not text.strip():
-        print(f"mlx_whisper returned no text for {video_id}", file=sys.stderr)
-        return None, None, None
-    # Whisper detects the spoken language; this is the only language signal on
-    # the audio path, and `delivery_language` is derived from it.
-    raw_language = result.get("language") if isinstance(result, dict) else None
-    language = raw_language if isinstance(raw_language, str) else None
-    segments = result.get("segments") if isinstance(result, dict) else None
-    return text, language, segments if isinstance(segments, Iterable) else None
+    audio_path: Path,
+    video_id: str,
+    model: str,
+    *,
+    probe: MediaArtifactProbe | None = None,
+    trusted_root: Path | None = None,
+) -> tuple[str, str | None, Iterable[object] | None]:
+    """Use bounded Whisper, reusing established media facts without more byte I/O."""
+    _established, speech = transcribe_local_media(
+        audio_path,
+        model,
+        probe=probe,
+        trusted_root=trusted_root,
+    )
+    return speech["text"], speech["language"], speech["segments"]
 
 
 def fetch_whisper(
@@ -665,68 +447,28 @@ def fetch_whisper(
     model: str,
     *,
     ytdlp: str | Path | None = None,
-) -> tuple[str | None, str | None, Iterable[object] | None]:
-    """Download audio and return Whisper text, language, and timed segments."""
-    url = f"https://www.youtube.com/watch?v={video_id}"
-    audio: Path | None = None
-    failures: list[str] = []
-    try:
-        executable = Path(ytdlp) if ytdlp is not None else resolve_ytdlp()
-    except YtDlpResolutionError as exc:
-        print(str(exc), file=sys.stderr)
-        return None, None, None
-    # Each attempt downloads into its own directory. Sharing one path let a
-    # refused attempt leave a partial file behind, and the next attempt's
-    # "did the audio appear" check would accept those bytes as its own success
-    # — the retry chain would stop early and transcribe whatever the failure
-    # left. Isolation makes the check answer only for the attempt that ran.
-    for index, client in enumerate(YOUTUBE_PLAYER_CLIENTS):
-        attempt_dir = Path(work_dir) / f"download-{index}"
-        attempt_dir.mkdir(parents=True, exist_ok=True)
-        command = [
-            str(executable),
-            "-x",
-            "--audio-format",
-            "mp3",
-            "--no-playlist",
-            "-o",
-            str(attempt_dir / "audio.%(ext)s"),
-        ]
-        if client is not None:
-            command += ["--extractor-args", f"youtube:player_client={client}"]
-        command.append(url)
-        try:
-            download = subprocess.run(command, capture_output=True, text=True)
-        except (FileNotFoundError, OSError) as exc:
-            # A missing yt-dlp must not escape as a traceback: this script's
-            # callers parse its stdout JSON, and a script that dies without
-            # emitting it is the same silent-failure shape the whole file
-            # exists to prevent.
-            print(
-                f"cannot run yt-dlp ({exc}) — install the pinned version with "
-                "`pip install .` or set YT_DLP to its path",
-                file=sys.stderr,
-            )
-            return None, None, None
-        candidate = attempt_dir / "audio.mp3"
-        # A zero-byte artifact is a failed extraction wearing a filename.
-        if (
-            download.returncode == 0
-            and candidate.exists()
-            and candidate.stat().st_size > 0
-        ):
-            audio = candidate
-            break
-        failures.append(f"{client or 'default'}: {download.stderr.strip()[:200]}")
-    else:
-        print(
-            f"yt-dlp could not download audio for {video_id} under any player "
-            f"client — {'; '.join(failures)}",
-            file=sys.stderr,
-        )
-        return None, None, None
+) -> WhisperAcquisition:
+    """Download and transcribe within bounded, separately supervised operations.
 
-    return transcribe_audio(audio, video_id, model)
+    work_dir remains a compatibility argument; it cannot select or reuse a
+    workspace. The download owner creates and cleans its own private directory.
+    """
+    with download_youtube_audio(video_id, ytdlp=ytdlp) as (audio, duration):
+        probe = probe_local_media(audio, trusted_root=audio.parent)
+        if abs(probe.duration_seconds - duration) > 1.0:
+            raise LocalMediaError("ytdlp_media_duration_mismatch")
+        _established, speech = transcribe_local_media(
+            audio,
+            model,
+            probe=probe,
+            trusted_root=audio.parent,
+        )
+        return WhisperAcquisition(
+            speech["text"],
+            speech["language"],
+            speech["segments"],
+            duration,
+        )
 
 
 def prepare_optional_timing(
@@ -818,285 +560,174 @@ def _handle_local_audio(
     args: argparse.Namespace,
     requested_min_words: int | None,
 ) -> NoReturn:
-    """Process ``--audio`` through one private, byte-stable media snapshot."""
-    audio_path = Path(args.audio)
-    if not audio_path.is_file():
+    """Acquire local speech without reading media bytes in the CLI process."""
+    audio_path = Path(args.audio).absolute()
+    out = Path(args.out)
+    ensure_bundle_destinations_are_not_symlinks(out)
+    media = AssessedMediaSource(audio_path, probe_local_media(audio_path))
+    duration = media.probe.duration_seconds
+    if args.duration_seconds is not None and not duration_matches_expected(
+        args.duration_seconds,
+        duration,
+    ):
         emit(
             False,
             args.video,
             "none",
             0,
-            args.out,
-            f"--audio file does not exist or is not a file: {audio_path}",
+            out,
+            "--duration-seconds does not match the bounded local-media probe; "
+            "verify the recording and correct the expectation",
             2,
         )
-    out = Path(args.out)
-    ensure_bundle_destinations_are_not_symlinks(out)
+    quality_policy = build_quality_policy(
+        requested_min_words,
+        trusted_duration_seconds=duration,
+    )
+    quality_provenance = local_media_quality_provenance(media.sha256, duration)
+    timing_provenance = local_media_timing_provenance(media.sha256, duration)
+    minimum = quality_policy["min_words"]
+    if not isinstance(minimum, int):
+        raise ValueError("internal quality policy has no integer word floor")
 
-    with immutable_media_snapshot(audio_path) as media:
-        trusted_duration, duration_reason = probe_local_media_duration(media.path)
-        media.assert_unchanged()
-        if args.duration_seconds is not None:
-            if trusted_duration is None:
-                emit(
-                    False,
-                    args.video,
-                    "none",
-                    0,
-                    out,
-                    f"cannot verify --duration-seconds: {duration_reason}",
-                    2,
-                )
-            if not duration_matches_expected(
-                args.duration_seconds,
-                trusted_duration,
-            ):
-                emit(
-                    False,
-                    args.video,
-                    "none",
-                    0,
-                    out,
-                    "--duration-seconds does not match ffprobe for the immutable "
-                    f"local-media snapshot (expected {args.duration_seconds}, "
-                    f"source reports {trusted_duration})",
-                    2,
-                )
-        if trusted_duration is None:
-            print(
-                f"{duration_reason}; applying the fixed "
-                f"{DEFAULT_MIN_WORDS}-word quality floor",
-                file=sys.stderr,
-            )
-            quality_provenance = fixed_quality_provenance()
-        else:
-            quality_provenance = local_media_quality_provenance(
-                media.sha256,
-                trusted_duration,
-            )
-        quality_policy = build_quality_policy(
-            requested_min_words,
-            trusted_duration_seconds=trusted_duration,
-        )
-        timing_provenance = (
-            local_media_timing_provenance(media.sha256, trusted_duration)
-            if trusted_duration is not None
-            else None
-        )
-
-        if out.exists() and not args.force:
-            try:
-                existing = out.read_bytes().decode("utf-8")
-            except UnicodeDecodeError as exc:
-                emit(
-                    False,
-                    args.video,
-                    "none",
-                    0,
-                    out,
-                    f"existing transcript is not valid UTF-8: {exc}",
-                    2,
-                )
-            except OSError as exc:
-                emit(
-                    False,
-                    args.video,
-                    "none",
-                    0,
-                    out,
-                    f"existing transcript unreadable: {exc}",
-                    2,
-                )
-            policy_min_words = quality_policy["min_words"]
-            if not isinstance(policy_min_words, int):
-                emit(
-                    False,
-                    args.video,
-                    "none",
-                    0,
-                    out,
-                    "internal quality policy has no integer word floor",
-                    2,
-                )
-            ok, reason = validate_transcript(
-                existing,
-                min_words=policy_min_words,
-                duration_seconds=trusted_duration,
-            )
-            if not ok:
-                emit(
-                    False,
-                    args.video,
-                    "existing",
-                    count_words(existing),
-                    out,
-                    f"existing transcript is not usable: {reason}; inspect it and "
-                    "pass --force to authorize replacement",
-                    1,
-                )
-            receipt, _receipt_reason = load_verified_quality_receipt(out, existing)
-            expected_receipt = {
-                "policy": quality_policy,
-                "provenance": quality_provenance,
-            }
-            # Same rule as the YouTube branch: a probe that could not read the
-            # media leaves the fixed default in hand, and writing that over a
-            # receipt already recording a source-owned duration trades evidence
-            # for its absence. One condition this branch adds — the stored
-            # receipt is only the stronger one while it still describes these
-            # bytes. A receipt for different media is stale, not strong, so the
-            # digest must match before it is preserved.
-            would_discard_source_duration = (
-                trusted_duration is None
-                and receipt_claims_source_duration(receipt)
-                and receipt_matches_media_digest(receipt, media.sha256)
-            )
-            if receipt != expected_receipt and not would_discard_source_duration:
-                media.assert_unchanged(verify_source_digest=True)
-                try:
-                    write_quality_receipt(
-                        out,
-                        existing,
-                        quality_policy,
-                        quality_provenance,
-                    )
-                except (OSError, ValueError) as exc:
-                    emit(
-                        False,
-                        args.video,
-                        "existing",
-                        count_words(existing),
-                        out,
-                        "existing transcript is valid but its quality receipt "
-                        f"could not be written: {exc}",
-                        2,
-                    )
-            timed_segments, timing_reason = load_verified_segments(
-                out,
-                existing,
-                owner_source=args.existing_source,
-                owner_media_sha256=media.sha256,
-                owner_duration_seconds=trusted_duration,
-            )
-            media.assert_unchanged(verify_source_digest=True)
+    if out.exists() and not args.force:
+        try:
+            raw_existing = out.read_bytes()
+            existing = raw_existing.decode("utf-8")
+        except UnicodeDecodeError:
             emit(
-                True,
+                False,
+                args.video,
+                "none",
+                0,
+                out,
+                "existing transcript is not valid UTF-8; inspect it before "
+                "authorizing replacement with --force",
+                2,
+            )
+        ok, reason = validate_transcript(
+            existing,
+            min_words=minimum,
+            duration_seconds=duration,
+        )
+        if not ok:
+            emit(
+                False,
                 args.video,
                 "existing",
                 count_words(existing),
                 out,
-                f"kept existing transcript ({reason}); {timing_reason}",
-                0,
-                timed_path=sidecar_path(out) if timed_segments else None,
-                quality_path=quality_sidecar_path(out),
+                f"existing transcript is not usable: {reason}; inspect it and "
+                "pass --force to authorize replacement",
+                1,
             )
+        receipt, _receipt_reason = load_verified_quality_receipt(out, existing)
+        timed_segments, timing_reason = load_verified_segments(
+            out,
+            existing,
+            owner_source=args.existing_source,
+            owner_media_sha256=media.sha256,
+            owner_duration_seconds=duration,
+        )
 
-        transcription, lane_reason = run_optional_lane(
-            "mlx-whisper transcription lane",
-            lambda: transcribe_audio(media.path, args.video, args.whisper_model),
-            expected_errors=WHISPER_LANE_ERRORS,
-        )
-        if transcription is None:
-            emit(
-                False,
-                args.video,
-                "none",
-                0,
-                out,
-                f"local transcription failed — {lane_reason}; inspect stderr and "
-                "install or repair the whisper lane before retrying",
-                1,
-            )
-        text, language, segments = transcription
-        if text is None:
-            emit(
-                False,
-                args.video,
-                "none",
-                0,
-                out,
-                "local transcription produced no text — inspect stderr, then "
-                "repair the audio or whisper runtime before retrying",
-                1,
-            )
-        policy_min_words = quality_policy["min_words"]
-        if not isinstance(policy_min_words, int):
-            emit(
-                False,
-                args.video,
-                "none",
-                0,
-                out,
-                "internal quality policy has no integer word floor",
-                2,
-            )
-        ok, reason = validate_transcript(
-            text,
-            min_words=policy_min_words,
-            duration_seconds=trusted_duration,
-        )
-        if not ok:
-            if trusted_duration is None and count_words(text) < DEFAULT_MIN_WORDS:
-                reason += (
-                    "; a lower short-talk floor is unavailable because no "
-                    f"trusted media duration was available ({duration_reason})"
+        def before_quality_commit() -> None:
+            media.assert_unchanged()
+            ensure_bundle_destinations_are_not_symlinks(out)
+            if out.read_bytes() != raw_existing:
+                raise ValueError(
+                    "existing transcript changed during acquisition; retry "
+                    "against the current transcript without replacing it"
                 )
-            emit(
-                False,
-                args.video,
-                "whisper",
-                count_words(text),
+
+        expected_receipt = {"policy": quality_policy, "provenance": quality_provenance}
+        if receipt != expected_receipt:
+            write_quality_receipt(
                 out,
-                reason,
-                1,
-                language,
+                existing,
+                quality_policy,
+                quality_provenance,
+                before_commit=before_quality_commit,
             )
-        bundle_segments, bundle_timing_provenance, timing_reason = (
-            prepare_optional_timing_safely(
-                text,
-                segments,
-                source="whisper",
-                provenance=timing_provenance,
-            )
-        )
-        media.assert_unchanged(verify_source_digest=True)
-        try:
-            timed_path = write_transcript_bundle(
-                out,
-                text,
-                bundle_segments,
-                source="whisper",
-                timing_provenance=bundle_timing_provenance,
-                quality_policy=quality_policy,
-                quality_policy_provenance=quality_provenance,
-                force=args.force,
-            )
-        except (OSError, ValueError) as exc:
-            print(
-                f"cannot write the transcript bundle to {out}: {exc}", file=sys.stderr
-            )
-            emit(
-                False,
-                args.video,
-                "whisper",
-                count_words(text),
-                out,
-                f"transcript produced but its bundle could not be written: {exc}",
-                2,
-                language,
-            )
+        else:
+            before_quality_commit()
+        # No fallible media or timing check follows a committed quality refresh.
         emit(
             True,
             args.video,
-            "whisper",
-            count_words(text),
+            "existing",
+            count_words(existing),
             out,
-            reason if timed_path else f"{reason}; {timing_reason}",
+            f"kept existing transcript ({reason}); {timing_reason}",
             0,
-            language,
-            timed_path,
-            quality_sidecar_path(out),
+            timed_path=sidecar_path(out) if timed_segments else None,
+            quality_path=quality_sidecar_path(out),
         )
+
+    transcription, lane_reason = run_optional_lane(
+        "mlx-whisper transcription lane",
+        lambda: transcribe_audio(
+            media.path,
+            args.video,
+            args.whisper_model,
+            probe=media.probe,
+        ),
+        expected_errors=WHISPER_LANE_ERRORS,
+    )
+    if transcription is None:
+        emit(
+            False,
+            args.video,
+            "none",
+            0,
+            out,
+            f"local transcription failed — {lane_reason}; repair the Whisper "
+            "lane before retrying",
+            1,
+        )
+    text, language, segments = transcription
+    if text is None:
+        emit(
+            False,
+            args.video,
+            "none",
+            0,
+            out,
+            "local transcription produced no text; repair the audio or "
+            "Whisper runtime before retrying",
+            1,
+        )
+    ok, reason = validate_transcript(text, min_words=minimum, duration_seconds=duration)
+    if not ok:
+        emit(False, args.video, "whisper", count_words(text), out, reason, 1, language)
+    bundle_segments, bundle_provenance, timing_reason = prepare_optional_timing_safely(
+        text,
+        segments,
+        source="whisper",
+        provenance=timing_provenance,
+    )
+    timed_path = write_transcript_bundle(
+        out,
+        text,
+        bundle_segments,
+        source="whisper",
+        timing_provenance=bundle_provenance,
+        quality_policy=quality_policy,
+        quality_policy_provenance=quality_provenance,
+        force=args.force,
+        before_commit=media.assert_unchanged,
+    )
+    emit(
+        True,
+        args.video,
+        "whisper",
+        count_words(text),
+        out,
+        reason if timed_path else f"{reason}; {timing_reason}",
+        0,
+        language,
+        timed_path,
+        quality_sidecar_path(out),
+    )
 
 
 def main(argv: list[str] | None = None) -> NoReturn:
@@ -1171,6 +802,7 @@ def main(argv: list[str] | None = None) -> NoReturn:
         try:
             _handle_local_audio(args, requested_min_words)
         except (OSError, ValueError) as exc:
+            print(f"local-media acquisition failed: {exc}", file=sys.stderr)
             emit(
                 False,
                 args.video,
@@ -1509,15 +1141,33 @@ def main(argv: list[str] | None = None) -> NoReturn:
                 expected_errors=CAPTION_LANE_ERRORS,
             )
         else:
-            with tempfile.TemporaryDirectory() as work_dir:
-                lane_result, lane_reason = run_optional_lane(
-                    "YouTube Whisper lane",
-                    lambda: fetch_whisper(video_id, work_dir, args.whisper_model),
-                    expected_errors=WHISPER_LANE_ERRORS,
-                )
+            lane_result, lane_reason = run_optional_lane(
+                "YouTube Whisper lane",
+                lambda: fetch_whisper(video_id, "", args.whisper_model),
+                expected_errors=WHISPER_LANE_ERRORS,
+            )
         if lane_result is None:
             failures.append(f"{name}: {lane_reason}")
             continue
+        if isinstance(lane_result, WhisperAcquisition):
+            duration = lane_result.duration_seconds
+            if trusted_duration is not None and abs(duration - trusted_duration) > 1.0:
+                failures.append(
+                    "whisper: provider duration changed between metadata and download; verify the source and retry"
+                )
+                continue
+            if args.duration_seconds is not None and not duration_matches_expected(
+                args.duration_seconds, duration
+            ):
+                failures.append(
+                    "whisper: --duration-seconds does not match the downloaded recording; correct the expectation"
+                )
+                continue
+            trusted_duration = duration
+            quality_policy = build_quality_policy(
+                requested_min_words, trusted_duration_seconds=duration
+            )
+            quality_provenance = youtube_quality_provenance(video_id, duration)
         text, language, segments = lane_result
         if text is None:
             failures.append(f"{name}: unavailable")

--- a/skills/vault-ingress/scripts/local_media_contract.py
+++ b/skills/vault-ingress/scripts/local_media_contract.py
@@ -1,0 +1,442 @@
+"""Closed, path-neutral facts and resource policy for generic speech media.
+
+This contract does not open an artifact or authenticate a caller-supplied receipt.
+The local-media owner supplies facts from its authenticated worker, or explicitly
+converts a VideoArtifactProbe already established in the same assessment.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import math
+import re
+import stat
+from typing import Any, NoReturn
+
+from artifact_metadata import ArtifactAvailability, WINDOWS_REPARSE_POINT_ATTRIBUTE
+from artifact_supervisor import DiagnosticReceipt, FileGeneration, SupervisorLimits
+
+
+MEDIA_SCHEMA_VERSION = 1
+MEDIA_PIPELINE_VERSION = "1.0.0"
+MEDIA_MAX_INPUT_BYTES = 8 * 1024**3
+MEDIA_MAX_DURATION_SECONDS = 8 * 60 * 60
+MEDIA_MAX_STREAMS = 64
+MEDIA_FFPROBE_STDOUT_BYTES = 256 * 1024
+MEDIA_FFPROBE_STDERR_BYTES = 64 * 1024
+MEDIA_DIGEST_CHUNK_BYTES = 1024 * 1024
+WHISPER_MAX_TEXT_BYTES = 2 * 1024 * 1024
+WHISPER_MAX_SEGMENTS = 20000
+WHISPER_MAX_SEGMENT_TEXT_BYTES = 16384
+WHISPER_MAX_LANGUAGE_LENGTH = 32
+
+MEDIA_METADATA_LIMITS = SupervisorLimits(
+    profile_id="local-media-metadata-v1",
+    wall_seconds=15,
+    max_memory_bytes=256 * 1024**2,
+    max_input_bytes=64 * 1024,
+    max_output_bytes=64 * 1024,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=1,
+)
+MEDIA_PROBE_LIMITS = SupervisorLimits(
+    profile_id="local-media-probe-v1",
+    wall_seconds=300,
+    max_memory_bytes=512 * 1024**2,
+    max_input_bytes=64 * 1024,
+    max_output_bytes=64 * 1024,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=2,
+)
+MEDIA_DOWNLOAD_LIMITS = SupervisorLimits(
+    profile_id="local-media-download-v1",
+    wall_seconds=600,
+    max_memory_bytes=1024**3,
+    max_input_bytes=64 * 1024,
+    max_output_bytes=64 * 1024,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=4,
+)
+MEDIA_PROVIDER_METADATA_LIMITS = SupervisorLimits(
+    profile_id="local-media-provider-metadata-v1",
+    wall_seconds=120,
+    max_memory_bytes=1024**3,
+    max_input_bytes=64 * 1024,
+    max_output_bytes=64 * 1024,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=4,
+)
+MEDIA_WHISPER_LIMITS = SupervisorLimits(
+    profile_id="local-media-whisper-v1",
+    wall_seconds=900,
+    max_memory_bytes=16 * 1024**3,
+    max_input_bytes=64 * 1024,
+    max_output_bytes=8 * 1024**2,
+    max_diagnostic_bytes=64 * 1024,
+    max_processes=16,
+)
+
+CONTAINER_BY_SUFFIX = {
+    ".mp3": "mp3",
+    ".wav": "wav",
+    ".m4a": "iso_bmff",
+    ".mp4": "iso_bmff",
+    ".mov": "iso_bmff",
+    ".mkv": "matroska_webm",
+    ".webm": "matroska_webm",
+}
+FORMAT_NAMES_BY_CONTAINER = {
+    "mp3": frozenset({"mp3"}),
+    "wav": frozenset({"wav"}),
+    "iso_bmff": frozenset({"mov", "mp4", "m4a", "3gp", "3g2", "mj2"}),
+    "matroska_webm": frozenset({"matroska", "webm"}),
+}
+COUNT_FIELDS = (
+    "video_stream_count",
+    "audio_stream_count",
+    "attached_picture_count",
+    "other_stream_count",
+)
+FACT_FIELDS = frozenset(
+    {
+        "duration_seconds",
+        "duration_source",
+        "container_family",
+        "stream_count",
+        *COUNT_FIELDS,
+    }
+)
+PROBE_FIELDS = FACT_FIELDS | {
+    "schema_version",
+    "source_sha256",
+    "source_size_bytes",
+    "parser_diagnostics",
+}
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+_LANGUAGE = re.compile(r"[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*\Z")
+
+
+class LocalMediaError(ValueError):
+    """A typed acquisition refusal; raw paths and provider output stay private."""
+
+    def __init__(self, reason_code: str) -> None:
+        if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", reason_code) is None:
+            raise ValueError("invalid local-media failure code")
+        self.reason_code = reason_code
+        super().__init__(
+            f"{reason_code}; inspect the source and rerun the bounded media owner"
+        )
+
+
+def refuse(reason: str) -> NoReturn:
+    raise LocalMediaError(reason)
+
+
+def positive_duration(value: Any) -> float | None:
+    if type(value) not in {int, float} or not 0 < value <= MEDIA_MAX_DURATION_SECONDS:
+        return None
+    return float(value) if math.isfinite(value) else None
+
+
+def validate_media_size(value: Any) -> int:
+    if type(value) is not int or not 0 < value <= MEDIA_MAX_INPUT_BYTES:
+        refuse("media_size_limit")
+    return value
+
+
+def validate_available_generation(generation: FileGeneration) -> None:
+    try:
+        FileGeneration.from_dict(generation.to_dict())
+    except (TypeError, ValueError) as exc:
+        raise LocalMediaError("media_probe_malformed_result") from exc
+    if not stat.S_ISREG(generation.mode) or (
+        (generation.file_attributes or 0) & WINDOWS_REPARSE_POINT_ATTRIBUTE
+    ):
+        refuse("media_artifact_unavailable")
+    if ArtifactAvailability.from_generation(generation).state != "local":
+        refuse("media_cloud_placeholder_unavailable")
+    validate_media_size(generation.size)
+
+
+def parse_media_facts(document: Any, expected_container: str) -> dict[str, Any]:
+    """Validate bounded ffprobe JSON; audio is mandatory and video is optional."""
+    if (
+        not isinstance(document, Mapping)
+        or set(document) - {"format", "streams", "programs", "stream_groups"}
+        or document.get("programs", []) != []
+        or document.get("stream_groups", []) != []
+    ):
+        refuse("media_parser_rejected")
+    media_format, streams = document.get("format"), document.get("streams")
+    if not isinstance(media_format, Mapping) or not isinstance(streams, list):
+        refuse("media_invalid_container")
+    format_names = media_format.get("format_name")
+    allowed = FORMAT_NAMES_BY_CONTAINER.get(expected_container)
+    if (
+        not allowed
+        or not isinstance(format_names, str)
+        or not format_names
+        or not set(format_names.split(",")) <= allowed
+    ):
+        refuse("media_invalid_container")
+    if len(streams) > MEDIA_MAX_STREAMS:
+        refuse("media_stream_limit")
+    counts: dict[str, int] = dict.fromkeys(COUNT_FIELDS, 0)
+    usable_audio = 0
+    durations = []
+    for stream in streams:
+        if not isinstance(stream, Mapping) or not isinstance(
+            stream.get("codec_type"), str
+        ):
+            refuse("media_parser_rejected")
+        kind = stream["codec_type"]
+        disposition = stream.get("disposition", {})
+        if not isinstance(disposition, Mapping):
+            refuse("media_parser_rejected")
+        attached_flag = disposition.get("attached_pic", 0)
+        if type(attached_flag) not in {int, str} or attached_flag not in (
+            0,
+            1,
+            "0",
+            "1",
+        ):
+            refuse("media_parser_rejected")
+        attached = kind == "video" and attached_flag in (1, "1")
+        if kind == "audio" and _usable_audio_stream(stream):
+            usable_audio += 1
+        if attached:
+            counts["attached_picture_count"] += 1
+        elif kind in {"video", "audio"}:
+            counts[f"{kind}_stream_count"] += 1
+        else:
+            counts["other_stream_count"] += 1
+        if kind == "audio" or (kind == "video" and not attached):
+            duration = _probe_duration(stream.get("duration"))
+            if duration is not None:
+                durations.append(duration)
+    if counts["audio_stream_count"] == 0:
+        refuse("media_no_audio_stream")
+    if usable_audio == 0:
+        refuse("media_no_usable_audio_stream")
+    duration = _probe_duration(media_format.get("duration"))
+    source = "format"
+    if duration is None:
+        duration = max(durations) if durations else None
+        source = "stream"
+    if duration is None:
+        refuse("media_duration_unavailable")
+    if positive_duration(duration) is None:
+        refuse("media_duration_limit")
+    return {
+        "duration_seconds": duration,
+        "duration_source": source,
+        "container_family": expected_container,
+        "stream_count": len(streams),
+        **counts,
+    }
+
+
+def _usable_audio_stream(stream: Mapping[str, Any]) -> bool:
+    codec = stream.get("codec_name")
+    channels = stream.get("channels")
+    sample_rate = stream.get("sample_rate")
+    return (
+        isinstance(codec, str)
+        and re.fullmatch(r"[a-z0-9_]{1,64}", codec) is not None
+        and codec not in {"unknown", "none"}
+        and type(channels) is int
+        and channels > 0
+        and isinstance(sample_rate, str)
+        and len(sample_rate) <= 10
+        and sample_rate.isascii()
+        and sample_rate.isdecimal()
+        and int(sample_rate) > 0
+    )
+
+
+def _probe_duration(value: Any) -> float | None:
+    if value is None or value == "N/A":
+        return None
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        refuse("media_parser_rejected")
+    try:
+        result = float(value)
+    except OverflowError as exc:
+        raise LocalMediaError("media_duration_limit") from exc
+    except ValueError as exc:
+        raise LocalMediaError("media_parser_rejected") from exc
+    if not math.isfinite(result) or result <= 0:
+        refuse("media_parser_rejected")
+    if result > MEDIA_MAX_DURATION_SECONDS:
+        refuse("media_duration_limit")
+    return result
+
+
+@dataclass(frozen=True)
+class MediaArtifactProbe:
+    generation: FileGeneration
+    root_generation: FileGeneration | None
+    source_sha256: str
+    source_size_bytes: int
+    duration_seconds: float
+    duration_source: str
+    container_family: str
+    stream_count: int
+    video_stream_count: int
+    audio_stream_count: int
+    attached_picture_count: int
+    other_stream_count: int
+    parser_diagnostics: DiagnosticReceipt
+
+
+def decode_media_probe(
+    payload: Any, generation: FileGeneration, root_generation: FileGeneration | None
+) -> MediaArtifactProbe:
+    if not isinstance(payload, Mapping) or set(payload) != PROBE_FIELDS:
+        refuse("media_probe_malformed_result")
+    if (
+        type(payload["schema_version"]) is not int
+        or payload["schema_version"] != MEDIA_SCHEMA_VERSION
+    ):
+        refuse("media_probe_malformed_result")
+    validate_available_generation(generation)
+    size = validate_media_size(payload["source_size_bytes"])
+    digest = payload["source_sha256"]
+    if (
+        size != generation.size
+        or not isinstance(digest, str)
+        or _SHA256.fullmatch(digest) is None
+    ):
+        refuse("media_probe_malformed_result")
+    if (
+        positive_duration(payload["duration_seconds"]) is None
+        or payload["duration_source"] not in ("format", "stream")
+        or not isinstance(payload["container_family"], str)
+        or payload["container_family"] not in FORMAT_NAMES_BY_CONTAINER
+    ):
+        refuse("media_probe_malformed_result")
+    for name in ("stream_count", *COUNT_FIELDS):
+        if (
+            type(payload[name]) is not int
+            or not 0 <= payload[name] <= MEDIA_MAX_STREAMS
+        ):
+            refuse("media_probe_malformed_result")
+    if (
+        payload["audio_stream_count"] == 0
+        or sum(payload[name] for name in COUNT_FIELDS) != payload["stream_count"]
+    ):
+        refuse("media_probe_malformed_result")
+    diagnostic = payload["parser_diagnostics"]
+    if (
+        not isinstance(diagnostic, Mapping)
+        or set(diagnostic) != {"byte_count", "sha256", "truncated"}
+        or type(diagnostic["byte_count"]) is not int
+        or diagnostic["byte_count"] != 0
+        or diagnostic["sha256"] != DiagnosticReceipt.empty().sha256
+        or diagnostic["truncated"] is not False
+    ):
+        refuse("media_probe_malformed_result")
+    return MediaArtifactProbe(
+        generation=generation,
+        root_generation=root_generation,
+        source_sha256=digest,
+        source_size_bytes=size,
+        duration_seconds=float(payload["duration_seconds"]),
+        duration_source=payload["duration_source"],
+        container_family=payload["container_family"],
+        stream_count=payload["stream_count"],
+        **{name: payload[name] for name in COUNT_FIELDS},
+        parser_diagnostics=DiagnosticReceipt.empty(),
+    )
+
+
+def reuse_video_probe(probe: Any) -> MediaArtifactProbe:
+    """Convert established video facts without probing, copying, hashing, or statting."""
+    from video_evidence import VideoArtifactProbe
+
+    if not isinstance(probe, VideoArtifactProbe):
+        refuse("media_probe_malformed_result")
+    if probe.audio_stream_count == 0:
+        refuse("media_no_audio_stream")
+    return decode_media_probe(
+        {
+            "schema_version": MEDIA_SCHEMA_VERSION,
+            "source_sha256": probe.source_sha256,
+            "source_size_bytes": probe.source_size_bytes,
+            **{name: getattr(probe, name) for name in sorted(FACT_FIELDS)},
+            "parser_diagnostics": probe.parser_diagnostics.to_dict(),
+        },
+        probe.generation,
+        probe.root_generation,
+    )
+
+
+def bounded_whisper_result(value: Any) -> dict[str, Any]:
+    """Strip provider-only payloads before a worker returns bounded speech data.
+
+    Missing timing remains optional. A present unbounded/malformed container is
+    a resource/result failure, not an invitation to enumerate a provider iterator.
+    Segment timing semantics remain with the transcript-timing owner.
+    """
+    if not isinstance(value, Mapping):
+        refuse("whisper_result_invalid")
+    text = value.get("text")
+    if not isinstance(text, str) or not text.strip():
+        refuse("whisper_result_invalid")
+    _bounded_text(text, WHISPER_MAX_TEXT_BYTES, "whisper_text_limit")
+    language = value.get("language")
+    if language is not None and (
+        not isinstance(language, str)
+        or len(language) > WHISPER_MAX_LANGUAGE_LENGTH
+        or _LANGUAGE.fullmatch(language) is None
+    ):
+        refuse("whisper_language_invalid")
+    raw_segments = value.get("segments")
+    segments = None
+    if raw_segments is not None:
+        if not isinstance(raw_segments, list):
+            refuse("whisper_segments_invalid")
+        if len(raw_segments) > WHISPER_MAX_SEGMENTS:
+            refuse("whisper_segment_limit")
+        segments = []
+        timing_valid = True
+        total_segment_bytes = 0
+        for segment in raw_segments:
+            if not isinstance(segment, Mapping):
+                refuse("whisper_segments_invalid")
+            segment_text = segment.get("text")
+            if not isinstance(segment_text, str):
+                refuse("whisper_segments_invalid")
+            _bounded_text(
+                segment_text,
+                WHISPER_MAX_SEGMENT_TEXT_BYTES,
+                "whisper_segment_text_limit",
+            )
+            total_segment_bytes += len(segment_text.encode("utf-8"))
+            if total_segment_bytes > WHISPER_MAX_TEXT_BYTES:
+                refuse("whisper_segment_text_limit")
+            start, end = segment.get("start"), segment.get("end")
+            if not all(_segment_offset(number) for number in (start, end)):
+                # Bounded semantic timing failure: keep speech, omit timing.
+                timing_valid = False
+            else:
+                segments.append({"start": start, "end": end, "text": segment_text})
+        if not timing_valid:
+            segments = None
+    return {"text": text, "language": language, "segments": segments}
+
+
+def _segment_offset(value: Any) -> bool:
+    return type(value) in {int, float} and 0 <= value <= MEDIA_MAX_DURATION_SECONDS
+
+
+def _bounded_text(value: str, maximum: int, reason: str) -> None:
+    if len(value) > maximum:
+        refuse(reason)
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeError as exc:
+        raise LocalMediaError("whisper_result_invalid") from exc
+    if len(encoded) > maximum:
+        refuse(reason)

--- a/skills/vault-ingress/scripts/local_media_download.py
+++ b/skills/vault-ingress/scripts/local_media_download.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Bounded YouTube metadata/download workers with owner-owned private cleanup.
+
+Download bytes stream from yt-dlp stdout into one literal file with an enforced
+byte ceiling. No provider-controlled output template, postprocessor, playlist,
+user configuration or plugin can authorize additional artifacts. The downloaded
+file still needs the generic-media probe before Whisper may read it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+from typing import Any, Iterator, cast
+
+from artifact_supervisor import (
+    JsonValue,
+    SupervisorError,
+    WorkerRequest,
+    isolate_protocol_output,
+    read_worker_request,
+    run_authenticated_worker,
+    write_worker_response,
+)
+from local_media_contract import (
+    MEDIA_DOWNLOAD_LIMITS,
+    MEDIA_MAX_INPUT_BYTES,
+    MEDIA_PIPELINE_VERSION,
+    MEDIA_PROVIDER_METADATA_LIMITS,
+    MEDIA_SCHEMA_VERSION,
+    LocalMediaError,
+    positive_duration,
+    refuse,
+)
+from local_media_evidence import _admit_workspace, _inspect, private_media_workspace
+from local_media_process import MediaToolResult, run_media_tool
+from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
+
+
+WORKER_FLAG = "--supervised-worker"
+METADATA_OPERATION = "youtube_media_metadata"
+DOWNLOAD_OPERATION = "youtube_media_download"
+YOUTUBE_PLAYER_CLIENTS = (None, "mweb", "web_safari", "ios", "tv")
+YTDLP_METADATA_BYTES = 1024 * 1024
+YTDLP_DIAGNOSTIC_BYTES = 64 * 1024
+DOWNLOAD_EXTENSIONS = frozenset({"m4a", "webm", "mp3"})
+DOWNLOAD_FORMAT = "bestaudio[ext=m4a]/bestaudio[ext=webm]/bestaudio[ext=mp3]"
+_VIDEO_ID = re.compile(r"[A-Za-z0-9_-]{11}\Z")
+_FORMAT_ID = re.compile(r"[A-Za-z0-9_-]{1,64}\Z")
+_DOWNLOAD_FAILURES = frozenset(
+    {
+        "ytdlp_dependency_unavailable",
+        "ytdlp_provider_rejected",
+        "ytdlp_metadata_invalid",
+        "ytdlp_identity_mismatch",
+        "ytdlp_duration_unavailable",
+        "ytdlp_format_unavailable",
+        "ytdlp_stdout_limit",
+        "ytdlp_stderr_limit",
+        "ytdlp_download_size_limit",
+        "ytdlp_output_invalid",
+        "media_pipe_failed",
+        "media_cleanup_failed",
+        "media_private_workspace_unavailable",
+        "media_artifact_unavailable",
+        "media_size_limit",
+    }
+)
+
+
+def _video_id(value: Any) -> str:
+    if not isinstance(value, str) or _VIDEO_ID.fullmatch(value) is None:
+        refuse("ytdlp_identity_mismatch")
+    return value
+
+
+def _worker(operation: str, payload: dict[str, Any]) -> Any:
+    command = [sys.executable, str(Path(__file__).resolve()), WORKER_FLAG]
+    limits = (
+        MEDIA_DOWNLOAD_LIMITS
+        if operation == DOWNLOAD_OPERATION
+        else MEDIA_PROVIDER_METADATA_LIMITS
+    )
+    try:
+        result = run_authenticated_worker(
+            command,
+            operation,
+            {},
+            cast(JsonValue, payload),
+            limits,
+            immutable_process_identity=command[:2],
+            schema_generation=MEDIA_SCHEMA_VERSION,
+            pipeline_generation=MEDIA_PIPELINE_VERSION,
+        )
+    except SupervisorError as exc:
+        reason = exc.reason_code
+        if reason not in _DOWNLOAD_FAILURES:
+            reason = {
+                "worker_timeout": "ytdlp_worker_timeout",
+                "worker_memory_limit_exceeded": "ytdlp_worker_resource_limit",
+                "worker_process_limit_exceeded": "ytdlp_worker_resource_limit",
+                "worker_input_limit_exceeded": "ytdlp_worker_resource_limit",
+                "worker_output_limit_exceeded": "ytdlp_worker_resource_limit",
+                "worker_diagnostic_limit_exceeded": "ytdlp_worker_resource_limit",
+                "worker_cleanup_failed": "media_cleanup_failed",
+            }.get(reason, "ytdlp_worker_failed")
+        raise LocalMediaError(reason) from exc
+    return result.payload
+
+
+def _payload(video_id: str, ytdlp: Any, workspace: dict[str, Any]) -> dict[str, Any]:
+    if ytdlp is not None and (
+        not isinstance(ytdlp, (str, Path)) or not Path(ytdlp).is_absolute()
+    ):
+        refuse("ytdlp_dependency_unavailable")
+    return {
+        "video_id": _video_id(video_id),
+        "ytdlp": str(ytdlp) if ytdlp is not None else None,
+        "workspace": workspace,
+    }
+
+
+def _decode_result(value: Any, video_id: str, *, download: bool) -> dict[str, Any]:
+    fields = {"video_id", "duration_seconds"} | (
+        {"artifact_name"} if download else set()
+    )
+    if (
+        not isinstance(value, Mapping)
+        or set(value) != fields
+        or value.get("video_id") != video_id
+        or positive_duration(value.get("duration_seconds")) is None
+    ):
+        refuse("ytdlp_metadata_invalid")
+    if download and (
+        not isinstance(value["artifact_name"], str)
+        or value["artifact_name"] not in {f"audio.{ext}" for ext in DOWNLOAD_EXTENSIONS}
+    ):
+        refuse("ytdlp_output_invalid")
+    return dict(value)
+
+
+def probe_youtube_media_duration(video_id: str, *, ytdlp: Any = None) -> float:
+    """Return one identity-bound provider duration; no media download occurs."""
+    with private_media_workspace() as workspace:
+        payload = _payload(video_id, ytdlp, workspace)
+        value = _decode_result(
+            _worker(METADATA_OPERATION, payload), video_id, download=False
+        )
+        return float(value["duration_seconds"])
+
+
+@contextmanager
+def download_youtube_audio(
+    video_id: str, *, ytdlp: Any = None
+) -> Iterator[tuple[Path, float]]:
+    """Yield one private artifact and provider duration; clean up on every exit."""
+    with private_media_workspace() as workspace:
+        payload = _payload(video_id, ytdlp, workspace)
+        value = _decode_result(
+            _worker(DOWNLOAD_OPERATION, payload), video_id, download=True
+        )
+        yield (
+            Path(workspace["path"]) / value["artifact_name"],
+            float(value["duration_seconds"]),
+        )
+
+
+def _command(executable: Path, video_id: str, client: str | None) -> list[str]:
+    command = [
+        str(executable),
+        "--ignore-config",
+        "--no-plugin-dirs",
+        "--no-cache-dir",
+        "--no-playlist",
+        "--no-progress",
+        "--no-colors",
+        "--socket-timeout",
+        "30",
+        "--retries",
+        "1",
+        "--fragment-retries",
+        "1",
+        "--abort-on-unavailable-fragments",
+    ]
+    if client is not None:
+        command += ["--extractor-args", f"youtube:player_client={client}"]
+    return command + [f"https://www.youtube.com/watch?v={video_id}"]
+
+
+def _run(
+    command: list[str], workspace: Path, *, output: Path | None = None
+) -> MediaToolResult:
+    try:
+        return run_media_tool(
+            command,
+            stdout_limit=MEDIA_MAX_INPUT_BYTES
+            if output is not None
+            else YTDLP_METADATA_BYTES,
+            stderr_limit=YTDLP_DIAGNOSTIC_BYTES,
+            output=output,
+            cwd=workspace,
+        )
+    except LocalMediaError as exc:
+        reason = {
+            "media_tool_stdout_limit": "ytdlp_download_size_limit"
+            if output is not None
+            else "ytdlp_stdout_limit",
+            "media_tool_stderr_limit": "ytdlp_stderr_limit",
+            "media_dependency_unavailable": "ytdlp_dependency_unavailable",
+        }.get(exc.reason_code, exc.reason_code)
+        raise LocalMediaError(reason) from exc
+
+
+def _unique_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            refuse("ytdlp_metadata_invalid")
+        result[key] = value
+    return result
+
+
+def _reject_constant(_value: str) -> Any:
+    refuse("ytdlp_metadata_invalid")
+
+
+def _metadata(
+    command: list[str], workspace: Path, video_id: str, *, download: bool
+) -> dict[str, Any]:
+    extra = ["--dump-single-json", "--skip-download"]
+    if download:
+        extra += ["-f", DOWNLOAD_FORMAT]
+    response = _run(command[:-1] + extra + command[-1:], workspace)
+    if response.returncode != 0:
+        refuse("ytdlp_provider_rejected")
+    try:
+        value = json.loads(
+            response.stdout,
+            object_pairs_hook=_unique_pairs,
+            parse_constant=_reject_constant,
+        )
+    except (ValueError, UnicodeError, RecursionError) as exc:
+        raise LocalMediaError("ytdlp_metadata_invalid") from exc
+    if not isinstance(value, Mapping) or value.get("id") != video_id:
+        refuse("ytdlp_identity_mismatch")
+    duration = positive_duration(value.get("duration"))
+    if (
+        duration is None
+        or value.get("is_live") is True
+        or value.get("live_status") in ("is_live", "is_upcoming")
+    ):
+        refuse("ytdlp_duration_unavailable")
+    result = {"video_id": video_id, "duration_seconds": duration}
+    if download:
+        extension, format_id = value.get("ext"), value.get("format_id")
+        if (
+            not isinstance(extension, str)
+            or extension not in DOWNLOAD_EXTENSIONS
+            or not isinstance(format_id, str)
+            or _FORMAT_ID.fullmatch(format_id) is None
+            or value.get("vcodec") != "none"
+            or not isinstance(value.get("acodec"), str)
+            or value["acodec"] in ("none", "unknown", "")
+        ):
+            refuse("ytdlp_format_unavailable")
+        size = value.get("filesize")
+        if size is not None and (
+            type(size) is not int or not 0 < size <= MEDIA_MAX_INPUT_BYTES
+        ):
+            refuse("ytdlp_download_size_limit")
+        result.update(extension=extension, format_id=format_id)
+    return result
+
+
+def _require_only_artifact(workspace: Path, artifact: Path) -> None:
+    with os.scandir(workspace) as entries:
+        first = next(entries, None)
+        if (
+            first is None
+            or first.name != artifact.name
+            or next(entries, None) is not None
+        ):
+            refuse("ytdlp_output_invalid")
+    _inspect(artifact, workspace)
+
+
+def _download(executable: Path, workspace: Path, video_id: str) -> dict[str, Any]:
+    for client in YOUTUBE_PLAYER_CLIENTS:
+        command = _command(executable, video_id, client)
+        try:
+            metadata = _metadata(command, workspace, video_id, download=True)
+        except LocalMediaError as exc:
+            if exc.reason_code != "ytdlp_provider_rejected":
+                raise
+            continue
+        candidate = workspace / f"audio.{metadata['extension']}"
+        download = _run(
+            command[:-1]
+            + [
+                "-f",
+                metadata["format_id"],
+                "-o",
+                "-",
+                "--no-part",
+                "--max-filesize",
+                str(MEDIA_MAX_INPUT_BYTES),
+            ]
+            + command[-1:],
+            workspace,
+            output=candidate,
+        )
+        if download.returncode == 0 and download.streamed_bytes > 0:
+            _require_only_artifact(workspace, candidate)
+            os.chmod(candidate, stat.S_IREAD)
+            return {
+                "video_id": video_id,
+                "duration_seconds": metadata["duration_seconds"],
+                "artifact_name": candidate.name,
+            }
+        # Only the literal exclusive-create file from this failed attempt is removed.
+        # A resource, identity or malformed-output failure never reaches a retry.
+        candidate.unlink()
+        with os.scandir(workspace) as entries:
+            if next(entries, None) is not None:
+                refuse("ytdlp_output_invalid")
+    refuse("ytdlp_provider_rejected")
+
+
+def _dispatch(request: WorkerRequest) -> dict[str, Any]:
+    payload = request.payload
+    limits = (
+        MEDIA_DOWNLOAD_LIMITS
+        if request.operation == DOWNLOAD_OPERATION
+        else MEDIA_PROVIDER_METADATA_LIMITS
+    )
+    if (
+        request.operation not in {METADATA_OPERATION, DOWNLOAD_OPERATION}
+        or request.limit_profile_id != limits.profile_id
+        or request.expected_generations
+        or request.schema_generation != MEDIA_SCHEMA_VERSION
+        or request.pipeline_generation != MEDIA_PIPELINE_VERSION
+        or not isinstance(payload, Mapping)
+        or set(payload) != {"video_id", "ytdlp", "workspace"}
+    ):
+        raise SupervisorError("invalid_worker_request")
+    video_id = _video_id(payload["video_id"])
+    workspace = _admit_workspace(payload["workspace"])
+    override = payload["ytdlp"]
+    if override is not None and (
+        not isinstance(override, str) or not Path(override).is_absolute()
+    ):
+        refuse("ytdlp_dependency_unavailable")
+    try:
+        executable = Path(override) if override is not None else resolve_ytdlp()
+    except YtDlpResolutionError as exc:
+        raise LocalMediaError("ytdlp_dependency_unavailable") from exc
+    if request.operation == DOWNLOAD_OPERATION:
+        return _download(executable, workspace, video_id)
+    return _metadata(
+        _command(executable, video_id, None), workspace, video_id, download=False
+    )
+
+
+def _worker_main() -> int:
+    request = read_worker_request(max_input_bytes=MEDIA_DOWNLOAD_LIMITS.max_input_bytes)
+    stream = isolate_protocol_output()
+    try:
+        try:
+            value = _dispatch(request)
+            write_worker_response(
+                request,
+                payload=cast(JsonValue, value),
+                observed_generations={},
+                stream=stream,
+                max_output_bytes=MEDIA_DOWNLOAD_LIMITS.max_output_bytes,
+            )
+        except (LocalMediaError, SupervisorError, OSError) as exc:
+            reason = (
+                exc.reason_code
+                if isinstance(exc, SupervisorError)
+                or (
+                    isinstance(exc, LocalMediaError)
+                    and exc.reason_code in _DOWNLOAD_FAILURES
+                )
+                else "ytdlp_worker_failed"
+            )
+            write_worker_response(
+                request,
+                error=SupervisorError(reason),
+                observed_generations={},
+                stream=stream,
+                max_output_bytes=MEDIA_DOWNLOAD_LIMITS.max_output_bytes,
+            )
+    finally:
+        stream.close()
+    return 0
+
+
+def _main() -> int:
+    if sys.argv[1:] != [WORKER_FLAG]:
+        print(
+            "local_media_download.py is a library; use fetch-transcript.py",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        return _worker_main()
+    except SupervisorError as exc:
+        print(f"YouTube media worker failed: {exc.reason_code}", file=sys.stderr)
+        return 2
+    # A nonzero child without an authenticated response is the supervisor's
+    # closed crash signal. Emit only a fixed diagnostic; propagation would leak
+    # provider URLs, paths and credentials. outer-boundary-process-contract.
+    except Exception:  # noqa: BLE001
+        print("YouTube media worker failed: unexpected_error", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/skills/vault-ingress/scripts/local_media_evidence.py
+++ b/skills/vault-ingress/scripts/local_media_evidence.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Authenticated, bounded inspection of generic audio and video-with-audio."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+import tempfile
+from typing import Any, Iterator, NoReturn, cast
+
+from artifact_locator import (
+    ArtifactLocatorError,
+    materialize_artifact_locator,
+    materialize_native_root,
+)
+from artifact_metadata import (
+    ArtifactMetadataMalformed,
+    ArtifactMetadataReceipt,
+    ArtifactMetadataUnavailable,
+    METADATA_SCHEMA_VERSION,
+    WINDOWS_REPARSE_POINT_ATTRIBUTE,
+    canonicalize_trusted_artifact_locator,
+    decode_artifact_metadata_payload,
+    inspect_metadata_generation,
+)
+from artifact_supervisor import (
+    DiagnosticReceipt,
+    FileGeneration,
+    JsonValue,
+    SupervisorError,
+    SupervisorLimits,
+    WorkerRequest,
+    WorkerResult,
+    isolate_protocol_output,
+    read_worker_request,
+    run_authenticated_worker,
+    write_worker_response,
+)
+from local_media_contract import (
+    CONTAINER_BY_SUFFIX,
+    MEDIA_DIGEST_CHUNK_BYTES,
+    MEDIA_FFPROBE_STDERR_BYTES,
+    MEDIA_FFPROBE_STDOUT_BYTES,
+    MEDIA_METADATA_LIMITS,
+    MEDIA_PIPELINE_VERSION,
+    MEDIA_PROBE_LIMITS,
+    MEDIA_SCHEMA_VERSION,
+    LocalMediaError,
+    MediaArtifactProbe,
+    decode_media_probe,
+    parse_media_facts,
+    refuse,
+    validate_available_generation,
+)
+from local_media_process import run_media_tool
+
+
+WORKER_FLAG = "--supervised-worker"
+METADATA_OPERATION = "local_media_metadata"
+PROBE_OPERATION = "local_media_probe"
+CHECK_OPERATION = "local_media_check"
+_LOCAL_FAILURES = frozenset(
+    {
+        "media_artifact_unavailable",
+        "media_cloud_placeholder_unavailable",
+        "media_size_limit",
+        "media_duration_limit",
+        "media_duration_unavailable",
+        "media_stream_limit",
+        "media_no_audio_stream",
+        "media_no_usable_audio_stream",
+        "media_invalid_container",
+        "media_parser_rejected",
+        "media_parser_repair_required",
+        "media_dependency_unavailable",
+        "media_generation_changed",
+        "media_ffprobe_stdout_limit",
+        "media_ffprobe_stderr_limit",
+        "media_pipe_failed",
+        "media_private_workspace_unavailable",
+        "media_cleanup_failed",
+    }
+)
+
+
+def _worker_command() -> list[str]:
+    return [sys.executable, str(Path(__file__).resolve()), WORKER_FLAG]
+
+
+def _invoke_worker(
+    operation: str,
+    expected: dict[str, FileGeneration],
+    payload: dict[str, Any],
+    limits: SupervisorLimits,
+) -> WorkerResult:
+    command = _worker_command()
+    try:
+        result = run_authenticated_worker(
+            command,
+            operation,
+            expected,
+            cast(JsonValue, payload),
+            limits,
+            immutable_process_identity=command[:2],
+            sensitive_values=tuple(
+                value
+                for value in (payload.get("media_path"), payload.get("trusted_root"))
+                if value
+            ),
+            schema_generation=MEDIA_SCHEMA_VERSION,
+            pipeline_generation=MEDIA_PIPELINE_VERSION,
+        )
+    except SupervisorError as exc:
+        reason = exc.reason_code
+        if reason in _LOCAL_FAILURES:
+            raise LocalMediaError(reason) from exc
+        if reason == "worker_generation_changed":
+            reason = "media_generation_changed"
+        elif reason == "worker_timeout":
+            reason = "media_worker_timeout"
+        elif reason in {
+            "worker_memory_limit_exceeded",
+            "worker_process_limit_exceeded",
+            "worker_input_limit_exceeded",
+            "worker_output_limit_exceeded",
+            "worker_diagnostic_limit_exceeded",
+        }:
+            reason = "media_worker_resource_limit"
+        elif reason == "worker_cleanup_failed":
+            reason = "media_cleanup_failed"
+        else:
+            reason = "media_worker_failed"
+        raise LocalMediaError(reason) from exc
+    if result.diagnostics != DiagnosticReceipt.empty():
+        refuse("media_probe_malformed_result")
+    return result
+
+
+def _request_paths(path: Any, trusted_root: Any) -> tuple[Path, Path | None]:
+    try:
+        root = (
+            materialize_native_root(trusted_root) if trusted_root is not None else None
+        )
+        artifact = materialize_artifact_locator(path, trusted_root=root)
+    except ArtifactLocatorError as exc:
+        raise LocalMediaError("media_locator_invalid") from exc
+    if artifact.suffix.lower() not in CONTAINER_BY_SUFFIX:
+        refuse("media_unsupported_suffix")
+    return artifact, root
+
+
+def _path_payload(artifact: Path, root: Path | None) -> dict[str, Any]:
+    return {
+        "media_path": str(artifact),
+        "trusted_root": str(root) if root is not None else None,
+        "workspace": None,
+    }
+
+
+def _bindings(receipt: ArtifactMetadataReceipt) -> dict[str, FileGeneration]:
+    result = {"media": receipt.generation}
+    if receipt.root_generation is not None:
+        result["media_root"] = receipt.root_generation
+    return result
+
+
+def _decode_metadata(value: Any, root: Path | None) -> ArtifactMetadataReceipt:
+    if not isinstance(value, Mapping) or type(value.get("schema_version")) is not int:
+        refuse("media_probe_malformed_result")
+    try:
+        receipt = decode_artifact_metadata_payload(
+            value,
+            unavailable_reason_code="media_artifact_unavailable",
+            cloud_reparse_tags=frozenset(),
+        )
+    except ArtifactMetadataUnavailable as exc:
+        raise LocalMediaError("media_artifact_unavailable") from exc
+    except ArtifactMetadataMalformed as exc:
+        raise LocalMediaError("media_probe_malformed_result") from exc
+    if (root is None) != (receipt.root_generation is None):
+        refuse("media_probe_malformed_result")
+    validate_available_generation(receipt.generation)
+    return receipt
+
+
+def probe_local_media(path: Any, *, trusted_root: Any = None) -> MediaArtifactProbe:
+    """Do no byte I/O in the owner; admit metadata before the probe worker starts."""
+    artifact, root = _request_paths(path, trusted_root)
+    payload = _path_payload(artifact, root)
+    metadata = _invoke_worker(METADATA_OPERATION, {}, payload, MEDIA_METADATA_LIMITS)
+    receipt = _decode_metadata(metadata.payload, root)
+    with private_media_workspace() as workspace:
+        payload["workspace"] = workspace
+        result = _invoke_worker(
+            PROBE_OPERATION, _bindings(receipt), payload, MEDIA_PROBE_LIMITS
+        )
+        return decode_media_probe(
+            result.payload, receipt.generation, receipt.root_generation
+        )
+
+
+@contextmanager
+def private_media_workspace() -> Iterator[dict[str, Any]]:
+    """The owner cleans up even after a timed-out or killed worker cannot.
+
+    Only toolkit-created scratch paths are touched here, never source media.
+    TemporaryDirectory also restores read-only permissions during Windows cleanup.
+    """
+    try:
+        directory = tempfile.TemporaryDirectory(prefix="speaker-toolkit-local-media-")
+    except OSError as exc:
+        raise LocalMediaError("media_private_workspace_unavailable") from exc
+    try:
+        try:
+            path = Path(directory.name)
+            os.chmod(path, 0o700)
+            workspace = {
+                "path": str(path),
+                "generation": FileGeneration.from_stat(path.lstat()).to_dict(),
+            }
+        except OSError as exc:
+            raise LocalMediaError("media_private_workspace_unavailable") from exc
+        yield workspace
+    finally:
+        try:
+            directory.cleanup()
+        except OSError as exc:
+            raise LocalMediaError("media_cleanup_failed") from exc
+
+
+def _admit_workspace(value: Any) -> Path:
+    if not isinstance(value, Mapping) or set(value) != {"path", "generation"}:
+        raise SupervisorError("invalid_worker_request")
+    try:
+        path = materialize_native_root(value["path"])
+        generation = FileGeneration.from_dict(value["generation"])
+    except (ArtifactLocatorError, TypeError, ValueError) as exc:
+        raise SupervisorError("invalid_worker_request") from exc
+    try:
+        actual = FileGeneration.from_stat(path.lstat())
+        if (
+            actual != generation
+            or not stat.S_ISDIR(actual.mode)
+            or (actual.file_attributes or 0) & WINDOWS_REPARSE_POINT_ATTRIBUTE
+        ):
+            refuse("media_private_workspace_unavailable")
+        with os.scandir(path) as entries:
+            if next(entries, None) is not None:
+                refuse("media_private_workspace_unavailable")
+    except OSError as exc:
+        raise LocalMediaError("media_private_workspace_unavailable") from exc
+    return path
+
+
+def check_media_generation(
+    path: Any, probe: MediaArtifactProbe, *, trusted_root: Any = None
+) -> None:
+    """Recheck metadata through a bounded worker immediately before bundle commit."""
+    artifact, root = _request_paths(path, trusted_root)
+    receipt = ArtifactMetadataReceipt(probe.generation, probe.root_generation, None)
+    result = _invoke_worker(
+        CHECK_OPERATION,
+        _bindings(receipt),
+        _path_payload(artifact, root),
+        MEDIA_METADATA_LIMITS,
+    )
+    current = _decode_metadata(result.payload, root)
+    if current != receipt:
+        refuse("media_generation_changed")
+
+
+def _inspect(path: Path, root: Path | None) -> ArtifactMetadataReceipt:
+    try:
+        receipt = inspect_metadata_generation(
+            path, trusted_root=root, cloud_reparse_tags=frozenset()
+        )
+    except ArtifactMetadataUnavailable as exc:
+        raise LocalMediaError("media_artifact_unavailable") from exc
+    except ArtifactMetadataMalformed as exc:
+        raise LocalMediaError("media_locator_invalid") from exc
+    validate_available_generation(receipt.generation)
+    return receipt
+
+
+def _metadata_payload(receipt: ArtifactMetadataReceipt) -> dict[str, Any]:
+    return {
+        "schema_version": METADATA_SCHEMA_VERSION,
+        "status": "available",
+        "generation": receipt.generation.to_dict(),
+        "root_generation": receipt.root_generation.to_dict()
+        if receipt.root_generation is not None
+        else None,
+        "reparse_tag": receipt.reparse_tag,
+    }
+
+
+def _require_descriptor(descriptor: int, expected: FileGeneration) -> None:
+    actual = FileGeneration.from_stat(os.fstat(descriptor))
+    validate_available_generation(actual)
+    if actual != expected:
+        refuse("media_generation_changed")
+
+
+@contextmanager
+def _private_snapshot(
+    path: Path, expected: FileGeneration, workspace: Path
+) -> Iterator[tuple[Path, str, int]]:
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_BINARY", 0),
+        )
+    except OSError as exc:
+        raise LocalMediaError("media_artifact_unavailable") from exc
+    try:
+        _require_descriptor(descriptor, expected)
+        snapshot = workspace / f"source{path.suffix.lower()}"
+        digest = hashlib.sha256()
+        copied = 0
+        with snapshot.open("xb") as output:
+            os.chmod(snapshot, 0o600)
+            while chunk := os.read(descriptor, MEDIA_DIGEST_CHUNK_BYTES):
+                copied += len(chunk)
+                if copied > expected.size:
+                    refuse("media_generation_changed")
+                digest.update(chunk)
+                output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        if copied != expected.size:
+            refuse("media_generation_changed")
+        _require_descriptor(descriptor, expected)
+        os.chmod(snapshot, stat.S_IREAD)
+        yield snapshot, digest.hexdigest(), descriptor
+    except OSError as exc:
+        raise LocalMediaError("media_artifact_unavailable") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _run_ffprobe(path: Path) -> tuple[bytes, DiagnosticReceipt]:
+    executable = shutil.which("ffprobe")
+    if executable is None:
+        refuse("media_dependency_unavailable")
+    command = [
+        executable,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=format_name,duration:stream=codec_type,codec_name,channels,sample_rate,duration:stream_disposition=attached_pic",
+        "-of",
+        "json",
+        str(path),
+    ]
+    try:
+        result = run_media_tool(
+            command,
+            stdout_limit=MEDIA_FFPROBE_STDOUT_BYTES,
+            stderr_limit=MEDIA_FFPROBE_STDERR_BYTES,
+        )
+    except LocalMediaError as exc:
+        reason = {
+            "media_tool_stdout_limit": "media_ffprobe_stdout_limit",
+            "media_tool_stderr_limit": "media_ffprobe_stderr_limit",
+        }.get(exc.reason_code, exc.reason_code)
+        raise LocalMediaError(reason) from exc
+    if result.returncode:
+        refuse("media_parser_rejected")
+    if result.diagnostics.byte_count:
+        refuse("media_parser_repair_required")
+    return result.stdout, result.diagnostics
+
+
+def _unique_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            refuse("media_parser_rejected")
+        result[key] = value
+    return result
+
+
+def _reject_constant(_value: str) -> NoReturn:
+    refuse("media_parser_rejected")
+
+
+def _probe(
+    path: Path, root: Path | None, before: ArtifactMetadataReceipt, workspace: Path
+) -> dict[str, Any]:
+    with _private_snapshot(path, before.generation, workspace) as (
+        snapshot,
+        digest,
+        descriptor,
+    ):
+        snapshot_generation = FileGeneration.from_stat(snapshot.lstat())
+        raw, diagnostics = _run_ffprobe(snapshot)
+        try:
+            document = json.loads(
+                raw, object_pairs_hook=_unique_pairs, parse_constant=_reject_constant
+            )
+        except (ValueError, UnicodeError, RecursionError) as exc:
+            raise LocalMediaError("media_parser_rejected") from exc
+        facts = parse_media_facts(document, CONTAINER_BY_SUFFIX[path.suffix.lower()])
+        if (
+            FileGeneration.from_stat(snapshot.lstat()) != snapshot_generation
+            or _inspect(path, root) != before
+        ):
+            refuse("media_generation_changed")
+        _require_descriptor(descriptor, before.generation)
+        return {
+            "schema_version": MEDIA_SCHEMA_VERSION,
+            "source_sha256": digest,
+            "source_size_bytes": before.generation.size,
+            "parser_diagnostics": diagnostics.to_dict(),
+            **facts,
+        }
+
+
+def _dispatch(
+    request: WorkerRequest,
+) -> tuple[dict[str, Any], dict[str, FileGeneration]]:
+    if (
+        request.schema_generation != MEDIA_SCHEMA_VERSION
+        or request.pipeline_generation != MEDIA_PIPELINE_VERSION
+    ):
+        raise SupervisorError("invalid_worker_request")
+    payload = request.payload
+    if not isinstance(payload, Mapping) or set(payload) != {
+        "media_path",
+        "trusted_root",
+        "workspace",
+    }:
+        raise SupervisorError("invalid_worker_request")
+    expected_profile = (
+        MEDIA_PROBE_LIMITS
+        if request.operation == PROBE_OPERATION
+        else MEDIA_METADATA_LIMITS
+    )
+    if (
+        request.operation not in {METADATA_OPERATION, CHECK_OPERATION, PROBE_OPERATION}
+        or request.limit_profile_id != expected_profile.profile_id
+    ):
+        raise SupervisorError("invalid_worker_request")
+    if request.operation != PROBE_OPERATION and payload["workspace"] is not None:
+        raise SupervisorError("invalid_worker_request")
+    if request.operation == METADATA_OPERATION and request.expected_generations:
+        raise SupervisorError("invalid_worker_request")
+    try:
+        path, root = canonicalize_trusted_artifact_locator(
+            payload["media_path"], payload["trusted_root"]
+        )
+    except ArtifactMetadataMalformed as exc:
+        raise SupervisorError("invalid_worker_request") from exc
+    if path.suffix.lower() not in CONTAINER_BY_SUFFIX:
+        raise SupervisorError("invalid_worker_request")
+    before = _inspect(path, root)
+    observed = _bindings(before)
+    if request.operation == METADATA_OPERATION:
+        return _metadata_payload(before), {}
+    if set(request.expected_generations) != set(observed):
+        raise SupervisorError("invalid_worker_request")
+    if observed != request.expected_generations:
+        refuse("media_generation_changed")
+    if request.operation == CHECK_OPERATION:
+        return _metadata_payload(before), observed
+    result = _probe(path, root, before, _admit_workspace(payload["workspace"]))
+    if _inspect(path, root) != before:
+        refuse("media_generation_changed")
+    return result, observed
+
+
+def _worker_main() -> int:
+    request = read_worker_request(max_input_bytes=MEDIA_METADATA_LIMITS.max_input_bytes)
+    stream = isolate_protocol_output()
+    try:
+        try:
+            payload, observed = _dispatch(request)
+            write_worker_response(
+                request,
+                payload=cast(JsonValue, payload),
+                observed_generations=observed,
+                stream=stream,
+                max_output_bytes=MEDIA_PROBE_LIMITS.max_output_bytes,
+            )
+        except (LocalMediaError, SupervisorError) as exc:
+            reason = (
+                exc.reason_code
+                if isinstance(exc, SupervisorError)
+                or exc.reason_code in _LOCAL_FAILURES
+                else "media_artifact_unavailable"
+            )
+            write_worker_response(
+                request,
+                error=SupervisorError(reason),
+                observed_generations=request.expected_generations,
+                stream=stream,
+                max_output_bytes=MEDIA_PROBE_LIMITS.max_output_bytes,
+            )
+    finally:
+        stream.close()
+    return 0
+
+
+def _main() -> int:
+    if sys.argv[1:] != [WORKER_FLAG]:
+        print(
+            "local_media_evidence.py is a library; use fetch-transcript.py",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        return _worker_main()
+    except SupervisorError as exc:
+        print(f"local media worker failed: {exc.reason_code}", file=sys.stderr)
+        return 2
+    # A nonzero child with no authenticated frame is the supervisor's closed
+    # crash signal. Emit no traceback/path/provider payload: propagation would
+    # leak parser state onto that boundary. outer-boundary-process-contract.
+    except Exception:  # noqa: BLE001
+        print("local media worker failed: unexpected_error", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/skills/vault-ingress/scripts/local_media_process.py
+++ b/skills/vault-ingress/scripts/local_media_process.py
@@ -1,0 +1,184 @@
+"""Bounded subprocess pipes for use *inside* an authenticated media worker.
+
+The outer artifact supervisor owns wall, process-tree and memory limits. This
+helper adds strict retained-output and streamed-file byte limits without ever
+collecting a media download in memory. A failed stream is never a usable file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import threading
+import time
+from typing import BinaryIO, cast
+
+from artifact_supervisor import DiagnosticReceipt, _PipeDrainer
+from local_media_contract import LocalMediaError, refuse
+
+
+CHUNK_BYTES = 64 * 1024
+PIPE_JOIN_SECONDS = 1.0
+POLL_SECONDS = 0.01
+
+
+@dataclass(frozen=True)
+class MediaToolResult:
+    returncode: int
+    stdout: bytes
+    streamed_bytes: int
+    diagnostics: DiagnosticReceipt
+
+
+class _FileSink:
+    """Stop before the first byte that would exceed the on-disk ceiling."""
+
+    def __init__(self, source: BinaryIO, target: BinaryIO, limit: int) -> None:
+        self.source, self.target, self.limit = source, target, limit
+        self.byte_count = 0
+        self.overflowed = False
+        self.failed = False
+        self.complete = False
+        self.thread = threading.Thread(target=self._run, daemon=True)
+
+    @property
+    def alive(self) -> bool:
+        return self.thread.is_alive()
+
+    def start(self) -> None:
+        self.thread.start()
+
+    def join(self, seconds: float) -> None:
+        self.thread.join(seconds)
+
+    def close(self) -> None:
+        try:
+            self.source.close()
+        except OSError:
+            self.failed = True
+
+    def _run(self) -> None:
+        try:
+            while chunk := self.source.read(CHUNK_BYTES):
+                if self.byte_count + len(chunk) > self.limit:
+                    self.overflowed = True
+                    return
+                if self.target.write(chunk) != len(chunk):
+                    self.failed = True
+                    return
+                self.byte_count += len(chunk)
+            self.target.flush()
+            self.complete = True
+        except (OSError, ValueError):
+            self.failed = True
+
+
+def _stop(process: subprocess.Popen[bytes]) -> None:
+    try:
+        if process.poll() is None:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait(timeout=PIPE_JOIN_SECONDS)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=PIPE_JOIN_SECONDS)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise LocalMediaError("media_cleanup_failed") from exc
+
+
+def run_media_tool(
+    command: list[str],
+    *,
+    stdout_limit: int,
+    stderr_limit: int,
+    output: Path | None = None,
+    cwd: Path | None = None,
+) -> MediaToolResult:
+    """Capture bounded metadata or stream one literal exclusive-create output."""
+    destination = None
+    try:
+        if output is not None:
+            destination = output.open("xb", buffering=0)
+        return _run(command, stdout_limit, stderr_limit, destination, cwd)
+    except OSError as exc:
+        raise LocalMediaError("media_pipe_failed") from exc
+    finally:
+        if destination is not None:
+            destination.close()
+
+
+def _run(
+    command: list[str],
+    stdout_limit: int,
+    stderr_limit: int,
+    destination: BinaryIO | None,
+    cwd: Path | None,
+) -> MediaToolResult:
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            close_fds=True,
+            cwd=cwd,
+        )
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        raise LocalMediaError("media_dependency_unavailable") from exc
+    if process.stdout is None or process.stderr is None:
+        try:
+            _stop(process)
+        finally:
+            for pipe in (process.stdout, process.stderr):
+                if pipe is not None:
+                    pipe.close()
+        refuse("media_pipe_failed")
+    stdout = (
+        _FileSink(cast(BinaryIO, process.stdout), destination, stdout_limit)
+        if destination is not None
+        else _PipeDrainer(cast(BinaryIO, process.stdout), stdout_limit)
+    )
+    stderr = _PipeDrainer(cast(BinaryIO, process.stderr), stderr_limit)
+    try:
+        try:
+            stdout.start()
+            stderr.start()
+        except RuntimeError as exc:
+            raise LocalMediaError("media_pipe_failed") from exc
+        while process.poll() is None:
+            if stdout.overflowed or stderr.overflowed or stdout.failed or stderr.failed:
+                _stop(process)
+                break
+            time.sleep(POLL_SECONDS)
+        returncode = process.wait()
+        stdout.join(PIPE_JOIN_SECONDS)
+        stderr.join(PIPE_JOIN_SECONDS)
+        if stdout.overflowed:
+            refuse("media_tool_stdout_limit")
+        if stderr.overflowed:
+            refuse("media_tool_stderr_limit")
+        if (
+            stdout.alive
+            or stderr.alive
+            or stdout.failed
+            or stderr.failed
+            or (isinstance(stdout, _FileSink) and not stdout.complete)
+        ):
+            refuse("media_pipe_failed")
+        return MediaToolResult(
+            returncode,
+            stdout.data if isinstance(stdout, _PipeDrainer) else b"",
+            stdout.byte_count if isinstance(stdout, _FileSink) else 0,
+            stderr.receipt,
+        )
+    finally:
+        try:
+            _stop(process)
+        finally:
+            stdout.close()
+            stderr.close()

--- a/skills/vault-ingress/scripts/local_media_transcription.py
+++ b/skills/vault-ingress/scripts/local_media_transcription.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Run local Whisper in an authenticated worker bound to established media facts.
+
+An existing video/media probe is reused without another probe, copy, or hash.
+The worker holds a source descriptor and rechecks its generation and pathname
+around transcription. The caller rechecks again immediately before committing
+the transcript bundle. No transcript or receipt is written by this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import importlib
+import os
+from pathlib import Path
+import sys
+from typing import Any, cast
+
+from artifact_metadata import canonicalize_trusted_artifact_locator
+from artifact_supervisor import (
+    FileGeneration,
+    JsonValue,
+    SupervisorError,
+    WorkerRequest,
+    isolate_protocol_output,
+    read_worker_request,
+    run_authenticated_worker,
+    write_worker_response,
+)
+from local_media_contract import (
+    MEDIA_PIPELINE_VERSION,
+    MEDIA_SCHEMA_VERSION,
+    MEDIA_WHISPER_LIMITS,
+    LocalMediaError,
+    MediaArtifactProbe,
+    bounded_whisper_result,
+    refuse,
+    reuse_video_probe,
+)
+from local_media_evidence import (
+    _bindings,
+    _inspect,
+    _path_payload,
+    _request_paths,
+    _require_descriptor,
+    check_media_generation,
+    probe_local_media,
+)
+
+
+WORKER_FLAG = "--supervised-worker"
+WHISPER_OPERATION = "local_media_transcribe"
+WHISPER_FAILURES = frozenset(
+    {
+        "whisper_dependency_unavailable",
+        "whisper_provider_failed",
+        "whisper_result_invalid",
+        "whisper_text_limit",
+        "whisper_language_invalid",
+        "whisper_segments_invalid",
+        "whisper_segment_limit",
+        "whisper_segment_text_limit",
+        "media_generation_changed",
+        "media_artifact_unavailable",
+        "media_cloud_placeholder_unavailable",
+        "media_size_limit",
+    }
+)
+_PROVIDER_ERRORS = (
+    ImportError,
+    OSError,
+    RuntimeError,
+    AttributeError,
+    TypeError,
+    ValueError,
+    KeyError,
+)
+
+
+def _model(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > 512
+        or "\0" in value
+    ):
+        refuse("whisper_model_invalid")
+    return value
+
+
+def transcribe_local_media(
+    path: Any,
+    model: str,
+    *,
+    probe: Any = None,
+    trusted_root: Any = None,
+) -> tuple[MediaArtifactProbe, dict[str, Any]]:
+    """Return established media facts and bounded speech; never write a bundle."""
+    model = _model(model)
+    artifact, root = _request_paths(path, trusted_root)
+    if probe is None:
+        established = probe_local_media(artifact, trusted_root=root)
+    elif isinstance(probe, MediaArtifactProbe):
+        established = probe
+    else:
+        established = reuse_video_probe(probe)
+    check_media_generation(artifact, established, trusted_root=root)
+    expected = {"media": established.generation}
+    if established.root_generation is not None:
+        expected["media_root"] = established.root_generation
+    payload = _path_payload(artifact, root)
+    payload.pop("workspace")
+    payload["model"] = model
+    command = [sys.executable, str(Path(__file__).resolve()), WORKER_FLAG]
+    try:
+        result = run_authenticated_worker(
+            command,
+            WHISPER_OPERATION,
+            expected,
+            cast(JsonValue, payload),
+            MEDIA_WHISPER_LIMITS,
+            immutable_process_identity=command[:2],
+            sensitive_values=(str(artifact), model),
+            schema_generation=MEDIA_SCHEMA_VERSION,
+            pipeline_generation=MEDIA_PIPELINE_VERSION,
+        )
+    except SupervisorError as exc:
+        reason = exc.reason_code
+        if reason not in WHISPER_FAILURES:
+            reason = {
+                "worker_generation_changed": "media_generation_changed",
+                "worker_timeout": "whisper_worker_timeout",
+                "worker_memory_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_process_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_input_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_output_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_diagnostic_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_cleanup_failed": "media_cleanup_failed",
+            }.get(reason, "whisper_worker_failed")
+        raise LocalMediaError(reason) from exc
+    if not isinstance(result.payload, Mapping) or set(result.payload) != {
+        "text",
+        "language",
+        "segments",
+    }:
+        refuse("whisper_result_invalid")
+    speech = bounded_whisper_result(result.payload)
+    check_media_generation(artifact, established, trusted_root=root)
+    return established, speech
+
+
+def _transcribe_with_mlx(path: Path, model: str) -> dict[str, Any]:
+    """Only the actual Apple-Silicon provider call is platform-bound."""
+    try:
+        provider = importlib.import_module("mlx_whisper")
+    except _PROVIDER_ERRORS as exc:
+        raise LocalMediaError("whisper_dependency_unavailable") from exc
+    try:
+        value = provider.transcribe(str(path), path_or_hf_repo=model)
+    except _PROVIDER_ERRORS as exc:
+        raise LocalMediaError("whisper_provider_failed") from exc
+    return bounded_whisper_result(value)
+
+
+def _dispatch(
+    request: WorkerRequest,
+) -> tuple[dict[str, Any], dict[str, FileGeneration]]:
+    payload = request.payload
+    if (
+        request.operation != WHISPER_OPERATION
+        or request.limit_profile_id != MEDIA_WHISPER_LIMITS.profile_id
+        or request.schema_generation != MEDIA_SCHEMA_VERSION
+        or request.pipeline_generation != MEDIA_PIPELINE_VERSION
+        or not isinstance(payload, Mapping)
+        or set(payload) != {"media_path", "trusted_root", "model"}
+    ):
+        raise SupervisorError("invalid_worker_request")
+    model = _model(payload["model"])
+    path, root = canonicalize_trusted_artifact_locator(
+        payload["media_path"], payload["trusted_root"]
+    )
+    before = _inspect(path, root)
+    observed = _bindings(before)
+    if observed != request.expected_generations:
+        refuse("media_generation_changed")
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_BINARY", 0),
+        )
+    except OSError as exc:
+        raise LocalMediaError("media_artifact_unavailable") from exc
+    try:
+        _require_descriptor(descriptor, before.generation)
+        speech = _transcribe_with_mlx(path, model)
+        _require_descriptor(descriptor, before.generation)
+        if _inspect(path, root) != before:
+            refuse("media_generation_changed")
+        return speech, observed
+    except OSError as exc:
+        raise LocalMediaError("media_artifact_unavailable") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _worker_main() -> int:
+    request = read_worker_request(max_input_bytes=MEDIA_WHISPER_LIMITS.max_input_bytes)
+    stream = isolate_protocol_output()
+    try:
+        try:
+            speech, observed = _dispatch(request)
+            write_worker_response(
+                request,
+                payload=cast(JsonValue, speech),
+                observed_generations=observed,
+                stream=stream,
+                max_output_bytes=MEDIA_WHISPER_LIMITS.max_output_bytes,
+            )
+        except (LocalMediaError, SupervisorError) as exc:
+            reason = (
+                exc.reason_code
+                if isinstance(exc, SupervisorError)
+                or exc.reason_code in WHISPER_FAILURES
+                else "whisper_worker_failed"
+            )
+            write_worker_response(
+                request,
+                error=SupervisorError(reason),
+                observed_generations=request.expected_generations,
+                stream=stream,
+                max_output_bytes=MEDIA_WHISPER_LIMITS.max_output_bytes,
+            )
+    finally:
+        stream.close()
+    return 0
+
+
+def _main() -> int:
+    if sys.argv[1:] != [WORKER_FLAG]:
+        print(
+            "local_media_transcription.py is a library; use fetch-transcript.py",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        return _worker_main()
+    except SupervisorError as exc:
+        print(f"Whisper worker failed: {exc.reason_code}", file=sys.stderr)
+        return 2
+    # A nonzero child without an authenticated response is the supervisor's
+    # closed crash signal. Emit only a fixed diagnostic; an unhandled traceback
+    # would leak model/path/provider data. outer-boundary-process-contract.
+    except Exception:  # noqa: BLE001
+        print("Whisper worker failed: unexpected_error", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/skills/vault-ingress/scripts/transcript_timing.py
+++ b/skills/vault-ingress/scripts/transcript_timing.py
@@ -57,7 +57,7 @@ import stat
 import tempfile
 import unicodedata
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 from transcript_quality import (
     build_quality_policy,
@@ -368,7 +368,11 @@ def _stage_bytes(destination: Path, raw: bytes) -> Path:
     return temporary_path
 
 
-def _replace_transactionally(replacements: list[tuple[Path, bytes | None]]) -> None:
+def _replace_transactionally(
+    replacements: list[tuple[Path, bytes | None]],
+    *,
+    before_commit: Callable[[], None] | None = None,
+) -> None:
     """Replace a small artifact set and restore exact prior bytes on failure.
 
     There is no portable multi-file rename transaction. New files and exact
@@ -376,6 +380,10 @@ def _replace_transactionally(replacements: list[tuple[Path, bytes | None]]) -> N
     already attempted. A process death between renames can still leave a
     partial bundle. Hash checks reject changed-text mixtures; byte-identical
     replacement can expose an already valid new receipt before restart.
+
+    The optional before_commit guard runs after staging and before the first
+    replacement. Any guard failure or process-control signal leaves originals
+    untouched and removes staged files; the guard must perform no bundle writes.
     """
     destinations = [destination for destination, _raw in replacements]
     if len(destinations) != len(set(destinations)):
@@ -399,6 +407,9 @@ def _replace_transactionally(replacements: list[tuple[Path, bytes | None]]) -> N
                 staged_old[destination] = _stage_bytes(destination, original)
             if raw is not None:
                 staged_new[destination] = _stage_bytes(destination, raw)
+
+        if before_commit is not None:
+            before_commit()
 
         for destination, raw in replacements:
             if destination.is_symlink():
@@ -602,6 +613,7 @@ def write_transcript_bundle(
     quality_policy: dict[str, object] | None = None,
     quality_policy_provenance: dict[str, object] | None = None,
     force: bool = False,
+    before_commit: Callable[[], None] | None = None,
 ) -> Path | None:
     """Transactionally replace transcript text plus independent receipts.
 
@@ -659,7 +671,7 @@ def write_transcript_bundle(
             )
         )
     replacements.append((transcript, text.encode("utf-8")))
-    _replace_transactionally(replacements)
+    _replace_transactionally(replacements, before_commit=before_commit)
     return timing_path if normalized_segments else None
 
 
@@ -911,14 +923,18 @@ def write_quality_receipt(
     text: str,
     policy: dict[str, object],
     provenance: dict[str, object],
+    *,
+    before_commit: Callable[[], None] | None = None,
 ) -> Path:
-    """Atomically write one exact, transcript-hash-bound quality receipt."""
+    """Write one exact quality receipt after the optional precommit guard.
+
+    The guard runs after staging, before replacement; failure preserves the
+    current receipt. See _replace_transactionally for the transaction boundary.
+    """
     payload = _build_quality_receipt(text, policy, provenance)
     receipt_path = quality_sidecar_path(transcript_path)
-    write_atomically(
-        receipt_path,
-        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
-    )
+    raw = (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+    _replace_transactionally([(receipt_path, raw)], before_commit=before_commit)
     return receipt_path
 
 

--- a/tests/test_check_runtime.py
+++ b/tests/test_check_runtime.py
@@ -1108,6 +1108,15 @@ def test_lane_requirements_match_the_configured_interpreter_contract() -> None:
     assert requirements["google-drive"]["modules"] == {"gdown": "gdown"}
     assert requirements["captions"]["commands"] == {}
     assert requirements["youtube-download"]["commands"] == {"yt-dlp": "yt-dlp"}
+    assert requirements["youtube-download"]["modules"] == {"psutil": "psutil"}
+    assert requirements["whisper"] == {
+        "modules": {"mlx-whisper": "mlx_whisper", "psutil": "psutil"},
+        "commands": {"ffmpeg": "ffmpeg", "ffprobe": "ffprobe"},
+    }
+    assert requirements["source-media"] == {
+        "modules": {"psutil": "psutil"},
+        "commands": {"ffprobe": "ffprobe"},
+    }
     assert requirements["source-video"] == {
         "modules": {"psutil": "psutil"},
         "commands": {"ffprobe": "ffprobe"},
@@ -1141,6 +1150,45 @@ def test_no_markdown_deck_lane_is_selected_or_required_by_default() -> None:
     assert markdown_lanes
     assert markdown_lanes.isdisjoint(check_runtime.DEFAULT_LANES)
     assert markdown_lanes.isdisjoint(check_runtime.DEFAULT_REQUIRED_LANES)
+
+
+@pytest.mark.parametrize("required", [False, True])
+def test_missing_media_supervision_is_lane_local(monkeypatch, required):
+    monkeypatch.setattr(
+        check_runtime,
+        "_probe_module",
+        lambda name: (
+            _failed_probe("unavailable_import")
+            if name == "psutil"
+            else _available_probe()
+        ),
+    )
+    monkeypatch.setattr(check_runtime, "_command_available", lambda name: True)
+    lanes = ("source-media", "whisper", "captions")
+    report = check_runtime.build_report(
+        lanes, ("core", "source-media") if required else ("core",)
+    )
+    assert report["ok"] is (not required)
+    assert report["lanes"]["captions"]["available"] is True
+    assert report["lanes"]["source-media"]["missing_modules"] == ["psutil"]
+    assert report["lanes"]["whisper"]["missing_modules"] == ["psutil"]
+    assert ("source-media" in report["blocking_lanes"]) is required
+
+
+def test_generic_media_gate_does_not_require_whisper_or_video_extraction(monkeypatch):
+    inspected = []
+
+    def probe(name):
+        inspected.append(name)
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(
+        check_runtime, "_command_available", lambda name: name == "ffprobe"
+    )
+    report = check_runtime.build_report(("source-media",), ("core", "source-media"))
+    assert report["ok"] is True
+    assert set(inspected) == {"yaml", "psutil"}
 
 
 def test_an_absent_markdown_deck_lane_degrades_rather_than_blocks() -> None:

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -11,9 +11,9 @@ in CI without a network, without YouTube, and without Apple-Silicon Whisper.
 """
 
 import hashlib
+from contextlib import contextmanager
 import json
 import os
-import pathlib
 import subprocess
 import sys
 from pathlib import Path
@@ -275,188 +275,109 @@ def test_a_receipt_with_no_media_digest_never_matches(fetch_transcript):
     )
 
 
-def _blocking_yt_dlp(fetch_transcript, monkeypatch, serving_client, attempts):
-    """Mock yt-dlp as YouTube currently behaves: one client works, others 403.
+def _mock_media_probe(fetch_transcript, monkeypatch, path, duration=600.0):
+    """Supply trusted synthetic facts; real worker admission has its own suite."""
+    from artifact_supervisor import DiagnosticReceipt, FileGeneration
 
-    Writes the audio file only for `serving_client`, exactly as a real download
-    does, so the caller's "did a file appear" check decides the outcome.
-    """
-
-    def run(command, **_kwargs):
-        client = None
-        if "--extractor-args" in command:
-            client = command[command.index("--extractor-args") + 1].split("=")[-1]
-        attempts.append(client)
-        if client != serving_client:
-            return subprocess.CompletedProcess(
-                command, 1, stdout="", stderr="HTTP Error 403: Forbidden"
-            )
-        target = command[command.index("-o") + 1]
-        pathlib.Path(target.replace("%(ext)s", "mp3")).write_bytes(b"audio")
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
-
-
-def test_a_refused_attempt_that_left_bytes_behind_is_not_reused(
-    fetch_transcript, monkeypatch, tmp_path
-):
-    """A partial file from a failed client must not end the retry chain.
-
-    yt-dlp can exit nonzero having already written something. If every attempt
-    shared one output path, the next attempt's existence check would accept
-    those bytes as its own success and transcribe the failure's leftovers.
-    """
-    attempts: list[str | None] = []
-
-    def run(command, **_kwargs):
-        client = None
-        if "--extractor-args" in command:
-            client = command[command.index("--extractor-args") + 1].split("=")[-1]
-        attempts.append(client)
-        target = pathlib.Path(
-            command[command.index("-o") + 1].replace("%(ext)s", "mp3")
-        )
-        if client != "mweb":
-            # the failure leaves a truncated artifact behind
-            target.write_bytes(b"partial-garbage")
-            return subprocess.CompletedProcess(
-                command, 1, stdout="", stderr="HTTP Error 403: Forbidden"
-            )
-        target.write_bytes(b"real-audio")
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
-    transcribed: list[bytes] = []
-
-    def transcribe(audio_path, *_a, **_k):
-        transcribed.append(pathlib.Path(audio_path).read_bytes())
-        return "spoken words here", "en", None
-
-    monkeypatch.setattr(fetch_transcript, "transcribe_audio", transcribe)
-
-    text, _language, _segments = fetch_transcript.fetch_whisper(
-        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
+    probe = fetch_transcript.MediaArtifactProbe(
+        generation=FileGeneration.from_stat(path.lstat()),
+        root_generation=None,
+        source_sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+        source_size_bytes=path.stat().st_size,
+        duration_seconds=duration,
+        duration_source="format",
+        container_family="iso_bmff",
+        stream_count=2,
+        video_stream_count=1,
+        audio_stream_count=1,
+        attached_picture_count=0,
+        other_stream_count=0,
+        parser_diagnostics=DiagnosticReceipt.empty(),
     )
-
-    assert text == "spoken words here"
-    assert "mweb" in attempts, "a leftover file must not end the chain early"
-    assert transcribed == [b"real-audio"], "the failure's bytes must never be read"
+    monkeypatch.setattr(fetch_transcript, "probe_local_media", lambda *a, **kw: probe)
+    return probe
 
 
-def test_whisper_download_uses_the_resolved_executable(
-    fetch_transcript, monkeypatch, tmp_path
+def test_whisper_download_reuses_the_bound_probe_and_cleans_before_return(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
 ):
-    commands: list[list[str]] = []
+    media = tmp_path / "audio.mp4"
+    media.write_bytes(b"synthetic audio")
+    probe = _mock_media_probe(fetch_transcript, monkeypatch, media)
+    seen = []
 
-    def run(command, **_kwargs):
-        commands.append(command)
-        target = pathlib.Path(
-            command[command.index("-o") + 1].replace("%(ext)s", "mp3")
-        )
-        target.write_bytes(b"audio")
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+    @contextmanager
+    def downloaded(video_id, *, ytdlp):
+        seen.append((video_id, ytdlp))
+        try:
+            yield media, 600.0
+        finally:
+            seen.append("cleaned")
 
-    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
+    def transcribed(path, model, *, probe, trusted_root):
+        assert path == media
+        assert trusted_root == media.parent
+        assert probe.source_sha256 == hashlib.sha256(b"synthetic audio").hexdigest()
+        return probe, {"text": "spoken words", "language": "en", "segments": None}
+
+    monkeypatch.setattr(fetch_transcript, "download_youtube_audio", downloaded)
+    monkeypatch.setattr(fetch_transcript, "transcribe_local_media", transcribed)
+    executable = tmp_path / "yt-dlp"
+    result = fetch_transcript.fetch_whisper(
+        "Kl6tLcQ5hGI", str(tmp_path), "tiny", ytdlp=executable
+    )
+    assert tuple(result) == ("spoken words", "en", None)
+    assert result.duration_seconds == probe.duration_seconds
+    assert seen == [("Kl6tLcQ5hGI", executable), "cleaned"]
+
+
+def test_whisper_download_duration_must_match_probed_media(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+):
+    media = tmp_path / "audio.mp4"
+    media.write_bytes(b"synthetic audio")
+    _mock_media_probe(fetch_transcript, monkeypatch, media)
+
+    @contextmanager
+    def downloaded(*args, **kwargs):
+        yield media, 900.0
+
+    monkeypatch.setattr(fetch_transcript, "download_youtube_audio", downloaded)
     monkeypatch.setattr(
         fetch_transcript,
-        "transcribe_audio",
-        lambda *_args: ("spoken words here", "en", None),
+        "transcribe_local_media",
+        lambda *a, **kw: pytest.fail("mismatched source was transcribed"),
     )
-
-    executable = tmp_path / "runtime" / "yt-dlp"
-    text, _language, _segments = fetch_transcript.fetch_whisper(
-        "Kl6tLcQ5hGI",
-        str(tmp_path),
-        "tiny",
-        ytdlp=executable,
-    )
-
-    assert text == "spoken words here"
-    assert commands[0][0] == str(executable)
+    with pytest.raises(
+        fetch_transcript.LocalMediaError, match="ytdlp_media_duration_mismatch"
+    ):
+        fetch_transcript.fetch_whisper("Kl6tLcQ5hGI", str(tmp_path), "tiny")
 
 
-def test_a_zero_byte_download_is_not_a_success(fetch_transcript, monkeypatch, tmp_path):
-    """An empty artifact is a failed extraction wearing a filename."""
-    attempts: list[str | None] = []
-
-    def run(command, **_kwargs):
-        client = None
-        if "--extractor-args" in command:
-            client = command[command.index("--extractor-args") + 1].split("=")[-1]
-        attempts.append(client)
-        pathlib.Path(
-            command[command.index("-o") + 1].replace("%(ext)s", "mp3")
-        ).write_bytes(b"")
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(fetch_transcript.subprocess, "run", run)
-
-    text, language, segments = fetch_transcript.fetch_whisper(
-        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
-    )
-
-    assert (text, language, segments) == (None, None, None)
-    assert len(attempts) == len(fetch_transcript.YOUTUBE_PLAYER_CLIENTS)
-
-
-def test_a_refused_player_client_advances_to_the_next(
-    fetch_transcript, monkeypatch, tmp_path
+def test_whisper_download_refusal_stops_before_transcription(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
 ):
-    """The 403 that killed the fallback: a later client must still be tried."""
-    attempts: list[str | None] = []
-    _blocking_yt_dlp(fetch_transcript, monkeypatch, "mweb", attempts)
+    @contextmanager
+    def refused(*args, **kwargs):
+        raise fetch_transcript.LocalMediaError("ytdlp_provider_rejected")
+        yield  # pragma: no cover - context manager protocol
+
+    monkeypatch.setattr(fetch_transcript, "download_youtube_audio", refused)
     monkeypatch.setattr(
         fetch_transcript,
-        "transcribe_audio",
-        lambda *a, **k: ("spoken words here", "en", None),
+        "transcribe_local_media",
+        lambda *a, **kw: pytest.fail("refused download was transcribed"),
     )
-
-    text, language, _segments = fetch_transcript.fetch_whisper(
-        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
-    )
-
-    assert text == "spoken words here"
-    assert language == "en"
-    assert attempts[0] is None, "the default chain must be tried first"
-    assert "mweb" in attempts, "the serving client must be reached"
-
-
-def test_a_working_default_client_never_pays_for_the_fallbacks(
-    fetch_transcript, monkeypatch, tmp_path
-):
-    attempts: list[str | None] = []
-    _blocking_yt_dlp(fetch_transcript, monkeypatch, None, attempts)
-    monkeypatch.setattr(
-        fetch_transcript,
-        "transcribe_audio",
-        lambda *a, **k: ("spoken words here", "en", None),
-    )
-
-    text, _language, _segments = fetch_transcript.fetch_whisper(
-        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
-    )
-
-    assert text == "spoken words here"
-    assert attempts == [None], "a healthy environment must make exactly one attempt"
-
-
-def test_every_player_client_refusing_reports_failure(
-    fetch_transcript, monkeypatch, tmp_path, capsys
-):
-    """Exhaustion is a failure that names what was tried, not a traceback."""
-    attempts: list[str | None] = []
-    _blocking_yt_dlp(fetch_transcript, monkeypatch, "no-such-client", attempts)
-
-    text, language, segments = fetch_transcript.fetch_whisper(
-        "Kl6tLcQ5hGI", str(tmp_path), "tiny"
-    )
-
-    assert (text, language, segments) == (None, None, None)
-    assert len(attempts) == len(fetch_transcript.YOUTUBE_PLAYER_CLIENTS)
-    stderr = capsys.readouterr().err
-    assert "under any player client" in stderr
-    assert "403" in stderr
+    with pytest.raises(
+        fetch_transcript.LocalMediaError, match="ytdlp_provider_rejected"
+    ):
+        fetch_transcript.fetch_whisper("Kl6tLcQ5hGI", str(tmp_path), "tiny")
 
 
 def test_plausible_transcript_passes(fetch_transcript):
@@ -749,40 +670,40 @@ def test_unenumerated_provider_exception_reaches_the_process_boundary(
         )
 
 
-def test_direct_whisper_call_propagates_an_unisolated_import_failure(
-    fetch_transcript, monkeypatch, tmp_path
+def test_direct_whisper_call_uses_the_bounded_owner(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
 ):
-    audio = tmp_path / "audio.mp3"
+    audio = tmp_path / "audio.mp4"
     audio.write_bytes(b"synthetic")
+    probe = _mock_media_probe(fetch_transcript, monkeypatch, audio)
+    calls = []
 
-    def broken_import(_name):
-        raise TypeError("synthetic optional dependency import failure")
+    def transcribed(path, model, **kwargs):
+        calls.append((path, model, kwargs["probe"]))
+        return probe, {"text": "spoken words", "language": "en", "segments": None}
 
-    monkeypatch.setattr(fetch_transcript.importlib, "import_module", broken_import)
+    monkeypatch.setattr(fetch_transcript, "transcribe_local_media", transcribed)
+    assert fetch_transcript.transcribe_audio(
+        audio, "local-talk", "model", probe=probe
+    ) == ("spoken words", "en", None)
+    assert calls == [(audio, "model", probe)]
 
-    with pytest.raises(TypeError, match="synthetic optional dependency"):
-        fetch_transcript.transcribe_audio(audio, "local-talk", "model")
 
-
-def test_direct_whisper_call_propagates_an_unisolated_api_failure(
-    fetch_transcript, monkeypatch, tmp_path
+def test_direct_whisper_call_preserves_a_typed_provider_failure(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
 ):
-    audio = tmp_path / "audio.mp3"
-    audio.write_bytes(b"synthetic")
+    def failed(*args, **kwargs):
+        raise fetch_transcript.LocalMediaError("whisper_provider_failed")
 
-    class BrokenWhisper:
-        @staticmethod
-        def transcribe(*_args, **_kwargs):
-            raise KeyError("synthetic result-shape failure")
-
-    monkeypatch.setattr(
-        fetch_transcript.importlib,
-        "import_module",
-        lambda _name: BrokenWhisper,
-    )
-
-    with pytest.raises(KeyError, match="synthetic result-shape failure"):
-        fetch_transcript.transcribe_audio(audio, "local-talk", "model")
+    monkeypatch.setattr(fetch_transcript, "transcribe_local_media", failed)
+    with pytest.raises(
+        fetch_transcript.LocalMediaError, match="whisper_provider_failed"
+    ):
+        fetch_transcript.transcribe_audio(tmp_path / "audio.mp3", "local-talk", "model")
 
 
 def test_captions_report_the_track_language(fetch_transcript, monkeypatch):
@@ -816,44 +737,25 @@ def test_captions_report_the_track_language(fetch_transcript, monkeypatch):
 
 
 def test_youtube_duration_probe_is_bound_to_the_exact_video_id(
-    fetch_transcript, monkeypatch
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
 ):
     seen = []
 
-    def completed(command, **kwargs):
-        seen.append((command, kwargs))
-        return subprocess.CompletedProcess(
-            command,
-            0,
-            stdout=json.dumps({"id": "eg6gqvUFh6Q", "duration": 179.625}),
-            stderr="",
-        )
+    def bounded(video_id, *, ytdlp):
+        seen.append((video_id, ytdlp))
+        return 179.625
 
-    monkeypatch.setattr(fetch_transcript.subprocess, "run", completed)
-
-    ytdlp = Path("/runtime/bin/yt-dlp")
+    monkeypatch.setattr(fetch_transcript, "probe_youtube_media_duration", bounded)
+    executable = tmp_path / "yt-dlp"
     duration, reason = fetch_transcript.probe_youtube_duration(
-        "eg6gqvUFh6Q", ytdlp=ytdlp
+        "eg6gqvUFh6Q", ytdlp=executable
     )
-
     assert duration == 179.625
-    assert "trusted yt-dlp duration" in reason
-    assert seen == [
-        (
-            [
-                str(ytdlp),
-                "--dump-single-json",
-                "--skip-download",
-                "--no-playlist",
-                "https://www.youtube.com/watch?v=eg6gqvUFh6Q",
-            ],
-            {"capture_output": True, "text": True},
-        )
-    ]
-    assert fetch_transcript.youtube_quality_provenance(
-        "eg6gqvUFh6Q",
-        duration,
-    ) == {
+    assert "bounded yt-dlp duration" in reason
+    assert seen == [("eg6gqvUFh6Q", executable)]
+    assert fetch_transcript.youtube_quality_provenance("eg6gqvUFh6Q", duration) == {
         "kind": "youtube_duration",
         "video_id": "eg6gqvUFh6Q",
         "duration_seconds": 179.625,
@@ -863,52 +765,27 @@ def test_youtube_duration_probe_is_bound_to_the_exact_video_id(
 def test_youtube_duration_probe_rejects_provider_identity_drift(
     fetch_transcript, monkeypatch
 ):
-    monkeypatch.setattr(
-        fetch_transcript.subprocess,
-        "run",
-        lambda command, **kwargs: subprocess.CompletedProcess(
-            command,
-            0,
-            stdout=json.dumps({"id": "wb2C2ju_xRg", "duration": 179.625}),
-            stderr="",
-        ),
-    )
+    def rejected(*args, **kwargs):
+        raise fetch_transcript.LocalMediaError("ytdlp_identity_mismatch")
 
+    monkeypatch.setattr(fetch_transcript, "probe_youtube_media_duration", rejected)
     duration, reason = fetch_transcript.probe_youtube_duration("eg6gqvUFh6Q")
-
     assert duration is None
-    assert "identity mismatch" in reason
+    assert "ytdlp_identity_mismatch" in reason
 
 
-def test_local_duration_provenance_hashes_the_exact_media(
+def test_local_duration_provenance_uses_established_exact_media_facts(
     fetch_transcript, monkeypatch, tmp_path
 ):
     media = tmp_path / "recording.mp4"
     media.write_bytes(b"synthetic local media bytes")
-    monkeypatch.setattr(
-        fetch_transcript.subprocess,
-        "run",
-        lambda command, **kwargs: subprocess.CompletedProcess(
-            command,
-            0,
-            stdout="61.250000\n",
-            stderr="",
-        ),
-    )
-
-    duration, reason = fetch_transcript.probe_local_media_duration(media)
-
-    assert duration == 61.25
-    assert "trusted ffprobe duration" in reason
-    provenance = fetch_transcript.local_media_quality_provenance(
-        fetch_transcript.media_sha256(media),
-        duration,
-    )
-    assert provenance == {
+    probe = _mock_media_probe(fetch_transcript, monkeypatch, media, duration=61.25)
+    source = fetch_transcript.AssessedMediaSource(media, probe)
+    assert fetch_transcript.local_media_quality_provenance(
+        source.sha256, probe.duration_seconds
+    ) == {
         "kind": "local_media_duration",
-        "media_sha256": (
-            "2d252575385bde1cab2b5ee3f23e77129478a0412fef2ddecd53a07b650b9e14"
-        ),
+        "media_sha256": "2d252575385bde1cab2b5ee3f23e77129478a0412fef2ddecd53a07b650b9e14",
         "duration_seconds": 61.25,
     }
 
@@ -939,48 +816,35 @@ def _existing_local_audio_bundle(fetch_transcript, tmp_path, receipt_digest):
     return media, out
 
 
-def test_a_failed_probe_keeps_a_receipt_that_still_names_these_media_bytes(
-    fetch_transcript, monkeypatch, tmp_path, capsys
+@pytest.mark.parametrize(
+    "stored_digest",
+    [
+        hashlib.sha256(b"stable local media bytes").hexdigest(),
+        "f" * 64,
+    ],
+)
+def test_failed_local_probe_preserves_every_receipt_without_fallback_relabeling(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+    capsys,
+    stored_digest,
 ):
-    """ffprobe unavailable must not cost the duration a later bound needs."""
-    digest = hashlib.sha256(b"stable local media bytes").hexdigest()
-    media, out = _existing_local_audio_bundle(fetch_transcript, tmp_path, digest)
-    before = out.with_suffix(".quality.json").read_text(encoding="utf-8")
-    monkeypatch.setattr(
-        fetch_transcript,
-        "probe_local_media_duration",
-        lambda _path: (None, "ffprobe unavailable"),
-    )
+    media, out = _existing_local_audio_bundle(fetch_transcript, tmp_path, stored_digest)
+    timing = out.with_suffix(".segments.json")
+    timing.write_bytes(b"existing timing")
+    paths = [out, out.with_suffix(".quality.json"), timing]
+    before = {path: path.read_bytes() for path in paths}
 
+    def unavailable(*args, **kwargs):
+        raise fetch_transcript.LocalMediaError("media_dependency_unavailable")
+
+    monkeypatch.setattr(fetch_transcript, "probe_local_media", unavailable)
     with pytest.raises(SystemExit) as exited:
         fetch_transcript.main(["local-talk", "--audio", str(media), "--out", str(out)])
-
-    assert exited.value.code == 0
-    assert json.loads(capsys.readouterr().out)["ok"] is True
-    after = json.loads(out.with_suffix(".quality.json").read_text(encoding="utf-8"))
-    assert after == json.loads(before), "the source-owned receipt must survive"
-    assert after["provenance"]["kind"] == "local_media_duration"
-    assert after["policy"]["duration_seconds"] == 600.0
-
-
-def test_a_failed_probe_replaces_a_receipt_describing_other_media(
-    fetch_transcript, monkeypatch, tmp_path, capsys
-):
-    """A receipt for bytes nobody is reading is stale, not strong."""
-    media, out = _existing_local_audio_bundle(fetch_transcript, tmp_path, "f" * 64)
-    monkeypatch.setattr(
-        fetch_transcript,
-        "probe_local_media_duration",
-        lambda _path: (None, "ffprobe unavailable"),
-    )
-
-    with pytest.raises(SystemExit) as exited:
-        fetch_transcript.main(["local-talk", "--audio", str(media), "--out", str(out)])
-
-    assert exited.value.code == 0
-    after = json.loads(out.with_suffix(".quality.json").read_text(encoding="utf-8"))
-    assert after["provenance"] == {"kind": "fixed_default"}
-    assert after["policy"]["duration_seconds"] is None
+    assert exited.value.code == 2
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+    assert {path: path.read_bytes() for path in paths} == before
 
 
 def test_a_foreign_caption_track_falls_through_to_whisper(
@@ -1140,139 +1004,276 @@ def test_a_caption_track_within_its_recording_is_kept(
     assert json.loads(capsys.readouterr().out)["method"] == "captions"
 
 
-def test_local_audio_probe_transcription_and_receipts_share_one_snapshot(
-    fetch_transcript, monkeypatch, tmp_path, capsys
-):
-    media = tmp_path / "recording.mp4"
-    media_bytes = b"stable local media bytes"
-    media.write_bytes(media_bytes)
-    text = _talk(600)
-    seen: dict[str, Path] = {}
-
-    def probe(path):
-        seen["probe"] = path
-        return 600.0, "trusted synthetic duration"
-
-    def transcribe(path, _label, _model):
-        seen["transcribe"] = path
-        return text, "en", [{"text": text, "start": 0.0, "end": 600.0}]
-
-    monkeypatch.setattr(fetch_transcript, "probe_local_media_duration", probe)
-    monkeypatch.setattr(fetch_transcript, "transcribe_audio", transcribe)
-    out = tmp_path / "local-talk.txt"
-
-    with pytest.raises(SystemExit) as exited:
-        fetch_transcript.main(
-            [
-                "local-talk",
-                "--audio",
-                str(media),
-                "--out",
-                str(out),
-            ]
-        )
-
-    assert exited.value.code == 0
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["ok"] is True
-    assert seen["probe"] == seen["transcribe"]
-    assert seen["probe"] != media
-    digest = hashlib.sha256(media_bytes).hexdigest()
-    quality = json.loads(out.with_suffix(".quality.json").read_text(encoding="utf-8"))
-    timing = json.loads(out.with_suffix(".segments.json").read_text(encoding="utf-8"))
-    assert quality["provenance"]["media_sha256"] == digest
-    assert timing["provenance"]["media_sha256"] == digest
-
-
-@pytest.mark.parametrize("mutation_phase", ["probe", "transcription"])
-def test_local_audio_snapshot_mutation_fails_closed_without_a_bundle(
-    fetch_transcript, monkeypatch, tmp_path, capsys, mutation_phase
+def test_local_audio_transcription_and_receipts_reuse_one_assessment(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+    capsys,
 ):
     media = tmp_path / "recording.mp4"
     media.write_bytes(b"stable local media bytes")
+    probe = _mock_media_probe(fetch_transcript, monkeypatch, media)
     text = _talk(600)
+    seen = []
 
-    def mutate(path):
-        path.chmod(0o600)
-        path.write_bytes(b"provider-mutated snapshot")
-
-    def probe(path):
-        if mutation_phase == "probe":
-            mutate(path)
-        return 600.0, "trusted synthetic duration"
-
-    def transcribe(path, _label, _model):
-        if mutation_phase == "transcription":
-            mutate(path)
+    def transcribe(path, _label, _model, *, probe):
+        seen.append((path, probe))
         return text, "en", [{"text": text, "start": 0.0, "end": 600.0}]
 
-    monkeypatch.setattr(fetch_transcript, "probe_local_media_duration", probe)
     monkeypatch.setattr(fetch_transcript, "transcribe_audio", transcribe)
     out = tmp_path / "local-talk.txt"
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["local-talk", "--audio", str(media), "--out", str(out)])
+    assert exited.value.code == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+    assert seen == [(media, probe)]
+    for suffix in (".quality.json", ".segments.json"):
+        receipt = json.loads(out.with_suffix(suffix).read_text())
+        assert receipt["provenance"]["media_sha256"] == probe.source_sha256
+        assert receipt["provenance"]["duration_seconds"] == 600.0
 
+
+@pytest.mark.parametrize("phase", ["after_probe", "transcription", "bundle_staging"])
+def test_local_media_generation_changes_preserve_the_entire_prior_bundle(
+    fetch_transcript,
+    transcript_timing,
+    monkeypatch,
+    tmp_path,
+    capsys,
+    phase,
+):
+    media = tmp_path / "recording.mp4"
+    media.write_bytes(b"stable local media bytes")
+    probe = _mock_media_probe(fetch_transcript, monkeypatch, media)
+    text = _talk(600)
+    out = tmp_path / "local-talk.txt"
+    paths = [out, out.with_suffix(".quality.json"), out.with_suffix(".segments.json")]
+    for path in paths:
+        path.write_bytes(b"prior " + path.suffix.encode())
+    before = {path: path.read_bytes() for path in paths}
+
+    def mutate():
+        media.write_bytes(b"changed source bytes")
+
+    if phase == "after_probe":
+
+        def changed_probe(*args, **kwargs):
+            mutate()
+            return probe
+
+        monkeypatch.setattr(fetch_transcript, "probe_local_media", changed_probe)
+
+    def transcribe(path, _label, _model, **kwargs):
+        if phase == "transcription":
+            mutate()
+        return text, "en", [{"text": text, "start": 0.0, "end": 600.0}]
+
+    monkeypatch.setattr(fetch_transcript, "transcribe_audio", transcribe)
+    if phase == "bundle_staging":
+        stage = transcript_timing._stage_bytes
+
+        def changed_during_stage(*args, **kwargs):
+            result = stage(*args, **kwargs)
+            mutate()
+            return result
+
+        monkeypatch.setattr(transcript_timing, "_stage_bytes", changed_during_stage)
     with pytest.raises(SystemExit) as exited:
         fetch_transcript.main(
-            [
-                "local-talk",
-                "--audio",
-                str(media),
-                "--out",
-                str(out),
-            ]
+            ["local-talk", "--audio", str(media), "--out", str(out), "--force"]
         )
-
     assert exited.value.code == 2
-    payload = json.loads(capsys.readouterr().out)
-    assert "snapshot changed" in payload["reason"]
-    assert not out.exists()
-    assert not out.with_suffix(".quality.json").exists()
-    assert not out.with_suffix(".segments.json").exists()
+    assert "media_generation_changed" in json.loads(capsys.readouterr().out)["reason"]
+    assert {path: path.read_bytes() for path in paths} == before
+    assert not list(tmp_path.glob("*.partial"))
 
 
 def test_local_audio_source_replacement_during_transcription_fails_closed(
-    fetch_transcript, monkeypatch, tmp_path, capsys
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+    capsys,
 ):
     media = tmp_path / "recording.mp4"
     media.write_bytes(b"stable local media bytes")
+    _mock_media_probe(fetch_transcript, monkeypatch, media)
     text = _talk(600)
 
-    monkeypatch.setattr(
-        fetch_transcript,
-        "probe_local_media_duration",
-        lambda _path: (600.0, "trusted synthetic duration"),
-    )
-
-    def replace_source(_snapshot_path, _label, _model):
+    def replace_source(*args, **kwargs):
         replacement = tmp_path / "replacement.mp4"
         replacement.write_bytes(b"different media bytes")
         os.replace(replacement, media)
-        return text, "en", [{"text": text, "start": 0.0, "end": 600.0}]
+        return text, "en", [{"text": text, "start": 0, "end": 600}]
 
     monkeypatch.setattr(fetch_transcript, "transcribe_audio", replace_source)
     out = tmp_path / "local-talk.txt"
-
     with pytest.raises(SystemExit) as exited:
-        fetch_transcript.main(
-            [
-                "local-talk",
-                "--audio",
-                str(media),
-                "--out",
-                str(out),
-            ]
-        )
-
+        fetch_transcript.main(["local-talk", "--audio", str(media), "--out", str(out)])
     assert exited.value.code == 2
-    payload = json.loads(capsys.readouterr().out)
-    assert "source changed or was replaced" in payload["reason"]
-    assert not out.exists()
-    assert not out.with_suffix(".quality.json").exists()
-    assert not out.with_suffix(".segments.json").exists()
+    assert "media_generation_changed" in json.loads(capsys.readouterr().out)["reason"]
+    assert not any(
+        path.exists()
+        for path in [
+            out,
+            out.with_suffix(".quality.json"),
+            out.with_suffix(".segments.json"),
+        ]
+    )
 
 
 def test_expected_duration_must_match_source_probe(fetch_transcript):
     assert fetch_transcript.duration_matches_expected(180, 179.625) is True
     assert fetch_transcript.duration_matches_expected(60, 179.625) is False
+
+
+@pytest.mark.parametrize("change", ["source", "transcript"])
+def test_existing_local_quality_refresh_rechecks_after_staging(
+    fetch_transcript,
+    transcript_timing,
+    monkeypatch,
+    tmp_path,
+    capsys,
+    change,
+):
+    media, out = _existing_local_audio_bundle(fetch_transcript, tmp_path, "f" * 64)
+    _mock_media_probe(fetch_transcript, monkeypatch, media)
+    quality, timing = (
+        out.with_suffix(".quality.json"),
+        out.with_suffix(".segments.json"),
+    )
+    timing.write_bytes(b"prior timing")
+    before = {path: path.read_bytes() for path in (out, quality, timing)}
+    original_stage = transcript_timing._stage_bytes
+
+    def stage(*args, **kwargs):
+        result = original_stage(*args, **kwargs)
+        if change == "source":
+            media.write_bytes(b"replaced source")
+        else:
+            out.write_bytes(b"new user transcript")
+        return result
+
+    monkeypatch.setattr(transcript_timing, "_stage_bytes", stage)
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(["local-talk", "--audio", str(media), "--out", str(out)])
+    assert exited.value.code == 2
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+    assert quality.read_bytes() == before[quality]
+    assert timing.read_bytes() == before[timing]
+    assert out.read_bytes() == (
+        before[out] if change == "source" else b"new user transcript"
+    )
+    assert not list(tmp_path.glob("*.partial"))
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "whisper_worker_timeout",
+        "whisper_worker_resource_limit",
+        "whisper_worker_failed",
+        "whisper_provider_failed",
+        "whisper_result_invalid",
+        "whisper_text_limit",
+        "whisper_language_invalid",
+        "whisper_segment_limit",
+        "whisper_segment_text_limit",
+        "media_cleanup_failed",
+        "media_generation_changed",
+    ],
+)
+def test_local_worker_failure_retains_prior_bundle_and_one_json(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+    capsys,
+    reason,
+):
+    media, out = _existing_local_audio_bundle(fetch_transcript, tmp_path, "f" * 64)
+    _mock_media_probe(fetch_transcript, monkeypatch, media)
+    paths = [out, out.with_suffix(".quality.json"), out.with_suffix(".segments.json")]
+    paths[-1].write_bytes(b"prior timing")
+    before = {path: path.read_bytes() for path in paths}
+
+    def failed(*args, **kwargs):
+        raise fetch_transcript.LocalMediaError(reason)
+
+    monkeypatch.setattr(fetch_transcript, "transcribe_audio", failed)
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(
+            ["local-talk", "--audio", str(media), "--out", str(out), "--force"]
+        )
+    assert exited.value.code == 1
+    captured = capsys.readouterr()
+    assert len(captured.out.splitlines()) == 1
+    assert reason in json.loads(captured.out)["reason"]
+    assert {path: path.read_bytes() for path in paths} == before
+    assert not list(tmp_path.glob("*.partial"))
+
+
+def test_downloaded_whisper_duration_supplies_its_own_quality_provenance(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    video_id = "eg6gqvUFh6Q"
+    out = tmp_path / f"{video_id}.txt"
+    text = _talk(150)
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_youtube_duration",
+        lambda *a, **kw: (None, "transient metadata refusal"),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_whisper",
+        lambda *a, **kw: fetch_transcript.WhisperAcquisition(text, "en", None, 180.0),
+    )
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main([video_id, "--out", str(out), "--method", "whisper"])
+    assert exited.value.code == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+    receipt = json.loads(out.with_suffix(".quality.json").read_text())
+    assert receipt["provenance"] == {
+        "kind": "youtube_duration",
+        "video_id": video_id,
+        "duration_seconds": 180.0,
+    }
+    assert receipt["policy"]["duration_seconds"] == 180.0
+
+
+def test_downloaded_whisper_duration_drift_preserves_prior_bundle(
+    fetch_transcript,
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    video_id = "eg6gqvUFh6Q"
+    out = tmp_path / f"{video_id}.txt"
+    paths = [out, out.with_suffix(".quality.json"), out.with_suffix(".segments.json")]
+    for path in paths:
+        path.write_bytes(b"prior " + path.suffix.encode())
+    before = {path: path.read_bytes() for path in paths}
+    monkeypatch.setattr(
+        fetch_transcript,
+        "probe_youtube_duration",
+        lambda *a, **kw: (600.0, "trusted duration"),
+    )
+    monkeypatch.setattr(
+        fetch_transcript,
+        "fetch_whisper",
+        lambda *a, **kw: fetch_transcript.WhisperAcquisition(
+            _talk(600), "en", None, 900.0
+        ),
+    )
+    with pytest.raises(SystemExit) as exited:
+        fetch_transcript.main(
+            [video_id, "--out", str(out), "--method", "whisper", "--force"]
+        )
+    assert exited.value.code == 1
+    assert "duration changed" in json.loads(capsys.readouterr().out)["reason"]
+    assert {path: path.read_bytes() for path in paths} == before
 
 
 def test_transcript_receipt_docs_keep_quality_separate_from_timing(
@@ -1490,7 +1491,7 @@ def test_cli_rejects_a_missing_audio_file(fetch_transcript, tmp_path):
     assert result.returncode == 2
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
-    assert "does not exist" in payload["reason"]
+    assert "media_artifact_unavailable" in payload["reason"]
     assert not (tmp_path / "x.txt").exists()
 
 
@@ -1599,11 +1600,7 @@ def test_stricter_minimum_cannot_authorize_local_audio_overwrite(
         quality: quality.read_bytes(),
         timing: timing.read_bytes(),
     }
-    monkeypatch.setattr(
-        fetch_transcript,
-        "probe_local_media_duration",
-        lambda _path: (600.0, "trusted synthetic duration"),
-    )
+    _mock_media_probe(fetch_transcript, monkeypatch, audio)
 
     def must_not_transcribe(*_args, **_kwargs):
         raise AssertionError("local transcription must require --force")
@@ -1644,15 +1641,11 @@ def test_failed_forced_local_transcription_preserves_existing_bundle(
         quality: quality.read_bytes(),
         timing: timing.read_bytes(),
     }
-    monkeypatch.setattr(
-        fetch_transcript,
-        "probe_local_media_duration",
-        lambda _path: (600.0, "trusted synthetic duration"),
-    )
+    _mock_media_probe(fetch_transcript, monkeypatch, audio)
     monkeypatch.setattr(
         fetch_transcript,
         "transcribe_audio",
-        lambda *_args: (None, None, None),
+        lambda *_args, **_kwargs: (None, None, None),
     )
 
     with pytest.raises(SystemExit) as exited:
@@ -1682,15 +1675,11 @@ def test_mismatched_whisper_timing_does_not_poison_semantic_bundle(
     stale_timing = out.with_suffix(".segments.json")
     stale_timing.write_bytes(b"stale timing")
     text = _talk(600)
-    monkeypatch.setattr(
-        fetch_transcript,
-        "probe_local_media_duration",
-        lambda _path: (600.0, "trusted synthetic duration"),
-    )
+    _mock_media_probe(fetch_transcript, monkeypatch, audio)
     monkeypatch.setattr(
         fetch_transcript,
         "transcribe_audio",
-        lambda *_args: (
+        lambda *_args, **_kwargs: (
             text,
             "en",
             [{"text": "different optional segment text", "start": 0.0, "end": 1.0}],

--- a/tests/test_local_media_contract.py
+++ b/tests/test_local_media_contract.py
@@ -1,0 +1,321 @@
+"""Deterministic resource/fact checks for the generic media owner."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+import stat
+
+import pytest
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+@pytest.fixture
+def contract():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_contract.py", "local_media_contract"
+    )
+
+
+def _document(format_name="mp3", **updates):
+    result = {
+        "format": {"format_name": format_name, "duration": "60.25"},
+        "streams": [
+            {
+                "codec_type": "audio",
+                "codec_name": "mp3",
+                "channels": 1,
+                "sample_rate": "16000",
+                "duration": "60.25",
+            }
+        ],
+    }
+    result.update(updates)
+    return result
+
+
+def _generation():
+    from artifact_supervisor import FileGeneration
+
+    return FileGeneration(256, 10, 11, 1, 2, stat.S_IFREG | 0o600)
+
+
+def _payload(contract):
+    from artifact_supervisor import DiagnosticReceipt
+
+    return {
+        "schema_version": 1,
+        "source_sha256": "a" * 64,
+        "source_size_bytes": 256,
+        "parser_diagnostics": DiagnosticReceipt.empty().to_dict(),
+        **contract.parse_media_facts(_document(), "mp3"),
+    }
+
+
+@pytest.mark.parametrize(
+    "suffix,format_name",
+    [
+        (".mp3", "mp3"),
+        (".wav", "wav"),
+        (".m4a", "mov,mp4,m4a,3gp,3g2,mj2"),
+        (".mp4", "mov,mp4,m4a,3gp,3g2,mj2"),
+        (".mov", "mov"),
+        (".webm", "matroska,webm"),
+        (".mkv", "matroska,webm"),
+    ],
+)
+def test_closed_container_policy_accepts_audio_with_optional_video(
+    contract, suffix, format_name
+):
+    document = _document(format_name)
+    document["streams"].extend(
+        [
+            {"codec_type": "video", "duration": "60.25"},
+            {"codec_type": "video", "disposition": {"attached_pic": 1}},
+            {"codec_type": "subtitle"},
+        ]
+    )
+    facts = contract.parse_media_facts(document, contract.CONTAINER_BY_SUFFIX[suffix])
+    assert facts["stream_count"] == 4
+    assert facts["audio_stream_count"] == 1
+    assert facts["video_stream_count"] == 1
+    assert facts["attached_picture_count"] == 1
+    assert facts["other_stream_count"] == 1
+    assert facts["duration_seconds"] == 60.25
+
+
+def test_audio_only_mp4_and_cover_art_are_not_delivery_video(contract):
+    document = _document("mp4")
+    document["streams"].append(
+        {"codec_type": "video", "disposition": {"attached_pic": "1"}}
+    )
+    facts = contract.parse_media_facts(document, "iso_bmff")
+    assert facts["video_stream_count"] == 0
+    assert facts["audio_stream_count"] == 1
+    assert facts["attached_picture_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "change,reason",
+    [
+        ({"streams": [{"codec_type": "video"}]}, "media_no_audio_stream"),
+        ({"streams": []}, "media_no_audio_stream"),
+        ({"streams": [None]}, "media_parser_rejected"),
+        (
+            {"format": {"format_name": "wav", "duration": "1"}},
+            "media_invalid_container",
+        ),
+        (
+            {"format": {"format_name": "mp3,unknown", "duration": "1"}},
+            "media_invalid_container",
+        ),
+        ({"streams": [{"codec_type": "audio"}] * 65}, "media_stream_limit"),
+        (
+            {"format": {"format_name": "mp3", "duration": "28801"}},
+            "media_duration_limit",
+        ),
+        ({"programs": [{}]}, "media_parser_rejected"),
+        ({"extra": True}, "media_parser_rejected"),
+    ],
+)
+def test_invalid_container_or_stream_facts_fail_closed(contract, change, reason):
+    with pytest.raises(contract.LocalMediaError, match=reason):
+        contract.parse_media_facts(_document(**change), "mp3")
+
+
+def test_duration_falls_back_to_real_stream_not_attached_picture(contract):
+    document = _document()
+    document["format"].pop("duration")
+    document["streams"].append(
+        {"codec_type": "video", "disposition": {"attached_pic": 1}, "duration": "28000"}
+    )
+    facts = contract.parse_media_facts(document, "mp3")
+    assert facts["duration_source"] == "stream"
+    assert facts["duration_seconds"] == 60.25
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("codec_name", "unknown"),
+        ("channels", 0),
+        ("channels", True),
+        ("sample_rate", "0"),
+        ("sample_rate", "NaN"),
+    ],
+)
+def test_at_least_one_audio_stream_must_be_usable(contract, field, value):
+    document = _document()
+    document["streams"][0][field] = value
+    with pytest.raises(contract.LocalMediaError, match="media_no_usable_audio_stream"):
+        contract.parse_media_facts(document, "mp3")
+    document["streams"].append(_document()["streams"][0])
+    assert contract.parse_media_facts(document, "mp3")["audio_stream_count"] == 2
+
+
+def test_boolean_cover_art_flag_is_not_an_integer_fact(contract):
+    document = _document()
+    document["streams"].append(
+        {"codec_type": "video", "disposition": {"attached_pic": True}}
+    )
+    with pytest.raises(contract.LocalMediaError, match="media_parser_rejected"):
+        contract.parse_media_facts(document, "mp3")
+
+
+@pytest.mark.parametrize("duration", ["NaN", "Infinity", "garbage", True, 0, -1])
+def test_malformed_format_duration_cannot_fall_back_to_a_short_stream(
+    contract, duration
+):
+    document = _document()
+    document["format"]["duration"] = duration
+    with pytest.raises(contract.LocalMediaError, match="media_parser_rejected"):
+        contract.parse_media_facts(document, "mp3")
+
+
+def test_overlong_stream_cannot_hide_behind_a_short_format_duration(contract):
+    document = _document()
+    document["streams"][0]["duration"] = "28801"
+    with pytest.raises(contract.LocalMediaError, match="media_duration_limit"):
+        contract.parse_media_facts(document, "mp3")
+
+
+@pytest.mark.parametrize(
+    "value", [True, 0, -1, float("nan"), float("inf"), 10**400, "60"]
+)
+def test_untrusted_duration_cannot_become_evidence(contract, value):
+    assert contract.positive_duration(value) is None
+
+
+@pytest.mark.parametrize("value", [True, 0, -1, 8 * 1024**3 + 1, 1.0, "256"])
+def test_media_input_limit_is_exact_and_positive(contract, value):
+    with pytest.raises(contract.LocalMediaError, match="media_size_limit"):
+        contract.validate_media_size(value)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 2),
+        ("source_sha256", "private/path"),
+        ("source_size_bytes", 257),
+        ("audio_stream_count", 0),
+        ("stream_count", 2),
+        ("duration_seconds", True),
+        ("duration_source", []),
+        ("container_family", []),
+        (
+            "parser_diagnostics",
+            {"byte_count": 1, "sha256": "a" * 64, "truncated": False},
+        ),
+    ],
+)
+def test_worker_probe_payload_is_closed_and_generation_bound(contract, field, value):
+    payload = _payload(contract)
+    payload[field] = value
+    with pytest.raises(contract.LocalMediaError):
+        contract.decode_media_probe(payload, _generation(), None)
+
+
+@pytest.mark.parametrize("attributes", [0x1000, 0x40000, 0x400000, 0x400])
+def test_offline_recall_and_reparse_facts_do_not_authorize_reads(contract, attributes):
+    generation = replace(_generation(), file_attributes=attributes)
+    with pytest.raises(contract.LocalMediaError):
+        contract.decode_media_probe(_payload(contract), generation, None)
+
+
+def test_video_fact_reuse_is_zero_io(contract, monkeypatch):
+    from artifact_metadata import ArtifactAvailability
+    from artifact_supervisor import DiagnosticReceipt
+    import video_evidence
+
+    probe = video_evidence.VideoArtifactProbe(
+        generation=_generation(),
+        root_generation=None,
+        availability=ArtifactAvailability.from_generation(_generation()),
+        source_sha256="a" * 64,
+        source_size_bytes=256,
+        duration_seconds=60.25,
+        duration_source="format",
+        container_family="iso_bmff",
+        stream_count=2,
+        video_stream_count=1,
+        audio_stream_count=1,
+        attached_picture_count=0,
+        other_stream_count=0,
+        parser_diagnostics=DiagnosticReceipt.empty(),
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("video receipt reuse performed artifact I/O")
+
+    for name in (
+        "probe_video_artifact",
+        "_run_bounded_metadata_worker",
+        "_run_bounded_video_probe",
+        "_copy_source_snapshot",
+        "_digest_exact_generation",
+    ):
+        monkeypatch.setattr(video_evidence, name, forbidden)
+    result = contract.reuse_video_probe(probe)
+    assert result.generation == probe.generation
+    assert result.source_sha256 == probe.source_sha256
+    assert result.duration_seconds == probe.duration_seconds
+    with pytest.raises(contract.LocalMediaError, match="media_no_audio_stream"):
+        contract.reuse_video_probe(replace(probe, audio_stream_count=0, stream_count=1))
+
+
+def test_whisper_payload_discards_provider_only_objects(contract):
+    value = {
+        "text": "Synthetic speech",
+        "language": "en",
+        "segments": [
+            {
+                "text": "Synthetic speech",
+                "start": 0.0,
+                "end": 2.0,
+                "tokens": object(),
+                "provider_extra": "private/path",
+            }
+        ],
+        "model": object(),
+    }
+    assert contract.bounded_whisper_result(value) == {
+        "text": "Synthetic speech",
+        "language": "en",
+        "segments": [{"text": "Synthetic speech", "start": 0.0, "end": 2.0}],
+    }
+
+
+@pytest.mark.parametrize(
+    "update,reason",
+    [
+        ({"text": ""}, "whisper_result_invalid"),
+        ({"text": "x" * (2 * 1024 * 1024 + 1)}, "whisper_text_limit"),
+        ({"text": "\ud800"}, "whisper_result_invalid"),
+        ({"language": "private/path"}, "whisper_language_invalid"),
+        ({"language": "x" * 33}, "whisper_language_invalid"),
+        ({"segments": iter(())}, "whisper_segments_invalid"),
+        ({"segments": [None] * 20001}, "whisper_segment_limit"),
+        ({"segments": [None]}, "whisper_segments_invalid"),
+        ({"segments": [{"text": "x" * 16385}]}, "whisper_segment_text_limit"),
+    ],
+)
+def test_whisper_resource_failures_are_path_neutral(contract, update, reason):
+    with pytest.raises(contract.LocalMediaError, match=reason) as caught:
+        contract.bounded_whisper_result(
+            {"text": "Synthetic speech", "language": "en", **update}
+        )
+    assert "private/path" not in str(caught.value)
+
+
+def test_optional_timing_downgrade_still_checks_every_segment_ceiling(contract):
+    value = {
+        "text": "Synthetic speech",
+        "segments": [{"text": "Synthetic speech", "start": None, "end": 2}],
+    }
+    assert contract.bounded_whisper_result(value)["segments"] is None
+    value["segments"].append({"text": "x" * 16385, "start": 2, "end": 3})
+    with pytest.raises(contract.LocalMediaError, match="whisper_segment_text_limit"):
+        contract.bounded_whisper_result(value)

--- a/tests/test_local_media_download.py
+++ b/tests/test_local_media_download.py
@@ -1,0 +1,322 @@
+"""Synthetic yt-dlp providers exercise download isolation without network I/O."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+VIDEO_ID = "abcdefghijk"
+
+
+@pytest.fixture
+def download():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_download.py", "local_media_download"
+    )
+
+
+def _metadata(**updates):
+    return {
+        "id": VIDEO_ID,
+        "duration": 60.25,
+        "ext": "mp3",
+        "format_id": "140",
+        "acodec": "mp3",
+        "vcodec": "none",
+        **updates,
+    }
+
+
+def _synthetic_worker(
+    download, tmp_path, monkeypatch, body, *, timeout=None, byte_limit=None
+):
+    # The provider is a Python program selected by a test-only worker bootstrap.
+    # The runtime's actual child protocol, pipe caps and literal sink remain real.
+    provider = tmp_path / "synthetic_ytdlp.py"
+    provider.write_text(
+        "import sys, json\nfrom pathlib import Path\n" + body + "\n", encoding="utf-8"
+    )
+    script = tmp_path / "synthetic_download_worker.py"
+    script.write_text(
+        "import sys\n"
+        f"sys.path.insert(0, {str(Path(SCRIPTS_VI).resolve())!r})\n"
+        "import local_media_download as owner\n"
+        "original = owner._command\n"
+        f"owner._command = lambda executable, video_id, client: [sys.executable, {str(provider)!r}] + original(executable, video_id, client)[1:]\n"
+        + (
+            f"owner.MEDIA_MAX_INPUT_BYTES = {byte_limit}\n"
+            if byte_limit is not None
+            else ""
+        )
+        + "raise SystemExit(owner._main())\n",
+        encoding="utf-8",
+    )
+    real = download.run_authenticated_worker
+    workspaces = []
+
+    def invoke(command, operation, expected, payload, limits, **kwargs):
+        workspaces.append(Path(payload["workspace"]["path"]))
+        command = [sys.executable, str(script), download.WORKER_FLAG]
+        kwargs["immutable_process_identity"] = command[:2]
+        if timeout is not None:
+            limits = replace(limits, wall_seconds=timeout)
+        return real(command, operation, expected, payload, limits, **kwargs)
+
+    monkeypatch.setattr(download, "run_authenticated_worker", invoke)
+    return workspaces
+
+
+def test_real_protocol_metadata_is_identity_bound_and_cleaned(
+    download, tmp_path, monkeypatch
+):
+    workspaces = _synthetic_worker(
+        download, tmp_path, monkeypatch, f"print(json.dumps({_metadata()!r}))"
+    )
+    assert (
+        download.probe_youtube_media_duration(VIDEO_ID, ytdlp=tmp_path / "yt-dlp")
+        == 60.25
+    )
+    assert len(workspaces) == 1
+    assert not workspaces[0].exists()
+
+
+def test_download_is_literal_private_and_removed_after_consumer_failure(
+    download, tmp_path, monkeypatch
+):
+    workspaces = _synthetic_worker(
+        download,
+        tmp_path,
+        monkeypatch,
+        "if '--dump-single-json' in sys.argv:\n"
+        f"    print(json.dumps({_metadata()!r}))\n"
+        "else:\n    sys.stdout.buffer.write(b'synthetic media bytes')",
+    )
+    with pytest.raises(ValueError, match="consumer failed"):
+        with download.download_youtube_audio(VIDEO_ID, ytdlp=tmp_path / "yt-dlp") as (
+            path,
+            duration,
+        ):
+            assert path.name == "audio.mp3"
+            assert path.read_bytes() == b"synthetic media bytes"
+            assert duration == 60.25
+            assert list(path.parent.iterdir()) == [path]
+            raise ValueError("consumer failed")
+    assert not workspaces[0].exists()
+
+
+def test_download_retries_only_provider_refusals_with_no_partial_reuse(
+    download, tmp_path, monkeypatch
+):
+    workspaces = _synthetic_worker(
+        download,
+        tmp_path,
+        monkeypatch,
+        "if '--dump-single-json' in sys.argv:\n"
+        f"    print(json.dumps({_metadata()!r}))\n"
+        "elif 'youtube:player_client=mweb' in sys.argv:\n"
+        "    assert list(Path.cwd().iterdir()) == [Path.cwd() / 'audio.mp3']\n"
+        "    assert (Path.cwd() / 'audio.mp3').stat().st_size == 0\n"
+        "    sys.stdout.buffer.write(b'complete retry bytes')\n"
+        "else:\n    sys.stdout.buffer.write(b'failed partial')\n    sys.exit(1)",
+    )
+    with download.download_youtube_audio(VIDEO_ID, ytdlp=tmp_path / "yt-dlp") as (
+        path,
+        _,
+    ):
+        assert path.read_bytes() == b"complete retry bytes"
+    assert not workspaces[0].exists()
+
+
+@pytest.mark.parametrize("empty_first", [False, True])
+def test_first_usable_download_stops_retries(
+    download, tmp_path, monkeypatch, empty_first
+):
+    calls = tmp_path / "provider-calls.txt"
+    workspaces = _synthetic_worker(
+        download,
+        tmp_path,
+        monkeypatch,
+        f"with Path({str(calls)!r}).open('a') as log:\n"
+        "    log.write(('metadata' if '--dump-single-json' in sys.argv else 'download') + '\\n')\n"
+        "if '--dump-single-json' in sys.argv:\n"
+        f"    print(json.dumps({_metadata()!r}))\n"
+        f"elif {empty_first!r} and '--extractor-args' not in sys.argv:\n"
+        "    pass\n"
+        "else:\n"
+        "    assert (Path.cwd() / 'audio.mp3').stat().st_size == 0\n"
+        "    sys.stdout.buffer.write(b'complete media')",
+    )
+    with download.download_youtube_audio(VIDEO_ID, ytdlp=tmp_path / "yt-dlp") as (
+        path,
+        _,
+    ):
+        assert path.read_bytes() == b"complete media"
+        assert calls.read_text().splitlines() == ["metadata", "download"] * (
+            2 if empty_first else 1
+        )
+    assert not workspaces[0].exists()
+
+
+def test_all_zero_byte_downloads_fail_and_cleanup(download, tmp_path, monkeypatch):
+    workspaces = _synthetic_worker(
+        download,
+        tmp_path,
+        monkeypatch,
+        f"if '--dump-single-json' in sys.argv:\n    print(json.dumps({_metadata()!r}))",
+    )
+    with pytest.raises(download.LocalMediaError, match="ytdlp_provider_rejected"):
+        with download.download_youtube_audio(VIDEO_ID, ytdlp=tmp_path / "yt-dlp"):
+            pytest.fail("zero-byte download became usable")
+    assert not workspaces[0].exists()
+
+
+@pytest.mark.parametrize(
+    "body,reason",
+    [
+        ("print('not JSON')", "ytdlp_metadata_invalid"),
+        (
+            'print(\'{"id":"abcdefghijk","id":"abcdefghijk"}\')',
+            "ytdlp_metadata_invalid",
+        ),
+        (
+            f"print(json.dumps({_metadata(id='different-id')!r}))",
+            "ytdlp_identity_mismatch",
+        ),
+        (f"print(json.dumps({_metadata(duration=0)!r}))", "ytdlp_duration_unavailable"),
+        (
+            f"print(json.dumps({_metadata(is_live=True)!r}))",
+            "ytdlp_duration_unavailable",
+        ),
+        (
+            f"print(json.dumps({_metadata(ext='../private/path')!r}))",
+            "ytdlp_format_unavailable",
+        ),
+        ("sys.stdout.buffer.write(b'x' * (1024 * 1024 + 1))", "ytdlp_stdout_limit"),
+        ("sys.stderr.write('x' * 65537)", "ytdlp_stderr_limit"),
+        (
+            "sys.stderr.write('private provider detail'); sys.exit(1)",
+            "ytdlp_provider_rejected",
+        ),
+    ],
+)
+def test_invalid_provider_output_stops_and_cleans_without_redaction_leak(
+    download, tmp_path, monkeypatch, body, reason
+):
+    workspaces = _synthetic_worker(download, tmp_path, monkeypatch, body)
+    with pytest.raises(download.LocalMediaError) as caught:
+        with download.download_youtube_audio(VIDEO_ID, ytdlp=tmp_path / "yt-dlp"):
+            pytest.fail("invalid download became usable")
+    assert caught.value.reason_code == reason
+    assert "private" not in str(caught.value)
+    assert not workspaces[0].exists()
+
+
+@pytest.mark.parametrize(
+    "body,reason",
+    [
+        ("sys.stdout.buffer.write(b'x' * 262144)", "ytdlp_download_size_limit"),
+        (
+            "sys.stdout.buffer.write(b'partial'); import time; time.sleep(30)",
+            "ytdlp_worker_timeout",
+        ),
+        (
+            "sys.stdout.buffer.write(b'media'); Path('extra-output').write_bytes(b'bad')",
+            "ytdlp_output_invalid",
+        ),
+    ],
+)
+def test_download_resource_and_output_failures_leave_no_workspace(
+    download, tmp_path, monkeypatch, body, reason
+):
+    program = (
+        "if '--dump-single-json' in sys.argv:\n"
+        + f"    print(json.dumps({_metadata()!r}))\nelse:\n"
+        + "\n".join("    " + line for line in body.splitlines())
+    )
+    workspaces = _synthetic_worker(
+        download,
+        tmp_path,
+        monkeypatch,
+        program,
+        timeout=1.0 if reason == "ytdlp_worker_timeout" else None,
+        byte_limit=65536,
+    )
+    with pytest.raises(download.LocalMediaError) as caught:
+        with download.download_youtube_audio(VIDEO_ID, ytdlp=tmp_path / "yt-dlp"):
+            pytest.fail("failed download became usable")
+    assert caught.value.reason_code == reason
+    assert not workspaces[0].exists()
+
+
+def test_literal_download_output_must_be_regular(download, tmp_path):
+    candidate = tmp_path / "audio.mp3"
+    candidate.mkdir()
+    with pytest.raises(download.LocalMediaError, match="media_artifact_unavailable"):
+        download._require_only_artifact(tmp_path, candidate)
+
+
+@pytest.mark.parametrize(
+    "failure,reason",
+    [
+        ("worker_timeout", "ytdlp_worker_timeout"),
+        ("worker_memory_limit_exceeded", "ytdlp_worker_resource_limit"),
+        ("worker_process_limit_exceeded", "ytdlp_worker_resource_limit"),
+        ("worker_input_limit_exceeded", "ytdlp_worker_resource_limit"),
+        ("worker_output_limit_exceeded", "ytdlp_worker_resource_limit"),
+        ("worker_diagnostic_limit_exceeded", "ytdlp_worker_resource_limit"),
+        ("worker_cleanup_failed", "media_cleanup_failed"),
+        ("worker_containment_unavailable", "ytdlp_worker_failed"),
+        ("worker_monitor_unavailable", "ytdlp_worker_failed"),
+        ("invalid_worker_response", "ytdlp_worker_failed"),
+    ],
+)
+def test_supervisor_refusal_mapping_is_closed(download, monkeypatch, failure, reason):
+    def failed(*args, **kwargs):
+        raise download.SupervisorError(failure)
+
+    monkeypatch.setattr(download, "run_authenticated_worker", failed)
+    with pytest.raises(download.LocalMediaError) as caught:
+        download.probe_youtube_media_duration(VIDEO_ID)
+    assert caught.value.reason_code == reason
+
+
+@pytest.mark.parametrize(
+    "name", [None, [], "../escape.mp3", "/private/audio.mp3", "audio.exe"]
+)
+def test_malformed_result_never_selects_an_arbitrary_artifact(
+    download, monkeypatch, name
+):
+    monkeypatch.setattr(
+        download,
+        "run_authenticated_worker",
+        lambda *a, **kw: SimpleNamespace(
+            payload={
+                "video_id": VIDEO_ID,
+                "duration_seconds": 60.25,
+                "artifact_name": name,
+            }
+        ),
+    )
+    with pytest.raises(download.LocalMediaError, match="ytdlp_output_invalid"):
+        with download.download_youtube_audio(VIDEO_ID):
+            pytest.fail("malformed artifact selector accepted")
+
+
+def test_download_command_closes_unrelated_provider_writes(download, tmp_path):
+    command = download._command(tmp_path / "yt-dlp", VIDEO_ID, "mweb")
+    assert {
+        "--ignore-config",
+        "--no-plugin-dirs",
+        "--no-cache-dir",
+        "--no-playlist",
+        "--abort-on-unavailable-fragments",
+    } <= set(command)
+    assert command[-1] == f"https://www.youtube.com/watch?v={VIDEO_ID}"
+    assert "youtube:player_client=mweb" in command

--- a/tests/test_local_media_evidence.py
+++ b/tests/test_local_media_evidence.py
@@ -1,0 +1,435 @@
+"""Generic-media admission, worker boundaries, generation races and cleanup."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+import pytest
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+@pytest.fixture
+def media():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_evidence.py", "local_media_evidence"
+    )
+
+
+def _audio(path, codec):
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:sample_rate=16000",
+            "-t",
+            "1",
+            "-c:a",
+            codec,
+            "-y",
+            str(path),
+        ],
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    return path.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "suffix,codec,container",
+    [
+        (".mp3", "libmp3lame", "mp3"),
+        (".wav", "pcm_s16le", "wav"),
+        (".m4a", "aac", "iso_bmff"),
+        (".mp4", "aac", "iso_bmff"),
+        (".mov", "aac", "iso_bmff"),
+        (".mkv", "flac", "matroska_webm"),
+        (".webm", "libopus", "matroska_webm"),
+    ],
+)
+def test_real_worker_accepts_audio_only_and_binds_exact_bytes(
+    media, tmp_path, suffix, codec, container
+):
+    path = tmp_path / f"speech{suffix}"
+    raw = _audio(path, codec)
+    result = media.probe_local_media(path.name, trusted_root=tmp_path)
+    assert result.source_sha256 == hashlib.sha256(raw).hexdigest()
+    assert result.source_size_bytes == len(raw)
+    assert result.generation == media.FileGeneration.from_stat(path.lstat())
+    assert result.container_family == container
+    assert result.duration_seconds == pytest.approx(1.0, abs=0.15)
+    assert result.audio_stream_count == 1
+    assert result.video_stream_count == 0
+    assert result.stream_count == 1
+    media.check_media_generation(path.name, result, trusted_root=tmp_path)
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.parametrize(
+    "case,reason",
+    [
+        ("empty", "media_size_limit"),
+        ("corrupt", "media_parser_rejected"),
+        ("wrong_suffix", "media_invalid_container"),
+        ("truncated", "media_parser_rejected"),
+        ("directory", "media_artifact_unavailable"),
+        ("missing", "media_artifact_unavailable"),
+    ],
+)
+def test_real_worker_rejects_invalid_media_without_exposing_paths(
+    media, tmp_path, case, reason
+):
+    path = tmp_path / "private-recording.mp3"
+    if case == "empty":
+        path.touch()
+    elif case == "corrupt":
+        path.write_bytes(b"not an audio container")
+    elif case == "wrong_suffix":
+        wav = tmp_path / "source.wav"
+        path.write_bytes(_audio(wav, "pcm_s16le"))
+    elif case == "truncated":
+        path.write_bytes(_audio(path, "libmp3lame")[:10])
+    elif case == "directory":
+        path.mkdir()
+    with pytest.raises(media.LocalMediaError) as caught:
+        media.probe_local_media(path.name, trusted_root=tmp_path)
+    assert caught.value.reason_code == reason
+    assert str(path) not in str(caught.value)
+
+
+def test_real_worker_refuses_a_recording_without_audio(media, tmp_path):
+    path = tmp_path / "silent.mp4"
+    created = subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x90:r=2",
+            "-t",
+            "1",
+            "-an",
+            "-c:v",
+            "mpeg4",
+            str(path),
+        ],
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert created.returncode == 0, created.stderr.decode("utf-8", errors="replace")
+    with pytest.raises(media.LocalMediaError, match="media_no_audio_stream"):
+        media.probe_local_media(path, trusted_root=tmp_path)
+
+
+@pytest.mark.parametrize("path", ["../private.mp3", "bad\0path.mp3", "speech.avi"])
+def test_invalid_locator_does_not_launch_a_worker(media, tmp_path, monkeypatch, path):
+    monkeypatch.setattr(
+        media,
+        "run_authenticated_worker",
+        lambda *a, **kw: pytest.fail("invalid locator launched worker"),
+    )
+    with pytest.raises(media.LocalMediaError):
+        media.probe_local_media(path, trusted_root=tmp_path)
+
+
+@pytest.mark.parametrize("attribute", [0x1000, 0x40000, 0x400000, 0x400])
+def test_cloud_flags_block_all_byte_io(media, tmp_path, monkeypatch, attribute):
+    generation = media.FileGeneration(
+        100, 1, 2, 3, 4, stat.S_IFREG | 0o600, file_attributes=attribute
+    )
+    receipt = media.ArtifactMetadataReceipt(generation, None, None)
+    monkeypatch.setattr(media, "inspect_metadata_generation", lambda *a, **kw: receipt)
+    monkeypatch.setattr(
+        media.os, "open", lambda *a, **kw: pytest.fail("cloud placeholder opened")
+    )
+    with pytest.raises(media.LocalMediaError):
+        media._inspect(tmp_path / "speech.mp3", None)
+
+
+def test_dataless_mac_metadata_blocks_before_copy(media, tmp_path, monkeypatch):
+    # Inject the platform-independent interpretation; do not depend on runner OS.
+    import artifact_metadata
+
+    generation = media.FileGeneration(
+        100, 1, 2, 3, 4, stat.S_IFREG | 0o600, flags=0x40000000
+    )
+    unavailable = artifact_metadata.ArtifactAvailability.from_generation(
+        generation, macos_dataless_flag=0x40000000
+    )
+    monkeypatch.setattr(
+        artifact_metadata.ArtifactAvailability,
+        "from_generation",
+        lambda value: unavailable,
+    )
+    receipt = media.ArtifactMetadataReceipt(generation, None, None)
+    monkeypatch.setattr(media, "inspect_metadata_generation", lambda *a, **kw: receipt)
+    monkeypatch.setattr(
+        media.os, "open", lambda *a, **kw: pytest.fail("dataless source opened")
+    )
+    with pytest.raises(
+        media.LocalMediaError, match="media_cloud_placeholder_unavailable"
+    ):
+        media._inspect(tmp_path / "speech.mp3", None)
+
+
+@pytest.mark.parametrize(
+    "failure,reason",
+    [
+        ("worker_timeout", "media_worker_timeout"),
+        ("worker_memory_limit_exceeded", "media_worker_resource_limit"),
+        ("worker_process_limit_exceeded", "media_worker_resource_limit"),
+        ("worker_input_limit_exceeded", "media_worker_resource_limit"),
+        ("worker_output_limit_exceeded", "media_worker_resource_limit"),
+        ("worker_diagnostic_limit_exceeded", "media_worker_resource_limit"),
+        ("worker_generation_changed", "media_generation_changed"),
+        ("worker_cleanup_failed", "media_cleanup_failed"),
+        ("worker_exit", "media_worker_failed"),
+        ("worker_monitor_unavailable", "media_worker_failed"),
+        ("worker_response_authentication_failed", "media_worker_failed"),
+    ],
+)
+def test_supervisor_failure_mapping_is_closed_and_redacted(
+    media, monkeypatch, failure, reason
+):
+    def fail(*args, **kwargs):
+        raise media.SupervisorError(failure, {"private": "/private/recording.mp3"})
+
+    monkeypatch.setattr(media, "run_authenticated_worker", fail)
+    with pytest.raises(media.LocalMediaError) as caught:
+        media._invoke_worker(
+            media.METADATA_OPERATION, {}, {}, media.MEDIA_METADATA_LIMITS
+        )
+    assert caught.value.reason_code == reason
+    assert "/private/recording.mp3" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "failure", ["worker_timeout", "worker_exit", "worker_cleanup_failed"]
+)
+def test_owner_removes_partial_workspace_after_worker_failure(
+    media, tmp_path, monkeypatch, failure
+):
+    path = tmp_path / "speech.wav"
+    _audio(path, "pcm_s16le")
+    original = media.run_authenticated_worker
+    workspaces = []
+
+    def invoke(command, operation, expected, payload, limits, **kwargs):
+        if operation == media.PROBE_OPERATION:
+            workspace = Path(payload["workspace"]["path"])
+            workspaces.append(workspace)
+            partial = workspace / "source.wav"
+            partial.write_bytes(b"partial private copy")
+            partial.chmod(stat.S_IREAD)
+            raise media.SupervisorError(failure)
+        return original(command, operation, expected, payload, limits, **kwargs)
+
+    monkeypatch.setattr(media, "run_authenticated_worker", invoke)
+    with pytest.raises(media.LocalMediaError):
+        media.probe_local_media(path, trusted_root=tmp_path)
+    assert len(workspaces) == 1
+    assert not workspaces[0].exists()
+
+
+def test_workspace_is_fresh_private_and_cleanup_is_not_suppressed(media, monkeypatch):
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    workspaces = []
+    directories = []
+
+    def directory_factory(**kwargs):
+        directory = TemporaryDirectory(**kwargs)
+        directories.append(directory)
+        return directory
+
+    monkeypatch.setattr(media.tempfile, "TemporaryDirectory", directory_factory)
+
+    def cannot_cleanup(self):
+        raise OSError("private cleanup failure")
+
+    with pytest.raises(media.LocalMediaError, match="media_cleanup_failed"):
+        with media.private_media_workspace() as workspace:
+            path = Path(workspace["path"])
+            workspaces.append(path)
+            assert list(path.iterdir()) == []
+            if os.name != "nt":
+                assert stat.S_IMODE(path.stat().st_mode) == 0o700
+            monkeypatch.setattr(TemporaryDirectory, "cleanup", cannot_cleanup)
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", original)
+    assert len(workspaces) == 1
+    original(directories[0])
+    assert not workspaces[0].exists()
+
+
+@pytest.mark.parametrize("cover_art", [False, True])
+def test_real_worker_distinguishes_delivery_video_from_cover_art(
+    media, tmp_path, cover_art
+):
+    path = tmp_path / ("cover-art.m4a" if cover_art else "delivery.mp4")
+    command = [
+        "ffmpeg",
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=160x90:r=2",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:sample_rate=16000",
+        "-t",
+        "1",
+        "-map",
+        "0:v",
+        "-map",
+        "1:a",
+        "-c:a",
+        "aac",
+        "-c:v",
+        "mjpeg" if cover_art else "mpeg4",
+    ]
+    if cover_art:
+        command += ["-frames:v", "1", "-disposition:v", "attached_pic"]
+    created = subprocess.run(
+        command + [str(path)], capture_output=True, check=False, timeout=30
+    )
+    assert created.returncode == 0, created.stderr.decode("utf-8", errors="replace")
+    probe = media.probe_local_media(path, trusted_root=tmp_path)
+    assert probe.audio_stream_count == 1
+    assert probe.video_stream_count == int(not cover_art)
+    assert probe.attached_picture_count == int(cover_art)
+    assert probe.stream_count == 2
+
+
+@pytest.mark.parametrize("change", ["replace", "mutate", "truncate"])
+def test_source_generation_races_reject_before_any_probe(
+    media, tmp_path, monkeypatch, change
+):
+    path = tmp_path / "speech.wav"
+    _audio(path, "pcm_s16le")
+    before = media._inspect(path, tmp_path)
+    if change == "replace":
+        replacement = tmp_path / "replacement.wav"
+        replacement.write_bytes(path.read_bytes())
+        replacement.replace(path)
+    elif change == "mutate":
+        path.write_bytes(b"different" + path.read_bytes()[9:])
+    else:
+        path.write_bytes(b"short")
+    monkeypatch.setattr(
+        media, "_run_ffprobe", lambda *a: pytest.fail("stale source reached ffprobe")
+    )
+    with media.private_media_workspace() as workspace:
+        with pytest.raises(media.LocalMediaError, match="media_generation_changed"):
+            media._probe(path, tmp_path, before, Path(workspace["path"]))
+
+
+@pytest.mark.parametrize("target", ["source", "snapshot"])
+def test_probe_rejects_mutation_during_parser(media, tmp_path, monkeypatch, target):
+    path = tmp_path / "speech.wav"
+    raw = _audio(path, "pcm_s16le")
+    before = media._inspect(path, tmp_path)
+
+    def probe(snapshot):
+        selected = path if target == "source" else snapshot
+        selected.chmod(stat.S_IREAD | stat.S_IWRITE)
+        selected.write_bytes(b"changed" + raw[7:])
+        return json.dumps(
+            {
+                "format": {"format_name": "wav", "duration": "1"},
+                "streams": [
+                    {
+                        "codec_type": "audio",
+                        "codec_name": "pcm_s16le",
+                        "channels": 1,
+                        "sample_rate": "16000",
+                    }
+                ],
+            }
+        ).encode(), media.DiagnosticReceipt.empty()
+
+    monkeypatch.setattr(media, "_run_ffprobe", probe)
+    with media.private_media_workspace() as workspace:
+        with pytest.raises(media.LocalMediaError, match="media_generation_changed"):
+            media._probe(path, tmp_path, before, Path(workspace["path"]))
+
+
+@pytest.mark.parametrize(
+    "program,reason",
+    [
+        (
+            "import sys; sys.stdout.buffer.write(b'x' * 262145)",
+            "media_ffprobe_stdout_limit",
+        ),
+        (
+            "import sys; sys.stderr.buffer.write(b'x' * 65537)",
+            "media_ffprobe_stderr_limit",
+        ),
+        (
+            "import sys; sys.stderr.write('/private/source.wav')",
+            "media_parser_repair_required",
+        ),
+        ("raise SystemExit(3)", "media_parser_rejected"),
+    ],
+)
+def test_parser_output_limits_and_nonzero_are_typed(
+    media, tmp_path, monkeypatch, program, reason
+):
+    real_popen = subprocess.Popen
+    monkeypatch.setattr(media.shutil, "which", lambda name: sys.executable)
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        lambda command, **kwargs: real_popen([sys.executable, "-c", program], **kwargs),
+    )
+    with pytest.raises(media.LocalMediaError) as caught:
+        media._run_ffprobe(tmp_path / "speech.wav")
+    assert caught.value.reason_code == reason
+    assert "/private/source.wav" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "raw", [b'{"format":{},"format":{}}', b'{"value":NaN}', b"\xff", b"[]"]
+)
+def test_malformed_parser_json_is_not_evidence(media, tmp_path, monkeypatch, raw):
+    path = tmp_path / "speech.wav"
+    _audio(path, "pcm_s16le")
+    before = media._inspect(path, tmp_path)
+    monkeypatch.setattr(
+        media, "_run_ffprobe", lambda path: (raw, media.DiagnosticReceipt.empty())
+    )
+    with media.private_media_workspace() as workspace:
+        with pytest.raises(media.LocalMediaError, match="media_parser_rejected"):
+            media._probe(path, tmp_path, before, Path(workspace["path"]))
+
+
+def test_generation_recheck_rejects_replaced_source(media, tmp_path):
+    path = tmp_path / "speech.wav"
+    _audio(path, "pcm_s16le")
+    probe = media.probe_local_media(path, trusted_root=tmp_path)
+    path.write_bytes(b"replaced source")
+    with pytest.raises(media.LocalMediaError, match="media_generation_changed"):
+        media.check_media_generation(path, probe, trusted_root=tmp_path)

--- a/tests/test_local_media_process.py
+++ b/tests/test_local_media_process.py
@@ -1,0 +1,158 @@
+"""Real synthetic subprocesses exercise bounded captured and streamed pipes."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import sys
+
+import pytest
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+@pytest.fixture
+def process():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_process.py", "local_media_process"
+    )
+
+
+def test_captured_metadata_and_diagnostics_have_separate_bounds(process):
+    result = process.run_media_tool(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('metadata'); sys.stderr.write('diagnostic')",
+        ],
+        stdout_limit=128,
+        stderr_limit=32,
+    )
+    assert result.returncode == 0
+    assert result.stdout == b"metadata\n"
+    assert result.streamed_bytes == 0
+    assert result.diagnostics.byte_count == 10
+
+
+def test_media_stream_goes_only_to_literal_output(process, tmp_path):
+    path = tmp_path / "audio.mp3"
+    result = process.run_media_tool(
+        [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'x' * 1024)"],
+        stdout_limit=1024,
+        stderr_limit=32,
+        output=path,
+    )
+    assert result.returncode == 0
+    assert result.stdout == b""
+    assert result.streamed_bytes == 1024
+    assert path.read_bytes() == b"x" * 1024
+
+
+@pytest.mark.parametrize(
+    "stream,limit,reason",
+    [
+        ("stdout", 32, "media_tool_stdout_limit"),
+        ("stderr", 32, "media_tool_stderr_limit"),
+    ],
+)
+def test_captured_overflow_is_never_success(process, stream, limit, reason):
+    with pytest.raises(process.LocalMediaError, match=reason):
+        process.run_media_tool(
+            [sys.executable, "-c", f"import sys; sys.{stream}.write('x' * 33)"],
+            stdout_limit=limit,
+            stderr_limit=limit,
+        )
+
+
+def test_on_disk_ceiling_is_enforced_before_excess_bytes_are_written(process, tmp_path):
+    path = tmp_path / "audio.mp3"
+    with pytest.raises(process.LocalMediaError, match="media_tool_stdout_limit"):
+        process.run_media_tool(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write(b'x' * 262144)",
+            ],
+            stdout_limit=65536,
+            stderr_limit=32,
+            output=path,
+        )
+    assert path.stat().st_size <= 65536
+
+
+def test_exclusive_create_does_not_replace_prior_file(process, tmp_path):
+    path = tmp_path / "audio.mp3"
+    path.write_bytes(b"original")
+    with pytest.raises(process.LocalMediaError, match="media_pipe_failed"):
+        process.run_media_tool(
+            [sys.executable, "-c", "print('replace')"],
+            stdout_limit=128,
+            stderr_limit=32,
+            output=path,
+        )
+    assert path.read_bytes() == b"original"
+
+
+def test_nonzero_return_is_explicit_and_not_an_exception(process):
+    result = process.run_media_tool(
+        [sys.executable, "-c", "raise SystemExit(3)"], stdout_limit=128, stderr_limit=32
+    )
+    assert result.returncode == 3
+
+
+def test_missing_tool_is_typed(process, tmp_path):
+    with pytest.raises(process.LocalMediaError, match="media_dependency_unavailable"):
+        process.run_media_tool(
+            [str(tmp_path / "missing")], stdout_limit=128, stderr_limit=32
+        )
+
+
+def test_thread_start_failure_stops_child_and_is_typed(process, monkeypatch):
+    def failed_start(self):
+        raise RuntimeError("cannot allocate drainer")
+
+    monkeypatch.setattr(process._PipeDrainer, "start", failed_start)
+    with pytest.raises(process.LocalMediaError, match="media_pipe_failed"):
+        process.run_media_tool(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            stdout_limit=128,
+            stderr_limit=32,
+        )
+
+
+def test_partial_sink_write_is_a_failure_not_a_short_success(process):
+    class ShortWriter(io.BytesIO):
+        def write(self, value):
+            return super().write(value[:1])
+
+    target = ShortWriter()
+    sink = process._FileSink(io.BytesIO(b"synthetic media"), target, 128)
+    sink.start()
+    sink.join(1)
+    assert sink.failed
+    assert sink.byte_count == 0
+
+
+def test_failed_sink_read_is_explicit(process):
+    class BrokenReader(io.BytesIO):
+        def read(self, count: int | None = -1):
+            raise OSError("private/source failed")
+
+    sink = process._FileSink(BrokenReader(), io.BytesIO(), 128)
+    sink.start()
+    sink.join(1)
+    assert sink.failed
+    assert sink.byte_count == 0
+
+
+def test_a_sink_that_did_not_finish_cannot_report_success(
+    process, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(process._FileSink, "_run", lambda self: None)
+    with pytest.raises(process.LocalMediaError, match="media_pipe_failed"):
+        process.run_media_tool(
+            [sys.executable, "-c", "print('media')"],
+            stdout_limit=128,
+            stderr_limit=32,
+            output=tmp_path / "audio.mp3",
+        )

--- a/tests/test_local_media_transcription.py
+++ b/tests/test_local_media_transcription.py
@@ -1,0 +1,306 @@
+"""Bounded Whisper orchestration uses synthetic providers, never model downloads."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import wave
+
+import pytest
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+@pytest.fixture
+def whisper():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_transcription.py", "local_media_transcription"
+    )
+
+
+@pytest.fixture
+def speech_file(tmp_path):
+    path = tmp_path / "private-speech.wav"
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(16000)
+        output.writeframes(b"\0\0" * 16000)
+    return path
+
+
+def _fake_provider_worker(
+    whisper, tmp_path, monkeypatch, body, *, timeout=None, result_limit=None
+):
+    script = tmp_path / "synthetic_whisper_worker.py"
+    script.write_text(
+        "import sys\nfrom types import SimpleNamespace\nfrom dataclasses import replace\n"
+        f"sys.path.insert(0, {str(Path(SCRIPTS_VI).resolve())!r})\n"
+        "import local_media_transcription as owner\n"
+        + (
+            f"owner.MEDIA_WHISPER_LIMITS = replace(owner.MEDIA_WHISPER_LIMITS, max_output_bytes={result_limit})\n"
+            if result_limit is not None
+            else ""
+        )
+        + "def transcribe(path, **kwargs):\n"
+        + "\n".join("    " + line for line in body.splitlines())
+        + "\nsys.modules['mlx_whisper'] = SimpleNamespace(transcribe=transcribe)\n"
+        + "raise SystemExit(owner._main())\n",
+        encoding="utf-8",
+    )
+    real = whisper.run_authenticated_worker
+
+    def invoke(command, operation, expected, payload, limits, **kwargs):
+        command = [sys.executable, str(script), whisper.WORKER_FLAG]
+        kwargs["immutable_process_identity"] = command[:2]
+        if timeout is not None:
+            limits = replace(limits, wall_seconds=timeout)
+        return real(command, operation, expected, payload, limits, **kwargs)
+
+    monkeypatch.setattr(whisper, "run_authenticated_worker", invoke)
+
+
+def test_real_protocol_keeps_provider_stdout_out_of_result(
+    whisper, speech_file, tmp_path, monkeypatch
+):
+    _fake_provider_worker(
+        whisper,
+        tmp_path,
+        monkeypatch,
+        "print('private provider chatter')\n"
+        "return {'text': 'Synthetic speech', 'language': 'en', 'segments': [{'start': 0, 'end': 1, 'text': 'Synthetic speech', 'tokens': [1,2]}], 'private': path}",
+    )
+    probe, result = whisper.transcribe_local_media(
+        speech_file, "synthetic-model", trusted_root=tmp_path
+    )
+    assert probe.audio_stream_count == 1
+    assert result == {
+        "text": "Synthetic speech",
+        "language": "en",
+        "segments": [{"start": 0, "end": 1, "text": "Synthetic speech"}],
+    }
+    assert "private" not in repr(result)
+
+
+@pytest.mark.parametrize(
+    "body,reason",
+    [
+        ("raise OSError('private/path provider failure')", "whisper_provider_failed"),
+        ("return {'text': ''}", "whisper_result_invalid"),
+        ("return {'text': 'x' * (2 * 1024 * 1024 + 1)}", "whisper_text_limit"),
+        (
+            "return {'text': 'speech', 'language': 'private/path'}",
+            "whisper_language_invalid",
+        ),
+        (
+            "return {'text': 'speech', 'segments': [None] * 20001}",
+            "whisper_segment_limit",
+        ),
+        (
+            "return {'text': 'speech', 'segments': [{'text': 'x' * 16385}]}",
+            "whisper_segment_text_limit",
+        ),
+        ("raise ZeroDivisionError('private/path crash')", "whisper_worker_failed"),
+        (
+            "import sys\nsys.stderr.write('x' * 65537)\nreturn {'text': 'speech'}",
+            "whisper_worker_resource_limit",
+        ),
+        (
+            "from pathlib import Path\nPath(path).write_bytes(b'changed')\nreturn {'text': 'speech'}",
+            "media_generation_changed",
+        ),
+    ],
+)
+def test_real_worker_failure_is_closed_and_does_not_write_bundle(
+    whisper, speech_file, tmp_path, monkeypatch, body, reason
+):
+    prior = {}
+    for suffix in (".txt", ".quality.json", ".segments.json"):
+        path = tmp_path / f"prior{suffix}"
+        path.write_bytes(b"original " + suffix.encode())
+        prior[path] = path.read_bytes()
+    _fake_provider_worker(whisper, tmp_path, monkeypatch, body)
+    with pytest.raises(whisper.LocalMediaError) as caught:
+        whisper.transcribe_local_media(
+            speech_file, "synthetic-model", trusted_root=tmp_path
+        )
+    assert caught.value.reason_code == reason
+    assert "private/path" not in str(caught.value)
+    assert {path: path.read_bytes() for path in prior} == prior
+
+
+def test_real_worker_timeout_is_internal_and_killable(
+    whisper, speech_file, tmp_path, monkeypatch
+):
+    _fake_provider_worker(
+        whisper,
+        tmp_path,
+        monkeypatch,
+        "import time\ntime.sleep(30)\nreturn {'text': 'speech'}",
+        timeout=1.0,
+    )
+    with pytest.raises(whisper.LocalMediaError, match="whisper_worker_timeout"):
+        whisper.transcribe_local_media(
+            speech_file, "synthetic-model", trusted_root=tmp_path
+        )
+
+
+def test_worker_result_serialization_limit_is_preserved_as_resource_failure(
+    whisper, speech_file, tmp_path, monkeypatch
+):
+    _fake_provider_worker(
+        whisper, tmp_path, monkeypatch, "return {'text': 'x' * 8192}", result_limit=4096
+    )
+    with pytest.raises(whisper.LocalMediaError, match="whisper_worker_resource_limit"):
+        whisper.transcribe_local_media(
+            speech_file, "synthetic-model", trusted_root=tmp_path
+        )
+
+
+def test_established_probe_reuse_does_not_probe_copy_or_hash_again(
+    whisper, speech_file, tmp_path, monkeypatch
+):
+    import video_evidence
+    from artifact_metadata import ArtifactAvailability
+
+    probe = whisper.probe_local_media(speech_file, trusted_root=tmp_path)
+    # VideoArtifactProbe is the existing owner's trusted in-memory boundary.
+    # Its original video counts are distinct from the generic audio-only policy.
+    video = video_evidence.VideoArtifactProbe(
+        **{field: getattr(probe, field) for field in probe.__dataclass_fields__},
+        availability=ArtifactAvailability.from_generation(probe.generation),
+    )
+    _fake_provider_worker(
+        whisper, tmp_path, monkeypatch, "return {'text': 'Synthetic speech'}"
+    )
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("reused media facts performed a second probe/copy/hash")
+
+    monkeypatch.setattr(whisper, "probe_local_media", forbidden)
+    for name in (
+        "probe_video_artifact",
+        "_run_bounded_video_probe",
+        "_copy_source_snapshot",
+        "_digest_exact_generation",
+    ):
+        monkeypatch.setattr(video_evidence, name, forbidden)
+    result_probe, result = whisper.transcribe_local_media(
+        speech_file, "synthetic-model", probe=video, trusted_root=tmp_path
+    )
+    assert result_probe == probe
+    assert result["text"] == "Synthetic speech"
+
+
+@pytest.mark.parametrize(
+    "failure,reason",
+    [
+        ("worker_timeout", "whisper_worker_timeout"),
+        ("worker_generation_changed", "media_generation_changed"),
+        ("worker_memory_limit_exceeded", "whisper_worker_resource_limit"),
+        ("worker_process_limit_exceeded", "whisper_worker_resource_limit"),
+        ("worker_output_limit_exceeded", "whisper_worker_resource_limit"),
+        ("worker_input_limit_exceeded", "whisper_worker_resource_limit"),
+        ("worker_diagnostic_limit_exceeded", "whisper_worker_resource_limit"),
+        ("worker_cleanup_failed", "media_cleanup_failed"),
+        ("worker_monitor_unavailable", "whisper_worker_failed"),
+        ("worker_containment_unavailable", "whisper_worker_failed"),
+        ("invalid_worker_response", "whisper_worker_failed"),
+    ],
+)
+def test_supervisor_failures_are_typed(
+    whisper, speech_file, tmp_path, monkeypatch, failure, reason
+):
+    probe = whisper.probe_local_media(speech_file, trusted_root=tmp_path)
+
+    def fail(*args, **kwargs):
+        raise whisper.SupervisorError(failure, {"private": str(speech_file)})
+
+    monkeypatch.setattr(whisper, "run_authenticated_worker", fail)
+    with pytest.raises(whisper.LocalMediaError) as caught:
+        whisper.transcribe_local_media(
+            speech_file, "synthetic-model", probe=probe, trusted_root=tmp_path
+        )
+    assert caught.value.reason_code == reason
+    assert str(speech_file) not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        [],
+        {"text": "speech", "language": None, "segments": None, "private": "payload"},
+    ],
+)
+def test_authenticated_but_wrong_result_shape_is_not_trusted(
+    whisper, speech_file, tmp_path, monkeypatch, value
+):
+    probe = whisper.probe_local_media(speech_file, trusted_root=tmp_path)
+    monkeypatch.setattr(
+        whisper,
+        "run_authenticated_worker",
+        lambda *a, **kw: SimpleNamespace(payload=value),
+    )
+    with pytest.raises(whisper.LocalMediaError, match="whisper_result_invalid"):
+        whisper.transcribe_local_media(
+            speech_file, "synthetic-model", probe=probe, trusted_root=tmp_path
+        )
+
+
+def test_generation_change_after_worker_result_is_not_accepted(
+    whisper, speech_file, tmp_path, monkeypatch
+):
+    probe = whisper.probe_local_media(speech_file, trusted_root=tmp_path)
+
+    def replace_after_result(*args, **kwargs):
+        speech_file.write_bytes(b"changed after response")
+        return SimpleNamespace(
+            payload={"text": "speech", "language": None, "segments": None}
+        )
+
+    monkeypatch.setattr(whisper, "run_authenticated_worker", replace_after_result)
+    with pytest.raises(whisper.LocalMediaError, match="media_generation_changed"):
+        whisper.transcribe_local_media(
+            speech_file, "synthetic-model", probe=probe, trusted_root=tmp_path
+        )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ImportError,
+        OSError,
+        RuntimeError,
+        AttributeError,
+        TypeError,
+        ValueError,
+        KeyError,
+    ],
+)
+def test_optional_provider_import_failure_is_path_neutral(whisper, monkeypatch, error):
+    def fail(name):
+        raise error("private/model/path")
+
+    monkeypatch.setattr(whisper.importlib, "import_module", fail)
+    with pytest.raises(
+        whisper.LocalMediaError, match="whisper_dependency_unavailable"
+    ) as caught:
+        whisper._transcribe_with_mlx(Path("unused.wav"), "model")
+    assert "private/model/path" not in str(caught.value)
+
+
+@pytest.mark.parametrize("signal", [KeyboardInterrupt, SystemExit])
+def test_process_control_signals_are_not_swallowed(whisper, monkeypatch, signal):
+    def interrupt(path, **kwargs):
+        raise signal()
+
+    monkeypatch.setattr(
+        whisper.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(transcribe=interrupt),
+    )
+    with pytest.raises(signal):
+        whisper._transcribe_with_mlx(Path("unused.wav"), "model")

--- a/tests/test_transcript_timing.py
+++ b/tests/test_transcript_timing.py
@@ -977,3 +977,54 @@ def test_overlong_whisper_timestamps_are_sloppy_not_foreign(
 
     assert "different, longer recording" not in reason
     assert "1.40x" not in reason
+
+
+@pytest.mark.parametrize(
+    "error", [ValueError, OSError, RuntimeError, KeyboardInterrupt, SystemExit]
+)
+@pytest.mark.parametrize("quality_only", [False, True])
+def test_precommit_guard_runs_after_staging_and_preserves_all_prior_bytes(
+    transcript_timing,
+    tmp_path,
+    error,
+    quality_only,
+):
+    transcript = tmp_path / "talk.txt"
+    paths = [
+        transcript,
+        transcript.with_suffix(".quality.json"),
+        transcript.with_suffix(".segments.json"),
+    ]
+    for path in paths:
+        path.write_bytes(b"prior " + path.suffix.encode())
+    before = {path: path.read_bytes() for path in paths}
+    policy = {"schema_version": 1, "min_words": 400, "duration_seconds": None}
+
+    def guard():
+        assert list(tmp_path.glob("*.partial")), "guard must run after staging"
+        assert {path: path.read_bytes() for path in paths} == before
+        raise error("source generation changed")
+
+    with pytest.raises(error):
+        if quality_only:
+            transcript_timing.write_quality_receipt(
+                transcript,
+                "new text",
+                policy,
+                {"kind": "fixed_default"},
+                before_commit=guard,
+            )
+        else:
+            transcript_timing.write_transcript_bundle(
+                transcript,
+                "new text",
+                None,
+                source="whisper",
+                timing_provenance=None,
+                quality_policy=policy,
+                quality_policy_provenance={"kind": "fixed_default"},
+                force=True,
+                before_commit=guard,
+            )
+    assert {path: path.read_bytes() for path in paths} == before
+    assert not list(tmp_path.glob("*.partial"))


### PR DESCRIPTION
## Summary

- Add authenticated, resource-bounded generic-media, yt-dlp, and Whisper workers for #219. Reject unsupported/cloud-placeholder inputs before byte I/O, reuse established video/media facts, and keep downloads in a private literal-output workspace.
- Bind transcript duration and digest to a verified source generation, then recheck after bundle staging and before commit. Preserve existing transcript, quality, and timing bytes on failed acquisition; keep caption and other artifact lanes independent.
- Document the runtime lanes and failure contract. Narrow the platform-bound test exemption to the actual MLX import/provider call; deterministic orchestration and failure mappings are tested. No persistent receipt schema, CI configuration, or dependency changes.

## Test plan

- [x] Full suite: **7,115 passed, 8 skipped** (258.21 seconds).
- [x] Ruff lint and formatting: clean; Pyright: zero errors, warnings, or information diagnostics.
- [x] Package contents (315 files), shipped extensions, entrypoints, conflict markers, Tessl pins, publish composer, shell syntax, plugin lint, and staged diff whitespace checks: pass.
- [x] Audit against all 26 governing coding-policy rules, transcript-fetch authority, loaded-prose connective markers, and outer-boundary exception markers.
- [x] Synthetic/native generated-media regressions cover input/container admission, resource limits, provider failures, source-generation drift, prior-bundle preservation, literal download enumeration/cleanup, and zero duplicate video-probe/hash/copy work.
- [x] Attempt mandatory `tessl review run skills/vault-ingress --threshold 85`: exact organization-out-of-credits failure. **The skill has not passed Tessl quality review.** Apply the existing `skill-review-credit-outage: skip` opt-in under coding-policy's Credit-Outage Review Carve-Out; publish must retry and name `vault-ingress` in its warning, summary, and unreviewed-skills output. No thresholds or CI gates are changed.
- [ ] Actual MLX runtime/model execution: not run here; the narrowed platform-bound manual procedure is documented in `rules/transcript-fetch-authority.md`.

## Scope and release

Related to #219; leave it open for the separately recorded live QCon provenance case. This implementation authenticates the media generation it processes; it does not establish a missing catalog-to-recording identity, relabel old receipts, perform live calibration (#368), or reparse the vault. The previously shipped QR schema repair is unchanged.

Patch release via the existing automatic version/stamp workflow. Release completion requires both automated reviewers, green CI, all feedback threads addressed, and post-merge publish-run success, registry advance, and moderation clearance.
