### PR TITLE
feat(illustrations): Add subscription image CLI lane

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,4 @@ skills/**/*.js.txt linguist-generated=true merge=ours
 # install the graph that was reviewed. Regenerate with
 # `npm install --package-lock-only`, never by hand.
 scripts/deck-renderers/package-lock.json linguist-generated=true merge=ours
+skills/illustrations/scripts/codex-cli/package-lock.json linguist-generated=true merge=ours

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,4 +25,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
-
+  - package-ecosystem: "npm"
+    directory: "/skills/illustrations/scripts/codex-cli"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .pytest_cache/
 *.egg-info/
 .venv/
+/skills/illustrations/scripts/codex-cli/node_modules/
 
 # OS metadata. `tessl plugin pack` reads the working tree, not the git index, so
 # an unignored .DS_Store under skills/ ships to consumers.

--- a/.tesslignore
+++ b/.tesslignore
@@ -30,7 +30,7 @@
 /.tessl/
 /.venv/
 node_modules/
-package-lock.json
+/package-lock.json
 
 # VCS metadata
 /.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 Add per-render CLI/API selection shared by both generators (#385), explicit
 lane overrides, lazy API credentials, bounded authenticated native execution,
-and visible failures without metered retries. Renew installed CLI capability
-and authentication per use. Preserve dated aliases and exact geometry on API;
+and visible failures without metered retries. Declare a locked optional Codex
+runtime with weekly Dependabot renewal; enforce its exact version and check
+capability/authentication per use. Preserve dated aliases and exact geometry on API;
 native output requires explicit opt-in and reports its unpinned identity,
 observed dimensions, and digest. Gemini, Imagen, masks, and thumbnail composition
 retain their verified API paths. Unmasked native builds edit the preceding frame.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### Route compatible image requests through subscription Codex
+
+Add per-render CLI/API selection shared by both generators (#385), explicit
+lane overrides, lazy API credentials, bounded authenticated native execution,
+and visible failures without metered retries. Renew installed CLI capability
+and authentication per use. Preserve dated aliases and exact geometry on API;
+native output requires explicit opt-in and reports its unpinned identity,
+observed dimensions, and digest. Gemini, Imagen, masks, and thumbnail composition
+retain their verified API paths. Unmasked native builds edit the preceding frame.
+
+Version the exploration manifest to v2 with requested/served lane provenance;
+keep historical API-only v1 readable and refuse native cells as evidence for a
+dated API model. Label native comparison files and contact sheets explicitly.
+Test routing, subprocess/resource failures, output/reference validation, chain
+behavior, and the bake gate with fake vendors. No catalog reparse or live-vault
+mutation is part of this change.
+
 ## 0.20.125 — 2026-09-05
 
 ### Bound transcript media acquisition to supervised source generations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,10 +126,11 @@ pythonVersion = "3.10"
 include = ["scripts", "skills", "tests"]
 exclude = ["**/__pycache__", ".venv", ".tessl"]
 executionEnvironments = [
-    # illustrations reads the outline schema from presentation-creator.
+    # illustrations reads the outline schema and the shared artifact supervisor.
     { root = "skills/illustrations/scripts", extraPaths = [
         "skills/illustrations/scripts",
         "skills/presentation-creator/scripts",
+        "skills/vault-ingress/scripts",
     ] },
     # The outline reader consumes the vault-profile-owned speech-rate contract.
     { root = "skills/presentation-creator/scripts", extraPaths = [

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -50,6 +50,7 @@ Do not restate them here — apply them.
 | `style-explore/` (alongside outline) | Phase 2 exploration grid (style × model × format) + `index.md` + `rendered.json` manifest |
 | [skills/illustrations/references/strategy.md](references/strategy.md) | Phase 2 detail — idea-sourcing wizard, optimization priorities, model shortlist, style proposals, exploration render, the render-before-bake gate, continuity devices |
 | [skills/illustrations/references/generation.md](references/generation.md) | Deck generation, edit/fix workflow, model comparison |
+| [skills/illustrations/references/image-provider-lanes.md](references/image-provider-lanes.md) | Subscription CLI capability, authentication, failure handling, and renewal |
 | [skills/illustrations/references/builds.md](references/builds.md) | Backwards-chained build generation |
 | [skills/illustrations/references/thumbnails.md](references/thumbnails.md) | Phase 7 thumbnail composition + slide selection |
 | [skills/illustrations/references/style-explore-candidates-schema.md](references/style-explore-candidates-schema.md) | `--style-explore` contract — `candidates.json` input + `rendered.json` output |
@@ -118,6 +119,15 @@ that to the speaker — they keep the baked model or re-run the exploration
 (OpenAI). A model from a new vendor family needs a `model_family()` +
 `_call_<vendor>` adapter before it can render — surface that as a follow-up
 script change.
+
+Both generators default to `--image-lane auto`: prefer a compatible subscription
+CLI; preserve pinned models and exact geometry on API. Use `--image-lane api`
+to force HTTP. Use `--image-lane cli --allow-cli-native` for OpenAI native,
+unpinned output at observed dimensions. Gemini, Imagen, masked edits, and
+multi-reference thumbnails remain API-only. Report the emitted lane and any
+failure; never retry a failing CLI through API without an explicit API choice.
+Read [skills/illustrations/references/image-provider-lanes.md](references/image-provider-lanes.md)
+before selecting native output. Native previews are not dated-model bake evidence.
 
 Proceed immediately to Step 3 or Step 10 per Step 1's routing.
 

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -32,6 +32,14 @@ python3 "{speaker_toolkit_root}/skills/illustrations/scripts/generate-illustrati
 
 Output: `illustrations/builds/slide-NN-build-MM.jpg`.
 
+Lane options are shared with generation; see
+[image-provider-lanes.md](image-provider-lanes.md). Unmasked OpenAI edits can
+chain through Codex with `--image-lane cli --allow-cli-native`. Each call edits
+the previous frame; it does not regenerate from a fresh prompt. Native geometry
+may vary. `erase_region` remains API-only: auto reports the API decision;
+forcing CLI refuses with `cli_mask_not_supported` before the edit. A failed
+edit aborts that slide's remaining chain and exits non-zero.
+
 ## Edit-Prompt Authoring
 
 Each build step in `outline.yaml` carries two fields. `desc` is the additive,

--- a/skills/illustrations/references/generation.md
+++ b/skills/illustrations/references/generation.md
@@ -8,7 +8,15 @@ are auto-loaded — apply them, don't restate them.
 
 Before generating, ensure:
 
-1. **API key(s)** — the script dispatches by model-name prefix:
+1. **Lane and credentials** — `--image-lane auto` prefers a compatible
+   subscription CLI. Existing pinned-model/exact-size requests use API;
+   `--allow-cli-native` explicitly permits OpenAI's unpinned native model and
+   observed dimensions. Force HTTP with `--image-lane api`, or require native
+   Codex with `--image-lane cli --allow-cli-native`. Gemini and Imagen remain
+   API-only. See [image-provider-lanes.md](image-provider-lanes.md) for the
+   capability/authentication boundary and diagnostics.
+
+   API requests dispatch by model-name prefix:
    `gpt-image-*` → OpenAI; `imagen-*` and `gemini-*` / `nano-banana-*` →
    Google. Add whichever keys the run will actually use to
    `{vault}/secrets.json` (preferred):
@@ -18,12 +26,10 @@ Before generating, ensure:
      "openai": { "api_key": "your-openai-key" }
    }
    ```
-   For single-model generation (`generate`, `--edit`, `--build`, `--fix`),
-   only the key for the outline's baked `style_anchor.model` vendor is required —
-   the other can be omitted. For `--compare`, every vendor in `COMPARE_MODELS`
-   is hit; for `--style-explore`, every vendor among the `candidates.json`
-   models is hit — provide all corresponding keys (the current roster spans
-   both Google and OpenAI, so both are usually needed).
+   Only vendors that select API need keys. Native-only runs never read
+   `secrets.json` or require an API key. Mixed comparison/exploration runs check
+   each API vendor on first use; provide those keys before starting to avoid
+   a partially rendered grid. A present but failing CLI never retries API.
    Env-var fallbacks: `GEMINI_API_KEY`, `OPENAI_API_KEY`. Get keys from
    https://aistudio.google.com/app/apikey (Google) and
    https://platform.openai.com/api-keys (OpenAI).
@@ -33,8 +39,10 @@ Before generating, ensure:
    Imagen models have no edit endpoint — `--edit`, `--build`, and `--fix`
    require a Gemini or OpenAI model.
 
-3. **Python 3** — stdlib only (`urllib`, `json`, `base64`, `uuid`). No pip
-   install needed.
+3. **Python 3.10+** — install the project's declared dependencies from
+   `pyproject.toml`. API-only plain generation uses the standard library;
+   masked edits need Pillow. The native lane also uses the co-shipped process
+   supervisor and its declared psutil dependency.
 
 ## Slide Selection Modes
 

--- a/skills/illustrations/references/image-provider-lanes.md
+++ b/skills/illustrations/references/image-provider-lanes.md
@@ -1,0 +1,107 @@
+# Image Provider Lanes
+
+Both generators use `model_registry.resolve_image_lane` before API credentials
+or provider calls. `image_provider.py` supplies the shared options, fresh probe,
+and stderr diagnostics. Resolution happens separately for each render.
+
+## Choosing a lane
+
+| Options | Behavior |
+| --- | --- |
+| Default: `--image-lane auto` | Prefer a compatible CLI. Preserve current pinned API models and exact-size requirements on API. |
+| `--image-lane auto --allow-cli-native` | Prefer Codex for unmasked, single-reference OpenAI edits and generation. An absent executable permits reported API fallback. |
+| `--image-lane cli --allow-cli-native` | Require the compatible subscription CLI; absence or unsupported constraints fail. No API-key requirement. |
+| `--image-lane api` | Use the existing HTTP adapter without probing a CLI. |
+
+`--allow-cli-native` is an explicit relaxation of image-model pinning and exact
+geometry, not an alias change. The baked `gpt-image-2` alias still resolves to its
+dated API snapshot. Native results report
+`codex-native-image-model-unpinned`, actual width/height, and the output SHA-256.
+They are not labelled as that snapshot or resized to pretend a size was served.
+Use the API lane for exact output requirements or lane-pinned cost comparisons;
+neither lane promises pixel-identical repeated generation.
+
+Example, for an outline that has already passed its render-before-bake gate:
+
+```bash
+python3 "{speaker_toolkit_root}/skills/illustrations/scripts/generate-illustrations.py" \
+  outline.yaml --image-lane cli --allow-cli-native -v 2
+```
+
+Native exploration grids are previews only. Their contact sheet and version-2
+manifest retain requested and served identities; they cannot establish that a
+dated API model was seen. Comparison/exploration native filenames carry
+`-cli-native-unpinned`. The normal bake gate remains in force. A native preview
+does not authorize overwriting the outline's model or claiming cross-lane parity.
+
+## Verified capability and limits
+
+The [installed-CLI probe record](https://github.com/jbaruch/speaker-toolkit/issues/385#issuecomment-5546340204)
+records native Codex generation and editing, plus the failed Gemini attempts.
+Only the proven OpenAI native lane is enabled. Gemini and Imagen use API; forcing
+CLI reports `family_api_only`. Thumbnail composition is Gemini-only and uses two
+reference images, so it remains API-only, including its optional portrait pass.
+Slide extraction does not invoke an image provider.
+
+Codex image-model pinning, exact dimensions, masks, and multiple references are
+not proven by the installed probe. Masked builds stay on API in auto mode and
+refuse forced CLI. Unmasked native builds preserve the existing backward edit
+chain; inspect native dimensions and visual continuity before applying a deck.
+
+## Authentication and failures
+
+The adapter observes `codex login status`; only ChatGPT authentication is
+eligible. It does not log in, log out, inspect auth files, set a forced login
+method, or edit global configuration. Select subscription authentication yourself
+if the probe reports API or unknown authentication. The child environment omits
+API-key/token/secret/password variables; the caller's environment is unchanged.
+This is an observed CLI authentication mode, not independent proof of billing.
+See the official [authentication documentation](https://learn.chatgpt.com/docs/auth)
+and [native image documentation](https://learn.chatgpt.com/docs/image-generation).
+
+Every attempted render emits an `IMAGE_LANE` JSON line to stderr with lane,
+family, operation, requested/served model, geometry, reason, and resolved binary
+and version (`null` for API). Successful native renders add `IMAGE_OUTPUT` with
+observed dimensions and digest. Raw CLI stderr, prompts, credentials, and
+assistant text are not included in adapter failures.
+
+Installed Codex can emit non-fatal `item.completed` diagnostics before the turn
+starts and during it. Completed renders surface their count as a stderr warning
+and `provenance.warning_count`; raw diagnostic text is withheld. Top-level
+`error`, `turn.failed`, a non-zero exit, or invalid image output still refuse the
+render. The [non-interactive CLI documentation](https://learn.chatgpt.com/docs/non-interactive-mode)
+describes the JSONL event families; the pre-turn item ordering is established by
+the installed 0.153.2 probe and covered by a fixed synthetic fixture.
+
+Absence is an expected non-result. A present executable that fails capability,
+authentication, generation, quota, output validation, or supervision checks
+produces a visible failure; no automatic metered retry follows. Repair the CLI
+or explicitly rerun with `--image-lane api`. Generation, comparison, exploration,
+and build commands exit non-zero if any requested render fails. Exploration
+writes its partial result manifest before that exit.
+
+## Dependency renewal and execution boundary
+
+Codex is an optional runtime dependency, discovered on PATH. Capability is
+renewed on every CLI selection and again before each render: resolved executable
+identity, parsed version, required non-interactive flags, and authentication.
+No minimum-version pin replaces that probe. A version change between selection
+and rendering refuses the run. The actual image-tool invocation remains a
+separate capability check: help text alone never counts as image success.
+
+`image_cli.py` uses the co-shipped authenticated supervisor and an owner-private
+temporary workspace. Its probe and render profiles bound wall time, memory, and
+descendants; `image_cli_process.py` bounds pipes and workspace growth. Exact
+limits and closed failure codes live in those modules. Output must be the literal
+`image.png`, a bounded regular local leaf, with a valid single-frame PNG and a
+completed structured CLI turn. The adapter checks copied reference bytes and
+the original reference generation, verifies the output digest, and removes
+scratch on success, refusal, and interruption. It never treats assistant prose
+or an arbitrary returned path as output evidence.
+
+The test suite uses fake CLI/process/provider boundaries only; it never invokes
+a vendor binary or endpoint. Renew the manual probe after a capability change:
+run one authorized native generation and one single-reference edit, inspect the
+images, record binary/version, dimensions, and digests in the issue, then update
+fixtures if the structured event contract changed. Do not induce quota exhaustion
+or change authentication automatically.

--- a/skills/illustrations/references/image-provider-lanes.md
+++ b/skills/illustrations/references/image-provider-lanes.md
@@ -82,12 +82,23 @@ writes its partial result manifest before that exit.
 
 ## Dependency renewal and execution boundary
 
-Codex is an optional runtime dependency, discovered on PATH. Capability is
-renewed on every CLI selection and again before each render: resolved executable
-identity, parsed version, required non-interactive flags, and authentication.
-No minimum-version pin replaces that probe. A version change between selection
-and rendering refuses the run. The actual image-tool invocation remains a
-separate capability check: help text alone never counts as image success.
+Codex is an optional runtime dependency declared and pinned by
+`skills/illustrations/scripts/codex-cli/package.json` and `package-lock.json`.
+Weekly Dependabot PRs renew the pin; dependency bumps retain their own review
+and capability validation. Install the isolated, locked runtime without changing
+your global CLI or login:
+
+```bash
+npm ci --ignore-scripts --prefix "{speaker_toolkit_root}/skills/illustrations/scripts/codex-cli"
+```
+
+The adapter prefers this local installation, then discovers Codex on PATH when
+the local installation is absent. Either must match the manifest's exact version;
+a mismatched or broken installation fails visibly, without selecting another
+binary or billing API. `pinned_cli_version` reads the manifest as the sole pin.
+Every selection/render also checks executable identity, required invocation
+flags, and authentication. The actual image-tool invocation remains a separate
+capability check: a matching version and help text alone never count as success.
 
 `image_cli.py` uses the co-shipped authenticated supervisor and an owner-private
 temporary workspace. Its probe and render profiles bound wall time, memory, and

--- a/skills/illustrations/references/style-explore-candidates-schema.md
+++ b/skills/illustrations/references/style-explore-candidates-schema.md
@@ -70,14 +70,15 @@ either version do not migrate or rewrite the input.
 
 - **Writer**: `generate-illustrations.py --style-explore` (`write_rendered_manifest`)
 - **Readers**: `generate-illustrations.py --check-style-explore` and the
-  `run_generate` render-before-bake guard
+  `run_generate` / `run_build` render-before-bake guards; strategy consumers use
+  the `--check-style-explore` verdict, not their own manifest parser
 - **Purpose**: the machine-readable record of what actually rendered, so the gate
   can confirm a baked model was rendered. `index.md` is the human contact sheet;
   `rendered.json` is the gate's source of truth.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "outline": "outline.yaml",
   "outline_dir": "devnexus26-robocoders",
   "rendered_at": "2026-06-08T12:00:00Z",
@@ -85,10 +86,16 @@ either version do not migrate or rewrite the input.
   "cells": [
     {"style": "Blueprint Schematic", "format": "FULL",
      "model": "nano-banana-pro", "model_resolved": "gemini-3-pro-image",
-     "status": "OK", "rel_path": "blueprint-schematic/full/gemini-3-pro-image.png"},
+     "status": "OK", "rel_path": "blueprint-schematic/full/gemini-3-pro-image.png",
+     "provenance": {
+       "lane": {"family": "gemini", "lane": "api", "operation": "generate",
+                "requested_model": "gemini-3-pro-image", "served_model": "gemini-3-pro-image",
+                "geometry": "requested", "reason_code": "family_api_only",
+                "binary": null, "version": null},
+       "width": null, "height": null, "sha256": null, "warning_count": 0}},
     {"style": "Blueprint Schematic", "format": "FULL",
      "model": "gpt-image-2", "model_resolved": "gpt-image-2-2026-04-21",
-     "status": "FAIL", "error": "rate limited"}
+     "status": "FAIL", "error": "rate limited", "provenance": null}
   ]
 }
 ```
@@ -97,10 +104,30 @@ Fields:
 
 - `outline` — outline filename; `outline_dir` — talk-directory name. Together a
   per-talk discriminator.
-- `models_rendered_ok` — human-readable summary of OK-rendered canonical ids.
+- `models_rendered_ok` — human-readable summary of successful **served** model
+  identities, not a list of bake-eligible requested models.
 - `cells` — one entry per rendered cell: `model` / `model_resolved` (codenames
   resolve via the registry alias map), `format`, `style`, `status`, and `rel_path`
-  (relative to `style-explore/`) or `error`.
+  (relative to `style-explore/`) or `error`, plus `provenance`.
+- `provenance` — `null` for a failure before selection; otherwise `lane` carries
+  the dispatch plan's fields shown above. `width`, `height`, and `sha256` are
+  populated from verified native output, or `null` when unavailable. API output
+  keeps its existing adapter contract; these fields do not invent an inspection.
+  `warning_count` is a non-negative integer counting native non-fatal item
+  diagnostics, also announced on stderr; API outcomes use zero.
+- Native `lane: cli` uses served model `codex-native-image-model-unpinned`,
+  `geometry: native_observed`, and the resolved absolute binary/version. Such a
+  cell cannot prove a dated API model, even if `model_resolved` names one.
+
+The writer emits v2. The reader accepts historical API-only v1 and v2 during the
+additive rollout; reading either version is read-only. V1 has no native cells,
+so its historical model identity remains usable subject to existing live-file
+checks. V2 never infers absent provenance. The next owner `--style-explore` run
+replaces its prior grid manifest with v2 from actual new render outcomes; no
+reader stamps old images with guessed native metadata. Missing, malformed, or
+future versions provide no usable prior state and return an actionable failure.
+Other skills must not rewrite this artifact or initiate a paid rerender merely
+to migrate it.
 
 The render-before-bake gate's eligibility predicate — which cells count, the
 live-file evidence check, path containment, and the per-talk copied/stale

--- a/skills/illustrations/scripts/codex-cli/package-lock.json
+++ b/skills/illustrations/scripts/codex-cli/package-lock.json
@@ -1,0 +1,137 @@
+{
+  "name": "speaker-toolkit-image-cli",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "speaker-toolkit-image-cli",
+      "version": "1.0.0",
+      "dependencies": {
+        "@openai/codex": "0.153.2"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.153.2",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.2.tgz",
+      "integrity": "sha512-IRocJlE+jCZGYHwIJWBja2nDswTSZY4sNddQgU5xiR/mVWxo5WcO8pqcajXJea1XDoNK9CaVzizVhUxDhFkU6g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.2-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.2-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.2-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.153.2-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.2-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.153.2-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.153.2-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.2-darwin-arm64.tgz",
+      "integrity": "sha512-8cEJWOIW5WnSn2+W1RUjc1sm2sN1H6NP+cCrOe73ImamUy2yOk3QKjZM2SfkA9jf3fqgwlBNUslhGMen2omc5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.153.2-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.2-darwin-x64.tgz",
+      "integrity": "sha512-hY68UBhIUE3xIn40SdoujokNiCBeHn9Jp9bEtcIrYeYd2IUtu1oCFwxFnkGhw6+UjHn7piiMxohAomddRA4MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.153.2-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.2-linux-arm64.tgz",
+      "integrity": "sha512-QDkOdJzIdMGaOCViY2dqGqr8WhQv81WfmJkAghC3doFedsOfHt87RuAO4yFN7m0FSR3y5UsScSDUT4zOCcmEVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.153.2-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.2-linux-x64.tgz",
+      "integrity": "sha512-CPUPhFmykKRdIcgwiOfKvFKHBP62dPfaiP+pzQ2bVNAfLTW+i0Kasd7hQryoxZUmTPvw0h9HyM2NgsnQ9AJlTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.153.2-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.2-win32-arm64.tgz",
+      "integrity": "sha512-+49dim0F4FoxKLBDBLzMQL4C1m9FG2kx6twg98jo2USesKfmj8XG3HSCe2tW2zOfRArSgHCDyNDHFdts3AfaBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.153.2-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.2-win32-x64.tgz",
+      "integrity": "sha512-x1PnFo9Uy81NEIlPx3qxkP3PQgkfmJOY/2LqKCKlvxArWIL+PrEV9xKcmKeo9Yw23PPU2TDH3AyqcdeblqtNNg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/skills/illustrations/scripts/codex-cli/package.json
+++ b/skills/illustrations/scripts/codex-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "speaker-toolkit-image-cli",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Optional pinned Codex runtime for subscription image generation",
+  "dependencies": {
+    "@openai/codex": "0.153.2"
+  }
+}

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -1167,7 +1167,7 @@ def generate_image(prompt, model, keys, slide_format=None):
 
 def edit_image(
     input_path, edit_prompt, model, keys, slide_format=None, erase_region=None
-):
+) -> ImageRender:
     """Edit an existing image via the appropriate vendor endpoint.
 
     Auto-appends vendor-agnostic safety suffixes to the prompt to prevent
@@ -1183,7 +1183,8 @@ def edit_image(
             When None, the historical whole-frame regeneration is used.
 
     Returns:
-        tuple (image_bytes, mime_type) on success, or (None, error_message) on failure.
+        ImageRender with bytes/MIME type or a failure message, plus lane provenance.
+        Two-value unpacking remains compatible with the historical tuple result.
     """
     suffixes = []
     lower_prompt = edit_prompt.lower()
@@ -1199,10 +1200,12 @@ def edit_image(
     sizing = sizing_for(slide_format)
 
     if family == "imagen":
-        return None, (
+        return ImageRender(
+            None,
             f"Image editing is not supported for Imagen models ({model}). "
             "Imagen has no public edit endpoint — use a Gemini or OpenAI "
-            "model for --edit / --build / --fix workflows."
+            "model for --edit / --build / --fix workflows.",
+            None,
         )
 
     width, height = sizing["openai_size"].split("x")

--- a/skills/illustrations/scripts/generate-illustrations.py
+++ b/skills/illustrations/scripts/generate-illustrations.py
@@ -3,9 +3,8 @@
 Generate illustrations for a presentation outline.
 
 Reads outline.yaml (the single source of truth) for the baked model, per-format
-style anchors, and per-slide image prompts, generates images via the
-appropriate vendor API (Google Gemini, Google Imagen, or OpenAI — dispatched by
-model-name prefix), and saves them to an illustrations/ directory.
+style anchors, and per-slide image prompts, selects a compatible subscription
+CLI or vendor API, and saves images to an illustrations/ directory.
 
 Usage:
     python3 generate-illustrations.py <outline.yaml> all
@@ -20,7 +19,12 @@ Usage:
     python3 generate-illustrations.py <outline.yaml> --fix 5 "Make the road wider"
     python3 generate-illustrations.py <outline.yaml> -v 2 5 9
 
-Requires:
+Lane options:
+    --image-lane auto|api|cli (default: auto)
+    --allow-cli-native permits unpinned OpenAI native output and observed geometry.
+    A failing CLI never retries API. Pinned/exact requests remain on API.
+
+Requires for API-selected renders only:
     - For Google models (gemini-*, nano-banana-*, imagen-*):
         Gemini API key in {vault}/secrets.json (preferred) or
         GEMINI_API_KEY env var (fallback).
@@ -28,11 +32,9 @@ Requires:
         OpenAI API key in {vault}/secrets.json under "openai".api_key
         or OPENAI_API_KEY env var (fallback).
     - Python 3.10+ (matches the project's requires-python in pyproject.toml;
-      uses union-type syntax via the shared outline_schema). The core
-      generation paths are stdlib-only. The masked-edit build path
-      (`--build` with a step `erase_region`) needs Pillow, a declared project
-      dependency (pyproject.toml); it is imported lazily only when a region is
-      used, so plain generation still runs without it.
+      uses union-type syntax via the shared outline_schema). Install the project's
+      declared dependencies; masked edits use Pillow and the native lane uses
+      Pillow plus the co-shipped process supervisor and psutil.
 """
 
 import argparse
@@ -53,6 +55,14 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+from image_lane_contract import ImageLaneError
+from image_provider import (
+    ImageProviderOptions,
+    ImageRender,
+    add_image_lane_arguments,
+    render_cli,
+    select_image_lane,
+)
 from model_registry import (
     COMPARE_MODELS,
     GEMINI_API_BASE,
@@ -733,40 +743,47 @@ def _require_keys_for_families(keys, families, secrets_path):
     sys.exit(1)
 
 
+class ImageKeys:
+    """Per-run credentials, loaded only after a render selects the API lane."""
+
+    def __init__(self, vault_path=None, options=None):
+        self.vault_path = vault_path
+        self.options = options or ImageProviderOptions()
+        self._loaded = None
+
+    def require(self, family):
+        if self._loaded is None:
+            self._loaded = load_secrets(self.vault_path)
+        keys, _ = self._loaded
+        key_name = family_key_name(family)
+        if not keys.get(key_name):
+            variable = "OPENAI_API_KEY" if key_name == "openai" else "GEMINI_API_KEY"
+            raise ImageLaneError(
+                "image_api_key_missing",
+                f"configure {key_name}.api_key in the vault secrets.json or set {variable}",
+            )
+        return keys
+
+
 def _load_context(
-    outline_path, require_model=True, vault_path=None, compare_mode=False
+    outline_path,
+    require_model=True,
+    vault_path=None,
+    compare_mode=False,
+    lane_options=None,
 ):
-    """Common preamble: load API keys, parse outline, compute paths.
+    """Parse the outline and paths without reading provider credentials.
 
-    Determines which vendor families need keys based on:
-        - compare_mode=True → every family in COMPARE_MODELS + outline's
-          baked Model (if any)
-        - compare_mode=False → just the outline's Model family
-
-    Returns:
-        tuple (keys, outline, output_dir) where keys is a dict
-        {"gemini": str|None, "openai": str|None}.
+    Compare mode may select different lanes per cell. Each API render checks only
+    its own vendor key; native-only runs never read secrets.json or API keys.
     """
-    keys, secrets_path = load_secrets(vault_path)
+    keys = ImageKeys(vault_path, lane_options)
     outline = parse_outline(outline_path)
 
     if require_model and not outline["model"]:
         print("ERROR: No model found in outline. Add a `style_anchor.model` field")
         print("to outline.yaml.")
         sys.exit(1)
-
-    families = set()
-    if compare_mode:
-        for m in COMPARE_MODELS:
-            families.add(model_family(m))
-        if outline["model"]:
-            families.add(model_family(outline["model"]))
-    elif outline["model"]:
-        families.add(model_family(outline["model"]))
-    else:
-        families.add("gemini")
-
-    _require_keys_for_families(keys, families, secrets_path)
 
     output_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)), "illustrations"
@@ -1116,15 +1133,36 @@ def generate_image(prompt, model, keys, slide_format=None):
     model = resolve_model_id(model)
     family = model_family(model)
     sizing = sizing_for(slide_format)
+    width, height = sizing["openai_size"].split("x")
+    size = (int(width), int(height))
+    try:
+        lane = select_image_lane(
+            model,
+            getattr(keys, "options", None),
+            requested_size=size if family == "openai" else None,
+        )
+    except ImageLaneError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return ImageRender(None, str(error), None)
+    if lane.lane == "cli":
+        return render_cli(lane, prompt)
+    if isinstance(keys, ImageKeys):
+        try:
+            keys = keys.require(family)
+        except ImageLaneError as error:
+            print(f"ERROR: {error}", file=sys.stderr)
+            return ImageRender(None, str(error), lane)
     if family == "openai":
-        return _call_openai_generate(
+        data, detail = _call_openai_generate(
             prompt, model, keys["openai"], size=sizing["openai_size"]
         )
-    if family == "imagen":
-        return _call_imagen(
+    elif family == "imagen":
+        data, detail = _call_imagen(
             prompt, model, keys["gemini"], aspect_ratio=sizing["imagen_aspect"]
         )
-    return _call_gemini([{"text": prompt}], model, keys["gemini"])
+    else:
+        data, detail = _call_gemini([{"text": prompt}], model, keys["gemini"])
+    return ImageRender(data, detail, lane)
 
 
 def edit_image(
@@ -1167,6 +1205,29 @@ def edit_image(
             "model for --edit / --build / --fix workflows."
         )
 
+    width, height = sizing["openai_size"].split("x")
+    size = (int(width), int(height))
+    try:
+        lane = select_image_lane(
+            model,
+            getattr(keys, "options", None),
+            operation="edit",
+            requested_size=size if family == "openai" else None,
+            reference_count=1,
+            masked=erase_region is not None,
+        )
+    except ImageLaneError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return ImageRender(None, str(error), None)
+    if lane.lane == "cli":
+        return render_cli(lane, edit_prompt, input_path)
+    if isinstance(keys, ImageKeys):
+        try:
+            keys = keys.require(family)
+        except ImageLaneError as error:
+            print(f"ERROR: {error}", file=sys.stderr)
+            return ImageRender(None, str(error), lane)
+
     if family == "openai":
         # A mask lets the model edit in-place with surrounding context; the
         # composite below then guarantees the kept region byte-for-byte.
@@ -1198,8 +1259,8 @@ def edit_image(
     # Confine the change to the erase box: paste the edited region back over the
     # prior frame so everything outside it is the source pixels exactly (#90).
     if erase_region and image_bytes is not None:
-        return composite_region(input_path, image_bytes, erase_region)
-    return image_bytes, result
+        image_bytes, result = composite_region(input_path, image_bytes, erase_region)
+    return ImageRender(image_bytes, result, lane)
 
 
 # --- Style-explore manifest + render-before-bake gate ---
@@ -1224,22 +1285,27 @@ def write_rendered_manifest(base_dir, outline_path, results):
     ok_models = []
     for r in results:
         resolved = resolve_model_id(r["model"])
+        provenance = r.get("provenance")
+        lane = provenance.get("lane") if isinstance(provenance, dict) else None
+        served = lane.get("served_model") if isinstance(lane, dict) else None
         cell = {
             "style": r["style"],
             "format": r["format"],
             "model": r["model"],
             "model_resolved": resolved,
             "status": r["status"],
+            "provenance": provenance,
         }
         if r["status"] == "OK":
             cell["rel_path"] = r.get("rel_path")
-            ok_models.append(resolved)
+            if isinstance(served, str):
+                ok_models.append(served)
         else:
             cell["error"] = r.get("error")
         cells.append(cell)
 
     manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "outline": os.path.basename(outline_path),
         # Talk-directory name — a per-talk discriminator. Outline filenames are
         # identical across talks (outline.yaml), so the basename alone can't
@@ -1320,10 +1386,11 @@ def check_style_explore(outline_path):
     # Fail closed on a manifest we can't trust: an unsupported schema, or one
     # copied in from a different talk (basename AND talk-dir must match — see
     # rules/stateful-artifacts.md, "stale state is the default").
-    if manifest.get("schema_version") != 1:
+    schema_version = manifest.get("schema_version")
+    if type(schema_version) is not int or schema_version not in (1, 2):
         verdict["error"] = (
             f"{manifest_path} has unsupported schema_version "
-            f"{manifest.get('schema_version')!r} (expected 1) — re-run "
+            f"{schema_version!r} (expected 1 or 2) — re-run "
             "--style-explore to regenerate it."
         )
         return verdict
@@ -1377,6 +1444,19 @@ def check_style_explore(outline_path):
         if not isinstance(cell_model_raw, str):
             continue
         cell_model = resolve_model_id(cell_model_raw)
+        if schema_version == 2:
+            provenance = cell.get("provenance")
+            lane = provenance.get("lane") if isinstance(provenance, dict) else None
+            # Native CLI output cannot prove that a dated API model was seen.
+            # Missing provenance is unusable, never inferred from a filename.
+            if (
+                not isinstance(lane, dict)
+                or lane.get("lane") != "api"
+                or lane.get("requested_model") != cell_model
+                or lane.get("served_model") != cell_model
+                or lane.get("geometry") != "requested"
+            ):
+                continue
         if cell_model:
             verified.add(cell_model)
     rendered = sorted(verified)
@@ -1423,9 +1503,9 @@ def enforce_render_gate(outline_path):
 # --- Main Commands ---
 
 
-def run_generate(outline_path, slide_args, versioned=False):
+def run_generate(outline_path, slide_args, versioned=False, *, lane_options=None):
     """Generate illustrations for selected slides."""
-    keys, outline, output_dir = _load_context(outline_path)
+    keys, outline, output_dir = _load_context(outline_path, lane_options=lane_options)
     model = outline["model"]
     os.makedirs(output_dir, exist_ok=True)
 
@@ -1535,12 +1615,14 @@ def run_generate(outline_path, slide_args, versioned=False):
     print(
         f"Done: {success} generated, {failed} failed, out of {len(to_generate)} requested."
     )
+    if failed:
+        sys.exit(1)
 
 
-def run_compare(outline_path, slide_num):
+def run_compare(outline_path, slide_num, *, lane_options=None):
     """Generate the same prompt across multiple models for comparison."""
     keys, outline, _ = _load_context(
-        outline_path, require_model=False, compare_mode=True
+        outline_path, require_model=False, compare_mode=True, lane_options=lane_options
     )
 
     slides_by_num = {s["slide_num"]: s for s in outline["slides"]}
@@ -1580,21 +1662,26 @@ def run_compare(outline_path, slide_num):
     for i, model in enumerate(models):
         print(f"[{i + 1}/{len(models)}] {model}...", end=" ", flush=True)
 
-        image_bytes, result = generate_image(prompt, model, keys, eff_format)
+        render = generate_image(prompt, model, keys, eff_format)
+        image_bytes, result = render
+        selected = render.lane if isinstance(render, ImageRender) else None
+        label = f"{selected.served_model} [{selected.lane}]" if selected else model
 
         if image_bytes is None:
             print(f"FAILED: {result[:100]}")
-            results.append((model, "FAIL", "-", "-"))
+            results.append((label, "FAIL", "-", "-"))
         else:
             ext = mime_to_ext(result)
             safe_model = model.replace("/", "_")
+            if selected and selected.lane == "cli":
+                safe_model += "-cli-native-unpinned"
             filename = f"slide-{slide_num:02d}-{safe_model}{ext}"
             filepath = os.path.join(output_dir, filename)
             with open(filepath, "wb") as f:
                 f.write(image_bytes)
             size_kb = len(image_bytes) / 1024
             print(f"OK ({size_kb:.0f} KB)")
-            results.append((model, "OK", f"{size_kb:.0f} KB", filepath))
+            results.append((label, "OK", f"{size_kb:.0f} KB", filepath))
 
         if i < len(models) - 1:
             time.sleep(RATE_LIMIT_DELAY)
@@ -1611,6 +1698,11 @@ def run_compare(outline_path, slide_num):
     print()
     print(f"Review images in: {output_dir}/")
     print("Set your chosen model in outline.yaml: `style_anchor.model: model-name`")
+    print(
+        "Native CLI comparisons are unpinned previews, not dated-model bake evidence."
+    )
+    if any(status == "FAIL" for _, status, _, _ in results):
+        sys.exit(1)
 
 
 # --- Style Exploration (Phase 2 strategy: style x model x format grid) ---
@@ -1732,6 +1824,10 @@ def render_explore_index(candidates, results):
         lines.append("")
         for r in by_style.get(name, []):
             label = f"**{r['format']}** · `{r['model']}`"
+            provenance = r.get("provenance")
+            lane = provenance.get("lane") if isinstance(provenance, dict) else None
+            if isinstance(lane, dict):
+                label += f" → `{lane['served_model']}` ({lane['lane']})"
             if r["status"] == "OK":
                 lines.append(f"- {label} — [{r['rel_path']}]({r['rel_path']})")
             else:
@@ -1740,7 +1836,7 @@ def render_explore_index(candidates, results):
     return "\n".join(lines).rstrip() + "\n"
 
 
-def run_style_explore(outline_path, candidates_path):
+def run_style_explore(outline_path, candidates_path, *, lane_options=None):
     """Render a style x model x format exploration grid for Phase 2 strategy.
 
     Reads candidate styles + a model shortlist from candidates.json, pulls each
@@ -1762,7 +1858,7 @@ def run_style_explore(outline_path, candidates_path):
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
 
-    keys, secrets_path = load_secrets()
+    keys = ImageKeys(options=lane_options)
     outline = parse_outline(outline_path)
     slides_by_num = {s["slide_num"]: s for s in outline["slides"]}
 
@@ -1780,9 +1876,6 @@ def run_style_explore(outline_path, candidates_path):
             file=sys.stderr,
         )
         sys.exit(1)
-
-    families = {model_family(resolve_model_id(m)) for m in candidates["models"]}
-    _require_keys_for_families(keys, families, secrets_path)
 
     base_dir = os.path.join(
         os.path.dirname(os.path.abspath(outline_path)), "style-explore"
@@ -1889,7 +1982,9 @@ def run_style_explore(outline_path, candidates_path):
     results = []
     for i, (style_name, fmt, model, prompt, eff_format) in enumerate(plan, 1):
         print(f"[{i}/{total}] {style_name} · {fmt} · {model}...", end=" ", flush=True)
-        image_bytes, result = generate_image(prompt, model, keys, eff_format)
+        render = generate_image(prompt, model, keys, eff_format)
+        image_bytes, result = render
+        provenance = render.provenance() if isinstance(render, ImageRender) else None
         if image_bytes is None:
             print(f"FAILED: {result[:80]}")
             results.append(
@@ -1899,11 +1994,19 @@ def run_style_explore(outline_path, candidates_path):
                     "model": model,
                     "status": "FAIL",
                     "error": result[:200],
+                    "provenance": provenance,
                 }
             )
         else:
             ext = mime_to_ext(result)
-            dest = explore_dest(base_dir, style_name, fmt, model, ext)
+            output_model = model
+            if (
+                isinstance(render, ImageRender)
+                and render.lane
+                and render.lane.lane == "cli"
+            ):
+                output_model += "-cli-native-unpinned"
+            dest = explore_dest(base_dir, style_name, fmt, output_model, ext)
             os.makedirs(os.path.dirname(dest), exist_ok=True)
             with open(dest, "wb") as fh:
                 fh.write(image_bytes)
@@ -1915,6 +2018,7 @@ def run_style_explore(outline_path, candidates_path):
                     "model": model,
                     "status": "OK",
                     "rel_path": os.path.relpath(dest, base_dir),
+                    "provenance": provenance,
                 }
             )
         if i < total:
@@ -1932,11 +2036,16 @@ def run_style_explore(outline_path, candidates_path):
     print(
         "Review the grid, pick a style + model, then bake them into outline.yaml's style_anchor."
     )
+    print(
+        "Native CLI cells are unpinned previews and do not pass the dated-model bake gate."
+    )
+    if any(r["status"] == "FAIL" for r in results):
+        sys.exit(1)
 
 
-def run_edit(outline_path, slide_num, edit_prompt):
+def run_edit(outline_path, slide_num, edit_prompt, *, lane_options=None):
     """Edit an existing slide illustration via the model's edit endpoint."""
-    keys, outline, output_dir = _load_context(outline_path)
+    keys, outline, output_dir = _load_context(outline_path, lane_options=lane_options)
     model = outline["model"]
 
     input_path = find_base_image(output_dir, slide_num)
@@ -1977,9 +2086,9 @@ def run_edit(outline_path, slide_num, edit_prompt):
     )
 
 
-def run_build(outline_path, slide_arg):
+def run_build(outline_path, slide_arg, *, lane_options=None):
     """Generate progressive-reveal build images using backwards-chaining."""
-    keys, outline, output_dir = _load_context(outline_path)
+    keys, outline, output_dir = _load_context(outline_path, lane_options=lane_options)
     model = outline["model"]
     builds_dir = os.path.join(output_dir, "builds")
     os.makedirs(builds_dir, exist_ok=True)
@@ -2149,9 +2258,9 @@ def run_build(outline_path, slide_arg):
     print("Done. Review build images in:", builds_dir)
 
 
-def run_fix(outline_path, slide_num, fix_prompt):
+def run_fix(outline_path, slide_num, fix_prompt, *, lane_options=None):
     """Apply a targeted fix to an existing slide image, saving as a new version."""
-    keys, outline, output_dir = _load_context(outline_path)
+    keys, outline, output_dir = _load_context(outline_path, lane_options=lane_options)
     model = outline["model"]
 
     input_path = find_latest_image(output_dir, slide_num)
@@ -2262,7 +2371,9 @@ def main():
         help="Slide selection: 'all', 'remaining', or slide numbers (e.g., 2 5 9, 2-10)",
     )
 
+    add_image_lane_arguments(parser)
     args = parser.parse_args()
+    lane_options = ImageProviderOptions(args.image_lane, args.allow_cli_native)
 
     if not os.path.isfile(args.outline):
         print(f"ERROR: Outline file not found: {args.outline}")
@@ -2273,19 +2384,23 @@ def main():
     _cli_vault_path = args.vault
 
     if args.edit:
-        run_edit(args.outline, int(args.edit[0]), args.edit[1])
+        run_edit(
+            args.outline, int(args.edit[0]), args.edit[1], lane_options=lane_options
+        )
     elif args.build:
-        run_build(args.outline, args.build)
+        run_build(args.outline, args.build, lane_options=lane_options)
     elif args.fix:
-        run_fix(args.outline, int(args.fix[0]), args.fix[1])
+        run_fix(args.outline, int(args.fix[0]), args.fix[1], lane_options=lane_options)
     elif args.compare:
-        run_compare(args.outline, args.compare)
+        run_compare(args.outline, args.compare, lane_options=lane_options)
     elif args.style_explore:
-        run_style_explore(args.outline, args.style_explore)
+        run_style_explore(args.outline, args.style_explore, lane_options=lane_options)
     elif args.check_style_explore:
         run_check_style_explore(args.outline)
     else:
-        run_generate(args.outline, args.slides, versioned=args.version)
+        run_generate(
+            args.outline, args.slides, versioned=args.version, lane_options=lane_options
+        )
 
 
 if __name__ == "__main__":

--- a/skills/illustrations/scripts/generate-thumbnail.py
+++ b/skills/illustrations/scripts/generate-thumbnail.py
@@ -29,7 +29,7 @@ Usage:
 Requires:
     - Gemini API key in {vault}/secrets.json (preferred) or GEMINI_API_KEY env var
     - Pillow (pip install Pillow)
-    - Python 3.7+
+    - Python 3.10+
 """
 
 import argparse
@@ -40,6 +40,14 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
+
+from image_lane_contract import ImageLaneError
+from image_provider import (
+    ImageProviderOptions,
+    add_image_lane_arguments,
+    report_lane,
+    select_image_lane,
+)
 
 try:
     from PIL import Image
@@ -605,8 +613,29 @@ def extract_slide_from_pptx(pptx_path, slide_num, output_path=None):
 
 def compose_thumbnail(args):
     """Generate a thumbnail by composing slide image + speaker photo via Gemini."""
-    api_key = load_api_key(args.vault)
     model = args.model or DEFAULT_MODEL
+    options = ImageProviderOptions(
+        getattr(args, "image_lane", "auto"), getattr(args, "allow_cli_native", False)
+    )
+    try:
+        lane = select_image_lane(
+            model,
+            options,
+            operation="edit",
+            reference_count=2,
+            requested_size=(YOUTUBE_WIDTH, YOUTUBE_HEIGHT),
+            report=False,
+        )
+        if lane.family != "gemini":
+            raise ImageLaneError(
+                "thumbnail_family_unsupported",
+                "select a Gemini image model for composition",
+            )
+    except ImageLaneError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(1)
+    model = lane.served_model
+    api_key = load_api_key(args.vault)
 
     # Load images
     print(f"Loading slide image: {args.slide_image}")
@@ -640,6 +669,12 @@ def compose_thumbnail(args):
             f"{'...' if len(anchor_preview) > 80 else ''}"
         )
         try:
+            select_image_lane(
+                model,
+                options,
+                operation="edit",
+                reference_count=1,
+            )
             speaker_b64, speaker_mime = stylize_portrait(
                 speaker_b64,
                 speaker_mime,
@@ -676,6 +711,7 @@ def compose_thumbnail(args):
             aesthetic=args.aesthetic,
         )
         parts = image_parts + [{"text": prompt}]
+        report_lane(lane)
         image_bytes, result_mime = call_gemini(parts, model, api_key)
         if image_bytes is not None:
             if softness != "default":
@@ -789,6 +825,7 @@ def main():
         help="Extract a slide image from a PPTX deck",
     )
 
+    add_image_lane_arguments(parser)
     args = parser.parse_args()
 
     # Extract-slide mode

--- a/skills/illustrations/scripts/image_cli.py
+++ b/skills/illustrations/scripts/image_cli.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Authenticated Codex image invocation with private output and no API retry.
+
+Capability is renewed on every selection and again before each render: resolve
+the executable, read its version/help, and check its current authentication
+method. No minimum-version assertion substitutes for these checks. The actual
+image tool may still be unavailable; that is a visible failed render.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import sys
+import tempfile
+from typing import Any, NoReturn, cast
+
+from image_lane_contract import CODEX_NATIVE_MODEL, CliProbe, ImageLane, ImageLaneError
+from image_cli_process import PROCESS_FAILURES, CliProcessError, run_cli_command
+
+# image_cli_process resolves this co-shipped supervisor from the plugin root.
+from artifact_metadata import ArtifactAvailability, WINDOWS_REPARSE_POINT_ATTRIBUTE
+from artifact_supervisor import (
+    FileGeneration,
+    JsonValue,
+    SupervisorError,
+    SupervisorLimits,
+    WorkerRequest,
+    isolate_protocol_output,
+    read_worker_request,
+    run_authenticated_worker,
+    write_worker_response,
+)
+
+
+WORKER_FLAG = "--supervised-worker"
+PROBE_OPERATION = "image_cli_probe"
+RENDER_OPERATION = "image_cli_render"
+PIPELINE_VERSION = "image-cli-v1"
+IMAGE_MAX_BYTES = 32 * 1024 * 1024
+IMAGE_MAX_PIXELS = 16 * 1024 * 1024
+IMAGE_MAX_DIMENSION = 8192
+PROMPT_MAX_BYTES = 64 * 1024
+MAX_EVENTS = 10000
+OUTPUT_NAME = "image.png"
+PROBE_LIMITS = SupervisorLimits(
+    profile_id="image-cli-probe-v1",
+    wall_seconds=45,
+    max_memory_bytes=512 * 1024 * 1024,
+    max_processes=16,
+)
+RENDER_LIMITS = SupervisorLimits(
+    profile_id="image-cli-render-v1",
+    wall_seconds=900,
+    max_memory_bytes=2 * 1024 * 1024 * 1024,
+    max_processes=32,
+    max_input_bytes=256 * 1024,
+)
+_VERSION = re.compile(r"codex(?:-cli)? ([0-9]+\.[0-9]+\.[0-9]+(?:[-+][\w.-]+)?)\Z")
+_FAILURES = PROCESS_FAILURES | {
+    "cli_binary_changed",
+    "cli_binary_invalid",
+    "cli_version_invalid",
+    "cli_invocation_unsupported",
+    "cli_auth_required",
+    "cli_auth_unverified",
+    "cli_subscription_required",
+    "cli_provider_failed",
+    "cli_events_invalid",
+    "cli_image_missing",
+    "cli_image_invalid",
+    "cli_image_limit",
+    "cli_image_changed",
+    "cli_image_dependency_unavailable",
+    "cli_reference_unavailable",
+    "cli_reference_changed",
+}
+
+
+@dataclass(frozen=True)
+class CliImage:
+    """Verified output bytes, not a claim of exact native model identity."""
+
+    data: bytes
+    width: int
+    height: int
+    sha256: str
+    mime_type: str = "image/png"
+    warning_count: int = 0
+
+
+def _fail(reason: str) -> NoReturn:
+    if reason not in _FAILURES:
+        raise ValueError("invalid CLI image failure code")
+    raise ImageLaneError(
+        reason,
+        "check CLI availability, login, quota and output; no API retry was selected",
+    )
+
+
+@contextmanager
+def _workspace() -> Iterator[tuple[Path, FileGeneration]]:
+    try:
+        directory = tempfile.TemporaryDirectory(prefix="speaker-image-cli-")
+    except OSError as exc:
+        raise ImageLaneError(
+            "cli_workspace_unavailable", "check local temporary-directory access"
+        ) from exc
+    try:
+        path = Path(directory.name).resolve()
+        yield path, FileGeneration.from_directory_identity(path.lstat())
+    finally:
+        try:
+            directory.cleanup()
+        except OSError as exc:
+            raise ImageLaneError(
+                "cli_cleanup_failed", "remove the private image scratch directory"
+            ) from exc
+
+
+def _worker(operation: str, payload: dict[str, Any]) -> Any:
+    limits = PROBE_LIMITS if operation == PROBE_OPERATION else RENDER_LIMITS
+    command = [sys.executable, str(Path(__file__).resolve()), WORKER_FLAG]
+    with _workspace() as (workspace, generation):
+        payload = {**payload, "workspace": str(workspace)}
+        try:
+            response = run_authenticated_worker(
+                command,
+                operation,
+                {"workspace": generation},
+                cast(JsonValue, payload),
+                limits,
+                immutable_process_identity=command[:2],
+                pipeline_generation=PIPELINE_VERSION,
+            )
+        except SupervisorError as exc:
+            reason = exc.reason_code
+            if reason not in _FAILURES:
+                reason = {
+                    "worker_timeout": "cli_worker_timeout",
+                    "worker_memory_limit_exceeded": "cli_worker_resource_limit",
+                    "worker_process_limit_exceeded": "cli_worker_resource_limit",
+                    "worker_input_limit_exceeded": "cli_worker_resource_limit",
+                    "worker_output_limit_exceeded": "cli_worker_resource_limit",
+                    "worker_diagnostic_limit_exceeded": "cli_worker_resource_limit",
+                    "worker_cleanup_failed": "cli_cleanup_failed",
+                }.get(reason, "cli_worker_failed")
+            raise ImageLaneError(
+                reason, "repair the CLI worker; no API retry was selected"
+            ) from exc
+        if operation == PROBE_OPERATION:
+            return response.payload
+        return _decode_image(response.payload, workspace)
+
+
+def probe_codex() -> CliProbe:
+    """Return absent separately from a present-but-failed fresh CLI probe."""
+    binary = shutil.which("codex")
+    if binary is None:
+        return CliProbe("absent")
+    binary = os.path.abspath(binary)
+    try:
+        value = _worker(PROBE_OPERATION, {"binary": binary})
+    except ImageLaneError as exc:
+        return CliProbe("failed", binary, failure_code=exc.reason_code)
+    if not isinstance(value, Mapping) or set(value) != {
+        "state",
+        "binary",
+        "version",
+        "failure_code",
+        "auth_mode",
+    }:
+        return CliProbe("failed", binary, failure_code="cli_probe_malformed")
+    probe = CliProbe(**value)
+    # The pure resolver owns probe validation. Do not reinterpret malformed
+    # output as executable absence or a paid fallback.
+    if probe.state != "ready":
+        return CliProbe("failed", binary, failure_code="cli_probe_malformed")
+    return probe
+
+
+def render_codex(
+    lane: ImageLane, prompt: str, *, reference_path: str | Path | None = None
+) -> CliImage:
+    """Generate/edit once and return verified PNG bytes; always remove scratch."""
+    if (
+        not isinstance(lane, ImageLane)
+        or lane.family != "openai"
+        or lane.lane != "cli"
+        or lane.served_model != CODEX_NATIVE_MODEL
+        or lane.operation not in ("generate", "edit")
+        or not isinstance(lane.binary, str)
+        or not os.path.isabs(lane.binary)
+        or not isinstance(lane.version, str)
+        or lane.geometry != "native_observed"
+    ):
+        raise ImageLaneError("invalid_cli_lane", "resolve the image lane first")
+    if (
+        not isinstance(prompt, str)
+        or not prompt.strip()
+        or "\0" in prompt
+        or len(prompt.encode("utf-8")) > PROMPT_MAX_BYTES
+    ):
+        raise ImageLaneError(
+            "invalid_image_prompt", "supply bounded image instructions"
+        )
+    if (lane.operation == "edit") != (reference_path is not None):
+        raise ImageLaneError("invalid_image_references", "match the selected operation")
+    reference = None
+    if reference_path is not None:
+        if not isinstance(reference_path, (str, Path)) or "\0" in str(reference_path):
+            raise ImageLaneError(
+                "invalid_image_references", "supply a local image path"
+            )
+        reference = os.path.abspath(os.path.expanduser(str(reference_path)))
+    return _worker(
+        RENDER_OPERATION,
+        {
+            "binary": lane.binary,
+            "version": lane.version,
+            "prompt": prompt,
+            "reference": reference,
+        },
+    )
+
+
+def _binary(path: str) -> tuple[Path, FileGeneration]:
+    try:
+        binary = Path(path).resolve(strict=True)
+        generation = FileGeneration.from_stat(binary.lstat())
+    except (OSError, RuntimeError) as exc:
+        raise ImageLaneError(
+            "cli_binary_invalid", "resolve the installed CLI again"
+        ) from exc
+    if not stat.S_ISREG(generation.mode) or generation.size <= 0:
+        _fail("cli_binary_invalid")
+    return binary, generation
+
+
+def _probe(binary_path: str, workspace: Path) -> CliProbe:
+    binary, generation = _binary(binary_path)
+    version_result = run_cli_command([str(binary), "--version"], workspace)
+    version_match = _VERSION.fullmatch(
+        version_result.stdout.decode("utf-8", errors="replace").strip()
+    )
+    if version_result.returncode != 0 or version_match is None:
+        _fail("cli_version_invalid")
+    help_result = run_cli_command([str(binary), "exec", "--help"], workspace)
+    required_flags = (
+        b"--ephemeral",
+        b"--skip-git-repo-check",
+        b"--json",
+        b"--image",
+        b"--sandbox",
+        b"--color",
+    )
+    if help_result.returncode != 0 or any(
+        flag not in help_result.stdout for flag in required_flags
+    ):
+        _fail("cli_invocation_unsupported")
+    auth = run_cli_command([str(binary), "login", "status"], workspace)
+    if auth.returncode != 0:
+        _fail("cli_auth_required")
+    lines = (
+        (auth.stdout + b"\n" + auth.stderr)
+        .decode("utf-8", errors="replace")
+        .splitlines()
+    )
+    if "Logged in using ChatGPT" in lines:
+        method = "chatgpt"
+    elif any(line.startswith("Logged in using an API key") for line in lines):
+        method = "api"
+    else:
+        _fail("cli_auth_unverified")
+    if _binary(str(binary)) != (binary, generation):
+        _fail("cli_binary_changed")
+    return CliProbe("ready", str(binary), version_match.group(1), auth_mode=method)
+
+
+def _read_image(path: Path) -> tuple[bytes, FileGeneration]:
+    """Read only a bounded, local, unchanged regular image leaf."""
+    try:
+        before = FileGeneration.from_stat(path.lstat())
+        if (
+            not stat.S_ISREG(before.mode)
+            or (before.file_attributes or 0) & WINDOWS_REPARSE_POINT_ATTRIBUTE
+            or ArtifactAvailability.from_generation(before).state != "local"
+        ):
+            _fail("cli_reference_unavailable")
+        if not 0 < before.size <= IMAGE_MAX_BYTES:
+            _fail("cli_image_limit")
+        descriptor = os.open(
+            path,
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_BINARY", 0),
+        )
+        with os.fdopen(descriptor, "rb") as source:
+            if FileGeneration.from_stat(os.fstat(source.fileno())) != before:
+                _fail("cli_reference_changed")
+            data = source.read(IMAGE_MAX_BYTES + 1)
+            if FileGeneration.from_stat(os.fstat(source.fileno())) != before:
+                _fail("cli_reference_changed")
+        if len(data) != before.size or FileGeneration.from_stat(path.lstat()) != before:
+            _fail("cli_reference_changed")
+        return data, before
+    except OSError as exc:
+        raise ImageLaneError(
+            "cli_reference_unavailable", "supply an available local image"
+        ) from exc
+
+
+def _image_facts(data: bytes, *, require_png: bool) -> tuple[int, int, str]:
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except ImportError as exc:
+        raise ImageLaneError(
+            "cli_image_dependency_unavailable", "install the declared Pillow dependency"
+        ) from exc
+    try:
+        with Image.open(io.BytesIO(data)) as picture:
+            width, height = picture.size
+            image_format = picture.format
+            if (
+                image_format not in ("PNG", "JPEG", "WEBP")
+                or (require_png and image_format != "PNG")
+                or not 0 < width <= IMAGE_MAX_DIMENSION
+                or not 0 < height <= IMAGE_MAX_DIMENSION
+                or width * height > IMAGE_MAX_PIXELS
+                or getattr(picture, "n_frames", 1) != 1
+            ):
+                _fail("cli_image_invalid")
+            picture.verify()
+        # verify() checks container integrity; load() must also decode the pixels.
+        with Image.open(io.BytesIO(data)) as picture:
+            picture.load()
+    except (
+        OSError,
+        ValueError,
+        SyntaxError,
+        UnidentifiedImageError,
+        Image.DecompressionBombError,
+    ) as exc:
+        if isinstance(exc, ImageLaneError):
+            raise
+        raise ImageLaneError(
+            "cli_image_invalid", "inspect the CLI's image output"
+        ) from exc
+    return width, height, {"PNG": ".png", "JPEG": ".jpg", "WEBP": ".webp"}[image_format]
+
+
+def _event_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    document = {}
+    for key, value in pairs:
+        if key in document:
+            _fail("cli_events_invalid")
+        document[key] = value
+    return document
+
+
+def _event_constant(_value: str) -> NoReturn:
+    _fail("cli_events_invalid")
+
+
+def _completed_turn(data: bytes) -> int:
+    lines = data.splitlines()
+    if not 0 < len(lines) <= MAX_EVENTS:
+        _fail("cli_events_invalid")
+    phase = "new"
+    warning_count = 0
+    try:
+        for line in lines:
+            value = json.loads(
+                line, object_pairs_hook=_event_pairs, parse_constant=_event_constant
+            )
+            if not isinstance(value, dict) or not isinstance(value.get("type"), str):
+                _fail("cli_events_invalid")
+            if value["type"] in ("error", "turn.failed"):
+                _fail("cli_provider_failed")
+            event = value["type"]
+            if phase == "complete":
+                _fail("cli_events_invalid")
+            if event == "thread.started" and phase == "new":
+                phase = "thread"
+            elif event == "turn.started" and phase == "thread":
+                phase = "active"
+            elif (
+                event == "item.completed"
+                and phase in ("thread", "active")
+                and isinstance(value.get("item"), dict)
+                and value["item"].get("type") == "error"
+            ):
+                # Installed 0.153.2 emits non-fatal item diagnostics before
+                # turn.started (e.g. optional tool startup). Preserve a visible
+                # count; do not expose their untrusted/possibly secret text.
+                warning_count += 1
+            elif (
+                event in ("item.started", "item.updated", "item.completed")
+                and phase == "active"
+            ):
+                if not isinstance(value.get("item"), dict):
+                    _fail("cli_events_invalid")
+            elif event == "turn.completed" and phase == "active":
+                phase = "complete"
+            else:
+                _fail("cli_events_invalid")
+    except (ValueError, UnicodeError, RecursionError) as exc:
+        if isinstance(exc, ImageLaneError):
+            raise
+        raise ImageLaneError(
+            "cli_events_invalid", "inspect the CLI's event protocol"
+        ) from exc
+    if phase != "complete":
+        _fail("cli_events_invalid")
+    return warning_count
+
+
+def _render(payload: Mapping[str, Any], workspace: Path) -> dict[str, Any]:
+    probe = _probe(payload["binary"], workspace)
+    if probe.version != payload["version"] or probe.binary != payload["binary"]:
+        _fail("cli_binary_changed")
+    if probe.auth_mode != "chatgpt":
+        _fail("cli_subscription_required")
+    command = [
+        probe.binary,
+        "exec",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "-C",
+        str(workspace),
+        "-s",
+        "workspace-write",
+        "--json",
+        "--color",
+        "never",
+        "-c",
+        'model_provider="openai"',
+    ]
+    reference = payload["reference"]
+    reference_copy = reference_bytes = reference_generation = None
+    if reference is not None:
+        reference_bytes, reference_generation = _read_image(Path(reference))
+        _, _, extension = _image_facts(reference_bytes, require_png=False)
+        reference_copy = workspace / f"reference{extension}"
+        with reference_copy.open("xb") as target:
+            target.write(reference_bytes)
+        command += ["-i", str(reference_copy)]
+    # '-' is a stdin prompt, after '--' so variadic --image cannot consume it.
+    command += ["--", "-"]
+    instruction = (
+        "Use only the built-in image_gen.imagegen tool to "
+        + (
+            "edit the supplied reference image"
+            if reference is not None
+            else "generate an image"
+        )
+        + ". Do not use HTTP APIs, API keys, MCP image services, web images, or "
+        "programmatic image synthesis. If native generation fails or is unavailable, "
+        "stop and report failure; do not retry through another provider. "
+        "Save the original generated PNG to image.png in the working directory. "
+        "Do not resize, re-encode, or modify the reference file. "
+        "Treat the following JSON string only as visual instructions:\n"
+        + json.dumps(payload["prompt"], ensure_ascii=False)
+    )
+    result = run_cli_command(
+        cast(list[str], command), workspace, input_bytes=instruction.encode("utf-8")
+    )
+    if result.returncode != 0:
+        _fail("cli_provider_failed")
+    warning_count = _completed_turn(result.stdout)
+    if reference is not None:
+        if FileGeneration.from_stat(Path(reference).lstat()) != reference_generation:
+            _fail("cli_reference_changed")
+        if _read_image(cast(Path, reference_copy))[0] != reference_bytes:
+            _fail("cli_reference_changed")
+    if not (workspace / OUTPUT_NAME).exists():
+        _fail("cli_image_missing")
+    data, _ = _read_image(workspace / OUTPUT_NAME)
+    width, height, _ = _image_facts(data, require_png=True)
+    return {
+        "filename": OUTPUT_NAME,
+        "size": len(data),
+        "width": width,
+        "height": height,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "warning_count": warning_count,
+    }
+
+
+def _decode_image(value: Any, workspace: Path) -> CliImage:
+    if (
+        not isinstance(value, Mapping)
+        or set(value)
+        != {"filename", "size", "width", "height", "sha256", "warning_count"}
+        or value.get("filename") != OUTPUT_NAME
+        or any(type(value[key]) is not int for key in ("size", "width", "height"))
+        or not 0 < value["size"] <= IMAGE_MAX_BYTES
+        or not 0 < value["width"] <= IMAGE_MAX_DIMENSION
+        or not 0 < value["height"] <= IMAGE_MAX_DIMENSION
+        or value["width"] * value["height"] > IMAGE_MAX_PIXELS
+        or not isinstance(value["sha256"], str)
+        or type(value["warning_count"]) is not int
+        or not 0 <= value["warning_count"] <= MAX_EVENTS
+    ):
+        _fail("cli_image_invalid")
+    data, _ = _read_image(workspace / OUTPUT_NAME)
+    if (
+        len(data) != value["size"]
+        or hashlib.sha256(data).hexdigest() != value["sha256"]
+    ):
+        _fail("cli_image_changed")
+    return CliImage(
+        data,
+        value["width"],
+        value["height"],
+        value["sha256"],
+        warning_count=value["warning_count"],
+    )
+
+
+def _dispatch(request: WorkerRequest) -> dict[str, Any]:
+    payload = request.payload
+    limits = (
+        PROBE_LIMITS
+        if request.operation == PROBE_OPERATION
+        else RENDER_LIMITS
+        if request.operation == RENDER_OPERATION
+        else None
+    )
+    fields = {"workspace", "binary"}
+    if request.operation == RENDER_OPERATION:
+        fields |= {"version", "prompt", "reference"}
+    if (
+        limits is None
+        or request.limit_profile_id != limits.profile_id
+        or request.pipeline_generation != PIPELINE_VERSION
+        or request.schema_generation != 1
+        or not isinstance(payload, Mapping)
+        or set(payload) != fields
+        or not isinstance(payload["workspace"], str)
+        or not isinstance(payload["binary"], str)
+        or not os.path.isabs(payload["binary"])
+        or set(request.expected_generations) != {"workspace"}
+    ):
+        raise SupervisorError("invalid_worker_request")
+    workspace = Path(payload["workspace"])
+    facts = workspace.lstat()
+    if (
+        not workspace.is_absolute()
+        or not stat.S_ISDIR(facts.st_mode)
+        or FileGeneration.from_directory_identity(facts)
+        != request.expected_generations["workspace"]
+        or (os.name == "posix" and stat.S_IMODE(facts.st_mode) & 0o077)
+        or any(workspace.iterdir())
+    ):
+        _fail("cli_workspace_invalid")
+    if request.operation == PROBE_OPERATION:
+        return asdict(_probe(payload["binary"], workspace))
+    if (
+        not isinstance(payload["version"], str)
+        or not isinstance(payload["prompt"], str)
+        or not payload["prompt"].strip()
+        or "\0" in payload["prompt"]
+        or len(payload["prompt"].encode("utf-8")) > PROMPT_MAX_BYTES
+        or (
+            payload["reference"] is not None
+            and (
+                not isinstance(payload["reference"], str)
+                or not os.path.isabs(payload["reference"])
+                or "\0" in payload["reference"]
+            )
+        )
+    ):
+        raise SupervisorError("invalid_worker_request")
+    result = _render(payload, workspace)
+    if (
+        FileGeneration.from_directory_identity(workspace.lstat())
+        != request.expected_generations["workspace"]
+    ):
+        _fail("cli_workspace_invalid")
+    return result
+
+
+def _worker_main() -> int:
+    request = read_worker_request(max_input_bytes=RENDER_LIMITS.max_input_bytes)
+    stream = isolate_protocol_output()
+    try:
+        try:
+            value = _dispatch(request)
+            write_worker_response(
+                request,
+                payload=cast(JsonValue, value),
+                observed_generations=request.expected_generations,
+                stream=stream,
+            )
+        except (ImageLaneError, CliProcessError, SupervisorError) as exc:
+            reason = (
+                exc.reason_code if exc.reason_code in _FAILURES else "cli_worker_failed"
+            )
+            write_worker_response(
+                request,
+                error=SupervisorError(reason),
+                observed_generations=request.expected_generations,
+                stream=stream,
+            )
+    finally:
+        stream.close()
+    return 0
+
+
+def _main() -> int:
+    if sys.argv[1:] != [WORKER_FLAG]:
+        print(
+            "image_cli.py is a library; use the illustration generator", file=sys.stderr
+        )
+        return 2
+    try:
+        return _worker_main()
+    except (SupervisorError, OSError):
+        print("Image CLI worker failed: invalid_worker_request", file=sys.stderr)
+        return 2
+    # The supervisor treats nonzero/no authenticated stdout as a crash. Emit a
+    # fixed diagnostic; propagation would leak prompts/paths in a traceback.
+    # outer-boundary-process-contract
+    except Exception:  # noqa: BLE001
+        print("Image CLI worker failed: unexpected_error", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/skills/illustrations/scripts/image_cli.py
+++ b/skills/illustrations/scripts/image_cli.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Authenticated Codex image invocation with private output and no API retry.
 
-Capability is renewed on every selection and again before each render: resolve
-the executable, read its version/help, and check its current authentication
-method. No minimum-version assertion substitutes for these checks. The actual
-image tool may still be unavailable; that is a visible failed render.
+The optional runtime is pinned in scripts/codex-cli/package.json and its lock,
+renewed by weekly Dependabot updates. Each selection/render checks that exact
+version plus capability and authentication. The actual image tool may still be
+unavailable; that is a visible failed render.
 """
 
 from __future__ import annotations
@@ -52,6 +52,7 @@ IMAGE_MAX_DIMENSION = 8192
 PROMPT_MAX_BYTES = 64 * 1024
 MAX_EVENTS = 10000
 OUTPUT_NAME = "image.png"
+CLI_PACKAGE_DIR = Path(__file__).resolve().parent / "codex-cli"
 PROBE_LIMITS = SupervisorLimits(
     profile_id="image-cli-probe-v1",
     wall_seconds=45,
@@ -70,6 +71,8 @@ _FAILURES = PROCESS_FAILURES | {
     "cli_binary_changed",
     "cli_binary_invalid",
     "cli_version_invalid",
+    "cli_dependency_invalid",
+    "cli_version_not_pinned",
     "cli_invocation_unsupported",
     "cli_auth_required",
     "cli_auth_unverified",
@@ -164,7 +167,16 @@ def _worker(operation: str, payload: dict[str, Any]) -> Any:
 
 def probe_codex() -> CliProbe:
     """Return absent separately from a present-but-failed fresh CLI probe."""
-    binary = shutil.which("codex")
+    local_binary = (
+        CLI_PACKAGE_DIR
+        / "node_modules"
+        / ".bin"
+        / ("codex.cmd" if os.name == "nt" else "codex")
+    )
+    # A broken local install is present-and-failing, never a PATH fallback.
+    binary = (
+        str(local_binary) if os.path.lexists(local_binary) else shutil.which("codex")
+    )
     if binary is None:
         return CliProbe("absent")
     binary = os.path.abspath(binary)
@@ -246,7 +258,38 @@ def _binary(path: str) -> tuple[Path, FileGeneration]:
     return binary, generation
 
 
+def pinned_cli_version() -> str:
+    """Read the committed optional-runtime manifest, never an independent pin."""
+    try:
+        with (CLI_PACKAGE_DIR / "package.json").open("rb") as source:
+            data = source.read(65537)
+        if len(data) > 65536:
+            _fail("cli_dependency_invalid")
+        manifest = json.loads(data)
+        dependencies = (
+            manifest.get("dependencies") if isinstance(manifest, dict) else None
+        )
+        version = (
+            dependencies.get("@openai/codex")
+            if isinstance(dependencies, dict)
+            else None
+        )
+        if (
+            not isinstance(version, str)
+            or re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version) is None
+        ):
+            _fail("cli_dependency_invalid")
+        return version
+    except (OSError, ValueError, UnicodeError, RecursionError) as exc:
+        if isinstance(exc, ImageLaneError):
+            raise
+        raise ImageLaneError(
+            "cli_dependency_invalid", "restore the shipped Codex dependency manifest"
+        ) from exc
+
+
 def _probe(binary_path: str, workspace: Path) -> CliProbe:
+    pinned = pinned_cli_version()
     binary, generation = _binary(binary_path)
     version_result = run_cli_command([str(binary), "--version"], workspace)
     version_match = _VERSION.fullmatch(
@@ -254,6 +297,11 @@ def _probe(binary_path: str, workspace: Path) -> CliProbe:
     )
     if version_result.returncode != 0 or version_match is None:
         _fail("cli_version_invalid")
+    if version_match.group(1) != pinned:
+        raise ImageLaneError(
+            "cli_version_not_pinned",
+            "install the shipped Codex lock with npm ci; see image-provider-lanes.md; no API retry was selected",
+        )
     help_result = run_cli_command([str(binary), "exec", "--help"], workspace)
     required_flags = (
         b"--ephemeral",

--- a/skills/illustrations/scripts/image_cli_process.py
+++ b/skills/illustrations/scripts/image_cli_process.py
@@ -1,0 +1,201 @@
+"""Bounded CLI pipes inside the authenticated image worker.
+
+The shared artifact supervisor owns wall time, memory and descendant cleanup.
+This helper limits retained CLI output and private-workspace growth. It is not
+a standalone process sandbox and must not be called outside that supervisor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import time
+from typing import BinaryIO, cast
+
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts")
+)
+from artifact_supervisor import _PipeDrainer, _PipeWriter  # noqa: E402
+from artifact_metadata import WINDOWS_REPARSE_POINT_ATTRIBUTE  # noqa: E402
+
+
+PIPE_JOIN_SECONDS = 1.0
+POLL_SECONDS = 0.02
+CLI_STDOUT_BYTES = 16 * 1024 * 1024
+CLI_STDERR_BYTES = 64 * 1024
+CLI_STDIN_BYTES = 128 * 1024
+WORKSPACE_MAX_BYTES = 128 * 1024 * 1024
+WORKSPACE_MAX_ENTRIES = 128
+WORKSPACE_MAX_DEPTH = 8
+PROCESS_FAILURES = frozenset(
+    {
+        "cli_start_failed",
+        "cli_pipe_failed",
+        "cli_stdout_limit",
+        "cli_stderr_limit",
+        "cli_stdin_limit",
+        "cli_workspace_limit",
+        "cli_workspace_invalid",
+        "cli_cleanup_failed",
+    }
+)
+
+
+class CliProcessError(RuntimeError):
+    """A closed failure category; never includes raw child diagnostics."""
+
+    def __init__(self, reason: str) -> None:
+        if reason not in PROCESS_FAILURES:
+            raise ValueError("invalid CLI process failure code")
+        self.reason_code = reason
+        super().__init__(reason)
+
+
+@dataclass(frozen=True)
+class CliProcessResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+def subscription_environment() -> dict[str, str]:
+    """Keep cached CLI login; withhold inherited API and access-token variables.
+
+    This does not read, replace or remove any credential file or change the
+    user's environment. The worker separately checks the CLI's active method.
+    """
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if not name.upper().endswith(("_API_KEY", "_TOKEN", "_SECRET", "_PASSWORD"))
+    }
+
+
+def check_workspace(path: Path) -> None:
+    """Bound private scratch growth without following any symlink."""
+    pending = [(path, 0)]
+    entries = byte_count = 0
+    try:
+        while pending:
+            directory, depth = pending.pop()
+            directory_facts = directory.lstat()
+            if not stat.S_ISDIR(directory_facts.st_mode) or (
+                getattr(directory_facts, "st_file_attributes", 0)
+                & WINDOWS_REPARSE_POINT_ATTRIBUTE
+            ):
+                raise CliProcessError("cli_workspace_invalid")
+            with os.scandir(directory) as children:
+                for child in children:
+                    entries += 1
+                    if entries > WORKSPACE_MAX_ENTRIES:
+                        raise CliProcessError("cli_workspace_limit")
+                    facts = child.stat(follow_symlinks=False)
+                    if (
+                        getattr(facts, "st_file_attributes", 0)
+                        & WINDOWS_REPARSE_POINT_ATTRIBUTE
+                    ):
+                        raise CliProcessError("cli_workspace_invalid")
+                    if stat.S_ISREG(facts.st_mode):
+                        byte_count += facts.st_size
+                        if byte_count > WORKSPACE_MAX_BYTES:
+                            raise CliProcessError("cli_workspace_limit")
+                    elif stat.S_ISDIR(facts.st_mode):
+                        if depth >= WORKSPACE_MAX_DEPTH:
+                            raise CliProcessError("cli_workspace_limit")
+                        pending.append((Path(child.path), depth + 1))
+                    else:
+                        raise CliProcessError("cli_workspace_invalid")
+    except OSError as exc:
+        raise CliProcessError("cli_workspace_invalid") from exc
+
+
+def _stop(process: subprocess.Popen[bytes]) -> None:
+    try:
+        if process.poll() is None:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait(timeout=PIPE_JOIN_SECONDS)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=PIPE_JOIN_SECONDS)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise CliProcessError("cli_cleanup_failed") from exc
+
+
+def run_cli_command(
+    command: list[str], workspace: Path, *, input_bytes: bytes = b""
+) -> CliProcessResult:
+    """Run one command inside the caller's authenticated worker, without retry."""
+    if not isinstance(input_bytes, bytes) or len(input_bytes) > CLI_STDIN_BYTES:
+        raise CliProcessError("cli_stdin_limit")
+    check_workspace(workspace)
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=workspace,
+            env=subscription_environment(),
+            close_fds=True,
+            bufsize=0,
+        )
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        raise CliProcessError("cli_start_failed") from exc
+    if process.stdin is None or process.stdout is None or process.stderr is None:
+        try:
+            _stop(process)
+        finally:
+            for pipe in (process.stdin, process.stdout, process.stderr):
+                if pipe is not None:
+                    pipe.close()
+        raise CliProcessError("cli_pipe_failed")
+    writer = _PipeWriter(cast(BinaryIO, process.stdin), input_bytes)
+    stdout = _PipeDrainer(cast(BinaryIO, process.stdout), CLI_STDOUT_BYTES)
+    stderr = _PipeDrainer(cast(BinaryIO, process.stderr), CLI_STDERR_BYTES)
+    streams = (writer, stdout, stderr)
+    started = []
+    try:
+        try:
+            for stream in streams:
+                stream.start()
+                started.append(stream)
+            while process.poll() is None:
+                if stdout.overflowed:
+                    raise CliProcessError("cli_stdout_limit")
+                if stderr.overflowed:
+                    raise CliProcessError("cli_stderr_limit")
+                if any(stream.failed for stream in streams):
+                    raise CliProcessError("cli_pipe_failed")
+                check_workspace(workspace)
+                time.sleep(POLL_SECONDS)
+            for stream in started:
+                stream.join(PIPE_JOIN_SECONDS)
+            if any(stream.alive or stream.failed for stream in streams):
+                raise CliProcessError("cli_pipe_failed")
+            if stdout.overflowed:
+                raise CliProcessError("cli_stdout_limit")
+            if stderr.overflowed:
+                raise CliProcessError("cli_stderr_limit")
+            check_workspace(workspace)
+            return CliProcessResult(int(process.returncode), stdout.data, stderr.data)
+        except (OSError, ValueError, RuntimeError) as exc:
+            if isinstance(exc, CliProcessError):
+                raise
+            raise CliProcessError("cli_pipe_failed") from exc
+    finally:
+        try:
+            _stop(process)
+        finally:
+            for stream in started:
+                stream.join(PIPE_JOIN_SECONDS)
+            for stream in streams:
+                stream.close()

--- a/skills/illustrations/scripts/image_lane_contract.py
+++ b/skills/illustrations/scripts/image_lane_contract.py
@@ -1,0 +1,272 @@
+"""Pure image-provider lane selection; no provider call or credential read.
+
+The caller supplies the current CLI probe outcome. A failed probe is distinct
+from an absent executable and never authorizes a metered retry. Resolution
+preserves the requested model/geometry unless the caller explicitly permits
+native output. This module describes a proposed render, not an output receipt.
+
+Codex's recorded generate/edit probe in issue #385 establishes native output,
+not an exact image-model snapshot, typed size control, masks, or multi-reference
+composition. Unsupported CLI requirements remain on their API adapter in auto
+mode; forcing CLI makes the incompatibility an error instead of weakening it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath, PureWindowsPath
+import re
+
+
+LANES = frozenset({"auto", "api", "cli"})
+FAMILIES = frozenset({"gemini", "imagen", "openai"})
+OPERATIONS = frozenset({"generate", "edit"})
+PROBE_STATES = frozenset({"absent", "ready", "failed"})
+CODEX_NATIVE_MODEL = "codex-native-image-model-unpinned"
+FAMILY_PREFIXES = {
+    "openai": ("gpt-image",),
+    "imagen": ("imagen",),
+    "gemini": ("gemini", "nano-banana"),
+}
+_MODEL = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]{0,255}\Z")
+_VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?\Z")
+_REASON = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+
+
+class ImageLaneError(ValueError):
+    """A closed selection failure; raw CLI diagnostics do not cross this boundary."""
+
+    def __init__(self, reason: str, action: str) -> None:
+        if _REASON.fullmatch(reason) is None:
+            raise ValueError("invalid image-lane reason code")
+        self.reason_code = reason
+        super().__init__(f"{reason}; {action}")
+
+
+@dataclass(frozen=True)
+class ImageRequest:
+    """The resolved API model and render constraints the caller must preserve."""
+
+    family: str
+    model: str
+    operation: str = "generate"
+    requested_size: tuple[int, int] | None = None
+    reference_count: int = 0
+    masked: bool = False
+    allow_native_model: bool = False
+    allow_native_geometry: bool = False
+
+
+@dataclass(frozen=True)
+class CliProbe:
+    """Fresh adapter probe result, not a cached claim of subscription eligibility.
+
+    Ready establishes executable/version, invocation surface, and authentication
+    mode without logging in or changing credentials. The actual
+    render can still fail for login, tool availability, quota, or provider errors.
+    None of those failures permits selecting a different lane afterwards.
+    """
+
+    state: str
+    binary: str | None = None
+    version: str | None = None
+    failure_code: str | None = None
+    auth_mode: str | None = None
+
+
+@dataclass(frozen=True)
+class ImageLane:
+    """One dispatch decision. No image-generation success is implied."""
+
+    family: str
+    lane: str
+    operation: str
+    requested_model: str
+    served_model: str
+    geometry: str
+    reason_code: str
+    binary: str | None = None
+    version: str | None = None
+
+
+def _validate_request(request: ImageRequest, forced_lane: str) -> None:
+    if not isinstance(request, ImageRequest):
+        raise ImageLaneError("invalid_image_request", "supply an ImageRequest")
+    if not isinstance(forced_lane, str) or forced_lane not in LANES:
+        raise ImageLaneError("invalid_image_lane", "select auto, api, or cli")
+    if not isinstance(request.family, str) or request.family not in FAMILIES:
+        raise ImageLaneError("unsupported_image_family", "select a supported vendor")
+    if not isinstance(request.model, str) or _MODEL.fullmatch(request.model) is None:
+        raise ImageLaneError("invalid_image_model", "supply a canonical model ID")
+    if not request.model.lower().startswith(FAMILY_PREFIXES[request.family]):
+        raise ImageLaneError(
+            "image_model_family_mismatch",
+            "resolve the model through the shared registry",
+        )
+    if not isinstance(request.operation, str) or request.operation not in OPERATIONS:
+        raise ImageLaneError("invalid_image_operation", "select generate or edit")
+    if any(
+        type(value) is not bool
+        for value in (
+            request.masked,
+            request.allow_native_model,
+            request.allow_native_geometry,
+        )
+    ):
+        raise ImageLaneError("invalid_image_request", "use explicit boolean options")
+    if (
+        type(request.reference_count) is not int
+        or not 0 <= request.reference_count <= 16
+    ):
+        raise ImageLaneError(
+            "invalid_image_references", "supply a bounded reference count"
+        )
+    if request.operation == "generate" and (request.reference_count or request.masked):
+        raise ImageLaneError(
+            "invalid_image_references", "use edit for reference images"
+        )
+    if request.operation == "edit" and request.reference_count == 0:
+        raise ImageLaneError("invalid_image_references", "supply the image to edit")
+    if request.requested_size is not None and (
+        not isinstance(request.requested_size, tuple)
+        or len(request.requested_size) != 2
+        or any(
+            type(value) is not int or not 0 < value <= 16384
+            for value in request.requested_size
+        )
+    ):
+        raise ImageLaneError("invalid_image_size", "supply positive width and height")
+    if request.family == "imagen" and request.operation == "edit":
+        raise ImageLaneError("image_edit_unsupported", "choose an edit-capable model")
+
+
+def _validate_probe(probe: CliProbe) -> None:
+    if (
+        not isinstance(probe, CliProbe)
+        or not isinstance(probe.state, str)
+        or probe.state not in PROBE_STATES
+    ):
+        raise ImageLaneError("invalid_cli_probe", "rerun the CLI adapter probe")
+    if probe.state == "absent":
+        if any(
+            value is not None
+            for value in (
+                probe.binary,
+                probe.version,
+                probe.failure_code,
+                probe.auth_mode,
+            )
+        ):
+            raise ImageLaneError("invalid_cli_probe", "rerun the CLI adapter probe")
+        return
+    if (
+        not isinstance(probe.binary, str)
+        or not probe.binary.strip()
+        or len(probe.binary) > 4096
+        or any(character in probe.binary for character in ("\0", "\n", "\r"))
+        or not (
+            PurePosixPath(probe.binary).is_absolute()
+            or PureWindowsPath(probe.binary).is_absolute()
+        )
+    ):
+        raise ImageLaneError("invalid_cli_probe", "resolve the CLI executable again")
+    if probe.state == "failed":
+        if (
+            not isinstance(probe.failure_code, str)
+            or _REASON.fullmatch(probe.failure_code) is None
+        ):
+            raise ImageLaneError("invalid_cli_probe", "rerun the CLI adapter probe")
+        return
+    if (
+        not isinstance(probe.version, str)
+        or len(probe.version) > 64
+        or _VERSION.fullmatch(probe.version) is None
+        or probe.failure_code is not None
+        or probe.auth_mode not in ("chatgpt", "api", "unknown")
+    ):
+        raise ImageLaneError("invalid_cli_probe", "resolve the CLI version again")
+
+
+def _cli_incompatibility(request: ImageRequest) -> str | None:
+    if request.family != "openai":
+        return "family_api_only"
+    if not request.allow_native_model:
+        return "cli_cannot_pin_image_model"
+    if request.requested_size is not None and not request.allow_native_geometry:
+        return "cli_cannot_guarantee_image_size"
+    if request.masked:
+        return "cli_mask_not_supported"
+    if request.reference_count > 1:
+        return "cli_multiple_references_unverified"
+    return None
+
+
+def resolve_image_lane(
+    request: ImageRequest,
+    probe: CliProbe | None,
+    *,
+    forced_lane: str = "auto",
+) -> ImageLane:
+    """Choose once, before credentials or rendering; never retry another provider.
+
+    API-only/forced-API requests need no CLI probe. A compatible auto/CLI request
+    requires a fresh one. Only an absent executable permits automatic API fallback;
+    a failed or malformed probe refuses dispatch. Native substitutions each require
+    their own request opt-in and are explicit in the returned lane description.
+    """
+    _validate_request(request, forced_lane)
+    reason = "api_forced" if forced_lane == "api" else _cli_incompatibility(request)
+    if reason is not None:
+        if forced_lane == "cli":
+            raise ImageLaneError(
+                reason, "use the API lane or revise explicit render constraints"
+            )
+        return ImageLane(
+            request.family,
+            "api",
+            request.operation,
+            request.model,
+            request.model,
+            "requested",
+            reason,
+        )
+    if probe is None:
+        raise ImageLaneError(
+            "cli_probe_required", "probe the installed CLI before selecting a lane"
+        )
+    _validate_probe(probe)
+    if probe.state == "failed":
+        raise ImageLaneError(
+            "cli_probe_failed",
+            f"repair the CLI ({probe.failure_code}); no automatic metered retry was selected",
+        )
+    if probe.state == "absent":
+        if forced_lane == "cli":
+            raise ImageLaneError(
+                "image_cli_absent", "install the CLI or explicitly select the API lane"
+            )
+        return ImageLane(
+            request.family,
+            "api",
+            request.operation,
+            request.model,
+            request.model,
+            "requested",
+            "cli_absent",
+        )
+    if probe.auth_mode != "chatgpt":
+        raise ImageLaneError(
+            "image_cli_subscription_required",
+            "select ChatGPT authentication yourself; this resolver changes no credentials and selects no metered retry",
+        )
+    return ImageLane(
+        request.family,
+        "cli",
+        request.operation,
+        request.model,
+        CODEX_NATIVE_MODEL,
+        "native_observed",
+        "cli_forced" if forced_lane == "cli" else "cli_available",
+        probe.binary,
+        probe.version,
+    )

--- a/skills/illustrations/scripts/image_provider.py
+++ b/skills/illustrations/scripts/image_provider.py
@@ -1,0 +1,153 @@
+"""Shared per-render routing and truthful image-lane diagnostics.
+
+API adapters stay in their existing generators. Only compatible native requests
+load the supervised Codex adapter; importing this module reads no credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import sys
+from typing import Any, Iterator
+
+from image_lane_contract import ImageLane, ImageLaneError
+from model_registry import resolve_image_lane
+
+
+@dataclass(frozen=True)
+class ImageProviderOptions:
+    lane: str = "auto"
+    allow_cli_native: bool = False
+
+
+@dataclass(frozen=True)
+class ImageRender:
+    """Two-value adapter outcome plus the actual selected lane, never a model guess."""
+
+    data: bytes | None
+    detail: str
+    lane: ImageLane | None
+    width: int | None = None
+    height: int | None = None
+    sha256: str | None = None
+    warning_count: int = 0
+
+    def __iter__(self) -> Iterator[Any]:
+        # Preserve the existing heterogeneous two-value unpacking interface.
+        yield self.data
+        yield self.detail
+
+    def provenance(self) -> dict:
+        return {
+            "lane": asdict(self.lane) if self.lane is not None else None,
+            "width": self.width,
+            "height": self.height,
+            "sha256": self.sha256,
+            "warning_count": self.warning_count,
+        }
+
+
+def add_image_lane_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--image-lane",
+        choices=("auto", "api", "cli"),
+        default="auto",
+        help="Prefer a compatible subscription CLI, force API, or require CLI. "
+        "A CLI failure never retries a paid API.",
+    )
+    parser.add_argument(
+        "--allow-cli-native",
+        action="store_true",
+        help="Opt into an unpinned native image model and observed dimensions. "
+        "Does not enable unverified masks or multi-reference composition.",
+    )
+
+
+def report_lane(lane: ImageLane) -> None:
+    # JSON quoting keeps paths and all other fields on one diagnostic line.
+    print("IMAGE_LANE " + json.dumps(asdict(lane), sort_keys=True), file=sys.stderr)
+
+
+def select_image_lane(
+    model: str,
+    options: ImageProviderOptions | None = None,
+    *,
+    operation: str = "generate",
+    requested_size: tuple[int, int] | None = None,
+    reference_count: int = 0,
+    masked: bool = False,
+    report: bool = True,
+) -> ImageLane:
+    """Select before reading API credentials; only absence permits API fallback."""
+    options = options or ImageProviderOptions()
+    if not isinstance(options, ImageProviderOptions):
+        raise ImageLaneError("invalid_image_lane", "supply ImageProviderOptions")
+
+    def resolve(probe=None):
+        return resolve_image_lane(
+            model,
+            probe,
+            forced_lane=options.lane,
+            operation=operation,
+            requested_size=requested_size,
+            reference_count=reference_count,
+            masked=masked,
+            allow_native_model=options.allow_cli_native,
+            allow_native_geometry=options.allow_cli_native,
+        )
+
+    try:
+        lane = resolve()
+    except ImageLaneError as error:
+        if error.reason_code != "cli_probe_required":
+            raise
+        from image_cli import probe_codex
+
+        lane = resolve(probe_codex())
+    if report:
+        report_lane(lane)
+    return lane
+
+
+def render_cli(
+    lane: ImageLane, prompt: str, reference: str | None = None
+) -> ImageRender:
+    """Execute once. An unsuccessful CLI has no API-dispatch path."""
+    from image_cli import render_codex
+
+    try:
+        image = render_codex(lane, prompt, reference_path=reference)
+    except ImageLaneError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return ImageRender(None, str(error), lane)
+    if image.warning_count:
+        print(
+            f"WARNING: cli_item_diagnostics ({image.warning_count}); Codex completed "
+            "with non-fatal item diagnostics. Inspect your CLI setup; diagnostic "
+            "text is withheld and no API retry was selected.",
+            file=sys.stderr,
+        )
+    print(
+        "IMAGE_OUTPUT "
+        + json.dumps(
+            {
+                "served_model": lane.served_model,
+                "width": image.width,
+                "height": image.height,
+                "sha256": image.sha256,
+            },
+            sort_keys=True,
+        ),
+        file=sys.stderr,
+    )
+    return ImageRender(
+        image.data,
+        image.mime_type,
+        lane,
+        image.width,
+        image.height,
+        image.sha256,
+        image.warning_count,
+    )

--- a/skills/illustrations/scripts/model_registry.py
+++ b/skills/illustrations/scripts/model_registry.py
@@ -22,6 +22,15 @@ import json
 import sys
 from datetime import date, datetime
 
+from image_lane_contract import (
+    CliProbe,
+    FAMILY_PREFIXES,
+    ImageLane,
+    ImageLaneError,
+    ImageRequest,
+    resolve_image_lane as _resolve_image_lane,
+)
+
 # --- Vendor endpoints ---
 #
 # Single source of truth for the API bases. Both generate-illustrations.py and
@@ -158,7 +167,59 @@ def resolve_model_id(name):
 # Model-id prefixes we ship a vendor adapter for (Google generateContent /
 # Imagen :predict, OpenAI images). model_family() falls back to "gemini" for any
 # unknown prefix, so it can't tell a real Gemini id from an unsupported vendor.
-SUPPORTED_MODEL_PREFIXES = ("gpt-image", "imagen", "gemini", "nano-banana")
+SUPPORTED_MODEL_PREFIXES = tuple(
+    prefix for prefixes in FAMILY_PREFIXES.values() for prefix in prefixes
+)
+
+
+def resolve_image_lane(
+    model: str,
+    probe: CliProbe | None = None,
+    *,
+    forced_lane: str = "auto",
+    operation: str = "generate",
+    requested_size: tuple[int, int] | None = None,
+    reference_count: int = 0,
+    masked: bool = False,
+    allow_native_model: bool = False,
+    allow_native_geometry: bool = False,
+) -> ImageLane:
+    """Resolve aliases and family once before the shared pure lane decision.
+
+    This is a dispatch plan, not a render or receipt. The adapter must supply a
+    fresh CLI probe when native output is permitted and must never fall back to
+    another provider after a selected lane fails. Snapshot aliases keep their
+    existing meaning; native output requires separate, explicit permissions.
+    """
+    if not isinstance(model, str):
+        raise ImageLaneError("invalid_image_model", "supply a model name")
+    canonical = resolve_model_id(model)
+    family = next(
+        (
+            family
+            for family, prefixes in FAMILY_PREFIXES.items()
+            if canonical.lower().startswith(prefixes)
+        ),
+        None,
+    )
+    if family is None:
+        raise ImageLaneError(
+            "unsupported_image_family", "select a supported image model"
+        )
+    return _resolve_image_lane(
+        ImageRequest(
+            family=family,
+            model=canonical,
+            operation=operation,
+            requested_size=requested_size,
+            reference_count=reference_count,
+            masked=masked,
+            allow_native_model=allow_native_model,
+            allow_native_geometry=allow_native_geometry,
+        ),
+        probe,
+        forced_lane=forced_lane,
+    )
 
 
 def is_supported_model(name):

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -143,7 +143,9 @@ def _single_build_slide(steps):
 def _stub_build_deps(gi, monkeypatch, tmp_path, outline, edit_calls):
     base = tmp_path / "slide-60.png"
     base.write_bytes(b"img")
-    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline, str(tmp_path)))
+    monkeypatch.setattr(
+        gi, "_load_context", lambda p, **kw: ({}, outline, str(tmp_path))
+    )
     monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
     monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
@@ -267,7 +269,9 @@ def test_run_build_forwards_erase_region_to_edit(
     base = tmp_path / "slide-60.png"
     base.write_bytes(b"img")
     calls = []
-    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline, str(tmp_path)))
+    monkeypatch.setattr(
+        gi, "_load_context", lambda p, **kw: ({}, outline, str(tmp_path))
+    )
     monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
     monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
@@ -305,7 +309,9 @@ def test_run_build_exits_nonzero_when_edit_fails(
             {"step": 1, "description": "[FULL] all panels", "is_full": True},
         ]
     )
-    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline, str(tmp_path)))
+    monkeypatch.setattr(
+        gi, "_load_context", lambda p, **kw: ({}, outline, str(tmp_path))
+    )
     monkeypatch.setattr(gi, "find_base_image", lambda d, n: str(base))
     monkeypatch.setattr(gi, "effective_slide_format", lambda *a, **k: None)
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
@@ -1215,6 +1221,9 @@ def test_rendered_manifest_excludes_failed(generate_illustrations, tmp_path):
             "model": "nano-banana-pro",
             "status": "OK",
             "rel_path": "a/full/x.png",
+            "provenance": gi.ImageRender(
+                b"image", "image/png", gi.select_image_lane("nano-banana-pro")
+            ).provenance(),
         },
         {
             "style": "A",
@@ -1226,7 +1235,7 @@ def test_rendered_manifest_excludes_failed(generate_illustrations, tmp_path):
     ]
     path = gi.write_rendered_manifest(str(base), str(outline), results)
     m = json.loads(open(path).read())
-    assert m["schema_version"] == 1
+    assert m["schema_version"] == 2
     # nano-banana-pro resolves to its canonical id; the failed model is absent
     assert m["models_rendered_ok"] == ["gemini-3-pro-image"]
     assert len(m["cells"]) == 2
@@ -1297,7 +1306,9 @@ def test_gate_fails_when_model_only_failed(generate_illustrations, tmp_path):
 
 
 def _stub_generate(gi, monkeypatch, outline_dict, output_dir, gen_calls):
-    monkeypatch.setattr(gi, "_load_context", lambda p: ({}, outline_dict, output_dir))
+    monkeypatch.setattr(
+        gi, "_load_context", lambda p, **kw: ({}, outline_dict, output_dir)
+    )
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
     monkeypatch.setattr(
         gi,
@@ -1436,7 +1447,7 @@ def test_run_generate_poster_embeds_text_and_skips_safe_zone(
 
     prompts = []
     monkeypatch.setattr(
-        gi, "_load_context", lambda p: ({}, outline_dict, str(tmp_path))
+        gi, "_load_context", lambda p, **kw: ({}, outline_dict, str(tmp_path))
     )
     monkeypatch.setattr(gi.time, "sleep", lambda *a, **k: None)
     monkeypatch.setattr(
@@ -1471,7 +1482,7 @@ def test_gate_fails_on_unsupported_schema_version(generate_illustrations, tmp_pa
     _write_raw_manifest(
         tmp_path,
         {
-            "schema_version": 2,
+            "schema_version": 3,
             "outline": "outline.yaml",
             "models_rendered_ok": ["gemini-3-pro-image"],
             "cells": [],

--- a/tests/test_image_cli.py
+++ b/tests/test_image_cli.py
@@ -14,8 +14,15 @@ from conftest import SCRIPTS_ILL, _import_script
 
 
 @pytest.fixture
-def cli():
-    return _import_script(Path(SCRIPTS_ILL) / "image_cli.py", "image_cli")
+def cli(monkeypatch, tmp_path):
+    module = _import_script(Path(SCRIPTS_ILL) / "image_cli.py", "image_cli")
+    package = tmp_path / "runtime"
+    package.mkdir()
+    (package / "package.json").write_text(
+        json.dumps({"dependencies": {"@openai/codex": "0.153.2"}})
+    )
+    monkeypatch.setattr(module, "CLI_PACKAGE_DIR", package)
+    return module
 
 
 @pytest.fixture
@@ -65,6 +72,112 @@ def test_absence_is_not_a_failed_probe(cli, monkeypatch):
     monkeypatch.setattr(cli.shutil, "which", lambda name: None)
     monkeypatch.setattr(cli, "_worker", lambda *a: pytest.fail("must not start worker"))
     assert cli.probe_codex() == cli.CliProbe("absent")
+
+
+def test_shipped_cli_pin_lock_and_renewal_agree():
+    import yaml
+
+    package = Path(SCRIPTS_ILL) / "codex-cli"
+    manifest = json.loads((package / "package.json").read_text())
+    lock = json.loads((package / "package-lock.json").read_text())
+    version = manifest["dependencies"]["@openai/codex"]
+    assert (
+        all(part.isdigit() for part in version.split("."))
+        and len(version.split(".")) == 3
+    )
+    assert lock["packages"][""]["dependencies"]["@openai/codex"] == version
+    assert lock["packages"]["node_modules/@openai/codex"]["version"] == version
+    assert lock["packages"]["node_modules/@openai/codex"]["integrity"].startswith(
+        "sha512-"
+    )
+    root = Path(__file__).resolve().parents[1]
+    updates = yaml.safe_load((root / ".github" / "dependabot.yml").read_text())[
+        "updates"
+    ]
+    assert any(
+        update["package-ecosystem"] == "npm"
+        and update["directory"] == "/skills/illustrations/scripts/codex-cli"
+        and update["schedule"]["interval"] == "weekly"
+        for update in updates
+    )
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        [],
+        {},
+        {"dependencies": []},
+        {"dependencies": {"@openai/codex": "latest"}},
+        {"dependencies": {"@openai/codex": "^0.153.2"}},
+    ],
+)
+def test_bad_dependency_manifest_is_a_closed_refusal(cli, manifest):
+    (cli.CLI_PACKAGE_DIR / "package.json").write_text(json.dumps(manifest))
+    with pytest.raises(cli.ImageLaneError, match="cli_dependency_invalid"):
+        cli.pinned_cli_version()
+
+
+def test_missing_dependency_manifest_is_not_a_runtime_guess(cli):
+    (cli.CLI_PACKAGE_DIR / "package.json").unlink()
+    with pytest.raises(cli.ImageLaneError, match="cli_dependency_invalid"):
+        cli.pinned_cli_version()
+
+
+@pytest.mark.parametrize("data", [b"{", b"\xff", b" " * 65537])
+def test_unreadable_or_oversized_dependency_data_is_a_closed_refusal(cli, data):
+    (cli.CLI_PACKAGE_DIR / "package.json").write_bytes(data)
+    with pytest.raises(cli.ImageLaneError, match="cli_dependency_invalid"):
+        cli.pinned_cli_version()
+
+
+def test_unpinned_cli_version_refuses_before_help_or_auth(cli, monkeypatch, tmp_path):
+    binary = tmp_path / "codex"
+    binary.write_bytes(b"fake")
+    calls = []
+
+    def run(command, workspace):
+        calls.append(command)
+        return SimpleNamespace(returncode=0, stdout=b"codex-cli 0.153.3", stderr=b"")
+
+    monkeypatch.setattr(cli, "run_cli_command", run)
+    with pytest.raises(cli.ImageLaneError, match="cli_version_not_pinned") as caught:
+        cli._probe(str(binary), tmp_path)
+    assert len(calls) == 1
+    assert "npm ci" in str(caught.value)
+
+
+def test_local_locked_install_is_preferred_over_path(cli, monkeypatch):
+    binary = (
+        cli.CLI_PACKAGE_DIR
+        / "node_modules"
+        / ".bin"
+        / ("codex.cmd" if cli.os.name == "nt" else "codex")
+    )
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"fixture executable")
+    monkeypatch.setattr(cli.shutil, "which", lambda *a: pytest.fail("consulted PATH"))
+
+    def worker(operation, payload):
+        assert payload["binary"] == str(binary)
+        return asdict(
+            cli.CliProbe("ready", str(binary), "0.153.2", auth_mode="chatgpt")
+        )
+
+    monkeypatch.setattr(cli, "_worker", worker)
+    assert cli.probe_codex().binary == str(binary)
+
+
+def test_broken_local_install_never_selects_a_second_binary(cli, monkeypatch):
+    monkeypatch.setattr(cli.os.path, "lexists", lambda *a: True)
+    monkeypatch.setattr(cli.shutil, "which", lambda *a: pytest.fail("consulted PATH"))
+
+    def worker(*a):
+        raise cli.ImageLaneError("cli_binary_invalid", "repair local install")
+
+    monkeypatch.setattr(cli, "_worker", worker)
+    result = cli.probe_codex()
+    assert result.state == "failed" and result.failure_code == "cli_binary_invalid"
 
 
 def test_present_probe_uses_authenticated_worker(cli, monkeypatch, ready):

--- a/tests/test_image_cli.py
+++ b/tests/test_image_cli.py
@@ -1,0 +1,479 @@
+"""Native-lane orchestration with fake CLI outcomes and generated image bytes."""
+
+from dataclasses import asdict, replace
+import hashlib
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from PIL import Image
+import pytest
+
+from conftest import SCRIPTS_ILL, _import_script
+
+
+@pytest.fixture
+def cli():
+    return _import_script(Path(SCRIPTS_ILL) / "image_cli.py", "image_cli")
+
+
+@pytest.fixture
+def png():
+    stream = io.BytesIO()
+    Image.new("RGB", (24, 16), "navy").save(stream, format="PNG")
+    return stream.getvalue()
+
+
+@pytest.fixture
+def events():
+    return b"\n".join(
+        json.dumps(value).encode()
+        for value in (
+            {"type": "thread.started", "thread_id": "fixed"},
+            {"type": "turn.started"},
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "done"},
+            },
+            {"type": "turn.completed", "usage": {}},
+        )
+    )
+
+
+@pytest.fixture
+def ready(cli):
+    return cli.CliProbe("ready", "/fake/codex", "0.153.2", auth_mode="chatgpt")
+
+
+@pytest.fixture
+def lane(cli, ready):
+    return cli.ImageLane(
+        "openai",
+        "cli",
+        "generate",
+        "gpt-image-2-2026-04-21",
+        cli.CODEX_NATIVE_MODEL,
+        "native_observed",
+        "cli_forced",
+        ready.binary,
+        ready.version,
+    )
+
+
+def test_absence_is_not_a_failed_probe(cli, monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli, "_worker", lambda *a: pytest.fail("must not start worker"))
+    assert cli.probe_codex() == cli.CliProbe("absent")
+
+
+def test_present_probe_uses_authenticated_worker(cli, monkeypatch, ready):
+    calls = []
+    monkeypatch.setattr(cli.shutil, "which", lambda name: ready.binary)
+
+    def worker(operation, payload):
+        calls.append((operation, payload))
+        return asdict(ready)
+
+    monkeypatch.setattr(cli, "_worker", worker)
+    assert cli.probe_codex() == ready
+    assert calls == [(cli.PROBE_OPERATION, {"binary": ready.binary})]
+
+
+@pytest.mark.parametrize(
+    "reason", ["cli_worker_timeout", "cli_auth_required", "cli_worker_resource_limit"]
+)
+def test_present_probe_failure_does_not_become_absence(cli, monkeypatch, reason):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/fake/codex")
+
+    def worker(*args):
+        raise cli.ImageLaneError(reason, "repair")
+
+    monkeypatch.setattr(cli, "_worker", worker)
+    result = cli.probe_codex()
+    assert result.state == "failed"
+    assert result.failure_code == reason
+
+
+@pytest.mark.parametrize("value", [None, {}, {"state": "absent"}])
+def test_malformed_probe_is_visible(cli, monkeypatch, value):
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/fake/codex")
+    monkeypatch.setattr(cli, "_worker", lambda *args: value)
+    assert cli.probe_codex().failure_code == "cli_probe_malformed"
+
+
+@pytest.mark.parametrize("auth_mode", ["chatgpt", "api"])
+def test_probe_observes_version_help_and_auth_without_logging_in(
+    cli, monkeypatch, tmp_path, auth_mode
+):
+    binary = tmp_path / "codex"
+    binary.write_bytes(b"fake executable")
+    calls = []
+    login = (
+        b"Logged in using ChatGPT"
+        if auth_mode == "chatgpt"
+        else b"Logged in using an API key - fixture-only"
+    )
+    outputs = [
+        (b"codex-cli 0.153.2\n", b""),
+        (b"--ephemeral --skip-git-repo-check --json --image --sandbox --color", b""),
+        (b"", login),
+    ]
+
+    def run(command, workspace):
+        calls.append(command)
+        stdout, stderr = outputs.pop(0)
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(cli, "run_cli_command", run)
+    probe = cli._probe(str(binary), tmp_path)
+    assert probe.version == "0.153.2"
+    assert probe.auth_mode == auth_mode
+    assert [command[1:] for command in calls] == [
+        ["--version"],
+        ["exec", "--help"],
+        ["login", "status"],
+    ]
+    assert "fixture-only" not in repr(probe)
+
+
+@pytest.mark.parametrize(
+    "stage,result,reason",
+    [
+        (0, (1, b"", b"private"), "cli_version_invalid"),
+        (0, (0, b"not a version", b""), "cli_version_invalid"),
+        (1, (0, b"--json", b""), "cli_invocation_unsupported"),
+        (2, (1, b"", b"private"), "cli_auth_required"),
+        (2, (0, b"", b"unrecognized private status"), "cli_auth_unverified"),
+    ],
+)
+def test_probe_failure_is_closed_and_stops(
+    cli, monkeypatch, tmp_path, stage, result, reason
+):
+    binary = tmp_path / "codex"
+    binary.write_bytes(b"fake executable")
+    outputs = [
+        (0, b"codex-cli 0.153.2", b""),
+        (0, b"--ephemeral --skip-git-repo-check --json --image --sandbox --color", b""),
+        (0, b"", b"Logged in using ChatGPT"),
+    ]
+    outputs[stage] = result
+    calls = []
+
+    def run(command, workspace):
+        calls.append(command)
+        code, out, err = outputs.pop(0)
+        return SimpleNamespace(returncode=code, stdout=out, stderr=err)
+
+    monkeypatch.setattr(cli, "run_cli_command", run)
+    with pytest.raises(cli.ImageLaneError, match=reason) as caught:
+        cli._probe(str(binary), tmp_path)
+    assert len(calls) == stage + 1
+    assert "private" not in str(caught.value)
+
+
+def test_render_sends_prompt_on_stdin_and_reads_literal_output(
+    cli, monkeypatch, tmp_path, png, events, ready
+):
+    monkeypatch.setattr(cli, "_probe", lambda *args: ready)
+    calls = []
+
+    def run(command, workspace, *, input_bytes):
+        calls.append((command, input_bytes))
+        (workspace / cli.OUTPUT_NAME).write_bytes(png)
+        return SimpleNamespace(returncode=0, stdout=events, stderr=b"")
+
+    monkeypatch.setattr(cli, "run_cli_command", run)
+    metadata = cli._render(
+        {
+            "binary": ready.binary,
+            "version": ready.version,
+            "prompt": "private visual request",
+            "reference": None,
+        },
+        tmp_path,
+    )
+    image = cli._decode_image(metadata, tmp_path)
+    assert image.data == png
+    assert (image.width, image.height, image.mime_type) == (24, 16, "image/png")
+    assert image.sha256 == hashlib.sha256(png).hexdigest()
+    command, stdin = calls[0]
+    assert command[-2:] == ["--", "-"]
+    assert "private visual request" not in " ".join(command)
+    assert b"private visual request" in stdin
+    assert "workspace-write" in command
+    assert not any(
+        "bypass" in argument or "ignore-rules" in argument for argument in command
+    )
+
+
+def test_edit_uses_private_reference_and_variadic_separator(
+    cli, monkeypatch, tmp_path, png, events, ready
+):
+    reference = tmp_path / "original.png"
+    reference.write_bytes(png)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(cli, "_probe", lambda *args: ready)
+    calls = []
+
+    def run(command, directory, *, input_bytes):
+        calls.append(command)
+        (directory / cli.OUTPUT_NAME).write_bytes(png)
+        return SimpleNamespace(returncode=0, stdout=events, stderr=b"")
+
+    monkeypatch.setattr(cli, "run_cli_command", run)
+    cli._render(
+        {
+            "binary": ready.binary,
+            "version": ready.version,
+            "prompt": "make it red",
+            "reference": str(reference),
+        },
+        workspace,
+    )
+    assert calls[0][-4:] == ["-i", str(workspace / "reference.png"), "--", "-"]
+    assert str(reference) not in calls[0]
+    assert reference.read_bytes() == png
+
+
+@pytest.mark.parametrize(
+    "updates,reason",
+    [
+        ({"version": "0.153.3"}, "cli_binary_changed"),
+        ({"binary": "/different/codex"}, "cli_binary_changed"),
+        ({"auth_mode": "api"}, "cli_subscription_required"),
+    ],
+)
+def test_render_rechecks_version_and_subscription(
+    cli, monkeypatch, tmp_path, ready, updates, reason
+):
+    monkeypatch.setattr(cli, "_probe", lambda *args: replace(ready, **updates))
+    monkeypatch.setattr(
+        cli, "run_cli_command", lambda *a, **kw: pytest.fail("must not render")
+    )
+    with pytest.raises(cli.ImageLaneError, match=reason):
+        cli._render(
+            {
+                "binary": ready.binary,
+                "version": ready.version,
+                "prompt": "image",
+                "reference": None,
+            },
+            tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "code,output,event_output,reason",
+    [
+        (55, b"valid", "valid", "cli_provider_failed"),
+        (0, None, "valid", "cli_image_missing"),
+        (0, b"not an image", "valid", "cli_image_invalid"),
+        (0, b"valid", "invalid", "cli_events_invalid"),
+        (0, b"valid", "failed", "cli_provider_failed"),
+    ],
+)
+def test_failed_native_attempt_never_becomes_success_or_retry(
+    cli, monkeypatch, tmp_path, ready, png, events, code, output, event_output, reason
+):
+    monkeypatch.setattr(cli, "_probe", lambda *args: ready)
+    calls = []
+
+    def run(command, workspace, *, input_bytes):
+        calls.append(command)
+        if output is not None:
+            (workspace / cli.OUTPUT_NAME).write_bytes(
+                png if output == b"valid" else output
+            )
+        data = (
+            events
+            if event_output == "valid"
+            else (
+                b'{"type":"turn.failed","error":{"message":"private provider error"}}'
+                if event_output == "failed"
+                else b"unstructured success"
+            )
+        )
+        return SimpleNamespace(returncode=code, stdout=data, stderr=b"private details")
+
+    monkeypatch.setattr(cli, "run_cli_command", run)
+    with pytest.raises(cli.ImageLaneError, match=reason) as caught:
+        cli._render(
+            {
+                "binary": ready.binary,
+                "version": ready.version,
+                "prompt": "image",
+                "reference": None,
+            },
+            tmp_path,
+        )
+    assert len(calls) == 1
+    assert "private" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"",
+        b"[]",
+        b"done",
+        b'{"type":"turn.completed"}',
+        b'{"type":"thread.started","type":"turn.completed"}',
+        b'{"type":"thread.started","value":NaN}',
+        b'{"type":"turn.started"}\n{"type":"thread.started"}\n{"type":"turn.completed"}',
+        b'{"type":"thread.started"}\n{"type":"turn.started"}\n{"type":"item.completed"}\n{"type":"turn.completed"}',
+    ],
+)
+def test_events_cannot_claim_completion_from_malformed_or_reordered_state(cli, data):
+    with pytest.raises(cli.ImageLaneError, match="cli_events_invalid"):
+        cli._completed_turn(data)
+
+
+def test_completed_stream_cannot_continue_or_repeat(cli, events):
+    cli._completed_turn(events)
+    with pytest.raises(cli.ImageLaneError, match="cli_events_invalid"):
+        cli._completed_turn(events + b'\n{"type":"turn.completed"}')
+
+
+def test_installed_cli_pre_turn_item_diagnostics_are_counted_not_suppressed(cli):
+    # Shape observed on 0.153.2 with a completed, exit-zero minimal CLI turn.
+    # Diagnostic text is synthetic and must never leave the adapter.
+    records = [
+        {"type": "thread.started", "thread_id": "fixed"},
+        {
+            "type": "item.completed",
+            "item": {"type": "error", "message": "synthetic-private-value"},
+        },
+        {"type": "turn.started"},
+        {
+            "type": "item.completed",
+            "item": {"type": "error", "message": "synthetic-private-value"},
+        },
+        {"type": "item.completed", "item": {"type": "agent_message", "text": "ready"}},
+        {"type": "turn.completed", "usage": {}},
+    ]
+    assert (
+        cli._completed_turn(b"\n".join(json.dumps(value).encode() for value in records))
+        == 2
+    )
+    for event in ("error", "turn.failed"):
+        failed = records[:3] + [{"type": event, "message": "synthetic-private-value"}]
+        with pytest.raises(cli.ImageLaneError, match="cli_provider_failed") as caught:
+            cli._completed_turn(
+                b"\n".join(json.dumps(value).encode() for value in failed)
+            )
+        assert "synthetic-private-value" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "item_type", ["agent_message", "command_execution", "file_change"]
+)
+def test_non_diagnostic_items_before_turn_still_refuse(cli, item_type):
+    records = [
+        {"type": "thread.started"},
+        {"type": "item.completed", "item": {"type": item_type}},
+        {"type": "turn.started"},
+        {"type": "turn.completed"},
+    ]
+    with pytest.raises(cli.ImageLaneError, match="cli_events_invalid"):
+        cli._completed_turn(b"\n".join(json.dumps(value).encode() for value in records))
+
+
+def test_output_digest_rejects_replaced_bytes(cli, tmp_path, png):
+    (tmp_path / cli.OUTPUT_NAME).write_bytes(png)
+    metadata = {
+        "filename": cli.OUTPUT_NAME,
+        "size": len(png),
+        "width": 24,
+        "height": 16,
+        "sha256": "0" * 64,
+        "warning_count": 0,
+    }
+    with pytest.raises(cli.ImageLaneError, match="cli_image_changed"):
+        cli._decode_image(metadata, tmp_path)
+
+
+def test_worker_owns_scratch_cleanup_on_success_and_refusal(cli, monkeypatch, png):
+    seen = []
+    fail = False
+
+    def supervise(command, operation, generations, payload, limits, **kwargs):
+        workspace = Path(payload["workspace"])
+        seen.append(workspace)
+        assert command[-1] == cli.WORKER_FLAG
+        assert set(generations) == {"workspace"}
+        (workspace / cli.OUTPUT_NAME).write_bytes(png)
+        if fail:
+            raise cli.SupervisorError("worker_timeout")
+        return SimpleNamespace(
+            payload={
+                "filename": cli.OUTPUT_NAME,
+                "size": len(png),
+                "width": 24,
+                "height": 16,
+                "sha256": hashlib.sha256(png).hexdigest(),
+                "warning_count": 0,
+            }
+        )
+
+    monkeypatch.setattr(cli, "run_authenticated_worker", supervise)
+    result = cli._worker(cli.RENDER_OPERATION, {})
+    assert result.data == png
+    assert not seen[-1].exists()
+    fail = True
+    with pytest.raises(cli.ImageLaneError, match="cli_worker_timeout"):
+        cli._worker(cli.RENDER_OPERATION, {})
+    assert not seen[-1].exists()
+
+
+def test_worker_preserves_interrupt_and_cleans_scratch(cli, monkeypatch):
+    seen = []
+
+    def supervise(command, operation, generations, payload, limits, **kwargs):
+        seen.append(Path(payload["workspace"]))
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "run_authenticated_worker", supervise)
+    with pytest.raises(KeyboardInterrupt):
+        cli._worker(cli.RENDER_OPERATION, {})
+    assert not seen[0].exists()
+
+
+@pytest.mark.parametrize(
+    "updates,reference,reason",
+    [
+        ({"lane": "api"}, None, "invalid_cli_lane"),
+        ({"served_model": "gpt-image-2-2026-04-21"}, None, "invalid_cli_lane"),
+        ({"operation": "edit"}, None, "invalid_image_references"),
+        ({}, "/fake/reference.png", "invalid_image_references"),
+    ],
+)
+def test_public_render_rejects_incoherent_plan(cli, lane, updates, reference, reason):
+    with pytest.raises(cli.ImageLaneError, match=reason):
+        cli.render_codex(replace(lane, **updates), "image", reference_path=reference)
+
+
+def test_public_render_dispatches_without_losing_the_requested_operation(
+    cli, monkeypatch, lane, png
+):
+    calls = []
+    expected = cli.CliImage(png, 24, 16, hashlib.sha256(png).hexdigest())
+
+    def worker(operation, payload):
+        calls.append((operation, payload))
+        return expected
+
+    monkeypatch.setattr(cli, "_worker", worker)
+    assert cli.render_codex(lane, "image") == expected
+    assert calls == [
+        (
+            cli.RENDER_OPERATION,
+            {
+                "binary": lane.binary,
+                "version": lane.version,
+                "prompt": "image",
+                "reference": None,
+            },
+        )
+    ]

--- a/tests/test_image_cli_process.py
+++ b/tests/test_image_cli_process.py
@@ -1,0 +1,235 @@
+"""CLI pipe/resource outcomes against fake processes, never a vendor executable."""
+
+import io
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from conftest import SCRIPTS_ILL, _import_script
+
+
+@pytest.fixture
+def process_module():
+    return _import_script(
+        Path(SCRIPTS_ILL) / "image_cli_process.py", "image_cli_process"
+    )
+
+
+class InputSink(io.BytesIO):
+    received = b""
+
+    def close(self):
+        if not self.closed:
+            self.received = self.getvalue()
+        super().close()
+
+
+class FakeProcess:
+    def __init__(self, stdout=b"image result", stderr=b"", returncode=0):
+        self.stdin = InputSink()
+        self.stdout = io.BytesIO(stdout)
+        self.stderr = io.BytesIO(stderr)
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def test_command_retains_outputs_and_withholds_api_environment(
+    process_module, monkeypatch, tmp_path
+):
+    child = FakeProcess(stderr=b"diagnostic")
+    seen = {}
+
+    def spawn(command, **kwargs):
+        seen.update(command=command, **kwargs)
+        return child
+
+    monkeypatch.setenv("OPENAI_API_KEY", "fixture-only")
+    monkeypatch.setenv("GEMINI_API_KEY", "fixture-only")
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "fixture-only")
+    monkeypatch.setenv("IMAGE_TEST_SETTING", "kept")
+    monkeypatch.setattr(process_module.subprocess, "Popen", spawn)
+    result = process_module.run_cli_command(
+        ["/fake/codex", "exec", "--", "-"], tmp_path, input_bytes=b"private prompt"
+    )
+    assert (result.returncode, result.stdout, result.stderr) == (
+        0,
+        b"image result",
+        b"diagnostic",
+    )
+    assert child.stdin.received == b"private prompt"
+    assert seen["cwd"] == tmp_path
+    assert not any(
+        "API_KEY" in key or key == "CODEX_ACCESS_TOKEN" for key in seen["env"]
+    )
+    assert seen["env"]["IMAGE_TEST_SETTING"] == "kept"
+    assert seen["close_fds"] is True
+    assert all(pipe.closed for pipe in (child.stdin, child.stdout, child.stderr))
+    # The worker's environment shaping does not change the caller environment.
+    assert process_module.os.environ["OPENAI_API_KEY"] == "fixture-only"
+
+
+@pytest.mark.parametrize("returncode", [1, 55, 137])
+def test_failed_exit_is_returned_not_retried(
+    process_module, monkeypatch, tmp_path, returncode
+):
+    calls = []
+
+    def spawn(command, **kwargs):
+        calls.append(command)
+        return FakeProcess(returncode=returncode)
+
+    monkeypatch.setattr(process_module.subprocess, "Popen", spawn)
+    result = process_module.run_cli_command(["/fake/codex"], tmp_path)
+    assert result.returncode == returncode
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "stream,constant,reason",
+    [
+        ("stdout", "CLI_STDOUT_BYTES", "cli_stdout_limit"),
+        ("stderr", "CLI_STDERR_BYTES", "cli_stderr_limit"),
+    ],
+)
+def test_output_overflow_refuses_even_after_child_exits(
+    process_module, monkeypatch, tmp_path, stream, constant, reason
+):
+    child = FakeProcess(
+        stdout=b"12345" if stream == "stdout" else b"",
+        stderr=b"12345" if stream == "stderr" else b"",
+    )
+    monkeypatch.setattr(process_module, constant, 4)
+    monkeypatch.setattr(process_module.subprocess, "Popen", lambda *a, **kw: child)
+    with pytest.raises(process_module.CliProcessError, match=reason):
+        process_module.run_cli_command(["/fake/codex"], tmp_path)
+    assert all(pipe.closed for pipe in (child.stdin, child.stdout, child.stderr))
+
+
+def test_oversized_input_does_not_spawn(process_module, monkeypatch, tmp_path):
+    monkeypatch.setattr(process_module, "CLI_STDIN_BYTES", 4)
+    monkeypatch.setattr(
+        process_module.subprocess,
+        "Popen",
+        lambda *a, **kw: pytest.fail("must not spawn"),
+    )
+    with pytest.raises(process_module.CliProcessError, match="cli_stdin_limit"):
+        process_module.run_cli_command(["/fake/codex"], tmp_path, input_bytes=b"12345")
+
+
+@pytest.mark.parametrize("error", [OSError("private"), ValueError("private")])
+def test_spawn_failure_is_redacted(process_module, monkeypatch, tmp_path, error):
+    def spawn(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(process_module.subprocess, "Popen", spawn)
+    with pytest.raises(
+        process_module.CliProcessError, match="cli_start_failed"
+    ) as caught:
+        process_module.run_cli_command(["/fake/codex"], tmp_path)
+    assert "private" not in str(caught.value)
+
+
+def test_thread_start_failure_closes_every_pipe(process_module, monkeypatch, tmp_path):
+    child = FakeProcess()
+    monkeypatch.setattr(process_module.subprocess, "Popen", lambda *a, **kw: child)
+
+    def cannot_start(self):
+        raise RuntimeError("private thread error")
+
+    monkeypatch.setattr(process_module._PipeDrainer, "start", cannot_start)
+    with pytest.raises(process_module.CliProcessError, match="cli_pipe_failed"):
+        process_module.run_cli_command(["/fake/codex"], tmp_path)
+    assert all(pipe.closed for pipe in (child.stdin, child.stdout, child.stderr))
+
+
+@pytest.mark.parametrize(
+    "constant,value,setup",
+    [
+        ("WORKSPACE_MAX_BYTES", 2, "bytes"),
+        ("WORKSPACE_MAX_ENTRIES", 1, "entries"),
+        ("WORKSPACE_MAX_DEPTH", 0, "depth"),
+    ],
+)
+def test_workspace_growth_refuses(
+    process_module, monkeypatch, tmp_path, constant, value, setup
+):
+    if setup == "bytes":
+        (tmp_path / "image.png").write_bytes(b"123")
+    elif setup == "entries":
+        (tmp_path / "one").touch()
+        (tmp_path / "two").touch()
+    else:
+        (tmp_path / "nested").mkdir()
+    monkeypatch.setattr(process_module, constant, value)
+    with pytest.raises(process_module.CliProcessError, match="cli_workspace_limit"):
+        process_module.check_workspace(tmp_path)
+
+
+def test_workspace_accepts_small_regular_nested_outputs(process_module, tmp_path):
+    (tmp_path / "scratch").mkdir()
+    (tmp_path / "scratch" / "artifact").write_bytes(b"fixed")
+    process_module.check_workspace(tmp_path)
+
+
+def test_workspace_refuses_non_directory_root(process_module, tmp_path):
+    image = tmp_path / "image.png"
+    image.write_bytes(b"fixed")
+    with pytest.raises(process_module.CliProcessError, match="cli_workspace_invalid"):
+        process_module.check_workspace(image)
+
+
+def test_fake_cli_reads_stdin_and_writes_bounded_pipes(
+    process_module, monkeypatch, tmp_path
+):
+    real_spawn = subprocess.Popen
+
+    def fake_cli(command, **kwargs):
+        assert command == ["/fake/codex", "exec", "--", "-"]
+        return real_spawn(
+            [
+                sys.executable,
+                "-c",
+                "import sys; data=sys.stdin.buffer.read(); "
+                "sys.stdout.buffer.write(data.upper()); sys.stderr.write('fake only')",
+            ],
+            **kwargs,
+        )
+
+    monkeypatch.setattr(process_module.subprocess, "Popen", fake_cli)
+    result = process_module.run_cli_command(
+        ["/fake/codex", "exec", "--", "-"], tmp_path, input_bytes=b"fixture"
+    )
+    assert result.stdout == b"FIXTURE"
+    assert result.stderr == b"fake only"
+    assert result.returncode == 0
+
+
+def test_stop_escalates_and_bounds_waits(process_module):
+    events = []
+
+    class Stubborn:
+        def poll(self):
+            return None
+
+        def terminate(self):
+            events.append("terminate")
+
+        def wait(self, timeout):
+            events.append(("wait", timeout))
+            if "kill" not in events:
+                raise subprocess.TimeoutExpired("fake", timeout)
+
+        def kill(self):
+            events.append("kill")
+
+    process_module._stop(Stubborn())
+    assert events == [
+        "terminate",
+        ("wait", process_module.PIPE_JOIN_SECONDS),
+        "kill",
+        ("wait", process_module.PIPE_JOIN_SECONDS),
+    ]

--- a/tests/test_image_lane_contract.py
+++ b/tests/test_image_lane_contract.py
@@ -1,0 +1,275 @@
+"""Pure lane decisions against fixed fake CLI probe outcomes; no provider I/O."""
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from conftest import SCRIPTS_ILL, _import_script
+
+
+@pytest.fixture
+def lanes():
+    return _import_script(
+        Path(SCRIPTS_ILL) / "image_lane_contract.py", "image_lane_contract"
+    )
+
+
+@pytest.fixture
+def image_request(lanes):
+    return lanes.ImageRequest(
+        "openai", "gpt-image-2-2026-04-21", requested_size=(2048, 1152)
+    )
+
+
+@pytest.fixture
+def native_request(image_request):
+    return replace(image_request, allow_native_model=True, allow_native_geometry=True)
+
+
+@pytest.fixture
+def ready(lanes):
+    return lanes.CliProbe(
+        "ready", "/synthetic/bin/codex", "0.153.2", auth_mode="chatgpt"
+    )
+
+
+@pytest.mark.parametrize("forced", ["auto", "api"])
+def test_exact_model_stays_exact_without_consulting_cli(lanes, image_request, forced):
+    result = lanes.resolve_image_lane(image_request, None, forced_lane=forced)
+    assert result.lane == "api"
+    assert result.served_model == image_request.model
+    assert result.geometry == "requested"
+
+
+@pytest.mark.parametrize(
+    "updates,reason",
+    [
+        ({}, "cli_cannot_pin_image_model"),
+        ({"allow_native_model": True}, "cli_cannot_guarantee_image_size"),
+        ({"family": "gemini", "model": "gemini-3-pro-image"}, "family_api_only"),
+        (
+            {"family": "imagen", "model": "imagen-4.0-ultra-generate-001"},
+            "family_api_only",
+        ),
+    ],
+)
+def test_forced_cli_cannot_weaken_constraints(lanes, image_request, updates, reason):
+    with pytest.raises(lanes.ImageLaneError) as caught:
+        lanes.resolve_image_lane(
+            replace(image_request, **updates), None, forced_lane="cli"
+        )
+    assert caught.value.reason_code == reason
+
+
+@pytest.mark.parametrize("forced", ["auto", "cli"])
+@pytest.mark.parametrize("edit", [False, True])
+def test_native_choice_is_explicit_and_names_real_binary(
+    lanes, native_request, ready, forced, edit
+):
+    if edit:
+        native_request = replace(native_request, operation="edit", reference_count=1)
+    result = lanes.resolve_image_lane(native_request, ready, forced_lane=forced)
+    assert result.lane == "cli"
+    assert result.served_model == lanes.CODEX_NATIVE_MODEL
+    assert result.served_model != result.requested_model
+    assert result.geometry == "native_observed"
+    assert (result.binary, result.version) == (ready.binary, ready.version)
+    assert result.operation == native_request.operation
+
+
+def test_only_absence_authorizes_auto_api_fallback(lanes, native_request):
+    result = lanes.resolve_image_lane(native_request, lanes.CliProbe("absent"))
+    assert result.lane == "api"
+    assert result.reason_code == "cli_absent"
+    assert result.served_model == native_request.model
+
+
+def test_forced_cli_absence_never_selects_api(lanes, native_request):
+    with pytest.raises(lanes.ImageLaneError, match="image_cli_absent"):
+        lanes.resolve_image_lane(
+            native_request, lanes.CliProbe("absent"), forced_lane="cli"
+        )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "timeout",
+        "auth_required",
+        "quota_exhausted",
+        "unsupported_client",
+        "version_invalid",
+    ],
+)
+@pytest.mark.parametrize("forced", ["auto", "cli"])
+def test_present_cli_failure_never_selects_a_paid_retry(
+    lanes, native_request, failure, forced
+):
+    probe = lanes.CliProbe("failed", "/synthetic/bin/codex", failure_code=failure)
+    with pytest.raises(lanes.ImageLaneError, match="cli_probe_failed"):
+        lanes.resolve_image_lane(native_request, probe, forced_lane=forced)
+
+
+def test_forced_api_needs_no_cli_or_native_substitution(lanes, native_request):
+    result = lanes.resolve_image_lane(native_request, None, forced_lane="api")
+    assert (result.lane, result.served_model, result.reason_code) == (
+        "api",
+        native_request.model,
+        "api_forced",
+    )
+
+
+@pytest.mark.parametrize(
+    "updates,reason",
+    [
+        ({"masked": True}, "cli_mask_not_supported"),
+        ({"reference_count": 2}, "cli_multiple_references_unverified"),
+    ],
+)
+def test_unproven_build_or_composition_capabilities_refuse_cli(
+    lanes, native_request, ready, updates, reason
+):
+    image_request = replace(native_request, operation="edit", reference_count=1)
+    image_request = replace(image_request, **updates)
+    assert lanes.resolve_image_lane(image_request, ready).lane == "api"
+    with pytest.raises(lanes.ImageLaneError, match=reason):
+        lanes.resolve_image_lane(image_request, ready, forced_lane="cli")
+
+
+@pytest.mark.parametrize("forced", ["auto", "api", "cli"])
+def test_imagen_edit_never_routes_to_an_unsupported_endpoint(
+    lanes, image_request, forced
+):
+    image_request = replace(
+        image_request,
+        family="imagen",
+        model="imagen-4.0-ultra-generate-001",
+        operation="edit",
+        reference_count=1,
+    )
+    with pytest.raises(lanes.ImageLaneError, match="image_edit_unsupported"):
+        lanes.resolve_image_lane(image_request, None, forced_lane=forced)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"family": []},
+        {"family": "unknown"},
+        {"model": "private\nvalue"},
+        {"operation": "unknown"},
+        {"operation": []},
+        {"reference_count": True},
+        {"reference_count": -1},
+        {"reference_count": 17},
+        {"reference_count": 1},
+        {"operation": "edit"},
+        {"masked": True},
+        {"masked": 1},
+        {"allow_native_model": 1},
+        {"allow_native_geometry": "yes"},
+        {"requested_size": [2048, 1152]},
+        {"requested_size": (0, 1152)},
+        {"requested_size": (True, 1152)},
+        {"requested_size": (2048,)},
+    ],
+)
+def test_malformed_request_fails_before_any_lane_is_selected(
+    lanes, image_request, updates
+):
+    with pytest.raises(lanes.ImageLaneError):
+        lanes.resolve_image_lane(replace(image_request, **updates), None)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"state": "unknown"},
+        {"state": []},
+        {"binary": "bad\npath"},
+        {"binary": ""},
+        {"version": "0.153.2 private data"},
+        {"version": None},
+        {"failure_code": "unexpected"},
+        {"state": "absent"},
+        {"state": "failed"},
+    ],
+)
+def test_malformed_probe_never_becomes_api_fallback(
+    lanes, native_request, ready, updates
+):
+    with pytest.raises(lanes.ImageLaneError, match="invalid_cli_probe"):
+        lanes.resolve_image_lane(native_request, replace(ready, **updates))
+
+
+def test_missing_probe_does_not_mean_absent(lanes, native_request):
+    with pytest.raises(lanes.ImageLaneError, match="cli_probe_required"):
+        lanes.resolve_image_lane(native_request, None)
+
+
+def test_model_cannot_cross_vendor_dispatch(lanes, image_request):
+    with pytest.raises(lanes.ImageLaneError, match="image_model_family_mismatch"):
+        lanes.resolve_image_lane(
+            replace(image_request, model="gemini-3-pro-image"), None
+        )
+
+
+@pytest.mark.parametrize("binary", ["codex", "relative/codex", "C:codex"])
+def test_cli_binary_must_be_resolved(lanes, native_request, ready, binary):
+    with pytest.raises(lanes.ImageLaneError, match="invalid_cli_probe"):
+        lanes.resolve_image_lane(native_request, replace(ready, binary=binary))
+
+
+@pytest.mark.parametrize("binary", ["/synthetic/bin/codex", r"C:\synthetic\codex.exe"])
+def test_native_platform_binary_identity_is_preserved(
+    lanes, native_request, ready, binary
+):
+    result = lanes.resolve_image_lane(native_request, replace(ready, binary=binary))
+    assert result.binary == binary
+
+
+@pytest.mark.parametrize("forced", [None, [], "unknown"])
+def test_invalid_lane_override_is_not_auto(lanes, image_request, forced):
+    with pytest.raises(lanes.ImageLaneError, match="invalid_image_lane"):
+        lanes.resolve_image_lane(image_request, None, forced_lane=forced)
+
+
+def test_failed_probe_category_is_visible_but_raw_provider_text_is_not_accepted(
+    lanes, native_request
+):
+    with pytest.raises(lanes.ImageLaneError, match="quota_exhausted"):
+        lanes.resolve_image_lane(
+            native_request,
+            lanes.CliProbe(
+                "failed", "/synthetic/bin/codex", failure_code="quota_exhausted"
+            ),
+        )
+    with pytest.raises(lanes.ImageLaneError, match="invalid_cli_probe"):
+        lanes.resolve_image_lane(
+            native_request,
+            lanes.CliProbe(
+                "failed",
+                "/synthetic/bin/codex",
+                failure_code="secret=private provider response",
+            ),
+        )
+
+
+@pytest.mark.parametrize("auth_mode", ["api", "unknown"])
+@pytest.mark.parametrize("forced", ["auto", "cli"])
+def test_cli_cannot_masquerade_api_auth_as_subscription(
+    lanes, native_request, ready, auth_mode, forced
+):
+    with pytest.raises(lanes.ImageLaneError, match="image_cli_subscription_required"):
+        lanes.resolve_image_lane(
+            native_request, replace(ready, auth_mode=auth_mode), forced_lane=forced
+        )
+
+
+@pytest.mark.parametrize("auth_mode", [None, "private response", [], True])
+def test_unverified_auth_probe_is_not_cli_readiness(
+    lanes, native_request, ready, auth_mode
+):
+    with pytest.raises(lanes.ImageLaneError, match="invalid_cli_probe"):
+        lanes.resolve_image_lane(native_request, replace(ready, auth_mode=auth_mode))

--- a/tests/test_image_provider.py
+++ b/tests/test_image_provider.py
@@ -1,0 +1,682 @@
+"""Per-render integration with fake CLI/API boundaries; no vendor process or network."""
+
+import argparse
+from dataclasses import replace
+import hashlib
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from PIL import Image
+import pytest
+
+from conftest import SCRIPTS_ILL, _import_script
+from test_generate_illustrations import (
+    _candidates,
+    _single_build_slide,
+    _write_candidates,
+    _write_gate_outline,
+    _write_manifest,
+)
+
+
+@pytest.fixture
+def provider():
+    return _import_script(Path(SCRIPTS_ILL) / "image_provider.py", "image_provider")
+
+
+@pytest.fixture
+def cli():
+    return _import_script(Path(SCRIPTS_ILL) / "image_cli.py", "image_cli")
+
+
+@pytest.fixture
+def png():
+    stream = io.BytesIO()
+    Image.new("RGB", (24, 16), "navy").save(stream, format="PNG")
+    return stream.getvalue()
+
+
+@pytest.fixture
+def ready(cli, monkeypatch, png):
+    result = cli.CliProbe("ready", "/fake/codex", "0.153.2", auth_mode="chatgpt")
+    monkeypatch.setattr(cli, "probe_codex", lambda: result)
+    monkeypatch.setattr(
+        cli,
+        "render_codex",
+        lambda *a, **kw: cli.CliImage(png, 24, 16, hashlib.sha256(png).hexdigest()),
+    )
+    return result
+
+
+@pytest.fixture
+def no_credentials(generate_illustrations, monkeypatch):
+    gi = generate_illustrations
+    monkeypatch.setattr(
+        gi, "load_secrets", lambda *a: pytest.fail("read API credentials")
+    )
+    for name in (
+        "_call_openai_generate",
+        "_call_openai_edit",
+        "_call_gemini",
+        "_call_imagen",
+    ):
+        monkeypatch.setattr(gi, name, lambda *a, **kw: pytest.fail("called paid API"))
+
+
+@pytest.mark.parametrize("lane", ["auto", "api", "cli"])
+def test_public_arguments_are_shared(provider, lane):
+    parser = argparse.ArgumentParser()
+    provider.add_image_lane_arguments(parser)
+    args = parser.parse_args(["--image-lane", lane, "--allow-cli-native"])
+    assert (args.image_lane, args.allow_cli_native) == (lane, True)
+    assert parser.parse_args([]).image_lane == "auto"
+    assert parser.parse_args([]).allow_cli_native is False
+
+
+@pytest.mark.parametrize("lane", ["auto", "api"])
+@pytest.mark.parametrize(
+    "model", ["gpt-image-2", "nano-banana-pro", "imagen-4.0-generate-001"]
+)
+def test_exact_and_api_only_requests_never_probe(
+    provider, cli, monkeypatch, lane, model, capsys
+):
+    monkeypatch.setattr(
+        cli, "probe_codex", lambda: pytest.fail("unnecessary CLI probe")
+    )
+    result = provider.select_image_lane(model, provider.ImageProviderOptions(lane))
+    assert result.lane == "api"
+    assert result.served_model == result.requested_model
+    message = json.loads(capsys.readouterr().err.removeprefix("IMAGE_LANE "))
+    assert message["lane"] == "api"
+    assert message["binary"] is None and message["version"] is None
+
+
+def test_native_probe_is_fresh_for_each_selection(
+    provider, cli, ready, monkeypatch, capsys
+):
+    probes = iter([ready, replace(ready, version="0.153.3")])
+    monkeypatch.setattr(cli, "probe_codex", lambda: next(probes))
+    options = provider.ImageProviderOptions("auto", True)
+    first = provider.select_image_lane("gpt-image-2", options)
+    second = provider.select_image_lane("gpt-image-2", options)
+    assert (first.version, second.version) == ("0.153.2", "0.153.3")
+    assert first.served_model == cli.CODEX_NATIVE_MODEL
+    assert first.requested_model != first.served_model
+    assert len(capsys.readouterr().err.splitlines()) == 2
+
+
+def test_nonfatal_cli_diagnostics_are_visible_on_success(
+    provider, cli, ready, monkeypatch, png, capsys
+):
+    lane = provider.select_image_lane(
+        "gpt-image-2", provider.ImageProviderOptions("cli", True)
+    )
+    monkeypatch.setattr(
+        cli,
+        "render_codex",
+        lambda *a, **kw: cli.CliImage(
+            png,
+            24,
+            16,
+            hashlib.sha256(png).hexdigest(),
+            warning_count=4,
+        ),
+    )
+    result = provider.render_cli(lane, "cup")
+    assert result.data == png and result.provenance()["warning_count"] == 4
+    assert "WARNING: cli_item_diagnostics (4)" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("lane", ["auto", "cli"])
+@pytest.mark.parametrize("edit", [False, True])
+def test_native_generate_edit_need_no_api_credentials(
+    provider,
+    cli,
+    ready,
+    generate_illustrations,
+    no_credentials,
+    monkeypatch,
+    png,
+    tmp_path,
+    capsys,
+    lane,
+    edit,
+):
+    gi = generate_illustrations
+    keys = gi.ImageKeys(options=provider.ImageProviderOptions(lane, True))
+    reference = tmp_path / "source.png"
+    reference.write_bytes(png)
+    calls = []
+
+    def render(plan, prompt, *, reference_path=None):
+        calls.append((plan.operation, prompt, reference_path))
+        return cli.CliImage(png, 24, 16, hashlib.sha256(png).hexdigest())
+
+    monkeypatch.setattr(cli, "render_codex", render)
+    result = (
+        gi.edit_image(str(reference), "Erase cup. Keep table.", "gpt-image-2", keys)
+        if edit
+        else gi.generate_image("A blue cup", "gpt-image-2", keys)
+    )
+    assert result.data == png
+    assert result.lane.lane == "cli"
+    assert result.width == 24 and result.height == 16
+    assert calls[0][0] == ("edit" if edit else "generate")
+    assert calls[0][2] == (str(reference) if edit else None)
+    if edit:
+        assert "DO NOT add any new elements" in calls[0][1]
+    assert reference.read_bytes() == png
+    stderr = capsys.readouterr().err
+    assert '"binary": "/fake/codex"' in stderr
+    assert '"version": "0.153.2"' in stderr
+    assert '"width": 24' in stderr
+
+
+@pytest.mark.parametrize("failure", ["probe", "auth", "render"])
+def test_present_failure_never_reads_keys_or_retries_api(
+    provider,
+    cli,
+    ready,
+    generate_illustrations,
+    no_credentials,
+    monkeypatch,
+    capsys,
+    failure,
+):
+    gi = generate_illustrations
+    if failure == "probe":
+        monkeypatch.setattr(
+            cli,
+            "probe_codex",
+            lambda: replace(ready, state="failed", failure_code="cli_auth_required"),
+        )
+    elif failure == "auth":
+        monkeypatch.setattr(cli, "probe_codex", lambda: replace(ready, auth_mode="api"))
+    else:
+
+        def fail(*a, **kw):
+            raise provider.ImageLaneError(
+                "cli_provider_failed", "repair CLI; no API retry"
+            )
+
+        monkeypatch.setattr(cli, "render_codex", fail)
+    result = gi.generate_image(
+        "cup",
+        "gpt-image-2",
+        gi.ImageKeys(options=provider.ImageProviderOptions("auto", True)),
+    )
+    assert result.data is None
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_absent_cli_uses_existing_api_and_reports_it(
+    provider,
+    cli,
+    generate_illustrations,
+    monkeypatch,
+    capsys,
+    png,
+):
+    gi = generate_illustrations
+    monkeypatch.setattr(cli, "probe_codex", lambda: cli.CliProbe("absent"))
+    calls = []
+    monkeypatch.setattr(
+        gi, "load_secrets", lambda *a: ({"openai": "fixture-key"}, "/fake/secrets.json")
+    )
+
+    def api(prompt, model, key, *, size):
+        calls.append((model, key, size))
+        return png, "image/png"
+
+    monkeypatch.setattr(gi, "_call_openai_generate", api)
+    result = gi.generate_image(
+        "cup",
+        "gpt-image-2",
+        gi.ImageKeys(options=provider.ImageProviderOptions("auto", True)),
+    )
+    assert result.data == png
+    assert calls == [("gpt-image-2-2026-04-21", "fixture-key", "2048x1152")]
+    stderr = capsys.readouterr().err
+    assert '"reason_code": "cli_absent"' in stderr
+    assert "fixture-key" not in stderr
+
+
+@pytest.mark.parametrize(
+    "model,masked,reason",
+    [
+        ("gpt-image-2", False, "cli_cannot_pin_image_model"),
+        ("gpt-image-2", True, "cli_mask_not_supported"),
+        ("gemini-3-pro-image", False, "family_api_only"),
+    ],
+)
+def test_forced_cli_refuses_unverified_edit_constraints(
+    provider,
+    generate_illustrations,
+    no_credentials,
+    model,
+    masked,
+    reason,
+):
+    gi = generate_illustrations
+    options = provider.ImageProviderOptions("cli", masked)
+    result = gi.edit_image(
+        "/unused/source.png",
+        "erase",
+        model,
+        gi.ImageKeys(options=options),
+        erase_region=[0, 0, 1, 1] if masked else None,
+    )
+    assert result.data is None
+    assert reason in result.detail
+
+
+def test_generate_runner_absent_cli_exits_success_and_writes_image(
+    provider,
+    cli,
+    generate_illustrations,
+    monkeypatch,
+    tmp_path,
+    png,
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    _write_manifest(tmp_path, ["gpt-image-2"])
+    monkeypatch.setattr(cli, "probe_codex", lambda: cli.CliProbe("absent"))
+    monkeypatch.setattr(
+        gi, "load_secrets", lambda *a: ({"openai": "fixture-key"}, "/fake/secrets.json")
+    )
+    monkeypatch.setattr(
+        gi, "_call_openai_generate", lambda *a, **kw: (png, "image/png")
+    )
+    gi.run_generate(
+        str(outline), ["all"], lane_options=provider.ImageProviderOptions("auto", True)
+    )
+    assert (tmp_path / "illustrations" / "slide-01.png").read_bytes() == png
+
+
+def test_generate_runner_present_failure_exits_nonzero(
+    provider,
+    cli,
+    ready,
+    generate_illustrations,
+    no_credentials,
+    monkeypatch,
+    tmp_path,
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    _write_manifest(tmp_path, ["gpt-image-2"])
+    monkeypatch.setattr(
+        cli,
+        "probe_codex",
+        lambda: replace(ready, state="failed", failure_code="cli_auth_required"),
+    )
+    with pytest.raises(SystemExit) as caught:
+        gi.run_generate(
+            str(outline),
+            ["all"],
+            lane_options=provider.ImageProviderOptions("auto", True),
+        )
+    assert caught.value.code == 1
+    assert not (tmp_path / "illustrations" / "slide-01.png").exists()
+
+
+@pytest.mark.parametrize("edit", [False, True])
+def test_missing_api_key_is_a_reported_cell_failure_without_provider_call(
+    generate_illustrations,
+    monkeypatch,
+    edit,
+    capsys,
+):
+    gi = generate_illustrations
+    monkeypatch.setattr(gi, "load_secrets", lambda *a: ({}, "/fake/secrets.json"))
+    monkeypatch.setattr(
+        gi, "_call_openai_generate", lambda *a, **kw: pytest.fail("called API")
+    )
+    monkeypatch.setattr(
+        gi, "_call_openai_edit", lambda *a, **kw: pytest.fail("called API")
+    )
+    result = (
+        gi.edit_image("/unused.png", "erase", "gpt-image-2", gi.ImageKeys())
+        if edit
+        else gi.generate_image("cup", "gpt-image-2", gi.ImageKeys())
+    )
+    assert result.data is None and "image_api_key_missing" in result.detail
+    assert result.lane.lane == "api"
+    assert "OPENAI_API_KEY" in capsys.readouterr().err
+
+
+def test_mixed_grid_retains_native_success_when_api_key_is_missing(
+    provider,
+    ready,
+    generate_illustrations,
+    monkeypatch,
+    tmp_path,
+    png,
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    candidates = _write_candidates(
+        tmp_path,
+        _candidates(
+            slides={"FULL": 1},
+            models=["gpt-image-2", "gemini-3-pro-image"],
+            styles=[{"name": "Ink", "anchors": {"FULL": "Ink drawing."}}],
+        ),
+    )
+    monkeypatch.setattr(gi, "load_secrets", lambda *a: ({}, "/fake/secrets.json"))
+    monkeypatch.setattr(gi, "_call_gemini", lambda *a: pytest.fail("called API"))
+    monkeypatch.setattr(gi.time, "sleep", lambda *a: None)
+    with pytest.raises(SystemExit) as caught:
+        gi.run_style_explore(
+            str(outline),
+            candidates,
+            lane_options=provider.ImageProviderOptions("auto", True),
+        )
+    assert caught.value.code == 1
+    base = tmp_path / "style-explore"
+    cells = json.loads((base / "rendered.json").read_text())["cells"]
+    assert [cell["status"] for cell in cells] == ["OK", "FAIL"]
+    assert (base / cells[0]["rel_path"]).read_bytes() == png
+    assert "image_api_key_missing" in cells[1]["error"]
+
+
+@pytest.mark.parametrize("native", [False, True])
+def test_v2_manifest_gate_uses_served_model_not_requested_model(
+    provider,
+    ready,
+    generate_illustrations,
+    tmp_path,
+    png,
+    native,
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    base = tmp_path / "style-explore"
+    base.mkdir()
+    (base / "image.png").write_bytes(png)
+    lane = provider.select_image_lane(
+        "gpt-image-2", provider.ImageProviderOptions("auto", native)
+    )
+    render = provider.ImageRender(png, "image/png", lane)
+    result = {
+        "style": "A",
+        "format": "FULL",
+        "model": "gpt-image-2",
+        "status": "OK",
+        "rel_path": "image.png",
+        "provenance": render.provenance(),
+    }
+    path = gi.write_rendered_manifest(str(base), str(outline), [result])
+    manifest = json.loads(Path(path).read_text())
+    assert manifest["schema_version"] == 2
+    assert manifest["models_rendered_ok"] == [lane.served_model]
+    assert gi.check_style_explore(str(outline))["gate_passed"] is (not native)
+    index = gi.render_explore_index({"styles": [{"name": "A"}]}, [result])
+    assert lane.served_model in index
+    assert f"({lane.lane})" in index
+    assert Path(path).read_text() == json.dumps(manifest, indent=2)
+
+
+@pytest.mark.parametrize(
+    "provenance", [None, {}, {"lane": {}}, {"lane": {"lane": "api"}}]
+)
+def test_v2_missing_provenance_never_becomes_bake_evidence(
+    generate_illustrations, tmp_path, png, provenance
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    base = tmp_path / "style-explore"
+    base.mkdir()
+    (base / "image.png").write_bytes(png)
+    gi.write_rendered_manifest(
+        str(base),
+        str(outline),
+        [
+            {
+                "style": "A",
+                "format": "FULL",
+                "model": "gpt-image-2",
+                "status": "OK",
+                "rel_path": "image.png",
+                "provenance": provenance,
+            }
+        ],
+    )
+    assert gi.check_style_explore(str(outline))["gate_passed"] is False
+
+
+@pytest.mark.parametrize(
+    "model,reason",
+    [
+        ("gemini-3-pro-image", "family_api_only"),
+        ("gpt-image-2", "cli_multiple_references_unverified"),
+    ],
+)
+def test_thumbnail_forced_cli_refuses_before_keys_and_images(
+    generate_thumbnail,
+    monkeypatch,
+    model,
+    reason,
+    capsys,
+):
+    gt = generate_thumbnail
+    monkeypatch.setattr(gt, "load_api_key", lambda *a: pytest.fail("loaded API key"))
+    monkeypatch.setattr(
+        gt, "load_image_as_base64", lambda *a: pytest.fail("loaded source image")
+    )
+    args = SimpleNamespace(model=model, image_lane="cli", allow_cli_native=True)
+    with pytest.raises(SystemExit) as caught:
+        gt.compose_thumbnail(args)
+    assert caught.value.code == 1
+    assert reason in capsys.readouterr().err
+
+
+def test_thumbnail_reports_each_api_render_and_resolves_alias(
+    generate_thumbnail,
+    monkeypatch,
+    tmp_path,
+    png,
+    capsys,
+):
+    gt = generate_thumbnail
+    monkeypatch.setattr(gt, "load_api_key", lambda *a: "fixture-key")
+    monkeypatch.setattr(
+        gt, "load_image_as_base64", lambda *a: ("fixture-image", "image/png")
+    )
+    calls = []
+
+    def api(parts, model, key):
+        calls.append(model)
+        return png, "image/png"
+
+    monkeypatch.setattr(gt, "call_gemini", api)
+    args = SimpleNamespace(
+        model="nano-banana-pro",
+        image_lane="api",
+        allow_cli_native=False,
+        vault=None,
+        slide_image="slide.png",
+        speaker_photo="photo.png",
+        brand_colors=None,
+        aesthetic="photo",
+        style="overlay",
+        title="A cup",
+        subtitle=None,
+        portrait_style="ink",
+        title_position="top",
+        output=str(tmp_path / "thumbnail.png"),
+    )
+    gt.compose_thumbnail(args)
+    assert calls == ["gemini-3-pro-image", "gemini-3-pro-image"]
+    lines = capsys.readouterr().err.splitlines()
+    lanes = [
+        json.loads(line.removeprefix("IMAGE_LANE "))
+        for line in lines
+        if line.startswith("IMAGE_LANE ")
+    ]
+    assert len(lanes) == 2
+    assert all(
+        lane["lane"] == "api" and lane["reason_code"] == "api_forced" for lane in lanes
+    )
+    with Image.open(args.output) as image:
+        assert image.size == (1280, 720)
+
+
+def test_native_style_grid_persists_observed_output_without_passing_bake_gate(
+    provider,
+    cli,
+    ready,
+    generate_illustrations,
+    no_credentials,
+    monkeypatch,
+    tmp_path,
+    png,
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    candidates = _write_candidates(
+        tmp_path,
+        _candidates(
+            slides={"FULL": 1},
+            models=["gpt-image-2"],
+            styles=[{"name": "Ink", "anchors": {"FULL": "Ink drawing."}}],
+        ),
+    )
+    monkeypatch.setattr(gi.time, "sleep", lambda *a: None)
+    gi.run_style_explore(
+        str(outline),
+        candidates,
+        lane_options=provider.ImageProviderOptions("cli", True),
+    )
+    base = tmp_path / "style-explore"
+    manifest = json.loads((base / "rendered.json").read_text())
+    cell = manifest["cells"][0]
+    assert cell["status"] == "OK"
+    assert "cli-native-unpinned" in cell["rel_path"]
+    assert (base / cell["rel_path"]).read_bytes() == png
+    assert cell["provenance"]["width"] == 24
+    assert cell["provenance"]["sha256"] == hashlib.sha256(png).hexdigest()
+    assert cli.CODEX_NATIVE_MODEL in (base / "index.md").read_text()
+    assert gi.check_style_explore(str(outline))["gate_passed"] is False
+
+
+def test_native_compare_labels_observed_model_and_output_file(
+    provider,
+    cli,
+    ready,
+    generate_illustrations,
+    no_credentials,
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    monkeypatch.setattr(gi, "COMPARE_MODELS", ["gpt-image-2"])
+    gi.run_compare(
+        str(outline), 1, lane_options=provider.ImageProviderOptions("cli", True)
+    )
+    outputs = list((tmp_path / "illustrations" / "model-comparison").glob("*.png"))
+    assert len(outputs) == 1 and "cli-native-unpinned" in outputs[0].name
+    assert f"{cli.CODEX_NATIVE_MODEL} [cli]" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("masked", [False, True])
+def test_build_uses_previous_native_edit_or_refuses_masked_cli(
+    provider,
+    cli,
+    ready,
+    generate_illustrations,
+    no_credentials,
+    monkeypatch,
+    tmp_path,
+    png,
+    masked,
+):
+    gi = generate_illustrations
+    outline = _single_build_slide(
+        [
+            {"step": 0, "description": "Erase cup. Keep table.", "is_full": False},
+            {
+                "step": 1,
+                "description": "Erase glass. Keep table.",
+                "is_full": False,
+                "erase_region": [0, 0, 1, 1] if masked else None,
+            },
+            {"step": 2, "description": "full", "is_full": True},
+        ]
+    )
+    outline["model"] = "gpt-image-2"
+    source = tmp_path / "slide-60.png"
+    source.write_bytes(png)
+    options = provider.ImageProviderOptions("cli", True)
+    monkeypatch.setattr(
+        gi,
+        "_load_context",
+        lambda *a, **kw: (gi.ImageKeys(options=options), outline, str(tmp_path)),
+    )
+    monkeypatch.setattr(gi, "enforce_render_gate", lambda *a: None)
+    monkeypatch.setattr(gi.time, "sleep", lambda *a: None)
+    seen = []
+
+    def render(lane, prompt, *, reference_path):
+        seen.append(reference_path)
+        assert lane.operation == "edit"
+        assert Path(reference_path).read_bytes() == png
+        return cli.CliImage(png, 24, 16, hashlib.sha256(png).hexdigest())
+
+    monkeypatch.setattr(cli, "render_codex", render)
+    if masked:
+        with pytest.raises(SystemExit) as caught:
+            gi.run_build("ignored.yaml", "60", lane_options=options)
+        assert caught.value.code == 1
+        assert seen == []
+        assert not (tmp_path / "builds" / "slide-60-build-00.png").exists()
+    else:
+        gi.run_build("ignored.yaml", "60", lane_options=options)
+        assert seen == [str(source), str(tmp_path / "builds" / "slide-60-build-01.png")]
+        assert (tmp_path / "builds" / "slide-60-build-00.png").read_bytes() == png
+    assert source.read_bytes() == png
+
+
+@pytest.mark.parametrize(
+    "mode,arguments",
+    [
+        ("run_generate", ["all"]),
+        ("run_edit", ["--edit", "1", "erase"]),
+        ("run_fix", ["--fix", "1", "change"]),
+        ("run_build", ["--build", "all"]),
+        ("run_compare", ["--compare", "1"]),
+        ("run_style_explore", ["--style-explore", "candidates.json"]),
+    ],
+)
+def test_main_forwards_lane_options_to_every_render_mode(
+    provider,
+    generate_illustrations,
+    monkeypatch,
+    tmp_path,
+    mode,
+    arguments,
+):
+    gi = generate_illustrations
+    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    seen = []
+    monkeypatch.setattr(gi, mode, lambda *a, **kw: seen.append(kw["lane_options"]))
+    monkeypatch.setattr(gi, "_cli_vault_path", None)
+    monkeypatch.setattr(
+        gi.sys,
+        "argv",
+        [
+            "generate",
+            str(outline),
+            *arguments,
+            "--image-lane",
+            "cli",
+            "--allow-cli-native",
+        ],
+    )
+    gi.main()
+    assert seen == [provider.ImageProviderOptions("cli", True)]

--- a/tests/test_image_provider.py
+++ b/tests/test_image_provider.py
@@ -93,6 +93,24 @@ def test_exact_and_api_only_requests_never_probe(
     assert message["binary"] is None and message["version"] is None
 
 
+@pytest.mark.parametrize("lane", ["auto", "api", "cli"])
+def test_unsupported_imagen_edit_returns_provider_failure_without_side_effects(
+    provider, cli, generate_illustrations, no_credentials, monkeypatch, lane
+):
+    monkeypatch.setattr(cli, "probe_codex", lambda: pytest.fail("probed CLI"))
+    gi = generate_illustrations
+    result = gi.edit_image(
+        "/unused-reference.png",
+        "erase cup",
+        "imagen-4.0-generate-001",
+        gi.ImageKeys(options=provider.ImageProviderOptions(lane, True)),
+    )
+    assert result.data is None and result.lane is None
+    assert "Image editing is not supported for Imagen" in result.detail
+    assert result.provenance()["lane"] is None
+    assert tuple(result) == (None, result.detail)
+
+
 def test_native_probe_is_fresh_for_each_selection(
     provider, cli, ready, monkeypatch, capsys
 ):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -2,6 +2,47 @@
 
 from datetime import date
 
+import pytest
+
+
+@pytest.mark.parametrize(
+    "model,canonical,family",
+    [
+        ("GPT-IMAGE-2", "gpt-image-2-2026-04-21", "openai"),
+        ("Nano-Banana-Pro", "gemini-3-pro-image", "gemini"),
+        ("imagen-4-ultra", "imagen-4.0-ultra-generate-001", "imagen"),
+        ("gpt-image-ad-hoc", "gpt-image-ad-hoc", "openai"),
+    ],
+)
+def test_lane_resolver_uses_the_registry_alias_contract(
+    model_registry, model, canonical, family
+):
+    result = model_registry.resolve_image_lane(model)
+    assert (
+        result.requested_model,
+        result.served_model,
+        result.family,
+        result.lane,
+    ) == (canonical, canonical, family, "api")
+
+
+@pytest.mark.parametrize("model", [None, [], "", "unsupported-vendor-model"])
+def test_lane_resolver_rejects_unknown_vendor_before_dispatch(model_registry, model):
+    with pytest.raises(model_registry.ImageLaneError):
+        model_registry.resolve_image_lane(model)
+
+
+def test_registry_native_choice_never_claims_the_snapshot(model_registry):
+    probe = model_registry.CliProbe(
+        "ready", "/synthetic/bin/codex", "0.153.2", auth_mode="chatgpt"
+    )
+    result = model_registry.resolve_image_lane(
+        "gpt-image-2", probe, allow_native_model=True
+    )
+    assert result.lane == "cli"
+    assert result.requested_model == "gpt-image-2-2026-04-21"
+    assert result.served_model == "codex-native-image-model-unpinned"
+
 
 # --- Registry shape ---
 


### PR DESCRIPTION
## Summary

- Add a shared, per-render subscription CLI/API resolver, explicit overrides, lazy API keys, and truthful lane diagnostics to both image generators. Preserve dated models/exact geometry on API; opt-in native Codex output stays explicitly unpinned. Gemini, Imagen, masks, and multi-reference thumbnails remain on their proven API paths.
- Supervise Codex capability/authentication probes and native generation/editing with bounded pipes, private output, reference preservation, verified PNG bytes, and cleanup. Distinguish absent CLI fallback from present CLI failure; never automatically retry a failed CLI through a metered API.
- Declare the optional Codex runtime in a shipped npm manifest/lock with weekly Dependabot renewal. Prefer the isolated locked install, enforce the exact pin on local or PATH installations, and retain capability/authentication probes. No global CLI or login changes.
- Keep backward build chains intact and write v2 exploration provenance without treating native previews as dated-model bake evidence. Preserve read-only compatibility with historical API-only v1 grids and retain successful cells when another vendor's key is missing.

Closes #385. The issue explicitly permits narrowing to the CLIs whose generation/edit capability is demonstrated; the [installed-CLI probe record](https://github.com/jbaruch/speaker-toolkit/issues/385#issuecomment-5546340204) establishes that boundary. Existing default requests remain API-routed when their pinned model or exact size cannot be served by the CLI. Use `--image-lane cli --allow-cli-native` to require native subscription output, or `--image-lane api` to force HTTP.

## Test plan

- [x] Final full pytest suite: **7,323 passed, 8 platform skips** in 250.06 seconds; fake vendor/process tests only, with no real vendor binary or endpoint invoked by tests.
- [x] Ruff lint/format, Pyright zero findings, staged diff checks, and repository pre-publish package/extension/entrypoint/plugin-lint gates.
- [x] Focused routing and adapter tests cover absent/present-failing CLI, API authentication refusal, missing keys, native generation/edit, every command mode, previous-frame build chaining, mask refusal, stream/resource limits, output validation, source preservation, cleanup, warning visibility, and the v1/v2 bake gate.
- [x] Locked `npm ci --ignore-scripts` install and a real metadata-only probe passed on Codex 0.153.2 with ChatGPT authentication. Regression tests cover malformed/missing dependency manifests, mismatched versions, local-install precedence, broken-install refusal, and consistent provider results for unsupported Imagen edits.
- [x] Separate authorized local smoke probes through the actual adapter on Codex 0.153.2: native generation PNG 1329×1183, SHA-256 `b0ba6304762b79f255260eb5e5f5e2dbfa2ecd463e4d88a79b35d6b068655f6d`; native edit PNG 1536×1024, SHA-256 `7a091f6c04a6e59a4204e98dcda6a202a07257bcc09042c1e049cbdebfbf39d8`. The edit preserved the source; both cleaned private output and reported four non-fatal item diagnostics. No API fallback or authentication/configuration changes.
- [x] Tessl review attempted at threshold 85. It returned `Your organization has run out of credits`. This is **not a quality-review pass**: the existing `.github/workflows/publish.yml` opts into coding-policy's exact credit-outage exception. Publication retries review and must flag any skipped skill.

The first native smoke probe exposed pre-turn `item.completed` diagnostic events and was correctly refused without API fallback. A minimal exit-zero CLI probe established their ordering; fixed synthetic regression tests now preserve a visible warning count while top-level errors and failed turns remain fatal. Official OpenAI documentation informed the authentication and event-stream handling, not an assumed image-model pin or size guarantee.

Patch release; the existing publish workflow owns version stamping. No live-vault mutation, catalog repair, or reparsing is included in this PR.
