### PR TITLE
feat(profile): Derive family-balanced narration calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+### Derive family-balanced narration calibration from fresh audio samples
+
+Add #368's vault-root calibration command with a metadata-only planning mode,
+explicit download opt-in, strict catalog/interpreter authority and a final
+catalog-generation check. Retain every cohort, acquisition and quality
+exclusion. Prefer declared local recordings, resolve explicit duplicates and
+keep repeated deliveries from overweighting one presentation family.
+
+Extend the ingress media owner with bounded interior PCM/WAV sampling, fresh
+native word alignment and measured language confidence. Bind original and
+sample generations, keep model revision and provider version, and clean private
+samples on success, failure and worker termination. Pin the model resolver in
+the optional Whisper extra and document the expanded native validation boundary.
+
+Keep schema-v2 calibration separate from v1 equal-sample arithmetic. Preserve
+all four word-gap metrics, per-recording and per-family values, family-balanced
+means, medians, ranges and conditional bootstrap intervals. Sparse cohorts
+remain explicitly low confidence without a planning default. No transcript,
+catalog, queue or existing speech-profile replacement is part of calibration.
+
+Add read-only v1/v2 planning and creator readers. Keep the narration mean,
+historical recording range, conditional mean interval and conservative planning
+budget separate, and refuse sparse v2 profiles even when an assumption is
+available. Final recording verification still consumes actual aligned words
+and complete recording duration. Recorder integration remains open under #364.
+
+Native validation found losslessly convertible NumPy timestamps and words
+straddling retained Whisper segment boundaries. Preserve exact timestamps and
+explicit segment membership in sampled receipt v2; reject missing overlap,
+nonpositive/overlapping word spans and sample-bound violations. Numeric-only
+worker diagnostics expose failing boundaries without leaking words or paths.
+Use correctly rounded bootstrap means so degenerate family distributions retain
+their exact observed endpoint and remain valid planning inputs.
+
 ## 0.20.126 — 2026-09-05
 
 ### Route compatible image requests through subscription Codex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ markdown-deck = [
 # caption path works everywhere without it.
 whisper = [
     "mlx-whisper==0.4.3",
+    # Resolve a pinned model revision before native transcription; weekly Dependabot.
+    "huggingface-hub==1.4.1",
 ]
 
 [tool.setuptools]

--- a/rules/transcript-fetch-authority.md
+++ b/rules/transcript-fetch-authority.md
@@ -14,12 +14,16 @@ description: Authority of record for the Whisper transcription layer's Platform-
 
 ## Covered Artifact
 
-- The `mlx_whisper` import and actual `provider.transcribe()` call inside
+- The `mlx_whisper` imports, actual `provider.transcribe()` call, native model
+  access, spectrogram construction and `detect_language()` call inside
   `_transcribe_with_mlx()` in
   `skills/vault-ingress/scripts/local_media_transcription.py` are exempt.
 - Both YouTube `--method whisper` and non-YouTube `--audio` delegate to that
   worker. Their orchestration, media admission, resource supervision, download,
   result validation, cleanup, and receipt writes are not exempt.
+- Sampled-word acquisition delegates to the same native boundary. Read its
+  receipt contract and validation procedure in
+  `skills/vault-ingress/references/sampled-word-evidence.md`.
 - `mlx-whisper` is declared as the optional `whisper` extra in `pyproject.toml`, never a base dependency. The caption path and every validator work without it.
 - Route non-YouTube talks through `fetch-transcript.py --audio`. Never call
   `mlx_whisper.transcribe()` from skill prose.
@@ -139,7 +143,7 @@ A pass requires all eight checks.
 
 ## Scope Limits
 
-- The carve-out covers only the named Apple-Silicon import and provider call.
+- The carve-out covers only the named Apple-Silicon imports and native calls.
   It does not extend to another script, dependency, or the caption path.
 - Adding a second exempt artifact requires naming it here AND documenting its own validation procedure. Adding one without both invalidates the precondition.
 - "Hard to install in CI" does not qualify — see `jbaruch/coding-policy: ci-safety` Install, Don't Skip. `mlx-whisper` cannot run on the runner's architecture and qualifies for the carve-out.

--- a/skills/presentation-creator/references/phase3-content.md
+++ b/skills/presentation-creator/references/phase3-content.md
@@ -57,6 +57,10 @@ For long-form duration planning, use
 Keep a measured profile's complete rate and provenance when copying it into
 `talk.pacing_rate`. Use an explicit assumption only when no measured profile
 exists; a present invalid profile is an owner error, not a fallback trigger.
+The reader supports both v1 equal-sample and v2 family-balanced rates. A present
+low-confidence v2 profile also requires owner attention, not an assumed default.
+Keep v2 mean, conservative-planning rate, historical range and conditional mean
+interval separate. A conservative estimate is not proof that a recording fits.
 The full contract and command shapes are in
 `skills/vault-profile/references/speech-rates.md`. Recording verification uses
 actual complete-recording duration and aligned words, independently of the

--- a/skills/presentation-creator/scripts/extract-script.py
+++ b/skills/presentation-creator/scripts/extract-script.py
@@ -113,7 +113,20 @@ def render(outline: _os.Outline) -> str:
     rate = outline.talk.narration_rate
     low, high = rate["range"]
     provenance = rate["provenance"]
-    if rate["basis"] == "measured":
+    if rate["schema_version"] == 2:
+        ci_low, ci_high = rate["mean_confidence_interval_95"]
+        rate_source = (
+            f"measured family-balanced mean {rate['value']:g} WPM; "
+            f"conservative planning {rate['conservative_planning_wpm']:g} WPM; "
+            f"{provenance['sample_count']} recordings, "
+            f"{provenance['presentation_family_count']} families, "
+            f"{provenance['analyzed_duration_seconds']:g} s analyzed; "
+            f"cohort {provenance['cohort']}; language {provenance['language']}; "
+            f"{provenance['method_version']}; observed recording range; "
+            f"conditional mean 95% interval {ci_low:g}–{ci_high:g} WPM, "
+            "not a prediction interval"
+        )
+    elif rate["basis"] == "measured":
         rate_source = (
             f"measured; {provenance['sample_count']} samples, "
             f"{provenance['analyzed_duration_seconds']:g} s analyzed; "

--- a/skills/vault-ingress/references/local-media-acquisition.md
+++ b/skills/vault-ingress/references/local-media-acquisition.md
@@ -30,6 +30,9 @@ pins. A failed optional lane does not invalidate independent captions or slides.
   in-memory media/video probe from its owner. It reuses those facts and rechecks
   source generation. A serialized or hand-constructed receipt is not authority
   to skip acquisition.
+- `transcribe_local_words` uses the same acquisition owner for bounded interior
+  samples. Read [sampled-word-evidence.md](sampled-word-evidence.md) before using
+  this independent word-evidence lane; it does not write catalog transcripts.
 - `local_media_download.py`'s `download_youtube_audio` yields a private local
   artifact plus provider duration and removes the workspace when its consumer
   exits. It does not register or preserve a recording in the vault.

--- a/skills/vault-ingress/references/sampled-word-evidence.md
+++ b/skills/vault-ingress/references/sampled-word-evidence.md
@@ -1,0 +1,143 @@
+# Sampled Word Evidence
+
+Owner: `vault-ingress`. `local_media_transcription.transcribe_local_words()`
+returns established source-probe facts and a schema-v2 word receipt. It writes
+no transcript, timing/quality sidecar, speech profile or catalog record. This
+lane is separate from the existing transcript acquisition contract.
+
+## Acquisition and Native Boundary
+
+The caller supplies a local locator, `sample_start_seconds`,
+`sample_duration_seconds`, optional trusted root and optional current in-memory
+media/video probe. Missing probe facts are acquired by `probe_local_media`.
+Never supply a serialized or manufactured probe. The original source's open
+descriptor and pathname generation must remain unchanged throughout sampling
+and transcription. The caller receives no usable result after a failed final
+generation check or failed workspace cleanup.
+
+The parent creates an owner-private workspace; the authenticated Whisper worker
+decodes only the requested interval with FFmpeg. Streamed PCM has a strict byte
+ceiling, a measured duration from frame count and a private WAV wrapper. The
+sample has its own digest and generation. The original source is not copied or
+hashed again when a current owner probe is reused. Parent-owned cleanup removes
+sample files even when the worker times out or is killed.
+
+`MEDIA_WHISPER_LIMITS` owns wall, memory, process and protocol/diagnostic limits.
+`local_media_sampling.py` owns PCM format, clip bounds and decoder refusals.
+All parsing, normalization, protocol framing, generation checks and cleanup
+run in CI with real synthetic workers. Only native MLX calls use the documented
+platform-bound carve-out in the [transcription authority](../../../rules/transcript-fetch-authority.md).
+
+The supported model ID and immutable Hugging Face revision live in
+`local_media_words.DEFAULT_WORD_MODEL`. Renew quarterly with native validation.
+The optional `whisper` manifest extra pins mlx-whisper and huggingface-hub;
+weekly Dependabot tracks their versions. The SDK resolves only the pinned
+model's configuration and weights into its normal reusable cache; it does not
+download remote Python code, use stored access tokens, or receive audio.
+Model acquisition shares the worker's timeout/resource bounds. SDK cache state
+is separate from per-recording scratch and is not deleted after each sample.
+
+The native call requests real word timestamps, deterministic temperature and no
+previous-text conditioning. The same model separately measures language
+probability from the first 30 seconds of the decoded sample. A language label
+alone, a word probability, or the expected language does not supply that value.
+This probe does not prove language homogeneity across the complete sample.
+
+## Closed Receipt Schema
+
+All listed keys are required; unknown keys and future versions refuse:
+
+```text
+{schema_version: 2, pipeline_version: "sampled-words-v2",
+ source_sha256, sample_sha256, source_duration_seconds,
+ sample_start_seconds, sample_duration_seconds,
+ provider: "mlx-whisper", provider_version,
+ model: {id, revision}, language, language_probability, language_probe_seconds,
+ words: [{text, start_seconds, end_seconds, probability, segment_index}, ...],
+ segments: [{start_seconds, end_seconds, compression_ratio,
+             average_log_probability, no_speech_probability}, ...],
+ token_exclusions: [{token_index, reason: "punctuation_only"}, ...]}
+```
+
+The root receipt version owns the fixed nested model, word, segment and token
+exclusion shapes. Words carry one lexical token each; the model's tokenization
+convention is preserved. Only punctuation-only tokens are omitted, with an
+explicit original token index. Invalid lexical timestamps, overlaps, missing
+word alignment, invalid Unicode and segment membership failures refuse the
+sample. No timestamps are interpolated, repaired, stretched or clipped.
+
+Word and segment times are relative to the sample, not the full recording.
+Each word retains its zero-based provider `segment_index`. Indices are ordered;
+each word must overlap its declared segment by a positive duration. Native MLX
+boundary adjustments can retain a segment timestamp inside its boundary word;
+strict containment is not a provider guarantee. Neither timestamp is changed.
+All word and segment spans remain positive, ordered, non-overlapping and inside
+the sample. Source and sample SHA-256 values
+bind different byte artifacts. `sample_start_seconds` maps the decoded interval
+back to the original source, and its actual PCM duration must fit that source.
+Confidence/probability fields are measurements, not quality verdicts. The
+separate profile owner records the versioned policy that accepts or excludes
+each sample.
+
+`normalize_word_result()` projects bounded provider data into this receipt;
+`validate_word_sample()` is the non-mutating reader. Both raise the path-neutral
+`LocalMediaError` contract. Neither pure helper authenticates arbitrary supplied
+digests. Consumers obtain receipts from `transcribe_local_words`, preserve them
+unchanged and recheck live source freshness through ingress before reuse.
+Missing receipts mean no word evidence. Segment-only timing sidecars are not
+migrated into words; obtain fresh alignment through this owner. The experimental
+v1 receipt omitted explicit membership; it is not accepted or auto-migrated.
+Run fresh owner acquisition to obtain v2 evidence.
+
+`WordSampleError` adds closed numeric failure details: `schema_version: 1`,
+`word_index`, `word_count`, `word_start_seconds`, `word_end_seconds`,
+`segment_index`, `segment_count`, `segment_start_seconds` and
+`segment_end_seconds`. Indices/counts are bounded integers and times are finite
+sample-relative seconds. A missing segment uses null index/start/end together.
+Unknown keys, words and source paths are forbidden. Worker transport revalidates
+these details before exposing them to a caller.
+
+## Native Manual Validation
+
+Run on Apple Silicon with the configured interpreter and optional `whisper`
+extra. Use an authorized recording whose solo-speaker identity and language
+are independently known. This procedure covers only the MLX import, native
+transcription, spectrogram/model access and language-detection call named in
+the [transcription authority](../../../rules/transcript-fetch-authority.md); it does not exempt orchestration tests.
+
+1. Resolve the vault root, speaker name and exact interpreter through the strict
+   owner bootstrap in vault-profile. Record the owner's catalog digest and
+   preserve any existing speech profile and transcript artifacts.
+2. Require native capability:
+
+   ```bash
+   "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/check-runtime.py" \
+     --lanes core,source-media,speech-calibration --require-lanes core,source-media,speech-calibration
+   ```
+
+   Include `youtube-download` in both lists if downloads are authorized.
+3. Run a metadata plan through `calibrate-speech.py` with the explicit speaker,
+   language and `--maximum-recordings 1`. Inspect the selected source identity;
+   no recording is opened by the plan. Use `--allow-download` only for authorized
+   YouTube acquisition and retain that same option for the measured run.
+4. Repeat with `--run`, capturing stdout into a **fresh** private report. Require
+   exit 0, `ok: true`, one admitted recording and `status: "low_confidence"` for
+   this intentionally single-recording test. An acquisition or quality exclusion
+   is not a pass. It requires source/provider investigation, not lowered gates.
+5. Inspect `data.profile.calibration.samples[0].words`: current provider version,
+   pinned model ID/revision, exact source/sample digests, actual interval bounds,
+   lexical word start/end times and real language probability are present.
+   Listen to the authorized source at the recorded sample interval and check
+   several word boundaries near the beginning, middle and end. Require plausible
+   word alignment and correct language; evenly spaced invented timestamps fail.
+   A high reported probability does not excuse a wrong detected language.
+6. Require all four metric names with their owner thresholds, the recording's
+   actual word count and interval, explicit low confidence and null conservative
+   planning rates. The single-family confidence interval remains null.
+7. Repeat the strict catalog read and require the starting digest. Confirm no
+   transcript, timing/quality receipt or prior profile changed and no private
+   sample workspace survives. Model weights may remain in the SDK cache.
+
+A native pass requires all seven checks. A single-recording validation does not
+establish a representative speaker profile or recorder acceptance. Run the full
+cohort separately and keep its sparse/missing-mode uncertainty explicit.

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -80,6 +80,14 @@ LANE_REQUIREMENTS: dict[str, dict[str, dict[str, str]]] = {
         "modules": {"mlx-whisper": "mlx_whisper", "psutil": "psutil"},
         "commands": {"ffmpeg": "ffmpeg", "ffprobe": "ffprobe"},
     },
+    "speech-calibration": {
+        "modules": {
+            "mlx-whisper": "mlx_whisper",
+            "huggingface-hub": "huggingface_hub",
+            "psutil": "psutil",
+        },
+        "commands": {"ffmpeg": "ffmpeg", "ffprobe": "ffprobe"},
+    },
     "source-media": {
         "modules": {"psutil": "psutil"},
         "commands": {"ffprobe": "ffprobe"},

--- a/skills/vault-ingress/scripts/local_media_sampling.py
+++ b/skills/vault-ingress/scripts/local_media_sampling.py
@@ -1,0 +1,126 @@
+"""Bounded audio clipping inside the authenticated ingress transcription worker.
+
+The caller holds the admitted original descriptor and verifies its generation
+around this operation. The parent owns the private workspace and its cleanup,
+including timeout/kill paths. Only a decoded interval is materialized here;
+source media is never changed. PCM byte count establishes actual clip duration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import stat
+from typing import Any
+import wave
+
+from artifact_supervisor import FileGeneration
+from local_media_contract import LocalMediaError, refuse
+from local_media_evidence import _inspect, _require_descriptor
+from local_media_process import run_media_tool
+from local_media_words import WORDS_MAX_SAMPLE_SECONDS, WORDS_MAX_SOURCE_SECONDS
+
+
+SAMPLE_RATE = 16000
+PCM_BYTES_PER_SECOND = SAMPLE_RATE * 2
+SAMPLE_DIAGNOSTIC_BYTES = 64 * 1024
+CHUNK_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True)
+class SpeechClip:
+    path: Path
+    generation: FileGeneration
+    sha256: str
+    duration_seconds: float
+
+
+def validate_sample_window(start: Any, duration: Any, source_duration: Any) -> None:
+    if (
+        type(source_duration) not in (int, float)
+        or not 0 < source_duration <= WORDS_MAX_SOURCE_SECONDS
+        or type(start) not in (int, float)
+        or not 0 <= start < source_duration
+        or type(duration) not in (int, float)
+        or not 0 < duration <= WORDS_MAX_SAMPLE_SECONDS
+        or start + duration > source_duration
+    ):
+        refuse("whisper_sample_window_invalid")
+
+
+def extract_speech_clip(
+    path: Path, workspace: Path, *, start: float, duration: float
+) -> SpeechClip:
+    """Worker-only: decode one bounded interval to private 16-kHz mono PCM/WAV."""
+    validate_sample_window(start, duration, WORDS_MAX_SOURCE_SECONDS)
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        refuse("media_dependency_unavailable")
+    pcm, wav = workspace / "sample.pcm", workspace / "sample.wav"
+    result = run_media_tool(
+        [
+            ffmpeg,
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-xerror",
+            "-ss",
+            str(start),
+            "-i",
+            str(path),
+            "-t",
+            str(duration),
+            "-map",
+            "0:a:0",
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            str(SAMPLE_RATE),
+            "-c:a",
+            "pcm_s16le",
+            "-f",
+            "s16le",
+            "pipe:1",
+        ],
+        stdout_limit=int(duration * PCM_BYTES_PER_SECOND) + 2,
+        stderr_limit=SAMPLE_DIAGNOSTIC_BYTES,
+        output=pcm,
+        cwd=workspace,
+    )
+    if result.returncode or result.diagnostics.byte_count:
+        refuse("whisper_sample_decode_failed")
+    size = result.streamed_bytes
+    actual_duration = size / PCM_BYTES_PER_SECOND
+    if size <= 0 or size % 2 or abs(actual_duration - duration) > 1 / SAMPLE_RATE:
+        refuse("whisper_sample_duration_mismatch")
+    try:
+        os.chmod(pcm, 0o600)
+        with pcm.open("rb") as source, wav.open("xb") as output:
+            os.chmod(wav, 0o600)
+            with wave.open(output, "wb") as audio:
+                audio.setnchannels(1)
+                audio.setsampwidth(2)
+                audio.setframerate(SAMPLE_RATE)
+                audio.setnframes(size // 2)
+                while chunk := source.read(CHUNK_BYTES):
+                    audio.writeframesraw(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(wav, stat.S_IREAD)
+        generation = _inspect(wav, None).generation
+        digest = hashlib.sha256()
+        with wav.open("rb") as source:
+            _require_descriptor(source.fileno(), generation)
+            while chunk := source.read(CHUNK_BYTES):
+                digest.update(chunk)
+            _require_descriptor(source.fileno(), generation)
+        if _inspect(wav, None).generation != generation:
+            refuse("media_generation_changed")
+    except (OSError, wave.Error) as exc:
+        raise LocalMediaError("whisper_sample_decode_failed") from exc
+    return SpeechClip(wav, generation, digest.hexdigest(), actual_duration)

--- a/skills/vault-ingress/scripts/local_media_transcription.py
+++ b/skills/vault-ingress/scripts/local_media_transcription.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import importlib
+import importlib.metadata
 import os
 from pathlib import Path
 import sys
@@ -38,6 +39,7 @@ from local_media_contract import (
     reuse_video_probe,
 )
 from local_media_evidence import (
+    _admit_workspace,
     _bindings,
     _inspect,
     _path_payload,
@@ -45,13 +47,24 @@ from local_media_evidence import (
     _require_descriptor,
     check_media_generation,
     probe_local_media,
+    private_media_workspace,
+)
+from local_media_sampling import extract_speech_clip, validate_sample_window
+from local_media_words import (
+    DEFAULT_WORD_MODEL,
+    WORD_VALIDATION_FAILURES,
+    WordSampleError,
+    normalize_word_result,
+    validate_word_sample,
 )
 
 
 WORKER_FLAG = "--supervised-worker"
 WHISPER_OPERATION = "local_media_transcribe"
+WORDS_OPERATION = "local_media_sample_words"
 WHISPER_FAILURES = frozenset(
     {
+        *WORD_VALIDATION_FAILURES,
         "whisper_dependency_unavailable",
         "whisper_provider_failed",
         "whisper_result_invalid",
@@ -64,6 +77,17 @@ WHISPER_FAILURES = frozenset(
         "media_artifact_unavailable",
         "media_cloud_placeholder_unavailable",
         "media_size_limit",
+        "whisper_word_sample_invalid",
+        "whisper_sample_window_invalid",
+        "whisper_sample_decode_failed",
+        "whisper_sample_duration_mismatch",
+        "whisper_model_download_failed",
+        "whisper_provider_version_unsupported",
+        "media_private_workspace_unavailable",
+        "media_cleanup_failed",
+        "media_dependency_unavailable",
+        "media_tool_stdout_limit",
+        "media_tool_stderr_limit",
     }
 )
 _PROVIDER_ERRORS = (
@@ -149,17 +173,181 @@ def transcribe_local_media(
     return established, speech
 
 
-def _transcribe_with_mlx(path: Path, model: str) -> dict[str, Any]:
+def transcribe_local_words(
+    path: Any,
+    *,
+    sample_start_seconds: float,
+    sample_duration_seconds: float,
+    probe: Any = None,
+    trusted_root: Any = None,
+) -> tuple[MediaArtifactProbe, dict[str, Any]]:
+    """Sample fresh real word timing; never consume or write catalog transcripts."""
+    artifact, root = _request_paths(path, trusted_root)
+    if probe is None:
+        established = probe_local_media(artifact, trusted_root=root)
+    elif isinstance(probe, MediaArtifactProbe):
+        established = probe
+    else:
+        established = reuse_video_probe(probe)
+    validate_sample_window(
+        sample_start_seconds, sample_duration_seconds, established.duration_seconds
+    )
+    check_media_generation(artifact, established, trusted_root=root)
+    expected = {"media": established.generation}
+    if established.root_generation is not None:
+        expected["media_root"] = established.root_generation
+    payload = _path_payload(artifact, root)
+    payload.update(
+        source_sha256=established.source_sha256,
+        source_duration_seconds=established.duration_seconds,
+        sample_start_seconds=sample_start_seconds,
+        sample_duration_seconds=sample_duration_seconds,
+    )
+    command = [sys.executable, str(Path(__file__).resolve()), WORKER_FLAG]
+    try:
+        with private_media_workspace() as workspace:
+            payload["workspace"] = workspace
+            result = run_authenticated_worker(
+                command,
+                WORDS_OPERATION,
+                expected,
+                cast(JsonValue, payload),
+                MEDIA_WHISPER_LIMITS,
+                immutable_process_identity=command[:2],
+                sensitive_values=(str(artifact),),
+                schema_generation=MEDIA_SCHEMA_VERSION,
+                pipeline_generation=MEDIA_PIPELINE_VERSION,
+            )
+            speech = validate_word_sample(result.payload)
+            if (
+                speech["source_sha256"] != established.source_sha256
+                or speech["source_duration_seconds"] != established.duration_seconds
+                or speech["sample_start_seconds"] != sample_start_seconds
+                or abs(speech["sample_duration_seconds"] - sample_duration_seconds)
+                > 1 / 16000
+                or speech["model"] != DEFAULT_WORD_MODEL
+            ):
+                refuse("whisper_word_sample_invalid")
+            check_media_generation(artifact, established, trusted_root=root)
+    except SupervisorError as exc:
+        reason = exc.reason_code
+        if reason not in WHISPER_FAILURES:
+            reason = {
+                "worker_generation_changed": "media_generation_changed",
+                "worker_timeout": "whisper_worker_timeout",
+                "worker_memory_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_process_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_input_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_output_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_diagnostic_limit_exceeded": "whisper_worker_resource_limit",
+                "worker_cleanup_failed": "media_cleanup_failed",
+            }.get(reason, "whisper_worker_failed")
+        if reason == "whisper_word_sample_invalid_word_segment" and set(
+            exc.details
+        ) == {"word_timing"}:
+            raise WordSampleError(exc.details["word_timing"]) from exc
+        raise LocalMediaError(reason) from exc
+    return established, speech
+
+
+def _word_model_path() -> tuple[str, str]:
+    """Resolve the supported immutable weights before the native provider call."""
+    try:
+        version = importlib.metadata.version("mlx-whisper")
+        hub = importlib.import_module("huggingface_hub")
+    except _PROVIDER_ERRORS as exc:
+        raise LocalMediaError("whisper_dependency_unavailable") from exc
+    # Native language-detection integration is verified against this API.
+    # Renew with the optional whisper manifest pin in a focused change.
+    if version != "0.4.3":
+        refuse("whisper_provider_version_unsupported")
+    try:
+        path = hub.snapshot_download(
+            repo_id=DEFAULT_WORD_MODEL["id"],
+            revision=DEFAULT_WORD_MODEL["revision"],
+            allow_patterns=["config.json", "weights.safetensors", "weights.npz"],
+            max_workers=1,
+            token=False,
+        )
+    except _PROVIDER_ERRORS as exc:
+        raise LocalMediaError("whisper_model_download_failed") from exc
+    return _model(path), version
+
+
+def _transcribe_with_mlx(
+    path: Path, model: str, *, word_timestamps: bool = False
+) -> dict[str, Any]:
     """Only the actual Apple-Silicon provider call is platform-bound."""
     try:
         provider = importlib.import_module("mlx_whisper")
     except _PROVIDER_ERRORS as exc:
         raise LocalMediaError("whisper_dependency_unavailable") from exc
     try:
-        value = provider.transcribe(str(path), path_or_hf_repo=model)
+        if not word_timestamps:
+            value = provider.transcribe(str(path), path_or_hf_repo=model)
+        else:
+            value = provider.transcribe(
+                str(path),
+                path_or_hf_repo=model,
+                word_timestamps=True,
+                temperature=0.0,
+                condition_on_previous_text=False,
+                verbose=None,
+            )
+            if not isinstance(value, Mapping):
+                refuse("whisper_word_sample_invalid")
+            # mlx-whisper returns a language label, not its probability. Obtain
+            # that probability from the same model's real first-30-second probe.
+            native = importlib.import_module("mlx_whisper.transcribe")
+            dtype = native.mx.float16
+            network = native.ModelHolder.get_model(model, dtype)
+            mel = native.log_mel_spectrogram(
+                str(path), n_mels=network.dims.n_mels, padding=native.N_SAMPLES
+            )
+            segment = native.pad_or_trim(mel, native.N_FRAMES, axis=-2).astype(dtype)
+            _, probabilities = network.detect_language(segment)
+            probability = float(probabilities[value["language"]])
+            return {"raw": value, "language_probability": probability}
+    except LocalMediaError:
+        raise
     except _PROVIDER_ERRORS as exc:
         raise LocalMediaError("whisper_provider_failed") from exc
     return bounded_whisper_result(value)
+
+
+def _sampled_words(path: Path, payload: Mapping) -> dict[str, Any]:
+    validate_sample_window(
+        payload["sample_start_seconds"],
+        payload["sample_duration_seconds"],
+        payload["source_duration_seconds"],
+    )
+    workspace = _admit_workspace(payload["workspace"])
+    clip = extract_speech_clip(
+        path,
+        workspace,
+        start=payload["sample_start_seconds"],
+        duration=payload["sample_duration_seconds"],
+    )
+    model, version = _word_model_path()
+    with clip.path.open("rb") as descriptor:
+        _require_descriptor(descriptor.fileno(), clip.generation)
+        if _inspect(clip.path, None).generation != clip.generation:
+            refuse("media_generation_changed")
+        result = _transcribe_with_mlx(clip.path, model, word_timestamps=True)
+        _require_descriptor(descriptor.fileno(), clip.generation)
+        if _inspect(clip.path, None).generation != clip.generation:
+            refuse("media_generation_changed")
+    return normalize_word_result(
+        result["raw"],
+        source_sha256=payload["source_sha256"],
+        sample_sha256=clip.sha256,
+        source_duration_seconds=payload["source_duration_seconds"],
+        sample_start_seconds=payload["sample_start_seconds"],
+        sample_duration_seconds=clip.duration_seconds,
+        provider_version=version,
+        model=DEFAULT_WORD_MODEL,
+        language_probability=result["language_probability"],
+    )
 
 
 def _dispatch(
@@ -167,15 +355,26 @@ def _dispatch(
 ) -> tuple[dict[str, Any], dict[str, FileGeneration]]:
     payload = request.payload
     if (
-        request.operation != WHISPER_OPERATION
+        request.operation not in {WHISPER_OPERATION, WORDS_OPERATION}
         or request.limit_profile_id != MEDIA_WHISPER_LIMITS.profile_id
         or request.schema_generation != MEDIA_SCHEMA_VERSION
         or request.pipeline_generation != MEDIA_PIPELINE_VERSION
         or not isinstance(payload, Mapping)
-        or set(payload) != {"media_path", "trusted_root", "model"}
     ):
         raise SupervisorError("invalid_worker_request")
-    model = _model(payload["model"])
+    fields = {"media_path", "trusted_root"} | (
+        {"model"}
+        if request.operation == WHISPER_OPERATION
+        else {
+            "source_sha256",
+            "source_duration_seconds",
+            "sample_start_seconds",
+            "sample_duration_seconds",
+            "workspace",
+        }
+    )
+    if set(payload) != fields:
+        raise SupervisorError("invalid_worker_request")
     path, root = canonicalize_trusted_artifact_locator(
         payload["media_path"], payload["trusted_root"]
     )
@@ -195,7 +394,11 @@ def _dispatch(
         raise LocalMediaError("media_artifact_unavailable") from exc
     try:
         _require_descriptor(descriptor, before.generation)
-        speech = _transcribe_with_mlx(path, model)
+        speech = (
+            _transcribe_with_mlx(path, _model(payload["model"]))
+            if request.operation == WHISPER_OPERATION
+            else _sampled_words(path, payload)
+        )
         _require_descriptor(descriptor, before.generation)
         if _inspect(path, root) != before:
             refuse("media_generation_changed")
@@ -228,7 +431,12 @@ def _worker_main() -> int:
             )
             write_worker_response(
                 request,
-                error=SupervisorError(reason),
+                error=SupervisorError(
+                    reason,
+                    {"word_timing": exc.word_timing}
+                    if isinstance(exc, WordSampleError)
+                    else None,
+                ),
                 observed_generations=request.expected_generations,
                 stream=stream,
                 max_output_bytes=MEDIA_WHISPER_LIMITS.max_output_bytes,

--- a/skills/vault-ingress/scripts/local_media_words.py
+++ b/skills/vault-ingress/scripts/local_media_words.py
@@ -1,0 +1,411 @@
+"""Closed sampled-word receipts owned by the ingress media-acquisition lane.
+
+This pure boundary validates and normalizes provider data; it does not acquire
+media or authenticate a caller-supplied digest. Times are sample-relative, never
+interpolated from segment timestamps. Only punctuation-only tokens are omitted,
+with an explicit index/reason record. Invalid lexical spans refuse the sample.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import copy
+import math
+from numbers import Real
+import re
+from typing import Any, NoReturn
+
+from local_media_contract import LocalMediaError
+
+
+WORDS_PIPELINE_VERSION = "sampled-words-v2"
+WORDS_MAX_SAMPLE_SECONDS = 1200
+WORDS_MAX_SOURCE_SECONDS = 14400
+WORDS_MAX_COUNT = 50000
+WORDS_MAX_SEGMENTS = 5000
+WORDS_MAX_TOKEN_BYTES = 1024
+WORD_VALIDATION_FAILURES = frozenset(
+    {
+        "whisper_word_sample_invalid",
+        "whisper_word_sample_invalid_token",
+        "whisper_word_sample_invalid_word_span",
+        "whisper_word_sample_invalid_word_overlap",
+        "whisper_word_sample_invalid_word_nonpositive_span",
+        "whisper_word_sample_invalid_word_probability",
+        "whisper_word_sample_invalid_segment_span",
+        "whisper_word_sample_invalid_word_segment",
+    }
+)
+_SHA = re.compile(r"[0-9a-f]{64}\Z")
+_REVISION = re.compile(r"[0-9a-f]{40}\Z")
+_MODEL = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\Z")
+_VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?\Z")
+_LANGUAGE = re.compile(r"[a-z]{2,3}(?:-[a-z0-9]{2,8})*\Z")
+
+# Renew the model pin quarterly in a dedicated dependency/capability change.
+# Verify native word alignment and language detection before accepting a new
+# revision. The Python packages retain their own manifest/Dependabot pins.
+DEFAULT_WORD_MODEL = {
+    "id": "mlx-community/whisper-large-v3-turbo",
+    "revision": "a4aaeec0636e6fef84abdcbe3544cb2bf7e9f6fb",
+}
+
+
+def _refuse(detail: str = "") -> NoReturn:
+    code = "whisper_word_sample_invalid" + ("_" + detail if detail else "")
+    if code not in WORD_VALIDATION_FAILURES:
+        raise ValueError("unsupported word-validation diagnostic")
+    raise LocalMediaError(code)
+
+
+def _token_bytes(text: str) -> int:
+    try:
+        return len(text.encode("utf-8"))
+    except UnicodeEncodeError:
+        _refuse()
+
+
+def _object(value: Any, fields: set[str]) -> dict:
+    if not isinstance(value, dict) or set(value) != fields:
+        _refuse()
+    return value
+
+
+def _number(value: Any, low: float, high: float) -> float:
+    if type(value) not in (int, float) or not low <= value <= high:
+        _refuse()
+    result = float(value)
+    if not math.isfinite(result):
+        _refuse()
+    return result
+
+
+def validate_word_diagnostic(value: Any) -> dict:
+    """Closed numeric-only failure evidence, never source locators or words."""
+    diagnostic = _object(
+        value,
+        {
+            "schema_version",
+            "word_index",
+            "word_count",
+            "word_start_seconds",
+            "word_end_seconds",
+            "segment_index",
+            "segment_count",
+            "segment_start_seconds",
+            "segment_end_seconds",
+        },
+    )
+    if (
+        type(diagnostic["schema_version"]) is not int
+        or diagnostic["schema_version"] != 1
+    ):
+        _refuse()
+    for field, maximum in (
+        ("word_count", WORDS_MAX_COUNT),
+        ("segment_count", WORDS_MAX_SEGMENTS),
+    ):
+        if type(diagnostic[field]) is not int or not 1 <= diagnostic[field] <= maximum:
+            _refuse()
+    index = diagnostic["word_index"]
+    if type(index) is not int or not 0 <= index < diagnostic["word_count"]:
+        _refuse()
+    begin = _number(diagnostic["word_start_seconds"], 0, WORDS_MAX_SAMPLE_SECONDS)
+    end = _number(diagnostic["word_end_seconds"], begin, WORDS_MAX_SAMPLE_SECONDS)
+    if end <= begin:
+        _refuse()
+    index = diagnostic["segment_index"]
+    if index is None:
+        if (
+            diagnostic["segment_start_seconds"] is not None
+            or diagnostic["segment_end_seconds"] is not None
+        ):
+            _refuse()
+    else:
+        if type(index) is not int or not 0 <= index < diagnostic["segment_count"]:
+            _refuse()
+        start = _number(
+            diagnostic["segment_start_seconds"], 0, WORDS_MAX_SAMPLE_SECONDS
+        )
+        finish = _number(
+            diagnostic["segment_end_seconds"], start, WORDS_MAX_SAMPLE_SECONDS
+        )
+        if finish <= start:
+            _refuse()
+    return diagnostic
+
+
+class WordSampleError(LocalMediaError):
+    """A segment-membership refusal with bounded numeric worker diagnostics."""
+
+    def __init__(self, diagnostic: Any):
+        self.word_timing = copy.deepcopy(validate_word_diagnostic(diagnostic))
+        super().__init__("whisper_word_sample_invalid_word_segment")
+
+
+def _provider_number(value: Any) -> Any:
+    # Native alignment returns NumPy real scalars. Project those losslessly to
+    # Python floats at this boundary; persisted receipts still require plain
+    # JSON numbers. This does not alter, interpolate or repair a timestamp.
+    if type(value) in (int, float) or not isinstance(value, Real):
+        return value
+    if isinstance(value, bool):
+        return value
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        _refuse()
+    if converted != value:
+        _refuse()
+    return converted
+
+
+def validate_word_model(value: Any) -> dict:
+    model = _object(value, {"id", "revision"})
+    if (
+        not isinstance(model["id"], str)
+        or len(model["id"]) > 120
+        or _MODEL.fullmatch(model["id"]) is None
+        or not isinstance(model["revision"], str)
+        or _REVISION.fullmatch(model["revision"]) is None
+    ):
+        _refuse()
+    return model
+
+
+def validate_word_sample(value: Any) -> dict:
+    sample = _object(
+        value,
+        {
+            "schema_version",
+            "pipeline_version",
+            "source_sha256",
+            "sample_sha256",
+            "source_duration_seconds",
+            "sample_start_seconds",
+            "sample_duration_seconds",
+            "provider",
+            "provider_version",
+            "model",
+            "language",
+            "language_probability",
+            "language_probe_seconds",
+            "words",
+            "segments",
+            "token_exclusions",
+        },
+    )
+    if (
+        type(sample["schema_version"]) is not int
+        or sample["schema_version"] != 2
+        or sample["pipeline_version"] != WORDS_PIPELINE_VERSION
+        or sample["provider"] != "mlx-whisper"
+        or not isinstance(sample["provider_version"], str)
+        or _VERSION.fullmatch(sample["provider_version"]) is None
+    ):
+        _refuse()
+    for key in ("source_sha256", "sample_sha256"):
+        if not isinstance(sample[key], str) or _SHA.fullmatch(sample[key]) is None:
+            _refuse()
+    validate_word_model(sample["model"])
+    duration = _number(sample["sample_duration_seconds"], 0, WORDS_MAX_SAMPLE_SECONDS)
+    source_duration = _number(
+        sample["source_duration_seconds"], 0, WORDS_MAX_SOURCE_SECONDS
+    )
+    start = _number(sample["sample_start_seconds"], 0, source_duration)
+    if duration <= 0 or start + duration > source_duration:
+        _refuse()
+    if (
+        not isinstance(sample["language"], str)
+        or _LANGUAGE.fullmatch(sample["language"]) is None
+    ):
+        _refuse()
+    _number(sample["language_probability"], 0, 1)
+    probe_seconds = _number(sample["language_probe_seconds"], 0, min(duration, 30))
+    if probe_seconds <= 0:
+        _refuse()
+    words = sample["words"]
+    if not isinstance(words, list) or not 1 <= len(words) <= WORDS_MAX_COUNT:
+        _refuse()
+    previous_end = 0.0
+    for word in words:
+        word = _object(
+            word,
+            {"text", "start_seconds", "end_seconds", "probability", "segment_index"},
+        )
+        text = word["text"]
+        if (
+            not isinstance(text, str)
+            or not text
+            or _token_bytes(text) > WORDS_MAX_TOKEN_BYTES
+            or any(ord(char) < 32 for char in text)
+            or any(char.isspace() for char in text)
+            or not any(char.isalnum() for char in text)
+        ):
+            _refuse("token")
+        try:
+            begin = _number(word["start_seconds"], 0, duration)
+            end = _number(word["end_seconds"], 0, duration)
+        except LocalMediaError:
+            _refuse("word_span")
+        if begin < previous_end:
+            _refuse("word_overlap")
+        if end <= begin:
+            _refuse("word_nonpositive_span")
+        try:
+            _number(word["probability"], 0, 1)
+        except LocalMediaError:
+            _refuse("word_probability")
+        previous_end = end
+    segments = sample["segments"]
+    if not isinstance(segments, list) or not 1 <= len(segments) <= WORDS_MAX_SEGMENTS:
+        _refuse()
+    previous_end = 0.0
+    for segment in segments:
+        segment = _object(
+            segment,
+            {
+                "start_seconds",
+                "end_seconds",
+                "compression_ratio",
+                "average_log_probability",
+                "no_speech_probability",
+            },
+        )
+        try:
+            begin = _number(segment["start_seconds"], previous_end, duration)
+            end = _number(segment["end_seconds"], begin, duration)
+        except LocalMediaError:
+            _refuse("segment_span")
+        if end <= begin:
+            _refuse("segment_span")
+        _number(segment["compression_ratio"], 0, 10000)
+        _number(segment["average_log_probability"], -10000, 0)
+        _number(segment["no_speech_probability"], 0, 1)
+        previous_end = end
+    # Preserve the provider's explicit membership, not a guessed containing box.
+    # MLX median-duration adjustments can place boundary words across the retained
+    # segment timestamp. Positive overlap binds quality metadata without changing
+    # either timestamp. Word/segment ordering and sample bounds still apply.
+    previous_index = 0
+    for word_index, word in enumerate(words):
+        index = word["segment_index"]
+        if type(index) is not int or not previous_index <= index < len(segments):
+            _refuse("word_segment")
+        previous_index = index
+        segment = segments[index]
+        if not (
+            segment["start_seconds"] < word["end_seconds"]
+            and word["start_seconds"] < segment["end_seconds"]
+        ):
+            raise WordSampleError(
+                {
+                    "schema_version": 1,
+                    "word_index": word_index,
+                    "word_count": len(words),
+                    "word_start_seconds": word["start_seconds"],
+                    "word_end_seconds": word["end_seconds"],
+                    "segment_index": index,
+                    "segment_count": len(segments),
+                    "segment_start_seconds": segment["start_seconds"],
+                    "segment_end_seconds": segment["end_seconds"],
+                }
+            )
+    exclusions = sample["token_exclusions"]
+    if not isinstance(exclusions, list) or len(exclusions) > WORDS_MAX_COUNT:
+        _refuse()
+    previous_index = -1
+    for item in exclusions:
+        item = _object(item, {"token_index", "reason"})
+        if (
+            type(item["token_index"]) is not int
+            or not previous_index < item["token_index"] < WORDS_MAX_COUNT
+            or item["reason"] != "punctuation_only"
+        ):
+            _refuse()
+        previous_index = item["token_index"]
+    return sample
+
+
+def normalize_word_result(
+    value: Any,
+    *,
+    source_sha256: str,
+    sample_sha256: str,
+    source_duration_seconds: float,
+    sample_start_seconds: float,
+    sample_duration_seconds: float,
+    provider_version: str,
+    model: dict,
+    language_probability: float,
+) -> dict:
+    """Project bounded provider output; never make up word times or confidence."""
+    if not isinstance(value, Mapping) or not isinstance(value.get("segments"), list):
+        _refuse()
+    if not 1 <= len(value["segments"]) <= WORDS_MAX_SEGMENTS:
+        _refuse()
+    words, segments, exclusions = [], [], []
+    token_index = 0
+    for segment_index, segment in enumerate(value["segments"]):
+        if not isinstance(segment, Mapping) or not isinstance(
+            segment.get("words"), list
+        ):
+            _refuse()
+        segments.append(
+            {
+                "start_seconds": _provider_number(segment.get("start")),
+                "end_seconds": _provider_number(segment.get("end")),
+                "compression_ratio": _provider_number(segment.get("compression_ratio")),
+                "average_log_probability": _provider_number(segment.get("avg_logprob")),
+                "no_speech_probability": _provider_number(
+                    segment.get("no_speech_prob")
+                ),
+            }
+        )
+        if token_index + len(segment["words"]) > WORDS_MAX_COUNT:
+            _refuse()
+        for word in segment["words"]:
+            if not isinstance(word, Mapping) or not isinstance(word.get("word"), str):
+                _refuse()
+            text = word["word"].strip()
+            if (
+                not text
+                or _token_bytes(text) > WORDS_MAX_TOKEN_BYTES
+                or any(ord(char) < 32 for char in text)
+            ):
+                _refuse()
+            if not any(char.isalnum() for char in text):
+                exclusions.append(
+                    {"token_index": token_index, "reason": "punctuation_only"}
+                )
+            else:
+                words.append(
+                    {
+                        "text": text,
+                        "start_seconds": _provider_number(word.get("start")),
+                        "end_seconds": _provider_number(word.get("end")),
+                        "probability": _provider_number(word.get("probability")),
+                        "segment_index": segment_index,
+                    }
+                )
+            token_index += 1
+    return validate_word_sample(
+        {
+            "schema_version": 2,
+            "pipeline_version": WORDS_PIPELINE_VERSION,
+            "source_sha256": source_sha256,
+            "sample_sha256": sample_sha256,
+            "source_duration_seconds": source_duration_seconds,
+            "sample_start_seconds": sample_start_seconds,
+            "sample_duration_seconds": sample_duration_seconds,
+            "provider": "mlx-whisper",
+            "provider_version": provider_version,
+            "model": copy.deepcopy(model),
+            "language": value.get("language"),
+            "language_probability": language_probability,
+            "language_probe_seconds": min(30.0, sample_duration_seconds),
+            "words": words,
+            "segments": segments,
+            "token_exclusions": exclusions,
+        }
+    )

--- a/skills/vault-profile/SKILL.md
+++ b/skills/vault-profile/SKILL.md
@@ -63,6 +63,8 @@ configuration. Never fall back to whichever `python3` happens to be on `PATH`.
   confirmed intents.
 - Read [speech-rates.md](references/speech-rates.md) before speech calibration or
   narration planning. Keep measured word-timing profiles separate from slide pacing.
+- Read [speech-calibration.md](references/speech-calibration.md) for the standalone
+  vault-root calibration command, sampled evidence, family balance and uncertainty.
 - Treat `tracking-database.json` as source of truth and `speaker-profile.json` as the
   output. Toolkit scripts, not prose, own cohort, opportunity, classification, pacing,
   and validation arithmetic.

--- a/skills/vault-profile/references/speech-calibration.md
+++ b/skills/vault-profile/references/speech-calibration.md
@@ -1,0 +1,182 @@
+# Family-Balanced Speech Calibration
+
+Owner: `vault-profile`. `speech_cohort.py` selects catalog declarations;
+`speech_calibration.py` owns the separate schema-v2 calibration profile. It
+does not restamp schema-v1 equal-sample profiles, change `speaker-profile.json`
+schema v5, or reparse talks. Fresh sampled word evidence comes exclusively from
+the ingress media owner; captions and segment-only receipts are not inputs.
+
+## Repeatable Command
+
+Use the parent skill's strict-owner bootstrap and exact configured interpreter.
+Pass its resolved vault root and explicit speaker identity and language:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-profile/scripts/calibrate-speech.py" \
+  "{vault_root}" --speaker "{speaker_name}" --language en
+```
+
+This defaults to metadata-only planning, including a core-runtime check. It does
+not open recordings or call providers. To acquire and measure, add `--run`;
+add `--allow-download` only when YouTube downloads are authorized. Local declared
+recordings remain preferred and a failed declared local source is not silently
+replaced by captions or another recording. `--maximum-recordings` bounds the
+selected cohort. Repeat `--demo-mode` for explicitly confirmed catalog mode IDs.
+`--as-of` accepts an explicit timezone-aware observation timestamp for replay.
+
+The script requires `core,source-media,speech-calibration` for `--run`, plus
+`youtube-download` when enabled. `check-runtime.py` owns the lane requirements.
+Missing configured runtime is a global refusal, never a fallback interpreter or
+automatic installation. Global model/dependency and scratch-cleanup failures
+abort without a candidate; source-specific acquisition failures remain exclusions.
+
+Stdout is one `{schema_version: 1, ok, data|error}` envelope. Successful `data`
+has `schema_version: 1`, `status`, `catalog_sha256`, `cohort`, `runtime`, and
+`profile`. Plan status is `plan_only` with null profile. A completed measured
+run has `calibrated` or `low_confidence` and a schema-v2 profile. `ok: true`
+means the command completed, not that its evidence supports confident planning.
+Retain the complete private report, including cohort exclusions and source
+locators, alongside any profile candidate. Progress diagnostics identify counts
+and closed reason codes, not transcript words or source paths. A segment/word
+membership refusal also emits one stderr JSON record with `schema_version: 1`,
+`code` and the ingress owner's closed numeric `word_timing` diagnostic. Exit codes and
+resource bounds belong to the command's module contract.
+
+The owner rereads the strict catalog before emitting a result. Any byte change
+invalidates the run. The command writes no vault artifacts; capture output only
+to a fresh private candidate and never redirect over a prior profile. Preserve
+existing transcripts, catalog state, queues and profiles throughout calibration.
+
+## Selection and Scope
+
+`plan_cohort(database, speaker, *, language, maximum_recordings=12,
+allow_download=False, demo_modes=())` accepts an ingress-owner-read database
+snapshot. The speaker must match `config.speaker_name`. Structured family,
+delivery mode, language and explicit solo-presenter declarations determine
+eligibility. Missing declarations remain exclusions, not inferred facts.
+Presentation-family IDs normalize whitespace and case, not title semantics.
+
+The schema-v1 plan retains its method version, speaker, language, options,
+ordered selected recording IDs and every catalog recording. Each recording
+has `schema_version: 1`, `recording_id`, `family`, `family_label`, `mode`,
+`language`, `year`, `youtube_id`, `source`, `status`, and `reasons`.
+Source is null or `{kind: "local_media", locator}` / `{kind: "youtube", video_id}`.
+Its shape belongs to the enclosing recording's version. A selected local
+locator is a declaration, not proof that the file is available. Source probing,
+duration, exact-byte identity and source-generation freshness belong to ingress.
+
+Explicit same-recording relationships prevent repeated selection. Conflicting
+families, unresolved duplicate identities, and multi-speaker declarations in
+otherwise excluded duplicates block that identity. Selection balances families,
+then prefers local sources and less-represented years and modes. Downloads
+require explicit opt-in. Budget exclusions remain visible. A cohort is not a
+random population sample; broad coverage does not remove catalog-selection bias.
+
+`sample_window()` chooses a substantial interior interval from the media owner's
+measured duration. Its constants own interval and source bounds. Unknown or
+short durations refuse. Interior placement avoids recording edges; it does
+not prove absence of audience Q&A, music or another voice. No diarization is
+performed. Explicit multi-speaker talks are excluded as whole recordings.
+Unverified mixed-speaker samples must not be promoted to speaker-only evidence.
+Demo/tutorial subsets require explicit catalog mode IDs; no mode is guessed
+from a title or assumed to mean demo.
+
+## Schema-v2 Request and Profile
+
+`speech_calibration.calibrate(request)` is pure arithmetic with no I/O. The
+closed request has exactly:
+
+```text
+{schema_version: 2, speaker, language, catalog_sha256, generated_at,
+ demo_modes: [mode_id, ...], samples: [sample, ...], exclusions: [exclusion, ...]}
+sample = {schema_version: 1, recording_id, family, mode, year: integer|null,
+          words: <ingress sampled-word receipt v2>}
+exclusion = {schema_version: 1, recording_id, reasons: [closed_reason_code, ...]}
+```
+
+`catalog_sha256` identifies the exact strict-reader snapshot; `generated_at`
+is an explicit timezone-aware observation time. Recording IDs occur once across
+samples and acquisition/selection exclusions. Bounds are code-owned. Malformed
+receipts fail the request rather than being repaired. Family IDs must already
+be normalized by the cohort owner. The input is retained unchanged apart from
+canonical ordering of samples, exclusions and demo IDs.
+
+The closed profile has exactly:
+
+```text
+{schema_version: 2, method_version, calibration, calibration_sha256,
+ quality_policy, confidence_policy, bootstrap, recordings, exclusions,
+ summary, by_mode, demo_subset, scope}
+```
+
+`calibration` is the complete request, including rejected transcription evidence.
+`calibration_sha256` is the owner's canonical JSON digest, not an authentication
+claim. Each admitted `recordings` row has `schema_version: 1`, `recording_id`,
+`family`, `year`, `mode`, `language`, `source_sha256`, `sample_sha256`,
+`sample_start_seconds`, `sample_duration_seconds`, `evidence_sha256`, `word_count`,
+`values`, and `denominators`. The last two maps retain all four named metrics.
+Acquisition and quality exclusions share the explicit exclusion shape above.
+
+`summary` has `schema_version: 1`, recording/family counts, analyzed and narration
+durations, year/mode coverage, confidence, families and metrics. Each family row
+has `schema_version: 1`, `family`, `recording_ids`, and four equally weighted
+recording `means`. Each metric has `schema_version: 1`, unit, pause threshold,
+family-balanced mean, family median, family standard deviation, family-mean
+range, observed-recording range, 95% mean confidence interval and conservative
+planning WPM. `speech_calibration.py` owns their exact key names and recomputation.
+`by_mode` maps mode IDs to the same summary shape. `demo_subset` retains explicit
+classification, mode IDs and a summary; an unclassified subset is not evidence
+that there are no demos. The enclosing profile version covers these fixed maps.
+
+## Quality and Uncertainty
+
+The versioned `quality_policy` rejects insufficient lexical evidence, short
+samples, low language/word confidence, excessive provider compression, poor log
+probability, non-speech hallucination indicators, impossible local word rates
+and repeated token blocks. Policy constants are not speaker-rate defaults.
+Genuine slow delivery is retained, not removed as a statistical outlier.
+The source-byte deduplication pass accepts at most one quality-passing sample
+per source; conflicting source durations refuse, and conflicting families
+exclude all samples for that digest.
+
+All metrics reuse the word-gap definitions from [speech-rates.md](speech-rates.md).
+The overall estimate weights each presentation family equally. Repeated
+deliveries affect their family's estimate, not its weight. Both mean and median
+are retained. `bootstrap` records schema, method, family-mean resampling unit,
+fixed seed, replicate count and interpretation. Its percentile interval is
+conditional uncertainty of the selected-family mean, **not** a future-recording
+prediction interval. It does not account for alignment errors or selection bias.
+
+The versioned confidence policy checks independent recordings, families,
+analyzed duration, actual narration duration, years and modes. Unknown years
+remain explicit. A homogeneous per-mode subset does not require multiple modes.
+Empty/sparse evidence reports low confidence; missing point estimates or
+intervals are null. Conservative planning rates remain null under low confidence.
+The result never substitutes research averages, articulation, or a generic WPM.
+
+## Persistence and Reader Contract
+
+Only vault-profile may write a calibration profile. Keep retained words and
+source locators private with the vault; never publish them in a plugin or issue.
+Validate a fresh candidate with `speech_calibration.validate_profile()` before
+publishing it. That reader recomputes every derived field and rejects tampering,
+unknown fields and unsupported versions. Preserve the old profile on failure.
+The shared `speech_rates.py calibrate` command also accepts the explicit v2
+request above, enabling owner recomputation from retained word receipts. Supply
+the request, not an old profile with edited derived fields. This arithmetic-only
+command does not acquire media or establish freshness. Its output envelope has
+the v2 profile in `data`; keep any replacement as a fresh private candidate.
+Before acting on stored evidence, revalidate source and catalog freshness
+through their owners; a matching internal digest alone is insufficient.
+
+Schema-v1 equal-sample profiles cannot be automatically upgraded: they lack
+family, speaker and quality evidence required by this method. Regenerate through
+the owner from fresh word samples. Non-owner readers never migrate or rewrite.
+The shared speech-rate reader, narration planner and creator outline/script
+readers support both v1 and v2 read-only. The v2 selector refuses low-confidence
+profiles and emits separate narration and conservative-planning fields; see
+[speech-rates.md](speech-rates.md) for the closed planning shapes. Deploy these
+readers before replacing a prior v1 profile. Recorder integration and human
+acceptance remain separate from calibration: an outline planning adapter is not
+an end-to-end screencast recorder. Recording verification remains based on actual full-recording
+word timestamps and duration, never on any planning-rate field.

--- a/skills/vault-profile/references/speech-rates.md
+++ b/skills/vault-profile/references/speech-rates.md
@@ -2,10 +2,16 @@
 
 Owner: `vault-profile`. Executable owner:
 `skills/vault-profile/scripts/speech_rates.py`. This is an independent
-schema-v1 artifact lane, not a change to `speaker-profile.json` schema v5 or
+versioned artifact lane, not a change to `speaker-profile.json` schema v5 or
 the tracking database. No operation here acquires media, runs Whisper, or
 reparses talks. Acquisition and source-generation verification remain the
 ingress owner's responsibility.
+
+The separate [family-balanced calibration contract](speech-calibration.md)
+defines schema v2, catalog cohort selection, sampled-transcription quality and
+bootstrap uncertainty. Schema v1 below remains the equal-sample arithmetic
+contract; it cannot be relabeled as schema-v2 evidence. `calibrate()`, `validate_profile()`,
+`validate_rate()` and `plan_duration()` accept both supported shapes read-only.
 
 ## Four Different Metrics
 
@@ -125,9 +131,42 @@ An assumed rate has the same rate keys, with `basis: "assumption"` and
 `provenance: {schema_version: 1, reason: string}`. Its positive ordered range
 must contain its point value. Library callers can construct one through
 `assumed_narration(low, high, reason=...)`. Never attach measured provenance
-to an assumption. `plan_duration` emits a schema-v1 prediction containing the
+to an assumption. With a v1 rate, `plan_duration` emits a schema-v1 prediction containing the
 selected complete rate, intended metric, word count, point duration, and
 inverted duration range, labeled `kind: "prediction_not_verification"`.
+
+With a v2 family-balanced profile, the owner validates the complete retained
+evidence and requires conditional confidence before selecting narration. A
+present sparse profile is rejected with `pace_confidence_insufficient`, even
+when an assumption is also supplied. No mean from a single recording becomes
+a planning default. The v2 output adds `conservative_estimated_seconds` and
+`range_kind: "observed_recording_range_not_prediction_interval"` to the same
+prediction fields and carries `schema_version: 2`. The point duration uses
+the family-balanced mean; the conservative duration uses the lower mean-CI
+rate. The duration range inverts historical recording rates, not the mean CI.
+Neither duration is a fit guarantee or substitutes for actual recording checks.
+
+`speech_calibration.narration_rate(profile)` returns this closed copied rate:
+
+```text
+{schema_version: 2, metric: "narration", unit: "words_per_minute",
+ pause_threshold_seconds: 2.0, value: <family-balanced mean>,
+ range: <observed recording range>, basis: "measured",
+ mean_confidence_interval_95: [low, high], conservative_planning_wpm: <CI low>,
+ provenance: {schema_version: 2, sample_count, presentation_family_count,
+   analyzed_duration_seconds, cohort: <speaker>, language, method_version,
+   evidence_sha256: [digest, ...], calibration_sha256,
+   range_kind: "observed_recording_range_not_prediction_interval",
+   confidence_level: "conditional",
+   interval_kind: "mean_uncertainty_conditional_on_selected_families_not_a_prediction_interval"}}
+```
+
+The rate retains distinct mean, observed range and conditional mean uncertainty.
+The method version is `family-balanced-word-gaps-v2`. Its calibration digest
+binds the complete owner request; evidence digests identify admitted recordings.
+This selector uses the overall cohort, not an implicitly inferred demo subset.
+An embedded rate is structurally checked but cannot independently authenticate
+the raw evidence: obtain it from a freshly owner-validated full profile.
 
 `verify_recording(evidence, *, maximum_duration_seconds)` has no planning-rate
 input. It requires word evidence covering the complete recording, not an
@@ -171,7 +210,7 @@ JSON help envelope without reading stdin. Interrupts propagate.
 New outlines carry root `schema_version: 1` and exactly one
 `talk.pacing_rate`: the complete typed narration rate from planning output.
 Both complete and partial outline readers reject unsupported explicit root
-versions and validate the embedded rate. The creator never recalculates or
+versions and validate v1/v2 embedded rates without migration. The creator never recalculates or
 edits measured provenance. Use a fresh owner-validated measured profile when
 available. A stale or invalid present profile requires owner attention.
 
@@ -182,6 +221,8 @@ unverified narration planning assumption with the v1 2-second gap definition.
 It cannot coexist with `pacing_rate`; the owner replaces it with a typed
 record on the next authoring pass. `extract-script.py` explicitly reports the
 metric, threshold, assumption/measured basis, and measured provenance/range.
+For a v2 rate, it also reports family count, family-balanced mean, conservative
+planning rate and conditional mean interval, explicitly not a prediction interval.
 It never labels predicted timing as verification.
 
 Legacy `speaker-profile.json.pacing.wpm_range` has the same unverified

--- a/skills/vault-profile/scripts/calibrate-speech.py
+++ b/skills/vault-profile/scripts/calibrate-speech.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Plan or derive a family-balanced speech calibration from one configured vault.
+
+Usage: calibrate-speech.py VAULT_ROOT --speaker NAME --language CODE [--run]
+       [--allow-download] [--maximum-recordings 12] [--demo-mode ID ...]
+       [--as-of TIMEZONE_AWARE_ISO_TIME]
+
+Default is metadata-only planning. --run enables bounded source acquisition and
+fresh native word transcription; --allow-download additionally enables the
+ingress YouTube owner when no local recording is declared. No captions, catalog
+reparsing, transcript writes, or existing-profile replacement occur. Use the
+database-configured interpreter; there is no PATH fallback or auto-install.
+
+Stdout: one schema-v1 {ok, data|error} JSON envelope. Successful data retains the
+catalog digest, complete cohort plan, runtime report, and (with --run) a complete
+schema-v2 profile. Treat this output as private evidence. A valid low-confidence
+report is not permission to use a planning default. Save to a fresh candidate,
+never redirect over an existing profile. Exit 0 reports a completed plan/run,
+1 rejects inputs or capabilities, 2 reports usage or unexpected tool failure.
+Per-recording acquisition failures remain explicit exclusions; global failures
+emit no usable candidate. Interrupts propagate. Bounds are owned by the cohort,
+speech-profile and ingress media contracts, not overridable CLI thresholds.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Iterator, NoReturn
+
+INGRESS = Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts"
+if str(INGRESS) not in sys.path:
+    sys.path.insert(0, str(INGRESS))
+
+from local_media_contract import LocalMediaError  # noqa: E402
+from local_media_download import download_youtube_audio  # noqa: E402
+from local_media_evidence import probe_local_media  # noqa: E402
+from local_media_transcription import transcribe_local_words  # noqa: E402
+from local_media_words import WordSampleError  # noqa: E402
+from speech_calibration import calibrate  # noqa: E402
+from speech_cohort import plan_cohort, sample_window  # noqa: E402
+from speech_rates import SpeechRateError, encode  # noqa: E402
+from tracking_database_io import TrackingDatabaseIOError  # noqa: E402
+from vault_root_authority import (  # noqa: E402
+    VaultRootAuthorityError,
+    materialize_native_authority,
+    resolve_vault_root_authority,
+)
+
+
+def _owner_script(filename: str) -> ModuleType:
+    """Load fixed shipped entrypoints; callers never choose a module or path."""
+    name = "speech_calibration_owner_" + filename.replace("-", "_").replace(".", "_")
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, INGRESS / filename)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("shipped owner module unavailable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _read_context(vault_root: str) -> tuple[Path, dict]:
+    root = materialize_native_authority(vault_root, authority="cli_root")
+    report = _owner_script("read-tracking-database.py").execute(
+        root / "tracking-database.json"
+    )
+    config = report["database"]["config"]
+    root = resolve_vault_root_authority(
+        database_path=report["database_path"], config=config, cli_vault_root=root
+    )
+    configured = config.get("python_path")
+    if not isinstance(configured, str) or configured != sys.executable:
+        raise SpeechRateError(
+            "pace_interpreter_mismatch",
+            "Use config.python_path from the strict owner read; repair missing configuration through ingress.",
+        )
+    return root, report
+
+
+@contextmanager
+def _source(row: dict, root: Path) -> Iterator[tuple[object, object]]:
+    source = row["source"]
+    if source["kind"] == "local_media":
+        # The acquisition owner receives the original locator. Do not resolve,
+        # pre-open, hash or hydrate the declared recording in this caller.
+        yield source["locator"], root
+    else:
+        with download_youtube_audio(source["video_id"]) as (path, provider_duration):
+            if provider_duration <= 0:
+                raise LocalMediaError("ytdlp_metadata_invalid")
+            yield path, path.parent
+
+
+def execute(args: argparse.Namespace) -> dict:
+    root, catalog = _read_context(args.vault_root)
+    generated_at = args.as_of or datetime.now(timezone.utc).isoformat()
+    # Validate supplied time before acquiring any media, using the owner schema.
+    calibration = {
+        "schema_version": 2,
+        "speaker": args.speaker,
+        "language": args.language,
+        "catalog_sha256": catalog["sha256"],
+        "generated_at": generated_at,
+        "demo_modes": args.demo_mode,
+        "samples": [],
+        "exclusions": [],
+    }
+    calibrate(calibration)
+    plan = plan_cohort(
+        catalog["database"],
+        args.speaker,
+        language=args.language,
+        maximum_recordings=args.maximum_recordings,
+        allow_download=args.allow_download,
+        demo_modes=args.demo_mode,
+    )
+    required = ["core"]
+    if args.run:
+        required += ["source-media", "speech-calibration"]
+        if args.allow_download:
+            required.append("youtube-download")
+    runtime = _owner_script("check-runtime.py").build_report(
+        tuple(required), tuple(required)
+    )
+    if runtime["ok"] is not True:
+        raise SpeechRateError(
+            "pace_runtime_unavailable",
+            "Run the configured interpreter's check-runtime.py for the required lanes; repair missing dependencies before calibration.",
+        )
+    result = {
+        "schema_version": 1,
+        "status": "plan_only",
+        "catalog_sha256": catalog["sha256"],
+        "cohort": plan,
+        "runtime": runtime,
+        "profile": None,
+    }
+    if args.run:
+        by_id = {row["recording_id"]: row for row in plan["recordings"]}
+        calibration["speaker"] = plan["speaker"]
+        calibration["exclusions"] = [
+            {
+                "schema_version": 1,
+                "recording_id": row["recording_id"],
+                "reasons": row["reasons"],
+            }
+            for row in plan["recordings"]
+            if row["status"] != "selected"
+        ]
+        for index, recording_id in enumerate(plan["selected_recording_ids"], 1):
+            print(
+                f"Speech calibration: recording {index}/{len(plan['selected_recording_ids'])}",
+                file=sys.stderr,
+                flush=True,
+            )
+            row = by_id[recording_id]
+            try:
+                with _source(row, root) as (path, trusted_root):
+                    probe = probe_local_media(path, trusted_root=trusted_root)
+                    start, duration = sample_window(probe.duration_seconds)
+                    _, receipt = transcribe_local_words(
+                        path,
+                        probe=probe,
+                        trusted_root=trusted_root,
+                        sample_start_seconds=start,
+                        sample_duration_seconds=duration,
+                    )
+                # A download context's cleanup must succeed before admission.
+                calibration["samples"].append(
+                    {
+                        "schema_version": 1,
+                        "recording_id": recording_id,
+                        "family": row["family"],
+                        "mode": row["mode"],
+                        "year": row["year"],
+                        "words": receipt,
+                    }
+                )
+            except (LocalMediaError, SpeechRateError) as exc:
+                reason = (
+                    exc.reason_code if isinstance(exc, LocalMediaError) else exc.code
+                )
+                if reason in {
+                    "media_cleanup_failed",
+                    "whisper_dependency_unavailable",
+                    "whisper_provider_version_unsupported",
+                    "whisper_model_download_failed",
+                }:
+                    raise
+                calibration["exclusions"].append(
+                    {
+                        "schema_version": 1,
+                        "recording_id": recording_id,
+                        "reasons": [reason],
+                    }
+                )
+                if isinstance(exc, WordSampleError):
+                    print(
+                        json.dumps(
+                            {
+                                "schema_version": 1,
+                                "code": reason,
+                                "word_timing": exc.word_timing,
+                            }
+                        ),
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                print(
+                    f"Speech calibration: recording excluded ({reason}); inspect the source through its owner.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+        profile = calibrate(calibration)
+        result["profile"] = profile
+        result["status"] = (
+            "calibrated"
+            if profile["summary"]["confidence"]["level"] == "conditional"
+            else "low_confidence"
+        )
+    _, current = _read_context(str(root))
+    if current["sha256"] != catalog["sha256"]:
+        raise SpeechRateError(
+            "pace_catalog_changed",
+            "The catalog changed during calibration; rerun against one unchanged owner snapshot.",
+        )
+    encode(result)
+    return result
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        raise SpeechRateError(
+            "pace_usage_invalid", "Use --help for the command's arguments."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv == ["--help"]:
+        print(json.dumps({"schema_version": 1, "ok": True, "data": {"help": __doc__}}))
+        return 0
+    parser = _Parser(add_help=False)
+    parser.add_argument("vault_root")
+    parser.add_argument("--speaker", required=True)
+    parser.add_argument("--language", required=True)
+    parser.add_argument("--run", action="store_true")
+    parser.add_argument("--allow-download", action="store_true")
+    parser.add_argument("--maximum-recordings", type=int, default=12)
+    parser.add_argument("--demo-mode", action="append", default=[])
+    parser.add_argument("--as-of")
+    try:
+        result = execute(parser.parse_args(argv))
+    except (
+        SpeechRateError,
+        LocalMediaError,
+        TrackingDatabaseIOError,
+        VaultRootAuthorityError,
+    ) as exc:
+        if isinstance(exc, SpeechRateError):
+            code, message = exc.code, str(exc)
+        elif isinstance(exc, LocalMediaError):
+            code, message = (
+                exc.reason_code,
+                "Repair the bounded media owner's source, runtime or cleanup failure before rerunning.",
+            )
+        else:
+            code, message = (
+                "pace_catalog_unavailable",
+                "Repair the vault root or catalog through its strict ingress owner reader.",
+            )
+        print(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "ok": False,
+                    "error": {"code": code, "message": message},
+                }
+            )
+        )
+        print(f"Speech calibration failed: {code}; {message}", file=sys.stderr)
+        return 2 if code == "pace_usage_invalid" else 1
+    print(encode({"schema_version": 1, "ok": True, "data": result}).decode())
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    # Callers require one JSON failure envelope; a traceback/non-JSON exit is
+    # their silent-failure shape. Emit a closed tool error so propagation cannot
+    # erase the report or disclose provider/source data. outer-boundary-process-contract.
+    except Exception:  # noqa: BLE001
+        print(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "ok": False,
+                    "error": {
+                        "code": "pace_tool_failed",
+                        "message": "Inspect the configured runtime and rerun the calibration owner.",
+                    },
+                }
+            )
+        )
+        print("Speech calibration failed: pace_tool_failed", file=sys.stderr)
+        raise SystemExit(2) from None

--- a/skills/vault-profile/scripts/speech_calibration.py
+++ b/skills/vault-profile/scripts/speech_calibration.py
@@ -1,0 +1,580 @@
+"""Family-balanced sampled-speech profiles; deterministic arithmetic, no I/O.
+
+Owner: vault-profile. Profile schema v2 is distinct from the v1 equal-sample
+profile; v1 data must never be relabeled as family-balanced evidence. Every
+derived field can be recomputed from the retained calibration request. Bootstrap
+intervals describe the mean conditional on the selected presentation families,
+not a prediction interval for an individual future recording.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import copy
+from datetime import datetime
+import hashlib
+import math
+from pathlib import Path
+import random
+import re
+import statistics
+import sys
+from typing import Any, NoReturn
+
+INGRESS_SCRIPTS = Path(__file__).resolve().parents[2] / "vault-ingress" / "scripts"
+if str(INGRESS_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(INGRESS_SCRIPTS))
+
+from local_media_words import LocalMediaError, validate_word_sample  # noqa: E402
+from speech_rates import (  # noqa: E402
+    MAX_SAMPLES,
+    THRESHOLDS,
+    SpeechRateError,
+    encode,
+    measure,
+    validate_rate,
+)
+
+
+CALIBRATION_METHOD = "family-balanced-word-gaps-v2"
+MEAN_INTERVAL_KIND = (
+    "mean_uncertainty_conditional_on_selected_families_not_a_prediction_interval"
+)
+QUALITY_METHOD = "sampled-whisper-quality-v1"
+BOOTSTRAP_SEED = 368
+BOOTSTRAP_REPLICATES = 4000
+QUALITY_POLICY = {
+    "schema_version": 1,
+    "method_version": QUALITY_METHOD,
+    "minimum_language_probability": 0.8,
+    "minimum_mean_word_probability": 0.65,
+    "maximum_compression_ratio": 2.4,
+    "minimum_average_log_probability": -1.0,
+    "maximum_no_speech_probability": 0.6,
+    "maximum_twelve_word_wpm": 600.0,
+    "minimum_lexical_words": 50,
+    "minimum_sample_seconds": 180.0,
+    "repetition_minimum_cycles": 4,
+    "repetition_minimum_words": 24,
+}
+CONFIDENCE_POLICY = {
+    "schema_version": 1,
+    "minimum_recordings": 8,
+    "minimum_families": 5,
+    "minimum_analyzed_seconds": 3600.0,
+    "minimum_years": 3,
+    "minimum_modes": 2,
+    "minimum_narration_seconds": 1800.0,
+}
+_SHA = re.compile(r"[0-9a-f]{64}\Z")
+_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+
+
+def _fail(code: str, action: str) -> NoReturn:
+    raise SpeechRateError(code, action)
+
+
+def _closed(value: Any, version: int, fields: set[str]) -> dict:
+    if (
+        not isinstance(value, dict)
+        or set(value) != fields | {"schema_version"}
+        or type(value["schema_version"]) is not int
+        or value["schema_version"] != version
+    ):
+        _fail("pace_shape_invalid", "Use the documented owner calibration schema.")
+    return value
+
+
+def _label(value: Any, *, maximum: int = 500) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > maximum
+        or any(ord(char) < 32 for char in value)
+    ):
+        _fail(
+            "pace_metadata_invalid",
+            "Preserve bounded recording and cohort identifiers.",
+        )
+    return value
+
+
+def _sample(value: Any) -> dict:
+    sample = _closed(value, 1, {"recording_id", "family", "mode", "year", "words"})
+    for key in ("recording_id", "family", "mode"):
+        _label(sample[key])
+    if sample["family"] != " ".join(sample["family"].split()).casefold():
+        _fail("pace_family_invalid", "Use the cohort owner's normalized family ID.")
+    year = sample["year"]
+    if year is not None and (type(year) is not int or not 1 <= year <= 9999):
+        _fail(
+            "pace_metadata_invalid",
+            "Preserve the catalog year or an explicit unknown year.",
+        )
+    validate_word_sample(sample["words"])
+    return sample
+
+
+def _word_evidence(sample: dict) -> dict:
+    words = sample["words"]
+    model = words["model"]
+    aligner = (
+        f"mlx-whisper/{words['provider_version']};{model['id']}@{model['revision']}"
+    )
+    return {
+        "schema_version": 1,
+        "timing_kind": "recorded_words",
+        "source_sha256": words["source_sha256"],
+        "source_duration_seconds": words["source_duration_seconds"],
+        "sample_start_seconds": words["sample_start_seconds"],
+        "sample_duration_seconds": words["sample_duration_seconds"],
+        "aligner": aligner,
+        "words": [
+            [item["text"], item["start_seconds"], item["end_seconds"]]
+            for item in words["words"]
+        ],
+    }
+
+
+def _repetitive(tokens: list[str]) -> bool:
+    for width in range(2, 9):
+        for offset in range(width):
+            previous = None
+            run = 0
+            for index in range(offset, len(tokens) - width + 1, width):
+                block = tokens[index : index + width]
+                run = run + 1 if block == previous else 1
+                previous = block
+                if (
+                    run >= QUALITY_POLICY["repetition_minimum_cycles"]
+                    and run * width >= QUALITY_POLICY["repetition_minimum_words"]
+                ):
+                    return True
+    return False
+
+
+def quality_findings(sample: dict, expected_language: str) -> list[str]:
+    """Reject source/timing pathologies, not legitimate slow or fast outliers."""
+    receipt = sample["words"]
+    words = receipt["words"]
+    reasons = set()
+    if receipt["language"] != expected_language:
+        reasons.add("transcribed_language_mismatch")
+    if receipt["language_probability"] < QUALITY_POLICY["minimum_language_probability"]:
+        reasons.add("language_confidence_low")
+    if len(words) < QUALITY_POLICY["minimum_lexical_words"]:
+        reasons.add("insufficient_lexical_evidence")
+    if receipt["sample_duration_seconds"] < QUALITY_POLICY["minimum_sample_seconds"]:
+        reasons.add("sample_too_short")
+    if (
+        statistics.mean(word["probability"] for word in words)
+        < QUALITY_POLICY["minimum_mean_word_probability"]
+    ):
+        reasons.add("word_confidence_low")
+    for segment in receipt["segments"]:
+        if segment["compression_ratio"] > QUALITY_POLICY["maximum_compression_ratio"]:
+            reasons.add("transcription_compression_excessive")
+        if (
+            segment["average_log_probability"]
+            < QUALITY_POLICY["minimum_average_log_probability"]
+        ):
+            reasons.add("transcription_log_probability_low")
+            if (
+                segment["no_speech_probability"]
+                > QUALITY_POLICY["maximum_no_speech_probability"]
+            ):
+                reasons.add("nonspeech_hallucination")
+    for index in range(len(words) - 11):
+        elapsed = words[index + 11]["end_seconds"] - words[index]["start_seconds"]
+        if 12 * 60 / elapsed > QUALITY_POLICY["maximum_twelve_word_wpm"]:
+            reasons.add("impossible_local_word_rate")
+            break
+    tokens = [re.sub(r"\W+", "", word["text"].casefold()) for word in words]
+    if _repetitive(tokens):
+        reasons.add("repeated_phrase_hallucination")
+    return sorted(reasons)
+
+
+def _quantile(ordered: list[float], probability: float) -> float:
+    position = (len(ordered) - 1) * probability
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def _bootstrap(values: list[float]) -> list[float] | None:
+    if len(values) < 2:
+        return None
+    # The production algorithm owns its fixed resampling seed and count. Test
+    # fixtures never use RNG to generate or select the data under test.
+    rng = random.Random(BOOTSTRAP_SEED)
+    means = sorted(
+        # Use the same correctly rounded mean as the reported family estimate.
+        # Summing then dividing can round a constant five-family resample just
+        # beyond its observed endpoint and make a valid copied rate fail closed.
+        statistics.mean(values[rng.randrange(len(values))] for _ in values)
+        for _ in range(BOOTSTRAP_REPLICATES)
+    )
+    return [_quantile(means, 0.025), _quantile(means, 0.975)]
+
+
+def _confidence(recordings: list[dict], *, mode_subset: bool = False) -> dict:
+    families = {row["family"] for row in recordings}
+    years = {row["year"] for row in recordings if row["year"] is not None}
+    modes = {row["mode"] for row in recordings}
+    seconds = math.fsum(row["sample_duration_seconds"] for row in recordings)
+    reasons = []
+    for failed, reason in (
+        (
+            len(recordings) < CONFIDENCE_POLICY["minimum_recordings"],
+            "too_few_recordings",
+        ),
+        (
+            len(families) < CONFIDENCE_POLICY["minimum_families"],
+            "too_few_presentation_families",
+        ),
+        (
+            seconds < CONFIDENCE_POLICY["minimum_analyzed_seconds"],
+            "too_little_recorded_speech",
+        ),
+        (len(years) < CONFIDENCE_POLICY["minimum_years"], "year_coverage_narrow"),
+        (
+            not mode_subset and len(modes) < CONFIDENCE_POLICY["minimum_modes"],
+            "delivery_modes_homogeneous",
+        ),
+        (any(row["year"] is None for row in recordings), "catalog_year_unknown"),
+        (
+            math.fsum(row["denominators"]["narration"] for row in recordings)
+            < CONFIDENCE_POLICY["minimum_narration_seconds"],
+            "too_little_narration_evidence",
+        ),
+    ):
+        if failed:
+            reasons.append(reason)
+    return {
+        "schema_version": 1,
+        "level": "low" if reasons else "conditional",
+        "reasons": reasons,
+    }
+
+
+def _summarize(recordings: list[dict], *, mode_subset: bool = False) -> dict:
+    by_family = defaultdict(list)
+    for recording in recordings:
+        by_family[recording["family"]].append(recording)
+    families = []
+    for family in sorted(by_family):
+        members = by_family[family]
+        families.append(
+            {
+                "schema_version": 1,
+                "family": family,
+                "recording_ids": sorted(member["recording_id"] for member in members),
+                "means": {
+                    metric: statistics.mean(
+                        member["values"][metric] for member in members
+                    )
+                    for metric in THRESHOLDS
+                },
+            }
+        )
+    confidence = _confidence(recordings, mode_subset=mode_subset)
+    metrics = {}
+    for metric, threshold in THRESHOLDS.items():
+        observed = [row["values"][metric] for row in recordings]
+        means = [family["means"][metric] for family in families]
+        interval = _bootstrap(means) if means else None
+        metrics[metric] = {
+            "schema_version": 1,
+            "unit": "words_per_minute",
+            "pause_threshold_seconds": threshold,
+            "family_balanced_mean": statistics.mean(means) if means else None,
+            "family_median": statistics.median(means) if means else None,
+            "family_standard_deviation": statistics.pstdev(means) if means else None,
+            "family_mean_range": [min(means), max(means)] if means else None,
+            "observed_recording_range": [min(observed), max(observed)]
+            if observed
+            else None,
+            "mean_confidence_interval_95": interval,
+            "conservative_planning_wpm": interval[0]
+            if interval is not None and confidence["level"] == "conditional"
+            else None,
+        }
+    return {
+        "schema_version": 1,
+        "recording_count": len(recordings),
+        "presentation_family_count": len(families),
+        "analyzed_duration_seconds": math.fsum(
+            row["sample_duration_seconds"] for row in recordings
+        ),
+        "narration_duration_seconds": math.fsum(
+            row["denominators"]["narration"] for row in recordings
+        ),
+        "years": sorted({row["year"] for row in recordings if row["year"] is not None}),
+        "modes": sorted({row["mode"] for row in recordings}),
+        "confidence": confidence,
+        "families": families,
+        "metrics": metrics,
+    }
+
+
+def calibrate(request: Any) -> dict:
+    """Build v2 from owner word samples and explicit acquisition exclusions."""
+    encode(request)
+    request = _closed(
+        request,
+        2,
+        {
+            "speaker",
+            "language",
+            "catalog_sha256",
+            "generated_at",
+            "demo_modes",
+            "samples",
+            "exclusions",
+        },
+    )
+    _label(request["speaker"])
+    _label(request["language"], maximum=32)
+    if re.fullmatch(r"[a-z]{2,3}(?:-[a-z0-9]{2,8})*", request["language"]) is None:
+        _fail("pace_language_invalid", "Supply an explicit language code.")
+    digest = request["catalog_sha256"]
+    if not isinstance(digest, str) or _SHA.fullmatch(digest) is None:
+        _fail(
+            "pace_catalog_binding_invalid",
+            "Use the exact strict-owner catalog snapshot digest.",
+        )
+    generated_at = _label(request["generated_at"], maximum=100)
+    try:
+        stamp = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise SpeechRateError(
+            "pace_timestamp_invalid",
+            "Supply an explicit timezone-aware observation time.",
+        ) from exc
+    if stamp.utcoffset() is None:
+        _fail(
+            "pace_timestamp_invalid",
+            "Supply an explicit timezone-aware observation time.",
+        )
+    demo_modes = request["demo_modes"]
+    if not isinstance(demo_modes, list) or len(demo_modes) > 64:
+        _fail(
+            "pace_demo_modes_invalid",
+            "Supply a bounded list of explicit demo/tutorial mode IDs.",
+        )
+    for mode in demo_modes:
+        _label(mode, maximum=64)
+    if len(set(demo_modes)) != len(demo_modes):
+        _fail("pace_demo_modes_invalid", "Supply unique demo/tutorial mode IDs.")
+    samples = request["samples"]
+    exclusions = request["exclusions"]
+    if (
+        not isinstance(samples, list)
+        or len(samples) > MAX_SAMPLES
+        or not isinstance(exclusions, list)
+        or len(exclusions) > 10000
+    ):
+        _fail(
+            "pace_cohort_limit_invalid",
+            "Use at most 64 samples and 10,000 explicit exclusions.",
+        )
+    identifiers = set()
+    rejected = []
+    for exclusion in exclusions:
+        exclusion = _closed(exclusion, 1, {"recording_id", "reasons"})
+        identifier = _label(exclusion["recording_id"])
+        reasons = exclusion["reasons"]
+        if (
+            not isinstance(reasons, list)
+            or not 1 <= len(reasons) <= 64
+            or any(
+                not isinstance(reason, str) or _CODE.fullmatch(reason) is None
+                for reason in reasons
+            )
+        ):
+            _fail(
+                "pace_exclusion_invalid",
+                "Record bounded, explicit exclusion reason codes.",
+            )
+        if identifier in identifiers:
+            _fail("pace_recording_duplicate", "Report each recording identity once.")
+        identifiers.add(identifier)
+        rejected.append(copy.deepcopy(exclusion))
+    admitted = []
+    source_groups = defaultdict(list)
+    for value in samples:
+        sample = _sample(value)
+        identifier = sample["recording_id"]
+        if identifier in identifiers:
+            _fail("pace_recording_duplicate", "Report each recording identity once.")
+        identifiers.add(identifier)
+        source_groups[sample["words"]["source_sha256"]].append(sample)
+    for source in sorted(source_groups):
+        group = sorted(source_groups[source], key=lambda sample: sample["recording_id"])
+        if len({sample["words"]["source_duration_seconds"] for sample in group}) != 1:
+            _fail(
+                "pace_source_inconsistent",
+                "Use one measured duration per unchanged source digest.",
+            )
+        conflicting_family = len({sample["family"] for sample in group}) != 1
+        source_admitted = False
+        for sample in group:
+            reasons = quality_findings(sample, request["language"])
+            if conflicting_family:
+                reasons.append("source_family_conflict")
+            elif source_admitted:
+                reasons.append("duplicate_source_bytes")
+            if reasons:
+                rejected.append(
+                    {
+                        "schema_version": 1,
+                        "recording_id": sample["recording_id"],
+                        "reasons": sorted(set(reasons)),
+                    }
+                )
+                continue
+            result = measure(_word_evidence(sample))
+            source_admitted = True
+            admitted.append(
+                {
+                    "schema_version": 1,
+                    "recording_id": sample["recording_id"],
+                    "family": sample["family"],
+                    "year": sample["year"],
+                    "mode": sample["mode"],
+                    "language": sample["words"]["language"],
+                    "source_sha256": sample["words"]["source_sha256"],
+                    "sample_sha256": sample["words"]["sample_sha256"],
+                    "sample_start_seconds": sample["words"]["sample_start_seconds"],
+                    "sample_duration_seconds": sample["words"][
+                        "sample_duration_seconds"
+                    ],
+                    "evidence_sha256": result["evidence_sha256"],
+                    "word_count": result["word_count"],
+                    "values": {
+                        rate["metric"]: rate["value"] for rate in result["rates"]
+                    },
+                    "denominators": {
+                        rate["metric"]: rate["denominator_seconds"]
+                        for rate in result["rates"]
+                    },
+                }
+            )
+    admitted.sort(key=lambda recording: recording["recording_id"])
+    rejected.sort(key=lambda exclusion: exclusion["recording_id"])
+    canonical = copy.deepcopy(request)
+    canonical["samples"] = sorted(
+        canonical["samples"], key=lambda sample: sample["recording_id"]
+    )
+    canonical["exclusions"] = sorted(
+        canonical["exclusions"], key=lambda exclusion: exclusion["recording_id"]
+    )
+    canonical["demo_modes"] = sorted(demo_modes)
+    summary = _summarize(admitted)
+    demo = [row for row in admitted if row["mode"] in demo_modes]
+    result = {
+        "schema_version": 2,
+        "method_version": CALIBRATION_METHOD,
+        "calibration": canonical,
+        "calibration_sha256": hashlib.sha256(encode(canonical)).hexdigest(),
+        "quality_policy": copy.deepcopy(QUALITY_POLICY),
+        "confidence_policy": copy.deepcopy(CONFIDENCE_POLICY),
+        "bootstrap": {
+            "schema_version": 1,
+            "unit": "presentation_family_mean",
+            "method": "percentile",
+            "replicates": BOOTSTRAP_REPLICATES,
+            "seed": BOOTSTRAP_SEED,
+            "interpretation": MEAN_INTERVAL_KIND,
+        },
+        "recordings": admitted,
+        "exclusions": rejected,
+        "summary": summary,
+        "by_mode": {
+            mode: _summarize(
+                [row for row in admitted if row["mode"] == mode], mode_subset=True
+            )
+            for mode in summary["modes"]
+        },
+        "demo_subset": {
+            "classification": "explicit_mode_ids" if demo_modes else "not_classified",
+            "mode_ids": sorted(demo_modes),
+            "summary": _summarize(demo, mode_subset=True),
+        },
+        "scope": {
+            "speaker_basis": "catalog_declared_solo_presenter",
+            "language_confidence_basis": "first_30_seconds_of_each_sample",
+            "speaker_diarization": "not_performed",
+            "population_generalization": "not_established",
+        },
+    }
+    encode(result)
+    return result
+
+
+def validate_profile(value: Any) -> dict:
+    if (
+        not isinstance(value, dict)
+        or type(value.get("schema_version")) is not int
+        or value.get("schema_version") != 2
+    ):
+        _fail("pace_shape_invalid", "Use a current family-balanced owner profile.")
+    if "calibration" not in value:
+        _fail("pace_shape_invalid", "Retain the complete owner calibration request.")
+    try:
+        expected = calibrate(value["calibration"])
+    except LocalMediaError:
+        _fail(
+            "pace_word_evidence_invalid",
+            "Reacquire invalid word evidence through the ingress owner before planning.",
+        )
+    if encode(value) != encode(expected):
+        _fail(
+            "pace_profile_inconsistent",
+            "Regenerate derived calibration fields through the owner; never restamp them.",
+        )
+    return value
+
+
+def narration_rate(profile: Any) -> dict:
+    """Select an overall v2 narration rate only from validated, covered evidence."""
+    profile = validate_profile(profile)
+    summary = profile["summary"]
+    if summary["confidence"]["level"] != "conditional":
+        _fail(
+            "pace_confidence_insufficient",
+            "Acquire broader independent recording evidence through the owner; a low-confidence profile is not a planning default.",
+        )
+    metric = summary["metrics"]["narration"]
+    return validate_rate(
+        {
+            "schema_version": 2,
+            "metric": "narration",
+            "unit": metric["unit"],
+            "pause_threshold_seconds": metric["pause_threshold_seconds"],
+            "value": metric["family_balanced_mean"],
+            "range": copy.deepcopy(metric["observed_recording_range"]),
+            "basis": "measured",
+            "mean_confidence_interval_95": copy.deepcopy(
+                metric["mean_confidence_interval_95"]
+            ),
+            "conservative_planning_wpm": metric["conservative_planning_wpm"],
+            "provenance": {
+                "schema_version": 2,
+                "sample_count": summary["recording_count"],
+                "presentation_family_count": summary["presentation_family_count"],
+                "analyzed_duration_seconds": summary["analyzed_duration_seconds"],
+                "cohort": profile["calibration"]["speaker"],
+                "language": profile["calibration"]["language"],
+                "method_version": CALIBRATION_METHOD,
+                "evidence_sha256": [
+                    row["evidence_sha256"] for row in profile["recordings"]
+                ],
+                "calibration_sha256": profile["calibration_sha256"],
+                "range_kind": "observed_recording_range_not_prediction_interval",
+                "confidence_level": "conditional",
+                "interval_kind": MEAN_INTERVAL_KIND,
+            },
+        }
+    )

--- a/skills/vault-profile/scripts/speech_cohort.py
+++ b/skills/vault-profile/scripts/speech_cohort.py
@@ -1,0 +1,329 @@
+"""Deterministic, read-only cohort planning for recorded speech calibration.
+
+The caller supplies a strict ingress-owner database snapshot. This module does
+not open media, infer speaker identity, infer presentation families, or rewrite
+catalog data. Every talk remains in the report, including exclusions. Family,
+mode, language, and solo-speaker declarations come from structured_data.
+Actual source availability, duration, and generation are acquisition-owner facts,
+not established by this metadata-only plan.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from datetime import date
+import re
+from typing import Any, NoReturn
+
+from speech_rates import MAX_DURATION_SECONDS, MAX_SAMPLES, SpeechRateError
+
+
+COHORT_METHOD = "catalog-solo-family-coverage-v1"
+MAX_TALKS = 10000
+SAMPLE_TARGET_SECONDS = 600.0
+SAMPLE_MINIMUM_SECONDS = 180.0
+EDGE_MARGIN_SECONDS = 30.0
+_VIDEO_ID = re.compile(r"[A-Za-z0-9_-]{11}\Z")
+_LANGUAGE = re.compile(r"[a-z]{2,3}(?:-[a-z0-9]{2,8})*\Z")
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpeechRateError(code, message)
+
+
+def _label(value: Any, *, limit: int = 500) -> str | None:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > limit
+        or any(ord(char) < 32 for char in value)
+    ):
+        return None
+    return " ".join(value.split())
+
+
+def _year(value: Any) -> int | None:
+    if (
+        not isinstance(value, str)
+        or re.fullmatch(r"\d{4}(?:-\d{2}(?:-\d{2})?)?", value) is None
+    ):
+        return None
+    parts = [int(part) for part in value.split("-")]
+    try:
+        return date(*parts, *([1] * (3 - len(parts)))).year
+    except ValueError:
+        return None
+
+
+def _candidate(talk: dict, language: str, allow_download: bool) -> dict:
+    filename = talk["filename"]
+    structured = talk.get("structured_data")
+    structured = structured if isinstance(structured, Mapping) else {}
+    family = _label(structured.get("talk_family"))
+    mode = _label(structured.get("mode"), limit=64)
+    declared_language = _label(structured.get("delivery_language"), limit=32)
+    declared_language = declared_language.casefold() if declared_language else None
+    reasons = []
+    if family is None:
+        reasons.append("presentation_family_missing")
+    if mode is None:
+        reasons.append("delivery_mode_missing")
+    if declared_language is None:
+        reasons.append("delivery_language_missing")
+    elif declared_language != language:
+        reasons.append("different_delivery_language")
+    # A missing declaration is not proof of single-speaker audio. Never infer
+    # which voice belongs to the vault owner from a talk title or transcript.
+    if structured.get("co_presenter") is not False:
+        reasons.append(
+            "multiple_speakers"
+            if structured.get("co_presenter") is True
+            else "solo_speaker_scope_unverified"
+        )
+    co_presenters = structured.get("co_presenters")
+    if co_presenters not in (None, []):
+        reasons.append("co_presenters_declared")
+    extraction = structured.get("video_extraction")
+    extraction = extraction if isinstance(extraction, Mapping) else {}
+    declared_paths = [
+        value
+        for value in (
+            talk.get("video_local_path"),
+            talk.get("video_path"),
+            extraction.get("source_video_path"),
+        )
+        if value is not None and value != ""
+    ]
+    source = None
+    if declared_paths:
+        if any(_label(value, limit=8192) is None for value in declared_paths):
+            reasons.append("local_recording_locator_invalid")
+        elif len(set(declared_paths)) != 1:
+            reasons.append("local_recording_locator_conflict")
+        else:
+            # Keep the literal locator. Only the acquisition owner resolves it.
+            source = {"kind": "local_media", "locator": declared_paths[0]}
+    video_id = talk.get("youtube_id")
+    if video_id in (None, ""):
+        video_id = None
+    elif not isinstance(video_id, str) or _VIDEO_ID.fullmatch(video_id) is None:
+        reasons.append("recording_identity_invalid")
+        video_id = None
+    if source is None and not declared_paths:
+        if video_id is not None and allow_download:
+            source = {"kind": "youtube", "video_id": video_id}
+        else:
+            reasons.append(
+                "recording_download_not_enabled"
+                if video_id is not None
+                else "recording_source_missing"
+            )
+    return {
+        "schema_version": 1,
+        "recording_id": filename,
+        "family": family.casefold() if family else None,
+        "family_label": family,
+        "mode": mode,
+        "language": declared_language,
+        "year": _year(talk.get("date")),
+        "youtube_id": video_id,
+        "source": source,
+        "status": "excluded" if reasons else "eligible",
+        "reasons": sorted(set(reasons)),
+    }
+
+
+def _canonical_duplicate(group: list[dict], talks: dict[str, dict]) -> dict | None:
+    """Honor an explicit same-recording relation; never merge conflicting facts."""
+    if len({row["family"] for row in group}) != 1:
+        return None
+    names = {row["recording_id"] for row in group}
+    canonical = []
+    for row in group:
+        talk = talks[row["recording_id"]]
+        relation = talk.get("source_relation")
+        target = None
+        if isinstance(relation, Mapping) and relation.get("type") in {
+            "duplicate",
+            "borrowed_recording",
+        }:
+            target = relation.get("target_filename")
+        if target is None:
+            target = next(
+                (
+                    talk[key]
+                    for key in (
+                        "duplicate_of",
+                        "_duplicate_of",
+                        "borrowed_recording_from",
+                        "_borrowed_recording_from",
+                    )
+                    if key in talk
+                ),
+                None,
+            )
+        if target is None:
+            canonical.append(row)
+        elif (
+            not isinstance(target, str)
+            or target not in names
+            or target == row["recording_id"]
+        ):
+            return None
+    return canonical[0] if len(canonical) == 1 else None
+
+
+def plan_cohort(
+    database: Any,
+    speaker: str,
+    *,
+    language: str,
+    maximum_recordings: int = 12,
+    allow_download: bool = False,
+    demo_modes: tuple[str, ...] = (),
+) -> dict:
+    """Plan a bounded diverse cohort; all metadata decisions remain inspectable."""
+    if not isinstance(database, dict) or not isinstance(database.get("config"), dict):
+        _fail("pace_database_invalid", "Read a strict ingress-owner database snapshot.")
+    requested = _label(speaker)
+    configured = _label(database["config"].get("speaker_name"))
+    if (
+        requested is None
+        or configured is None
+        or requested.casefold() != configured.casefold()
+    ):
+        _fail(
+            "pace_speaker_unverified",
+            "Select the speaker explicitly named in the vault configuration.",
+        )
+    if not isinstance(language, str) or _LANGUAGE.fullmatch(language) is None:
+        _fail(
+            "pace_language_invalid",
+            "Select an explicit lowercase delivery-language code.",
+        )
+    if (
+        type(maximum_recordings) is not int
+        or not 1 <= maximum_recordings <= MAX_SAMPLES
+    ):
+        _fail("pace_cohort_limit_invalid", "Select one to 64 recordings.")
+    if type(allow_download) is not bool:
+        _fail(
+            "pace_download_option_invalid",
+            "Explicitly enable or disable recording downloads.",
+        )
+    if (
+        not isinstance(demo_modes, (tuple, list))
+        or any(
+            _label(mode, limit=64) is None or _label(mode, limit=64) != mode
+            for mode in demo_modes
+        )
+        or len(set(demo_modes)) != len(demo_modes)
+    ):
+        _fail(
+            "pace_demo_modes_invalid",
+            "Supply unique explicit demo/tutorial mode identifiers.",
+        )
+    raw = database.get("talks")
+    if not isinstance(raw, list) or len(raw) > MAX_TALKS:
+        _fail(
+            "pace_database_invalid",
+            "Read an owner snapshot containing at most 10,000 talks.",
+        )
+    talks = {}
+    for talk in raw:
+        if (
+            not isinstance(talk, dict)
+            or _label(talk.get("filename"), limit=500) is None
+            or _label(talk.get("filename"), limit=500) != talk.get("filename")
+        ):
+            _fail(
+                "pace_talk_identity_invalid",
+                "Repair missing or malformed talk identities through ingress.",
+            )
+        name = talk["filename"]
+        if name in talks:
+            _fail(
+                "pace_talk_identity_duplicate",
+                "Resolve duplicate talk identities through ingress.",
+            )
+        talks[name] = talk
+    rows = [_candidate(talks[name], language, allow_download) for name in sorted(talks)]
+    groups = defaultdict(list)
+    for row in rows:
+        if row["youtube_id"] is not None:
+            groups[row["youtube_id"]].append(row)
+    for group in groups.values():
+        if len(group) < 2:
+            continue
+        canonical = _canonical_duplicate(group, talks)
+        # An excluded declaration can contradict another row's solo-speaker
+        # claim. Do not hide that evidence by grouping eligible rows alone.
+        if any(
+            {"multiple_speakers", "co_presenters_declared"} & set(row["reasons"])
+            for row in group
+        ) or (canonical is not None and canonical["status"] != "eligible"):
+            canonical = None
+        for row in group:
+            if row is not canonical and row["status"] == "eligible":
+                row["status"] = "excluded"
+                row["reasons"] = [
+                    "duplicate_recording"
+                    if canonical is not None
+                    else "duplicate_recording_identity_unresolved"
+                ]
+    available = [row for row in rows if row["status"] == "eligible"]
+    family_counts, year_counts, mode_counts = Counter(), Counter(), Counter()
+    selected = []
+    while available and len(selected) < maximum_recordings:
+        row = min(
+            available,
+            key=lambda item: (
+                family_counts[item["family"]],
+                item["source"]["kind"] != "local_media",
+                year_counts[item["year"]],
+                mode_counts[item["mode"]],
+                item["recording_id"],
+            ),
+        )
+        available.remove(row)
+        row["status"] = "selected"
+        selected.append(row["recording_id"])
+        family_counts[row["family"]] += 1
+        year_counts[row["year"]] += 1
+        mode_counts[row["mode"]] += 1
+    for row in available:
+        row["status"] = "not_selected"
+        row["reasons"] = ["cohort_budget"]
+    return {
+        "schema_version": 1,
+        "method_version": COHORT_METHOD,
+        "speaker": configured,
+        "language": language,
+        "maximum_recordings": maximum_recordings,
+        "allow_download": allow_download,
+        "demo_modes": sorted(demo_modes),
+        "selected_recording_ids": selected,
+        "recordings": rows,
+    }
+
+
+def sample_window(duration_seconds: Any) -> tuple[float, float]:
+    """Choose an interior window from an acquisition-owner measured duration."""
+    if (
+        type(duration_seconds) not in (int, float)
+        or not 0 < duration_seconds <= MAX_DURATION_SECONDS
+    ):
+        _fail(
+            "pace_duration_invalid",
+            "Acquire a finite recording duration through the media owner.",
+        )
+    duration = float(duration_seconds)
+    margin = max(EDGE_MARGIN_SECONDS, duration * 0.1)
+    window = min(SAMPLE_TARGET_SECONDS, duration - 2 * margin)
+    if window < SAMPLE_MINIMUM_SECONDS:
+        _fail(
+            "pace_recording_too_short",
+            "Select a recording with at least three minutes of interior speech.",
+        )
+    return ((duration - window) / 2, window)

--- a/skills/vault-profile/scripts/speech_rates.py
+++ b/skills/vault-profile/scripts/speech_rates.py
@@ -66,13 +66,13 @@ def _fail(code: str, message: str) -> NoReturn:
     raise SpeechRateError(code, message)
 
 
-def _record(value: Any, keys: set[str]) -> dict:
+def _record(value: Any, keys: set[str], *, version: int = 1) -> dict:
     if not isinstance(value, dict) or set(value) != keys | {"schema_version"}:
         _fail("speech_shape_invalid", "Use the documented closed speech-rate shape.")
-    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+    if type(value["schema_version"]) is not int or value["schema_version"] != version:
         _fail(
             "speech_schema_unsupported",
-            "Use schema version 1; update the owner for other versions.",
+            "Use a supported schema version; update the owner for other versions.",
         )
     return value
 
@@ -245,6 +245,14 @@ def measure(evidence: Any) -> dict:
 
 
 def calibrate(request: Any) -> dict:
+    if (
+        isinstance(request, dict)
+        and type(request.get("schema_version")) is int
+        and request["schema_version"] == 2
+    ):
+        from speech_calibration import calibrate as calibrate_families
+
+        return calibrate_families(request)
     request = _record(request, {"cohort", "samples"})
     _text(request["cohort"])
     samples = request["samples"]
@@ -314,6 +322,14 @@ def calibrate(request: Any) -> dict:
 
 
 def validate_profile(value: Any) -> dict:
+    if (
+        isinstance(value, dict)
+        and type(value.get("schema_version")) is int
+        and value["schema_version"] == 2
+    ):
+        from speech_calibration import validate_profile as validate_family_profile
+
+        return validate_family_profile(value)
     profile = _record(value, {"calibration", "rates"})
     expected = calibrate(profile["calibration"])
     # Canonical JSON equality also rejects bool/int and int/float substitutions.
@@ -326,6 +342,16 @@ def validate_profile(value: Any) -> dict:
 
 
 def validate_rate(value: Any) -> dict:
+    family_rate = (
+        isinstance(value, dict)
+        and type(value.get("schema_version")) is int
+        and value["schema_version"] == 2
+    )
+    extra = (
+        {"mean_confidence_interval_95", "conservative_planning_wpm"}
+        if family_rate
+        else set()
+    )
     rate = _record(
         value,
         {
@@ -336,7 +362,9 @@ def validate_rate(value: Any) -> dict:
             "range",
             "basis",
             "provenance",
-        },
+        }
+        | extra,
+        version=2 if family_rate else 1,
     )
     metric = _metric(rate["metric"])
     threshold = rate["pause_threshold_seconds"]
@@ -360,6 +388,11 @@ def validate_rate(value: Any) -> dict:
             "speech_range_invalid",
             "Supply an ordered [low, high] rate range containing the point estimate.",
         )
+    if family_rate and (metric != "narration" or rate["basis"] != "measured"):
+        _fail(
+            "speech_definition_invalid",
+            "Use a measured family-balanced narration rate for schema v2.",
+        )
     if rate["basis"] == "assumption":
         provenance = _record(rate["provenance"], {"reason"})
         _text(provenance["reason"])
@@ -373,7 +406,19 @@ def validate_rate(value: Any) -> dict:
                 "method_version",
                 "evidence_sha256",
                 "range_kind",
-            },
+            }
+            | (
+                {
+                    "presentation_family_count",
+                    "language",
+                    "calibration_sha256",
+                    "confidence_level",
+                    "interval_kind",
+                }
+                if family_rate
+                else set()
+            ),
+            version=2 if family_rate else 1,
         )
         count = provenance["sample_count"]
         if type(count) is not int or not 1 <= count <= MAX_SAMPLES:
@@ -395,7 +440,9 @@ def validate_rate(value: Any) -> dict:
             )
         for digest in digests:
             _sha(digest)
-        if (
+        if family_rate:
+            _validate_family_rate(rate)
+        elif (
             provenance["method_version"] != METHOD_VERSION
             or provenance["range_kind"]
             != "observed_sample_range_not_confidence_interval"
@@ -410,6 +457,59 @@ def validate_rate(value: Any) -> dict:
             "Identify a rate as measured or an explicit assumption.",
         )
     return rate
+
+
+def _validate_family_rate(rate: dict) -> None:
+    # Called after common shape, number, range and evidence-digest validation.
+    # The full profile is validated when selecting a rate; an embedded outline
+    # rate carries provenance but cannot independently authenticate raw evidence.
+    from speech_calibration import (
+        CALIBRATION_METHOD,
+        CONFIDENCE_POLICY,
+        MEAN_INTERVAL_KIND,
+    )
+
+    provenance = rate["provenance"]
+    families = provenance["presentation_family_count"]
+    interval = rate["mean_confidence_interval_95"]
+    if not isinstance(interval, list) or len(interval) != 2:
+        _fail(
+            "speech_range_invalid",
+            "Preserve the two-sided family-mean confidence interval.",
+        )
+    lower, upper = (_number(n, positive=True) for n in interval)
+    conservative = _number(rate["conservative_planning_wpm"], positive=True)
+    observed_low, observed_high = rate["range"]
+    if (
+        not observed_low <= lower <= rate["value"] <= upper <= observed_high
+        or conservative != lower
+    ):
+        _fail(
+            "speech_range_invalid",
+            "Preserve the mean interval and its lower-bound planning rate; never replace the observed range with a confidence interval.",
+        )
+    if (
+        type(families) is not int
+        or not CONFIDENCE_POLICY["minimum_families"]
+        <= families
+        <= provenance["sample_count"]
+        or provenance["sample_count"] < CONFIDENCE_POLICY["minimum_recordings"]
+        or provenance["analyzed_duration_seconds"]
+        < CONFIDENCE_POLICY["minimum_analyzed_seconds"]
+        or provenance["method_version"] != CALIBRATION_METHOD
+        or provenance["range_kind"]
+        != "observed_recording_range_not_prediction_interval"
+        or provenance["interval_kind"] != MEAN_INTERVAL_KIND
+        or provenance["confidence_level"] != "conditional"
+        or not isinstance(provenance["language"], str)
+        or re.fullmatch(r"[a-z]{2,3}(?:-[a-z0-9]{2,8})*", provenance["language"])
+        is None
+    ):
+        _fail(
+            "speech_provenance_invalid",
+            "Copy a supported, sufficiently covered family-balanced narration rate from the owner.",
+        )
+    _sha(provenance["calibration_sha256"])
 
 
 def assumed_narration(low: float, high: float, *, reason: str) -> dict:
@@ -446,10 +546,19 @@ def plan_duration(
             "Supply a positive script word count within 50,000 words.",
         )
     if profile is not None:
-        profile = validate_profile(profile)
-        rate = next(
-            rate for rate in profile["rates"] if rate["metric"] == intended_metric
-        )
+        if (
+            isinstance(profile, dict)
+            and type(profile.get("schema_version")) is int
+            and profile["schema_version"] == 2
+        ):
+            from speech_calibration import narration_rate
+
+            rate = narration_rate(profile)
+        else:
+            profile = validate_profile(profile)
+            rate = next(
+                rate for rate in profile["rates"] if rate["metric"] == intended_metric
+            )
     elif assumption is not None:
         rate = validate_rate(assumption)
         if rate["metric"] != intended_metric or rate["basis"] != "assumption":
@@ -463,7 +572,7 @@ def plan_duration(
             "Provide a measured narration profile or an explicitly labeled assumption.",
         )
     low, high = rate["range"]
-    return {
+    result = {
         "schema_version": 1,
         "kind": "prediction_not_verification",
         "word_count": word_count,
@@ -475,6 +584,15 @@ def plan_duration(
             _number(word_count * 60 / low, positive=True),
         ],
     }
+    if rate["schema_version"] == 2:
+        result.update(
+            schema_version=2,
+            range_kind="observed_recording_range_not_prediction_interval",
+            conservative_estimated_seconds=_number(
+                word_count * 60 / rate["conservative_planning_wpm"], positive=True
+            ),
+        )
+    return result
 
 
 def verify_recording(evidence: Any, *, maximum_duration_seconds: float) -> dict:
@@ -605,4 +723,8 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    # Lazy family-profile dispatch imports this module's arithmetic and error
+    # class. Reuse this executable instance instead of creating a second class
+    # identity that the CLI's typed-error boundary could not catch.
+    sys.modules["speech_rates"] = sys.modules[__name__]
     raise SystemExit(main())

--- a/tests/test_calibrate_speech.py
+++ b/tests/test_calibrate_speech.py
@@ -1,0 +1,341 @@
+"""Command-level calibration preserves catalog and artifact ownership."""
+
+import argparse
+from contextlib import contextmanager
+import json
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from conftest import SCRIPTS_VP, _import_script
+from test_speech_calibration import sample
+
+
+@pytest.fixture
+def command():
+    return _import_script(Path(SCRIPTS_VP) / "calibrate-speech.py", "calibrate_speech")
+
+
+def talk(name="one", *, local=True):
+    return {
+        "filename": name + ".md",
+        "status": "processed",
+        "date": "2020-06-01",
+        "video_path": f"recordings/{name}.wav" if local else None,
+        "youtube_id": "abcdefghijk" if not local else None,
+        "structured_data": {
+            "talk_family": "family one",
+            "mode": "demo",
+            "delivery_language": "en",
+            "co_presenter": False,
+        },
+    }
+
+
+def vault(tmp_path, rows=None, **config):
+    database = {
+        "config": {
+            "python_path": sys.executable,
+            "speaker_name": "Fixture speaker",
+            **config,
+        },
+        "talks": [talk()] if rows is None else rows,
+    }
+    path = tmp_path / "tracking-database.json"
+    path.write_text(json.dumps(database), encoding="utf-8")
+    return path
+
+
+def options(tmp_path, **updates):
+    return argparse.Namespace(
+        vault_root=str(tmp_path),
+        speaker="Fixture speaker",
+        language="en",
+        run=updates.get("run", False),
+        allow_download=updates.get("allow_download", False),
+        maximum_recordings=12,
+        demo_mode=["demo"],
+        as_of="2024-06-01T12:00:00Z",
+    )
+
+
+def runtime_ok(command, monkeypatch):
+    real = command._owner_script
+    observed = []
+
+    def load(name):
+        if name != "check-runtime.py":
+            return real(name)
+
+        def report(lanes, required):
+            observed.append(required)
+            return {"schema_version": 1, "ok": True}
+
+        return SimpleNamespace(build_report=report)
+
+    monkeypatch.setattr(command, "_owner_script", load)
+    return observed
+
+
+def test_plan_is_read_only_and_never_opens_recordings(command, tmp_path, monkeypatch):
+    path = vault(tmp_path)
+    before = path.read_bytes()
+    lanes = runtime_ok(command, monkeypatch)
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("metadata plan acquired or transcribed source audio")
+
+    monkeypatch.setattr(command, "probe_local_media", forbidden)
+    monkeypatch.setattr(command, "download_youtube_audio", forbidden)
+    monkeypatch.setattr(command, "transcribe_local_words", forbidden)
+    result = command.execute(options(tmp_path))
+    assert result["status"] == "plan_only"
+    assert result["profile"] is None
+    assert result["cohort"]["selected_recording_ids"] == ["one.md"]
+    assert lanes == [("core",)]
+    assert path.read_bytes() == before
+
+
+def test_real_plan_command_and_json_help(command, tmp_path):
+    vault(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            command.__file__,
+            str(tmp_path),
+            "--speaker",
+            "Fixture speaker",
+            "--language",
+            "en",
+            "--as-of",
+            "2024-06-01T12:00:00Z",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["data"]["status"] == "plan_only"
+    help_result = subprocess.run(
+        [sys.executable, command.__file__, "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert help_result.returncode == 0
+    assert "--run" in json.loads(help_result.stdout)["data"]["help"]
+
+
+def test_run_consumes_owner_words_and_preserves_all_exclusions(
+    command, tmp_path, monkeypatch
+):
+    excluded = talk("excluded")
+    excluded["structured_data"]["co_presenter"] = True
+    path = vault(tmp_path, [talk(), excluded])
+    prior = tmp_path / "speech-rate-profile.json"
+    prior.write_bytes(b"existing profile")
+    before = path.read_bytes()
+    lanes = runtime_ok(command, monkeypatch)
+    probe = SimpleNamespace(duration_seconds=3600)
+    seen = []
+    monkeypatch.setattr(command, "probe_local_media", lambda *a, **k: probe)
+
+    def transcribe(path, **kwargs):
+        seen.append((path, kwargs))
+        receipt = sample()["words"]
+        receipt["sample_start_seconds"] = kwargs["sample_start_seconds"]
+        return probe, receipt
+
+    monkeypatch.setattr(command, "transcribe_local_words", transcribe)
+    result = command.execute(options(tmp_path, run=True))
+    assert result["status"] == "low_confidence"
+    assert result["profile"]["summary"]["recording_count"] == 1
+    assert result["profile"]["exclusions"] == [
+        {
+            "schema_version": 1,
+            "recording_id": "excluded.md",
+            "reasons": ["multiple_speakers"],
+        }
+    ]
+    assert seen[0][0] == "recordings/one.wav"
+    assert seen[0][1] == {
+        "probe": probe,
+        "trusted_root": tmp_path,
+        "sample_start_seconds": 1500.0,
+        "sample_duration_seconds": 600.0,
+    }
+    assert lanes == [("core", "source-media", "speech-calibration")]
+    assert path.read_bytes() == before
+    assert prior.read_bytes() == b"existing profile"
+
+
+def test_missing_local_source_remains_excluded_without_fallback(
+    command, tmp_path, monkeypatch
+):
+    vault(tmp_path)
+    runtime_ok(command, monkeypatch)
+
+    def fail(*args, **kwargs):
+        raise command.LocalMediaError("media_artifact_unavailable")
+
+    monkeypatch.setattr(command, "probe_local_media", fail)
+    result = command.execute(options(tmp_path, run=True))
+    assert result["profile"]["summary"]["recording_count"] == 0
+    assert result["profile"]["exclusions"][0]["reasons"] == [
+        "media_artifact_unavailable"
+    ]
+    assert result["status"] == "low_confidence"
+
+
+def test_segment_failure_logs_only_closed_numeric_evidence(
+    command, tmp_path, monkeypatch, capsys
+):
+    vault(tmp_path)
+    runtime_ok(command, monkeypatch)
+    monkeypatch.setattr(
+        command,
+        "probe_local_media",
+        lambda *a, **k: SimpleNamespace(duration_seconds=3600),
+    )
+    diagnostic = {
+        "schema_version": 1,
+        "word_index": 0,
+        "word_count": 2,
+        "word_start_seconds": 0.1,
+        "word_end_seconds": 0.2,
+        "segment_index": 0,
+        "segment_count": 1,
+        "segment_start_seconds": 0.3,
+        "segment_end_seconds": 0.5,
+    }
+
+    def fail(*args, **kwargs):
+        raise command.WordSampleError(diagnostic)
+
+    monkeypatch.setattr(command, "transcribe_local_words", fail)
+    result = command.execute(options(tmp_path, run=True))
+    captured = capsys.readouterr()
+    records = [
+        json.loads(line) for line in captured.err.splitlines() if line.startswith("{")
+    ]
+    assert records == [
+        {
+            "schema_version": 1,
+            "code": "whisper_word_sample_invalid_word_segment",
+            "word_timing": diagnostic,
+        }
+    ]
+    assert result["profile"]["exclusions"] == [
+        {
+            "schema_version": 1,
+            "recording_id": "one.md",
+            "reasons": ["whisper_word_sample_invalid_word_segment"],
+        }
+    ]
+    assert str(tmp_path) not in captured.err
+    assert "recordings/one.wav" not in captured.err
+
+
+def test_download_requires_option_and_cleanup_precedes_admission(
+    command, tmp_path, monkeypatch
+):
+    vault(tmp_path, [talk(local=False)])
+    lanes = runtime_ok(command, monkeypatch)
+    consumed = []
+
+    @contextmanager
+    def download(video_id):
+        consumed.append(video_id)
+        yield tmp_path / "private-audio.wav", 3600
+        raise command.LocalMediaError("media_cleanup_failed")
+
+    monkeypatch.setattr(command, "download_youtube_audio", download)
+    no_download = command.execute(options(tmp_path, run=True))
+    assert no_download["profile"]["summary"]["recording_count"] == 0
+    assert consumed == []
+    monkeypatch.setattr(
+        command,
+        "probe_local_media",
+        lambda *a, **k: SimpleNamespace(duration_seconds=3600),
+    )
+    monkeypatch.setattr(
+        command, "transcribe_local_words", lambda *a, **k: (None, sample()["words"])
+    )
+    with pytest.raises(command.LocalMediaError, match="media_cleanup_failed"):
+        command.execute(options(tmp_path, run=True, allow_download=True))
+    assert consumed == ["abcdefghijk"]
+    assert lanes[-1] == (
+        "core",
+        "source-media",
+        "speech-calibration",
+        "youtube-download",
+    )
+
+
+def test_catalog_change_before_output_refuses_candidate(command, tmp_path, monkeypatch):
+    path = vault(tmp_path)
+    runtime_ok(command, monkeypatch)
+    monkeypatch.setattr(
+        command,
+        "probe_local_media",
+        lambda *a, **k: SimpleNamespace(duration_seconds=3600),
+    )
+
+    def change(*args, **kwargs):
+        path.write_bytes(path.read_bytes() + b"\n")
+        return None, sample()["words"]
+
+    monkeypatch.setattr(command, "transcribe_local_words", change)
+    with pytest.raises(command.SpeechRateError) as exc:
+        command.execute(options(tmp_path, run=True))
+    assert exc.value.code == "pace_catalog_changed"
+
+
+def test_configured_interpreter_is_required(command, tmp_path):
+    vault(tmp_path, python_path="/wrong/private/python")
+    with pytest.raises(command.SpeechRateError) as exc:
+        command.execute(options(tmp_path))
+    assert exc.value.code == "pace_interpreter_mismatch"
+    assert "private/python" not in str(exc.value)
+
+
+def test_strict_reader_rejects_duplicate_keys(command, tmp_path, capsys):
+    (tmp_path / "tracking-database.json").write_bytes(
+        b'{"private_key":1,"private_key":2}'
+    )
+    assert (
+        command.main(
+            [str(tmp_path), "--speaker", "Fixture speaker", "--language", "en"]
+        )
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["error"]["code"] == "pace_catalog_unavailable"
+    assert "private_key" not in captured.out + captured.err
+
+
+def test_usage_refusal_is_json_without_private_arguments(command, capsys):
+    assert command.main(["--private-source"]) == 2
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["error"]["code"] == "pace_usage_invalid"
+    assert "private-source" not in captured.out + captured.err
+
+
+def test_missing_runtime_refuses_before_acquisition(command, tmp_path, monkeypatch):
+    vault(tmp_path)
+    real = command._owner_script
+    monkeypatch.setattr(
+        command,
+        "_owner_script",
+        lambda name: (
+            SimpleNamespace(build_report=lambda *a: {"ok": False})
+            if name == "check-runtime.py"
+            else real(name)
+        ),
+    )
+    with pytest.raises(command.SpeechRateError) as exc:
+        command.execute(options(tmp_path, run=True))
+    assert exc.value.code == "pace_runtime_unavailable"

--- a/tests/test_local_media_sampled_transcription.py
+++ b/tests/test_local_media_sampled_transcription.py
@@ -1,0 +1,345 @@
+"""Authenticated sampling with a synthetic native boundary; no model downloads."""
+
+from contextlib import contextmanager
+from dataclasses import replace
+import hashlib
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import wave
+
+import pytest
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+@pytest.fixture
+def owner():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_transcription.py", "local_media_transcription"
+    )
+
+
+@pytest.fixture
+def media(tmp_path):
+    path = tmp_path / "original.wav"
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(16000)
+        output.writeframes(b"\0\0" * 16000)
+    return path
+
+
+def raw_words():
+    return {
+        "language": "en",
+        "segments": [
+            {
+                "start": 0,
+                "end": 0.5,
+                "compression_ratio": 1.1,
+                "avg_logprob": -0.1,
+                "no_speech_prob": 0.01,
+                "words": [
+                    {"word": " First", "start": 0.1, "end": 0.2, "probability": 0.95},
+                    {"word": " word.", "start": 0.3, "end": 0.4, "probability": 0.98},
+                ],
+            }
+        ],
+    }
+
+
+def synthetic_worker(owner, tmp_path, monkeypatch, *, body=None, timeout=None):
+    native = body or f"return {{'raw': {raw_words()!r}, 'language_probability': 0.99}}"
+    script = tmp_path / "synthetic_words_worker.py"
+    script.write_text(
+        f"import sys\nsys.path.insert(0, {str(Path(SCRIPTS_VI).resolve())!r})\n"
+        "import local_media_transcription as owner\n"
+        "owner._word_model_path = lambda: ('fixture-model', '0.4.3')\n"
+        "def native(path, model, **options):\n"
+        + "\n".join("    " + line for line in native.splitlines())
+        + "\nowner._transcribe_with_mlx = native\nraise SystemExit(owner._main())\n",
+        encoding="utf-8",
+    )
+    real = owner.run_authenticated_worker
+    workspaces = []
+
+    def invoke(command, operation, expected, payload, limits, **kwargs):
+        assert operation == owner.WORDS_OPERATION
+        assert "original.wav" not in repr(command)
+        workspaces.append(Path(payload["workspace"]["path"]))
+        command = [sys.executable, str(script), owner.WORKER_FLAG]
+        kwargs["immutable_process_identity"] = command[:2]
+        if timeout is not None:
+            limits = replace(limits, wall_seconds=timeout)
+        return real(command, operation, expected, payload, limits, **kwargs)
+
+    monkeypatch.setattr(owner, "run_authenticated_worker", invoke)
+    return workspaces
+
+
+def test_real_worker_returns_fresh_words_and_cleans_private_samples(
+    owner, media, tmp_path, monkeypatch
+):
+    before = media.read_bytes()
+    probe = owner.probe_local_media(media, trusted_root=tmp_path)
+    workspaces = synthetic_worker(owner, tmp_path, monkeypatch)
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("an established source was reprobed")
+
+    monkeypatch.setattr(owner, "probe_local_media", forbidden)
+    established, receipt = owner.transcribe_local_words(
+        media,
+        sample_start_seconds=0.25,
+        sample_duration_seconds=0.5,
+        probe=probe,
+        trusted_root=tmp_path,
+    )
+    assert established is probe
+    assert receipt["source_sha256"] == hashlib.sha256(before).hexdigest()
+    assert receipt["source_duration_seconds"] == 1
+    assert receipt["sample_duration_seconds"] == 0.5
+    assert receipt["sample_start_seconds"] == 0.25
+    assert receipt["language_probability"] == 0.99
+    assert receipt["model"] == owner.DEFAULT_WORD_MODEL
+    assert [word["text"] for word in receipt["words"]] == ["First", "word."]
+    assert all(not path.exists() for path in workspaces)
+    assert media.read_bytes() == before
+    assert sorted(path.name for path in tmp_path.iterdir()) == [
+        "original.wav",
+        "synthetic_words_worker.py",
+    ]
+
+
+@pytest.mark.parametrize(
+    "body,reason",
+    [
+        ("raise RuntimeError('private failure')", "whisper_worker_failed"),
+        (
+            "return {'raw': {'segments': []}, 'language_probability': 0.99}",
+            "whisper_word_sample_invalid",
+        ),
+        (
+            "from pathlib import Path\nPath(path).chmod(0o600)\nPath(path).write_bytes(b'changed')\nreturn {}",
+            "media_generation_changed",
+        ),
+        (
+            "import sys\nsys.stderr.write('x' * 65537)\nreturn {}",
+            "whisper_worker_resource_limit",
+        ),
+    ],
+)
+def test_failed_worker_retains_old_artifacts_and_cleans_sample(
+    owner, media, tmp_path, monkeypatch, body, reason
+):
+    prior = tmp_path / "speech-rate-profile.json"
+    prior.write_bytes(b"prior profile")
+    workspaces = synthetic_worker(owner, tmp_path, monkeypatch, body=body)
+    with pytest.raises(owner.LocalMediaError, match=reason):
+        owner.transcribe_local_words(
+            media, sample_start_seconds=0.25, sample_duration_seconds=0.5
+        )
+    assert prior.read_bytes() == b"prior profile"
+    assert workspaces and all(not path.exists() for path in workspaces)
+
+
+def test_timeout_removes_sample_even_after_worker_killed(
+    owner, media, tmp_path, monkeypatch
+):
+    workspaces = synthetic_worker(
+        owner, tmp_path, monkeypatch, body="import time\ntime.sleep(30)", timeout=1.0
+    )
+    with pytest.raises(owner.LocalMediaError, match="whisper_worker_timeout"):
+        owner.transcribe_local_words(
+            media, sample_start_seconds=0.25, sample_duration_seconds=0.5
+        )
+    assert workspaces and all(not path.exists() for path in workspaces)
+
+
+def test_original_mutation_during_sample_transcription_refuses(
+    owner, media, tmp_path, monkeypatch
+):
+    body = f"from pathlib import Path\nPath({str(media)!r}).write_bytes(b'changed original')\nreturn {{'raw': {raw_words()!r}, 'language_probability': 0.99}}"
+    synthetic_worker(owner, tmp_path, monkeypatch, body=body)
+    with pytest.raises(owner.LocalMediaError, match="media_generation_changed"):
+        owner.transcribe_local_words(
+            media, sample_start_seconds=0.25, sample_duration_seconds=0.5
+        )
+
+
+def test_final_source_recheck_rejects_change_after_worker_response(
+    owner, media, tmp_path, monkeypatch
+):
+    synthetic_worker(owner, tmp_path, monkeypatch)
+    actual = owner.run_authenticated_worker
+
+    def mutate(*args, **kwargs):
+        result = actual(*args, **kwargs)
+        media.write_bytes(b"changed after worker")
+        return result
+
+    monkeypatch.setattr(owner, "run_authenticated_worker", mutate)
+    with pytest.raises(owner.LocalMediaError, match="media_generation_changed"):
+        owner.transcribe_local_words(
+            media, sample_start_seconds=0.25, sample_duration_seconds=0.5
+        )
+
+
+def test_cleanup_failure_never_returns_usable_receipt(
+    owner, media, tmp_path, monkeypatch
+):
+    synthetic_worker(owner, tmp_path, monkeypatch)
+    real = owner.private_media_workspace
+
+    @contextmanager
+    def failed_cleanup():
+        with real() as directory:
+            yield directory
+        raise owner.LocalMediaError("media_cleanup_failed")
+
+    monkeypatch.setattr(owner, "private_media_workspace", failed_cleanup)
+    with pytest.raises(owner.LocalMediaError, match="media_cleanup_failed"):
+        owner.transcribe_local_words(
+            media, sample_start_seconds=0.25, sample_duration_seconds=0.5
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("source_sha256", "f" * 64),
+        ("sample_start_seconds", 0.1),
+        ("source_duration_seconds", 2),
+    ],
+)
+def test_authenticated_receipt_with_wrong_source_binding_refuses(
+    owner, media, tmp_path, monkeypatch, field, value
+):
+    synthetic_worker(owner, tmp_path, monkeypatch)
+    actual = owner.run_authenticated_worker
+
+    def change(*args, **kwargs):
+        result = actual(*args, **kwargs)
+        receipt = dict(result.payload)
+        receipt[field] = value
+        return SimpleNamespace(payload=receipt)
+
+    monkeypatch.setattr(owner, "run_authenticated_worker", change)
+    with pytest.raises(owner.LocalMediaError, match="whisper_word_sample_invalid"):
+        owner.transcribe_local_words(
+            media, sample_start_seconds=0.25, sample_duration_seconds=0.5
+        )
+
+
+def test_native_options_preserve_real_word_timing_and_language_probability(
+    owner, monkeypatch
+):
+    observed = []
+
+    def transcribe(path, **options):
+        observed.append(options)
+        return raw_words()
+
+    network = SimpleNamespace(
+        dims=SimpleNamespace(n_mels=128),
+        detect_language=lambda mel: (None, {"en": 0.987, "ru": 0.013}),
+    )
+    native = SimpleNamespace(
+        mx=SimpleNamespace(float16="f16"),
+        N_SAMPLES=480000,
+        N_FRAMES=3000,
+        ModelHolder=SimpleNamespace(get_model=lambda path, dtype: network),
+        log_mel_spectrogram=lambda *a, **k: "mel",
+        pad_or_trim=lambda *a, **k: SimpleNamespace(astype=lambda dtype: "features"),
+    )
+    monkeypatch.setattr(
+        owner.importlib,
+        "import_module",
+        lambda name: (
+            SimpleNamespace(transcribe=transcribe) if name == "mlx_whisper" else native
+        ),
+    )
+    result = owner._transcribe_with_mlx(
+        Path("synthetic.wav"), "snapshot", word_timestamps=True
+    )
+    assert observed == [
+        {
+            "path_or_hf_repo": "snapshot",
+            "word_timestamps": True,
+            "temperature": 0.0,
+            "condition_on_previous_text": False,
+            "verbose": None,
+        }
+    ]
+    assert result["raw"] == raw_words()
+    assert result["language_probability"] == 0.987
+
+
+def test_model_resolution_pins_revision_and_downloads_no_remote_code(
+    owner, monkeypatch
+):
+    observed = []
+    monkeypatch.setattr(owner.importlib.metadata, "version", lambda name: "0.4.3")
+    monkeypatch.setattr(
+        owner.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(
+            snapshot_download=lambda **kwargs: (
+                observed.append(kwargs) or "/synthetic/snapshot"
+            )
+        ),
+    )
+    assert owner._word_model_path() == ("/synthetic/snapshot", "0.4.3")
+    assert observed == [
+        {
+            "repo_id": owner.DEFAULT_WORD_MODEL["id"],
+            "revision": owner.DEFAULT_WORD_MODEL["revision"],
+            "allow_patterns": ["config.json", "weights.safetensors", "weights.npz"],
+            "max_workers": 1,
+            "token": False,
+        }
+    ]
+
+
+def test_unsupported_native_version_refuses_before_download(owner, monkeypatch):
+    monkeypatch.setattr(owner.importlib.metadata, "version", lambda name: "0.0.1")
+    monkeypatch.setattr(
+        owner.importlib, "import_module", lambda name: SimpleNamespace()
+    )
+    with pytest.raises(
+        owner.LocalMediaError, match="whisper_provider_version_unsupported"
+    ):
+        owner._word_model_path()
+
+
+def test_numeric_segment_diagnostics_cross_worker_without_words(
+    owner, media, tmp_path, monkeypatch
+):
+    raw = raw_words()
+    raw["segments"][0]["end"] = 0.1
+    workspaces = synthetic_worker(
+        owner,
+        tmp_path,
+        monkeypatch,
+        body=f"return {{'raw': {raw!r}, 'language_probability': 0.99}}",
+    )
+    with pytest.raises(owner.WordSampleError) as exc:
+        owner.transcribe_local_words(
+            media, sample_start_seconds=0.25, sample_duration_seconds=0.5
+        )
+    assert exc.value.word_timing == {
+        "schema_version": 1,
+        "word_index": 0,
+        "word_count": 2,
+        "word_start_seconds": 0.1,
+        "word_end_seconds": 0.2,
+        "segment_index": 0,
+        "segment_count": 1,
+        "segment_start_seconds": 0,
+        "segment_end_seconds": 0.1,
+    }
+    assert "First" not in repr(exc.value.word_timing)
+    assert "private" not in repr(exc.value.word_timing)
+    assert workspaces and all(not path.exists() for path in workspaces)

--- a/tests/test_local_media_sampling.py
+++ b/tests/test_local_media_sampling.py
@@ -1,0 +1,100 @@
+"""Real FFmpeg sampling and pure bound checks, no network or speech model."""
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+import wave
+
+import pytest
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+@pytest.fixture
+def sampler():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_sampling.py", "local_media_sampling"
+    )
+
+
+@pytest.fixture
+def media(tmp_path):
+    path = tmp_path / "source.wav"
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(16000)
+        output.writeframes(b"\x01\x00" * 4000 + b"\x02\x00" * 8000 + b"\x03\x00" * 4000)
+    return path
+
+
+def test_real_sample_binds_only_requested_interval_and_preserves_source(
+    sampler, media, tmp_path
+):
+    before = media.read_bytes()
+    work = tmp_path / "private"
+    work.mkdir()
+    clip = sampler.extract_speech_clip(media, work, start=0.25, duration=0.5)
+    assert clip.duration_seconds == 0.5
+    assert clip.sha256 == hashlib.sha256(clip.path.read_bytes()).hexdigest()
+    with wave.open(str(clip.path), "rb") as audio:
+        assert audio.getnchannels() == 1
+        assert audio.getframerate() == 16000
+        assert audio.getnframes() == 8000
+        assert audio.readframes(8000) == b"\x02\x00" * 8000
+    assert media.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "start,duration,source",
+    [
+        (True, 1, 5),
+        (0, True, 5),
+        (0, 1, True),
+        (-1, 1, 5),
+        (5, 1, 5),
+        (4, 2, 5),
+        (0, 0, 5),
+        (0, 1201, 3600),
+        (0, 1, 14401),
+        (0, float("nan"), 5),
+        (float("inf"), 1, 5),
+        pytest.param(0, 1, 10**10000, id="huge-source-duration"),
+    ],
+)
+def test_bad_windows_refuse_without_decoding(sampler, start, duration, source):
+    with pytest.raises(sampler.LocalMediaError, match="whisper_sample_window_invalid"):
+        sampler.validate_sample_window(start, duration, source)
+
+
+@pytest.mark.parametrize(
+    "code,diagnostics,size,reason",
+    [
+        (1, 0, 16000, "whisper_sample_decode_failed"),
+        (0, 10, 16000, "whisper_sample_decode_failed"),
+        (0, 0, 0, "whisper_sample_duration_mismatch"),
+        (0, 0, 15999, "whisper_sample_duration_mismatch"),
+        (0, 0, 8000, "whisper_sample_duration_mismatch"),
+    ],
+)
+def test_decoder_error_or_partial_output_never_becomes_a_clip(
+    sampler, media, tmp_path, monkeypatch, code, diagnostics, size, reason
+):
+    monkeypatch.setattr(
+        sampler,
+        "run_media_tool",
+        lambda *a, **k: SimpleNamespace(
+            returncode=code,
+            diagnostics=SimpleNamespace(byte_count=diagnostics),
+            streamed_bytes=size,
+        ),
+    )
+    with pytest.raises(sampler.LocalMediaError, match=reason):
+        sampler.extract_speech_clip(media, tmp_path, start=0.25, duration=0.5)
+    assert not (tmp_path / "sample.wav").exists()
+
+
+def test_missing_decoder_is_actionable(sampler, media, tmp_path, monkeypatch):
+    monkeypatch.setattr(sampler.shutil, "which", lambda name: None)
+    with pytest.raises(sampler.LocalMediaError, match="media_dependency_unavailable"):
+        sampler.extract_speech_clip(media, tmp_path, start=0.25, duration=0.5)

--- a/tests/test_local_media_words.py
+++ b/tests/test_local_media_words.py
@@ -1,0 +1,268 @@
+"""Fixed provider-boundary data, never a model call or a media acquisition."""
+
+import copy
+from pathlib import Path
+
+import pytest
+import numpy as np
+
+from conftest import SCRIPTS_VI, _import_script
+
+
+@pytest.fixture
+def words():
+    return _import_script(
+        Path(SCRIPTS_VI) / "local_media_words.py", "local_media_words"
+    )
+
+
+def raw_result():
+    return {
+        "language": "en",
+        "segments": [
+            {
+                "start": 0.0,
+                "end": 3.0,
+                "compression_ratio": 1.1,
+                "avg_logprob": -0.1,
+                "no_speech_prob": 0.01,
+                "words": [
+                    {"word": " First", "start": 0.5, "end": 1.0, "probability": 0.9},
+                    {"word": " word.", "start": 1.5, "end": 2.0, "probability": 0.95},
+                ],
+            }
+        ],
+    }
+
+
+def normalized(words, raw=None):
+    return words.normalize_word_result(
+        raw_result() if raw is None else raw,
+        source_sha256="a" * 64,
+        sample_sha256="b" * 64,
+        source_duration_seconds=60,
+        sample_start_seconds=20,
+        sample_duration_seconds=3,
+        provider_version="0.4.3",
+        model=words.DEFAULT_WORD_MODEL,
+        language_probability=0.99,
+    )
+
+
+def test_normalization_retains_actual_word_times_and_source_binding(words):
+    result = normalized(words)
+    assert result["words"] == [
+        {
+            "text": "First",
+            "start_seconds": 0.5,
+            "end_seconds": 1.0,
+            "probability": 0.9,
+            "segment_index": 0,
+        },
+        {
+            "text": "word.",
+            "start_seconds": 1.5,
+            "end_seconds": 2.0,
+            "probability": 0.95,
+            "segment_index": 0,
+        },
+    ]
+    assert result["source_sha256"] == "a" * 64
+    assert result["sample_start_seconds"] == 20
+    assert result["model"] == words.DEFAULT_WORD_MODEL
+    assert result["language_probe_seconds"] == 3
+    assert result["token_exclusions"] == []
+
+
+def test_punctuation_only_token_is_reported_not_counted(words):
+    raw = raw_result()
+    raw["segments"][0]["words"].append(
+        {"word": "…", "start": 2.0, "end": 2.0, "probability": 1.0}
+    )
+    result = normalized(words, raw)
+    assert len(result["words"]) == 2
+    assert result["token_exclusions"] == [
+        {"token_index": 2, "reason": "punctuation_only"}
+    ]
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("start", True),
+        ("start", -1),
+        ("end", 0.5),
+        ("end", 7),
+        ("probability", float("nan")),
+        ("probability", 1.1),
+        ("word", "two words"),
+        ("word", "word\ud800"),
+        ("word", "word\u0000"),
+    ],
+)
+def test_invalid_lexical_word_is_not_repaired(words, field, value):
+    raw = raw_result()
+    raw["segments"][0]["words"][0][field] = value
+    with pytest.raises(words.LocalMediaError, match="whisper_word_sample_invalid"):
+        normalized(words, raw)
+
+
+def test_segment_only_timing_cannot_become_word_evidence(words):
+    raw = raw_result()
+    del raw["segments"][0]["words"]
+    with pytest.raises(words.LocalMediaError):
+        normalized(words, raw)
+
+
+def test_native_numeric_scalars_normalize_losslessly_at_provider_boundary(words):
+    raw = raw_result()
+    for segment in raw["segments"]:
+        for key in (
+            "start",
+            "end",
+            "compression_ratio",
+            "avg_logprob",
+            "no_speech_prob",
+        ):
+            segment[key] = np.float64(segment[key])
+        for word in segment["words"]:
+            for key in ("start", "end", "probability"):
+                word[key] = np.float64(word[key])
+    receipt = normalized(words, raw)
+    assert receipt == normalized(words)
+    assert all(
+        type(word[key]) is float
+        for word in receipt["words"]
+        for key in ("start_seconds", "end_seconds", "probability")
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 1),
+        ("schema_version", 3),
+        ("source_sha256", "unknown"),
+        ("language_probability", -0.1),
+        ("sample_duration_seconds", 1201),
+        ("sample_start_seconds", 59),
+        ("provider_version", "latest"),
+        ("words", []),
+        ("segments", []),
+    ],
+)
+def test_malformed_receipt_refuses(words, field, value):
+    result = normalized(words)
+    result[field] = value
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample(result)
+
+
+def test_overlapping_words_and_words_disjoint_from_segments_refuse(words):
+    result = normalized(words)
+    result["words"][1]["start_seconds"] = 0.8
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample(result)
+    result = normalized(words)
+    result["segments"][0]["end_seconds"] = 1.5
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample(result)
+
+
+@pytest.mark.parametrize(
+    "defect,reason",
+    [
+        ("zero", "whisper_word_sample_invalid_word_nonpositive_span"),
+        ("overlap", "whisper_word_sample_invalid_word_overlap"),
+        ("outside", "whisper_word_sample_invalid_word_segment"),
+    ],
+)
+def test_bad_alignment_diagnostics_do_not_disclose_words(words, defect, reason):
+    result = normalized(words)
+    if defect == "zero":
+        result["words"][0]["end_seconds"] = result["words"][0]["start_seconds"]
+    elif defect == "overlap":
+        result["words"][1]["start_seconds"] = 0.8
+    else:
+        result["segments"][0]["end_seconds"] = 1.5
+    with pytest.raises(words.LocalMediaError) as exc:
+        words.validate_word_sample(result)
+    assert exc.value.reason_code == reason
+    assert "First" not in str(exc.value)
+
+
+def test_model_revision_is_explicit_and_copy_is_independent(words):
+    result = normalized(words)
+    result["model"]["revision"] = "main"
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample(result)
+    assert words.DEFAULT_WORD_MODEL["revision"] != "main"
+    valid = normalized(words)
+    before = copy.deepcopy(valid)
+    assert words.validate_word_sample(valid) == before
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("word_index", True),
+        ("word_index", 2),
+        ("word_count", 50001),
+        ("word_start_seconds", -1),
+        ("word_end_seconds", 1201),
+        ("segment_count", 0),
+        ("segment_index", 1),
+        ("segment_end_seconds", "private"),
+        ("schema_version", True),
+        ("private_locator", "/private/source"),
+    ],
+)
+def test_untrusted_diagnostics_refuse_instead_of_echoing_values(words, field, value):
+    receipt = normalized(words)
+    receipt["segments"][0]["end_seconds"] = 1.5
+    with pytest.raises(words.WordSampleError) as exc:
+        words.validate_word_sample(receipt)
+    diagnostic = exc.value.word_timing
+    diagnostic[field] = value
+    with pytest.raises(words.LocalMediaError) as invalid:
+        words.WordSampleError(diagnostic)
+    assert "private" not in str(invalid.value)
+
+
+@pytest.mark.parametrize("edge", ["start", "end"])
+def test_native_boundary_straddling_keeps_exact_times_and_membership(words, edge):
+    # Native MLX alignment may adjust a boundary word using its median duration
+    # while retaining the segment timestamp. Neither time is a containment box.
+    raw = raw_result()
+    if edge == "start":
+        raw["segments"][0]["start"] = 0.68
+    else:
+        raw["segments"][0]["end"] = 1.8
+    receipt = normalized(words, raw)
+    assert receipt["schema_version"] == 2
+    assert receipt["words"] == normalized(words)["words"]
+    assert receipt["segments"][0][f"{edge}_seconds"] == raw["segments"][0][edge]
+
+
+@pytest.mark.parametrize("index", [True, -1, 1, 0.0, None])
+def test_invalid_explicit_segment_membership_refuses(words, index):
+    receipt = normalized(words)
+    receipt["words"][0]["segment_index"] = index
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample(receipt)
+
+
+def test_word_cannot_borrow_another_segments_quality_metadata(words):
+    raw = raw_result()
+    second = copy.deepcopy(raw["segments"][0])
+    raw["segments"][0]["end"] = 1.0
+    raw["segments"][0]["words"] = raw["segments"][0]["words"][:1]
+    second["start"] = 1.0
+    second["words"] = second["words"][1:]
+    raw["segments"].append(second)
+    receipt = normalized(words, raw)
+    assert [word["segment_index"] for word in receipt["words"]] == [0, 1]
+    receipt["words"][1]["segment_index"] = 0
+    with pytest.raises(words.WordSampleError):
+        words.validate_word_sample(receipt)

--- a/tests/test_speech_calibration.py
+++ b/tests/test_speech_calibration.py
@@ -1,0 +1,309 @@
+"""Fixed recording fixtures exercise the public family-calibration contract."""
+
+import copy
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from conftest import SCRIPTS_VI, SCRIPTS_VP, _import_script
+
+pace = _import_script(Path(SCRIPTS_VP) / "speech_calibration.py", "speech_calibration")
+word_owner = _import_script(
+    Path(SCRIPTS_VI) / "local_media_words.py", "local_media_words"
+)
+SpeechRateError = pace.SpeechRateError
+LocalMediaError = word_owner.LocalMediaError
+
+
+def sample(identifier="one", family="family one", *, gap=0.25, count=600):
+    duration = count * (0.25 + gap)
+    raw = {
+        "language": "en",
+        "segments": [
+            {
+                "start": 0,
+                "end": duration,
+                "compression_ratio": 1.2,
+                "avg_logprob": -0.1,
+                "no_speech_prob": 0.01,
+                "words": [
+                    {
+                        "word": f"token{index}",
+                        "start": index * (0.25 + gap),
+                        "end": index * (0.25 + gap) + 0.25,
+                        "probability": 0.95,
+                    }
+                    for index in range(count)
+                ],
+            }
+        ],
+    }
+    receipt = word_owner.normalize_word_result(
+        raw,
+        source_sha256=hashlib.sha256(identifier.encode()).hexdigest(),
+        sample_sha256=hashlib.sha256((identifier + "sample").encode()).hexdigest(),
+        source_duration_seconds=3600,
+        sample_start_seconds=600,
+        sample_duration_seconds=max(600, duration),
+        provider_version="0.4.3",
+        model=word_owner.DEFAULT_WORD_MODEL,
+        language_probability=0.99,
+    )
+    return {
+        "schema_version": 1,
+        "recording_id": identifier,
+        "family": family,
+        "mode": "demo",
+        "year": 2020,
+        "words": receipt,
+    }
+
+
+def request(samples=None):
+    return {
+        "schema_version": 2,
+        "speaker": "Fixture speaker",
+        "language": "en",
+        "catalog_sha256": "c" * 64,
+        "generated_at": "2024-06-01T12:00:00Z",
+        "demo_modes": ["demo"],
+        "samples": [sample()] if samples is None else samples,
+        "exclusions": [],
+    }
+
+
+def cohort():
+    result = []
+    for index in range(8):
+        row = sample(
+            f"recording{index}", f"family{index}", gap=0.25 + (index % 3) * 0.125
+        )
+        row.update(year=2018 + index % 3, mode="demo" if index % 2 else "lecture")
+        result.append(row)
+    return result
+
+
+def test_family_means_not_delivery_count_weight_the_estimate():
+    rows = [
+        sample("a1", "a"),
+        sample("a2", "a"),
+        sample("a3", "a"),
+        sample("b1", "b", gap=0.75),
+    ]
+    report = pace.calibrate(request(rows))
+    summary = report["summary"]
+    assert summary["recording_count"] == 4
+    assert summary["presentation_family_count"] == 2
+    values = [row["values"]["narration"] for row in report["recordings"]]
+    metric = summary["metrics"]["narration"]
+    expected = (values[0] + values[3]) / 2
+    assert metric["family_balanced_mean"] == pytest.approx(expected)
+    assert metric["family_balanced_mean"] != pytest.approx(sum(values) / 4)
+    assert metric["family_median"] == pytest.approx(expected)
+    assert metric["mean_confidence_interval_95"] == [values[3], values[0]]
+    assert metric["family_mean_range"] == [values[3], values[0]]
+    assert metric["conservative_planning_wpm"] is None
+    assert summary["confidence"]["level"] == "low"
+
+
+def test_all_metrics_intervals_and_mode_coverage_are_retained():
+    report = pace.calibrate(request(cohort()))
+    summary = report["summary"]
+    assert summary["analyzed_duration_seconds"] == 4800
+    assert summary["narration_duration_seconds"] > 1800
+    assert summary["years"] == [2018, 2019, 2020]
+    assert summary["modes"] == ["demo", "lecture"]
+    assert summary["confidence"] == {
+        "schema_version": 1,
+        "level": "conditional",
+        "reasons": [],
+    }
+    assert set(summary["metrics"]) == {
+        "timeline",
+        "narration",
+        "short_phrase",
+        "articulation",
+    }
+    for metric in summary["metrics"].values():
+        low, high = metric["mean_confidence_interval_95"]
+        assert low <= metric["family_balanced_mean"] <= high
+        assert metric["conservative_planning_wpm"] == low
+    assert report["demo_subset"]["summary"]["recording_count"] == 4
+    assert report["demo_subset"]["summary"]["confidence"]["level"] == "low"
+    assert report["by_mode"]["lecture"]["recording_count"] == 4
+    assert report["bootstrap"]["unit"] == "presentation_family_mean"
+    assert report["scope"]["population_generalization"] == "not_established"
+
+
+def test_order_independent_bootstrap_and_no_input_mutation():
+    data = request(cohort())
+    before = copy.deepcopy(data)
+    forward = pace.calibrate(data)
+    assert data == before
+    data["samples"].reverse()
+    assert pace.calibrate(data) == forward
+    assert pace.validate_profile(forward) == forward
+
+
+@pytest.mark.parametrize(
+    "defect,reason",
+    [
+        ("language", "transcribed_language_mismatch"),
+        ("language_probability", "language_confidence_low"),
+        ("probability", "word_confidence_low"),
+        ("compression_ratio", "transcription_compression_excessive"),
+        ("average_log_probability", "transcription_log_probability_low"),
+        ("nonspeech", "nonspeech_hallucination"),
+        ("repetition", "repeated_phrase_hallucination"),
+        ("speed", "impossible_local_word_rate"),
+        ("few_words", "insufficient_lexical_evidence"),
+        ("short", "sample_too_short"),
+    ],
+)
+def test_versioned_quality_gates_retain_exclusions(defect, reason):
+    row = sample(count=60)
+    receipt = row["words"]
+    if defect == "language":
+        receipt["language"] = "ru"
+    elif defect == "language_probability":
+        receipt["language_probability"] = 0.5
+    elif defect == "probability":
+        for word in receipt["words"]:
+            word["probability"] = 0.5
+    elif defect in ("compression_ratio", "average_log_probability"):
+        receipt["segments"][0][defect] = 3.0 if defect == "compression_ratio" else -2.0
+    elif defect == "nonspeech":
+        receipt["segments"][0].update(
+            average_log_probability=-2.0, no_speech_probability=0.9
+        )
+    elif defect == "repetition":
+        for index, word in enumerate(receipt["words"]):
+            word["text"] = ("Thank", "you.")[index % 2]
+    elif defect == "speed":
+        for word in receipt["words"]:
+            word["start_seconds"] /= 10
+            word["end_seconds"] /= 10
+    elif defect == "few_words":
+        receipt["words"] = receipt["words"][:49]
+    elif defect == "short":
+        receipt["sample_duration_seconds"] = 60
+    report = pace.calibrate(request([row]))
+    assert report["summary"]["recording_count"] == 0
+    assert reason in report["exclusions"][0]["reasons"]
+    assert report["calibration"]["samples"][0] == row
+
+
+def test_legitimate_slow_demo_is_retained_but_not_confident():
+    row = sample(count=60, gap=10)
+    report = pace.calibrate(request([row]))
+    assert report["summary"]["recording_count"] == 1
+    assert report["exclusions"] == []
+    assert report["summary"]["metrics"]["timeline"]["family_balanced_mean"] < 6
+    assert "too_little_narration_evidence" in report["summary"]["confidence"]["reasons"]
+
+
+def test_empty_evidence_never_produces_default_rate():
+    data = request([])
+    data["exclusions"] = [
+        {
+            "schema_version": 1,
+            "recording_id": "absent",
+            "reasons": ["local_media_unavailable"],
+        }
+    ]
+    data["demo_modes"] = []
+    report = pace.calibrate(data)
+    assert report["exclusions"] == data["exclusions"]
+    assert report["summary"]["recording_count"] == 0
+    assert report["summary"]["metrics"]["narration"]["family_balanced_mean"] is None
+    assert (
+        report["summary"]["metrics"]["narration"]["mean_confidence_interval_95"] is None
+    )
+    assert report["demo_subset"]["classification"] == "not_classified"
+
+
+def test_source_duplicates_count_once_and_failed_first_sample_does_not_hide_good_evidence():
+    first, second, third = sample("a"), sample("b"), sample("c")
+    second["words"]["source_sha256"] = first["words"]["source_sha256"]
+    third["words"]["source_sha256"] = first["words"]["source_sha256"]
+    first["words"]["language_probability"] = 0.1
+    report = pace.calibrate(request([third, second, first]))
+    assert [row["recording_id"] for row in report["recordings"]] == ["b"]
+    assert report["exclusions"] == [
+        {
+            "schema_version": 1,
+            "recording_id": "a",
+            "reasons": ["language_confidence_low"],
+        },
+        {
+            "schema_version": 1,
+            "recording_id": "c",
+            "reasons": ["duplicate_source_bytes"],
+        },
+    ]
+
+
+def test_conflicting_source_family_excludes_both_but_conflicting_duration_refuses():
+    first, second = sample("a", "one"), sample("b", "two")
+    second["words"]["source_sha256"] = first["words"]["source_sha256"]
+    report = pace.calibrate(request([first, second]))
+    assert report["summary"]["recording_count"] == 0
+    assert all(
+        row["reasons"] == ["source_family_conflict"] for row in report["exclusions"]
+    )
+    second["words"]["source_duration_seconds"] = 3601
+    with pytest.raises(SpeechRateError) as exc:
+        pace.calibrate(request([first, second]))
+    assert exc.value.code == "pace_source_inconsistent"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 3),
+        ("generated_at", "2024-06-01"),
+        ("generated_at", "not-a-date"),
+        ("speaker", ""),
+        ("language", "English"),
+        ("catalog_sha256", "unknown"),
+        ("demo_modes", ["demo", "demo"]),
+        ("demo_modes", [None]),
+        ("samples", None),
+        ("samples", [sample()] * 65),
+        ("exclusions", None),
+    ],
+)
+def test_malformed_request_is_rejected(field, value):
+    data = request()
+    data[field] = value
+    with pytest.raises(SpeechRateError):
+        pace.calibrate(data)
+
+
+def test_malformed_words_are_not_repaired_by_statistics_owner():
+    row = sample()
+    row["words"]["words"][0]["end_seconds"] = 0
+    with pytest.raises(LocalMediaError):
+        pace.calibrate(request([row]))
+
+
+def test_duplicate_recording_identity_and_noncanonical_family_refuse():
+    with pytest.raises(SpeechRateError) as exc:
+        pace.calibrate(request([sample(), sample()]))
+    assert exc.value.code == "pace_recording_duplicate"
+    with pytest.raises(SpeechRateError) as exc:
+        pace.calibrate(request([sample(family="Family  One")]))
+    assert exc.value.code == "pace_family_invalid"
+
+
+@pytest.mark.parametrize(
+    "field", ["summary", "bootstrap", "calibration_sha256", "extra"]
+)
+def test_present_profile_tampering_fails_closed(field):
+    report = pace.calibrate(request([]))
+    report[field] = "tampered"
+    with pytest.raises(SpeechRateError) as exc:
+        pace.validate_profile(report)
+    assert exc.value.code == "pace_profile_inconsistent"

--- a/tests/test_speech_cohort.py
+++ b/tests/test_speech_cohort.py
@@ -1,0 +1,177 @@
+"""Metadata-only cohort fixtures; no media, provider, or live vault access."""
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from conftest import SCRIPTS_VP, _import_script
+
+
+@pytest.fixture
+def cohort():
+    return _import_script(Path(SCRIPTS_VP) / "speech_cohort.py", "speech_cohort")
+
+
+def talk(name, family="family-a", year="2020", mode="lecture", **extra):
+    return {
+        "filename": name,
+        "date": year,
+        "video_path": f"recordings/{name}.mp4",
+        "structured_data": {
+            "talk_family": family,
+            "mode": mode,
+            "delivery_language": "en",
+            "co_presenter": False,
+        },
+        **extra,
+    }
+
+
+def database(*talks):
+    return {"config": {"speaker_name": "Fixture Speaker"}, "talks": list(talks)}
+
+
+def test_plan_balances_families_and_preserves_every_decision(cohort):
+    source = database(talk("a"), talk("b"), talk("c", "family-b", "2021"))
+    before = copy.deepcopy(source)
+    plan = cohort.plan_cohort(
+        source, "Fixture Speaker", language="en", maximum_recordings=2
+    )
+    assert plan["selected_recording_ids"] == ["a", "c"]
+    assert plan["recordings"][1]["reasons"] == ["cohort_budget"]
+    assert source == before
+    source["talks"].reverse()
+    assert (
+        cohort.plan_cohort(
+            source, "Fixture Speaker", language="en", maximum_recordings=2
+        )
+        == plan
+    )
+
+
+def test_explicit_duplicate_recording_is_counted_once(cohort):
+    source = database(
+        talk("a", youtube_id="abcdefghijk"),
+        talk(
+            "b",
+            youtube_id="abcdefghijk",
+            source_relation={"type": "duplicate", "target_filename": "a"},
+        ),
+    )
+    plan = cohort.plan_cohort(source, "Fixture Speaker", language="en")
+    assert plan["selected_recording_ids"] == ["a"]
+    assert plan["recordings"][1]["reasons"] == ["duplicate_recording"]
+
+
+def test_conflicting_duplicate_identity_is_not_guessed(cohort):
+    source = database(
+        talk("a", youtube_id="abcdefghijk"),
+        talk("b", "different", youtube_id="abcdefghijk"),
+    )
+    plan = cohort.plan_cohort(source, "Fixture Speaker", language="en")
+    assert plan["selected_recording_ids"] == []
+    assert all(
+        row["reasons"] == ["duplicate_recording_identity_unresolved"]
+        for row in plan["recordings"]
+    )
+
+
+def test_excluded_duplicate_cannot_hide_a_multiple_speaker_declaration(cohort):
+    canonical = talk("a", youtube_id="abcdefghijk")
+    duplicate = talk(
+        "b",
+        youtube_id="abcdefghijk",
+        source_relation={"type": "duplicate", "target_filename": "a"},
+    )
+    duplicate["structured_data"]["co_presenter"] = True
+    plan = cohort.plan_cohort(
+        database(canonical, duplicate), "Fixture Speaker", language="en"
+    )
+    assert plan["selected_recording_ids"] == []
+    assert plan["recordings"][0]["reasons"] == [
+        "duplicate_recording_identity_unresolved"
+    ]
+    assert plan["recordings"][1]["reasons"] == ["multiple_speakers"]
+
+
+@pytest.mark.parametrize(
+    "field,value,reason",
+    [
+        ("talk_family", None, "presentation_family_missing"),
+        ("mode", None, "delivery_mode_missing"),
+        ("delivery_language", None, "delivery_language_missing"),
+        ("delivery_language", "fr", "different_delivery_language"),
+        ("co_presenter", True, "multiple_speakers"),
+        ("co_presenter", None, "solo_speaker_scope_unverified"),
+        ("co_presenters", ["Second speaker"], "co_presenters_declared"),
+    ],
+)
+def test_unverified_or_out_of_scope_metadata_is_not_inferred(
+    cohort, field, value, reason
+):
+    row = talk("a")
+    row["structured_data"][field] = value
+    plan = cohort.plan_cohort(database(row), "Fixture Speaker", language="en")
+    assert plan["selected_recording_ids"] == []
+    assert reason in plan["recordings"][0]["reasons"]
+
+
+def test_download_requires_explicit_option_and_never_runs_in_plan(cohort):
+    source = database(talk("a", video_path=None, youtube_id="abcdefghijk"))
+    refused = cohort.plan_cohort(source, "Fixture Speaker", language="en")
+    assert refused["recordings"][0]["reasons"] == ["recording_download_not_enabled"]
+    selected = cohort.plan_cohort(
+        source, "Fixture Speaker", language="en", allow_download=True
+    )
+    assert selected["recordings"][0]["source"] == {
+        "kind": "youtube",
+        "video_id": "abcdefghijk",
+    }
+
+
+def test_conflicting_local_sources_are_not_silently_selected(cohort):
+    source = database(talk("a", video_local_path="other.mp4"))
+    plan = cohort.plan_cohort(source, "Fixture Speaker", language="en")
+    assert plan["selected_recording_ids"] == []
+    assert "local_recording_locator_conflict" in plan["recordings"][0]["reasons"]
+
+
+def test_unknown_speaker_and_duplicate_talk_id_fail_closed(cohort):
+    with pytest.raises(cohort.SpeechRateError, match="speaker explicitly named"):
+        cohort.plan_cohort(database(talk("a")), "Another Speaker", language="en")
+    with pytest.raises(cohort.SpeechRateError, match="duplicate talk identities"):
+        cohort.plan_cohort(
+            database(talk("a"), talk("a")), "Fixture Speaker", language="en"
+        )
+
+
+@pytest.mark.parametrize(
+    "row", [{}, {"filename": None}, {"filename": 7}, {"filename": " padded "}]
+)
+def test_malformed_talk_identity_is_a_closed_error(cohort, row):
+    with pytest.raises(cohort.SpeechRateError):
+        cohort.plan_cohort(database(row), "Fixture Speaker", language="en")
+
+
+@pytest.mark.parametrize("modes", [(None,), (["demo"],), ("demo", "demo")])
+def test_invalid_demo_mode_declarations_fail_closed(cohort, modes):
+    with pytest.raises(cohort.SpeechRateError):
+        cohort.plan_cohort(
+            database(talk("a")), "Fixture Speaker", language="en", demo_modes=modes
+        )
+
+
+@pytest.mark.parametrize(
+    "duration,expected", [(3600, (1500, 600)), (300, (30, 240)), (240, (30, 180))]
+)
+def test_sample_window_uses_actual_source_duration(cohort, duration, expected):
+    assert cohort.sample_window(duration) == expected
+
+
+@pytest.mark.parametrize(
+    "duration", [True, "600", float("nan"), float("inf"), -1, 239, 10**1000, 14401]
+)
+def test_inadequate_or_invalid_duration_refuses(cohort, duration):
+    with pytest.raises(cohort.SpeechRateError):
+        cohort.sample_window(duration)

--- a/tests/test_speech_planning.py
+++ b/tests/test_speech_planning.py
@@ -1,0 +1,217 @@
+"""Family-balanced planning remains distinct from actual-recording evidence."""
+
+import copy
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from conftest import SCRIPTS_VP, _import_script
+from test_speech_calibration import cohort, pace, request, sample
+
+rates = _import_script(Path(SCRIPTS_VP) / "speech_rates.py", "speech_rates")
+
+
+@pytest.fixture
+def profile():
+    return pace.calibrate(request(cohort()))
+
+
+def test_plan_retains_mean_observed_range_and_separate_conservative_budget(profile):
+    before = copy.deepcopy(profile)
+    assert rates.validate_profile(profile) == before
+    result = rates.plan_duration(120, intended_metric="narration", profile=profile)
+    metric = profile["summary"]["metrics"]["narration"]
+    assert result["schema_version"] == 2
+    assert result["kind"] == "prediction_not_verification"
+    assert result["rate"]["value"] == metric["family_balanced_mean"]
+    assert (
+        result["rate"]["mean_confidence_interval_95"]
+        == metric["mean_confidence_interval_95"]
+    )
+    assert result["rate"]["range"] == metric["observed_recording_range"]
+    assert result["range_kind"] == "observed_recording_range_not_prediction_interval"
+    assert result["estimated_range_seconds"] == pytest.approx(
+        [
+            7200 / metric["observed_recording_range"][1],
+            7200 / metric["observed_recording_range"][0],
+        ]
+    )
+    assert result["estimated_seconds"] == pytest.approx(
+        7200 / metric["family_balanced_mean"]
+    )
+    assert result["conservative_estimated_seconds"] == pytest.approx(
+        7200 / metric["conservative_planning_wpm"]
+    )
+    assert result["conservative_estimated_seconds"] > result["estimated_seconds"]
+    provenance = result["rate"]["provenance"]
+    assert provenance["sample_count"] == 8
+    assert provenance["presentation_family_count"] == 8
+    assert provenance["calibration_sha256"] == profile["calibration_sha256"]
+    assert len(provenance["evidence_sha256"]) == 8
+    assert profile == before
+
+
+def test_real_calibration_cli_recomputes_v2_from_retained_owner_evidence(profile):
+    original = rates.encode(profile["calibration"])
+    result = subprocess.run(
+        [sys.executable, str(Path(SCRIPTS_VP) / "speech_rates.py"), "calibrate"],
+        input=original,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert len(result.stdout.splitlines()) == 1
+    assert result.stderr == b""
+    report = json.loads(result.stdout)
+    assert report == {"schema_version": 1, "ok": True, "data": profile}
+    assert rates.encode(profile["calibration"]) == original
+
+
+def test_family_profile_wins_over_assumption_but_low_confidence_never_falls_back(
+    profile,
+):
+    assumption = rates.assumed_narration(150, 160, reason="fixture assumption")
+    result = rates.plan_duration(
+        120, intended_metric="narration", profile=profile, assumption=assumption
+    )
+    assert result["rate"]["basis"] == "measured"
+    for rows in ([], [sample()]):
+        sparse = pace.calibrate(request(rows))
+        with pytest.raises(rates.SpeechRateError) as exc:
+            rates.plan_duration(
+                120, intended_metric="narration", profile=sparse, assumption=assumption
+            )
+        assert exc.value.code == "pace_confidence_insufficient"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", True),
+        ("schema_version", 3),
+        ("metric", "articulation"),
+        ("basis", "assumption"),
+        ("mean_confidence_interval_95", None),
+        ("mean_confidence_interval_95", [0, 120]),
+        ("mean_confidence_interval_95", [120, 70]),
+        ("conservative_planning_wpm", True),
+        ("conservative_planning_wpm", 1),
+        ("unknown", "private value"),
+    ],
+)
+def test_bad_family_rate_refuses_without_relabeling(profile, field, value):
+    rate = pace.narration_rate(profile)
+    rate[field] = value
+    with pytest.raises(rates.SpeechRateError):
+        rates.validate_rate(rate)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("schema_version", 1),
+        ("presentation_family_count", True),
+        ("presentation_family_count", 1),
+        ("presentation_family_count", 9),
+        ("sample_count", 1),
+        ("analyzed_duration_seconds", 1),
+        ("evidence_sha256", None),
+        ("evidence_sha256", ["a" * 64] * 8),
+        ("calibration_sha256", "unknown"),
+        ("language", "English"),
+        ("confidence_level", "high"),
+        ("interval_kind", "prediction_interval"),
+        ("range_kind", "confidence_interval"),
+        ("method_version", "word-gaps-v1"),
+    ],
+)
+def test_bad_family_provenance_is_not_accepted_by_readers(profile, field, value):
+    rate = pace.narration_rate(profile)
+    rate["provenance"][field] = value
+    with pytest.raises(rates.SpeechRateError):
+        rates.validate_rate(rate)
+
+
+@pytest.mark.parametrize("families", [5, 6, 7, 8])
+def test_homogeneous_rates_with_broad_coverage_are_representable(families):
+    rows = cohort()
+    for index, row in enumerate(rows):
+        row["family"] = f"family{index % families}"
+        original = sample(row["recording_id"], row["family"])
+        row["words"] = original["words"]
+    report = pace.calibrate(request(rows))
+    rate = pace.narration_rate(report)
+    assert rate["mean_confidence_interval_95"] == [rate["value"], rate["value"]]
+    assert rate["conservative_planning_wpm"] == rate["value"]
+
+
+def test_v2_rate_survives_outline_and_script_without_becoming_a_duration_guarantee(
+    profile, outline_schema, extract_script
+):
+    outline = outline_schema.load_outline(
+        Path(__file__).parent / "fixtures" / "outline-example.yaml"
+    )
+    data = outline.model_dump(mode="json")
+    data["talk"]["pacing_wpm"] = None
+    data["talk"]["pacing_rate"] = pace.narration_rate(profile)
+    restored = outline_schema.Outline.model_validate_json(json.dumps(data))
+    assert restored.talk.narration_rate == data["talk"]["pacing_rate"]
+    rendered = extract_script.render(restored)
+    assert "measured family-balanced mean" in rendered
+    assert "conservative planning" in rendered
+    assert "8 recordings, 8 families" in rendered
+    assert "conditional mean 95% interval" in rendered
+    assert "not a prediction interval" in rendered
+    assert "actual word timestamps and actual duration" in rendered
+    assert "observed sample range" not in rendered
+
+
+@pytest.mark.parametrize(
+    "defect,code",
+    [
+        (None, None),
+        ("low", "pace_confidence_insufficient"),
+        ("words", "pace_word_evidence_invalid"),
+        ("tampered", "pace_profile_inconsistent"),
+    ],
+)
+def test_real_cli_dispatch_preserves_typed_errors_and_never_writes_input(
+    profile, tmp_path, defect, code
+):
+    if defect == "low":
+        profile = pace.calibrate(request([]))
+    elif defect == "words":
+        profile["calibration"]["samples"][0]["words"]["words"][0]["end_seconds"] = 0
+    elif defect == "tampered":
+        profile["summary"]["metrics"]["narration"]["family_balanced_mean"] = 1
+    payload = {
+        "schema_version": 1,
+        "word_count": 120,
+        "intended_metric": "narration",
+        "profile": profile,
+        "assumption": None,
+    }
+    original = rates.encode(payload)
+    source = tmp_path / "planning.json"
+    source.write_bytes(original)
+    result = subprocess.run(
+        [sys.executable, str(Path(SCRIPTS_VP) / "speech_rates.py"), "plan"],
+        input=original,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert result.returncode == (1 if defect else 0), result.stderr
+    assert len(result.stdout.splitlines()) == 1
+    report = json.loads(result.stdout)
+    assert report["ok"] is (defect is None)
+    if defect:
+        assert report["error"]["code"] == code
+        assert "token0" not in result.stdout.decode() + result.stderr.decode()
+    else:
+        assert report["data"]["schema_version"] == 2
+    assert source.read_bytes() == original


### PR DESCRIPTION
## Summary

- Implement #368's repeatable vault-root calibration command using strict catalog/interpreter authority and bounded ingress-owned audio sampling, fresh native word timestamps, immutable model identity, exact-generation checks and private scratch cleanup.
- Retain all selection/acquisition/quality exclusions, family-balanced metrics and conditional bootstrap uncertainty. Add v1/v2 owner recomputation, planning and creator readers; keep mean, historical range and conservative budget distinct and reject sparse profiles without a fallback default.
- Preserve existing transcripts, tracking state, queues and profiles. No catalog reparsing or profile promotion occurs. This advances #368 but does not close it: recorder consumption and the accepted vertical slice remain under #364/#369.

## Test plan

- [x] Full pytest suite: 7,518 passed, 8 skipped; no new skips introduced.
- [x] Ruff lint/format and full Pyright gate with the test interpreter: zero findings.
- [x] Plugin lint, package inclusion, shipped-extension, skill-entrypoint, dependency-pin and conflict-marker gates.
- [x] Fixed regressions for duplicate-family weighting, hallucination rejection, native NumPy timestamps, explicit segment membership, degenerate bootstrap endpoints, typed CLI errors, v1 compatibility and v2 outline/script rendering.
- [x] Native Apple-Silicon test through the configured interpreter: one 10-minute recording admitted. Expanded 24-recording run admitted nine recordings across eight families (90 minutes), retained 15 alignment exclusions, and remained low-confidence for an unverified catalog year. Catalog digest unchanged throughout.
- [x] Recompute the retained native evidence through the owner CLI and verify that planning refuses its low-confidence candidate.

## Remaining acceptance and review state

No full native manual-validation pass is claimed: listening checks and speaker-only acceptance remain required before promoting the private profile. No end-to-end screencast recorder or human-accepted 2–3 minute slice is claimed.

Required Tessl reviews were attempted at threshold 85 for vault-profile, vault-ingress and presentation-creator. All returned the exact out-of-credits error, not a score. The existing publish workflow explicitly opts into coding-policy's credit-outage skip; these skills remain **unreviewed**, not quality-passed. No review threshold or CI configuration was changed. PR policy review, Copilot review and publish/registry/moderation verification remain required.

Versioning: use the release workflow's default patch bump; no manual manifest restamp.
