### PR TITLE
fix(ingress): Reject repetitive Whisper output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### Refuse pathological unspaced Whisper output before transcript replacement
+
+Native #219 validation exposed an intermittent repetitive syllable suffix that
+passed the word/duration floor while its timing was correctly withheld. Add a
+bounded acquisition-only periodic-letter-run guard with a path-neutral refusal,
+preserving the entire prior transcript bundle instead of trimming or inventing
+timing. Long nonrepetitive words and unspaced languages remain admissible.
+Use greedy decoding without previous-window text prompts for full transcription;
+Whisper documents previous-text conditioning as a repetition-loop risk. Retain
+the independent optional timing downgrade and all existing receipt schemas.
+Advance the transient media pipeline version for the changed acquisition gate.
+
 ## 0.20.127 — 2026-09-05
 
 ### Derive family-balanced narration calibration from fresh audio samples

--- a/skills/vault-ingress/references/local-media-acquisition.md
+++ b/skills/vault-ingress/references/local-media-acquisition.md
@@ -38,6 +38,14 @@ pins. A failed optional lane does not invalidate independent captions or slides.
   exits. It does not register or preserve a recording in the vault.
 - Worker arguments contain no source locator or model path. Authenticated
   private request payloads carry them; diagnostics remain bounded and redacted.
+- Full Whisper acquisition uses greedy decoding without previous-window text
+  prompts. Its bounded result gate rejects extreme unspaced periodic letter
+  runs with `whisper_repetitive_text`; see
+  `skills/vault-ingress/scripts/local_media_contract.py` —
+  `WHISPER_REPETITION_POLICY_VERSION` and `_reject_repetitive_whisper_text`.
+  This is a decoder-loop guard, not a complete hallucination detector. A refusal
+  returns no truncated transcript and preserves the prior bundle. It does not
+  migrate an existing quality receipt or authenticate a recording's catalog identity.
 
 ## Refusal and Recovery
 

--- a/skills/vault-ingress/scripts/local_media_contract.py
+++ b/skills/vault-ingress/scripts/local_media_contract.py
@@ -16,10 +16,11 @@ from typing import Any, NoReturn
 
 from artifact_metadata import ArtifactAvailability, WINDOWS_REPARSE_POINT_ATTRIBUTE
 from artifact_supervisor import DiagnosticReceipt, FileGeneration, SupervisorLimits
+from transcript_quality import WORD
 
 
 MEDIA_SCHEMA_VERSION = 1
-MEDIA_PIPELINE_VERSION = "1.0.0"
+MEDIA_PIPELINE_VERSION = "1.1.0"
 MEDIA_MAX_INPUT_BYTES = 8 * 1024**3
 MEDIA_MAX_DURATION_SECONDS = 8 * 60 * 60
 MEDIA_MAX_STREAMS = 64
@@ -30,6 +31,15 @@ WHISPER_MAX_TEXT_BYTES = 2 * 1024 * 1024
 WHISPER_MAX_SEGMENTS = 20000
 WHISPER_MAX_SEGMENT_TEXT_BYTES = 16384
 WHISPER_MAX_LANGUAGE_LENGTH = 32
+# Acquisition-only decoder-loop guard, not a complete hallucination detector.
+# Native #219 evidence appended hundreds of unspaced repeated syllables to
+# otherwise plausible speech, hiding the defect from duration/word-count floors.
+# A run must span at least 256 letters with a period no longer than 32 letters:
+# at least eight cycles, far beyond ordinary stuttering or a long technical word.
+# Never truncate the output or infer what the speaker actually said.
+WHISPER_REPETITION_POLICY_VERSION = "unspaced-periodic-text-v1"
+WHISPER_REPETITION_MIN_CHARACTERS = 256
+WHISPER_REPETITION_MAX_PERIOD = 32
 
 MEDIA_METADATA_LIMITS = SupervisorLimits(
     profile_id="local-media-metadata-v1",
@@ -385,6 +395,7 @@ def bounded_whisper_result(value: Any) -> dict[str, Any]:
     if not isinstance(text, str) or not text.strip():
         refuse("whisper_result_invalid")
     _bounded_text(text, WHISPER_MAX_TEXT_BYTES, "whisper_text_limit")
+    _reject_repetitive_whisper_text(text)
     language = value.get("language")
     if language is not None and (
         not isinstance(language, str)
@@ -425,6 +436,26 @@ def bounded_whisper_result(value: Any) -> dict[str, Any]:
         if not timing_valid:
             segments = None
     return {"text": text, "language": language, "segments": segments}
+
+
+def _reject_repetitive_whisper_text(text: str) -> None:
+    """Refuse long periodic letter runs in bounded text, without rewriting it.
+
+    Reuse the transcript owner's Unicode lexical boundaries. Ordinary long
+    words and unspaced nonrepetitive languages remain valid. Work is linear in
+    text length times the fixed maximum period; there is no backtracking regex,
+    model call, or growing substring table. Short words cost one length check.
+    """
+    for word in WORD.finditer(text):
+        start, end = word.span()
+        if end - start < WHISPER_REPETITION_MIN_CHARACTERS:
+            continue
+        for period in range(1, WHISPER_REPETITION_MAX_PERIOD + 1):
+            run = period
+            for index in range(start + period, end):
+                run = run + 1 if text[index] == text[index - period] else period
+                if run >= WHISPER_REPETITION_MIN_CHARACTERS:
+                    refuse("whisper_repetitive_text")
 
 
 def _segment_offset(value: Any) -> bool:

--- a/skills/vault-ingress/scripts/local_media_transcription.py
+++ b/skills/vault-ingress/scripts/local_media_transcription.py
@@ -68,6 +68,7 @@ WHISPER_FAILURES = frozenset(
         "whisper_dependency_unavailable",
         "whisper_provider_failed",
         "whisper_result_invalid",
+        "whisper_repetitive_text",
         "whisper_text_limit",
         "whisper_language_invalid",
         "whisper_segments_invalid",
@@ -284,7 +285,13 @@ def _transcribe_with_mlx(
         raise LocalMediaError("whisper_dependency_unavailable") from exc
     try:
         if not word_timestamps:
-            value = provider.transcribe(str(path), path_or_hf_repo=model)
+            value = provider.transcribe(
+                str(path),
+                path_or_hf_repo=model,
+                temperature=0.0,
+                condition_on_previous_text=False,
+                verbose=None,
+            )
         else:
             value = provider.transcribe(
                 str(path),

--- a/tests/test_fetch_transcript.py
+++ b/tests/test_fetch_transcript.py
@@ -1174,6 +1174,7 @@ def test_existing_local_quality_refresh_rechecks_after_staging(
         "whisper_worker_failed",
         "whisper_provider_failed",
         "whisper_result_invalid",
+        "whisper_repetitive_text",
         "whisper_text_limit",
         "whisper_language_invalid",
         "whisper_segment_limit",

--- a/tests/test_local_media_contract.py
+++ b/tests/test_local_media_contract.py
@@ -319,3 +319,63 @@ def test_optional_timing_downgrade_still_checks_every_segment_ceiling(contract):
     value["segments"].append({"text": "x" * 16385, "start": 2, "end": 3})
     with pytest.raises(contract.LocalMediaError, match="whisper_segment_text_limit"):
         contract.bounded_whisper_result(value)
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        "a",
+        "ed",
+        "eda",
+        "абв",
+        "你好",
+        "abcdefghijklmnop",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+    ],
+)
+def test_whisper_rejects_long_unspaced_periodic_runs(contract, unit):
+    # Synthetic shape of the native #219 suffix, never a copied talk transcript.
+    repeated = (unit * 256)[:256]
+    text = "Ordinary speech before. prefix" + repeated + "suffix. Speech after."
+    with pytest.raises(contract.LocalMediaError) as caught:
+        contract.bounded_whisper_result({"text": text, "language": "en"})
+    assert caught.value.reason_code == "whisper_repetitive_text"
+    assert repeated not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "a" * 255,
+        "eda " * 100,
+        "Long paragraphs may contain ordinary repeated words. " * 100,
+        " ".join("eda" * 70 for _ in range(10)),
+        "\n" * 1000 + "Actual speech",
+        "".join(chr(0x4E00 + index) for index in range(1024)),
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg" * 20,  # period 33, outside policy
+    ],
+)
+def test_whisper_preserves_text_outside_the_bounded_repetition_policy(contract, text):
+    assert contract.bounded_whisper_result({"text": text})["text"] == text
+
+
+def test_whisper_repetition_failure_never_returns_a_trimmed_prefix(contract):
+    value = {
+        "text": "Complete useful speech. " + "eda" * 220,
+        "segments": [{"text": "Complete useful speech.", "start": 0, "end": 2}],
+    }
+    with pytest.raises(contract.LocalMediaError, match="whisper_repetitive_text"):
+        contract.bounded_whisper_result(value)
+    assert value["text"].endswith("eda" * 220)
+
+
+def test_repetition_guard_keeps_optional_timing_mismatch_independent(contract):
+    value = {
+        "text": "Complete useful speech.",
+        "segments": [{"text": "Different optional timing.", "start": 0, "end": 2}],
+    }
+    assert contract.bounded_whisper_result(value) == {
+        "text": value["text"],
+        "language": None,
+        "segments": value["segments"],
+    }

--- a/tests/test_local_media_transcription.py
+++ b/tests/test_local_media_transcription.py
@@ -89,6 +89,10 @@ def test_real_protocol_keeps_provider_stdout_out_of_result(
     [
         ("raise OSError('private/path provider failure')", "whisper_provider_failed"),
         ("return {'text': ''}", "whisper_result_invalid"),
+        (
+            "return {'text': 'Complete useful speech. ' + 'eda' * 220}",
+            "whisper_repetitive_text",
+        ),
         ("return {'text': 'x' * (2 * 1024 * 1024 + 1)}", "whisper_text_limit"),
         (
             "return {'text': 'speech', 'language': 'private/path'}",
@@ -151,7 +155,11 @@ def test_worker_result_serialization_limit_is_preserved_as_resource_failure(
     whisper, speech_file, tmp_path, monkeypatch
 ):
     _fake_provider_worker(
-        whisper, tmp_path, monkeypatch, "return {'text': 'x' * 8192}", result_limit=4096
+        whisper,
+        tmp_path,
+        monkeypatch,
+        "return {'text': 'speech ' * 1200}",
+        result_limit=4096,
     )
     with pytest.raises(whisper.LocalMediaError, match="whisper_worker_resource_limit"):
         whisper.transcribe_local_media(
@@ -304,3 +312,26 @@ def test_process_control_signals_are_not_swallowed(whisper, monkeypatch, signal)
     )
     with pytest.raises(signal):
         whisper._transcribe_with_mlx(Path("unused.wav"), "model")
+
+
+def test_native_full_transcription_uses_greedy_independent_windows(
+    whisper, monkeypatch
+):
+    def transcribe(
+        path, *, path_or_hf_repo, temperature, condition_on_previous_text, verbose
+    ):
+        assert path == "speech.wav"
+        assert path_or_hf_repo == "model"
+        assert temperature == 0.0
+        assert condition_on_previous_text is False
+        assert verbose is None
+        return {"text": "Complete useful speech.", "language": "en"}
+
+    monkeypatch.setitem(
+        sys.modules, "mlx_whisper", SimpleNamespace(transcribe=transcribe)
+    )
+    assert whisper._transcribe_with_mlx(Path("speech.wav"), "model") == {
+        "text": "Complete useful speech.",
+        "language": "en",
+        "segments": None,
+    }


### PR DESCRIPTION
## Summary

- Fix the native repetitive-syllable output defect recorded on #219. Refuse extreme unspaced periodic letter runs before returning full Whisper speech, with a closed path-neutral error and no trimming or replacement of the prior transcript bundle.
- Use greedy, independent-window decoding for full transcription. Preserve the existing optional-timing downgrade, persistent receipt schemas, caption behavior, and sampled-word lane. Advance only the transient media worker pipeline generation for the changed acquisition contract.
- Document this acquisition-only guard's scope: it is not a complete hallucination detector, a catalog identity repair, or permission to reparse the vault.

## Test plan

- [x] Targeted suites: 295 passed, including native-shaped periodic suffixes, threshold boundaries, Unicode/nonrepetitive text, authenticated failure propagation, prior-bundle preservation, and decoder options.
- [x] Full regression suite: **7,537 passed, 8 skipped** in 285.06 seconds.
- [x] Full Ruff lint/format (471 files), Pyright, package/extension checks, entrypoint checks, conflict markers, Tessl pin check, and exact CI plugin lint: pass.
- [x] Exact retained bad native transcript: released 0.20.127 accepts it; patched acquisition gate refuses `whisper_repetitive_text`. Synthetic fixtures preserve the observed failure shape without copying a talk transcript into the repository.
- [x] Fresh native run of the public #219 recording `Kl6tLcQ5hGI`: 797 words, 318-second provider duration, 86 valid source-bound timing segments, clean ending prose, and exact transcript digests matching both receipts. No live vault output was replaced.
- [x] Mandatory Tessl quality review attempted: exact organization-out-of-credits failure. The existing `skill-review-credit-outage: skip` exception applies; this skill has not received a quality-review pass. CI must retry and disclose any unreviewed publication.
- [ ] Complete eight-check native procedure, including an independently supplied non-YouTube source: not claimed. The QCon provenance case still requires the original or authorized replacement media plus owner-supported binding; #219 remains open.

## Scope and release

Patch release through the coding-policy release workflow: both automated reviewers, every feedback thread handled, green CI, exact-merge publish success, registry advance, moderation pass, and branch/worktree cleanup. No CI or dependency changes, source-registration changes, live transcript migration, or catalog reparsing.
