### PR TITLE
feat(catalog): Seed styles from all recent delivered talks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Seed reusable styles from twenty delivered-talk decks
+
+Complete #92's separate delivered-talk evidence pass across all twenty public
+deliveries from April 1 through September 5, 2026: inspect 819 PDF pages and add
+nine reusable styles without replacing the three Berglund exploration seeds.
+Record each delivery's style mapping, representative pages, exclusions and
+source fingerprint. Keep repeated deliveries deduplicated and mixed terminal/
+arcade decks explicit. Samples link to already-public decks; no local artifacts,
+slide images or vault data are published. Preserve style-only anchors, personal
+overlay semantics, candidate receipts and render-before-choice gates.
+
 ## 0.20.128 — 2026-09-05
 
 ### Refuse pathological unspaced Whisper output before transcript replacement

--- a/skills/illustrations/catalog/styles.json
+++ b/skills/illustrations/catalog/styles.json
@@ -87,6 +87,276 @@
         "reference": "https://github.com/jbaruch/speaker-toolkit/issues/92",
         "note": "Owner-supplied anchor from the Building Agents with MCP and Data Streams exploration. Style detail is retained; lettering is separated and scene/page-furniture instructions are conditional under #87."
       }
+    },
+    {
+      "schema_version": 1,
+      "slug": "wartime-technical-manual",
+      "name": "Wartime Technical Manual",
+      "anchors": {
+        "FULL": "A mid-twentieth-century technical-manual illustration: precise black and warm-sepia pen linework, fine crosshatching and stippled shadows, restrained engraved detail, and lightly foxed cream paper with an aged matte print texture. Mechanical and human forms use period instructional-drawing proportions rather than glossy contemporary 3D rendering.",
+        "IMG+TXT": "A mid-twentieth-century technical-manual illustration: precise black and warm-sepia pen linework, fine crosshatching and stippled shadows, restrained engraved detail, and lightly foxed cream paper with an aged matte print texture. Mechanical and human forms use period instructional-drawing proportions rather than glossy contemporary 3D rendering."
+      },
+      "text_treatment": "Use heavy, condensed, upright black sans-serif capitals with the slightly uneven ink character of old technical printing. Render any explicitly requested handwritten annotation in restrained blue ink.",
+      "conventions": "Keep the main drawing monochrome. Reserve muted blue for an explanatory emphasis and red for a warning when those meanings are requested. Borders, seals, stamps, numbered figures, arrows, labels, panels and machinery are scene content, never automatic decorations.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "historical",
+        "technical",
+        "line-art",
+        "paper"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1sRoSrOn4YH5bwDATlow9UR4JlOuLJCED/view",
+        "description": "Representative delivered-deck PDF page 18. The 58-page local source associated with this public deck was rendered and visually inspected on 2026-09-05. This is a deck reference, not bundled as a raster sample or approval of a newly generated exploration image."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/2026-04-14-arcofai26-ai-native-dev/",
+        "note": "Derived from the visual language of The AI-Native Developer at Arc of AI, 2026-04-14. Source-specific people, claims, branding, page furniture and diagrams are not part of the reusable anchor."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "synthwave-line-art-comic",
+      "name": "Synthwave Line-Art Comic",
+      "anchors": {
+        "FULL": "A retro-futurist synthwave comic illustration with clean, continuous contour lines, flat cel-shaded forms, deep midnight-blue shadows, electric-cyan edge light, and saturated orange highlights. Use crisp vector-like detail, controlled neon glow and strong dark-to-luminous contrast rather than visible pixel blocks or photographic texture.",
+        "IMG+TXT": "A retro-futurist synthwave comic illustration with clean, continuous contour lines, flat cel-shaded forms, deep midnight-blue shadows, electric-cyan edge light, and saturated orange highlights. Use crisp vector-like detail, controlled neon glow and strong dark-to-luminous contrast rather than visible pixel blocks or photographic texture."
+      },
+      "text_treatment": "Use bold forward-slanted block capitals with orange fill, a fine pale outline and a restrained dark extrusion. Keep lettering crisp and consistent with the illustrated linework.",
+      "conventions": "Maintain a cool blue/cyan field with concentrated warm-orange emphasis. Perspective grids, circuit traces, lightning, vehicles, characters, interface panels and footer text appear only when the individual scene requests them; no recurring franchise imagery is implied.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "retro",
+        "synthwave",
+        "comic",
+        "high-contrast"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1Nz07GwJtFc1qfieKsNuhQmIHurZVAC6h/view",
+        "description": "Representative delivered-deck PDF page 19. The 66-page local source associated with this public deck was rendered and visually inspected on 2026-09-05. This is a deck reference, not bundled as a raster sample or approval of a newly generated exploration image."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/2026-04-16-arcofai-bttf-2026/",
+        "note": "Derived from the illustrated pages of Back To The Future of Software at Arc of AI, 2026-04-16. Photographs, embedded screenshots, film characters and recurring branded scenery remain source-specific content."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "neon-pixel-arcade",
+      "name": "Neon Pixel Arcade",
+      "anchors": {
+        "FULL": "A richly detailed retro-arcade pixel illustration with visibly stepped sprite edges, compact pixel clusters, hard dark contours, dithered shading and subtle horizontal CRT scanline texture. Set luminous cyan, violet and magenta against near-black navy, with selective amber highlights and tightly controlled emissive bloom.",
+        "IMG+TXT": "A richly detailed retro-arcade pixel illustration with visibly stepped sprite edges, compact pixel clusters, hard dark contours, dithered shading and subtle horizontal CRT scanline texture. Set luminous cyan, violet and magenta against near-black navy, with selective amber highlights and tightly controlled emissive bloom."
+      },
+      "text_treatment": "Use crisp arcade block or monospaced capitals with pixel-stepped outlines. Main display lettering may use a bright cyan or warm-amber face with a dark outline and restrained neon highlight; supporting labels remain legible, compact and monospaced.",
+      "conventions": "When a scene explicitly names opposing roles, maintain a stable amber/orange accent for one and cyan/blue for the other. Robots, arenas, scoreboards, health bars, versus marks, stage labels, cabinets and city scenery are optional scene content, not permanent style furniture.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "retro",
+        "arcade",
+        "pixel-art",
+        "neon"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1Egbfosfz_Ki7jVjlDCnne88Gq2tXeYIh/view",
+        "description": "Representative delivered-deck PDF page 10. All 17 pages were rendered and visually inspected, with page 10 checked individually on 2026-09-05. The arcade treatment also appears in the separately inspected JNation Codepocalypse deck. This is a deck reference, not bundled as a raster sample or generated-style approval."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/2026-05-26-jnation-2026-robocoders-judgment-day/",
+        "note": "Derived from the illustrated stage pages of RoboCoders at JNation, 2026-05-26. The same deck's terminal-style text pages are a separate visual mode; the arcade anchor does not claim to describe every page."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "midnight-terminal",
+      "name": "Midnight Terminal",
+      "anchors": {
+        "FULL": "A restrained terminal/editor visual language: an untextured near-black or dark-indigo ground, crisp pale monospaced lettering and sparse flat geometric marks, with muted lavender, mint and warm amber accents. Keep edges clear, contrast readable and rendering deliberately two-dimensional, without photographic lighting, glossy depth or neon bloom.",
+        "IMG+TXT": "A restrained terminal/editor visual language: an untextured near-black or dark-indigo ground, crisp pale monospaced lettering and sparse flat geometric marks, with muted lavender, mint and warm amber accents. Keep edges clear, contrast readable and rendering deliberately two-dimensional, without photographic lighting, glossy depth or neon bloom."
+      },
+      "text_treatment": "Use bold upright monospaced titles in warm cream or amber, pale gray body text and restrained syntax-like accent colors. Keep text readable and editable through the overlay composition.",
+      "conventions": "Use accent colors consistently for roles explicitly named in the scene, and reserve high-saturation red for a requested warning. Code blocks, prompts, tables, flowcharts, progress markers and footer handles are content decisions; do not add them to an unrelated scene.",
+      "composition": "overlay",
+      "tags": [
+        "minimal",
+        "terminal",
+        "technical",
+        "typographic"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1gQ98-dgxuiiP347z5xb8oGrsK8r-AYfh/view",
+        "description": "Representative delivered-deck PDF page 12. All 33 pages were visually inspected, alongside the separate 17-page Arc of AI RoboCoders deck. This is a typographic presentation style, not evidence of a painted illustration. The PDF reference is not bundled as a raster sample."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/2026-04-14-arcofai26-codepocalypse-now/",
+        "note": "Derived from Codepocalypse Now at Arc of AI, 2026-04-14, with corroborating terminal-mode pages in Arc of AI RoboCoders. Overlay is the proposed reusable implementation, not a claim that the original PDF exposed editable title layers. The Devoxx UK and JavaZone 300 Tokens decks corroborate a sparser near-black variant."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "halftone-editorial-comic",
+      "name": "Halftone Editorial Comic",
+      "anchors": {
+        "FULL": "A pop-art editorial cartoon with rounded expressive drawing, confident black contours, saturated flat colors and soft cel-shaded volume. Use visible Ben-Day dot screening across colored surfaces and a lightly printed texture. Favor playful caricature and clear silhouettes over muscular superhero anatomy or cinematic photorealism.",
+        "IMG+TXT": "A pop-art editorial cartoon with rounded expressive drawing, confident black contours, saturated flat colors and soft cel-shaded volume. Use visible Ben-Day dot screening across colored surfaces and a lightly printed texture. Favor playful caricature and clear silhouettes over muscular superhero anatomy or cinematic photorealism."
+      },
+      "text_treatment": "Use heavy, condensed, forward-slanted comic capitals. Set display text in black on a light ground or white with a crisp black outline on a colored ground; supporting prose uses a clean rounded sans-serif.",
+      "conventions": "Keep a coherent bright palette of yellow, cyan, purple, coral and green, with stable colors for any repeated semantic roles. Speech bubbles, starbursts, panels, drop shadows, arrows, monkeys, brains, memes and footer handles are optional scene content, not automatic decorations.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "comic",
+        "pop-art",
+        "halftone",
+        "editorial"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1kdQXJ3qe2p982yzP2bA0Bp_cufT3y_2v/view",
+        "description": "Representative PDF page 38; all 78 source pages were rendered and visually inspected on 2026-09-05. This public deck reference is not bundled as a raster sample and is not approval of a newly generated exploration image."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/2026-04-01-vdams26-coding-fast-and-slow/",
+        "note": "Derived from Coding Fast and Slow at Voxxed Days Amsterdam, 2026-04-01; corroborated across four separately inspected Never Trust a Monkey deliveries. This lighter editorial lettering and multicolor print treatment is distinct from the existing Comic Book Hero exploration."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "patinated-ochre-oil",
+      "name": "Patinated Ochre Oil",
+      "anchors": {
+        "FULL": "An early-modernist oil-painted illustration with elongated simplified forms, dark brushed contours, shallow pictorial depth and visible scumbled paint texture. Use warm ochre, burnt sienna, olive and cream against deep brown-black shadows, with subdued amber illumination and an aged varnish patina. Preserve tactile brushwork rather than clean vector edges or glossy CGI.",
+        "IMG+TXT": "An early-modernist oil-painted illustration with elongated simplified forms, dark brushed contours, shallow pictorial depth and visible scumbled paint texture. Use warm ochre, burnt sienna, olive and cream against deep brown-black shadows, with subdued amber illumination and an aged varnish patina. Preserve tactile brushwork rather than clean vector edges or glossy CGI."
+      },
+      "text_treatment": "Use sturdy condensed display lettering in warm cream or ochre with a dark outline. Keep the letterforms legible against the textured paint and give secondary text a simpler upright treatment.",
+      "conventions": "Keep highlights warm and the overall palette earthy and low-key. Cats, cafes, Parisian posters, period clothing, laptops, crates, signs and recurring people belong to the individual scene, not the reusable style.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "painterly",
+        "oil-paint",
+        "historical",
+        "earth-tones"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1lRNiK6PKoZacB6rJoWmEhtsb4INeEelu/view",
+        "description": "Representative PDF page 9; all 20 source pages were rendered and visually inspected on 2026-09-05. This public deck reference is not bundled as a raster sample and is not approval of a newly generated exploration image."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/aidevcon-london-2026-dont-write-prompts/",
+        "note": "Derived from Don't Write Prompts, Write Software at AI Native DevCon London, 2026-06-02. Page 9 provides a text-free paint reference; lettering is evidenced by the surrounding pages. Source characters and setting are excluded."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "selective-color-noir",
+      "name": "Selective-Color Noir",
+      "anchors": {
+        "FULL": "A cinematic film-noir illustration rendered in grayscale ink and charcoal-like shading: hard directional light, deep black shadow masses, luminous pale highlights, fine tonal grain and carefully drawn continuous contours. Use strong chiaroscuro, controlled atmospheric softness and a worn photographic-print texture; retain an illustrated rather than purely photographic finish.",
+        "IMG+TXT": "A cinematic film-noir illustration rendered in grayscale ink and charcoal-like shading: hard directional light, deep black shadow masses, luminous pale highlights, fine tonal grain and carefully drawn continuous contours. Use strong chiaroscuro, controlled atmospheric softness and a worn photographic-print texture; retain an illustrated rather than purely photographic finish."
+      },
+      "text_treatment": "Use luminous white mid-century sign lettering: flowing script for short display phrases and condensed upright capitals for denser labels, with restrained haloing and readable contrast.",
+      "conventions": "Keep the image predominantly monochrome. Small green or red accents may mark explicitly requested success or danger; warm light may mark a requested resolution. Detectives, faceless figures, blinds, smoke, rain, guns, office furniture, borders and inset captions are not automatic scene additions.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "noir",
+        "monochrome",
+        "cinematic",
+        "high-contrast"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1Kjn6qv6dYgaUlqqikHRsIpwBZV_W4YqE/view",
+        "description": "Representative PDF page 21; all 35 source pages were rendered and visually inspected on 2026-09-05. This public deck reference is not bundled as a raster sample and is not approval of a newly generated exploration image."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/2026-06-16-checkmarx-agentsecops/",
+        "note": "Derived from DevSecOps Is Dead. Meet AgentSecOps at the Checkmarx virtual summit, 2026-06-16. The recurring detective story, characters and forensic props are content, not part of the reusable anchor."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "primary-brick-diorama",
+      "name": "Primary Brick Diorama",
+      "anchors": {
+        "FULL": "A clean toy-construction illustration in which requested forms are built from interlocking molded-plastic bricks with visible studs, modular seams and crisp beveled edges. Use bright primary red, blue and yellow with green accents, thin dark contours, restrained plastic highlights and soft contact shadows against a white or near-white ground. Preserve tangible small-scale depth and clear three-quarter views.",
+        "IMG+TXT": "A clean toy-construction illustration in which requested forms are built from interlocking molded-plastic bricks with visible studs, modular seams and crisp beveled edges. Use bright primary red, blue and yellow with green accents, thin dark contours, restrained plastic highlights and soft contact shadows against a white or near-white ground. Preserve tangible small-scale depth and clear three-quarter views."
+      },
+      "text_treatment": "Use heavy upright black sans-serif capitals for main headings and simple bold label lettering. Short emphasis may use primary red or blue; keep the words crisp rather than making every label into a brick object.",
+      "conventions": "Assign a stable primary color to each explicitly named repeated role. Minifigures, conveyor belts, baseplates, houses, arrows, labels, logos and blue footer bands appear only when requested by the scene. Studded material does not imply a particular branded character or set.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "systems",
+        "modular",
+        "toy",
+        "three-dimensional"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1nwhvo-Kh5IAzGsbbbEIjOXsmPb-EgQo6/view",
+        "description": "Representative PDF page 8; all 18 source pages were rendered and visually inspected on 2026-09-05. This public deck reference is not bundled as a raster sample and is not approval of a newly generated exploration image."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/agentcon-miami-2026-skill-issue/",
+        "note": "Derived from Skill Issue at AgentCon Miami, 2026-06-12, and corroborated by the separately inspected St. Louis delivery, 2026-06-25. Studded primary-color construction differs from the existing smooth, low-poly Isometric Systems 3D exploration."
+      }
+    },
+    {
+      "schema_version": 1,
+      "slug": "indigo-vermilion-woodblock",
+      "name": "Indigo Vermilion Woodblock",
+      "anchors": {
+        "FULL": "A Japanese woodblock-inspired print illustration with flattened layered depth, flowing carved contour lines, dense fine-line detail and broad areas of restrained pigment. Use deep indigo, muted blue-green, warm vermilion and pale ochre on visibly fibrous, aged cream paper. Keep ink edges slightly irregular and surface color matte, with subtle rubbed and weathered print texture.",
+        "IMG+TXT": "A Japanese woodblock-inspired print illustration with flattened layered depth, flowing carved contour lines, dense fine-line detail and broad areas of restrained pigment. Use deep indigo, muted blue-green, warm vermilion and pale ochre on visibly fibrous, aged cream paper. Keep ink edges slightly irregular and surface color matte, with subtle rubbed and weathered print texture."
+      },
+      "text_treatment": "Use dark-indigo, heavy slab-serif display lettering with modest printed wear. Render any explicitly supplied non-Latin text faithfully; the style does not require inventing additional characters or calligraphy.",
+      "conventions": "When opposing roles are explicitly requested, preserve vermilion for one and blue-green for the other. Waves, mountains, monsters, lightning, cartouches, borders and footer bands are scene choices, not permanent decorations.",
+      "composition": "poster-theatrical",
+      "tags": [
+        "woodblock",
+        "historical",
+        "print",
+        "limited-palette"
+      ],
+      "sample": {
+        "schema_version": 1,
+        "kind": "reference",
+        "location": "https://drive.google.com/file/d/1-vD_Xs1ZhYizsH45-AP0EBRU1Jrxa9U7/view",
+        "description": "Representative PDF page 6; all 16 source pages were rendered and visually inspected on 2026-09-05. This public deck reference is not bundled as a raster sample and is not approval of a newly generated exploration image."
+      },
+      "provenance": {
+        "schema_version": 1,
+        "kind": "delivered-talk",
+        "reference": "https://speaking.jbaru.ch/talks/jspring-2026-robocoders/",
+        "note": "Derived from RoboCoders at J-Spring, 2026-06-04. Source monsters, wave imagery and Japanese labels are excluded from the reusable anchor; this matte woodblock treatment is distinct from the other RoboCoders deliveries' neon arcade art."
+      }
     }
   ]
 }

--- a/skills/illustrations/references/delivered-style-seeds.md
+++ b/skills/illustrations/references/delivered-style-seeds.md
@@ -1,0 +1,90 @@
+# Delivered-Talk Style Seeds
+
+## Scope and evidence
+
+The #92 seed pass covers all 20 deliveries listed at
+[speaking.jbaru.ch](https://speaking.jbaru.ch/) from 2026-04-01 through
+2026-09-05, including JavaZone on September 3. The April boundary is inclusive.
+Inspection on 2026-09-05 covered all 819 PDF pages, not just title slides.
+Numbered contact sheets covered every page; representative pages were also
+checked individually. Page numbers below are one-based PDF pages, not printed
+slide numbers. The ingress PDF owner admitted each source before rendering and
+confirmed the same source generation after rendering.
+
+This is the maintainer-requested public seed pass in
+[issue #92](https://github.com/jbaruch/speaker-toolkit/issues/92), not an automatic
+post-ingress contribution. Samples remain links to decks the speaker already
+published through the shownotes. No slide images, transcripts, local paths,
+vault records or inspection renders are bundled or uploaded. A `reference`
+entry does not deliver an inspected raster to a future reader: fetch and inspect
+its representative page before choosing it for a new exploration. No generated
+style or new talk outline is approved by this audit.
+
+Nine delivered-talk entries augment the three existing exploration entries in
+`skills/illustrations/catalog/styles.json`. A repeated delivery reuses an entry
+only after its own deck inspection. Mixed decks may map to two entries; an
+embedded screenshot, meme or promotional slide does not create another style.
+The catalog's composition is the proposed reusable implementation, not a claim
+about editable layers in the source PDF. No tracking-schema change, personal
+catalog write, queue mutation or talk reparse is part of this pass.
+
+## Delivery coverage
+
+Every row represents a separately inspected PDF. The notes name illustrative
+pages, while the page count records the complete inspected deck.
+
+| Delivery / public shownotes | Pages | Catalog entries | Visual evidence and exclusions |
+|---|---:|---|---|
+| [2026-04-01 · Amsterdam · Never Trust a Monkey](https://speaking.jbaru.ch/talks/2026-04-01-vdams26-monkey/) | 29 | `halftone-editorial-comic` | Pages 7, 17, 22 and 24 use black-contour cartoons and dot screening; text cards use condensed italic comic lettering. Photographs and screenshots are embedded content. |
+| [2026-04-01 · Amsterdam · Coding Fast and Slow](https://speaking.jbaru.ch/talks/2026-04-01-vdams26-coding-fast-and-slow/) | 78 | `halftone-editorial-comic` | Pages 27, 38 and 59 show expressive cartoons, saturated color and visible halftone dots. Page 38 was checked individually. Speech balloons and panel geometry are not anchor requirements. |
+| [2026-04-14 · Arc of AI · AI-Native Developer](https://speaking.jbaru.ch/talks/2026-04-14-arcofai26-ai-native-dev/) | 58 | `wartime-technical-manual` | Cream aged paper, sepia/black crosshatching and technical-print capitals; page 18 checked individually. Blue annotations and red warnings are conditional, not mandatory page furniture. |
+| [2026-04-14 · Arc of AI · Codepocalypse Now](https://speaking.jbaru.ch/talks/2026-04-14-arcofai26-codepocalypse-now/) | 33 | `midnight-terminal` | Dark-indigo ground, pale monospaced text, restrained flat charts and syntax accents; page 12 is representative. This is a typographic mode, not painted-illustration evidence. |
+| [2026-04-16 · Arc of AI · Back To The Future](https://speaking.jbaru.ch/talks/2026-04-16-arcofai-bttf-2026/) | 66 | `synthwave-line-art-comic` | Continuous cel-shaded outlines, cyan edge light and orange italic display type; page 19 checked individually. Film characters, vehicles and circuit borders are excluded. |
+| [2026-04-16 · Arc of AI · RoboCoders](https://speaking.jbaru.ch/talks/2026-04-16-arcofai26-robocoders-judgment-day/) | 17 | `midnight-terminal` | Navy/amber monospaced presentation with embedded lavender sketch diagrams; page 13 checked individually. The diagrams are an embedded mode, not pixel-art evidence. |
+| [2026-04-22 · JCON · Never Trust a Monkey](https://speaking.jbaru.ch/talks/2026-04-22-jcon-eu-2026-monkey/) | 101 | `halftone-editorial-comic` | Pages 33, 73, 76, 77 and 80 corroborate the print-cartoon treatment. Screenshots, photos and memes interrupt but do not redefine the reusable visual language. |
+| [2026-05-07 · Devoxx UK · 300 Tokens](https://speaking.jbaru.ch/talks/2026-05-07-devoxx-uk-2026-300-tokens/) | 34 | `midnight-terminal` | Sparse near-black ground, pale monospaced text and red/blue/yellow/green chapter accents, especially pages 7–18 and 25–32. Thin rules and footer text are not automatic decorations. |
+| [2026-05-14 · GeeCON · You're Absolutely Right](https://speaking.jbaru.ch/talks/geecon-2026-absolutely-right/) | 75 | `wartime-technical-manual` | Pages 9, 24–26, 38 and 61 corroborate sepia instructional linework and weathered paper. Numbered figures, military seals, stamps and recurring robots stay scene-specific. |
+| [2026-05-22 · KotlinConf · RoboCoders](https://speaking.jbaru.ch/talks/2026-05-22-kotlinconf-26-robocoders-judgment-day/) | 19 | `neon-pixel-arcade`, `midnight-terminal` | Illustrated stages on pages 9, 10, 12, 15 and 16 use neon arcade rendering; intervening slides use the navy terminal mode. Scoreboards, fighters and team colors remain conditional scene choices. |
+| [2026-05-26 · JNation · Codepocalypse Now](https://speaking.jbaru.ch/talks/2026-05-26-codepocalypse-jnation-2026/) | 12 | `neon-pixel-arcade` | Neon cybercity/arcade illustrations with cyan, violet and magenta, interleaved with white text bands. The bands do not prove editable PDF layers or require a duplicate style. |
+| [2026-05-26 · JNation · RoboCoders](https://speaking.jbaru.ch/talks/2026-05-26-jnation-2026-robocoders-judgment-day/) | 17 | `neon-pixel-arcade`, `midnight-terminal` | Page 10 checked individually: stepped sprite edges and CRT scanline texture are visible. Terminal prose is a separate mode; not every page is arcade art. |
+| [2026-06-02 · AI Native DevCon London · Don't Write Prompts](https://speaking.jbaru.ch/aidevcon-london-2026-dont-write-prompts/) | 20 | `patinated-ochre-oil` | All pages use earthy, scumbled oil paint, elongated forms and low-key warm light; text-free page 9 checked individually. Cats, cafe interiors and posters are not anchor requirements. |
+| [2026-06-04 · J-Spring · Never Trust a Monkey](https://speaking.jbaru.ch/talks/jspring-2026-monkey/) | 42 | `halftone-editorial-comic` | Pages 19, 20, 23, 33 and 35 retain the screened editorial-cartoon language. Text cards and screenshots remain distinct content modes. |
+| [2026-06-04 · J-Spring · RoboCoders](https://speaking.jbaru.ch/talks/jspring-2026-robocoders/) | 16 | `indigo-vermilion-woodblock` | Matte paper, flattened depth, carved contours and indigo/vermilion pigment; page 6 checked individually. Monsters, waves, mountains and Japanese cartouches are content, not defaults. |
+| [2026-06-12 · AgentCon Miami · Skill Issue](https://speaking.jbaru.ch/talks/agentcon-miami-2026-skill-issue/) | 18 | `primary-brick-diorama` | Studded interlocking plastic, primary colors, thin contours and white ground; page 8 checked individually. Characters, baseplates, arrows and footer bands are optional scene content. |
+| [2026-06-16 · Checkmarx · AgentSecOps](https://speaking.jbaru.ch/talks/2026-06-16-checkmarx-agentsecops/) | 35 | `selective-color-noir` | Grayscale illustrated chiaroscuro, grain and luminous sign lettering, with selective signal color; page 21 checked individually. Detectives, faceless figures, blinds and smoke are excluded from the anchor. |
+| [2026-06-18 · Voxxed Luxembourg · Never Trust a Monkey](https://speaking.jbaru.ch/talks/voxxed-lu-2026-monkey/) | 98 | `halftone-editorial-comic` | Pages 35, 75, 78, 79 and 82 corroborate the print-cartoon treatment. The short branded orange-stripe insert is not promoted to a reusable signature style. |
+| [2026-06-25 · AgentCon St. Louis · Skill Issue](https://speaking.jbaru.ch/talks/agentcon-st-louis-2026-skill-issue/) | 18 | `primary-brick-diorama` | Independently inspected deck retains the same studded material and primary-color treatment, including page 8; changed shownotes and closing artwork do not create a second style. |
+| [2026-09-03 · JavaZone · 300 Tokens](https://speaking.jbaru.ch/talks/2026-09-03-javazone-2026-300-tokens/) | 33 | `midnight-terminal` | Independently inspected near-black, monospaced variant corroborates Devoxx UK. Chapter colors and thin rules are content-level conventions; no illustrated style is invented from the title. |
+
+## Source fingerprints
+
+These SHA-256 values identify the exact inspected PDF bytes. Public Drive links
+can later change; a digest is an audit fingerprint, not a promise that a future
+download is unchanged. All twenty public downloads were verified without
+account cookies. The six Arc/JNation sources initially inspected from local
+caches matched their fresh public downloads byte-for-byte through the ingress
+PDF owner's probe; the other fourteen were rendered directly from their public
+downloads. Rendering outputs remained private.
+
+| Public deck | SHA-256 of inspected PDF |
+|---|---|
+| [Amsterdam Monkey](https://drive.google.com/file/d/1-qLTom2Plf3RkQ3EbfWf8Qb3ga7BIFCW/view) | `b20f2e8d9814afbc9d4b4b8dd1ec7bcae23f4398751173c4db30f243c7ff4cda` |
+| [Amsterdam Coding](https://drive.google.com/file/d/1kdQXJ3qe2p982yzP2bA0Bp_cufT3y_2v/view) | `e8fe49aec8c6252b60e1c6f8c14a357e9bf882bf108997d4ece23d0b15b7b2e2` |
+| [Arc AI-Native](https://drive.google.com/file/d/1sRoSrOn4YH5bwDATlow9UR4JlOuLJCED/view) | `9424051db728ca80d8c38def4b01ac337dedd65f5d39c70c2e335125d1d80640` |
+| [Arc Codepocalypse](https://drive.google.com/file/d/1gQ98-dgxuiiP347z5xb8oGrsK8r-AYfh/view) | `e5a7fd4dab63356f0defb14466100ee868e9726d5de4389f06ae059568031369` |
+| [Arc Back To The Future](https://drive.google.com/file/d/1Nz07GwJtFc1qfieKsNuhQmIHurZVAC6h/view) | `2bf236a177562153ded7764016ce495aec33a17450c6789a03838e825ebd2dba` |
+| [Arc RoboCoders](https://drive.google.com/file/d/1ykjblzGZuiORaMtIkv1EMaKX8YdN-swK/view) | `017931483e503a28a6a9a993a89d2348be6b2b78f9cea716426c9863e17fe8be` |
+| [JCON Monkey](https://drive.google.com/file/d/1132bCeAKmY36YRgo6SUpWjzbJWf4sF26/view) | `05a01ac534446dc19a83aa9d4bcc09fffcd3af85f64556e91a3a698241161988` |
+| [Devoxx UK](https://drive.google.com/file/d/1n6ahv2X1fmn1dEQp8G3vWDFvIbA8UjLc/view) | `41ebaf092db1b8f2284774c9587837c183abcecafd93d6cc90df18d94771a074` |
+| [GeeCON](https://drive.google.com/file/d/10ZbYU0r9w0kJ75QHIOmZRBRR8KdXcS_g/view) | `0b1e35e513ab91e5d8a07c7889ec401678933edcea09779dedb3beaee1d1119f` |
+| [KotlinConf](https://drive.google.com/file/d/19CZmxze_UsVL7M-db5e5RF9xwp6ZIq3Z/view) | `92e0063b17bbf9086fb77f274c625c6cbadcecd8c8d06228fe2b605653dad86a` |
+| [JNation Codepocalypse](https://drive.google.com/file/d/1GVlLDVGR6MTlOD5h0mUZEXxNyVLG5i8B/view) | `686e3a92129d3c1903d4c7fe5584ec0f7668f2ddf4db86f97041f5be515b2b56` |
+| [JNation RoboCoders](https://drive.google.com/file/d/1Egbfosfz_Ki7jVjlDCnne88Gq2tXeYIh/view) | `8a864f9377f1b63a92a9f8ab709c6a7c262f45e4e43266a9e6828f4a02f38502` |
+| [AI Native DevCon London](https://drive.google.com/file/d/1lRNiK6PKoZacB6rJoWmEhtsb4INeEelu/view) | `f1b9f89c6c3ec5f058e04d953bc16449bd0950abd37d3590e8c29e336c78db18` |
+| [J-Spring Monkey](https://drive.google.com/file/d/116kEslnHtN4UYwCOvfHGvxstsCSRSG8j/view) | `f3ac062825447dab38c20d025674585ba245080b3c51914e72b3ed974649fd26` |
+| [J-Spring RoboCoders](https://drive.google.com/file/d/1-vD_Xs1ZhYizsH45-AP0EBRU1Jrxa9U7/view) | `44b1b11484af7327668c85a1651d8f09505cc352af17371325aee8971ead028a` |
+| [AgentCon Miami](https://drive.google.com/file/d/1nwhvo-Kh5IAzGsbbbEIjOXsmPb-EgQo6/view) | `1636899ae2340c0591a089bcc90f9c0b89a026fa76e61472df1f569fc0e12dc1` |
+| [Checkmarx](https://drive.google.com/file/d/1Kjn6qv6dYgaUlqqikHRsIpwBZV_W4YqE/view) | `ddb8ea1fd93daac699a57917c4e18c508cc9211e43dfa64d426bc69a1f4a0d95` |
+| [Voxxed Luxembourg](https://drive.google.com/file/d/11mGbaAvS_HWAWuUBFXUeYJxNWJOdqBx8/view) | `1cc22c044d5b66f3be7f251a4dc9033e024f75f33fbf2e7139da3a7ec1b4ea77` |
+| [AgentCon St. Louis](https://drive.google.com/file/d/1YTRSxWWEh1ukHRccs7b_eVJ8jiBq3AN5/view) | `e98a17fbf06ac0f8186e12c876dc42fa8376f3197ddc0755cb69f8c981c7dcf8` |
+| [JavaZone](https://drive.google.com/file/d/1M0JDvLyqiVkRDN7dk5ENjWsJDaAfXFWe/view) | `1ca0a4655e9676701e823b6f6d7ed985d9db99d12c91be4cdcb9ec6afd1136c3` |

--- a/skills/illustrations/references/style-catalog.md
+++ b/skills/illustrations/references/style-catalog.md
@@ -154,8 +154,10 @@ before adding it to the public catalog. An issue is a proposal, not automatic
 catalog admission, rendered-sample approval, or permission to publish a vault.
 
 The initial three Berglund exploration entries cite their owner-supplied issue
-anchors; their images are unbundled references. Seeding from delivered talks
-dated April 2026 onward is a separate evidence pass after this format lands:
-verify the delivery/source identity, inspect actual slides, extract style-only
-features, and retain a consented sample with exact provenance. Do not label the
-three exploration seeds as that completed delivered-talk pass.
+anchors; their images are unbundled references. The separate
+[delivered-talk seed audit](delivered-style-seeds.md) covers the April 2026 onward
+deliveries visible on 2026-09-05. It records per-deck inspection, reusable style
+mappings and source fingerprints. Its samples are existing public deck links,
+not bundled raster images. For later additions, verify delivery/source identity,
+inspect actual slides, extract style-only features, and retain a consented sample
+with exact provenance. The three exploration seeds are not delivered-talk evidence.

--- a/tests/test_style_catalog.py
+++ b/tests/test_style_catalog.py
@@ -3,6 +3,7 @@
 import copy
 import json
 from pathlib import Path
+import re
 import stat
 import subprocess
 import sys
@@ -12,6 +13,19 @@ import pytest
 
 from conftest import SCRIPTS_ILL, _import_script
 from test_generate_illustrations import _write_outline
+
+
+DELIVERED_SLUGS = {
+    "halftone-editorial-comic",
+    "indigo-vermilion-woodblock",
+    "midnight-terminal",
+    "neon-pixel-arcade",
+    "patinated-ochre-oil",
+    "primary-brick-diorama",
+    "selective-color-noir",
+    "synthwave-line-art-comic",
+    "wartime-technical-manual",
+}
 
 
 @pytest.fixture
@@ -44,7 +58,7 @@ def write_json(path, value):
 
 def test_packaged_seeds_are_closed_versioned_references(catalog):
     merged = catalog.load_merged()
-    assert {style["slug"] for style in merged["styles"]} == {
+    assert {style["slug"] for style in merged["styles"]} == DELIVERED_SLUGS | {
         "comic-book-hero",
         "isometric-systems-3d",
         "illuminated-manuscript",
@@ -58,6 +72,58 @@ def test_packaged_seeds_are_closed_versioned_references(catalog):
     assert merged["personal_sha256"] == "missing"
 
 
+@pytest.mark.parametrize("slug", sorted(DELIVERED_SLUGS))
+def test_delivered_seed_survives_real_candidate_reader(
+    catalog, generate_illustrations, tmp_path, slug
+):
+    merged = catalog.load_merged()
+    source = next(style for style in merged["styles"] if style["slug"] == slug)
+    assert source["provenance"]["kind"] == "delivered-talk"
+    assert source["provenance"]["reference"].startswith("https://speaking.jbaru.ch/")
+    assert source["sample"]["location"].startswith("https://drive.google.com/file/d/")
+    assert "PDF page" in source["sample"]["description"]
+    formats = {"FULL": 3}
+    if source["composition"] == "overlay":
+        formats["IMG+TXT"] = 4
+    candidate = catalog.seed_candidates(merged, selection([slug], slides=formats))
+    path = write_json(tmp_path / "candidates.json", candidate)
+    parsed = generate_illustrations.parse_candidates(str(path))
+    assert parsed["styles"] == [source]
+    assert parsed["slides"] == formats
+
+
+def test_delivered_audit_covers_twenty_decks_and_every_new_style(catalog):
+    audit = (
+        Path(SCRIPTS_ILL).parent / "references" / "delivered-style-seeds.md"
+    ).read_text(encoding="utf-8")
+    coverage = re.findall(
+        r"^\| \[(2026-[^\]]+)\]\((https://speaking\.jbaru\.ch/[^)]+)\)"
+        r" \| (\d+) \| ([^|]+) \|",
+        audit,
+        re.MULTILINE,
+    )
+    assert len(coverage) == 20
+    assert len({url for _, url, _, _ in coverage}) == 20
+    assert sum(int(pages) for _, _, pages, _ in coverage) == 819
+    assert min(label[:10] for label, _, _, _ in coverage) == "2026-04-01"
+    assert max(label[:10] for label, _, _, _ in coverage) == "2026-09-03"
+    mapped = set()
+    for _, _, _, entries in coverage:
+        slugs = set(re.findall(r"`([a-z0-9-]+)`", entries))
+        assert slugs and slugs <= DELIVERED_SLUGS
+        mapped.update(slugs)
+    assert mapped == DELIVERED_SLUGS
+    fingerprints = re.findall(
+        r"\]\((https://drive\.google\.com/file/d/[^)]+)\) \| `([0-9a-f]{64})`",
+        audit,
+    )
+    assert len(fingerprints) == len({url for url, _ in fingerprints}) == 20
+    references = {url for url, _ in fingerprints}
+    for style in catalog.load_merged()["styles"]:
+        if style["slug"] in DELIVERED_SLUGS:
+            assert style["sample"]["location"] in references
+
+
 def test_personal_shadow_and_union_leave_public_untouched(catalog, tmp_path):
     original = catalog.PUBLIC_PATH.read_bytes()
     entry = personal_entry(catalog, "comic-book-hero")
@@ -67,7 +133,7 @@ def test_personal_shadow_and_union_leave_public_untouched(catalog, tmp_path):
         {"schema_version": 1, "styles": [entry, custom]},
     )
     merged = catalog.load_merged(tmp_path)
-    assert len(merged["styles"]) == 4
+    assert len(merged["styles"]) == len(catalog.load_merged()["styles"]) + 1
     shadow = next(
         style for style in merged["styles"] if style["slug"] == "comic-book-hero"
     )
@@ -258,7 +324,9 @@ def test_preview_apply_backup_and_exact_idempotence(catalog, tmp_path):
     second = personal_entry(catalog, "second-style")
     changed = catalog.put_entry(tmp_path, second, catalog.digest(original), apply=True)
     assert Path(changed["backup"]).read_bytes() == original
-    assert len(catalog.load_merged(tmp_path)["styles"]) == 5
+    assert len(catalog.load_merged(tmp_path)["styles"]) == (
+        len(catalog.load_merged()["styles"]) + 2
+    )
     assert (
         next(
             item


### PR DESCRIPTION
## Summary

- Complete the maintainer-requested delivered-talk seed pass for #92: inspect all 20 public deliveries from April 1 through September 5, 2026 (819 PDF pages) and add nine reusable styles beside the three existing exploration seeds.
- Preserve per-delivery coverage, representative PDF pages, public source links and exact inspected-byte fingerprints. Deduplicate repeated visual languages and identify mixed terminal/arcade decks explicitly; keep source characters, branding and page furniture out of reusable anchors.
- Keep samples as already-published deck references, with their unbundled limitations visible. No local paths, private source text, slide images, vault writes, schema changes or reparsing are included.

Fixes #92.

## Test plan

- [x] Visually inspect all 819 pages across 20 source decks; verify source generations before/after rendering and inspect representative pages individually. Match all six initially cached PDFs byte-for-byte to fresh public downloads.
- [x] Catalog suite: 106 passed, including every new entry through the real candidate reader, complete delivery coverage, source references, and unchanged personal overlay/owner-write behavior.
- [x] Ruff lint and format, Pyright (zero diagnostics), pre-publish gates, and plugin lint.
- [x] Complete repository suite: 7,547 passed, eight existing skips.
- [x] Policy review, Copilot review, exact-commit CI, registry advance, and moderation clearance.

## Release notes

Patch release: additive catalog data and evidence/tests; no schema or API change.
The required local Tessl skill-quality review was attempted at threshold 85 and
failed with the explicit out-of-credits signature. The repository's existing
`skill-review-credit-outage: skip` configuration permits that specific case;
the illustrations skill is unreviewed, not quality-approved. The publish log
confirmed that classification. All other review and release gates passed,
including exact-merge main CI, registry advance to 0.20.129, and moderation.
