### PR TITLE
fix(vault): Migrate catalog root without reparsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,16 @@
 # Changelog
 
-### Preserve legacy catalog generations during reviewed metadata corrections
+### Migrate the catalog root without disturbing talk analysis or claims
 
-The #339 delivery-date audit found a session stored on the conference's opening
-day instead of its scheduled day. The metadata writer already supported legacy
-talks, but its root-current gate still blocked the live root-v2 catalog; normal
-migration correctly refused its active queue claims. Admit only metadata-only
-plans on the validated pre-source-alias root with current config. Preserve root
-and talk generations, analysis, claim history, and all unrelated state. Keep
-mixed plans, older/future roots, and malformed owner state closed. Cover exact
-preservation, CLI dry-run/apply digests, stale input refusal, and scope isolation.
-Make the owner's migration-policy exception explicit for standalone reviewed
-metadata repairs, with owner readback and an immediate stop before processing.
+The #339 delivery-date corrections were blocked by a legacy catalog root and
+active claims. The full migration also advances independent analysis records;
+metadata corrections must not trigger that work. Add an explicit `--root-only`
+owner migration for the additive root upgrade already supported by deployed
+dual readers. Preserve every child value and claim contract, with complete owner
+validation, exact backups, hash-bound apply, and concurrent-generation refusal.
+Keep the metadata writer's current-root gate: no policy exception or legacy-root
+write bypass. Verify child preservation, idempotence, claim replay, and stale
+queue/result-writer reload. Full migration and processing gates remain separate.
 
 ## 0.20.129 — 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ plans on the validated pre-source-alias root with current config. Preserve root
 and talk generations, analysis, claim history, and all unrelated state. Keep
 mixed plans, older/future roots, and malformed owner state closed. Cover exact
 preservation, CLI dry-run/apply digests, stale input refusal, and scope isolation.
+Make the owner's migration-policy exception explicit for standalone reviewed
+metadata repairs, with owner readback and an immediate stop before processing.
 
 ## 0.20.129 — 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ### Preserve legacy catalog generations during reviewed metadata corrections
 
 The #339 delivery-date audit found a session stored on the conference's opening

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Preserve legacy catalog generations during reviewed metadata corrections
+
+The #339 delivery-date audit found a session stored on the conference's opening
+day instead of its scheduled day. The metadata writer already supported legacy
+talks, but its root-current gate still blocked the live root-v2 catalog; normal
+migration correctly refused its active queue claims. Admit only metadata-only
+plans on the validated pre-source-alias root with current config. Preserve root
+and talk generations, analysis, claim history, and all unrelated state. Keep
+mixed plans, older/future roots, and malformed owner state closed. Cover exact
+preservation, CLI dry-run/apply digests, stale input refusal, and scope isolation.
+
 ## 0.20.129 — 2026-09-05
 
 ### Seed reusable styles from twenty delivered-talk decks

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -100,21 +100,11 @@ re-renders without being located again. The `pptx_catalog` array fuzzy-matches
 
 ## Step 1 — Bootstrap Vault State
 
-Narrow exception for a standalone, explicitly requested catalog metadata repair
-under `stateful-artifacts` Migration Policy:
-
-1. Use the owner read and mutation commands above; submit only reviewed metadata
-   corrections through the compatibility contract in
-   [references/schemas-db.md](references/schemas-db.md#owner-read-and-mutation-contract).
-2. Require a successful dry run, then bind application to its input and candidate
-   digests. An owner refusal authorizes no write or manual compatibility override.
-3. Preserve schema generations, analysis, active claims, claim history, and all
-   fields outside the reviewed plan. Do not migrate or recover claims for this repair.
-4. Re-read through the owner, verify the intended changes, report, and finish here.
-   Do not select a batch, reparse, or regenerate derived artifacts.
-
-Every other owner write follows the normal migration policy. Processing runs
-continue through bootstrap and the following steps.
+For an explicitly requested standalone catalog metadata repair, use the
+[root-only owner migration](references/schemas-db.md#root-only-owner-migration)
+before the reviewed metadata transaction. Re-read through the owner, verify the
+changes, report, and finish here. Do not select a batch, reparse, or regenerate
+derived artifacts. Processing runs continue through bootstrap below.
 
 Execute [Bootstrap and Preflight](references/bootstrap-and-preflight.md) in full.
 Do not select work until migration succeeds, the catalog is structurally valid,

--- a/skills/vault-ingress/SKILL.md
+++ b/skills/vault-ingress/SKILL.md
@@ -100,6 +100,22 @@ re-renders without being located again. The `pptx_catalog` array fuzzy-matches
 
 ## Step 1 — Bootstrap Vault State
 
+Narrow exception for a standalone, explicitly requested catalog metadata repair
+under `stateful-artifacts` Migration Policy:
+
+1. Use the owner read and mutation commands above; submit only reviewed metadata
+   corrections through the compatibility contract in
+   [references/schemas-db.md](references/schemas-db.md#owner-read-and-mutation-contract).
+2. Require a successful dry run, then bind application to its input and candidate
+   digests. An owner refusal authorizes no write or manual compatibility override.
+3. Preserve schema generations, analysis, active claims, claim history, and all
+   fields outside the reviewed plan. Do not migrate or recover claims for this repair.
+4. Re-read through the owner, verify the intended changes, report, and finish here.
+   Do not select a batch, reparse, or regenerate derived artifacts.
+
+Every other owner write follows the normal migration policy. Processing runs
+continue through bootstrap and the following steps.
+
 Execute [Bootstrap and Preflight](references/bootstrap-and-preflight.md) in full.
 Do not select work until migration succeeds, the catalog is structurally valid,
 and offline preflight has no blocking finding. Before preflight may inspect any

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -706,7 +706,8 @@ updates and human-approved conflict decisions stay separate paths; source lanes
 stay with `apply-source-repairs.py`.
 
 Metadata-only plans also have a generation-preserving root compatibility path,
-owned by `_require_mutation_database` in that command. It validates the entire
+authorized by the standalone repair exception in `SKILL.md` Step 1 and owned by
+`_require_mutation_database` in that command. It validates the entire
 database before and after the edit without migrating the root, config, talk
 records, observations, or queue claims. Mixing any other operation into the
 plan retains the normal current-root requirement. Active claims are not

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -705,6 +705,14 @@ transition it demands are named at the top of
 updates and human-approved conflict decisions stay separate paths; source lanes
 stay with `apply-source-repairs.py`.
 
+Metadata-only plans also have a generation-preserving root compatibility path,
+owned by `_require_mutation_database` in that command. It validates the entire
+database before and after the edit without migrating the root, config, talk
+records, observations, or queue claims. Mixing any other operation into the
+plan retains the normal current-root requirement. Active claims are not
+recovered, cancelled, or restamped to make a catalog correction possible; the
+shared transaction still rejects a competing writer's changed snapshot.
+
 The command owns each operation's closed fields and record validation; do not
 reimplement those allowlists in skill prose. PPTX catalog records require exact
 integer `schema_version: 2`, since only v2 carries the visual-evidence

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -30,8 +30,8 @@ config, PPTX, QR, resource, thumbnail, confirmed-intent, source-rejection, and
 goal versions likewise map only to their validated historical v1 shapes. Config
 v2 adds the owner-controlled `pptx_directory_exclusions` discovery boundary.
 Run the owner migration in vault-ingress Step 1.
-Dry-run emits the exact input SHA-256. Apply requires that digest, refuses active
-queue claims, stores the complete original bytes under `.backups/`, and replaces
+Dry-run emits the exact input SHA-256. Apply requires that digest, stores the
+complete original bytes under `.backups/`, and replaces
 the verified generation atomically. Backup directory and file opens do not
 follow symbolic links. The target input comparison remains exact across bytes
 and every `FileGeneration` field, including `mtime_ns` and `ctime_ns`, after
@@ -43,6 +43,52 @@ are each stable across one byte-read window within the writer-owned bounded
 attempts. Exhaustion and every hard staged mismatch raise
 `StagedCandidateConflictError` carrying the failed invariant. The class is
 defined in `skills/vault-ingress/scripts/tracking_database_io.py`.
+Full migration refuses active queue claims. The independently scoped
+[root-only migration](#root-only-owner-migration) preserves supported claims.
+
+### Root-only owner migration
+
+For a standalone catalog metadata repair, use the configured interpreter and
+strict owner read from the bootstrap contract. Deploy the dual readers before
+applying this migration; do not use an older toolkit worker that rejects its
+target root. Capture the pre-migration persisted-observation audit on a database
+copy as described in [bootstrap-and-preflight.md](bootstrap-and-preflight.md).
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" --root-only
+```
+
+The supported inputs and root-only transformation are owned by
+`migrate_tracking_database_root` in
+`skills/vault-ingress/scripts/tracking_database.py`. The command validates
+the complete input and candidate. It preserves every child value, including
+analysis generations, observations, active claims, baselines, and history.
+It never repairs evidence, requeues a talk, or creates a source alias.
+
+Exit 0 emits the normal migration report plus `migration_scope: "root_only"`.
+Review the root transition, input/output digests, zero child-record changes,
+and zero repaired/requeued observations. Apply only that successful preview:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/migrate-tracking-database.py" \
+  "{vault_root}/tracking-database.json" --root-only \
+  --apply --expected-sha256 "{input_sha256}"
+```
+
+The command retains the shared atomic transaction and exact backup contract.
+A stale digest, concurrent writer, unsupported generation, or inconsistent
+claim refuses without overwriting the database. A pre-migration writer must
+reload through its owner before retrying; do not recover its unchanged claim.
+Re-read through `read-tracking-database.py`, compare the output digest, and
+verify that only the root version changed. Repeating the root-only operation
+on its installed output is a byte-and-inode-preserving no-op.
+
+After root migration, dry-run the reviewed metadata plan through
+`mutate-tracking-database.py`, bind apply to both reported digests, and re-read
+to verify only the intended fields changed. Report the result and finish the
+standalone repair. This mode does not replace full bootstrap or preflight for
+processing and cannot be combined with the QR-version repair mode.
 
 ### `pptx_catalog` v1 -> v2 -> v3
 
@@ -171,9 +217,10 @@ defaults; a valid owner-supplied list is preserved exactly. It
 preserves every other JSON value and missing-vs-present distinction, including
 legacy-v1 `pattern_observations` objects, arrays, or nulls and every historical
 citation/source-inspection field. Explicit version 0 sentinels, future owner
-versions, ambiguous or malformed historical records, and active claims fail
+versions, and ambiguous or malformed historical records fail
 before backup or write. An exact current database is a byte-and-inode-preserving
-no-op.
+no-op. Full migration additionally refuses active claims when changing record
+or root state; the standalone root-only mode below preserves their contracts.
 
 | Independent record | Current schema |
 |---|---:|
@@ -705,14 +752,9 @@ transition it demands are named at the top of
 updates and human-approved conflict decisions stay separate paths; source lanes
 stay with `apply-source-repairs.py`.
 
-Metadata-only plans also have a generation-preserving root compatibility path,
-authorized by the standalone repair exception in `SKILL.md` Step 1 and owned by
-`_require_mutation_database` in that command. It validates the entire
-database before and after the edit without migrating the root, config, talk
-records, observations, or queue claims. Mixing any other operation into the
-plan retains the normal current-root requirement. Active claims are not
-recovered, cancelled, or restamped to make a catalog correction possible; the
-shared transaction still rejects a competing writer's changed snapshot.
+Metadata mutations still require the current root. A standalone correction may
+use the [root-only owner migration](#root-only-owner-migration) first. Never
+recover, cancel, or restamp an active claim merely to permit a catalog edit.
 
 The command owns each operation's closed fields and record validation; do not
 reimplement those allowlists in skill prose. PPTX catalog records require exact

--- a/skills/vault-ingress/scripts/migrate-tracking-database.py
+++ b/skills/vault-ingress/scripts/migrate-tracking-database.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Migrate one tracking database with a hash precondition and exact backup.
 
+--root-only selects the additive root migration defined by
+tracking_database.migrate_tracking_database_root. Deploy dual readers first.
+It upgrades the root before catalog writes while preserving every child record,
+active claim, and analysis value. It does not authorize processing; that still
+requires full bootstrap and preflight. The two explicit modes are exclusive.
+
 --repair-missing-qr-versions selects a separate preservation-only owner repair,
 not the normal migration: see tracking_database.repair_missing_qr_schema_versions.
 It never restamps talks, repairs observations, or requeues work. A successful
@@ -28,6 +34,7 @@ from tracking_database import (
     TrackingDatabaseError,
     TrackingDatabaseRepairError,
     migrate_tracking_database,
+    migrate_tracking_database_root,
     repair_missing_qr_schema_versions,
 )
 from tracking_database_io import (
@@ -80,7 +87,12 @@ def execute(
     apply: bool,
     expected_sha256: str | None,
     repair_missing_qr_versions: bool = False,
+    root_only: bool = False,
 ) -> dict[str, object]:
+    if root_only and repair_missing_qr_versions:
+        raise TrackingDatabaseMigrationError(
+            "choose either --root-only or --repair-missing-qr-versions, not both"
+        )
     database_path = path.expanduser().absolute()
     if expected_sha256 is not None:
         _validate_expected_digest(expected_sha256)
@@ -105,6 +117,8 @@ def execute(
         migration = (
             repair_missing_qr_schema_versions(database)
             if repair_missing_qr_versions
+            else migrate_tracking_database_root(database)
+            if root_only
             else migrate_tracking_database(database)
         )
         # Run on the migrated candidate, before it is rendered: the whole defect
@@ -112,7 +126,7 @@ def execute(
         # detections, so the gate has to sit between the stamp and the write.
         observation_counts = (
             {"repaired": 0, "requeued": 0}
-            if repair_missing_qr_versions
+            if repair_missing_qr_versions or root_only
             else gate_persisted_observations(migration.database)
         )
         changed = migration.changed or any(observation_counts.values())
@@ -180,6 +194,8 @@ def execute(
             "kind": "missing_qr_schema_versions",
             "python_path": migration.database["config"].get("python_path"),
         }
+    if root_only:
+        report["migration_scope"] = "root_only"
     return report
 
 
@@ -245,7 +261,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("database", type=Path)
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--expected-sha256")
-    parser.add_argument("--repair-missing-qr-versions", action="store_true")
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--repair-missing-qr-versions", action="store_true")
+    modes.add_argument("--root-only", action="store_true")
     repair_requested = False
     try:
         args = parser.parse_args(argv)
@@ -255,6 +273,7 @@ def main(argv: list[str] | None = None) -> int:
             apply=args.apply,
             expected_sha256=args.expected_sha256,
             repair_missing_qr_versions=args.repair_missing_qr_versions,
+            root_only=args.root_only,
         )
     except TrackingDatabaseMigrationError as exc:
         # Repair is a bootstrap boundary over an unreadable database; neither

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -5,11 +5,6 @@ The default mode is a dry run.  ``--apply`` requires ``--expected-sha256`` from
 that dry run (or the literal ``missing`` for initialization).  Every operation
 declares the exact record or field value it expects, so a reviewed plan cannot
 silently target a different logical state even when its file hash is current.
-
-A nonempty plan containing only ``apply_reviewed_metadata`` may also preserve
-the pre-source-alias root generation with current config. Complete owner
-validation still runs before and after the change. No root, talk, observation,
-or queue-claim migration runs; every other plan requires the current root.
 """
 
 from __future__ import annotations
@@ -40,13 +35,11 @@ from tracking_database import (
     THUMBNAIL_RECORD_SCHEMA_VERSION,
     THUMBNAIL_REQUIRED_FIELDS as OWNER_THUMBNAIL_REQUIRED_FIELDS,
     LEGACY_TALK_RECORD_SCHEMA_VERSION,
-    PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
     MARKDOWN_DECK_RECORD_SCHEMA_VERSION,
     SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION,
     TALK_RECORD_SCHEMA_VERSION,
     TRACKING_DATABASE_SCHEMA_VERSION,
     TrackingDatabaseError,
-    assess_tracking_database,
     require_current_tracking_database,
     validate_markdown_deck,
     validate_source_title_equivalence,
@@ -1895,30 +1888,12 @@ def initial_database(mutation: dict[str, Any], *, index: int) -> dict[str, Any]:
     }
 
 
-def _require_mutation_database(
-    database: dict[str, Any], mutations: list[dict[str, Any]]
-) -> None:
-    """Admit the predecessor root only for generation-preserving catalog edits."""
-    if mutations and all(
-        mutation.get("kind") == "apply_reviewed_metadata" for mutation in mutations
-    ):
-        assessment = assess_tracking_database(database)
-        if (
-            assessment.usable
-            and assessment.schema_version
-            == PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION
-            and database["config"]["schema_version"] == CONFIG_RECORD_SCHEMA_VERSION
-        ):
-            return
-    require_current_tracking_database(database)
-
-
 def build_candidate(
     database: dict[str, Any],
     mutations: list[dict[str, Any]],
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     try:
-        _require_mutation_database(database, mutations)
+        require_current_tracking_database(database)
     except TrackingDatabaseError as exc:
         raise TrackingDatabaseMutationError(str(exc)) from exc
     candidate = copy.deepcopy(database)
@@ -1974,7 +1949,7 @@ def build_candidate(
             )
     _validate_database_shape(candidate)
     try:
-        _require_mutation_database(candidate, mutations)
+        require_current_tracking_database(candidate)
     except TrackingDatabaseError as exc:
         raise TrackingDatabaseMutationError(
             f"mutation candidate violates the tracking-database schema: {exc}"

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -5,6 +5,11 @@ The default mode is a dry run.  ``--apply`` requires ``--expected-sha256`` from
 that dry run (or the literal ``missing`` for initialization).  Every operation
 declares the exact record or field value it expects, so a reviewed plan cannot
 silently target a different logical state even when its file hash is current.
+
+A nonempty plan containing only ``apply_reviewed_metadata`` may also preserve
+the pre-source-alias root generation with current config. Complete owner
+validation still runs before and after the change. No root, talk, observation,
+or queue-claim migration runs; every other plan requires the current root.
 """
 
 from __future__ import annotations
@@ -35,11 +40,13 @@ from tracking_database import (
     THUMBNAIL_RECORD_SCHEMA_VERSION,
     THUMBNAIL_REQUIRED_FIELDS as OWNER_THUMBNAIL_REQUIRED_FIELDS,
     LEGACY_TALK_RECORD_SCHEMA_VERSION,
+    PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
     MARKDOWN_DECK_RECORD_SCHEMA_VERSION,
     SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION,
     TALK_RECORD_SCHEMA_VERSION,
     TRACKING_DATABASE_SCHEMA_VERSION,
     TrackingDatabaseError,
+    assess_tracking_database,
     require_current_tracking_database,
     validate_markdown_deck,
     validate_source_title_equivalence,
@@ -1888,12 +1895,30 @@ def initial_database(mutation: dict[str, Any], *, index: int) -> dict[str, Any]:
     }
 
 
+def _require_mutation_database(
+    database: dict[str, Any], mutations: list[dict[str, Any]]
+) -> None:
+    """Admit the predecessor root only for generation-preserving catalog edits."""
+    if mutations and all(
+        mutation.get("kind") == "apply_reviewed_metadata" for mutation in mutations
+    ):
+        assessment = assess_tracking_database(database)
+        if (
+            assessment.usable
+            and assessment.schema_version
+            == PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION
+            and database["config"]["schema_version"] == CONFIG_RECORD_SCHEMA_VERSION
+        ):
+            return
+    require_current_tracking_database(database)
+
+
 def build_candidate(
     database: dict[str, Any],
     mutations: list[dict[str, Any]],
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     try:
-        require_current_tracking_database(database)
+        _require_mutation_database(database, mutations)
     except TrackingDatabaseError as exc:
         raise TrackingDatabaseMutationError(str(exc)) from exc
     candidate = copy.deepcopy(database)
@@ -1949,7 +1974,7 @@ def build_candidate(
             )
     _validate_database_shape(candidate)
     try:
-        require_current_tracking_database(candidate)
+        _require_mutation_database(candidate, mutations)
     except TrackingDatabaseError as exc:
         raise TrackingDatabaseMutationError(
             f"mutation candidate violates the tracking-database schema: {exc}"

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1965,6 +1965,55 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
     )
 
 
+def migrate_tracking_database_root(database: object) -> TrackingDatabaseMigration:
+    """Upgrade only the additive pre-source-alias root; preserve child contracts.
+
+    Root v3 adds an optional source-alias collection. Its absence already means
+    no aliases, so this migration changes only the root version. In particular,
+    it does not restamp analysed talks, lift title ledgers, repair observations,
+    or requeue work. Those remain the full migration's independent operations.
+
+    Deployed dual readers already accept both roots. Supported active claims
+    retain their exact return contract and baseline. The CLI uses the shared
+    generation-locked transaction: stale writers must reload, never overwrite
+    this migration or recover a claim to continue. Unknown/malformed child
+    state and claim/status drift refuse before any backup or write.
+    """
+    assessment = assess_tracking_database(database)
+    if (
+        not isinstance(database, dict)
+        or not assessment.usable
+        or assessment.schema_version
+        not in {
+            PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
+            TRACKING_DATABASE_SCHEMA_VERSION,
+        }
+        or database["config"]["schema_version"] != CONFIG_RECORD_SCHEMA_VERSION
+    ):
+        raise TrackingDatabaseError(
+            "root-only migration requires a readable pre-source-alias or current "
+            "root with current config; repair unsupported owner state or use "
+            "the full owner migration"
+        )
+    try:
+        validate_queue_claim_database(database)
+    except QueueClaimContractError as exc:
+        raise TrackingDatabaseError(
+            "root-only migration requires consistent queue claims; resolve the "
+            f"owner queue defect before retrying ({exc})"
+        ) from exc
+    candidate = copy.deepcopy(database)
+    candidate["schema_version"] = TRACKING_DATABASE_SCHEMA_VERSION
+    require_current_tracking_database(candidate)
+    return TrackingDatabaseMigration(
+        database=candidate,
+        changed=assessment.schema_version != TRACKING_DATABASE_SCHEMA_VERSION,
+        from_schema_version=assessment.schema_version,
+        to_schema_version=TRACKING_DATABASE_SCHEMA_VERSION,
+        record_counts=_empty_record_counts(),
+    )
+
+
 def migrate_tracking_database(database: object) -> TrackingDatabaseMigration:
     """Build the deterministic owner migration to root v3/config v2."""
     assessment = assess_tracking_database(database)

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1716,29 +1716,39 @@ def _pre_alias_metadata_database() -> dict[str, Any]:
         ("conference", "Correct event"),
     ],
 )
-def test_pre_alias_root_metadata_repair_preserves_every_unrelated_value(
-    mutate_tracking_database, field, value
+def test_root_migration_then_metadata_repair_preserves_every_child_value(
+    mutate_tracking_database, tracking_database, field, value
 ) -> None:
     database = _pre_alias_metadata_database()
     before = copy.deepcopy(database)
     mutation = _repair({field: value}, {field: database["talks"][0][field]})
 
-    candidate, changes = mutate_tracking_database.build_candidate(database, [mutation])
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(database, [mutation])
+    migrated = tracking_database.migrate_tracking_database_root(database).database
+    candidate, changes = mutate_tracking_database.build_candidate(migrated, [mutation])
 
     expected = copy.deepcopy(before)
+    expected["schema_version"] = tracking_database.TRACKING_DATABASE_SCHEMA_VERSION
     expected["talks"][0][field] = value
     assert candidate == expected
     assert database == before
     assert len(changes) == 1
 
 
-def test_pre_alias_root_metadata_cli_dry_run_and_hash_bound_apply(
-    mutate_tracking_database, tmp_path, capsys
+def test_root_migration_then_metadata_cli_dry_run_and_hash_bound_apply(
+    mutate_tracking_database, migrate_tracking_database, tmp_path, capsys
 ) -> None:
     database = _pre_alias_metadata_database()
     path = tmp_path / "tracking-database.json"
     plan_path = tmp_path / "plan.json"
     _write_json(path, database)
+    migration = migrate_tracking_database.execute(
+        path, apply=False, expected_sha256=None, root_only=True
+    )
+    migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=migration["input_sha256"], root_only=True
+    )
     original_bytes = path.read_bytes()
     _write_json(
         plan_path,
@@ -1778,14 +1788,15 @@ def test_pre_alias_root_metadata_cli_dry_run_and_hash_bound_apply(
     )
     applied = json.loads(capsys.readouterr().out)
     expected = copy.deepcopy(database)
+    expected["schema_version"] = 3
     expected["talks"][0]["date"] = "2018-08-31"
     assert applied["database_written"] is True
     assert applied["output_sha256"] == preview["output_sha256"]
     assert json.loads(path.read_text()) == expected
 
 
-@pytest.mark.parametrize("root_version", [0, 1, 99])
-def test_metadata_compatibility_does_not_admit_other_legacy_or_future_roots(
+@pytest.mark.parametrize("root_version", [0, 1, 2, 99])
+def test_metadata_writer_requires_owner_migration_for_every_legacy_root(
     mutate_tracking_database, root_version
 ) -> None:
     database = _pre_alias_metadata_database()
@@ -1797,10 +1808,11 @@ def test_metadata_compatibility_does_not_admit_other_legacy_or_future_roots(
 
 
 @pytest.mark.parametrize("defect", ["config", "talk", "claim", "collection"])
-def test_metadata_compatibility_keeps_complete_owner_validation(
-    mutate_tracking_database, defect
+def test_post_migration_metadata_keeps_complete_owner_validation(
+    mutate_tracking_database, tracking_database, defect
 ) -> None:
     database = _pre_alias_metadata_database()
+    database = tracking_database.migrate_tracking_database_root(database).database
     if defect == "config":
         database["config"]["schema_version"] = 1
     elif defect == "talk":

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1678,6 +1678,159 @@ def test_a_reviewed_delivery_date_applies_with_an_exact_precondition(
     assert database["talks"][0]["date"] == "2014"
 
 
+def _pre_alias_metadata_database() -> dict[str, Any]:
+    database = _catalog_database(date="2018-08-30")
+    database["schema_version"] = 2
+    talk = database["talks"][0]
+    talk["schema_version"] = 1
+    talk["pattern_observations"] = [{"pattern": "legacy", "evidence": "retained"}]
+    talk["status"] = "reprocessing-inflight"
+    talk["reprocess_generation"] = 2
+    talk["_queue_claim"] = {
+        "schema_version": 1,
+        "run_id": "metadata-test",
+        "batch_id": "active",
+        "claimed_at": "2026-07-31T12:00:00+00:00",
+        "previous_status": "needs-reprocessing",
+        "reprocess_generation": 2,
+        "state": "claimed",
+    }
+    talk["_queue_claim_history"] = [
+        {
+            **talk["_queue_claim"],
+            "batch_id": "previous",
+            "reprocess_generation": 1,
+            "state": "stale_recovered",
+            "released_at": "2026-07-31T12:30:00+00:00",
+            "release_reason": "recovered stale batch",
+        }
+    ]
+    return database
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("date", "2018-08-31"),
+        ("title", "Correct title"),
+        ("conference", "Correct event"),
+    ],
+)
+def test_pre_alias_root_metadata_repair_preserves_every_unrelated_value(
+    mutate_tracking_database, field, value
+) -> None:
+    database = _pre_alias_metadata_database()
+    before = copy.deepcopy(database)
+    mutation = _repair({field: value}, {field: database["talks"][0][field]})
+
+    candidate, changes = mutate_tracking_database.build_candidate(database, [mutation])
+
+    expected = copy.deepcopy(before)
+    expected["talks"][0][field] = value
+    assert candidate == expected
+    assert database == before
+    assert len(changes) == 1
+
+
+def test_pre_alias_root_metadata_cli_dry_run_and_hash_bound_apply(
+    mutate_tracking_database, tmp_path, capsys
+) -> None:
+    database = _pre_alias_metadata_database()
+    path = tmp_path / "tracking-database.json"
+    plan_path = tmp_path / "plan.json"
+    _write_json(path, database)
+    original_bytes = path.read_bytes()
+    _write_json(
+        plan_path,
+        {
+            "schema_version": 1,
+            "mutations": [_repair({"date": "2018-08-31"}, {"date": "2018-08-30"})],
+        },
+    )
+
+    assert mutate_tracking_database.main([str(path), str(plan_path)]) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["database_written"] is False
+    assert path.read_bytes() == original_bytes
+    assert (
+        mutate_tracking_database.main(
+            [str(path), str(plan_path), "--apply", "--expected-sha256", "0" * 64]
+        )
+        == 2
+    )
+    refusal = json.loads(capsys.readouterr().out)
+    assert refusal["ok"] is False
+    assert path.read_bytes() == original_bytes
+
+    assert (
+        mutate_tracking_database.main(
+            [
+                str(path),
+                str(plan_path),
+                "--apply",
+                "--expected-sha256",
+                preview["input_sha256"],
+                "--expected-output-sha256",
+                preview["output_sha256"],
+            ]
+        )
+        == 0
+    )
+    applied = json.loads(capsys.readouterr().out)
+    expected = copy.deepcopy(database)
+    expected["talks"][0]["date"] = "2018-08-31"
+    assert applied["database_written"] is True
+    assert applied["output_sha256"] == preview["output_sha256"]
+    assert json.loads(path.read_text()) == expected
+
+
+@pytest.mark.parametrize("root_version", [0, 1, 99])
+def test_metadata_compatibility_does_not_admit_other_legacy_or_future_roots(
+    mutate_tracking_database, root_version
+) -> None:
+    database = _pre_alias_metadata_database()
+    database["schema_version"] = root_version
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database, [_repair({"date": "2018-08-31"}, {"date": "2018-08-30"})]
+        )
+
+
+@pytest.mark.parametrize("defect", ["config", "talk", "claim", "collection"])
+def test_metadata_compatibility_keeps_complete_owner_validation(
+    mutate_tracking_database, defect
+) -> None:
+    database = _pre_alias_metadata_database()
+    if defect == "config":
+        database["config"]["schema_version"] = 1
+    elif defect == "talk":
+        database["talks"][0]["schema_version"] = 99
+    elif defect == "claim":
+        database["talks"][0]["_queue_claim"]["state"] = "invalid"
+    else:
+        del database["qr_codes"]
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(
+            database, [_repair({"date": "2018-08-31"}, {"date": "2018-08-30"})]
+        )
+
+
+@pytest.mark.parametrize("mixed", [False, True])
+def test_pre_alias_root_cannot_launder_other_mutations_through_metadata_plan(
+    mutate_tracking_database, mixed
+) -> None:
+    database = _pre_alias_metadata_database()
+    before = copy.deepcopy(database)
+    mutations = [
+        {"kind": "set_config", "path": ["enabled"], "expect": MISSING, "value": True}
+    ]
+    if mixed:
+        mutations.insert(0, _repair({"date": "2018-08-31"}, {"date": "2018-08-30"}))
+    with pytest.raises(mutate_tracking_database.TrackingDatabaseMutationError):
+        mutate_tracking_database.build_candidate(database, mutations)
+    assert database == before
+
+
 def test_a_reviewed_delivery_date_may_be_a_bare_year(
     mutate_tracking_database,
 ) -> None:

--- a/tests/test_tracking_database_mutation_docs.py
+++ b/tests/test_tracking_database_mutation_docs.py
@@ -10,6 +10,24 @@ def _read(relative: str) -> str:
     return (ROOT / relative).read_text(encoding="utf-8")
 
 
+def test_standalone_metadata_repair_has_an_explicit_owner_migration_exception() -> None:
+    skill = " ".join(_read("skills/vault-ingress/SKILL.md").split())
+    schema = " ".join(_read("skills/vault-ingress/references/schemas-db.md").split())
+
+    assert (
+        "Narrow exception for a standalone, explicitly requested catalog metadata repair"
+        in skill
+    )
+    assert "under `stateful-artifacts` Migration Policy" in skill
+    assert "bind application to its input and candidate digests" in skill
+    assert (
+        "An owner refusal authorizes no write or manual compatibility override" in skill
+    )
+    assert "Do not select a batch, reparse, or regenerate derived artifacts" in skill
+    assert "Every other owner write follows the normal migration policy" in skill
+    assert "standalone repair exception in `SKILL.md` Step 1" in schema
+
+
 def test_config_deletion_and_reserved_marker_recovery_are_documented() -> None:
     schema = _read("skills/vault-ingress/references/schemas-db.md")
     bootstrap = _read("skills/vault-ingress/references/bootstrap-and-preflight.md")

--- a/tests/test_tracking_database_mutation_docs.py
+++ b/tests/test_tracking_database_mutation_docs.py
@@ -10,22 +10,19 @@ def _read(relative: str) -> str:
     return (ROOT / relative).read_text(encoding="utf-8")
 
 
-def test_standalone_metadata_repair_has_an_explicit_owner_migration_exception() -> None:
+def test_standalone_metadata_repair_requires_explicit_owner_root_migration() -> None:
     skill = " ".join(_read("skills/vault-ingress/SKILL.md").split())
     schema = " ".join(_read("skills/vault-ingress/references/schemas-db.md").split())
 
-    assert (
-        "Narrow exception for a standalone, explicitly requested catalog metadata repair"
-        in skill
-    )
-    assert "under `stateful-artifacts` Migration Policy" in skill
-    assert "bind application to its input and candidate digests" in skill
-    assert (
-        "An owner refusal authorizes no write or manual compatibility override" in skill
-    )
+    assert "standalone catalog metadata repair" in skill
+    assert "root-only owner migration" in skill
     assert "Do not select a batch, reparse, or regenerate derived artifacts" in skill
-    assert "Every other owner write follows the normal migration policy" in skill
-    assert "standalone repair exception in `SKILL.md` Step 1" in schema
+    assert "--root-only" in schema
+    assert "Deploy the dual readers before applying" in schema
+    assert "migrate_tracking_database_root" in schema
+    assert "Metadata mutations still require the current root" in schema
+    assert "standalone repair exception" not in schema
+    assert "under `stateful-artifacts` Migration Policy" not in skill
 
 
 def test_config_deletion_and_reserved_marker_recovery_are_documented() -> None:

--- a/tests/test_tracking_database_root_migration.py
+++ b/tests/test_tracking_database_root_migration.py
@@ -1,0 +1,318 @@
+"""The additive owner-root migration never changes an analysis or claim contract."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from test_tracking_database_schema import (
+    _expected_migration,
+    _legacy_database,
+    _qr_repair_with_active_claim,
+    _write_database,
+)
+
+
+def _root_database(tracking_database, claim_version=None):
+    if claim_version is None:
+        database = _expected_migration(_legacy_database())
+    else:
+        database = _qr_repair_with_active_claim(tracking_database, claim_version)
+        database["qr_codes"][0]["schema_version"] = 1
+    database["schema_version"] = 2
+    return database
+
+
+@pytest.mark.parametrize("claim_version", [None, *range(1, 8)])
+@pytest.mark.parametrize("talk_version", [1, 5, 6, 7])
+def test_root_upgrade_preserves_every_child_value_and_reader_contract(
+    tracking_database, queue_state, claim_version, talk_version
+):
+    database = _root_database(tracking_database, claim_version)
+    database["talks"][0]["schema_version"] = talk_version
+    before = copy.deepcopy(database)
+    claims_before = queue_state.reconstruct_run(database, "schema-test")
+    assert tracking_database.assess_tracking_database(database).usable is True
+
+    result = tracking_database.migrate_tracking_database_root(database)
+
+    expected = copy.deepcopy(before)
+    expected["schema_version"] = 3
+    assert result.database == expected
+    assert database == before
+    assert result.changed is True
+    assert (result.from_schema_version, result.to_schema_version) == (2, 3)
+    assert not any(result.record_counts.values())
+    assert (
+        tracking_database.assess_tracking_database(result.database).state == "current"
+    )
+    assert queue_state.reconstruct_run(result.database, "schema-test") == claims_before
+    repeat = tracking_database.migrate_tracking_database_root(result.database)
+    assert repeat.database == expected
+    assert repeat.changed is False
+
+
+@pytest.mark.parametrize(
+    "defect",
+    [
+        "root_missing",
+        "root_zero",
+        "root_one",
+        "root_future",
+        "root_bool",
+        "config_legacy",
+        "talk_future",
+        "qr_unstamped",
+        "claim_future",
+        "claim_invalid",
+        "claim_status_drift",
+        "collection_missing",
+        "duplicate_talk",
+    ],
+)
+def test_root_upgrade_refuses_unrelated_or_ambiguous_owner_state(
+    tracking_database, defect
+):
+    database = _root_database(tracking_database, 7)
+    if defect == "root_missing":
+        del database["schema_version"]
+    elif defect.startswith("root_"):
+        database["schema_version"] = {
+            "root_zero": 0,
+            "root_one": 1,
+            "root_future": 99,
+            "root_bool": True,
+        }[defect]
+    elif defect == "config_legacy":
+        database["config"]["schema_version"] = 1
+    elif defect == "talk_future":
+        database["talks"][0]["schema_version"] = 99
+    elif defect == "qr_unstamped":
+        del database["qr_codes"][0]["schema_version"]
+    elif defect == "claim_future":
+        database["talks"][0]["_queue_claim"]["schema_version"] = 99
+    elif defect == "claim_invalid":
+        database["talks"][0]["_queue_claim"]["state"] = "invalid"
+    elif defect == "claim_status_drift":
+        database["talks"][0]["status"] = "processed"
+    elif defect == "collection_missing":
+        del database["qr_codes"]
+    else:
+        database["talks"].append(copy.deepcopy(database["talks"][0]))
+    before = copy.deepcopy(database)
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.migrate_tracking_database_root(database)
+    assert database == before
+
+
+def test_root_cli_preserves_evidence_backups_and_noop_inode(
+    tracking_database, migrate_tracking_database, tmp_path, capsys
+):
+    path = tmp_path / "tracking-database.json"
+    database = _root_database(tracking_database, 7)
+    # Full migration would requeue this legacy observation; root-only must not.
+    completed = copy.deepcopy(database["talks"][0])
+    completed.update(filename="completed.md", status="processed")
+    for key in ("_queue_claim", "_queue_claim_history", "reprocess_generation"):
+        completed.pop(key)
+    database["talks"].append(completed)
+    raw = _write_database(path, database)
+    assert migrate_tracking_database.main([str(path), "--root-only"]) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["migration_scope"] == "root_only"
+    assert preview["persisted_observations"] == {"repaired": 0, "requeued": 0}
+    assert preview["database_written"] is False
+    assert path.read_bytes() == raw
+    assert not (tmp_path / ".backups").exists()
+    for extra in ([], ["--expected-sha256", "0" * 64]):
+        assert (
+            migrate_tracking_database.main(
+                [str(path), "--root-only", "--apply", *extra]
+            )
+            == 2
+        )
+        assert json.loads(capsys.readouterr().out)["ok"] is False
+        assert path.read_bytes() == raw
+        assert not (tmp_path / ".backups").exists()
+    applied = migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=preview["input_sha256"], root_only=True
+    )
+    expected = copy.deepcopy(database)
+    expected["schema_version"] = 3
+    assert json.loads(path.read_bytes()) == expected
+    assert applied["output_sha256"] == preview["output_sha256"]
+    assert Path(applied["backup"]).read_bytes() == raw
+    installed = path.read_bytes()
+    inode = path.stat().st_ino
+    repeated = migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=applied["output_sha256"], root_only=True
+    )
+    assert repeated["changed"] is False
+    assert repeated["database_written"] is False
+    assert repeated["backup"] is None
+    assert path.read_bytes() == installed
+    assert path.stat().st_ino == inode
+
+
+@pytest.mark.parametrize("writer", ["queue", "results"])
+def test_root_migration_rejects_stale_writers_and_allows_claim_preserving_reload(
+    tracking_database,
+    tracking_database_io,
+    migrate_tracking_database,
+    queue_state,
+    persist_results,
+    tmp_path,
+    writer,
+):
+    path = tmp_path / "tracking-database.json"
+    database = _root_database(tracking_database, 7)
+    raw = _write_database(path, database)
+    stale = tracking_database_io.snapshot_tracking_database(path)
+    applied = migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=stale.sha256, root_only=True
+    )
+    installed = path.read_bytes()
+    if writer == "queue":
+        write, read, error = (
+            queue_state.write_database_atomically,
+            queue_state.load_database_snapshot,
+            queue_state.QueueStateError,
+        )
+    else:
+        write, read, error = (
+            persist_results.atomic_write_json,
+            persist_results.load_tracking_database,
+            ValueError,
+        )
+    with pytest.raises(error, match="generation changed"):
+        write(path, database, expected_snapshot=stale)
+    assert path.read_bytes() == installed
+    assert Path(applied["backup"]).read_bytes() == raw
+    current, fresh = read(path)
+    assert current["talks"] == database["talks"]
+    assert current["schema_version"] == 3
+    current["config"]["speaker_name"] = "Synthetic speaker"
+    assert write(path, current, expected_snapshot=fresh).installed is True
+    reloaded, _ = read(path)
+    assert reloaded == current
+    assert reloaded["talks"] == database["talks"]
+
+
+def test_root_migration_preserves_final_window_competing_writer(
+    tracking_database,
+    tracking_database_io,
+    migrate_tracking_database,
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "tracking-database.json"
+    database = _root_database(tracking_database, 7)
+    _write_database(path, database)
+    preview = migrate_tracking_database.execute(
+        path, apply=False, expected_sha256=None, root_only=True
+    )
+    competing = copy.deepcopy(database)
+    competing["config"]["speaker_name"] = "Concurrent writer"
+    original_stage = tracking_database_io._stage_candidate
+    competing_raw = b""
+
+    def stage_and_replace(target, candidate, mode):
+        nonlocal competing_raw
+        stage = original_stage(target, candidate, mode)
+        replacement = tmp_path / "competing.json"
+        competing_raw = _write_database(replacement, competing)
+        os.replace(replacement, path)
+        return stage
+
+    monkeypatch.setattr(tracking_database_io, "_stage_candidate", stage_and_replace)
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError,
+        match="generation changed",
+    ):
+        migrate_tracking_database.execute(
+            path, apply=True, expected_sha256=preview["input_sha256"], root_only=True
+        )
+    assert path.read_bytes() == competing_raw
+    assert not (tmp_path / ".backups").exists()
+
+
+def test_root_and_qr_modes_are_exclusive_before_any_file_access(
+    migrate_tracking_database, tmp_path, capsys
+):
+    path = tmp_path / "absent.json"
+    assert (
+        migrate_tracking_database.main(
+            [str(path), "--root-only", "--repair-missing-qr-versions"]
+        )
+        == 2
+    )
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+    with pytest.raises(
+        migrate_tracking_database.TrackingDatabaseMigrationError, match="not both"
+    ):
+        migrate_tracking_database.execute(
+            path,
+            apply=False,
+            expected_sha256=None,
+            root_only=True,
+            repair_missing_qr_versions=True,
+        )
+    assert not path.exists()
+
+
+def test_full_migration_still_refuses_active_claims(tracking_database):
+    database = _root_database(tracking_database, 7)
+    before = copy.deepcopy(database)
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="active queue writers"
+    ):
+        tracking_database.migrate_tracking_database(database)
+    assert database == before
+
+
+@pytest.mark.parametrize("claim_version", range(1, 8))
+def test_existing_claim_replays_through_current_queue_cli_after_root_migration(
+    tracking_database,
+    migrate_tracking_database,
+    queue_state,
+    tmp_path,
+    capsys,
+    claim_version,
+):
+    path = tmp_path / "tracking-database.json"
+    database = _root_database(tracking_database, claim_version)
+    _write_database(path, database)
+    preview = migrate_tracking_database.execute(
+        path, apply=False, expected_sha256=None, root_only=True
+    )
+    migrate_tracking_database.execute(
+        path, apply=True, expected_sha256=preview["input_sha256"], root_only=True
+    )
+    installed = path.read_bytes()
+
+    assert (
+        queue_state.main(
+            [
+                str(path),
+                "claim",
+                "--run-id",
+                "schema-test",
+                "--batch-id",
+                "active",
+                "--now",
+                "2026-07-31T12:05:00+00:00",
+            ]
+        )
+        == 0
+    )
+    report = json.loads(capsys.readouterr().out)
+    assert report["idempotent_replay"] is True
+    assert len(report["claimed"]) == 1
+    assert report["claimed"][0]["schema_version"] == claim_version
+    assert report["claimed"][0]["reprocess_generation"] == 2
+    assert path.read_bytes() == installed
+    assert json.loads(installed)["talks"] == database["talks"]


### PR DESCRIPTION
## Summary

- Replace the legacy-root metadata-write bypass with an explicit `--root-only` owner migration. The metadata writer continues to require the current root before every write.
- Upgrade the additive root independently of talk analysis, observation repair, and queue generations. Preserve every child value and supported active claim; validate the complete input and candidate and use the shared hash-bound atomic transaction and exact backup.
- Keep full bootstrap/migration and processing gates unchanged. The standalone catalog workflow migrates the root, applies only reviewed metadata, reads back, and stops without reparsing. No coding-policy exception is requested.

Addresses the blocking migration-policy findings in the preceding revision. The redundant metadata assessment noted by Copilot disappears with the removed bypass.

## Test plan

- [x] Full local suite: **7,620 passed, 8 skipped**.
- [x] Ruff lint/format, Pyright, plugin lint, package contents, shipped extensions, and skill entrypoint gates.
- [x] Preservation across historical talk generations and all seven supported claim versions; current queue CLI replays the unchanged claims.
- [x] Exact dry-run/apply/backup/no-op behavior; stale queue/result writers refuse and reload; final-window competing writes survive; invalid state and mixed migration modes refuse.
- [x] Native configured-interpreter dry run on the 250-talk catalog: root 2 → 3, zero child changes, five active claims preserved, no operational write.
- [x] On a private owner-exported copy, apply root migration, eight reviewed date corrections/two event-label corrections, and the inverse metadata plan. Whole-database equality proves all unrelated values preserved and exact metadata rollback. This rehearsal did not change the live catalog.
- [x] Fresh policy approval and Copilot review on aa70cca; every finding has a disposition. Pre-merge CI and [post-merge CI](https://github.com/jbaruch/speaker-toolkit/actions/runs/34030977143) passed.
- [x] Merged, [publication succeeded](https://github.com/jbaruch/speaker-toolkit/actions/runs/34030977434), registry advanced from 0.20.129 to 0.20.130, moderation passed, and merged worktree/branch cleanup completed.
- [x] Applied the released migration and reviewed metadata transactions to the operational catalog with fresh digests and exact readback: root 2 → 3, eight dates and two event labels corrected, all 250 talks and five active claims preserved, zero reparsing/requeueing.

The registry skill-quality review is **UNREVIEWED**, not passed: the publish workflow used its documented credit-outage carve-out. Policy review, tests, artifact publication, and moderation completed successfully. Post-repair full preflight retains the same one pre-existing QCon transcript-provenance blocker tracked in #219 and 606 warnings; it is not an all-green vault acceptance result.

Related: #339. This PR enables the audited corrections; it does not claim the complete catalog issue or reparse-dependent work is accepted.
