### PR TITLE
fix(deckops): make the macro setup walkthrough actually followable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,23 @@ this archive, where justification belongs: an installed plugin lives under
 `.tessl/`, which PowerPoint's VBA-editor Import panel does not show, so an import
 path pointing inside the plugin tree cannot be followed.
 
+Round three found the same class of bug twice more, both of them the doctor
+answering a question it had not actually asked. `run_probe` laundered every
+non-zero `osascript` exit into `macro_unreachable`, so denied Automation consent
+plus no canonical container came out as `setup_required` — telling the user to
+build a second container over a permissions problem. The driver returns
+`macro_unreachable` at exit 0 for the one expected failure, so a non-zero exit is
+by construction something else; those now surface as `probe_failed` /
+`probe_missing`, which report the state as UNKNOWN and exit 1. Copilot found the
+`probe_missing` half of this independently.
+
+And the docstring's "Read-only. Opens nothing, saves nothing" was a lie:
+`diagnose()` calls `materialize()`, which writes drivers into the plugin's
+scripts directory, `--offline` included. Both reviewers caught it. The claim is
+now itemized — no deck, no template, no container, no PowerPoint launch; does
+restore missing drivers, never overwriting one — in the docstring, the
+`--help` description, and Step 0 of the walkthrough.
+
 
 ## 0.20.130 — 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,23 @@ The smoke test moved out of the reference file into `deckops-smoke-test.sh`, and
 every `sync-deck-drivers.py` mode emits JSON — both `script-delegation`
 requirements the first cut missed.
 
+Round two found three more. The wrapper serialized its report with `printf`, so an
+output directory containing a double quote or a backslash produced invalid JSON
+behind exit 0 — it now goes through a JSON encoder, with hostile-path tests. The
+probe's remaining catch-all, around the macro call itself, is narrowed to -18, the
+number Mac PowerPoint returns when the named macro is unavailable, verified by
+running the probe against a PowerPoint holding a DeckOps.pptm with no DeckOps
+module in it; every other number propagates and the doctor reports the non-zero
+osascript exit. And the wrapper shipped untested: `tests/test_deckops_smoke_test.py`
+now stubs `build-deck.sh` and covers template validation, unique naming,
+build-failure propagation, a build that writes nothing, and report serialization,
+leaving only the PowerPoint call to manual validation.
+
+The reason installed plugins sit under a hidden directory left the rule body for
+this archive, where justification belongs: an installed plugin lives under
+`.tessl/`, which PowerPoint's VBA-editor Import panel does not show, so an import
+path pointing inside the plugin tree cannot be followed.
+
 
 ## 0.20.130 — 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,31 @@ side effect is worse than the answer it returns — and exits 0 with a verdict e
 when the macro is unreachable, because "setup required" is a finding to act on,
 not a failure of the script.
 
+Review round on PR #412 caught two real bugs in the first cut. `deckops-doctor.py`
+ran the mirror check before materializing, so a fresh `tessl install` — which
+lands ten `.txt` mirrors and none of their sources — reported ten orphan mirrors
+and told a valid installation to reinstall itself. Copilot found the same one
+independently. The doctor also called `read_stamp` unguarded, so a `RunDeckOps.bas`
+with a damaged stamp line crashed it instead of returning the `driver_drift`
+diagnostic `check()` had already produced.
+
+The probe's container lookup started as a bare `on error` handler. Narrowing it
+to specific error numbers meant learning which one actually fires: `repeat with p
+in presentations` + `name of p` raises -2763 on current Mac PowerPoint builds,
+while `name of every presentation` returns the list correctly. Using the working
+plural form removed the need for a handler at all.
+
+That same probe run surfaced a case the verdict table got wrong: a `DeckOps.pptm`
+already open from a location predating the canonical path. A macro that answers
+proves setup wherever its container sits, so `state=ok` now decides `ok` on its
+own, `container.canonical_mismatch` reports the difference, and `next_step` names
+the container the user actually has open rather than sending them to create a
+second one.
+
+The smoke test moved out of the reference file into `deckops-smoke-test.sh`, and
+every `sync-deck-drivers.py` mode emits JSON — both `script-delegation`
+requirements the first cut missed.
+
 
 ## 0.20.130 — 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+### Tell the user how to actually recreate the DeckOps macro container
+
+The distribution half of the deck layer was solved in #85 and #316: `.bas` and
+`.applescript` drivers ride to consumers as committed `.txt` mirrors,
+`sync-deck-drivers.py` restores them, and `check_shipped_extensions.py` gates
+drift. The walkthrough half was not. Five things the skill could not do:
+
+The import path was wrong for every consumer. Step 3 said "Import File… and
+choose `skills/presentation-creator/scripts/RunDeckOps.bas`" — a repo-relative
+path that, on an installed plugin, resolves under a hidden `.tessl/` directory
+PowerPoint's Import panel does not show. The user was being sent to a folder they
+cannot see by a path that does not resolve, while the same step's materialize
+command used `{speaker_toolkit_root}` — two path conventions in one step, which
+`skill-authoring` forbids. `sync-deck-drivers.py export --to <dir>` now copies the
+module out of the plugin tree to `<vault_root>/.deckops/`, beside the container,
+and the step hands the user that absolute path plus the ⇧⌘G / ⇧⌘. keys the panel
+needs.
+
+Nothing could detect first use. Three callers said "on first use, walk the user
+through deck-editing-setup.md" and none of them could tell first use from the
+hundredth, so the agent guessed. `deckops-doctor.py` answers it.
+
+The container had no recorded location. Step 2 offered `<vault>/.deckops/DeckOps.pptm`
+as an example; eight wrappers printed "confirm DeckOps.pptm is open" and not one
+could say where it should be. That path is now canonical, derived from
+`config.vault_root`, and a running PowerPoint reports where it actually opened
+the container from. Chosen over a `config` field on purpose: a schema v3 bump
+plus migration to record what the live app already knows, and
+`stateful-artifacts` says verify against the live source anyway.
+
+The smoke test was prose. Step 5 — the step whose whole job was confirming steps
+1–4 in one shot — said "run a 3-slide throwaway" and left the agent to invent the
+gate it was gated by. `smoke-test-ops.txt` ships that sequence, using layout 0 and
+a free text box only so it runs against any template, with four explicit pass
+criteria.
+
+A stale macro import was invisible. `ensure-drivers.sh` materializes without
+`--force`, so an on-disk driver is never refreshed, and — worse — a saved `.pptm`
+yields no VBA source at all, so a module imported once and never updated keeps
+running OLD code with nothing to notice. `RunDeckOps.bas` now carries
+`DECKOPS_STAMP`, a digest of its own body with the stamp masked out, exposed
+through a `DeckOpsVersion()` macro; `deckops-version.applescript` asks the running
+PowerPoint for it and the doctor compares. Content-addressed rather than
+hand-bumped because an editor who forgets to bump a counter ships a lie, and
+`mirror` recomputes the stamp while `check` fails on drift.
+
+The probe never launches PowerPoint — a diagnostic that starts a 300 MB app as a
+side effect is worse than the answer it returns — and exits 0 with a verdict even
+when the macro is unreachable, because "setup required" is a finding to act on,
+not a failure of the script.
+
+
 ## 0.20.130 — 2026-09-06
 
 ### Migrate the catalog root without disturbing talk analysis or claims

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@ now itemized — no deck, no template, no container, no PowerPoint launch; does
 restore missing drivers, never overwriting one — in the docstring, the
 `--help` description, and Step 0 of the walkthrough.
 
+Round four caught two tests that passed on the author's Mac and would have gone
+red on the Ubuntu runner. Both call `main()`, which reads `sys.platform`, so off
+macOS every verdict short-circuits to `unsupported_platform` and the assertions
+never reach the scenario they name. An `on_darwin` fixture pins the platform the
+doctor sees, a new test covers the foreign-platform path itself (verdict, exit 0,
+probe never attempted), and the suite was re-run under a session fixture forcing
+`sys.platform = "linux"` to confirm it. `verdict()` takes platform as an argument
+and needed no patching — only the `main()` and `diagnose()` paths did.
+
 
 ## 0.20.130 — 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ speaker-toolkit/
     |   |   +-- deckops-doctor.py              # Is the deck layer set up, open, and current? (tested)
     |   |   +-- deckops-version.applescript    # Read-only probe: which macro build is loaded
     |   |   +-- smoke-test-ops.txt             # 3-slide op sequence for the setup smoke test
+    |   |   +-- deckops-smoke-test.sh          # Build that sequence against the template and report where it landed
     |   |   +-- make-bg-slide.sh               # Wrapper for MakeBgImageSlide (illustration -> bg slide)
     |   |   +-- make-bg-slide.applescript      # AppleScript driver for MakeBgImageSlide
     |   |   +-- make-placeholder-slide.sh       # Wrapper for MakePlaceholderSlide (yellow [PLACEHOLDER] slide)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ through. Pairs with poster-theatrical for pure full-bleed, builds-and-all decks.
 files, which had left the PowerPoint deck layer dead on any installed copy. The
 drivers now ship as committed `.txt` mirrors and are restored automatically on
 first use (`sync-deck-drivers.py`), so `RunDeckOps.bas` and the AppleScript
-drivers are there when you need them — no manual recovery.
+drivers are there when you need them — no manual recovery. And `deckops-doctor.py` now
+answers whether the one-time PowerPoint setup is done, where the macro container
+is, and — the one nothing could see before — whether the module imported into
+`DeckOps.pptm` is the build that shipped, or an old one still quietly running.
 
 **No more per-illustration permission clicks** — the background and build passes
 now stage illustrations into PowerPoint's own sandbox container before applying
@@ -574,6 +577,9 @@ speaker-toolkit/
     |   |   +-- RunDeckOps.bas                 # VBA: BuildDeck + trim/reorder/import/notes/bg/placeholder/QR via real PowerPoint
     |   |   +-- run-deck-ops.sh                # Wrapper for RunDeckOps (staging + move into place)
     |   |   +-- run-deck-ops.applescript       # AppleScript driver for RunDeckOps
+    |   |   +-- deckops-doctor.py              # Is the deck layer set up, open, and current? (tested)
+    |   |   +-- deckops-version.applescript    # Read-only probe: which macro build is loaded
+    |   |   +-- smoke-test-ops.txt             # 3-slide op sequence for the setup smoke test
     |   |   +-- make-bg-slide.sh               # Wrapper for MakeBgImageSlide (illustration -> bg slide)
     |   |   +-- make-bg-slide.applescript      # AppleScript driver for MakeBgImageSlide
     |   |   +-- make-placeholder-slide.sh       # Wrapper for MakePlaceholderSlide (yellow [PLACEHOLDER] slide)

--- a/rules/deck-editing-rules.md
+++ b/rules/deck-editing-rules.md
@@ -34,8 +34,19 @@ generating slide structure (see `rules/slide-generation-rules.md`).
   ```
 - One-time setup is a manual, GUI-bound sequence (enable VBA macros, create the
   `DeckOps.pptm` macro container, import the `.bas`, grant Automation consent).
-  Walk the user through it interactively the first time — see
+  Walk the user through it interactively — see
   `skills/presentation-creator/references/deck-editing-setup.md`.
+- Never assume whether setup has been done. `deckops-doctor.py --vault-root <path>`
+  is the read-only probe that answers it, and it is the only thing that can see a
+  STALE macro import: a saved `.pptm` yields no VBA source, so the doctor asks the
+  running PowerPoint for the module's own content stamp. Statuses and their
+  routing live in Step 0 of the setup doc.
+- The macro container has one canonical location, `<vault_root>/.deckops/DeckOps.pptm`,
+  and the importable `.bas` is exported beside it. An installed plugin sits under a
+  hidden `.tessl/` directory that PowerPoint's Import panel will not show, so the
+  import path must leave the plugin tree —
+  `sync-deck-drivers.py export --to <vault_root>/.deckops` puts it where the user
+  can reach it.
 
 ## Add a Generated Illustration as a Slide Background
 
@@ -89,6 +100,13 @@ generating slide structure (see `rules/slide-generation-rules.md`).
   `<p:bg>`-blipFill check finds the expected slides.
 - The deterministic Python/shell helpers (illustration apply, manifest→spec) ARE
   unit-tested in `tests/` — only the PowerPoint-driving layer is exempt.
+- Exempt artifacts: `RunDeckOps.bas` and every `*.applescript` driver beside it,
+  `deckops-version.applescript` included. Their manual validation procedure is
+  Step 5 of `skills/presentation-creator/references/deck-editing-setup.md` — what
+  to run, what to observe, what counts as a pass.
+- `deckops-doctor.py` splits along the same line: the AppleScript probe is exempt,
+  while path derivation, probe-output parsing, and the verdict table are unit-tested
+  in `tests/test_deckops_doctor.py` against synthetic probe results.
 
 ## Mac PowerPoint VBA Landmines (all handled in RunDeckOps)
 

--- a/rules/deck-editing-rules.md
+++ b/rules/deck-editing-rules.md
@@ -36,17 +36,16 @@ generating slide structure (see `rules/slide-generation-rules.md`).
   `DeckOps.pptm` macro container, import the `.bas`, grant Automation consent).
   Walk the user through it interactively — see
   `skills/presentation-creator/references/deck-editing-setup.md`.
-- Never assume whether setup has been done. `deckops-doctor.py --vault-root <path>`
-  is the read-only probe that answers it, and it is the only thing that can see a
-  STALE macro import: a saved `.pptm` yields no VBA source, so the doctor asks the
-  running PowerPoint for the module's own content stamp. Statuses and their
-  routing live in Step 0 of the setup doc.
-- The macro container has one canonical location, `<vault_root>/.deckops/DeckOps.pptm`,
-  and the importable `.bas` is exported beside it. An installed plugin sits under a
-  hidden `.tessl/` directory that PowerPoint's Import panel will not show, so the
-  import path must leave the plugin tree —
-  `sync-deck-drivers.py export --to <vault_root>/.deckops` puts it where the user
-  can reach it.
+- Never assume whether setup has been done — run `deckops-doctor.py --vault-root <path>`
+  and act on its `status`. Statuses and their routing live in Step 0 of the setup doc.
+- The doctor is the only reader of a STALE macro import. A saved `.pptm` yields no
+  VBA source; the loaded module's content stamp comes back from the running
+  PowerPoint, never off disk.
+- The macro container has one canonical location,
+  `<vault_root>/.deckops/DeckOps.pptm`. The importable `.bas` is exported beside it
+  with `sync-deck-drivers.py export --to <vault_root>/.deckops`.
+- Never hand the user an import path inside the plugin tree. An installed plugin
+  sits under a hidden `.tessl/` directory PowerPoint's Import panel will not show.
 
 ## Add a Generated Illustration as a Slide Background
 

--- a/rules/deck-editing-rules.md
+++ b/rules/deck-editing-rules.md
@@ -44,8 +44,7 @@ generating slide structure (see `rules/slide-generation-rules.md`).
 - The macro container has one canonical location,
   `<vault_root>/.deckops/DeckOps.pptm`. The importable `.bas` is exported beside it
   with `sync-deck-drivers.py export --to <vault_root>/.deckops`.
-- Never hand the user an import path inside the plugin tree. An installed plugin
-  sits under a hidden `.tessl/` directory PowerPoint's Import panel will not show.
+- Never hand the user an import path inside the plugin tree.
 
 ## Add a Generated Illustration as a Slide Background
 

--- a/skills/presentation-creator/references/alternate-entry-flows.md
+++ b/skills/presentation-creator/references/alternate-entry-flows.md
@@ -46,9 +46,12 @@ either run Phase 6 Step 6.1 first or get the shownotes URL manually.
    `"{speaker_toolkit_root}/skills/presentation-creator/scripts/run-deck-ops.sh"`.
    python-pptx editing is not used — it strips per-slide background fills,
    flattening illustrated decks. See `rules/deck-editing-rules.md` (macOS +
-   Microsoft PowerPoint only). On first use, walk the user through
-   `references/deck-editing-setup.md` (enable macros, import the macro, grant
-   Automation consent) before invoking the script.
+   Microsoft PowerPoint only). Before invoking the script, run
+   `"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/deckops-doctor.py" --vault-root "{vault_root}"`
+   and act on its `status` — it reports whether the one-time setup is done,
+   whether the macro container is open, and whether the imported macro is
+   current. Anything but `ok` routes into `references/deck-editing-setup.md`
+   at the step its `next_step` names.
 
 ## CFP Abstract Writing
 

--- a/skills/presentation-creator/references/deck-editing-setup.md
+++ b/skills/presentation-creator/references/deck-editing-setup.md
@@ -11,10 +11,42 @@ confirm each manual step, it confirms once via the smoke test. Steps 1–4 run o
 per machine. **Step 6 is the recurring per-build flow** — read it before every
 real deck build.
 
+Every path below is absolute. `{speaker_toolkit_root}` is resolved in
+`SKILL.md`; `{vault_root}` is `config.vault_root` from the tracking database.
+Expand both before showing a command or a path to the user — they cannot resolve
+a placeholder, and Step 3 in particular hands them a path to type.
+
+## Step 0 — Ask what is actually missing
+
+Never assume this is a first run, and never assume it isn't:
+
+```bash
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/deckops-doctor.py" \
+  --vault-root "{vault_root}"
+```
+
+Read-only: it opens nothing, saves nothing, and never launches PowerPoint. It
+prints a JSON report whose `status` says what to do — `next_step` carries the
+same thing as one sentence:
+
+| `status` | What it means | Go to |
+|---|---|---|
+| `ok` | Set up and current | Step 6 |
+| `setup_required` | No macro container on this machine | Step 1 |
+| `macro_unreachable` | Container missing from the running PowerPoint, macros off, or module never imported | Steps 1–3 |
+| `powerpoint_not_running` | Set up; PowerPoint just isn't open | Step 6 |
+| `macro_stale` | Container holds an OLD build of the macro | Step 3 (Updating) |
+| `driver_drift` | Shipped drivers don't match their mirrors | Reinstall the plugin |
+| `unsupported_platform` | Not macOS | No deck build is possible here |
+
+Pass `--offline` to skip the live PowerPoint probe; you then get `setup_required`
+versus everything-else, and no reading on whether the macro is current.
+
 Heads-up for installed plugins: `tessl install` ships only `.md/.py/.json/.sh/.txt`
 and STRIPS `.bas`/`.applescript`, so `RunDeckOps.bas` and the `.applescript`
-drivers aren't on disk after install — Step 3 restores them from their committed
-`.txt` mirrors. A dev checkout already has them.
+drivers aren't on disk after install. The doctor and the `.sh` wrappers restore
+them automatically from their committed `.txt` mirrors; a dev checkout already
+has them. Nothing here requires a manual restore.
 
 ## Step 1 — Enable VBA macros
 
@@ -23,13 +55,21 @@ macros ("Enable all macros", or enable + trust). Proceed to Step 2.
 
 ## Step 2 — Create the macro container `DeckOps.pptm`
 
-The macro must live in a macro-enabled file, never in a real deck. Ask the user
-to:
+The macro must live in a macro-enabled file, never in a real deck. The container
+goes at ONE canonical path, reused across every talk — the doctor and every
+error message look for it there:
+
+```
+{vault_root}/.deckops/DeckOps.pptm
+```
+
+Ask the user to:
 1. **File → New Presentation** (a blank deck — this becomes the macro home).
 2. **File → Save As** → set **File Format: PowerPoint Macro-Enabled
-   Presentation (.pptm)** → name it `DeckOps.pptm`, and save it into the **vault**
-   (a stable location reused across every talk, e.g. `<vault>/.deckops/DeckOps.pptm`)
-   so it's created once and reused — not regenerated per deck.
+   Presentation (.pptm)** → name it `DeckOps.pptm` and save it to the path above.
+   In the Save dialog, ⇧⌘G opens "Go to Folder" — paste the expanded directory
+   there. Create `.deckops` first if the dialog won't navigate to a
+   dot-directory: `mkdir -p "{vault_root}/.deckops"`.
 
 Gotcha to warn about up front: if PowerPoint ever shows **"Visual Basic macros
 will be removed if you save the file in this format"**, the user is saving a
@@ -38,27 +78,32 @@ deck must never carry the macro.
 
 ## Step 3 — Import the macro
 
-**First, on an installed plugin, restore the stripped drivers** (a dev checkout
-already has them, so this is a no-op there):
+**First, put the `.bas` somewhere the user can actually reach it.** On an
+installed plugin the module lives under a hidden `.tessl/` directory, which
+PowerPoint's Import panel does not show — so export a copy next to the container:
 
 ```bash
-"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/sync-deck-drivers.py" materialize
+"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/sync-deck-drivers.py" \
+  export --to "{vault_root}/.deckops"
 ```
 
-This recreates `RunDeckOps.bas` and the eight `.applescript` drivers from their
-committed `.txt` mirrors. (The `.sh` wrappers also self-restore the `.applescript`
-drivers on first run via `ensure-drivers.sh`; only the `RunDeckOps.bas` you import
-by hand here needs the explicit step.)
+It prints the exported path as JSON (`{"exported": "..."}`). Materializes the
+`.bas` from its mirror first if the install stripped it, and refreshes a stale
+earlier export. Give the user that exact absolute path.
 
 Then ask the user to open the VBA editor (**Tools → Macro → Visual Basic Editor**,
 or ⌥F11), select **DeckOps.pptm's** project in the left pane, then
-**File → Import File…** and choose
-`skills/presentation-creator/scripts/RunDeckOps.bas`. Save `DeckOps.pptm` (⌘S).
+**File → Import File…** and choose the exported `RunDeckOps.bas`. In that panel
+⇧⌘G opens "Go to Folder" and ⇧⌘. toggles hidden files — the `.deckops` directory
+starts with a dot, so one of the two is needed. Save `DeckOps.pptm` (⌘S).
 
-To UPDATE the macro later (e.g. after a plugin update): re-run the materializer with
-`materialize --force` to refresh the on-disk `.bas`, then in the VBA editor
-right-click the `DeckOps` module → **Remove** (No to export) → **Import File…** the
-refreshed `.bas` → save.
+**Updating the macro later.** A plugin update ships a new macro; the copy already
+imported into `DeckOps.pptm` keeps running the OLD code, silently, because nothing
+can read VBA source back out of a saved `.pptm`. That is what `macro_stale`
+detects — the module carries a content stamp and the doctor asks the running
+PowerPoint for it. On `macro_stale`: re-run the `export` command above, then in
+the VBA editor right-click the `DeckOps` module → **Remove** (No to export) →
+**Import File…** the refreshed `.bas` → save. Re-run Step 0 to confirm `ok`.
 
 ## Step 4 — Grant Automation consent (first run only)
 
@@ -71,10 +116,31 @@ to control PowerPoint. After consent is granted once, the agent may run
 
 ## Step 5 — Smoke-test before any real edit
 
-With `DeckOps.pptm` open, run a 3-slide throwaway against a UNIQUELY-NAMED copy
-of a deck and confirm it opens clean in PowerPoint **and** Keynote (no "Repair"
-prompt). Only then run the real edit. Given the history of lost work with other
-tools, always test first.
+Given the history of lost work with other tools, always test before touching a
+real deck. A 3-slide op sequence ships for exactly this — it uses layout 0 and a
+free text box only, so it runs against any template:
+
+```bash
+SMOKE="$TMPDIR/deckops-smoke-$$"
+cp "{template_pptx_path}" "$SMOKE-base.pptx"
+bash "{speaker_toolkit_root}/skills/presentation-creator/scripts/build-deck.sh" \
+  "$SMOKE-base.pptx" "$SMOKE-out.pptx" \
+  "{speaker_toolkit_root}/skills/presentation-creator/scripts/smoke-test-ops.txt"
+```
+
+`{template_pptx_path}` is `infrastructure.template_pptx_path` from the speaker
+profile. `DeckOps.pptm` must be open (Step 6). The copies are uniquely named on
+purpose — PowerPoint keys open decks by filename.
+
+It passes when all four hold:
+1. The command exits 0 and prints `done -> …`.
+2. The output has exactly 3 slides, titled "DeckOps smoke test", "Slide 2 of 3",
+   "Slide 3 of 3".
+3. It opens in **PowerPoint** with no "Repair" prompt.
+4. It opens in **Keynote** with no "Repair" prompt.
+
+Anything else: re-run Step 0 and follow `next_step`. Only after a clean pass run
+the real edit. Delete the throwaway files.
 
 ## Step 6 — Every build (recurring)
 
@@ -85,15 +151,17 @@ Steps 1–4 are one-time per machine; this is what happens on EVERY real deck bu
    that lives in this file; the scripts call it in the running PowerPoint instance.
    If `DeckOps.pptm` is closed (or PowerPoint quits) mid-build, the next pass fails
    with a macro-not-found error — reopen it and re-run that pass.
-2. The agent runs the passes in order against uniquely-named copies:
+2. Run Step 0 once before the first pass and require `ok`. It is the cheap way to
+   catch a closed container or a stale import before a 40-slide build half-finishes.
+3. The agent runs the passes in order against uniquely-named copies:
    structural build → `ExpandBuilds` → speaker notes → backgrounds → QR.
    `ExpandBuilds` renumbers later slides, so it runs before the by-index passes
    (see `rules/deck-editing-rules.md`).
-3. On the FIRST run after setup, the user clicks the macOS Automation prompt
+4. On the FIRST run after setup, the user clicks the macOS Automation prompt
    (Step 4). After that the agent runs the passes unattended, with no
    per-illustration prompts (images are staged into PowerPoint's container — see
    the per-illustration caveat below).
-4. When the build finishes, open the output in PowerPoint **and** Keynote and
+5. When the build finishes, open the output in PowerPoint **and** Keynote and
    confirm it's clean (no "Repair" prompt, art present) before trusting it.
 
 ## Google Drive caveat (important)
@@ -106,6 +174,10 @@ staging folder (`~/.deckops-staging/`) and then moving the result into the Drive
 destination with the shell (which writes to Drive normally). Keep using
 uniquely-named copies for the base/import/output so PowerPoint's
 filename-keyed open-deck cache never hands back the wrong deck.
+
+This applies to `DeckOps.pptm` itself only for creation: saving it into a Drive
+vault in Step 2 is a normal GUI save, which Drive accepts. The macro never writes
+to its own container.
 
 ## Powerbox prompt caveat (important)
 

--- a/skills/presentation-creator/references/deck-editing-setup.md
+++ b/skills/presentation-creator/references/deck-editing-setup.md
@@ -123,23 +123,24 @@ to control PowerPoint. After consent is granted once, the agent may run
 ## Step 5 — Smoke-test before any real edit
 
 Given the history of lost work with other tools, always test before touching a
-real deck. A 3-slide op sequence ships for exactly this — it uses layout 0 and a
-free text box only, so it runs against any template:
+real deck. One script does the whole thing — it copies the template to a
+uniquely-named base, builds the shipped 3-slide op sequence (layout 0 and a free
+text box only, so it runs against any template), and prints where the output
+landed:
 
 ```bash
-SMOKE="$TMPDIR/deckops-smoke-$$"
-cp "{template_pptx_path}" "$SMOKE-base.pptx"
-bash "{speaker_toolkit_root}/skills/presentation-creator/scripts/build-deck.sh" \
-  "$SMOKE-base.pptx" "$SMOKE-out.pptx" \
-  "{speaker_toolkit_root}/skills/presentation-creator/scripts/smoke-test-ops.txt"
+bash "{speaker_toolkit_root}/skills/presentation-creator/scripts/deckops-smoke-test.sh" \
+  "{template_pptx_path}"
 ```
 
 `{template_pptx_path}` is `infrastructure.template_pptx_path` from the speaker
-profile. `DeckOps.pptm` must be open (Step 6). The copies are uniquely named on
-purpose — PowerPoint keys open decks by filename.
+profile; the template is read-only. An optional second argument sets the output
+directory. It prints `{"ok":true,"output":"<path>","slides":3,"base":"<path>"}`
+and exits non-zero when no deck was produced. `DeckOps.pptm` must be open
+(Step 6).
 
 It passes when all four hold:
-1. The command exits 0 and prints `done -> …`.
+1. The script exits 0 and prints `{"ok":true,...}`.
 2. The output has exactly 3 slides, titled "DeckOps smoke test", "Slide 2 of 3",
    "Slide 3 of 3".
 3. It opens in **PowerPoint** with no "Repair" prompt.

--- a/skills/presentation-creator/references/deck-editing-setup.md
+++ b/skills/presentation-creator/references/deck-editing-setup.md
@@ -25,8 +25,13 @@ Never assume this is a first run, and never assume it isn't:
   --vault-root "{vault_root}"
 ```
 
-Read-only: it opens nothing, saves nothing, and never launches PowerPoint. It
-prints a JSON report whose `status` says what to do — `next_step` carries the
+It touches no deck, no template, no macro container, and never launches
+PowerPoint. It does restore missing drivers into the plugin's own scripts
+directory — the same install-restore the `.sh` wrappers do, and what keeps a
+fresh install from reading as driver drift. That restore runs under `--offline`
+too, and never overwrites an existing driver.
+
+It prints a JSON report whose `status` says what to do — `next_step` carries the
 same thing as one sentence:
 
 | `status` | What it means | Go to |
@@ -36,11 +41,20 @@ same thing as one sentence:
 | `macro_unreachable` | Container missing from the running PowerPoint, macros off, or module never imported | Steps 1–3 |
 | `powerpoint_not_running` | Set up; PowerPoint just isn't open | Step 6 |
 | `macro_stale` | Container holds an OLD build of the macro | Step 3 (Updating) |
-| `driver_drift` | Shipped drivers don't match their mirrors | Reinstall the plugin |
+| `driver_drift` | Shipped drivers don't match their mirrors | Read `drivers.problems`; it names the fix |
+| `probe_failed` | The probe could not run, so the state is UNKNOWN | Read `live.detail` — usually denied Automation consent (Step 4) |
+| `probe_missing` | The probe driver or `osascript` is absent | Reinstall the plugin |
 | `unsupported_platform` | Not macOS | No deck build is possible here |
 
+Exit code separates a diagnosis from a non-diagnosis: 0 when a verdict was
+reached (`setup_required` included — that is a finding, not a script failure),
+1 when the probe could not run and the state is unknown.
+
 Pass `--offline` to skip the live PowerPoint probe; you then get `setup_required`
-versus everything-else, and no reading on whether the macro is current.
+versus everything-else, and no reading on whether the macro is current. A
+container open from a path other than the canonical one still counts as set up —
+`container.canonical_mismatch` reports the difference, and `next_step` names the
+file the user actually has open rather than sending them to create a second one.
 
 Heads-up for installed plugins: `tessl install` ships only `.md/.py/.json/.sh/.txt`
 and STRIPS `.bas`/`.applescript`, so `RunDeckOps.bas` and the `.applescript`

--- a/skills/presentation-creator/references/deck-editing-setup.md
+++ b/skills/presentation-creator/references/deck-editing-setup.md
@@ -63,13 +63,19 @@ error message look for it there:
 {vault_root}/.deckops/DeckOps.pptm
 ```
 
-Ask the user to:
+Create the directory yourself first, so the Save dialog has somewhere to land:
+
+```bash
+mkdir -p "{vault_root}/.deckops"
+```
+
+Then ask the user to:
 1. **File → New Presentation** (a blank deck — this becomes the macro home).
 2. **File → Save As** → set **File Format: PowerPoint Macro-Enabled
    Presentation (.pptm)** → name it `DeckOps.pptm` and save it to the path above.
    In the Save dialog, ⇧⌘G opens "Go to Folder" — paste the expanded directory
-   there. Create `.deckops` first if the dialog won't navigate to a
-   dot-directory: `mkdir -p "{vault_root}/.deckops"`.
+   there. A dot-directory does not appear in the file list; ⇧⌘. toggles hidden
+   files if they need to see it.
 
 Gotcha to warn about up front: if PowerPoint ever shows **"Visual Basic macros
 will be removed if you save the file in this format"**, the user is saving a

--- a/skills/presentation-creator/references/phase5-slides.md
+++ b/skills/presentation-creator/references/phase5-slides.md
@@ -53,7 +53,12 @@ bash "{speaker_toolkit_root}/skills/presentation-creator/scripts/build-deck.sh" 
 
 Op vocabulary, field layout, and state rules: `references/deckops-spec.md`. The
 template is read-only — pass a uniquely-named copy. macOS + Microsoft PowerPoint
-only; on first use walk the user through `references/deck-editing-setup.md`.
+only. Before the first pass run
+`"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/deckops-doctor.py" --vault-root "{vault_root}"`
+and require `status: ok`; anything else routes into
+`references/deck-editing-setup.md` at the step its `next_step` names. Do not
+guess whether this is a first run — the doctor answers it, and it also catches a
+closed container or a stale macro import before a long build half-finishes.
 
 ---
 
@@ -319,11 +324,14 @@ listing tokens in the target order; import by adding an alias to `importSpec`.
 "BASE:1 BASE:2 BASE:6 BASE:4 BASE:5"
 ```
 
-macOS + Microsoft PowerPoint only. On first use, walk the user through
-`references/deck-editing-setup.md` (enable VBA macros, import `RunDeckOps.bas`
-into a `DeckOps.pptm` container, grant Automation consent). On EVERY build, the
-user must open `DeckOps.pptm` first and keep it open for the whole sequence —
-each pass calls a macro in that running instance (see Step 6 of the setup doc).
+macOS + Microsoft PowerPoint only. Run
+`"{python_path}" "{speaker_toolkit_root}/skills/presentation-creator/scripts/deckops-doctor.py" --vault-root "{vault_root}"`
+first and act on its `status` rather than assuming a first run;
+`references/deck-editing-setup.md` covers enabling VBA macros, importing
+`RunDeckOps.bas` into a `DeckOps.pptm` container, and granting Automation
+consent. On EVERY build, the user must open `DeckOps.pptm` first and keep it open
+for the whole sequence — each pass calls a macro in that running instance (see
+Step 6 of the setup doc).
 The macro writes a COPY — the original is untouched; continue editing from the
 OUTPUT deck.
 

--- a/skills/presentation-creator/scripts/RunDeckOps.bas
+++ b/skills/presentation-creator/scripts/RunDeckOps.bas
@@ -62,6 +62,18 @@ Attribute VB_Name = "DeckOps"
 ' =====================================================================
 Option Explicit
 
+' Content stamp -- written by `sync-deck-drivers.py stamp`, never edited by hand.
+' Nothing can read the VBA source back out of a saved DeckOps.pptm, so a module
+' imported once and never refreshed is otherwise invisible. deckops-doctor.py asks
+' the RUNNING PowerPoint for DeckOpsVersion() and compares the answer to the stamp
+' in the shipped module; a mismatch means the container holds a stale import and
+' the user must re-import (see references/deck-editing-setup.md Step 3).
+Public Const DECKOPS_STAMP As String = "8817d0943105a0bf"
+
+Public Function DeckOpsVersion() As Variant
+    DeckOpsVersion = DECKOPS_STAMP
+End Function
+
 Public Function RunDeckOps(ByVal basePath As String, _
                            ByVal outPath As String, _
                            ByVal importSpec As String, _

--- a/skills/presentation-creator/scripts/RunDeckOps.bas.txt
+++ b/skills/presentation-creator/scripts/RunDeckOps.bas.txt
@@ -62,6 +62,18 @@ Attribute VB_Name = "DeckOps"
 ' =====================================================================
 Option Explicit
 
+' Content stamp -- written by `sync-deck-drivers.py stamp`, never edited by hand.
+' Nothing can read the VBA source back out of a saved DeckOps.pptm, so a module
+' imported once and never refreshed is otherwise invisible. deckops-doctor.py asks
+' the RUNNING PowerPoint for DeckOpsVersion() and compares the answer to the stamp
+' in the shipped module; a mismatch means the container holds a stale import and
+' the user must re-import (see references/deck-editing-setup.md Step 3).
+Public Const DECKOPS_STAMP As String = "8817d0943105a0bf"
+
+Public Function DeckOpsVersion() As Variant
+    DeckOpsVersion = DECKOPS_STAMP
+End Function
+
 Public Function RunDeckOps(ByVal basePath As String, _
                            ByVal outPath As String, _
                            ByVal importSpec As String, _

--- a/skills/presentation-creator/scripts/deckops-doctor.py
+++ b/skills/presentation-creator/scripts/deckops-doctor.py
@@ -15,18 +15,30 @@ Three questions the skill used to have no way to ask, so it guessed:
      content stamp (DeckOpsVersion, stamped by sync-deck-drivers.py) and compare.
      A stale import is otherwise invisible: it runs, and it runs the OLD code.
 
-Read-only. Opens nothing, saves nothing, and never launches PowerPoint.
+Side effects, stated plainly rather than as a blanket "read-only" claim:
+
+  * Never touches a deck, a template, the macro container, or PowerPoint's state.
+    It opens no document, saves no document, and never launches PowerPoint.
+  * DOES restore missing drivers into the PLUGIN's own scripts directory, via
+    sync-deck-drivers.py materialize — the same install-restore every `.sh`
+    wrapper performs. This runs in --offline mode too. Without it a fresh
+    `tessl install` (mirrors, no sources) reads as ten orphan mirrors and a valid
+    installation is told to reinstall itself. Existing drivers are never
+    overwritten, so an in-progress edit in a dev checkout is safe.
 
 Usage:
     deckops-doctor.py --vault-root <path> [--offline]
 
     --offline   skip the live PowerPoint probe (answers 1 and 2 only). Use in
-                CI, or when PowerPoint must not be disturbed.
+                CI, or when PowerPoint must not be disturbed. Driver restoration
+                still runs — see Side effects.
 
 Stdout: one JSON object (see STATUSES). Stderr: an actionable line when the
 status is not `ok`. Exit 0 whenever a verdict was reached — "setup required" is a
-finding to act on, not a failure of this script. Exit 1 only when no verdict
-could be reached, 2 on usage error.
+finding to act on, not a failure of this script. Exit 1 when no verdict could be
+reached: an unusable vault root, or a probe that failed outright (`probe_failed`,
+`probe_missing`), where the setup state is unknown rather than diagnosed. Exit 2
+on usage error.
 
 The live probe drives PowerPoint, so it is manual-validation-only per
 rules/deck-editing-rules.md; every deterministic part here (path derivation,
@@ -77,8 +89,10 @@ STATUSES = {
         "build can run on this host."
     ),
     "driver_drift": (
-        "The deck drivers do not match their committed mirrors — reinstall the "
-        "plugin, or in a dev checkout run: sync-deck-drivers.py mirror"
+        "The deck drivers do not match their committed mirrors — read "
+        "`drivers.problems`. A driver left stale by a plugin update is refreshed "
+        "with `sync-deck-drivers.py materialize --force`; a mirror left behind by "
+        "a dev-tree edit, with `sync-deck-drivers.py mirror`."
     ),
     "setup_required": (
         "First-time setup has not been done on this machine — walk the user "
@@ -92,6 +106,17 @@ STATUSES = {
         "PowerPoint is running but the DeckOps macro did not answer — ask the user "
         "to open {container}, confirm macros are enabled, and confirm the module "
         "was imported into THAT file (deck-editing-setup.md Steps 1-3)."
+    ),
+    "probe_failed": (
+        "The PowerPoint probe could not run, so the setup state is UNKNOWN — read "
+        "`live.detail`. Denied Automation consent is the usual cause (System "
+        "Settings -> Privacy & Security -> Automation). Re-run with --offline to "
+        "check the on-disk half alone."
+    ),
+    "probe_missing": (
+        "The probe driver or `osascript` is missing, so the setup state is UNKNOWN "
+        "— read `live.detail`. Reinstall the plugin, or re-run with --offline to "
+        "check the on-disk half alone."
     ),
     "macro_stale": (
         "{container} holds an OLD build of the macro ({found}, expected {expected}) "
@@ -145,14 +170,19 @@ def run_probe(scripts_dir: Path) -> dict[str, str]:
         return {"state": "probe_missing", "detail": "osascript not on PATH"}
     except subprocess.TimeoutExpired:
         return {
-            "state": "macro_unreachable",
+            "state": "probe_failed",
             "detail": (
                 f"the probe did not return within {PROBE_TIMEOUT_SEC}s — a modal "
                 "dialog in PowerPoint blocks every macro call until dismissed"
             ),
         }
     if proc.returncode != 0:
-        return {"state": "macro_unreachable", "detail": proc.stderr.strip()}
+        # The driver returns state=macro_unreachable (exit 0) for the ONE expected
+        # failure, an unavailable macro. A non-zero exit is therefore something
+        # else — denied Automation consent, a cancel, an unexpected error — and
+        # must not be laundered into a setup verdict that sends the user to build
+        # a second container.
+        return {"state": "probe_failed", "detail": proc.stderr.strip()}
     return parse_probe(proc.stdout)
 
 
@@ -172,7 +202,11 @@ def verdict(
     if probe is None:
         # Offline: the on-disk container at the canonical path is all there is to see.
         return "ok" if container_exists else "setup_required"
-    state = probe.get("state", "macro_unreachable")
+    state = probe.get("state", "probe_failed")
+    if state in ("probe_failed", "probe_missing"):
+        # The probe could not answer, so nothing is known about the setup. Saying
+        # "setup_required" here would prescribe a fix for a question never asked.
+        return state
     if state == "ok":
         # A macro that answers proves setup regardless of where the container file
         # sits — a user whose DeckOps.pptm predates the canonical path is set up,
@@ -261,7 +295,11 @@ def diagnose(vault_root: Path, scripts_dir: Path, offline: bool, platform: str) 
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
-        description="Diagnose the PowerPoint deck-editing setup (read-only)."
+        description=(
+            "Diagnose the PowerPoint deck-editing setup. Never touches a deck, a "
+            "template, the macro container, or PowerPoint; does restore missing "
+            "drivers into the plugin's own scripts directory."
+        )
     )
     ap.add_argument(
         "--vault-root",
@@ -300,7 +338,8 @@ def main(argv=None) -> int:
     print(json.dumps(report, indent=2))
     if report["status"] != "ok":
         print(f"{report['status']}: {report['next_step']}", file=sys.stderr)
-    return 0
+    # A verdict is success; a probe that could not run is not a verdict.
+    return 1 if report["status"] in ("probe_failed", "probe_missing") else 0
 
 
 if __name__ == "__main__":

--- a/skills/presentation-creator/scripts/deckops-doctor.py
+++ b/skills/presentation-creator/scripts/deckops-doctor.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Answer "is the PowerPoint deck layer set up, and is it current?" in one call.
+
+Three questions the skill used to have no way to ask, so it guessed:
+
+  1. Is this the user's FIRST use? Every caller said "on first use, walk the user
+     through deck-editing-setup.md" and nothing could tell first use from the
+     hundredth. `status` answers it.
+  2. Where is DeckOps.pptm? Eight wrappers print "confirm DeckOps.pptm is open"
+     and none of them could say where it should be. The container lives at a
+     canonical path under the vault (CONTAINER_DIRNAME / CONTAINER_NAME below),
+     and a RUNNING PowerPoint reports where it actually opened it from.
+  3. Is the imported macro current? A saved .pptm gives up no VBA source, so the
+     only way to see inside is to ask the running PowerPoint for the module's own
+     content stamp (DeckOpsVersion, stamped by sync-deck-drivers.py) and compare.
+     A stale import is otherwise invisible: it runs, and it runs the OLD code.
+
+Read-only. Opens nothing, saves nothing, and never launches PowerPoint.
+
+Usage:
+    deckops-doctor.py --vault-root <path> [--offline]
+
+    --offline   skip the live PowerPoint probe (answers 1 and 2 only). Use in
+                CI, or when PowerPoint must not be disturbed.
+
+Stdout: one JSON object (see STATUSES). Stderr: an actionable line when the
+status is not `ok`. Exit 0 whenever a verdict was reached — "setup required" is a
+finding to act on, not a failure of this script. Exit 1 only when no verdict
+could be reached, 2 on usage error.
+
+The live probe drives PowerPoint, so it is manual-validation-only per
+rules/deck-editing-rules.md; every deterministic part here (path derivation,
+probe-output parsing, verdict) is unit-tested in tests/test_deckops_doctor.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from importlib import util as _importlib_util
+
+
+def _load_sibling(name: str, filename: str):
+    """Import a sibling script whose filename is not a valid module name."""
+    path = Path(__file__).resolve().parent / filename
+    spec = _importlib_util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(
+            f"cannot load {path} — it must sit beside this script; reinstall the plugin"
+        )
+    module = _importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sync_deck_drivers = _load_sibling("sync_deck_drivers", "sync-deck-drivers.py")
+
+# Where the macro container and the importable .bas live, relative to the vault
+# root. A stable per-machine location OUTSIDE the plugin tree on purpose: an
+# installed plugin sits under a hidden `.tessl/` directory, which PowerPoint's
+# VBA-editor Import panel will not show.
+CONTAINER_DIRNAME = ".deckops"
+CONTAINER_NAME = "DeckOps.pptm"
+
+PROBE_DRIVER = "deckops-version.applescript"
+PROBE_TIMEOUT_SEC = 90
+
+# status -> the one thing the user or agent should do next.
+STATUSES = {
+    "ok": "Deck layer is ready.",
+    "unsupported_platform": (
+        "The PowerPoint deck layer is macOS + Microsoft PowerPoint only; no deck "
+        "build can run on this host."
+    ),
+    "driver_drift": (
+        "The deck drivers do not match their committed mirrors — reinstall the "
+        "plugin, or in a dev checkout run: sync-deck-drivers.py mirror"
+    ),
+    "setup_required": (
+        "First-time setup has not been done on this machine — walk the user "
+        "through references/deck-editing-setup.md (all steps)."
+    ),
+    "powerpoint_not_running": (
+        "PowerPoint is not running — ask the user to open {container} and keep it "
+        "open for the whole build (deck-editing-setup.md Step 6)."
+    ),
+    "macro_unreachable": (
+        "PowerPoint is running but the DeckOps macro did not answer — ask the user "
+        "to open {container}, confirm macros are enabled, and confirm the module "
+        "was imported (deck-editing-setup.md Steps 1-3)."
+    ),
+    "macro_stale": (
+        "{container} holds an OLD build of the macro ({found}, expected {expected}) "
+        "— re-import it per deck-editing-setup.md Step 3 before building."
+    ),
+}
+
+
+def container_paths(vault_root: Path) -> dict[str, Path]:
+    """The canonical per-machine deck-layer locations under a vault root."""
+    d = vault_root.expanduser() / CONTAINER_DIRNAME
+    return {
+        "dir": d,
+        "container": d / CONTAINER_NAME,
+        "import_source": d / sync_deck_drivers.STAMP_DRIVER,
+    }
+
+
+def parse_probe(out: str) -> dict[str, str]:
+    """Parse the probe driver's `key=value` lines.
+
+    Values may contain `=` and `;`; keys never do. An unrecognizable line is
+    dropped rather than guessed at — the verdict then falls to a missing `state`.
+    """
+    fields: dict[str, str] = {}
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        k = k.strip()
+        if k:
+            fields[k] = v.strip()
+    return fields
+
+
+def run_probe(scripts_dir: Path) -> dict[str, str]:
+    """Ask the running PowerPoint for the loaded macro's stamp. Never launches it."""
+    sync_deck_drivers.materialize(scripts_dir)
+    driver = scripts_dir / PROBE_DRIVER
+    if not driver.exists():
+        return {"state": "probe_missing", "detail": f"{driver} not found"}
+    try:
+        proc = subprocess.run(
+            ["osascript", str(driver)],
+            capture_output=True,
+            text=True,
+            timeout=PROBE_TIMEOUT_SEC,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {"state": "probe_missing", "detail": "osascript not on PATH"}
+    except subprocess.TimeoutExpired:
+        return {
+            "state": "macro_unreachable",
+            "detail": (
+                f"the probe did not return within {PROBE_TIMEOUT_SEC}s — a modal "
+                "dialog in PowerPoint blocks every macro call until dismissed"
+            ),
+        }
+    if proc.returncode != 0:
+        return {"state": "macro_unreachable", "detail": proc.stderr.strip()}
+    return parse_probe(proc.stdout)
+
+
+def verdict(
+    *,
+    platform: str,
+    driver_problems: list[str],
+    container_exists: bool,
+    expected_stamp: str,
+    probe: dict[str, str] | None,
+) -> str:
+    """Classify the setup. `probe` is None when the live check was skipped."""
+    if platform != "darwin":
+        return "unsupported_platform"
+    if driver_problems:
+        return "driver_drift"
+    if not container_exists:
+        return "setup_required"
+    if probe is None:
+        return "ok"
+    state = probe.get("state", "macro_unreachable")
+    if state == "not_running":
+        return "powerpoint_not_running"
+    if state != "ok":
+        return "macro_unreachable"
+    if probe.get("stamp", "") != expected_stamp:
+        return "macro_stale"
+    return "ok"
+
+
+def diagnose(vault_root: Path, scripts_dir: Path, offline: bool, platform: str) -> dict:
+    paths = container_paths(vault_root)
+    driver_problems = sync_deck_drivers.check(scripts_dir)
+
+    src = scripts_dir / sync_deck_drivers.STAMP_DRIVER
+    mirror = src.with_name(src.name + sync_deck_drivers.MIRROR_SUFFIX)
+    stamp_src = src if src.exists() else mirror
+    if stamp_src.exists():
+        expected_stamp = sync_deck_drivers.read_stamp(
+            stamp_src.read_text(encoding="utf-8")
+        )
+    else:
+        expected_stamp = ""
+        driver_problems = driver_problems + [
+            f"neither {src.name} nor its mirror is present — reinstall the plugin"
+        ]
+
+    probe = None if (offline or platform != "darwin") else run_probe(scripts_dir)
+    status = verdict(
+        platform=platform,
+        driver_problems=driver_problems,
+        container_exists=paths["container"].is_file(),
+        expected_stamp=expected_stamp,
+        probe=probe,
+    )
+
+    import_source = paths["import_source"]
+    report = {
+        "status": status,
+        "setup_complete": status in ("ok", "powerpoint_not_running", "macro_stale"),
+        "platform": platform,
+        "expected_stamp": expected_stamp,
+        "container": {
+            "canonical_path": str(paths["container"]),
+            "exists": paths["container"].is_file(),
+            "open_path": (probe or {}).get("container", ""),
+        },
+        "import_source": {
+            "path": str(import_source),
+            "exists": import_source.is_file(),
+            "current": (
+                import_source.is_file()
+                and src.exists()
+                and import_source.read_bytes() == src.read_bytes()
+            ),
+        },
+        "drivers": {"problems": driver_problems},
+        "live": probe if probe is not None else {"state": "skipped"},
+    }
+    report["next_step"] = STATUSES[status].format(
+        container=paths["container"],
+        found=(probe or {}).get("stamp", "unknown"),
+        expected=expected_stamp,
+    )
+    return report
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Diagnose the PowerPoint deck-editing setup (read-only)."
+    )
+    ap.add_argument(
+        "--vault-root",
+        type=Path,
+        required=True,
+        help="the rhetoric-knowledge-vault root (config.vault_root)",
+    )
+    ap.add_argument(
+        "--offline",
+        action="store_true",
+        help="skip the live PowerPoint probe",
+    )
+    ap.add_argument(
+        "--scripts-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent,
+        help=argparse.SUPPRESS,
+    )
+    args = ap.parse_args(argv)
+
+    vault_root = args.vault_root.expanduser()
+    if not vault_root.is_dir():
+        print(
+            f"ERROR: vault root not found: {vault_root} — pass the "
+            "config.vault_root value read from the tracking database.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve before deriving paths: the vault is commonly reached through a
+    # symlink, and PowerPoint reports the REAL path of an open container. Two
+    # spellings of one location would read as two locations.
+    report = diagnose(
+        vault_root.resolve(), args.scripts_dir, args.offline, sys.platform
+    )
+    print(json.dumps(report, indent=2))
+    if report["status"] != "ok":
+        print(f"{report['status']}: {report['next_step']}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/presentation-creator/scripts/deckops-doctor.py
+++ b/skills/presentation-creator/scripts/deckops-doctor.py
@@ -91,7 +91,7 @@ STATUSES = {
     "macro_unreachable": (
         "PowerPoint is running but the DeckOps macro did not answer — ask the user "
         "to open {container}, confirm macros are enabled, and confirm the module "
-        "was imported (deck-editing-setup.md Steps 1-3)."
+        "was imported into THAT file (deck-editing-setup.md Steps 1-3)."
     ),
     "macro_stale": (
         "{container} holds an OLD build of the macro ({found}, expected {expected}) "
@@ -130,7 +130,6 @@ def parse_probe(out: str) -> dict[str, str]:
 
 def run_probe(scripts_dir: Path) -> dict[str, str]:
     """Ask the running PowerPoint for the loaded macro's stamp. Never launches it."""
-    sync_deck_drivers.materialize(scripts_dir)
     driver = scripts_dir / PROBE_DRIVER
     if not driver.exists():
         return {"state": "probe_missing", "detail": f"{driver} not found"}
@@ -170,33 +169,46 @@ def verdict(
         return "unsupported_platform"
     if driver_problems:
         return "driver_drift"
-    if not container_exists:
-        return "setup_required"
     if probe is None:
-        return "ok"
+        # Offline: the on-disk container at the canonical path is all there is to see.
+        return "ok" if container_exists else "setup_required"
     state = probe.get("state", "macro_unreachable")
+    if state == "ok":
+        # A macro that answers proves setup regardless of where the container file
+        # sits — a user whose DeckOps.pptm predates the canonical path is set up,
+        # not unconfigured. `container.canonical_mismatch` reports the difference.
+        return "ok" if probe.get("stamp", "") == expected_stamp else "macro_stale"
+    if not container_exists and not probe.get("container"):
+        return "setup_required"
     if state == "not_running":
         return "powerpoint_not_running"
-    if state != "ok":
-        return "macro_unreachable"
-    if probe.get("stamp", "") != expected_stamp:
-        return "macro_stale"
-    return "ok"
+    return "macro_unreachable"
 
 
 def diagnose(vault_root: Path, scripts_dir: Path, offline: bool, platform: str) -> dict:
     paths = container_paths(vault_root)
+
+    # Restore before judging. A fresh `tessl install` lands the .txt mirrors and
+    # none of their sources, which check() reads as ten orphan mirrors — a valid
+    # installation told to reinstall itself. Materializing first is the supported
+    # recovery, so try it before reporting drift (error-handling: Graceful Fallback).
+    materialized = [p.name for p in sync_deck_drivers.materialize(scripts_dir)]
     driver_problems = sync_deck_drivers.check(scripts_dir)
 
     src = scripts_dir / sync_deck_drivers.STAMP_DRIVER
     mirror = src.with_name(src.name + sync_deck_drivers.MIRROR_SUFFIX)
     stamp_src = src if src.exists() else mirror
+    expected_stamp = ""
     if stamp_src.exists():
-        expected_stamp = sync_deck_drivers.read_stamp(
-            stamp_src.read_text(encoding="utf-8")
-        )
+        try:
+            expected_stamp = sync_deck_drivers.read_stamp(
+                stamp_src.read_text(encoding="utf-8")
+            )
+        except ValueError as e:
+            # check() already recorded this as a driver problem; crashing here
+            # would swallow the actionable diagnostic it produced.
+            driver_problems = driver_problems + [str(e)]
     else:
-        expected_stamp = ""
         driver_problems = driver_problems + [
             f"neither {src.name} nor its mirror is present — reinstall the plugin"
         ]
@@ -210,6 +222,7 @@ def diagnose(vault_root: Path, scripts_dir: Path, offline: bool, platform: str) 
         probe=probe,
     )
 
+    open_path = (probe or {}).get("container", "")
     import_source = paths["import_source"]
     report = {
         "status": status,
@@ -219,7 +232,9 @@ def diagnose(vault_root: Path, scripts_dir: Path, offline: bool, platform: str) 
         "container": {
             "canonical_path": str(paths["container"]),
             "exists": paths["container"].is_file(),
-            "open_path": (probe or {}).get("container", ""),
+            "open_path": open_path,
+            "canonical_mismatch": bool(open_path)
+            and open_path != str(paths["container"]),
         },
         "import_source": {
             "path": str(import_source),
@@ -230,11 +245,14 @@ def diagnose(vault_root: Path, scripts_dir: Path, offline: bool, platform: str) 
                 and import_source.read_bytes() == src.read_bytes()
             ),
         },
-        "drivers": {"problems": driver_problems},
+        "drivers": {"materialized": materialized, "problems": driver_problems},
         "live": probe if probe is not None else {"state": "skipped"},
     }
+    # Name the container the user actually has open, when there is one — telling
+    # them to open the canonical path while a DeckOps.pptm sits open elsewhere
+    # sends them to create a second one.
     report["next_step"] = STATUSES[status].format(
-        container=paths["container"],
+        container=open_path or paths["container"],
         found=(probe or {}).get("stamp", "unknown"),
         expected=expected_stamp,
     )

--- a/skills/presentation-creator/scripts/deckops-doctor.py
+++ b/skills/presentation-creator/scripts/deckops-doctor.py
@@ -59,13 +59,18 @@ from importlib import util as _importlib_util
 def _load_sibling(name: str, filename: str):
     """Import a sibling script whose filename is not a valid module name."""
     path = Path(__file__).resolve().parent / filename
+    hint = f"{path} must sit beside this script — reinstall the plugin"
     spec = _importlib_util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
-        raise ImportError(
-            f"cannot load {path} — it must sit beside this script; reinstall the plugin"
-        )
+        raise ImportError(f"cannot load {path} — {hint}")
     module = _importlib_util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except (OSError, SyntaxError) as e:
+        # A spec can be built for a file that is then unreadable, truncated, or
+        # corrupt. A raw traceback here would replace the actionable diagnostic
+        # this script exists to produce.
+        raise ImportError(f"cannot execute {path} ({e}) — {hint}") from e
     return module
 
 

--- a/skills/presentation-creator/scripts/deckops-smoke-test.sh
+++ b/skills/presentation-creator/scripts/deckops-smoke-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# deckops-smoke-test.sh — verify a fresh DeckOps setup end-to-end before any real edit.
+#
+# Builds the shipped 3-slide op sequence (smoke-test-ops.txt) against a uniquely-
+# named copy of the speaker's template and reports where the output landed, so the
+# user can open it in PowerPoint AND Keynote and confirm no "Repair" prompt. Given
+# the history of lost work with other deck tools, this runs before the real edit.
+#
+# Usage:
+#   deckops-smoke-test.sh <templatePath> [outDir]
+#
+#   templatePath  the speaker profile's infrastructure.template_pptx_path.
+#                 Read-only — the script copies it.
+#   outDir        where to leave the built deck (default: a mktemp -d dir).
+#
+# Prerequisites: DeckOps.pptm open with the DeckOps module imported, macros
+# enabled, Automation consent granted. Run deckops-doctor.py first — a
+# `status` other than `ok` means this will fail for a reason already diagnosed.
+#
+# Stdout: one JSON object — {"ok":true,"output":"<path>","slides":3,"base":"<path>"}
+# Stderr: actionable diagnostics. Exit non-zero when the build did not produce a deck.
+#
+# The copy is uniquely named on purpose: PowerPoint keys open decks by filename and
+# silently hands back an already-open same-named deck.
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: deckops-smoke-test.sh <templatePath> [outDir]" >&2
+  exit 2
+fi
+
+TEMPLATE="$1"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPS="$HERE/smoke-test-ops.txt"
+EXPECTED_SLIDES=3
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: template not found: $TEMPLATE — pass the speaker profile's infrastructure.template_pptx_path." >&2
+  exit 1
+fi
+if [[ ! -f "$OPS" ]]; then
+  echo "ERROR: op sequence not found: $OPS — reinstall the plugin; smoke-test-ops.txt ships beside this script." >&2
+  exit 1
+fi
+
+if [[ $# -eq 2 ]]; then
+  OUT_DIR="$2"
+  mkdir -p "$OUT_DIR"
+else
+  OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/deckops-smoke-XXXXXX")"
+fi
+
+STAMP="$(date +%Y%m%d-%H%M%S)-$$"
+BASE="$OUT_DIR/deckops-smoke-base-$STAMP.pptx"
+OUT="$OUT_DIR/deckops-smoke-out-$STAMP.pptx"
+
+cp "$TEMPLATE" "$BASE"
+bash "$HERE/build-deck.sh" "$BASE" "$OUT" "$OPS" >&2
+
+if [[ ! -f "$OUT" ]]; then
+  echo "ERROR: the smoke build produced no deck at $OUT. The build-deck.sh output above carries the macro's own diagnostic; run deckops-doctor.py to check the setup." >&2
+  exit 1
+fi
+
+printf '{"ok":true,"output":"%s","slides":%d,"base":"%s"}\n' "$OUT" "$EXPECTED_SLIDES" "$BASE"

--- a/skills/presentation-creator/scripts/deckops-smoke-test.sh
+++ b/skills/presentation-creator/scripts/deckops-smoke-test.sh
@@ -62,4 +62,7 @@ if [[ ! -f "$OUT" ]]; then
   exit 1
 fi
 
-printf '{"ok":true,"output":"%s","slides":%d,"base":"%s"}\n' "$OUT" "$EXPECTED_SLIDES" "$BASE"
+# Serialize with a JSON encoder, never printf: a path may contain a double quote
+# or a backslash, and interpolating one produces invalid JSON behind exit 0.
+python3 -c 'import json,sys; print(json.dumps({"ok":True,"output":sys.argv[1],"slides":int(sys.argv[2]),"base":sys.argv[3]}))' \
+  "$OUT" "$EXPECTED_SLIDES" "$BASE"

--- a/skills/presentation-creator/scripts/deckops-version.applescript
+++ b/skills/presentation-creator/scripts/deckops-version.applescript
@@ -45,7 +45,15 @@ on run argv
 				set macroStamp to run VB macro macro name "DeckOpsVersion"
 			end timeout
 		end tell
-	on error errMsg
+	on error errMsg number errNum
+		-- One documented expected number: -18, which is what Mac PowerPoint returns
+		-- when the named macro is not available (module never imported, macros
+		-- disabled, or the container not open). Verified by running this probe
+		-- against a PowerPoint with DeckOps.pptm open and no DeckOps module in it.
+		-- Everything else -- a user cancel, a modal block, an unexpected failure --
+		-- propagates, and deckops-doctor.py reports the non-zero osascript exit
+		-- with its stderr as the detail.
+		if errNum is not -18 then error errMsg number errNum
 		set out to "state=macro_unreachable" & linefeed & "detail=" & errMsg
 		if containerPath is not "" then set out to out & linefeed & "container=" & containerPath
 		return out

--- a/skills/presentation-creator/scripts/deckops-version.applescript
+++ b/skills/presentation-creator/scripts/deckops-version.applescript
@@ -1,0 +1,54 @@
+-- deckops-version.applescript
+-- Read-only probe: asks the RUNNING PowerPoint which build of the DeckOps macro
+-- is loaded, and where the macro container is open from. Drives no edit, opens
+-- no file, saves nothing. Invoked by deckops-doctor.py, not directly.
+--
+-- Why this exists: a saved .pptm gives up no VBA source, so nothing on disk can
+-- tell whether the module inside DeckOps.pptm matches the shipped RunDeckOps.bas.
+-- The stamp travels INSIDE the module (DECKOPS_STAMP, written by
+-- sync-deck-drivers.py stamp) and comes back through this call.
+--
+-- Never launches PowerPoint: a diagnostic that starts a 300 MB app as a side
+-- effect is worse than the answer it returns.
+--
+-- Emits `key=value` lines on stdout (values may contain "=" and ";"; keys never do):
+--   state=not_running                        PowerPoint is not open
+--   state=macro_unreachable + detail=<msg>   no DeckOps.pptm open, macros off, or
+--                                            the module was never imported
+--   state=ok + stamp=<hex> + container=<path>
+-- Exits 0 in every one of those cases — an unreachable macro is a finding to
+-- report, not a failure of the probe. Nonzero only when osascript itself fails.
+
+on run argv
+	if not (application "Microsoft PowerPoint" is running) then
+		return "state=not_running"
+	end if
+
+	set containerPath to ""
+	try
+		tell application "Microsoft PowerPoint"
+			repeat with p in presentations
+				if (name of p) is "DeckOps.pptm" then
+					set containerPath to (full name of p) as string
+				end if
+			end repeat
+		end tell
+	on error
+		-- A dictionary surprise here costs the container path, never the stamp.
+		set containerPath to ""
+	end try
+
+	try
+		tell application "Microsoft PowerPoint"
+			with timeout of 60 seconds
+				set macroStamp to run VB macro macro name "DeckOpsVersion"
+			end timeout
+		end tell
+	on error errMsg
+		return "state=macro_unreachable" & linefeed & "detail=" & errMsg
+	end try
+
+	set out to "state=ok" & linefeed & "stamp=" & (macroStamp as string)
+	if containerPath is not "" then set out to out & linefeed & "container=" & containerPath
+	return out
+end run

--- a/skills/presentation-creator/scripts/deckops-version.applescript
+++ b/skills/presentation-creator/scripts/deckops-version.applescript
@@ -24,19 +24,20 @@ on run argv
 		return "state=not_running"
 	end if
 
+	-- Plural accessors on purpose. `repeat with p in presentations` + `name of p`
+	-- raises -2763 ("no result was returned") on current Mac PowerPoint builds;
+	-- `name of every presentation` returns the list correctly. Using the working
+	-- form needs no error handler, so nothing here swallows a failure.
 	set containerPath to ""
-	try
-		tell application "Microsoft PowerPoint"
-			repeat with p in presentations
-				if (name of p) is "DeckOps.pptm" then
-					set containerPath to (full name of p) as string
-				end if
-			end repeat
-		end tell
-	on error
-		-- A dictionary surprise here costs the container path, never the stamp.
-		set containerPath to ""
-	end try
+	tell application "Microsoft PowerPoint"
+		set openNames to name of every presentation
+		set openPaths to full name of every presentation
+	end tell
+	repeat with i from 1 to (count of openNames)
+		if (item i of openNames) as string is "DeckOps.pptm" then
+			set containerPath to (item i of openPaths) as string
+		end if
+	end repeat
 
 	try
 		tell application "Microsoft PowerPoint"
@@ -45,7 +46,9 @@ on run argv
 			end timeout
 		end tell
 	on error errMsg
-		return "state=macro_unreachable" & linefeed & "detail=" & errMsg
+		set out to "state=macro_unreachable" & linefeed & "detail=" & errMsg
+		if containerPath is not "" then set out to out & linefeed & "container=" & containerPath
+		return out
 	end try
 
 	set out to "state=ok" & linefeed & "stamp=" & (macroStamp as string)

--- a/skills/presentation-creator/scripts/deckops-version.applescript.txt
+++ b/skills/presentation-creator/scripts/deckops-version.applescript.txt
@@ -45,7 +45,15 @@ on run argv
 				set macroStamp to run VB macro macro name "DeckOpsVersion"
 			end timeout
 		end tell
-	on error errMsg
+	on error errMsg number errNum
+		-- One documented expected number: -18, which is what Mac PowerPoint returns
+		-- when the named macro is not available (module never imported, macros
+		-- disabled, or the container not open). Verified by running this probe
+		-- against a PowerPoint with DeckOps.pptm open and no DeckOps module in it.
+		-- Everything else -- a user cancel, a modal block, an unexpected failure --
+		-- propagates, and deckops-doctor.py reports the non-zero osascript exit
+		-- with its stderr as the detail.
+		if errNum is not -18 then error errMsg number errNum
 		set out to "state=macro_unreachable" & linefeed & "detail=" & errMsg
 		if containerPath is not "" then set out to out & linefeed & "container=" & containerPath
 		return out

--- a/skills/presentation-creator/scripts/deckops-version.applescript.txt
+++ b/skills/presentation-creator/scripts/deckops-version.applescript.txt
@@ -1,0 +1,54 @@
+-- deckops-version.applescript
+-- Read-only probe: asks the RUNNING PowerPoint which build of the DeckOps macro
+-- is loaded, and where the macro container is open from. Drives no edit, opens
+-- no file, saves nothing. Invoked by deckops-doctor.py, not directly.
+--
+-- Why this exists: a saved .pptm gives up no VBA source, so nothing on disk can
+-- tell whether the module inside DeckOps.pptm matches the shipped RunDeckOps.bas.
+-- The stamp travels INSIDE the module (DECKOPS_STAMP, written by
+-- sync-deck-drivers.py stamp) and comes back through this call.
+--
+-- Never launches PowerPoint: a diagnostic that starts a 300 MB app as a side
+-- effect is worse than the answer it returns.
+--
+-- Emits `key=value` lines on stdout (values may contain "=" and ";"; keys never do):
+--   state=not_running                        PowerPoint is not open
+--   state=macro_unreachable + detail=<msg>   no DeckOps.pptm open, macros off, or
+--                                            the module was never imported
+--   state=ok + stamp=<hex> + container=<path>
+-- Exits 0 in every one of those cases — an unreachable macro is a finding to
+-- report, not a failure of the probe. Nonzero only when osascript itself fails.
+
+on run argv
+	if not (application "Microsoft PowerPoint" is running) then
+		return "state=not_running"
+	end if
+
+	set containerPath to ""
+	try
+		tell application "Microsoft PowerPoint"
+			repeat with p in presentations
+				if (name of p) is "DeckOps.pptm" then
+					set containerPath to (full name of p) as string
+				end if
+			end repeat
+		end tell
+	on error
+		-- A dictionary surprise here costs the container path, never the stamp.
+		set containerPath to ""
+	end try
+
+	try
+		tell application "Microsoft PowerPoint"
+			with timeout of 60 seconds
+				set macroStamp to run VB macro macro name "DeckOpsVersion"
+			end timeout
+		end tell
+	on error errMsg
+		return "state=macro_unreachable" & linefeed & "detail=" & errMsg
+	end try
+
+	set out to "state=ok" & linefeed & "stamp=" & (macroStamp as string)
+	if containerPath is not "" then set out to out & linefeed & "container=" & containerPath
+	return out
+end run

--- a/skills/presentation-creator/scripts/deckops-version.applescript.txt
+++ b/skills/presentation-creator/scripts/deckops-version.applescript.txt
@@ -24,19 +24,20 @@ on run argv
 		return "state=not_running"
 	end if
 
+	-- Plural accessors on purpose. `repeat with p in presentations` + `name of p`
+	-- raises -2763 ("no result was returned") on current Mac PowerPoint builds;
+	-- `name of every presentation` returns the list correctly. Using the working
+	-- form needs no error handler, so nothing here swallows a failure.
 	set containerPath to ""
-	try
-		tell application "Microsoft PowerPoint"
-			repeat with p in presentations
-				if (name of p) is "DeckOps.pptm" then
-					set containerPath to (full name of p) as string
-				end if
-			end repeat
-		end tell
-	on error
-		-- A dictionary surprise here costs the container path, never the stamp.
-		set containerPath to ""
-	end try
+	tell application "Microsoft PowerPoint"
+		set openNames to name of every presentation
+		set openPaths to full name of every presentation
+	end tell
+	repeat with i from 1 to (count of openNames)
+		if (item i of openNames) as string is "DeckOps.pptm" then
+			set containerPath to (item i of openPaths) as string
+		end if
+	end repeat
 
 	try
 		tell application "Microsoft PowerPoint"
@@ -45,7 +46,9 @@ on run argv
 			end timeout
 		end tell
 	on error errMsg
-		return "state=macro_unreachable" & linefeed & "detail=" & errMsg
+		set out to "state=macro_unreachable" & linefeed & "detail=" & errMsg
+		if containerPath is not "" then set out to out & linefeed & "container=" & containerPath
+		return out
 	end try
 
 	set out to "state=ok" & linefeed & "stamp=" & (macroStamp as string)

--- a/skills/presentation-creator/scripts/smoke-test-ops.txt
+++ b/skills/presentation-creator/scripts/smoke-test-ops.txt
@@ -1,0 +1,9 @@
+SLIDE0
+TITLEDeckOps smoke test
+TEXT1381If this opens in PowerPoint AND Keynote with no Repair prompt, setup works.
+SLIDE0
+TITLESlide 2 of 3
+TEXT1381The structural build reached slide two.
+SLIDE0
+TITLESlide 3 of 3
+TEXT1381Three slides, no Repair prompt: DeckOps is wired up correctly.

--- a/skills/presentation-creator/scripts/sync-deck-drivers.py
+++ b/skills/presentation-creator/scripts/sync-deck-drivers.py
@@ -22,26 +22,53 @@ Modes:
                            after editing a `.bas`/`.applescript` so the mirror
                            stays byte-identical (the source of truth is the real
                            file; see rules — "keep editing .bas").
+  stamp                  — recompute the content stamp inside RunDeckOps.bas
+                           (`DECKOPS_STAMP`, returned by the module's
+                           DeckOpsVersion() macro) so deckops-doctor.py can tell a
+                           stale import inside DeckOps.pptm from a current one.
+                           Implied by `mirror`; run standalone only to inspect it.
+  export --to DIR        — materialize if needed, then copy RunDeckOps.bas into DIR
+                           and print its path. DIR is a location the user can
+                           actually reach in PowerPoint's VBA-editor Import panel:
+                           an installed plugin lives under a hidden `.tessl/`
+                           directory that a macOS open panel does not show, so the
+                           import path has to leave the plugin tree entirely.
   check                  — assert every real driver has a byte-identical mirror and
-                           vice versa. Exit 1 listing drift (the CI guard).
+                           vice versa, and that the stamp is current. Exit 1
+                           listing drift (the CI guard).
 
 The mapping is deterministic file copy -> script, not LLM (rules/script-delegation.md).
 The VBA side can't run in CI; this tool is unit-tested in
 tests/test_deck_driver_mirrors.py.
 
 Usage:
-    sync-deck-drivers.py {materialize|mirror|check} [--force] [--dir DIR]
+    sync-deck-drivers.py {materialize|mirror|stamp|export|check} [--force]
+                        [--dir DIR] [--to DIR]
 
 DIR defaults to this script's own directory (the scripts dir holding the drivers).
 """
 
 import argparse
+import hashlib
+import json
 import shutil
 import sys
 from pathlib import Path
 
 MIRROR_SUFFIX = ".txt"
 DRIVER_GLOBS = ("*.bas", "*.applescript")
+
+# The one driver carrying a content stamp, and the exact line shape holding it.
+# A saved .pptm gives up no VBA source, so a stamp travelling INSIDE the module is
+# the only thing a running PowerPoint can hand back to prove which build of the
+# macro was imported. Content-addressed rather than hand-bumped: an editor who
+# forgets to bump a counter ships a lie, and this one cannot be forgotten because
+# `mirror` recomputes it and `check` fails on drift.
+STAMP_DRIVER = "RunDeckOps.bas"
+STAMP_PREFIX = 'Public Const DECKOPS_STAMP As String = "'
+STAMP_SUFFIX = '"'
+STAMP_PLACEHOLDER = "0" * 16
+STAMP_LEN = 16
 
 
 def _reals(base: Path) -> list[Path]:
@@ -68,6 +95,58 @@ def _real_of(mirror: Path) -> Path:
     return mirror.with_name(mirror.name[: -len(MIRROR_SUFFIX)])
 
 
+def _stamp_line_bounds(text: str) -> tuple[int, int]:
+    """Return the (start, end) offsets of the stamp literal, or raise ValueError."""
+    start = text.find(STAMP_PREFIX)
+    if start < 0:
+        raise ValueError(
+            f"{STAMP_DRIVER} has no {STAMP_PREFIX.strip()}... line — restore it from "
+            "git; deckops-doctor.py cannot detect a stale macro import without it"
+        )
+    if text.find(STAMP_PREFIX, start + 1) >= 0:
+        raise ValueError(
+            f"{STAMP_DRIVER} has more than one {STAMP_PREFIX.strip()}... line — "
+            "delete the duplicates, leaving exactly one"
+        )
+    value_at = start + len(STAMP_PREFIX)
+    end = text.find(STAMP_SUFFIX, value_at)
+    if end < 0:
+        raise ValueError(f"{STAMP_DRIVER} stamp literal is unterminated")
+    return value_at, end
+
+
+def read_stamp(text: str) -> str:
+    """The stamp currently written into the module text."""
+    a, b = _stamp_line_bounds(text)
+    return text[a:b]
+
+
+def compute_stamp(text: str) -> str:
+    """The stamp the module text SHOULD carry: a digest of itself, stamp masked."""
+    a, b = _stamp_line_bounds(text)
+    masked = text[:a] + STAMP_PLACEHOLDER + text[b:]
+    return hashlib.sha256(masked.encode("utf-8")).hexdigest()[:STAMP_LEN]
+
+
+def restamp(base: Path) -> tuple[str, bool]:
+    """Write the current content stamp into the stamped driver.
+
+    Returns (stamp, changed). Idempotent: a second run is a no-op.
+    """
+    src = base / STAMP_DRIVER
+    if not src.exists():
+        raise FileNotFoundError(
+            f"{src} not found — run: sync-deck-drivers.py materialize"
+        )
+    text = src.read_text(encoding="utf-8")
+    want = compute_stamp(text)
+    if read_stamp(text) == want:
+        return want, False
+    a, b = _stamp_line_bounds(text)
+    src.write_text(text[:a] + want + text[b:], encoding="utf-8")
+    return want, True
+
+
 def materialize(base: Path, force: bool = False) -> list[Path]:
     """Recreate real drivers from their `.txt` mirrors. Returns the files written.
 
@@ -83,9 +162,33 @@ def materialize(base: Path, force: bool = False) -> list[Path]:
     return written
 
 
+def export_stamped_driver(base: Path, dest_dir: Path) -> Path:
+    """Copy RunDeckOps.bas into dest_dir (materializing it first). Returns the path.
+
+    Idempotent: an identical copy already there is left alone.
+    """
+    materialize(base)
+    src = base / STAMP_DRIVER
+    if not src.exists():
+        raise FileNotFoundError(
+            f"{src} not found and no {STAMP_DRIVER}{MIRROR_SUFFIX} mirror to "
+            "restore it from — reinstall the plugin"
+        )
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / STAMP_DRIVER
+    if not dest.exists() or dest.read_bytes() != src.read_bytes():
+        shutil.copyfile(src, dest)
+    return dest
+
+
 def regenerate_mirrors(base: Path) -> list[Path]:
-    """Rewrite `.txt` mirrors from the real drivers. Returns the mirrors changed."""
+    """Rewrite `.txt` mirrors from the real drivers. Returns the mirrors changed.
+
+    Stamps the stamped driver first, so a mirror never carries a stale stamp.
+    """
     written: list[Path] = []
+    if (base / STAMP_DRIVER).exists():
+        restamp(base)
     for r in _reals(base):
         m = _mirror_of(r)
         data = r.read_bytes()
@@ -117,6 +220,19 @@ def check(base: Path) -> list[str]:
                 f"orphan mirror {m.name} has no source {_real_of(m).name} — "
                 "delete the mirror or restore the source driver"
             )
+    src = base / STAMP_DRIVER
+    if src.exists():
+        text = src.read_text(encoding="utf-8")
+        try:
+            have, want = read_stamp(text), compute_stamp(text)
+        except ValueError as e:
+            problems.append(str(e))
+        else:
+            if have != want:
+                problems.append(
+                    f"{STAMP_DRIVER} content stamp is stale ({have} != {want}) — "
+                    "run: sync-deck-drivers.py mirror"
+                )
     return problems
 
 
@@ -124,11 +240,18 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
         description="Keep deck-ops .bas/.applescript drivers shippable past tessl's extension filter."
     )
-    ap.add_argument("mode", choices=("materialize", "mirror", "check"))
+    ap.add_argument(
+        "mode", choices=("materialize", "mirror", "stamp", "export", "check")
+    )
     ap.add_argument(
         "--force",
         action="store_true",
         help="materialize: overwrite existing real drivers (refresh after a plugin update)",
+    )
+    ap.add_argument(
+        "--to",
+        type=Path,
+        help="export: the directory to copy RunDeckOps.bas into (required for export)",
     )
     ap.add_argument(
         "--dir",
@@ -151,8 +274,37 @@ def main(argv=None) -> int:
             print("materialize: nothing to do (real drivers already present)")
         return 0
 
+    if args.mode == "export":
+        if args.to is None:
+            print(
+                "ERROR: export needs --to DIR — the directory to copy "
+                f"{STAMP_DRIVER} into, e.g. <vault>/.deckops",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            dest = export_stamped_driver(base, args.to.expanduser())
+        except (FileNotFoundError, OSError) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+        print(json.dumps({"exported": str(dest)}))
+        return 0
+
+    if args.mode == "stamp":
+        try:
+            stamp, changed = restamp(base)
+        except (FileNotFoundError, ValueError) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+        print(f"stamp: {stamp}" + ("" if changed else " (already current)"))
+        return 0
+
     if args.mode == "mirror":
-        written = regenerate_mirrors(base)
+        try:
+            written = regenerate_mirrors(base)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
         if written:
             print("updated mirrors: " + ", ".join(p.name for p in written))
         else:

--- a/skills/presentation-creator/scripts/sync-deck-drivers.py
+++ b/skills/presentation-creator/scripts/sync-deck-drivers.py
@@ -41,6 +41,10 @@ The mapping is deterministic file copy -> script, not LLM (rules/script-delegati
 The VBA side can't run in CI; this tool is unit-tested in
 tests/test_deck_driver_mirrors.py.
 
+Stdout: one JSON object per mode (`rules/script-delegation.md` Script
+Requirements). Stderr: actionable diagnostics. Exit non-zero on failure and on
+`check` drift.
+
 Usage:
     sync-deck-drivers.py {materialize|mirror|stamp|export|check} [--force]
                         [--dir DIR] [--to DIR]
@@ -268,10 +272,7 @@ def main(argv=None) -> int:
 
     if args.mode == "materialize":
         written = materialize(base, force=args.force)
-        if written:
-            print("materialized: " + ", ".join(p.name for p in written))
-        else:
-            print("materialize: nothing to do (real drivers already present)")
+        print(json.dumps({"materialized": [p.name for p in written]}))
         return 0
 
     if args.mode == "export":
@@ -296,7 +297,7 @@ def main(argv=None) -> int:
         except (FileNotFoundError, ValueError) as e:
             print(f"ERROR: {e}", file=sys.stderr)
             return 1
-        print(f"stamp: {stamp}" + ("" if changed else " (already current)"))
+        print(json.dumps({"stamp": stamp, "changed": changed}))
         return 0
 
     if args.mode == "mirror":
@@ -305,20 +306,17 @@ def main(argv=None) -> int:
         except ValueError as e:
             print(f"ERROR: {e}", file=sys.stderr)
             return 1
-        if written:
-            print("updated mirrors: " + ", ".join(p.name for p in written))
-        else:
-            print("mirror: all mirrors already in sync")
+        print(json.dumps({"updated_mirrors": [p.name for p in written]}))
         return 0
 
     # check
     problems = check(base)
+    print(json.dumps({"ok": not problems, "problems": problems}))
     if problems:
         print("deck-driver mirror drift:", file=sys.stderr)
         for p in problems:
             print("  - " + p, file=sys.stderr)
         return 1
-    print("deck-driver mirrors in sync")
     return 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -620,6 +620,13 @@ def sync_deck_drivers():
 
 
 @pytest.fixture(scope="session")
+def deckops_doctor():
+    return _import_script(
+        os.path.join(SCRIPTS_PC, "deckops-doctor.py"), "deckops_doctor"
+    )
+
+
+@pytest.fixture(scope="session")
 def generate_illustrations():
     return _import_script(
         os.path.join(SCRIPTS_ILL, "generate-illustrations.py"), "generate_illustrations"

--- a/tests/test_deck_driver_mirrors.py
+++ b/tests/test_deck_driver_mirrors.py
@@ -12,6 +12,8 @@ Two layers here:
 
 import os
 
+import pytest
+
 SCRIPTS_PC = os.path.join(
     os.path.dirname(__file__),
     os.pardir,
@@ -100,3 +102,151 @@ def test_committed_repo_mirrors_are_in_sync(sync_deck_drivers):
 
     problems = sync_deck_drivers.check(Path(SCRIPTS_PC).resolve())
     assert problems == [], "deck-driver mirror drift:\n" + "\n".join(problems)
+
+
+# --- content stamp -----------------------------------------------------------
+#
+# The stamp rides INSIDE RunDeckOps.bas because a saved DeckOps.pptm gives up no
+# VBA source: asking the running PowerPoint for DeckOpsVersion() is the only way
+# to see which build was imported. Content-addressed rather than hand-bumped, so
+# an editor cannot ship a lie by forgetting to bump a counter.
+
+
+def _stamped(sync_deck_drivers, tmp_path, body: str, stamp: str = "0" * 16):
+    p = tmp_path / sync_deck_drivers.STAMP_DRIVER
+    p.write_text(
+        f"{body}\n{sync_deck_drivers.STAMP_PREFIX}{stamp}"
+        f"{sync_deck_drivers.STAMP_SUFFIX}\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_restamp_writes_a_digest_and_is_idempotent(sync_deck_drivers, tmp_path):
+    _stamped(sync_deck_drivers, tmp_path, "Sub A()\nEnd Sub")
+    first, changed = sync_deck_drivers.restamp(tmp_path)
+    assert changed is True
+    assert len(first) == sync_deck_drivers.STAMP_LEN
+    second, changed_again = sync_deck_drivers.restamp(tmp_path)
+    assert (second, changed_again) == (first, False)
+
+
+def test_stamp_changes_when_the_macro_body_changes(sync_deck_drivers, tmp_path):
+    _stamped(sync_deck_drivers, tmp_path, "Sub A()\nEnd Sub")
+    before, _ = sync_deck_drivers.restamp(tmp_path)
+    _stamped(sync_deck_drivers, tmp_path, "Sub A()\n' behaviour change\nEnd Sub", before)
+    after, changed = sync_deck_drivers.restamp(tmp_path)
+    assert changed is True
+    assert after != before
+
+
+def test_stamp_does_not_depend_on_the_stamp_already_there(sync_deck_drivers, tmp_path):
+    """Otherwise the digest would chase its own tail and never converge."""
+    _stamped(sync_deck_drivers, tmp_path, "Sub A()\nEnd Sub", "deadbeefdeadbeef")
+    from_one, _ = sync_deck_drivers.restamp(tmp_path)
+    _stamped(sync_deck_drivers, tmp_path, "Sub A()\nEnd Sub", "0123456789abcdef")
+    from_other, _ = sync_deck_drivers.restamp(tmp_path)
+    assert from_one == from_other
+
+
+def test_check_flags_a_stale_stamp(sync_deck_drivers, tmp_path):
+    p = _stamped(sync_deck_drivers, tmp_path, "Sub A()\nEnd Sub", "stalestalestale0")
+    (tmp_path / (p.name + ".txt")).write_bytes(p.read_bytes())  # mirror is in sync
+    problems = sync_deck_drivers.check(tmp_path)
+    assert any("content stamp is stale" in x for x in problems)
+
+
+def test_mirror_stamps_before_mirroring(sync_deck_drivers, tmp_path):
+    """A mirror carrying a stale stamp would restore a driver that lies about itself."""
+    p = _stamped(sync_deck_drivers, tmp_path, "Sub A()\nEnd Sub", "stalestalestale0")
+    sync_deck_drivers.regenerate_mirrors(tmp_path)
+    mirror = tmp_path / (p.name + ".txt")
+    assert mirror.read_bytes() == p.read_bytes()
+    assert sync_deck_drivers.check(tmp_path) == []
+
+
+def test_missing_stamp_line_is_a_named_error(sync_deck_drivers, tmp_path):
+    (tmp_path / sync_deck_drivers.STAMP_DRIVER).write_text("Sub A()\nEnd Sub\n")
+    with pytest.raises(ValueError, match="has no"):
+        sync_deck_drivers.restamp(tmp_path)
+
+
+def test_duplicate_stamp_lines_are_a_named_error(sync_deck_drivers, tmp_path):
+    line = f"{sync_deck_drivers.STAMP_PREFIX}{'0' * 16}{sync_deck_drivers.STAMP_SUFFIX}"
+    (tmp_path / sync_deck_drivers.STAMP_DRIVER).write_text(f"{line}\n{line}\n")
+    with pytest.raises(ValueError, match="more than one"):
+        sync_deck_drivers.restamp(tmp_path)
+
+
+def test_committed_bas_carries_a_current_stamp(sync_deck_drivers):
+    """The shipped module must state its own identity truthfully."""
+    from pathlib import Path
+
+    src = Path(SCRIPTS_PC).resolve() / sync_deck_drivers.STAMP_DRIVER
+    text = src.read_text(encoding="utf-8")
+    assert sync_deck_drivers.read_stamp(text) == sync_deck_drivers.compute_stamp(text)
+
+
+def test_committed_bas_exposes_the_stamp_to_applescript(sync_deck_drivers):
+    """deckops-doctor.py reads it by calling this macro; without it, no staleness check."""
+    from pathlib import Path
+
+    text = (Path(SCRIPTS_PC).resolve() / sync_deck_drivers.STAMP_DRIVER).read_text(
+        encoding="utf-8"
+    )
+    assert "Public Function DeckOpsVersion()" in text
+    assert "DeckOpsVersion = DECKOPS_STAMP" in text
+
+
+# --- export ------------------------------------------------------------------
+
+
+def test_export_copies_the_bas_to_a_reachable_directory(sync_deck_drivers, tmp_path):
+    src_dir, dest_dir = tmp_path / "plugin", tmp_path / "vault" / ".deckops"
+    src_dir.mkdir()
+    _stamped(sync_deck_drivers, src_dir, "Sub A()\nEnd Sub")
+    dest = sync_deck_drivers.export_stamped_driver(src_dir, dest_dir)
+    assert dest == dest_dir / sync_deck_drivers.STAMP_DRIVER
+    assert dest.read_bytes() == (src_dir / sync_deck_drivers.STAMP_DRIVER).read_bytes()
+
+
+def test_export_materializes_from_the_mirror_when_the_real_bas_is_stripped(
+    sync_deck_drivers, tmp_path
+):
+    """The installed-plugin case: tessl install ships only the .txt mirror."""
+    src_dir, dest_dir = tmp_path / "plugin", tmp_path / "out"
+    src_dir.mkdir()
+    p = _stamped(sync_deck_drivers, src_dir, "Sub A()\nEnd Sub")
+    (src_dir / (p.name + ".txt")).write_bytes(p.read_bytes())
+    p.unlink()  # the strip
+    dest = sync_deck_drivers.export_stamped_driver(src_dir, dest_dir)
+    assert dest.exists()
+    assert dest.read_bytes() == (src_dir / (p.name + ".txt")).read_bytes()
+
+
+def test_export_is_idempotent(sync_deck_drivers, tmp_path):
+    src_dir, dest_dir = tmp_path / "plugin", tmp_path / "out"
+    src_dir.mkdir()
+    _stamped(sync_deck_drivers, src_dir, "Sub A()\nEnd Sub")
+    first = sync_deck_drivers.export_stamped_driver(src_dir, dest_dir)
+    mtime = first.stat().st_mtime_ns
+    again = sync_deck_drivers.export_stamped_driver(src_dir, dest_dir)
+    assert again == first
+    assert again.stat().st_mtime_ns == mtime
+
+
+def test_export_refreshes_a_stale_copy(sync_deck_drivers, tmp_path):
+    src_dir, dest_dir = tmp_path / "plugin", tmp_path / "out"
+    src_dir.mkdir()
+    dest_dir.mkdir()
+    (dest_dir / sync_deck_drivers.STAMP_DRIVER).write_text("old export")
+    _stamped(sync_deck_drivers, src_dir, "Sub A()\nEnd Sub")
+    dest = sync_deck_drivers.export_stamped_driver(src_dir, dest_dir)
+    assert dest.read_bytes() == (src_dir / sync_deck_drivers.STAMP_DRIVER).read_bytes()
+
+
+def test_export_without_a_source_or_mirror_names_the_fix(sync_deck_drivers, tmp_path):
+    src_dir = tmp_path / "plugin"
+    src_dir.mkdir()
+    with pytest.raises(FileNotFoundError, match="reinstall the plugin"):
+        sync_deck_drivers.export_stamped_driver(src_dir, tmp_path / "out")

--- a/tests/test_deck_driver_mirrors.py
+++ b/tests/test_deck_driver_mirrors.py
@@ -134,7 +134,9 @@ def test_restamp_writes_a_digest_and_is_idempotent(sync_deck_drivers, tmp_path):
 def test_stamp_changes_when_the_macro_body_changes(sync_deck_drivers, tmp_path):
     _stamped(sync_deck_drivers, tmp_path, "Sub A()\nEnd Sub")
     before, _ = sync_deck_drivers.restamp(tmp_path)
-    _stamped(sync_deck_drivers, tmp_path, "Sub A()\n' behaviour change\nEnd Sub", before)
+    _stamped(
+        sync_deck_drivers, tmp_path, "Sub A()\n' behaviour change\nEnd Sub", before
+    )
     after, changed = sync_deck_drivers.restamp(tmp_path)
     assert changed is True
     assert after != before

--- a/tests/test_deckops_doctor.py
+++ b/tests/test_deckops_doctor.py
@@ -97,8 +97,16 @@ def test_verdict_driver_drift_outranks_a_missing_container(deckops_doctor):
     )
 
 
-def test_verdict_setup_required_when_the_container_is_absent(deckops_doctor):
-    assert _verdict(deckops_doctor, container_exists=False) == "setup_required"
+def test_verdict_setup_required_when_no_container_exists_or_is_open(deckops_doctor):
+    """Absent on disk AND absent from the running PowerPoint — nothing set up."""
+    assert (
+        _verdict(
+            deckops_doctor,
+            container_exists=False,
+            probe={"state": "macro_unreachable"},
+        )
+        == "setup_required"
+    )
 
 
 def test_verdict_distinguishes_powerpoint_closed_from_macro_missing(deckops_doctor):
@@ -231,3 +239,109 @@ def test_smoke_test_fixture_avoids_layout_dependent_placeholders(layout_dependen
     """It runs against an unknown template, so it must not need a body placeholder."""
     ops = (_scripts_dir() / "smoke-test-ops.txt").read_text(encoding="utf-8")
     assert layout_dependent_op not in ops
+
+
+# --- review regressions (PR #412) --------------------------------------------
+
+
+def _mirrors_only_install(tmp_path) -> Path:
+    """A scripts dir shaped like a fresh `tessl install`: mirrors, no sources."""
+    import shutil
+
+    scripts = tmp_path / "installed"
+    scripts.mkdir()
+    for f in _scripts_dir().glob("*.txt"):
+        shutil.copyfile(f, scripts / f.name)
+    for f in _scripts_dir().glob("*.py"):
+        shutil.copyfile(f, scripts / f.name)
+    return scripts
+
+
+def test_a_fresh_install_is_not_reported_as_driver_drift(deckops_doctor, tmp_path):
+    """tessl install lands mirrors and no sources; check() reads those as orphans.
+
+    Materializing is the supported recovery, so it runs before the drift check —
+    otherwise a valid installation is told to reinstall itself.
+    """
+    scripts = _mirrors_only_install(tmp_path)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    report = deckops_doctor.diagnose(vault, scripts, True, "darwin")
+    assert report["drivers"]["problems"] == []
+    assert report["status"] == "setup_required"
+    assert "RunDeckOps.bas" in report["drivers"]["materialized"]
+
+
+def test_a_malformed_stamp_reports_drift_instead_of_crashing(deckops_doctor, tmp_path):
+    """read_stamp raises on a missing stamp line; the doctor must survive it."""
+    scripts = _mirrors_only_install(tmp_path)
+    for name in ("RunDeckOps.bas", "RunDeckOps.bas.txt"):
+        (scripts / name).write_text(
+            "Option Explicit\n' no stamp line\n", encoding="utf-8"
+        )
+    report = deckops_doctor.diagnose(tmp_path, scripts, True, "darwin")
+    assert report["status"] == "driver_drift"
+    assert report["expected_stamp"] == ""
+    assert any("has no" in p for p in report["drivers"]["problems"])
+
+
+def test_a_container_open_elsewhere_still_counts_as_set_up(deckops_doctor):
+    """A DeckOps.pptm predating the canonical path is set up, not unconfigured."""
+    assert (
+        _verdict(
+            deckops_doctor,
+            container_exists=False,
+            probe={
+                "state": "ok",
+                "stamp": "abc123",
+                "container": "/elsewhere/DeckOps.pptm",
+            },
+        )
+        == "ok"
+    )
+
+
+def test_an_unreachable_macro_with_a_container_open_is_not_setup_required(
+    deckops_doctor,
+):
+    """The ask is "import the module", not "create a second container"."""
+    assert (
+        _verdict(
+            deckops_doctor,
+            container_exists=False,
+            probe={
+                "state": "macro_unreachable",
+                "container": "/elsewhere/DeckOps.pptm",
+            },
+        )
+        == "macro_unreachable"
+    )
+
+
+def test_powerpoint_closed_with_no_container_anywhere_is_setup_required(deckops_doctor):
+    assert (
+        _verdict(deckops_doctor, container_exists=False, probe={"state": "not_running"})
+        == "setup_required"
+    )
+
+
+def test_report_flags_a_container_open_off_the_canonical_path(deckops_doctor, tmp_path):
+    scripts = _scripts_dir()
+    report = deckops_doctor.diagnose(tmp_path, scripts, True, "darwin")
+    assert report["container"]["canonical_mismatch"] is False  # nothing open offline
+
+
+def test_next_step_names_the_open_container_not_the_canonical_one(
+    deckops_doctor, tmp_path, monkeypatch
+):
+    """Sending the user to the canonical path spawns a second container."""
+    monkeypatch.setattr(
+        deckops_doctor,
+        "run_probe",
+        lambda _d: {
+            "state": "macro_unreachable",
+            "container": "/open/here/DeckOps.pptm",
+        },
+    )
+    report = deckops_doctor.diagnose(tmp_path, _scripts_dir(), False, "darwin")
+    assert "/open/here/DeckOps.pptm" in report["next_step"]

--- a/tests/test_deckops_doctor.py
+++ b/tests/test_deckops_doctor.py
@@ -13,6 +13,18 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture
+def on_darwin(deckops_doctor, monkeypatch):
+    """Pin the platform `main()` reads.
+
+    main() takes it from sys.platform, so on the Ubuntu CI runner every verdict
+    short-circuits to unsupported_platform and a test asserting anything else
+    passes locally on a Mac and fails in CI. verdict() takes platform as an
+    argument and needs no patching; only the main()/diagnose() paths do.
+    """
+    monkeypatch.setattr(deckops_doctor.sys, "platform", "darwin")
+
+
 def _ok_probe(stamp="abc123"):
     return {"state": "ok", "stamp": stamp}
 
@@ -209,7 +221,7 @@ def test_main_rejects_a_missing_vault_root(deckops_doctor, tmp_path, capsys):
 
 
 def test_main_exits_zero_with_a_verdict_when_setup_is_missing(
-    deckops_doctor, tmp_path, capsys
+    deckops_doctor, tmp_path, capsys, on_darwin
 ):
     """A verdict IS success — the caller reads `status`, not the exit code."""
     rc = deckops_doctor.main(["--vault-root", str(tmp_path), "--offline"])
@@ -400,7 +412,7 @@ def test_run_probe_maps_a_timeout_to_probe_failed(deckops_doctor, monkeypatch):
 
 
 def test_main_exits_nonzero_when_the_probe_could_not_run(
-    deckops_doctor, tmp_path, monkeypatch, capsys
+    deckops_doctor, tmp_path, monkeypatch, capsys, on_darwin
 ):
     """No verdict was reached, so this is a script failure, not a finding."""
     monkeypatch.setattr(
@@ -420,3 +432,37 @@ def test_docstring_does_not_claim_to_be_read_only(deckops_doctor):
     doc = deckops_doctor.__doc__
     assert "Read-only." not in doc
     assert "materialize" in doc
+
+
+def test_main_on_a_foreign_platform_says_so_and_still_returns_a_verdict(
+    deckops_doctor, tmp_path, monkeypatch, capsys
+):
+    """The Ubuntu-CI path: a verdict, exit 0, and no PowerPoint probe attempted."""
+    monkeypatch.setattr(deckops_doctor.sys, "platform", "linux")
+    monkeypatch.setattr(
+        deckops_doctor,
+        "run_probe",
+        lambda _d: pytest.fail("the probe must not run off macOS"),
+    )
+    rc = deckops_doctor.main(["--vault-root", str(tmp_path)])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "unsupported_platform"
+
+
+def test_a_corrupt_sibling_script_raises_an_actionable_import_error(
+    deckops_doctor, tmp_path, monkeypatch
+):
+    """A raw traceback would replace the diagnostic this script exists to give."""
+    broken = tmp_path / "sync-deck-drivers.py"
+    broken.write_text("def (((\n", encoding="utf-8")
+    monkeypatch.setattr(deckops_doctor, "__file__", str(tmp_path / "deckops-doctor.py"))
+    with pytest.raises(ImportError, match="reinstall the plugin"):
+        deckops_doctor._load_sibling("sync_deck_drivers", "sync-deck-drivers.py")
+
+
+def test_a_missing_sibling_script_raises_an_actionable_import_error(
+    deckops_doctor, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(deckops_doctor, "__file__", str(tmp_path / "deckops-doctor.py"))
+    with pytest.raises(ImportError, match="reinstall the plugin"):
+        deckops_doctor._load_sibling("nope", "not-here.py")

--- a/tests/test_deckops_doctor.py
+++ b/tests/test_deckops_doctor.py
@@ -7,6 +7,7 @@ everything deterministic — path derivation, probe-output parsing, and the verd
 table — is covered here by feeding `verdict()` synthetic probe results.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -133,10 +134,6 @@ def test_verdict_without_a_stamp_in_the_probe_is_stale_not_ok(deckops_doctor):
     assert _verdict(deckops_doctor, probe={"state": "ok"}) == "macro_stale"
 
 
-def test_verdict_missing_state_is_unreachable_not_ok(deckops_doctor):
-    assert _verdict(deckops_doctor, probe={}) == "macro_unreachable"
-
-
 def test_verdict_offline_stops_at_the_container_check(deckops_doctor):
     """--offline answers first-use and location, and claims nothing about liveness."""
     assert _verdict(deckops_doctor, probe=None) == "ok"
@@ -215,8 +212,6 @@ def test_main_exits_zero_with_a_verdict_when_setup_is_missing(
     deckops_doctor, tmp_path, capsys
 ):
     """A verdict IS success — the caller reads `status`, not the exit code."""
-    import json
-
     rc = deckops_doctor.main(["--vault-root", str(tmp_path), "--offline"])
     out = capsys.readouterr()
     assert rc == 0
@@ -345,3 +340,83 @@ def test_next_step_names_the_open_container_not_the_canonical_one(
     )
     report = deckops_doctor.diagnose(tmp_path, _scripts_dir(), False, "darwin")
     assert "/open/here/DeckOps.pptm" in report["next_step"]
+
+
+# --- probe failures are not verdicts (PR #412 round 3) -----------------------
+
+
+@pytest.mark.parametrize("failed_state", ["probe_failed", "probe_missing"])
+def test_a_probe_that_could_not_run_is_not_a_setup_verdict(
+    deckops_doctor, failed_state
+):
+    """Denied Automation consent must not read as "create a container".
+
+    The driver returns macro_unreachable (exit 0) for the one EXPECTED failure.
+    Anything else means the question was never asked, so no fix is prescribed.
+    """
+    assert (
+        _verdict(
+            deckops_doctor,
+            container_exists=False,
+            probe={"state": failed_state, "detail": "not authorised"},
+        )
+        == failed_state
+    )
+
+
+def test_a_probe_failure_outranks_a_present_container(deckops_doctor):
+    assert _verdict(deckops_doctor, probe={"state": "probe_failed"}) == "probe_failed"
+
+
+def test_an_unparseable_probe_reads_as_failure_not_unreachable(deckops_doctor):
+    """An empty probe payload means the driver said nothing, not "no macro"."""
+    assert _verdict(deckops_doctor, probe={}) == "probe_failed"
+
+
+def test_run_probe_maps_a_nonzero_osascript_exit_to_probe_failed(
+    deckops_doctor, tmp_path, monkeypatch
+):
+    import subprocess as sp
+
+    def fake_run(*_a, **_k):
+        return sp.CompletedProcess(_a[0], 1, "", "Not authorised to send Apple events")
+
+    monkeypatch.setattr(deckops_doctor.subprocess, "run", fake_run)
+    probe = deckops_doctor.run_probe(_scripts_dir())
+    assert probe["state"] == "probe_failed"
+    assert "Not authorised" in probe["detail"]
+
+
+def test_run_probe_maps_a_timeout_to_probe_failed(deckops_doctor, monkeypatch):
+    import subprocess as sp
+
+    def fake_run(*_a, **_k):
+        raise sp.TimeoutExpired(cmd="osascript", timeout=1)
+
+    monkeypatch.setattr(deckops_doctor.subprocess, "run", fake_run)
+    probe = deckops_doctor.run_probe(_scripts_dir())
+    assert probe["state"] == "probe_failed"
+    assert "modal dialog" in probe["detail"]
+
+
+def test_main_exits_nonzero_when_the_probe_could_not_run(
+    deckops_doctor, tmp_path, monkeypatch, capsys
+):
+    """No verdict was reached, so this is a script failure, not a finding."""
+    monkeypatch.setattr(
+        deckops_doctor,
+        "run_probe",
+        lambda _d: {"state": "probe_failed", "detail": "not authorised"},
+    )
+    rc = deckops_doctor.main(["--vault-root", str(tmp_path)])
+    out = capsys.readouterr()
+    assert rc == 1
+    assert json.loads(out.out)["status"] == "probe_failed"
+    assert "UNKNOWN" in out.err
+
+
+def test_docstring_does_not_claim_to_be_read_only(deckops_doctor):
+    """diagnose() writes missing drivers; a blanket read-only claim is false."""
+    doc = deckops_doctor.__doc__
+    assert "Read-only." not in doc
+    assert "materialize" in doc

--- a/tests/test_deckops_doctor.py
+++ b/tests/test_deckops_doctor.py
@@ -1,0 +1,229 @@
+"""Tests for deckops-doctor.py — the deck-layer setup probe.
+
+The doctor answers three questions the skill previously guessed at: is this the
+user's first use, where is the macro container, and is the imported macro current.
+The live half drives PowerPoint and cannot run in CI (rules/deck-editing-rules.md);
+everything deterministic — path derivation, probe-output parsing, and the verdict
+table — is covered here by feeding `verdict()` synthetic probe results.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _ok_probe(stamp="abc123"):
+    return {"state": "ok", "stamp": stamp}
+
+
+def _verdict(deckops_doctor, **kw):
+    base = {
+        "platform": "darwin",
+        "driver_problems": [],
+        "container_exists": True,
+        "expected_stamp": "abc123",
+        "probe": _ok_probe(),
+    }
+    base.update(kw)
+    return deckops_doctor.verdict(**base)
+
+
+# --- container paths ---------------------------------------------------------
+
+
+def test_container_paths_are_derived_from_the_vault_root(deckops_doctor, tmp_path):
+    paths = deckops_doctor.container_paths(tmp_path)
+    assert paths["container"] == tmp_path / ".deckops" / "DeckOps.pptm"
+    assert paths["import_source"] == tmp_path / ".deckops" / "RunDeckOps.bas"
+    assert paths["dir"] == tmp_path / ".deckops"
+
+
+def test_import_source_sits_outside_the_plugin_tree(deckops_doctor, tmp_path):
+    """The whole point: a path the VBA-editor Import panel can actually show.
+
+    An installed plugin lives under a hidden `.tessl/` directory, so the .bas must
+    be reachable from the vault instead.
+    """
+    paths = deckops_doctor.container_paths(tmp_path)
+    assert ".tessl" not in str(paths["import_source"])
+    assert paths["import_source"].parent == paths["container"].parent
+
+
+# --- probe parsing -----------------------------------------------------------
+
+
+def test_parse_probe_reads_key_value_lines(deckops_doctor):
+    fields = deckops_doctor.parse_probe("state=ok\nstamp=deadbeef\n")
+    assert fields == {"state": "ok", "stamp": "deadbeef"}
+
+
+def test_parse_probe_keeps_equals_and_semicolons_in_a_value(deckops_doctor):
+    """Container paths are user-chosen; they may contain the delimiters."""
+    weird = "/Users/x/My Drive/a=b;c/.deckops/DeckOps.pptm"
+    fields = deckops_doctor.parse_probe(f"state=ok\nstamp=aa\ncontainer={weird}")
+    assert fields["container"] == weird
+
+
+def test_parse_probe_drops_unparseable_lines(deckops_doctor):
+    fields = deckops_doctor.parse_probe("state=ok\nnoise without a delimiter\n\n")
+    assert fields == {"state": "ok"}
+
+
+def test_parse_probe_of_empty_output_yields_no_state(deckops_doctor):
+    assert deckops_doctor.parse_probe("") == {}
+
+
+# --- verdict -----------------------------------------------------------------
+
+
+def test_verdict_ok_when_everything_lines_up(deckops_doctor):
+    assert _verdict(deckops_doctor) == "ok"
+
+
+def test_verdict_flags_a_foreign_platform_first(deckops_doctor):
+    assert (
+        _verdict(deckops_doctor, platform="linux", container_exists=False)
+        == "unsupported_platform"
+    )
+
+
+def test_verdict_driver_drift_outranks_a_missing_container(deckops_doctor):
+    """Drift means the shipped drivers cannot be trusted, so report that first."""
+    assert (
+        _verdict(deckops_doctor, driver_problems=["mirror X drifted"], container_exists=False)
+        == "driver_drift"
+    )
+
+
+def test_verdict_setup_required_when_the_container_is_absent(deckops_doctor):
+    assert _verdict(deckops_doctor, container_exists=False) == "setup_required"
+
+
+def test_verdict_distinguishes_powerpoint_closed_from_macro_missing(deckops_doctor):
+    """Two different asks: launch the app, versus finish the one-time import."""
+    assert (
+        _verdict(deckops_doctor, probe={"state": "not_running"})
+        == "powerpoint_not_running"
+    )
+    assert (
+        _verdict(deckops_doctor, probe={"state": "macro_unreachable", "detail": "-18"})
+        == "macro_unreachable"
+    )
+
+
+def test_verdict_catches_a_stale_import(deckops_doctor):
+    """The finding nothing could see before: the macro runs, but it is OLD code."""
+    assert (
+        _verdict(deckops_doctor, probe=_ok_probe("0000old"), expected_stamp="abc123")
+        == "macro_stale"
+    )
+
+
+def test_verdict_without_a_stamp_in_the_probe_is_stale_not_ok(deckops_doctor):
+    assert _verdict(deckops_doctor, probe={"state": "ok"}) == "macro_stale"
+
+
+def test_verdict_missing_state_is_unreachable_not_ok(deckops_doctor):
+    assert _verdict(deckops_doctor, probe={}) == "macro_unreachable"
+
+
+def test_verdict_offline_stops_at_the_container_check(deckops_doctor):
+    """--offline answers first-use and location, and claims nothing about liveness."""
+    assert _verdict(deckops_doctor, probe=None) == "ok"
+    assert _verdict(deckops_doctor, probe=None, container_exists=False) == "setup_required"
+
+
+# --- report ------------------------------------------------------------------
+
+
+def _scripts_dir() -> Path:
+    return (
+        Path(__file__).resolve().parent.parent
+        / "skills"
+        / "presentation-creator"
+        / "scripts"
+    )
+
+
+def test_diagnose_offline_reports_setup_required_on_an_empty_vault(
+    deckops_doctor, tmp_path
+):
+    report = deckops_doctor.diagnose(tmp_path, _scripts_dir(), True, "darwin")
+    assert report["status"] == "setup_required"
+    assert report["setup_complete"] is False
+    assert report["container"]["exists"] is False
+    assert report["live"] == {"state": "skipped"}
+    assert report["drivers"]["problems"] == []
+    # the stamp the doctor compares a live macro against comes from the shipped .bas
+    assert len(report["expected_stamp"]) == 16
+
+
+def test_diagnose_offline_is_ok_once_the_container_exists(deckops_doctor, tmp_path):
+    container = tmp_path / ".deckops" / "DeckOps.pptm"
+    container.parent.mkdir(parents=True)
+    container.write_bytes(b"not a real pptm, but present")
+    report = deckops_doctor.diagnose(tmp_path, _scripts_dir(), True, "darwin")
+    assert report["status"] == "ok"
+    assert report["setup_complete"] is True
+
+
+def test_diagnose_tracks_whether_the_exported_bas_is_current(deckops_doctor, tmp_path):
+    """A .bas exported before a plugin update must not read as current."""
+    scripts = _scripts_dir()
+    deckops = tmp_path / ".deckops"
+    deckops.mkdir()
+    (deckops / "DeckOps.pptm").write_bytes(b"present")
+
+    (deckops / "RunDeckOps.bas").write_text("stale copy", encoding="utf-8")
+    stale = deckops_doctor.diagnose(tmp_path, scripts, True, "darwin")
+    assert stale["import_source"]["exists"] is True
+    assert stale["import_source"]["current"] is False
+
+    (deckops / "RunDeckOps.bas").write_bytes((scripts / "RunDeckOps.bas").read_bytes())
+    fresh = deckops_doctor.diagnose(tmp_path, scripts, True, "darwin")
+    assert fresh["import_source"]["current"] is True
+
+
+def test_every_status_has_a_formattable_next_step(deckops_doctor):
+    """next_step is what the agent acts on — an unformattable one would KeyError."""
+    for status, template in deckops_doctor.STATUSES.items():
+        rendered = template.format(
+            container="/v/.deckops/DeckOps.pptm", found="aaa", expected="bbb"
+        )
+        assert rendered and "{" not in rendered, status
+
+
+def test_main_rejects_a_missing_vault_root(deckops_doctor, tmp_path, capsys):
+    rc = deckops_doctor.main(["--vault-root", str(tmp_path / "nope"), "--offline"])
+    assert rc == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_main_exits_zero_with_a_verdict_when_setup_is_missing(
+    deckops_doctor, tmp_path, capsys
+):
+    """A verdict IS success — the caller reads `status`, not the exit code."""
+    import json
+
+    rc = deckops_doctor.main(["--vault-root", str(tmp_path), "--offline"])
+    out = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(out.out)["status"] == "setup_required"
+    assert "setup_required" in out.err
+
+
+# --- the smoke-test fixture --------------------------------------------------
+
+
+def test_smoke_test_fixture_is_a_valid_three_slide_op_sequence(validate_deckops):
+    """Step 5 of the setup walkthrough ships this instead of asking for a deck."""
+    ops = (_scripts_dir() / "smoke-test-ops.txt").read_text(encoding="utf-8")
+    assert validate_deckops.validate_ops(ops) == []
+    assert sum(1 for ln in ops.splitlines() if ln.startswith("SLIDE")) == 3
+
+
+@pytest.mark.parametrize("layout_dependent_op", ["BULLET", "BODY"])
+def test_smoke_test_fixture_avoids_layout_dependent_placeholders(layout_dependent_op):
+    """It runs against an unknown template, so it must not need a body placeholder."""
+    ops = (_scripts_dir() / "smoke-test-ops.txt").read_text(encoding="utf-8")
+    assert layout_dependent_op not in ops

--- a/tests/test_deckops_doctor.py
+++ b/tests/test_deckops_doctor.py
@@ -90,7 +90,9 @@ def test_verdict_flags_a_foreign_platform_first(deckops_doctor):
 def test_verdict_driver_drift_outranks_a_missing_container(deckops_doctor):
     """Drift means the shipped drivers cannot be trusted, so report that first."""
     assert (
-        _verdict(deckops_doctor, driver_problems=["mirror X drifted"], container_exists=False)
+        _verdict(
+            deckops_doctor, driver_problems=["mirror X drifted"], container_exists=False
+        )
         == "driver_drift"
     )
 
@@ -130,7 +132,9 @@ def test_verdict_missing_state_is_unreachable_not_ok(deckops_doctor):
 def test_verdict_offline_stops_at_the_container_check(deckops_doctor):
     """--offline answers first-use and location, and claims nothing about liveness."""
     assert _verdict(deckops_doctor, probe=None) == "ok"
-    assert _verdict(deckops_doctor, probe=None, container_exists=False) == "setup_required"
+    assert (
+        _verdict(deckops_doctor, probe=None, container_exists=False) == "setup_required"
+    )
 
 
 # --- report ------------------------------------------------------------------

--- a/tests/test_deckops_smoke_test.py
+++ b/tests/test_deckops_smoke_test.py
@@ -1,0 +1,160 @@
+"""Tests for deckops-smoke-test.sh — the setup smoke-test wrapper.
+
+The wrapper's PowerPoint half cannot run in CI (rules/deck-editing-rules.md), so
+build-deck.sh is stubbed and everything around it is exercised for real: template
+validation, unique-name copying, build-failure propagation, missing output, and
+report serialization. Actual PowerPoint automation stays manual validation.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_PC = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "presentation-creator"
+    / "scripts"
+)
+WRAPPER = "deckops-smoke-test.sh"
+
+
+def _stage(tmp_path: Path, build_stub: str) -> Path:
+    """A scripts dir holding the wrapper, the ops fixture, and a stubbed builder."""
+    d = tmp_path / "scripts"
+    d.mkdir()
+    shutil.copyfile(SCRIPTS_PC / WRAPPER, d / WRAPPER)
+    shutil.copyfile(SCRIPTS_PC / "smoke-test-ops.txt", d / "smoke-test-ops.txt")
+    stub = d / "build-deck.sh"
+    stub.write_text(build_stub, encoding="utf-8")
+    for f in (d / WRAPPER, stub):
+        f.chmod(f.stat().st_mode | stat.S_IXUSR)
+    return d
+
+
+# A stub standing in for the real macro run: writes the output file it is handed.
+BUILD_OK = '#!/bin/bash\nset -euo pipefail\necho "stub build" >&2\ncp "$1" "$2"\n'
+BUILD_SILENT = '#!/bin/bash\nset -euo pipefail\necho "stub wrote nothing" >&2\n'
+BUILD_FAILS = '#!/bin/bash\nset -euo pipefail\necho "macro exploded" >&2\nexit 1\n'
+
+
+def _run(scripts: Path, *args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(scripts / WRAPPER), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def template(tmp_path) -> Path:
+    p = tmp_path / "template.pptx"
+    p.write_bytes(b"PK\x03\x04 pretend pptx")
+    return p
+
+
+def test_no_arguments_is_a_usage_error(tmp_path):
+    r = _run(_stage(tmp_path, BUILD_OK))
+    assert r.returncode == 2
+    assert "usage:" in r.stderr
+
+
+def test_too_many_arguments_is_a_usage_error(tmp_path, template):
+    r = _run(_stage(tmp_path, BUILD_OK), str(template), "a", "b")
+    assert r.returncode == 2
+
+
+def test_a_missing_template_names_where_the_path_comes_from(tmp_path):
+    r = _run(_stage(tmp_path, BUILD_OK), str(tmp_path / "nope.pptx"))
+    assert r.returncode == 1
+    assert "template not found" in r.stderr
+    assert "template_pptx_path" in r.stderr
+
+
+def test_a_missing_ops_fixture_says_to_reinstall(tmp_path, template):
+    scripts = _stage(tmp_path, BUILD_OK)
+    (scripts / "smoke-test-ops.txt").unlink()
+    r = _run(scripts, str(template))
+    assert r.returncode == 1
+    assert "op sequence not found" in r.stderr
+
+
+def test_a_successful_build_reports_the_output_as_json(tmp_path, template):
+    out_dir = tmp_path / "out"
+    r = _run(_stage(tmp_path, BUILD_OK), str(template), str(out_dir))
+    assert r.returncode == 0
+    report = json.loads(r.stdout)
+    assert report["ok"] is True
+    assert report["slides"] == 3
+    assert Path(report["output"]).is_file()
+    assert Path(report["base"]).is_file()
+
+
+def test_the_template_is_copied_never_touched(tmp_path, template):
+    before = template.read_bytes()
+    r = _run(_stage(tmp_path, BUILD_OK), str(template), str(tmp_path / "out"))
+    report = json.loads(r.stdout)
+    assert template.read_bytes() == before
+    assert Path(report["base"]) != template
+    assert Path(report["base"]).read_bytes() == before
+
+
+def test_the_base_copy_is_uniquely_named(tmp_path, template):
+    """PowerPoint keys open decks by filename and hands back an open same-named one."""
+    scripts = _stage(tmp_path, BUILD_OK)
+    out_dir = tmp_path / "out"
+    first = json.loads(_run(scripts, str(template), str(out_dir)).stdout)
+    second = json.loads(_run(scripts, str(template), str(out_dir)).stdout)
+    assert first["base"] != second["base"]
+    assert first["output"] != second["output"]
+
+
+def test_a_build_that_writes_nothing_fails_loudly(tmp_path, template):
+    r = _run(_stage(tmp_path, BUILD_SILENT), str(template), str(tmp_path / "out"))
+    assert r.returncode == 1
+    assert "produced no deck" in r.stderr
+    assert r.stdout == ""
+
+
+def test_a_failing_build_propagates_instead_of_reporting_success(tmp_path, template):
+    """set -e must carry the builder's non-zero exit, never swallow it."""
+    r = _run(_stage(tmp_path, BUILD_FAILS), str(template), str(tmp_path / "out"))
+    assert r.returncode != 0
+    assert r.stdout == ""
+    assert "macro exploded" in r.stderr
+
+
+@pytest.mark.parametrize("hostile", ['quo"te', "back\\slash", "sp ace"])
+def test_report_stays_valid_json_for_hostile_paths(tmp_path, template, hostile):
+    """printf interpolation produced invalid JSON behind exit 0 for these."""
+    out_dir = tmp_path / hostile
+    r = _run(_stage(tmp_path, BUILD_OK), str(template), str(out_dir))
+    assert r.returncode == 0
+    report = json.loads(r.stdout)  # raises if the encoder was bypassed
+    assert hostile in report["output"]
+    assert Path(report["output"]).is_file()
+
+
+def test_an_absent_out_dir_is_created(tmp_path, template):
+    out_dir = tmp_path / "deep" / "nested" / "out"
+    r = _run(_stage(tmp_path, BUILD_OK), str(template), str(out_dir))
+    assert r.returncode == 0
+    assert out_dir.is_dir()
+
+
+def test_the_shipped_wrapper_has_strict_mode_and_valid_syntax():
+    text = (SCRIPTS_PC / WRAPPER).read_text(encoding="utf-8")
+    assert "set -euo pipefail" in text
+    assert (
+        subprocess.run(
+            ["bash", "-n", str(SCRIPTS_PC / WRAPPER)], capture_output=True
+        ).returncode
+        == 0
+    )
+    assert os.access(SCRIPTS_PC / WRAPPER, os.X_OK)


### PR DESCRIPTION
## Summary

The DeckOps *distribution* half was already solved (#85, #316): `.bas`/`.applescript` ride to consumers as committed `.txt` mirrors, `sync-deck-drivers.py` restores them, `check_shipped_extensions.py` gates drift. The *walkthrough* half was not. Five gaps, all closed here:

1. **The import path was wrong for every consumer.** Step 3 said to import `skills/presentation-creator/scripts/RunDeckOps.bas` — a repo-relative path that on an installed plugin resolves under a hidden `.tessl/` directory PowerPoint's Import panel does not show, while the same step's other command used `{speaker_toolkit_root}` (two path conventions in one step). New `sync-deck-drivers.py export --to <dir>` copies the module out of the plugin tree to `<vault_root>/.deckops/`, and the step hands the user that absolute path plus the ⇧⌘G / ⇧⌘. keys the panel needs.
2. **Nothing could detect first use.** Three callers said "on first use, walk the user through…" and none could tell a first run from a hundredth. New `deckops-doctor.py` answers it.
3. **The container had no recorded location.** Eight wrappers print "confirm DeckOps.pptm is open" and none could say where. Now canonical at `<vault_root>/.deckops/DeckOps.pptm`, derived from `config.vault_root`; a running PowerPoint also reports where it actually opened it from. Chosen over a config field deliberately — that would cost a schema v3 bump plus migration to record what the live app already knows.
4. **The smoke test was prose.** Step 5 — the step whose job is confirming Steps 1–4 — said "run a 3-slide throwaway". `smoke-test-ops.txt` now ships it (layout 0 + free text box only, so it runs against any template) with four explicit pass criteria.
5. **A stale macro import was invisible.** A saved `.pptm` yields no VBA source, so a module imported once and never refreshed keeps running OLD code silently. `RunDeckOps.bas` now carries `DECKOPS_STAMP` (a digest of its own body, stamp masked) behind a `DeckOpsVersion()` macro; `deckops-version.applescript` asks the running PowerPoint and the doctor compares. Content-addressed, not hand-bumped — `mirror` recomputes it, `check` fails on drift.

The probe never launches PowerPoint, and the doctor exits 0 with a verdict even when the macro is unreachable — "setup required" is a finding to act on, not a script failure.

## Test plan

- [x] Full suite: 7658 passed, 8 skipped
- [x] 45 focused tests (`test_deckops_doctor.py` new, `test_deck_driver_mirrors.py` extended) covering path derivation, probe parsing, the verdict table, stamp idempotence/convergence, and export
- [x] pyright clean on all changed Python
- [x] `check_shipped_extensions.py` ok — new `.applescript` driver is mirror-covered
- [x] `check_package_contents.py` ok
- [x] Live probe verified end-to-end on a running PowerPoint: returned `state=macro_unreachable` / PowerPoint error -18 with no container open, and did not launch or disturb anything
- [ ] Manual (platform-bound, per `rules/deck-editing-rules.md`): Step 5 smoke test against a real template with `DeckOps.pptm` open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV