### PR TITLE
fix(deckops): Report damaged stamps once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Report a damaged DeckOps stamp once
+
+The setup doctor no longer repeats a stamp-parse problem already reported by
+the driver checker (#414). Its mirror-only fallback still reports that problem
+when the real driver is absent; unrelated driver findings remain intact.
+
 ## 0.20.131 — 2026-09-07
 
 ### Tell the user how to actually recreate the DeckOps macro container

--- a/skills/presentation-creator/scripts/deckops-doctor.py
+++ b/skills/presentation-creator/scripts/deckops-doctor.py
@@ -244,9 +244,9 @@ def diagnose(vault_root: Path, scripts_dir: Path, offline: bool, platform: str) 
                 stamp_src.read_text(encoding="utf-8")
             )
         except ValueError as e:
-            # check() already recorded this as a driver problem; crashing here
-            # would swallow the actionable diagnostic it produced.
-            driver_problems = driver_problems + [str(e)]
+            # check() validates the real driver's stamp, not an orphan mirror.
+            if stamp_src == mirror:
+                driver_problems = driver_problems + [str(e)]
     else:
         driver_problems = driver_problems + [
             f"neither {src.name} nor its mirror is present — reinstall the plugin"

--- a/tests/test_deckops_doctor.py
+++ b/tests/test_deckops_doctor.py
@@ -279,17 +279,45 @@ def test_a_fresh_install_is_not_reported_as_driver_drift(deckops_doctor, tmp_pat
     assert "RunDeckOps.bas" in report["drivers"]["materialized"]
 
 
-def test_a_malformed_stamp_reports_drift_instead_of_crashing(deckops_doctor, tmp_path):
-    """read_stamp raises on a missing stamp line; the doctor must survive it."""
+@pytest.mark.parametrize(
+    ("stamp_text", "problem"),
+    [
+        ("Option Explicit\n' no stamp line\n", "has no"),
+        ('Public Const DECKOPS_STAMP As String = "unfinished\n', "unterminated"),
+        ('Public Const DECKOPS_STAMP As String = "abc"\n' * 2, "more than one"),
+    ],
+)
+def test_a_malformed_stamp_reports_drift_instead_of_crashing(
+    deckops_doctor, tmp_path, stamp_text, problem
+):
+    """A damaged real driver gets one actionable stamp diagnostic, not two."""
     scripts = _mirrors_only_install(tmp_path)
     for name in ("RunDeckOps.bas", "RunDeckOps.bas.txt"):
-        (scripts / name).write_text(
-            "Option Explicit\n' no stamp line\n", encoding="utf-8"
-        )
+        (scripts / name).write_text(stamp_text, encoding="utf-8")
     report = deckops_doctor.diagnose(tmp_path, scripts, True, "darwin")
     assert report["status"] == "driver_drift"
     assert report["expected_stamp"] == ""
-    assert any("has no" in p for p in report["drivers"]["problems"])
+    problems = report["drivers"]["problems"]
+    assert sum(problem in p for p in problems) == 1
+    assert len(problems) == len(set(problems))
+
+
+def test_a_mirror_only_stamp_problem_is_not_lost(deckops_doctor, tmp_path, monkeypatch):
+    """The fallback mirror needs its own stamp check when no real is available."""
+    scripts = _mirrors_only_install(tmp_path)
+    (scripts / "RunDeckOps.bas.txt").write_text(
+        "Option Explicit\n' no stamp line\n", encoding="utf-8"
+    )
+    # Keep this test on the fallback-reader branch rather than restoring the real.
+    monkeypatch.setattr(deckops_doctor.sync_deck_drivers, "materialize", lambda _: [])
+    report = deckops_doctor.diagnose(tmp_path, scripts, True, "darwin")
+    assert report["status"] == "driver_drift"
+    assert report["expected_stamp"] == ""
+    problems = report["drivers"]["problems"]
+    assert (
+        sum(p.startswith("RunDeckOps.bas has no Public Const") for p in problems) == 1
+    )
+    assert any("orphan mirror" in p and "RunDeckOps.bas.txt" in p for p in problems)
 
 
 def test_a_container_open_elsewhere_still_counts_as_set_up(deckops_doctor):


### PR DESCRIPTION
## Summary

- Report a damaged real DeckOps stamp once, using the driver checker's existing diagnostic.
- Preserve the extra stamp diagnostic when only the mirror is available; keep other driver findings unchanged.
- Add regression coverage for missing, unterminated, and duplicate stamp declarations and the mirror-only fallback.

Closes #414.

## Test plan

- [x] Reproduce duplicate messages on the unpatched code for all three stamp-error shapes.
- [x] Run the doctor and driver-mirror suites: 65 passed.
- [x] Run Ruff lint and format checks, Pyright, conflict-marker, package-content, shipped-extension, floating-pin, and plugin-lint gates.
- [x] Full test suite: 7,692 passed, 8 existing platform skips.

Patch release; the configured publish workflow owns the version bump and changelog stamp.
