### PR TITLE
chore(ci): Renew cache action to Node.js 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     ignore:
       # gh-aw-generated review-*.lock.yml files pin a coordinated action set per
       # compiler version; bump those via `gh aw compile`, not Dependabot.
-      - dependency-name: "actions/cache*"
       - dependency-name: "actions/download-artifact"
       - dependency-name: "actions/github-script"
       - dependency-name: "actions/setup-node"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
         # every run, so a cache that restored 185 MiB still paid a full network
         # round-trip — and that fetch, not the download, is what stalled the job
         # for 20 minutes. With the indices here too, a hit installs offline.
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             /tmp/apt-cache
@@ -173,7 +173,7 @@ jobs:
         # and each postinstall downloads into its own cache root. Caching the
         # npm tree without them would restore a tree whose postinstalls never
         # run again and leave reveal-md with no browser at all.
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ${{ github.workspace }}/deck-renderers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Renew the CI cache action's runtime
+
+Both dependency caches use `actions/cache@v6`, which declares Node.js 24, to
+remove the runner's Node.js 20 deprecation warning (#417). Cache keys, paths,
+restore/save defaults, and test jobs are unchanged. The cache-only legacy
+Dependabot exclusion is removed so weekly action updates can renew this pin.
+
 ## 0.20.132 — 2026-09-07
 
 ### Report a damaged DeckOps stamp once

--- a/tests/test_workflow_cache_contracts.py
+++ b/tests/test_workflow_cache_contracts.py
@@ -1,0 +1,65 @@
+"""CI cache identity and renewal contracts; runner execution proves the runtime."""
+
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.mark.parametrize(
+    ("name", "paths", "key"),
+    [
+        (
+            "Cache apt package downloads and package indices",
+            ["/tmp/apt-cache", "/tmp/apt-lists"],
+            "apt-${{ runner.os }}-${{ steps.apt-cache-key.outputs.codename }}-"
+            "${{ steps.apt-cache-key.outputs.packages }}-"
+            "${{ steps.apt-cache-key.outputs.week }}",
+        ),
+        (
+            "Cache the markdown deck renderers",
+            [
+                "${{ github.workspace }}/deck-renderers",
+                "~/.cache/ms-playwright",
+                "~/.cache/puppeteer",
+            ],
+            "deck-renderers-${{ runner.os }}-"
+            "${{ steps.deck-renderers.outputs.digest }}",
+        ),
+    ],
+)
+def test_cache_runtime_renewal_preserves_cache_identity(name, paths, key):
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
+    )
+    matches = [
+        step for step in workflow["jobs"]["test"]["steps"] if step.get("name") == name
+    ]
+    assert len(matches) == 1
+    step = matches[0]
+    assert step["uses"].startswith("actions/cache@")
+    assert set(step) == {"name", "uses", "with"}
+    assert set(step["with"]) == {"path", "key"}
+    assert step["with"]["path"].splitlines() == paths
+    assert step["with"]["key"] == key
+
+
+def test_dependabot_can_renew_the_cache_action():
+    config = yaml.safe_load(
+        (ROOT / ".github/dependabot.yml").read_text(encoding="utf-8")
+    )
+    updates = [
+        update
+        for update in config["updates"]
+        if update["package-ecosystem"] == "github-actions"
+        and update["directory"] == "/"
+    ]
+    assert len(updates) == 1
+    assert updates[0]["schedule"]["interval"] == "weekly"
+    assert not any(
+        fnmatchcase("actions/cache", ignored["dependency-name"])
+        for ignored in updates[0].get("ignore", [])
+    )


### PR DESCRIPTION
## Summary

- Renew both CI dependency caches from `actions/cache@v4` to `actions/cache@v6` (currently v6.1.0), which declares Node.js 24.
- Remove only the cache action's legacy Dependabot exclusion, restoring weekly renewal.
- Preserve cache keys, paths, restore/save defaults, and every test job; add deterministic cache-identity and renewal tests.

Closes #417. This PR is explicitly scoped to CI dependency/runtime renewal.

Upstream: [v6 migration](https://github.com/actions/cache/releases/tag/v6.0.0), [current v6.1.0 release](https://github.com/actions/cache/releases/tag/v6.1.0), [runtime/runner requirements](https://github.com/actions/cache#whats-new).
The v6 and v6.1.0 tags both resolved to `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` during verification. Its `action.yml` declares `node24`; our hosted runners reported 2.337.0, above the documented 2.327.1 minimum.

## Test plan

- [x] Reproduce the blocked-renewal test on the original Dependabot configuration.
- [x] Run 62 focused cache/installer tests.
- [x] Verify parsed YAML differs only at the two action references and the one cache-only ignore entry.
- [x] Run Ruff lint/format, Pyright, conflict-marker, package-content, shipped-extension, floating-pin, and plugin-lint gates.
- [x] Full local suite: 7,695 passed, 8 existing skips.
- [x] Verify real CI restores the existing caches and no cache-action Node.js 20 deprecation annotation remains.

The [completed PR Tests run](https://github.com/jbaruch/speaker-toolkit/actions/runs/34130120831) resolved the verified v6 SHA and successfully restored both existing primary keys: `apt-Linux-noble-e2b1293aa4dea474-2026-37` and `deck-renderers-Linux-98f0633a6b877953`. Both post steps correctly skipped saving an existing primary-key hit. The completed cache job has no annotations; lint/type, Linux full-suite, Windows, and macOS jobs all passed.

Patch versioning remains owned by the publish workflow. No catalog reparse or live-vault mutation is involved.
