### PR TITLE
test(deckops): Locate corrupt payload by ZIP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ### Locate the corrupt DeckOps test payload structurally
 
 The damaged-deflate fixture locates the VBA payload from the ZIP member's local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Locate the corrupt DeckOps test payload structurally
+
+The damaged-deflate fixture locates the VBA payload from the ZIP member's local
+header instead of searching for a separately compressed byte prefix (#423).
+It sets the reserved block type to make decompression fail independently of
+compression level. Regression cases verify that the archive remains readable
+but its member raises `zlib.error` at levels 0, 1, 6, and 9. Runtime behavior and
+the existing diagnosis assertions are unchanged.
+
 ## 0.20.134 — 2026-09-07
 
 ### Tell a stale DeckOps import from one that never happened

--- a/tests/test_deckops_doctor.py
+++ b/tests/test_deckops_doctor.py
@@ -650,7 +650,7 @@ def test_a_stale_next_step_names_the_absent_version_readably(
     assert "unknown" not in report["next_step"]
 
 
-def _corrupt_deflate_pptm(path: Path) -> Path:
+def _corrupt_deflate_pptm(path: Path, *, compresslevel: int = 6) -> Path:
     """A structurally valid .pptm whose vbaProject.bin deflate stream is garbage.
 
     Distinct from a non-zip file: the archive parses, the member is listed, and
@@ -658,23 +658,43 @@ def _corrupt_deflate_pptm(path: Path) -> Path:
     from Exception rather than OSError and so escapes an OSError handler.
     """
     import io
+    import struct
     import zipfile
-    import zlib
 
     data = b"DeckOps RunDeckOps " * 300
-    raw = zlib.compress(data, 9)[2:-4]
-    bad = bytearray(raw)
-    bad[len(bad) // 2] ^= 0xFF
     buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as z:
-        z.writestr("ppt/vbaProject.bin", data, zipfile.ZIP_DEFLATED)
+    with zipfile.ZipFile(
+        buf, "w", zipfile.ZIP_DEFLATED, compresslevel=compresslevel
+    ) as z:
+        z.writestr("ppt/vbaProject.bin", data)
+        info = z.getinfo("ppt/vbaProject.bin")
     blob = bytearray(buf.getvalue())
-    start = blob.find(raw[:8])
-    assert start >= 0, "could not locate the compressed payload to corrupt"
-    blob[start : start + len(raw)] = bytes(bad)
+    # Local-header lengths locate the actual bytes, independent of compressor output.
+    name_size, extra_size = struct.unpack_from("<HH", blob, info.header_offset + 26)
+    start = info.header_offset + 30 + name_size + extra_size
+    assert info.compress_size > 0 and start + info.compress_size <= len(blob)
+    # RFC 1951 section 3.2.3: BTYPE=11 is invalid; BFINAL and all other bits stay put.
+    blob[start] |= 0b110
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(bytes(blob))
     return path
+
+
+@pytest.mark.parametrize("compresslevel", [0, 1, 6, 9])
+def test_corrupt_deflate_fixture_preserves_zip_but_breaks_decompression(
+    tmp_path, compresslevel
+):
+    import zipfile
+    import zlib
+
+    path = _corrupt_deflate_pptm(tmp_path / "DeckOps.pptm", compresslevel=compresslevel)
+    with zipfile.ZipFile(path) as archive:
+        assert archive.namelist() == ["ppt/vbaProject.bin"]
+        info = archive.getinfo("ppt/vbaProject.bin")
+        assert info.compress_type == zipfile.ZIP_DEFLATED
+        assert info.file_size == len(b"DeckOps RunDeckOps " * 300)
+        with pytest.raises(zlib.error, match="invalid block type"):
+            archive.read(info)
 
 
 def test_corrupt_compressed_vba_does_not_abort_the_diagnosis(deckops_doctor, tmp_path):


### PR DESCRIPTION
## Summary

- Locate the corrupt VBA test payload from the ZIP member's local header, removing the separately compressed prefix search in `_corrupt_deflate_pptm`.
- Set the reserved DEFLATE block type instead of relying on an arbitrary flipped byte to fail decoding. This follows [RFC 1951 section 3.2.3](https://www.rfc-editor.org/rfc/rfc1951#section-3.2.3).
- Verify archive enumeration still succeeds while the intended member raises `zlib.error` at compression levels 0, 1, 6, and 9. Existing diagnosis assertions and other corruption builders are unchanged.

Closes #423. Test-only maintenance plus changelog: no runtime behavior, CI configuration, dependencies, catalog data, or reparsing changes. Patch release via the existing publish workflow; no manual version bump.

## Test plan

- [x] Focused DeckOps suite: 73 passed.
- [x] Full local suite: 7,724 passed, 8 existing skips (333.39 seconds).
- [x] Ruff lint and format: clean (477 files formatted).
- [x] Pyright with the project interpreter: 0 errors, 0 warnings.
- [x] Conflict-marker, Tessl-pin, package-content, shipped-extension, and plugin-lint gates: passed.
- [x] Diff self-audit: only `tests/test_deckops_doctor.py` and `CHANGELOG.md`; existing test assertions retained, fixed fixture inputs, no new exception handlers or binaries.
- [x] PR CI and both review bodies read; every review thread addressed.
- [x] Exact-merge publish run, registry advance, moderation pass, post-merge Tests, and branch cleanup verified.

## Release verification

Merged as `76787e5d1490c6974681ef8109afd798490763de`. Version **0.20.135** published: [publish run](https://github.com/jbaruch/speaker-toolkit/actions/runs/34138326096) succeeded, registry advanced from 0.20.134, and moderation passed. The actual changelog stamp is `0.20.135 — 2026-09-07`.

[Final-head PR CI](https://github.com/jbaruch/speaker-toolkit/actions/runs/34137184084) and [exact-merge post-release Tests](https://github.com/jbaruch/speaker-toolkit/actions/runs/34138325501) passed every job. Both reviews were read, the stamping correction was verified, and Copilot's conflicting old-version suggestion was [answered with the release contract](https://github.com/jbaruch/speaker-toolkit/pull/424#discussion_r3951004389).

No skills changed, so the changed-skill reviewer processed zero skills. The publisher emitted its known post-publication credit warning, verified that the exact new version had landed, and successfully pushed the manifest bump. Worktree and branch cleanup completed; the user's separate active edits were preserved.
