### PR TITLE
fix(pyright): point the analyzer at the project virtualenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+### Point pyright at the project environment
+
+`[tool.pyright]` configured `pythonVersion`, `include`, `exclude`, and
+per-root `extraPaths`, but never said where the virtualenv is. Pyright therefore
+resolved third-party imports against whatever interpreter it happened to pick,
+so a bare `pyright` reported every venv-only dependency as unresolved while
+`pyright --pythonpath .venv/bin/python` reported clean.
+
+The block's own comment already warned about the consequence — "Run against a
+bare system Python and 94 resolution false-positives reappear, hiding the real
+findings underneath" — and then relied on every caller remembering the flag.
+Tooling does not remember. `coding-policy`'s `stop-handoff-hygiene.sh` invokes a
+bare `pyright` and blocks the handoff on its findings, so an unresolvable import
+in any uncommitted file wedges a session on a defect that does not exist
+(jbaruch/coding-policy#351 covers the hook side).
+
+`venvPath = "."` plus `venv = ".venv"` makes the bare invocation correct too.
+Verified both ways: bare `pyright` on the file that triggered this goes from one
+`reportMissingImports` to zero, and the repo-wide `--pythonpath` run stays at
+zero, so nothing that already worked changed.
+
+Not fixed here: a bare `pyright` from an older global install can still differ.
+Homebrew's 1.1.408 reports `jpg_bytes` possibly-unbound in
+`generate-thumbnail.py`, which the project's own 1.1.411 does not — the loop it
+sits in iterates a non-empty literal tuple, so the variable is provably bound and
+the older analyzer simply cannot see it. That is a binary-version difference, not
+a resolution problem, and the code is left alone rather than contorted for an
+analyzer the project does not use.
+
+
 ## 0.20.135 — 2026-09-07
 
 ### Locate the corrupt DeckOps test payload structurally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,14 @@ select = ["E4", "E7", "E9", "F", "BLE"]
 # then `pyright`. Run against a bare system Python and 94 resolution
 # false-positives reappear, hiding the real findings underneath.
 pythonVersion = "3.10"
+# Point pyright at the project environment. Without this it resolves third-party
+# imports against whatever interpreter it picks up, so every venv-only dependency
+# reports reportMissingImports — noise that buries the real findings and, in a
+# `pyright`-invoking Stop hook, blocks handoff on a defect that does not exist.
+# Callers passing --pythonpath already worked; this makes a bare `pyright` correct
+# too, which is what tooling in the wild actually runs.
+venvPath = "."
+venv = ".venv"
 include = ["scripts", "skills", "tests"]
 exclude = ["**/__pycache__", ".venv", ".tessl"]
 executionEnvironments = [


### PR DESCRIPTION
## Summary

`[tool.pyright]` configured `pythonVersion`, `include`, `exclude`, and per-root `extraPaths` — but never said where the virtualenv is. Pyright resolves third-party imports against whatever interpreter it picks, so a bare `pyright` reports every venv-only dependency as unresolved, while `pyright --pythonpath .venv/bin/python` reports clean.

The block's own comment already warned about the consequence:

> Run against a bare system Python and 94 resolution false-positives reappear, hiding the real findings underneath.

…and then relied on every caller remembering the flag. Tooling does not remember. `coding-policy`'s `stop-handoff-hygiene.sh` runs a bare `pyright` on changed `.py` files and **blocks the handoff** on its findings, so an unresolvable import in any uncommitted file wedges a session on a defect that does not exist. That is what surfaced this — see jbaruch/coding-policy#351 for the hook-side fix.

`venvPath = "."` + `venv = ".venv"` makes the bare invocation correct too.

## Verification

```
# before
$ pyright tests/test_return_validation.py
  tests/test_return_validation.py:12:6 - error: Import "pypdf" could not be resolved
1 error

# after
$ pyright tests/test_return_validation.py
0 errors, 0 warnings, 0 informations

# the documented invocation, repo-wide, unchanged
$ .venv/bin/pyright --pythonpath .venv/bin/python
0 errors, 0 warnings, 0 informations
```

`pypdf` was installed (6.15.0) and declared at `pyproject.toml:22` the whole time — nothing was wrong with the code.

## Deliberately not fixed here

A bare `pyright` from an *older* global install can still differ. Homebrew's **1.1.408** reports `jpg_bytes` possibly-unbound at `skills/illustrations/scripts/generate-thumbnail.py:210`; the project's own **1.1.411** does not. The loop it sits in iterates a non-empty literal tuple `(95, 90, 85, 80, 75)`, so the variable is provably bound — the older analyzer just cannot see it.

That is a binary-version difference, not a resolution problem, and it does not gate anything today (the hook lints only *changed* files, and this one isn't). Contorting correct code to satisfy an analyzer version the project doesn't pin would be the wrong trade. The durable fix is the hook preferring `.venv/bin/pyright`, proposed in coding-policy#351.

## Test plan

- [x] Bare `pyright` on the triggering file: 1 error → 0
- [x] Repo-wide `--pythonpath` run: still 0 errors (nothing that worked changed)
- [x] `ruff check` + `ruff format --check` clean
- [x] Test slice green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV