### PR TITLE
fix(ingress): Reconcile clean Darwin worker exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### Reconcile a macOS worker's clean exit after root metadata disappears
+
+The #219 native trace captured a root becoming unavailable to psutil before
+`waitpid` could reap its successful exit. When the first bounded wait expired,
+cleanup confirmed exit 0 after a refused group signal, but the supervisor kept
+the earlier identity error. It now reconciles that specific root-disappearance
+failure after successful cleanup, only within the original wall deadline and
+without any successful root or observed-descendant kill. Authentication,
+generation bindings, response validation and late pipe checks still run.
+Changed identities, resource failures, invalid word timing and failed cleanup
+remain refusals; no resource limit or wait budget increases.
+
 ## 0.20.136 — 2026-09-07
 
 ### Point pyright at the project environment
@@ -30,7 +42,6 @@ sits in iterates a non-empty literal tuple, so the variable is provably bound an
 the older analyzer simply cannot see it. That is a binary-version difference, not
 a resolution problem, and the code is left alone rather than contorted for an
 analyzer the project does not use.
-
 
 ## 0.20.135 — 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ the older analyzer simply cannot see it. That is a binary-version difference, no
 a resolution problem, and the code is left alone rather than contorted for an
 analyzer the project does not use.
 
+
 ## 0.20.135 — 2026-09-07
 
 ### Locate the corrupt DeckOps test payload structurally

--- a/skills/vault-ingress/scripts/artifact_supervisor.py
+++ b/skills/vault-ingress/scripts/artifact_supervisor.py
@@ -83,6 +83,13 @@ class SupervisorError(RuntimeError):
         super().__init__(reason_code)
 
 
+class _RootProcessDisappeared(SupervisorError):
+    """Root metadata vanished; only Popen can confirm this child's exit."""
+
+    def __init__(self) -> None:
+        super().__init__("worker_monitor_identity_changed")
+
+
 @dataclass(frozen=True)
 class FileGeneration:
     """Path-free identity snapshot used to bind requests and responses."""
@@ -502,6 +509,8 @@ def run_authenticated_worker(
     clock_fn = clock if clock is not None else time.monotonic
     sleep_fn = sleeper if sleeper is not None else time.sleep
     started = clock_fn()
+    deadline = started + limits.wall_seconds
+    request_started = False
     process: subprocess.Popen[bytes] | None = None
     controller: _ProcessController | None = None
     monitor: _ProcessTreeMonitor | None = None
@@ -563,13 +572,13 @@ def run_authenticated_worker(
                 ) from exc
             raise
 
-        deadline = started + limits.wall_seconds
         if clock_fn() >= deadline:
             raise SupervisorError("worker_timeout")
 
         stdout_reader.start()
         stderr_reader.start()
         stdin_writer.start()
+        request_started = True
 
         while process.poll() is None:
             if stdout_reader.overflowed:
@@ -654,6 +663,24 @@ def run_authenticated_worker(
                 },
                 diagnostic_receipt,
             ) from cleanup_error
+        if (
+            sys.platform == "darwin"
+            and request_started
+            and isinstance(primary_error, _RootProcessDisappeared)
+            and process is not None
+            and process.returncode == 0
+            and controller is not None
+            and not controller.termination_sent
+            and monitor is not None
+            and not monitor.termination_sent
+            and clock_fn() < deadline
+        ):
+            # Darwin can expose root ESRCH before waitpid can reap it. Existing
+            # bounded cleanup may learn the clean exit after the first settle
+            # wait expires. Reconcile only without a successful kill and after
+            # cleanup proves all seen processes and pipe threads are gone.
+            # Keep late pipe checks and authenticated response validation below.
+            primary_error = None
         late_pipe_error = _pipe_error_after_cleanup(
             stdin_writer,
             stdout_reader,
@@ -1083,6 +1110,7 @@ class _ProcessTreeMonitor:
         self._root: Any | None = None
         self._root_create_time: float | None = None
         self._seen: dict[tuple[int, float], Any] = {}
+        self.termination_sent = False
 
     def establish(self) -> None:
         psutil_module = _load_psutil()
@@ -1111,9 +1139,10 @@ class _ProcessTreeMonitor:
                 raise SupervisorError("worker_monitor_identity_changed")
             candidates = [self._root, *self._root.children(recursive=True)]
         except psutil_module.NoSuchProcess as exc:
-            # Callers sample only while Popen still reports the child running.
-            # Disappearance here is therefore a containment/identity failure,
-            # not a clean exit.
+            if exc.pid == self._pid and not isinstance(
+                exc, psutil_module.ZombieProcess
+            ):
+                raise _RootProcessDisappeared() from exc
             raise SupervisorError("worker_monitor_identity_changed") from exc
         except (
             psutil_module.AccessDenied,
@@ -1134,6 +1163,10 @@ class _ProcessTreeMonitor:
                     continue
             except psutil_module.NoSuchProcess as exc:
                 if candidate.pid == self._pid:
+                    if exc.pid == self._pid and not isinstance(
+                        exc, psutil_module.ZombieProcess
+                    ):
+                        raise _RootProcessDisappeared() from exc
                     raise SupervisorError("worker_monitor_identity_changed") from exc
                 continue
             except (
@@ -1180,6 +1213,7 @@ class _ProcessTreeMonitor:
         for process in processes:
             try:
                 process.kill()
+                self.termination_sent = True
             except psutil_module.NoSuchProcess:
                 continue
             except (
@@ -1214,6 +1248,7 @@ class _ProcessController:
         self._process = process
         self._limits = limits
         self._windows_job: _WindowsJob | None = None
+        self.termination_sent = False
 
     def establish(self) -> None:
         if os.name == "nt":
@@ -1237,6 +1272,7 @@ class _ProcessController:
         if self._windows_job is not None:
             try:
                 self._windows_job.terminate()
+                self.termination_sent = True
             except OSError as exc:
                 failures.append(exc)
         elif os.name == "posix" and self._process.poll() is None:
@@ -1247,6 +1283,7 @@ class _ProcessController:
             # _ProcessTreeMonitor even after the root has exited.
             try:
                 os.killpg(self._process.pid, signal.SIGKILL)
+                self.termination_sent = True
             except ProcessLookupError:
                 pass
             except PermissionError as exc:
@@ -1280,6 +1317,7 @@ class _ProcessController:
         if self._process.poll() is None:
             try:
                 self._process.kill()
+                self.termination_sent = True
             except ProcessLookupError:
                 # The process group kill can win the race after poll() but
                 # before this direct-child fallback. ESRCH means the cleanup

--- a/tests/test_artifact_supervisor.py
+++ b/tests/test_artifact_supervisor.py
@@ -1393,6 +1393,9 @@ def cleanup_exit_run(monkeypatch):
             "sys",
             SimpleNamespace(**{**vars(sys), "platform": state.platform}),
         )
+        # Windows has no SIGKILL. Supply the simulated POSIX signal API along
+        # with os.name/killpg, without changing the host's real signal module.
+        monkeypatch.setattr(artifact_supervisor, "signal", SimpleNamespace(SIGKILL=9))
         monkeypatch.setattr(
             artifact_supervisor,
             "psutil",
@@ -1427,6 +1430,15 @@ def test_cleanup_reconciles_disappeared_root_only_after_clean_exit(
     assert state.process.returncode == 0
     assert state.process.killed is False
     assert state.process.wait_timeouts[:2] == [0.01, 0.01]
+
+
+def test_cleanup_replay_does_not_require_host_posix_signals(
+    cleanup_exit_run, monkeypatch
+):
+    _, run = cleanup_exit_run
+    monkeypatch.setattr(artifact_supervisor, "signal", SimpleNamespace())
+
+    assert run().payload == {"value": 1}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_artifact_supervisor.py
+++ b/tests/test_artifact_supervisor.py
@@ -1207,6 +1207,306 @@ def test_monitor_identity_loss_does_not_accept_a_still_live_worker():
     assert caught.value.reason_code == "worker_monitor_identity_changed"
 
 
+@pytest.fixture
+def cleanup_exit_run(monkeypatch):
+    """Replay root loss, an expired settle wait, EPERM, then a reaped exit.
+
+    Real request/response framing, pipe threads, psutil accounting and cleanup
+    run against fixed process observations. Events finish the pipe traffic
+    before root loss; runner scheduling never decides the response's validity.
+    """
+
+    state = SimpleNamespace(
+        exit_code=0,
+        exits_in_cleanup=True,
+        monitor_failure="memory_missing",
+        group_signal="eperm",
+        descendant_alive=False,
+        descendant_killed=False,
+        platform="darwin",
+        response="success",
+        late_pipe_error=None,
+        cleanup_failure=False,
+        in_cleanup=False,
+        finish_time=0.0,
+        now=0.0,
+    )
+    pipe_done = [threading.Event() for _ in range(3)]
+
+    class ReadPipe(io.BytesIO):
+        def __init__(self, data, done):
+            super().__init__(data)
+            self.done = done
+
+        def read(self, size: int | None = -1):
+            result = super().read(size)
+            if not result:
+                self.done.set()
+            return result
+
+    class WritePipe(io.BytesIO):
+        def close(self):
+            super().close()
+            pipe_done[0].set()
+
+    class CleanupExitProcess(ScriptedProcess):
+        def wait(self, timeout=0.0):
+            self.wait_timeouts.append(timeout)
+            if self.returncode is None:
+                if not state.in_cleanup or not state.exits_in_cleanup:
+                    raise subprocess.TimeoutExpired("worker", timeout)
+                self.returncode = state.exit_code
+            return self.returncode
+
+    process = CleanupExitProcess(exit_code=0)
+    state.process = process
+    prepare_request = artifact_supervisor._prepare_request
+
+    def prepare(*args, **kwargs):
+        pending = prepare_request(*args, **kwargs)
+        stream = io.BytesIO()
+        if state.response == "word_error":
+            artifact_supervisor.write_worker_response(
+                pending.request,
+                error=artifact_supervisor.SupervisorError(
+                    "whisper_word_sample_invalid_word_nonpositive_span"
+                ),
+                observed_generations=pending.request.expected_generations,
+                stream=stream,
+            )
+        else:
+            artifact_supervisor.write_worker_response(
+                pending.request,
+                payload={"value": 1},
+                observed_generations=pending.request.expected_generations,
+                stream=stream,
+            )
+        frame = stream.getvalue()
+        if state.response == "bad_mac":
+            document = json.loads(frame[4:])
+            document["hmac_sha256"] = "0" * 64
+            encoded = json.dumps(document).encode()
+            frame = struct.pack("!I", len(encoded)) + encoded
+        elif state.response == "truncated":
+            frame = frame[:-1]
+        elif state.response == "trailing":
+            frame += b"x"
+        process.stdin = WritePipe()
+        process.stdout = ReadPipe(frame, pipe_done[1])
+        process.stderr = ReadPipe(b"", pipe_done[2])
+        return pending
+
+    class ObservedProcess:
+        def __init__(self, pid):
+            self.pid = pid
+            self.samples = 0
+
+        def create_time(self):
+            if self.pid == process.pid and self.samples:
+                for done in pipe_done:
+                    done.wait()
+            if self.samples and state.monitor_failure == "identity_replaced":
+                return 2.0
+            return 1.0
+
+        def children(self, recursive):
+            assert recursive
+            if self.samples and state.monitor_failure in {
+                "children_missing",
+                "other_process_missing",
+            }:
+                missing = self.pid if state.monitor_failure == "children_missing" else 9
+                raise psutil.NoSuchProcess(missing)
+            return [descendant] if state.descendant_alive else []
+
+        def memory_info(self):
+            if self.pid == process.pid:
+                self.samples += 1
+                if state.monitor_failure == "barrier_missing":
+                    raise psutil.NoSuchProcess(self.pid)
+                if self.samples > 1:
+                    for done in pipe_done:
+                        done.wait()
+                    if state.monitor_failure == "memory_missing":
+                        raise psutil.NoSuchProcess(self.pid)
+                    if state.monitor_failure == "memory_other_pid":
+                        raise psutil.NoSuchProcess(9)
+                    if state.monitor_failure == "zombie":
+                        raise psutil.ZombieProcess(self.pid)
+                    if state.monitor_failure == "unavailable":
+                        raise psutil.AccessDenied(self.pid)
+                    if state.monitor_failure == "memory_limit":
+                        return SimpleNamespace(rss=1024**3)
+            return SimpleNamespace(rss=1)
+
+        def is_running(self):
+            if self.pid != process.pid:
+                return state.descendant_alive
+            if self.samples > 1 and state.monitor_failure == "not_running":
+                return False
+            return process.returncode is None
+
+        def status(self):
+            return psutil.STATUS_RUNNING
+
+        def kill(self):
+            assert self.pid != process.pid
+            state.descendant_alive = False
+            state.descendant_killed = True
+
+    root = ObservedProcess(process.pid)
+    descendant = ObservedProcess(process.pid + 1)
+
+    def killpg(pid, sig):
+        assert pid == process.pid
+        assert sig == artifact_supervisor.signal.SIGKILL
+        if state.group_signal == "eperm":
+            raise PermissionError(1, "Operation not permitted")
+        if state.group_signal == "esrch":
+            raise ProcessLookupError(3, "No such process")
+        assert state.group_signal == "success"
+        process.kill()
+
+    cleanup = artifact_supervisor._cleanup_invocation
+
+    def finish_cleanup(*args, **kwargs):
+        state.in_cleanup = True
+        result = cleanup(*args, **kwargs)
+        if state.late_pipe_error is not None:
+            pipe_index, event = state.late_pipe_error
+            getattr(args[pipe_index], event).set()
+        state.now = state.finish_time
+        if state.cleanup_failure:
+            return RuntimeError("synthetic cleanup failure")
+        return result
+
+    def run():
+        monkeypatch.setattr(artifact_supervisor, "_prepare_request", prepare)
+        monkeypatch.setattr(artifact_supervisor, "_cleanup_invocation", finish_cleanup)
+        monkeypatch.setattr(
+            artifact_supervisor,
+            "os",
+            SimpleNamespace(**{**vars(os), "name": "posix", "killpg": killpg}),
+        )
+        monkeypatch.setattr(
+            artifact_supervisor,
+            "sys",
+            SimpleNamespace(**{**vars(sys), "platform": state.platform}),
+        )
+        monkeypatch.setattr(
+            artifact_supervisor,
+            "psutil",
+            SimpleNamespace(
+                **{
+                    **vars(psutil),
+                    "Process": lambda pid: root,
+                    "wait_procs": lambda processes, timeout: (processes, []),
+                }
+            ),
+        )
+        return _run(
+            "success",
+            process_backend=lambda *args, **kwargs: process,
+            monitor_factory=artifact_supervisor._ProcessTreeMonitor,
+            credentials=artifact_supervisor.WorkerCredentials(b"k" * 32),
+            clock=lambda: state.now,
+            sleeper=lambda seconds: None,
+        )
+
+    return state, run
+
+
+@pytest.mark.parametrize("failure", ["memory_missing", "children_missing"])
+def test_cleanup_reconciles_disappeared_root_only_after_clean_exit(
+    cleanup_exit_run, failure
+):
+    state, run = cleanup_exit_run
+    state.monitor_failure = failure
+
+    assert run().payload == {"value": 1}
+    assert state.process.returncode == 0
+    assert state.process.killed is False
+    assert state.process.wait_timeouts[:2] == [0.01, 0.01]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "reason"),
+    [
+        ("exit_code", 1, "worker_monitor_identity_changed"),
+        ("monitor_failure", "identity_replaced", "worker_monitor_identity_changed"),
+        ("monitor_failure", "other_process_missing", "worker_monitor_identity_changed"),
+        ("monitor_failure", "memory_other_pid", "worker_monitor_identity_changed"),
+        ("monitor_failure", "zombie", "worker_monitor_identity_changed"),
+        ("monitor_failure", "barrier_missing", "worker_monitor_identity_changed"),
+        ("monitor_failure", "not_running", "worker_monitor_identity_changed"),
+        ("monitor_failure", "unavailable", "worker_monitor_unavailable"),
+        ("monitor_failure", "memory_limit", "worker_memory_limit_exceeded"),
+        ("group_signal", "success", "worker_monitor_identity_changed"),
+        ("group_signal", "esrch", "worker_monitor_identity_changed"),
+        ("descendant_alive", True, "worker_monitor_identity_changed"),
+        ("platform", "linux", "worker_cleanup_failed"),
+        ("exits_in_cleanup", False, "worker_cleanup_failed"),
+        ("finish_time", 5.0, "worker_monitor_identity_changed"),
+        ("cleanup_failure", True, "worker_cleanup_failed"),
+    ],
+)
+def test_cleanup_cannot_reconcile_unsafe_or_late_exit(
+    cleanup_exit_run, field, value, reason
+):
+    state, run = cleanup_exit_run
+    setattr(state, field, value)
+
+    with pytest.raises(artifact_supervisor.SupervisorError) as caught:
+        run()
+
+    assert caught.value.reason_code == reason
+    if field == "descendant_alive":
+        assert state.descendant_killed
+
+
+@pytest.mark.parametrize(
+    ("response", "reason"),
+    [
+        ("bad_mac", "worker_response_authentication_failed"),
+        ("truncated", "invalid_worker_response"),
+        ("trailing", "invalid_worker_response"),
+        ("word_error", "whisper_word_sample_invalid_word_nonpositive_span"),
+    ],
+)
+def test_cleanup_reconciled_exit_still_validates_response(
+    cleanup_exit_run, response, reason
+):
+    state, run = cleanup_exit_run
+    state.response = response
+
+    with pytest.raises(artifact_supervisor.SupervisorError) as caught:
+        run()
+
+    assert caught.value.reason_code == reason
+
+
+@pytest.mark.parametrize(
+    ("pipe_index", "event", "reason"),
+    [
+        (3, "_failed", "worker_request_write_failed"),
+        (4, "_failed", "worker_output_read_failed"),
+        (5, "_failed", "worker_diagnostic_read_failed"),
+        (4, "_overflow", "worker_output_limit_exceeded"),
+        (5, "_overflow", "worker_diagnostic_limit_exceeded"),
+    ],
+)
+def test_cleanup_reconciled_exit_still_rejects_late_pipe_failure(
+    cleanup_exit_run, pipe_index, event, reason
+):
+    state, run = cleanup_exit_run
+    state.late_pipe_error = (pipe_index, event)
+
+    with pytest.raises(artifact_supervisor.SupervisorError) as caught:
+        run()
+
+    assert caught.value.reason_code == reason
+
+
 def test_cleanup_failure_overrides_signed_success(tmp_path):
     class CleanupFailingMonitor:
         def __init__(self, _pid, _limits):


### PR DESCRIPTION
## Summary

- Address #219's captured macOS shutdown race: psutil loses the root, the first bounded wait expires, then existing cleanup reaps exit 0 after a refused group signal.
- Reconcile only that root-disappearance error after successful cleanup, without a successful root/observed-descendant kill and before the original deadline. Changed identities, failed barriers, resource failures, and other platforms retain their refusal paths.
- Preserve authentication, generation bindings, response validation, late pipe failures, and all resource/wait limits. A clean exit does not make invalid word timestamps valid.

## Test plan

- [x] 28 deterministic regressions replay the captured observation order and unsafe variants, using real supervisor framing, pipe threads, monitor accounting, and cleanup, including a host with no POSIX signal API.
- [x] Ruff lint and format, full Pyright using the project interpreter, plugin lint, and all packaging/conflict gates.
- [x] Final-head full local test suite: 7,752 passed, 8 existing skips (311.54 seconds); 139 supervisor/manifest checks also passed separately.
- [x] One unchanged-model native run: root metadata disappeared and the existing first settle wait reaped exit 0. Authenticated response handling preserved `whisper_word_sample_invalid_word_nonpositive_span`. No signal was sent, source identity and strict catalog digest stayed unchanged, and owner scratch was removed. This run did **not** exercise the new cleanup-reconciliation branch and is **not** a valid word-sample pass; the captured failing sequence is covered by the deterministic replay.
- [x] Policy and Copilot review, all PR checks, exact-merge publish verification, registry advance to 0.20.137, moderation clearance, and post-merge tests. Tessl skill-quality review was explicitly credit-skipped, not reported as passed.

Acceptance scope: #219's original generic-media supervision implementation shipped in #406; [all eight documented native checks passed](https://github.com/jbaruch/speaker-toolkit/issues/219#issuecomment-5571106048). This PR addresses its remaining reproduced shutdown defect. Close #219 only after this release's full verification. Earlier comments also held it for the separate QCon receipt binding; that remains an unmet whole-vault preflight criterion in #333, not a claim this code fixes it. Sampled-speech confidence (#368), recorder acceptance (#369), and reparse-dependent #374 remain separate. No catalog, transcript receipt, word timestamp, or queue claim is changed.
