### PR TITLE
fix(vault-ingress): report what the evidence layer actually observed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ degenerate — inflating the very number it exists to measure.
 narrowing told static analysis a caller could assume a float. Corrected to
 `TypeGuard[int | float]` here and in `verify-storyboard.py`, which shipped the
 identical mistake in 0.20.138.
+
+A further round applied the same standard to the other side of the classifier,
+which had stayed broad while the removal side was tightened. `unable to download
+webpage` also wraps an HTTP 403, `ssl` also wraps an expired certificate, and a
+bot check needs cookies — none is fixed by trying again, so advising a retry
+wasted the operator's time exactly as the `PermissionError` case did. The test is
+now whether a plain retry can plausibly succeed, not whether the message sounds
+like weather. A specific cause inside a generic wrapper still classifies, so
+nothing legitimate was lost.
 ## 0.20.139 — 2026-09-07
 
 ### A wrong path reads as a wrong path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+### Tell a dead recording from a bad minute, and count the degenerate words
+
+Two places where the evidence layer under-reported what it had actually seen.
+
+`audit-source-identities.py` surfaced every yt-dlp failure as one
+`metadata_fetch_failed` at high priority, so "the provider no longer serves this
+recording" and "I could not reach YouTube just now" were indistinguishable in the
+output. #429 was filed on that basis for two recordings; re-checking them found
+both resolve fine — they were transient failures reported as link rot. The
+operator's next action differs completely between the two, so findings now carry
+`failure_class` (`upstream_gone` / `transient` / `unclassified`) and `retryable`,
+matched against an enumerated set of yt-dlp signatures. An unrecognised message
+stays `unclassified` rather than being sorted into a bucket, since guessing is
+what produced the wrong issue.
+
+`local_media_words.py` refused a whole ten-minute sample on the first word with
+`end == start`, which excluded 11 of 24 recordings in the last cohort run and
+left the speaker profile at `low_confidence`. Whether that is over-rejection or a
+genuine alignment guard depends on how many degenerate words a failing sample
+carries, and nothing measured it — the stored `.segments.json` artifacts keep no
+word-level data, so the count has to come off the sample while it is in hand.
+
+The refusal is deliberately unchanged. `WordSpanError` now carries a bounded,
+numeric-only report — word count, non-positive count, first index, never token
+text — and `calibrate-speech.py` emits it alongside the existing `word_timing`
+diagnostic. A cohort run therefore now reports whether the rule is rejecting one
+bad word or half of them, which is the measurement #431 asks for before anyone
+changes the admission rule. Choosing a threshold first would be picking a number
+blind.
+
+
 ## 0.20.138 — 2026-09-07
 
 ### A recorded demo can now be judged instead of trusted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ bad word or half of them, which is the measurement #431 asks for before anyone
 changes the admission rule. Choosing a threshold first would be picking a number
 blind.
 
+Review sharpened all three. A bare "video unavailable" was being read as removal,
+but yt-dlp says it for geographic restriction too — and that is the exact message
+that misled #429 into being filed as link rot, so it now falls through to
+`unclassified` rather than claiming a fact it does not establish. Failing to run
+yt-dlp at all reached the same wrapper as a network timeout, so a
+`PermissionError` was advising a retry that would fail identically forever; it has
+its own `tooling` class asking for a repair, with the errno separating a timeout
+from a permission inside the same message. And the span report guarded `bool` on
+only one endpoint, so `{"start_seconds": 1.0, "end_seconds": False}` counted as
+degenerate — inflating the very number it exists to measure.
+
 
 ## 0.20.138 — 2026-09-07
 

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -85,6 +85,71 @@ CANDIDATE_CONFLICT_CODES = {
     "existing_slides_url_conflict": "slides_url",
 }
 YT_DLP_TIMEOUT_SECONDS = 60
+
+# yt-dlp reports "the upstream video is gone" and "I could not reach YouTube
+# just now" through the same non-zero exit, so both arrived as one high-priority
+# finding. A transient minute then read as link rot: #429 was filed for two
+# recordings that resolve fine on a later run.
+#
+# Signatures are matched case-insensitively against yt-dlp's own message. An
+# unrecognised message stays `unclassified` — never silently sorted into either
+# bucket, because guessing is what produced the wrong issue in the first place.
+UPSTREAM_GONE_SIGNATURES = (
+    "video unavailable",
+    "this video is not available",
+    "this video has been removed",
+    "private video",
+    "video has been removed by the uploader",
+    "account associated with this video has been terminated",
+    "this video is no longer available",
+    "removed for violating",
+)
+TRANSIENT_SIGNATURES = (
+    "unable to download webpage",
+    "temporary failure in name resolution",
+    "connection reset",
+    "connection refused",
+    "connection timed out",
+    "read timed out",
+    "timed out",
+    "http error 429",
+    "http error 500",
+    "http error 502",
+    "http error 503",
+    "http error 504",
+    "sign in to confirm you're not a bot",
+    "cannot run yt-dlp",
+    "network is unreachable",
+    "ssl",
+)
+
+
+FETCH_FAILURE_MESSAGES = {
+    "upstream_gone": "the provider no longer serves this recording",
+    "transient": "yt-dlp metadata capture failed transiently; retry before acting",
+    "unclassified": "yt-dlp metadata capture failed",
+}
+
+
+def classify_fetch_failure(message: Any) -> dict:
+    """Sort a fetch failure into upstream-gone, transient, or unclassified.
+
+    Deterministic string matching over an enumerated signature set, so it is a
+    script rather than a judgement (`rules/script-delegation.md`). The point is
+    the operator's next action: an upstream-gone recording needs a decision
+    about its derived claims; a transient one needs a retry; an unclassified one
+    needs reading.
+    """
+    text = message.casefold() if isinstance(message, str) else ""
+    for signature in UPSTREAM_GONE_SIGNATURES:
+        if signature in text:
+            return {"failure_class": "upstream_gone", "retryable": False}
+    for signature in TRANSIENT_SIGNATURES:
+        if signature in text:
+            return {"failure_class": "transient", "retryable": True}
+    return {"failure_class": "unclassified", "retryable": None}
+
+
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 CLIP_MARKERS = frozenset(
     {
@@ -908,14 +973,17 @@ def audit_database(
             source["fetch_status"] = "error"
             source["error"] = str(exc)
             failure_code = lane_code("metadata_fetch_failed")
+            classification = classify_fetch_failure(str(exc))
+            source["failure_class"] = classification["failure_class"]
+            source["retryable"] = classification["retryable"]
             findings.append(
                 _finding(
                     failure_code,
                     video_id,
                     indexes,
                     filenames,
-                    "yt-dlp metadata capture failed",
-                    {"error": str(exc)},
+                    FETCH_FAILURE_MESSAGES[classification["failure_class"]],
+                    {"error": str(exc), **classification},
                     "high" if failure_code in ERROR_CODES else "medium",
                 )
             )

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -108,8 +108,13 @@ UPSTREAM_GONE_SIGNATURES = (
     "account associated with this video has been terminated",
     "no longer available because the youtube account",
 )
+# Only causes where a plain retry can plausibly succeed. The test is that
+# question, not "does it sound like weather": "unable to download webpage" also
+# wraps HTTP 403, and "ssl" also wraps an expired certificate, and neither is
+# fixed by trying again. Both were removed — the specific cause inside such a
+# message ("timed out", "429") still classifies it, and a message carrying only
+# the generic wrapper stays unclassified for a human to read.
 TRANSIENT_SIGNATURES = (
-    "unable to download webpage",
     "temporary failure in name resolution",
     "connection reset",
     "connection refused",
@@ -122,9 +127,6 @@ TRANSIENT_SIGNATURES = (
     "http error 502",
     "http error 503",
     "http error 504",
-    "sign in to confirm you're not a bot",
-    "network is unreachable",
-    "ssl",
 )
 # Failing to run the tool at all is persistent configuration, not weather.
 # Telling an operator to retry a PermissionError wastes their time, so these get

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -94,15 +94,19 @@ YT_DLP_TIMEOUT_SECONDS = 60
 # Signatures are matched case-insensitively against yt-dlp's own message. An
 # unrecognised message stays `unclassified` — never silently sorted into either
 # bucket, because guessing is what produced the wrong issue in the first place.
+# Only signatures that state REMOVAL. A bare "video unavailable" is ambiguous —
+# yt-dlp uses it for geographic restriction too ("This video is not available in
+# your country"), which establishes nothing about whether the recording still
+# exists. Assigning meaning to that is the Regex Trap, so it falls through to
+# `unclassified` and gets read by a human.
 UPSTREAM_GONE_SIGNATURES = (
-    "video unavailable",
-    "this video is not available",
     "this video has been removed",
-    "private video",
     "video has been removed by the uploader",
-    "account associated with this video has been terminated",
-    "this video is no longer available",
     "removed for violating",
+    "private video",
+    "this video is private",
+    "account associated with this video has been terminated",
+    "no longer available because the youtube account",
 )
 TRANSIENT_SIGNATURES = (
     "unable to download webpage",
@@ -112,22 +116,33 @@ TRANSIENT_SIGNATURES = (
     "connection timed out",
     "read timed out",
     "timed out",
+    "timeout",
     "http error 429",
     "http error 500",
     "http error 502",
     "http error 503",
     "http error 504",
     "sign in to confirm you're not a bot",
-    "cannot run yt-dlp",
     "network is unreachable",
     "ssl",
+)
+# Failing to run the tool at all is persistent configuration, not weather.
+# Telling an operator to retry a PermissionError wastes their time, so these get
+# their own class with a repair instruction instead of a retry.
+TOOLING_SIGNATURES = (
+    "permission denied",
+    "no such file or directory",
+    "exec format error",
+    "is a directory",
+    "yt-dlp is not installed",
 )
 
 
 FETCH_FAILURE_MESSAGES = {
     "upstream_gone": "the provider no longer serves this recording",
     "transient": "yt-dlp metadata capture failed transiently; retry before acting",
-    "unclassified": "yt-dlp metadata capture failed",
+    "tooling": "yt-dlp could not be run; repair the installation before retrying",
+    "unclassified": "yt-dlp metadata capture failed; read the error before acting",
 }
 
 
@@ -144,9 +159,15 @@ def classify_fetch_failure(message: Any) -> dict:
     for signature in UPSTREAM_GONE_SIGNATURES:
         if signature in text:
             return {"failure_class": "upstream_gone", "retryable": False}
+    # Transient before tooling: "cannot run yt-dlp: [Errno 60] Operation timed
+    # out" reaches the same wrapper as a PermissionError, and only the errno
+    # tells them apart. A timeout is weather; a permission is a repair.
     for signature in TRANSIENT_SIGNATURES:
         if signature in text:
             return {"failure_class": "transient", "retryable": True}
+    for signature in TOOLING_SIGNATURES:
+        if signature in text:
+            return {"failure_class": "tooling", "retryable": False}
     return {"failure_class": "unclassified", "retryable": None}
 
 

--- a/skills/vault-ingress/scripts/local_media_words.py
+++ b/skills/vault-ingress/scripts/local_media_words.py
@@ -135,6 +135,58 @@ def validate_word_diagnostic(value: Any) -> dict:
     return diagnostic
 
 
+def nonpositive_span_report(words: Any) -> dict:
+    """Count words whose span is non-positive. Judges nothing; refuses nothing.
+
+    #431 asks whether a refused sample typically carries one degenerate word or
+    hundreds, because that decides whether the all-or-nothing refusal is
+    over-rejection or a genuine alignment guard. Nothing measured it, and the
+    stored `.segments.json` artifacts keep no word-level data, so the count has
+    to come off the sample while it is in hand.
+
+    Numeric only — counts and indexes, never token text — matching the privacy
+    contract `LocalMediaError` states.
+    """
+    if not isinstance(words, list):
+        return {
+            "schema_version": 1,
+            "word_count": 0,
+            "nonpositive_count": 0,
+            "first_index": None,
+        }
+    nonpositive = []
+    for index, word in enumerate(words):
+        if not isinstance(word, dict):
+            continue
+        begin, end = word.get("start_seconds"), word.get("end_seconds")
+        if (
+            isinstance(begin, Real)
+            and isinstance(end, Real)
+            and not isinstance(begin, bool)
+        ):
+            if end <= begin:
+                nonpositive.append(index)
+    return {
+        "schema_version": 1,
+        "word_count": len(words),
+        "nonpositive_count": len(nonpositive),
+        "first_index": nonpositive[0] if nonpositive else None,
+    }
+
+
+class WordSpanError(LocalMediaError):
+    """A non-positive-span refusal carrying how widespread the defect is.
+
+    The refusal is unchanged — the sample is still rejected. What is new is that
+    the receipt says whether one word or half of them were degenerate, which is
+    the measurement #431 needs before anyone changes the admission rule.
+    """
+
+    def __init__(self, report: dict):
+        self.word_spans = copy.deepcopy(report)
+        super().__init__("whisper_word_sample_invalid_word_nonpositive_span")
+
+
 class WordSampleError(LocalMediaError):
     """A segment-membership refusal with bounded numeric worker diagnostics."""
 
@@ -251,7 +303,10 @@ def validate_word_sample(value: Any) -> dict:
         if begin < previous_end:
             _refuse("word_overlap")
         if end <= begin:
-            _refuse("word_nonpositive_span")
+            # Scan the rest for the same defect before refusing, so the receipt
+            # records its extent. Ordering is untouched: an earlier word with a
+            # different fault has already refused above.
+            raise WordSpanError(nonpositive_span_report(words))
         try:
             _number(word["probability"], 0, 1)
         except LocalMediaError:

--- a/skills/vault-ingress/scripts/local_media_words.py
+++ b/skills/vault-ingress/scripts/local_media_words.py
@@ -13,7 +13,7 @@ import copy
 import math
 from numbers import Real
 import re
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TypeGuard
 
 from local_media_contract import LocalMediaError
 
@@ -135,6 +135,11 @@ def validate_word_diagnostic(value: Any) -> dict:
     return diagnostic
 
 
+def _timestamp(value: Any) -> TypeGuard[float]:
+    """A real number that is not a bool. `bool` is a `Real`, so it needs naming."""
+    return isinstance(value, Real) and not isinstance(value, bool)
+
+
 def nonpositive_span_report(words: Any) -> dict:
     """Count words whose span is non-positive. Judges nothing; refuses nothing.
 
@@ -159,13 +164,13 @@ def nonpositive_span_report(words: Any) -> dict:
         if not isinstance(word, dict):
             continue
         begin, end = word.get("start_seconds"), word.get("end_seconds")
-        if (
-            isinstance(begin, Real)
-            and isinstance(end, Real)
-            and not isinstance(begin, bool)
-        ):
-            if end <= begin:
-                nonpositive.append(index)
+        # bool is a Real in Python, and guarding only `begin` let
+        # {"start_seconds": 1.0, "end_seconds": False} count as degenerate —
+        # inflating the very number this exists to measure.
+        if not _timestamp(begin) or not _timestamp(end):
+            continue
+        if end <= begin:
+            nonpositive.append(index)
     return {
         "schema_version": 1,
         "word_count": len(words),

--- a/skills/vault-profile/scripts/calibrate-speech.py
+++ b/skills/vault-profile/scripts/calibrate-speech.py
@@ -42,7 +42,7 @@ from local_media_contract import LocalMediaError  # noqa: E402
 from local_media_download import download_youtube_audio  # noqa: E402
 from local_media_evidence import probe_local_media  # noqa: E402
 from local_media_transcription import transcribe_local_words  # noqa: E402
-from local_media_words import WordSampleError  # noqa: E402
+from local_media_words import WordSampleError, WordSpanError  # noqa: E402
 from speech_calibration import calibrate  # noqa: E402
 from speech_cohort import plan_cohort, sample_window  # noqa: E402
 from speech_rates import SpeechRateError, encode  # noqa: E402
@@ -210,6 +210,20 @@ def execute(args: argparse.Namespace) -> dict:
                                 "schema_version": 1,
                                 "code": reason,
                                 "word_timing": exc.word_timing,
+                            }
+                        ),
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                if isinstance(exc, WordSpanError):
+                    # How widespread the defect is, so a cohort run reports
+                    # whether the all-or-nothing refusal is over-rejecting.
+                    print(
+                        json.dumps(
+                            {
+                                "schema_version": 1,
+                                "code": reason,
+                                "word_spans": exc.word_spans,
                             }
                         ),
                         file=sys.stderr,

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -1152,14 +1152,54 @@ def test_ambiguous_unavailability_is_never_called_removal(
         "ERROR: unable to download webpage: <urlopen error timed out>",
         "ERROR: HTTP Error 429: Too Many Requests",
         "ERROR: HTTP Error 503: Service Unavailable",
-        "ERROR: [youtube] Sign in to confirm you're not a bot",
         "cannot run yt-dlp: [Errno 60] Operation timed out",
         "ERROR: Connection reset by peer",
+        "ERROR: Temporary failure in name resolution",
     ],
 )
 def test_a_transient_message_is_retryable(audit_source_identities, message):
+    """The test is whether a plain retry can plausibly succeed."""
     result = audit_source_identities.classify_fetch_failure(message)
     assert result == {"failure_class": "transient", "retryable": True}
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "ERROR: unable to download webpage: HTTP Error 403: Forbidden",
+        "ERROR: unable to download webpage: <urlopen error [SSL: "
+        "CERTIFICATE_VERIFY_FAILED] certificate verify failed>",
+        "ERROR: unable to download webpage",
+        "ERROR: [youtube] Sign in to confirm you're not a bot",
+    ],
+)
+def test_a_generic_wrapper_is_not_evidence_of_a_transient_failure(
+    audit_source_identities, message
+):
+    """ "unable to download webpage" also wraps a 403, and "ssl" also wraps an
+    expired certificate; neither is fixed by trying again. A bot check needs
+    cookies, not a retry. Advising one would waste the operator's time exactly
+    as the PermissionError case did."""
+    result = audit_source_identities.classify_fetch_failure(message)
+    assert result == {"failure_class": "unclassified", "retryable": None}
+
+
+def test_a_specific_cause_inside_a_generic_wrapper_still_classifies(
+    audit_source_identities,
+):
+    """Dropping the wrapper must not lose the cases it legitimately carried."""
+    assert (
+        audit_source_identities.classify_fetch_failure(
+            "ERROR: unable to download webpage: <urlopen error timed out>"
+        )["failure_class"]
+        == "transient"
+    )
+    assert (
+        audit_source_identities.classify_fetch_failure(
+            "ERROR: unable to download webpage; This video has been removed"
+        )["failure_class"]
+        == "upstream_gone"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1216,16 +1256,6 @@ def test_matching_is_case_insensitive(audit_source_identities):
     )
 
 
-def test_a_stated_removal_over_a_flaky_connection_is_still_a_removal(
-    audit_source_identities,
-):
-    message = "ERROR: unable to download webpage; This video has been removed"
-    assert (
-        audit_source_identities.classify_fetch_failure(message)["failure_class"]
-        == "upstream_gone"
-    )
-
-
 def test_every_classification_carries_both_fields(audit_source_identities):
     for message in ("Private video", "timed out", "Permission denied", "mystery"):
         result = audit_source_identities.classify_fetch_failure(message)
@@ -1243,7 +1273,7 @@ def test_each_class_has_its_own_operator_message(audit_source_identities):
     "message,failure_class,retryable",
     [
         ("ERROR: [youtube] X: Private video", "upstream_gone", False),
-        ("ERROR: unable to download webpage", "transient", True),
+        ("ERROR: HTTP Error 503: Service Unavailable", "transient", True),
         ("cannot run yt-dlp: [Errno 13] Permission denied", "tooling", False),
         ("ERROR: brand new failure mode", "unclassified", None),
     ],

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -1102,3 +1102,132 @@ def test_bare_year_catalog_date_accepts_an_upload_within_that_year(
 
     assert "provider_upload_predates_catalog" not in finding_codes(report)
     assert report["talks"][0]["comparison"]["upload_predates_catalog_date"] is False
+
+
+# --- transient is not link rot (#429) ----------------------------------------
+#
+# yt-dlp reports "the video is gone" and "I could not reach YouTube just now"
+# through the same non-zero exit, so both arrived as one high-priority finding.
+# #429 was filed for two recordings on that basis; both resolve fine on a later
+# run. The operator's next action differs — decide about derived claims, or
+# retry — so the report has to distinguish them.
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "ERROR: [youtube] aBc: Video unavailable",
+        "ERROR: [youtube] aBc: This video is not available",
+        "ERROR: [youtube] aBc: This video has been removed by the uploader",
+        "ERROR: [youtube] aBc: Private video. Sign in if you have been granted access",
+        "The account associated with this video has been terminated",
+    ],
+)
+def test_an_upstream_gone_message_is_not_retryable(audit_source_identities, message):
+    result = audit_source_identities.classify_fetch_failure(message)
+    assert result == {"failure_class": "upstream_gone", "retryable": False}
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "ERROR: unable to download webpage: <urlopen error timed out>",
+        "ERROR: HTTP Error 429: Too Many Requests",
+        "ERROR: HTTP Error 503: Service Unavailable",
+        "ERROR: [youtube] Sign in to confirm you're not a bot",
+        "cannot run yt-dlp: [Errno 60] Operation timed out",
+        "ERROR: Connection reset by peer",
+    ],
+)
+def test_a_transient_message_is_retryable(audit_source_identities, message):
+    result = audit_source_identities.classify_fetch_failure(message)
+    assert result == {"failure_class": "transient", "retryable": True}
+
+
+@pytest.mark.parametrize("message", ["something new", "", None, 7, "ERROR:"])
+def test_an_unrecognised_message_is_never_guessed_into_a_bucket(
+    audit_source_identities, message
+):
+    """Guessing is what produced the wrong issue; unknown stays unknown."""
+    result = audit_source_identities.classify_fetch_failure(message)
+    assert result == {"failure_class": "unclassified", "retryable": None}
+
+
+def test_matching_is_case_insensitive(audit_source_identities):
+    assert (
+        audit_source_identities.classify_fetch_failure("VIDEO UNAVAILABLE")[
+            "failure_class"
+        ]
+        == "upstream_gone"
+    )
+
+
+def test_upstream_gone_is_checked_before_transient(audit_source_identities):
+    """A takedown notice served over a flaky connection is still a takedown."""
+    message = "ERROR: unable to download webpage; This video is not available"
+    assert (
+        audit_source_identities.classify_fetch_failure(message)["failure_class"]
+        == "upstream_gone"
+    )
+
+
+def test_every_classification_carries_both_fields(audit_source_identities):
+    for message in ("Video unavailable", "timed out", "mystery"):
+        result = audit_source_identities.classify_fetch_failure(message)
+        assert set(result) == {"failure_class", "retryable"}
+
+
+def test_each_class_has_its_own_operator_message(audit_source_identities):
+    messages = audit_source_identities.FETCH_FAILURE_MESSAGES
+    assert set(messages) == {"upstream_gone", "transient", "unclassified"}
+    assert len(set(messages.values())) == 3
+    assert "retry" in messages["transient"]
+
+
+@pytest.mark.parametrize(
+    "message,failure_class,retryable",
+    [
+        ("ERROR: [youtube] X: This video is not available", "upstream_gone", False),
+        ("ERROR: unable to download webpage", "transient", True),
+        ("ERROR: brand new failure mode", "unclassified", None),
+    ],
+)
+def test_a_fetch_failure_carries_its_class_into_the_report(
+    audit_source_identities, message, failure_class, retryable
+):
+    """The classification has to reach the operator, not just the helper."""
+
+    def failing_fetcher(video_id):
+        raise audit_source_identities.MetadataFetchError(message)
+
+    database = {"talks": [talk()]}
+    report, _calls = _audit(audit_source_identities, database, None, failing_fetcher)
+
+    finding = next(
+        item for item in report["findings"] if item["code"] == "metadata_fetch_failed"
+    )
+    assert finding["evidence"]["failure_class"] == failure_class
+    assert finding["evidence"]["retryable"] is retryable
+    assert finding["evidence"]["error"] == message
+
+    source = next(item for item in report["sources"] if item["fetch_status"] == "error")
+    assert source["failure_class"] == failure_class
+    assert source["retryable"] is retryable
+
+
+def test_a_transient_failure_reads_differently_from_link_rot(
+    audit_source_identities,
+):
+    """#429 was filed because these were indistinguishable in the output."""
+
+    def failing_fetcher(video_id):
+        raise audit_source_identities.MetadataFetchError("ERROR: HTTP Error 429")
+
+    report, _calls = _audit(
+        audit_source_identities, {"talks": [talk()]}, None, failing_fetcher
+    )
+    finding = next(
+        item for item in report["findings"] if item["code"] == "metadata_fetch_failed"
+    )
+    assert "retry" in finding["message"]
+    assert finding["evidence"]["retryable"] is True

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -1106,11 +1106,25 @@ def test_bare_year_catalog_date_accepts_an_upload_within_that_year(
 
 # --- transient is not link rot (#429) ----------------------------------------
 #
-# yt-dlp reports "the video is gone" and "I could not reach YouTube just now"
-# through the same non-zero exit, so both arrived as one high-priority finding.
-# #429 was filed for two recordings on that basis; both resolve fine on a later
-# run. The operator's next action differs — decide about derived claims, or
-# retry — so the report has to distinguish them.
+# yt-dlp reports "the video is gone", "I could not reach YouTube", and "I could
+# not run at all" through the same non-zero exit, so all three arrived as one
+# high-priority finding. #429 was filed for two recordings on that basis; both
+# resolve fine. The operator's next action differs in each case.
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "ERROR: [youtube] aBc: This video has been removed by the uploader",
+        "ERROR: [youtube] aBc: Private video. Sign in if you have been granted access",
+        "This video is private",
+        "The account associated with this video has been terminated",
+        "removed for violating YouTube's Terms of Service",
+    ],
+)
+def test_a_stated_removal_is_not_retryable(audit_source_identities, message):
+    result = audit_source_identities.classify_fetch_failure(message)
+    assert result == {"failure_class": "upstream_gone", "retryable": False}
 
 
 @pytest.mark.parametrize(
@@ -1118,14 +1132,18 @@ def test_bare_year_catalog_date_accepts_an_upload_within_that_year(
     [
         "ERROR: [youtube] aBc: Video unavailable",
         "ERROR: [youtube] aBc: This video is not available",
-        "ERROR: [youtube] aBc: This video has been removed by the uploader",
-        "ERROR: [youtube] aBc: Private video. Sign in if you have been granted access",
-        "The account associated with this video has been terminated",
+        "Video unavailable. This video is not available in your country",
     ],
 )
-def test_an_upstream_gone_message_is_not_retryable(audit_source_identities, message):
+def test_ambiguous_unavailability_is_never_called_removal(
+    audit_source_identities, message
+):
+    """yt-dlp says "not available" for geographic restriction too, which
+    establishes nothing about whether the recording still exists. This is the
+    exact message that misled #429 into being filed as link rot."""
     result = audit_source_identities.classify_fetch_failure(message)
-    assert result == {"failure_class": "upstream_gone", "retryable": False}
+    assert result["failure_class"] == "unclassified"
+    assert result["retryable"] is None
 
 
 @pytest.mark.parametrize(
@@ -1144,6 +1162,44 @@ def test_a_transient_message_is_retryable(audit_source_identities, message):
     assert result == {"failure_class": "transient", "retryable": True}
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        "cannot run yt-dlp: [Errno 13] Permission denied",
+        "cannot run yt-dlp: [Errno 2] No such file or directory",
+        "cannot run yt-dlp: [Errno 8] Exec format error",
+        "cannot run yt-dlp: [Errno 21] Is a directory",
+    ],
+)
+def test_a_tooling_failure_asks_for_repair_not_a_retry(
+    audit_source_identities, message
+):
+    """Every OSError reached the same wrapper, so a PermissionError was being
+    reported as transient — telling the operator to retry something that will
+    fail identically every time."""
+    result = audit_source_identities.classify_fetch_failure(message)
+    assert result == {"failure_class": "tooling", "retryable": False}
+    assert "repair" in audit_source_identities.FETCH_FAILURE_MESSAGES["tooling"]
+
+
+def test_a_timeout_inside_the_run_wrapper_is_still_transient(
+    audit_source_identities,
+):
+    """Both reach `cannot run yt-dlp`; only the errno separates them."""
+    assert (
+        audit_source_identities.classify_fetch_failure(
+            "cannot run yt-dlp: [Errno 60] Operation timed out"
+        )["failure_class"]
+        == "transient"
+    )
+    assert (
+        audit_source_identities.classify_fetch_failure(
+            "cannot run yt-dlp: [Errno 13] Permission denied"
+        )["failure_class"]
+        == "tooling"
+    )
+
+
 @pytest.mark.parametrize("message", ["something new", "", None, 7, "ERROR:"])
 def test_an_unrecognised_message_is_never_guessed_into_a_bucket(
     audit_source_identities, message
@@ -1155,16 +1211,15 @@ def test_an_unrecognised_message_is_never_guessed_into_a_bucket(
 
 def test_matching_is_case_insensitive(audit_source_identities):
     assert (
-        audit_source_identities.classify_fetch_failure("VIDEO UNAVAILABLE")[
-            "failure_class"
-        ]
+        audit_source_identities.classify_fetch_failure("PRIVATE VIDEO")["failure_class"]
         == "upstream_gone"
     )
 
 
-def test_upstream_gone_is_checked_before_transient(audit_source_identities):
-    """A takedown notice served over a flaky connection is still a takedown."""
-    message = "ERROR: unable to download webpage; This video is not available"
+def test_a_stated_removal_over_a_flaky_connection_is_still_a_removal(
+    audit_source_identities,
+):
+    message = "ERROR: unable to download webpage; This video has been removed"
     assert (
         audit_source_identities.classify_fetch_failure(message)["failure_class"]
         == "upstream_gone"
@@ -1172,23 +1227,24 @@ def test_upstream_gone_is_checked_before_transient(audit_source_identities):
 
 
 def test_every_classification_carries_both_fields(audit_source_identities):
-    for message in ("Video unavailable", "timed out", "mystery"):
+    for message in ("Private video", "timed out", "Permission denied", "mystery"):
         result = audit_source_identities.classify_fetch_failure(message)
         assert set(result) == {"failure_class", "retryable"}
 
 
 def test_each_class_has_its_own_operator_message(audit_source_identities):
     messages = audit_source_identities.FETCH_FAILURE_MESSAGES
-    assert set(messages) == {"upstream_gone", "transient", "unclassified"}
-    assert len(set(messages.values())) == 3
+    assert set(messages) == {"upstream_gone", "transient", "tooling", "unclassified"}
+    assert len(set(messages.values())) == 4
     assert "retry" in messages["transient"]
 
 
 @pytest.mark.parametrize(
     "message,failure_class,retryable",
     [
-        ("ERROR: [youtube] X: This video is not available", "upstream_gone", False),
+        ("ERROR: [youtube] X: Private video", "upstream_gone", False),
         ("ERROR: unable to download webpage", "transient", True),
+        ("cannot run yt-dlp: [Errno 13] Permission denied", "tooling", False),
         ("ERROR: brand new failure mode", "unclassified", None),
     ],
 )
@@ -1200,8 +1256,9 @@ def test_a_fetch_failure_carries_its_class_into_the_report(
     def failing_fetcher(video_id):
         raise audit_source_identities.MetadataFetchError(message)
 
-    database = {"talks": [talk()]}
-    report, _calls = _audit(audit_source_identities, database, None, failing_fetcher)
+    report, _calls = _audit(
+        audit_source_identities, {"talks": [talk()]}, None, failing_fetcher
+    )
 
     finding = next(
         item for item in report["findings"] if item["code"] == "metadata_fetch_failed"
@@ -1209,25 +1266,11 @@ def test_a_fetch_failure_carries_its_class_into_the_report(
     assert finding["evidence"]["failure_class"] == failure_class
     assert finding["evidence"]["retryable"] is retryable
     assert finding["evidence"]["error"] == message
+    assert (
+        finding["message"]
+        == audit_source_identities.FETCH_FAILURE_MESSAGES[failure_class]
+    )
 
     source = next(item for item in report["sources"] if item["fetch_status"] == "error")
     assert source["failure_class"] == failure_class
     assert source["retryable"] is retryable
-
-
-def test_a_transient_failure_reads_differently_from_link_rot(
-    audit_source_identities,
-):
-    """#429 was filed because these were indistinguishable in the output."""
-
-    def failing_fetcher(video_id):
-        raise audit_source_identities.MetadataFetchError("ERROR: HTTP Error 429")
-
-    report, _calls = _audit(
-        audit_source_identities, {"talks": [talk()]}, None, failing_fetcher
-    )
-    finding = next(
-        item for item in report["findings"] if item["code"] == "metadata_fetch_failed"
-    )
-    assert "retry" in finding["message"]
-    assert finding["evidence"]["retryable"] is True

--- a/tests/test_local_media_words.py
+++ b/tests/test_local_media_words.py
@@ -266,3 +266,102 @@ def test_word_cannot_borrow_another_segments_quality_metadata(words):
     receipt["words"][1]["segment_index"] = 0
     with pytest.raises(words.WordSampleError):
         words.validate_word_sample(receipt)
+
+
+# --- degenerate-span instrumentation (#431) ----------------------------------
+#
+# A single word with end == start refuses the whole ten-minute sample, which
+# excluded 11 of 24 recordings in the last cohort run. Whether that is
+# over-rejection or a genuine alignment guard depends on how many degenerate
+# words a failing sample carries — and nothing measured it. The refusal is
+# unchanged here; only the receipt is richer.
+
+
+def _spans(pairs):
+    return [
+        {
+            "text": f"w{i}",
+            "start_seconds": begin,
+            "end_seconds": end,
+            "probability": 0.9,
+            "segment_index": 0,
+        }
+        for i, (begin, end) in enumerate(pairs)
+    ]
+
+
+def test_a_clean_sample_reports_no_degenerate_spans(words):
+    assert words.nonpositive_span_report(_spans([(0.0, 0.5), (0.5, 1.0)])) == {
+        "schema_version": 1,
+        "word_count": 2,
+        "nonpositive_count": 0,
+        "first_index": None,
+    }
+
+
+def test_the_report_counts_every_degenerate_span_not_just_the_first(words):
+    """One versus many is the entire question #431 asks."""
+    report = words.nonpositive_span_report(
+        _spans([(0.0, 0.5), (0.5, 0.5), (0.6, 1.0), (1.0, 1.0), (1.2, 1.1)])
+    )
+    assert report["word_count"] == 5
+    assert report["nonpositive_count"] == 3
+    assert report["first_index"] == 1
+
+
+def test_the_report_judges_nothing_and_refuses_nothing(words):
+    """A measurement; admission is decided elsewhere and is unchanged."""
+    assert words.nonpositive_span_report(_spans([(1.0, 1.0)]))["nonpositive_count"] == 1
+
+
+@pytest.mark.parametrize("garbage", [None, "words", 7, {}])
+def test_the_report_survives_a_non_list(words, garbage):
+    report = words.nonpositive_span_report(garbage)
+    assert report["word_count"] == 0 and report["nonpositive_count"] == 0
+
+
+def test_the_report_skips_entries_it_cannot_read(words):
+    """Malformed entries count toward the total but never as degenerate, so the
+    share is not inflated by unrelated corruption."""
+    report = words.nonpositive_span_report(
+        [{"start_seconds": 0.0, "end_seconds": 0.0}, "not-a-word", {"no": "spans"}]
+    )
+    assert report["word_count"] == 3
+    assert report["nonpositive_count"] == 1
+
+
+def test_a_boolean_is_not_a_timestamp(words):
+    report = words.nonpositive_span_report(
+        [{"start_seconds": True, "end_seconds": True}]
+    )
+    assert report["nonpositive_count"] == 0
+
+
+def test_the_refusal_now_carries_how_widespread_the_defect_is(words):
+    """Same verdict as before; the receipt says one word or half of them."""
+    result = normalized(words)
+    result["words"][0]["end_seconds"] = result["words"][0]["start_seconds"]
+    with pytest.raises(words.WordSpanError) as exc:
+        words.validate_word_sample(result)
+    assert exc.value.reason_code == "whisper_word_sample_invalid_word_nonpositive_span"
+    assert exc.value.word_spans["nonpositive_count"] == 1
+    assert exc.value.word_spans["word_count"] == len(result["words"])
+    assert exc.value.word_spans["first_index"] == 0
+    assert "First" not in str(exc.value)
+
+
+def test_the_span_error_is_still_a_local_media_error(words):
+    """Callers catching LocalMediaError are unaffected by the new type."""
+    assert issubclass(words.WordSpanError, words.LocalMediaError)
+
+
+def test_the_span_report_is_copied_not_aliased(words):
+    report = {
+        "schema_version": 1,
+        "word_count": 2,
+        "nonpositive_count": 1,
+        "first_index": 0,
+    }
+    error = words.WordSpanError(report)
+    report["nonpositive_count"] = 999
+    assert error.word_spans["nonpositive_count"] == 1

--- a/tests/test_local_media_words.py
+++ b/tests/test_local_media_words.py
@@ -330,13 +330,6 @@ def test_the_report_skips_entries_it_cannot_read(words):
     assert report["nonpositive_count"] == 1
 
 
-def test_a_boolean_is_not_a_timestamp(words):
-    report = words.nonpositive_span_report(
-        [{"start_seconds": True, "end_seconds": True}]
-    )
-    assert report["nonpositive_count"] == 0
-
-
 def test_the_refusal_now_carries_how_widespread_the_defect_is(words):
     """Same verdict as before; the receipt says one word or half of them."""
     result = normalized(words)
@@ -365,3 +358,17 @@ def test_the_span_report_is_copied_not_aliased(words):
     error = words.WordSpanError(report)
     report["nonpositive_count"] = 999
     assert error.word_spans["nonpositive_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "word",
+    [
+        {"start_seconds": 1.0, "end_seconds": False},
+        {"start_seconds": True, "end_seconds": 2.0},
+        {"start_seconds": True, "end_seconds": False},
+    ],
+)
+def test_a_boolean_endpoint_never_counts_as_degenerate(words, word):
+    """bool is a Real, and guarding only `begin` let start=1.0/end=False count —
+    inflating the very number this exists to measure."""
+    assert words.nonpositive_span_report([word])["nonpositive_count"] == 0


### PR DESCRIPTION
Closes #429. Instruments #431.

Two places where the evidence layer under-reported what it had seen. Both are reporting changes — **no admission or verdict behaviour changes in either.**

## #429 — a transient minute was filed as link rot

`audit-source-identities.py` surfaced every yt-dlp failure as one `metadata_fetch_failed` at high priority, so *"the provider no longer serves this recording"* and *"I could not reach YouTube just now"* were indistinguishable in the output.

I filed #429 on that basis for two recordings. Re-checking them:

```
P01v0-2Dtzo    DevOps Patterns and AntiPatterns for Continuous Software Updates
wDKzRI8bT6Y    Codepocalypse Now Lang Chain4j vs Spring Al
```

Both resolve fine. They were transient failures, and the issue's own first acceptance criterion — *"confirmed genuinely gone (not a transient fetch failure or a region block)"* — is answered: they are not gone. **So #429's real defect was never two dead videos; it was that the audit could not tell the two apart**, which is its third criterion.

Findings now carry `failure_class` (`upstream_gone` / `transient` / `unclassified`) and `retryable`, matched case-insensitively against an enumerated set of yt-dlp signatures, with a distinct operator message per class. Upstream-gone is checked before transient, so a takedown served over a flaky connection is still a takedown.

An unrecognised message stays **`unclassified` with `retryable: null`** — never sorted into a bucket. Guessing is what produced the wrong issue.

## #431 — instrumenting before choosing a threshold

`local_media_words.py` refuses a whole ten-minute sample on the first word with `end == start`. That excluded **11 of 24 recordings** in the last cohort run and is why the speaker profile sits at `low_confidence`.

Whether that is over-rejection or a genuine alignment guard depends on how many degenerate words a failing sample carries — and nothing measured it. The stored `.segments.json` artifacts keep only segment-level `start_seconds`/`end_seconds`/`text`; **no word-level data is retained**, so the count has to come off the sample while it is in hand.

**The refusal is deliberately unchanged.** `WordSpanError` carries a bounded, numeric-only report — `word_count`, `nonpositive_count`, `first_index`, never token text, matching the privacy contract `LocalMediaError` states — and `calibrate-speech.py` emits it alongside the existing `word_timing` diagnostic. A cohort run now reports whether the rule rejects one bad word or half of them.

That is the measurement #431 asks for *before* the admission rule changes. Picking a threshold first would be choosing a number blind.

Two design notes:
- `WordSpanError` is a **new** shape, not a version bump of `validate_word_diagnostic` — which requires `end > begin` and so structurally cannot describe a degenerate span. Nothing consumes the new shape yet, so nothing breaks.
- The scan runs only once a degenerate span is reached, so which fault fires first is unchanged; an earlier word with a different defect still refuses first.

## Test plan

- [x] Full suite: **8006 passed**, 8 skipped
- [x] Classification over real yt-dlp messages: unavailable, private, terminated, 429, 503, bot-check, timeout, and unknown
- [x] Integration: the class reaches both the finding's evidence and the source record, not just the helper
- [x] Span report: counts *every* degenerate span not just the first; survives non-lists and malformed entries; a `bool` is not a timestamp
- [x] The existing `("zero", "whisper_word_sample_invalid_word_nonpositive_span")` case still passes — the verdict is unchanged
- [x] ruff check + format clean, pyright 0 errors, packaging gate ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV