### PR TITLE
fix(screencast-recorder): a missing database path is a wrong path, not a structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### A wrong path reads as a wrong path
+
+`resolve-interpreter.py` decided between "vault root" and "database path" with
+`Path.is_file()` alone, so a path that *was* the intended database but did not
+exist took the vault-root branch and had the filename appended a second time:
+
+```
+ERROR: no tracking-database.json at /vault/tracking-database.json/tracking-database.json
+```
+
+A typo therefore looked like a structural problem, which is the opposite of what
+an actionable diagnostic should do. The name is checked before existence now,
+both accepted call shapes still work, and the reported path is the one the caller
+actually named.
+
+
 ## 0.20.138 — 2026-09-07
 
 ### A recorded demo can now be judged instead of trusted

--- a/skills/screencast-recorder/scripts/resolve-interpreter.py
+++ b/skills/screencast-recorder/scripts/resolve-interpreter.py
@@ -30,7 +30,16 @@ REPAIR = "run vault-ingress Step 1 to repair the configuration"
 
 
 def locate_database(target: Path) -> Path:
-    """The database itself, or the one inside a vault root."""
+    """The database itself, or the one inside a vault root.
+
+    Decided by name before existence. Falling back on `is_file()` alone meant a
+    database path that was simply missing took the vault-root branch and had the
+    filename appended a second time, so a typo reported
+    `.../tracking-database.json/tracking-database.json` and read as a structural
+    problem rather than a wrong path.
+    """
+    if target.name == DATABASE_NAME:
+        return target
     return target if target.is_file() else target / DATABASE_NAME
 
 

--- a/tests/test_resolve_interpreter.py
+++ b/tests/test_resolve_interpreter.py
@@ -121,3 +121,53 @@ def test_valid_json_that_is_not_an_object_is_refused(
     (tmp_path / "tracking-database.json").write_text(document, encoding="utf-8")
     with pytest.raises(ValueError, match="must contain a JSON object"):
         resolve_interpreter.resolve(tmp_path)
+
+
+# --- a missing database path is a wrong path, not a structure (#433) ---------
+
+
+def test_a_missing_database_path_is_reported_once_not_doubled(
+    resolve_interpreter, tmp_path
+):
+    """`is_file()` alone sent a missing database down the vault-root branch,
+    so the filename was appended again and a typo looked structural."""
+    missing = tmp_path / "tracking-database.json"
+    with pytest.raises(ValueError) as excinfo:
+        resolve_interpreter.resolve(missing)
+    message = str(excinfo.value)
+    assert message.count("tracking-database.json") == 2  # the name, and the path once
+    assert "tracking-database.json/tracking-database.json" not in message
+    assert str(missing) in message
+
+
+def test_a_named_database_path_is_never_treated_as_a_directory(
+    resolve_interpreter, tmp_path
+):
+    nested = tmp_path / "deep" / "tracking-database.json"
+    assert resolve_interpreter.locate_database(nested) == nested
+
+
+def test_a_vault_root_still_gets_the_filename_appended(resolve_interpreter, tmp_path):
+    assert (
+        resolve_interpreter.locate_database(tmp_path)
+        == tmp_path / "tracking-database.json"
+    )
+
+
+def test_an_existing_database_under_another_name_is_still_accepted(
+    resolve_interpreter, tmp_path
+):
+    """The caller may point at a copy; existence still decides for other names."""
+    other = tmp_path / "snapshot.json"
+    other.write_text("{}", encoding="utf-8")
+    assert resolve_interpreter.locate_database(other) == other
+
+
+def test_a_missing_path_under_another_name_still_reads_as_a_vault_root(
+    resolve_interpreter, tmp_path
+):
+    missing = tmp_path / "not-a-vault"
+    assert (
+        resolve_interpreter.locate_database(missing)
+        == missing / "tracking-database.json"
+    )


### PR DESCRIPTION
Closes #433.

`locate_database()` decided between "vault root" and "database path" with `Path.is_file()` alone, so a path that *was* the intended database but did not exist took the vault-root branch and had the filename appended a second time:

```
ERROR: no tracking-database.json at /vault/tracking-database.json/tracking-database.json
```

A typo therefore read as a structural problem — the opposite of what an actionable diagnostic should do, in a script whose whole job is producing one.

The name is checked before existence now. Both accepted call shapes still work, and the reported path is the one the caller actually named:

```
ERROR: no tracking-database.json at /tmp/nope/tracking-database.json — pass a vault root or the database path
```

One deliberate detail: only the exact `tracking-database.json` basename short-circuits. A path under any other name still falls through to the existence check, so pointing at an existing copy under a different filename keeps working, and a missing path under another name still reads as a vault root.

## Test plan

- [x] Full suite: **7975 passed**, 8 skipped
- [x] The doubled-path message is asserted absent, and the named path asserted present
- [x] Both call shapes: a vault root still gets the filename appended; a named database path is never treated as a directory
- [x] The other-name cases both ways — existing file accepted, missing path still reads as a root
- [x] ruff clean, pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV