### PR TITLE
fix(vault-ingress): tell an upstream loss from a fetch failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ __pycache__/
 *.pyc
 .pytest_cache/
 *.egg-info/
-.venv/
+# Trailing slash alone misses a worktree's symlink to a shared interpreter.
+.venv
 /skills/illustrations/scripts/codex-cli/node_modules/
 
 # OS metadata. `tessl plugin pack` reads the working tree, not the git index, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+### An upstream loss is not a fetch failure
+
+`audit-source-identities.py` filed every refused `yt-dlp` fetch as
+`metadata_fetch_failed` at `review_priority: high`, blocking the audit. Two
+catalogued recordings — `P01v0-2Dtzo` (NashDevOps 2020) and `wDKzRI8bT6Y`
+(DevFest Toulouse 2025) — are gone from YouTube, so those two findings re-read as
+fresh high-priority fetch errors on every run and could never clear.
+
+Refusals are classified now. `classify_fetch_failure` separates a provider
+verdict that the recording itself is gone (`source_unavailable_upstream`,
+non-blocking, `retryable: false`, `fetch_status: "unavailable"`, counted by the
+new `metadata_unavailable_count`) from every retryable refusal, which keeps
+`metadata_fetch_failed`.
+
+Access restrictions are tested first and outrank every unavailability signature.
+The region block is the case that forces the precedence: `This video is not
+available in your country` contains an unavailability signature verbatim, and the
+recording still exists for a viewer the provider will serve. Geo blocks, age
+gates, bot checks, members-only content and private videos therefore stay
+retryable rather than being filed as link rot.
+
+Both recordings were confirmed gone, not transiently unfetchable: a control fetch
+against a known-good ID succeeded in the same session, and `--geo-bypass-country`
+probes through US, NO and FR returned the identical message.
+
+The reference now records the decision the issue asked for: an unavailable source
+does not retract a claim already derived from it. Derived artifacts stand on their
+own receipts — the local artifact's digest, and the provider evidence captured at
+`captured_at` — neither of which is a live re-read. What is lost is forward
+capability: re-verification, re-download, and fresh extraction. `P01v0-2Dtzo` has
+a local archived copy and keeps all three; `wDKzRI8bT6Y` has only its transcripts,
+which are now the sole remaining record.
+
+Report contract v3. Closes #429.
+
 ## 0.20.139 — 2026-09-07
 
 ### A wrong path reads as a wrong path

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -119,11 +119,11 @@ identity without rejecting it or replacing the canonical recording.
 An owner-approved official-upload switch uses the separate atomic promotion
 contract in that reference, not a repair followed by an alias append.
 
-## Report contract (v2)
+## Report contract (v3)
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "captured_at": "2026-07-31T19:00:00Z",
   "database": "/vault/tracking-database.json",
   "complete": true,
@@ -132,6 +132,7 @@ contract in that reference, not a repair followed by an alias append.
   "unique_youtube_id_count": 1,
   "metadata_fetch_count": 1,
   "metadata_fetch_error_count": 0,
+  "metadata_unavailable_count": 0,
   "candidate_count": 1,
   "summary": {
     "finding_count": 1,
@@ -145,8 +146,10 @@ contract in that reference, not a repair followed by an alias append.
 
 `sources` contains one record per fetched ID, with the sorted talk indexes and
 filenames that caused the fetch, `fetch_status`, provider evidence, and any
-error. `talks` contains one record per active URL, its catalog comparison, and
-the proposed evidence. `findings` and `summary.by_code` are sorted; with the same
+error. `fetch_status` is `ok`, `error`, `invalid`, or `unavailable`.
+`metadata_fetch_error_count` counts every status but `ok` and `unavailable`;
+`metadata_unavailable_count` counts `unavailable` alone. `talks` contains one
+record per active URL, its catalog comparison, and the proposed evidence. `findings` and `summary.by_code` are sorted; with the same
 database, provider responses, and `captured_at`, the decoded JSON is identical.
 
 Stable finding codes:
@@ -156,7 +159,8 @@ Stable finding codes:
 | `active_youtube_url_invalid` | An active YouTube-looking URL has no valid ID |
 | `active_video_provider_unsupported` | Active URL is not a supported YouTube source; no fetch occurred |
 | `stored_youtube_id_mismatch` | URL identity disagrees with stored `youtube_id` |
-| `metadata_fetch_failed` | `yt-dlp` was missing, timed out, failed, or returned unusable JSON |
+| `metadata_fetch_failed` | `yt-dlp` was missing, timed out, failed, returned unusable JSON, or was refused access; retryable |
+| `source_unavailable_upstream` | The provider reports the recording itself is gone; not retryable and not blocking |
 | `provider_video_id_mismatch` | Returned provider ID differs from the requested ID; no proposal is emitted |
 | `provider_webpage_identity_mismatch` | Returned webpage names another ID; no proposal is emitted |
 | `provider_metadata_incomplete` | A stable capture field is absent/invalid |
@@ -167,6 +171,38 @@ Stable finding codes:
 | `stored_source_identity_differs` | Fresh stable facts differ from an existing evidence block |
 | `likely_non_delivery_clip` | Conservative title/duration signals suggest a demo, teaser, excerpt, or other non-delivery artifact |
 | `same_id_cross_talk_collision` | One ID is active on records with materially different titles or delivery dates |
+
+## Upstream Loss Versus Fetch Failure
+
+A refused fetch is classified before it becomes a finding. `classify_fetch_failure`
+owns the decision; its two signature tables and their precedence are named at the
+top of `skills/vault-ingress/scripts/audit-source-identities.py`.
+
+An access restriction always outranks an unavailability signature. A region block
+reads `This video is not available in your country`, which contains an
+unavailability signature verbatim, and the recording still exists for a viewer the
+provider will serve. Precedence, not the signature list, is what keeps a
+geo-blocked, age-gated, bot-checked, members-only or private recording out of the
+link-rot bucket.
+
+`source_unavailable_upstream` is absent from `ERROR_CODES`, so an upstream loss
+never sets `complete: false`. Recording it as a distinct code and status is what
+stops a permanent loss from re-reading as a fresh high-priority fetch error on
+every later run. Each finding carries `evidence.retryable`.
+
+### Derived claims survive the source
+
+An unavailable source does not retract a claim already derived from it. Every
+derived artifact stands on its own receipts — the local artifact's own digest,
+and the provider evidence captured at the time of capture with its `captured_at`.
+Neither is a live re-read of the provider, so neither weakens when the provider
+stops serving the recording.
+
+What is lost is forward capability, not past evidence: no re-verification against
+the provider, no re-download, and no fresh extraction for a recording held only
+upstream. A locally archived copy restores all three; without one, the derived
+artifacts are the only remaining record and must not be discarded to force a
+re-fetch.
 
 Title and explicit-event comparison are separate: an abbreviated title cannot
 waive a delivery's event identity. Their matching contract is owned by

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -46,7 +46,7 @@ from tracking_database_io import (
 from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
 
 
-REPORT_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 3
 SOURCE_IDENTITY_SCHEMA_VERSION = 1
 
 # Candidate mode reads scan-shownotes.py conflict entries. Only the video lane
@@ -74,6 +74,7 @@ NO_CANDIDATE_REPORT = object()
 # blocking code. Codes here are deliberately absent from ERROR_CODES.
 CANDIDATE_LANE_LOCAL_CODES = {
     "metadata_fetch_failed": "candidate_metadata_fetch_failed",
+    "source_unavailable_upstream": "candidate_source_unavailable_upstream",
     "provider_metadata_incomplete": "candidate_provider_metadata_incomplete",
     "provider_video_id_mismatch": "candidate_provider_video_id_mismatch",
     "provider_webpage_identity_mismatch": (
@@ -85,6 +86,52 @@ CANDIDATE_CONFLICT_CODES = {
     "existing_slides_url_conflict": "slides_url",
 }
 YT_DLP_TIMEOUT_SECONDS = 60
+
+# yt-dlp verdicts that the recording itself is gone from the provider. These are
+# durable: the same fetch returns the same verdict on every later run, so the
+# finding is link rot to record once, not a fetch defect to retry.
+UPSTREAM_UNAVAILABLE_SIGNATURES = (
+    "video unavailable",
+    "this video is not available",
+    "this video is no longer available",
+    "this video is unavailable",
+    "this video has been removed",
+    "removed by the uploader",
+    "has been terminated",
+    "the uploader has closed their youtube account",
+    "video has been deleted",
+    "incomplete youtube id",
+    "does not exist",
+)
+
+# Access restrictions checked FIRST and winning over every signature above: the
+# recording still exists for a viewer the provider will serve, so a refusal here
+# is retryable and must never be recorded as gone. The overlap is real -- "this
+# video is not available in your country" contains an unavailable signature
+# verbatim -- so precedence, not the signature list, is what keeps a region
+# block from being filed as link rot.
+PROVIDER_ACCESS_RESTRICTION_SIGNATURES = (
+    "this video is private",
+    "private video",
+    "in your country",
+    "in your location",
+    "geo restricted",
+    "geo-restricted",
+    "geo blocked",
+    "sign in to confirm your age",
+    "age-restricted",
+    "age restricted",
+    "confirm you're not a bot",
+    "confirm you are not a bot",
+    "sign in to confirm",
+    "sign in if you've been granted access",
+    "members-only",
+    "join this channel",
+    "http error 429",
+    "too many requests",
+    "temporarily unavailable",
+    "try again later",
+)
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 CLIP_MARKERS = frozenset(
     {
@@ -125,6 +172,23 @@ class MetadataFetchError(RuntimeError):
 
 def _nonempty(value: Any) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def classify_fetch_failure(message: Any) -> str:
+    """Tell an upstream recording that is gone from a fetch that merely failed.
+
+    Returns ``source_unavailable_upstream`` only when the provider affirmatively
+    reports the recording no longer exists, and ``metadata_fetch_failed`` for
+    everything else: transport faults, timeouts, a missing yt-dlp, unusable JSON,
+    and every access restriction. Restrictions are tested first so a message that
+    carries both shapes is retryable, never recorded as gone.
+    """
+    text = " ".join(str(message).lower().split()) if message is not None else ""
+    if any(mark in text for mark in PROVIDER_ACCESS_RESTRICTION_SIGNATURES):
+        return "metadata_fetch_failed"
+    if any(mark in text for mark in UPSTREAM_UNAVAILABLE_SIGNATURES):
+        return "source_unavailable_upstream"
+    return "metadata_fetch_failed"
 
 
 def parse_youtube_id(value: Any) -> str | None:
@@ -905,17 +969,23 @@ def audit_database(
             if not isinstance(raw_metadata, dict):
                 raise MetadataFetchError("metadata fetcher returned a non-object")
         except (MetadataFetchError, OSError, RuntimeError) as exc:
-            source["fetch_status"] = "error"
+            classified = classify_fetch_failure(exc)
+            gone = classified == "source_unavailable_upstream"
+            source["fetch_status"] = "unavailable" if gone else "error"
             source["error"] = str(exc)
-            failure_code = lane_code("metadata_fetch_failed")
+            failure_code = lane_code(classified)
             findings.append(
                 _finding(
                     failure_code,
                     video_id,
                     indexes,
                     filenames,
-                    "yt-dlp metadata capture failed",
-                    {"error": str(exc)},
+                    (
+                        "provider reports the recording is no longer available"
+                        if gone
+                        else "yt-dlp metadata capture failed"
+                    ),
+                    {"error": str(exc), "retryable": not gone},
                     "high" if failure_code in ERROR_CODES else "medium",
                 )
             )
@@ -1179,7 +1249,12 @@ def audit_database(
     talk_audits.sort(key=lambda item: (item["talk_index"], item["filename"]))
     sources.sort(key=lambda item: item["video_id"])
     by_code = Counter(item["code"] for item in findings)
-    fetch_errors = sum(1 for item in sources if item["fetch_status"] != "ok")
+    # "unavailable" leaves this count so a permanent upstream loss stops reading
+    # as a fresh fetch error every run; "invalid" stays in it, as before.
+    unavailable = sum(1 for item in sources if item["fetch_status"] == "unavailable")
+    fetch_errors = sum(
+        1 for item in sources if item["fetch_status"] not in ("ok", "unavailable")
+    )
     complete = not any(item["code"] in ERROR_CODES for item in findings)
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -1191,6 +1266,7 @@ def audit_database(
         "unique_youtube_id_count": len(groups),
         "metadata_fetch_count": len(set(groups) | set(candidate_members)),
         "metadata_fetch_error_count": fetch_errors,
+        "metadata_unavailable_count": unavailable,
         "summary": {
             "finding_count": len(findings),
             "by_code": {key: by_code[key] for key in sorted(by_code)},

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -1102,3 +1102,118 @@ def test_bare_year_catalog_date_accepts_an_upload_within_that_year(
 
     assert "provider_upload_predates_catalog" not in finding_codes(report)
     assert report["talks"][0]["comparison"]["upload_predates_catalog_date"] is False
+
+
+@pytest.mark.parametrize(
+    ("message", "code"),
+    [
+        # The two live findings that opened #429, verbatim from yt-dlp.
+        (
+            "ERROR: [youtube] P01v0-2Dtzo: This video is not available",
+            "source_unavailable_upstream",
+        ),
+        (
+            "ERROR: [youtube] wDKzRI8bT6Y: This video is not available",
+            "source_unavailable_upstream",
+        ),
+        ("Video unavailable", "source_unavailable_upstream"),
+        (
+            "This video has been removed by the uploader",
+            "source_unavailable_upstream",
+        ),
+        # Private is an access state, not a deletion: the recording still exists
+        # for a viewer the provider will serve.
+        (
+            "Private video. Sign in if you've been granted access",
+            "metadata_fetch_failed",
+        ),
+        ("This video is private", "metadata_fetch_failed"),
+        (
+            "This video is no longer available because the YouTube account "
+            "associated with this video has been terminated.",
+            "source_unavailable_upstream",
+        ),
+        # Access restrictions: the recording still exists for some viewer, so the
+        # fetch stays retryable. The region block is the load-bearing case — its
+        # message contains an unavailable signature verbatim.
+        (
+            "This video is not available in your country",
+            "metadata_fetch_failed",
+        ),
+        (
+            "Video unavailable. The uploader has not made this video available "
+            "in your country",
+            "metadata_fetch_failed",
+        ),
+        ("Sign in to confirm your age", "metadata_fetch_failed"),
+        ("Sign in to confirm you're not a bot", "metadata_fetch_failed"),
+        (
+            "Join this channel to get access to members-only content",
+            "metadata_fetch_failed",
+        ),
+        # Transport and tooling faults carry no provider verdict at all.
+        ("cannot run yt-dlp: timed out after 60s", "metadata_fetch_failed"),
+        ("yt-dlp did not return valid JSON", "metadata_fetch_failed"),
+        ("HTTP Error 429: Too Many Requests", "metadata_fetch_failed"),
+        ("", "metadata_fetch_failed"),
+        (None, "metadata_fetch_failed"),
+    ],
+)
+def test_classify_fetch_failure_separates_gone_from_merely_failed(
+    audit_source_identities, message, code
+):
+    """#429 acceptance 3: an upstream loss is not a fetch failure."""
+    assert audit_source_identities.classify_fetch_failure(message) == code
+
+
+def test_upstream_loss_is_recorded_without_failing_the_audit(audit_source_identities):
+    """A recording YouTube no longer serves is link rot, not an audit defect."""
+    database = {"talks": [talk()]}
+
+    def fetcher(video_id):
+        raise audit_source_identities.MetadataFetchError(
+            f"ERROR: [youtube] {video_id}: This video is not available"
+        )
+
+    report, _calls = _audit(
+        audit_source_identities,
+        database,
+        audit_source_identities.NO_CANDIDATE_REPORT,
+        fetcher,
+    )
+
+    assert finding_codes(report) == ["source_unavailable_upstream"]
+    finding = report["findings"][0]
+    assert finding["evidence"]["retryable"] is False
+    assert finding["review_priority"] == "medium"
+    assert report["sources"][0]["fetch_status"] == "unavailable"
+    # The distinction the counts have to carry: a permanent loss stops reading as
+    # a fresh fetch error on every later run.
+    assert report["metadata_fetch_error_count"] == 0
+    assert report["metadata_unavailable_count"] == 1
+    assert report["complete"] is True
+
+
+def test_a_region_block_stays_a_retryable_fetch_failure(audit_source_identities):
+    """The message names an unavailable video; the cause is a geo block."""
+    database = {"talks": [talk()]}
+
+    def fetcher(video_id):
+        raise audit_source_identities.MetadataFetchError(
+            f"ERROR: [youtube] {video_id}: This video is not available in your country"
+        )
+
+    report, _calls = _audit(
+        audit_source_identities,
+        database,
+        audit_source_identities.NO_CANDIDATE_REPORT,
+        fetcher,
+    )
+
+    assert finding_codes(report) == ["metadata_fetch_failed"]
+    assert report["findings"][0]["evidence"]["retryable"] is True
+    assert report["sources"][0]["fetch_status"] == "error"
+    assert report["metadata_fetch_error_count"] == 1
+    assert report["metadata_unavailable_count"] == 0
+    # An active identity the audit could not verify still blocks.
+    assert report["complete"] is False


### PR DESCRIPTION
Closes #429.

`audit-source-identities.py` filed every refused `yt-dlp` fetch as
`metadata_fetch_failed` at `review_priority: high`. Two catalogued recordings are
gone from YouTube, so those two findings re-read as fresh high-priority fetch
errors on every run and could never clear.

Refusals are classified now. `classify_fetch_failure` separates a provider verdict
that the recording itself is gone — `source_unavailable_upstream`, absent from
`ERROR_CODES` so it never sets `complete: false`, with `retryable: false`,
`fetch_status: "unavailable"`, and the new `metadata_unavailable_count` — from
every retryable refusal, which keeps `metadata_fetch_failed`.

**Access restrictions are tested first and outrank every unavailability
signature.** The region block is the case that forces the precedence: `This video
is not available in your country` contains an unavailability signature verbatim,
and the recording still exists for a viewer the provider will serve. Geo blocks,
age gates, bot checks, members-only content and private videos stay retryable
rather than being filed as link rot.

## Acceptance

- [x] **Both recordings confirmed genuinely gone.** A control fetch against a
  known-good ID returned `availability: public` in the same session, and
  `--geo-bypass-country` probes through US, NO and FR each returned the identical
  `This video is not available` for both IDs.

  | talk | video id | local archive |
  |---|---|---|
  | `2020-06-14-nashdevops-...` (index 233) | `P01v0-2Dtzo` | mp4 + slide PDFs + extraction JSON + transcript |
  | `2025-11-01-devfest-toulouse-2025-...` (index 57) | `wDKzRI8bT6Y` | transcripts only |

- [x] **A decision recorded on whether existing derived claims stand.** They
  stand. `source-identity-audit.md` now carries it: derived artifacts rest on
  their own receipts — the local artifact's digest and the provider evidence
  captured at `captured_at` — neither of which is a live re-read. What is lost is
  forward capability, not past evidence. `P01v0-2Dtzo` has a local copy and keeps
  re-verification, re-download and fresh extraction; `wDKzRI8bT6Y` has only its
  transcripts, which are now the sole remaining record and must not be discarded
  to force a re-fetch.

- [x] **The audit distinguishes "upstream is gone" from "fetch failed."** Distinct
  code, distinct `fetch_status`, distinct count, and `evidence.retryable` on the
  finding. Report contract v3.

## Test plan

- [x] Full suite: **7994 passed**, 8 skipped
- [x] 16 classifier cases, including both live messages verbatim, the region
      block that contains an unavailability signature, age gate, bot check,
      members-only, private, timeout, unusable JSON, empty and `None`
- [x] Audit-level: an upstream loss keeps `complete: true` with
      `metadata_fetch_error_count == 0` and `metadata_unavailable_count == 1`
- [x] Audit-level: a region block stays blocking, retryable, and counted as a
      fetch error
- [x] ruff clean, pyright 0 errors

Also ignores a `.venv` symlink — a worktree points it at the base checkout's
interpreter, and the trailing-slash pattern does not match a symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV