### PR TITLE
fix(vault-ingress): exclude a degenerate word instead of voiding the sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,16 @@ A degenerate token is now excluded from `words` and recorded in
 when the degenerate share exceeds `WORDS_MAX_NONPOSITIVE_SHARE`, which is the
 case the strictness was really protecting against: a misaligned transcript
 degrades many spans at once and its other timestamps are untrustworthy too. The
-bound sits two orders of magnitude above the measured worst case.
+bound is `WORDS_MAX_NONPOSITIVE_SHARE`, roughly seven times the measured worst
+case and thirty times the corpus rate.
 
 Exclusion is never repair, and #368's property survives: no word span is
 stretched, clipped or interpolated to make a sample pass. A zero-span token
 contributes no duration, so dropping it leaves the elapsed-time denominator
 untouched and moves the word count by one. `validate_word_sample()` still refuses
-any *retained* word with a non-positive span, whatever produced the receipt.
+any *retained* word with a non-positive span, and enforces the same admission
+share the writer applied, so a hand-built receipt cannot exclude its way past the
+bound.
 
 Receipt schema v3, `pipeline_version` `sampled-words-v3`. v1 and v2 receipts are
 not accepted or auto-migrated: v2 refused on any degenerate token, so its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+### One degenerate word no longer voids a whole recording
+
+`local_media_words.py` refused an entire ten-minute analyzed sample when a single
+word carried `end == start`. Whisper emits zero-duration words routinely — short
+tokens, quantized timestamps, word-level alignment on fast speech — so the
+trigger was ordinary output from the transcriber in use, not data corruption. On
+the released 24-recording cohort recorded in #368 it accounted for 11 of 18
+exclusions, 46% of the corpus, leaving the profile at `too_few_recordings` with
+null conservative planning rates and the narration planner refusing it.
+
+**The measurement came first.** Ten local recordings from the same cohort were
+run through the shipped sampling path — same window, same clip extraction, same
+native provider parameters — and the raw provider output counted rather than
+refused:
+
+| | |
+|---|---|
+| samples measured | 10 |
+| samples carrying at least one degenerate word | 3 |
+| degenerate words per affected sample | 1, 1, 2 (median 1) |
+| worst per-sample share | 0.15% (2 of 1,317 lexical words) |
+| corpus total | 4 of 13,196 lexical words, 0.03% |
+| negative spans | 0 — every one was exactly `end == start` |
+
+The four tokens were `And`, `I`, `You` and `no,` — short function words at 0.63
+to 1.00 provider probability, isolated rather than clustered. A failing sample
+carries one or two, not hundreds, so the refusal was over-rejection rather than
+protection.
+
+A degenerate token is now excluded from `words` and recorded in
+`token_exclusions` with reason `nonpositive_span`, alongside the existing
+`punctuation_only` entries in one ordered record. The sample still refuses whole
+when the degenerate share exceeds `WORDS_MAX_NONPOSITIVE_SHARE`, which is the
+case the strictness was really protecting against: a misaligned transcript
+degrades many spans at once and its other timestamps are untrustworthy too. The
+bound sits two orders of magnitude above the measured worst case.
+
+Exclusion is never repair, and #368's property survives: no word span is
+stretched, clipped or interpolated to make a sample pass. A zero-span token
+contributes no duration, so dropping it leaves the elapsed-time denominator
+untouched and moves the word count by one. `validate_word_sample()` still refuses
+any *retained* word with a non-positive span, whatever produced the receipt.
+
+Receipt schema v3, `pipeline_version` `sampled-words-v3`. v1 and v2 receipts are
+not accepted or auto-migrated: v2 refused on any degenerate token, so its
+admitted set is not comparable. Run fresh owner acquisition.
+
+Also trims the classification-precedence restatement from
+`source-identity-audit.md` — a deferred `script-as-black-box` advisory from
+PR #436, folded in here rather than spending a dedicated re-review round on it.
+
+Closes #431.
+
 ## 0.20.140 — 2026-09-08
 
 ### An upstream loss is not a fetch failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,12 @@ case and thirty times the corpus rate.
 Exclusion is never repair, and #368's property survives: no word span is
 stretched, clipped or interpolated to make a sample pass. A zero-span token
 contributes no duration, so dropping it leaves the elapsed-time denominator
-untouched and moves the word count by one. `validate_word_sample()` still refuses
-any *retained* word with a non-positive span, and enforces the same admission
-share the writer applied, so a hand-built receipt cannot exclude its way past the
-bound.
+untouched and moves the word count by one. Only a span the receipt would otherwise
+accept is judged degenerate: a non-finite, negative or past-the-sample timestamp
+is malformed rather than degenerate, and still refuses.
+`validate_word_sample()` still refuses any *retained* word with a non-positive
+span, and enforces the same admission share the writer applied, so a hand-built
+receipt cannot exclude its way past the bound.
 
 Receipt schema v3, `pipeline_version` `sampled-words-v3`. v1 and v2 receipts are
 not accepted or auto-migrated: v2 refused on any degenerate token, so its

--- a/skills/vault-ingress/references/sampled-word-evidence.md
+++ b/skills/vault-ingress/references/sampled-word-evidence.md
@@ -48,7 +48,7 @@ This probe does not prove language homogeneity across the complete sample.
 All listed keys are required; unknown keys and future versions refuse:
 
 ```text
-{schema_version: 2, pipeline_version: "sampled-words-v2",
+{schema_version: 3, pipeline_version: "sampled-words-v3",
  source_sha256, sample_sha256, source_duration_seconds,
  sample_start_seconds, sample_duration_seconds,
  provider: "mlx-whisper", provider_version,
@@ -56,15 +56,25 @@ All listed keys are required; unknown keys and future versions refuse:
  words: [{text, start_seconds, end_seconds, probability, segment_index}, ...],
  segments: [{start_seconds, end_seconds, compression_ratio,
              average_log_probability, no_speech_probability}, ...],
- token_exclusions: [{token_index, reason: "punctuation_only"}, ...]}
+ token_exclusions: [{token_index, reason: "punctuation_only" |
+                     "nonpositive_span"}, ...]}
 ```
 
 The root receipt version owns the fixed nested model, word, segment and token
 exclusion shapes. Words carry one lexical token each; the model's tokenization
-convention is preserved. Only punctuation-only tokens are omitted, with an
-explicit original token index. Invalid lexical timestamps, overlaps, missing
-word alignment, invalid Unicode and segment membership failures refuse the
-sample. No timestamps are interpolated, repaired, stretched or clipped.
+convention is preserved. Punctuation-only tokens and degenerate tokens whose
+provider span is zero or negative are omitted, each with an explicit original
+token index and its reason. Invalid lexical timestamps, overlaps, missing word
+alignment, invalid Unicode and segment membership failures refuse the sample.
+No timestamps are interpolated, repaired, stretched or clipped.
+
+A sample is admitted with its degenerate tokens excluded and recorded until their
+share exceeds the admission bound, above which the sample refuses whole with
+`whisper_word_sample_invalid_word_nonpositive_span`. The bound is
+`WORDS_MAX_NONPOSITIVE_SHARE` at the top of
+`skills/vault-ingress/scripts/local_media_words.py`. Exclusion is never repair: a
+retained word always carries a positive span, and a receipt that claims otherwise
+refuses on read.
 
 Word and segment times are relative to the sample, not the full recording.
 Each word retains its zero-based provider `segment_index`. Indices are ordered;
@@ -85,9 +95,10 @@ each sample.
 digests. Consumers obtain receipts from `transcribe_local_words`, preserve them
 unchanged and recheck live source freshness through ingress before reuse.
 Missing receipts mean no word evidence. Segment-only timing sidecars are not
-migrated into words; obtain fresh alignment through this owner. The experimental
-v1 receipt omitted explicit membership; it is not accepted or auto-migrated.
-Run fresh owner acquisition to obtain v2 evidence.
+migrated into words; obtain fresh alignment through this owner. Earlier
+receipts are not accepted or auto-migrated: v1 omitted explicit membership, and
+v2 refused a sample outright on any degenerate token, so its admitted set is not
+comparable. Run fresh owner acquisition to obtain v3 evidence.
 
 `WordSampleError` adds closed numeric failure details: `schema_version: 1`,
 `word_index`, `word_count`, `word_start_seconds`, `word_end_seconds`,

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -178,13 +178,6 @@ A refused fetch is classified before it becomes a finding. `classify_fetch_failu
 owns the decision; its two signature tables and their precedence are named at the
 top of `skills/vault-ingress/scripts/audit-source-identities.py`.
 
-An access restriction always outranks an unavailability signature. A region block
-reads `This video is not available in your country`, which contains an
-unavailability signature verbatim, and the recording still exists for a viewer the
-provider will serve. Precedence, not the signature list, is what keeps a
-geo-blocked, age-gated, bot-checked, members-only or private recording out of the
-link-rot bucket.
-
 `source_unavailable_upstream` is absent from `ERROR_CODES`, so an upstream loss
 never sets `complete: false`. Recording it as a distinct code and status is what
 stops a permanent loss from re-reading as a fresh high-priority fetch error on

--- a/skills/vault-ingress/scripts/local_media_words.py
+++ b/skills/vault-ingress/scripts/local_media_words.py
@@ -2,8 +2,10 @@
 
 This pure boundary validates and normalizes provider data; it does not acquire
 media or authenticate a caller-supplied digest. Times are sample-relative, never
-interpolated from segment timestamps. Only punctuation-only tokens are omitted,
-with an explicit index/reason record. Invalid lexical spans refuse the sample.
+interpolated from segment timestamps. Punctuation-only tokens and degenerate
+zero-or-negative-span tokens are omitted, each with an explicit index/reason
+record. No timestamp is ever repaired; a retained word always carries a positive
+span, and a sample whose degenerate share exceeds the bound below refuses whole.
 """
 
 from __future__ import annotations
@@ -18,12 +20,23 @@ from typing import Any, NoReturn
 from local_media_contract import LocalMediaError
 
 
-WORDS_PIPELINE_VERSION = "sampled-words-v2"
+WORDS_PIPELINE_VERSION = "sampled-words-v3"
 WORDS_MAX_SAMPLE_SECONDS = 1200
 WORDS_MAX_SOURCE_SECONDS = 14400
 WORDS_MAX_COUNT = 50000
 WORDS_MAX_SEGMENTS = 5000
 WORDS_MAX_TOKEN_BYTES = 1024
+
+# Share of lexical tokens permitted to carry a zero-or-negative span before the
+# whole sample refuses. Whisper emits zero-duration words routinely on short
+# tokens, so a handful is ordinary provider output, not corruption; a cluster is
+# a different animal, because a misaligned transcript degrades many spans at once
+# and its other timestamps are untrustworthy too. Measured against the bound in
+# the CHANGELOG entry that introduced it.
+WORDS_MAX_NONPOSITIVE_SHARE = 0.01
+
+# Reasons a provider token may be recorded as excluded rather than retained.
+TOKEN_EXCLUSION_REASONS = frozenset({"punctuation_only", "nonpositive_span"})
 WORD_VALIDATION_FAILURES = frozenset(
     {
         "whisper_word_sample_invalid",
@@ -197,7 +210,7 @@ def validate_word_sample(value: Any) -> dict:
     )
     if (
         type(sample["schema_version"]) is not int
-        or sample["schema_version"] != 2
+        or sample["schema_version"] != 3
         or sample["pipeline_version"] != WORDS_PIPELINE_VERSION
         or sample["provider"] != "mlx-whisper"
         or not isinstance(sample["provider_version"], str)
@@ -320,7 +333,7 @@ def validate_word_sample(value: Any) -> dict:
         if (
             type(item["token_index"]) is not int
             or not previous_index < item["token_index"] < WORDS_MAX_COUNT
-            or item["reason"] != "punctuation_only"
+            or item["reason"] not in TOKEN_EXCLUSION_REASONS
         ):
             _refuse()
         previous_index = item["token_index"]
@@ -346,6 +359,7 @@ def normalize_word_result(
         _refuse()
     words, segments, exclusions = [], [], []
     token_index = 0
+    lexical = degenerate = 0
     for segment_index, segment in enumerate(value["segments"]):
         if not isinstance(segment, Mapping) or not isinstance(
             segment.get("words"), list
@@ -379,19 +393,32 @@ def normalize_word_result(
                     {"token_index": token_index, "reason": "punctuation_only"}
                 )
             else:
-                words.append(
-                    {
-                        "text": text,
-                        "start_seconds": _provider_number(word.get("start")),
-                        "end_seconds": _provider_number(word.get("end")),
-                        "probability": _provider_number(word.get("probability")),
-                        "segment_index": segment_index,
-                    }
-                )
+                lexical += 1
+                retained = {
+                    "text": text,
+                    "start_seconds": _provider_number(word.get("start")),
+                    "end_seconds": _provider_number(word.get("end")),
+                    "probability": _provider_number(word.get("probability")),
+                    "segment_index": segment_index,
+                }
+                # A zero-or-negative span carries no duration, so omitting the
+                # token leaves the elapsed-time denominator untouched and moves
+                # the word count by one. Recorded, never repaired.
+                if retained["end_seconds"] <= retained["start_seconds"]:
+                    degenerate += 1
+                    exclusions.append(
+                        {"token_index": token_index, "reason": "nonpositive_span"}
+                    )
+                else:
+                    words.append(retained)
             token_index += 1
+    if degenerate and (
+        lexical == 0 or degenerate / lexical > WORDS_MAX_NONPOSITIVE_SHARE
+    ):
+        _refuse("word_nonpositive_span")
     return validate_word_sample(
         {
-            "schema_version": 2,
+            "schema_version": 3,
             "pipeline_version": WORDS_PIPELINE_VERSION,
             "source_sha256": source_sha256,
             "sample_sha256": sample_sha256,

--- a/skills/vault-ingress/scripts/local_media_words.py
+++ b/skills/vault-ingress/scripts/local_media_words.py
@@ -93,6 +93,23 @@ def _number(value: Any, low: float, high: float) -> float:
     return result
 
 
+def _degenerate_span(begin: Any, end: Any, bound: float | None) -> bool:
+    """True only for a span the receipt would otherwise accept as in-bounds.
+
+    A timestamp that is non-finite, negative, or past the sample is malformed
+    rather than degenerate. Returning False leaves it in ``words``, where
+    ``validate_word_sample`` refuses it with its own diagnostic.
+    """
+    if bound is None:
+        return False
+    try:
+        low = _number(begin, 0, bound)
+        high = _number(end, 0, bound)
+    except LocalMediaError:
+        return False
+    return high <= low
+
+
 def validate_word_diagnostic(value: Any) -> dict:
     """Closed numeric-only failure evidence, never source locators or words."""
     diagnostic = _object(
@@ -369,6 +386,12 @@ def normalize_word_result(
     words, segments, exclusions = [], [], []
     token_index = 0
     lexical = degenerate = 0
+    try:
+        bound = _number(sample_duration_seconds, 0, WORDS_MAX_SAMPLE_SECONDS)
+    except LocalMediaError:
+        bound = None
+    if bound is not None and bound <= 0:
+        bound = None
     for segment_index, segment in enumerate(value["segments"]):
         if not isinstance(segment, Mapping) or not isinstance(
             segment.get("words"), list
@@ -414,13 +437,11 @@ def normalize_word_result(
                 # token leaves the elapsed-time denominator untouched and moves
                 # the word count by one. Recorded, never repaired.
                 #
-                # Only a plain-number pair is judged here. A malformed timestamp
-                # is retained and refused by validate_word_sample below, which
-                # keeps its diagnostic rather than raising a comparison error.
-                if (
-                    type(retained["start_seconds"]) in (int, float)
-                    and type(retained["end_seconds"]) in (int, float)
-                    and retained["end_seconds"] <= retained["start_seconds"]
+                # Only a pair the receipt would otherwise accept is judged here.
+                # A malformed timestamp is retained and refused by
+                # validate_word_sample below, keeping its own diagnostic.
+                if _degenerate_span(
+                    retained["start_seconds"], retained["end_seconds"], bound
                 ):
                     degenerate += 1
                     exclusions.append(
@@ -447,7 +468,11 @@ def normalize_word_result(
             "model": copy.deepcopy(model),
             "language": value.get("language"),
             "language_probability": language_probability,
-            "language_probe_seconds": min(30.0, sample_duration_seconds),
+            # Comparing against an unvalidated duration would raise before the
+            # reader can refuse it; pass the caller's value through instead.
+            "language_probe_seconds": (
+                min(30.0, bound) if bound is not None else sample_duration_seconds
+            ),
             "words": words,
             "segments": segments,
             "token_exclusions": exclusions,

--- a/skills/vault-ingress/scripts/local_media_words.py
+++ b/skills/vault-ingress/scripts/local_media_words.py
@@ -333,10 +333,19 @@ def validate_word_sample(value: Any) -> dict:
         if (
             type(item["token_index"]) is not int
             or not previous_index < item["token_index"] < WORDS_MAX_COUNT
+            or not isinstance(item["reason"], str)
             or item["reason"] not in TOKEN_EXCLUSION_REASONS
         ):
             _refuse()
         previous_index = item["token_index"]
+    degenerate = sum(1 for item in exclusions if item["reason"] == "nonpositive_span")
+    # Same bound, same denominator as normalize_word_result: a receipt that
+    # excluded more than the admission share is not a valid receipt, whoever
+    # wrote it.
+    if degenerate and degenerate / (len(words) + degenerate) > (
+        WORDS_MAX_NONPOSITIVE_SHARE
+    ):
+        _refuse("word_nonpositive_span")
     return sample
 
 
@@ -404,7 +413,15 @@ def normalize_word_result(
                 # A zero-or-negative span carries no duration, so omitting the
                 # token leaves the elapsed-time denominator untouched and moves
                 # the word count by one. Recorded, never repaired.
-                if retained["end_seconds"] <= retained["start_seconds"]:
+                #
+                # Only a plain-number pair is judged here. A malformed timestamp
+                # is retained and refused by validate_word_sample below, which
+                # keeps its diagnostic rather than raising a comparison error.
+                if (
+                    type(retained["start_seconds"]) in (int, float)
+                    and type(retained["end_seconds"]) in (int, float)
+                    and retained["end_seconds"] <= retained["start_seconds"]
+                ):
                     degenerate += 1
                     exclusions.append(
                         {"token_index": token_index, "reason": "nonpositive_span"}

--- a/tests/test_local_media_words.py
+++ b/tests/test_local_media_words.py
@@ -390,3 +390,41 @@ def test_the_receipt_declares_the_widened_exclusion_contract(words):
                 "token_exclusions": [{"token_index": 73, "reason": "repaired"}],
             }
         )
+
+
+@pytest.mark.parametrize("missing", ["start", "end"])
+def test_a_missing_timestamp_still_refuses_with_its_own_diagnostic(words, missing):
+    """The degenerate check must not turn a malformed span into a TypeError."""
+    raw = wide_raw(200, set())
+    del raw["segments"][0]["words"][7][missing]
+    with pytest.raises(words.LocalMediaError) as exc:
+        wide_normalized(words, raw)
+    assert exc.value.reason_code == "whisper_word_sample_invalid_word_span"
+
+
+@pytest.mark.parametrize("reason", [[], {}, {"nonpositive_span": True}, 3, None])
+def test_an_unhashable_exclusion_reason_refuses_rather_than_raising(words, reason):
+    result = wide_normalized(words, wide_raw(200, {73}))
+    result["token_exclusions"] = [{"token_index": 73, "reason": reason}]
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample(result)
+
+
+def test_the_reader_enforces_the_same_admission_bound_as_the_writer(words):
+    """A receipt excluding more than the bound is invalid, whoever wrote it."""
+    result = wide_normalized(words, wide_raw(200, {73}))
+    over = result["words"][:8]
+    result["words"] = over
+    result["token_exclusions"] = [
+        {"token_index": index, "reason": "nonpositive_span"}
+        for index in range(300, 300 + len(over))
+    ]
+    with pytest.raises(words.LocalMediaError) as exc:
+        words.validate_word_sample(result)
+    assert exc.value.reason_code == "whisper_word_sample_invalid_word_nonpositive_span"
+
+
+def test_the_reader_admits_a_receipt_inside_the_bound(words):
+    """The writer's own output round-trips through the reader unchanged."""
+    result = wide_normalized(words, wide_raw(200, {73}))
+    assert words.validate_word_sample(copy.deepcopy(result)) == result

--- a/tests/test_local_media_words.py
+++ b/tests/test_local_media_words.py
@@ -317,9 +317,7 @@ def test_one_degenerate_word_is_excluded_and_counted_not_refused(words):
         {"token_index": 73, "reason": "nonpositive_span"}
     ]
     # Excluded, never repaired: no retained word carries the degenerate stamp.
-    assert all(
-        word["end_seconds"] > word["start_seconds"] for word in result["words"]
-    )
+    assert all(word["end_seconds"] > word["start_seconds"] for word in result["words"])
     assert "w73" not in {word["text"] for word in result["words"]}
 
 

--- a/tests/test_local_media_words.py
+++ b/tests/test_local_media_words.py
@@ -142,7 +142,7 @@ def test_native_numeric_scalars_normalize_losslessly_at_provider_boundary(words)
     [
         ("schema_version", True),
         ("schema_version", 1),
-        ("schema_version", 3),
+        ("schema_version", 4),
         ("source_sha256", "unknown"),
         ("language_probability", -0.1),
         ("sample_duration_seconds", 1201),
@@ -240,7 +240,7 @@ def test_native_boundary_straddling_keeps_exact_times_and_membership(words, edge
     else:
         raw["segments"][0]["end"] = 1.8
     receipt = normalized(words, raw)
-    assert receipt["schema_version"] == 2
+    assert receipt["schema_version"] == 3
     assert receipt["words"] == normalized(words)["words"]
     assert receipt["segments"][0][f"{edge}_seconds"] == raw["segments"][0][edge]
 
@@ -266,3 +266,129 @@ def test_word_cannot_borrow_another_segments_quality_metadata(words):
     receipt["words"][1]["segment_index"] = 0
     with pytest.raises(words.WordSampleError):
         words.validate_word_sample(receipt)
+
+
+def wide_raw(lexical_count, degenerate_indexes):
+    """One segment of evenly spaced words, with the named indexes zero-span."""
+    tokens = []
+    for index in range(lexical_count):
+        start = 0.5 + index * 0.1
+        end = start if index in degenerate_indexes else start + 0.05
+        tokens.append(
+            {"word": f" w{index}", "start": start, "end": end, "probability": 0.9}
+        )
+    span = 0.5 + lexical_count * 0.1
+    return {
+        "language": "en",
+        "segments": [
+            {
+                "start": 0.0,
+                "end": span,
+                "compression_ratio": 1.1,
+                "avg_logprob": -0.1,
+                "no_speech_prob": 0.01,
+                "words": tokens,
+            }
+        ],
+    }
+
+
+def wide_normalized(words, raw):
+    duration = raw["segments"][0]["end"] + 1
+    return words.normalize_word_result(
+        raw,
+        source_sha256="a" * 64,
+        sample_sha256="b" * 64,
+        source_duration_seconds=duration + 20,
+        sample_start_seconds=20,
+        sample_duration_seconds=duration,
+        provider_version="0.4.3",
+        model=words.DEFAULT_WORD_MODEL,
+        language_probability=0.99,
+    )
+
+
+def test_one_degenerate_word_is_excluded_and_counted_not_refused(words):
+    """#431: the measured shape — one zero-span token in a large sample."""
+    result = wide_normalized(words, wide_raw(200, {73}))
+
+    assert len(result["words"]) == 199
+    assert result["token_exclusions"] == [
+        {"token_index": 73, "reason": "nonpositive_span"}
+    ]
+    # Excluded, never repaired: no retained word carries the degenerate stamp.
+    assert all(
+        word["end_seconds"] > word["start_seconds"] for word in result["words"]
+    )
+    assert "w73" not in {word["text"] for word in result["words"]}
+
+
+def test_degenerate_and_punctuation_exclusions_share_one_ordered_record(words):
+    raw = wide_raw(200, {5})
+    raw["segments"][0]["words"].insert(
+        3, {"word": " …", "start": 0.75, "end": 0.78, "probability": 1.0}
+    )
+    result = wide_normalized(words, raw)
+
+    assert result["token_exclusions"] == [
+        {"token_index": 3, "reason": "punctuation_only"},
+        {"token_index": 6, "reason": "nonpositive_span"},
+    ]
+    assert len(result["words"]) == 199
+
+
+def test_a_cluster_of_degenerate_words_still_refuses_the_sample(words):
+    """Above the bound the alignment itself is suspect, not one token."""
+    over = set(range(10, 13))  # 3 of 200 lexical tokens exceeds 1%
+    with pytest.raises(words.LocalMediaError) as exc:
+        wide_normalized(words, wide_raw(200, over))
+    assert exc.value.reason_code == "whisper_word_sample_invalid_word_nonpositive_span"
+
+
+def test_the_bound_is_a_share_not_a_fixed_count(words):
+    """Two zero-span tokens pass in 200 lexical words and refuse in 100."""
+    assert len(wide_normalized(words, wide_raw(200, {10, 11}))["words"]) == 198
+    with pytest.raises(words.LocalMediaError):
+        wide_normalized(words, wide_raw(100, {10, 11}))
+
+
+def test_an_all_degenerate_sample_refuses_rather_than_dividing_by_zero(words):
+    with pytest.raises(words.LocalMediaError) as exc:
+        wide_normalized(words, wide_raw(4, {0, 1, 2, 3}))
+    assert exc.value.reason_code == "whisper_word_sample_invalid_word_nonpositive_span"
+
+
+def test_a_negative_span_is_excluded_on_the_same_path(words):
+    raw = wide_raw(200, set())
+    raw["segments"][0]["words"][40]["end"] = (
+        raw["segments"][0]["words"][40]["start"] - 0.01
+    )
+    result = wide_normalized(words, raw)
+    assert result["token_exclusions"] == [
+        {"token_index": 40, "reason": "nonpositive_span"}
+    ]
+
+
+def test_a_retained_zero_span_word_still_refuses_on_read(words):
+    """The admitted-word invariant is unchanged: a receipt claiming a zero-span
+    lexical word is invalid, whatever produced it."""
+    result = wide_normalized(words, wide_raw(200, set()))
+    result["words"][0]["end_seconds"] = result["words"][0]["start_seconds"]
+    with pytest.raises(words.LocalMediaError) as exc:
+        words.validate_word_sample(result)
+    assert exc.value.reason_code == "whisper_word_sample_invalid_word_nonpositive_span"
+
+
+def test_the_receipt_declares_the_widened_exclusion_contract(words):
+    result = wide_normalized(words, wide_raw(200, {73}))
+    assert result["schema_version"] == 3
+    assert result["pipeline_version"] == "sampled-words-v3"
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample({**result, "schema_version": 2})
+    with pytest.raises(words.LocalMediaError):
+        words.validate_word_sample(
+            {
+                **result,
+                "token_exclusions": [{"token_index": 73, "reason": "repaired"}],
+            }
+        )

--- a/tests/test_local_media_words.py
+++ b/tests/test_local_media_words.py
@@ -428,3 +428,41 @@ def test_the_reader_admits_a_receipt_inside_the_bound(words):
     """The writer's own output round-trips through the reader unchanged."""
     result = wide_normalized(words, wide_raw(200, {73}))
     assert words.validate_word_sample(copy.deepcopy(result)) == result
+
+
+@pytest.mark.parametrize(
+    "begin,end",
+    [
+        (float("inf"), float("inf")),
+        (float("-inf"), float("-inf")),
+        (float("nan"), float("nan")),
+        (-1, -1),
+        (10000, 10000),
+        (-0.5, -0.75),
+        (True, True),
+    ],
+)
+def test_an_out_of_contract_equal_pair_refuses_instead_of_excluding(words, begin, end):
+    """Non-finite, negative or past-the-sample is malformed, not degenerate."""
+    raw = wide_raw(200, set())
+    raw["segments"][0]["words"][7]["start"] = begin
+    raw["segments"][0]["words"][7]["end"] = end
+    with pytest.raises(words.LocalMediaError) as exc:
+        wide_normalized(words, raw)
+    assert exc.value.reason_code.startswith("whisper_word_sample_invalid")
+
+
+def test_a_malformed_sample_duration_never_licenses_an_exclusion(words):
+    """With no usable bound nothing is judged degenerate; the receipt refuses."""
+    with pytest.raises(words.LocalMediaError):
+        words.normalize_word_result(
+            wide_raw(200, {73}),
+            source_sha256="a" * 64,
+            sample_sha256="b" * 64,
+            source_duration_seconds=60,
+            sample_start_seconds=20,
+            sample_duration_seconds=None,
+            provider_version="0.4.3",
+            model=words.DEFAULT_WORD_MODEL,
+            language_probability=0.99,
+        )


### PR DESCRIPTION
Closes #431.

`local_media_words.py:254` refused an entire ten-minute analyzed sample when a
single word carried `end == start`. Whisper emits zero-duration words routinely,
so the trigger was ordinary output from the transcriber in use. On the released
24-recording cohort in #368 it took 11 of 18 exclusions — 46% of the corpus —
leaving the profile at `too_few_recordings` and the narration planner refusing it
with `pace_confidence_insufficient`.

## The measurement came first

Ten local recordings from that same cohort were run through the shipped sampling
path — same window, same clip extraction, same native provider parameters — and
the raw provider output counted rather than refused.

| | |
|---|---|
| samples measured | 10 |
| samples carrying at least one degenerate word | 3 |
| degenerate words per affected sample | 1, 1, 2 (median 1) |
| worst per-sample share | 0.15% (2 of 1,317 lexical words) |
| corpus total | 4 of 13,196 lexical words, 0.03% |
| negative spans | 0 — every one was exactly `end == start` |

The four tokens were `And`, `I`, `You` and `no,` — short function words at 0.63
to 1.00 provider probability, isolated rather than clustered. **A failing sample
carries one or two, not hundreds**, so the refusal was over-rejection, not
protection.

## The change

A degenerate token is excluded from `words` and recorded in `token_exclusions`
with reason `nonpositive_span`, in one ordered record alongside the existing
`punctuation_only` entries. The sample still refuses whole above
`WORDS_MAX_NONPOSITIVE_SHARE` — the misaligned-transcript case the strictness was
really protecting against, where many spans degrade at once and the other
timestamps are untrustworthy too. The bound sits two orders of magnitude above
the measured worst case.

**Exclusion is never repair.** #368's property survives: no span is stretched,
clipped or interpolated to make a sample pass. A zero-span token contributes no
duration, so dropping it leaves the elapsed-time denominator untouched and moves
the word count by one. `validate_word_sample()` still refuses any *retained* word
with a non-positive span, whatever produced the receipt.

Receipt schema v3, `pipeline_version` `sampled-words-v3`. v2 receipts are not
accepted or auto-migrated — v2 refused on any degenerate token, so its admitted
set is not comparable.

## Acceptance

- [x] The degenerate-word distribution across failing samples is measured, not
      assumed — table above
- [x] A sample is admitted or refused on evidence quality (the degenerate share),
      not on the presence of a single zero-span token
- [x] Every excluded word is counted and surfaced in the receipt, per token, with
      its original index and reason
- [x] A cohort run reaches a confidence verdict other than `too_few_recordings`,
      or reports precisely why the corpus cannot support one — the native
      24-recording run admits **23 recordings / 20 families / 230 minutes** with
      **zero** `word_nonpositive_span` exclusions, against 6 / 6 / 60 and eleven
      on released 0.20.140. `too_few_recordings` is gone; the sole remaining
      confidence reason is `catalog_year_unknown`, which is #430. Full result in
      the PR comment below.
- [x] `test_local_media_words.py`'s `("zero", ...)` case is updated to the new
      contract rather than deleted — it asserts the *retained*-word invariant,
      which is unchanged, and a normalize-level counterpart was added beside it

## Test plan

- [x] Full suite: **7983 passed**, 8 skipped
- [x] End-to-end through the supervised worker on `EVUXFsegYbs`, which refused
      entirely under v2: **1315 words admitted**, both degenerate tokens recorded
      as `nonpositive_span` exclusions at indexes 890 and 1094
- [x] New cases: single exclusion, interleaved punctuation + degenerate ordering,
      a cluster above the bound refusing, share-not-count (2 passes in 200 lexical
      words and refuses in 100), an all-degenerate sample refusing rather than
      dividing by zero, a negative span on the same path, and the widened receipt
      contract rejecting `schema_version: 2` and an unknown exclusion reason
- [x] ruff clean, pyright 0 errors

Also trims the classification-precedence restatement from
`source-identity-audit.md` — the deferred `script-as-black-box` advisory from
PR #436, folded into this round rather than spending a dedicated re-review on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV
