### PR TITLE
feat(vault-ingress): record how a delivery date was established

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ top-level collection rather than a talk field for the reason `markdown_decks`
 already documents: `TALK_RECORD_SCHEMA_VERSION` means the analysis generation,
 and the records this is for are the legacy ones, so a talk-field version would
 be unreachable for exactly the records that need it. No talk record changes
-shape, no migration owns the collection, and absent means nothing was recorded.
+shape, and absent means nothing was recorded.
+
+A top-level key is part of the root record's shape, so the root advances to v4
+exactly as `markdown_decks` moved it to v2 and `source_aliases` to v3. The
+root-only migration accepts v2, v3 and v4, preserves every child value, and
+invents no provenance. Test fixtures that pinned the root by literal now read
+`conftest.CURRENT_ROOT_SCHEMA_VERSION`, which is what that constant's own
+comment asked for after the last bump.
 
 `method` is the only strength signal and it is deliberately not stored as one.
 Readers call `date_provenance_basis()`, which maps a method to `proved`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+### A date now says how it was established
+
+Half the catalog carries a bare year or nothing where a delivery day belongs —
+126 of 251 records have a day, 91 a bare year, 26 nothing, 8 a month. Before
+this, a date proved from an organizer program, a date inferred from an event's
+opening day, and a date that is just a year were the same string. Each audit
+re-derived what the previous one had already worked out and left its working in
+an issue thread (#333, #339).
+
+The new optional `date_provenance` collection records the difference. It is a
+top-level collection rather than a talk field for the reason `markdown_decks`
+already documents: `TALK_RECORD_SCHEMA_VERSION` means the analysis generation,
+and the records this is for are the legacy ones, so a talk-field version would
+be unreachable for exactly the records that need it. No talk record changes
+shape, no migration owns the collection, and absent means nothing was recorded.
+
+`method` is the only strength signal and it is deliberately not stored as one.
+Readers call `date_provenance_basis()`, which maps a method to `proved`,
+`inferred`, or `bounded`, so a record cannot claim more than its method
+supports. `evidence` is required and non-empty because a method names a kind of
+evidence, never the evidence itself — the field is the trace an owner follows to
+re-check a claim without opening GitHub.
+
+`not_later_than` is an independent fact rather than a weaker date. A provider
+upload cannot precede the recording it publishes, so a talk with no date at all
+still has a ceiling. Measured against every talk that has both a proved day and
+a stored upload date, the bound holds 74 of 74, with the single −1 day inside
+the repo's own `UPLOAD_TIMEZONE_GRACE`. It is compared through
+`upload_predates_catalog`, the same comparator and grace the live
+source-identity audit uses, so a ceiling that contradicts the record it bounds
+refuses rather than being stored beside a date it disagrees with.
+
+`live_broadcast_release` proves rather than bounds, which is the one place a
+provider date is delivery evidence: for a `was_live` recording the release
+timestamp is the stream running, not a later publication.
+
+Schema and validation only. Establishing provenance for the existing catalog is
+separate work — see #430.
+
 ## 0.20.141 — 2026-09-08
 
 ### One degenerate word no longer voids a whole recording

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ a stored upload date, the bound holds 74 of 74, with the single −1 day inside
 the repo's own `UPLOAD_TIMEZONE_GRACE`. It is compared through
 `upload_predates_catalog`, the same comparator and grace the live
 source-identity audit uses, so a ceiling that contradicts the record it bounds
-refuses rather than being stored beside a date it disagrees with.
+refuses rather than being stored beside a date it disagrees with. A `date` the
+comparator cannot read at all — month precision — refuses the ceiling rather
+than storing a bound nothing checks; teaching `parse_catalog_date` to read
+month precision belongs with the `source_identity_date_uncheckable` re-scope.
 
 `live_broadcast_release` proves rather than bounds, which is the one place a
 provider date is delivery evidence: for a `was_live` recording the release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,18 @@ a stored upload date, the bound holds 74 of 74, with the single −1 day inside
 the repo's own `UPLOAD_TIMEZONE_GRACE`. It is compared through
 `upload_predates_catalog`, the same comparator and grace the live
 source-identity audit uses, so a ceiling that contradicts the record it bounds
-refuses rather than being stored beside a date it disagrees with. A `date` the
-comparator cannot read at all — month precision — refuses the ceiling rather
-than storing a bound nothing checks; teaching `parse_catalog_date` to read
-month precision belongs with the `source_identity_date_uncheckable` re-scope.
+refuses rather than being stored beside a date it disagrees with. A `date` that is present but
+uncomparable — month precision, a non-string, a calendar-boundary year — refuses
+the ceiling rather than storing a bound nothing checks; only an absent or blank
+date lets a ceiling stand alone. Teaching `parse_catalog_date` to read month
+precision belongs with the `source_identity_date_uncheckable` re-scope.
+
+Separately, `parse_catalog_date` now refuses years 0 and 1. The grace
+subtraction in `upload_predates_catalog` underflows the calendar there, so a
+catalog date of `0000` raised `ValueError` and `0001` raised `OverflowError` out
+of the shared comparator — reachable from preflight, not only from the new
+collection. Such a record is a typo rather than a delivery, so it reads as
+uncomparable instead of crashing its caller.
 
 `live_broadcast_release` proves rather than bounds, which is the one place a
 provider date is delivery evidence: for a `was_live` recording the release

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -779,6 +779,11 @@ a ceiling that contradicts the record it bounds refuses here rather than being
 stored beside a date it disagrees with. A method that establishes no day of its
 own requires one; `DATE_PROVENANCE_CEILING_REQUIRED_METHODS` names those.
 
+An absent or empty `date` leaves a ceiling standing alone, which is the case
+this collection exists for. A `date` that is present but outside what
+`parse_catalog_date` reads — month precision, or anything else — refuses the
+ceiling instead of storing a bound nothing ever checks.
+
 One record per talk: a date established again replaces its account rather than
 appending a second one. The collection is optional — absent means nothing was
 recorded about a date, which is the state most of the catalog is in — and no

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -10,7 +10,8 @@ shape, and all migrations. vault-clarification may write current config,
 confirmed-intent, and improvement-goal records. presentation-creator may write
 current QR records. vault-profile and the remaining presentation consumers are
 read-only. Non-owner readers accept every readable database generation during
-rollout — legacy 0, pre-`markdown_decks` 1, pre-`source_aliases` 2, and current 3. They never rewrite
+rollout — legacy 0, pre-`markdown_decks` 1, pre-`source_aliases` 2,
+pre-`date_provenance` 3, and current 4. They never rewrite
 legacy state. An unsupported future database or record version is no usable
 prior state.
 
@@ -200,9 +201,9 @@ v1 and v2 for the rollout window.
 
 ### Schema versioning
 
-A schema-v3 database with current child records is an idempotent no-op.
+A schema-v4 database with current child records is an idempotent no-op.
 Earlier roots advance to v3; config v1 advances to v2 in the same pass.
-The root-only v2-to-v3 transition preserves every child value and does not
+The root-only transition to v4 preserves every child value and does not
 create or infer any source alias. Before migration, queue `inspect` may read
 schema 0 and queue `recover` may close an active schema-0 lease in place.
 Recovery changes only queue lease/status state and never stamps database or talk
@@ -224,7 +225,7 @@ or root state; the standalone root-only mode below preserves their contracts.
 
 | Independent record | Current schema |
 |---|---:|
-| database root | 3 (schemas 0-2 remain readable migration inputs) |
+| database root | 4 (schemas 0-3 remain readable migration inputs) |
 | config | 2 (schema 1 remains readable owner-migration input) |
 | talk | 8 (schemas 1-7 remain readable historical state; v5-v7 restamp) |
 | PPTX catalog | 3 (schemas 1 and 2 remain readable legacy state) |
@@ -239,17 +240,17 @@ or root state; the standalone root-only mode below preserves their contracts.
 
 | Component | Access | Contract |
 |---|---|---|
-| vault-ingress migration | owner read/write | Accept root schema 0/1/2/3 and config schema 1/2; migrate to root v3/config v2; never downgrade future state |
+| vault-ingress migration | owner read/write | Accept root schema 0/1/2/3/4 and config schema 1/2; migrate to root v4/config v2; never downgrade future state |
 | vault-ingress queue inspection/recovery | owner compatibility transition | Inspect schema 0/1/2/3; recover active leases in readable roots; never stamp artifact or talk schema versions |
-| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 3, config schema 2, and supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
-| vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0-3; gate through existing finding/error channels; never rewrite |
+| vault-ingress queue normalization/claim, persistence, shownotes apply, source repair | current read/write | Require database schema 4, config schema 2, and supported explicit owner-record versions; targeted writers emit their current record generation and never migrate the root implicitly |
+| vault-ingress preflight, source audit, analysis rendering, shownotes dry-run | dual reader | Parse schemas 0-4; gate through existing finding/error channels; never rewrite |
 | vault-clarification | current read/write | Route schema migration to vault-ingress; preserve config v2 and stamp confirmed intent v1/improvement goal v2 |
-| presentation-creator QR writer | dual reader/current writer | Read schemas 0-3; require schema 3 before URL creation or QR metadata persistence; stamp QR v2 |
-| presentation-creator publishing/post-event | authorized current writer | Require schema 3 before tracking writes; stamp resource v1 and preserve talk v8 |
-| illustrations thumbnail workflow | authorized current writer | Require schema 3 before tracking writes; stamp thumbnail v1 and preserve talk v8 |
-| vault-profile | dual reader | Parse schemas 0-3; treat unsupported generations as unavailable; never migrate |
+| presentation-creator QR writer | dual reader/current writer | Read schemas 0-4; require schema 4 before URL creation or QR metadata persistence; stamp QR v2 |
+| presentation-creator publishing/post-event | authorized current writer | Require schema 4 before tracking writes; stamp resource v1 and preserve talk v8 |
+| illustrations thumbnail workflow | authorized current writer | Require schema 4 before tracking writes; stamp thumbnail v1 and preserve talk v8 |
+| vault-profile | dual reader | Parse schemas 0-4; treat unsupported generations as unavailable; never migrate |
 
-Current database schema 3 with config schema 2 requires all eight top-level
+Current database schema 4 with config schema 2 requires all eight top-level
 state fields shown below. `source_title_equivalences`, `source_aliases`,
 `markdown_decks`, and `date_provenance` are optional owner collections. For
 `markdown_decks`, absent means no talk has a registered markdown deck, which is
@@ -406,7 +407,7 @@ customization, not the owner default. See the
       "not_evaluable": []
     }
   }],
-  "_comment_schema_version": "Database root schema v3 is owner-migrated by vault-ingress and introduces the optional top-level source_aliases collection. Root v2 introduced markdown_decks. Root migration infers neither deck registrations nor aliases. A missing talk record version is the historical implicit-v1 lineage. Talk v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds pattern_score_basis and a possibly-fractional pattern_score at the weighted scoring generation. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level source_title_equivalences collection at record v2, so v7 adds no field a v6 record lacks. V8 adds provider_auto to the transcript-source enum. Migration restamps v5-v7 records to v8 without rescoring or relabeling their source and lifts a nested v1 title ledger into the top-level collection. It preserves historical evidence and never synthesizes v5 outcomes.",
+  "_comment_schema_version": "Database root schema v4 is owner-migrated by vault-ingress and introduces the optional top-level date_provenance collection. Root v3 introduced source_aliases. Root v2 introduced markdown_decks. Root migration infers neither deck registrations nor aliases. A missing talk record version is the historical implicit-v1 lineage. Talk v2 makes transcript_source optional. Two incompatible v3 lineages were emitted; v4 is their source-located union and remains archival with evidence ledger v1. V5 adds applicability assessments, exhaustive outcomes, opportunity-coverage identity, and evidence ledger v2. V6 adds pattern_score_basis and a possibly-fractional pattern_score at the weighted scoring generation. V7 was introduced for the owner-reviewed title-equivalence ledger, which now lives in the top-level source_title_equivalences collection at record v2, so v7 adds no field a v6 record lacks. V8 adds provider_auto to the transcript-source enum. Migration restamps v5-v7 records to v8 without rescoring or relabeling their source and lifts a nested v1 title ledger into the top-level collection. It preserves historical evidence and never synthesizes v5 outcomes.",
   "_comment_absent_transcript_source": "Absent transcript_source: the key may be MISSING on a talk, and missing is meaningful — it means provenance is unknown, not that no transcript exists (that is the explicit value `none`). It arises on one path: fetch-transcript.py returning method `existing`, where a valid transcript was already on disk and no fetch ran, so nothing was learned about where it came from. Writers MUST NOT backfill a guess; `manual` in particular asserts a human produced it. Readers gauging transcript reliability MUST treat absent as unknown and MUST NOT default it to any value.",
   "pptx_catalog": [{
     "schema_version": 3,
@@ -783,6 +784,12 @@ An absent or empty `date` leaves a ceiling standing alone, which is the case
 this collection exists for. A `date` that is present but outside what
 `parse_catalog_date` reads — month precision, or anything else — refuses the
 ceiling instead of storing a bound nothing ever checks.
+
+The collection is the root v4 shape, for the same reason `markdown_decks` is the
+root v2 shape: a top-level key is part of the root record, and a version on each
+nested record does not version its parent. A database at an older root carrying
+a `date_provenance` key is never `current`; the root-only migration advances the
+root and preserves the records.
 
 One record per talk: a date established again replaces its account rather than
 appending a second one. The collection is optional — absent means nothing was

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -202,7 +202,7 @@ v1 and v2 for the rollout window.
 ### Schema versioning
 
 A schema-v4 database with current child records is an idempotent no-op.
-Earlier roots advance to v3; config v1 advances to v2 in the same pass.
+Earlier roots advance to v4; config v1 advances to v2 in the same pass.
 The root-only transition to v4 preserves every child value and does not
 create or infer any source alias. Before migration, queue `inspect` may read
 schema 0 and queue `recover` may close an active schema-0 lease in place.
@@ -211,7 +211,7 @@ schema fields; the established queue transition may advance a recovered claim
 receipt from v1 to v2 while adding its release fields.
 
 The owner migration is a preservation migration. Its only allowed semantic
-changes are advancing the root to schema v3, adding the validated historical
+changes are advancing the root to schema v4, adding the validated historical
 version to an unversioned owner record, creating absent owned arrays as empty
 arrays, and upgrading config v1 to v2. A missing exclusion list receives the canonical
 defaults; a valid owner-supplied list is preserved exactly. It
@@ -280,7 +280,7 @@ customization, not the owner default. See the
 
 ```json
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "config": {
     "schema_version": 2,
     "vault_root": "~/.claude/rhetoric-knowledge-vault",

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -780,9 +780,9 @@ a ceiling that contradicts the record it bounds refuses here rather than being
 stored beside a date it disagrees with. A method that establishes no day of its
 own requires one; `DATE_PROVENANCE_CEILING_REQUIRED_METHODS` names those.
 
-An absent or empty `date` leaves a ceiling standing alone, which is the case
-this collection exists for. A `date` that is present but outside what
-`parse_catalog_date` reads — month precision, or anything else — refuses the
+An absent or blank `date` leaves a ceiling standing alone, which is the case
+this collection exists for. Every other present value `parse_catalog_date`
+refuses — month precision, a non-string, a calendar-boundary year — refuses the
 ceiling instead of storing a bound nothing ever checks.
 
 The collection is the root v4 shape, for the same reason `markdown_decks` is the

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -250,10 +250,11 @@ or root state; the standalone root-only mode below preserves their contracts.
 | vault-profile | dual reader | Parse schemas 0-3; treat unsupported generations as unavailable; never migrate |
 
 Current database schema 3 with config schema 2 requires all eight top-level
-state fields shown below. `source_title_equivalences`, `source_aliases`, and
-`markdown_decks` are optional owner collections. For `markdown_decks`,
-absent means no talk has a registered markdown deck, which is what every
-database written before root v2 says.
+state fields shown below. `source_title_equivalences`, `source_aliases`,
+`markdown_decks`, and `date_provenance` are optional owner collections. For
+`markdown_decks`, absent means no talk has a registered markdown deck, which is
+what every database written before root v2 says. For `date_provenance`, absent
+means nothing was recorded about how any delivery date was established.
 Missing legacy arrays become empty during owner migration. Current writers do
 not create them opportunistically. A schema-v1 improvement goal remains valid
 historical state; migration never fabricates the schema-v2 baseline provenance
@@ -736,6 +737,53 @@ reason to refuse the whole database. The collection is optional — absent means
 no registered deck, which is the correct reading of every database written
 before it existed — and no migration owns it: a deck is registered by an owner
 who knows where the file is, never inferred.
+
+`date_provenance` is a top-level collection for the same reason, and it answers
+a question the catalog cannot ask of itself:
+
+```json
+"date_provenance": [{
+  "schema_version": 1,
+  "talk_filename": "playlist-5jhzguKLEr4.md",
+  "method": "live_broadcast_release",
+  "evidence": "youtube 5jhzguKLEr4 was_live=true, release_timestamp 1453343702",
+  "established_at": "2026-09-08T00:00:00Z",
+  "not_later_than": "2016-01-21"
+}]
+```
+
+Half the catalog carries a bare year or nothing where a delivery day belongs.
+Before this collection a date proved from an organizer program, a date inferred
+from an event's opening day, and a date that is just a year were the same
+string, so each audit re-derived what the previous one had already established
+and left its working in an issue thread.
+
+`method` is the only strength signal, and it is not stored as one: readers call
+`tracking_database.date_provenance_basis()`, which maps a method to `proved`,
+`inferred`, or `bounded`. Keeping strength derived means a record cannot claim
+more than its method supports. The accepted methods and their mapping are
+`DATE_PROVENANCE_BASIS_BY_METHOD` in
+`skills/vault-ingress/scripts/tracking_database.py`.
+
+`evidence` is required and non-empty because a method names a kind of evidence,
+never the evidence: the field is the trace an owner follows to re-check the
+claim without reading GitHub.
+
+`not_later_than` is an independent fact rather than a weaker date. A provider
+upload cannot precede the recording it publishes, so a talk with no date at all
+still has a ceiling, and a talk with a proved day can carry one that corroborates
+it. It is compared against the talk's own `date` through `upload_predates_catalog`
+(`skills/vault-ingress/scripts/source_identity_matching.py`) — the same
+comparator and the same timezone grace the live source-identity audit uses — so
+a ceiling that contradicts the record it bounds refuses here rather than being
+stored beside a date it disagrees with. A method that establishes no day of its
+own requires one; `DATE_PROVENANCE_CEILING_REQUIRED_METHODS` names those.
+
+One record per talk: a date established again replaces its account rather than
+appending a second one. The collection is optional — absent means nothing was
+recorded about a date, which is the state most of the catalog is in — and no
+migration owns it. Provenance is written by an owner who checked something,
+never inferred from a date that happens to be present.
 
 `apply_reviewed_metadata` exists because `scan-shownotes.py --apply` refuses
 review-required entries by design: an approved catalog correction otherwise had

--- a/skills/vault-ingress/scripts/source_identity_matching.py
+++ b/skills/vault-ingress/scripts/source_identity_matching.py
@@ -9,7 +9,7 @@ from the wrong delivery.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import date, timedelta
+from datetime import MINYEAR, date, timedelta
 import math
 import re
 from typing import Any
@@ -382,10 +382,19 @@ def parse_catalog_date(value: Any) -> tuple[date | None, int] | None:
         return None
     value = value.strip()
     if CATALOG_YEAR_RE.fullmatch(value):
-        return None, int(value)
+        year = int(value)
+        # `upload_predates_catalog` subtracts a day of timezone grace from the
+        # year's first day, which underflows the calendar at years 0 and 1. A
+        # record dated there is a typo, not a delivery, so it reads as
+        # uncomparable here rather than crashing every caller downstream.
+        if year < MINYEAR + 1:
+            return None
+        return None, year
     try:
         parsed = date.fromisoformat(value)
     except ValueError:
+        return None
+    if parsed.year < MINYEAR + 1:
         return None
     return parsed, parsed.year
 

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -29,6 +29,7 @@ from pptx_discovery_contract import (
 )
 from pptx_talk_identity import unassessed_legacy_binding
 from source_alias_contract import SourceAliasError, validate_alias_database
+from source_identity_matching import parse_catalog_date, upload_predates_catalog
 
 
 LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
@@ -76,6 +77,14 @@ IMPROVEMENT_GOAL_RECORD_SCHEMA_VERSION = 2
 # owns it (it is absent from `_RECORD_COUNT_KEYS` for that reason): a deck is
 # registered by an owner who knows where the file is, never inferred.
 MARKDOWN_DECK_RECORD_SCHEMA_VERSION = 1
+# How a talk's delivery date was established (#430). Its own top-level
+# collection for the same reason `markdown_decks` is one: the records this is
+# for are the legacy ones, and `TALK_RECORD_SCHEMA_VERSION` means the analysis
+# generation. Optional — absent means nothing was recorded about a date, which
+# is the state half the catalog is in. No migration owns it, and it is absent
+# from `_RECORD_COUNT_KEYS`: provenance is established by an owner who checked
+# something, never inferred from a date that happens to be present.
+DATE_PROVENANCE_RECORD_SCHEMA_VERSION = 1
 
 READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS = frozenset(
     {
@@ -237,6 +246,33 @@ MARKDOWN_DECK_REQUIRED_FIELDS = frozenset({"talk_filename", "deck_source_path"})
 # authors markdown, so a deck source named with any other suffix is a mistyped
 # path rather than a deck.
 MARKDOWN_DECK_SOURCE_SUFFIXES = frozenset({".md", ".markdown"})
+DATE_PROVENANCE_REQUIRED_FIELDS = frozenset(
+    {"talk_filename", "method", "evidence", "established_at"}
+)
+DATE_PROVENANCE_OPTIONAL_FIELDS = frozenset({"not_later_than"})
+# What a provenance record establishes, and how strongly. The mapping IS the
+# honesty of this collection: `basis` is never stored, so a record cannot claim
+# a strength its method does not support.
+#
+#   proved   — direct evidence of the delivery day itself
+#   inferred — derived from something adjacent to the delivery
+#   bounded  — establishes no day at all, only a ceiling
+#
+# A live broadcast's release timestamp is the stream running, which is why it
+# proves rather than bounds: for `was_live` media the provider's date is the
+# delivery moment, not a later publication. For everything else a provider
+# upload date is publication time and bounds only — see
+# `skills/vault-ingress/references/source-identity-audit.md`.
+DATE_PROVENANCE_BASIS_BY_METHOD = {
+    "live_broadcast_release": "proved",
+    "organizer_program": "proved",
+    "event_opening_day": "inferred",
+    "provider_upload_ceiling": "bounded",
+}
+# A method that establishes no day must carry the ceiling that is its whole
+# content; a record with neither would assert nothing.
+DATE_PROVENANCE_CEILING_REQUIRED_METHODS = frozenset({"provider_upload_ceiling"})
+_ISO_DAY = re.compile(r"\d{4}-\d{2}-\d{2}")
 SOURCE_TITLE_EQUIVALENCE_REQUIRED_FIELDS = frozenset(
     {
         "talk_filename",
@@ -1241,6 +1277,118 @@ def validate_markdown_deck(
         )
 
 
+def date_provenance_basis(method: object) -> str | None:
+    """Name how strongly a provenance method establishes a delivery date.
+
+    Returns ``proved``, ``inferred``, ``bounded``, or ``None`` for a method this
+    reader does not know. Callers read strength through this rather than a
+    stored field, so a record cannot claim more than its method supports. The
+    mapping is ``DATE_PROVENANCE_BASIS_BY_METHOD``.
+    """
+    if not isinstance(method, str):
+        return None
+    return DATE_PROVENANCE_BASIS_BY_METHOD.get(method)
+
+
+def validate_date_provenance(
+    record: Mapping[str, object],
+    *,
+    label: str,
+    talk: Mapping[str, object] | None = None,
+) -> None:
+    """Validate one record of how a talk's delivery date was established.
+
+    The record answers a question the catalog cannot: whether a `date` was
+    proved from the delivery, inferred from something next to it, or never
+    established at all. Half the catalog carries a bare year or nothing, and
+    before this the three were the same string, so each audit re-derived what
+    the last one had already worked out (#430).
+
+    `not_later_than` is an independent fact rather than a weaker date: a
+    provider upload cannot precede the recording it publishes, so a talk with no
+    date at all still has a ceiling, and one with a proved day can carry a
+    ceiling that corroborates it. It is compared against the talk's own date
+    through `upload_predates_catalog`, the same comparator and the same
+    timezone grace the live source-identity audit uses, so a ceiling that
+    contradicts the catalog refuses here instead of being stored as a fact that
+    disagrees with the record beside it.
+    """
+    _require_closed_shape(
+        record,
+        required=DATE_PROVENANCE_REQUIRED_FIELDS,
+        optional=DATE_PROVENANCE_OPTIONAL_FIELDS,
+        label=label,
+    )
+    # `_require_closed_shape` ignores `schema_version` for every record, so the
+    # generation is checked explicitly. A record this reader cannot name must
+    # refuse rather than be coerced into the current shape.
+    recorded = record.get("schema_version")
+    if (
+        isinstance(recorded, bool)
+        or not isinstance(recorded, int)
+        or recorded != DATE_PROVENANCE_RECORD_SCHEMA_VERSION
+    ):
+        raise TrackingDatabaseError(
+            f"{label}.schema_version must be {DATE_PROVENANCE_RECORD_SCHEMA_VERSION}"
+        )
+    _require_nonempty_string(record["talk_filename"], f"{label}.talk_filename")
+    # The trace an owner follows to check the claim without reading an issue
+    # thread. A method alone names a kind of evidence, never the evidence.
+    _require_nonempty_string(record["evidence"], f"{label}.evidence")
+    method = _require_nonempty_string(record["method"], f"{label}.method")
+    if date_provenance_basis(method) is None:
+        raise TrackingDatabaseError(
+            f"{label}.method must be one of "
+            f"{sorted(DATE_PROVENANCE_BASIS_BY_METHOD)}, not {method!r}"
+        )
+    established_at = _require_nonempty_string(
+        record["established_at"],
+        f"{label}.established_at",
+    )
+    try:
+        parsed = dt.datetime.fromisoformat(established_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TrackingDatabaseError(
+            f"{label}.established_at must be a timezone-aware ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise TrackingDatabaseError(
+            f"{label}.established_at must be a timezone-aware ISO-8601 timestamp"
+        )
+    ceiling_raw = record.get("not_later_than")
+    if ceiling_raw is None:
+        if method in DATE_PROVENANCE_CEILING_REQUIRED_METHODS:
+            raise TrackingDatabaseError(
+                f"{label}.not_later_than is required for method {method!r}, "
+                "which establishes no delivery day of its own"
+            )
+        return
+    ceiling_text = _require_nonempty_string(ceiling_raw, f"{label}.not_later_than")
+    # Hyphenated form only. `date.fromisoformat` also reads the compact
+    # `YYYYMMDD` the provider emits, and accepting both would put two spellings
+    # of one day in a collection every other date in the catalog spells one way.
+    if not _ISO_DAY.fullmatch(ceiling_text):
+        raise TrackingDatabaseError(
+            f"{label}.not_later_than must be an ISO-8601 calendar date, "
+            f"not {ceiling_text!r}"
+        )
+    try:
+        ceiling = dt.date.fromisoformat(ceiling_text)
+    except ValueError as exc:
+        raise TrackingDatabaseError(
+            f"{label}.not_later_than must be an ISO-8601 calendar date, "
+            f"not {ceiling_text!r}"
+        ) from exc
+    if talk is None:
+        return
+    if upload_predates_catalog(ceiling, parse_catalog_date(talk.get("date"))):
+        raise TrackingDatabaseError(
+            f"{label}.not_later_than {ceiling_text!r} precedes the talk's own "
+            f"date {talk.get('date')!r}; a ceiling cannot contradict the record "
+            "it bounds"
+        )
+
+
 def validate_source_title_equivalence(
     equivalence: Mapping[str, object],
     *,
@@ -1570,11 +1718,12 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
     equivalences = database.get("source_title_equivalences", [])
     if not isinstance(equivalences, list):
         raise TrackingDatabaseError("source_title_equivalences must be an array")
-    known_filenames = {
-        talk.get("filename")
+    talks_by_filename = {
+        talk.get("filename"): talk
         for talk in collections["talks"]
         if isinstance(talk, Mapping)
     }
+    known_filenames = set(talks_by_filename)
     for index, equivalence in enumerate(equivalences):
         if not isinstance(equivalence, Mapping):
             raise TrackingDatabaseError(
@@ -1627,6 +1776,34 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
                 f"{talk_filename!r}; a talk has one authored deck source"
             )
         claimed_by_talk.add(talk_filename)
+
+    provenance = database.get("date_provenance", [])
+    if not isinstance(provenance, list):
+        raise TrackingDatabaseError("date_provenance must be an array")
+    dated_talks: set[object] = set()
+    for index, record in enumerate(provenance):
+        if not isinstance(record, Mapping):
+            raise TrackingDatabaseError(
+                f"date_provenance[{index}] must be a JSON object"
+            )
+        label = f"date_provenance[{index}]"
+        talk_filename = record.get("talk_filename")
+        if talk_filename not in known_filenames:
+            raise TrackingDatabaseError(
+                f"{label}.talk_filename names no talk: {talk_filename!r}"
+            )
+        validate_date_provenance(
+            record, label=label, talk=talks_by_filename[talk_filename]
+        )
+        # One record per talk. A second would leave a reader choosing between
+        # two accounts of the same date with nothing saying which is current;
+        # a date established again is a replacement, not an append.
+        if talk_filename in dated_talks:
+            raise TrackingDatabaseError(
+                f"{label} is a second date provenance for {talk_filename!r}; "
+                "a talk has one account of how its date was established"
+            )
+        dated_talks.add(talk_filename)
 
     try:
         validate_alias_database(database)

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1395,7 +1395,21 @@ def validate_date_provenance(
         ) from exc
     if talk is None:
         return
-    if upload_predates_catalog(ceiling, parse_catalog_date(talk.get("date"))):
+    catalog = parse_catalog_date(talk.get("date"))
+    recorded_date = talk.get("date")
+    # A date the comparator cannot read is not the same as no date. An absent or
+    # empty one leaves the ceiling standing alone, which is the case this
+    # collection exists for. A present-but-unreadable one — month precision, or
+    # anything else `parse_catalog_date` refuses — would store a bound nothing
+    # ever checks, so it refuses until the catalog value is one the comparator
+    # can reach.
+    if catalog is None and isinstance(recorded_date, str) and recorded_date.strip():
+        raise TrackingDatabaseError(
+            f"{label}.not_later_than cannot be checked against the talk's date "
+            f"{recorded_date!r}, which is neither YYYY nor an ISO-8601 calendar "
+            "date; record a comparable date before bounding it"
+        )
+    if upload_predates_catalog(ceiling, catalog):
         raise TrackingDatabaseError(
             f"{label}.not_later_than {ceiling_text!r} precedes the talk's own "
             f"date {talk.get('date')!r}; a ceiling cannot contradict the record "

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1294,7 +1294,7 @@ def validate_date_provenance(
     record: Mapping[str, object],
     *,
     label: str,
-    talk: Mapping[str, object] | None = None,
+    talks_by_filename: Mapping[object, Mapping[str, object]] | None = None,
 ) -> None:
     """Validate one record of how a talk's delivery date was established.
 
@@ -1312,6 +1312,10 @@ def validate_date_provenance(
     timezone grace the live source-identity audit uses, so a ceiling that
     contradicts the catalog refuses here instead of being stored as a fact that
     disagrees with the record beside it.
+
+    `talks_by_filename` binds the record to the catalog it describes. Given, an
+    unknown `talk_filename` refuses and the ceiling is compared against that
+    talk; omitted, the record is checked for shape alone.
     """
     _require_closed_shape(
         record,
@@ -1355,6 +1359,16 @@ def validate_date_provenance(
         raise TrackingDatabaseError(
             f"{label}.established_at must be a timezone-aware ISO-8601 timestamp"
         )
+    # Resolved here rather than by the caller so the lookup happens after
+    # `talk_filename` is a proven string: a JSON array in that field would raise
+    # an unhandled TypeError on set membership instead of naming the field.
+    talk: Mapping[str, object] | None = None
+    if talks_by_filename is not None:
+        if record["talk_filename"] not in talks_by_filename:
+            raise TrackingDatabaseError(
+                f"{label}.talk_filename names no talk: {record['talk_filename']!r}"
+            )
+        talk = talks_by_filename[record["talk_filename"]]
     ceiling_raw = record.get("not_later_than")
     if ceiling_raw is None:
         if method in DATE_PROVENANCE_CEILING_REQUIRED_METHODS:
@@ -1718,7 +1732,7 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
     equivalences = database.get("source_title_equivalences", [])
     if not isinstance(equivalences, list):
         raise TrackingDatabaseError("source_title_equivalences must be an array")
-    talks_by_filename = {
+    talks_by_filename: dict[object, Mapping[str, object]] = {
         talk.get("filename"): talk
         for talk in collections["talks"]
         if isinstance(talk, Mapping)
@@ -1787,14 +1801,10 @@ def assess_tracking_database(database: object) -> TrackingDatabaseAssessment:
                 f"date_provenance[{index}] must be a JSON object"
             )
         label = f"date_provenance[{index}]"
-        talk_filename = record.get("talk_filename")
-        if talk_filename not in known_filenames:
-            raise TrackingDatabaseError(
-                f"{label}.talk_filename names no talk: {talk_filename!r}"
-            )
         validate_date_provenance(
-            record, label=label, talk=talks_by_filename[talk_filename]
+            record, label=label, talks_by_filename=talks_by_filename
         )
+        talk_filename = record["talk_filename"]
         # One record per talk. A second would leave a reader choosing between
         # two accounts of the same date with nothing saying which is current;
         # a date established again is a replacement, not an append.

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -1403,13 +1403,16 @@ def validate_date_provenance(
         return
     catalog = parse_catalog_date(talk.get("date"))
     recorded_date = talk.get("date")
-    # A date the comparator cannot read is not the same as no date. An absent or
-    # empty one leaves the ceiling standing alone, which is the case this
-    # collection exists for. A present-but-unreadable one — month precision, or
-    # anything else `parse_catalog_date` refuses — would store a bound nothing
-    # ever checks, so it refuses until the catalog value is one the comparator
-    # can reach.
-    if catalog is None and isinstance(recorded_date, str) and recorded_date.strip():
+    # A date the comparator cannot read is not the same as no date. Absent, or
+    # a string of whitespace, leaves the ceiling standing alone, which is the
+    # case this collection exists for. Every other present value the comparator
+    # refuses — month precision, a non-string, a calendar-boundary year — would
+    # store a bound nothing ever checks, so it refuses until the catalog value
+    # is one the comparator can reach.
+    absent = recorded_date is None or (
+        isinstance(recorded_date, str) and not recorded_date.strip()
+    )
+    if catalog is None and not absent:
         raise TrackingDatabaseError(
             f"{label}.not_later_than cannot be checked against the talk's date "
             f"{recorded_date!r}, which is neither YYYY nor an ISO-8601 calendar "

--- a/skills/vault-ingress/scripts/tracking_database.py
+++ b/skills/vault-ingress/scripts/tracking_database.py
@@ -39,7 +39,12 @@ LEGACY_TRACKING_DATABASE_SCHEMA_VERSION = 0
 # root generation (`stateful-artifacts` Migration Policy).
 PRE_MARKDOWN_DECKS_TRACKING_DATABASE_SCHEMA_VERSION = 1
 PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION = 2
-TRACKING_DATABASE_SCHEMA_VERSION = 3
+# The root shape before the `date_provenance` collection (#430), for the same
+# reason the two above exist: a top-level key is part of the ROOT record's
+# shape, and a version on each nested provenance record does not version its
+# parent database (`stateful-artifacts` Migration Policy).
+PRE_DATE_PROVENANCE_TRACKING_DATABASE_SCHEMA_VERSION = 3
+TRACKING_DATABASE_SCHEMA_VERSION = 4
 LEGACY_TALK_RECORD_SCHEMA_VERSION = 1
 FLAT_SCORE_TALK_RECORD_SCHEMA_VERSION = 5
 # The generation before the owner-reviewed title-equivalence ledger (#333).
@@ -91,6 +96,7 @@ READABLE_TRACKING_DATABASE_SCHEMA_VERSIONS = frozenset(
         LEGACY_TRACKING_DATABASE_SCHEMA_VERSION,
         PRE_MARKDOWN_DECKS_TRACKING_DATABASE_SCHEMA_VERSION,
         PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
+        PRE_DATE_PROVENANCE_TRACKING_DATABASE_SCHEMA_VERSION,
         TRACKING_DATABASE_SCHEMA_VERSION,
     }
 )
@@ -2111,6 +2117,7 @@ def repair_missing_qr_schema_versions(database: object) -> TrackingDatabaseMigra
         or assessment.schema_version
         not in {
             PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
+            PRE_DATE_PROVENANCE_TRACKING_DATABASE_SCHEMA_VERSION,
             TRACKING_DATABASE_SCHEMA_VERSION,
         }
         or (
@@ -2187,6 +2194,7 @@ def migrate_tracking_database_root(database: object) -> TrackingDatabaseMigratio
         or assessment.schema_version
         not in {
             PRE_SOURCE_ALIASES_TRACKING_DATABASE_SCHEMA_VERSION,
+            PRE_DATE_PROVENANCE_TRACKING_DATABASE_SCHEMA_VERSION,
             TRACKING_DATABASE_SCHEMA_VERSION,
         }
         or database["config"]["schema_version"] != CONFIG_RECORD_SCHEMA_VERSION

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ DEFAULT_PPTX_DIRECTORY_EXCLUSIONS = [
 # The owner-current root generation, in one place. A fixture that pins it by
 # literal has to be hunted down on every root bump, and the ones that were
 # missed failed as "assert 2 == 1" with nothing naming the generation.
-CURRENT_ROOT_SCHEMA_VERSION = 3
+CURRENT_ROOT_SCHEMA_VERSION = 4
 
 
 def current_tracking_config(**updates: object) -> dict[str, object]:

--- a/tests/test_apply_source_repairs.py
+++ b/tests/test_apply_source_repairs.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
 from conftest import current_tracking_config
 
 
@@ -15,7 +16,7 @@ def write_json(path, value):
 
 def base_database():
     return {
-        "schema_version": 3,
+        "schema_version": CURRENT_ROOT,
         "config": current_tracking_config(),
         "talks": [
             {

--- a/tests/test_generate_qr.py
+++ b/tests/test_generate_qr.py
@@ -22,7 +22,7 @@ from conftest import (
 
 def _current_tracking_database():
     return {
-        "schema_version": 3,
+        "schema_version": CURRENT_ROOT,
         "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],

--- a/tests/test_mutate_tracking_database.py
+++ b/tests/test_mutate_tracking_database.py
@@ -1788,7 +1788,7 @@ def test_root_migration_then_metadata_cli_dry_run_and_hash_bound_apply(
     )
     applied = json.loads(capsys.readouterr().out)
     expected = copy.deepcopy(database)
-    expected["schema_version"] = 3
+    expected["schema_version"] = CURRENT_ROOT
     expected["talks"][0]["date"] = "2018-08-31"
     assert applied["database_written"] is True
     assert applied["output_sha256"] == preview["output_sha256"]

--- a/tests/test_pptx_catalog_generation.py
+++ b/tests/test_pptx_catalog_generation.py
@@ -23,6 +23,7 @@ import json
 import pathlib
 from typing import Any
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
 import pytest
 
 
@@ -379,7 +380,7 @@ def test_a_non_integer_record_version_is_rejected(tracking_database) -> None:
 
 def _database(records: list[dict]) -> dict:
     return {
-        "schema_version": 3,
+        "schema_version": CURRENT_ROOT,
         "config": {"schema_version": 2, "pptx_directory_exclusions": []},
         "talks": [],
         "pptx_catalog": records,

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -13,6 +13,7 @@ import sys
 from typing import Any
 import zipfile
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
 import pytest
 from conftest import video_source_receipt_for, write_tiny_video
 from PIL import Image
@@ -142,7 +143,7 @@ def write_database(fixture, talks, config=None, *, current=False, equivalences=N
     if current:
         database.update(
             {
-                "schema_version": 3,
+                "schema_version": CURRENT_ROOT,
                 "pptx_catalog": [],
                 "qr_codes": [],
                 "resources": [],

--- a/tests/test_source_identity_matching.py
+++ b/tests/test_source_identity_matching.py
@@ -422,3 +422,27 @@ def test_the_ledger_generation_matches_its_owner() -> None:
         source_identity_matching.SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION
         == tracking_database.SOURCE_TITLE_EQUIVALENCE_RECORD_SCHEMA_VERSION
     )
+
+
+@pytest.mark.parametrize("value", ["0000", "0001", "0001-05-05", "0001-01-01"])
+def test_a_calendar_boundary_year_reads_as_uncomparable(value):
+    """`upload_predates_catalog` subtracts a day of grace from the year's first
+    day, which underflows at years 0 and 1. Such a record is a typo, not a
+    delivery, so it must read as uncomparable rather than crash a caller."""
+    assert source_identity_matching.parse_catalog_date(value) is None
+    assert (
+        source_identity_matching.upload_predates_catalog(
+            date(2016, 1, 1), source_identity_matching.parse_catalog_date(value)
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("value", ["0002", "0002-01-01", "2016", "2016-03-04"])
+def test_a_year_above_the_boundary_still_compares(value):
+    parsed = source_identity_matching.parse_catalog_date(value)
+    assert parsed is not None
+    assert (
+        source_identity_matching.upload_predates_catalog(date(2016, 6, 1), parsed)
+        is not None
+    )

--- a/tests/test_sweep_pptx_talk_identity.py
+++ b/tests/test_sweep_pptx_talk_identity.py
@@ -17,6 +17,8 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
+
 import pytest
 
 from test_pptx_deck_facts import full_deck_members, write_deck
@@ -78,7 +80,7 @@ def catalog_row(pptx_path: str, talk_filename: str | None, **overrides: Any) -> 
 def database(rows: list[dict], talks: list[dict], source_root: Path) -> dict:
     """One owner-current database whose only interesting part is the catalog."""
     return {
-        "schema_version": 3,
+        "schema_version": CURRENT_ROOT,
         "config": {
             "schema_version": 2,
             "pptx_directory_exclusions": [],

--- a/tests/test_tracking_database_root_migration.py
+++ b/tests/test_tracking_database_root_migration.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
 import pytest
 
 from test_tracking_database_schema import (
@@ -41,11 +42,11 @@ def test_root_upgrade_preserves_every_child_value_and_reader_contract(
     result = tracking_database.migrate_tracking_database_root(database)
 
     expected = copy.deepcopy(before)
-    expected["schema_version"] = 3
+    expected["schema_version"] = CURRENT_ROOT
     assert result.database == expected
     assert database == before
     assert result.changed is True
-    assert (result.from_schema_version, result.to_schema_version) == (2, 3)
+    assert (result.from_schema_version, result.to_schema_version) == (2, CURRENT_ROOT)
     assert not any(result.record_counts.values())
     assert (
         tracking_database.assess_tracking_database(result.database).state == "current"
@@ -142,7 +143,7 @@ def test_root_cli_preserves_evidence_backups_and_noop_inode(
         path, apply=True, expected_sha256=preview["input_sha256"], root_only=True
     )
     expected = copy.deepcopy(database)
-    expected["schema_version"] = 3
+    expected["schema_version"] = CURRENT_ROOT
     assert json.loads(path.read_bytes()) == expected
     assert applied["output_sha256"] == preview["output_sha256"]
     assert Path(applied["backup"]).read_bytes() == raw
@@ -194,7 +195,7 @@ def test_root_migration_rejects_stale_writers_and_allows_claim_preserving_reload
     assert Path(applied["backup"]).read_bytes() == raw
     current, fresh = read(path)
     assert current["talks"] == database["talks"]
-    assert current["schema_version"] == 3
+    assert current["schema_version"] == CURRENT_ROOT
     current["config"]["speaker_name"] = "Synthetic speaker"
     assert write(path, current, expected_snapshot=fresh).installed is True
     reloaded, _ = read(path)
@@ -316,3 +317,50 @@ def test_existing_claim_replays_through_current_queue_cli_after_root_migration(
     assert report["claimed"][0]["reprocess_generation"] == 2
     assert path.read_bytes() == installed
     assert json.loads(installed)["talks"] == database["talks"]
+
+
+@pytest.mark.parametrize("start", [2, 3])
+def test_a_pre_provenance_root_migrates_to_current_preserving_children(
+    tracking_database, start
+):
+    """The root advances; no provenance is invented for a database without any."""
+    database = _root_database(tracking_database)
+    database["schema_version"] = start
+    before = copy.deepcopy(database)
+
+    result = tracking_database.migrate_tracking_database_root(database)
+
+    expected = copy.deepcopy(before)
+    expected["schema_version"] = CURRENT_ROOT
+    assert result.database == expected
+    assert "date_provenance" not in result.database
+    assert (result.from_schema_version, result.to_schema_version) == (
+        start,
+        CURRENT_ROOT,
+    )
+    assert not any(result.record_counts.values())
+
+
+def test_a_pre_provenance_root_carrying_the_collection_is_not_current(
+    tracking_database,
+):
+    """The collection IS the current root shape, so an older root claiming it
+    must not read as current — the fix is the migration, not a refusal."""
+    database = _root_database(tracking_database)
+    database["schema_version"] = 3
+    database["date_provenance"] = [
+        {
+            "schema_version": 1,
+            "talk_filename": database["talks"][0]["filename"],
+            "method": "organizer_program",
+            "evidence": "published schedule",
+            "established_at": "2026-09-08T00:00:00Z",
+        }
+    ]
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.state != "current"
+    migrated = tracking_database.migrate_tracking_database_root(database).database
+    assert migrated["date_provenance"] == database["date_provenance"]
+    assert tracking_database.assess_tracking_database(migrated).state == "current"

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -2658,3 +2658,22 @@ def test_the_collection_must_be_an_array(tracking_database):
         tracking_database.TrackingDatabaseError, match="must be an array"
     ):
         tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("value", [[], {}, ["one.md"], 3, None, True, ""])
+def test_a_malformed_talk_filename_refuses_with_a_named_field(tracking_database, value):
+    """An unhashable value must name the field, not raise on set membership."""
+    database = _database_with_provenance(
+        tracking_database, [_provenance(talk_filename=value)]
+    )
+
+    with pytest.raises(tracking_database.TrackingDatabaseError) as exc:
+        tracking_database.assess_tracking_database(database)
+    assert "date_provenance[0].talk_filename" in str(exc.value)
+
+
+def test_shape_alone_is_checkable_without_a_catalog(tracking_database):
+    """Omitting the map checks the record without binding it to a talk."""
+    tracking_database.validate_date_provenance(
+        _provenance(talk_filename="not-in-any-catalog.md"), label="record"
+    )

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -2444,3 +2444,217 @@ def test_migrating_a_pre_v2_root_without_the_collection_reaches_v2(
     assert tracking_database.assess_tracking_database(result.database).state == (
         "current"
     )
+
+
+# How a talk's delivery date was established (#430).
+
+
+def _provenance(**updates):
+    record = {
+        "schema_version": 1,
+        "talk_filename": "one.md",
+        "method": "organizer_program",
+        "evidence": "DevNexus 2015 published schedule, session page, retrieved 2026-09-08",
+        "established_at": "2026-09-08T00:00:00Z",
+    }
+    record.update(updates)
+    return record
+
+
+def _database_with_provenance(tracking_database, records, *, talk_date=None):
+    migrated = tracking_database.migrate_tracking_database(_legacy_database()).database
+    if talk_date is not None:
+        migrated["talks"][0]["date"] = talk_date
+    migrated["date_provenance"] = records
+    return migrated
+
+
+def test_a_provenance_record_leaves_the_database_current(tracking_database):
+    """The collection is optional and additive: no talk record changes shape."""
+    database = _database_with_provenance(tracking_database, [_provenance()])
+
+    assessment = tracking_database.assess_tracking_database(database)
+
+    assert assessment.state == "current"
+    assert assessment.usable is True
+    # The talk record is untouched: provenance lives beside it, so a legacy
+    # record keeps its own generation and needs no migration to carry one.
+    without = tracking_database.migrate_tracking_database(_legacy_database()).database
+    assert database["talks"] == without["talks"]
+
+
+def test_a_database_without_the_provenance_collection_stays_current(tracking_database):
+    """Absent means nothing recorded — the state half the catalog is in."""
+    database = tracking_database.migrate_tracking_database(_legacy_database()).database
+
+    assert "date_provenance" not in database
+    assert tracking_database.assess_tracking_database(database).state == "current"
+
+
+@pytest.mark.parametrize(
+    "method,basis",
+    [
+        ("live_broadcast_release", "proved"),
+        ("organizer_program", "proved"),
+        ("event_opening_day", "inferred"),
+        ("provider_upload_ceiling", "bounded"),
+    ],
+)
+def test_strength_is_read_from_the_method_never_stored(
+    tracking_database, method, basis
+):
+    """A record cannot claim a strength its method does not support."""
+    assert tracking_database.date_provenance_basis(method) == basis
+
+
+@pytest.mark.parametrize("method", ["proved", "guess", "", None, 3])
+def test_an_unknown_method_refuses_the_database(tracking_database, method):
+    database = _database_with_provenance(
+        tracking_database,
+        [_provenance(method=method, not_later_than="2016-01-21")],
+    )
+
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_ceiling_only_method_must_carry_its_ceiling(tracking_database):
+    """`provider_upload_ceiling` establishes no day, so without one it says nothing."""
+    database = _database_with_provenance(
+        tracking_database, [_provenance(method="provider_upload_ceiling")]
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="not_later_than is required"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_ceiling_that_contradicts_the_catalog_date_refuses(tracking_database):
+    """A provider upload cannot precede the recording it publishes."""
+    database = _database_with_provenance(
+        tracking_database,
+        [_provenance(not_later_than="2014-01-21")],
+        talk_date="2016-03-04",
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="cannot contradict"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_ceiling_inside_the_timezone_grace_is_accepted(tracking_database):
+    """Same comparator and same grace as the live source-identity audit."""
+    database = _database_with_provenance(
+        tracking_database,
+        [_provenance(not_later_than="2016-03-03")],
+        talk_date="2016-03-04",
+    )
+
+    assert tracking_database.assess_tracking_database(database).state == "current"
+
+
+def test_a_ceiling_stands_alone_when_the_talk_has_no_date(tracking_database):
+    """The case this collection exists for: no date, but still a known bound."""
+    database = _database_with_provenance(
+        tracking_database,
+        [
+            _provenance(
+                method="provider_upload_ceiling",
+                evidence="youtube upload_date for 5jhzguKLEr4, captured 2026-08-18",
+                not_later_than="2016-01-21",
+            )
+        ],
+    )
+
+    assert "date" not in database["talks"][0]
+    assert tracking_database.assess_tracking_database(database).state == "current"
+
+
+def test_a_provenance_naming_no_talk_refuses_the_database(tracking_database):
+    database = _database_with_provenance(
+        tracking_database, [_provenance(talk_filename="absent.md")]
+    )
+
+    with pytest.raises(tracking_database.TrackingDatabaseError, match="names no talk"):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_second_provenance_for_one_talk_refuses_the_database(tracking_database):
+    """A date established again is a replacement, never an append."""
+    database = _database_with_provenance(
+        tracking_database, [_provenance(), _provenance(method="event_opening_day")]
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="second date provenance"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize(
+    "field", ["talk_filename", "method", "evidence", "established_at"]
+)
+def test_a_missing_required_field_refuses_the_database(tracking_database, field):
+    record = _provenance()
+    del record[field]
+    database = _database_with_provenance(tracking_database, [record])
+
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_an_unknown_field_refuses_the_database(tracking_database):
+    database = _database_with_provenance(
+        tracking_database, [_provenance(confidence="high")]
+    )
+
+    with pytest.raises(tracking_database.TrackingDatabaseError, match="unknown fields"):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("version", [0, 2, "1", True, None])
+def test_a_record_generation_this_reader_cannot_name_refuses(
+    tracking_database, version
+):
+    database = _database_with_provenance(
+        tracking_database, [_provenance(schema_version=version)]
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="schema_version must be 1"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize(
+    "value", ["2026-09-08", "not-a-time", "2026-09-08T00:00:00", ""]
+)
+def test_a_naive_or_malformed_timestamp_refuses(tracking_database, value):
+    database = _database_with_provenance(
+        tracking_database, [_provenance(established_at=value)]
+    )
+
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("value", ["2016", "2016-01", "20160121", "", 20160121])
+def test_a_ceiling_that_is_not_a_calendar_date_refuses(tracking_database, value):
+    """A ceiling is a day: a year would silently widen the bound it asserts."""
+    database = _database_with_provenance(
+        tracking_database, [_provenance(not_later_than=value)]
+    )
+
+    with pytest.raises(tracking_database.TrackingDatabaseError):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_the_collection_must_be_an_array(tracking_database):
+    database = _database_with_provenance(tracking_database, {"one.md": _provenance()})
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="must be an array"
+    ):
+        tracking_database.assess_tracking_database(database)

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -2731,3 +2731,41 @@ def test_a_bare_year_catalog_date_is_comparable(tracking_database):
         tracking_database.TrackingDatabaseError, match="cannot contradict"
     ):
         tracking_database.assess_tracking_database(contradicting)
+
+
+@pytest.mark.parametrize(
+    "talk_date",
+    [
+        2016,
+        ["2016-03-04"],
+        {"year": 2016},
+        True,
+        20160304,
+        "0000",
+        "0001",
+        "0001-05-05",
+    ],
+)
+def test_a_present_but_uncomparable_date_refuses_a_ceiling(
+    tracking_database, talk_date
+):
+    """The guard is about presence, not type: only absent lets a ceiling stand."""
+    database = _database_with_provenance(
+        tracking_database,
+        [_provenance(not_later_than="2014-01-21")],
+        talk_date=talk_date,
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="cannot be checked against"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+def test_a_missing_date_key_still_lets_a_ceiling_stand_alone(tracking_database):
+    database = _database_with_provenance(
+        tracking_database, [_provenance(not_later_than="2014-01-21")]
+    )
+    database["talks"][0].pop("date", None)
+
+    assert tracking_database.assess_tracking_database(database).state == "current"

--- a/tests/test_tracking_database_schema.py
+++ b/tests/test_tracking_database_schema.py
@@ -2677,3 +2677,57 @@ def test_shape_alone_is_checkable_without_a_catalog(tracking_database):
     tracking_database.validate_date_provenance(
         _provenance(talk_filename="not-in-any-catalog.md"), label="record"
     )
+
+
+@pytest.mark.parametrize("talk_date", ["2016-03", "spring 2016", "2016-3", "16-03-04"])
+def test_a_ceiling_refuses_when_the_catalog_date_cannot_be_compared(
+    tracking_database, talk_date
+):
+    """A bound nothing checks is worse than no bound: `parse_catalog_date`
+    reads YYYY and ISO days only, so month precision would skip the
+    contradiction check silently."""
+    database = _database_with_provenance(
+        tracking_database,
+        [_provenance(not_later_than="2014-01-21")],
+        talk_date=talk_date,
+    )
+
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="cannot be checked against"
+    ):
+        tracking_database.assess_tracking_database(database)
+
+
+@pytest.mark.parametrize("talk_date", ["", "   "])
+def test_an_empty_catalog_date_still_lets_a_ceiling_stand_alone(
+    tracking_database, talk_date
+):
+    """Absent is not the same as unreadable — absent is what this is for."""
+    database = _database_with_provenance(
+        tracking_database,
+        [_provenance(not_later_than="2014-01-21")],
+        talk_date=talk_date,
+    )
+
+    assert tracking_database.assess_tracking_database(database).state == "current"
+
+
+def test_a_bare_year_catalog_date_is_comparable(tracking_database):
+    """Year precision reaches the comparator, so the ceiling is checked."""
+    database = _database_with_provenance(
+        tracking_database,
+        [_provenance(not_later_than="2016-06-01")],
+        talk_date="2016",
+    )
+
+    assert tracking_database.assess_tracking_database(database).state == "current"
+
+    contradicting = _database_with_provenance(
+        tracking_database,
+        [_provenance(not_later_than="2014-06-01")],
+        talk_date="2016",
+    )
+    with pytest.raises(
+        tracking_database.TrackingDatabaseError, match="cannot contradict"
+    ):
+        tracking_database.assess_tracking_database(contradicting)

--- a/tests/test_tracking_database_writer_races.py
+++ b/tests/test_tracking_database_writer_races.py
@@ -10,6 +10,7 @@ import threading
 
 import pytest
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
 from conftest import current_tracking_config
 
 
@@ -21,7 +22,7 @@ def _write(path: Path, value: object) -> bytes:
 
 def _current_database() -> dict[str, object]:
     return {
-        "schema_version": 3,
+        "schema_version": CURRENT_ROOT,
         "config": current_tracking_config(),
         "talks": [],
         "pptx_catalog": [],

--- a/tests/test_write_analysis.py
+++ b/tests/test_write_analysis.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
 from conftest import current_tracking_config
 
 
@@ -330,7 +331,7 @@ def _write_tracking_db(
     path.write_text(
         json.dumps(
             {
-                "schema_version": 3,
+                "schema_version": CURRENT_ROOT,
                 "config": current_tracking_config(),
                 "talks": talks,
                 "pptx_catalog": [],


### PR DESCRIPTION
First of three for #430. Schema and validation only — no vault write, no
backfill.

Half the catalog carries a bare year or nothing where a delivery day belongs:

| `date` precision | count | share |
|---|---:|---:|
| day | 126 | 50.2% |
| year | 91 | 36.3% |
| absent | 26 | 10.4% |
| month | 8 | 3.2% |

Before this, a date proved from an organizer program, a date inferred from an
event's opening day, and a date that is just a year were the same string. So
#333 and #339 each proved dates by hand and left their working in issue threads,
and the next audit could not tell an evidenced date from a guess.

## The collection

```json
"date_provenance": [{
  "schema_version": 1,
  "talk_filename": "playlist-5jhzguKLEr4.md",
  "method": "live_broadcast_release",
  "evidence": "youtube 5jhzguKLEr4 was_live=true, release_timestamp 1453343702",
  "established_at": "2026-09-08T00:00:00Z",
  "not_later_than": "2016-01-21"
}]
```

**Top-level rather than a talk field**, following the precedent
`tracking_database.py` already documents for `markdown_decks`:
`TALK_RECORD_SCHEMA_VERSION` means the analysis generation, so a shape change
there is unreachable for the legacy records this is for — and the coarse dates
*are* the legacy records. No talk record changes shape, no migration owns the
collection, absent means nothing recorded.

**Strength is derived, never stored.** `method` is the only signal; readers call
`date_provenance_basis()`, which maps it to `proved` / `inferred` / `bounded`. A
record therefore cannot claim more than its method supports, and the two cannot
drift apart.

**`evidence` is required and non-empty**, because a method names a *kind* of
evidence and never the evidence — this field is the trace an owner follows to
re-check the claim without opening GitHub, which is acceptance criterion 1.

**`not_later_than` is an independent fact, not a weaker date.** A provider
upload cannot precede the recording it publishes, so a talk with no date at all
still has a ceiling, and one with a proved day can carry a corroborating ceiling.
Measured across every talk that has both a proved day and a stored upload date,
the bound holds **74 of 74**, with the single −1 day inside the repo's own
`UPLOAD_TIMEZONE_GRACE`. It is compared through `upload_predates_catalog` — the
same comparator and grace the live source-identity audit uses — so a ceiling
contradicting the record it bounds refuses rather than being stored next to a
date it disagrees with.

`live_broadcast_release` is the one method where a provider date *proves*: for a
`was_live` recording the release timestamp is the stream running, not a later
publication. A sweep of all 124 coarse-dated recordings found 3 such broadcasts,
all of them among the 26 with no date at all.

## Scope

This PR is the contract. The other two:

2. an establisher that derives provenance from stored and live provider evidence
   and emits a report (read-only), covering acceptance criterion 3
3. the vault backfill plus the `source_identity_date_uncheckable` re-scope,
   covering criteria 2 and 4

## Test plan

- [x] Full suite: **8056 passed**, 8 skipped
- [x] 20 new cases: optional/additive, method enum, strength mapping, ceiling
      required for a ceiling-only method, ceiling contradicting the catalog date,
      ceiling inside the timezone grace, ceiling standing alone with no catalog
      date, orphan record, second record for one talk, each missing required
      field, unknown field, unnameable generation, naive/malformed timestamp,
      non-calendar ceiling, non-array collection
- [x] Asserted the talk records are byte-identical with and without the
      collection
- [x] ruff clean, pyright 0 errors

Pyright caught that the new "database without the collection" test shadowed the
`markdown_decks` test of the same name and had silently disabled it; renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV