### PR TITLE
feat(vault-ingress): record the provider ceiling for undated talks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+### The date backlog is now countable
+
+`establish-date-provenance.py` records the provider ceiling for every talk whose
+delivery date is unrecorded, so the 26 catalog records carrying no date at all
+stop being an unbounded research question. Every one of them already has a
+stored `source_identity.upload_date`, so the bound costs no fetch.
+
+It writes `date_provenance` records only. It never writes a talk's `date`, never
+fetches from a provider, and never uses a method that claims a delivery day —
+the only thing it can add is a bound. A talk whose date already parses is left
+alone: a stored upload date says nothing about how a date that exists was
+arrived at, and one record per talk means writing a ceiling there would displace
+the real account.
+
+Every refusal is named rather than silently skipped —
+`date_already_comparable`, `date_present_but_uncomparable`,
+`provenance_already_recorded`, `no_provider_upload_date` — and the report's
+coverage block counts them, which is what makes backlog progress measurable
+across runs instead of re-derived by each audit. Running it twice is a no-op.
+
+Dry run by default; `--apply` requires the input digest from that dry run and
+commits through the owner transaction with a backup, like the migration CLI.
+`--as-of` pins `established_at` so a run is reproducible.
+
+Establishing actual delivery days — the live-broadcast method, and migrating the
+dates proved by hand in #333 — is separate work under #430.
+
 ## 0.20.142 — 2026-09-08
 
 ### A date now says how it was established

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -797,6 +797,15 @@ recorded about a date, which is the state most of the catalog is in — and no
 migration owns it. Provenance is written by an owner who checked something,
 never inferred from a date that happens to be present.
 
+`skills/vault-ingress/scripts/establish-date-provenance.py` writes the ceiling
+records. It is a dry run by default and `--apply` requires the input digest from
+that dry run, like the migration CLI. It writes `date_provenance` records only —
+never a talk's `date`, and never a method that claims a delivery day — so the
+only thing it can add is a bound. Its report names every proposal, every talk it
+refused and why (the closed `BLOCKED_REASONS` in that file), and a coverage block
+that makes backlog progress measurable across runs. Running it twice is a no-op:
+a talk that already carries an account keeps it.
+
 `apply_reviewed_metadata` exists because `scan-shownotes.py --apply` refuses
 review-required entries by design: an approved catalog correction otherwise had
 no owner writer at all. The same writer carries an owner-reviewed delivery-date

--- a/skills/vault-ingress/scripts/establish-date-provenance.py
+++ b/skills/vault-ingress/scripts/establish-date-provenance.py
@@ -64,8 +64,14 @@ class DateProvenanceError(RuntimeError):
     """The owner refused an input; the message names the repair."""
 
 
-def _upload_date(talk: Any) -> str | None:
-    """Return the stored provider upload day, or None when there is not one."""
+def _upload_evidence(talk: Any) -> tuple[str, str] | None:
+    """Return the stored upload day and the identity it came from.
+
+    Both halves come out of the same `source_identity` block. The talk's own
+    `youtube_id` is deliberately not consulted: the bound is derived from that
+    block, so citing anything else could point a later re-check at a different
+    recording than the one that produced the date.
+    """
     identity = talk.get("source_identity")
     if not isinstance(identity, dict):
         return None
@@ -77,7 +83,13 @@ def _upload_date(talk: Any) -> str | None:
         dt.date.fromisoformat(stamped)
     except ValueError:
         return None
-    return stamped
+    provider = identity.get("provider")
+    video_id = identity.get("video_id")
+    if not isinstance(provider, str) or not provider.strip():
+        return None
+    if not isinstance(video_id, str) or not video_id.strip():
+        return None
+    return stamped, f"{provider.strip()} {video_id.strip()}"
 
 
 def classify_talk(talk: Any, *, has_provenance: bool) -> str | None:
@@ -98,7 +110,7 @@ def classify_talk(talk: Any, *, has_provenance: bool) -> str | None:
         # Month precision and anything else the comparator refuses. The ceiling
         # would be unverifiable against it, so the reader refuses it too.
         return "date_present_but_uncomparable"
-    if _upload_date(talk) is None:
+    if _upload_evidence(talk) is None:
         return "no_provider_upload_date"
     return None
 
@@ -128,15 +140,16 @@ def plan_ceilings(database: Any, *, established_at: str) -> dict[str, Any]:
         if reason is not None:
             blocked.append({"talk_filename": filename, "reason": reason})
             continue
-        upload = _upload_date(talk)
+        evidence = _upload_evidence(talk)
+        assert evidence is not None  # classify_talk returned a reason otherwise
+        upload, identity = evidence
         proposals.append(
             {
                 "schema_version": DATE_PROVENANCE_RECORD_SCHEMA_VERSION,
                 "talk_filename": filename,
                 "method": CEILING_METHOD,
                 "evidence": (
-                    "stored source_identity.upload_date "
-                    f"{upload} for provider video {talk.get('youtube_id')}"
+                    f"stored source_identity.upload_date {upload} for {identity}"
                 ),
                 "established_at": established_at,
                 "not_later_than": upload,

--- a/skills/vault-ingress/scripts/establish-date-provenance.py
+++ b/skills/vault-ingress/scripts/establish-date-provenance.py
@@ -27,6 +27,7 @@ import hashlib
 import json
 from pathlib import Path
 import re
+import sys
 from typing import Any, NoReturn
 
 from source_identity_matching import parse_catalog_date
@@ -279,12 +280,14 @@ def execute(
 
 
 def _fail(message: str) -> NoReturn:
+    """Refuse on both channels: stdout stays the report, stderr the diagnostic."""
     print(
         json.dumps(
             {"schema_version": REPORT_SCHEMA_VERSION, "ok": False, "error": message},
             indent=2,
         )
     )
+    print(f"establish-date-provenance failed: {message}", file=sys.stderr)
     raise SystemExit(1)
 
 

--- a/skills/vault-ingress/scripts/establish-date-provenance.py
+++ b/skills/vault-ingress/scripts/establish-date-provenance.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Record the provider ceiling for every talk whose delivery date is unrecorded.
+
+Usage: establish-date-provenance.py DATABASE [--apply --expected-sha256 SHA]
+       [--as-of TIMEZONE_AWARE_ISO_TIME]
+
+Default is a dry run. The report names every proposal, every talk this owner
+cannot bound and why, and a coverage block that makes backlog progress
+measurable across runs instead of re-derived by each audit (#430).
+
+This owner writes `date_provenance` records only. It never writes a talk's
+`date`, never fetches from a provider, and never invents a delivery day: a
+provider upload bounds a recording, and only methods that establish a day may
+supply one. Talks whose date is already comparable are left alone — their
+provenance is a question about evidence a human holds, not one this owner can
+answer from a stored upload date.
+
+Stdout: one schema-v1 {schema_version, ok, ...} report. Exit 0 on a completed
+plan or apply, 1 on a refused input or failed precondition, 2 on usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any, NoReturn
+
+from source_identity_matching import parse_catalog_date
+from tracking_database import (
+    DATE_PROVENANCE_RECORD_SCHEMA_VERSION,
+    TrackingDatabaseError,
+    require_current_tracking_database,
+)
+from tracking_database_io import (
+    BackupRequest,
+    TrackingDatabaseIOError,
+    commit_tracking_database,
+    decode_json_object,
+    render_json_object,
+    snapshot_tracking_database,
+)
+
+REPORT_SCHEMA_VERSION = 1
+CEILING_METHOD = "provider_upload_ceiling"
+_ISO_DAY = re.compile(r"\d{4}-\d{2}-\d{2}")
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+# Why a talk this owner looked at received no proposal. Closed so a new refusal
+# has to be named here rather than disappearing into a silent skip.
+BLOCKED_REASONS = (
+    "date_already_comparable",
+    "date_present_but_uncomparable",
+    "provenance_already_recorded",
+    "no_provider_upload_date",
+)
+
+
+class DateProvenanceError(RuntimeError):
+    """The owner refused an input; the message names the repair."""
+
+
+def _upload_date(talk: Any) -> str | None:
+    """Return the stored provider upload day, or None when there is not one."""
+    identity = talk.get("source_identity")
+    if not isinstance(identity, dict):
+        return None
+    value = identity.get("upload_date")
+    if not isinstance(value, str) or not _ISO_DAY.fullmatch(value.strip()):
+        return None
+    stamped = value.strip()
+    try:
+        dt.date.fromisoformat(stamped)
+    except ValueError:
+        return None
+    return stamped
+
+
+def classify_talk(talk: Any, *, has_provenance: bool) -> str | None:
+    """Name why a talk gets no ceiling, or None when one should be proposed.
+
+    A talk whose date already parses is left alone: this owner knows only that
+    the recording was published by some day, which says nothing about how a date
+    that exists was arrived at, and one record per talk means writing a ceiling
+    there would displace the real account.
+    """
+    if has_provenance:
+        return "provenance_already_recorded"
+    recorded = talk.get("date")
+    if parse_catalog_date(recorded) is not None:
+        return "date_already_comparable"
+    absent = recorded is None or (isinstance(recorded, str) and not recorded.strip())
+    if not absent:
+        # Month precision and anything else the comparator refuses. The ceiling
+        # would be unverifiable against it, so the reader refuses it too.
+        return "date_present_but_uncomparable"
+    if _upload_date(talk) is None:
+        return "no_provider_upload_date"
+    return None
+
+
+def plan_ceilings(database: Any, *, established_at: str) -> dict[str, Any]:
+    """Return the proposals, the refusals, and the coverage this run observed."""
+    talks = database.get("talks")
+    if not isinstance(talks, list):
+        raise DateProvenanceError("tracking database has no readable talks array")
+    recorded = {
+        record.get("talk_filename")
+        for record in database.get("date_provenance", [])
+        if isinstance(record, dict)
+    }
+    proposals: list[dict[str, Any]] = []
+    blocked: list[dict[str, str]] = []
+    comparable = 0
+    for index, talk in enumerate(talks):
+        if not isinstance(talk, dict):
+            raise DateProvenanceError(f"talks[{index}] must be a JSON object")
+        filename = talk.get("filename")
+        if not isinstance(filename, str) or not filename.strip():
+            raise DateProvenanceError(f"talks[{index}] has no usable filename")
+        if parse_catalog_date(talk.get("date")) is not None:
+            comparable += 1
+        reason = classify_talk(talk, has_provenance=filename in recorded)
+        if reason is not None:
+            blocked.append({"talk_filename": filename, "reason": reason})
+            continue
+        upload = _upload_date(talk)
+        proposals.append(
+            {
+                "schema_version": DATE_PROVENANCE_RECORD_SCHEMA_VERSION,
+                "talk_filename": filename,
+                "method": CEILING_METHOD,
+                "evidence": (
+                    "stored source_identity.upload_date "
+                    f"{upload} for provider video {talk.get('youtube_id')}"
+                ),
+                "established_at": established_at,
+                "not_later_than": upload,
+            }
+        )
+    proposals.sort(key=lambda record: record["talk_filename"])
+    blocked.sort(key=lambda item: (item["talk_filename"], item["reason"]))
+    return {
+        "proposals": proposals,
+        "blocked": blocked,
+        "coverage": {
+            "talks": len(talks),
+            "with_comparable_date": comparable,
+            "with_provenance_before": len(recorded),
+            "with_provenance_after": len(recorded) + len(proposals),
+            "blocked_by_reason": {
+                reason: sum(1 for item in blocked if item["reason"] == reason)
+                for reason in BLOCKED_REASONS
+            },
+        },
+    }
+
+
+def _validate_expected_digest(value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise DateProvenanceError("--expected-sha256 must be 64 lowercase hex digits")
+
+
+def _validate_as_of(value: str) -> str:
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise DateProvenanceError(
+            "--as-of must be a timezone-aware ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise DateProvenanceError("--as-of must be a timezone-aware ISO-8601 timestamp")
+    return value
+
+
+def _backup_path(path: Path, input_sha256: str) -> Path:
+    return path.with_name(f"{path.name}.{input_sha256[:12]}.bak")
+
+
+def execute(
+    path: Path,
+    *,
+    apply: bool,
+    expected_sha256: str | None,
+    as_of: str,
+) -> dict[str, Any]:
+    database_path = path.expanduser().absolute()
+    if expected_sha256 is not None:
+        _validate_expected_digest(expected_sha256)
+    if apply and expected_sha256 is None:
+        raise DateProvenanceError(
+            "--apply requires --expected-sha256 from a dry-run report"
+        )
+    try:
+        snapshot = snapshot_tracking_database(database_path)
+        database = decode_json_object(snapshot)
+    except TrackingDatabaseIOError as exc:
+        raise DateProvenanceError(str(exc)) from exc
+    database_path = snapshot.path
+    if expected_sha256 is not None and expected_sha256 != snapshot.sha256:
+        raise DateProvenanceError(
+            "input sha256 precondition failed: "
+            f"expected {expected_sha256}, found {snapshot.sha256}"
+        )
+    try:
+        require_current_tracking_database(database)
+    except TrackingDatabaseError as exc:
+        raise DateProvenanceError(
+            f"{exc}; migrate the tracking database before establishing provenance"
+        ) from exc
+
+    plan = plan_ceilings(database, established_at=as_of)
+    changed = bool(plan["proposals"])
+    candidate = json.loads(json.dumps(database))
+    if changed:
+        candidate.setdefault("date_provenance", [])
+        candidate["date_provenance"] = sorted(
+            [*candidate["date_provenance"], *plan["proposals"]],
+            key=lambda record: record["talk_filename"],
+        )
+        # The reader is the authority on whether these records are admissible.
+        # Validating the candidate before it is rendered keeps a refusal a
+        # refusal rather than a file the next reader rejects.
+        try:
+            require_current_tracking_database(candidate)
+        except TrackingDatabaseError as exc:
+            raise DateProvenanceError(
+                f"proposed provenance would not validate: {exc}"
+            ) from exc
+    try:
+        rendered = render_json_object(candidate) if changed else snapshot.raw
+    except (TrackingDatabaseError, TrackingDatabaseIOError) as exc:
+        raise DateProvenanceError(str(exc)) from exc
+
+    predicted_backup = _backup_path(database_path, snapshot.sha256) if changed else None
+    output_sha256 = hashlib.sha256(rendered).hexdigest()
+    database_written = False
+    durability_state = "dry_run"
+    warnings: list[str] = []
+    reported_backup = str(predicted_backup) if predicted_backup is not None else None
+
+    if apply:
+        try:
+            result = commit_tracking_database(
+                snapshot,
+                rendered,
+                backup=(
+                    BackupRequest(path=predicted_backup, input_sha256=snapshot.sha256)
+                    if predicted_backup is not None
+                    else None
+                ),
+            )
+        except TrackingDatabaseIOError as exc:
+            raise DateProvenanceError(str(exc)) from exc
+        output_sha256 = result.output_sha256
+        database_written = result.installed
+        durability_state = result.durability_state
+        warnings = list(result.warnings)
+        reported_backup = result.backup
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "ok": True,
+        "mode": "apply" if apply else "dry-run",
+        "database": str(database_path),
+        "input_sha256": snapshot.sha256,
+        "established_at": as_of,
+        "changed": changed,
+        "database_written": database_written,
+        "backup": reported_backup,
+        "output_sha256": output_sha256,
+        "durability_state": durability_state,
+        "warnings": warnings,
+        **plan,
+    }
+
+
+def _fail(message: str) -> NoReturn:
+    print(
+        json.dumps(
+            {"schema_version": REPORT_SCHEMA_VERSION, "ok": False, "error": message},
+            indent=2,
+        )
+    )
+    raise SystemExit(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("database", type=Path)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--expected-sha256")
+    parser.add_argument(
+        "--as-of",
+        help="timezone-aware ISO-8601 stamp for established_at; defaults to now",
+    )
+    args = parser.parse_args(argv)
+    try:
+        as_of = (
+            _validate_as_of(args.as_of)
+            if args.as_of is not None
+            else dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+        report = execute(
+            args.database,
+            apply=args.apply,
+            expected_sha256=args.expected_sha256,
+            as_of=as_of,
+        )
+    except DateProvenanceError as exc:
+        _fail(str(exc))
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -382,6 +382,14 @@ def read_tracking_database():
 
 
 @pytest.fixture(scope="session")
+def establish_date_provenance():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "establish-date-provenance.py"),
+        "establish_date_provenance",
+    )
+
+
+@pytest.fixture(scope="session")
 def queue_state():
     return _import_script(
         os.path.join(SCRIPTS_VI, "queue-state.py"),

--- a/tests/test_establish_date_provenance.py
+++ b/tests/test_establish_date_provenance.py
@@ -16,7 +16,10 @@ from conftest import current_tracking_config
 import pytest
 
 
-AS_OF = "2026-09-08T00:00:00Z"
+# Two fixed past stamps. A later run only needs a different stamp, and a
+# future literal would rot as the run date advances.
+AS_OF = "2026-01-05T00:00:00Z"
+SECOND_RUN = "2026-02-09T00:00:00Z"
 
 
 def _talk(
@@ -195,7 +198,7 @@ def test_a_second_apply_is_a_no_op(establish_date_provenance, tmp_path):
         path,
         apply=True,
         expected_sha256=hashlib.sha256(after_first).hexdigest(),
-        as_of="2027-01-01T00:00:00Z",
+        as_of=SECOND_RUN,
     )
 
     assert again["changed"] is False
@@ -280,9 +283,13 @@ def test_the_cli_reports_a_refusal_as_json_and_exits_one(
         establish_date_provenance.main([str(path)])
 
     assert exc.value.code == 1
-    report = json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
     assert report["ok"] is False
     assert "migrate the tracking" in report["error"]
+    # stdout stays the report; the diagnostic also has to reach stderr.
+    assert "establish-date-provenance failed" in captured.err
+    assert "migrate the tracking" in captured.err
 
 
 def test_the_cli_prints_a_plan_and_exits_zero(

--- a/tests/test_establish_date_provenance.py
+++ b/tests/test_establish_date_provenance.py
@@ -1,0 +1,308 @@
+"""Offline tests for the ceiling establisher (#430).
+
+Every database is built in-test from fixed literals, and `established_at` is
+always passed explicitly, so a run today and a run next year agree.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+from conftest import CURRENT_ROOT_SCHEMA_VERSION as CURRENT_ROOT
+from conftest import current_tracking_config
+import pytest
+
+
+AS_OF = "2026-09-08T00:00:00Z"
+
+
+def _talk(
+    filename: str,
+    *,
+    date: object = "",
+    upload_date: str | None = "2016-01-21",
+    **updates: object,
+):
+    talk = {
+        "filename": filename,
+        "title": "A Talk",
+        "conference": "ExampleConf",
+        "date": date,
+        "status": "processed",
+        "schema_version": 8,
+        "youtube_id": "AbCdEfGhI_1",
+    }
+    if upload_date is not None:
+        talk["source_identity"] = {
+            "schema_version": 1,
+            "provider": "youtube",
+            "video_id": "AbCdEfGhI_1",
+            "upload_date": upload_date,
+            "captured_at": "2026-08-18T19:55:38Z",
+        }
+    talk.update(updates)
+    return talk
+
+
+def _database(talks, provenance=None):
+    database = {
+        "schema_version": CURRENT_ROOT,
+        "config": current_tracking_config(),
+        "talks": talks,
+        "pptx_catalog": [],
+        "qr_codes": [],
+        "resources": [],
+        "thumbnails": [],
+        "confirmed_intents": [],
+        "improvement_goals": [],
+    }
+    if provenance is not None:
+        database["date_provenance"] = provenance
+    return database
+
+
+def _write(tmp_path: Path, database) -> tuple[Path, str]:
+    path = tmp_path / "tracking-database.json"
+    raw = json.dumps(database, indent=2, ensure_ascii=False).encode()
+    path.write_bytes(raw)
+    return path, hashlib.sha256(raw).hexdigest()
+
+
+def test_a_dateless_talk_with_a_stored_upload_gets_a_ceiling(
+    establish_date_provenance,
+):
+    plan = establish_date_provenance.plan_ceilings(
+        _database([_talk("dateless.md")]), established_at=AS_OF
+    )
+
+    assert [record["talk_filename"] for record in plan["proposals"]] == ["dateless.md"]
+    record = plan["proposals"][0]
+    assert record["method"] == "provider_upload_ceiling"
+    assert record["not_later_than"] == "2016-01-21"
+    assert record["established_at"] == AS_OF
+    assert "2016-01-21" in record["evidence"]
+    assert plan["blocked"] == []
+
+
+@pytest.mark.parametrize(
+    "talk,reason",
+    [
+        (_talk("dated.md", date="2016-03-04"), "date_already_comparable"),
+        (_talk("year.md", date="2016"), "date_already_comparable"),
+        (_talk("month.md", date="2016-03"), "date_present_but_uncomparable"),
+        (_talk("junk.md", date="spring 2016"), "date_present_but_uncomparable"),
+        (_talk("nosource.md", upload_date=None), "no_provider_upload_date"),
+        (_talk("badupload.md", upload_date="20160121"), "no_provider_upload_date"),
+    ],
+)
+def test_every_refusal_is_named_rather_than_silently_skipped(
+    establish_date_provenance, talk, reason
+):
+    plan = establish_date_provenance.plan_ceilings(
+        _database([talk]), established_at=AS_OF
+    )
+
+    assert plan["proposals"] == []
+    assert plan["blocked"] == [{"talk_filename": talk["filename"], "reason": reason}]
+    assert plan["coverage"]["blocked_by_reason"][reason] == 1
+
+
+def test_a_talk_that_already_has_provenance_is_left_alone(establish_date_provenance):
+    """One record per talk: a second run must not displace the first account."""
+    existing = {
+        "schema_version": 1,
+        "talk_filename": "dateless.md",
+        "method": "organizer_program",
+        "evidence": "published schedule",
+        "established_at": AS_OF,
+    }
+    plan = establish_date_provenance.plan_ceilings(
+        _database([_talk("dateless.md")], [existing]), established_at=AS_OF
+    )
+
+    assert plan["proposals"] == []
+    assert plan["blocked"] == [
+        {"talk_filename": "dateless.md", "reason": "provenance_already_recorded"}
+    ]
+
+
+def test_coverage_makes_backlog_progress_measurable(establish_date_provenance):
+    database = _database(
+        [
+            _talk("a.md", date="2016-03-04"),
+            _talk("b.md", date="2016"),
+            _talk("c.md"),
+            _talk("d.md"),
+            _talk("e.md", date="2016-03"),
+            _talk("f.md", upload_date=None),
+        ]
+    )
+
+    plan = establish_date_provenance.plan_ceilings(database, established_at=AS_OF)
+
+    assert plan["coverage"] == {
+        "talks": 6,
+        "with_comparable_date": 2,
+        "with_provenance_before": 0,
+        "with_provenance_after": 2,
+        "blocked_by_reason": {
+            "date_already_comparable": 2,
+            "date_present_but_uncomparable": 1,
+            "provenance_already_recorded": 0,
+            "no_provider_upload_date": 1,
+        },
+    }
+
+
+def test_a_dry_run_writes_nothing_and_an_apply_writes_once(
+    establish_date_provenance, tmp_path
+):
+    database = _database([_talk("dateless.md"), _talk("dated.md", date="2016-03-04")])
+    path, digest = _write(tmp_path, database)
+
+    preview = establish_date_provenance.execute(
+        path, apply=False, expected_sha256=None, as_of=AS_OF
+    )
+
+    assert preview["mode"] == "dry-run"
+    assert preview["changed"] is True
+    assert preview["database_written"] is False
+    assert json.loads(path.read_bytes()) == database
+
+    applied = establish_date_provenance.execute(
+        path, apply=True, expected_sha256=digest, as_of=AS_OF
+    )
+
+    assert applied["database_written"] is True
+    assert applied["output_sha256"] == preview["output_sha256"]
+    written = json.loads(path.read_bytes())
+    assert [r["talk_filename"] for r in written["date_provenance"]] == ["dateless.md"]
+    assert written["talks"] == database["talks"], "a ceiling never edits a talk"
+
+
+def test_a_second_apply_is_a_no_op(establish_date_provenance, tmp_path):
+    """Repeatable: progress accumulates instead of restarting each run."""
+    path, digest = _write(tmp_path, _database([_talk("dateless.md")]))
+    establish_date_provenance.execute(
+        path, apply=True, expected_sha256=digest, as_of=AS_OF
+    )
+    after_first = path.read_bytes()
+
+    again = establish_date_provenance.execute(
+        path,
+        apply=True,
+        expected_sha256=hashlib.sha256(after_first).hexdigest(),
+        as_of="2027-01-01T00:00:00Z",
+    )
+
+    assert again["changed"] is False
+    assert again["proposals"] == []
+    assert path.read_bytes() == after_first
+
+
+def test_apply_requires_the_digest_from_a_dry_run(establish_date_provenance, tmp_path):
+    path, digest = _write(tmp_path, _database([_talk("dateless.md")]))
+
+    with pytest.raises(establish_date_provenance.DateProvenanceError, match="requires"):
+        establish_date_provenance.execute(
+            path, apply=True, expected_sha256=None, as_of=AS_OF
+        )
+
+    stale = hashlib.sha256(b"something else").hexdigest()
+    with pytest.raises(
+        establish_date_provenance.DateProvenanceError, match="precondition failed"
+    ):
+        establish_date_provenance.execute(
+            path, apply=True, expected_sha256=stale, as_of=AS_OF
+        )
+    assert digest == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_a_legacy_root_refuses_with_the_repair_named(
+    establish_date_provenance, tmp_path
+):
+    database = _database([_talk("dateless.md")])
+    database["schema_version"] = 1
+    path, _digest = _write(tmp_path, database)
+
+    with pytest.raises(
+        establish_date_provenance.DateProvenanceError, match="migrate the tracking"
+    ):
+        establish_date_provenance.execute(
+            path, apply=False, expected_sha256=None, as_of=AS_OF
+        )
+
+
+def test_the_written_records_survive_the_readers_own_validation(
+    establish_date_provenance, tracking_database, tmp_path
+):
+    path, digest = _write(tmp_path, _database([_talk("dateless.md")]))
+    establish_date_provenance.execute(
+        path, apply=True, expected_sha256=digest, as_of=AS_OF
+    )
+
+    written = json.loads(path.read_bytes())
+
+    assert tracking_database.assess_tracking_database(written).state == "current"
+
+
+def test_a_malformed_talk_refuses_rather_than_being_skipped(
+    establish_date_provenance,
+):
+    database = _database([_talk("ok.md")])
+    database["talks"].append({"title": "no filename"})
+
+    with pytest.raises(
+        establish_date_provenance.DateProvenanceError, match="no usable filename"
+    ):
+        establish_date_provenance.plan_ceilings(database, established_at=AS_OF)
+
+
+@pytest.mark.parametrize("value", ["not-a-time", "2026-09-08T00:00:00", "2026-09-08"])
+def test_a_naive_or_malformed_as_of_refuses(establish_date_provenance, value):
+    with pytest.raises(
+        establish_date_provenance.DateProvenanceError, match="timezone-aware"
+    ):
+        establish_date_provenance._validate_as_of(value)
+
+
+def test_the_cli_reports_a_refusal_as_json_and_exits_one(
+    establish_date_provenance, tmp_path, capsys
+):
+    database = _database([_talk("dateless.md")])
+    database["schema_version"] = 1
+    path, _digest = _write(tmp_path, database)
+
+    with pytest.raises(SystemExit) as exc:
+        establish_date_provenance.main([str(path)])
+
+    assert exc.value.code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is False
+    assert "migrate the tracking" in report["error"]
+
+
+def test_the_cli_prints_a_plan_and_exits_zero(
+    establish_date_provenance, tmp_path, capsys
+):
+    path, _digest = _write(tmp_path, _database([_talk("dateless.md")]))
+
+    assert establish_date_provenance.main([str(path), "--as-of", AS_OF]) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["mode"] == "dry-run"
+    assert len(report["proposals"]) == 1
+    assert report["established_at"] == AS_OF
+
+
+def test_the_plan_never_mutates_the_database_it_reads(establish_date_provenance):
+    database = _database([_talk("dateless.md")])
+    before = copy.deepcopy(database)
+
+    establish_date_provenance.plan_ceilings(database, established_at=AS_OF)
+
+    assert database == before

--- a/tests/test_establish_date_provenance.py
+++ b/tests/test_establish_date_provenance.py
@@ -74,6 +74,20 @@ def _write(tmp_path: Path, database) -> tuple[Path, str]:
     return path, hashlib.sha256(raw).hexdigest()
 
 
+def test_the_trace_never_cites_a_talk_youtube_id_that_disagrees(
+    establish_date_provenance,
+):
+    """A stale youtube_id must not send a re-check at the wrong recording."""
+    talk = _talk("dateless.md", youtube_id="StaleStale1")
+    plan = establish_date_provenance.plan_ceilings(
+        _database([talk]), established_at=AS_OF
+    )
+
+    evidence = plan["proposals"][0]["evidence"]
+    assert "StaleStale1" not in evidence
+    assert "youtube AbCdEfGhI_1" in evidence
+
+
 def test_a_dateless_talk_with_a_stored_upload_gets_a_ceiling(
     establish_date_provenance,
 ):
@@ -86,7 +100,11 @@ def test_a_dateless_talk_with_a_stored_upload_gets_a_ceiling(
     assert record["method"] == "provider_upload_ceiling"
     assert record["not_later_than"] == "2016-01-21"
     assert record["established_at"] == AS_OF
-    assert "2016-01-21" in record["evidence"]
+    # The trace cites the identity block the bound came from, never the talk's
+    # own youtube_id, which can disagree with it.
+    assert record["evidence"] == (
+        "stored source_identity.upload_date 2016-01-21 for youtube AbCdEfGhI_1"
+    )
     assert plan["blocked"] == []
 
 
@@ -99,6 +117,28 @@ def test_a_dateless_talk_with_a_stored_upload_gets_a_ceiling(
         (_talk("junk.md", date="spring 2016"), "date_present_but_uncomparable"),
         (_talk("nosource.md", upload_date=None), "no_provider_upload_date"),
         (_talk("badupload.md", upload_date="20160121"), "no_provider_upload_date"),
+        (
+            _talk(
+                "noidentityid.md",
+                source_identity={
+                    "schema_version": 1,
+                    "provider": "youtube",
+                    "upload_date": "2016-01-21",
+                },
+            ),
+            "no_provider_upload_date",
+        ),
+        (
+            _talk(
+                "noprovider.md",
+                source_identity={
+                    "schema_version": 1,
+                    "video_id": "AbCdEfGhI_1",
+                    "upload_date": "2016-01-21",
+                },
+            ),
+            "no_provider_upload_date",
+        ),
     ],
 )
 def test_every_refusal_is_named_rather_than_silently_skipped(


### PR DESCRIPTION
Second of three for #430. Builds on #439 (the schema, released 0.20.142).

26 catalog records carry no delivery date at all, which made them an unbounded
research question. Every one of them already has a stored
`source_identity.upload_date`, so a ceiling costs no fetch — a provider upload
cannot precede the recording it publishes.

## What it does

`establish-date-provenance.py` proposes a `provider_upload_ceiling` record for
every talk whose date is unrecorded, and refuses to guess anything else:

- **writes `date_provenance` records only** — never a talk's `date`, never a
  method that claims a delivery day. The only thing it can add is a bound.
- **no network.** The ceiling comes from evidence already in the database.
- **leaves a comparable date alone.** A stored upload date says nothing about how
  a date that already exists was arrived at, and one record per talk means
  writing a ceiling there would displace the real account.

Dry run by default; `--apply` requires the input digest from that dry run and
commits through the owner transaction with a backup, like the migration CLI.
`--as-of` pins `established_at` so a run is reproducible.

## Acceptance criterion 3

> A repeatable way to work the backlog, so progress is measurable instead of
> restarting each audit

Every refusal is named rather than silently skipped, and counted. Verified
against a copy of the live catalog (root-migrated first, live vault untouched):

```
"coverage": {
  "talks": 251,
  "with_comparable_date": 217,
  "with_provenance_before": 0,
  "with_provenance_after": 26,
  "blocked_by_reason": {
    "date_already_comparable": 217,
    "date_present_but_uncomparable": 8,
    "provenance_already_recorded": 0,
    "no_provider_upload_date": 0
  }
}
```

26 proposals, matching the read-only analysis on #430 exactly. The 8 blocked are
the month-precision records — `parse_catalog_date` does not read `YYYY-MM`, so a
ceiling there would be unverifiable and the reader refuses it. Teaching the
parser month precision is part 3, with the `source_identity_date_uncheckable`
re-scope.

Running it twice is a no-op: a talk that already carries an account keeps it.

## Scope

Part 3 covers acceptance criteria 2 and 4: the live-broadcast method that
establishes an actual day, migrating the dates proved by hand in #333, the
month-precision parse, and the `source_identity_date_uncheckable` re-scope.

## Test plan

- [x] Full suite: **8112 passed**, 8 skipped
- [x] 21 new cases: proposal shape, each of the four named refusals, the
      already-has-provenance case, coverage arithmetic, dry-run writes nothing,
      apply writes once and never edits a talk, second apply is a no-op, apply
      without a digest and with a stale digest both refuse, legacy root refuses
      naming the repair, written records survive the reader's own validation,
      malformed talk refuses rather than being skipped, naive `--as-of` refuses,
      both CLI exit paths, and the planner never mutates its input
- [x] End-to-end on a copy of the live catalog, dry run only
- [x] ruff clean, pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV