### PR TITLE
fix(vault-ingress): put the provenance backup where the others live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### The provenance backup lands where the others do
+
+`establish-date-provenance.py --apply` wrote its backup next to the database
+instead of into `.backups/`, where this vault already collects them, leaving a
+stray `.bak` in a directory a human reads. It goes beside the owner migration's
+backups now and names its own operation, so two backups of one input stay
+distinguishable.
+
+
 ## 0.20.144 — 2026-09-08
 
 ### An unrecorded date now says what is known

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -808,8 +808,9 @@ one that exists. Provenance is written by an owner who checked something, never
 inferred from a date that happens to be present.
 
 `skills/vault-ingress/scripts/establish-date-provenance.py` writes the ceiling
-records. It is a dry run by default and `--apply` requires the input digest from
-that dry run, like the migration CLI. It writes `date_provenance` records only —
+records. It is a dry run by default, `--apply` requires the input digest from
+that dry run, and the backup lands under `.backups/` beside the owner
+migration's, all like the migration CLI. It writes `date_provenance` records only —
 never a talk's `date`, and never a method that claims a delivery day — so the
 only thing it can add is a bound. Its report names every proposal, every talk it
 refused and why (the closed `BLOCKED_REASONS` in that file), and a coverage block

--- a/skills/vault-ingress/scripts/establish-date-provenance.py
+++ b/skills/vault-ingress/scripts/establish-date-provenance.py
@@ -191,7 +191,14 @@ def _validate_as_of(value: str) -> str:
 
 
 def _backup_path(path: Path, input_sha256: str) -> Path:
-    return path.with_name(f"{path.name}.{input_sha256[:12]}.bak")
+    """Beside the owner migration's backups, never loose in the vault root.
+
+    The vault already collects database backups under `.backups/`, and a `.bak`
+    dropped next to the database is a stray file in a directory a human reads.
+    The operation is named in the filename for the same reason the migration
+    names its own: two backups of one input are otherwise indistinguishable.
+    """
+    return path.parent / ".backups" / f"{path.name}.date-provenance-{input_sha256}.bak"
 
 
 def execute(

--- a/tests/test_establish_date_provenance.py
+++ b/tests/test_establish_date_provenance.py
@@ -355,3 +355,23 @@ def test_the_plan_never_mutates_the_database_it_reads(establish_date_provenance)
     establish_date_provenance.plan_ceilings(database, established_at=AS_OF)
 
     assert database == before
+
+
+def test_the_backup_lands_beside_the_owner_migrations(
+    establish_date_provenance, tmp_path
+):
+    """`.backups/` is where this vault collects database backups; a stray .bak
+    next to the database is a loose file in a directory a human reads."""
+    path, digest = _write(tmp_path, _database([_talk("dateless.md")]))
+
+    applied = establish_date_provenance.execute(
+        path, apply=True, expected_sha256=digest, as_of=AS_OF
+    )
+
+    backup = Path(applied["backup"])
+    assert backup.parent == path.parent / ".backups"
+    assert backup.name == f"{path.name}.date-provenance-{digest}.bak"
+    assert backup.is_file()
+    assert list(path.parent.glob("*.bak")) == []
+    # The backup is the exact input, which is what makes it an undo.
+    assert hashlib.sha256(backup.read_bytes()).hexdigest() == digest


### PR DESCRIPTION
Follow-up to #440, found while running the #430 backfill against the live vault.

`establish-date-provenance.py --apply` wrote its backup next to the database:

```
rhetoric-knowledge-vault/tracking-database.json.add08c55e87d.bak
```

The vault already collects database backups under `.backups/`, where the owner
migration puts its own, so that left a stray `.bak` in a directory a human reads.
It now lands beside them and names its own operation, so two backups of one input
stay distinguishable:

```
rhetoric-knowledge-vault/.backups/tracking-database.json.date-provenance-<sha>.bak
```

## Test plan

- [x] Full suite: **8154 passed**, 8 skipped
- [x] New case asserts the directory, the filename, that no `.bak` is left beside
      the database, and that the backup's digest equals the input's — which is
      what makes it an undo
- [x] ruff clean, pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV