### PR TITLE
fix(vault-ingress): tell a slow import from a missing one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+### A slow import is no longer reported as a missing module
+
+`check-runtime.py` probes each lane's modules in a bounded child, and a probe
+that exceeded the 30-second budget was filed under `missing_modules` next to
+genuinely absent packages. The lane then refused with "install the missing
+modules", sending an operator after a package that was already installed.
+
+The configured interpreter can live on a network filesystem — the vault's own
+`config.python_path` points at a Drive-hosted `.venv` — where a cold import reads
+its dependencies over the network. Measured there, `import mlx_whisper` took
+**568 seconds** cold and **1 second** warm, almost all of it `scipy` submodules
+at one to two seconds each. Thirty seconds is generous for local disk and 19×
+short for that, so no single budget is right for both states; the reason has to
+reach the operator instead.
+
+Each lane now carries `unresolved_modules` alongside `missing_modules`, naming
+the subset whose probe never answered — `timeout` and `probe_start_failure`.
+`missing_modules` still lists every unavailable name, so existing readers are
+unaffected, and `available` is unchanged: an unresolved lane is still unusable.
+
+Both the stderr advice and `calibrate-speech.py`'s `pace_runtime_unavailable`
+now name the module and the reason, and point at warming the interpreter rather
+than reinstalling. `unresolved_module_probes()` is the shared reader.
+
+This cost most of a session on #443 and produced two wrong diagnoses before the
+import was profiled.
+
 ## 0.20.145 — 2026-09-08
 
 ### The provenance backup lands where the others do

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -397,7 +397,9 @@ def unresolved_module_probes(report: Mapping[str, Any]) -> dict[str, str]:
     """Map each module whose probe never answered to the reason it did not.
 
     Separated from the missing set because the two need different repairs: a
-    missing module is installed, an unresolved one is usually warmed.
+    missing module is one the probe found absent, repaired by installing it; an
+    unresolved one is a module whose presence the probe never established,
+    usually repaired by warming the interpreter it lives on.
     """
     unresolved: dict[str, str] = {}
     for lane in report.get("lanes", {}).values():

--- a/skills/vault-ingress/scripts/check-runtime.py
+++ b/skills/vault-ingress/scripts/check-runtime.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, BinaryIO, Callable, TypedDict
+from typing import Any, BinaryIO, Callable, Mapping, TypedDict
 
 from ytdlp_runtime import (
     YTDLP_REQUIRED_VERSION,
@@ -36,6 +36,12 @@ MODULE_PROBE_SCHEMA_VERSION = 1
 MODULE_PROBE_TIMEOUT_SECONDS = 30
 MODULE_PROBE_MAX_OUTPUT_BYTES = 4096
 MODULE_PROBE_CHILD_FLAG = "--module-probe-child"
+# Probe outcomes that leave the module's presence UNKNOWN rather than answered.
+# A timeout is the ordinary one: the configured interpreter can live on a
+# network filesystem, where a cold import reads its dependencies over the
+# network and a healthy install takes minutes. Measured on a Drive-hosted vault
+# venv, `import mlx_whisper` took 568s cold and 1s warm, almost all of it scipy.
+UNRESOLVED_PROBE_REASONS = frozenset({"timeout", "probe_start_failure"})
 MINIMUM_PYTHON = (3, 10)
 PSUTIL_REQUIRED_VERSION = "7.2.2"
 FILELOCK_REQUIRED_VERSION = "3.32.2"
@@ -387,6 +393,39 @@ def _command_available(command: str) -> bool:
     return shutil.which(command) is not None
 
 
+def unresolved_module_probes(report: Mapping[str, Any]) -> dict[str, str]:
+    """Map each module whose probe never answered to the reason it did not.
+
+    Separated from the missing set because the two need different repairs: a
+    missing module is installed, an unresolved one is usually warmed.
+    """
+    unresolved: dict[str, str] = {}
+    for lane in report.get("lanes", {}).values():
+        failures = lane.get("module_failures", {})
+        for name in lane.get("unresolved_modules", []):
+            failure = failures.get(name)
+            if isinstance(failure, dict):
+                unresolved[name] = str(failure.get("reason"))
+    return unresolved
+
+
+def _unresolved_advice(report: Mapping[str, Any]) -> str:
+    """Name the modules whose presence is unknown, and the repair that fits."""
+    unresolved = unresolved_module_probes(report)
+    if not unresolved:
+        return ""
+    named = ", ".join(
+        f"{name} ({reason})" for name, reason in sorted(unresolved.items())
+    )
+    return (
+        f". NOTE: the probe did not resolve {named}, so these may be installed "
+        "but slow to import rather than absent — an interpreter on a network "
+        "filesystem reads its dependencies over the network on a cold import. "
+        "Read the package files once to warm them, then rerun this check, "
+        "before reinstalling anything"
+    )
+
+
 def _probe_command(
     label: str,
     command: str,
@@ -512,6 +551,18 @@ def build_report(
         missing_modules = sorted(
             name for name, available in modules.items() if not available
         )
+        # A probe that never finished says nothing about whether the module is
+        # installed. Reporting one as missing sends an operator to install a
+        # package that is already there — the repair for a cold interpreter on a
+        # network filesystem is to warm it, not to reinstall it. `missing_modules`
+        # keeps every unavailable name so existing readers are unaffected; this
+        # names the subset whose answer is unknown rather than "absent".
+        unresolved_modules = sorted(
+            name
+            for name, failure in module_failures.items()
+            if isinstance(failure, dict)
+            and failure.get("reason") in UNRESOLVED_PROBE_REASONS
+        )
         missing_commands = sorted(
             name for name, available in commands.items() if not available
         )
@@ -536,6 +587,7 @@ def build_report(
                 else {}
             ),
             "missing_modules": missing_modules,
+            "unresolved_modules": unresolved_modules,
             "missing_commands": missing_commands,
         }
     blocking = sorted(lane for lane in required if not lane_reports[lane]["available"])
@@ -584,7 +636,7 @@ def main(argv: list[str] | None = None) -> int:
             "and install the missing modules or commands at their required "
             "versions, or repair failed "
             f"dependency initialization, listed in the JSON in {sys.executable}, "
-            "then rerun this check",
+            "then rerun this check" + _unresolved_advice(report),
             file=sys.stderr,
         )
     elif report["degraded_lanes"]:
@@ -594,7 +646,7 @@ def main(argv: list[str] | None = None) -> int:
             f"{degraded}; install the missing modules or commands at their "
             "required versions, or repair "
             "failed dependency initialization, listed in the JSON in "
-            f"{sys.executable}, then rerun this check",
+            f"{sys.executable}, then rerun this check" + _unresolved_advice(report),
             file=sys.stderr,
         )
     return 0 if report["ok"] else 1

--- a/skills/vault-profile/scripts/calibrate-speech.py
+++ b/skills/vault-profile/scripts/calibrate-speech.py
@@ -128,10 +128,26 @@ def execute(args: argparse.Namespace) -> dict:
         required += ["source-media", "speech-calibration"]
         if args.allow_download:
             required.append("youtube-download")
-    runtime = _owner_script("check-runtime.py").build_report(
-        tuple(required), tuple(required)
-    )
+    check_runtime = _owner_script("check-runtime.py")
+    runtime = check_runtime.build_report(tuple(required), tuple(required))
     if runtime["ok"] is not True:
+        # A probe that never answered is not a missing dependency, and telling an
+        # operator to install one sends them after a package that is already
+        # there. The lane report already separates the two, so the refusal says
+        # which it is.
+        unresolved = check_runtime.unresolved_module_probes(runtime)
+        if unresolved:
+            named = ", ".join(
+                f"{name} ({reason})" for name, reason in sorted(unresolved.items())
+            )
+            raise SpeechRateError(
+                "pace_runtime_unavailable",
+                f"The runtime probe did not resolve {named}; these may be "
+                "installed but slow to import rather than absent. Read the "
+                "interpreter's package files once to warm them, rerun the "
+                "configured interpreter's check-runtime.py, and reinstall only "
+                "if it still reports them missing.",
+            )
         raise SpeechRateError(
             "pace_runtime_unavailable",
             "Run the configured interpreter's check-runtime.py for the required lanes; repair missing dependencies before calibration.",

--- a/tests/test_calibrate_speech.py
+++ b/tests/test_calibrate_speech.py
@@ -331,7 +331,10 @@ def test_missing_runtime_refuses_before_acquisition(command, tmp_path, monkeypat
         command,
         "_owner_script",
         lambda name: (
-            SimpleNamespace(build_report=lambda *a: {"ok": False})
+            SimpleNamespace(
+                build_report=lambda *a: {"ok": False},
+                unresolved_module_probes=lambda report: {},
+            )
             if name == "check-runtime.py"
             else real(name)
         ),
@@ -339,3 +342,35 @@ def test_missing_runtime_refuses_before_acquisition(command, tmp_path, monkeypat
     with pytest.raises(command.SpeechRateError) as exc:
         command.execute(options(tmp_path, run=True))
     assert exc.value.code == "pace_runtime_unavailable"
+    assert "repair missing dependencies" in str(exc.value)
+
+
+def test_an_unresolved_probe_is_not_reported_as_a_missing_dependency(
+    command, tmp_path, monkeypatch
+):
+    """A probe that timed out says nothing about whether the module is there.
+
+    Telling an operator to install it sends them after a package that is already
+    installed, which is what a cold interpreter on a network filesystem looks
+    like (#444).
+    """
+    vault(tmp_path)
+    real = command._owner_script
+    monkeypatch.setattr(
+        command,
+        "_owner_script",
+        lambda name: (
+            SimpleNamespace(
+                build_report=lambda *a: {"ok": False},
+                unresolved_module_probes=lambda report: {"mlx-whisper": "timeout"},
+            )
+            if name == "check-runtime.py"
+            else real(name)
+        ),
+    )
+    with pytest.raises(command.SpeechRateError) as exc:
+        command.execute(options(tmp_path, run=True))
+    assert exc.value.code == "pace_runtime_unavailable"
+    assert "mlx-whisper (timeout)" in str(exc.value)
+    assert "warm" in str(exc.value)
+    assert "repair missing dependencies" not in str(exc.value)

--- a/tests/test_check_runtime.py
+++ b/tests/test_check_runtime.py
@@ -1305,3 +1305,97 @@ def test_video_dependency_version_authorities_are_synchronized() -> None:
         )
         assert manifest_versions == [required_version]
         assert f'"{package}=={required_version}"' in reference
+
+
+# A probe that never answered is not a missing module (#444).
+
+
+def test_a_timed_out_probe_is_reported_as_unresolved_not_merely_missing(
+    monkeypatch,
+) -> None:
+    """An interpreter on a network filesystem reads its dependencies over the
+    network on a cold import, so a healthy install can blow the probe budget."""
+
+    def probe(name: str) -> dict[str, object]:
+        if name == "pptx":
+            return check_runtime._failed_module_probe("timeout", timeout_seconds=30)
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    report = check_runtime.build_report(("core", "pptx"), ("core",))
+
+    lane = report["lanes"]["pptx"]
+    assert lane["available"] is False
+    assert lane["unresolved_modules"] == ["python-pptx"]
+    # Still in missing_modules, so every existing reader is unaffected.
+    assert lane["missing_modules"] == ["python-pptx"]
+    assert check_runtime.unresolved_module_probes(report) == {"python-pptx": "timeout"}
+
+
+def test_an_absent_module_is_not_reported_as_unresolved(monkeypatch) -> None:
+    def probe(name: str) -> dict[str, object]:
+        if name == "pptx":
+            return _failed_probe("unavailable_import")
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    report = check_runtime.build_report(("core", "pptx"), ("core",))
+
+    assert report["lanes"]["pptx"]["missing_modules"] == ["python-pptx"]
+    assert report["lanes"]["pptx"]["unresolved_modules"] == []
+    assert check_runtime.unresolved_module_probes(report) == {}
+
+
+def test_a_healthy_lane_reports_no_unresolved_modules(monkeypatch) -> None:
+    monkeypatch.setattr(check_runtime, "_probe_module", lambda _n: _available_probe())
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    report = check_runtime.build_report(("core",), ("core",))
+
+    assert report["lanes"]["core"]["unresolved_modules"] == []
+    assert check_runtime.unresolved_module_probes(report) == {}
+
+
+def test_the_stderr_advice_names_the_module_and_the_warming_repair(
+    monkeypatch, capsys
+) -> None:
+    """The message that misled this project: 'install the missing modules' for a
+    package that was installed and merely cold."""
+
+    def probe(name: str) -> dict[str, object]:
+        if name == "pptx":
+            return check_runtime._failed_module_probe("timeout", timeout_seconds=30)
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    exit_code = check_runtime.main(["--lanes", "core,pptx", "--require-lanes", "pptx"])
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "python-pptx (timeout)" in stderr
+    assert "warm" in stderr
+    assert "before reinstalling anything" in stderr
+
+
+def test_the_stderr_advice_stays_silent_when_every_probe_answered(
+    monkeypatch, capsys
+) -> None:
+    def probe(name: str) -> dict[str, object]:
+        if name == "pptx":
+            return _failed_probe("unavailable_import")
+        return _available_probe()
+
+    monkeypatch.setattr(check_runtime, "_probe_module", probe)
+    monkeypatch.setattr(check_runtime, "_command_available", lambda _name: True)
+
+    check_runtime.main(["--lanes", "core,pptx", "--require-lanes", "pptx"])
+
+    stderr = capsys.readouterr().err
+    assert "install the missing modules" in stderr
+    assert "did not resolve" not in stderr


### PR DESCRIPTION
Closes #444. Found the hard way while running #443's acceptance cohort.

## The defect

`check-runtime.py` probes each lane's modules in a bounded child. A probe that
exceeded the 30-second budget was filed under `missing_modules`, beside genuinely
absent packages:

```json
"speech-calibration": {
  "available": false,
  "missing_modules": ["mlx-whisper"],
  "module_failures": {"mlx-whisper": {"reason": "timeout", "timeout_seconds": 30}}
}
```

The lane then said **"install the missing modules"**, and `calibrate-speech.py`
refused with **"repair missing dependencies"** — for a package that was installed
and working.

## Why 30 seconds is not the fix

The configured interpreter can live on a network filesystem; the vault's own
`config.python_path` points at a Drive-hosted `.venv`. A cold import reads its
dependencies over the network. Profiled there:

```
import time:  349 | 568850886 | mlx_whisper     <- 568.9s total

38.7s  scipy.ndimage._measurements
34.8s  scipy.ndimage._fourier
15.7s  scipy.signal._spectral_py
```

Same machine, same interpreter, once those files are resident:

```
import ok
elapsed=1s
```

**568s → 1s.** Thirty seconds is generous for local disk and 19× short for a
cold network filesystem, so no single budget is right for both. The reason has to
reach the operator instead of being flattened into "missing".

## The change

Each lane gains `unresolved_modules` beside `missing_modules`, naming the subset
whose probe never *answered* — `timeout` and `probe_start_failure`, the two
outcomes that leave presence unknown rather than decided.

**Deliberately additive.** `missing_modules` still lists every unavailable name,
so every existing reader is unaffected, and `available` is unchanged: an
unresolved lane is still unusable. The only thing that changes is that the
operator is told which repair fits.

Both consuming messages now name the module and the reason and point at warming
the interpreter rather than reinstalling. `unresolved_module_probes()` is the
shared reader, so the CLI and the calibration owner cannot drift.

## Test plan

- [x] Full suite: **8160 passed**, 8 skipped
- [x] A timed-out probe lands in `unresolved_modules` *and* stays in
      `missing_modules`; an absent one lands only in `missing_modules`
- [x] A healthy lane reports neither
- [x] The stderr advice names `python-pptx (timeout)`, says "warm", and says
      "before reinstalling anything" — and stays silent when every probe answered
- [x] `calibrate-speech.py` refuses with the module and reason on an unresolved
      probe, and keeps its original wording otherwise
- [x] ruff clean, pyright 0 errors

The existing `test_missing_runtime_refuses_before_acquisition` stub gained the
new function and an assertion on its message, so both refusal branches are now
covered rather than one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV