### PR TITLE
fix(vault-ingress): say what failed when cleanup fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ causes — the exception's class and its errno, with the symbolic name — and
 neither carries a filename, a command, or any caller-supplied value.
 `OSError.filename` is deliberately not read.
 
+The errno usually sits one frame down: `_ProcessController.terminate` and
+`_ProcessTreeMonitor.kill_seen` both wrap an OSError in a SupervisorError before
+it reaches the aggregation, so classifying the outer exception alone would report
+`SupervisorError` for exactly the paths this exists to explain. The explicit
+`__cause__` chain is followed to a bounded depth, and only that chain — an
+implicit `__context__` can carry an unrelated exception from elsewhere in the
+frame.
+
 `LocalMediaError` gained an optional `details`, so the owners pass that
 classification through instead of discarding it, and `calibrate-speech.py` names
 it in the refusal:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+### A cleanup failure says what failed
+
+`worker_cleanup_failed` reached a caller as a reason code alone. Every media
+owner maps it straight onto its own `media_cleanup_failed`, so the exception that
+actually failed survived only as a `__cause__` nobody printed, and an
+intermittent fault cost a fresh investigation each time it appeared.
+
+`classify_cleanup_failure()` records the two facts that separate the plausible
+causes — the exception's class and its errno, with the symbolic name — and
+neither carries a filename, a command, or any caller-supplied value.
+`OSError.filename` is deliberately not read.
+
+`LocalMediaError` gained an optional `details`, so the owners pass that
+classification through instead of discarding it, and `calibrate-speech.py` names
+it in the refusal:
+
+```
+media_cleanup_failed: Underlying failure: cleanup_errno_name=EPERM,
+cleanup_error_type=PermissionError. Repair the bounded media owner's ...
+```
+
+`details` is closed rather than trimmed: a key is a short snake-case name, a
+string value a short identifier, and anything else is dropped whole. A path or a
+provider message cannot ride along, which is the contract's whole job. A caller
+that passes nothing gets exactly the previous message.
+
+This is #438's first criterion only. Reproducing the fault, and deciding whether
+a cohort run should survive one cleanup failure instead of discarding 23
+completed recordings, remain open there.
+
 ## 0.20.146 — 2026-09-08
 
 ### A slow import is no longer reported as a missing module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,14 @@ media_cleanup_failed: Underlying failure: cleanup_errno_name=EPERM,
 cleanup_error_type=PermissionError. Repair the bounded media owner's ...
 ```
 
-`details` is closed rather than trimmed: a key is a short snake-case name, a
-string value a short identifier, and anything else is dropped whole. A path or a
-provider message cannot ride along, which is the contract's whole job. A caller
-that passes nothing gets exactly the previous message.
+`details` is an explicit field allowlist, not a shape check. A shape check is not
+a safety check — `[A-Za-z0-9_.:-]{1,64}` happily admits a token or a relative
+filename — so each field is verified for what it actually is: an errno must be a
+real one, an errno name must be a real name, an exception-type name must name a
+real exception class, and a reason code must match the supervisor's own pattern.
+A field this owner cannot name is dropped whatever it contains, so the contract
+never has to reason about whether an unknown value was a path, a token, or
+provider text. A caller that passes nothing gets exactly the previous message.
 
 This is #438's first criterion only. Reproducing the fault, and deciding whether
 a cohort run should survive one cleanup failure instead of discarding 23

--- a/skills/vault-ingress/scripts/artifact_supervisor.py
+++ b/skills/vault-ingress/scripts/artifact_supervisor.py
@@ -84,6 +84,11 @@ class SupervisorError(RuntimeError):
         super().__init__(reason_code)
 
 
+# A wrapped cleanup failure is one or two frames deep; a longer walk would be
+# chasing an unrelated chain rather than the cause of this failure.
+_CLEANUP_CAUSE_MAX_DEPTH = 8
+
+
 def classify_cleanup_failure(error: BaseException | None) -> dict[str, JsonValue]:
     """Describe a cleanup failure without disclosing a path or a value.
 
@@ -101,13 +106,31 @@ def classify_cleanup_failure(error: BaseException | None) -> dict[str, JsonValue
     if error is None:
         return {}
     details: dict[str, JsonValue] = {"cleanup_error_type": type(error).__name__}
-    number = getattr(error, "errno", None)
-    if isinstance(number, int) and not isinstance(number, bool):
-        details["cleanup_errno"] = number
-        details["cleanup_errno_name"] = errno.errorcode.get(number, "UNKNOWN")
     reason_code = getattr(error, "reason_code", None)
     if isinstance(reason_code, str):
         details["cleanup_reason_code"] = reason_code
+    # The errno usually sits one level down. `_ProcessController.terminate` and
+    # `_ProcessTreeMonitor.kill_seen` both wrap an OSError in a SupervisorError
+    # before it reaches the aggregation, so classifying the outer exception
+    # alone would report `SupervisorError` for exactly the paths this exists to
+    # explain. Only the explicit `__cause__` chain is followed — an implicit
+    # `__context__` can carry an unrelated exception from elsewhere in the frame.
+    seen: set[int] = set()
+    cause: BaseException | None = error
+    depth = 0
+    while cause is not None and depth < _CLEANUP_CAUSE_MAX_DEPTH:
+        if id(cause) in seen:
+            break
+        seen.add(id(cause))
+        number = getattr(cause, "errno", None)
+        if isinstance(number, int) and not isinstance(number, bool):
+            details["cleanup_errno"] = number
+            details["cleanup_errno_name"] = errno.errorcode.get(number, "UNKNOWN")
+            if cause is not error:
+                details["cleanup_cause_type"] = type(cause).__name__
+            break
+        cause = cause.__cause__
+        depth += 1
     return details
 
 

--- a/skills/vault-ingress/scripts/artifact_supervisor.py
+++ b/skills/vault-ingress/scripts/artifact_supervisor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import base64
 import binascii
 import ctypes
+import errno
 import hashlib
 import hmac
 import importlib
@@ -81,6 +82,33 @@ class SupervisorError(RuntimeError):
         self.details = dict(details or {})
         self.diagnostics = diagnostics or DiagnosticReceipt.empty()
         super().__init__(reason_code)
+
+
+def classify_cleanup_failure(error: BaseException | None) -> dict[str, JsonValue]:
+    """Describe a cleanup failure without disclosing a path or a value.
+
+    `worker_cleanup_failed` used to reach a caller as the reason code alone, and
+    every owner maps it straight to its own cleanup code, so the exception that
+    actually failed survived only as a `__cause__` nobody printed. An
+    intermittent fault then costs a fresh investigation every time it appears
+    (#438).
+
+    `errno` and the exception's class are the two facts that separate the
+    plausible causes — EPERM on a process group, ESRCH on a reaped child, a
+    cleanup deadline — and neither carries a filename, a command, or any
+    caller-supplied value. `OSError.filename` is deliberately not read.
+    """
+    if error is None:
+        return {}
+    details: dict[str, JsonValue] = {"cleanup_error_type": type(error).__name__}
+    number = getattr(error, "errno", None)
+    if isinstance(number, int) and not isinstance(number, bool):
+        details["cleanup_errno"] = number
+        details["cleanup_errno_name"] = errno.errorcode.get(number, "UNKNOWN")
+    reason_code = getattr(error, "reason_code", None)
+    if isinstance(reason_code, str):
+        details["cleanup_reason_code"] = reason_code
+    return details
 
 
 class _RootProcessDisappeared(SupervisorError):
@@ -659,7 +687,8 @@ def run_authenticated_worker(
                 {
                     "prior_reason_code": primary_error.reason_code
                     if primary_error
-                    else None
+                    else None,
+                    **classify_cleanup_failure(cleanup_error),
                 },
                 diagnostic_receipt,
             ) from cleanup_error

--- a/skills/vault-ingress/scripts/local_media_contract.py
+++ b/skills/vault-ingress/scripts/local_media_contract.py
@@ -127,15 +127,59 @@ _SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 _LANGUAGE = re.compile(r"[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*\Z")
 
 
-class LocalMediaError(ValueError):
-    """A typed acquisition refusal; raw paths and provider output stay private."""
+# Closed shapes for a disclosable detail. A key is a short snake-case name and a
+# string value is a short identifier — an errno name, a reason code — never free
+# text, which is how a path or provider message would get in.
+_DETAIL_KEY = re.compile(r"[a-z][a-z0-9_]{0,63}")
+_DETAIL_VALUE = re.compile(r"[A-Za-z0-9_.:-]{1,64}")
 
-    def __init__(self, reason_code: str) -> None:
+
+def _safe_details(details: Mapping[str, object] | None) -> dict[str, object]:
+    """Keep only disclosable scalars, so no path or provider text can ride along.
+
+    A value this reader cannot vouch for is dropped rather than trimmed: the
+    point of the contract is that a caller never has to audit what reached a log.
+    """
+    if not details:
+        return {}
+    safe: dict[str, object] = {}
+    for key, value in details.items():
+        if not isinstance(key, str) or _DETAIL_KEY.fullmatch(key) is None:
+            continue
+        if isinstance(value, bool) or isinstance(value, int):
+            safe[key] = value
+        elif isinstance(value, str) and _DETAIL_VALUE.fullmatch(value) is not None:
+            safe[key] = value
+    return safe
+
+
+class LocalMediaError(ValueError):
+    """A typed acquisition refusal; raw paths and provider output stay private.
+
+    `details` is optional and closed: numbers, booleans, and short identifiers an
+    owner already treats as safe to disclose. It exists so a refusal that maps a
+    worker failure onto an owner code does not discard what actually failed —
+    an intermittent fault otherwise costs a fresh investigation each time (#438).
+    Callers that pass nothing get exactly the previous behaviour.
+    """
+
+    def __init__(
+        self,
+        reason_code: str,
+        details: Mapping[str, object] | None = None,
+    ) -> None:
         if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", reason_code) is None:
             raise ValueError("invalid local-media failure code")
         self.reason_code = reason_code
+        self.details = _safe_details(details)
+        detail_text = (
+            " (" + ", ".join(f"{k}={v}" for k, v in sorted(self.details.items())) + ")"
+            if self.details
+            else ""
+        )
         super().__init__(
-            f"{reason_code}; inspect the source and rerun the bounded media owner"
+            f"{reason_code}{detail_text}; inspect the source and rerun the "
+            "bounded media owner"
         )
 
 

--- a/skills/vault-ingress/scripts/local_media_contract.py
+++ b/skills/vault-ingress/scripts/local_media_contract.py
@@ -7,7 +7,9 @@ converts a VideoArtifactProbe already established in the same assessment.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import builtins
+import errno
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import math
 import re
@@ -127,30 +129,68 @@ _SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 _LANGUAGE = re.compile(r"[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*\Z")
 
 
-# Closed shapes for a disclosable detail. A key is a short snake-case name and a
-# string value is a short identifier — an errno name, a reason code — never free
-# text, which is how a path or provider message would get in.
-_DETAIL_KEY = re.compile(r"[a-z][a-z0-9_]{0,63}")
-_DETAIL_VALUE = re.compile(r"[A-Za-z0-9_.:-]{1,64}")
+# Which diagnostic fields may be disclosed, and what each one must actually be.
+# A shape check is not a safety check: `[A-Za-z0-9_.:-]{1,64}` happily admits a
+# token or a relative filename, so a key is only disclosable if this owner can
+# say what the value means and verify it. Everything else is dropped.
+#
+# Exception class names are checked against real exception classes rather than
+# an identifier pattern, so a value shaped like a name but naming nothing is
+# refused along with everything else.
+_PROJECT_EXCEPTION_NAMES = frozenset({"SupervisorError", "LocalMediaError"})
+_REASON_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}")
+
+
+def _is_errno(value: object) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value in errno.errorcode
+    )
+
+
+def _is_errno_name(value: object) -> bool:
+    return isinstance(value, str) and (
+        value == "UNKNOWN" or value in set(errno.errorcode.values())
+    )
+
+
+def _is_exception_type_name(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    if value in _PROJECT_EXCEPTION_NAMES:
+        return True
+    candidate = getattr(builtins, value, None)
+    return isinstance(candidate, type) and issubclass(candidate, BaseException)
+
+
+def _is_reason_code(value: object) -> bool:
+    return isinstance(value, str) and _REASON_CODE.fullmatch(value) is not None
+
+
+DISCLOSABLE_DETAILS: Mapping[str, Callable[[object], bool]] = {
+    "cleanup_errno": _is_errno,
+    "cleanup_errno_name": _is_errno_name,
+    "cleanup_error_type": _is_exception_type_name,
+    "cleanup_cause_type": _is_exception_type_name,
+    "cleanup_reason_code": _is_reason_code,
+}
 
 
 def _safe_details(details: Mapping[str, object] | None) -> dict[str, object]:
-    """Keep only disclosable scalars, so no path or provider text can ride along.
+    """Keep only fields this owner can name and verify.
 
-    A value this reader cannot vouch for is dropped rather than trimmed: the
-    point of the contract is that a caller never has to audit what reached a log.
+    A field absent from `DISCLOSABLE_DETAILS` is dropped whatever it contains, so
+    the contract never has to reason about whether an unknown value was a path,
+    a token, or provider text.
     """
     if not details:
         return {}
-    safe: dict[str, object] = {}
-    for key, value in details.items():
-        if not isinstance(key, str) or _DETAIL_KEY.fullmatch(key) is None:
-            continue
-        if isinstance(value, bool) or isinstance(value, int):
-            safe[key] = value
-        elif isinstance(value, str) and _DETAIL_VALUE.fullmatch(value) is not None:
-            safe[key] = value
-    return safe
+    return {
+        key: value
+        for key, value in details.items()
+        if key in DISCLOSABLE_DETAILS and DISCLOSABLE_DETAILS[key](value)
+    }
 
 
 class LocalMediaError(ValueError):

--- a/skills/vault-ingress/scripts/local_media_download.py
+++ b/skills/vault-ingress/scripts/local_media_download.py
@@ -110,7 +110,11 @@ def _worker(operation: str, payload: dict[str, Any]) -> Any:
                 "worker_diagnostic_limit_exceeded": "ytdlp_worker_resource_limit",
                 "worker_cleanup_failed": "media_cleanup_failed",
             }.get(reason, "ytdlp_worker_failed")
-        raise LocalMediaError(reason) from exc
+        # Carry the supervisor's classification: a cleanup failure that
+        # arrives as a bare owner code costs a fresh investigation each
+        # time it recurs (#438). `details` is closed, so nothing a caller
+        # supplied can ride along.
+        raise LocalMediaError(reason, exc.details) from exc
     return result.payload
 
 

--- a/skills/vault-ingress/scripts/local_media_evidence.py
+++ b/skills/vault-ingress/scripts/local_media_evidence.py
@@ -137,7 +137,10 @@ def _invoke_worker(
             reason = "media_cleanup_failed"
         else:
             reason = "media_worker_failed"
-        raise LocalMediaError(reason) from exc
+        # Carry the supervisor's classification: a cleanup failure that arrives
+        # as a bare owner code costs a fresh investigation each time it recurs
+        # (#438). `details` is closed, so nothing a caller supplied rides along.
+        raise LocalMediaError(reason, exc.details) from exc
     if result.diagnostics != DiagnosticReceipt.empty():
         refuse("media_probe_malformed_result")
     return result

--- a/skills/vault-ingress/scripts/local_media_transcription.py
+++ b/skills/vault-ingress/scripts/local_media_transcription.py
@@ -162,7 +162,11 @@ def transcribe_local_media(
                 "worker_diagnostic_limit_exceeded": "whisper_worker_resource_limit",
                 "worker_cleanup_failed": "media_cleanup_failed",
             }.get(reason, "whisper_worker_failed")
-        raise LocalMediaError(reason) from exc
+        # Carry the supervisor's classification: a cleanup failure that
+        # arrives as a bare owner code costs a fresh investigation each
+        # time it recurs (#438). `details` is closed, so nothing a caller
+        # supplied can ride along.
+        raise LocalMediaError(reason, exc.details) from exc
     if not isinstance(result.payload, Mapping) or set(result.payload) != {
         "text",
         "language",

--- a/skills/vault-profile/scripts/calibrate-speech.py
+++ b/skills/vault-profile/scripts/calibrate-speech.py
@@ -285,9 +285,14 @@ def main(argv: list[str] | None = None) -> int:
         if isinstance(exc, SpeechRateError):
             code, message = exc.code, str(exc)
         elif isinstance(exc, LocalMediaError):
+            # The owner's closed details name what actually failed. Without them
+            # an intermittent worker fault reads as a bare code and has to be
+            # re-investigated from scratch every time it appears (#438).
+            named = ", ".join(f"{k}={v}" for k, v in sorted(exc.details.items()))
             code, message = (
                 exc.reason_code,
-                "Repair the bounded media owner's source, runtime or cleanup failure before rerunning.",
+                (f"Underlying failure: {named}. " if named else "")
+                + "Repair the bounded media owner's source, runtime or cleanup failure before rerunning.",
             )
         else:
             code, message = (

--- a/tests/test_artifact_supervisor.py
+++ b/tests/test_artifact_supervisor.py
@@ -2796,3 +2796,69 @@ def test_an_unnumbered_errno_still_classifies():
     assert artifact_supervisor.classify_cleanup_failure(error) == {
         "cleanup_error_type": "OSError"
     }
+
+
+def _wrapped(inner: BaseException, outer: BaseException) -> BaseException:
+    try:
+        try:
+            raise inner
+        except BaseException as caught:
+            raise outer from caught
+    except BaseException as raised:
+        return raised
+
+
+def test_an_os_failure_wrapped_by_the_supervisor_still_reports_its_errno():
+    """`terminate()` and `kill_seen()` both wrap an OSError before it reaches the
+    aggregation, so classifying the outer exception alone would report
+    SupervisorError for exactly the paths this exists to explain (#438)."""
+    wrapped = _wrapped(
+        PermissionError(1, "Operation not permitted", "/vault/private/media.mp4"),
+        artifact_supervisor.SupervisorError("worker_cleanup_failed"),
+    )
+
+    details = artifact_supervisor.classify_cleanup_failure(wrapped)
+
+    assert details == {
+        "cleanup_error_type": "SupervisorError",
+        "cleanup_reason_code": "worker_cleanup_failed",
+        "cleanup_errno": 1,
+        "cleanup_errno_name": "EPERM",
+        "cleanup_cause_type": "PermissionError",
+    }
+    assert "media.mp4" not in str(details)
+
+
+def test_the_cause_walk_stops_rather_than_chasing_an_unrelated_chain():
+    deepest = ProcessLookupError(3, "No such process")
+    chain: BaseException = deepest
+    for _ in range(artifact_supervisor._CLEANUP_CAUSE_MAX_DEPTH + 2):
+        chain = _wrapped(chain, RuntimeError("wrapper"))
+
+    details = artifact_supervisor.classify_cleanup_failure(chain)
+
+    assert "cleanup_errno" not in details
+    assert details["cleanup_error_type"] == "RuntimeError"
+
+
+def test_a_cyclic_cause_chain_terminates():
+    first = RuntimeError("first")
+    second = RuntimeError("second")
+    first.__cause__ = second
+    second.__cause__ = first
+
+    assert artifact_supervisor.classify_cleanup_failure(first) == {
+        "cleanup_error_type": "RuntimeError"
+    }
+
+
+def test_an_implicit_context_is_not_followed():
+    """`__context__` can carry an unrelated exception from elsewhere in the frame,
+    so only the explicit cause chain is read."""
+    unrelated = PermissionError(1, "Operation not permitted")
+    outer = artifact_supervisor.SupervisorError("worker_cleanup_failed")
+    outer.__context__ = unrelated
+
+    details = artifact_supervisor.classify_cleanup_failure(outer)
+
+    assert "cleanup_errno" not in details

--- a/tests/test_artifact_supervisor.py
+++ b/tests/test_artifact_supervisor.py
@@ -2798,13 +2798,15 @@ def test_an_unnumbered_errno_still_classifies():
     }
 
 
-def _wrapped(inner: BaseException, outer: BaseException) -> BaseException:
+def _wrapped(inner: Exception, outer: Exception) -> Exception:
+    """Build the real shape: an exception raised `from` another, as the cleanup
+    paths do, so the fixture exercises `__cause__` rather than setting it."""
     try:
         try:
             raise inner
-        except BaseException as caught:
+        except type(inner) as caught:
             raise outer from caught
-    except BaseException as raised:
+    except type(outer) as raised:
         return raised
 
 
@@ -2831,7 +2833,7 @@ def test_an_os_failure_wrapped_by_the_supervisor_still_reports_its_errno():
 
 def test_the_cause_walk_stops_rather_than_chasing_an_unrelated_chain():
     deepest = ProcessLookupError(3, "No such process")
-    chain: BaseException = deepest
+    chain: Exception = deepest
     for _ in range(artifact_supervisor._CLEANUP_CAUSE_MAX_DEPTH + 2):
         chain = _wrapped(chain, RuntimeError("wrapper"))
 

--- a/tests/test_artifact_supervisor.py
+++ b/tests/test_artifact_supervisor.py
@@ -1548,7 +1548,13 @@ def test_cleanup_failure_overrides_signed_success(tmp_path):
         )
 
     assert caught.value.reason_code == "worker_cleanup_failed"
-    assert caught.value.details == {"prior_reason_code": None}
+    # The classification rides along: a bare reason code makes an intermittent
+    # cleanup fault cost a fresh investigation each time it recurs (#438).
+    assert caught.value.details["prior_reason_code"] is None
+    assert (
+        caught.value.details["cleanup_error_type"]
+        == type(caught.value.__cause__).__name__
+    )
 
 
 def test_cleanup_steps_share_one_absolute_timeout_budget():
@@ -2728,3 +2734,65 @@ def test_windows_job_process_handle_close_failure_is_visible():
 
     with pytest.raises(OSError):
         job.assign(99)
+
+
+# A cleanup failure names what failed (#438).
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (None, {}),
+        (
+            PermissionError(1, "Operation not permitted", "/vault/private/media.mp4"),
+            {
+                "cleanup_error_type": "PermissionError",
+                "cleanup_errno": 1,
+                "cleanup_errno_name": "EPERM",
+            },
+        ),
+        (
+            ProcessLookupError(3, "No such process"),
+            {
+                "cleanup_error_type": "ProcessLookupError",
+                "cleanup_errno": 3,
+                "cleanup_errno_name": "ESRCH",
+            },
+        ),
+        (
+            TimeoutError("worker cleanup deadline exceeded"),
+            {"cleanup_error_type": "TimeoutError"},
+        ),
+    ],
+)
+def test_a_cleanup_failure_is_classified_without_disclosing_a_path(error, expected):
+    """errno and the exception class separate EPERM on a process group from a
+    reaped child from a blown deadline. `OSError.filename` is never read."""
+    assert artifact_supervisor.classify_cleanup_failure(error) == expected
+
+
+def test_a_classified_cleanup_failure_never_carries_the_filename():
+    error = PermissionError(1, "Operation not permitted", "/vault/private/media.mp4")
+
+    details = artifact_supervisor.classify_cleanup_failure(error)
+
+    assert "/vault/private/media.mp4" not in str(details)
+    assert all("media.mp4" not in str(value) for value in details.values())
+
+
+def test_a_supervisor_cleanup_failure_keeps_its_own_reason_code():
+    error = artifact_supervisor.SupervisorError("worker_monitor_unavailable")
+
+    assert artifact_supervisor.classify_cleanup_failure(error) == {
+        "cleanup_error_type": "SupervisorError",
+        "cleanup_reason_code": "worker_monitor_unavailable",
+    }
+
+
+def test_an_unnumbered_errno_still_classifies():
+    """A bool is not an errno, and a missing one is simply absent."""
+    error = OSError("no errno at all")
+
+    assert artifact_supervisor.classify_cleanup_failure(error) == {
+        "cleanup_error_type": "OSError"
+    }

--- a/tests/test_calibrate_speech.py
+++ b/tests/test_calibrate_speech.py
@@ -374,3 +374,49 @@ def test_an_unresolved_probe_is_not_reported_as_a_missing_dependency(
     assert "mlx-whisper (timeout)" in str(exc.value)
     assert "warm" in str(exc.value)
     assert "repair missing dependencies" not in str(exc.value)
+
+
+def test_the_cli_envelope_carries_the_underlying_failure(
+    command, tmp_path, monkeypatch, capsys
+):
+    vault(tmp_path)
+    monkeypatch.setattr(
+        command,
+        "execute",
+        lambda _args: (_ for _ in ()).throw(
+            command.LocalMediaError(
+                "media_cleanup_failed",
+                {
+                    "cleanup_error_type": "PermissionError",
+                    "cleanup_errno_name": "EPERM",
+                },
+            )
+        ),
+    )
+
+    code = command.main([str(tmp_path), "--speaker", "A Speaker", "--language", "en"])
+
+    report = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert report["error"]["code"] == "media_cleanup_failed"
+    assert "cleanup_errno_name=EPERM" in report["error"]["message"]
+    assert "cleanup_error_type=PermissionError" in report["error"]["message"]
+
+
+def test_the_cli_envelope_is_unchanged_when_there_is_nothing_to_name(
+    command, tmp_path, monkeypatch, capsys
+):
+    vault(tmp_path)
+    monkeypatch.setattr(
+        command,
+        "execute",
+        lambda _args: (_ for _ in ()).throw(
+            command.LocalMediaError("media_cleanup_failed")
+        ),
+    )
+
+    command.main([str(tmp_path), "--speaker", "A Speaker", "--language", "en"])
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["error"]["message"].startswith("Repair the bounded media owner")
+    assert "Underlying failure" not in report["error"]["message"]

--- a/tests/test_local_media_contract.py
+++ b/tests/test_local_media_contract.py
@@ -407,18 +407,19 @@ def test_disclosable_details_reach_the_message_and_the_attribute(contract):
 @pytest.mark.parametrize(
     "details",
     [
+        # The reviewer's case: identifier-shaped values that a shape check would
+        # have admitted. A field this owner cannot name is dropped whatever it
+        # looks like.
+        {"token": "synthetic-secret-value", "path": "confidential.mp4"},
         {"path": "/Users/someone/vault/media.mp4"},
         {"note": "failed while removing /tmp/scratch"},
         {"stderr": "ffmpeg: no such file or directory"},
         {"Bad-Key": "value"},
-        {"value": 1.5},
-        {"value": None},
-        {"value": ["a"]},
         {"": "x"},
     ],
 )
-def test_a_value_this_contract_cannot_vouch_for_is_dropped(contract, details):
-    """Paths and provider text stay private, which is the contract's whole job."""
+def test_a_field_this_contract_cannot_name_is_dropped(contract, details):
+    """Paths, tokens and provider text stay private, which is the whole job."""
     error = contract.LocalMediaError("media_cleanup_failed", details)
 
     assert error.details == {}
@@ -426,9 +427,60 @@ def test_a_value_this_contract_cannot_vouch_for_is_dropped(contract, details):
         assert str(value) not in str(error)
 
 
-def test_a_long_identifier_is_dropped_rather_than_truncated(contract):
-    error = contract.LocalMediaError(
-        "media_cleanup_failed", {"cleanup_reason_code": "x" * 65}
-    )
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        # Smuggling the same values into an ALLOWED key: each field is verified,
+        # not merely shape-checked.
+        ("cleanup_error_type", "confidential.mp4"),
+        ("cleanup_error_type", "synthetic-secret-value"),
+        ("cleanup_cause_type", "NotAnExceptionClass"),
+        ("cleanup_errno_name", "synthetic-secret"),
+        ("cleanup_errno_name", "media.mp4"),
+        ("cleanup_errno", 999999),
+        ("cleanup_errno", True),
+        ("cleanup_errno", "1"),
+        ("cleanup_reason_code", "Not A Code"),
+        ("cleanup_reason_code", "/tmp/path"),
+    ],
+)
+def test_an_allowed_field_still_has_to_be_what_it_claims(contract, key, value):
+    error = contract.LocalMediaError("media_cleanup_failed", {key: value})
 
     assert error.details == {}
+    assert str(value) not in str(error)
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("cleanup_errno", 1),
+        ("cleanup_errno_name", "EPERM"),
+        ("cleanup_errno_name", "UNKNOWN"),
+        ("cleanup_error_type", "PermissionError"),
+        ("cleanup_error_type", "TimeoutError"),
+        ("cleanup_cause_type", "ProcessLookupError"),
+        ("cleanup_error_type", "SupervisorError"),
+        ("cleanup_reason_code", "worker_cleanup_failed"),
+    ],
+)
+def test_a_verified_field_is_disclosed(contract, key, value):
+    error = contract.LocalMediaError("media_cleanup_failed", {key: value})
+
+    assert error.details == {key: value}
+    assert str(value) in str(error)
+
+
+def test_the_supervisor_classification_survives_the_contract(contract):
+    """The producer and the gate agree, so a real cleanup failure is disclosed."""
+    classified = {
+        "cleanup_error_type": "SupervisorError",
+        "cleanup_reason_code": "worker_cleanup_failed",
+        "cleanup_errno": 1,
+        "cleanup_errno_name": "EPERM",
+        "cleanup_cause_type": "PermissionError",
+    }
+
+    error = contract.LocalMediaError("media_cleanup_failed", classified)
+
+    assert error.details == classified

--- a/tests/test_local_media_contract.py
+++ b/tests/test_local_media_contract.py
@@ -379,3 +379,56 @@ def test_repetition_guard_keeps_optional_timing_mismatch_independent(contract):
         "language": None,
         "segments": value["segments"],
     }
+
+
+# A refusal carries what actually failed (#438).
+
+
+def test_a_refusal_without_details_reads_exactly_as_before(contract):
+    error = contract.LocalMediaError("media_cleanup_failed")
+
+    assert error.details == {}
+    assert str(error) == (
+        "media_cleanup_failed; inspect the source and rerun the bounded media owner"
+    )
+
+
+def test_disclosable_details_reach_the_message_and_the_attribute(contract):
+    error = contract.LocalMediaError(
+        "media_cleanup_failed",
+        {"cleanup_errno": 1, "cleanup_errno_name": "EPERM"},
+    )
+
+    assert error.details == {"cleanup_errno": 1, "cleanup_errno_name": "EPERM"}
+    assert "cleanup_errno=1" in str(error)
+    assert "cleanup_errno_name=EPERM" in str(error)
+
+
+@pytest.mark.parametrize(
+    "details",
+    [
+        {"path": "/Users/someone/vault/media.mp4"},
+        {"note": "failed while removing /tmp/scratch"},
+        {"stderr": "ffmpeg: no such file or directory"},
+        {"Bad-Key": "value"},
+        {"value": 1.5},
+        {"value": None},
+        {"value": ["a"]},
+        {"": "x"},
+    ],
+)
+def test_a_value_this_contract_cannot_vouch_for_is_dropped(contract, details):
+    """Paths and provider text stay private, which is the contract's whole job."""
+    error = contract.LocalMediaError("media_cleanup_failed", details)
+
+    assert error.details == {}
+    for value in details.values():
+        assert str(value) not in str(error)
+
+
+def test_a_long_identifier_is_dropped_rather_than_truncated(contract):
+    error = contract.LocalMediaError(
+        "media_cleanup_failed", {"cleanup_reason_code": "x" * 65}
+    )
+
+    assert error.details == {}


### PR DESCRIPTION
First of #438's criteria. Does **not** close it — see Scope.

## The defect

`worker_cleanup_failed` reached a caller as a reason code alone. Every media
owner maps it straight onto its own `media_cleanup_failed`, so the exception that
actually failed survived only as a `__cause__` that nothing printed:

```
Speech calibration failed: media_cleanup_failed; Repair the bounded media owner's
source, runtime or cleanup failure before rerunning.
```

That is the entire diagnostic. It aborted #431's acceptance cohort twice and
#430's backfill once during this session, and #368 recorded the same fault a
week earlier and could not reproduce it — three investigations, no evidence
retained from any of them.

## The change

`classify_cleanup_failure()` records the two facts that separate the plausible
causes — the exception's class and its errno with the symbolic name:

```python
PermissionError(EPERM, ..., "/vault/private/media.mp4")
  -> {"cleanup_error_type": "PermissionError",
      "cleanup_errno": 1, "cleanup_errno_name": "EPERM"}

TimeoutError("worker cleanup deadline exceeded")
  -> {"cleanup_error_type": "TimeoutError"}
```

That is enough to tell EPERM on a process group from a reaped child from a blown
deadline, which is what the existing Darwin carve-out in `_cleanup_invocation`
is already guessing about.

`LocalMediaError` gained an **optional** `details`, so the three owner sites pass
the classification through rather than discarding it, and `calibrate-speech.py`
names it:

```
media_cleanup_failed: Underlying failure: cleanup_errno_name=EPERM,
cleanup_error_type=PermissionError. Repair the bounded media owner's ...
```

## Nothing private rides along

`details` is **closed, and drops rather than trims**: a key must be a short
snake-case name, a string value a short identifier, and every other value is
discarded whole. `OSError.filename` is deliberately never read. A caller that
passes nothing gets byte-identical behaviour to before.

Tested with real paths and provider text — `/Users/someone/vault/media.mp4`,
`ffmpeg: no such file or directory` — asserting they reach neither `details` nor
the message.

## Scope

`LocalMediaError`'s new parameter is optional, so all ~40 existing raise sites
are untouched. I had assumed otherwise earlier and deferred this work; that was
wrong, and re-checking cost nothing.

**Still open on #438:**
- reproducing the fault, which needs it to recur
- whether a cohort run should survive one cleanup failure instead of discarding
  23 completed recordings — a design decision, not a bug fix

## Test plan

- [x] Full suite: **8180 passed**, 8 skipped
- [x] Classifier: none, EPERM with a filename present, ESRCH, a bare
      `TimeoutError`, a `SupervisorError` keeping its reason code, and an
      `OSError` with no errno
- [x] The filename is asserted absent from both `details` and its repr
- [x] Contract: no details reads exactly as before; disclosable details reach the
      message and the attribute; eight unsafe shapes are dropped whole; an
      over-long identifier is dropped rather than truncated
- [x] CLI envelope names the failure, and is unchanged when there is nothing to
      name
- [x] ruff clean, pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV