### PR TITLE
fix(media): the intermittent cohort abort was a lost teardown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ Three changes:
   `cleanup_attempts`, which separates a teardown that lost its race once from
   one that never won it.
 
+The teardown runs in a `finally`, so it also runs on the way out of a failure.
+Raising its own failure there would replace the one already travelling to the
+caller — and `media_workspace_cleanup_failed` is precisely the code that does
+not stop a caller, so a containment failure plus a lost teardown race would
+have let calibration keep spawning workers with containment unconfirmed. A
+teardown failure over an active one is reported beside it instead, and an
+interrupt still outranks a scratch directory.
+
 Not made resumable. A run that survives its most common abort has much less to
 resume, and a durable partial-cohort artifact is a stateful artifact with a
 schema, an owner, and a staleness contract — its own change, not a bug fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+### The intermittent cohort abort was a lost teardown race
+
+`media_cleanup_failed` had killed three separate speech-calibration
+investigations — #368's, and twice during #430/#431's acceptance runs — and the
+standing theory was a Darwin process-group race in the supervisor's
+`_cleanup_invocation`. It was not. The fault is in the filesystem, one layer
+above the supervisor, and it reproduces on demand.
+
+`shutil.rmtree` lists a directory, unlinks what it listed, then removes the
+directory. Anything that creates an entry inside that window makes the final
+removal fail with ENOTEMPTY. `TemporaryDirectory.cleanup` swallows ENOENT and
+re-raises everything else, and `private_media_workspace` turned that single
+re-raise into a fatal `media_cleanup_failed`. Racing a create against a real
+workspace teardown reproduces it 30 times out of 30.
+
+That explains every property the issue recorded. It needs no unusual process
+state, so driving either owner in isolation never showed it. A cohort recording
+tears down two private workspaces — one for the download, one for the
+transcription — so a 24-recording run takes roughly fifty independent coin
+flips against a race an isolated owner call takes one. And it aborted at
+recording 4, then at recording 1, because each flip is independent of the last.
+
+Three changes:
+
+- **The teardown re-attempts a lost race.** Five attempts at 50 ms, and only for
+  the codes that mean something is in the directory (ENOTEMPTY, EEXIST, and
+  EBUSY for a held-open entry). A writer that keeps producing entries still
+  exhausts them and still fails, and an error the retry cannot be about — EACCES
+  on an undeletable directory — still fails on the first attempt.
+
+- **A scratch directory is not a process.** The teardown failure had shared
+  `media_cleanup_failed` with the supervisor's containment cleanup, which is why
+  it ended whole runs: nothing may spawn another worker past a cleanup that may
+  have left a live one. A workspace that could not be removed leaks a temporary
+  directory, and the next recording gets a fresh one. It is now
+  `media_workspace_cleanup_failed` and an ordinary per-recording exclusion, so
+  one lost race costs one recording instead of twenty-three transcriptions and
+  twenty minutes.
+
+- **The two raise sites the previous fix could not reach now name what failed.**
+  0.20.147 taught `SupervisorError` cleanup failures to carry an errno, but
+  `private_media_workspace` and `local_media_process._stop` raise
+  `media_cleanup_failed` directly and never touch a `SupervisorError`, so they
+  kept emitting a bare code. Both classify now, and the workspace teardown adds
+  `cleanup_attempts`, which separates a teardown that lost its race once from
+  one that never won it.
+
+Not made resumable. A run that survives its most common abort has much less to
+resume, and a durable partial-cohort artifact is a stateful artifact with a
+schema, an owner, and a staleness contract — its own change, not a bug fix.
+A containment cleanup failure still ends the run and still discards it.
+
 ## 0.20.147 — 2026-09-08
 
 ### A cleanup failure says what failed

--- a/skills/vault-ingress/scripts/local_media_contract.py
+++ b/skills/vault-ingress/scripts/local_media_contract.py
@@ -29,6 +29,19 @@ MEDIA_MAX_STREAMS = 64
 MEDIA_FFPROBE_STDOUT_BYTES = 256 * 1024
 MEDIA_FFPROBE_STDERR_BYTES = 64 * 1024
 MEDIA_DIGEST_CHUNK_BYTES = 1024 * 1024
+# Scratch-workspace teardown re-attempts. `rmtree` removes the entries it listed
+# and then the directory, so an entry created inside that window fails the final
+# removal; a re-attempt removes what appeared. Five attempts at 50 ms outlast a
+# straggler flush or an indexer pass without letting a writer that keeps
+# producing entries stall the owner: such a writer exhausts them and fails.
+WORKSPACE_CLEANUP_ATTEMPTS = 5
+WORKSPACE_CLEANUP_BACKOFF_SECONDS = 0.05
+# ENOENT never reaches here — TemporaryDirectory swallows it. These are the
+# "something is in the directory" codes: POSIX lets a system answer a non-empty
+# removal with either ENOTEMPTY or EEXIST, and a held-open entry answers EBUSY.
+WORKSPACE_CLEANUP_RETRIED_ERRNOS = frozenset(
+    {errno.ENOTEMPTY, errno.EEXIST, errno.EBUSY}
+)
 WHISPER_MAX_TEXT_BYTES = 2 * 1024 * 1024
 WHISPER_MAX_SEGMENTS = 20000
 WHISPER_MAX_SEGMENT_TEXT_BYTES = 16384
@@ -168,12 +181,22 @@ def _is_reason_code(value: object) -> bool:
     return isinstance(value, str) and _REASON_CODE.fullmatch(value) is not None
 
 
+def _is_cleanup_attempt(value: object) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and 1 <= value <= WORKSPACE_CLEANUP_ATTEMPTS
+    )
+
+
 DISCLOSABLE_DETAILS: Mapping[str, Callable[[object], bool]] = {
     "cleanup_errno": _is_errno,
     "cleanup_errno_name": _is_errno_name,
     "cleanup_error_type": _is_exception_type_name,
     "cleanup_cause_type": _is_exception_type_name,
     "cleanup_reason_code": _is_reason_code,
+    # Separates a teardown that lost its race once from one that never won it.
+    "cleanup_attempts": _is_cleanup_attempt,
 }
 
 

--- a/skills/vault-ingress/scripts/local_media_download.py
+++ b/skills/vault-ingress/scripts/local_media_download.py
@@ -67,6 +67,7 @@ _DOWNLOAD_FAILURES = frozenset(
         "ytdlp_output_invalid",
         "media_pipe_failed",
         "media_cleanup_failed",
+        "media_workspace_cleanup_failed",
         "media_private_workspace_unavailable",
         "media_artifact_unavailable",
         "media_size_limit",

--- a/skills/vault-ingress/scripts/local_media_evidence.py
+++ b/skills/vault-ingress/scripts/local_media_evidence.py
@@ -215,7 +215,9 @@ def probe_local_media(path: Any, *, trusted_root: Any = None) -> MediaArtifactPr
         )
 
 
-def _remove_private_workspace(directory: tempfile.TemporaryDirectory) -> None:
+def _remove_private_workspace(
+    directory: tempfile.TemporaryDirectory, active: BaseException | None
+) -> None:
     """Remove one scratch directory, re-attempting a lost teardown race.
 
     `rmtree` lists a directory, unlinks what it listed, then removes the
@@ -230,6 +232,11 @@ def _remove_private_workspace(directory: tempfile.TemporaryDirectory) -> None:
     recording, so a per-teardown coin flip ended whole runs while an isolated
     owner call almost never lost (#438). A writer that keeps producing entries
     still exhausts the attempts and still fails.
+
+    `active` is the failure already travelling to the caller, if there is one.
+    Raising over it would replace it, and `media_workspace_cleanup_failed` does
+    not stop a caller the way a containment failure or an interrupt must, so a
+    teardown failure is reported beside that one rather than in place of it.
     """
     for attempt in range(1, WORKSPACE_CLEANUP_ATTEMPTS + 1):
         try:
@@ -241,9 +248,13 @@ def _remove_private_workspace(directory: tempfile.TemporaryDirectory) -> None:
                 exc.errno not in WORKSPACE_CLEANUP_RETRIED_ERRNOS
                 or attempt == WORKSPACE_CLEANUP_ATTEMPTS
             ):
-                raise LocalMediaError(
-                    "media_workspace_cleanup_failed", details
-                ) from exc
+                failure = LocalMediaError("media_workspace_cleanup_failed", details)
+                if active is None:
+                    raise failure from exc
+                # Closed by construction: a reason code and allowlisted
+                # numbers, never a path or provider text.
+                print(f"local media: {failure}", file=sys.stderr, flush=True)
+                return
             time.sleep(WORKSPACE_CLEANUP_BACKOFF_SECONDS)
         else:
             return
@@ -260,6 +271,7 @@ def private_media_workspace() -> Iterator[dict[str, Any]]:
         directory = tempfile.TemporaryDirectory(prefix="speaker-toolkit-local-media-")
     except OSError as exc:
         raise LocalMediaError("media_private_workspace_unavailable") from exc
+    delivered = False
     try:
         try:
             path = Path(directory.name)
@@ -271,8 +283,13 @@ def private_media_workspace() -> Iterator[dict[str, Any]]:
         except OSError as exc:
             raise LocalMediaError("media_private_workspace_unavailable") from exc
         yield workspace
+        delivered = True
     finally:
-        _remove_private_workspace(directory)
+        # `delivered` is what separates the two exits. `sys.exc_info()` alone
+        # would also see an exception the caller merely happens to be handling
+        # around a workspace that closed cleanly, and would drop a real
+        # teardown failure on the floor.
+        _remove_private_workspace(directory, None if delivered else sys.exc_info()[1])
 
 
 def _admit_workspace(value: Any) -> Path:

--- a/skills/vault-ingress/scripts/local_media_evidence.py
+++ b/skills/vault-ingress/scripts/local_media_evidence.py
@@ -13,6 +13,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import time
 from typing import Any, Iterator, NoReturn, cast
 
 from artifact_locator import (
@@ -38,6 +39,7 @@ from artifact_supervisor import (
     SupervisorLimits,
     WorkerRequest,
     WorkerResult,
+    classify_cleanup_failure,
     isolate_protocol_output,
     read_worker_request,
     run_authenticated_worker,
@@ -52,6 +54,9 @@ from local_media_contract import (
     MEDIA_PIPELINE_VERSION,
     MEDIA_PROBE_LIMITS,
     MEDIA_SCHEMA_VERSION,
+    WORKSPACE_CLEANUP_ATTEMPTS,
+    WORKSPACE_CLEANUP_BACKOFF_SECONDS,
+    WORKSPACE_CLEANUP_RETRIED_ERRNOS,
     LocalMediaError,
     MediaArtifactProbe,
     decode_media_probe,
@@ -86,6 +91,7 @@ _LOCAL_FAILURES = frozenset(
         "media_pipe_failed",
         "media_private_workspace_unavailable",
         "media_cleanup_failed",
+        "media_workspace_cleanup_failed",
     }
 )
 
@@ -209,6 +215,40 @@ def probe_local_media(path: Any, *, trusted_root: Any = None) -> MediaArtifactPr
         )
 
 
+def _remove_private_workspace(directory: tempfile.TemporaryDirectory) -> None:
+    """Remove one scratch directory, re-attempting a lost teardown race.
+
+    `rmtree` lists a directory, unlinks what it listed, then removes the
+    directory itself. Anything that creates an entry inside that window makes
+    the final removal fail with ENOTEMPTY (EEXIST on the platforms POSIX allows
+    it to, EBUSY where the new entry is held open): a straggler tool flushing a
+    fragment, a content indexer, an endpoint-security agent. A re-attempt walks
+    the directory again and removes whatever appeared.
+
+    `TemporaryDirectory.cleanup` swallows ENOENT already and re-raises the rest,
+    which made one lost race fatal. A cohort tears a workspace down twice per
+    recording, so a per-teardown coin flip ended whole runs while an isolated
+    owner call almost never lost (#438). A writer that keeps producing entries
+    still exhausts the attempts and still fails.
+    """
+    for attempt in range(1, WORKSPACE_CLEANUP_ATTEMPTS + 1):
+        try:
+            directory.cleanup()
+        except OSError as exc:
+            details = dict(classify_cleanup_failure(exc))
+            details["cleanup_attempts"] = attempt
+            if (
+                exc.errno not in WORKSPACE_CLEANUP_RETRIED_ERRNOS
+                or attempt == WORKSPACE_CLEANUP_ATTEMPTS
+            ):
+                raise LocalMediaError(
+                    "media_workspace_cleanup_failed", details
+                ) from exc
+            time.sleep(WORKSPACE_CLEANUP_BACKOFF_SECONDS)
+        else:
+            return
+
+
 @contextmanager
 def private_media_workspace() -> Iterator[dict[str, Any]]:
     """The owner cleans up even after a timed-out or killed worker cannot.
@@ -232,10 +272,7 @@ def private_media_workspace() -> Iterator[dict[str, Any]]:
             raise LocalMediaError("media_private_workspace_unavailable") from exc
         yield workspace
     finally:
-        try:
-            directory.cleanup()
-        except OSError as exc:
-            raise LocalMediaError("media_cleanup_failed") from exc
+        _remove_private_workspace(directory)
 
 
 def _admit_workspace(value: Any) -> Path:

--- a/skills/vault-ingress/scripts/local_media_process.py
+++ b/skills/vault-ingress/scripts/local_media_process.py
@@ -14,7 +14,11 @@ import threading
 import time
 from typing import BinaryIO, cast
 
-from artifact_supervisor import DiagnosticReceipt, _PipeDrainer
+from artifact_supervisor import (
+    DiagnosticReceipt,
+    _PipeDrainer,
+    classify_cleanup_failure,
+)
 from local_media_contract import LocalMediaError, refuse
 
 
@@ -87,7 +91,12 @@ def _stop(process: subprocess.Popen[bytes]) -> None:
                 process.kill()
                 process.wait(timeout=PIPE_JOIN_SECONDS)
     except (OSError, subprocess.SubprocessError) as exc:
-        raise LocalMediaError("media_cleanup_failed") from exc
+        # Name what failed. This site never reached the supervisor, so it was
+        # still emitting a bare code after the supervisor's own cleanup
+        # failures learned to carry one (#438).
+        raise LocalMediaError(
+            "media_cleanup_failed", classify_cleanup_failure(exc)
+        ) from exc
 
 
 def run_media_tool(

--- a/skills/vault-ingress/scripts/local_media_transcription.py
+++ b/skills/vault-ingress/scripts/local_media_transcription.py
@@ -86,6 +86,7 @@ WHISPER_FAILURES = frozenset(
         "whisper_provider_version_unsupported",
         "media_private_workspace_unavailable",
         "media_cleanup_failed",
+        "media_workspace_cleanup_failed",
         "media_dependency_unavailable",
         "media_tool_stdout_limit",
         "media_tool_stderr_limit",

--- a/skills/vault-profile/scripts/calibrate-speech.py
+++ b/skills/vault-profile/scripts/calibrate-speech.py
@@ -18,8 +18,12 @@ report is not permission to use a planning default. Save to a fresh candidate,
 never redirect over an existing profile. Exit 0 reports a completed plan/run,
 1 rejects inputs or capabilities, 2 reports usage or unexpected tool failure.
 Per-recording acquisition failures remain explicit exclusions; global failures
-emit no usable candidate. Interrupts propagate. Bounds are owned by the cohort,
-speech-profile and ingress media contracts, not overridable CLI thresholds.
+emit no usable candidate. A scratch directory that could not be removed is a
+per-recording exclusion, not a global failure: it leaks a temporary directory,
+not a process. Only a containment cleanup failure, which may have left a live
+worker, ends the run — see `_ABORTING_FAILURES`. Interrupts propagate. Bounds
+are owned by the cohort, speech-profile and ingress media contracts, not
+overridable CLI thresholds.
 """
 
 from __future__ import annotations
@@ -51,6 +55,26 @@ from vault_root_authority import (  # noqa: E402
     VaultRootAuthorityError,
     materialize_native_authority,
     resolve_vault_root_authority,
+)
+
+
+# Failures that end the run instead of excluding one recording. A worker whose
+# containment cleanup failed may have left a live process, and nothing may spawn
+# another worker past that. A missing or unusable whisper provider fails the same
+# way on every recording left.
+#
+# A scratch directory that could not be removed is neither. It leaks a temporary
+# directory, not a process, and the next recording gets a fresh workspace. It
+# shared `media_cleanup_failed` with the containment failure until a lost
+# teardown race was found discarding whole 24-recording cohorts (#438), so
+# `media_workspace_cleanup_failed` is an ordinary per-recording exclusion.
+_ABORTING_FAILURES = frozenset(
+    {
+        "media_cleanup_failed",
+        "whisper_dependency_unavailable",
+        "whisper_provider_version_unsupported",
+        "whisper_model_download_failed",
+    }
 )
 
 
@@ -190,7 +214,8 @@ def execute(args: argparse.Namespace) -> dict:
                         sample_start_seconds=start,
                         sample_duration_seconds=duration,
                     )
-                # A download context's cleanup must succeed before admission.
+                # A download context's cleanup must succeed before admission:
+                # a sample is admitted only once its workspace is gone.
                 calibration["samples"].append(
                     {
                         "schema_version": 1,
@@ -205,12 +230,7 @@ def execute(args: argparse.Namespace) -> dict:
                 reason = (
                     exc.reason_code if isinstance(exc, LocalMediaError) else exc.code
                 )
-                if reason in {
-                    "media_cleanup_failed",
-                    "whisper_dependency_unavailable",
-                    "whisper_provider_version_unsupported",
-                    "whisper_model_download_failed",
-                }:
+                if reason in _ABORTING_FAILURES:
                     raise
                 calibration["exclusions"].append(
                     {

--- a/tests/test_calibrate_speech.py
+++ b/tests/test_calibrate_speech.py
@@ -172,6 +172,75 @@ def test_run_consumes_owner_words_and_preserves_all_exclusions(
     assert prior.read_bytes() == b"existing profile"
 
 
+def test_one_lost_teardown_race_does_not_discard_the_rest_of_the_cohort(
+    command, tmp_path, monkeypatch
+):
+    """The expensive half of #438: a 24-recording cohort died at recording 4
+    and threw away everything already transcribed.
+
+    A scratch directory that could not be removed leaks a temporary directory,
+    not a process, so it excludes its own recording and the run goes on.
+    """
+    names = ["one", "two", "three"]
+    vault(tmp_path, [talk(name) for name in names])
+    runtime_ok(command, monkeypatch)
+    probe = SimpleNamespace(duration_seconds=3600)
+    monkeypatch.setattr(command, "probe_local_media", lambda *a, **k: probe)
+    transcribed = []
+
+    def transcribe(path, **kwargs):
+        name = Path(str(path)).stem
+        transcribed.append(Path(str(path)).name)
+        if name == "two":
+            raise command.LocalMediaError(
+                "media_workspace_cleanup_failed",
+                {"cleanup_errno_name": "ENOTEMPTY", "cleanup_attempts": 5},
+            )
+        # Distinct source digests: the profile collapses identical recordings.
+        return probe, sample(name)["words"]
+
+    monkeypatch.setattr(command, "transcribe_local_words", transcribe)
+    result = command.execute(options(tmp_path, run=True))
+
+    # Every recording was attempted; nothing already done was thrown away.
+    assert sorted(transcribed) == ["one.wav", "three.wav", "two.wav"]
+    assert result["profile"]["summary"]["recording_count"] == 2
+    assert result["profile"]["exclusions"] == [
+        {
+            "schema_version": 1,
+            "recording_id": "two.md",
+            "reasons": ["media_workspace_cleanup_failed"],
+        }
+    ]
+
+
+def test_a_containment_cleanup_failure_still_ends_the_run(
+    command, tmp_path, monkeypatch
+):
+    """A worker whose containment cleanup failed may have left a live process.
+    Nothing may spawn another worker past that, so this one keeps aborting."""
+    names = ["one", "two", "three"]
+    vault(tmp_path, [talk(name) for name in names])
+    runtime_ok(command, monkeypatch)
+    probe = SimpleNamespace(duration_seconds=3600)
+    monkeypatch.setattr(command, "probe_local_media", lambda *a, **k: probe)
+    transcribed = []
+
+    def transcribe(path, **kwargs):
+        transcribed.append(Path(str(path)).name)
+        if Path(str(path)).name == "one.wav":
+            raise command.LocalMediaError("media_cleanup_failed")
+        return probe, sample()["words"]
+
+    monkeypatch.setattr(command, "transcribe_local_words", transcribe)
+    with pytest.raises(command.LocalMediaError, match="media_cleanup_failed"):
+        command.execute(options(tmp_path, run=True))
+    # The run stopped at the failing recording rather than working through the
+    # rest of the cohort.
+    assert transcribed == ["one.wav"]
+    assert "media_workspace_cleanup_failed" not in command._ABORTING_FAILURES
+
+
 def test_missing_local_source_remains_excluded_without_fallback(
     command, tmp_path, monkeypatch
 ):

--- a/tests/test_local_media_evidence.py
+++ b/tests/test_local_media_evidence.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import os
 from pathlib import Path
+import shutil
 import stat
 import subprocess
 import sys
@@ -267,7 +269,9 @@ def test_workspace_is_fresh_private_and_cleanup_is_not_suppressed(media, monkeyp
     def cannot_cleanup(self):
         raise OSError("private cleanup failure")
 
-    with pytest.raises(media.LocalMediaError, match="media_cleanup_failed"):
+    with pytest.raises(
+        media.LocalMediaError, match="media_workspace_cleanup_failed"
+    ) as caught:
         with media.private_media_workspace() as workspace:
             path = Path(workspace["path"])
             workspaces.append(path)
@@ -276,9 +280,122 @@ def test_workspace_is_fresh_private_and_cleanup_is_not_suppressed(media, monkeyp
                 assert stat.S_IMODE(path.stat().st_mode) == 0o700
             monkeypatch.setattr(TemporaryDirectory, "cleanup", cannot_cleanup)
     monkeypatch.setattr(TemporaryDirectory, "cleanup", original)
+    # An error the retry cannot be about is refused on the first attempt.
+    assert caught.value.details["cleanup_attempts"] == 1
     assert len(workspaces) == 1
     original(directories[0])
     assert not workspaces[0].exists()
+
+
+def test_workspace_teardown_survives_a_lost_race_against_a_concurrent_create(
+    media, monkeypatch
+):
+    """The #438 fault: rmtree lists a directory, then removes it.
+
+    An entry created between those two steps fails the removal with ENOTEMPTY.
+    One attempt used to make that fatal, and a cohort tears a workspace down
+    twice per recording.
+    """
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    attempts = []
+    slept = []
+    monkeypatch.setattr(media.time, "sleep", slept.append)
+
+    def racy_cleanup(self):
+        attempts.append(self.name)
+        if len(attempts) < 3:
+            straggler = Path(self.name) / f"fragment-{len(attempts)}.part"
+            straggler.write_bytes(b"a tool flushed this after the scan")
+            raise OSError(errno.ENOTEMPTY, "Directory not empty", self.name)
+        return original(self)
+
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", racy_cleanup)
+    with media.private_media_workspace() as workspace:
+        path = Path(workspace["path"])
+    assert len(attempts) == 3
+    assert slept == [media.WORKSPACE_CLEANUP_BACKOFF_SECONDS] * 2
+    assert not path.exists()
+
+
+def test_workspace_teardown_still_fails_when_the_race_is_never_won(media, monkeypatch):
+    """A bounded retry, not an unbounded one: a writer that keeps producing
+    entries exhausts the attempts and the owner still refuses."""
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    attempts = []
+    monkeypatch.setattr(media.time, "sleep", lambda _seconds: None)
+
+    def never_empty(self):
+        attempts.append(self.name)
+        raise OSError(errno.ENOTEMPTY, "Directory not empty", self.name)
+
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", never_empty)
+    opened: list[Path] = []
+    with pytest.raises(media.LocalMediaError) as caught:
+        with media.private_media_workspace() as workspace:
+            opened.append(Path(workspace["path"]))
+    assert len(attempts) == media.WORKSPACE_CLEANUP_ATTEMPTS
+    assert caught.value.reason_code == "media_workspace_cleanup_failed"
+    # Bare `media_cleanup_failed` cost three investigations (#438).
+    assert caught.value.details == {
+        "cleanup_error_type": "OSError",
+        "cleanup_errno": errno.ENOTEMPTY,
+        "cleanup_errno_name": "ENOTEMPTY",
+        "cleanup_attempts": media.WORKSPACE_CLEANUP_ATTEMPTS,
+    }
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", original)
+    shutil.rmtree(opened[0], ignore_errors=True)
+
+
+@pytest.mark.parametrize("number", sorted({errno.ENOTEMPTY, errno.EEXIST, errno.EBUSY}))
+def test_workspace_teardown_retries_every_occupied_directory_errno(
+    media, monkeypatch, number
+):
+    """POSIX lets a non-empty removal answer ENOTEMPTY or EEXIST; a held-open
+    entry answers EBUSY. All three mean something is in the directory."""
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    attempts = []
+    monkeypatch.setattr(media.time, "sleep", lambda _seconds: None)
+
+    def occupied_once(self):
+        attempts.append(self.name)
+        if len(attempts) == 1:
+            raise OSError(number, os.strerror(number), self.name)
+        return original(self)
+
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", occupied_once)
+    with media.private_media_workspace() as workspace:
+        path = Path(workspace["path"])
+    assert len(attempts) == 2
+    assert not path.exists()
+
+
+def test_workspace_teardown_does_not_retry_an_unrelated_failure(media, monkeypatch):
+    """The retry is for a lost race, not for a directory that cannot be
+    removed at all: EACCES fails on the first attempt, as it always did."""
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    attempts = []
+
+    def denied(self):
+        attempts.append(self.name)
+        raise OSError(errno.EACCES, "Permission denied", self.name)
+
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", denied)
+    opened: list[Path] = []
+    with pytest.raises(media.LocalMediaError) as caught:
+        with media.private_media_workspace() as workspace:
+            opened.append(Path(workspace["path"]))
+    assert attempts == [str(opened[0])]
+    assert caught.value.details["cleanup_errno_name"] == "EACCES"
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", original)
+    shutil.rmtree(opened[0], ignore_errors=True)
 
 
 @pytest.mark.parametrize("cover_art", [False, True])

--- a/tests/test_local_media_evidence.py
+++ b/tests/test_local_media_evidence.py
@@ -375,6 +375,85 @@ def test_workspace_teardown_retries_every_occupied_directory_errno(
     assert not path.exists()
 
 
+def test_a_teardown_failure_never_displaces_a_containment_failure(
+    media, monkeypatch, capsys
+):
+    """Both failures at once: the caller must still see the one that stops it.
+
+    `media_workspace_cleanup_failed` is a per-recording exclusion, so raising it
+    over a containment failure would let calibration keep spawning workers with
+    containment unconfirmed.
+    """
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    monkeypatch.setattr(media.time, "sleep", lambda _seconds: None)
+    opened: list[Path] = []
+
+    def never_empty(self):
+        raise OSError(errno.ENOTEMPTY, "Directory not empty", self.name)
+
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", never_empty)
+    with pytest.raises(media.LocalMediaError) as caught:
+        with media.private_media_workspace() as workspace:
+            opened.append(Path(workspace["path"]))
+            raise media.LocalMediaError("media_cleanup_failed")
+
+    assert caught.value.reason_code == "media_cleanup_failed"
+    # Reported beside the containment failure, not in place of it.
+    reported = capsys.readouterr().err
+    assert "media_workspace_cleanup_failed" in reported
+    assert str(opened[0]) not in reported
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", original)
+    shutil.rmtree(opened[0], ignore_errors=True)
+
+
+def test_a_teardown_failure_never_displaces_an_interrupt(media, monkeypatch):
+    """An interrupt outranks a scratch directory; the owner stays killable."""
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    monkeypatch.setattr(media.time, "sleep", lambda _seconds: None)
+    opened: list[Path] = []
+
+    def never_empty(self):
+        raise OSError(errno.ENOTEMPTY, "Directory not empty", self.name)
+
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", never_empty)
+    with pytest.raises(KeyboardInterrupt):
+        with media.private_media_workspace() as workspace:
+            opened.append(Path(workspace["path"]))
+            raise KeyboardInterrupt
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", original)
+    shutil.rmtree(opened[0], ignore_errors=True)
+
+
+def test_a_teardown_failure_still_raises_around_an_unrelated_handled_error(
+    media, monkeypatch
+):
+    """A workspace that closed cleanly is not an excuse to drop its own
+    failure: the caller merely handling something else must not suppress it."""
+    from tempfile import TemporaryDirectory
+
+    original = TemporaryDirectory.cleanup
+    monkeypatch.setattr(media.time, "sleep", lambda _seconds: None)
+    opened: list[Path] = []
+
+    def never_empty(self):
+        raise OSError(errno.ENOTEMPTY, "Directory not empty", self.name)
+
+    try:
+        raise ValueError("something the caller is already handling")
+    except ValueError:
+        monkeypatch.setattr(TemporaryDirectory, "cleanup", never_empty)
+        with pytest.raises(media.LocalMediaError) as caught:
+            with media.private_media_workspace() as workspace:
+                opened.append(Path(workspace["path"]))
+    assert caught.value.reason_code == "media_workspace_cleanup_failed"
+    monkeypatch.setattr(TemporaryDirectory, "cleanup", original)
+    shutil.rmtree(opened[0], ignore_errors=True)
+
+
 def test_workspace_teardown_does_not_retry_an_unrelated_failure(media, monkeypatch):
     """The retry is for a lost race, not for a directory that cannot be
     removed at all: EACCES fails on the first attempt, as it always did."""

--- a/tests/test_local_media_process.py
+++ b/tests/test_local_media_process.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import io
 from pathlib import Path
 import sys
@@ -118,6 +119,34 @@ def test_thread_start_failure_stops_child_and_is_typed(process, monkeypatch):
             stdout_limit=128,
             stderr_limit=32,
         )
+
+
+def test_a_failed_tool_stop_names_what_failed(process, monkeypatch):
+    """This stop never reaches the supervisor, so #438's classification had to
+    be wired here too or the refusal stays a bare code."""
+    import subprocess
+
+    def cannot_wait(self, timeout=None):
+        raise OSError(errno.ECHILD, "No child processes")
+
+    monkeypatch.setattr(subprocess.Popen, "wait", cannot_wait)
+    monkeypatch.setattr(process._PipeDrainer, "start", _refuse_to_start)
+    with pytest.raises(process.LocalMediaError) as caught:
+        process.run_media_tool(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            stdout_limit=128,
+            stderr_limit=32,
+        )
+    assert caught.value.reason_code == "media_cleanup_failed"
+    assert caught.value.details == {
+        "cleanup_error_type": "ChildProcessError",
+        "cleanup_errno": errno.ECHILD,
+        "cleanup_errno_name": "ECHILD",
+    }
+
+
+def _refuse_to_start(self):
+    raise RuntimeError("cannot allocate drainer")
 
 
 def test_partial_sink_write_is_a_failure_not_a_short_success(process):


### PR DESCRIPTION
Closes #438.

The first acceptance criterion shipped in #446 (0.20.147). This is the other
two: the fault is reproduced, and a cohort no longer discards completed
recordings when one cleanup fails.

## It was not the supervisor

The standing theory — the issue's own "Where to look" — was a Darwin
process-group race in `artifact_supervisor._cleanup_invocation`, next to the
existing EPERM carve-out. I measured that path first. A SIGKILLed process
tears down in 2–100 ms depending on RSS, `_ProcessTreeMonitor.kill_seen`
blocks until its descendants are actually gone even when handed a zero
budget, and it reported clean every time. That is not the fault.

The fault is one layer above the supervisor, in the filesystem.

`shutil.rmtree` lists a directory, unlinks what it listed, then removes the
directory. Anything creating an entry inside that window fails the final
removal with `ENOTEMPTY`. `TemporaryDirectory.cleanup` swallows `ENOENT` and
re-raises everything else, and `private_media_workspace` turned that single
re-raise into a fatal `media_cleanup_failed`.

Racing a create against a real workspace teardown reproduces it **30 times
out of 30**, and it accounts for every property the issue recorded:

- It needs no unusual process state, so driving either owner in isolation
  never showed it.
- A cohort recording tears down two private workspaces — one for the
  download, one for the transcription — so a 24-recording run takes roughly
  fifty independent coin flips where an isolated owner call takes one.
- Each flip is independent, which is why it aborted at recording 4, then at
  recording 1, then not at all.

`media_cleanup_failed` from this site also carried **no** details, so #446's
classification never reached it. Neither this site nor
`local_media_process._stop` raises through a `SupervisorError`.

## What changed

1. **The teardown re-attempts a lost race.** Bounded, and only for the codes
   that mean something is in the directory. A writer that keeps producing
   entries still exhausts the attempts and still fails; `EACCES` on an
   undeletable directory still fails on the first attempt, as before.

2. **A scratch directory is not a process.** The teardown failure had shared
   `media_cleanup_failed` with the supervisor's containment cleanup, which is
   why it ended whole runs — nothing may spawn another worker past a cleanup
   that may have left a live one. A workspace that could not be removed leaks
   a temporary directory, and the next recording gets a fresh one. It is now
   `media_workspace_cleanup_failed` and an ordinary per-recording exclusion,
   so one lost race costs one recording instead of twenty-three
   transcriptions. A containment cleanup failure still ends the run.

3. **Both direct raise sites name what failed**, including a
   `cleanup_attempts` count that separates a teardown that lost its race once
   from one that never won it.

## Not made resumable

Recorded in the CHANGELOG and in `calibrate-speech.py`'s contract. A durable
partial-cohort artifact is a stateful artifact with a schema, an owner and a
staleness contract — its own change, not a bug fix — and a run that survives
its most common abort has much less left to resume.

## Verification

- Full suite: 8209 passed, 8 skipped.
- `ruff check`, `ruff format --check`, `pyright`: clean.
- New coverage: the lost race is survived; a race never won still fails with
  a full diagnostic; every occupied-directory errno retries; an unrelated
  errno does not; a cohort survives one teardown failure and still profiles
  the rest; a containment failure still ends the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV