### PR TITLE
fix(illustrations): replace GPT Image 2 with GPT Image 2.5 Flare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ where editing precision matters most. The registry's OpenAI entry moves from
 `gpt-image-2-2026-04-21` to the snapshot-pinned `gpt-image-2.5-flare-2026-09-08`, with the
 rolling `gpt-image-2.5-flare` id as its alias. The speed tier moves from `slow` to `medium` on
 the vendor's latency claim; cost and quality tiers are unchanged. The retired `gpt-image-2`
-alias is dropped from the roster rather than remapped: an outline that baked it still
-dispatches by family prefix to OpenAI's `gpt-image-2` unchanged (the roster is a seed cache,
-not an allowlist), and silently rendering a baked style anchor on a different model would
-defeat the snapshot pin — a new test locks that in. Sunburst is not cached; it can be ranked
+alias leaves the roster (so `--compare` and `--shortlist` never rank a superseded model) and
+moves to a new `LEGACY_MODEL_ALIASES` table that `resolve_model_id` consults after the roster,
+still pinned to `gpt-image-2-2026-04-21`: an outline baked against it keeps rendering on the
+exact snapshot it was baked against. Neither remapping it onto Flare nor passing the rolling id
+through to the vendor would do — the first renders a baked style anchor on a different model,
+the second lets the vendor move the rolling id to a newer snapshot; the policy reviewer caught
+the second on the first cut. A new test locks the legacy resolution in. Sunburst is not cached; it can be ranked
 for one talk via `--shortlist --add`. Tests, the candidates-schema example, the provider-lanes
 reference, and the freshness eval fixture follow the new ids. `REGISTRY_LAST_REVIEWED` bumps
 to 2026-09-08.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### fix(illustrations) — replace GPT Image 2 with GPT Image 2.5 Flare in the model roster
+
+OpenAI shipped GPT Image 2.5 on 2026-09-08 as two API models: `gpt-image-2.5-flare`, the
+vendor's stated default for most applications (higher quality than GPT Image 2 at up to 50%
+lower latency, token rates unchanged), and `gpt-image-2.5-sunburst`, positioned for workflows
+where editing precision matters most. The registry's OpenAI entry moves from
+`gpt-image-2-2026-04-21` to the snapshot-pinned `gpt-image-2.5-flare-2026-09-08`, with the
+rolling `gpt-image-2.5-flare` id as its alias. The speed tier moves from `slow` to `medium` on
+the vendor's latency claim; cost and quality tiers are unchanged. The retired `gpt-image-2`
+alias is dropped from the roster rather than remapped: an outline that baked it still
+dispatches by family prefix to OpenAI's `gpt-image-2` unchanged (the roster is a seed cache,
+not an allowlist), and silently rendering a baked style anchor on a different model would
+defeat the snapshot pin — a new test locks that in. Sunburst is not cached; it can be ranked
+for one talk via `--shortlist --add`. Tests, the candidates-schema example, the provider-lanes
+reference, and the freshness eval fixture follow the new ids. `REGISTRY_LAST_REVIEWED` bumps
+to 2026-09-08.
+
 ## 0.20.148 — 2026-09-08
 
 ### The intermittent cohort abort was a lost teardown race

--- a/evals/illustrations-freshness-current-outline/criteria.json
+++ b/evals/illustrations-freshness-current-outline/criteria.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "No spurious model-change proposal",
-      "description": "The agent does NOT propose editing the registry roster and does NOT propose changing the outline's model, when the baked model (`gpt-image-2`) is among the current MODEL_REGISTRY roster. Surfacing such a proposal anyway fails this criterion.",
+      "description": "The agent does NOT propose editing the registry roster and does NOT propose changing the outline's model, when the baked model (`gpt-image-2.5-flare`) is among the current MODEL_REGISTRY roster. Surfacing such a proposal anyway fails this criterion.",
       "max_score": 27
     },
     {

--- a/evals/illustrations-freshness-current-outline/task.md
+++ b/evals/illustrations-freshness-current-outline/task.md
@@ -27,7 +27,7 @@ talk:
   architecture: "talklet"
 
 style_anchor:
-  model: "gpt-image-2"
+  model: "gpt-image-2.5-flare"
   full: |
     A clean technical-manual aesthetic: aged ivory paper, black ink line
     drawings with halftone shading, period-correct typography, no painterly
@@ -74,7 +74,7 @@ EOF
 touch -m talk-dir/outline.yaml
 ```
 
-The model picked in `style_anchor.model` (`gpt-image-2`) is one of the entries the comparison helper produced for the speaker this morning.
+The model picked in `style_anchor.model` (`gpt-image-2.5-flare`) is one of the entries the comparison helper produced for the speaker this morning.
 
 ## What the Speaker Asks
 

--- a/skills/illustrations/references/image-provider-lanes.md
+++ b/skills/illustrations/references/image-provider-lanes.md
@@ -14,7 +14,7 @@ and stderr diagnostics. Resolution happens separately for each render.
 | `--image-lane api` | Use the existing HTTP adapter without probing a CLI. |
 
 `--allow-cli-native` is an explicit relaxation of image-model pinning and exact
-geometry, not an alias change. The baked `gpt-image-2` alias still resolves to its
+geometry, not an alias change. The baked `gpt-image-2.5-flare` alias still resolves to its
 dated API snapshot. Native results report
 `codex-native-image-model-unpinned`, actual width/height, and the output SHA-256.
 They are not labelled as that snapshot or resized to pretend a size was served.

--- a/skills/illustrations/references/style-explore-candidates-schema.md
+++ b/skills/illustrations/references/style-explore-candidates-schema.md
@@ -94,7 +94,7 @@ either version do not migrate or rewrite the input.
                 "binary": null, "version": null},
        "width": null, "height": null, "sha256": null, "warning_count": 0}},
     {"style": "Blueprint Schematic", "format": "FULL",
-     "model": "gpt-image-2", "model_resolved": "gpt-image-2-2026-04-21",
+     "model": "gpt-image-2.5-flare", "model_resolved": "gpt-image-2.5-flare-2026-09-08",
      "status": "FAIL", "error": "rate limited", "provenance": null}
   ]
 }

--- a/skills/illustrations/scripts/model_registry.py
+++ b/skills/illustrations/scripts/model_registry.py
@@ -120,9 +120,9 @@ MODEL_REGISTRY = [
         # dispatch. Flare is OpenAI's stated default of the two GPT Image 2.5
         # models (2026-09-08); "gpt-image-2.5-sunburst" targets edit-precision
         # workflows and can be ranked per talk via `--shortlist --add`. The
-        # retired "gpt-image-2" is deliberately NOT an alias here: remapping a
-        # baked outline to a different model would defeat the snapshot pin, and
-        # an outline that names it still dispatches by family prefix unchanged.
+        # retired "gpt-image-2" is deliberately NOT an alias here — it would
+        # remap baked outlines onto a different model — it lives in
+        # LEGACY_MODEL_ALIASES, pinned to the snapshot it was current on.
         "id": "gpt-image-2.5-flare-2026-09-08",
         "display": "GPT Image 2.5 Flare",
         "family": "openai",
@@ -137,6 +137,18 @@ MODEL_REGISTRY = [
 # Historical id list — preserves the COMPARE_MODELS contract for --compare and
 # any downstream code/tests that referenced the bare list.
 COMPARE_MODELS = [m["id"] for m in MODEL_REGISTRY]
+
+# Retired rolling ids that baked outlines may still carry, mapped to the dated
+# snapshot each was pinned to while it was current. Kept OUT of MODEL_REGISTRY
+# so --compare and --shortlist never rank a superseded model, but consulted by
+# resolve_model_id() after the roster: an outline baked against the old alias
+# keeps rendering on the exact snapshot it was baked against. Passing the
+# rolling id through to the vendor instead would let the vendor move it to a
+# newer snapshot and silently change the illustration style.
+LEGACY_MODEL_ALIASES = {
+    # Superseded by gpt-image-2.5-flare on 2026-09-08.
+    "gpt-image-2": "gpt-image-2-2026-04-21",
+}
 
 # Soft ranking priorities: attribute + tier ordering (best first).
 PRIORITY_RANKINGS = {
@@ -165,6 +177,9 @@ def resolve_model_id(name):
             return m["id"]
         if any(key == alias.lower() for alias in m.get("aliases", [])):
             return m["id"]
+    legacy = LEGACY_MODEL_ALIASES.get(key)
+    if legacy:
+        return legacy
     # Unknown id: return it stripped so stray whitespace can't misclassify the
     # vendor family in model_family()'s prefix check.
     return stripped

--- a/skills/illustrations/scripts/model_registry.py
+++ b/skills/illustrations/scripts/model_registry.py
@@ -72,7 +72,7 @@ OPENAI_API_BASE = "https://api.openai.com/v1"
 # Tiers are coarse and drift with the market. The freshness check refreshes
 # both the roster and these tiers when new flagships ship — bump
 # REGISTRY_LAST_REVIEWED (ISO date) whenever this block is reconciled.
-REGISTRY_LAST_REVIEWED = "2026-06-15"
+REGISTRY_LAST_REVIEWED = "2026-09-08"
 REGISTRY_FRESHNESS_MAX_AGE_DAYS = 90
 
 MODEL_REGISTRY = [
@@ -116,13 +116,19 @@ MODEL_REGISTRY = [
     },
     {
         # Snapshot-pinned for reproducible illustration style; the rolling
-        # "gpt-image-2" alias resolves here so baked outlines still dispatch.
-        "id": "gpt-image-2-2026-04-21",
-        "display": "GPT Image 2",
+        # "gpt-image-2.5-flare" alias resolves here so baked outlines still
+        # dispatch. Flare is OpenAI's stated default of the two GPT Image 2.5
+        # models (2026-09-08); "gpt-image-2.5-sunburst" targets edit-precision
+        # workflows and can be ranked per talk via `--shortlist --add`. The
+        # retired "gpt-image-2" is deliberately NOT an alias here: remapping a
+        # baked outline to a different model would defeat the snapshot pin, and
+        # an outline that names it still dispatches by family prefix unchanged.
+        "id": "gpt-image-2.5-flare-2026-09-08",
+        "display": "GPT Image 2.5 Flare",
         "family": "openai",
-        "aliases": ["gpt-image-2"],
+        "aliases": ["gpt-image-2.5-flare"],
         "cost": "high",
-        "speed": "slow",
+        "speed": "medium",
         "quality": "high",
         "edit": "strong",
     },

--- a/tests/test_generate_illustrations.py
+++ b/tests/test_generate_illustrations.py
@@ -567,7 +567,7 @@ def test_effective_slide_format_safe_zone_wins(generate_illustrations):
 
 
 def test_model_family_openai(generate_illustrations):
-    assert generate_illustrations.model_family("gpt-image-2") == "openai"
+    assert generate_illustrations.model_family("gpt-image-2.5-flare") == "openai"
     assert generate_illustrations.model_family("gpt-image-1") == "openai"
 
 
@@ -720,7 +720,7 @@ def test_parse_outline_handles_img_plus_txt_format(generate_illustrations, tmp_p
     # anchor map and drives 2:3 sizing in the cross-vendor dispatchers.
     outline = _write_outline(
         tmp_path,
-        model="gpt-image-2",
+        model="gpt-image-2.5-flare",
         slides=[
             {
                 "n": 3,
@@ -812,14 +812,14 @@ def test_parse_empty_builds_list_yields_no_builds_key(generate_illustrations, tm
 
 def test_multipart_body_structure(generate_illustrations):
     body, boundary = generate_illustrations._multipart_body(
-        fields={"model": "gpt-image-2", "prompt": "edit this", "n": "1"},
+        fields={"model": "gpt-image-2.5-flare", "prompt": "edit this", "n": "1"},
         files=[("image", "input.png", "image/png", b"\x89PNG\r\n")],
     )
     assert boundary.startswith("----GenIllustBnd")
     text = body.decode("utf-8", errors="replace")
     # Every field present with form-data disposition
     assert 'name="model"' in text
-    assert "gpt-image-2" in text
+    assert "gpt-image-2.5-flare" in text
     assert 'name="prompt"' in text
     assert "edit this" in text
     # File field carries filename + content-type
@@ -837,7 +837,7 @@ def _candidates(**overrides):
     base = {
         "schema_version": 1,
         "slides": {"FULL": 3, "IMG+TXT": 7},
-        "models": ["gemini-3-pro-image", "gpt-image-2"],
+        "models": ["gemini-3-pro-image", "gpt-image-2.5-flare"],
         "styles": [
             {
                 "name": "Blueprint Schematic",
@@ -931,16 +931,16 @@ def test_parse_candidates_style_without_anchors(generate_illustrations, tmp_path
 def test_parse_candidates_non_string_model_rejected(generate_illustrations, tmp_path):
     import pytest
 
-    path = _write_candidates(tmp_path, _candidates(models=["gpt-image-2", 7]))
+    path = _write_candidates(tmp_path, _candidates(models=["gpt-image-2.5-flare", 7]))
     with pytest.raises(ValueError) as exc:
         generate_illustrations.parse_candidates(path)
     assert "models[1]" in str(exc.value)
 
 
 def test_parse_candidates_strips_model_whitespace(generate_illustrations, tmp_path):
-    path = _write_candidates(tmp_path, _candidates(models=["  gpt-image-2  "]))
+    path = _write_candidates(tmp_path, _candidates(models=["  gpt-image-2.5-flare  "]))
     data = generate_illustrations.parse_candidates(path)
-    assert data["models"] == ["gpt-image-2"]
+    assert data["models"] == ["gpt-image-2.5-flare"]
 
 
 def test_parse_candidates_blank_anchor_rejected(generate_illustrations, tmp_path):
@@ -1127,9 +1127,9 @@ def test_render_explore_index_groups_by_style(generate_illustrations):
         {
             "style": "Blueprint Schematic",
             "format": "FULL",
-            "model": "gpt-image-2",
+            "model": "gpt-image-2.5-flare",
             "status": "OK",
-            "rel_path": "blueprint-schematic/full/gpt-image-2.png",
+            "rel_path": "blueprint-schematic/full/gpt-image-2.5-flare.png",
         },
         {
             "style": "Watercolor",
@@ -1144,7 +1144,7 @@ def test_render_explore_index_groups_by_style(generate_illustrations):
     assert "## Blueprint Schematic" in md
     assert "## Watercolor" in md
     # OK render links to the relative image path
-    assert "(blueprint-schematic/full/gpt-image-2.png)" in md
+    assert "(blueprint-schematic/full/gpt-image-2.5-flare.png)" in md
     # FAIL render surfaces the error, not a broken link
     assert "FAILED: rate limited" in md
     # representative slide mapping is documented in the header
@@ -1228,7 +1228,7 @@ def test_rendered_manifest_excludes_failed(generate_illustrations, tmp_path):
         {
             "style": "A",
             "format": "FULL",
-            "model": "gpt-image-2",
+            "model": "gpt-image-2.5-flare",
             "status": "FAIL",
             "error": "boom",
         },
@@ -1263,7 +1263,7 @@ def test_gate_passes_on_codename_resolution(generate_illustrations, tmp_path):
 def test_gate_fails_when_model_not_rendered(generate_illustrations, tmp_path):
     gi = generate_illustrations
     outline = _write_gate_outline(tmp_path, model="gemini-3-pro-image")
-    _write_manifest(tmp_path, ["gpt-image-2"])
+    _write_manifest(tmp_path, ["gpt-image-2.5-flare"])
     v = gi.check_style_explore(str(outline))
     assert v["gate_passed"] is False
     assert "not rendered" in v["error"]

--- a/tests/test_image_cli.py
+++ b/tests/test_image_cli.py
@@ -59,7 +59,7 @@ def lane(cli, ready):
         "openai",
         "cli",
         "generate",
-        "gpt-image-2-2026-04-21",
+        "gpt-image-2.5-flare-2026-09-08",
         cli.CODEX_NATIVE_MODEL,
         "native_observed",
         "cli_forced",
@@ -557,7 +557,7 @@ def test_worker_preserves_interrupt_and_cleans_scratch(cli, monkeypatch):
     "updates,reference,reason",
     [
         ({"lane": "api"}, None, "invalid_cli_lane"),
-        ({"served_model": "gpt-image-2-2026-04-21"}, None, "invalid_cli_lane"),
+        ({"served_model": "gpt-image-2.5-flare-2026-09-08"}, None, "invalid_cli_lane"),
         ({"operation": "edit"}, None, "invalid_image_references"),
         ({}, "/fake/reference.png", "invalid_image_references"),
     ],

--- a/tests/test_image_lane_contract.py
+++ b/tests/test_image_lane_contract.py
@@ -18,7 +18,7 @@ def lanes():
 @pytest.fixture
 def image_request(lanes):
     return lanes.ImageRequest(
-        "openai", "gpt-image-2-2026-04-21", requested_size=(2048, 1152)
+        "openai", "gpt-image-2.5-flare-2026-09-08", requested_size=(2048, 1152)
     )
 
 

--- a/tests/test_image_provider.py
+++ b/tests/test_image_provider.py
@@ -77,7 +77,7 @@ def test_public_arguments_are_shared(provider, lane):
 
 @pytest.mark.parametrize("lane", ["auto", "api"])
 @pytest.mark.parametrize(
-    "model", ["gpt-image-2", "nano-banana-pro", "imagen-4.0-generate-001"]
+    "model", ["gpt-image-2.5-flare", "nano-banana-pro", "imagen-4.0-generate-001"]
 )
 def test_exact_and_api_only_requests_never_probe(
     provider, cli, monkeypatch, lane, model, capsys
@@ -117,8 +117,8 @@ def test_native_probe_is_fresh_for_each_selection(
     probes = iter([ready, replace(ready, version="0.153.3")])
     monkeypatch.setattr(cli, "probe_codex", lambda: next(probes))
     options = provider.ImageProviderOptions("auto", True)
-    first = provider.select_image_lane("gpt-image-2", options)
-    second = provider.select_image_lane("gpt-image-2", options)
+    first = provider.select_image_lane("gpt-image-2.5-flare", options)
+    second = provider.select_image_lane("gpt-image-2.5-flare", options)
     assert (first.version, second.version) == ("0.153.2", "0.153.3")
     assert first.served_model == cli.CODEX_NATIVE_MODEL
     assert first.requested_model != first.served_model
@@ -129,7 +129,7 @@ def test_nonfatal_cli_diagnostics_are_visible_on_success(
     provider, cli, ready, monkeypatch, png, capsys
 ):
     lane = provider.select_image_lane(
-        "gpt-image-2", provider.ImageProviderOptions("cli", True)
+        "gpt-image-2.5-flare", provider.ImageProviderOptions("cli", True)
     )
     monkeypatch.setattr(
         cli,
@@ -174,9 +174,11 @@ def test_native_generate_edit_need_no_api_credentials(
 
     monkeypatch.setattr(cli, "render_codex", render)
     result = (
-        gi.edit_image(str(reference), "Erase cup. Keep table.", "gpt-image-2", keys)
+        gi.edit_image(
+            str(reference), "Erase cup. Keep table.", "gpt-image-2.5-flare", keys
+        )
         if edit
-        else gi.generate_image("A blue cup", "gpt-image-2", keys)
+        else gi.generate_image("A blue cup", "gpt-image-2.5-flare", keys)
     )
     assert result.data == png
     assert result.lane.lane == "cli"
@@ -222,7 +224,7 @@ def test_present_failure_never_reads_keys_or_retries_api(
         monkeypatch.setattr(cli, "render_codex", fail)
     result = gi.generate_image(
         "cup",
-        "gpt-image-2",
+        "gpt-image-2.5-flare",
         gi.ImageKeys(options=provider.ImageProviderOptions("auto", True)),
     )
     assert result.data is None
@@ -251,11 +253,11 @@ def test_absent_cli_uses_existing_api_and_reports_it(
     monkeypatch.setattr(gi, "_call_openai_generate", api)
     result = gi.generate_image(
         "cup",
-        "gpt-image-2",
+        "gpt-image-2.5-flare",
         gi.ImageKeys(options=provider.ImageProviderOptions("auto", True)),
     )
     assert result.data == png
-    assert calls == [("gpt-image-2-2026-04-21", "fixture-key", "2048x1152")]
+    assert calls == [("gpt-image-2.5-flare-2026-09-08", "fixture-key", "2048x1152")]
     stderr = capsys.readouterr().err
     assert '"reason_code": "cli_absent"' in stderr
     assert "fixture-key" not in stderr
@@ -264,8 +266,8 @@ def test_absent_cli_uses_existing_api_and_reports_it(
 @pytest.mark.parametrize(
     "model,masked,reason",
     [
-        ("gpt-image-2", False, "cli_cannot_pin_image_model"),
-        ("gpt-image-2", True, "cli_mask_not_supported"),
+        ("gpt-image-2.5-flare", False, "cli_cannot_pin_image_model"),
+        ("gpt-image-2.5-flare", True, "cli_mask_not_supported"),
         ("gemini-3-pro-image", False, "family_api_only"),
     ],
 )
@@ -299,8 +301,8 @@ def test_generate_runner_absent_cli_exits_success_and_writes_image(
     png,
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
-    _write_manifest(tmp_path, ["gpt-image-2"])
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
+    _write_manifest(tmp_path, ["gpt-image-2.5-flare"])
     monkeypatch.setattr(cli, "probe_codex", lambda: cli.CliProbe("absent"))
     monkeypatch.setattr(
         gi, "load_secrets", lambda *a: ({"openai": "fixture-key"}, "/fake/secrets.json")
@@ -324,8 +326,8 @@ def test_generate_runner_present_failure_exits_nonzero(
     tmp_path,
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
-    _write_manifest(tmp_path, ["gpt-image-2"])
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
+    _write_manifest(tmp_path, ["gpt-image-2.5-flare"])
     monkeypatch.setattr(
         cli,
         "probe_codex",
@@ -357,9 +359,9 @@ def test_missing_api_key_is_a_reported_cell_failure_without_provider_call(
         gi, "_call_openai_edit", lambda *a, **kw: pytest.fail("called API")
     )
     result = (
-        gi.edit_image("/unused.png", "erase", "gpt-image-2", gi.ImageKeys())
+        gi.edit_image("/unused.png", "erase", "gpt-image-2.5-flare", gi.ImageKeys())
         if edit
-        else gi.generate_image("cup", "gpt-image-2", gi.ImageKeys())
+        else gi.generate_image("cup", "gpt-image-2.5-flare", gi.ImageKeys())
     )
     assert result.data is None and "image_api_key_missing" in result.detail
     assert result.lane.lane == "api"
@@ -375,12 +377,12 @@ def test_mixed_grid_retains_native_success_when_api_key_is_missing(
     png,
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
     candidates = _write_candidates(
         tmp_path,
         _candidates(
             slides={"FULL": 1},
-            models=["gpt-image-2", "gemini-3-pro-image"],
+            models=["gpt-image-2.5-flare", "gemini-3-pro-image"],
             styles=[{"name": "Ink", "anchors": {"FULL": "Ink drawing."}}],
         ),
     )
@@ -411,18 +413,18 @@ def test_v2_manifest_gate_uses_served_model_not_requested_model(
     native,
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
     base = tmp_path / "style-explore"
     base.mkdir()
     (base / "image.png").write_bytes(png)
     lane = provider.select_image_lane(
-        "gpt-image-2", provider.ImageProviderOptions("auto", native)
+        "gpt-image-2.5-flare", provider.ImageProviderOptions("auto", native)
     )
     render = provider.ImageRender(png, "image/png", lane)
     result = {
         "style": "A",
         "format": "FULL",
-        "model": "gpt-image-2",
+        "model": "gpt-image-2.5-flare",
         "status": "OK",
         "rel_path": "image.png",
         "provenance": render.provenance(),
@@ -445,7 +447,7 @@ def test_v2_missing_provenance_never_becomes_bake_evidence(
     generate_illustrations, tmp_path, png, provenance
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
     base = tmp_path / "style-explore"
     base.mkdir()
     (base / "image.png").write_bytes(png)
@@ -456,7 +458,7 @@ def test_v2_missing_provenance_never_becomes_bake_evidence(
             {
                 "style": "A",
                 "format": "FULL",
-                "model": "gpt-image-2",
+                "model": "gpt-image-2.5-flare",
                 "status": "OK",
                 "rel_path": "image.png",
                 "provenance": provenance,
@@ -470,7 +472,7 @@ def test_v2_missing_provenance_never_becomes_bake_evidence(
     "model,reason",
     [
         ("gemini-3-pro-image", "family_api_only"),
-        ("gpt-image-2", "cli_multiple_references_unverified"),
+        ("gpt-image-2.5-flare", "cli_multiple_references_unverified"),
     ],
 )
 def test_thumbnail_forced_cli_refuses_before_keys_and_images(
@@ -554,12 +556,12 @@ def test_native_style_grid_persists_observed_output_without_passing_bake_gate(
     png,
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
     candidates = _write_candidates(
         tmp_path,
         _candidates(
             slides={"FULL": 1},
-            models=["gpt-image-2"],
+            models=["gpt-image-2.5-flare"],
             styles=[{"name": "Ink", "anchors": {"FULL": "Ink drawing."}}],
         ),
     )
@@ -592,8 +594,8 @@ def test_native_compare_labels_observed_model_and_output_file(
     capsys,
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
-    monkeypatch.setattr(gi, "COMPARE_MODELS", ["gpt-image-2"])
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
+    monkeypatch.setattr(gi, "COMPARE_MODELS", ["gpt-image-2.5-flare"])
     gi.run_compare(
         str(outline), 1, lane_options=provider.ImageProviderOptions("cli", True)
     )
@@ -627,7 +629,7 @@ def test_build_uses_previous_native_edit_or_refuses_masked_cli(
             {"step": 2, "description": "full", "is_full": True},
         ]
     )
-    outline["model"] = "gpt-image-2"
+    outline["model"] = "gpt-image-2.5-flare"
     source = tmp_path / "slide-60.png"
     source.write_bytes(png)
     options = provider.ImageProviderOptions("cli", True)
@@ -680,7 +682,7 @@ def test_main_forwards_lane_options_to_every_render_mode(
     arguments,
 ):
     gi = generate_illustrations
-    outline = _write_gate_outline(tmp_path, "gpt-image-2")
+    outline = _write_gate_outline(tmp_path, "gpt-image-2.5-flare")
     seen = []
     monkeypatch.setattr(gi, mode, lambda *a, **kw: seen.append(kw["lane_options"]))
     monkeypatch.setattr(gi, "_cli_vault_path", None)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -8,7 +8,7 @@ import pytest
 @pytest.mark.parametrize(
     "model,canonical,family",
     [
-        ("GPT-IMAGE-2", "gpt-image-2-2026-04-21", "openai"),
+        ("GPT-IMAGE-2.5-FLARE", "gpt-image-2.5-flare-2026-09-08", "openai"),
         ("Nano-Banana-Pro", "gemini-3-pro-image", "gemini"),
         ("imagen-4-ultra", "imagen-4.0-ultra-generate-001", "imagen"),
         ("gpt-image-ad-hoc", "gpt-image-ad-hoc", "openai"),
@@ -37,10 +37,10 @@ def test_registry_native_choice_never_claims_the_snapshot(model_registry):
         "ready", "/synthetic/bin/codex", "0.153.2", auth_mode="chatgpt"
     )
     result = model_registry.resolve_image_lane(
-        "gpt-image-2", probe, allow_native_model=True
+        "gpt-image-2.5-flare", probe, allow_native_model=True
     )
     assert result.lane == "cli"
-    assert result.requested_model == "gpt-image-2-2026-04-21"
+    assert result.requested_model == "gpt-image-2.5-flare-2026-09-08"
     assert result.served_model == "codex-native-image-model-unpinned"
 
 
@@ -110,20 +110,32 @@ def test_resolve_deprecated_preview_ids_to_ga(model_registry):
 
 def test_resolve_rolling_openai_alias_to_snapshot(model_registry):
     # The canonical id is snapshot-pinned; the rolling alias resolves to it.
-    assert model_registry.resolve_model_id("gpt-image-2") == "gpt-image-2-2026-04-21"
+    assert (
+        model_registry.resolve_model_id("gpt-image-2.5-flare")
+        == "gpt-image-2.5-flare-2026-09-08"
+    )
+
+
+def test_retired_openai_id_is_not_remapped(model_registry):
+    # A baked outline that names the retired rolling id must keep dispatching
+    # to that id by family prefix, never be silently rendered on the newer
+    # snapshot — that would defeat the pin the outline was baked against.
+    assert model_registry.resolve_model_id("gpt-image-2") == "gpt-image-2"
+    assert model_registry.is_supported_model("gpt-image-2")
 
 
 def test_resolve_is_case_insensitive(model_registry):
     assert model_registry.resolve_model_id("Nano-Banana-Pro") == "gemini-3-pro-image"
     assert (
-        model_registry.resolve_model_id("  GPT-IMAGE-2  ") == "gpt-image-2-2026-04-21"
+        model_registry.resolve_model_id("  GPT-IMAGE-2.5-FLARE  ")
+        == "gpt-image-2.5-flare-2026-09-08"
     )
 
 
 def test_resolve_canonical_id_unchanged(model_registry):
     assert (
-        model_registry.resolve_model_id("gpt-image-2-2026-04-21")
-        == "gpt-image-2-2026-04-21"
+        model_registry.resolve_model_id("gpt-image-2.5-flare-2026-09-08")
+        == "gpt-image-2.5-flare-2026-09-08"
     )
 
 
@@ -146,7 +158,7 @@ def test_resolve_empty(model_registry):
 
 
 def test_is_supported_model(model_registry):
-    assert model_registry.is_supported_model("gpt-image-2")
+    assert model_registry.is_supported_model("gpt-image-2.5-flare")
     assert model_registry.is_supported_model("imagen-4.0-ultra-generate-001")
     assert model_registry.is_supported_model("gemini-9-future-image")
     assert model_registry.is_supported_model("nano-banana-pro")  # alias resolves
@@ -229,7 +241,9 @@ def test_shortlist_injects_web_discovered_model(model_registry):
     ids = [m["id"] for m in ranked]
     assert "gemini-5-ultra-image" in ids
     # high quality + low cost ranks it ahead of the cached high-cost model
-    assert ids.index("gemini-5-ultra-image") < ids.index("gpt-image-2-2026-04-21")
+    assert ids.index("gemini-5-ultra-image") < ids.index(
+        "gpt-image-2.5-flare-2026-09-08"
+    )
 
 
 def test_shortlist_injected_model_respects_editability_filter(model_registry):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -116,12 +116,20 @@ def test_resolve_rolling_openai_alias_to_snapshot(model_registry):
     )
 
 
-def test_retired_openai_id_is_not_remapped(model_registry):
-    # A baked outline that names the retired rolling id must keep dispatching
-    # to that id by family prefix, never be silently rendered on the newer
-    # snapshot — that would defeat the pin the outline was baked against.
-    assert model_registry.resolve_model_id("gpt-image-2") == "gpt-image-2"
+def test_retired_openai_alias_keeps_its_snapshot(model_registry):
+    # An outline baked against the retired rolling id must keep rendering on
+    # the snapshot it was pinned to — never drift to whatever the vendor serves
+    # for the rolling id today, and never be remapped onto the newer model.
+    # The retired model stays out of the roster so nothing ranks it.
+    assert model_registry.resolve_model_id("gpt-image-2") == "gpt-image-2-2026-04-21"
+    assert (
+        model_registry.resolve_model_id("  GPT-Image-2  ") == "gpt-image-2-2026-04-21"
+    )
     assert model_registry.is_supported_model("gpt-image-2")
+    assert "gpt-image-2-2026-04-21" not in model_registry.COMPARE_MODELS
+    assert "gpt-image-2-2026-04-21" not in [
+        m["id"] for m in model_registry.shortlist_models([])
+    ]
 
 
 def test_resolve_is_case_insensitive(model_registry):


### PR DESCRIPTION
## Summary
- OpenAI shipped GPT Image 2.5 on 2026-09-08 as two API models; Flare is the vendor's stated default (token rates match GPT Image 2, up to 50% lower latency). The roster's OpenAI entry moves to the snapshot-pinned `gpt-image-2.5-flare-2026-09-08` with rolling `gpt-image-2.5-flare` as its alias; speed tier `slow` → `medium`, `REGISTRY_LAST_REVIEWED` → 2026-09-08.
- The retired `gpt-image-2` id leaves the roster (so `--compare` / `--shortlist` never rank a superseded model) and moves to a new `LEGACY_MODEL_ALIASES` table, still pinned to `gpt-image-2-2026-04-21`, so an outline baked against it keeps rendering on the exact snapshot it was baked against. A new test locks that resolution in.
- Tests, the candidates-schema example, the provider-lanes reference, and the freshness eval fixture follow the new ids. Sunburst is not cached; `--shortlist --add` ranks it per talk.

## Test plan
- [x] `ruff check .` and `ruff format --check .` clean
- [x] `pyright` — 0 errors
- [x] `pytest tests/test_model_registry.py tests/test_image_provider.py tests/test_image_cli.py tests/test_image_lane_contract.py tests/test_generate_illustrations.py` — 326 passed
- [x] `scripts/check_conflict_markers.py` and `scripts/check_plugin_lint.py` pass
- [ ] CI green on the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJzr7YWkcHGBNkd2tDPQo8