### PR TITLE
fix(vault-ingress): carry evidence for talks published off YouTube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+### A talk published off YouTube can finally carry its own evidence
+
+JavaZone publishes to Vimeo. The 2026 talk arrived with a full evidence set —
+a published 1080p recording, a preserved local source, a Whisper transcript
+with schema-v2 timing and quality receipts, the delivered PDF — and could only
+be scored from the PDF. Eight of twenty-eight detections were lost, including
+the two that mattered most: `live-demo`, the defining finding of the delivery,
+and `display-of-high-value`, whose eval result exists only on the projected
+terminal because the narration misstates it. The weighted score fell 26.0 →
+18.0 with no thinner delivery behind it.
+
+It was not one talk hitting an edge. `2016-qcon-sf-java-puzzlers-ng-s02.md` has
+been sitting in the catalog on InfoQ for a decade, and between them those two
+talks owned all three blocking findings in an otherwise-clean 251-talk
+preflight — so preflight could not reach zero.
+
+Every lane resolved a bare `youtube_id`, and each failed differently. Preflight
+blocked a Vimeo ID as "not an 11-character YouTube ID". `_local_video_binding`
+returned nothing without a `youtube_id`, which nulled the trusted local-media
+digest, which turned a well-formed receipt with a correct hash into
+`receipt_owner_mismatch` — and left `delivery_video` reported as an unavailable
+source from the same absent binding. The alias ledger failed closed on every
+provider but YouTube, so the recording could not even be registered as a
+reviewed alias. The audit reported both talks as faults to review rather than
+as a lane it does not fetch from, costing an operator the cheap pre-check on
+any vault holding one. And the extractor named its artifacts from an
+11-character ID, so a manifest could not be produced for these talks at all.
+
+Talk identity is now a provider (`youtube`, `vimeo`, `infoq`) plus that
+provider's own ID, resolved once in `ingress_contract.py`. Artifacts bind to a
+**binding token** derived from it. A YouTube token is the bare ID, which is the
+property that made this safe to land: every stored artifact, manifest, receipt
+and filename binds to exactly the string it always did, and no vault content
+moves. Other providers carry a prefix (`vimeo-1223667266`,
+`infoq-java-puzzle`), which is also what keeps two providers sharing an ID from
+reading as one identity. InfoQ publishes no video ID at all — `infoq.com/
+presentations/java-puzzle/` — so its presentation slug is the identity, which
+is why the token could not simply be a different ID format.
+
+Two deliberate asymmetries. The YouTube-owned transcript provenance kinds
+(`youtube_captions`, `youtube_whisper`, `youtube_duration`) still compare the
+bare YouTube ID, because only a YouTube talk can satisfy them; the local-media
+kinds carry every other provider. And the owner-declared `video_local_path`
+keeps its permissive naming: a YouTube download lands as `{id}.mp4` and its
+name is identity evidence, while a room-camera capture is registered under the
+name it was captured with and the record's own declaration is what binds it.
+Requiring a derived filename there would have broken the working half of the
+lane this issue is about.
+
+Promotion is the one place that stayed YouTube-only. It writes the talk's
+`youtube_id`, so it refuses a non-YouTube canonical outright rather than
+stamping a foreign ID into a field that means something else.
+
+The audit's report contract goes to v4: `out_of_scope_talk_count`, a per-talk
+`source_provider`, and `active_source_provider_out_of_scope` — low priority,
+never setting `review_required`, because a provider the audit does not fetch
+from is not a fault the talk committed.
+
+Closes #427. #428 was the same root cause found from the other direction and
+was closed as a duplicate.
+
 ## 0.20.148 — 2026-09-08
 
 ### The intermittent cohort abort was a lost teardown race

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,19 @@ provider's own ID, resolved once in `ingress_contract.py`. Artifacts bind to a
 **binding token** derived from it. A YouTube token is the bare ID, which is the
 property that made this safe to land: every stored artifact, manifest, receipt
 and filename binds to exactly the string it always did, and no vault content
-moves. Other providers carry a prefix (`vimeo-1223667266`,
-`infoq-java-puzzle`), which is also what keeps two providers sharing an ID from
+moves. Other providers carry a prefix (`vimeo+1223667266`,
+`infoq+java-puzzle`), which is also what keeps two providers sharing an ID from
 reading as one identity. InfoQ publishes no video ID at all — `infoq.com/
 presentations/java-puzzle/` — so its presentation slug is the identity, which
 is why the token could not simply be a different ID format.
+
+The separator is `+` because `-` was not safe. Review caught that with an
+in-alphabet separator the InfoQ slug `kafka` and a real YouTube ID
+`infoq-kafka` produce the same token, and every ownership, alias, and
+duplicate check keyed on that token would conflate two different recordings.
+A character no YouTube ID can contain makes the overlap unrepresentable
+rather than unlikely, and it makes the token's inverse total — one token, one
+identity, no reading to choose between.
 
 Two deliberate asymmetries. The YouTube-owned transcript provenance kinds
 (`youtube_captions`, `youtube_whisper`, `youtube_duration`) still compare the
@@ -52,6 +60,12 @@ lane this issue is about.
 Promotion is the one place that stayed YouTube-only. It writes the talk's
 `youtube_id`, so it refuses a non-YouTube canonical outright rather than
 stamping a foreign ID into a field that means something else.
+
+The extraction manifest goes to schema v5, where `source_video_id` is that
+binding token. v4 read it as a YouTube ID and stays readable: a YouTube ID is
+exactly its own token, so no vault record needs migrating and nothing needs
+re-extracting. What keeps the two contracts distinguishable is that a v4
+record may not carry a provider-prefixed token.
 
 The audit's report contract goes to v4: `out_of_scope_talk_count`, a per-talk
 `source_provider`, and `active_source_provider_out_of_scope` — low priority,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ reviewed alias. The audit reported both talks as faults to review rather than
 as a lane it does not fetch from, costing an operator the cheap pre-check on
 any vault holding one. And the extractor named its artifacts from an
 11-character ID, so a manifest could not be produced for these talks at all.
+(The subagent `video_extracted` flow stays YouTube-only — nothing here acquires
+from another provider — so a non-YouTube manifest is an owner running the
+extractor against a source video they already hold. A talk published elsewhere
+registers its recording as `video_local_path`, which is the lane that carries
+its delivery-video and transcript evidence.)
 
 Talk identity is now a provider (`youtube`, `vimeo`, `infoq`) plus that
 provider's own ID, resolved once in `ingress_contract.py`. Artifacts bind to a

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1577,10 +1577,10 @@ portable canonical form `slides/<artifact>.pdf`; persistence copies it to the ta
 record and the analysis writer renders it in the provenance header. For
 `slide_source: "video_extracted"`, the filename must be
 `slides/{structured_data.video_extraction.source_video_id}.pdf`. `status: "processed"`
-requires that path plus a complete schema-v4 manifest whose top-level crop provenance
-and `slide_region` artifact independently agree on a verified manual crop. The return's
-manifest identity is also matched against the claimed talk's `youtube_id` before either
-writer changes state.
+requires that path plus a complete readable-version manifest whose top-level crop
+provenance and `slide_region` artifact independently agree on a verified manual crop.
+The return's manifest identity is also matched against the claimed talk's source
+binding token before either writer changes state.
 
 Any video-extracted return without a promoted artifact must omit
 `slides_local_path`, include it in `clear_fields`, and cannot finish `processed`. A
@@ -1912,12 +1912,18 @@ quality receipt while removing stale timing in the same transaction. Direct
 Produced by `skills/vault-ingress/scripts/video-slide-extraction.py`.
 Stored in `structured_data.video_extraction` on the talk entry. `source_video_id`
 is the talk's source binding token, which is the bare ID for a YouTube talk and
-carries a provider prefix for every other supported provider:
+carries a provider prefix for every other supported provider.
+
+Readers accept **v4 and v5**. v4 read `source_video_id` as a YouTube ID; v5
+reads it as that binding token. A YouTube ID is exactly its own token, so a v4
+record needs no migration and no re-extraction — but it may not carry a
+provider-prefixed token, which is what keeps the two contracts distinguishable.
+The extractor writes v5.
 
 ```json
 {
   "slide_source": "video_extracted",
-  "schema_version": 4,
+  "schema_version": 5,
   "pipeline_version": "0.14.0",
   "source_video_id": "AbCdEfGhI_1",
   "source_video_path": "/vault/slides-rebuild/AbCdEfGhI_1/AbCdEfGhI_1.mp4",
@@ -2079,7 +2085,7 @@ counts agree with `unique_frame_count`; and artifact scope, crop method, verific
 and trust flags are mutually consistent. `review_required: false` is accepted only for
 a verified manual `slide_region`; setting one optimistic flag cannot turn a context PDF
 into a deck. Persistence replaces this complete owner-versioned manifest rather than
-deep-merging it, so obsolete v1/v2/v3 fields cannot survive inside a schema-v4 record.
+deep-merging it, so obsolete v1/v2/v3 fields cannot survive inside a current record.
 
 `retained_frames` maps each PDF page to the zero-based index in the sampled frame
 sequence and its approximate video timestamp (`frame_index / fps_used`). Both artifacts

--- a/skills/vault-ingress/references/schemas-db.md
+++ b/skills/vault-ingress/references/schemas-db.md
@@ -1910,7 +1910,9 @@ quality receipt while removing stale timing in the same transaction. Direct
 ## Video Extraction Output Schema
 
 Produced by `skills/vault-ingress/scripts/video-slide-extraction.py`.
-Stored in `structured_data.video_extraction` on the talk entry:
+Stored in `structured_data.video_extraction` on the talk entry. `source_video_id`
+is the talk's source binding token, which is the bare ID for a YouTube talk and
+carries a provider prefix for every other supported provider:
 
 ```json
 {

--- a/skills/vault-ingress/references/source-aliases.md
+++ b/skills/vault-ingress/references/source-aliases.md
@@ -23,10 +23,14 @@ delivery date. Upload dates and uploader accounts are not delivery facts.
 Compare recording content, transcripts, or artifacts when available; retain
 the compared artifact hashes. Title similarity alone is not equivalence.
 
-The current record accepts the YouTube video lane. Unsupported providers or
-lanes fail closed; do not relabel them as YouTube. The auditor supplies provider
-facts, not an automatic alias decision or transcript comparison. An owner must
-review and approve the independent evidence before writing the plan.
+The record accepts every provider
+`skills/vault-ingress/scripts/ingress_contract.py` supports. A provider outside
+that set still fails closed; do not relabel it as one that is supported. Each
+block names the provider it was published on, and the ledger compares identities
+by binding token, so two providers that happen to share an ID stay two
+identities. The auditor supplies provider facts, not an automatic alias decision
+or transcript comparison. An owner must review and approve the independent
+evidence before writing the plan.
 
 ## Persisted shape
 
@@ -37,7 +41,8 @@ validation. Every record contains:
 - `schema_version`, `talk_filename`, and the reviewed `catalog_title`.
 - `source_type`, `alias`, and `canonical`. Each provider block carries
   `provider`, `video_id`, `url`, `title`, `uploader`, `upload_date`,
-  `duration_seconds`, and timezone-aware `captured_at`.
+  `duration_seconds`, and timezone-aware `captured_at`. `provider` must name a
+  supported provider and agree with what `url` and `video_id` identify.
 - `relationship` and nullable `canonical_choice_reason`; the reason explains
   the canonical choice without calling the alternate invalid.
 - `event`: independent `url`, `conference`, delivery `date`, and `speakers`.
@@ -110,6 +115,10 @@ Appending an alias does not change acquisition. For an owner-approved switch to
 a verified official upload, use `promote_source_alias` as the plan's sole
 mutation. Review independent event identity and recording comparison again;
 an existing alias decision alone does not authorize changing the canonical.
+
+Promotion writes the talk's `video_url` and `youtube_id`, so its `canonical`
+must be a YouTube upload; the writer refuses any other provider rather than
+stamping a foreign ID into `youtube_id`. Record such an upload as an alias.
 
 Supply a complete **v1** decision with the old current upload in `alias`, the
 new official upload in `canonical`, relationship

--- a/skills/vault-ingress/references/source-identity-audit.md
+++ b/skills/vault-ingress/references/source-identity-audit.md
@@ -119,15 +119,16 @@ identity without rejecting it or replacing the canonical recording.
 An owner-approved official-upload switch uses the separate atomic promotion
 contract in that reference, not a repair followed by an alias append.
 
-## Report contract (v3)
+## Report contract (v4)
 
 ```json
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "captured_at": "2026-07-31T19:00:00Z",
   "database": "/vault/tracking-database.json",
   "complete": true,
   "review_required": true,
+  "out_of_scope_talk_count": 0,
   "active_talk_count": 2,
   "unique_youtube_id_count": 1,
   "metadata_fetch_count": 1,
@@ -149,7 +150,10 @@ filenames that caused the fetch, `fetch_status`, provider evidence, and any
 error. `fetch_status` is `ok`, `error`, `invalid`, or `unavailable`.
 `metadata_fetch_error_count` counts every status but `ok` and `unavailable`;
 `metadata_unavailable_count` counts `unavailable` alone. `talks` contains one
-record per active URL, its catalog comparison, and the proposed evidence. `findings` and `summary.by_code` are sorted; with the same
+record per active URL, its `source_provider`, its catalog comparison, and the
+proposed evidence. `out_of_scope_talk_count` counts the active sources on a
+supported provider this YouTube audit does not fetch from; those never set
+`review_required`, because there is no fault to review. `findings` and `summary.by_code` are sorted; with the same
 database, provider responses, and `captured_at`, the decoded JSON is identical.
 
 Stable finding codes:
@@ -157,7 +161,8 @@ Stable finding codes:
 | Code | Meaning |
 |---|---|
 | `active_youtube_url_invalid` | An active YouTube-looking URL has no valid ID |
-| `active_video_provider_unsupported` | Active URL is not a supported YouTube source; no fetch occurred |
+| `active_video_provider_unsupported` | Active URL names no supported provider at all; no fetch occurred |
+| `active_source_provider_out_of_scope` | Active URL is a supported non-YouTube identity this audit does not fetch; no fault, no review |
 | `stored_youtube_id_mismatch` | URL identity disagrees with stored `youtube_id` |
 | `metadata_fetch_failed` | `yt-dlp` was missing, timed out, failed, returned unusable JSON, or was refused access; retryable |
 | `source_unavailable_upstream` | The provider reports the recording itself is gone; not retryable and not blocking |

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -322,7 +322,7 @@ entries and blocks an active `video_url` or `slides_url` that names the same
 rejected URL or provider identity (YouTube ID, Drive file/deck ID). Scanners
 compare against this ledger before importing an upstream link.
 
-## YouTube identity and duplicate relation
+## Source identity and duplicate relation
 
 Accepted inactive uploads live in the owner's top-level `source_aliases` ledger,
 not `source_rejections`. The shared schema assessment rejects malformed/future
@@ -330,16 +330,24 @@ aliases, conflicting ownership, canonical/rejection overlap, and invalid lineage
 before evidence access. See [source-aliases.md](source-aliases.md) for the record
 and reviewed-write contract. Aliases supply no artifact or acquisition capability.
 
-The parser accepts these URL identities:
+A talk's identity is provider-qualified: a provider plus that provider's own
+ID. `skills/vault-ingress/scripts/ingress_contract.py` owns the supported
+provider set and each provider's URL forms and ID shape.
 
-- `youtube.com/watch?v={id}`
-- `youtu.be/{id}`
-- `youtube.com/shorts/{id}`
-- `youtube.com/embed/{id}` (including `youtube-nocookie.com`)
+Every artifact, manifest, and receipt binds to the identity's **binding token**.
+A YouTube token is the bare 11-character ID, so an artifact named before
+providers were qualified binds to the same token it always did; every other
+provider carries its name as a prefix (`vimeo-1223667266`,
+`infoq-java-puzzle`). InfoQ publishes no video ID at all, so its presentation
+slug is the identity.
 
-IDs are exactly 11 URL-safe characters and must agree with `youtube_id`.
-Duplicate IDs are blocking unless all but one canonical record explicitly point
-to another record in the same identity group:
+A YouTube ID is exactly 11 URL-safe characters and must agree with `youtube_id`;
+`youtube_id` is a YouTube field and stays absent on every other provider.
+`source_identity.provider` must name the provider the active URL publishes on —
+relabelling another provider's upload as YouTube is blocking, not a warning.
+
+Duplicate tokens are blocking unless all but one canonical record explicitly
+point to another record in the same identity group:
 
 ```json
 {
@@ -351,7 +359,7 @@ to another record in the same identity group:
 ```
 
 `type` is `duplicate` or `borrowed_recording`. The target must exist, must not
-be the same record, and must carry the same YouTube ID. Legacy `duplicate_of`,
+be the same record, and must carry the same source identity. Legacy `duplicate_of`,
 `_duplicate_of`, `borrowed_recording_from`, and `_borrowed_recording_from`
 aliases are recognized when they describe the same recording. A legacy
 `_duplicate_of` between different recordings can continue to describe duplicate
@@ -379,8 +387,10 @@ completeness and must be rerun before an absence conclusion.
 
 - Transcript source enum: `youtube_auto`, `provider_auto`, `whisper`, `manual`,
   `none`. Absence remains valid “unknown provenance.” Unless the value is `none`, the expected
-  file is `transcripts/{youtube_id}.txt`; an explicit relative
-  `transcript_path` is resolved from the vault root.
+  file is `transcripts/{youtube_id}.txt` for a YouTube talk; every other
+  provider registers its transcript through an explicit relative
+  `transcript_path`, resolved from the vault root, whose ownership its quality
+  receipt establishes rather than its filename.
 - Slide source enum: `pptx`, `pdf`, `both`, `video_extracted`, `markdown`, `none`.
 - `markdown` records a deck authored in Slidev, presenterm, Marp, reveal-md or
   remark. It is provenance, not evidence: nothing renders markdown here, so the
@@ -411,8 +421,8 @@ completeness and must be rerun before an absence conclusion.
   values resolve from the vault root.
 - Without an explicit local path, `pdf`/`both` requires `google_drive_id` and
   `slides/{google_drive_id}.pdf`.
-- Without an explicit local path, `video_extracted` requires a valid YouTube
-  identity. `processed` also requires `slides/{youtube_id}.pdf`;
+- Without an explicit local path, `video_extracted` requires a valid source
+  identity. `processed` also requires `slides/{binding_token}.pdf`;
   `processed_partial` may intentionally retain only manifest-declared source and
   derivative artifacts.
 - A present video-extracted PDF is not sufficient deck evidence by itself. A
@@ -425,7 +435,8 @@ completeness and must be rerun before an absence conclusion.
   probed and its bounded page count must match the manifest before either
   preflight or current-return persistence accepts the referential unit. Manifest
   paths reject NUL/dot ambiguity. The schema-v4 source is exactly
-  `<youtube_id>.mp4`; it takes precedence over legacy top-level video path
+  `<binding_token>.mp4`, and the manifest's `source_video_id` is that same
+  token; it takes precedence over legacy top-level video path
   fields and must pass the bounded `source-video` evidence probe as a
   root-confined regular ISO-BMFF recording with a usable video stream and
   positive duration. A promoted PDF must have the
@@ -481,8 +492,8 @@ The thirteen stable slide-contract fault classes are:
 | `slide_pdf_artifact_missing` | Explicit or Drive-ID PDF does not exist |
 | `slide_pdf_artifact_unavailable` | PDF is an offline cloud placeholder |
 | `slide_pdf_artifact_unreadable` | PDF could not complete bounded evidence inspection; use the nested reason code to distinguish parse, dependency, monitor, identity, containment, and resource causes |
-| `slide_video_reference_missing` | Video extraction has no valid YouTube identity |
-| `slide_video_artifact_missing` | Required explicit/processed YouTube-ID PDF does not exist |
+| `slide_video_reference_missing` | Video extraction has no valid source identity |
+| `slide_video_artifact_missing` | Required explicit/processed identity-named PDF does not exist |
 | `slide_video_artifact_unavailable` | Video-derived PDF is an offline cloud placeholder |
 | `slide_video_artifact_unreadable` | Video-derived PDF could not complete bounded evidence inspection; use the nested reason code to select remediation |
 

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -341,8 +341,12 @@ provider carries its name as a prefix (`vimeo+1223667266`,
 `infoq+java-puzzle`). InfoQ publishes no video ID at all, so its presentation
 slug is the identity.
 
-A YouTube ID is exactly 11 URL-safe characters and must agree with `youtube_id`;
-`youtube_id` is a YouTube field and stays absent on every other provider.
+A YouTube ID is exactly 11 URL-safe characters and must agree with `youtube_id`.
+`youtube_id` is a YouTube field and must be absent on every other provider: a
+stored ID left behind on a source that publishes elsewhere outranks the active
+URL, so it is blocking (`youtube_id_provider_conflict`) and the record resolves
+to no identity rather than binding artifacts to the recording it no longer
+points at.
 `source_identity.provider` must name the provider the active URL publishes on —
 relabelling another provider's upload as YouTube is blocking, not a warning.
 

--- a/skills/vault-ingress/references/source-identity-preflight.md
+++ b/skills/vault-ingress/references/source-identity-preflight.md
@@ -337,8 +337,8 @@ provider set and each provider's URL forms and ID shape.
 Every artifact, manifest, and receipt binds to the identity's **binding token**.
 A YouTube token is the bare 11-character ID, so an artifact named before
 providers were qualified binds to the same token it always did; every other
-provider carries its name as a prefix (`vimeo-1223667266`,
-`infoq-java-puzzle`). InfoQ publishes no video ID at all, so its presentation
+provider carries its name as a prefix (`vimeo+1223667266`,
+`infoq+java-puzzle`). InfoQ publishes no video ID at all, so its presentation
 slug is the identity.
 
 A YouTube ID is exactly 11 URL-safe characters and must agree with `youtube_id`;

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -187,20 +187,21 @@ text.
   top of `skills/vault-ingress/scripts/batch-download-videos.py` for the report
   shape, the exit codes, and the closed failure vocabulary.
 
-  The downloader is a YouTube lane: it accepts 11-character YouTube IDs and
-  builds YouTube URLs. A talk published on another supported provider never
-  reaches it, and its prerequisite is a different one — the orchestrator
-  acquires the recording itself and places it at
-  `{vault_root}/slides-rebuild/{source_token}/{source_token}.mp4`. Confirm that
-  file exists and is a readable MP4 before extracting; there is no downloader
-  report to branch on, and an absent file is a talk with no video source,
-  handled exactly as a `fail` entry is.
+  This whole lane is YouTube-only: the downloader accepts 11-character YouTube
+  IDs and builds YouTube URLs, and no script here acquires from another
+  provider. Do not hand-place a file to work around that — a talk published
+  elsewhere takes the pre-registered lane instead. Register the recording on
+  the talk as `video_local_path` and set `slide_source` from the deck you
+  actually have (`pdf`, `both`, or `pptx`). The bounded video owner validates
+  that recording and reports `source_video_artifact_missing` /
+  `_unavailable` / `_unreadable` against it, so the check stays a script's,
+  never a judgment made here. The recording still carries delivery-video and
+  transcript evidence; only video-extracted slides are unavailable.
 
-  Extract once the lane's prerequisite holds — this id's `results` entry is
-  `ok` or `skip` on YouTube, or the placed MP4 is confirmed on every other
-  provider. The extractor's third argument is the talk's source binding token
-  (the bare ID for a YouTube talk, `vimeo+<id>` or `infoq+<slug>` otherwise),
-  and `{youtube_id}` in the paths below is that token:
+  Only once this id's `results` entry is `ok` or `skip`, extract. The
+  extractor's third argument is the talk's source binding token, which for
+  this lane is the YouTube ID, so `{youtube_id}` in the paths below reads
+  exactly as before:
   ```bash
   "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/video-slide-extraction.py" \
     "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -187,7 +187,10 @@ text.
   top of `skills/vault-ingress/scripts/batch-download-videos.py` for the report
   shape, the exit codes, and the closed failure vocabulary.
 
-  Only once this id's entry is `ok` or `skip`, extract:
+  Only once this id's entry is `ok` or `skip`, extract. The extractor's third
+  argument is the talk's source binding token — the bare ID for a YouTube talk,
+  `vimeo-<id>` or `infoq-<slug>` otherwise — and `{youtube_id}` in the paths
+  below is that token:
   ```bash
   "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/video-slide-extraction.py" \
     "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -189,7 +189,7 @@ text.
 
   Only once this id's entry is `ok` or `skip`, extract. The extractor's third
   argument is the talk's source binding token — the bare ID for a YouTube talk,
-  `vimeo-<id>` or `infoq-<slug>` otherwise — and `{youtube_id}` in the paths
+  `vimeo+<id>` or `infoq+<slug>` otherwise — and `{youtube_id}` in the paths
   below is that token:
   ```bash
   "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/video-slide-extraction.py" \

--- a/skills/vault-ingress/references/subagent-instructions.md
+++ b/skills/vault-ingress/references/subagent-instructions.md
@@ -187,10 +187,20 @@ text.
   top of `skills/vault-ingress/scripts/batch-download-videos.py` for the report
   shape, the exit codes, and the closed failure vocabulary.
 
-  Only once this id's entry is `ok` or `skip`, extract. The extractor's third
-  argument is the talk's source binding token — the bare ID for a YouTube talk,
-  `vimeo+<id>` or `infoq+<slug>` otherwise — and `{youtube_id}` in the paths
-  below is that token:
+  The downloader is a YouTube lane: it accepts 11-character YouTube IDs and
+  builds YouTube URLs. A talk published on another supported provider never
+  reaches it, and its prerequisite is a different one — the orchestrator
+  acquires the recording itself and places it at
+  `{vault_root}/slides-rebuild/{source_token}/{source_token}.mp4`. Confirm that
+  file exists and is a readable MP4 before extracting; there is no downloader
+  report to branch on, and an absent file is a talk with no video source,
+  handled exactly as a `fail` entry is.
+
+  Extract once the lane's prerequisite holds — this id's `results` entry is
+  `ok` or `skip` on YouTube, or the placed MP4 is confirmed on every other
+  provider. The extractor's third argument is the talk's source binding token
+  (the bare ID for a YouTube talk, `vimeo+<id>` or `infoq+<slug>` otherwise),
+  and `{youtube_id}` in the paths below is that token:
   ```bash
   "{python_path}" "{speaker_toolkit_root}/skills/vault-ingress/scripts/video-slide-extraction.py" \
     "{vault_root}/slides-rebuild/{youtube_id}/{youtube_id}.mp4" \

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -151,14 +151,16 @@ grammars.
 The downloader result and exit-code contract lives in
 [subagent-instructions.md](subagent-instructions.md#slide-acquisition-per-slide_source),
 under `video_extracted`. Follow it before invoking the extractor. That
-downloader is a YouTube lane; the same section names the prerequisite a talk on
-another supported provider satisfies instead.
+downloader is a YouTube lane, and so is the `video_extracted` flow around it;
+the same section says what a talk published on another provider does instead.
 
 The third argument is the talk's **source binding token**: the bare
 11-character ID for a YouTube talk, `vimeo+<id>` or `infoq+<slug>` for the
 other providers `skills/vault-ingress/scripts/ingress_contract.py` supports.
 `{youtube_id}` in the paths below is that token; a YouTube talk's token is its
-ID, so those paths are unchanged. It is validated before any filesystem or
+ID, so those paths are unchanged. The subagent `video_extracted` flow is
+YouTube-only, so a non-YouTube manifest comes from an owner running this
+extractor directly against a preserved source video they already hold. It is validated before any filesystem or
 process boundary, is never normalized, and is the only component used to derive
 the frame workspace, PDF filenames, and manifest ownership. Every derived path must stay
 under the canonical authorized output root; an existing redirecting symlink is

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -153,7 +153,7 @@ The downloader result and exit-code contract lives in
 under `video_extracted`. Follow it before invoking the extractor.
 
 The third argument is the talk's **source binding token**: the bare
-11-character ID for a YouTube talk, `vimeo-<id>` or `infoq-<slug>` for the
+11-character ID for a YouTube talk, `vimeo+<id>` or `infoq+<slug>` for the
 other providers `skills/vault-ingress/scripts/ingress_contract.py` supports.
 `{youtube_id}` in the paths below is that token; a YouTube talk's token is its
 ID, so those paths are unchanged. It is validated before any filesystem or

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -152,10 +152,13 @@ The downloader result and exit-code contract lives in
 [subagent-instructions.md](subagent-instructions.md#slide-acquisition-per-slide_source),
 under `video_extracted`. Follow it before invoking the extractor.
 
-`youtube_id` must match the shared ingress grammar exactly:
-`[A-Za-z0-9_-]{11}`. It is validated before any filesystem or process boundary,
-is never normalized, and is the only component used to derive the frame
-workspace, PDF filenames, and manifest ownership. Every derived path must stay
+The third argument is the talk's **source binding token**: the bare
+11-character ID for a YouTube talk, `vimeo-<id>` or `infoq-<slug>` for the
+other providers `skills/vault-ingress/scripts/ingress_contract.py` supports.
+`{youtube_id}` in the paths below is that token; a YouTube talk's token is its
+ID, so those paths are unchanged. It is validated before any filesystem or
+process boundary, is never normalized, and is the only component used to derive
+the frame workspace, PDF filenames, and manifest ownership. Every derived path must stay
 under the canonical authorized output root; an existing redirecting symlink is
 rejected. The script passes video/output paths to ffmpeg as argv data with no
 shell interpolation, so shell metacharacters in valid native POSIX filenames do

--- a/skills/vault-ingress/references/video-slide-extraction.md
+++ b/skills/vault-ingress/references/video-slide-extraction.md
@@ -150,7 +150,9 @@ grammars.
 
 The downloader result and exit-code contract lives in
 [subagent-instructions.md](subagent-instructions.md#slide-acquisition-per-slide_source),
-under `video_extracted`. Follow it before invoking the extractor.
+under `video_extracted`. Follow it before invoking the extractor. That
+downloader is a YouTube lane; the same section names the prerequisite a talk on
+another supported provider satisfies instead.
 
 The third argument is the talk's **source binding token**: the bare
 11-character ID for a YouTube talk, `vimeo+<id>` or `infoq+<slug>` for the

--- a/skills/vault-ingress/scripts/audit-source-identities.py
+++ b/skills/vault-ingress/scripts/audit-source-identities.py
@@ -22,6 +22,7 @@ import sys
 from typing import Any, Callable
 from urllib.parse import parse_qs, urlparse
 
+from ingress_contract import parse_source_identity
 from source_identity_matching import (
     event_agreement,
     expected_duration_seconds,
@@ -46,7 +47,7 @@ from tracking_database_io import (
 from ytdlp_runtime import YtDlpResolutionError, resolve_ytdlp
 
 
-REPORT_SCHEMA_VERSION = 3
+REPORT_SCHEMA_VERSION = 4
 SOURCE_IDENTITY_SCHEMA_VERSION = 1
 
 # Candidate mode reads scan-shownotes.py conflict entries. Only the video lane
@@ -147,6 +148,11 @@ CLIP_MARKERS = frozenset(
         "trailer",
     }
 )
+# A supported provider this YouTube audit does not fetch from. The talk is not
+# faulty and there is nothing to review: the audit simply has no lane for it.
+# Reporting it as a finding that demands review is what made an operator lose
+# the cheap pre-check on any vault holding one.
+OUT_OF_SCOPE_CODES = frozenset({"active_source_provider_out_of_scope"})
 ERROR_CODES = frozenset(
     {
         "active_youtube_url_invalid",
@@ -374,6 +380,12 @@ def provider_evidence(
 def proposed_source_identity(evidence: dict[str, Any]) -> dict[str, Any]:
     """Return provider facts only; uploader and upload date are not human identity."""
     return {key: value for key, value in evidence.items() if value is not None}
+
+
+def _review_priority(code: str) -> str:
+    if code in ERROR_CODES:
+        return "high"
+    return "low" if code in OUT_OF_SCOPE_CODES else "medium"
 
 
 def _finding(
@@ -836,10 +848,12 @@ def audit_database(
         active_count += 1
         filename = _filename(talk, index)
         video_id = parse_youtube_id(video_url)
+        source = parse_source_identity(video_url)
         audit = {
             "talk_index": index,
             "filename": filename,
             "active_video_url": video_url,
+            "source_provider": None if source is None else source.provider,
             "youtube_id": video_id,
             "stored_youtube_id": talk.get("youtube_id"),
             "catalog": {
@@ -854,20 +868,27 @@ def audit_database(
         talk_audits.append(audit)
         audits_by_index[index] = audit
         if video_id is None:
-            code = (
-                "active_youtube_url_invalid"
-                if is_youtube_url(video_url)
-                else "active_video_provider_unsupported"
-            )
+            if is_youtube_url(video_url):
+                code = "active_youtube_url_invalid"
+                message = "active video source cannot be audited as a YouTube identity"
+            elif source is not None:
+                code = "active_source_provider_out_of_scope"
+                message = (
+                    f"active video source is a supported {source.provider} identity "
+                    "this YouTube audit does not fetch"
+                )
+            else:
+                code = "active_video_provider_unsupported"
+                message = "active video source cannot be audited as a YouTube identity"
             findings.append(
                 _finding(
                     code,
                     None,
                     [index],
                     [filename],
-                    "active video source cannot be audited as a YouTube identity",
+                    message,
                     {"active_video_url": video_url},
-                    "high" if code in ERROR_CODES else "medium",
+                    _review_priority(code),
                 )
             )
             continue
@@ -1256,12 +1277,16 @@ def audit_database(
         1 for item in sources if item["fetch_status"] not in ("ok", "unavailable")
     )
     complete = not any(item["code"] in ERROR_CODES for item in findings)
+    out_of_scope = sum(1 for item in findings if item["code"] in OUT_OF_SCOPE_CODES)
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
         "captured_at": captured,
         "database": database_name,
         "complete": complete,
-        "review_required": bool(findings),
+        "review_required": any(
+            item["code"] not in OUT_OF_SCOPE_CODES for item in findings
+        ),
+        "out_of_scope_talk_count": out_of_scope,
         "active_talk_count": active_count,
         "unique_youtube_id_count": len(groups),
         "metadata_fetch_count": len(set(groups) | set(candidate_members)),

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -241,6 +241,28 @@ def talk_binding_token(talk: Mapping[str, Any]) -> str | None:
     return None if identity is None else identity.binding_token
 
 
+def is_source_binding_token(value: Any) -> bool:
+    """Return whether some supported identity produces this exact token.
+
+    Any 11 URL-safe characters are a YouTube ID, so a string that reads as a
+    prefixed token at that length (``infoq-Upper``) is accepted as the YouTube
+    token it also is. The token still names exactly one talk's artifacts, which
+    is all a binding asks of it.
+    """
+    if not isinstance(value, str):
+        return False
+    if YOUTUBE_ID_RE.fullmatch(value):
+        return True
+    return any(
+        value.startswith(f"{provider}-")
+        and _PROVIDER_ID_PATTERNS[provider].fullmatch(
+            value[len(provider) + 1 :],
+        )
+        for provider in SUPPORTED_SOURCE_PROVIDERS
+        if provider != "youtube"
+    )
+
+
 def parse_google_drive_id(url: Any) -> str | None:
     """Return a stable file/deck ID from common Google Drive URL forms."""
     if not isinstance(url, str) or not url.strip():

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -38,6 +40,15 @@ VIDEO_EXTRACTION_SCHEMA_VERSION = 4
 ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION = 3
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 GOOGLE_DRIVE_ID_RE = re.compile(r"[A-Za-z0-9_-]{3,}")
+VIMEO_ID_RE = re.compile(r"[0-9]{6,12}")
+# An InfoQ presentation is addressed by a path slug, not a numeric id. The
+# provider exposes no video id at all, so the slug is the identity.
+INFOQ_SLUG_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{1,79}[a-z0-9])?")
+# Providers whose recordings this pipeline can bind evidence to. A provider
+# outside the set is readable as a URL and remains unusable as an identity:
+# nothing derives a binding token for it, so its artifacts stay unbound rather
+# than binding to a token that no reader can reproduce.
+SUPPORTED_SOURCE_PROVIDERS = ("youtube", "vimeo", "infoq")
 
 
 class IngressContractError(ValueError):
@@ -102,6 +113,132 @@ def is_youtube_url(url: Any) -> bool:
         "youtube-nocookie.com",
         "www.youtube-nocookie.com",
     }
+
+
+def parse_vimeo_id(url: Any) -> str | None:
+    """Return the numeric ID from supported Vimeo URL forms, otherwise ``None``."""
+    parsed = _parsed_provider_url(url)
+    if parsed is None:
+        return None
+    host, parts = parsed
+    if host == "player.vimeo.com":
+        candidate = parts[1] if len(parts) >= 2 and parts[0] == "video" else None
+    elif host == "vimeo.com":
+        if len(parts) >= 3 and parts[0] in {"groups", "event"} and parts[2] == "videos":
+            candidate = parts[3] if len(parts) >= 4 else None
+        elif len(parts) >= 3 and parts[0] == "channels":
+            candidate = parts[2]
+        else:
+            # A bare `/<id>` optionally followed by an unlisted-link hash.
+            candidate = parts[0] if parts else None
+    else:
+        return None
+    return (
+        candidate
+        if isinstance(candidate, str) and VIMEO_ID_RE.fullmatch(candidate)
+        else None
+    )
+
+
+def parse_infoq_id(url: Any) -> str | None:
+    """Return the presentation slug from an InfoQ presentation URL."""
+    parsed = _parsed_provider_url(url)
+    if parsed is None:
+        return None
+    host, parts = parsed
+    if host != "infoq.com" or len(parts) < 2 or parts[0] != "presentations":
+        return None
+    slug = parts[1].casefold()
+    return slug if INFOQ_SLUG_RE.fullmatch(slug) else None
+
+
+def _parsed_provider_url(url: Any) -> tuple[str, list[str]] | None:
+    """Return one URL's normalized host and non-empty path segments."""
+    if not isinstance(url, str) or not url.strip():
+        return None
+    candidate = url.strip()
+    if "://" not in candidate:
+        candidate = "https://" + candidate
+    parsed = urlparse(candidate)
+    if parsed.scheme.casefold() not in {"http", "https"}:
+        return None
+    host = (parsed.hostname or "").casefold().rstrip(".")
+    for prefix in ("www.", "m."):
+        if host.startswith(prefix):
+            host = host[len(prefix) :]
+    return host, [part for part in parsed.path.split("/") if part]
+
+
+@dataclass(frozen=True)
+class SourceIdentity:
+    """One talk recording's provider-qualified identity.
+
+    ``binding_token`` is what every artifact, manifest, and receipt binds to.
+    A YouTube token is the bare 11-character ID, so every identity written
+    before providers were qualified keeps binding to the same token and no
+    stored artifact changes meaning. Other providers carry their prefix, which
+    is what keeps two providers' identically-named recordings apart.
+    """
+
+    provider: str
+    video_id: str
+
+    @property
+    def binding_token(self) -> str:
+        if self.provider == "youtube":
+            return self.video_id
+        return f"{self.provider}-{self.video_id}"
+
+
+_PROVIDER_PARSERS = (
+    ("youtube", parse_youtube_id),
+    ("vimeo", parse_vimeo_id),
+    ("infoq", parse_infoq_id),
+)
+_PROVIDER_ID_PATTERNS = {
+    "youtube": YOUTUBE_ID_RE,
+    "vimeo": VIMEO_ID_RE,
+    "infoq": INFOQ_SLUG_RE,
+}
+
+
+def parse_source_identity(url: Any) -> SourceIdentity | None:
+    """Return the provider-qualified identity a supported URL names."""
+    for provider, parser in _PROVIDER_PARSERS:
+        video_id = parser(url)
+        if video_id is not None:
+            return SourceIdentity(provider, video_id)
+    return None
+
+
+def source_identity_for(provider: Any, video_id: Any) -> SourceIdentity | None:
+    """Return a validated identity for one declared provider/ID pair."""
+    if not isinstance(provider, str) or not isinstance(video_id, str):
+        return None
+    pattern = _PROVIDER_ID_PATTERNS.get(provider)
+    if pattern is None or not pattern.fullmatch(video_id):
+        return None
+    return SourceIdentity(provider, video_id)
+
+
+def talk_source_identity(talk: Mapping[str, Any]) -> SourceIdentity | None:
+    """Return the identity a talk record's active source names.
+
+    The stored ``youtube_id`` keeps its precedence over ``video_url`` so a
+    YouTube talk resolves exactly as it did before providers were qualified;
+    every other provider resolves from the active URL, which is the only place
+    a non-YouTube identity is recorded.
+    """
+    youtube_id = talk.get("youtube_id")
+    if isinstance(youtube_id, str) and YOUTUBE_ID_RE.fullmatch(youtube_id):
+        return SourceIdentity("youtube", youtube_id)
+    return parse_source_identity(talk.get("video_url"))
+
+
+def talk_binding_token(talk: Mapping[str, Any]) -> str | None:
+    """Return the token a talk's artifacts and receipts bind to."""
+    identity = talk_source_identity(talk)
+    return None if identity is None else identity.binding_token
 
 
 def parse_google_drive_id(url: Any) -> str | None:

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -62,6 +62,25 @@ def is_readable_video_extraction_version(value: Any) -> bool:
     )
 
 
+def video_extraction_version_admits_token(version: Any, token: Any) -> bool:
+    """Return whether a manifest of this version may carry this binding token.
+
+    The one place the v4/v5 distinction lives. A v4 record was written when
+    `source_video_id` held a YouTube ID, so it may not carry another provider's
+    token; a v5 record may carry any supported provider's, a YouTube ID
+    included. Every reader and the return validator ask here, because a rule
+    enforced in one reader and not the other is the same as no rule.
+    """
+    if not is_readable_video_extraction_version(version):
+        return False
+    identity = token_source_identity(token)
+    if identity is None:
+        return False
+    if version == YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION:
+        return identity.provider == "youtube"
+    return True
+
+
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 GOOGLE_DRIVE_ID_RE = re.compile(r"[A-Za-z0-9_-]{3,}")
 VIMEO_ID_RE = re.compile(r"[0-9]{6,12}")

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -45,6 +45,23 @@ VIDEO_EXTRACTION_SCHEMA_VERSION = 5
 YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION = 4
 READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS = frozenset({4, 5})
 ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION = 3
+
+
+def is_readable_video_extraction_version(value: Any) -> bool:
+    """Return whether a manifest declares a version this pipeline reads.
+
+    Membership alone would raise ``TypeError`` on the unhashable values a JSON
+    document can legitimately hold (a list, an object), which escapes past a
+    caller's typed error and its actionable message. The type check is the
+    reason this is a function rather than an ``in``.
+    """
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int)
+        and value in READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS
+    )
+
+
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 GOOGLE_DRIVE_ID_RE = re.compile(r"[A-Za-z0-9_-]{3,}")
 VIMEO_ID_RE = re.compile(r"[0-9]{6,12}")

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -303,11 +303,20 @@ def talk_source_identity(talk: Mapping[str, Any]) -> SourceIdentity | None:
     YouTube talk resolves exactly as it did before providers were qualified;
     every other provider resolves from the active URL, which is the only place
     a non-YouTube identity is recorded.
+
+    A record carrying both — a stale ``youtube_id`` and an active URL on
+    another provider — contradicts itself, and there is no honest winner:
+    binding to either half binds artifacts to a source the record does not
+    actually name. That resolves to no identity, and preflight reports the
+    conflict as `youtube_id_provider_conflict`.
     """
+    active = parse_source_identity(talk.get("video_url"))
     youtube_id = talk.get("youtube_id")
     if isinstance(youtube_id, str) and YOUTUBE_ID_RE.fullmatch(youtube_id):
+        if active is not None and active.provider != "youtube":
+            return None
         return SourceIdentity("youtube", youtube_id)
-    return parse_source_identity(talk.get("video_url"))
+    return active
 
 
 def talk_binding_token(talk: Mapping[str, Any]) -> str | None:

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Mapping
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 from tracking_database import TALK_RECORD_SCHEMA_VERSION
 
@@ -111,7 +111,12 @@ def has_nonempty_source_field(talk: dict, field: str) -> bool:
 
 
 def parse_youtube_id(url: Any) -> str | None:
-    """Return an ID from supported YouTube URL forms, otherwise ``None``."""
+    """Return an ID from supported YouTube URL forms, otherwise ``None``.
+
+    Total: a malformed URL is an absent identity, never a raised ValueError.
+    Callers sit behind typed contracts whose actionable message a raw parser
+    exception would escape.
+    """
     if not isinstance(url, str) or not url.strip():
         return None
     candidate = url.strip()
@@ -122,7 +127,9 @@ def parse_youtube_id(url: Any) -> str | None:
         or candidate.startswith("youtu.be/")
     ):
         candidate = "https://" + candidate
-    parsed = urlparse(candidate)
+    parsed = _safe_urlparse(candidate)
+    if parsed is None:
+        return None
     host = (parsed.hostname or "").casefold().rstrip(".")
     if host.startswith("www."):
         host = host[4:]
@@ -146,14 +153,30 @@ def parse_youtube_id(url: Any) -> str | None:
     )
 
 
+def _safe_urlparse(candidate: str) -> ParseResult | None:
+    """Parse one URL, reading a malformed one as absent rather than raising.
+
+    `urlparse` raises ValueError on inputs like `https://[broken`. Every
+    identity parser here is documented total, and a raw exception from one of
+    them escapes the typed failure its caller promised.
+    """
+    try:
+        return urlparse(candidate)
+    except ValueError:
+        return None
+
+
 def is_youtube_url(url: Any) -> bool:
-    """Return whether ``url`` names a recognized YouTube host."""
+    """Return whether ``url`` names a recognized YouTube host. Total."""
     if not isinstance(url, str) or not url.strip():
         return False
     candidate = url.strip()
     if "://" not in candidate:
         candidate = "https://" + candidate
-    host = (urlparse(candidate).hostname or "").casefold().rstrip(".")
+    parsed = _safe_urlparse(candidate)
+    if parsed is None:
+        return False
+    host = (parsed.hostname or "").casefold().rstrip(".")
     return host in {
         "youtube.com",
         "www.youtube.com",
@@ -203,13 +226,15 @@ def parse_infoq_id(url: Any) -> str | None:
 
 
 def _parsed_provider_url(url: Any) -> tuple[str, list[str]] | None:
-    """Return one URL's normalized host and non-empty path segments."""
+    """Return one URL's normalized host and non-empty path segments. Total."""
     if not isinstance(url, str) or not url.strip():
         return None
     candidate = url.strip()
     if "://" not in candidate:
         candidate = "https://" + candidate
-    parsed = urlparse(candidate)
+    parsed = _safe_urlparse(candidate)
+    if parsed is None:
+        return None
     if parsed.scheme.casefold() not in {"http", "https"}:
         return None
     host = (parsed.hostname or "").casefold().rstrip(".")
@@ -314,13 +339,15 @@ def token_source_identity(value: Any) -> SourceIdentity | None:
 
 
 def parse_google_drive_id(url: Any) -> str | None:
-    """Return a stable file/deck ID from common Google Drive URL forms."""
+    """Return a stable file/deck ID from common Drive URL forms. Total."""
     if not isinstance(url, str) or not url.strip():
         return None
     candidate = url.strip()
     if "://" not in candidate:
         candidate = "https://" + candidate
-    parsed = urlparse(candidate)
+    parsed = _safe_urlparse(candidate)
+    if parsed is None:
+        return None
     host = (parsed.hostname or "").casefold().rstrip(".")
     if host not in {"drive.google.com", "docs.google.com"}:
         return None
@@ -337,7 +364,9 @@ def parse_google_drive_id(url: Any) -> str | None:
 def _valid_http_url(value: object) -> bool:
     if not isinstance(value, str) or not value.strip():
         return False
-    parsed = urlparse(value.strip())
+    parsed = _safe_urlparse(value.strip())
+    if parsed is None:
+        return False
     return parsed.scheme.casefold() in {"http", "https"} and bool(parsed.hostname)
 
 

--- a/skills/vault-ingress/scripts/ingress_contract.py
+++ b/skills/vault-ingress/scripts/ingress_contract.py
@@ -33,10 +33,17 @@ LOCAL_ARTIFACT_FIELDS = (
 )
 # Shape version of the structured_data.video_extraction record. Owned by
 # skills/vault-ingress/scripts/video-slide-extraction.py and shared here so the
-# producer and every reader gate on one number. v4 binds each derivative to the
-# engine-owned source receipt; v3 stays readable as an archival/reprocessing
-# input and is never upgraded in place.
-VIDEO_EXTRACTION_SCHEMA_VERSION = 4
+# producer and every reader gate on one number. v5 reads `source_video_id` as a
+# provider-qualified binding token; v4 read it as a YouTube ID, which every v5
+# reader still accepts because a YouTube ID is exactly its own token. That is
+# what makes this a backward-compatible widening rather than a repurposed
+# field: a v4 record needs no migration and no re-extraction, and the two
+# contracts stay distinguishable because a v4 record may not carry a
+# provider-prefixed token. v3 predates the source receipt and stays readable
+# only as an archival/reprocessing input, never upgraded in place.
+VIDEO_EXTRACTION_SCHEMA_VERSION = 5
+YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION = 4
+READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS = frozenset({4, 5})
 ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION = 3
 YOUTUBE_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 GOOGLE_DRIVE_ID_RE = re.compile(r"[A-Za-z0-9_-]{3,}")
@@ -49,6 +56,13 @@ INFOQ_SLUG_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{1,79}[a-z0-9])?")
 # nothing derives a binding token for it, so its artifacts stay unbound rather
 # than binding to a token that no reader can reproduce.
 SUPPORTED_SOURCE_PROVIDERS = ("youtube", "vimeo", "infoq")
+# The provider separator sits OUTSIDE the YouTube ID alphabet on purpose. With
+# an in-alphabet separator, the InfoQ slug `kafka` and a real YouTube ID
+# `infoq-kafka` produce the same token, and every ownership, alias, and
+# duplicate check keyed on that token conflates two different recordings. A
+# character no YouTube ID can contain makes the overlap unrepresentable rather
+# than unlikely.
+SOURCE_PROVIDER_SEPARATOR = "+"
 
 
 class IngressContractError(ValueError):
@@ -187,7 +201,7 @@ class SourceIdentity:
     def binding_token(self) -> str:
         if self.provider == "youtube":
             return self.video_id
-        return f"{self.provider}-{self.video_id}"
+        return f"{self.provider}{SOURCE_PROVIDER_SEPARATOR}{self.video_id}"
 
 
 _PROVIDER_PARSERS = (
@@ -242,25 +256,25 @@ def talk_binding_token(talk: Mapping[str, Any]) -> str | None:
 
 
 def is_source_binding_token(value: Any) -> bool:
-    """Return whether some supported identity produces this exact token.
+    """Return whether exactly one supported identity produces this token."""
+    return token_source_identity(value) is not None
 
-    Any 11 URL-safe characters are a YouTube ID, so a string that reads as a
-    prefixed token at that length (``infoq-Upper``) is accepted as the YouTube
-    token it also is. The token still names exactly one talk's artifacts, which
-    is all a binding asks of it.
+
+def token_source_identity(value: Any) -> SourceIdentity | None:
+    """Return the one identity a binding token names, otherwise ``None``.
+
+    The inverse of ``binding_token`` and total: the separator cannot appear in a
+    YouTube ID, so a prefixed token and a YouTube token are never the same
+    string and this never has to choose between two readings.
     """
     if not isinstance(value, str):
-        return False
+        return None
     if YOUTUBE_ID_RE.fullmatch(value):
-        return True
-    return any(
-        value.startswith(f"{provider}-")
-        and _PROVIDER_ID_PATTERNS[provider].fullmatch(
-            value[len(provider) + 1 :],
-        )
-        for provider in SUPPORTED_SOURCE_PROVIDERS
-        if provider != "youtube"
-    )
+        return SourceIdentity("youtube", value)
+    provider, separator, video_id = value.partition(SOURCE_PROVIDER_SEPARATOR)
+    if not separator or provider == "youtube":
+        return None
+    return source_identity_for(provider, video_id)
 
 
 def parse_google_drive_id(url: Any) -> str | None:

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -1161,7 +1161,12 @@ def _apply_promote_source_alias(
             )
     existing = database.get("source_aliases", [])
     retired = next(
-        (item for item in existing if item["alias"]["video_id"] == promoted_id), None
+        (
+            item
+            for item in existing
+            if record_identity_token(item["alias"]) == promoted_token
+        ),
+        None,
     )
     if retired is not None and retired["talk_filename"] != filename:
         raise TrackingDatabaseMutationError(

--- a/skills/vault-ingress/scripts/mutate-tracking-database.py
+++ b/skills/vault-ingress/scripts/mutate-tracking-database.py
@@ -70,7 +70,8 @@ from source_alias_contract import (
     SourceAliasError,
     active_identity,
     validate_alias_record,
-    youtube_identity,
+    record_identity_token,
+    source_identity_token,
 )
 
 
@@ -1137,16 +1138,22 @@ def _apply_promote_source_alias(
     if (
         record["relationship"] != "superseded_by_official_upload"
         or record["canonical_choice_reason"] is None
-        or active_identity(talk) != record["alias"]["video_id"]
+        or active_identity(talk) != record_identity_token(record["alias"])
     ):
         raise TrackingDatabaseMutationError(
             f"{label}: promotion requires the current source as alias, an official-upload relationship, and a reviewed reason"
         )
     _require_alias_delivery(talk, record, label=label)
     promoted_id = record["canonical"]["video_id"]
+    if record["canonical"]["provider"] != "youtube":
+        raise TrackingDatabaseMutationError(
+            f"{label}: promotion writes the talk's youtube_id and supports a "
+            "YouTube canonical only; record the upload as an alias instead"
+        )
+    promoted_token = record_identity_token(record["canonical"])
     for other in database["talks"]:
-        if other["filename"] != filename and promoted_id in (
-            youtube_identity(other.get("video_url")),
+        if other["filename"] != filename and promoted_token in (
+            source_identity_token(other.get("video_url")),
             other.get("youtube_id"),
         ):
             raise TrackingDatabaseMutationError(

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -29,8 +29,8 @@ from ingress_contract import (
     SourceIdentity,
     has_remote_slide_acquisition,
     has_remote_video_acquisition,
-    is_readable_video_extraction_version,
     talk_source_identity,
+    video_extraction_version_admits_token,
 )
 from artifact_metadata import canonicalize_trusted_artifact_locator
 from cloud_artifacts import unavailable_cloud_artifacts
@@ -708,7 +708,9 @@ def _local_video_binding(
         if identity is None:
             return None, "video_extraction manifest has no claimed source identity"
         if (
-            not is_readable_video_extraction_version(manifest.get("schema_version"))
+            not video_extraction_version_admits_token(
+                manifest.get("schema_version"), manifest.get("source_video_id")
+            )
             or manifest.get("source_video_id") != identity.binding_token
         ):
             return (
@@ -877,7 +879,9 @@ def _trusted_video_slide_probe(
         except PatternEvidenceError as exc:
             return None, str(exc), None
     trusted = (
-        is_readable_video_extraction_version(manifest.get("schema_version"))
+        video_extraction_version_admits_token(
+            manifest.get("schema_version"), manifest.get("source_video_id")
+        )
         and manifest.get("source_video_id") == identity.binding_token
         and manifest.get("slide_region_method") == "manual"
         and manifest.get("slide_region_applied") is True

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -646,7 +646,10 @@ def _declared_pdf_path(talk: Mapping[str, object]) -> tuple[str, object] | None:
 
 
 def _identity_duration(talk: Mapping[str, object]) -> float | None:
-    """Return the recorded provider duration when it names this talk's source."""
+    """Return the recorded provider duration when it names this talk's source.
+
+    Provider/source-owned duration only, never prior analysis prose.
+    """
     source = talk_source_identity(talk)
     identity = talk.get("source_identity")
     if source is None or not (
@@ -665,11 +668,6 @@ def _identity_duration(talk: Mapping[str, object]) -> float | None:
     ):
         return None
     return float(duration)
-
-
-def _catalog_duration(talk: Mapping[str, object]) -> float | None:
-    """Return only provider/source-owned duration, never prior analysis prose."""
-    return _identity_duration(talk)
 
 
 def _selected_video_assessment(
@@ -1280,7 +1278,7 @@ def _validate_transcript_quality_for_owner(
 
     provenance_kind = provenance.get("kind")
     owner_youtube_id = talk.get("youtube_id")
-    owner_duration = _catalog_duration(talk)
+    owner_duration = _identity_duration(talk)
     if provenance_kind == "youtube_duration":
         if provenance.get("video_id") != owner_youtube_id:
             return (
@@ -1639,7 +1637,7 @@ def build_evidence_context(
     }:
         canonical_transcript_source = cast(str, recorded_transcript_source)
     timing_owner_source = canonical_transcript_source or "unknown"
-    timing_owner_duration = _catalog_duration(talk)
+    timing_owner_duration = _identity_duration(talk)
     if timing_owner_duration is None:
         timing_owner_duration = predeclared_video_duration
     timing_owner_media_sha256 = (

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -26,10 +26,10 @@ from artifact_locator import (
     materialize_native_root,
 )
 from ingress_contract import (
-    READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS,
     SourceIdentity,
     has_remote_slide_acquisition,
     has_remote_video_acquisition,
+    is_readable_video_extraction_version,
     talk_source_identity,
 )
 from artifact_metadata import canonicalize_trusted_artifact_locator
@@ -708,8 +708,7 @@ def _local_video_binding(
         if identity is None:
             return None, "video_extraction manifest has no claimed source identity"
         if (
-            manifest.get("schema_version")
-            not in READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS
+            not is_readable_video_extraction_version(manifest.get("schema_version"))
             or manifest.get("source_video_id") != identity.binding_token
         ):
             return (
@@ -878,7 +877,7 @@ def _trusted_video_slide_probe(
         except PatternEvidenceError as exc:
             return None, str(exc), None
     trusted = (
-        manifest.get("schema_version") in READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS
+        is_readable_video_extraction_version(manifest.get("schema_version"))
         and manifest.get("source_video_id") == identity.binding_token
         and manifest.get("slide_region_method") == "manual"
         and manifest.get("slide_region_applied") is True

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -27,8 +27,10 @@ from artifact_locator import (
 )
 from ingress_contract import (
     VIDEO_EXTRACTION_SCHEMA_VERSION,
+    SourceIdentity,
     has_remote_slide_acquisition,
     has_remote_video_acquisition,
+    talk_source_identity,
 )
 from artifact_metadata import canonicalize_trusted_artifact_locator
 from cloud_artifacts import unavailable_cloud_artifacts
@@ -643,13 +645,15 @@ def _declared_pdf_path(talk: Mapping[str, object]) -> tuple[str, object] | None:
     return None
 
 
-def _identity_duration(talk: Mapping[str, object], youtube_id: str) -> float | None:
+def _identity_duration(talk: Mapping[str, object]) -> float | None:
+    """Return the recorded provider duration when it names this talk's source."""
+    source = talk_source_identity(talk)
     identity = talk.get("source_identity")
-    if not (
+    if source is None or not (
         isinstance(identity, Mapping)
         and identity.get("schema_version") == 1
-        and identity.get("provider") == "youtube"
-        and identity.get("video_id") == youtube_id
+        and identity.get("provider") == source.provider
+        and identity.get("video_id") == source.video_id
     ):
         return None
     duration = identity.get("duration_seconds")
@@ -665,10 +669,7 @@ def _identity_duration(talk: Mapping[str, object], youtube_id: str) -> float | N
 
 def _catalog_duration(talk: Mapping[str, object]) -> float | None:
     """Return only provider/source-owned duration, never prior analysis prose."""
-    youtube_id = talk.get("youtube_id")
-    if isinstance(youtube_id, str):
-        return _identity_duration(talk, youtube_id)
-    return None
+    return _identity_duration(talk)
 
 
 def _selected_video_assessment(
@@ -699,28 +700,28 @@ def _video_unavailable_record(
 def _local_video_binding(
     vault_root: str | Path,
     owner: Mapping[str, object],
-    youtube_id: str | None,
+    identity: SourceIdentity | None,
 ) -> tuple[Path | None, str]:
     structured = owner.get("structured_data")
     manifest = (
         structured.get("video_extraction") if isinstance(structured, Mapping) else None
     )
     if isinstance(manifest, Mapping):
-        if youtube_id is None:
-            return None, "video_extraction manifest has no claimed video id"
+        if identity is None:
+            return None, "video_extraction manifest has no claimed source identity"
         if (
             manifest.get("schema_version") != VIDEO_EXTRACTION_SCHEMA_VERSION
-            or manifest.get("source_video_id") != youtube_id
+            or manifest.get("source_video_id") != identity.binding_token
         ):
             return (
                 None,
-                "video_extraction manifest is not bound to the claimed video id",
+                "video_extraction manifest is not bound to the claimed source",
             )
         try:
             source_path = resolve_video_extraction_source(
                 vault_root,
                 manifest,
-                youtube_id,
+                identity.binding_token,
             )
         except PatternEvidenceError as exc:
             return None, str(exc)
@@ -737,7 +738,17 @@ def _local_video_binding(
             )
         except PatternEvidenceError as exc:
             return None, str(exc)
-        if youtube_id is not None and source_path.stem != youtube_id:
+        # A YouTube download lands in the shared store as `{id}.mp4`, so its
+        # name is itself identity evidence. Every other provider's recording is
+        # registered by the owner under the name it was captured with — a room
+        # camera file, a conference export — and the record's own declaration is
+        # what binds it. Renaming those to a derived token would prove nothing
+        # the declaration does not already prove.
+        if (
+            identity is not None
+            and identity.provider == "youtube"
+            and source_path.stem != identity.video_id
+        ):
             return None, f"{field} filename is not bound to youtube_id"
         return source_path, f"pre-registered local source video {source_path}"
     return None, "no predeclared local video artifact"
@@ -746,7 +757,7 @@ def _local_video_binding(
 def resolve_video_extraction_source(
     vault_root: str | Path,
     manifest: Mapping[str, object],
-    youtube_id: str,
+    source_token: str,
 ) -> Path:
     """Resolve one manifest MP4 lexically; the bounded probe owns leaf I/O."""
     source_path = _resolve_local_video_artifact(
@@ -755,9 +766,9 @@ def resolve_video_extraction_source(
         label="video_extraction.source_video_path",
         suffixes=frozenset({".mp4"}),
     )
-    if source_path.name != f"{youtube_id}.mp4":
+    if source_path.name != f"{source_token}.mp4":
         raise PatternEvidenceError(
-            "local source-video filename is not bound to youtube_id"
+            "local source-video filename is not bound to the source identity"
         )
     return source_path
 
@@ -765,7 +776,7 @@ def resolve_video_extraction_source(
 def _probe_video_manifest_artifacts(
     vault_root: str | Path,
     manifest: Mapping[str, object],
-    youtube_id: str,
+    identity: SourceIdentity,
 ) -> dict[str, tuple[PdfArtifactProbe, Path]]:
     """Bound every current manifest PDF before any part can be persisted."""
     artifacts = manifest.get("artifacts")
@@ -798,7 +809,7 @@ def _probe_video_manifest_artifacts(
                 f"video_extraction artifact {index} has an invalid scope"
             )
         if (
-            artifact.get("source_video_id") != youtube_id
+            artifact.get("source_video_id") != identity.binding_token
             or artifact.get("page_count") != count
         ):
             raise PatternEvidenceError(
@@ -840,7 +851,7 @@ def _probe_video_manifest_artifacts(
 def _trusted_video_slide_probe(
     vault_root: str | Path,
     owner: Mapping[str, object],
-    youtube_id: str,
+    identity: SourceIdentity,
     *,
     artifact_probes: Mapping[str, tuple[PdfArtifactProbe, Path]] | None = None,
     source_video_probe: VideoArtifactProbe | None = None,
@@ -863,13 +874,13 @@ def _trusted_video_slide_probe(
             artifact_probes = _probe_video_manifest_artifacts(
                 vault_root,
                 manifest,
-                youtube_id,
+                identity,
             )
         except PatternEvidenceError as exc:
             return None, str(exc), None
     trusted = (
         manifest.get("schema_version") == VIDEO_EXTRACTION_SCHEMA_VERSION
-        and manifest.get("source_video_id") == youtube_id
+        and manifest.get("source_video_id") == identity.binding_token
         and manifest.get("slide_region_method") == "manual"
         and manifest.get("slide_region_applied") is True
         and manifest.get("slide_region_verified") is True
@@ -881,7 +892,7 @@ def _trusted_video_slide_probe(
     )
     if not trusted:
         return None, "video slide-region provenance is not trusted", None
-    local_path, local_reason = _local_video_binding(vault_root, owner, youtube_id)
+    local_path, local_reason = _local_video_binding(vault_root, owner, identity)
     if local_path is None:
         return None, local_reason, None
     if source_video_probe is None:
@@ -923,7 +934,7 @@ def _trusted_video_slide_probe(
     if (
         artifact.get("trusted_for_authored_slide_analysis") is not True
         or artifact.get("crop_verified") is not True
-        or artifact.get("source_video_id") != youtube_id
+        or artifact.get("source_video_id") != identity.binding_token
         or artifact.get("source_video_path") != manifest.get("source_video_path")
         or artifact.get("page_count") != count
     ):
@@ -1071,12 +1082,12 @@ def _returned_slide_artifact(
             None,
         )
     if slide_source == "video_extracted":
-        youtube_id = talk.get("youtube_id")
-        if not isinstance(youtube_id, str) or _YOUTUBE_ID.fullmatch(youtube_id) is None:
+        identity = talk_source_identity(talk)
+        if identity is None:
             raise PatternEvidenceError(
-                "return video slides have no valid preclaim youtube_id"
+                "return video slides have no valid preclaim source identity"
             )
-        expected = f"slides/{youtube_id}.pdf"
+        expected = f"slides/{identity.binding_token}.pdf"
         if _nonempty(returned_path) and returned_path != expected:
             raise PatternEvidenceError(
                 f"return video slide path must be the identity-derived {expected!r}"
@@ -1091,7 +1102,7 @@ def _returned_slide_artifact(
             raise PatternEvidenceError(
                 "return video slides have no video_extraction manifest"
             )
-        local_path, local_reason = _local_video_binding(vault_root, ret, youtube_id)
+        local_path, local_reason = _local_video_binding(vault_root, ret, identity)
         if local_path is None:
             raise PatternEvidenceError(
                 "return video extraction source is unavailable: " + local_reason
@@ -1111,12 +1122,12 @@ def _returned_slide_artifact(
         artifact_probes = _probe_video_manifest_artifacts(
             vault_root,
             manifest,
-            youtube_id,
+            identity,
         )
         probe, reason, slide_path = _trusted_video_slide_probe(
             vault_root,
             ret,
-            youtube_id,
+            identity,
             artifact_probes=artifact_probes,
             source_video_probe=source_video_probe,
             video_evidence_assessment=video_evidence_assessment,
@@ -1361,13 +1372,9 @@ def validate_transcript_quality_for_owner(
     validity with a true receipt flag is therefore an owner/provenance or
     transcript-quality failure, not a missing-receipt failure.
     """
-    raw_youtube_id = talk.get("youtube_id")
-    youtube_id = (
-        raw_youtube_id
-        if isinstance(raw_youtube_id, str) and _YOUTUBE_ID.fullmatch(raw_youtube_id)
-        else None
+    local_media_path, _ = _local_video_binding(
+        vault_root, talk, talk_source_identity(talk)
     )
-    local_media_path, _ = _local_video_binding(vault_root, talk, youtube_id)
     local_media_duration: float | None = None
     local_media_sha256: str | None = None
     if local_media_path is not None:
@@ -1592,13 +1599,18 @@ def build_evidence_context(
     """Resolve preclaim sources plus identity-derived current-run artifacts."""
     selected_video_assessment = _selected_video_assessment(video_evidence_assessment)
     raw_youtube_id = talk.get("youtube_id")
+    # Two different questions. `bound_youtube_id` answers "does YouTube-owned
+    # provenance name this talk", which only a YouTube talk can satisfy.
+    # `bound_source_token` answers "which artifacts belong to this talk", which
+    # every supported provider answers. They are the same string on YouTube.
     bound_youtube_id = (
         raw_youtube_id
         if isinstance(raw_youtube_id, str) and _YOUTUBE_ID.fullmatch(raw_youtube_id)
         else None
     )
+    bound_identity = talk_source_identity(talk)
     predeclared_video_path, predeclared_video_reason = _local_video_binding(
-        vault_root, talk, bound_youtube_id
+        vault_root, talk, bound_identity
     )
     predeclared_video_duration: float | None = None
     predeclared_video_probe: VideoArtifactProbe | None = None
@@ -1836,15 +1848,14 @@ def build_evidence_context(
         # static-slide lane unavailable without disturbing independent sources.
         slide_artifact_sha256s.pop("static_slides", None)
         slide_artifact_probes.pop("static_slides", None)
-        youtube_id = talk.get("youtube_id")
-        if isinstance(youtube_id, str) and _YOUTUBE_ID.fullmatch(youtube_id):
+        if bound_identity is not None:
             video_slide_path: Path | None = None
             try:
                 video_probe, video_slide_reason, video_slide_path = (
                     _trusted_video_slide_probe(
                         vault_root,
                         talk,
-                        youtube_id,
+                        bound_identity,
                         source_video_probe=predeclared_video_probe,
                         video_evidence_assessment=selected_video_assessment,
                     )
@@ -1876,8 +1887,8 @@ def build_evidence_context(
                 elif declared_pdf is None and talk.get("status") != "processed_partial":
                     expected_path = _resolve_local_pdf_artifact(
                         _canonical_pdf_root(vault_root),
-                        f"slides/{youtube_id}.pdf",
-                        label="youtube_id-derived video slide PDF",
+                        f"slides/{bound_identity.binding_token}.pdf",
+                        label="identity-derived video slide PDF",
                     )
                     try:
                         probe_pdf_artifact(
@@ -1896,7 +1907,7 @@ def build_evidence_context(
             static_slides_absence_complete = False
         else:
             source_reasons["static_slides"] = (
-                "video-extracted slides have no valid pre-return youtube_id"
+                "video-extracted slides have no valid pre-return source identity"
             )
     elif slide_source == "pdf":
         if pdf_count is not None:
@@ -2020,15 +2031,11 @@ def build_evidence_context(
         else predeclared_video_reason
     )
     video_probe = current_video_probe or predeclared_video_probe
-    if local_video_path is not None or bound_youtube_id is not None:
+    if local_video_path is not None or bound_identity is not None:
         if local_video_path is not None:
             if video_probe is not None:
                 probed_duration = video_probe.duration_seconds
-                identity_duration = (
-                    _identity_duration(talk, bound_youtube_id)
-                    if bound_youtube_id is not None
-                    else None
-                )
+                identity_duration = _identity_duration(talk)
                 tolerance = (
                     max(60.0, identity_duration * 0.05)
                     if identity_duration is not None
@@ -4246,17 +4253,10 @@ def assess_persisted_pattern_evidence_freshness(
         if isinstance(kind, str) and kind.startswith("preclaim:"):
             field = kind.removeprefix("preclaim:")
             if field == "video_local_path" and bounded_suffix == _VIDEO_SUFFIXES:
-                raw_youtube_id = talk.get("youtube_id")
-                bound_youtube_id = (
-                    raw_youtube_id
-                    if isinstance(raw_youtube_id, str)
-                    and _YOUTUBE_ID.fullmatch(raw_youtube_id)
-                    else None
-                )
                 legacy_video_path, _reason = _local_video_binding(
                     vault_root,
                     talk,
-                    bound_youtube_id,
+                    talk_source_identity(talk),
                 )
                 if legacy_video_path is not None:
                     return legacy_video_path.parent
@@ -4529,17 +4529,10 @@ def assess_persisted_pattern_evidence_freshness(
                 if isinstance(youtube_id, str) and _YOUTUBE_ID.fullmatch(youtube_id):
                     values.append(f"transcripts/{youtube_id}.txt")
         elif source == "delivery_video":
-            owner_youtube_id = talk.get("youtube_id")
-            bound_youtube_id = (
-                owner_youtube_id
-                if isinstance(owner_youtube_id, str)
-                and _YOUTUBE_ID.fullmatch(owner_youtube_id)
-                else None
-            )
             bound_path, _reason = _local_video_binding(
                 vault_root,
                 talk,
-                bound_youtube_id,
+                talk_source_identity(talk),
             )
             if bound_path is not None:
                 return [_lexical_absolute(bound_path)]

--- a/skills/vault-ingress/scripts/pattern_evidence.py
+++ b/skills/vault-ingress/scripts/pattern_evidence.py
@@ -26,7 +26,7 @@ from artifact_locator import (
     materialize_native_root,
 )
 from ingress_contract import (
-    VIDEO_EXTRACTION_SCHEMA_VERSION,
+    READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS,
     SourceIdentity,
     has_remote_slide_acquisition,
     has_remote_video_acquisition,
@@ -708,7 +708,8 @@ def _local_video_binding(
         if identity is None:
             return None, "video_extraction manifest has no claimed source identity"
         if (
-            manifest.get("schema_version") != VIDEO_EXTRACTION_SCHEMA_VERSION
+            manifest.get("schema_version")
+            not in READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS
             or manifest.get("source_video_id") != identity.binding_token
         ):
             return (
@@ -877,7 +878,7 @@ def _trusted_video_slide_probe(
         except PatternEvidenceError as exc:
             return None, str(exc), None
     trusted = (
-        manifest.get("schema_version") == VIDEO_EXTRACTION_SCHEMA_VERSION
+        manifest.get("schema_version") in READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS
         and manifest.get("source_video_id") == identity.binding_token
         and manifest.get("slide_region_method") == "manual"
         and manifest.get("slide_region_applied") is True

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -920,12 +920,33 @@ class VaultPreflight:
                 actual=valid_stored_id,
             )
 
-        identity_id = parsed_id or valid_stored_id
-        identity = (
-            SourceIdentity("youtube", identity_id)
-            if identity_id is not None
-            else talk_source_identity(talk)
+        active_source = parse_source_identity(video_url)
+        foreign_active = (
+            active_source
+            if active_source is not None and active_source.provider != "youtube"
+            else None
         )
+        identity_id = parsed_id or valid_stored_id
+        identity: SourceIdentity | None
+        if valid_stored_id is not None and foreign_active is not None:
+            # `youtube_id` is a YouTube field. Left behind on a source that
+            # publishes elsewhere it does not merely go unused: it outranks the
+            # active URL, so identity evidence naming YouTube would validate and
+            # artifacts would bind to a recording this talk no longer points at.
+            self.talk_add(
+                index,
+                "blocking",
+                "youtube_id_provider_conflict",
+                "stored youtube_id contradicts the active source's provider",
+                field="youtube_id",
+                expected=f"no stored youtube_id on a {foreign_active.provider} source",
+                actual=valid_stored_id,
+            )
+            identity = None
+        elif identity_id is not None:
+            identity = SourceIdentity("youtube", identity_id)
+        else:
+            identity = talk_source_identity(talk)
         if identity is not None:
             self.source_identities[index] = identity
             self.source_tokens[index] = identity.binding_token

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -920,9 +920,10 @@ class VaultPreflight:
                 actual=valid_stored_id,
             )
 
+        identity_id = parsed_id or valid_stored_id
         identity = (
             SourceIdentity("youtube", identity_id)
-            if (identity_id := parsed_id or valid_stored_id) is not None
+            if identity_id is not None
             else talk_source_identity(talk)
         )
         if identity is not None:

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -1384,9 +1384,12 @@ class VaultPreflight:
                     severity,
                     "slide_video_reference_missing",
                     "video_extracted source requires a valid source identity",
-                    field="youtube_id",
+                    field="video_url",
                     expected="a supported provider identity",
-                    actual=talk.get("video_url"),
+                    actual={
+                        "video_url": talk.get("video_url"),
+                        "youtube_id": talk.get("youtube_id"),
+                    },
                 )
             else:
                 pdf_path = self.vault_root / "slides" / f"{youtube_id}.pdf"

--- a/skills/vault-ingress/scripts/preflight-vault.py
+++ b/skills/vault-ingress/scripts/preflight-vault.py
@@ -39,10 +39,15 @@ from cloud_artifacts import (
     summarize_cloud_artifacts,
 )
 from ingress_contract import (
+    SUPPORTED_SOURCE_PROVIDERS,
     YOUTUBE_ID_RE,
+    SourceIdentity,
     is_youtube_url,
     parse_google_drive_id,
+    parse_source_identity,
     parse_youtube_id,
+    source_identity_for,
+    talk_source_identity,
     source_capabilities,
 )
 
@@ -316,7 +321,11 @@ class VaultPreflight:
         self.source_indexes: list[int] = []
         self.config: dict[str, Any] = {}
         self.filenames: dict[str, int] = {}
-        self.youtube_ids: dict[int, str] = {}
+        # The token every artifact, manifest, and receipt binds to, plus the
+        # provider-qualified identity it came from. A YouTube talk's token is
+        # its bare ID, so both maps read exactly as `youtube_ids` did.
+        self.source_tokens: dict[int, str] = {}
+        self.source_identities: dict[int, SourceIdentity] = {}
         self.valid_relations: dict[int, tuple[str, str]] = {}
         self.event_aliases: set[EventAlias] = set()
         self.artifact_capabilities: dict[int, dict[str, object]] = {}
@@ -911,9 +920,14 @@ class VaultPreflight:
                 actual=valid_stored_id,
             )
 
-        identity_id = parsed_id or valid_stored_id
-        if identity_id is not None:
-            self.youtube_ids[index] = identity_id
+        identity = (
+            SourceIdentity("youtube", identity_id)
+            if (identity_id := parsed_id or valid_stored_id) is not None
+            else talk_source_identity(talk)
+        )
+        if identity is not None:
+            self.source_identities[index] = identity
+            self.source_tokens[index] = identity.binding_token
 
     def _needs_artifact_checks(self, talk: dict[str, Any]) -> bool:
         transcript_source = talk.get("transcript_source")
@@ -1362,16 +1376,16 @@ class VaultPreflight:
                         require_trusted=True,
                     )
                 return
-            youtube_id = self.youtube_ids.get(index)
+            youtube_id = self.source_tokens.get(index)
             if youtube_id is None:
                 self.talk_add(
                     index,
                     severity,
                     "slide_video_reference_missing",
-                    "video_extracted source requires a valid YouTube identity",
+                    "video_extracted source requires a valid source identity",
                     field="youtube_id",
-                    expected="valid YouTube ID",
-                    actual=talk.get("youtube_id"),
+                    expected="a supported provider identity",
+                    actual=talk.get("video_url"),
                 )
             else:
                 pdf_path = self.vault_root / "slides" / f"{youtube_id}.pdf"
@@ -1673,9 +1687,9 @@ class VaultPreflight:
 
         errors: list[str] = []
         trusted_slide_region_probe: PdfArtifactProbe | None = None
-        expected_id = self.youtube_ids.get(index)
+        expected_id = self.source_tokens.get(index)
         if state.source_video_id != expected_id:
-            errors.append("source_video_id must match the talk's YouTube identity")
+            errors.append("source_video_id must match the talk's source identity")
         else:
             try:
                 source_video_path = resolve_video_extraction_source(
@@ -1971,32 +1985,55 @@ class VaultPreflight:
                 actual=schema_version,
             )
 
-        provider = evidence.get("provider")
-        if provider is not None and provider != "youtube":
+        source = self.source_identities.get(index)
+        declared_provider = evidence.get("provider")
+        if declared_provider is not None and (
+            declared_provider not in SUPPORTED_SOURCE_PROVIDERS
+        ):
             self.talk_add(
                 index,
                 "warning",
                 "source_identity_provider_unknown",
                 "source_identity provider is not currently understood",
                 field="source_identity.provider",
-                expected="youtube",
-                actual=provider,
+                expected=" | ".join(SUPPORTED_SOURCE_PROVIDERS),
+                actual=declared_provider,
             )
-
-        evidence_id = evidence.get("video_id")
-        expected_id = self.youtube_ids.get(index)
-        if evidence_id is None:
-            self._identity_gap(index, "video_id")
-        elif not isinstance(evidence_id, str) or not YOUTUBE_ID_RE.fullmatch(
-            evidence_id
+        elif (
+            declared_provider is not None
+            and source is not None
+            and declared_provider != source.provider
         ):
             self.talk_add(
                 index,
                 "blocking",
+                "source_identity_provider_mismatch",
+                "recorded identity evidence names a provider the active source "
+                "does not publish on",
+                field="source_identity.provider",
+                expected=source.provider,
+                actual=declared_provider,
+            )
+
+        # A record written before providers were qualified carries no provider
+        # field; it was a YouTube identity by construction.
+        provider = (
+            declared_provider
+            if declared_provider in SUPPORTED_SOURCE_PROVIDERS
+            else (source.provider if source is not None else "youtube")
+        )
+        evidence_id = evidence.get("video_id")
+        expected_id = source.video_id if source is not None else None
+        if evidence_id is None:
+            self._identity_gap(index, "video_id")
+        elif source_identity_for(provider, evidence_id) is None:
+            self.talk_add(
+                index,
+                "blocking",
                 "source_identity_video_id_invalid",
-                "source_identity video_id must be an 11-character YouTube ID",
+                f"source_identity video_id must be a {provider} video ID",
                 field="source_identity.video_id",
-                expected="11-character YouTube ID",
+                expected=f"{provider} video ID",
                 actual=evidence_id,
             )
         elif expected_id is not None and evidence_id != expected_id:
@@ -2015,6 +2052,7 @@ class VaultPreflight:
             evidence,
             evidence_id,
             expected_id,
+            provider,
         )
         self._validate_identity_title(index, evidence)
         self._validate_identity_speakers(index, evidence)
@@ -2027,6 +2065,7 @@ class VaultPreflight:
         evidence: dict[str, Any],
         evidence_id: Any,
         expected_id: str | None,
+        provider: str,
     ) -> None:
         for field in ("uploader", "uploader_id"):
             value = evidence.get(field)
@@ -2043,21 +2082,26 @@ class VaultPreflight:
 
         anchor_id = (
             evidence_id
-            if isinstance(evidence_id, str) and YOUTUBE_ID_RE.fullmatch(evidence_id)
+            if source_identity_for(provider, evidence_id) is not None
             else expected_id
         )
         webpage_url = evidence.get("webpage_url")
         webpage_url_id: str | None = None
         if webpage_url is not None:
-            webpage_url_id = parse_youtube_id(webpage_url)
+            captured = parse_source_identity(webpage_url)
+            webpage_url_id = (
+                captured.video_id
+                if captured is not None and captured.provider == provider
+                else None
+            )
             if webpage_url_id is None:
                 self.talk_add(
                     index,
                     "blocking",
                     "source_identity_webpage_url_invalid",
-                    "source_identity webpage_url must be a supported YouTube URL",
+                    f"source_identity webpage_url must be a supported {provider} URL",
                     field="source_identity.webpage_url",
-                    expected="YouTube URL with an 11-character video ID",
+                    expected=f"{provider} URL carrying its video ID",
                     actual=webpage_url,
                 )
             elif anchor_id is not None and webpage_url_id != anchor_id:
@@ -2073,16 +2117,14 @@ class VaultPreflight:
 
         webpage_video_id = evidence.get("webpage_video_id")
         if webpage_video_id is not None:
-            if not isinstance(webpage_video_id, str) or not YOUTUBE_ID_RE.fullmatch(
-                webpage_video_id
-            ):
+            if source_identity_for(provider, webpage_video_id) is None:
                 self.talk_add(
                     index,
                     "blocking",
                     "source_identity_webpage_video_id_invalid",
-                    "source_identity webpage_video_id must be an 11-character YouTube ID",
+                    f"source_identity webpage_video_id must be a {provider} video ID",
                     field="source_identity.webpage_video_id",
-                    expected="11-character YouTube ID",
+                    expected=f"{provider} video ID",
                     actual=webpage_video_id,
                 )
             else:
@@ -2483,8 +2525,8 @@ class VaultPreflight:
                     actual=target,
                 )
                 continue
-            source_id = self.youtube_ids.get(index)
-            target_id = self.youtube_ids.get(target_index)
+            source_id = self.source_tokens.get(index)
+            target_id = self.source_tokens.get(target_index)
             if source_id is None or source_id != target_id:
                 # Legacy `_duplicate_of` records describe duplicate *content*
                 # as well as duplicate recordings.  A different video simply
@@ -2495,7 +2537,8 @@ class VaultPreflight:
                         index,
                         "blocking",
                         "source_relation_identity_mismatch",
-                        "duplicate/borrowed relation target must carry the same YouTube identity",
+                        "duplicate/borrowed relation target must carry the same "
+                        "source identity",
                         field="source_relation.target_filename",
                         expected=source_id,
                         actual=target_id,
@@ -2505,7 +2548,7 @@ class VaultPreflight:
 
     def _validate_duplicate_youtube_ids(self) -> None:
         groups: defaultdict[str, list[int]] = defaultdict(list)
-        for index, video_id in self.youtube_ids.items():
+        for index, video_id in self.source_tokens.items():
             groups[video_id].append(index)
         for video_id, indexes in sorted(groups.items()):
             if len(indexes) < 2:
@@ -2520,7 +2563,7 @@ class VaultPreflight:
             self.add(
                 "blocking",
                 "duplicate_youtube_id",
-                "YouTube ID is used by multiple talks without an explicit "
+                "source identity is used by multiple talks without an explicit "
                 "duplicate/borrowed-recording relation",
                 field="youtube_id",
                 expected="one canonical record plus explicit relations",

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -44,7 +44,10 @@ from catalog_io import (
 )
 from ingress_contract import (
     ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION,
+    READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS,
+    YOUTUBE_ID_RE,
     VIDEO_EXTRACTION_SCHEMA_VERSION,
+    YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION,
     IngressContractError,
     has_local_source_artifact,
     has_pdf_source,
@@ -52,6 +55,7 @@ from ingress_contract import (
     has_remote_acquisition_source,
     has_transcript_source,
     has_video_source,
+    is_source_binding_token,
     source_capabilities,
     talk_binding_token,
     validate_talk_record_schemas,
@@ -278,7 +282,10 @@ SUBSTANTIVE_PROSE_FIELDS = frozenset(
 )
 LANGUAGE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$")
 CONDITION_ID_RE = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
-VIDEO_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+# Accepts a bare YouTube ID and a provider-qualified binding token; the
+# per-version rules in `validate_video_extraction_manifest` decide which of
+# those the manifest at hand is allowed to carry.
+VIDEO_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9_+-]+$")
 QUEUE_CLAIM_SCHEMA_VERSION = 7
 SOURCE_LOCATED_QUEUE_CLAIM_SCHEMA_VERSION = 4
 BASELINE_QUEUE_CLAIM_SCHEMA_VERSION = 3
@@ -1160,14 +1167,14 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
             "slide_source video_extracted requires a complete "
             "structured_data.video_extraction schema-v4 manifest"
         )
-    if manifest.get("schema_version") != VIDEO_EXTRACTION_SCHEMA_VERSION:
+    manifest_version = manifest.get("schema_version")
+    if manifest_version not in READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS:
         # An archival record is separable from a malformed one: it was valid
         # under its own contract and names the exact repair (reacquire the
         # source, re-extract), so readers surface it as work rather than rot.
         reason = (
             "video_extraction.schema_version_archival"
-            if manifest.get("schema_version")
-            == ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION
+            if manifest_version == ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION
             else None
         )
         _manifest_error(
@@ -1192,6 +1199,28 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
     ):
         _manifest_error(
             "source_video_id", "must be a non-empty URL-safe identity token"
+        )
+    # What separates the two readable contracts. A v4 record was written when
+    # the field held a YouTube ID, so it may not carry a provider-prefixed
+    # token; a v5 record may carry either, because a YouTube ID is its own
+    # token. Nothing rewrites a v4 record to say so.
+    if (
+        manifest_version == YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION
+        and YOUTUBE_ID_RE.fullmatch(source_video_id) is None
+    ):
+        _manifest_error(
+            "source_video_id",
+            f"must be a YouTube ID in a schema-"
+            f"{YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION} manifest; a "
+            f"provider-qualified token requires schema "
+            f"{VIDEO_EXTRACTION_SCHEMA_VERSION}",
+        )
+    elif (
+        manifest_version == VIDEO_EXTRACTION_SCHEMA_VERSION
+        and not is_source_binding_token(source_video_id)
+    ):
+        _manifest_error(
+            "source_video_id", "must be a supported provider's binding token"
         )
     source_video_path = _validate_absolute_manifest_path(
         manifest.get("source_video_path"), "source_video_path"

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -44,7 +44,6 @@ from catalog_io import (
 )
 from ingress_contract import (
     ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION,
-    READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS,
     YOUTUBE_ID_RE,
     VIDEO_EXTRACTION_SCHEMA_VERSION,
     YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION,
@@ -55,6 +54,7 @@ from ingress_contract import (
     has_remote_acquisition_source,
     has_transcript_source,
     has_video_source,
+    is_readable_video_extraction_version,
     is_source_binding_token,
     source_capabilities,
     talk_binding_token,
@@ -1168,7 +1168,7 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
             "structured_data.video_extraction schema-v4 manifest"
         )
     manifest_version = manifest.get("schema_version")
-    if manifest_version not in READABLE_VIDEO_EXTRACTION_SCHEMA_VERSIONS:
+    if not is_readable_video_extraction_version(manifest_version):
         # An archival record is separable from a malformed one: it was valid
         # under its own contract and names the exact repair (reacquire the
         # source, re-extract), so readers surface it as work rather than rot.

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -53,6 +53,7 @@ from ingress_contract import (
     has_transcript_source,
     has_video_source,
     source_capabilities,
+    talk_binding_token,
     validate_talk_record_schemas,
 )
 from pattern_evidence import (
@@ -4498,15 +4499,17 @@ def validate_claim_against_talk(
                 f"{filename} return has no validated video_extraction manifest"
             )
         returned_id = manifest.get("source_video_id")
-        expected_id = talk.get("youtube_id")
-        if not isinstance(expected_id, str) or not expected_id.strip():
+        expected_id = talk_binding_token(talk)
+        if expected_id is None:
             raise ReturnValidationError(
-                f"{filename} has no youtube_id to bind the video extraction manifest"
+                f"{filename} has no source identity to bind the video extraction "
+                "manifest"
             )
         if returned_id != expected_id:
             raise ReturnValidationError(
                 "structured_data.video_extraction.source_video_id "
-                f"{returned_id!r} does not match talk youtube_id {expected_id!r}"
+                f"{returned_id!r} does not match talk source identity "
+                f"{expected_id!r}"
             )
     if (
         ret.get("status") in ANALYSIS_STATUSES

--- a/skills/vault-ingress/scripts/return_validation.py
+++ b/skills/vault-ingress/scripts/return_validation.py
@@ -44,7 +44,6 @@ from catalog_io import (
 )
 from ingress_contract import (
     ARCHIVAL_VIDEO_EXTRACTION_SCHEMA_VERSION,
-    YOUTUBE_ID_RE,
     VIDEO_EXTRACTION_SCHEMA_VERSION,
     YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION,
     IngressContractError,
@@ -55,10 +54,10 @@ from ingress_contract import (
     has_transcript_source,
     has_video_source,
     is_readable_video_extraction_version,
-    is_source_binding_token,
     source_capabilities,
     talk_binding_token,
     validate_talk_record_schemas,
+    video_extraction_version_admits_token,
 )
 from pattern_evidence import (
     APPLICABILITY_INSPECTION_REASON_CODE,
@@ -1200,27 +1199,15 @@ def validate_video_extraction_manifest(structured: dict) -> VideoExtractionState
         _manifest_error(
             "source_video_id", "must be a non-empty URL-safe identity token"
         )
-    # What separates the two readable contracts. A v4 record was written when
-    # the field held a YouTube ID, so it may not carry a provider-prefixed
-    # token; a v5 record may carry either, because a YouTube ID is its own
-    # token. Nothing rewrites a v4 record to say so.
-    if (
-        manifest_version == YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION
-        and YOUTUBE_ID_RE.fullmatch(source_video_id) is None
-    ):
+    # The v4/v5 distinction is `video_extraction_version_admits_token`'s alone;
+    # the evidence readers ask the same function.
+    if not video_extraction_version_admits_token(manifest_version, source_video_id):
         _manifest_error(
             "source_video_id",
             f"must be a YouTube ID in a schema-"
             f"{YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION} manifest; a "
             f"provider-qualified token requires schema "
             f"{VIDEO_EXTRACTION_SCHEMA_VERSION}",
-        )
-    elif (
-        manifest_version == VIDEO_EXTRACTION_SCHEMA_VERSION
-        and not is_source_binding_token(source_video_id)
-    ):
-        _manifest_error(
-            "source_video_id", "must be a supported provider's binding token"
         )
     source_video_path = _validate_absolute_manifest_path(
         manifest.get("source_video_path"), "source_video_path"

--- a/skills/vault-ingress/scripts/source_alias_contract.py
+++ b/skills/vault-ingress/scripts/source_alias_contract.py
@@ -165,6 +165,14 @@ def record_identity_token(block: Mapping[str, Any]) -> str | None:
     return None if identity is None else identity.binding_token
 
 
+def _bound_token(block: Mapping[str, Any], label: str) -> str:
+    """Return one validated block's token; absence is a contract bug, not data."""
+    token = record_identity_token(block)
+    if token is None:
+        _refuse(label, "provider block does not name a supported identity")
+    return token
+
+
 def _provider(value: Any, label: str) -> Mapping[str, Any]:
     record = _shape(value, PROVIDER_FIELDS, label)
     url = _url(record["url"], f"{label}.url")
@@ -371,9 +379,8 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
         if filename not in talks:
             _refuse(label, "alias names no canonical talk")
         _text(record["alias"]["video_id"], f"{label}.alias.video_id")
-        # The lineage graph is keyed by token: the record shape is already
-        # validated, so a token here is never None.
-        identity = record_identity_token(record["alias"])
+        # The lineage graph is keyed by token, not by bare provider ID.
+        identity = _bound_token(record["alias"], f"{label}.alias")
         if identity in active_ids:
             _refuse(label, "accepted alias overlaps an active canonical source")
         if identity in edges:
@@ -383,9 +390,8 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
             for rejection in talks[filename].get("source_rejections", [])
             if rejection["source_type"] == "video"
         }
-        if identity in rejected or record_identity_token(record["canonical"]) in (
-            rejected
-        ):
+        canonical_token = _bound_token(record["canonical"], f"{label}.canonical")
+        if identity in rejected or canonical_token in rejected:
             _refuse(label, "accepted source overlaps the talk's rejection ledger")
         edges[identity] = record
     resolved: dict[str, str] = {}
@@ -395,7 +401,7 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
         if terminal is None:
             _refuse("source_aliases", "talk has no agreeing canonical URL/ID")
         visited = {identity}
-        target = record_identity_token(record["canonical"])
+        target = _bound_token(record["canonical"], "source_aliases")
         while target != terminal:
             if resolved.get(target) == filename:
                 break
@@ -408,7 +414,7 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
                     "source_aliases",
                     "alias lineage does not end at its talk's canonical source",
                 )
-            target = record_identity_token(parent["canonical"])
+            target = _bound_token(parent["canonical"], "source_aliases")
         for visited_identity in visited:
             resolved[visited_identity] = filename
 

--- a/skills/vault-ingress/scripts/source_alias_contract.py
+++ b/skills/vault-ingress/scripts/source_alias_contract.py
@@ -139,21 +139,29 @@ def _url(value: Any, label: str) -> str:
     return text
 
 
-def source_identity_token(value: Any) -> str | None:
-    """Return the binding token one provider URL names, otherwise ``None``.
+def source_identity(value: Any) -> Any:
+    """Return the identity one provider URL names, otherwise ``None``.
 
-    Comparing tokens rather than bare provider IDs is what keeps a Vimeo and an
-    InfoQ recording that happen to share an ID from reading as one identity.
+    The single entry point into the URL parser for this module. A malformed URL
+    (``https://[broken``) reads as an absent identity: `parse_source_identity`
+    is total, so no raw ValueError escapes the alias ledger's typed failure or
+    the reader's, which is where the actionable message would have been lost.
     """
     # Resolve lazily: tracking_database owns this contract and ingress_contract
     # re-exports the talk schema from tracking_database. No parsing runs during
     # import, so both import orders use the existing provider parser safely.
     from ingress_contract import parse_source_identity
 
-    try:
-        identity = parse_source_identity(value)
-    except ValueError:
-        return None
+    return parse_source_identity(value)
+
+
+def source_identity_token(value: Any) -> str | None:
+    """Return the binding token one provider URL names, otherwise ``None``.
+
+    Comparing tokens rather than bare provider IDs is what keeps a Vimeo and an
+    InfoQ recording that happen to share an ID from reading as one identity.
+    """
+    identity = source_identity(value)
     return None if identity is None else identity.binding_token
 
 
@@ -338,9 +346,7 @@ def validate_alias_record(value: Any, *, label: str = "source_alias") -> None:
 
 def active_identity(talk: Mapping[str, Any]) -> str | None:
     """Return the token the talk's active source names, when it agrees itself."""
-    from ingress_contract import parse_source_identity
-
-    identity = parse_source_identity(talk.get("video_url"))
+    identity = source_identity(talk.get("video_url"))
     stored_youtube_id = (
         identity.video_id
         if identity is not None and identity.provider == "youtube"

--- a/skills/vault-ingress/scripts/source_alias_contract.py
+++ b/skills/vault-ingress/scripts/source_alias_contract.py
@@ -139,28 +139,47 @@ def _url(value: Any, label: str) -> str:
     return text
 
 
-def youtube_identity(value: Any) -> str | None:
+def source_identity_token(value: Any) -> str | None:
+    """Return the binding token one provider URL names, otherwise ``None``.
+
+    Comparing tokens rather than bare provider IDs is what keeps a Vimeo and an
+    InfoQ recording that happen to share an ID from reading as one identity.
+    """
     # Resolve lazily: tracking_database owns this contract and ingress_contract
     # re-exports the talk schema from tracking_database. No parsing runs during
     # import, so both import orders use the existing provider parser safely.
-    from ingress_contract import parse_youtube_id
+    from ingress_contract import parse_source_identity
 
     try:
-        return parse_youtube_id(value)
+        identity = parse_source_identity(value)
     except ValueError:
         return None
+    return None if identity is None else identity.binding_token
+
+
+def record_identity_token(block: Mapping[str, Any]) -> str | None:
+    """Return the token one reviewed provider block names."""
+    from ingress_contract import source_identity_for
+
+    identity = source_identity_for(block.get("provider"), block.get("video_id"))
+    return None if identity is None else identity.binding_token
 
 
 def _provider(value: Any, label: str) -> Mapping[str, Any]:
     record = _shape(value, PROVIDER_FIELDS, label)
     url = _url(record["url"], f"{label}.url")
-    identity = youtube_identity(url)
+    identity = source_identity_token(url)
     parsed = urlparse(url)
+    # The ambiguous-`v` check is a YouTube URL property; every other provider
+    # carries its ID in the path, where there is nothing to disambiguate.
     if (
-        record["provider"] != "youtube"
-        or identity is None
-        or record["video_id"] != identity
-        or (parsed.path == "/watch" and len(parse_qs(parsed.query).get("v", [])) != 1)
+        identity is None
+        or record_identity_token(record) != identity
+        or (
+            record["provider"] == "youtube"
+            and parsed.path == "/watch"
+            and len(parse_qs(parsed.query).get("v", [])) != 1
+        )
     ):
         _refuse(label, "unsupported provider or URL/ID disagreement")
     for field in ("title", "uploader"):
@@ -203,7 +222,7 @@ def _validate_alias_record(value: Any, *, label: str) -> Mapping[str, Any]:
     _timestamp(record["verified_at"], f"{label}.verified_at")
     alias = _provider(record["alias"], f"{label}.alias")
     canonical = _provider(record["canonical"], f"{label}.canonical")
-    if alias["video_id"] == canonical["video_id"]:
+    if record_identity_token(alias) == record_identity_token(canonical):
         _refuse(label, "an alias cannot name its own canonical identity")
     event = _shape(
         record["event"],
@@ -211,7 +230,10 @@ def _validate_alias_record(value: Any, *, label: str) -> Mapping[str, Any]:
         f"{label}.event",
     )
     event_url = _url(event["url"], f"{label}.event.url")
-    if youtube_identity(event_url) in {alias["video_id"], canonical["video_id"]}:
+    if source_identity_token(event_url) in {
+        record_identity_token(alias),
+        record_identity_token(canonical),
+    }:
         _refuse(label, "event evidence must be independent of the two provider pages")
     _text(event["conference"], f"{label}.event.conference")
     _date(event["date"], f"{label}.event.date")
@@ -271,7 +293,7 @@ def _validate_alias_record(value: Any, *, label: str) -> Mapping[str, Any]:
             _refuse(label, "unsupported prior-source-state schema version")
         old_url = _url(prior["video_url"], f"{label}.prior_state.video_url")
         old_id = prior["youtube_id"]
-        if youtube_identity(old_url) != alias["video_id"] or (
+        if source_identity_token(old_url) != record_identity_token(alias) or (
             not _missing(old_id) and old_id not in (None, "", alias["video_id"])
         ):
             _refuse(
@@ -299,22 +321,29 @@ def validate_alias_record(value: Any, *, label: str = "source_alias") -> None:
         if depth > MAX_RETIRED_ALIAS_DEPTH:
             _refuse(label, "retired alias history exceeds the supported depth")
         parent = _validate_alias_record(retired, label=f"{label}.retired_alias")
-        if (
-            parent["talk_filename"] != record["talk_filename"]
-            or parent["alias"]["video_id"] != record["canonical"]["video_id"]
-        ):
+        if parent["talk_filename"] != record["talk_filename"] or record_identity_token(
+            parent["alias"]
+        ) != record_identity_token(record["canonical"]):
             _refuse(label, "retired decision does not belong to the promoted identity")
         record = parent
 
 
 def active_identity(talk: Mapping[str, Any]) -> str | None:
-    identity = youtube_identity(talk.get("video_url"))
+    """Return the token the talk's active source names, when it agrees itself."""
+    from ingress_contract import parse_source_identity
+
+    identity = parse_source_identity(talk.get("video_url"))
+    stored_youtube_id = (
+        identity.video_id
+        if identity is not None and identity.provider == "youtube"
+        else None
+    )
     stored = talk.get("youtube_id")
     if stored is not None and (
-        not isinstance(stored, str) or stored not in {"", identity}
+        not isinstance(stored, str) or stored not in {"", stored_youtube_id}
     ):
         return None
-    return identity
+    return None if identity is None else identity.binding_token
 
 
 def validate_alias_database(database: Mapping[str, Any]) -> None:
@@ -329,7 +358,7 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
         identity
         for talk in talks.values()
         for identity in (
-            youtube_identity(talk.get("video_url")),
+            source_identity_token(talk.get("video_url")),
             talk.get("youtube_id"),
         )
         if isinstance(identity, str) and identity
@@ -341,17 +370,22 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
         filename = record["talk_filename"]
         if filename not in talks:
             _refuse(label, "alias names no canonical talk")
-        identity = _text(record["alias"]["video_id"], f"{label}.alias.video_id")
+        _text(record["alias"]["video_id"], f"{label}.alias.video_id")
+        # The lineage graph is keyed by token: the record shape is already
+        # validated, so a token here is never None.
+        identity = record_identity_token(record["alias"])
         if identity in active_ids:
             _refuse(label, "accepted alias overlaps an active canonical source")
         if identity in edges:
             _refuse(label, "duplicate alias ownership")
         rejected = {
-            youtube_identity(rejection["url"])
+            source_identity_token(rejection["url"])
             for rejection in talks[filename].get("source_rejections", [])
             if rejection["source_type"] == "video"
         }
-        if identity in rejected or record["canonical"]["video_id"] in rejected:
+        if identity in rejected or record_identity_token(record["canonical"]) in (
+            rejected
+        ):
             _refuse(label, "accepted source overlaps the talk's rejection ledger")
         edges[identity] = record
     resolved: dict[str, str] = {}
@@ -361,7 +395,7 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
         if terminal is None:
             _refuse("source_aliases", "talk has no agreeing canonical URL/ID")
         visited = {identity}
-        target = record["canonical"]["video_id"]
+        target = record_identity_token(record["canonical"])
         while target != terminal:
             if resolved.get(target) == filename:
                 break
@@ -374,7 +408,7 @@ def validate_alias_database(database: Mapping[str, Any]) -> None:
                     "source_aliases",
                     "alias lineage does not end at its talk's canonical source",
                 )
-            target = parent["canonical"]["video_id"]
+            target = record_identity_token(parent["canonical"])
         for visited_identity in visited:
             resolved[visited_identity] = filename
 
@@ -383,7 +417,7 @@ def matched_alias(
     database: Mapping[str, Any], talk: Mapping[str, Any], url: Any
 ) -> Mapping[str, Any] | None:
     """Look up only a reviewed identity; callers first validate the database."""
-    identity = youtube_identity(url)
+    identity = source_identity_token(url)
     if identity is None:
         return None
     return next(
@@ -391,7 +425,7 @@ def matched_alias(
             record
             for record in database.get("source_aliases", [])
             if record["talk_filename"] == talk.get("filename")
-            and record["alias"]["video_id"] == identity
+            and record_identity_token(record["alias"]) == identity
         ),
         None,
     )

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -5,7 +5,7 @@ Downloads frames via ffmpeg, resolves a slide-region crop, deduplicates using
 perceptual hashing, and writes separately scoped slide-region/context PDFs.
 
 Usage:
-    video-slide-extraction.py <video> <outdir> <youtube_id> [--fps 0.5]
+    video-slide-extraction.py <video> <outdir> <source_token> [--fps 0.5]
                               [--threshold 8]
                               [--region auto|none|LEFT,TOP,RIGHT,BOTTOM]
                               [--region-verified]
@@ -13,7 +13,10 @@ Usage:
 
     <video>       Path to downloaded MP4 video
     <outdir>      Directory for intermediate files and output artifacts
-    <youtube_id>  YouTube video ID (used for naming the output PDF)
+    <source_token>
+                  The talk's source binding token, used to name the output PDF:
+                  the bare ID for a YouTube talk, `vimeo-<id>` or
+                  `infoq-<slug>` for the other supported providers
     --fps         Frames per second to extract (default: 0.5 = 1 frame per 2s)
     --threshold   Largest perceptual-hash distance treated as the same slide
                   (default: 8). Higher values merge more and keep fewer frames.
@@ -41,7 +44,7 @@ import sys
 import tempfile
 
 from artifact_locator import ArtifactLocatorError, materialize_native_root
-from ingress_contract import YOUTUBE_ID_RE
+from ingress_contract import is_source_binding_token
 from video_evidence import (
     VideoEvidenceAssessment,
     VideoEvidenceError,
@@ -90,10 +93,11 @@ except ImportError as exc:
 NormalizedSlideRegion = tuple[float, float, float, float]
 
 
-def validate_youtube_id(value: object) -> str:
-    """Return one canonical ingress YouTube ID or fail with a closed reason."""
-    if not isinstance(value, str) or YOUTUBE_ID_RE.fullmatch(value) is None:
-        raise ValueError("youtube_id_invalid")
+def validate_source_token(value: object) -> str:
+    """Return one canonical source binding token or fail with a closed reason."""
+    if not is_source_binding_token(value):
+        raise ValueError("source_token_invalid")
+    assert isinstance(value, str)  # narrowed by is_source_binding_token
     return value
 
 
@@ -240,10 +244,10 @@ def _video_run_lock(path):
     return FileLock(path)
 
 
-def _video_run_lock_path(output_dir: str, youtube_id: str) -> str:
+def _video_run_lock_path(output_dir: str, source_token: str) -> str:
     """Map one local output identity to a stable OS-temporary lock file."""
     identity = (
-        os.fsencode(os.path.normcase(output_dir)) + b"\0" + youtube_id.encode("ascii")
+        os.fsencode(os.path.normcase(output_dir)) + b"\0" + source_token.encode("ascii")
     )
     lock_name = f"{hashlib.sha256(identity).hexdigest()}.lock"
     lock_root = os.path.join(tempfile.gettempdir(), "speaker-toolkit-video-locks")
@@ -832,7 +836,7 @@ def combine_to_pdf(
     if artifact_scope == "full_frame_context" and slide_region is not None:
         raise ValueError("full_frame_context artifacts must preserve the full frame")
     if source_video_id is not None:
-        source_video_id = validate_youtube_id(source_video_id)
+        source_video_id = validate_source_token(source_video_id)
 
     if not unique_frames:
         print("  WARNING: No unique frames found", file=sys.stderr)
@@ -948,7 +952,7 @@ def artifact_record(
         crop_method == "manual" and crop_verified
     ):
         raise ValueError("authored-slide trust requires a verified manual crop")
-    source_video_id = validate_youtube_id(source_video_id)
+    source_video_id = validate_source_token(source_video_id)
     return {
         "path": canonical_path(path),
         "artifact_scope": artifact_scope,
@@ -967,7 +971,7 @@ def artifact_record(
 def _extract_slides_in_workspace(
     video_path,
     output_dir,
-    youtube_id,
+    source_token,
     frames_dir,
     source_receipt,
     published,
@@ -982,7 +986,7 @@ def _extract_slides_in_workspace(
     Args:
         video_path: Path to downloaded MP4
         output_dir: Directory for intermediate files and output PDF
-        youtube_id: YouTube video ID (used for naming)
+        source_token: the talk's source binding token (used for naming)
         source_receipt: Engine-owned receipt for the exact source generation,
                         stamped onto the manifest and every derivative record.
         published: Caller-owned list this appends each staged PDF path to the
@@ -1002,18 +1006,18 @@ def _extract_slides_in_workspace(
     Returns:
         dict with extraction results for structured_data
     """
-    youtube_id = validate_youtube_id(youtube_id)
+    source_token = validate_source_token(source_token)
     if fps <= 0:
         raise ValueError("fps must be greater than zero")
     output_dir = canonical_path(output_dir)
     source_video_path = canonical_path(video_path)
     slide_pdf = _confined_output_path(
         output_dir,
-        f"{youtube_id}.slide-region.pdf",
+        f"{source_token}.slide-region.pdf",
     )
-    context_pdf = _confined_output_path(output_dir, f"{youtube_id}.context.pdf")
+    context_pdf = _confined_output_path(output_dir, f"{source_token}.context.pdf")
 
-    print(f"Extracting video artifacts from {youtube_id}...", file=sys.stderr)
+    print(f"Extracting video artifacts from {source_token}...", file=sys.stderr)
 
     # Step 2: Extract frames
     frames = extract_frames(source_video_path, frames_dir, fps=fps)
@@ -1022,7 +1026,7 @@ def _extract_slides_in_workspace(
             "slide_source": "video_extracted",
             "schema_version": SCHEMA_VERSION,
             "pipeline_version": PIPELINE_VERSION,
-            "source_video_id": youtube_id,
+            "source_video_id": source_token,
             "source_video_path": source_video_path,
             "source_receipt": copy.deepcopy(source_receipt),
             "total_frames_extracted": 0,
@@ -1060,7 +1064,7 @@ def _extract_slides_in_workspace(
             slide_pdf,
             resolved_region,
             artifact_scope="slide_region",
-            source_video_id=youtube_id,
+            source_video_id=source_token,
             crop_method=region_provenance["slide_region_method"],
             crop_verified=region_provenance["slide_region_verified"],
             commit=False,
@@ -1072,7 +1076,7 @@ def _extract_slides_in_workspace(
                     slide_pdf_path,
                     "slide_region",
                     len(unique_frames),
-                    youtube_id,
+                    source_token,
                     source_video_path,
                     source_receipt,
                     crop_method=region_provenance["slide_region_method"],
@@ -1089,7 +1093,7 @@ def _extract_slides_in_workspace(
             unique_frames,
             context_pdf,
             artifact_scope="full_frame_context",
-            source_video_id=youtube_id,
+            source_video_id=source_token,
             commit=False,
         )
         if context_pdf_path:
@@ -1099,7 +1103,7 @@ def _extract_slides_in_workspace(
                     context_pdf_path,
                     "full_frame_context",
                     len(unique_frames),
-                    youtube_id,
+                    source_token,
                     source_video_path,
                     source_receipt,
                 )
@@ -1109,7 +1113,7 @@ def _extract_slides_in_workspace(
         "slide_source": "video_extracted",
         "schema_version": SCHEMA_VERSION,
         "pipeline_version": PIPELINE_VERSION,
-        "source_video_id": youtube_id,
+        "source_video_id": source_token,
         "source_video_path": source_video_path,
         "source_receipt": copy.deepcopy(source_receipt),
         "total_frames_extracted": len(frames),
@@ -1134,7 +1138,7 @@ def _extract_slides_in_workspace(
 def extract_slides_from_video(
     video_path,
     output_dir,
-    youtube_id,
+    source_token,
     fps=0.5,
     hash_threshold=8,
     slide_region: str | NormalizedSlideRegion = "auto",
@@ -1154,7 +1158,7 @@ def extract_slides_from_video(
     leave a half-bound PDF behind and a failed re-extraction leaves the previous
     run's artifacts exactly as it found them.
     """
-    youtube_id = validate_youtube_id(youtube_id)
+    source_token = validate_source_token(source_token)
     if expected_source_sha256 is not None:
         validate_expected_source_sha256(expected_source_sha256)
     if fps <= 0:
@@ -1162,7 +1166,7 @@ def extract_slides_from_video(
     output_dir = canonical_path(output_dir)
     source_video_path = canonical_path(video_path)
     os.makedirs(output_dir, exist_ok=True)
-    run_lock = _video_run_lock_path(output_dir, youtube_id)
+    run_lock = _video_run_lock_path(output_dir, source_token)
 
     with _video_run_lock(run_lock):
         assessment = VideoEvidenceAssessment()
@@ -1176,8 +1180,8 @@ def extract_slides_from_video(
                 reason_code="video_review_source_mismatch",
             )
         for filename in (
-            f"{youtube_id}.slide-region.pdf",
-            f"{youtube_id}.context.pdf",
+            f"{source_token}.slide-region.pdf",
+            f"{source_token}.context.pdf",
         ):
             destination = _confined_output_path(output_dir, filename)
             _recover_stale_pdf_publish(destination)
@@ -1191,7 +1195,7 @@ def extract_slides_from_video(
                 result = _extract_slides_in_workspace(
                     source_video_path,
                     output_dir,
-                    youtube_id,
+                    source_token,
                     frames_dir,
                     source_receipt,
                     published,
@@ -1224,7 +1228,9 @@ def main():
         "outdir", nargs="?", help="Directory for intermediate files and output PDF"
     )
     parser.add_argument(
-        "youtube_id", nargs="?", help="YouTube video ID (used for naming)"
+        "source_token",
+        nargs="?",
+        help="the talk's source binding token (used for naming)",
     )
     parser.add_argument(
         "--fps",
@@ -1270,14 +1276,14 @@ def main():
         print(json.dumps({"pipeline_version": PIPELINE_VERSION}))
         return
 
-    if None in (args.video, args.outdir, args.youtube_id):
-        parser.error("video, outdir, and youtube_id are required")
+    if None in (args.video, args.outdir, args.source_token):
+        parser.error("video, outdir, and source_token are required")
     if args.region_verified and not isinstance(args.region, tuple):
         parser.error(
             "--region-verified requires manual LEFT,TOP,RIGHT,BOTTOM coordinates"
         )
     try:
-        youtube_id = validate_youtube_id(args.youtube_id)
+        source_token = validate_source_token(args.source_token)
     except ValueError as exc:
         parser.error(str(exc))
 
@@ -1292,7 +1298,7 @@ def main():
         result = extract_slides_from_video(
             args.video,
             args.outdir,
-            youtube_id,
+            source_token,
             fps=args.fps,
             hash_threshold=args.threshold,
             slide_region=args.region,

--- a/skills/vault-ingress/scripts/video-slide-extraction.py
+++ b/skills/vault-ingress/scripts/video-slide-extraction.py
@@ -15,8 +15,8 @@ Usage:
     <outdir>      Directory for intermediate files and output artifacts
     <source_token>
                   The talk's source binding token, used to name the output PDF:
-                  the bare ID for a YouTube talk, `vimeo-<id>` or
-                  `infoq-<slug>` for the other supported providers
+                  the bare ID for a YouTube talk, `vimeo+<id>` or
+                  `infoq+<slug>` for the other supported providers
     --fps         Frames per second to extract (default: 0.5 = 1 frame per 2s)
     --threshold   Largest perceptual-hash distance treated as the same slide
                   (default: 8). Higher values merge more and keep fewer frames.
@@ -44,7 +44,10 @@ import sys
 import tempfile
 
 from artifact_locator import ArtifactLocatorError, materialize_native_root
-from ingress_contract import is_source_binding_token
+from ingress_contract import (
+    VIDEO_EXTRACTION_SCHEMA_VERSION,
+    is_source_binding_token,
+)
 from video_evidence import (
     VideoEvidenceAssessment,
     VideoEvidenceError,
@@ -62,10 +65,12 @@ PIPELINE_VERSION = "0.14.0"
 
 # Shape version of the structured_data.video_extraction record (distinct from
 # PIPELINE_VERSION, which tracks extractor behavior — this tracks the record's
-# field shape). Bump on any field add/remove/rename. Records written before this
-# field existed have no schema_version and are read as the legacy shape (0).
+# field shape). The number itself lives in ingress_contract so the producer and
+# every reader gate on one constant; a second copy here is how they drift apart.
+# Records written before this field existed have no schema_version and are read
+# as the legacy shape (0).
 # See skills/vault-ingress/references/schemas-db.md ("Video Extraction Output Schema").
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = VIDEO_EXTRACTION_SCHEMA_VERSION
 
 VIDEO_DEPENDENCY_INSTALL = (
     'pip install "ImageHash==4.3.2" "numpy==2.2.6" "Pillow==12.3.0" "filelock==3.32.2"'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,6 +309,13 @@ def persist_results():
 
 
 @pytest.fixture(scope="session")
+def ingress_contract():
+    return _import_script(
+        os.path.join(SCRIPTS_VI, "ingress_contract.py"), "ingress_contract"
+    )
+
+
+@pytest.fixture(scope="session")
 def tracking_database_io():
     return _import_script(
         os.path.join(SCRIPTS_VI, "tracking_database_io.py"),

--- a/tests/test_audit_source_identities.py
+++ b/tests/test_audit_source_identities.py
@@ -1217,3 +1217,73 @@ def test_a_region_block_stays_a_retryable_fetch_failure(audit_source_identities)
     assert report["metadata_unavailable_count"] == 0
     # An active identity the audit could not verify still blocks.
     assert report["complete"] is False
+
+
+# ── #427: the cheap pre-check survives a non-YouTube source ────────────
+VIMEO_URL = "https://vimeo.com/1223667266"
+INFOQ_URL = "https://www.infoq.com/presentations/java-puzzle/"
+
+
+@pytest.mark.parametrize(
+    ("video_url", "provider"),
+    [(VIMEO_URL, "vimeo"), (INFOQ_URL, "infoq")],
+)
+def test_supported_non_youtube_source_is_out_of_scope_not_a_fault(
+    audit_source_identities, video_url, provider
+):
+    """The audit has no lane for it; that is not the talk's fault to review."""
+    calls = []
+
+    report = audit_source_identities.audit_database(
+        {"talks": [talk(video_url=video_url, youtube_id=None)]},
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=lambda video_id: calls.append(video_id),
+        captured_at=CAPTURED_AT,
+    )
+
+    assert calls == [], "an out-of-scope provider must not be fetched"
+    assert finding_codes(report) == ["active_source_provider_out_of_scope"]
+    assert report["findings"][0]["review_priority"] == "low"
+    assert provider in report["findings"][0]["message"]
+    assert report["talks"][0]["source_provider"] == provider
+    assert report["complete"] is True
+    assert report["review_required"] is False
+    assert report["out_of_scope_talk_count"] == 1
+
+
+def test_an_out_of_scope_source_never_masks_a_real_finding(
+    audit_source_identities,
+):
+    report = audit_source_identities.audit_database(
+        {
+            "talks": [
+                talk("vimeo.md", video_url=VIMEO_URL, youtube_id=None),
+                talk("broken.md", video_url="https://www.youtube.com/watch?v=short"),
+            ]
+        },
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=lambda video_id: metadata(video_id),
+        captured_at=CAPTURED_AT,
+    )
+
+    assert set(finding_codes(report)) == {
+        "active_source_provider_out_of_scope",
+        "active_youtube_url_invalid",
+    }
+    assert report["review_required"] is True
+    assert report["complete"] is False
+
+
+def test_a_wholly_unknown_provider_is_still_reported_as_unsupported(
+    audit_source_identities,
+):
+    report = audit_source_identities.audit_database(
+        {"talks": [talk(video_url="https://example.com/talks/1", youtube_id=None)]},
+        database_path="/vault/tracking-database.json",
+        metadata_fetcher=lambda video_id: metadata(video_id),
+        captured_at=CAPTURED_AT,
+    )
+
+    assert finding_codes(report) == ["active_video_provider_unsupported"]
+    assert report["talks"][0]["source_provider"] is None
+    assert report["review_required"] is True

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -4120,3 +4120,49 @@ def test_youtube_local_video_filename_still_binds_to_its_id(tmp_path: Path) -> N
 
     assert bound_path is None
     assert "not bound to youtube_id" in reason
+
+
+def test_a_v4_manifest_never_binds_a_provider_token(tmp_path: Path) -> None:
+    """The evidence reader enforces the same v4/v5 rule the validator does.
+
+    A v4 record was written when `source_video_id` held a YouTube ID. Accepting
+    a Vimeo token there in one reader and rejecting it in the other is the same
+    as having no rule (#427 review).
+    """
+    vault = tmp_path / "vault"
+    talk = _manifest_bound_talk(vault, video_url=VIMEO_TALK_URL, token=VIMEO_TOKEN)
+    manifest = talk["structured_data"]["video_extraction"]
+    manifest["schema_version"] = (
+        ingress_contract.YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION
+    )
+
+    bound_path, reason = pattern_evidence._local_video_binding(
+        vault,
+        talk,
+        ingress_contract.talk_source_identity(talk),
+    )
+
+    assert bound_path is None
+    assert "not bound to the claimed source" in reason
+
+
+def test_a_v4_manifest_still_binds_its_youtube_id(tmp_path: Path) -> None:
+    """The predecessor stays readable; no vault record needs re-extraction."""
+    vault = tmp_path / "vault"
+    talk = _manifest_bound_talk(
+        vault,
+        video_url=f"https://youtu.be/{SYNTHETIC_VIDEO_ID}",
+        token=SYNTHETIC_VIDEO_ID,
+    )
+    manifest = talk["structured_data"]["video_extraction"]
+    manifest["schema_version"] = (
+        ingress_contract.YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION
+    )
+
+    bound_path, reason = pattern_evidence._local_video_binding(
+        vault,
+        talk,
+        ingress_contract.talk_source_identity(talk),
+    )
+
+    assert bound_path is not None, reason

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -3972,9 +3972,9 @@ def test_detection_claim_leaves_non_string_sources_used_untouched() -> None:
 # could still only be scored from the slides PDF, because every binding lane
 # resolved a bare `youtube_id`. These are the two shapes from the live vault.
 VIMEO_TALK_URL = "https://vimeo.com/1223667266"
-VIMEO_TOKEN = "vimeo-1223667266"
+VIMEO_TOKEN = "vimeo+1223667266"
 INFOQ_TALK_URL = "https://www.infoq.com/presentations/java-puzzle/"
-INFOQ_TOKEN = "infoq-java-puzzle"
+INFOQ_TOKEN = "infoq+java-puzzle"
 
 
 def _receipt_bound_transcript(vault: Path, media: Path) -> Path:

--- a/tests/test_pattern_evidence.py
+++ b/tests/test_pattern_evidence.py
@@ -27,6 +27,7 @@ if str(SCRIPTS) not in sys.path:
 
 artifact_supervisor = importlib.import_module("artifact_supervisor")
 artifact_metadata = importlib.import_module("artifact_metadata")
+ingress_contract = importlib.import_module("ingress_contract")
 pattern_evidence = importlib.import_module("pattern_evidence")
 pdf_evidence = importlib.import_module("pdf_evidence")
 pptx_evidence = importlib.import_module("pptx_evidence")
@@ -34,6 +35,7 @@ return_validation = importlib.import_module("return_validation")
 transcript_timing = importlib.import_module("transcript_timing")
 video_evidence = importlib.import_module("video_evidence")
 SYNTHETIC_VIDEO_ID = "abcdefghijk"
+SYNTHETIC_IDENTITY = ingress_contract.SourceIdentity("youtube", SYNTHETIC_VIDEO_ID)
 SYNTHETIC_DURATION = 600.0
 
 
@@ -997,7 +999,7 @@ def test_foreign_video_manifest_pdf_never_reaches_current_context_probe(
         pattern_evidence._probe_video_manifest_artifacts(
             tmp_path / "vault",
             manifest,
-            SYNTHETIC_VIDEO_ID,
+            SYNTHETIC_IDENTITY,
         )
 
     assert foreign_pdf not in str(caught.value)
@@ -1700,7 +1702,7 @@ def test_persisted_context_manifest_reanalysis_never_touches_pdf_in_owner(
     probe, reason, path = pattern_evidence._trusted_video_slide_probe(
         vault,
         {"structured_data": {"video_extraction": manifest}},
-        SYNTHETIC_VIDEO_ID,
+        SYNTHETIC_IDENTITY,
     )
 
     assert probe is None
@@ -3873,7 +3875,7 @@ def test_replaced_source_video_withdraws_authored_slide_trust(
     probe, reason, path = pattern_evidence._trusted_video_slide_probe(
         vault,
         owner,
-        SYNTHETIC_VIDEO_ID,
+        SYNTHETIC_IDENTITY,
         video_evidence_assessment=_TestVideoAssessment(),
     )
     assert probe is not None
@@ -3884,7 +3886,7 @@ def test_replaced_source_video_withdraws_authored_slide_trust(
     probe, reason, path = pattern_evidence._trusted_video_slide_probe(
         vault,
         owner,
-        SYNTHETIC_VIDEO_ID,
+        SYNTHETIC_IDENTITY,
         video_evidence_assessment=_TestVideoAssessment(),
     )
 
@@ -3927,7 +3929,7 @@ def test_derivatives_from_two_runs_are_rejected_before_persistence(
         pattern_evidence._probe_video_manifest_artifacts(
             vault,
             manifest,
-            SYNTHETIC_VIDEO_ID,
+            SYNTHETIC_IDENTITY,
         )
 
 
@@ -3960,3 +3962,161 @@ def test_detection_claim_leaves_non_string_sources_used_untouched() -> None:
         {"source": "a"},
         2,
     ]
+
+
+# ── #427: a talk published off YouTube carries its own evidence ────────
+#
+# JavaZone publishes to Vimeo and InfoQ to its own presentation pages. Both
+# talks had a full evidence set — a published recording, a preserved local
+# source, a validated transcript with a local-media quality receipt — and
+# could still only be scored from the slides PDF, because every binding lane
+# resolved a bare `youtube_id`. These are the two shapes from the live vault.
+VIMEO_TALK_URL = "https://vimeo.com/1223667266"
+VIMEO_TOKEN = "vimeo-1223667266"
+INFOQ_TALK_URL = "https://www.infoq.com/presentations/java-puzzle/"
+INFOQ_TOKEN = "infoq-java-puzzle"
+
+
+def _receipt_bound_transcript(vault: Path, media: Path) -> Path:
+    """Write the transcript plus the local-media receipt that owns it."""
+    transcript = vault / "transcripts" / "conference-talk.txt"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    text = "\n".join(_transcript_lines())
+    transcript.write_text(text, encoding="utf-8")
+    transcript_timing.write_quality_receipt(
+        transcript,
+        text,
+        transcript_timing.build_quality_policy(
+            400,
+            trusted_duration_seconds=SYNTHETIC_DURATION,
+        ),
+        {
+            "kind": "local_media_duration",
+            "media_sha256": hashlib.sha256(media.read_bytes()).hexdigest(),
+            "duration_seconds": SYNTHETIC_DURATION,
+        },
+    )
+    return transcript
+
+
+def _manifest_bound_talk(vault: Path, *, video_url: str, token: str) -> dict:
+    """A talk whose preserved source video is declared by a v4 manifest."""
+    source_video = vault / "slides-rebuild" / token / f"{token}.mp4"
+    source_video.parent.mkdir(parents=True, exist_ok=True)
+    source_video.write_bytes(b"preserved conference recording bytes")
+    manifest = _untrusted_video_manifest(vault, source_video)
+    manifest["source_video_id"] = token
+    manifest["artifacts"][0]["source_video_id"] = token
+    transcript = _receipt_bound_transcript(vault, source_video)
+    return {
+        "filename": "2026-09-03-conference-talk.md",
+        "video_url": video_url,
+        "transcript_path": transcript.relative_to(vault).as_posix(),
+        "transcript_source": "whisper",
+        "slide_source": "none",
+        "structured_data": {"video_extraction": manifest},
+    }
+
+
+@pytest.mark.parametrize(
+    ("video_url", "token"),
+    [(VIMEO_TALK_URL, VIMEO_TOKEN), (INFOQ_TALK_URL, INFOQ_TOKEN)],
+)
+def test_non_youtube_talk_carries_transcript_and_video_evidence(
+    tmp_path: Path, video_url: str, token: str
+) -> None:
+    """The #427 headline: 8 of 28 detections were lost to an absent YouTube ID."""
+    vault = tmp_path / "vault"
+    talk = _manifest_bound_talk(vault, video_url=video_url, token=token)
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        talk,
+        video_evidence_assessment=_TestVideoAssessment(),
+    )
+
+    verified = context["verified_evidence_sources"]
+    assert "transcript" in verified, context["transcript_reason"]
+    assert "delivery_video" in verified, context["source_reasons"]["delivery_video"]
+
+
+def test_non_youtube_receipt_still_rejects_another_talks_media(
+    tmp_path: Path,
+) -> None:
+    """Generalising the owner never widened it: a foreign digest stays foreign."""
+    vault = tmp_path / "vault"
+    talk = _manifest_bound_talk(vault, video_url=VIMEO_TALK_URL, token=VIMEO_TOKEN)
+    manifest = talk["structured_data"]["video_extraction"]
+    (vault / manifest["source_video_path"]).write_bytes(b"a different recording")
+
+    context = pattern_evidence.build_evidence_context(
+        vault,
+        talk,
+        video_evidence_assessment=_TestVideoAssessment(),
+    )
+
+    assert "transcript" not in context["verified_evidence_sources"]
+    assert "receipt_owner_mismatch" in context["transcript_reason"]
+
+
+def test_manifest_bound_to_another_provider_is_not_this_talks_source(
+    tmp_path: Path,
+) -> None:
+    """A Vimeo talk never adopts an InfoQ manifest that shares its shape."""
+    vault = tmp_path / "vault"
+    talk = _manifest_bound_talk(vault, video_url=VIMEO_TALK_URL, token=VIMEO_TOKEN)
+    talk["structured_data"]["video_extraction"]["source_video_id"] = INFOQ_TOKEN
+
+    bound_path, reason = pattern_evidence._local_video_binding(
+        vault,
+        talk,
+        ingress_contract.talk_source_identity(talk),
+    )
+
+    assert bound_path is None
+    assert "not bound to the claimed source" in reason
+
+
+def test_declared_local_recording_still_binds_without_a_manifest(
+    tmp_path: Path,
+) -> None:
+    """The owner-declared lane predates #427 and keeps its permissive naming."""
+    vault = tmp_path / "vault"
+    recording = vault / "videos" / "javazone-room-camera.mov"
+    recording.parent.mkdir(parents=True)
+    recording.write_bytes(b"owner-captured room recording bytes")
+    talk = {
+        "filename": "2026-09-03-conference-talk.md",
+        "video_url": VIMEO_TALK_URL,
+        "video_local_path": recording.relative_to(vault).as_posix(),
+    }
+
+    bound_path, reason = pattern_evidence._local_video_binding(
+        vault,
+        talk,
+        ingress_contract.talk_source_identity(talk),
+    )
+
+    assert bound_path == recording, reason
+
+
+def test_youtube_local_video_filename_still_binds_to_its_id(tmp_path: Path) -> None:
+    """The YouTube naming guarantee survives the generalisation."""
+    vault = tmp_path / "vault"
+    recording = vault / "videos" / "some-other-name.mp4"
+    recording.parent.mkdir(parents=True)
+    recording.write_bytes(b"mislabelled recording")
+    talk = {
+        "youtube_id": SYNTHETIC_VIDEO_ID,
+        "video_url": f"https://youtu.be/{SYNTHETIC_VIDEO_ID}",
+        "video_local_path": recording.relative_to(vault).as_posix(),
+    }
+
+    bound_path, reason = pattern_evidence._local_video_binding(
+        vault,
+        talk,
+        ingress_contract.talk_source_identity(talk),
+    )
+
+    assert bound_path is None
+    assert "not bound to youtube_id" in reason

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4725,3 +4725,127 @@ def test_a_calendar_edge_bound_compares_instead_of_overflowing(
 
     codes = finding_codes(report, "warning") | finding_codes(report, "blocking")
     assert "source_identity_date_uncheckable" not in codes
+
+
+# ── #427: a non-YouTube identity is evidence, not a blocking fault ─────
+VIMEO_URL = "https://vimeo.com/1223667266"
+VIMEO_ID = "1223667266"
+INFOQ_URL = "https://www.infoq.com/presentations/java-puzzle/"
+
+
+def vimeo_identity(**updates):
+    evidence = source_identity(
+        provider="vimeo",
+        video_id=VIMEO_ID,
+        webpage_url=VIMEO_URL,
+        webpage_video_id=VIMEO_ID,
+    )
+    evidence.update(updates)
+    return evidence
+
+
+def vimeo_talk(**updates):
+    talk = base_talk(video_url=VIMEO_URL, transcript_source="whisper")
+    talk.pop("youtube_id")
+    talk.update(updates)
+    return talk
+
+
+def test_non_youtube_source_identity_is_not_a_blocking_fault(
+    preflight_vault, vault_fixture
+):
+    """The three blocking findings in a 251-talk vault all came from here."""
+    transcript = materialize_transcript(vault_fixture, "javazone-2026")
+    talk = vimeo_talk(
+        transcript_path=transcript.relative_to(vault_fixture["root"]).as_posix(),
+        source_identity=vimeo_identity(),
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["blocking_count"] == 0, report["findings"]
+
+
+def test_infoq_presentation_slug_is_a_usable_identity(preflight_vault, vault_fixture):
+    """The provider exposes no video id at all; the slug is the identity."""
+    transcript = materialize_transcript(vault_fixture, "infoq-java-puzzlers")
+    talk = vimeo_talk(
+        video_url=INFOQ_URL,
+        transcript_path=transcript.relative_to(vault_fixture["root"]).as_posix(),
+        source_identity=source_identity(
+            provider="infoq",
+            video_id="java-puzzle",
+            webpage_url=INFOQ_URL,
+            webpage_video_id="java-puzzle",
+        ),
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert report["blocking_count"] == 0, report["findings"]
+
+
+def test_identity_evidence_naming_another_provider_is_blocking(
+    preflight_vault, vault_fixture
+):
+    """ "Do not relabel them as YouTube" is now enforced, not just documented."""
+    talk = vimeo_talk(source_identity=vimeo_identity(provider="youtube"))
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "source_identity_provider_mismatch" in finding_codes(report, "blocking")
+
+
+def test_a_provider_id_in_the_wrong_shape_is_still_blocking(
+    preflight_vault, vault_fixture
+):
+    talk = vimeo_talk(source_identity=vimeo_identity(video_id="not-numeric"))
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "source_identity_video_id_invalid" in finding_codes(report, "blocking")
+
+
+def test_an_unsupported_provider_stays_a_warning(preflight_vault, vault_fixture):
+    talk = vimeo_talk(source_identity=vimeo_identity(provider="twitch"))
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "source_identity_provider_unknown" in finding_codes(report, "warning")
+
+
+def test_captured_webpage_from_another_provider_is_blocking(
+    preflight_vault, vault_fixture
+):
+    talk = vimeo_talk(
+        source_identity=vimeo_identity(
+            webpage_url=f"https://www.youtube.com/watch?v={OTHER_VIDEO_ID}"
+        )
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "source_identity_webpage_url_invalid" in finding_codes(report, "blocking")
+
+
+def test_two_providers_sharing_an_id_are_not_a_duplicate_recording(
+    preflight_vault, vault_fixture
+):
+    talks = [
+        vimeo_talk(filename="vimeo.md"),
+        vimeo_talk(
+            filename="infoq.md",
+            video_url="https://www.infoq.com/presentations/1223667266/",
+        ),
+    ]
+    write_database(vault_fixture, talks)
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "duplicate_youtube_id" not in finding_codes(report)

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4428,7 +4428,7 @@ def test_archival_v3_manifest_asks_for_re_extraction_not_a_stamped_digest(
         for item in report["findings"]
         if item["code"] == "video_extraction_source_receipt_missing"
     )
-    assert finding["expected"] == 4
+    assert finding["expected"] == preflight_vault.VIDEO_EXTRACTION_SCHEMA_VERSION
     assert finding["actual"] == 3
     # Preflight reports the gap; it never writes a receipt of its own.
     stored = json.loads(vault_fixture["database"].read_text())["talks"][0]
@@ -4849,3 +4849,28 @@ def test_two_providers_sharing_an_id_are_not_a_duplicate_recording(
     report = preflight_vault.run_preflight(vault_fixture["root"])
 
     assert "duplicate_youtube_id" not in finding_codes(report)
+
+
+def test_missing_identity_for_video_slides_names_the_field_it_read(
+    preflight_vault, vault_fixture
+):
+    """A Vimeo talk has no `youtube_id` by design; reporting one misleads."""
+    talk = vimeo_talk(
+        video_url="https://example.com/talks/1",
+        slide_source="video_extracted",
+        status="pending",
+    )
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    finding = next(
+        item
+        for item in report["findings"]
+        if item["code"] == "slide_video_reference_missing"
+    )
+    assert finding["field"] == "video_url"
+    assert finding["actual"] == {
+        "video_url": "https://example.com/talks/1",
+        "youtube_id": None,
+    }

--- a/tests/test_preflight_vault.py
+++ b/tests/test_preflight_vault.py
@@ -4874,3 +4874,31 @@ def test_missing_identity_for_video_slides_names_the_field_it_read(
         "video_url": "https://example.com/talks/1",
         "youtube_id": None,
     }
+
+
+def test_a_stale_youtube_id_on_a_vimeo_source_is_blocking(
+    preflight_vault, vault_fixture
+):
+    """Left behind, it outranks the active URL and binds artifacts to the wrong
+    recording, so identity evidence naming YouTube would validate (#427 review)."""
+    talk = vimeo_talk(youtube_id=VIDEO_ID, source_identity=source_identity())
+    write_database(vault_fixture, [talk])
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    assert "youtube_id_provider_conflict" in finding_codes(report, "blocking")
+
+
+def test_a_conflicting_record_binds_no_source_identity(preflight_vault, vault_fixture):
+    talks = [
+        vimeo_talk(filename="conflicted.md", youtube_id=VIDEO_ID),
+        base_talk(filename="genuine.md"),
+    ]
+    write_database(vault_fixture, talks)
+
+    report = preflight_vault.run_preflight(vault_fixture["root"])
+
+    # The conflicted record contributes no token, so it cannot collide with the
+    # genuine YouTube talk that actually owns that ID.
+    assert "duplicate_youtube_id" not in finding_codes(report)
+    assert "youtube_id_provider_conflict" in finding_codes(report, "blocking")

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -1072,7 +1072,7 @@ def test_video_manifest_identity_is_bound_to_the_claimed_talk(return_validation)
     )
     with pytest.raises(return_validation.ReturnValidationError) as excinfo:
         return_validation.validate_claim_against_talk(talk, value)
-    assert "does not match talk youtube_id" in str(excinfo.value)
+    assert "does not match talk source identity" in str(excinfo.value)
 
 
 def test_claim_generation_must_equal_talk_generation(return_validation):

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -2931,3 +2931,16 @@ def test_a_v4_manifest_with_a_youtube_id_still_reads(return_validation):
     )
 
     assert state.source_video_id == manifest["source_video_id"]
+
+
+@pytest.mark.parametrize("version", [[], {}, "four", None, True, 4.0])
+def test_a_malformed_schema_version_is_typed_not_a_typeerror(
+    return_validation, version
+):
+    """A JSON document can hold an unhashable value; membership alone raised
+    TypeError past the caller's actionable message (#427 review)."""
+    value = _video_return()
+    value["structured_data"]["video_extraction"]["schema_version"] = version
+
+    with pytest.raises(return_validation.ReturnValidationError):
+        return_validation.validate_video_extraction_manifest(value["structured_data"])

--- a/tests/test_return_validation.py
+++ b/tests/test_return_validation.py
@@ -2901,3 +2901,33 @@ def test_manifest_state_carries_the_canonical_receipt_for_lineage_readers(
     )
 
     assert state.source_receipt == manifest["source_receipt"]
+
+
+def test_a_v4_manifest_may_not_carry_a_provider_token(return_validation):
+    """The two readable contracts stay distinguishable (#427 review)."""
+    value = _video_return()
+    manifest = value["structured_data"]["video_extraction"]
+    manifest["schema_version"] = (
+        return_validation.YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION
+    )
+    manifest["source_video_id"] = "vimeo+1223667266"
+
+    with pytest.raises(return_validation.ReturnValidationError) as excinfo:
+        return_validation.validate_video_extraction_manifest(value["structured_data"])
+
+    assert "must be a YouTube ID in a schema-4 manifest" in str(excinfo.value)
+
+
+def test_a_v4_manifest_with_a_youtube_id_still_reads(return_validation):
+    """A vault full of v4 records needs no migration and no re-extraction."""
+    value = _video_return()
+    manifest = value["structured_data"]["video_extraction"]
+    manifest["schema_version"] = (
+        return_validation.YOUTUBE_BOUND_VIDEO_EXTRACTION_SCHEMA_VERSION
+    )
+
+    state = return_validation.validate_video_extraction_manifest(
+        value["structured_data"]
+    )
+
+    assert state.source_video_id == manifest["source_video_id"]

--- a/tests/test_source_alias_contract.py
+++ b/tests/test_source_alias_contract.py
@@ -667,3 +667,19 @@ def test_two_providers_sharing_an_id_are_not_one_identity():
     contract.validate_alias_record(
         _record(alias=alias, canonical=canonical), label="record"
     )
+
+
+@pytest.mark.parametrize("url", ["https://[broken", "https://[", "http://[::1"])
+def test_a_malformed_active_url_fails_typed_not_raw(tracking_database, url):
+    """A raw ValueError here would escape the ledger's typed failure and the
+    reader's, losing the actionable message (#427 review)."""
+    contract = importlib.import_module("source_alias_contract")
+    assert contract.active_identity({"video_url": url}) is None
+    assert contract.source_identity_token(url) is None
+
+    database = _database()
+    database["talks"][0]["video_url"] = url
+    database["talks"][0].pop("youtube_id", None)
+    database["source_aliases"] = [_record()]
+    with pytest.raises(contract.SourceAliasError):
+        contract.validate_alias_database(database)

--- a/tests/test_source_alias_contract.py
+++ b/tests/test_source_alias_contract.py
@@ -613,3 +613,57 @@ def test_catalog_rollout_consumers_reference_owner_schema(relative):
         encoding="utf-8"
     )
     assert "### Schema versioning" in owner
+
+
+# ── #427: an alias can be recorded as the provider it actually is ──────
+def _vimeo_provider(video_id="1223667266"):
+    return {
+        "provider": "vimeo",
+        "video_id": video_id,
+        "url": f"https://vimeo.com/{video_id}",
+        "title": "Synthetic delivery",
+        "uploader": "Synthetic event channel",
+        "upload_date": "2026-01-02",
+        "duration_seconds": 2700,
+        "captured_at": "2026-02-01T12:00:00Z",
+    }
+
+
+def test_a_supported_non_youtube_upload_is_a_valid_reviewed_alias():
+    """Before #427 the ledger failed closed on every provider but YouTube."""
+    contract = importlib.import_module("source_alias_contract")
+    contract.validate_alias_record(_record(alias=_vimeo_provider()), label="record")
+
+
+def test_a_provider_block_still_refuses_a_url_that_names_another_id():
+    contract = importlib.import_module("source_alias_contract")
+    block = _vimeo_provider()
+    block["url"] = "https://vimeo.com/999999999"
+    with pytest.raises(contract.SourceAliasError):
+        contract.validate_alias_record(_record(alias=block), label="record")
+
+
+def test_a_provider_block_still_refuses_an_unsupported_provider():
+    contract = importlib.import_module("source_alias_contract")
+    block = _vimeo_provider()
+    block["provider"] = "twitch"
+    with pytest.raises(contract.SourceAliasError):
+        contract.validate_alias_record(_record(alias=block), label="record")
+
+
+def test_two_providers_sharing_an_id_are_not_one_identity():
+    """A bare-ID comparison would have read these as an alias of itself."""
+    contract = importlib.import_module("source_alias_contract")
+    shared = "123456789012"
+    canonical = _vimeo_provider(shared)
+    alias = dict(canonical)
+    alias.update(
+        {
+            "provider": "infoq",
+            "video_id": "java-puzzle",
+            "url": "https://www.infoq.com/presentations/java-puzzle/",
+        }
+    )
+    contract.validate_alias_record(
+        _record(alias=alias, canonical=canonical), label="record"
+    )

--- a/tests/test_source_alias_promotion.py
+++ b/tests/test_source_alias_promotion.py
@@ -507,3 +507,23 @@ def test_promotion_contract_documents_history_and_evidence_boundary():
     for field in ("prior_state", "retired_alias", "source_added"):
         assert f"`{field}`" in reference
     assert "Never clear or relabel those receipts to bypass a gate" in reference
+
+
+def test_promotion_refuses_a_non_youtube_canonical(mutate_tracking_database):
+    """#427 opened the alias ledger to other providers; promotion writes
+    `youtube_id`, so it stays a YouTube-only operation rather than silently
+    stamping a Vimeo ID into a field that means something else."""
+    from test_source_alias_contract import _vimeo_provider
+
+    database = _database()
+    plan = _promotion(database)
+    plan["record"]["canonical"] = _vimeo_provider()
+    original = copy.deepcopy(database)
+
+    with pytest.raises(
+        mutate_tracking_database.TrackingDatabaseMutationError
+    ) as caught:
+        mutate_tracking_database.build_candidate(database, [plan])
+
+    assert "YouTube canonical only" in str(caught.value)
+    assert database == original

--- a/tests/test_source_alias_promotion.py
+++ b/tests/test_source_alias_promotion.py
@@ -527,3 +527,30 @@ def test_promotion_refuses_a_non_youtube_canonical(mutate_tracking_database):
 
     assert "YouTube canonical only" in str(caught.value)
     assert database == original
+
+
+# An all-digit YouTube ID is also a syntactically valid Vimeo ID, which is the
+# only way two providers can genuinely share a bare `video_id` string.
+SHARED_BARE_ID = "12345678901"
+
+
+def test_promotion_retires_by_token_not_by_bare_id(mutate_tracking_database):
+    """A Vimeo alias whose bare ID equals the promoted YouTube ID must not be
+    retired in its place (#427 review)."""
+    from test_source_alias_contract import _vimeo_provider
+
+    database = _database()
+    decoy = _record(
+        alias=_vimeo_provider(SHARED_BARE_ID),
+        canonical=_provider(database["talks"][0]["youtube_id"]),
+        relationship="valid_duplicate",
+    )
+    database["source_aliases"] = [decoy]
+
+    candidate, _ = mutate_tracking_database.build_candidate(
+        database, [_promotion(database, SHARED_BARE_ID)]
+    )
+
+    latest = candidate["source_aliases"][-1]
+    assert latest["retired_alias"] is None, "a bare-ID match retired the wrong record"
+    assert decoy in candidate["source_aliases"]

--- a/tests/test_source_identity_contract.py
+++ b/tests/test_source_identity_contract.py
@@ -138,10 +138,26 @@ def test_declared_pairs_validate_against_their_provider(
     assert (identity is not None) is valid
 
 
-def test_supported_providers_are_the_ones_with_parsers(ingress_contract):
-    assert set(ingress_contract.SUPPORTED_SOURCE_PROVIDERS) == set(
-        ingress_contract._PROVIDER_ID_PATTERNS
-    )
+# One representative published URL per supported provider. The test below is
+# what keeps a provider from being declared supported without a working parser.
+PROVIDER_SAMPLE_URLS = {
+    "youtube": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "vimeo": "https://vimeo.com/1223667266",
+    "infoq": "https://www.infoq.com/presentations/java-puzzle/",
+}
+
+
+def test_every_supported_provider_has_a_sample_url(ingress_contract):
+    """A missing sample would make the parser test below vacuous."""
+    assert set(ingress_contract.SUPPORTED_SOURCE_PROVIDERS) == set(PROVIDER_SAMPLE_URLS)
+
+
+@pytest.mark.parametrize("provider", sorted(PROVIDER_SAMPLE_URLS))
+def test_every_supported_provider_parses_a_real_url(ingress_contract, provider):
+    identity = ingress_contract.parse_source_identity(PROVIDER_SAMPLE_URLS[provider])
+    assert identity is not None
+    assert identity.provider == provider
+    assert ingress_contract.source_identity_for(provider, identity.video_id) == identity
 
 
 @pytest.mark.parametrize(

--- a/tests/test_source_identity_contract.py
+++ b/tests/test_source_identity_contract.py
@@ -86,17 +86,6 @@ def test_two_providers_sharing_an_id_get_different_tokens(ingress_contract):
     assert vimeo.binding_token != infoq.binding_token
 
 
-def test_stored_youtube_id_outranks_the_active_url(ingress_contract):
-    """A YouTube talk resolves exactly as it did before providers existed."""
-    talk = {
-        "youtube_id": "dQw4w9WgXcQ",
-        "video_url": "https://vimeo.com/1223667266",
-    }
-    identity = ingress_contract.talk_source_identity(talk)
-    assert identity == ingress_contract.SourceIdentity("youtube", "dQw4w9WgXcQ")
-    assert ingress_contract.talk_binding_token(talk) == "dQw4w9WgXcQ"
-
-
 @pytest.mark.parametrize(
     ("talk", "token"),
     [
@@ -250,3 +239,33 @@ def test_a_malformed_url_reads_as_no_acquisition_source(ingress_contract, url):
     assert ingress_contract.has_remote_video_acquisition({"video_url": url}) is False
     assert ingress_contract.has_remote_slide_acquisition({"slides_url": url}) is False
     assert ingress_contract.talk_source_identity({"video_url": url}) is None
+
+
+def test_a_stale_youtube_id_on_another_provider_resolves_to_nothing(
+    ingress_contract,
+):
+    """Binding to either half would name a source the record does not (#427 review)."""
+    talk = {
+        "youtube_id": "dQw4w9WgXcQ",
+        "video_url": "https://vimeo.com/1223667266",
+    }
+    assert ingress_contract.talk_source_identity(talk) is None
+    assert ingress_contract.talk_binding_token(talk) is None
+
+
+@pytest.mark.parametrize(
+    "video_url",
+    [
+        "https://youtu.be/dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=ZyXwVuTsR_2",
+        "https://example.com/not-a-provider",
+        None,
+    ],
+)
+def test_a_youtube_id_still_wins_where_no_other_provider_claims_the_source(
+    ingress_contract, video_url
+):
+    talk = {"youtube_id": "dQw4w9WgXcQ", "video_url": video_url}
+    assert ingress_contract.talk_source_identity(talk) == (
+        ingress_contract.SourceIdentity("youtube", "dQw4w9WgXcQ")
+    )

--- a/tests/test_source_identity_contract.py
+++ b/tests/test_source_identity_contract.py
@@ -70,8 +70,8 @@ def test_youtube_binding_token_is_the_bare_id(ingress_contract):
 @pytest.mark.parametrize(
     ("provider", "video_id", "token"),
     [
-        ("vimeo", "1223667266", "vimeo-1223667266"),
-        ("infoq", "java-puzzle", "infoq-java-puzzle"),
+        ("vimeo", "1223667266", "vimeo+1223667266"),
+        ("infoq", "java-puzzle", "infoq+java-puzzle"),
     ],
 )
 def test_other_providers_carry_their_prefix(
@@ -100,10 +100,10 @@ def test_stored_youtube_id_outranks_the_active_url(ingress_contract):
 @pytest.mark.parametrize(
     ("talk", "token"),
     [
-        ({"video_url": "https://vimeo.com/1223667266"}, "vimeo-1223667266"),
+        ({"video_url": "https://vimeo.com/1223667266"}, "vimeo+1223667266"),
         (
             {"video_url": "https://www.infoq.com/presentations/java-puzzle/"},
-            "infoq-java-puzzle",
+            "infoq+java-puzzle",
         ),
         ({"video_url": "https://youtu.be/dQw4w9WgXcQ"}, "dQw4w9WgXcQ"),
         ({"video_url": "https://example.com/talk"}, None),
@@ -146,7 +146,7 @@ def test_supported_providers_are_the_ones_with_parsers(ingress_contract):
 
 @pytest.mark.parametrize(
     "token",
-    ["dQw4w9WgXcQ", "vimeo-1223667266", "infoq-java-puzzle"],
+    ["dQw4w9WgXcQ", "vimeo+1223667266", "infoq+java-puzzle"],
 )
 def test_every_identity_produces_a_recognized_binding_token(ingress_contract, token):
     assert ingress_contract.is_source_binding_token(token) is True
@@ -154,14 +154,60 @@ def test_every_identity_produces_a_recognized_binding_token(ingress_contract, to
 
 @pytest.mark.parametrize(
     "token",
-    ["vimeo-1234", "infoq-Upper-Case", "vimeo-", "twitch-1223667266", "", None, 11],
+    ["vimeo+1234", "infoq+Upper-Case", "vimeo+", "twitch+1223667266", "", None, 11],
 )
 def test_malformed_tokens_bind_nothing(ingress_contract, token):
     assert ingress_contract.is_source_binding_token(token) is False
 
 
-def test_an_eleven_character_token_is_a_youtube_id_whatever_it_spells(
-    ingress_contract,
+@pytest.mark.parametrize(
+    ("provider", "video_id", "colliding_youtube_id"),
+    # A Vimeo ID is at least six digits, so `vimeo-<id>` was never 11
+    # characters and never collided. InfoQ slugs are the real surface.
+    [
+        ("infoq", "kafka", "infoq-kafka"),
+        ("infoq", "abc", "infoq-abc12"),
+    ],
+)
+def test_no_token_can_be_mistaken_for_a_youtube_id(
+    ingress_contract, provider, video_id, colliding_youtube_id
 ):
-    """Documented in `is_source_binding_token`; pinned so it stays deliberate."""
-    assert ingress_contract.is_source_binding_token("infoq-Upper") is True
+    """The separator is outside the YouTube alphabet, so overlap is unrepresentable.
+
+    With an in-alphabet separator the InfoQ slug `kafka` and the YouTube ID
+    `infoq-kafka` produced one token, and every ownership, alias, and duplicate
+    check keyed on it conflated two different recordings.
+    """
+    token = ingress_contract.SourceIdentity(provider, video_id).binding_token
+    assert token != colliding_youtube_id
+    assert ingress_contract.token_source_identity(token) == (
+        ingress_contract.SourceIdentity(provider, video_id)
+    )
+    assert ingress_contract.token_source_identity(colliding_youtube_id) == (
+        ingress_contract.SourceIdentity("youtube", colliding_youtube_id)
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "video_id"),
+    [
+        ("youtube", "dQw4w9WgXcQ"),
+        ("vimeo", "1223667266"),
+        ("infoq", "java-puzzle"),
+    ],
+)
+def test_the_token_round_trips_back_to_its_identity(
+    ingress_contract, provider, video_id
+):
+    identity = ingress_contract.SourceIdentity(provider, video_id)
+    assert ingress_contract.token_source_identity(identity.binding_token) == identity
+
+
+def test_the_separator_is_outside_the_youtube_alphabet(ingress_contract):
+    """The property every collision guarantee above rests on."""
+    assert (
+        ingress_contract.YOUTUBE_ID_RE.fullmatch(
+            ingress_contract.SOURCE_PROVIDER_SEPARATOR * 11
+        )
+        is None
+    )

--- a/tests/test_source_identity_contract.py
+++ b/tests/test_source_identity_contract.py
@@ -227,3 +227,26 @@ def test_the_separator_is_outside_the_youtube_alphabet(ingress_contract):
         )
         is None
     )
+
+
+# A URL `urlparse` itself rejects. Every parser here is documented total, so a
+# malformed URL is an absent identity rather than an escaping ValueError that
+# would take a caller's actionable message with it (#427 review).
+MALFORMED_URLS = ["https://[broken", "https://[", "http://[::1", "//[bad]"]
+
+
+@pytest.mark.parametrize("url", MALFORMED_URLS)
+def test_a_malformed_url_is_an_absent_identity_not_an_exception(ingress_contract, url):
+    assert ingress_contract.parse_source_identity(url) is None
+    assert ingress_contract.parse_youtube_id(url) is None
+    assert ingress_contract.parse_vimeo_id(url) is None
+    assert ingress_contract.parse_infoq_id(url) is None
+    assert ingress_contract.parse_google_drive_id(url) is None
+    assert ingress_contract.is_youtube_url(url) is False
+
+
+@pytest.mark.parametrize("url", MALFORMED_URLS)
+def test_a_malformed_url_reads_as_no_acquisition_source(ingress_contract, url):
+    assert ingress_contract.has_remote_video_acquisition({"video_url": url}) is False
+    assert ingress_contract.has_remote_slide_acquisition({"slides_url": url}) is False
+    assert ingress_contract.talk_source_identity({"video_url": url}) is None

--- a/tests/test_source_identity_contract.py
+++ b/tests/test_source_identity_contract.py
@@ -1,0 +1,144 @@
+"""Provider-qualified talk source identity (#427).
+
+A talk published anywhere other than YouTube could not carry transcript or
+video evidence, because every binding lane resolved a bare ``youtube_id``.
+These tests pin the shared ingress_contract those lanes now resolve instead: the
+provider parsers, the binding token, and the guarantee that a YouTube talk's
+token is still the bare ID every stored artifact was named for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", ("youtube", "dQw4w9WgXcQ")),
+        ("https://youtu.be/dQw4w9WgXcQ", ("youtube", "dQw4w9WgXcQ")),
+        ("https://vimeo.com/1223667266", ("vimeo", "1223667266")),
+        ("https://vimeo.com/1223667266/9f3c1a2b4d", ("vimeo", "1223667266")),
+        ("https://player.vimeo.com/video/1223667266", ("vimeo", "1223667266")),
+        ("https://vimeo.com/channels/staffpicks/1223667266", ("vimeo", "1223667266")),
+        (
+            "https://vimeo.com/groups/javazone/videos/1223667266",
+            ("vimeo", "1223667266"),
+        ),
+        ("https://vimeo.com/event/55555/videos/1223667266", ("vimeo", "1223667266")),
+        ("vimeo.com/1223667266", ("vimeo", "1223667266")),
+        ("https://www.infoq.com/presentations/java-puzzle/", ("infoq", "java-puzzle")),
+        ("https://www.infoq.com/presentations/java-puzzle", ("infoq", "java-puzzle")),
+        ("https://infoq.com/presentations/Java-Puzzle/", ("infoq", "java-puzzle")),
+    ],
+)
+def test_supported_provider_urls_resolve_to_an_identity(
+    ingress_contract, url, expected
+):
+    identity = ingress_contract.parse_source_identity(url)
+    assert identity is not None
+    assert (identity.provider, identity.video_id) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        None,
+        "",
+        "   ",
+        42,
+        "https://example.com/videos/1223667266",
+        "https://vimeo.com/abcdefgh",
+        "https://vimeo.com/12345",
+        "https://vimeo.com/channels/staffpicks",
+        "https://www.infoq.com/podcasts/java-puzzle/",
+        "https://www.infoq.com/presentations/",
+        "ftp://vimeo.com/1223667266",
+    ],
+)
+def test_unsupported_or_malformed_sources_resolve_to_nothing(ingress_contract, url):
+    assert ingress_contract.parse_source_identity(url) is None
+
+
+def test_youtube_binding_token_is_the_bare_id(ingress_contract):
+    """Every artifact named before this change keeps binding to its own name."""
+    identity = ingress_contract.parse_source_identity("https://youtu.be/dQw4w9WgXcQ")
+    assert identity is not None
+    assert identity.binding_token == "dQw4w9WgXcQ"
+
+
+@pytest.mark.parametrize(
+    ("provider", "video_id", "token"),
+    [
+        ("vimeo", "1223667266", "vimeo-1223667266"),
+        ("infoq", "java-puzzle", "infoq-java-puzzle"),
+    ],
+)
+def test_other_providers_carry_their_prefix(
+    ingress_contract, provider, video_id, token
+):
+    assert ingress_contract.SourceIdentity(provider, video_id).binding_token == token
+
+
+def test_two_providers_sharing_an_id_get_different_tokens(ingress_contract):
+    vimeo = ingress_contract.SourceIdentity("vimeo", "123456789012")
+    infoq = ingress_contract.SourceIdentity("infoq", "123456789012")
+    assert vimeo.binding_token != infoq.binding_token
+
+
+def test_stored_youtube_id_outranks_the_active_url(ingress_contract):
+    """A YouTube talk resolves exactly as it did before providers existed."""
+    talk = {
+        "youtube_id": "dQw4w9WgXcQ",
+        "video_url": "https://vimeo.com/1223667266",
+    }
+    identity = ingress_contract.talk_source_identity(talk)
+    assert identity == ingress_contract.SourceIdentity("youtube", "dQw4w9WgXcQ")
+    assert ingress_contract.talk_binding_token(talk) == "dQw4w9WgXcQ"
+
+
+@pytest.mark.parametrize(
+    ("talk", "token"),
+    [
+        ({"video_url": "https://vimeo.com/1223667266"}, "vimeo-1223667266"),
+        (
+            {"video_url": "https://www.infoq.com/presentations/java-puzzle/"},
+            "infoq-java-puzzle",
+        ),
+        ({"video_url": "https://youtu.be/dQw4w9WgXcQ"}, "dQw4w9WgXcQ"),
+        ({"video_url": "https://example.com/talk"}, None),
+        ({"youtube_id": "not-an-id"}, None),
+        ({}, None),
+    ],
+)
+def test_talk_binding_token_resolves_from_the_active_source(
+    ingress_contract, talk, token
+):
+    assert ingress_contract.talk_binding_token(talk) == token
+
+
+@pytest.mark.parametrize(
+    ("provider", "video_id", "valid"),
+    [
+        ("youtube", "dQw4w9WgXcQ", True),
+        ("vimeo", "1223667266", True),
+        ("infoq", "java-puzzle", True),
+        ("youtube", "short", False),
+        ("vimeo", "not-numeric", False),
+        ("infoq", "Upper-Case", False),
+        ("twitch", "1223667266", False),
+        ("vimeo", 1223667266, False),
+        (None, "1223667266", False),
+    ],
+)
+def test_declared_pairs_validate_against_their_provider(
+    ingress_contract, provider, video_id, valid
+):
+    identity = ingress_contract.source_identity_for(provider, video_id)
+    assert (identity is not None) is valid
+
+
+def test_supported_providers_are_the_ones_with_parsers(ingress_contract):
+    assert set(ingress_contract.SUPPORTED_SOURCE_PROVIDERS) == set(
+        ingress_contract._PROVIDER_ID_PATTERNS
+    )

--- a/tests/test_source_identity_contract.py
+++ b/tests/test_source_identity_contract.py
@@ -142,3 +142,26 @@ def test_supported_providers_are_the_ones_with_parsers(ingress_contract):
     assert set(ingress_contract.SUPPORTED_SOURCE_PROVIDERS) == set(
         ingress_contract._PROVIDER_ID_PATTERNS
     )
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["dQw4w9WgXcQ", "vimeo-1223667266", "infoq-java-puzzle"],
+)
+def test_every_identity_produces_a_recognized_binding_token(ingress_contract, token):
+    assert ingress_contract.is_source_binding_token(token) is True
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["vimeo-1234", "infoq-Upper-Case", "vimeo-", "twitch-1223667266", "", None, 11],
+)
+def test_malformed_tokens_bind_nothing(ingress_contract, token):
+    assert ingress_contract.is_source_binding_token(token) is False
+
+
+def test_an_eleven_character_token_is_a_youtube_id_whatever_it_spells(
+    ingress_contract,
+):
+    """Documented in `is_source_binding_token`; pinned so it stays deliberate."""
+    assert ingress_contract.is_source_binding_token("infoq-Upper") is True

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -2201,7 +2201,7 @@ def test_a_backup_left_by_a_killed_publish_is_restored_next_run(
 
 @pytest.mark.parametrize(
     "source_token",
-    [YOUTUBE_ID, "vimeo-1223667266", "infoq-java-puzzle"],
+    [YOUTUBE_ID, "vimeo+1223667266", "infoq+java-puzzle"],
 )
 def test_pipeline_names_artifacts_for_any_supported_provider(
     video_slide_extraction, source_token
@@ -2214,7 +2214,7 @@ def test_pipeline_names_artifacts_for_any_supported_provider(
 # so the cases below are all longer than one.
 @pytest.mark.parametrize(
     "source_token",
-    ["vimeo-1234", "infoq-Upper-Case", "vimeo-", "twitch-1223667266"],
+    ["vimeo+1234", "infoq+Upper-Case", "vimeo+", "twitch+1223667266"],
 )
 def test_pipeline_rejects_a_malformed_provider_token(
     video_slide_extraction, source_token

--- a/tests/test_video_slide_extraction.py
+++ b/tests/test_video_slide_extraction.py
@@ -352,7 +352,7 @@ def test_extract_frames_enumerates_only_literal_numbered_jpegs(
         "ＡbCdEfGhI_1",
     ],
 )
-def test_video_pipeline_rejects_noncanonical_youtube_id_before_io(
+def test_video_pipeline_rejects_noncanonical_source_token_before_io(
     video_slide_extraction,
     monkeypatch,
     tmp_path,
@@ -376,7 +376,7 @@ def test_video_pipeline_rejects_noncanonical_youtube_id_before_io(
             youtube_id,
         )
 
-    assert str(caught.value) == "youtube_id_invalid"
+    assert str(caught.value) == "source_token_invalid"
     if isinstance(youtube_id, str) and youtube_id:
         assert youtube_id not in str(caught.value)
 
@@ -1115,7 +1115,7 @@ def test_success_cli_emits_only_result_json_on_stdout(
     "youtube_id",
     ["../escape-id", r"abc\defghij", YOUTUBE_ID + "\x00"],
 )
-def test_cli_rejects_noncanonical_youtube_id_before_pipeline_io(
+def test_cli_rejects_noncanonical_source_token_before_pipeline_io(
     video_slide_extraction,
     monkeypatch,
     capsys,
@@ -1142,7 +1142,7 @@ def test_cli_rejects_noncanonical_youtube_id_before_pipeline_io(
 
     assert caught.value.code == 2
     captured = capsys.readouterr()
-    assert "youtube_id_invalid" in captured.err
+    assert "source_token_invalid" in captured.err
     assert youtube_id not in captured.err
 
 
@@ -2197,3 +2197,28 @@ def test_a_backup_left_by_a_killed_publish_is_restored_next_run(
 
     assert open(context_pdf, "rb").read() == prior
     assert not os.path.exists(video_slide_extraction._pdf_backup_path(context_pdf))
+
+
+@pytest.mark.parametrize(
+    "source_token",
+    [YOUTUBE_ID, "vimeo-1223667266", "infoq-java-puzzle"],
+)
+def test_pipeline_names_artifacts_for_any_supported_provider(
+    video_slide_extraction, source_token
+):
+    """#427: a Vimeo or InfoQ talk can produce a manifest at all."""
+    assert video_slide_extraction.validate_source_token(source_token) == source_token
+
+
+# An 11-character token is a YouTube ID by construction, whatever it spells,
+# so the cases below are all longer than one.
+@pytest.mark.parametrize(
+    "source_token",
+    ["vimeo-1234", "infoq-Upper-Case", "vimeo-", "twitch-1223667266"],
+)
+def test_pipeline_rejects_a_malformed_provider_token(
+    video_slide_extraction, source_token
+):
+    with pytest.raises(ValueError) as caught:
+        video_slide_extraction.validate_source_token(source_token)
+    assert str(caught.value) == "source_token_invalid"


### PR DESCRIPTION
Closes #427.

A talk published anywhere other than YouTube could not carry transcript or video evidence. JavaZone 2026 (Vimeo) arrived with a complete evidence set — published recording, preserved local source, Whisper transcript with schema-v2 timing and quality receipts, delivered PDF — and could only be scored from the PDF: 8 of 28 detections lost, weighted score 26.0 → 18.0 with no thinner delivery behind it. `2016-qcon-sf-java-puzzlers-ng-s02.md` (InfoQ) has been in the catalog for a decade with the same problem, and between them those two talks owned all three blocking findings in an otherwise-clean 251-talk preflight.

## The shape of the fix

Talk identity becomes a provider plus that provider's own ID, resolved once in `ingress_contract.py`. Artifacts bind to a **binding token** derived from it.

**A YouTube token is the bare 11-character ID.** That is the property that made this safe to land: every stored artifact, manifest, receipt and filename binds to exactly the string it always did, and no vault content moves. Other providers carry a prefix (`vimeo-1223667266`, `infoq-java-puzzle`), which also keeps two providers sharing an ID from reading as one identity. InfoQ publishes no video ID at all, so its presentation slug is the identity — which is why the token could not simply be a different ID format.

## The five lanes

| Lane | Was | Now |
|---|---|---|
| `preflight-vault.py` | a Vimeo ID blocked as "not an 11-character YouTube ID" | validated against its own provider's shape; a relabelled provider is blocking |
| `pattern_evidence.py::_local_video_binding` | no `youtube_id` ⇒ null trusted digest ⇒ `receipt_owner_mismatch` on a correct hash | binds on the token |
| `pattern_evidence.py` video binding | `no identity-bound timed video artifact` | `delivery_video` resolves |
| `source-aliases.md` / `source_alias_contract.py` | failed closed on every provider but YouTube | records the provider it actually is; comparisons run on tokens |
| `audit-source-identities.py` | reported both talks as faults to review | `active_source_provider_out_of_scope`, low priority, never sets `review_required` |

Plus `video-slide-extraction.py`, which named artifacts from an 11-character ID and so could not produce a manifest for these talks at all — leaving the evidence layer's new binding with nothing to read.

## Two deliberate asymmetries

- The YouTube-owned transcript provenance kinds (`youtube_captions`, `youtube_whisper`, `youtube_duration`) still compare the bare YouTube ID, because only a YouTube talk can satisfy them. The local-media kinds carry every other provider.
- The owner-declared `video_local_path` keeps its permissive naming. A YouTube download lands as `{id}.mp4` and its name is identity evidence; a room-camera capture is registered under the name it was captured with, and the record's own declaration is what binds it. Requiring a derived filename there would have broken the working half of the lane this issue is about.

Promotion stayed YouTube-only: it writes the talk's `youtube_id`, so it refuses a non-YouTube canonical outright rather than stamping a foreign ID into a field that means something else.

## Contract change

The identity audit's report contract goes to **v4**: adds `out_of_scope_talk_count` and a per-talk `source_provider`, and `review_required` no longer fires on an out-of-scope note.

## Verification

- Full suite green; ruff clean; pyright 0 errors.
- The headline acceptance tests were confirmed **red on `origin/main`** with the new contract module dropped in and the lanes unfixed, then green here.
- Negative coverage kept: a foreign local-media digest still fails owner binding, a manifest bound to another provider's token still refuses, and a YouTube `video_local_path` whose filename is not its ID still refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJfgXoxsCAT7y6Vj1nGNJV
