### PR TITLE
feat(illustrations): lean on GPT Image 2.5 whenever a talk has builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### feat(illustrations) — lean hard on GPT Image 2.5 whenever a talk has builds
+
+GPT Image 2.5 fixes the failure that made build chains fragile on every earlier
+generation: chained edits no longer degrade. A build is a backwards chain of edits — each
+frame is the previous frame with one element erased — and on the pre-2.5 editors every step
+redraws the frame, so small deviations compound across the chain (`erase_region` scopes that
+drift to a box; it never removes it). The `edit` attribute becomes a ranked tier instead of
+a yes/no: `precise` (GPT Image 2.5 Sunburst, OpenAI's pick "for workflows where editing
+precision matters most"), `stable` (GPT Image 2.5 Flare — edits follow instructions across
+multiple turns, subjects preserved), `strong` (the Gemini editors: capable, drifting), `none`
+(Imagen). `gpt-image-2.5-sunburst-2026-09-08` joins the roster (alias
+`gpt-image-2.5-sunburst`; same token rates as Flare; no published latency claim, so it keeps
+GPT Image 2's `slow` tier). `--shortlist` with `build-editability` still filters `none` out
+and now sorts the survivors by edit tier FIRST, soft signals second: a talk with builds lands
+on a 2.5 model before cost, speed, or quality is weighed, and the cheapest, fastest Gemini
+ranks below both. Without `build-editability` the ranking is unchanged. The illustration
+rule, the skill's Step 4, the strategy and builds references say the same thing in prose:
+with builds, carry only the edit-stable models into the exploration render; a `strong`-tier
+editor enters only on the speaker's explicit request. The priority-model-shortlist eval's
+cost criterion is restated for the lean.
+
 ## 0.20.149 — 2026-09-08
 
 ### fix(illustrations) — replace GPT Image 2 with GPT Image 2.5 Flare in the model roster

--- a/evals/illustrations-priority-model-shortlist/criteria.json
+++ b/evals/illustrations-priority-model-shortlist/criteria.json
@@ -1,5 +1,5 @@
 {
-  "context": "Tests the illustrations skill's style-strategy model-selection logic (Steps 4-6): priorities drive a data-narrowed model shortlist before any rendering. The deck has progressive-reveal builds (slides 4 and 9), and the speaker optimizes for cost. The tile's contribution is the staged process — surface priorities, recognize builds require an edit-capable model, narrow the roster by attributes, then confirm visually — rather than naming a model from general knowledge. A baseline agent without the skill tends to recommend a single model on quality/reputation grounds.",
+  "context": "Tests the illustrations skill's style-strategy model-selection logic (Steps 4-6): priorities drive a data-narrowed model shortlist before any rendering. The deck has progressive-reveal builds (slides 4 and 9), and the speaker optimizes for cost. The tile's contribution is the staged process — surface priorities, recognize builds require an edit-capable model, narrow the roster by attributes (where the build lean outranks the cost signal: chained edits drift on pre-2.5 editors, so the shortlist leads with the edit-stable GPT Image 2.5 models), then confirm visually — rather than naming a model from general knowledge. A baseline agent without the skill tends to recommend a single model on quality/reputation grounds.",
   "type": "weighted_checklist",
   "checklist": [
     {
@@ -18,8 +18,8 @@
       "max_score": 20
     },
     {
-      "name": "Shortlist excludes the non-editing model and favors low cost",
-      "description": "The recommended shortlist excludes Imagen (it has no image-edit endpoint, so build chains cannot run on it) and favors the lower-cost edit-capable option for this cost-sensitive deck. Checkable against the model_registry.py attributes as committed at eval time.",
+      "name": "Shortlist excludes the non-editing model and leads with the edit-stable models",
+      "description": "The recommended shortlist excludes Imagen (it has no image-edit endpoint, so build chains cannot run on it) and, despite the cost priority, leads with the edit-stable GPT Image 2.5 models — a build chain edits the previous frame at every step, and the pre-2.5 editors drift across the chain. The lower-cost Gemini editor ranks after them as an explicit-request fallback, not the default; recommending it first for this build-heavy deck fails this criterion. Checkable against the model_registry.py `edit` tiers and `--shortlist cost,build-editability` output as committed at eval time.",
       "max_score": 20
     },
     {

--- a/rules/illustration-rules.md
+++ b/rules/illustration-rules.md
@@ -107,6 +107,10 @@ Don't:
   and only the *unchanged* surroundings are taken from the prior frame.
 - Generate each build stage independently from prompts — visual drift
   between stages will be jarring even if each individual stage looks fine.
+- Run a build chain on a `strong`-tier editor when an edit-stable model is
+  shortlisted. Chained edits drift on `strong`-tier editors; `erase_region`
+  scopes that drift, never removes it. Tiers and the build-editability ranking:
+  `skills/illustrations/scripts/model_registry.py` (`edit` attribute comment).
 
 Naming convention: `builds/slide-NN-build-MM.jpg` where `MM` is the stage
 index (`00` is empty, `01` adds the first element, etc.).

--- a/skills/illustrations/SKILL.md
+++ b/skills/illustrations/SKILL.md
@@ -150,8 +150,10 @@ Proceed immediately to Step 4.
 
 Elicit what the speaker optimizes for with an `AskUserQuestion` multi-select
 (checkboxes, not radio): cost, speed, quality, build-editability. Auto-add
-build-editability when any slide has a `Builds:` block. Never skip this step
-silently — the priorities drive the shortlist in Step 6.
+build-editability when any slide has a `Builds:` block. With builds, the Step 6
+shortlist leads with edit-stable models (GPT Image 2.5); carry only those into
+the exploration render unless the speaker explicitly asks for another editor.
+Never skip this step silently — the priorities drive the shortlist in Step 6.
 
 Proceed immediately to Step 5.
 

--- a/skills/illustrations/references/builds.md
+++ b/skills/illustrations/references/builds.md
@@ -23,6 +23,17 @@ Reference for Step 5 (builds) and the build-insertion portion of Step 6
 This backwards approach produces better results than building up from empty,
 because the model preserves the existing composition and style at each step.
 
+## Model
+
+Run the chain on an edit-stable model. GPT Image 2.5 holds subjects and
+composition across successive edits; the pre-2.5 editors compound small
+deviations step by step, which is the drift `erase_region` scopes but does not
+remove. The Step 6 shortlist leads with the 2.5 models whenever
+`build-editability` is flagged (Sunburst first — OpenAI's pick where editing
+precision matters most — then Flare); the tiers are the registry's
+(`model_registry.py`, `edit` attribute). Pick a `strong`-tier editor for a
+build talk only on the speaker's explicit request.
+
 ## Run
 
 ```bash

--- a/skills/illustrations/references/strategy.md
+++ b/skills/illustrations/references/strategy.md
@@ -64,7 +64,10 @@ shortlist (Step 6):
 - **speed** — faster turnaround per image
 - **quality** — top-tier fidelity
 - **build-editability** — the model must support image editing; required for
-  progressive-reveal builds and edit/fix iteration
+  progressive-reveal builds and edit/fix iteration. It also leads the ranking
+  with edit-stable models (GPT Image 2.5): a build chain edits the previous
+  frame at every step, and the pre-2.5 editors compound small deviations
+  across the chain — the drift `erase_region` scopes but does not remove
 
 Present with `AskUserQuestion` as a **multi-select** (checkboxes, not radio) — the
 speaker can pick several (e.g. `quality,build-editability`). Pass every chosen
@@ -72,7 +75,9 @@ priority to `--shortlist` (Step 6).
 
 Auto-flag `build-editability` when any slide carries a `Builds:` block — build
 frames are produced by editing the previous frame, so the model must support
-editing. A deck with no builds can drop the constraint.
+editing. A deck with no builds can drop the constraint. With builds, carry only
+the edit-stable models the shortlist leads with into the exploration render;
+a `strong`-tier editor enters only on the speaker's explicit request.
 
 Per-model attributes and how priorities rank them live in
 `skills/illustrations/scripts/model_registry.py` (the `MODEL_REGISTRY` entries and

--- a/skills/illustrations/scripts/model_registry.py
+++ b/skills/illustrations/scripts/model_registry.py
@@ -58,8 +58,22 @@ OPENAI_API_BASE = "https://api.openai.com/v1"
 #   cost     — relative price tier: low | medium | high
 #   speed    — relative latency tier: fast | medium | slow
 #   quality  — relative fidelity tier: medium | high
-#   edit     — image-edit support: strong | none. Drives build-editability:
-#              Imagen has no edit endpoint, so build chains cannot run on it.
+#   edit     — image-edit tier, best first (EDIT_RANKING):
+#                precise — chained edits hold, and the vendor positions the
+#                          model for edit precision (GPT Image 2.5 Sunburst)
+#                stable  — chained edits hold across steps (GPT Image 2.5
+#                          Flare: edits follow instructions reliably across
+#                          multiple turns, subjects preserved)
+#                strong  — edits well, but a CHAINED sequence drifts: every
+#                          step redraws the frame and small deviations
+#                          compound across a build (the pre-2.5 editors)
+#                none    — no edit endpoint (Imagen); build chains cannot
+#                          run on it
+#              Drives build-editability: `none` is filtered out, and the tier
+#              is the PRIMARY sort key ahead of every soft signal — a talk with
+#              builds lands on an edit-stable model before cost, speed, or
+#              quality is weighed. Chained-edit drift is the failure that ruins
+#              builds; `erase_region` scopes it but does not remove it.
 #
 # This roster is a SEED CACHE, not an allowlist. Rendering dispatches by family
 # prefix and accepts any id (see generate-illustrations.py model_family /
@@ -118,9 +132,9 @@ MODEL_REGISTRY = [
         # Snapshot-pinned for reproducible illustration style; the rolling
         # "gpt-image-2.5-flare" alias resolves here so baked outlines still
         # dispatch. Flare is OpenAI's stated default of the two GPT Image 2.5
-        # models (2026-09-08); "gpt-image-2.5-sunburst" targets edit-precision
-        # workflows and can be ranked per talk via `--shortlist --add`. The
-        # retired "gpt-image-2" is deliberately NOT an alias here — it would
+        # models (2026-09-08); Sunburst, the edit-precision sibling, is the
+        # next entry. The retired "gpt-image-2" is deliberately NOT an alias
+        # here — it would
         # remap baked outlines onto a different model — it lives in
         # LEGACY_MODEL_ALIASES, pinned to the snapshot it was current on.
         "id": "gpt-image-2.5-flare-2026-09-08",
@@ -130,7 +144,20 @@ MODEL_REGISTRY = [
         "cost": "high",
         "speed": "medium",
         "quality": "high",
-        "edit": "strong",
+        "edit": "stable",
+    },
+    {
+        # OpenAI's pick "for workflows where editing precision matters most"
+        # (2026-09-08) — the build-chain model. Token rates match Flare. No
+        # latency claim is published for it, so speed keeps GPT Image 2's tier.
+        "id": "gpt-image-2.5-sunburst-2026-09-08",
+        "display": "GPT Image 2.5 Sunburst",
+        "family": "openai",
+        "aliases": ["gpt-image-2.5-sunburst"],
+        "cost": "high",
+        "speed": "slow",
+        "quality": "high",
+        "edit": "precise",
     },
 ]
 
@@ -156,7 +183,10 @@ PRIORITY_RANKINGS = {
     "speed": ("speed", ["fast", "medium", "slow"]),
     "quality": ("quality", ["high", "medium"]),
 }
-# build-editability is a hard filter, not a soft rank.
+# build-editability is a hard filter (drop edit == "none") AND the primary
+# sort key over the survivors, best tier first. An unknown tier string on an
+# injected model survives the filter but ranks after every known tier.
+EDIT_RANKING = ["precise", "stable", "strong"]
 VALID_PRIORITIES = set(PRIORITY_RANKINGS) | {"build-editability"}
 
 
@@ -269,7 +299,11 @@ def shortlist_models(priorities, registry=None, extra_models=None):
     """Filter + rank the registry by optimization priorities, best first.
 
     - "build-editability" is a HARD filter: drops models whose edit == "none"
-      (Imagen has no edit endpoint, so build chains cannot run on it).
+      (Imagen has no edit endpoint, so build chains cannot run on it). It is
+      also the PRIMARY sort key over the survivors (EDIT_RANKING, best first):
+      an edit-stable model outranks a drifting one whatever the soft signals
+      say, so a talk with builds lands on GPT Image 2.5 before cost, speed, or
+      quality is weighed.
     - cost / speed / quality are SOFT signals: candidates are ranked by the
       summed tier-position across the requested signals (lower is better), with
       registry order as a stable tie-break.
@@ -299,7 +333,8 @@ def shortlist_models(priorities, registry=None, extra_models=None):
                 f"Unknown priority '{p}'. Valid priorities: "
                 f"{', '.join(sorted(VALID_PRIORITIES))}."
             )
-    if "build-editability" in priorities:
+    builds = "build-editability" in priorities
+    if builds:
         # Keep only models EXPLICITLY marked edit-capable. A missing/blank edit
         # field (e.g. an injected model that forgot it) must not slip into a
         # build-required shortlist, so treat unknown edit support as not-capable.
@@ -314,6 +349,12 @@ def shortlist_models(priorities, registry=None, extra_models=None):
             total += order.index(tier) if tier in order else len(order)
         return total
 
+    def edit_rank(model):
+        tier = model.get("edit")
+        return EDIT_RANKING.index(tier) if tier in EDIT_RANKING else len(EDIT_RANKING)
+
+    if builds:
+        return sorted(reg, key=lambda m: (edit_rank(m), score(m)))
     return sorted(reg, key=score)
 
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -64,7 +64,7 @@ def test_registry_entries_well_formed(model_registry):
         assert m["cost"] in {"low", "medium", "high"}
         assert m["speed"] in {"fast", "medium", "slow"}
         assert m["quality"] in {"medium", "high"}
-        assert m["edit"] in {"strong", "none"}
+        assert m["edit"] in {"precise", "stable", "strong", "none"}
 
 
 def test_compare_models_derived_from_registry(model_registry):
@@ -140,6 +140,13 @@ def test_resolve_is_case_insensitive(model_registry):
     )
 
 
+def test_resolve_sunburst_alias_to_snapshot(model_registry):
+    assert (
+        model_registry.resolve_model_id("gpt-image-2.5-sunburst")
+        == "gpt-image-2.5-sunburst-2026-09-08"
+    )
+
+
 def test_resolve_canonical_id_unchanged(model_registry):
     assert (
         model_registry.resolve_model_id("gpt-image-2.5-flare-2026-09-08")
@@ -199,6 +206,55 @@ def test_shortlist_cost_ranks_cheapest_first(model_registry):
     ranked = model_registry.shortlist_models(["cost"])
     assert ranked[0]["cost"] == "low"
     assert ranked[-1]["cost"] == "high"
+
+
+def test_shortlist_build_editability_leads_with_edit_stable_models(model_registry):
+    # A talk with builds lands on GPT Image 2.5: the edit tier is the primary
+    # key, so both 2.5 models precede every pre-2.5 editor, Sunburst (the
+    # vendor's edit-precision pick) first.
+    ranked = model_registry.shortlist_models(["build-editability"])
+    ids = [m["id"] for m in ranked]
+    assert ids[:2] == [
+        "gpt-image-2.5-sunburst-2026-09-08",
+        "gpt-image-2.5-flare-2026-09-08",
+    ]
+    assert all(m["edit"] == "strong" for m in ranked[2:])
+
+
+def test_shortlist_build_editability_outranks_soft_signals(model_registry):
+    # The lean is heavy: the cheapest, fastest editor still ranks below every
+    # 2.5 model when builds are in play. Without builds, cost rules as before.
+    with_builds = model_registry.shortlist_models(
+        ["cost", "speed", "build-editability"]
+    )
+    ids = [m["id"] for m in with_builds]
+    flash = ids.index("gemini-3.1-flash-image")
+    assert flash > ids.index("gpt-image-2.5-flare-2026-09-08")
+    assert flash > ids.index("gpt-image-2.5-sunburst-2026-09-08")
+    # Tier beats the soft signals within 2.5 too: Flare is the faster model,
+    # Sunburst (precise) still leads.
+    assert ids.index("gpt-image-2.5-sunburst-2026-09-08") < ids.index(
+        "gpt-image-2.5-flare-2026-09-08"
+    )
+    without_builds = model_registry.shortlist_models(["cost", "speed"])
+    assert without_builds[0]["id"] == "gemini-3.1-flash-image"
+
+
+def test_shortlist_injected_unknown_edit_tier_ranks_last(model_registry):
+    # An injected editor with a tier string the ranking does not know survives
+    # the filter but never outranks a known tier.
+    odd = {
+        "id": "vendor-x-editor",
+        "family": "gemini",
+        "cost": "low",
+        "speed": "fast",
+        "quality": "high",
+        "edit": "yes",
+    }
+    ranked = model_registry.shortlist_models(
+        ["cost", "build-editability"], extra_models=[odd]
+    )
+    assert ranked[-1]["id"] == "vendor-x-editor"
 
 
 def test_shortlist_quality_then_editability(model_registry):


### PR DESCRIPTION
## Summary
- GPT Image 2.5 fixes the failure that made build chains fragile on every earlier generation: chained edits no longer degrade. A build is a backwards chain of edits, and on the pre-2.5 editors every step redraws the frame so deviations compound; `erase_region` scopes that drift, never removes it.
- The `edit` attribute becomes a ranked tier: `precise` (GPT Image 2.5 Sunburst, OpenAI's pick "for workflows where editing precision matters most"), `stable` (Flare), `strong` (the Gemini editors), `none` (Imagen). `gpt-image-2.5-sunburst-2026-09-08` joins the roster (alias `gpt-image-2.5-sunburst`, same token rates as Flare, no published latency claim so it keeps the `slow` tier).
- `--shortlist` with `build-editability` still filters `none` out and now sorts survivors by edit tier first, soft signals second: a talk with builds lands on 2.5 before cost/speed/quality is weighed. Without `build-editability` the ranking is unchanged. The illustration rule, SKILL Step 4, the strategy and builds references, and the priority-model-shortlist eval say the same in prose: with builds, carry only edit-stable models into the exploration render; a `strong`-tier editor enters only on the speaker's explicit request.

## Test plan
- [x] `ruff check .` / `ruff format --check .` clean, `pyright` 0 errors
- [x] `pytest tests/test_model_registry.py tests/test_image_provider.py tests/test_generate_illustrations.py tests/test_policy_delegation_docs.py` green, including four new ranking/alias tests
- [x] `model_registry.py --shortlist cost,speed,build-editability` puts Sunburst, Flare ahead of the cheaper, faster Gemini Flash; `--shortlist cost,speed` still leads with Flash
- [x] `check_conflict_markers.py`, `check_plugin_lint.py` pass
- [ ] CI green on the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJzr7YWkcHGBNkd2tDPQo8